### PR TITLE
chore: fix develop processes not killing

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -14,5 +14,6 @@ cd "${PROJECT_ROOT}"
 (
   trap 'kill 0' SIGINT
   CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
-  go run cmd/coder/main.go start --dev --skip-tunnel
+  go run cmd/coder/main.go start --dev --skip-tunnel &
+  wait
 )


### PR DESCRIPTION
While running the `./develop.sh` script locally and then hitting Ctrl+C to kill, it doesn't always kill the processes. After reading [this StackOverflow answer](https://stackoverflow.com/questions/3004811/how-do-you-run-multiple-programs-in-parallel-from-a-bash-script), it seems like we need to add `wait`.