### PR TITLE
chore: Disable deploy action until fix is in

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -192,7 +192,7 @@ jobs:
     # As a part of a fix for that, uncomment the below line
     # and delete the 'if' after:
     # if: github.event_name != 'pull_request'
-    if: ${{ false }}  
+    if: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -187,7 +187,12 @@ jobs:
   deploy:
     name: "deploy"
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Temporarily disable the 'deploy' job until issue is fixed:
+    # https://github.com/coder/coder/issues/287
+    # As a part of a fix for that, uncomment the below line
+    # and delete the 'if' after:
+    # if: github.event_name != 'pull_request'
+    if: ${{ false }}  
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Related to #287 

Temporarily disable the deploy action until we have a fix available.