### PR TITLE
fix: Disable TURN logs

### DIFF
--- a/coderd/turnconn/turnconn.go
+++ b/coderd/turnconn/turnconn.go
@@ -42,7 +42,7 @@ func New(relayAddress *turn.RelayAddressGeneratorStatic) (*Server, error) {
 		}
 	}
 	logger := logging.NewDefaultLoggerFactory()
-	logger.DefaultLogLevel = logging.LogLevelDebug
+	logger.DefaultLogLevel = logging.LogLevelDisabled
 	server := &Server{
 		conns:  make(chan net.Conn, 1),
 		closed: make(chan struct{}),


### PR DESCRIPTION
This was accidentally merged as part of the TURN PR. In the future
we can wrap this to provide useful output, but right now it's too
verbose.
