### PR TITLE
fix: Use docs/README.md in deploy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,8 @@ archives:
     builds:
       - coder
     files:
-      - README.md
+      - src: docs/README.md
+        dst: README.md
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
The release build should probably dry-run in CI,
but it's rare for files like README.md to move
so we can punt that to the future!