### PR TITLE
chore: Formatting - bring .prettierrc over from cdr/m

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -94,7 +94,9 @@ jobs:
       - run: go install gotest.tools/gotestsum@latest
 
       # Windows is not happy with backslashed commands.
-      - run: gotestsum --jsonfile="gotests.json" --packages="./..." -- -covermode=atomic -coverprofile="gotests.coverage"
+      - run:
+          gotestsum --jsonfile="gotests.json" --packages="./..." --
+          -covermode=atomic -coverprofile="gotests.coverage"
 
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -93,7 +93,6 @@ jobs:
 
       - run: go install gotest.tools/gotestsum@latest
 
-      # Windows is not happy with backslashed commands.
       - run:
           gotestsum --jsonfile="gotests.json" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "printWidth": 120,
+  "semi": false,
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": ["./README.md", "**/*.yaml", "**/*.yml"],
+      "options": {
+        "printWidth": 80,
+        "proseWrap": "always"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This brings over the same `.prettierrc` we used in `cdr/m`, and runs the formatter w/ the new settings