### PR TITLE
fix(site): rm duplicate mask-icon; refactor(site): reorder <head>

### DIFF
--- a/site/html_templates/index.html
+++ b/site/html_templates/index.html
@@ -2,7 +2,6 @@
 
 <head>
   <meta charset="utf-8" />
-  <link rel="mask-icon" href="/favicon.svg" color="#000000" />
   <link rel="alternate icon" type="image/png" href="/favicon.png" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +10,7 @@
   <meta property="og:type" content="website" />
   <meta property="csrf-token" content="{{ .CSRF.Token }}" />
   <meta property="csp-nonce" content="{{ .CSP.Nonce }}" />
-  <link crossorigin="use-credentials" rel="mask-icon" href="/static/favicon.svg" color="#000000" />
+  <link rel="mask-icon" href="/static/favicon.svg" color="#000000" crossorigin="use-credentials" />
   <title>Coder</title>
 </head>
 

--- a/site/html_templates/index.html
+++ b/site/html_templates/index.html
@@ -2,15 +2,15 @@
 
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#17172E" />
+  <meta name="application-name" content="Coder" />
+  <meta property="og:type" content="website" />
+  <meta property="csp-nonce" content="{{ .CSP.Nonce }}" />
+  <meta property="csrf-token" content="{{ .CSRF.Token }}" />
+  <link rel="mask-icon" href="/static/favicon.svg" color="#000000" crossorigin="use-credentials" />
   <link rel="alternate icon" type="image/png" href="/favicon.png" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="application-name" content="Coder" />
-  <meta name="theme-color" content="#17172E" />
-  <meta property="og:type" content="website" />
-  <meta property="csrf-token" content="{{ .CSRF.Token }}" />
-  <meta property="csp-nonce" content="{{ .CSP.Nonce }}" />
-  <link rel="mask-icon" href="/static/favicon.svg" color="#000000" crossorigin="use-credentials" />
   <title>Coder</title>
 </head>
 


### PR DESCRIPTION
## Summary

There was a duplicate `rel=mask-icon` tag in `html_templates/index.html`. First and foremost, this was fixed in 2eca17ebd301c1baac33c815d33f4905d4417e09. The source of the confusion was likely that the `rel` attribute was in a different order for the case whereby we specified `crossorigin`, so I re-arranged those attributes.

Then, to make v2 match v1, I re-orderd the meta and link tags at large in https://github.com/coder/coder/pull/425/commits/a4b56cc4f221a2cc7244668a2ab56eab6de084a5 to be in the same order (grouping meta and links rather than interleaving them).

### Impact of change

There's likely no harm in having two `rel=mask-icon` tags, I imagine only one (not sure which) gets picked up by Apple. But it's certainly unnecessary and a tad confusing. Overall this is mostly a quality of life refactor and v1 -> v2 parity.