### PR TITLE
fix: MacOS PTY flake when reading after command exists

### DIFF
--- a/pty/start_other.go
+++ b/pty/start_other.go
@@ -17,9 +17,6 @@ func startPty(cmd *exec.Cmd) (PTY, *os.Process, error) {
 	if err != nil {
 		return nil, nil, xerrors.Errorf("open: %w", err)
 	}
-	defer func() {
-		_ = tty.Close()
-	}()
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid:  true,
 		Setctty: true,


### PR DESCRIPTION
The TTY wasn't buffering properly because the FD was closed.
I did this initially to clone how creack/pty handles it, but it's
unnecessary because we get the entire PTY back to close.

I tested this on my Mac by adding a `time.Sleep` between spawning a command and reading its output, and the `io.EOF` occurred every time.