### PR TITLE
fix: Disable Windows Defender on agent binary

### DIFF
--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -14,6 +14,7 @@ var (
 			"amd64": `
 $ProgressPreference = "SilentlyContinue"
 Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-amd64.exe -OutFile $env:TEMP\sshd.exe
+Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
 $env:CODER_AUTH = "${AUTH_TYPE}"
 $env:CODER_URL = "${ACCESS_URL}"
 Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru


### PR DESCRIPTION
Windows (reasonably) detected our CLI as a virus due to the name
being "sshd" for VS Code support. See:
https://github.com/microsoft/vscode-remote-release/issues/5699

This disables monitoring for our binary prior to run, which
fixes our Windows example.
