### PR TITLE
refactor: Add install script for coder CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+INSTALL_DIR=$(shell go env GOPATH)/bin
+
 bin/coder:
 	mkdir -p bin
 	go build -o bin/coder cmd/coder/main.go
@@ -50,6 +52,12 @@ fmt: fmt/prettier fmt/sql
 
 gen: database/generate peerbroker/proto provisionersdk/proto provisionerd/proto
 .PHONY: gen
+
+install: 
+	@echo "--- Copying from bin to $(INSTALL_DIR)"
+	cp -r ./bin $(INSTALL_DIR)
+	@echo "-- CLI available at $(INSTALL_DIR)/coder"
+.PHONY: install
 
 peerbroker/proto: peerbroker/proto/peerbroker.proto
 	protoc \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ gen: database/generate peerbroker/proto provisionersdk/proto provisionerd/proto
 install: 
 	@echo "--- Copying from bin to $(INSTALL_DIR)"
 	cp -r ./bin $(INSTALL_DIR)
-	@echo "-- CLI available at $(INSTALL_DIR)/coder"
+	@echo "-- CLI available at $(shell ls $(INSTALL_DIR)/coder*)"
 .PHONY: install
 
 peerbroker/proto: peerbroker/proto/peerbroker.proto

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This repository contains source code for Coder V2. Additional documentation:
 
 ## Development
 
+### Pre-requisites
+
+- `git` installed
+- `node` and `yarn` installed
+- `go` version 1.17, with the `GOPATH` environment variable set
+
 ### Cloning
 
 - `git clone https://github.com/coder/coder`
@@ -23,17 +29,15 @@ This repository contains source code for Coder V2. Additional documentation:
 ### Building
 
 - `make build`
+- `make install`
+
+The `coder` CLI binary will now be available at `$GOPATH/bin/coder`
 
 ### Development
 
 - `./develop.sh`
 
 The `develop.sh` script runs the server locally on port `3000`, and runs a hot-reload server for front-end code on `8080`.
-
-### CLI
-
-- `./install.sh` will `go install` the `coder` CLI
-- `coder --help`
 
 ## Front-End Plan
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ This repository contains source code for Coder V2. Additional documentation:
 
 The `develop.sh` script runs the server locally on port `3000`, and runs a hot-reload server for front-end code on `8080`.
 
+### CLI
+
+- `./install.sh` will `go install` the `coder` CLI
+- `coder --help`
+
 ## Front-End Plan
 
 For the front-end team, we're planning on 2 phases to the 'v2' work:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ This repository contains source code for Coder V2. Additional documentation:
 
 ### Pre-requisites
 
-- `git` installed
-- `node` and `yarn` installed
+- `git`
 - `go` version 1.17, with the `GOPATH` environment variable set
+- `node`
+- `yarn`
 
 ### Cloning
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-go install cmd/coder/main.go
-echo "Coder CLI now installed at:"
-echo "$(which coder)"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+go install cmd/coder/main.go
+echo "Coder CLI now installed at:"
+echo "$(which coder)"


### PR DESCRIPTION
This adds an `install.sh` script at the root which runs `go install cmd/coder/main.go` - making `coder` available by default in our workspaces (where the `go` bin folder is already in the `PATH`).

I thought this might be helpful for developer who aren't familiar with `go` or the directory structure, in running `coder` CLI locally. Open to other ideas though!