### PR TITLE
chore: Add XState machines to model flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   },
   "devDependencies": {
     "prettier": "2.5.1"
+  },
+  "dependencies": {
+    "@xstate/react": "^1.6.3",
+    "xstate": "^4.27.0"
   }
 }

--- a/provisionersdk/proto/xstate_models.ts
+++ b/provisionersdk/proto/xstate_models.ts
@@ -1,0 +1,116 @@
+import { createMachine } from 'xstate';
+
+/** If using VSCode, install the XState VSCode extension to get a 
+ * "Open Inspector" link above each machine in your code that will 
+ * visualize the machine. Otherwise, you can paste code into stately.ai/viz.
+ */
+
+interface WorkspaceContext {
+  errorMessage?: string
+}
+
+type WorkspaceEvent =
+  | { type: "START" }
+  | { type: "STOP" }
+  | { type: "REBUILD" }
+
+export const workspaceModel = createMachine<WorkspaceContext, WorkspaceEvent>(
+  {
+    id: "workspaceV2Model",
+    initial: "off",
+    states: {
+      off: { 
+        on: {
+          START: "starting"
+        }
+      },
+      starting: {
+        invoke: {
+          src: "buildWorkspace",
+          onDone: "running",
+          onError: "error",
+        },
+      },
+      running: {
+        on: {
+          STOP: "stopping",
+          REBUILD: "rebuilding"
+        }
+      },
+      stopping: {
+        invoke: {
+          src: "stopWorkspace",
+          onDone: "off",
+          onError: "error"
+        }
+      },
+      rebuilding: {
+        invoke: {
+          src: "stopAndStartWorkspace",
+          onDone: "running",
+          onError: "error"
+        }
+      },
+      error: {
+        entry: "saveErrorMessage",
+      },
+    },
+  },
+)
+
+export const provisionerModel = createMachine({
+  id: 'provisionerModel',
+  initial: 'starting',
+  context: {
+    automator: undefined,
+    supportedProjects: []
+  },
+  states: {
+    starting: {
+      on: {
+        PROVISION: 'provisioning',
+        PARSE: 'parsing'
+      }
+    },
+    provisioning: {
+      invoke: {
+        src: "provision",
+        onDone: 'off',
+        onError: 'off'
+      }
+    },
+    parsing: {
+      invoke: {
+        src: 'parse',
+        onDone: 'off',
+        onError: 'off'
+      }
+    },
+    off: {
+      type: 'final'
+    }
+  }
+})
+
+export const provisionerDaemonModel = createMachine({
+  id: 'provisionerd',
+  initial: 'polling',
+  states: {
+    polling: {
+      on: { 
+        JOB_HAS_PROVISIONER_REGISTERED: 'executing',
+        NO_JOB_READY: 'polling'
+      }
+    },
+    executing: {
+      invoke: {
+        id: 'callProvisionerWithParameters',
+        src: 'provisionerModel',
+        onDone: {target: 'polling', actions: ['returnState', 'parseProjectCode']},
+        onError: {target: 'polling', actions: ['returnState', 'markJobFailed']}
+      }
+    }
+  }
+}, {
+  services: { provisionerModel }
+})

--- a/provisionersdk/proto/xstate_models.ts
+++ b/provisionersdk/proto/xstate_models.ts
@@ -1,7 +1,7 @@
-import { createMachine } from 'xstate';
+import { createMachine } from "xstate"
 
-/** If using VSCode, install the XState VSCode extension to get a 
- * "Open Inspector" link above each machine in your code that will 
+/** If using VSCode, install the XState VSCode extension to get a
+ * "Open Inspector" link above each machine in your code that will
  * visualize the machine. Otherwise, you can paste code into stately.ai/viz.
  */
 
@@ -9,108 +9,106 @@ interface WorkspaceContext {
   errorMessage?: string
 }
 
-type WorkspaceEvent =
-  | { type: "START" }
-  | { type: "STOP" }
-  | { type: "REBUILD" }
+type WorkspaceEvent = { type: "START" } | { type: "STOP" } | { type: "REBUILD" }
 
-export const workspaceModel = createMachine<WorkspaceContext, WorkspaceEvent>(
-  {
-    id: "workspaceV2Model",
-    initial: "off",
-    states: {
-      off: { 
-        on: {
-          START: "starting"
-        }
-      },
-      starting: {
-        invoke: {
-          src: "buildWorkspace",
-          onDone: "running",
-          onError: "error",
-        },
-      },
-      running: {
-        on: {
-          STOP: "stopping",
-          REBUILD: "rebuilding"
-        }
-      },
-      stopping: {
-        invoke: {
-          src: "stopWorkspace",
-          onDone: "off",
-          onError: "error"
-        }
-      },
-      rebuilding: {
-        invoke: {
-          src: "stopAndStartWorkspace",
-          onDone: "running",
-          onError: "error"
-        }
-      },
-      error: {
-        entry: "saveErrorMessage",
+export const workspaceModel = createMachine<WorkspaceContext, WorkspaceEvent>({
+  id: "workspaceV2Model",
+  initial: "off",
+  states: {
+    off: {
+      on: {
+        START: "starting",
       },
     },
+    starting: {
+      invoke: {
+        src: "buildWorkspace",
+        onDone: "running",
+        onError: "error",
+      },
+    },
+    running: {
+      on: {
+        STOP: "stopping",
+        REBUILD: "rebuilding",
+      },
+    },
+    stopping: {
+      invoke: {
+        src: "stopWorkspace",
+        onDone: "off",
+        onError: "error",
+      },
+    },
+    rebuilding: {
+      invoke: {
+        src: "stopAndStartWorkspace",
+        onDone: "running",
+        onError: "error",
+      },
+    },
+    error: {
+      entry: "saveErrorMessage",
+    },
   },
-)
+})
 
 export const provisionerModel = createMachine({
-  id: 'provisionerModel',
-  initial: 'starting',
+  id: "provisionerModel",
+  initial: "starting",
   context: {
     automator: undefined,
-    supportedProjects: []
+    supportedProjects: [],
   },
   states: {
     starting: {
       on: {
-        PROVISION: 'provisioning',
-        PARSE: 'parsing'
-      }
+        PROVISION: "provisioning",
+        PARSE: "parsing",
+      },
     },
     provisioning: {
       invoke: {
         src: "provision",
-        onDone: 'off',
-        onError: 'off'
-      }
+        onDone: "off",
+        onError: "off",
+      },
     },
     parsing: {
       invoke: {
-        src: 'parse',
-        onDone: 'off',
-        onError: 'off'
-      }
+        src: "parse",
+        onDone: "off",
+        onError: "off",
+      },
     },
     off: {
-      type: 'final'
-    }
-  }
+      type: "final",
+    },
+  },
 })
 
-export const provisionerDaemonModel = createMachine({
-  id: 'provisionerd',
-  initial: 'polling',
-  states: {
-    polling: {
-      on: { 
-        JOB_HAS_PROVISIONER_REGISTERED: 'executing',
-        NO_JOB_READY: 'polling'
-      }
+export const provisionerDaemonModel = createMachine(
+  {
+    id: "provisionerd",
+    initial: "polling",
+    states: {
+      polling: {
+        on: {
+          JOB_HAS_PROVISIONER_REGISTERED: "executing",
+          NO_JOB_READY: "polling",
+        },
+      },
+      executing: {
+        invoke: {
+          id: "callProvisionerWithParameters",
+          src: "provisionerModel",
+          onDone: { target: "polling", actions: ["returnState", "parseProjectCode"] },
+          onError: { target: "polling", actions: ["returnState", "markJobFailed"] },
+        },
+      },
     },
-    executing: {
-      invoke: {
-        id: 'callProvisionerWithParameters',
-        src: 'provisionerModel',
-        onDone: {target: 'polling', actions: ['returnState', 'parseProjectCode']},
-        onError: {target: 'polling', actions: ['returnState', 'markJobFailed']}
-      }
-    }
-  }
-}, {
-  services: { provisionerModel }
-})
+  },
+  {
+    services: { provisionerModel },
+  },
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,37 @@
 # yarn lockfile v1
 
 
+"@xstate/react@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.6.3.tgz#706f3beb7bc5879a78088985c8fd43b9dab7f725"
+  integrity sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-subscription "^1.3.0"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
 prettier@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
+use-isomorphic-layout-effect@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
+  integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
+
+use-subscription@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
+  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
+  dependencies:
+    object-assign "^4.1.1"
+
+xstate@^4.27.0:
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.27.0.tgz#f3c918ac4229bd5e6dec2231e991ba55c6bfa559"
+  integrity sha512-ohOwDM9tViC/zSSmY9261CHblDPqiaAk5vyjVbi69uJv9fGWMzlm0VDQwM2OvC61GKfXVBeuWSMkL7LPUsTpfA==


### PR DESCRIPTION
@kylecarbs and I worked out these XState machines to be able to visualize some of the concepts in Workspaces V2. There's a lot more than could be diagrammed and I'd love comments about how to make these better or for others to add on. 

The goal is to make it easier for us all to get on the same page about the plan. Accordingly, I optimized these more for comprehension than runnable implementation, but we could push the envelope there as we flesh out more details. 

I recommend opening the code in VSCode, installing the XState VSCode extension, and clicking Open Inspector just above each machine definition to see and interact with each one.

Some questions I still have include:
- what does a model of projects look like?
- what determines when a provisioner parses vs when it provisions? (Does it do them in sequence automatically or does provisionerd send one kind of instruction or the other?)

Sneak peek of one model:
<img width="673" alt="Screen Shot 2022-01-11 at 10 38 56 PM" src="https://user-images.githubusercontent.com/1290996/149059731-8e3cee20-4dbf-424c-ae1e-d1ea55d4d105.png">


