### PR TITLE
refactor(site): match v1 tsconfig; simplify tsconfig.test.json  

### DIFF
--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,23 +1,20 @@
 {
   "compilerOptions": {
-    "outDir": "./dist/",
-    "noImplicitAny": true,
-    "module": "commonjs",
-    "target": "es5",
-    "jsx": "react",
-    "allowJs": true,
     "downlevelIteration": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "moduleResolution": "node"
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist/",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es5"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "_jest", "**/*.test.tsx"]
 }

--- a/site/tsconfig.test.json
+++ b/site/tsconfig.test.json
@@ -1,13 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "jsx": "react",
-    "downlevelIteration": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "esModuleInterop": true
-  },
   "exclude": ["node_modules", "_jest"]
 }


### PR DESCRIPTION
## Summary (a1164f44685f131179a310175e363d2cc713786c)

Matched the `tsconfig.json` post migration to webpack with that of v1

### Details

* `allowJs` removed -> not needed after Next.js
* removed lingering `next-env.d.ts` from file `include`s
* `noImplicitAny` removed -> this is set to `true` by `strict` and is really only meaningful when being selectively strict
* strictNullChecks removed -> this is set to `true` by `strict` and is really only meaningful when being selectively strict
* ordered configurations for ease of readability

### Impact of Changes

There is no observable impact (this is just a refactor), outside of readability and parity with v1.

Why re-order?

Sometimes using an arbitrary ordering means more scans (think like a O(N) search) to figure out what properties are configured. In the case of TS configuration, I think alphabetical makes sense because the configurations are usually small. In other cases, it's helpful to have logical groupings. In other words, this improvement is in theme of "at a glance behaviors": being able to retrieve information "at a glance" without having to search for it. 

## Summary (7e195d3271e9d64a832e7fbb8af16139f6206bd9)

Greatly simplified the `tsconfig.test.json` given the changes that happened to the base `tsconfig.json` from the migration. The `tsconfig.test.json` was duplicating properties that were already configured in the base `tsconfig.json`! The only real difference now is the `includes/excludes`, which makes sense given that one is meant for the test project, and not the other. Having parity on all other configurations means less "magic" between these scenarios.

### Impact of Changes

* Easier to understand our TS project configuration and the differences between test and source environments.