### PR TITLE
ci: Don't run PostgreSQL tests in parallel

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -159,7 +159,7 @@ jobs:
         run:
           DB=true gotestsum --jsonfile="gotests.json" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
-          -count=1 -race -parallel=2
+          -count=1 -race -parallel=1
 
       - uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
~There have been race conditions when multiple instances
are created at once. This is an attempt to fix!~

There's an ipv4 and ipv6 conflict that can occur in Docker. We'll reduce the Go test parallel count back to 1 until we get time to investigate. See: https://github.com/moby/moby/issues/42442