### PR TITLE
refactor: strong type for getFormHelpers name

### DIFF
--- a/site/src/components/Form/index.ts
+++ b/site/src/components/Form/index.ts
@@ -17,8 +17,13 @@ interface FormHelpers {
   helperText?: string
 }
 
-export const getFormHelpers = <T>(form: FormikContextType<T>, name: string, error?: string): FormHelpers => {
-  // getIn is a util function from Formik that gets at any depth of nesting, and is necessary for the types to work
+export const getFormHelpers = <T>(form: FormikContextType<T>, name: keyof T, error?: string): FormHelpers => {
+  if (typeof name !== "string") {
+    throw new Error(`name must be type of string, instead received '${typeof name}'`)
+  }
+
+  // getIn is a util function from Formik that gets at any depth of nesting
+  // and is necessary for the types to work
   const touched = getIn(form.touched, name)
   const errors = error ?? getIn(form.errors, name)
   return {


### PR DESCRIPTION
Summary:

Modify `getFormHelpers` so that only the keys of the generic form interface
can be passed in for `name`.

Details:

Keys of an object in TS can naturally be of `string | number | symbol`. I don't think
there's an easy way to re-genericize this helper and type things that gets around this,
so I took the simple path of throwing an `Error` on `typeof !== "string"`.

Impact:

Minor improvement to dev experience using `getFormHelpers` (compile-time safety).