### PR TITLE
test: Fix ProjectVersionLogs returning error when using DB

### DIFF
--- a/coderd/projectversions_test.go
+++ b/coderd/projectversions_test.go
@@ -240,7 +240,8 @@ func TestProjectVersionLogs(t *testing.T) {
 	coderdtest.NewProvisionerDaemon(t, client)
 	before := time.Now()
 	version := coderdtest.CreateProjectVersion(t, client, user.OrganizationID, &echo.Responses{
-		Parse: echo.ParseComplete,
+		Parse:           echo.ParseComplete,
+		ProvisionDryRun: echo.ProvisionComplete,
 		Provision: []*proto.Provision_Response{{
 			Type: &proto.Provision_Response_Log{
 				Log: &proto.Log{


### PR DESCRIPTION
This didn't actually effect the test value, since we're just looking for
logs. It did produce spam in the logs though, and could be interpreted
as a failure.