### PR TITLE
feat: idea: Support start.yaml file for start command

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coder/coder/buildinfo"
-	"github.com/coder/coder/cli/cliflag"
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/cli/config"
 	"github.com/coder/coder/codersdk"
@@ -29,11 +28,6 @@ const (
 )
 
 func Root() *cobra.Command {
-	var (
-		localConfig string
-		forceTTY    bool
-		noOpen      bool
-	)
 	cmd := &cobra.Command{
 		Use:           "coder",
 		Version:       buildinfo.Version(),
@@ -82,14 +76,14 @@ func Root() *cobra.Command {
 		workspaceAgent(),
 	)
 
-	cliflag.StringVarP(cmd.PersistentFlags(), &localConfig, varGlobalConfig, "", "CODER_GLOBAL_CONFIG", configdir.LocalConfig("coderv2"), "Path to the global `coder` config directory")
-	cliflag.BoolVarP(cmd.PersistentFlags(), &forceTTY, varForceTty, "", "CODER_FORCE_TTY", false, "Force the `coder` command to run as if connected to a TTY")
+	cmd.PersistentFlags().String(varGlobalConfig, configdir.LocalConfig("coderv2"), "Path to the global `coder` config directory")
+	cmd.PersistentFlags().Bool(varForceTty, false, "Force the `coder` command to run as if connected to a TTY")
 	err := cmd.PersistentFlags().MarkHidden(varForceTty)
 	if err != nil {
 		// This should never return an error, because we just added the `--force-tty`` flag prior to calling MarkHidden.
 		panic(err)
 	}
-	cliflag.BoolVarP(cmd.PersistentFlags(), &noOpen, varNoOpen, "", "CODER_NO_OPEN", false, "Block automatically opening URLs in the browser.")
+	cmd.PersistentFlags().Bool(varNoOpen, false, "Block automatically opening URLs in the browser.")
 	err = cmd.PersistentFlags().MarkHidden(varNoOpen)
 	if err != nil {
 		panic(err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -31,7 +31,6 @@ const (
 func Root() *cobra.Command {
 	var (
 		localConfig string
-		startConfig string
 		forceTTY    bool
 		noOpen      bool
 	)

--- a/cli/root.go
+++ b/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coder/coder/buildinfo"
+	"github.com/coder/coder/cli/cliflag"
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/cli/config"
 	"github.com/coder/coder/codersdk"
@@ -28,6 +29,12 @@ const (
 )
 
 func Root() *cobra.Command {
+	var (
+		localConfig string
+		startConfig string
+		forceTTY    bool
+		noOpen      bool
+	)
 	cmd := &cobra.Command{
 		Use:           "coder",
 		Version:       buildinfo.Version(),
@@ -76,14 +83,14 @@ func Root() *cobra.Command {
 		workspaceAgent(),
 	)
 
-	cmd.PersistentFlags().String(varGlobalConfig, configdir.LocalConfig("coderv2"), "Path to the global `coder` config directory")
-	cmd.PersistentFlags().Bool(varForceTty, false, "Force the `coder` command to run as if connected to a TTY")
+	cliflag.StringVarP(cmd.PersistentFlags(), &localConfig, varGlobalConfig, "", "CODER_GLOBAL_CONFIG", configdir.LocalConfig("coderv2"), "Path to the global `coder` config directory")
+	cliflag.BoolVarP(cmd.PersistentFlags(), &forceTTY, varForceTty, "", "CODER_FORCE_TTY", false, "Force the `coder` command to run as if connected to a TTY")
 	err := cmd.PersistentFlags().MarkHidden(varForceTty)
 	if err != nil {
 		// This should never return an error, because we just added the `--force-tty`` flag prior to calling MarkHidden.
 		panic(err)
 	}
-	cmd.PersistentFlags().Bool(varNoOpen, false, "Block automatically opening URLs in the browser.")
+	cliflag.BoolVarP(cmd.PersistentFlags(), &noOpen, varNoOpen, "", "CODER_NO_OPEN", false, "Block automatically opening URLs in the browser.")
 	err = cmd.PersistentFlags().MarkHidden(varNoOpen)
 	if err != nil {
 		panic(err)

--- a/cli/start.go
+++ b/cli/start.go
@@ -42,12 +42,15 @@ import (
 )
 
 func start() *cobra.Command {
-	var flagConfig startConfig
+	var (
+		startConfigFile string
+		flagConfig      startConfig
+	)
 	root := &cobra.Command{
 		Use: "start",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// read start.yaml config file and apply flag and env var overrides
-			cfg := mergeStartConfig(cmd, flagConfig)
+			cfg := mergeStartConfig(startConfigFile, flagConfig)
 
 			if cfg.TraceDatadog {
 				tracer.Start()
@@ -336,6 +339,7 @@ func start() *cobra.Command {
 		},
 	}
 
+	cliflag.StringVarP(root.Flags(), &startConfigFile, "start-config", "", "CODER_START_CONFIG", "", "Specifies the start.yaml config file location")
 	cliflag.StringVarP(root.Flags(), &flagConfig.AccessURL, "access-url", "", "CODER_ACCESS_URL", "", "Specifies the external URL to access Coder")
 	cliflag.StringVarP(root.Flags(), &flagConfig.Address, "address", "a", "CODER_ADDRESS", "127.0.0.1:3000", "The address to serve the API and dashboard")
 	// systemd uses the CACHE_DIRECTORY environment variable!

--- a/cli/start.go
+++ b/cli/start.go
@@ -321,7 +321,7 @@ func start() *cobra.Command {
 				spin.Stop()
 			}
 
-			if dev && !skipTunnel {
+			if cfg.Dev && !cfg.SkipTunnel {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), cliui.Styles.Prompt.String()+"Waiting for dev tunnel to close...\n")
 				closeTunnel()
 				<-tunnelErrChan

--- a/cli/startconfig.go
+++ b/cli/startconfig.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type startConfig struct {
+	AccessURL              string `yaml:"access-url"`
+	Address                string `yaml:"address"`
+	CacheDir               string `yaml:"cache-dir"`
+	Dev                    bool   `yaml:"dev"`
+	PostgresURL            string `yaml:"postgres-url"`
+	ProvisionerDaemonCount uint8  `yaml:"provisioner-daemons"`
+	TLSCertFile            string `yaml:"tls-cert-file"`
+	TLSClientCAFile        string `yaml:"tls-client-ca-file"`
+	TLSClientAuth          string `yaml:"tls-client-auth"`
+	TLSEnable              bool   `yaml:"tls-enable"`
+	TLSKeyFile             string `yaml:"tls-key-file"`
+	TLSMinVersion          string `yaml:"tls-min-version"`
+	SkipTunnel             bool   `yaml:"skip-tunnel"`
+	TraceDatadog           bool   `yaml:"trace-datadog"`
+	SecureAuthCookie       bool   `yaml:"secure-auth-cookie"`
+	SSHKeygenAlgorithmRaw  string `yaml:"ssh-keygen-algorithm"`
+}
+
+func parseStartConfig(path string) startConfig {
+	var cfg startConfig
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return startConfig{}
+	}
+	err = yaml.Unmarshal(b, cfg)
+	if err != nil {
+		return startConfig{}
+	}
+
+	return cfg
+}

--- a/cli/startconfig.go
+++ b/cli/startconfig.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"os"
 
-	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,69 +25,65 @@ type startConfig struct {
 	SSHKeygenAlgorithmRaw  string `yaml:"ssh-keygen-algorithm"`
 }
 
-func mergeStartConfig(cmd *cobra.Command, flags startConfig) startConfig {
-	var cfg startConfig
-	f, err := cmd.Flags().GetString(varStartConfig)
+func mergeStartConfig(file string, flagCfg startConfig) startConfig {
+	var fileCfg startConfig
+	b, err := os.ReadFile(file)
 	if err != nil {
-		return flags
+		return flagCfg
 	}
-	b, err := os.ReadFile(f)
+	err = yaml.Unmarshal(b, fileCfg)
 	if err != nil {
-		return flags
-	}
-	err = yaml.Unmarshal(b, cfg)
-	if err != nil {
-		return flags
+		return flagCfg
 	}
 
-	if flags.AccessURL != "" {
-		cfg.AccessURL = flags.AccessURL
+	if flagCfg.AccessURL != "" {
+		fileCfg.AccessURL = flagCfg.AccessURL
 	}
-	if flags.Address != "" {
-		cfg.Address = flags.Address
+	if flagCfg.Address != "" {
+		fileCfg.Address = flagCfg.Address
 	}
-	if flags.CacheDir != "" {
-		cfg.CacheDir = flags.CacheDir
+	if flagCfg.CacheDir != "" {
+		fileCfg.CacheDir = flagCfg.CacheDir
 	}
-	if flags.Dev {
-		cfg.Dev = flags.Dev
+	if flagCfg.Dev {
+		fileCfg.Dev = flagCfg.Dev
 	}
-	if flags.PostgresURL != "" {
-		cfg.PostgresURL = flags.PostgresURL
+	if flagCfg.PostgresURL != "" {
+		fileCfg.PostgresURL = flagCfg.PostgresURL
 	}
-	if flags.ProvisionerDaemonCount != 0 {
-		cfg.ProvisionerDaemonCount = flags.ProvisionerDaemonCount
+	if flagCfg.ProvisionerDaemonCount != 0 {
+		fileCfg.ProvisionerDaemonCount = flagCfg.ProvisionerDaemonCount
 	}
-	if flags.TLSCertFile != "" {
-		cfg.TLSCertFile = flags.TLSCertFile
+	if flagCfg.TLSCertFile != "" {
+		fileCfg.TLSCertFile = flagCfg.TLSCertFile
 	}
-	if flags.TLSClientCAFile != "" {
-		cfg.TLSClientCAFile = flags.TLSClientCAFile
+	if flagCfg.TLSClientCAFile != "" {
+		fileCfg.TLSClientCAFile = flagCfg.TLSClientCAFile
 	}
-	if flags.TLSClientAuth != "" {
-		cfg.TLSClientAuth = flags.TLSClientAuth
+	if flagCfg.TLSClientAuth != "" {
+		fileCfg.TLSClientAuth = flagCfg.TLSClientAuth
 	}
-	if flags.TLSEnable {
-		cfg.TLSEnable = flags.TLSEnable
+	if flagCfg.TLSEnable {
+		fileCfg.TLSEnable = flagCfg.TLSEnable
 	}
-	if flags.TLSKeyFile != "" {
-		cfg.TLSKeyFile = flags.TLSKeyFile
+	if flagCfg.TLSKeyFile != "" {
+		fileCfg.TLSKeyFile = flagCfg.TLSKeyFile
 	}
-	if flags.TLSMinVersion != "" {
-		cfg.TLSMinVersion = flags.TLSMinVersion
+	if flagCfg.TLSMinVersion != "" {
+		fileCfg.TLSMinVersion = flagCfg.TLSMinVersion
 	}
-	if flags.SkipTunnel {
-		cfg.SkipTunnel = flags.SkipTunnel
+	if flagCfg.SkipTunnel {
+		fileCfg.SkipTunnel = flagCfg.SkipTunnel
 	}
-	if flags.TraceDatadog {
-		cfg.TraceDatadog = flags.TraceDatadog
+	if flagCfg.TraceDatadog {
+		fileCfg.TraceDatadog = flagCfg.TraceDatadog
 	}
-	if flags.SecureAuthCookie {
-		cfg.SecureAuthCookie = flags.SecureAuthCookie
+	if flagCfg.SecureAuthCookie {
+		fileCfg.SecureAuthCookie = flagCfg.SecureAuthCookie
 	}
-	if flags.SSHKeygenAlgorithmRaw != "" {
-		cfg.SSHKeygenAlgorithmRaw = flags.SSHKeygenAlgorithmRaw
+	if flagCfg.SSHKeygenAlgorithmRaw != "" {
+		fileCfg.SSHKeygenAlgorithmRaw = flagCfg.SSHKeygenAlgorithmRaw
 	}
 
-	return cfg
+	return fileCfg
 }

--- a/cli/startconfig.go
+++ b/cli/startconfig.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
@@ -25,15 +26,68 @@ type startConfig struct {
 	SSHKeygenAlgorithmRaw  string `yaml:"ssh-keygen-algorithm"`
 }
 
-func parseStartConfig(path string) startConfig {
+func mergeStartConfig(cmd *cobra.Command, flags startConfig) startConfig {
 	var cfg startConfig
-	b, err := os.ReadFile(path)
+	f, err := cmd.Flags().GetString(varStartConfig)
 	if err != nil {
-		return startConfig{}
+		return flags
+	}
+	b, err := os.ReadFile(f)
+	if err != nil {
+		return flags
 	}
 	err = yaml.Unmarshal(b, cfg)
 	if err != nil {
-		return startConfig{}
+		return flags
+	}
+
+	if flags.AccessURL != "" {
+		cfg.AccessURL = flags.AccessURL
+	}
+	if flags.Address != "" {
+		cfg.Address = flags.Address
+	}
+	if flags.CacheDir != "" {
+		cfg.CacheDir = flags.CacheDir
+	}
+	if flags.Dev {
+		cfg.Dev = flags.Dev
+	}
+	if flags.PostgresURL != "" {
+		cfg.PostgresURL = flags.PostgresURL
+	}
+	if flags.ProvisionerDaemonCount != 0 {
+		cfg.ProvisionerDaemonCount = flags.ProvisionerDaemonCount
+	}
+	if flags.TLSCertFile != "" {
+		cfg.TLSCertFile = flags.TLSCertFile
+	}
+	if flags.TLSClientCAFile != "" {
+		cfg.TLSClientCAFile = flags.TLSClientCAFile
+	}
+	if flags.TLSClientAuth != "" {
+		cfg.TLSClientAuth = flags.TLSClientAuth
+	}
+	if flags.TLSEnable {
+		cfg.TLSEnable = flags.TLSEnable
+	}
+	if flags.TLSKeyFile != "" {
+		cfg.TLSKeyFile = flags.TLSKeyFile
+	}
+	if flags.TLSMinVersion != "" {
+		cfg.TLSMinVersion = flags.TLSMinVersion
+	}
+	if flags.SkipTunnel {
+		cfg.SkipTunnel = flags.SkipTunnel
+	}
+	if flags.TraceDatadog {
+		cfg.TraceDatadog = flags.TraceDatadog
+	}
+	if flags.SecureAuthCookie {
+		cfg.SecureAuthCookie = flags.SecureAuthCookie
+	}
+	if flags.SSHKeygenAlgorithmRaw != "" {
+		cfg.SSHKeygenAlgorithmRaw = flags.SSHKeygenAlgorithmRaw
 	}
 
 	return cfg


### PR DESCRIPTION
This PR enables support for a yaml based config file named `start.yaml` that can be used as an alternative to flags and env variables. While flags and env vars are elegantly simple, they unfortunately do not gracefully support array or map like data structures. I forsee this being a problem when want to support features like multiple OIDC logins. 

## What this does:

- Looks for config file at `--start-config`
- Builds a start command config struct
- Passes those values into the `cliflags` functions as defaults - creating the following parsing priority order:
```
flags > env vars > config file
```
- If no config file exists no behavior from today changes (I didn't have to change any tests)

Example `start.yaml`:
```yaml
access-url: "http://mysite.org"
oidc:
- name: "keycloak"
  client-id: "coder-stable"
  client-secret: "***************"
  issuer: "https://keycloak.cdr.dev/auth/realms/google"
  additional-scopes: ".default"
- name: "new OIDC"
  client-id: "coder-stable"
  client-secret: "***************"
  issuer: "https://keycloak.cdr.dev/auth/realms/google"
  additional-scopes: ".differentScopes"
```

## Discussion

Static config is a very powerful tool to application administrators. It allows their infrastructure to be more ephemeral - they can tear down the deployment, lose the database, and start from scratch and still have OIDC working on first startup. I have some customer evidence of this being an ideal workflow for more established organizations. 

I'd like to use this PR to discuss if this would be something we would like to implement into the coderV2 product. 

