### PR TITLE
docs: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Help reviewers by listing the subtasks in this PR
+
+Here's an example:
+
+This PR adds a new feature to the CLI.
+
+## Subtasks
+
+- [x] added a test for feature
+
+Fixes #345
+
+-->


### PR DESCRIPTION
This PR adds a PR template which will show up when you create a new template. I figure we can keep it light for now and add more as needed. I imagine if we start to get a lot of community contributions, we may want to expand this. 

Fixes #652 