### PR TITLE
fix: Insert provisioner job logs async

### DIFF
--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -305,9 +305,8 @@ func (server *provisionerdServer) UpdateJob(stream proto.DRPCProvisionerDaemon_U
 			insertParams.Source = append(insertParams.Source, logSource)
 			insertParams.Output = append(insertParams.Output, log.Output)
 		}
-		logs, err := server.Database.InsertProvisionerJobLogs(stream.Context(), insertParams)
+		logs, err := server.Database.InsertProvisionerJobLogs(context.Background(), insertParams)
 		if err != nil {
-			server.Logger.Error(stream.Context(), "insert provisioner job logs", slog.Error(err))
 			return xerrors.Errorf("insert job logs: %w", err)
 		}
 		data, err := json.Marshal(logs)

--- a/database/dump.sql
+++ b/database/dump.sql
@@ -156,15 +156,6 @@ CREATE TABLE project_version (
     import_job_id uuid NOT NULL
 );
 
-CREATE TABLE project_version_log (
-    id uuid NOT NULL,
-    project_version_id uuid NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    source log_source NOT NULL,
-    level log_level NOT NULL,
-    output character varying(1024) NOT NULL
-);
-
 CREATE TABLE project_version_parameter (
     id uuid NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -300,6 +291,12 @@ ALTER TABLE ONLY project
 ALTER TABLE ONLY project_version
     ADD CONSTRAINT project_version_id_key UNIQUE (id);
 
+ALTER TABLE ONLY project_version_parameter
+    ADD CONSTRAINT project_version_parameter_id_key UNIQUE (id);
+
+ALTER TABLE ONLY project_version_parameter
+    ADD CONSTRAINT project_version_parameter_project_version_id_name_key UNIQUE (project_version_id, name);
+
 ALTER TABLE ONLY project_version
     ADD CONSTRAINT project_version_project_id_name_key UNIQUE (project_id, name);
 
@@ -338,9 +335,6 @@ ALTER TABLE ONLY workspace_resource
 
 ALTER TABLE ONLY workspace_resource
     ADD CONSTRAINT workspace_resource_workspace_history_id_name_key UNIQUE (workspace_history_id, name);
-
-ALTER TABLE ONLY project_version_log
-    ADD CONSTRAINT project_version_log_project_version_id_fkey FOREIGN KEY (project_version_id) REFERENCES project_version(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY project_version_parameter
     ADD CONSTRAINT project_version_parameter_project_version_id_fkey FOREIGN KEY (project_version_id) REFERENCES project_version(id) ON DELETE CASCADE;

--- a/database/models.go
+++ b/database/models.go
@@ -335,15 +335,6 @@ type ProjectVersion struct {
 	ImportJobID   uuid.UUID            `db:"import_job_id" json:"import_job_id"`
 }
 
-type ProjectVersionLog struct {
-	ID               uuid.UUID `db:"id" json:"id"`
-	ProjectVersionID uuid.UUID `db:"project_version_id" json:"project_version_id"`
-	CreatedAt        time.Time `db:"created_at" json:"created_at"`
-	Source           LogSource `db:"source" json:"source"`
-	Level            LogLevel  `db:"level" json:"level"`
-	Output           string    `db:"output" json:"output"`
-}
-
 type ProjectVersionParameter struct {
 	ID                       uuid.UUID                  `db:"id" json:"id"`
 	CreatedAt                time.Time                  `db:"created_at" json:"created_at"`


### PR DESCRIPTION
The context could be cancelled after a log is sent, which resulted
in a failure. This prevent's that from occurring by using the
background context.

Fixes this race: https://github.com/coder/coder/runs/5100325505?check_suite_focus=true#step:9:35