### PR TITLE
fix: Integrate front-end jest tests with datadog reporting

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -239,6 +239,11 @@ jobs:
             .eslintcache
           key: js-${{ runner.os }}-test-${{ hashFiles('**/yarn.lock') }}
 
+      # Go is required for uploading the test results to datadog
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.17"
+
       - uses: actions/setup-node@v2
         with:
           node-version: "14"

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -262,3 +262,11 @@ jobs:
           files: ./site/coverage/lcov.info
           flags: unittest-js
           fail_ci_if_error: true
+
+      - name: Upload DataDog Trace
+        if: (success() || failure()) && github.actor != 'dependabot[bot]'
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DD_DATABASE: postgresql
+          GIT_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: go run scripts/datadog-cireport/main.go site/test_results/junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ site/.eslintcache
 site/.next/
 site/node_modules/
 site/storybook-static/
+site/test_results/
 site/yarn-error.log
 coverage/
 

--- a/site/.eslintignore
+++ b/site/.eslintignore
@@ -7,3 +7,4 @@ out
 coverage
 .next
 storybook-static
+test_results

--- a/site/.prettierignore
+++ b/site/.prettierignore
@@ -15,3 +15,4 @@ yarn-error.log
 coverage/
 out/
 storybook-static/
+test_results/

--- a/site/jest.config.js
+++ b/site/jest.config.js
@@ -44,10 +44,15 @@ module.exports = {
     "!<rootDir>/out/**/*.*",
     "!<rootDir>/storybook-static/**/*.*",
   ],
-        reporters: [ "default", 
-      ["jest-junit", {
+  reporters: [
+    "default",
+    [
+      "jest-junit",
+      {
         suiteName: "Front-end Jest Tests",
         outputDirectory: "./test_results",
         outputName: "junit.xml",
-      }]],
+      },
+    ],
+  ],
 }

--- a/site/jest.config.js
+++ b/site/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
       coverageReporters: ["text", "lcov"],
       displayName: "test",
       preset: "ts-jest",
+
       roots: ["<rootDir>"],
       setupFilesAfterEnv: ["<rootDir>/_jest/setupTests.ts"],
       transform: {
@@ -43,4 +44,10 @@ module.exports = {
     "!<rootDir>/out/**/*.*",
     "!<rootDir>/storybook-static/**/*.*",
   ],
+        reporters: [ "default", 
+      ["jest-junit", {
+        suiteName: "Front-end Jest Tests",
+        outputDirectory: "./test_results",
+        outputName: "junit.xml",
+      }]],
 }

--- a/site/package.json
+++ b/site/package.json
@@ -50,6 +50,7 @@
     "formik": "2.2.9",
     "http-proxy-middleware": "2.0.3",
     "jest": "27.5.1",
+    "jest-junit": "13.0.0",
     "jest-runner-eslint": "1.0.0",
     "next": "12.0.10",
     "next-router-mock": "^0.6.5",

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -8499,6 +8499,16 @@ jest-jasmine2@^27.5.1:
     pretty-format "^27.5.1"
     throat "^6.0.1"
 
+jest-junit@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-13.0.0.tgz#479be347457aad98ae8a5983a23d7c3ec526c9a3"
+  integrity sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz#6ec9d54c3579dd6e3e66d70e3498adf80fde3fb8"
@@ -12655,6 +12665,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
@@ -13019,6 +13034,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Fixes #244 

- Adds `jest-junit` 
- Configures `jest-junit` to output `junit.xml` in `site/test_results`
- Uploads the emitted `junit.xml` to datadog as part of the `test/js` workflow