### PR TITLE
fix: cancel button on create-workspace page wasn't redirecting correctly

### DIFF
--- a/site/pages/projects/[organization]/[project]/create.tsx
+++ b/site/pages/projects/[organization]/[project]/create.tsx
@@ -27,7 +27,7 @@ const CreateWorkspacePage: React.FC = () => {
   }
 
   const onCancel = async () => {
-    await router.push(`/projects/${organization}/${project}`)
+    await router.push(`/projects/${organization}/${projectName}`)
   }
 
   const onSubmit = async (req: API.CreateWorkspaceRequest) => {


### PR DESCRIPTION
__Issue:__

Pressing `cancel` on the create-workspace page would give an unexpected result:

![2022-01-31 17 42 13](https://user-images.githubusercontent.com/88213859/151901069-2f823761-3fdf-4997-9967-9bebbcf69415.gif)

__Defect:__

Originally, the `project` variable was being used for the project name - but then got refactored to keep the actual `project` data. However, the `cancel` button logic wasn't updated to take this into account - pushing an incorrect URL.

__Fix:__

Use the `projectName` variable, which we already extract for the router