### PR TITLE
fix(site): vscode eslint plugin working directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,5 +75,6 @@
     "webrtc",
     "xerrors",
     "yamux"
-  ]
+  ],
+  "eslint.workingDirectories": ["./site"]
 }

--- a/site/.eslintrc.yaml
+++ b/site/.eslintrc.yaml
@@ -17,11 +17,12 @@ extends:
 parser: "@typescript-eslint/parser"
 parserOptions:
   ecmaVersion: 2018
-  project:
-    - "./tsconfig.test.json"
+  project: "./tsconfig.test.json"
   sourceType: module
   ecmaFeatures:
     jsx: true
+  # REMARK(Grey): We might want to move this to repository root eventually to
+  #               lint multiple projects (supply array to project property).
   tsconfigRootDir: "./"
 plugins:
   - "@typescript-eslint"


### PR DESCRIPTION
## Summary

The .eslintrc.yaml is located in site, rather than the root of the repository. The VS Code plugin has a CWD of the repository root, so it looks for tsconfig.test.json in the root rather in site (resolving `"./tsconfig.test.json"`)

### Impact of Change

No more red squiggles in VS Code on every open TypeScript (ts, tsx) file in `site`. I verified that the VS Code ESLint Plugin corrected code automatically (and applied yellow and red squiggles as appropriate). This may not have worked identically before, so we should see an improvement to the TS development experience in `site` 🎉 🎊 .

## See Also

- https://github.com/microsoft/vscode-eslint/issues/196
- https://github.com/typescript-eslint/typescript-eslint/issues/251

## Personal Note

This is my first primary author commit in this repo!