### PR TITLE
fix: DB - Add mount to place test databases in unique folder

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -63,7 +63,7 @@ func New(t *testing.T) Server {
 	// This can be hotswapped for a live database instance.
 	db := databasefake.New()
 	if os.Getenv("DB") != "" {
-		connectionURL, close, err := postgres.Open()
+		connectionURL, close, err := postgres.Open(t.TempDir())
 		require.NoError(t, err)
 		t.Cleanup(close)
 		sqlDB, err := sql.Open("postgres", connectionURL)

--- a/database/dump/main.go
+++ b/database/dump/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	connection, closeFn, err := postgres.Open()
+	connection, closeFn, err := postgres.Open("")
 	if err != nil {
 		panic(err)
 	}

--- a/database/migrate_test.go
+++ b/database/migrate_test.go
@@ -22,7 +22,7 @@ func TestMigrate(t *testing.T) {
 
 	t.Run("Once", func(t *testing.T) {
 		t.Parallel()
-		connection, closeFn, err := postgres.Open()
+		connection, closeFn, err := postgres.Open(t.TempDir())
 		require.NoError(t, err)
 		defer closeFn()
 		db, err := sql.Open("postgres", connection)
@@ -34,7 +34,7 @@ func TestMigrate(t *testing.T) {
 
 	t.Run("Twice", func(t *testing.T) {
 		t.Parallel()
-		connection, closeFn, err := postgres.Open()
+		connection, closeFn, err := postgres.Open(t.TempDir())
 		require.NoError(t, err)
 		defer closeFn()
 		db, err := sql.Open("postgres", connection)

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -11,11 +11,24 @@ import (
 )
 
 // Open creates a new PostgreSQL server using a Docker container.
-func Open() (string, func(), error) {
+func Open(databaseDirectory string) (string, func(), error) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		return "", nil, xerrors.Errorf("create pool: %w", err)
 	}
+
+	if err != nil {
+		return "", nil, xerrors.Errorf("Unable to create temp directory: %w", err)
+	}
+
+	mounts := []string{}
+	// If databaseDirectory is not specified, we'll just use the default bind path.
+	// Otherwise, this overrides the volume where postgresql puts its database
+	// This is important for tests, because we don't want all the tests to put their data in the same place!
+	if databaseDirectory != "" {
+		mounts = []string{databaseDirectory + ":/var/lib/postgresql/data"}
+	}
+
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
 		Tag:        "11",
@@ -25,6 +38,7 @@ func Open() (string, func(), error) {
 			"POSTGRES_DB=postgres",
 			"listen_addresses = '*'",
 		},
+		Mounts: mounts,
 	}, func(config *docker.HostConfig) {
 		// set AutoRemove to true so that stopped container goes away by itself
 		config.AutoRemove = true

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 func TestPostgres(t *testing.T) {
 	t.Parallel()
 
-	connect, close, err := postgres.Open()
+	connect, close, err := postgres.Open(t.TempDir())
 	require.NoError(t, err)
 	defer close()
 	db, err := sql.Open("postgres", connect)

--- a/database/pubsub_test.go
+++ b/database/pubsub_test.go
@@ -51,7 +51,7 @@ func TestPubsub(t *testing.T) {
 		t.Parallel()
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
-		connectionURL, close, err := postgres.Open()
+		connectionURL, close, err := postgres.Open(t.TempDir())
 		require.NoError(t, err)
 		defer close()
 		db, err := sql.Open("postgres", connectionURL)


### PR DESCRIPTION
@kylecarbs and I were observing some flakes when running the tests backed by postgres. We noticed that the postgres image sets up a volume: https://github.com/docker-library/postgres/blob/a83005b407ee6d810413500d8a041c957fb10cf0/11/alpine/Dockerfile#L155 and will use that location on the host as the default.

This change generates a random tempdir for the test and mounts that folder to the tempdir - hopefully avoiding collisions between parallel test runs.