### PR TITLE
chore: allow process.env.PORT in webpack.dev

### DIFF
--- a/site/webpack.dev.ts
+++ b/site/webpack.dev.ts
@@ -58,7 +58,7 @@ const config: Configuration = {
     // properly serving index.html on 404s.
     historyApiFallback: true,
     hot: true,
-    port: 8080,
+    port: process.env.PORT || 8080,
     proxy: {
       "/api": "http://localhost:3000",
     },


### PR DESCRIPTION
This PR adds a small improvement which allows you to override the port that webpack runs on using `PORT` as an environment variable. Adding this because some folks use applications (aka code-server) that run on 8080.