### PR TITLE
chore: Add comment explaining why testpackage is enabled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -251,6 +251,13 @@ linters:
     - staticcheck
     - structcheck
     - tenv
+    # In Go, it's possible for a package to test it's internal functionality
+    # without testing any exported functions. This is enabled to promote
+    # decomposing a package before testing it's internals. A function caller
+    # should be able to test most of the functionality from exported functions.
+    # 
+    # There are edge-cases to this rule, but they should be carefully considered
+    # to avoid structural inconsistency.
     - testpackage
     - tparallel
     - typecheck


### PR DESCRIPTION
A discussion (linked below) was had that touched on why this linter
is enabled. To avoid losing that history, adding the comment inline with
our linting rules can avoid duplicating this discussion!

https://github.com/coder/coder/pull/741#discussion_r839026254