### PR TITLE
fix: assign labels for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug
 title: "Bug: "
-labels: "bug 🐛"
+labels: "bug :bug:"
 ---
 
 ## OS Information

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -2,7 +2,7 @@
 name: Documentation improvement
 about: Suggest a documentation improvement
 title: "Docs: "
-labels: "documentation 📝"
+labels: "documentation :memo:"
 ---
 
 ## What is your suggestion?


### PR DESCRIPTION
I noticed the "bug" and "documentation" issue templates were not properly assigning labels. However, feature works.

