### PR TITLE
chore: Run 'yarn install' when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ provisionersdk/proto: provisionersdk/proto/provisioner.proto
 .PHONY: provisionersdk/proto
 
 site/out: 
+  cd site && yarn install
 	cd site && yarn build
 	cd site && yarn export
 .PHONY: site/out

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ provisionersdk/proto: provisionersdk/proto/provisioner.proto
 .PHONY: provisionersdk/proto
 
 site/out: 
-  cd site && yarn install
+	cd site && yarn install
 	cd site && yarn build
 	cd site && yarn export
 .PHONY: site/out

--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ This repository contains source code for Coder V2. Additional documentation:
   - [`semantic.yaml`](./github/semantic.yaml): Configuration for [semantic pull requests](https://github.com/apps/semantic-pull-requests)
 - `site`: Front-end UI code.
 
+## Development
+
+### Cloning
+
+- `git clone https://github.com/coder/coder`
+- `cd coder`
+
+### Building
+
+- `make build`
+
+### Development
+
+- `./develop.sh`
+
+The `develop.sh` script runs the server locally on port `3000`, and runs a hot-reload server for front-end code on `8080`.
+
 ## Front-End Plan
 
 For the front-end team, we're planning on 2 phases to the 'v2' work:

--- a/develop.sh
+++ b/develop.sh
@@ -21,6 +21,9 @@ function create_initial_user() {
     http://localhost:3000/api/v2/user
 }
 
+# Run yarn install, to make sure node_modules are ready to go
+yarn --cwd=./site install
+
 # Do initial build - a dev build for coderd.
 # It's OK that we don't build the front-end before - because the front-end
 # assets are handled by the `yarn dev` devserver.


### PR DESCRIPTION
I noticed when showing the development flow to a few engineers, there was one awkward step - you have to `cd site` and run `yarn install`, and then come back to root to `make build` or `./develop.sh`

This just adds `yarn install` as part of `make build` and `./develop.sh` - so whichever one is run first will start work.