### PR TITLE
chore(site): fix typegen usage

### DIFF
--- a/site/src/xServices/user/userXService.ts
+++ b/site/src/xServices/user/userXService.ts
@@ -3,7 +3,7 @@ import * as Types from "../../api/types"
 import * as API from "../../api"
 
 export interface UserContext {
-  getUserError?: Error | unknown // unknown is a concession while I work out typing issues
+  getUserError?: Error | unknown
   authError?: Error | unknown
   me?: Types.UserResponse
 }
@@ -23,7 +23,7 @@ export const userMachine =
             data: Types.UserResponse
           }
           signIn: {
-            data: Types.LoginResponse | undefined
+            data: Types.LoginResponse
           }
         },
       },
@@ -110,10 +110,8 @@ export const userMachine =
     },
     {
       services: {
-        signIn: async (_, event: UserEvent) => {
-          if (event.type === "SIGN_IN") {
-            return await API.login(event.email, event.password)
-          }
+        signIn: async (_, event) => {
+          return await API.login(event.email, event.password)
         },
         signOut: API.logout,
         getMe: API.getUser,


### PR DESCRIPTION
- I realized it's actually true that we don't know for sure what our errors are. Open to ideas about how we want to handle them (`as Error`, type checking as they come in, or be defensive throughout?)
- the reason I had to defensively check whether `event.type` was `SIGN_IN` even though the typegen file knew that it was always `SIGN_IN` is that I had annotated `event` as `UserEvent`. The lesson is, let typegen figure out your types for you.

I updated the Code Conventions doc with info on how to use typegen.