### PR TITLE
feat: Sign MacOS binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - "v*"
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -13,6 +13,17 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "~1.18"
+
+      - name: Install Gon
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+
+      - name: Import Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.AC_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.AC_CERTIFICATE_PASSWORD }}
 
       - name: Echo Go Cache Paths
         id: go-cache-paths
@@ -53,3 +64,5 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,13 +1,24 @@
 archives:
-  - id: coder
-    builds:
-      - coder
+  - id: coder-linux
+    builds: [coder-linux]
+    format: tar
     files:
       - src: docs/README.md
         dst: README.md
-    format_overrides:
-      - goos: windows
-        format: zip
+
+  - id: coder-darwin
+    builds: [coder-darwin]
+    format: zip
+    files:
+      - src: docs/README.md
+        dst: README.md
+
+  - id: coder-windows
+    builds: [coder-windows]
+    format: zip
+    files:
+      - src: docs/README.md
+        dst: README.md
 
 before:
   hooks:
@@ -27,14 +38,43 @@ builds:
       post: |
         cp {{.Path}} site/out/bin/coder-{{ .Os }}-{{ .Arch }}{{ trimprefix .Name "coder" }}
 
-  - id: coder
+  - id: coder-linux
     dir: cmd/coder
-    flags: ["-tags=embed"]
+    flags: [-tags=embed]
     ldflags:
       ["-s -w -X github.com/coder/coder/cli/buildinfo.tag={{ .Version }}"]
     env: [CGO_ENABLED=0]
-    goos: [darwin, linux, windows]
+    goos: [linux]
     goarch: [amd64, arm64]
+
+  - id: coder-windows
+    dir: cmd/coder
+    flags: [-tags=embed]
+    ldflags:
+      ["-s -w -X github.com/coder/coder/cli/buildinfo.tag={{ .Version }}"]
+    env: [CGO_ENABLED=0]
+    goos: [windows]
+    goarch: [amd64, arm64]
+
+  - id: coder-darwin
+    dir: cmd/coder
+    flags: [-tags=embed]
+    ldflags:
+      ["-s -w -X github.com/coder/coder/cli/buildinfo.tag={{ .Version }}"]
+    env: [CGO_ENABLED=0]
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    hooks:
+      # This signs the binary that will be located inside the zip.
+      # MacOS requires the binary to be signed for notarization.
+      # 
+      # If it doesn't successfully sign, the zip sign step will error.
+      post: |
+        sh -c 'codesign -s {{.Env.AC_APPLICATION_IDENTITY}} -f -v --timestamp --options runtime {{.Path}} || true'
+
+env:
+  # Apple identity for signing!
+  - AC_APPLICATION_IDENTITY=BDB050EB749EDD6A80C6F119BF1382ECA119CCCC
 
 nfpms:
   - id: packages
@@ -50,7 +90,7 @@ nfpms:
     suggests:
       - postgresql
     builds:
-      - coder
+      - coder-linux
     bindir: /usr/bin
     contents:
       - src: coder.env
@@ -60,7 +100,14 @@ nfpms:
         dst: /usr/lib/systemd/system/coder.service
 
 release:
-  ids: [coder, packages]
+  ids: [coder-linux, coder-darwin, coder-windows, packages]
+
+signs:
+  - ids: [coder-darwin]
+    artifacts: archive
+    cmd: ./scripts/sign_macos.sh
+    args: ["${artifact}"]
+    output: true
 
 snapshot:
   name_template: "{{ .Version }}-devel+{{ .ShortCommit }}"

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ provisionersdk/proto: provisionersdk/proto/provisioner.proto
 		./provisionersdk/proto/provisioner.proto
 .PHONY: provisionersdk/proto
 
-release: site/out
-	goreleaser release --snapshot --rm-dist
+release:
+	goreleaser release --snapshot --rm-dist --skip-sign
 .PHONY: release
 
 site/out:
@@ -102,4 +102,3 @@ site/out:
 
 test:
 	gotestsum -- -v -short ./...
-

--- a/scripts/sign_macos.sh
+++ b/scripts/sign_macos.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+codesign -s $AC_APPLICATION_IDENTITY -f -v --timestamp --options runtime $1 
+
+config="$(mktemp -d)/gon.json" 
+jq -r --null-input --arg path "$(pwd)/$1" '{
+    "notarize": [
+        {
+            "path": $path,
+            "bundle_id": "com.coder.cli"
+        }
+    ]
+}' > $config
+gon $config


### PR DESCRIPTION
This fixes virus warnings when launching Coder on darwin.

~*This temporarily enabled the release workflow for testing. That will be fixed prior to merge!~