### PR TITLE
test: Invalid error scope caused race in WorkspaceHistoryLogs

### DIFF
--- a/coderd/workspacehistorylogs_test.go
+++ b/coderd/workspacehistorylogs_test.go
@@ -85,14 +85,14 @@ func TestWorkspaceHistoryLogs(t *testing.T) {
 	t.Run("ReturnAll", func(t *testing.T) {
 		t.Parallel()
 
-		_, err = server.Client.WorkspaceHistoryLogs(context.Background(), "", workspace.Name, workspaceHistory.Name)
+		_, err := server.Client.WorkspaceHistoryLogs(context.Background(), "", workspace.Name, workspaceHistory.Name)
 		require.NoError(t, err)
 	})
 
 	t.Run("Between", func(t *testing.T) {
 		t.Parallel()
 
-		_, err = server.Client.WorkspaceHistoryLogsBetween(context.Background(), "", workspace.Name, workspaceHistory.Name, time.Time{}, database.Now())
+		_, err := server.Client.WorkspaceHistoryLogsBetween(context.Background(), "", workspace.Name, workspaceHistory.Name, time.Time{}, database.Now())
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
I'm dumbfounded CI didn't catch this earlier!