### PR TITLE
test: Increase disconnectTimeout to reduce test flakes

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -130,7 +130,7 @@ jobs:
       - run:
           gotestsum --jsonfile="gotests.json" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
-          -count=3 -race
+          -count=3 -race -parallel=2
 
       - uses: codecov/codecov-action@v2
         with:

--- a/peer/conn_test.go
+++ b/peer/conn_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	disconnectedTimeout = time.Millisecond * 200
+	disconnectedTimeout = time.Second
 	failedTimeout       = disconnectedTimeout * 5
 	keepAliveInterval   = time.Millisecond * 2
 )

--- a/peer/conn_test.go
+++ b/peer/conn_test.go
@@ -89,6 +89,7 @@ func TestConn(t *testing.T) {
 
 		sch, err := server.Accept(context.Background())
 		require.NoError(t, err)
+		defer sch.Close()
 
 		_ = cch.Close()
 		_, err = sch.Read(make([]byte, 4))
@@ -102,6 +103,7 @@ func TestConn(t *testing.T) {
 		require.NoError(t, err)
 		sch, err := server.Accept(context.Background())
 		require.NoError(t, err)
+		defer sch.Close()
 
 		err = wan.Stop()
 		require.NoError(t, err)
@@ -117,6 +119,7 @@ func TestConn(t *testing.T) {
 		require.NoError(t, err)
 		sch, err := server.Accept(context.Background())
 		require.NoError(t, err)
+		defer sch.Close()
 		go func() {
 			for i := 0; i < 1024; i++ {
 				_, err := cch.Write(make([]byte, 4096))


### PR DESCRIPTION
WebRTC uses UDP, which means a network connection is never open or closed. It uses timeouts to determine connection state; on a slow CI runner, these timeouts could be reached. Increasing this timeout should reduce flakes, but is unlikely to remove this flake entirely.