### PR TITLE
test: Skip leaked pion goroutines in peer

### DIFF
--- a/peer/conn_test.go
+++ b/peer/conn_test.go
@@ -48,7 +48,14 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	// pion/ice doesn't properly close immediately. The solution for this isn't yet known. See:
+	// https://github.com/pion/ice/pull/413
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("github.com/pion/ice/v2.(*Agent).startOnConnectionStateChangeRoutine.func1"),
+		goleak.IgnoreTopFunction("github.com/pion/ice/v2.(*Agent).startOnConnectionStateChangeRoutine.func2"),
+		goleak.IgnoreTopFunction("github.com/pion/ice/v2.(*Agent).taskLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	)
 }
 
 func TestConn(t *testing.T) {


### PR DESCRIPTION
These get cleaned up a few milliseconds after exit, but
cannot be hooked in the current pion API.