### PR TITLE
chore: update semantic types

### DIFF
--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -32,7 +32,7 @@ types:
   # Any work performed on CI.
   - ci
   
-  # Work that creates or improves examples
+  # Work that creates or improves examples.
   - example
 
   # Work that directly implements or supports the implementation of a feature.

--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -32,7 +32,6 @@ types:
   # Any work performed on CI.
   - ci
   
-  # Work that creates or improves examples.
   - example
 
   # Work that directly implements or supports the implementation of a feature.

--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -25,7 +25,7 @@ types:
   # A build of any kind.
   - build
 
-  # Any code task that operats outside of CI, docs, or the product. Examples
+  # Any code task that operates outside of CI, docs, or the product. Examples
   # include configurations, linters etc.
   - chore
 

--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -25,26 +25,23 @@ types:
   # A build of any kind.
   - build
 
-  # A RELEASED fix that will NOT be back-ported. The originating issue may have
-  # been discovered internally or externally to Coder.
-  - fix
-
-  # Any code task that is ignored for changelog purposes. Examples include
-  # devbin scripts and internal-only configurations.
+  # Any code task that operats outside of CI, docs, or the product. Examples
+  # include configurations, linters etc.
   - chore
 
   # Any work performed on CI.
   - ci
-
-  # An UNRELEASED correction. For example, features are often built
-  # incrementally and sometimes introduce minor flaws during a release cycle.
-  # Corrections address those increments and flaws.
-  - correct
+  
+  # Any work that improves documentation and examples.
+  - docs
 
   # Work that directly implements or supports the implementation of a feature.
   - feat
 
-  # A fix for a RELEASED bug (regression fix) that is intended for patch-release
+  # A fix for either a released or unrelesed bug.
+  - fix
+
+  # A fix for a released bug (regression fix) that is intended for patch-release
   # purposes.
   - hotfix
 

--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -32,8 +32,8 @@ types:
   # Any work performed on CI.
   - ci
   
-  # Any work that improves documentation and examples.
-  - docs
+  # Work that creates or improves examples
+  - example
 
   # Work that directly implements or supports the implementation of a feature.
   - feat


### PR DESCRIPTION
Summary:

PRs like #1025 feel like they deserve an `example:` type, but we didn't have one.
Furthermore our definitions for correct, fix, and hotfix were stale.