### PR TITLE
chore: assign site/ to frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-site @coder/frontend
+site/ @coder/frontend
 site/src/xServices @presleyp


### PR DESCRIPTION
It didn't seem like this was working as we expected. I think it's because we didn't have the `/` based on [these docs](https://docs.github.com/en/enterprise-server@3.1/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).