### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report a bug
+title: "Bug: "
+labels: "bug 🐛"
+---
+
+## OS Information
+
+- OS:
+- Browser (if applicable): 
+- Architecture:
+- `coder --version`:
+
+## Steps to Reproduce
+
+<!-- 1. -->
+<!-- 2. -->
+<!-- 3. -->
+
+## Expected
+
+<!-- What should happen? -->
+
+## Actual
+
+<!-- What actually happens? -->
+
+## Logs
+
+## Screenshot
+
+<!-- Ideally provide a screenshot, gif, video or screen recording. -->
+
+## Notes
+
+<!-- Anything else you want to share -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question?
+    url: https://github.com/coder/coder/discussions/new?category=q-a
+    about: Ask for help on our GitHub Discussions board

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -1,0 +1,12 @@
+---
+name: Documentation improvement
+about: Suggest a documentation improvement
+title: "Docs: "
+labels: "documentation 📝"
+---
+
+## What is your suggestion?
+
+## How will this improve the docs?
+
+## Are you interested in submitting a PR for this?


### PR DESCRIPTION
This PR adds the following issue templates:
- docs
- bug-report

It also allows for blank issue templates and encourages folks with questions to post in our GitHub Discussions. 

I would have used a new [issue form](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) since that's worked well on code-server, but it's only available for public repos (so we can switch over if that's desired). 

<img width="751" alt="image" src="https://user-images.githubusercontent.com/3806031/162024779-b91b16a1-7981-4fed-9869-dc62f7bb252f.png">


Fixes #648 