### PR TITLE
fix: `make install` references incorrect folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ site/out/
 *.tfplan
 *.lock.hcl
 .terraform/
+
+.vscode/*.log

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ gen: coderd/database/generate peerbroker/proto provisionersdk/proto provisionerd
 
 install: bin
 	@echo "--- Copying from bin to $(INSTALL_DIR)"
-	cp -r ./dist/coder_$(GOOS)_$(GOARCH)/* $(INSTALL_DIR)
+	cp -r ./dist/coder-$(GOOS)_$(GOOS)_$(GOARCH)*/* $(INSTALL_DIR)
 	@echo "-- CLI available at $(shell ls $(INSTALL_DIR)/coder*)"
 .PHONY: install
 


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
