### PR TITLE
chore: Add semantic pull requests

### DIFF
--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -1,0 +1,74 @@
+###############################################################################
+# This file configures "Semantic Pull Requests", which is documented here:
+# https://github.com/zeke/semantic-pull-requests
+#
+# This action/spec implements the "Conventional Commits" RFC which is
+# available here:
+# https://www.notion.so/coderhq/Conventional-commits-1d51287f58b64026bb29393f277734ed
+###############################################################################
+
+# Scopes are optionally supplied after a 'type'. For example, in
+#
+# feat(cdr): autostart ui
+#
+# '(cdr)' is the scope. Scopes are used to signify where the change occurred.
+scopes:
+  # The Coder product (front/back/deploy) (path: product/coder)
+  - cdr
+
+  # The Coder CLI (path: product/coder/service/cli)
+  - cli
+
+  # The Coder product e2e suite (path: product/coder/e2e)
+  - e2e
+
+  # A change to a shared library module (path: lib/)
+  - lib
+
+# We only check that the PR title is semantic. The PR title is automatically
+# applied to the "Squash & Merge" flow as the suggested commit message, so this
+# should suffice unless someone drastically alters the message in that flow.
+titleOnly: true
+
+# Types are the 'tag' types in a commit or PR title. For example, in
+#
+# chore: fix thing
+#
+# 'chore' is the type.
+types:
+  # A build of any kind.
+  - build
+
+  # A RELEASED fix that will NOT be back-ported. The originating issue may have
+  # been discovered internally or externally to Coder.
+  - fix
+
+  # Any code task that is ignored for changelog purposes. Examples include
+  # devbin scripts and internal-only configurations.
+  - chore
+
+  # Any work performed on CI.
+  - ci
+
+  # An UNRELEASED correction. For example, features are often built
+  # incrementally and sometimes introduce minor flaws during a release cycle.
+  # Corrections address those increments and flaws.
+  - correct
+
+  # Work that directly implements or supports the implementation of a feature.
+  - feat
+
+  # A fix for a RELEASED bug (regression fix) that is intended for patch-release
+  # purposes.
+  - hotfix
+
+  # A refactor changes code structure without any behavioral change.
+  - refactor
+
+  # A git revert for any style of commit.
+  - revert
+
+  # Adding tests of any kind. Should be separate from feature or fix
+  # implementations. For example, if a commit adds a fix + test, it's a fix
+  # commit. If a commit is simply bumping coverage, it's a test commit.
+  - test

--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -7,24 +7,6 @@
 # https://www.notion.so/coderhq/Conventional-commits-1d51287f58b64026bb29393f277734ed
 ###############################################################################
 
-# Scopes are optionally supplied after a 'type'. For example, in
-#
-# feat(cdr): autostart ui
-#
-# '(cdr)' is the scope. Scopes are used to signify where the change occurred.
-scopes:
-  # The Coder product (front/back/deploy) (path: product/coder)
-  - cdr
-
-  # The Coder CLI (path: product/coder/service/cli)
-  - cli
-
-  # The Coder product e2e suite (path: product/coder/e2e)
-  - e2e
-
-  # A change to a shared library module (path: lib/)
-  - lib
-
 # We only check that the PR title is semantic. The PR title is automatically
 # applied to the "Squash & Merge" flow as the suggested commit message, so this
 # should suffice unless someone drastically alters the message in that flow.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ This repository contains source code for Coder V2. Additional documentation:
 ## Directory Structure
 
 - `.github/`: Settings for [Dependabot for updating dependencies](https://docs.github.com/en/code-security/supply-chain-security/customizing-dependency-updates) and [build/deploy pipelines with GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+  - [`semantic.yaml`](./github/semantic.yaml): Configuration for [semantic pull requests](https://github.com/apps/semantic-pull-requests)


### PR DESCRIPTION
Add a semantic-pull-requests configuration (like we have for `coder/m`), to validate commit messages.

__TODO:__
- [x] Does the `semantic-pull-request` bot needed to be added to this repo? https://github.com/apps/semantic-pull-requests

