### PR TITLE
chore: Reduce dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "06:00"
       timezone: "America/Chicago"
     commit-message:


### PR DESCRIPTION
It was tiring seeing 5+ PRs a day for dependency updates.
Reducing this to a week should save some time!