### PR TITLE
chore: consolidate js, ts/js labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -41,6 +41,9 @@ updates:
       timezone: "America/Chicago"
     commit-message:
       prefix: "chore"
+    labels:
+      - "dependencies"
+      - "typescript/js"
     ignore:
       # Ignore major updates to Node.js types, because they need to
       # correspond to the Node.js engine version


### PR DESCRIPTION
Dependabot automagically applies the `javascript` label, but we use `typescript/js` elsewhere.
