### PR TITLE
fix: Remove "coder" user and group from systemd service

### DIFF
--- a/coder.service
+++ b/coder.service
@@ -10,15 +10,13 @@ StartLimitBurst=3
 [Service]
 Type=notify
 EnvironmentFile=/etc/coder.d/coder.env
-User=coder
-Group=coder
 ProtectSystem=full
 ProtectHome=read-only
 PrivateTmp=yes
 PrivateDevices=yes
 SecureBits=keep-caps
-AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE
 NoNewPrivileges=yes
 ExecStart=/usr/bin/coder start
 Restart=on-failure


### PR DESCRIPTION
This caused an inability to listen on privileged ports and read certs
from LetsEncrypt. It seems more hurtful rather than helpful, so
removing the restriction seems reasonable.