### PR TITLE
fix: types-generated.ts

### DIFF
--- a/site/src/api/types-generated.ts
+++ b/site/src/api/types-generated.ts
@@ -210,11 +210,11 @@ export interface UpdateWorkspaceAutostopRequest {
   readonly schedule: string
 }
 
-// From codersdk/workspaceresources.go:15:6.
-export type WorkspaceAgentStatus = "connecting" | "connected" | "disconnected"
-
 // From codersdk/parameters.go:16:6.
 export type ParameterScope = "organization" | "template" | "user" | "workspace"
 
 // From codersdk/provisionerdaemons.go:26:6.
 export type ProvisionerJobStatus = "pending" | "running" | "succeeded" | "canceling" | "canceled" | "failed"
+
+// From codersdk/workspaceresources.go:15:6.
+export type WorkspaceAgentStatus = "connecting" | "connected" | "disconnected"


### PR DESCRIPTION
#1047 had inconsistent CI results in the PR vs as a commit in master. Opening this after running `make apitypings/generate` in my workspace to see if we can fix the situation or at least spot an inconsistency if there really is one.

cc @f0ssel and @kylecarbs 