### PR TITLE
fix: Typo on Projects page

### DIFF
--- a/site/pages/projects/index.tsx
+++ b/site/pages/projects/index.tsx
@@ -55,7 +55,7 @@ const ProjectsPage: React.FC = () => {
   const description = (
     <div>
       <div className={styles.descriptionLabel}>Run the following command to get started:</div>
-      <CodeExample code="coder project create" />
+      <CodeExample code="coder projects create" />
     </div>
   )
 


### PR DESCRIPTION
While going through the create projects flow, I realized there's a typo on the projects page. 

The command should read `coder projects create`, but instead it is currently showing `coder project create`:
<img width="466" alt="Screen Shot 2022-03-01 at 5 31 19 PM" src="https://user-images.githubusercontent.com/88213859/156277646-6fc03977-6dda-4db4-9fce-e48b4b5efba3.png">

Fixing this typo will alleviate some confusion as we on-board developers to v2
