### PR TITLE
feat(site): add ActionCell component

### DIFF
--- a/site/src/components/AuditLog/ActionCell.stories.tsx
+++ b/site/src/components/AuditLog/ActionCell.stories.tsx
@@ -9,7 +9,14 @@ export default {
 
 const Template: Story<ActionCellProps> = (args) => <ActionCell {...args} />
 
-export const Example = Template.bind({})
-Example.args = {
+export const Success = Template.bind({})
+Success.args = {
   action: "create",
+  statusCode: 200,
+}
+
+export const Failure = Template.bind({})
+Failure.args = {
+  action: "create",
+  statusCode: 500,
 }

--- a/site/src/components/AuditLog/ActionCell.stories.tsx
+++ b/site/src/components/AuditLog/ActionCell.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, Story } from "@storybook/react"
+import React from "react"
+import { ActionCell, ActionCellProps } from "./ActionCell"
+
+export default {
+  title: "AuditLog/Cells/ActionCell",
+  component: ActionCell,
+} as ComponentMeta<typeof ActionCell>
+
+const Template: Story<ActionCellProps> = (args) => <ActionCell {...args} />
+
+export const Example = Template.bind({})
+Example.args = {
+  action: "create",
+}

--- a/site/src/components/AuditLog/ActionCell.test.tsx
+++ b/site/src/components/AuditLog/ActionCell.test.tsx
@@ -7,18 +7,19 @@ namespace Helpers {
 }
 
 describe("ActionCellProps", () => {
-  it.each<[ActionCellProps, boolean]>([
-    [{ action: "Create" }, false],
-    [{ action: "" }, true],
-  ])(`validate(%p) throws: %p`, (props, throws) => {
+  it.each<[ActionCellProps, ActionCellProps, boolean]>([
+    [{ action: "Create" }, { action: "Create" }, false],
+    [{ action: " Create " }, { action: "Create" }, false],
+    [{ action: "" }, { action: "" }, true],
+  ])(`validate(%p) throws: %p`, (props, expected, throws) => {
     const validate = () => {
-      ActionCellProps.validate(props)
+      return ActionCellProps.validate(props)
     }
 
     if (throws) {
       expect(validate).toThrowError()
     } else {
-      expect(validate).not.toThrowError()
+      expect(validate()).toStrictEqual(expected)
     }
   })
 })

--- a/site/src/components/AuditLog/ActionCell.test.tsx
+++ b/site/src/components/AuditLog/ActionCell.test.tsx
@@ -1,16 +1,20 @@
-import { ActionCell, ActionCellProps } from "./ActionCell"
+import { ActionCell, ActionCellProps, LANGUAGE } from "./ActionCell"
 import React from "react"
 import { render, screen } from "@testing-library/react"
 
 namespace Helpers {
+  export const Props: ActionCellProps = {
+    action: "create",
+    statusCode: 200,
+  }
   export const Component: React.FC<ActionCellProps> = (props) => <ActionCell {...props} />
 }
 
 describe("ActionCellProps", () => {
   it.each<[ActionCellProps, ActionCellProps, boolean]>([
-    [{ action: "Create" }, { action: "Create" }, false],
-    [{ action: " Create " }, { action: "Create" }, false],
-    [{ action: "" }, { action: "" }, true],
+    [{ action: "Create", statusCode: 200 }, { action: "Create", statusCode: 200 }, false],
+    [{ action: " Create ", statusCode: 400 }, { action: "Create", statusCode: 400 }, false],
+    [{ action: "", statusCode: 200 }, { action: "", statusCode: 200 }, true],
   ])(`validate(%p) throws: %p`, (props, expected, throws) => {
     const validate = () => {
       return ActionCellProps.validate(props)
@@ -22,14 +26,25 @@ describe("ActionCellProps", () => {
       expect(validate()).toStrictEqual(expected)
     }
   })
+  it.each<[number, boolean]>([
+    // success cases
+    [200, true],
+    [201, true],
+    [302, true],
+    // failure cases
+    [400, false],
+    [404, false],
+    [500, false],
+  ])(`isSuccessStatus(%p) returns %p`, (statusCode, expected) => {
+    expect(ActionCellProps.isSuccessStatus(statusCode)).toBe(expected)
+  })
 })
 
 describe("ActionCell", () => {
+  // action cases
   it("renders the action", () => {
     // Given
-    const props: ActionCellProps = {
-      action: "Create",
-    }
+    const props = Helpers.Props
 
     // When
     render(<Helpers.Component {...props} />)
@@ -37,10 +52,10 @@ describe("ActionCell", () => {
     // Then
     expect(screen.getByText(props.action)).toBeDefined()
   })
-
   it("throws when action is an empty string", () => {
     // Given
     const props: ActionCellProps = {
+      ...Helpers.Props,
       action: "",
     }
 
@@ -51,5 +66,29 @@ describe("ActionCell", () => {
 
     // Then
     expect(shouldThrow).toThrowError()
+  })
+
+  // statusCode cases
+  it.each<[number, string]>([
+    // Success cases
+    [200, LANGUAGE.statusCodeSuccess],
+    [201, LANGUAGE.statusCodeSuccess],
+    [302, LANGUAGE.statusCodeSuccess],
+    // Failure cases
+    [400, LANGUAGE.statusCodeFail],
+    [404, LANGUAGE.statusCodeFail],
+    [500, LANGUAGE.statusCodeFail],
+  ])("renders %p when statusCode is %p", (statusCode, expected) => {
+    // Given
+    const props: ActionCellProps = {
+      ...Helpers.Props,
+      statusCode,
+    }
+
+    // When
+    render(<Helpers.Component {...props} />)
+
+    // Then
+    expect(screen.getByText(expected)).toBeDefined()
   })
 })

--- a/site/src/components/AuditLog/ActionCell.test.tsx
+++ b/site/src/components/AuditLog/ActionCell.test.tsx
@@ -1,0 +1,54 @@
+import { ActionCell, ActionCellProps } from "./ActionCell"
+import React from "react"
+import { render, screen } from "@testing-library/react"
+
+namespace Helpers {
+  export const Component: React.FC<ActionCellProps> = (props) => <ActionCell {...props} />
+}
+
+describe("ActionCellProps", () => {
+  it.each<[ActionCellProps, boolean]>([
+    [{ action: "Create" }, false],
+    [{ action: "" }, true],
+  ])(`validate(%p) throws: %p`, (props, throws) => {
+    const validate = () => {
+      ActionCellProps.validate(props)
+    }
+
+    if (throws) {
+      expect(validate).toThrowError()
+    } else {
+      expect(validate).not.toThrowError()
+    }
+  })
+})
+
+describe("ActionCell", () => {
+  it("renders the action", () => {
+    // Given
+    const props: ActionCellProps = {
+      action: "Create",
+    }
+
+    // When
+    render(<Helpers.Component {...props} />)
+
+    // Then
+    expect(screen.getByText(props.action)).toBeDefined()
+  })
+
+  it("throws when action is an empty string", () => {
+    // Given
+    const props: ActionCellProps = {
+      action: "",
+    }
+
+    // When
+    const shouldThrow = () => {
+      render(<Helpers.Component {...props} />)
+    }
+
+    // Then
+    expect(shouldThrow).toThrowError()
+  })
+})

--- a/site/src/components/AuditLog/ActionCell.tsx
+++ b/site/src/components/AuditLog/ActionCell.tsx
@@ -11,15 +11,21 @@ export namespace ActionCellProps {
    *
    * @throws Error if invalid
    */
-  export const validate = (props: ActionCellProps): void => {
-    if (!props.action.trim()) {
+  export const validate = (props: ActionCellProps): ActionCellProps => {
+    const sanitizedAction = props.action.trim()
+
+    if (!sanitizedAction) {
       throw new Error(`invalid action: '${props.action}'`)
+    }
+
+    return {
+      action: sanitizedAction,
     }
   }
 }
 
-export const ActionCell: React.FC<ActionCellProps> = ({ action }) => {
-  ActionCellProps.validate({ action })
+export const ActionCell: React.FC<ActionCellProps> = (props) => {
+  const { action } = ActionCellProps.validate(props)
 
   return (
     <Box display="flex" alignItems="center">

--- a/site/src/components/AuditLog/ActionCell.tsx
+++ b/site/src/components/AuditLog/ActionCell.tsx
@@ -1,9 +1,16 @@
 import Box from "@material-ui/core/Box"
 import Typography from "@material-ui/core/Typography"
+import makeStyles from "@material-ui/core/styles/makeStyles"
 import React from "react"
+
+export const LANGUAGE = {
+  statusCodeFail: "failure",
+  statusCodeSuccess: "success",
+}
 
 export interface ActionCellProps {
   action: string
+  statusCode: number
 }
 export namespace ActionCellProps {
   /**
@@ -20,9 +27,20 @@ export namespace ActionCellProps {
 
     return {
       action: sanitizedAction,
+      statusCode: props.statusCode,
     }
   }
+
+  export const isSuccessStatus = (statusCode: ActionCellProps["statusCode"]): boolean => {
+    return statusCode >= 100 && statusCode < 400
+  }
 }
+
+const useStyles = makeStyles((theme) => ({
+  statusText: (isSuccess: boolean) => ({
+    color: isSuccess ? theme.palette.primary.main : theme.palette.error.main,
+  }),
+}))
 
 /**
  * ActionCell is a single cell in an audit log table row that contains
@@ -33,12 +51,17 @@ export namespace ActionCellProps {
  * Some common actions are CRUD, Open, signing in etc.
  */
 export const ActionCell: React.FC<ActionCellProps> = (props) => {
-  const { action } = ActionCellProps.validate(props)
+  const { action, statusCode } = ActionCellProps.validate(props)
+  const isSuccess = ActionCellProps.isSuccessStatus(statusCode)
+  const styles = useStyles(isSuccess)
 
   return (
-    <Box display="flex" alignItems="center">
-      <Typography color="textSecondary" variant="caption">
+    <Box alignItems="center" display="flex" flexDirection="column">
+      <Typography color="textSecondary" variant="h6">
         {action}
+      </Typography>
+      <Typography className={styles.statusText} variant="caption">
+        {isSuccess ? LANGUAGE.statusCodeSuccess : LANGUAGE.statusCodeFail}
       </Typography>
     </Box>
   )

--- a/site/src/components/AuditLog/ActionCell.tsx
+++ b/site/src/components/AuditLog/ActionCell.tsx
@@ -24,6 +24,14 @@ export namespace ActionCellProps {
   }
 }
 
+/**
+ * ActionCell is a single cell in an audit log table row that contains
+ * information about an action that was taken on a resource.
+ *
+ * @remarks
+ *
+ * Some common actions are CRUD, Open, signing in etc.
+ */
 export const ActionCell: React.FC<ActionCellProps> = (props) => {
   const { action } = ActionCellProps.validate(props)
 

--- a/site/src/components/AuditLog/ActionCell.tsx
+++ b/site/src/components/AuditLog/ActionCell.tsx
@@ -1,0 +1,31 @@
+import Box from "@material-ui/core/Box"
+import Typography from "@material-ui/core/Typography"
+import React from "react"
+
+export interface ActionCellProps {
+  action: string
+}
+export namespace ActionCellProps {
+  /**
+   * validate that the received props are valid
+   *
+   * @throws Error if invalid
+   */
+  export const validate = (props: ActionCellProps): void => {
+    if (!props.action.trim()) {
+      throw new Error(`invalid action: '${props.action}'`)
+    }
+  }
+}
+
+export const ActionCell: React.FC<ActionCellProps> = ({ action }) => {
+  ActionCellProps.validate({ action })
+
+  return (
+    <Box display="flex" alignItems="center">
+      <Typography color="textSecondary" variant="caption">
+        {action}
+      </Typography>
+    </Box>
+  )
+}


### PR DESCRIPTION
Summary:

This is a direct follow-up to #484 and a next step in porting over the AuditLog with appropriate refactoring. The old "StatusCell" was merged with "ActionCell", and the icon mapping was omitted.

Details:

- Port over ActionCell from v1, sans icons
- This isn't a direct port; we used to have a map of icons on the FE, but we want to no longer split the logic between FE and BE.  If we want icons at a later time point, we can return an icon identifier in the response, or we can simplify the view and gain real estate by omitting the icons. At the time of this commit, I prefer omitting the icons.
- Add tests and stories for ActionCell

Impact:

This change does not have any user-facing impact yet, because the
ActionCell is not yet rendered in the product. This enables an incremental
approach to migrating in the FE of the Audit Log, which is still waiting
on the BE port.

Relations:

- This commit relates to #472, but does not finish it.
- This commit should not merged until after #484 because it's based from
it

---

## Demo

### Old

![old-audit-log](https://user-images.githubusercontent.com/11184711/159140163-b5834edb-9932-41a2-9843-48c48efaa2fe.png)

### New ActionCell (Storybook)

![action-cell-storybook--failure](https://user-images.githubusercontent.com/11184711/159140167-cfb4a3f9-f9da-4aaa-b468-038238c3c283.png)
![action-cell-storybook--success](https://user-images.githubusercontent.com/11184711/159140168-eb05c45c-4c87-4f6f-9c20-06305dfb0177.png)

