### PR TITLE
fix: Disable Terraform plugin cache on Darwin

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -88,9 +88,9 @@ func (t *terraform) Provision(stream proto.DRPCProvisioner_ProvisionStream) erro
 			})
 		}
 	}()
-	// Windows doesn't work with a plugin cache directory.
-	// The cause is unknown, but it should work.
-	if t.cachePath != "" && runtime.GOOS != "windows" {
+	// Only Linux reliably works with the Terraform plugin
+	// cache directory. It's unknown why this is.
+	if t.cachePath != "" && runtime.GOOS == "linux" {
 		err = terraform.SetEnv(map[string]string{
 			"TF_PLUGIN_CACHE_DIR": t.cachePath,
 		})


### PR DESCRIPTION
It was occasionally failing without any clear indication of
what to fix on our side. The plugins weren't being found
by Terraform.

We already disable this on Windows, so figured it's fine on
Darwin too considering most production deployments will be Linux.
