### PR TITLE
fix: use `golang.org/x/term` instead of `golang.org/x/crypto/ssh/terminal`

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -11,9 +11,8 @@ import (
 	"github.com/pion/webrtc/v3"
 	"github.com/spf13/cobra"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/term"
 	"golang.org/x/xerrors"
-
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/coder/coder/cli/cliflag"
 	"github.com/coder/coder/cli/cliui"
@@ -131,12 +130,12 @@ func ssh() *cobra.Command {
 			}
 
 			if isatty.IsTerminal(os.Stdout.Fd()) {
-				state, err := terminal.MakeRaw(int(os.Stdin.Fd()))
+				state, err := term.MakeRaw(int(os.Stdin.Fd()))
 				if err != nil {
 					return err
 				}
 				defer func() {
-					_ = terminal.Restore(int(os.Stdin.Fd()), state)
+					_ = term.Restore(int(os.Stdin.Fd()), state)
 				}()
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220325170049-de3da57026de // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/tools v0.1.9 // indirect


### PR DESCRIPTION
The latter is deprecated: https://pkg.go.dev/golang.org/x/crypto/ssh/terminal

The deprecated packages linter doesn't seem to be working in 1.18 :disappointed: 