### PR TITLE
feat: Add env var config management

### DIFF
--- a/cli/config/env.go
+++ b/cli/config/env.go
@@ -6,7 +6,8 @@ import (
 	"strconv"
 )
 
-var (
+// Specify Key constants for EnvConfig here.
+const (
 	EnvCoderAccessURL          Key = "CODER_ACCESS_URL"
 	EnvCoderAddress            Key = "CODER_ADDRESS"
 	EnvCoderDevMode            Key = "CODER_DEV_MODE"
@@ -21,6 +22,19 @@ var (
 	EnvCoderDevTunnel          Key = "CODER_DEV_TUNNEL"
 )
 
+// EnvConfigSchema is the global schema for environment variables.
+// This schema is used when config.ReadEnvConfig() is called.
+// Add new items to the array and fill in Key, DefaultValue, and Usage fields.
+//
+// Example:
+// var (
+//	  root *cobra.Command
+//    accessURL string
+//    ec = config.ReadEnvironmentConfig()
+// )
+//
+// root.Flags().StringVarP(&accessURL, "access-url", "", ec.GetString(config.EnvCoderAccessURL), ec.Usage(config.EnvCoderAccessURL))
+//
 var EnvConfigSchema = EnvConfigSchemaFields{
 	{
 		Key:          EnvCoderAccessURL,
@@ -87,16 +101,21 @@ var EnvConfigSchema = EnvConfigSchemaFields{
 	},
 }
 
+// ReadEnvConfig reads the application environment variables and stores them in memory.
 func ReadEnvConfig() EnvConfig {
 	return EnvConfigSchema.readEnvironment()
 }
 
+// Key is the environment variable key.
 type Key string
 
+// EnvConfig allows reading of environment configuration.
 type EnvConfig map[Key]EnvConfigSchemaField
 
+// EnvConfigSchemaFields is the configuration schema for an EnvConfig.
 type EnvConfigSchemaFields []EnvConfigSchemaField
 
+// EnvConfigSchemaField represents an environment variable.
 type EnvConfigSchemaField struct {
 	Key          Key
 	DefaultValue string
@@ -120,20 +139,24 @@ func (e EnvConfigSchemaFields) readEnvironment() EnvConfig {
 	return c
 }
 
+// GetString looks up the Key and returns the value as a string.
 func (e EnvConfig) GetString(key Key) string {
 	return e[key].value
 }
 
+// GetBool looks up the Key and returns the value as a bool.
 func (e EnvConfig) GetBool(key Key) bool {
 	b, _ := strconv.ParseBool(e[key].value)
 	return b
 }
 
+// GetInt looks up the Key and returns the value as a int.
 func (e EnvConfig) GetInt(key Key) int {
 	b, _ := strconv.ParseInt(e[key].value, 10, 0)
 	return int(b)
 }
 
+// Usage looks up the Key and returns the formatted usage message.
 func (e EnvConfig) Usage(key Key) string {
 	return fmt.Sprintf("%s (uses $%s).", e[key].Usage, key)
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -44,7 +43,7 @@ func start() *cobra.Command {
 		address                string
 		dev                    bool
 		postgresURL            string
-		provisionerDaemonCount uint8
+		provisionerDaemonCount int
 		tlsCertFile            string
 		tlsClientCAFile        string
 		tlsClientAuth          string
@@ -57,10 +56,6 @@ func start() *cobra.Command {
 		Use: "start",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printLogo(cmd)
-			if postgresURL == "" {
-				// Default to the environment variable!
-				postgresURL = os.Getenv("CODER_PG_CONNECTION_URL")
-			}
 
 			listener, err := net.Listen("tcp", address)
 			if err != nil {
@@ -163,7 +158,7 @@ func start() *cobra.Command {
 			}
 
 			provisionerDaemons := make([]*provisionerd.Server, 0)
-			for i := uint8(0); i < provisionerDaemonCount; i++ {
+			for i := 0; i < provisionerDaemonCount; i++ {
 				daemonClose, err := newProvisionerDaemon(cmd.Context(), client, logger)
 				if err != nil {
 					return xerrors.Errorf("create provisioner daemon: %w", err)
@@ -306,46 +301,20 @@ func start() *cobra.Command {
 			return nil
 		},
 	}
-	defaultAddress := os.Getenv("CODER_ADDRESS")
-	if defaultAddress == "" {
-		defaultAddress = "127.0.0.1:3000"
-	}
-	root.Flags().StringVarP(&accessURL, "access-url", "", os.Getenv("CODER_ACCESS_URL"), "Specifies the external URL to access Coder (uses $CODER_ACCESS_URL).")
-	root.Flags().StringVarP(&address, "address", "a", defaultAddress, "The address to serve the API and dashboard (uses $CODER_ADDRESS).")
-	defaultDev, _ := strconv.ParseBool(os.Getenv("CODER_DEV_MODE"))
-	root.Flags().BoolVarP(&dev, "dev", "", defaultDev, "Serve Coder in dev mode for tinkering (uses $CODER_DEV_MODE).")
-	root.Flags().StringVarP(&postgresURL, "postgres-url", "", "",
-		"URL of a PostgreSQL database to connect to (defaults to $CODER_PG_CONNECTION_URL).")
-	root.Flags().Uint8VarP(&provisionerDaemonCount, "provisioner-daemons", "", 1, "The amount of provisioner daemons to create on start.")
-	defaultTLSEnable, _ := strconv.ParseBool(os.Getenv("CODER_TLS_ENABLE"))
-	root.Flags().BoolVarP(&tlsEnable, "tls-enable", "", defaultTLSEnable, "Specifies if TLS will be enabled (uses $CODER_TLS_ENABLE).")
-	root.Flags().StringVarP(&tlsCertFile, "tls-cert-file", "", os.Getenv("CODER_TLS_CERT_FILE"),
-		"Specifies the path to the certificate for TLS. It requires a PEM-encoded file. "+
-			"To configure the listener to use a CA certificate, concatenate the primary certificate "+
-			"and the CA certificate together. The primary certificate should appear first in the combined file (uses $CODER_TLS_CERT_FILE).")
-	root.Flags().StringVarP(&tlsClientCAFile, "tls-client-ca-file", "", os.Getenv("CODER_TLS_CLIENT_CA_FILE"),
-		"PEM-encoded Certificate Authority file used for checking the authenticity of client (uses $CODER_TLS_CLIENT_CA_FILE).")
-	defaultTLSClientAuth := os.Getenv("CODER_TLS_CLIENT_AUTH")
-	if defaultTLSClientAuth == "" {
-		defaultTLSClientAuth = "request"
-	}
-	root.Flags().StringVarP(&tlsClientAuth, "tls-client-auth", "", defaultTLSClientAuth,
-		`Specifies the policy the server will follow for TLS Client Authentication. `+
-			`Accepted values are "none", "request", "require-any", "verify-if-given", or "require-and-verify" (uses $CODER_TLS_CLIENT_AUTH).`)
-	root.Flags().StringVarP(&tlsKeyFile, "tls-key-file", "", os.Getenv("CODER_TLS_KEY_FILE"),
-		"Specifies the path to the private key for the certificate. It requires a PEM-encoded file (uses $CODER_TLS_KEY_FILE).")
-	defaultTLSMinVersion := os.Getenv("CODER_TLS_MIN_VERSION")
-	if defaultTLSMinVersion == "" {
-		defaultTLSMinVersion = "tls12"
-	}
-	root.Flags().StringVarP(&tlsMinVersion, "tls-min-version", "", defaultTLSMinVersion,
-		`Specifies the minimum supported version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13" (uses $CODER_TLS_MIN_VERSION).`)
-	defaultTunnelRaw := os.Getenv("CODER_DEV_TUNNEL")
-	if defaultTunnelRaw == "" {
-		defaultTunnelRaw = "true"
-	}
-	defaultTunnel, _ := strconv.ParseBool(defaultTunnelRaw)
-	root.Flags().BoolVarP(&useTunnel, "tunnel", "", defaultTunnel, "Serve dev mode through a Cloudflare Tunnel for easy setup (uses $CODER_DEV_TUNNEL).")
+	ec := config.ReadEnvConfig()
+
+	root.Flags().StringVarP(&accessURL, "access-url", "", ec.GetString(config.EnvCoderAccessURL), ec.Usage(config.EnvCoderAccessURL))
+	root.Flags().StringVarP(&address, "address", "a", ec.GetString(config.EnvCoderAddress), ec.Usage(config.EnvCoderAccessURL))
+	root.Flags().BoolVarP(&dev, "dev", "", ec.GetBool(config.EnvCoderDevMode), ec.Usage(config.EnvCoderAccessURL))
+	root.Flags().StringVarP(&postgresURL, "postgres-url", "", ec.GetString(config.EnvCoderPGConnectionURL), ec.Usage(config.EnvCoderPGConnectionURL))
+	root.Flags().IntVarP(&provisionerDaemonCount, "provisioner-daemons", "", ec.GetInt(config.EnvCoderProvisionerDaemons), ec.Usage(config.EnvCoderProvisionerDaemons))
+	root.Flags().BoolVarP(&tlsEnable, "tls-enable", "", ec.GetBool(config.EnvCoderTLSEnable), ec.Usage(config.EnvCoderTLSEnable))
+	root.Flags().StringVarP(&tlsCertFile, "tls-cert-file", "", ec.GetString(config.EnvCoderTLSCertFile), ec.Usage(config.EnvCoderTLSCertFile))
+	root.Flags().StringVarP(&tlsClientCAFile, "tls-client-ca-file", "", ec.GetString(config.EnvCoderTLSClientCAFile), ec.Usage(config.EnvCoderTLSClientCAFile))
+	root.Flags().StringVarP(&tlsClientAuth, "tls-client-auth", "", ec.GetString(config.EnvCoderTLSClientAuth), ec.Usage(config.EnvCoderTLSClientAuth))
+	root.Flags().StringVarP(&tlsKeyFile, "tls-key-file", "", ec.GetString(config.EnvCoderTLSKeyFile), ec.Usage(config.EnvCoderTLSKeyFile))
+	root.Flags().StringVarP(&tlsMinVersion, "tls-min-version", "", ec.GetString(config.EnvCoderTLSMinVersion), ec.Usage(config.EnvCoderTLSMinVersion))
+	root.Flags().BoolVarP(&useTunnel, "tunnel", "", ec.GetBool(config.EnvCoderDevTunnel), ec.Usage(config.EnvCoderDevTunnel))
 	_ = root.Flags().MarkHidden("tunnel")
 
 	return root


### PR DESCRIPTION
I've created a `config.EnvConfig` abstraction to handle environment variable consumption. The aim of this is to unify a single place in the code we handle environment variables for all the coder applications users will run. This is designed as a funnel for developers to have a "correct" place to consume environment variables. 

Features:
- Default values
- Supports string, bool, int
- Ties usage docs to env variable and flags
- Dedicated `config.Key` type will enforce type safety when doing lookups as a consumer