### PR TITLE
ci: remove building from test/js

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -386,10 +386,6 @@ jobs:
       - name: Install node_modules
         run: ./scripts/yarn_install.sh
 
-      - name: Build frontend
-        run: yarn build
-        working-directory: site
-
       - run: yarn test:coverage
         working-directory: site
 


### PR DESCRIPTION
Summary:

There's no reason to build in `test/js`, since we have e2e tests that build.

Details:

- Remove superfluous `yarn build` from `test/js` step in CI

Relates to #1004 but does not fix it.