### PR TITLE
fix: Leaking yamux session after HTTP handler is closed

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -150,9 +150,11 @@ jobs:
           terraform_wrapper: false
 
       - name: Test with Mock Database
+        env:
+          GOMAXPROCS: ${{ runner.os == 'Windows' && 1 || 2 }}
         run: gotestsum --junitfile="gotests.xml" --packages="./..." --
-          -covermode=atomic -coverprofile="gotests.coverage"
-          -timeout=3m -count=5 -race -short -parallel=2
+          -covermode=atomic -coverprofile="gotests.coverage" -failfast
+          -timeout=3m -count=5 -race -short
 
       - name: Upload DataDog Trace
         if: (success() || failure()) && github.actor != 'dependabot[bot]'
@@ -166,7 +168,7 @@ jobs:
         if: runner.os == 'Linux'
         run: DB=true gotestsum --junitfile="gotests.xml" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
-          -count=1 -race -parallel=2
+          -count=1 -race -parallel=2 -failfast
 
       - name: Upload DataDog Trace
         if: (success() || failure()) && github.actor != 'dependabot[bot]'

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -157,7 +157,7 @@ func AwaitProjectImportJob(t *testing.T, client *codersdk.Client, organization s
 		provisionerJob, err = client.ProjectImportJob(context.Background(), organization, job)
 		require.NoError(t, err)
 		return provisionerJob.Status.Completed()
-	}, 3*time.Second, 25*time.Millisecond)
+	}, 5*time.Second, 25*time.Millisecond)
 	return provisionerJob
 }
 
@@ -169,7 +169,7 @@ func AwaitWorkspaceProvisionJob(t *testing.T, client *codersdk.Client, organizat
 		provisionerJob, err = client.WorkspaceProvisionJob(context.Background(), organization, job)
 		require.NoError(t, err)
 		return provisionerJob.Status.Completed()
-	}, 3*time.Second, 25*time.Millisecond)
+	}, 5*time.Second, 25*time.Millisecond)
 	return provisionerJob
 }
 

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -84,8 +84,9 @@ func (api *api) provisionerDaemonsServe(rw http.ResponseWriter, r *http.Request)
 		_ = conn.Close(websocket.StatusInternalError, fmt.Sprintf("multiplex server: %s", err))
 		return
 	}
-	defer func() {
-		_ = session.Close()
+	go func() {
+		<-r.Context().Done()
+		_, _ = fmt.Printf("\n\n\n\nDONE\n\n\n\n")
 	}()
 	mux := drpcmux.New()
 	err = proto.DRPCRegisterProvisionerDaemon(mux, &provisionerdServer{

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -84,6 +84,9 @@ func (api *api) provisionerDaemonsServe(rw http.ResponseWriter, r *http.Request)
 		_ = conn.Close(websocket.StatusInternalError, fmt.Sprintf("multiplex server: %s", err))
 		return
 	}
+	defer func() {
+		_ = session.Close()
+	}()
 	mux := drpcmux.New()
 	err = proto.DRPCRegisterProvisionerDaemon(mux, &provisionerdServer{
 		ID:           daemon.ID,

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -110,10 +110,13 @@ func (p *provisionerDaemon) connect(ctx context.Context) {
 			if errors.Is(err, context.Canceled) {
 				return
 			}
+			p.closeMutex.Lock()
 			if p.isClosed() {
+				p.closeMutex.Unlock()
 				return
 			}
 			p.opts.Logger.Warn(context.Background(), "failed to dial", slog.Error(err))
+			p.closeMutex.Unlock()
 			continue
 		}
 		p.opts.Logger.Debug(context.Background(), "connected")


### PR DESCRIPTION
Closes #317. We depended on the context canceling the yamux connection,
but this isn't a sync operation. Explicitly calling close ensures the
handler waits for yamux to complete before exit.