### PR TITLE
fix: Leaking yamux session after HTTP handler is closed

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -122,7 +122,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          - windows-2022
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -138,9 +138,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ matrix.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ matrix.os }}-go-
 
       - run: go install gotest.tools/gotestsum@latest
 

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -150,9 +150,13 @@ jobs:
           terraform_wrapper: false
 
       - name: Test with Mock Database
+        shell: bash
+        env:
+          GOCOUNT: ${{ runner.os == 'Windows' && 3 || 5 }}
+          GOMAXPROCS: ${{ runner.os == 'Windows' && 1 || 2 }}
         run: gotestsum --junitfile="gotests.xml" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage"
-          -timeout=3m -count=5 -race -short -parallel=2
+          -timeout=3m -count=$GOCOUNT -race -short -failfast
 
       - name: Upload DataDog Trace
         if: (success() || failure()) && github.actor != 'dependabot[bot]'
@@ -166,10 +170,10 @@ jobs:
         if: runner.os == 'Linux'
         run: DB=true gotestsum --junitfile="gotests.xml" --packages="./..." --
           -covermode=atomic -coverprofile="gotests.coverage" -timeout=3m
-          -count=1 -race -parallel=2
+          -count=1 -race -parallel=2 -failfast
 
       - name: Upload DataDog Trace
-        if: (success() || failure()) && github.actor != 'dependabot[bot]'
+        if: (success() || failure()) && github.actor != 'dependabot[bot]' && runner.os == 'Linux'
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           DD_DATABASE: postgresql

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -110,10 +110,13 @@ func (p *provisionerDaemon) connect(ctx context.Context) {
 			if errors.Is(err, context.Canceled) {
 				return
 			}
+			p.closeMutex.Lock()
 			if p.isClosed() {
+				p.closeMutex.Unlock()
 				return
 			}
 			p.opts.Logger.Warn(context.Background(), "failed to dial", slog.Error(err))
+			p.closeMutex.Unlock()
 			continue
 		}
 		p.opts.Logger.Debug(context.Background(), "connected")


### PR DESCRIPTION
Closes #317. The httptest server cancels the context after the connection
is closed, but if a connection takes a long time to close, the request
would never end. This applies a context to the entire listener that cancels
on test cleanup.

After discussion with @bryphe-coder, reducing the parallel limit on
Windows is likely to reduce failures as well.