### PR TITLE
chore: speed up chromatic ci

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           buildScriptName: "storybook:build"
+          exitOnceUploaded: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: "./site"
 


### PR DESCRIPTION
This is an oversight from #896 . It turns out that because we use the GitHub integration with Chromatic, we don't need to wait for the results to be reported in the action - they get reported in the other checks created by Chromatic.

This option was spit-out in a check:

https://github.com/coder/coder/runs/5859427236?check_suite_focus=true#step:4:38

Relates to #444