### PR TITLE
fix: Add site to release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ provisionersdk/proto: provisionersdk/proto/provisioner.proto
 		./provisionersdk/proto/provisioner.proto
 .PHONY: provisionersdk/proto
 
-release:
+release: site/out
 	goreleaser release --snapshot --rm-dist --skip-sign
 .PHONY: release
 


### PR DESCRIPTION
This was accidentally removed when adding MacOS signing.
