### PR TITLE
chore(site): Add XState inspector

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -13,6 +13,6 @@ cd "${PROJECT_ROOT}"
 # https://stackoverflow.com/questions/3004811/how-do-you-run-multiple-programs-in-parallel-from-a-bash-script
 (
   trap 'kill 0' SIGINT
-  CODERV2_HOST=http://127.0.0.1:3000 yarn --cwd=./site dev &
+  CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
   go run cmd/coder/main.go start --dev --tunnel=false
 )

--- a/site/package.json
+++ b/site/package.json
@@ -28,6 +28,7 @@
     "@material-ui/core": "4.9.4",
     "@material-ui/icons": "4.5.1",
     "@material-ui/lab": "4.0.0-alpha.42",
+    "@xstate/inspect": "^0.6.4",
     "@xstate/react": "2.0.1",
     "axios": "0.26.1",
     "formik": "2.2.9",

--- a/site/src/Main.tsx
+++ b/site/src/Main.tsx
@@ -1,7 +1,20 @@
 import React from "react"
 import ReactDOM from "react-dom"
-
+import { inspect } from "@xstate/inspect";
+import { Interpreter } from "xstate"
 import { App } from "./app"
+
+// if this is a development build
+if (process.env.NODE_ENV === "development") {
+  // configure the XState inspector to open in a new tab
+  inspect({
+    url: "https://stately.ai/viz?inspect",
+    iframe: false
+  });
+  // configure all XServices to use the inspector
+  Interpreter.defaultOptions.devTools = true
+}
+
 
 // This is the entry point for the app - where everything start.
 // In the future, we'll likely bring in more bootstrapping logic -

--- a/site/src/Main.tsx
+++ b/site/src/Main.tsx
@@ -4,8 +4,8 @@ import { inspect } from "@xstate/inspect";
 import { Interpreter } from "xstate"
 import { App } from "./app"
 
-// if this is a development build
-if (process.env.NODE_ENV === "development") {
+// if this is a development build and the developer wants to inspect
+if (process.env.NODE_ENV === "development" && process.env.INSPECT_XSTATE === "true") {
   // configure the XState inspector to open in a new tab
   inspect({
     url: "https://stately.ai/viz?inspect",

--- a/site/src/Main.tsx
+++ b/site/src/Main.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { inspect } from "@xstate/inspect";
+import { inspect } from "@xstate/inspect"
 import { Interpreter } from "xstate"
 import { App } from "./app"
 
@@ -9,12 +9,11 @@ if (process.env.NODE_ENV === "development" && process.env.INSPECT_XSTATE === "tr
   // configure the XState inspector to open in a new tab
   inspect({
     url: "https://stately.ai/viz?inspect",
-    iframe: false
-  });
+    iframe: false,
+  })
   // configure all XServices to use the inspector
   Interpreter.defaultOptions.devTools = true
 }
-
 
 // This is the entry point for the app - where everything start.
 // In the future, we'll likely bring in more bootstrapping logic -

--- a/site/src/xServices/StateContext.tsx
+++ b/site/src/xServices/StateContext.tsx
@@ -18,7 +18,7 @@ interface XServiceContextType {
 export const XServiceContext = createContext({} as XServiceContextType)
 
 export const XServiceProvider: React.FC = ({ children }) => {
-  const userXService = useInterpret(userMachine, { devTools: true })
+  const userXService = useInterpret(userMachine)
 
   return <XServiceContext.Provider value={{ userXService }}>{children}</XServiceContext.Provider>
 }

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -4201,6 +4201,13 @@
     commander "^8.0.0"
     xstate "^4.29.0"
 
+"@xstate/inspect@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@xstate/inspect/-/inspect-0.6.4.tgz#dd12abb30375dcb0471b81e8db3b81377cd00be6"
+  integrity sha512-2Gz5wu/RdpeLEpQ93qWQe/lDybJHQq8NzgWyB/EmDUBhOggCeZu4JqJCT7/RsQ7FNSEenZILFbNTftOY00Kg4A==
+  dependencies:
+    fast-safe-stringify "^2.0.7"
+
 "@xstate/machine-extractor@0.6.2":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@xstate/machine-extractor/-/machine-extractor-0.6.2.tgz#2fe5edb6b965fd1f45fa68644a4ef69f125c4fc0"
@@ -7364,6 +7371,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-safe-stringify@^2.0.7:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.12"


### PR DESCRIPTION
New PR! 

In order to inspect your XState services, simply run the `./develop.sh` script or otherwise set the `INSPECT_XSTATE` environment variable to "true" while in dev mode.

Documentation here: https://www.notion.so/coderhq/Inspect-an-XState-machine-4de27670d836422db23f5d252241aed2