### PR TITLE
fix: Install terraform in Docker image to unblock deploy

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -187,12 +187,7 @@ jobs:
   deploy:
     name: "deploy"
     runs-on: ubuntu-latest
-    # Temporarily disable the 'deploy' job until issue is fixed:
-    # https://github.com/coder/coder/issues/287
-    # As a part of a fix for that, uncomment the below line
-    # and delete the 'if' after:
-    # if: github.event_name != 'pull_request'
-    if: true
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -192,7 +192,7 @@ jobs:
     # As a part of a fix for that, uncomment the below line
     # and delete the 'if' after:
     # if: github.event_name != 'pull_request'
-    if: false
+    if: true
     permissions:
       contents: read
       id-token: write

--- a/images/coder/Dockerfile
+++ b/images/coder/Dockerfile
@@ -1,5 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
+RUN yum install -y yum-utils
+RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+RUN yum install -y terraform
+
 COPY coderd /coder/coderd
 RUN chmod +x /coder/coderd
 


### PR DESCRIPTION
Fixes #287 and re-enables our deploy at https://proto.cdr.dev

- Installs `terraform` in our `images/coder/Dockerfile`
- Re-enables our `deploy` GH action

Example of successful deploy run: https://github.com/coder/coder/runs/5241614008?check_suite_focus=true

__TODO:__
- [x] Fix `if:` condition when deploy is green again