### PR TITLE
fix: Redirect to workspaces page after creation

### DIFF
--- a/site/pages/projects/[organization]/[project]/create.tsx
+++ b/site/pages/projects/[organization]/[project]/create.tsx
@@ -32,7 +32,7 @@ const CreateWorkspacePage: React.FC = () => {
 
   const onSubmit = async (req: API.CreateWorkspaceRequest) => {
     const workspace = await API.Workspace.create(req)
-    await router.push(`/workspaces/${workspace.id}`)
+    await router.push(`/workspaces/me/${workspace.name}`)
     return workspace
   }
 

--- a/site/pages/projects/[organization]/[project]/index.tsx
+++ b/site/pages/projects/[organization]/[project]/index.tsx
@@ -61,7 +61,7 @@ const ProjectPage: React.FC = () => {
     {
       key: "name",
       name: "Name",
-      renderer: (nameField: string, data: Workspace) => {
+      renderer: (nameField: string) => {
         return <Link href={`/workspaces/me/${nameField}`}>{nameField}</Link>
       },
     },

--- a/site/pages/projects/[organization]/[project]/index.tsx
+++ b/site/pages/projects/[organization]/[project]/index.tsx
@@ -62,7 +62,7 @@ const ProjectPage: React.FC = () => {
       key: "name",
       name: "Name",
       renderer: (nameField: string, data: Workspace) => {
-        return <Link href={`/projects/${organization}/${project}/${data.id}`}>{nameField}</Link>
+        return <Link href={`/workspaces/me/${nameField}`}>{nameField}</Link>
       },
     },
   ]


### PR DESCRIPTION
This is just a quick fix so that the redirection is correct after creating a workspace - so that we make it to our minimal 'workspaces' page. Mainly so we have a path for testing / onboarding more people.

Unfortunately the NextJS pages are a bit tricky to test - we don't have infra for it because of the special pathing requirements - we can potentially bring in a library like [next-page-tester](https://github.com/next-page-tester/next-page-tester) and create a separate test directory like `pages_test` - but since we may pick up the RFC to move away from Next, it doesn't seem like a useful effort.

With this, creating a project lands on our minimal workspaces page, and the links on the Projects page correctly navigate to the minimal workspaces page.
