### PR TITLE
chore: enable files.insertFinalNewline in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,6 +61,8 @@
   "files.exclude": {
     "**/node_modules": true
   },
+  // Ensure files always have a newline.
+  "files.insertFinalNewline": true,
   "go.lintTool": "golangci-lint",
   "go.lintFlags": ["--fast"],
   "go.lintOnSave": "package",
@@ -79,5 +81,5 @@
   },
   // We often use a version of TypeScript that's ahead of the version shipped
   // with VS Code.
-  "typescript.tsdk": "./site/node_modules/typescript/lib"
+  "typescript.tsdk": "./site/node_modules/typescript/lib",
 }


### PR DESCRIPTION
Ensures there's always a newline at the end of files. They seem to be
randomly missing, which cause weird diffs.
