### PR TITLE
fix: Parse prompt input JSON using object or array chars

### DIFF
--- a/cli/workspacecreate_test.go
+++ b/cli/workspacecreate_test.go
@@ -3,10 +3,11 @@ package cli_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/pty/ptytest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWorkspaceCreate(t *testing.T) {

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coder/coder/cryptorand"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/cryptorand"
 )
 
 // Required to prevent port collision during container creation.


### PR DESCRIPTION
Fixes #492. There is no more single-quote parsing, and instead we use a JSON decoder for multiline values. This is a much better UX!