### PR TITLE
chore: Set patch coverage to informational (always pass status check)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,9 @@ coverage:
         branches:
           - "main"
   status:
+    patch:
+      default:
+        informational: yes
     project:
       default:
         target: 70%


### PR DESCRIPTION
Came up in our 1:1 discussion - we have cases where the patch diff might not hit the coverage goal, but it doesn't overall coverage. An example would be changing a single line in a `/pages` component to fix a typo - that would have 0% coverage, but not impact overall coverage.

This just sets the `patch` check to `informational`, so the status check always passes (it still reports the diff %, though, which is useful for cases in general):  https://docs.codecov.com/docs/commit-status#patch-status
