### PR TITLE
chore: use /usr/bin/env bash

### DIFF
--- a/scripts/yarn_install.sh
+++ b/scripts/yarn_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run "yarn install" with flags appropriate to the environment
 # (local development vs build system)


### PR DESCRIPTION
This PR fixes an issue with running the `./develop.sh` script where `/bin/bash` is modified differently on a user's local machine. This change also makes `./develop.sh` and `./yarn_install.sh` more consistent. 

## Subtasks

- [x] tested locally

