### PR TITLE
ci: Run PostgreSQL with a scratch directory to improve CI durability

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -159,7 +159,7 @@ jobs:
         run:
           DB=true gotestsum --jsonfile="gotests.json" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
-          -count=1 -race -parallel=1
+          -count=1 -race -parallel=2
 
       - uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
When using parallel before, multiple PostgreSQL containers would
unintentionally interfere with the other's data. This ensures
both containers have separated data, and don't create a volume.

🌮 @bryphe-coder for the idea!