### PR TITLE
chore: add tparallel linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -241,6 +241,7 @@ linters:
     - staticcheck
     - structcheck
     - tenv
+    - tparallel
     - typecheck
     - unconvert
     - unused

--- a/database/pubsub_memory_test.go
+++ b/database/pubsub_memory_test.go
@@ -14,6 +14,8 @@ func TestPubsubMemory(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Memory", func(t *testing.T) {
+		t.Parallel()
+
 		pubsub := database.NewPubsubInMemory()
 		event := "test"
 		data := "testing"


### PR DESCRIPTION
Add the tparallel linter, which checks that subtests of a parallel
test also run in parallel.