### PR TITLE
fix: Remove ICEServer proxying from client to server

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -95,7 +95,7 @@ func TestAgent(t *testing.T) {
 func setup(t *testing.T) proto.DRPCPeerBrokerClient {
 	client, server := provisionersdk.TransportPipe()
 	closer := agent.New(func(ctx context.Context) (*peerbroker.Listener, error) {
-		return peerbroker.Listen(server, &peer.ConnOptions{
+		return peerbroker.Listen(server, nil, &peer.ConnOptions{
 			Logger: slogtest.Make(t, nil),
 		})
 	}, &agent.Options{

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20211115214459-90acf1ca460f
 	github.com/hashicorp/terraform-exec v0.15.0
+	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87
 	github.com/justinas/nosurf v1.1.1
@@ -109,7 +110,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.11.1 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform-json v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.5.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.2.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect

--- a/peerbroker/listen_test.go
+++ b/peerbroker/listen_test.go
@@ -23,7 +23,7 @@ func TestListen(t *testing.T) {
 		defer client.Close()
 		defer server.Close()
 
-		listener, err := peerbroker.Listen(server, nil)
+		listener, err := peerbroker.Listen(server, nil, nil)
 		require.NoError(t, err)
 
 		api := proto.NewDRPCPeerBrokerClient(provisionersdk.Conn(client))
@@ -43,7 +43,7 @@ func TestListen(t *testing.T) {
 		defer client.Close()
 		defer server.Close()
 
-		listener, err := peerbroker.Listen(server, nil)
+		listener, err := peerbroker.Listen(server, nil, nil)
 		require.NoError(t, err)
 		go listener.Close()
 		_, err = listener.Accept()

--- a/peerbroker/proto/peerbroker.pb.go
+++ b/peerbroker/proto/peerbroker.pb.go
@@ -75,19 +75,19 @@ func (x *WebRTCSessionDescription) GetSdp() string {
 	return ""
 }
 
-type WebRTCICEServer struct {
+type Exchange struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Urls           []string `protobuf:"bytes,1,rep,name=urls,proto3" json:"urls,omitempty"`
-	Username       string   `protobuf:"bytes,2,opt,name=username,proto3" json:"username,omitempty"`
-	Credential     string   `protobuf:"bytes,3,opt,name=credential,proto3" json:"credential,omitempty"`
-	CredentialType int32    `protobuf:"varint,4,opt,name=credential_type,json=credentialType,proto3" json:"credential_type,omitempty"`
+	// Types that are assignable to Message:
+	//	*Exchange_Sdp
+	//	*Exchange_IceCandidate
+	Message isExchange_Message `protobuf_oneof:"message"`
 }
 
-func (x *WebRTCICEServer) Reset() {
-	*x = WebRTCICEServer{}
+func (x *Exchange) Reset() {
+	*x = Exchange{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[1]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -95,13 +95,13 @@ func (x *WebRTCICEServer) Reset() {
 	}
 }
 
-func (x *WebRTCICEServer) String() string {
+func (x *Exchange) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*WebRTCICEServer) ProtoMessage() {}
+func (*Exchange) ProtoMessage() {}
 
-func (x *WebRTCICEServer) ProtoReflect() protoreflect.Message {
+func (x *Exchange) ProtoReflect() protoreflect.Message {
 	mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[1]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -113,299 +113,47 @@ func (x *WebRTCICEServer) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use WebRTCICEServer.ProtoReflect.Descriptor instead.
-func (*WebRTCICEServer) Descriptor() ([]byte, []int) {
+// Deprecated: Use Exchange.ProtoReflect.Descriptor instead.
+func (*Exchange) Descriptor() ([]byte, []int) {
 	return file_peerbroker_proto_peerbroker_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *WebRTCICEServer) GetUrls() []string {
-	if x != nil {
-		return x.Urls
-	}
-	return nil
-}
-
-func (x *WebRTCICEServer) GetUsername() string {
-	if x != nil {
-		return x.Username
-	}
-	return ""
-}
-
-func (x *WebRTCICEServer) GetCredential() string {
-	if x != nil {
-		return x.Credential
-	}
-	return ""
-}
-
-func (x *WebRTCICEServer) GetCredentialType() int32 {
-	if x != nil {
-		return x.CredentialType
-	}
-	return 0
-}
-
-type WebRTCICEServers struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	Servers []*WebRTCICEServer `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`
-}
-
-func (x *WebRTCICEServers) Reset() {
-	*x = WebRTCICEServers{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[2]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *WebRTCICEServers) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*WebRTCICEServers) ProtoMessage() {}
-
-func (x *WebRTCICEServers) ProtoReflect() protoreflect.Message {
-	mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[2]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use WebRTCICEServers.ProtoReflect.Descriptor instead.
-func (*WebRTCICEServers) Descriptor() ([]byte, []int) {
-	return file_peerbroker_proto_peerbroker_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *WebRTCICEServers) GetServers() []*WebRTCICEServer {
-	if x != nil {
-		return x.Servers
-	}
-	return nil
-}
-
-type NegotiateConnection struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-}
-
-func (x *NegotiateConnection) Reset() {
-	*x = NegotiateConnection{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[3]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *NegotiateConnection) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*NegotiateConnection) ProtoMessage() {}
-
-func (x *NegotiateConnection) ProtoReflect() protoreflect.Message {
-	mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[3]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use NegotiateConnection.ProtoReflect.Descriptor instead.
-func (*NegotiateConnection) Descriptor() ([]byte, []int) {
-	return file_peerbroker_proto_peerbroker_proto_rawDescGZIP(), []int{3}
-}
-
-type NegotiateConnection_ClientToServer struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	// Types that are assignable to Message:
-	//	*NegotiateConnection_ClientToServer_Servers
-	//	*NegotiateConnection_ClientToServer_Offer
-	//	*NegotiateConnection_ClientToServer_IceCandidate
-	Message isNegotiateConnection_ClientToServer_Message `protobuf_oneof:"message"`
-}
-
-func (x *NegotiateConnection_ClientToServer) Reset() {
-	*x = NegotiateConnection_ClientToServer{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[4]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *NegotiateConnection_ClientToServer) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*NegotiateConnection_ClientToServer) ProtoMessage() {}
-
-func (x *NegotiateConnection_ClientToServer) ProtoReflect() protoreflect.Message {
-	mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[4]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use NegotiateConnection_ClientToServer.ProtoReflect.Descriptor instead.
-func (*NegotiateConnection_ClientToServer) Descriptor() ([]byte, []int) {
-	return file_peerbroker_proto_peerbroker_proto_rawDescGZIP(), []int{3, 0}
-}
-
-func (m *NegotiateConnection_ClientToServer) GetMessage() isNegotiateConnection_ClientToServer_Message {
+func (m *Exchange) GetMessage() isExchange_Message {
 	if m != nil {
 		return m.Message
 	}
 	return nil
 }
 
-func (x *NegotiateConnection_ClientToServer) GetServers() *WebRTCICEServers {
-	if x, ok := x.GetMessage().(*NegotiateConnection_ClientToServer_Servers); ok {
-		return x.Servers
+func (x *Exchange) GetSdp() *WebRTCSessionDescription {
+	if x, ok := x.GetMessage().(*Exchange_Sdp); ok {
+		return x.Sdp
 	}
 	return nil
 }
 
-func (x *NegotiateConnection_ClientToServer) GetOffer() *WebRTCSessionDescription {
-	if x, ok := x.GetMessage().(*NegotiateConnection_ClientToServer_Offer); ok {
-		return x.Offer
-	}
-	return nil
-}
-
-func (x *NegotiateConnection_ClientToServer) GetIceCandidate() string {
-	if x, ok := x.GetMessage().(*NegotiateConnection_ClientToServer_IceCandidate); ok {
+func (x *Exchange) GetIceCandidate() string {
+	if x, ok := x.GetMessage().(*Exchange_IceCandidate); ok {
 		return x.IceCandidate
 	}
 	return ""
 }
 
-type isNegotiateConnection_ClientToServer_Message interface {
-	isNegotiateConnection_ClientToServer_Message()
+type isExchange_Message interface {
+	isExchange_Message()
 }
 
-type NegotiateConnection_ClientToServer_Servers struct {
-	Servers *WebRTCICEServers `protobuf:"bytes,1,opt,name=servers,proto3,oneof"`
+type Exchange_Sdp struct {
+	Sdp *WebRTCSessionDescription `protobuf:"bytes,1,opt,name=sdp,proto3,oneof"`
 }
 
-type NegotiateConnection_ClientToServer_Offer struct {
-	Offer *WebRTCSessionDescription `protobuf:"bytes,2,opt,name=offer,proto3,oneof"`
-}
-
-type NegotiateConnection_ClientToServer_IceCandidate struct {
-	IceCandidate string `protobuf:"bytes,3,opt,name=ice_candidate,json=iceCandidate,proto3,oneof"`
-}
-
-func (*NegotiateConnection_ClientToServer_Servers) isNegotiateConnection_ClientToServer_Message() {}
-
-func (*NegotiateConnection_ClientToServer_Offer) isNegotiateConnection_ClientToServer_Message() {}
-
-func (*NegotiateConnection_ClientToServer_IceCandidate) isNegotiateConnection_ClientToServer_Message() {
-}
-
-type NegotiateConnection_ServerToClient struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	// Types that are assignable to Message:
-	//	*NegotiateConnection_ServerToClient_Answer
-	//	*NegotiateConnection_ServerToClient_IceCandidate
-	Message isNegotiateConnection_ServerToClient_Message `protobuf_oneof:"message"`
-}
-
-func (x *NegotiateConnection_ServerToClient) Reset() {
-	*x = NegotiateConnection_ServerToClient{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[5]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *NegotiateConnection_ServerToClient) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*NegotiateConnection_ServerToClient) ProtoMessage() {}
-
-func (x *NegotiateConnection_ServerToClient) ProtoReflect() protoreflect.Message {
-	mi := &file_peerbroker_proto_peerbroker_proto_msgTypes[5]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use NegotiateConnection_ServerToClient.ProtoReflect.Descriptor instead.
-func (*NegotiateConnection_ServerToClient) Descriptor() ([]byte, []int) {
-	return file_peerbroker_proto_peerbroker_proto_rawDescGZIP(), []int{3, 1}
-}
-
-func (m *NegotiateConnection_ServerToClient) GetMessage() isNegotiateConnection_ServerToClient_Message {
-	if m != nil {
-		return m.Message
-	}
-	return nil
-}
-
-func (x *NegotiateConnection_ServerToClient) GetAnswer() *WebRTCSessionDescription {
-	if x, ok := x.GetMessage().(*NegotiateConnection_ServerToClient_Answer); ok {
-		return x.Answer
-	}
-	return nil
-}
-
-func (x *NegotiateConnection_ServerToClient) GetIceCandidate() string {
-	if x, ok := x.GetMessage().(*NegotiateConnection_ServerToClient_IceCandidate); ok {
-		return x.IceCandidate
-	}
-	return ""
-}
-
-type isNegotiateConnection_ServerToClient_Message interface {
-	isNegotiateConnection_ServerToClient_Message()
-}
-
-type NegotiateConnection_ServerToClient_Answer struct {
-	Answer *WebRTCSessionDescription `protobuf:"bytes,1,opt,name=answer,proto3,oneof"`
-}
-
-type NegotiateConnection_ServerToClient_IceCandidate struct {
+type Exchange_IceCandidate struct {
 	IceCandidate string `protobuf:"bytes,2,opt,name=ice_candidate,json=iceCandidate,proto3,oneof"`
 }
 
-func (*NegotiateConnection_ServerToClient_Answer) isNegotiateConnection_ServerToClient_Message() {}
+func (*Exchange_Sdp) isExchange_Message() {}
 
-func (*NegotiateConnection_ServerToClient_IceCandidate) isNegotiateConnection_ServerToClient_Message() {
-}
+func (*Exchange_IceCandidate) isExchange_Message() {}
 
 var File_peerbroker_proto_peerbroker_proto protoreflect.FileDescriptor
 
@@ -417,54 +165,23 @@ var file_peerbroker_proto_peerbroker_proto_rawDesc = []byte{
 	0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x19, 0x0a, 0x08, 0x73,
 	0x64, 0x70, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x05, 0x52, 0x07, 0x73,
 	0x64, 0x70, 0x54, 0x79, 0x70, 0x65, 0x12, 0x10, 0x0a, 0x03, 0x73, 0x64, 0x70, 0x18, 0x02, 0x20,
-	0x01, 0x28, 0x09, 0x52, 0x03, 0x73, 0x64, 0x70, 0x22, 0x8a, 0x01, 0x0a, 0x0f, 0x57, 0x65, 0x62,
-	0x52, 0x54, 0x43, 0x49, 0x43, 0x45, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x12, 0x12, 0x0a, 0x04,
-	0x75, 0x72, 0x6c, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x09, 0x52, 0x04, 0x75, 0x72, 0x6c, 0x73,
-	0x12, 0x1a, 0x0a, 0x08, 0x75, 0x73, 0x65, 0x72, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01,
-	0x28, 0x09, 0x52, 0x08, 0x75, 0x73, 0x65, 0x72, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1e, 0x0a, 0x0a,
-	0x63, 0x72, 0x65, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x61, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
-	0x52, 0x0a, 0x63, 0x72, 0x65, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x61, 0x6c, 0x12, 0x27, 0x0a, 0x0f,
-	0x63, 0x72, 0x65, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x61, 0x6c, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18,
-	0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x0e, 0x63, 0x72, 0x65, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x61,
-	0x6c, 0x54, 0x79, 0x70, 0x65, 0x22, 0x49, 0x0a, 0x10, 0x57, 0x65, 0x62, 0x52, 0x54, 0x43, 0x49,
-	0x43, 0x45, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x73, 0x12, 0x35, 0x0a, 0x07, 0x73, 0x65, 0x72,
-	0x76, 0x65, 0x72, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x70, 0x65, 0x65,
-	0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x57, 0x65, 0x62, 0x52, 0x54, 0x43, 0x49, 0x43,
-	0x45, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x52, 0x07, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x73,
-	0x22, 0xd7, 0x02, 0x0a, 0x13, 0x4e, 0x65, 0x67, 0x6f, 0x74, 0x69, 0x61, 0x74, 0x65, 0x43, 0x6f,
-	0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xba, 0x01, 0x0a, 0x0e, 0x43, 0x6c, 0x69,
-	0x65, 0x6e, 0x74, 0x54, 0x6f, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x12, 0x38, 0x0a, 0x07, 0x73,
-	0x65, 0x72, 0x76, 0x65, 0x72, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x70,
-	0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x57, 0x65, 0x62, 0x52, 0x54, 0x43,
-	0x49, 0x43, 0x45, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x73, 0x48, 0x00, 0x52, 0x07, 0x73, 0x65,
-	0x72, 0x76, 0x65, 0x72, 0x73, 0x12, 0x3c, 0x0a, 0x05, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x18, 0x02,
-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x70, 0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65,
-	0x72, 0x2e, 0x57, 0x65, 0x62, 0x52, 0x54, 0x43, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x44,
-	0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x48, 0x00, 0x52, 0x05, 0x6f, 0x66,
-	0x66, 0x65, 0x72, 0x12, 0x25, 0x0a, 0x0d, 0x69, 0x63, 0x65, 0x5f, 0x63, 0x61, 0x6e, 0x64, 0x69,
-	0x64, 0x61, 0x74, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x0c, 0x69, 0x63,
-	0x65, 0x43, 0x61, 0x6e, 0x64, 0x69, 0x64, 0x61, 0x74, 0x65, 0x42, 0x09, 0x0a, 0x07, 0x6d, 0x65,
-	0x73, 0x73, 0x61, 0x67, 0x65, 0x1a, 0x82, 0x01, 0x0a, 0x0e, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72,
-	0x54, 0x6f, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x12, 0x3e, 0x0a, 0x06, 0x61, 0x6e, 0x73, 0x77,
-	0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x70, 0x65, 0x65, 0x72, 0x62,
-	0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x57, 0x65, 0x62, 0x52, 0x54, 0x43, 0x53, 0x65, 0x73, 0x73,
-	0x69, 0x6f, 0x6e, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x48, 0x00,
-	0x52, 0x06, 0x61, 0x6e, 0x73, 0x77, 0x65, 0x72, 0x12, 0x25, 0x0a, 0x0d, 0x69, 0x63, 0x65, 0x5f,
-	0x63, 0x61, 0x6e, 0x64, 0x69, 0x64, 0x61, 0x74, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48,
-	0x00, 0x52, 0x0c, 0x69, 0x63, 0x65, 0x43, 0x61, 0x6e, 0x64, 0x69, 0x64, 0x61, 0x74, 0x65, 0x42,
-	0x09, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x32, 0x87, 0x01, 0x0a, 0x0a, 0x50,
-	0x65, 0x65, 0x72, 0x42, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x12, 0x79, 0x0a, 0x13, 0x4e, 0x65, 0x67,
-	0x6f, 0x74, 0x69, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
-	0x12, 0x2e, 0x2e, 0x70, 0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x4e, 0x65,
-	0x67, 0x6f, 0x74, 0x69, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f,
-	0x6e, 0x2e, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x54, 0x6f, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72,
-	0x1a, 0x2e, 0x2e, 0x70, 0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x4e, 0x65,
-	0x67, 0x6f, 0x74, 0x69, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f,
-	0x6e, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x54, 0x6f, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74,
-	0x28, 0x01, 0x30, 0x01, 0x42, 0x29, 0x5a, 0x27, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
-	0x6f, 0x6d, 0x2f, 0x63, 0x6f, 0x64, 0x65, 0x72, 0x2f, 0x63, 0x6f, 0x64, 0x65, 0x72, 0x2f, 0x70,
-	0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
-	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x01, 0x28, 0x09, 0x52, 0x03, 0x73, 0x64, 0x70, 0x22, 0x76, 0x0a, 0x08, 0x45, 0x78, 0x63, 0x68,
+	0x61, 0x6e, 0x67, 0x65, 0x12, 0x38, 0x0a, 0x03, 0x73, 0x64, 0x70, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x24, 0x2e, 0x70, 0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x57,
+	0x65, 0x62, 0x52, 0x54, 0x43, 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x44, 0x65, 0x73, 0x63,
+	0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x48, 0x00, 0x52, 0x03, 0x73, 0x64, 0x70, 0x12, 0x25,
+	0x0a, 0x0d, 0x69, 0x63, 0x65, 0x5f, 0x63, 0x61, 0x6e, 0x64, 0x69, 0x64, 0x61, 0x74, 0x65, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x0c, 0x69, 0x63, 0x65, 0x43, 0x61, 0x6e, 0x64,
+	0x69, 0x64, 0x61, 0x74, 0x65, 0x42, 0x09, 0x0a, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65,
+	0x32, 0x53, 0x0a, 0x0a, 0x50, 0x65, 0x65, 0x72, 0x42, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x12, 0x45,
+	0x0a, 0x13, 0x4e, 0x65, 0x67, 0x6f, 0x74, 0x69, 0x61, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x6e, 0x65,
+	0x63, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x14, 0x2e, 0x70, 0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b,
+	0x65, 0x72, 0x2e, 0x45, 0x78, 0x63, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x1a, 0x14, 0x2e, 0x70, 0x65,
+	0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2e, 0x45, 0x78, 0x63, 0x68, 0x61, 0x6e, 0x67,
+	0x65, 0x28, 0x01, 0x30, 0x01, 0x42, 0x29, 0x5a, 0x27, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
+	0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x6f, 0x64, 0x65, 0x72, 0x2f, 0x63, 0x6f, 0x64, 0x65, 0x72, 0x2f,
+	0x70, 0x65, 0x65, 0x72, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x72, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -479,27 +196,20 @@ func file_peerbroker_proto_peerbroker_proto_rawDescGZIP() []byte {
 	return file_peerbroker_proto_peerbroker_proto_rawDescData
 }
 
-var file_peerbroker_proto_peerbroker_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_peerbroker_proto_peerbroker_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_peerbroker_proto_peerbroker_proto_goTypes = []interface{}{
-	(*WebRTCSessionDescription)(nil),           // 0: peerbroker.WebRTCSessionDescription
-	(*WebRTCICEServer)(nil),                    // 1: peerbroker.WebRTCICEServer
-	(*WebRTCICEServers)(nil),                   // 2: peerbroker.WebRTCICEServers
-	(*NegotiateConnection)(nil),                // 3: peerbroker.NegotiateConnection
-	(*NegotiateConnection_ClientToServer)(nil), // 4: peerbroker.NegotiateConnection.ClientToServer
-	(*NegotiateConnection_ServerToClient)(nil), // 5: peerbroker.NegotiateConnection.ServerToClient
+	(*WebRTCSessionDescription)(nil), // 0: peerbroker.WebRTCSessionDescription
+	(*Exchange)(nil),                 // 1: peerbroker.Exchange
 }
 var file_peerbroker_proto_peerbroker_proto_depIdxs = []int32{
-	1, // 0: peerbroker.WebRTCICEServers.servers:type_name -> peerbroker.WebRTCICEServer
-	2, // 1: peerbroker.NegotiateConnection.ClientToServer.servers:type_name -> peerbroker.WebRTCICEServers
-	0, // 2: peerbroker.NegotiateConnection.ClientToServer.offer:type_name -> peerbroker.WebRTCSessionDescription
-	0, // 3: peerbroker.NegotiateConnection.ServerToClient.answer:type_name -> peerbroker.WebRTCSessionDescription
-	4, // 4: peerbroker.PeerBroker.NegotiateConnection:input_type -> peerbroker.NegotiateConnection.ClientToServer
-	5, // 5: peerbroker.PeerBroker.NegotiateConnection:output_type -> peerbroker.NegotiateConnection.ServerToClient
-	5, // [5:6] is the sub-list for method output_type
-	4, // [4:5] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	0, // 0: peerbroker.Exchange.sdp:type_name -> peerbroker.WebRTCSessionDescription
+	1, // 1: peerbroker.PeerBroker.NegotiateConnection:input_type -> peerbroker.Exchange
+	1, // 2: peerbroker.PeerBroker.NegotiateConnection:output_type -> peerbroker.Exchange
+	2, // [2:3] is the sub-list for method output_type
+	1, // [1:2] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_peerbroker_proto_peerbroker_proto_init() }
@@ -521,55 +231,7 @@ func file_peerbroker_proto_peerbroker_proto_init() {
 			}
 		}
 		file_peerbroker_proto_peerbroker_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*WebRTCICEServer); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_peerbroker_proto_peerbroker_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*WebRTCICEServers); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_peerbroker_proto_peerbroker_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NegotiateConnection); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_peerbroker_proto_peerbroker_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NegotiateConnection_ClientToServer); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_peerbroker_proto_peerbroker_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NegotiateConnection_ServerToClient); i {
+			switch v := v.(*Exchange); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -581,14 +243,9 @@ func file_peerbroker_proto_peerbroker_proto_init() {
 			}
 		}
 	}
-	file_peerbroker_proto_peerbroker_proto_msgTypes[4].OneofWrappers = []interface{}{
-		(*NegotiateConnection_ClientToServer_Servers)(nil),
-		(*NegotiateConnection_ClientToServer_Offer)(nil),
-		(*NegotiateConnection_ClientToServer_IceCandidate)(nil),
-	}
-	file_peerbroker_proto_peerbroker_proto_msgTypes[5].OneofWrappers = []interface{}{
-		(*NegotiateConnection_ServerToClient_Answer)(nil),
-		(*NegotiateConnection_ServerToClient_IceCandidate)(nil),
+	file_peerbroker_proto_peerbroker_proto_msgTypes[1].OneofWrappers = []interface{}{
+		(*Exchange_Sdp)(nil),
+		(*Exchange_IceCandidate)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -596,7 +253,7 @@ func file_peerbroker_proto_peerbroker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_peerbroker_proto_peerbroker_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/peerbroker/proto/peerbroker.proto
+++ b/peerbroker/proto/peerbroker.proto
@@ -9,40 +9,20 @@ message WebRTCSessionDescription {
     string sdp = 2;
 }
 
-message WebRTCICEServer {
-    repeated string urls = 1;
-    string username = 2;
-    string credential = 3;
-    int32 credential_type = 4;
-}
-
-message WebRTCICEServers {
-    repeated WebRTCICEServer servers = 1;
-}
-
-message NegotiateConnection {
-    message ClientToServer {
-        oneof message {
-            WebRTCICEServers servers = 1;
-            WebRTCSessionDescription offer = 2;
-            string ice_candidate = 3;
-        }
-    }
-    message ServerToClient {
-        oneof message {
-            WebRTCSessionDescription answer = 1;
-            string ice_candidate = 2;
-        }
+message Exchange {
+    oneof message {
+        WebRTCSessionDescription sdp = 1;
+        string ice_candidate = 2;
     }
 }
 
 // PeerBroker mediates WebRTC connection signaling.
 service PeerBroker {
     // NegotiateConnection establishes a bidirectional stream to negotiate a new WebRTC connection.
-    // 1. Client sends WebRTCSessionDescription and WebRTCICEServers to the server.
+    // 1. Client sends WebRTCSessionDescription to the server.
     // 2. Server sends WebRTCSessionDescription to the client, exchanging encryption keys.
     // 3. Client<->Server exchange ICE Candidates to establish a peered connection.
     // 
     // See: https://davekilian.com/webrtc-the-hard-way.html
-    rpc NegotiateConnection(stream NegotiateConnection.ClientToServer) returns (stream NegotiateConnection.ServerToClient);
+    rpc NegotiateConnection(stream Exchange) returns (stream Exchange);
 }

--- a/peerbroker/proto/peerbroker_drpc.pb.go
+++ b/peerbroker/proto/peerbroker_drpc.pb.go
@@ -62,27 +62,27 @@ func (c *drpcPeerBrokerClient) NegotiateConnection(ctx context.Context) (DRPCPee
 
 type DRPCPeerBroker_NegotiateConnectionClient interface {
 	drpc.Stream
-	Send(*NegotiateConnection_ClientToServer) error
-	Recv() (*NegotiateConnection_ServerToClient, error)
+	Send(*Exchange) error
+	Recv() (*Exchange, error)
 }
 
 type drpcPeerBroker_NegotiateConnectionClient struct {
 	drpc.Stream
 }
 
-func (x *drpcPeerBroker_NegotiateConnectionClient) Send(m *NegotiateConnection_ClientToServer) error {
+func (x *drpcPeerBroker_NegotiateConnectionClient) Send(m *Exchange) error {
 	return x.MsgSend(m, drpcEncoding_File_peerbroker_proto_peerbroker_proto{})
 }
 
-func (x *drpcPeerBroker_NegotiateConnectionClient) Recv() (*NegotiateConnection_ServerToClient, error) {
-	m := new(NegotiateConnection_ServerToClient)
+func (x *drpcPeerBroker_NegotiateConnectionClient) Recv() (*Exchange, error) {
+	m := new(Exchange)
 	if err := x.MsgRecv(m, drpcEncoding_File_peerbroker_proto_peerbroker_proto{}); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (x *drpcPeerBroker_NegotiateConnectionClient) RecvMsg(m *NegotiateConnection_ServerToClient) error {
+func (x *drpcPeerBroker_NegotiateConnectionClient) RecvMsg(m *Exchange) error {
 	return x.MsgRecv(m, drpcEncoding_File_peerbroker_proto_peerbroker_proto{})
 }
 
@@ -121,26 +121,26 @@ func DRPCRegisterPeerBroker(mux drpc.Mux, impl DRPCPeerBrokerServer) error {
 
 type DRPCPeerBroker_NegotiateConnectionStream interface {
 	drpc.Stream
-	Send(*NegotiateConnection_ServerToClient) error
-	Recv() (*NegotiateConnection_ClientToServer, error)
+	Send(*Exchange) error
+	Recv() (*Exchange, error)
 }
 
 type drpcPeerBroker_NegotiateConnectionStream struct {
 	drpc.Stream
 }
 
-func (x *drpcPeerBroker_NegotiateConnectionStream) Send(m *NegotiateConnection_ServerToClient) error {
+func (x *drpcPeerBroker_NegotiateConnectionStream) Send(m *Exchange) error {
 	return x.MsgSend(m, drpcEncoding_File_peerbroker_proto_peerbroker_proto{})
 }
 
-func (x *drpcPeerBroker_NegotiateConnectionStream) Recv() (*NegotiateConnection_ClientToServer, error) {
-	m := new(NegotiateConnection_ClientToServer)
+func (x *drpcPeerBroker_NegotiateConnectionStream) Recv() (*Exchange, error) {
+	m := new(Exchange)
 	if err := x.MsgRecv(m, drpcEncoding_File_peerbroker_proto_peerbroker_proto{}); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (x *drpcPeerBroker_NegotiateConnectionStream) RecvMsg(m *NegotiateConnection_ClientToServer) error {
+func (x *drpcPeerBroker_NegotiateConnectionStream) RecvMsg(m *Exchange) error {
 	return x.MsgRecv(m, drpcEncoding_File_peerbroker_proto_peerbroker_proto{})
 }

--- a/peerbroker/proxy.go
+++ b/peerbroker/proxy.go
@@ -135,7 +135,7 @@ func (*proxyListen) onServerToClientMessage(streamID string, stream proto.DRPCPe
 		// It's not trying to communicate with this stream!
 		return nil
 	}
-	var msg proto.NegotiateConnection_ServerToClient
+	var msg proto.Exchange
 	err := protobuf.Unmarshal(message[streamIDLength:], &msg)
 	if err != nil {
 		return xerrors.Errorf("unmarshal message: %w", err)
@@ -204,7 +204,7 @@ func (p *proxyDial) onClientToServerMessage(ctx context.Context, message []byte)
 	}
 	p.streamMutex.Unlock()
 
-	var msg proto.NegotiateConnection_ClientToServer
+	var msg proto.Exchange
 	err = protobuf.Unmarshal(message[streamIDLength:], &msg)
 	if err != nil {
 		return xerrors.Errorf("unmarshal message: %w", err)

--- a/peerbroker/proxy_test.go
+++ b/peerbroker/proxy_test.go
@@ -29,7 +29,7 @@ func TestProxy(t *testing.T) {
 	defer listenerClient.Close()
 	defer listenerServer.Close()
 
-	listener, err := peerbroker.Listen(listenerServer, &peer.ConnOptions{
+	listener, err := peerbroker.Listen(listenerServer, nil, &peer.ConnOptions{
 		Logger: slogtest.Make(t, nil).Named("server").Leveled(slog.LevelDebug),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This made testing simple, but enabled insecure behavior. This allows
the listener to fetch ICEServers from a remote location, which will
likely be coderd.