### PR TITLE
test: Fix flake with context.Cancelled in provisionerd

### DIFF
--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -466,15 +466,13 @@ func TestProvisionerd(t *testing.T) {
 					})
 					require.NoError(t, err)
 					<-shutdownCtx.Done()
-					err = stream.Send(&sdkproto.Provision_Response{
+					return stream.Send(&sdkproto.Provision_Response{
 						Type: &sdkproto.Provision_Response_Complete{
 							Complete: &sdkproto.Provision_Complete{
 								Error: "some error",
 							},
 						},
 					})
-					require.NoError(t, err)
-					return nil
 				},
 			}),
 		})


### PR DESCRIPTION
This occurred because the context can cancel in the same time a response
is sent. This isn't a bug, because the complete still occurs.

https://github.com/coder/coder/runs/5366075943?check_suite_focus=true#step:7:56