### PR TITLE
fix: Remove quotes on GitSSH

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -237,7 +237,7 @@ func (a *agent) handleSSHSession(session ssh.Session) error {
 	if err != nil {
 		return xerrors.Errorf("getting os executable: %w", err)
 	}
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_SSH_COMMAND="%s gitssh --"`, executablePath))
+	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_SSH_COMMAND=%s gitssh --`, executablePath))
 
 	sshPty, windowSize, isPty := session.Pty()
 	if isPty {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -57,7 +57,7 @@ func TestAgent(t *testing.T) {
 		}
 		output, err := session.Output(command)
 		require.NoError(t, err)
-		require.Contains(t, string(output), "gitssh --")
+		require.True(t, strings.HasSuffix(strings.TrimSpace(string(output)), "gitssh --"))
 	})
 
 	t.Run("SessionTTY", func(t *testing.T) {


### PR DESCRIPTION
This was a bug @f0ssel found that was breaking gitssh.
