### PR TITLE
fix: CLI - Add log for daemon start

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -50,6 +50,8 @@ func daemon() *cobra.Command {
 			}
 			defer listener.Close()
 
+			logger.Info(cmd.Context(), "daemon started", slog.F("url", accessURL.String()))
+
 			client := codersdk.New(accessURL)
 			daemonClose, err := newProvisionerDaemon(cmd.Context(), client, logger)
 			if err != nil {


### PR DESCRIPTION
While going through the manual CLI flow with some people on the team, there was some confusion with the `coder daemon` command - the fact there was no output to confirm that the daemon started:

```
coder ~/coder (bryphe/fix/daemon-log) $ dist/coder_linux_amd64/coder daemon

```

This PR just adds a simple log to confirm that the daemon has started:
```
coder ~/coder (bryphe/fix/daemon-log) $ dist/coder_linux_amd64/coder daemon
2022-03-16 17:57:20.358 [INFO]  <daemon.go:53>  daemon started  {"url": "http://127.0.0.1:3000"}
```

Just throwing this out there. Feel free to reject if you have concerns about adding this @kylecarbs !