### PR TITLE
ci: reduce maxWorkers in jest tests

### DIFF
--- a/site/jest.config.js
+++ b/site/jest.config.js
@@ -4,7 +4,7 @@
 //         unexpectedly, leading to OOM kills.
 //
 // SEE thread: https://github.com/coder/coder/pull/483#discussion_r829636583
-const maxWorkers = process.env.CI ? 16 : 2
+const maxWorkers = 2
 
 module.exports = {
   maxWorkers,


### PR DESCRIPTION
Summary:

When `maxWorkers` is high, there's a bug in `jest` that causes OOM kills.
Unfortunately, CI is experiencing this as well as local. For now, the best solution
is just reducing `maxWorkers`.

Resolves: #1004