### PR TITLE
docs: add SECURITY policy

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+Keeping your code secure is core to what we do. If you find a vulnerability,
+please send an email to security@coder.com, and our team will respond to you.


### PR DESCRIPTION
This PR adds a basic `SECURITY` policy for coder. 

Note: I decided to _not_ add Dependabot since I believe we're going to explore [Socket](https://socket.dev/). I'm meeting with the team next week and I will come back with more information. For the first public release, I believe this should be sufficient.

Fixes #656