### PR TITLE
chore: Remove varnamelen linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -265,5 +265,4 @@ linters:
     - unconvert
     - unused
     - varcheck
-    - varnamelen
     - wastedassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -177,27 +177,6 @@ linters-settings:
       - name: var-declaration
       - name: var-naming
       - name: waitgroup-by-value
-  varnamelen:
-    ignore-names:
-      - err
-      - rw
-      - r
-      - i
-      - db
-      - t
-      - id
-      - wg
-      - Me
-    # Optional list of variable declarations that should be ignored completely. (defaults to empty list)
-    # Entries must be in the form of "<variable name> <type>" or "<variable name> *<type>" for
-    # variables, or "const <name>" for constants.
-    ignore-decls:
-      - rw http.ResponseWriter
-      - r *http.Request
-      - t testing.T
-      - t testing.TB
-      - ok bool
-      - wg sync.WaitGroup
 
 issues:
   # Rules listed here: https://github.com/securego/gosec#available-rules


### PR DESCRIPTION
Golang prefers short var names in local scope. I think this is not idiomatic and excessive. I'd only assert this when the var exceeds local scope, but that is not supported.

https://github.com/golang/go/wiki/CodeReviewComments#variable-names