### PR TITLE
ci: Run tests using PostgreSQL database and mock

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -149,8 +149,16 @@ jobs:
 
       - run: go install gotest.tools/gotestsum@latest
 
-      - run:
+      - name: Test with Mock Database
+        run:
           gotestsum --jsonfile="gotests.json" --packages="./..." --
+          -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
+          -count=3 -race -parallel=2
+
+      - name: Test with PostgreSQL Database
+        if: runner.os == 'Linux'
+        run:
+          DB=true gotestsum --jsonfile="gotests.json" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
           -count=3 -race -parallel=2
 

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -160,7 +160,7 @@ jobs:
         run:
           DB=true gotestsum --jsonfile="gotests.json" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
-          -count=3 -race -parallel=2
+          -count=1 -race -parallel=2
 
       - uses: codecov/codecov-action@v2
         with:

--- a/database/query.sql
+++ b/database/query.sql
@@ -86,13 +86,14 @@ INSERT INTO
     email,
     name,
     login_type,
+    revoked,
     hashed_password,
     created_at,
     updated_at,
     username
   )
 VALUES
-  ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *;
+  ($1, $2, $3, $4, false, $5, $6, $7, $8) RETURNING *;
 
 -- name: UpdateAPIKeyByID :exec
 UPDATE

--- a/database/query.sql.go
+++ b/database/query.sql.go
@@ -243,13 +243,14 @@ INSERT INTO
     email,
     name,
     login_type,
+    revoked,
     hashed_password,
     created_at,
     updated_at,
     username
   )
 VALUES
-  ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, email, name, revoked, login_type, hashed_password, created_at, updated_at, temporary_password, avatar_hash, ssh_key_regenerated_at, username, dotfiles_git_uri, roles, status, relatime, gpg_key_regenerated_at, _decomissioned, shell
+  ($1, $2, $3, $4, false, $5, $6, $7, $8) RETURNING id, email, name, revoked, login_type, hashed_password, created_at, updated_at, temporary_password, avatar_hash, ssh_key_regenerated_at, username, dotfiles_git_uri, roles, status, relatime, gpg_key_regenerated_at, _decomissioned, shell
 `
 
 type InsertUserParams struct {

--- a/peer/channel.go
+++ b/peer/channel.go
@@ -135,6 +135,7 @@ func (c *Channel) init() {
 
 	c.conn.dcDisconnectListeners.Add(1)
 	c.conn.dcFailedListeners.Add(1)
+	c.conn.dcClosedWaitGroup.Add(1)
 	go func() {
 		var err error
 		// A DataChannel can disconnect multiple times, so this needs to loop.
@@ -274,6 +275,7 @@ func (c *Channel) closeWithError(err error) error {
 	close(c.sendMore)
 	c.conn.dcDisconnectListeners.Sub(1)
 	c.conn.dcFailedListeners.Sub(1)
+	c.conn.dcClosedWaitGroup.Done()
 
 	if c.rwc != nil {
 		_ = c.rwc.Close()

--- a/peer/conn.go
+++ b/peer/conn.go
@@ -113,6 +113,7 @@ type Conn struct {
 	dcDisconnectListeners atomic.Uint32
 	dcFailedChannel       chan struct{}
 	dcFailedListeners     atomic.Uint32
+	dcClosedWaitGroup     sync.WaitGroup
 
 	localCandidateChannel           chan webrtc.ICECandidateInit
 	localSessionDescriptionChannel  chan webrtc.SessionDescription
@@ -125,11 +126,10 @@ type Conn struct {
 	pingEchoChan  *Channel
 	pingEchoOnce  sync.Once
 	pingEchoError error
-
-	pingMutex sync.Mutex
-	pingOnce  sync.Once
-	pingChan  *Channel
-	pingError error
+	pingMutex     sync.Mutex
+	pingOnce      sync.Once
+	pingChan      *Channel
+	pingError     error
 }
 
 func (c *Conn) init() error {
@@ -502,5 +502,10 @@ func (c *Conn) CloseWithError(err error) error {
 	// this call will return an error that isn't typed. We don't check the error because
 	// closing an already closed connection isn't an issue for us.
 	_ = c.rtc.Close()
+
+	// Waits for all DataChannels' to exit before officially labeling as closed.
+	// All logging, goroutines, and async functionality is cleaned up after this.
+	c.dcClosedWaitGroup.Wait()
+
 	return err
 }

--- a/peer/conn.go
+++ b/peer/conn.go
@@ -503,7 +503,7 @@ func (c *Conn) CloseWithError(err error) error {
 	// closing an already closed connection isn't an issue for us.
 	_ = c.rtc.Close()
 
-	// Waits for all DataChannels' to exit before officially labeling as closed.
+	// Waits for all DataChannels to exit before officially labeling as closed.
 	// All logging, goroutines, and async functionality is cleaned up after this.
 	c.dcClosedWaitGroup.Wait()
 


### PR DESCRIPTION
This allows us to use the mock database for quick iterative testing,
and have confidence from CI using a real PostgreSQL database.

PostgreSQL tests are only ran on Linux. They are *really* slow on MacOS
and Windows runners, and don't provide much additional confidence.

This also allows `DB=true go test ...` locally to leverage our Docker PostgreSQL
code for running tests!