### PR TITLE
chore: fix storybook warnings

### DIFF
--- a/site/.storybook/main.js
+++ b/site/.storybook/main.js
@@ -23,7 +23,7 @@ module.exports = {
   // SEE: https://storybook.js.org/docs/react/configure/babel
   babel: async (options) => ({
     ...options,
-    plugins: ["@babel/plugin-proposal-class-properties"],
+    plugins: [["@babel/plugin-proposal-class-properties", { loose: true }]],
   }),
 
   // Static files loaded by storybook, relative to this file.

--- a/site/.storybook/main.js
+++ b/site/.storybook/main.js
@@ -26,6 +26,11 @@ module.exports = {
     plugins: ["@babel/plugin-proposal-class-properties"],
   }),
 
+  // Static files loaded by storybook, relative to this file.
+  //
+  // SEE: https://storybook.js.org/docs/react/configure/overview#using-storybook-api
+  staticDirs: ["../static"],
+
   // Storybook internally uses its own Webpack configuration instead of ours.
   //
   // SEE: https://storybook.js.org/docs/react/configure/webpack

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,7 @@
     "playwright:install": "playwright install",
     "playwright:install-deps": "playwright install-deps",
     "playwright:test": "playwright test --config=e2e/playwright.config.ts",
-    "storybook": "start-storybook -p 6006 -s ./static",
+    "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
     "test": "jest --selectProjects test",
     "test:coverage": "jest --selectProjects test --collectCoverage",


### PR DESCRIPTION
Summary:

Just fixes some warnings caused by deprecations and inconsistent babel
configs.

Details:

- https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#64-deprecations
- set `{ "loose": true }` for `@babel/plugin-proposal-class-properties`

Impact:

Clearer output from Storybook while developing

Resolves: #533 