### PR TITLE
experiment: provisionerdaemon - investigate intermittent job wait failure

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+
 	"github.com/coder/coder/provisionersdk/proto"
 )
 
@@ -149,6 +151,7 @@ func (t *terraform) Provision(request *proto.Provision_Request, stream proto.DRP
 	resources := make([]*proto.Resource, 0)
 	if state.Values != nil {
 		for _, resource := range state.Values.RootModule.Resources {
+			t.logger.Debug(ctx, "appending state file", slog.F("name", resource.Name), slog.F("type", resource.Type))
 			resources = append(resources, &proto.Resource{
 				Name: resource.Name,
 				Type: resource.Type,
@@ -156,6 +159,7 @@ func (t *terraform) Provision(request *proto.Provision_Request, stream proto.DRP
 		}
 	}
 
+	t.logger.Debug(ctx, "sending completion response")
 	return stream.Send(&proto.Provision_Response{
 		Type: &proto.Provision_Response_Complete{
 			Complete: &proto.Provision_Complete{

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -187,11 +187,12 @@ func (p *provisionerDaemon) acquireJob(ctx context.Context) {
 	p.acquiredJobDone = make(chan struct{})
 
 	p.opts.Logger.Info(context.Background(), "acquired job",
-		slog.F("job_id", p.acquiredJob.JobId)
+		slog.F("job_id", p.acquiredJob.JobId),
 		slog.F("organization_name", p.acquiredJob.OrganizationName),
 		slog.F("project_name", p.acquiredJob.ProjectName),
 		slog.F("username", p.acquiredJob.UserName),
 		slog.F("provisioner", p.acquiredJob.Provisioner),
+		slog.F("job_type", p.acquiredJob.Type),
 	)
 
 	go p.runJob(ctx)

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -515,7 +515,6 @@ func (p *provisionerDaemon) closeWithError(err error) error {
 	}
 
 	if p.isRunningJob() {
-
 		// We also need the 'acquire job' mutex here,
 		// so that a new `p.acquiredJobDone` channel isn't created
 		// while we're waiting on the mutex.

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -187,6 +187,7 @@ func (p *provisionerDaemon) acquireJob(ctx context.Context) {
 	p.acquiredJobDone = make(chan struct{})
 
 	p.opts.Logger.Info(context.Background(), "acquired job",
+		slog.F("job_id", p.acquiredJob.JobId)
 		slog.F("organization_name", p.acquiredJob.OrganizationName),
 		slog.F("project_name", p.acquiredJob.ProjectName),
 		slog.F("username", p.acquiredJob.UserName),
@@ -328,7 +329,7 @@ func (p *provisionerDaemon) runJob(ctx context.Context) {
 	}
 
 	p.acquiredJobCancel()
-	p.opts.Logger.Info(context.Background(), "completed job")
+	p.opts.Logger.Info(context.Background(), "completed job", slog.F("job_id", p.acquiredJob.JobId))
 }
 
 func (p *provisionerDaemon) runProjectImport(ctx context.Context, provisioner sdkproto.DRPCProvisionerClient, job *proto.AcquiredJob_ProjectImport_) {


### PR DESCRIPTION
Investigating failures like this: https://github.com/coder/coder/runs/5043435263?check_suite_focus=true#step:7:32

where it looks like the job is completed, but the completion condition is never satisfied

### Runs
- Run 1: peer failure
- Run 2: peer failure https://github.com/coder/coder/runs/5044293751?check_suite_focus=true#step:7:63
- Run 3: a different data race: https://github.com/coder/coder/runs/5044320845?check_suite_focus=true#step:7:83

### Issue 1: Data race in `p.acquiredJobDone` context (`provisioners.d`)

Failure trace: https://github.com/coder/coder/runs/5044320845?check_suite_focus=true#step:7:84

There is a race in the `p.acquiredJobDone` chan - in particular, there can be a case where we're waiting on the channel to finish (in close) with `<-p.acquiredJobDone`, but in parallel, an `acquireJob` could've been started, which would create a new channel for `p.acquiredJobDone`.

The fix I tried was to also grab the `acquiredJobMutex` in the `Close` function. This, at first, caused a deadlock - because there was another case where the mutexes could be grabbed in reverse order (`acquiredJobMutex` -> then `closeMutex`). That other place, though, was storing a bool in an atomic, so actually didn't need the mutex guard.

Attempted fix here: https://github.com/coder/coder/pull/146/commits/42ce721be04dd5bda0c69227af1a02896b9468fd

Still hit a related race: https://github.com/coder/coder/runs/5044320845?check_suite_focus=true#step:7:84

So tried a second fix here: https://github.com/coder/coder/pull/146/commits/84dd68aa39413ebd6ee2c7206dead04aac89e73a

The second fix didn't work, trying to switch from chan -> wait group: https://github.com/coder/coder/pull/146/commits/a8725cd495e69a65152876ea5991118f6eed83f4

- Run 1: ✅ 
- Run 2: peer failure