### PR TITLE
fix: correctly copy binaries in `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ gen: database/generate peerbroker/proto provisionersdk/proto provisionerd/proto
 
 install: bin
 	@echo "--- Copying from bin to $(INSTALL_DIR)"
-	cp -r ./dist/coder_$(GOOS)_$(GOARCH) $(INSTALL_DIR)
+	cp -r ./dist/coder_$(GOOS)_$(GOARCH)/* $(INSTALL_DIR)
 	@echo "-- CLI available at $(shell ls $(INSTALL_DIR)/coder*)"
 .PHONY: install
 


### PR DESCRIPTION
Since it copied to a nested directory, it's very confusing if you
already had a `coder` binary in your `~/go/bin`, since it would always
prefer the `coder` in the higher directory.
