### PR TITLE
ci: Use GITHUB_REF_NAME to identify branch with DataDog

### DIFF
--- a/scripts/datadog-cireport/main.go
+++ b/scripts/datadog-cireport/main.go
@@ -78,7 +78,7 @@ func main() {
 		"ci.provider.name":   "github",
 		"ci.workspace_path":  os.Getenv("GITHUB_WORKSPACE"),
 
-		"git.branch":         os.Getenv("GITHUB_HEAD_REF"),
+		"git.branch":         os.Getenv("GITHUB_REF_NAME"),
 		"git.commit.sha":     githubSHA,
 		"git.repository_url": fmt.Sprintf("%s/%s.git", githubServerURL, githubRepository),
 


### PR DESCRIPTION
The "main" branch wasn't uploading properly before.