### PR TITLE
test: Fix race condition in provisionerd on cleanup

### DIFF
--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -406,9 +406,9 @@ func createProvisionerDaemonClient(t *testing.T, server provisionerDaemonTestSer
 	err := proto.DRPCRegisterProvisionerDaemon(mux, &server)
 	require.NoError(t, err)
 	srv := drpcserver.New(mux)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
 	go func() {
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		t.Cleanup(cancelFunc)
 		_ = srv.Serve(ctx, serverPipe)
 	}()
 	return proto.NewDRPCProvisionerDaemonClient(provisionersdk.Conn(clientPipe))
@@ -426,9 +426,9 @@ func createProvisionerClient(t *testing.T, server provisionerTestServer) sdkprot
 	err := sdkproto.DRPCRegisterProvisioner(mux, &server)
 	require.NoError(t, err)
 	srv := drpcserver.New(mux)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
 	go func() {
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		t.Cleanup(cancelFunc)
 		_ = srv.Serve(ctx, serverPipe)
 	}()
 	return sdkproto.NewDRPCProvisionerClient(provisionersdk.Conn(clientPipe))


### PR DESCRIPTION
These goroutines could be ran after the pipe has already been closed.
I'm not certain this resolves this specific leak:

https://github.com/coder/coder/runs/5249481202?check_suite_focus=true#step:7:186

...but I find it likely.