### PR TITLE
fix(ci): don't run stability tests on prs

### DIFF
--- a/.github/workflows/coder-test-stability.yaml
+++ b/.github/workflows/coder-test-stability.yaml
@@ -6,17 +6,12 @@ on:
     # Run everyday around midnight Central.
     - cron: "0 6 * * *"
 
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/workflows/coder-test-stability.yaml
   workflow_dispatch:
     inputs:
       iterationCount:
-        description: 'Iteration Count'     
+        description: "Iteration Count"
         required: false
-        default: '10'
+        default: "10"
 
 # Cancel in-progress runs for pull requests when developers push
 # additional changes, and serialize builds in branches.


### PR DESCRIPTION
It looks like this was supposed to be removed.
