### PR TITLE
refactor: Remove "Opts" abbreviation

### DIFF
--- a/peer/channel.go
+++ b/peer/channel.go
@@ -27,7 +27,7 @@ const (
 // The initialization overrides listener handles, and detaches
 // the channel on open. The datachannel should not be manually
 // mutated after being passed to this function.
-func newChannel(conn *Conn, dc *webrtc.DataChannel, opts *ChannelOpts) *Channel {
+func newChannel(conn *Conn, dc *webrtc.DataChannel, opts *ChannelOptions) *Channel {
 	channel := &Channel{
 		opts: opts,
 		conn: conn,
@@ -41,7 +41,7 @@ func newChannel(conn *Conn, dc *webrtc.DataChannel, opts *ChannelOpts) *Channel 
 	return channel
 }
 
-type ChannelOpts struct {
+type ChannelOptions struct {
 	// ID is a channel ID that should be used when `Negotiated`
 	// is true.
 	ID uint16
@@ -72,7 +72,7 @@ type ChannelOpts struct {
 // WebRTC PeerConnection failure. This is done to emulate TCP connections.
 // This option can be changed in the options when creating a Channel.
 type Channel struct {
-	opts *ChannelOpts
+	opts *ChannelOptions
 
 	conn *Conn
 	dc   *webrtc.DataChannel

--- a/peer/conn_test.go
+++ b/peer/conn_test.go
@@ -104,7 +104,7 @@ func TestConn(t *testing.T) {
 	t.Run("Accept", func(t *testing.T) {
 		t.Parallel()
 		client, server, _ := createPair(t)
-		cch, err := client.Dial(context.Background(), "hello", &peer.ChannelOpts{})
+		cch, err := client.Dial(context.Background(), "hello", &peer.ChannelOptions{})
 		require.NoError(t, err)
 
 		sch, err := server.Accept(context.Background())
@@ -119,7 +119,7 @@ func TestConn(t *testing.T) {
 	t.Run("AcceptNetworkOffline", func(t *testing.T) {
 		t.Parallel()
 		client, server, wan := createPair(t)
-		cch, err := client.Dial(context.Background(), "hello", &peer.ChannelOpts{})
+		cch, err := client.Dial(context.Background(), "hello", &peer.ChannelOptions{})
 		require.NoError(t, err)
 		sch, err := server.Accept(context.Background())
 		require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestConn(t *testing.T) {
 	t.Run("Buffering", func(t *testing.T) {
 		t.Parallel()
 		client, server, _ := createPair(t)
-		cch, err := client.Dial(context.Background(), "hello", &peer.ChannelOpts{})
+		cch, err := client.Dial(context.Background(), "hello", &peer.ChannelOptions{})
 		require.NoError(t, err)
 		sch, err := server.Accept(context.Background())
 		require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestConn(t *testing.T) {
 		defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 		var cch *peer.Channel
 		defaultTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			cch, err = client.Dial(ctx, "hello", &peer.ChannelOpts{})
+			cch, err = client.Dial(ctx, "hello", &peer.ChannelOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -271,7 +271,7 @@ func createPair(t *testing.T) (client *peer.Conn, server *peer.Conn, wan *vnet.R
 	c1SettingEngine.SetVNet(c1Net)
 	c1SettingEngine.SetPrflxAcceptanceMinWait(0)
 	c1SettingEngine.SetICETimeouts(disconnectedTimeout, failedTimeout, keepAliveInterval)
-	channel1, err := peer.Client([]webrtc.ICEServer{}, &peer.ConnOpts{
+	channel1, err := peer.Client([]webrtc.ICEServer{}, &peer.ConnOptions{
 		SettingEngine: c1SettingEngine,
 		Logger:        slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug),
 	})
@@ -283,7 +283,7 @@ func createPair(t *testing.T) (client *peer.Conn, server *peer.Conn, wan *vnet.R
 	c2SettingEngine.SetVNet(c2Net)
 	c2SettingEngine.SetPrflxAcceptanceMinWait(0)
 	c2SettingEngine.SetICETimeouts(disconnectedTimeout, failedTimeout, keepAliveInterval)
-	channel2, err := peer.Server([]webrtc.ICEServer{}, &peer.ConnOpts{
+	channel2, err := peer.Server([]webrtc.ICEServer{}, &peer.ConnOptions{
 		SettingEngine: c2SettingEngine,
 		Logger:        slogtest.Make(t, nil).Named("server").Leveled(slog.LevelDebug),
 	})

--- a/peerbroker/dial.go
+++ b/peerbroker/dial.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Dial consumes the PeerBroker gRPC connection negotiation stream to produce a WebRTC peered connection.
-func Dial(stream proto.DRPCPeerBroker_NegotiateConnectionClient, iceServers []webrtc.ICEServer, opts *peer.ConnOpts) (*peer.Conn, error) {
+func Dial(stream proto.DRPCPeerBroker_NegotiateConnectionClient, iceServers []webrtc.ICEServer, opts *peer.ConnOptions) (*peer.Conn, error) {
 	// Convert WebRTC ICE servers to the protobuf type.
 	protoIceServers := make([]*proto.WebRTCICEServer, 0, len(iceServers))
 	for _, iceServer := range iceServers {

--- a/peerbroker/listen.go
+++ b/peerbroker/listen.go
@@ -19,7 +19,7 @@ import (
 
 // Listen consumes the transport as the server-side of the PeerBroker dRPC service.
 // The Accept function must be serviced, or new connections will hang.
-func Listen(transport drpc.Transport, opts *peer.ConnOpts) (*Listener, error) {
+func Listen(transport drpc.Transport, opts *peer.ConnOptions) (*Listener, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	listener := &Listener{
 		connectionChannel: make(chan *peer.Conn),
@@ -30,7 +30,7 @@ func Listen(transport drpc.Transport, opts *peer.ConnOpts) (*Listener, error) {
 
 	mux := drpcmux.New()
 	err := proto.DRPCRegisterPeerBroker(mux, &peerBrokerService{
-		connOpts: opts,
+		connOptions: opts,
 
 		listener: listener,
 	})
@@ -99,13 +99,13 @@ func (l *Listener) isClosed() bool {
 type peerBrokerService struct {
 	listener *Listener
 
-	connOpts *peer.ConnOpts
+	connOptions *peer.ConnOptions
 }
 
 // NegotiateConnection negotiates a WebRTC connection.
 func (b *peerBrokerService) NegotiateConnection(stream proto.DRPCPeerBroker_NegotiateConnectionStream) error {
 	// Start with no ICE servers. They can be sent by the client if provided.
-	peerConn, err := peer.Server([]webrtc.ICEServer{}, b.connOpts)
+	peerConn, err := peer.Server([]webrtc.ICEServer{}, b.connOptions)
 	if err != nil {
 		return xerrors.Errorf("create peer connection: %w", err)
 	}


### PR DESCRIPTION
Having a mixture of abbreviations in the codebase reduces
clarity. Although opts is common for options, I'd rather
set a precedent of clarifying verbosity.