### PR TITLE
chore: Fix dependabot path after moving package.json into site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
       prefix: "chore"
 
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/site/"
     schedule:
       interval: "daily"
       time: "06:00"


### PR DESCRIPTION
Missed in #128 - need to update the `dependabot.yml` to point to the correct package.json, which was moved from `/package.json` -> `/site/package.json`