### PR TITLE
ci: Pin the golangci-lint version to prevent breakage

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: 1.43.0
 
   style-lint-typescript:
     name: "style/lint/typescript"

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 1.43.0
+          version: v1.43.0
 
   style-lint-typescript:
     name: "style/lint/typescript"


### PR DESCRIPTION
The main branch broke because golangci-lint released a new version.
This pins it, so hopefully it never happens again!