### PR TITLE
fix: Add resiliency to daemon connections

### DIFF
--- a/coderd/provisionerdaemons_test.go
+++ b/coderd/provisionerdaemons_test.go
@@ -1,0 +1,48 @@
+package coderd_test
+
+import (
+	"context"
+	"crypto/rand"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/coderd/database"
+	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/provisionersdk"
+)
+
+func TestProvisionerDaemons(t *testing.T) {
+	t.Parallel()
+	t.Run("PayloadTooBig", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == "windows" {
+			// Takes too long to allocate memory on Windows!
+			t.Skip()
+		}
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		coderdtest.NewProvisionerDaemon(t, client)
+		data := make([]byte, provisionersdk.MaxMessageSize)
+		rand.Read(data)
+		resp, err := client.Upload(context.Background(), codersdk.ContentTypeTar, data)
+		require.NoError(t, err)
+		t.Log(resp.Hash)
+
+		version, err := client.CreateTemplateVersion(context.Background(), user.OrganizationID, codersdk.CreateTemplateVersionRequest{
+			StorageMethod: database.ProvisionerStorageMethodFile,
+			StorageSource: resp.Hash,
+			Provisioner:   database.ProvisionerTypeEcho,
+		})
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			var err error
+			version, err = client.TemplateVersion(context.Background(), version.ID)
+			require.NoError(t, err)
+			return version.Job.Error != ""
+		}, 5*time.Second, 25*time.Millisecond)
+	})
+}

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -70,8 +70,8 @@ func (c *Client) ListenProvisionerDaemon(ctx context.Context) (proto.DRPCProvisi
 		}
 		return nil, readBodyAsError(res)
 	}
-	// Allow _somewhat_ large payloads.
-	conn.SetReadLimit((1 << 20) * 2)
+	// Align with the frame size of yamux.
+	conn.SetReadLimit(256 * 1024)
 
 	config := yamux.DefaultConfig()
 	config.LogOutput = io.Discard

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,9 @@ replace github.com/chzyer/readline => github.com/kylecarbs/readline v0.0.0-20220
 // Required until https://github.com/briandowns/spinner/pull/136 is merged.
 replace github.com/briandowns/spinner => github.com/kylecarbs/spinner v1.18.2-0.20220329160715-20702b5af89e
 
+// Required until https://github.com/storj/drpc/pull/31 is merged.
+replace storj.io/drpc => github.com/kylecarbs/drpc v0.0.31-0.20220424193521-8ebbaf48bdff
+
 // opencensus-go leaks a goroutine by default.
 replace go.opencensus.io => github.com/kylecarbs/opencensus-go v0.23.1-0.20220307014935-4d0325a68f8b
 

--- a/go.sum
+++ b/go.sum
@@ -1107,6 +1107,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq19sBYvuMoyQ4=
+github.com/kylecarbs/drpc v0.0.31-0.20220424193521-8ebbaf48bdff h1:7qg425aXdULnZWCCQNPOzHO7c+M6BpbTfOUJLrk5+3w=
+github.com/kylecarbs/drpc v0.0.31-0.20220424193521-8ebbaf48bdff/go.mod h1:6rcOyR/QQkSTX/9L5ZGtlZaE2PtXTTZl8d+ulSeeYEg=
 github.com/kylecarbs/opencensus-go v0.23.1-0.20220307014935-4d0325a68f8b h1:1Y1X6aR78kMEQE1iCjQodB3lA7VO4jB88Wf8ZrzXSsA=
 github.com/kylecarbs/opencensus-go v0.23.1-0.20220307014935-4d0325a68f8b/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 github.com/kylecarbs/readline v0.0.0-20220211054233-0d62993714c8/go.mod h1:n/KX1BZoN1m9EwoXkn/xAV4fd3k8c++gGBsgLONaPOY=
@@ -2544,5 +2546,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-storj.io/drpc v0.0.30 h1:jqPe4T9KEu3CDBI05A2hCMgMSHLtd/E0N0yTF9QreIE=
-storj.io/drpc v0.0.30/go.mod h1:6rcOyR/QQkSTX/9L5ZGtlZaE2PtXTTZl8d+ulSeeYEg=

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
@@ -126,6 +127,7 @@ func TestProvisionerd(t *testing.T) {
 		// Ensures tars with "../../../etc/passwd" as the path
 		// are not allowed to run, and will fail the job.
 		t.Parallel()
+		var complete sync.Once
 		completeChan := make(chan struct{})
 		closer := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
 			return createProvisionerDaemonClient(t, provisionerDaemonTestServer{
@@ -145,7 +147,9 @@ func TestProvisionerd(t *testing.T) {
 				},
 				updateJob: noopUpdateJob,
 				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
-					close(completeChan)
+					complete.Do(func() {
+						close(completeChan)
+					})
 					return &proto.Empty{}, nil
 				},
 			}), nil
@@ -158,6 +162,7 @@ func TestProvisionerd(t *testing.T) {
 
 	t.Run("RunningPeriodicUpdate", func(t *testing.T) {
 		t.Parallel()
+		var complete sync.Once
 		completeChan := make(chan struct{})
 		closer := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
 			return createProvisionerDaemonClient(t, provisionerDaemonTestServer{
@@ -176,11 +181,9 @@ func TestProvisionerd(t *testing.T) {
 					}, nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
-					select {
-					case <-completeChan:
-					default:
+					complete.Do(func() {
 						close(completeChan)
-					}
+					})
 					return &proto.UpdateJobResponse{}, nil
 				},
 				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
@@ -492,6 +495,7 @@ func TestProvisionerd(t *testing.T) {
 
 	t.Run("ShutdownFromJob", func(t *testing.T) {
 		t.Parallel()
+		var updated sync.Once
 		updateChan := make(chan struct{})
 		completeChan := make(chan struct{})
 		server := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
@@ -513,7 +517,9 @@ func TestProvisionerd(t *testing.T) {
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
 					if len(update.Logs) > 0 && update.Logs[0].Source == proto.LogSource_PROVISIONER {
 						// Close on a log so we know when the job is in progress!
-						close(updateChan)
+						updated.Do(func() {
+							close(updateChan)
+						})
 					}
 					return &proto.UpdateJobResponse{
 						Canceled: true,
@@ -555,6 +561,139 @@ func TestProvisionerd(t *testing.T) {
 			}),
 		})
 		<-updateChan
+		<-completeChan
+		require.NoError(t, server.Close())
+	})
+
+	t.Run("ReconnectAndFail", func(t *testing.T) {
+		t.Parallel()
+		var second atomic.Bool
+		failChan := make(chan struct{})
+		failedChan := make(chan struct{})
+		completeChan := make(chan struct{})
+		server := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
+			client := createProvisionerDaemonClient(t, provisionerDaemonTestServer{
+				acquireJob: func(ctx context.Context, _ *proto.Empty) (*proto.AcquiredJob, error) {
+					if second.Load() {
+						return &proto.AcquiredJob{}, nil
+					}
+					return &proto.AcquiredJob{
+						JobId:       "test",
+						Provisioner: "someprovisioner",
+						TemplateSourceArchive: createTar(t, map[string]string{
+							"test.txt": "content",
+						}),
+						Type: &proto.AcquiredJob_WorkspaceBuild_{
+							WorkspaceBuild: &proto.AcquiredJob_WorkspaceBuild{
+								Metadata: &sdkproto.Provision_Metadata{},
+							},
+						},
+					}, nil
+				},
+				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
+					return &proto.UpdateJobResponse{}, nil
+				},
+				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
+					if second.Load() {
+						close(completeChan)
+						return &proto.Empty{}, nil
+					}
+					close(failChan)
+					<-failedChan
+					return &proto.Empty{}, nil
+				},
+			})
+			if !second.Load() {
+				go func() {
+					<-failChan
+					_ = client.DRPCConn().Close()
+					second.Store(true)
+					close(failedChan)
+				}()
+			}
+			return client, nil
+		}, provisionerd.Provisioners{
+			"someprovisioner": createProvisionerClient(t, provisionerTestServer{
+				provision: func(stream sdkproto.DRPCProvisioner_ProvisionStream) error {
+					// Ignore the first provision message!
+					_, _ = stream.Recv()
+					return stream.Send(&sdkproto.Provision_Response{
+						Type: &sdkproto.Provision_Response_Complete{
+							Complete: &sdkproto.Provision_Complete{
+								Error: "some error",
+							},
+						},
+					})
+				},
+			}),
+		})
+		<-completeChan
+		require.NoError(t, server.Close())
+	})
+
+	t.Run("ReconnectAndComplete", func(t *testing.T) {
+		t.Parallel()
+		var second atomic.Bool
+		failChan := make(chan struct{})
+		failedChan := make(chan struct{})
+		completeChan := make(chan struct{})
+		server := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
+			client := createProvisionerDaemonClient(t, provisionerDaemonTestServer{
+				acquireJob: func(ctx context.Context, _ *proto.Empty) (*proto.AcquiredJob, error) {
+					if second.Load() {
+						close(completeChan)
+						return &proto.AcquiredJob{}, nil
+					}
+					return &proto.AcquiredJob{
+						JobId:       "test",
+						Provisioner: "someprovisioner",
+						TemplateSourceArchive: createTar(t, map[string]string{
+							"test.txt": "content",
+						}),
+						Type: &proto.AcquiredJob_WorkspaceBuild_{
+							WorkspaceBuild: &proto.AcquiredJob_WorkspaceBuild{
+								Metadata: &sdkproto.Provision_Metadata{},
+							},
+						},
+					}, nil
+				},
+				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
+					return nil, yamux.ErrSessionShutdown
+				},
+				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
+					return &proto.UpdateJobResponse{}, nil
+				},
+				completeJob: func(ctx context.Context, job *proto.CompletedJob) (*proto.Empty, error) {
+					if second.Load() {
+						return &proto.Empty{}, nil
+					}
+					close(failChan)
+					<-failedChan
+					return &proto.Empty{}, nil
+				},
+			})
+			if !second.Load() {
+				go func() {
+					<-failChan
+					_ = client.DRPCConn().Close()
+					second.Store(true)
+					close(failedChan)
+				}()
+			}
+			return client, nil
+		}, provisionerd.Provisioners{
+			"someprovisioner": createProvisionerClient(t, provisionerTestServer{
+				provision: func(stream sdkproto.DRPCProvisioner_ProvisionStream) error {
+					// Ignore the first provision message!
+					_, _ = stream.Recv()
+					return stream.Send(&sdkproto.Provision_Response{
+						Type: &sdkproto.Provision_Response_Complete{
+							Complete: &sdkproto.Provision_Complete{},
+						},
+					})
+				},
+			}),
+		})
 		<-completeChan
 		require.NoError(t, server.Close())
 	})

--- a/provisionersdk/transport.go
+++ b/provisionersdk/transport.go
@@ -9,6 +9,12 @@ import (
 	"storj.io/drpc/drpcconn"
 )
 
+const (
+	// MaxMessageSize is the maximum payload size that can be
+	// transported without error.
+	MaxMessageSize = 4 << 20
+)
+
 // TransportPipe creates an in-memory pipe for dRPC transport.
 func TransportPipe() (*yamux.Session, *yamux.Session) {
 	clientReader, clientWriter := io.Pipe()


### PR DESCRIPTION
Connections could fail when massive payloads were transmitted.
This fixes an upstream bug in dRPC where the connection would
end with a context canceled if a message was too large.

This adds retransmission of completion and failures too. If
Coder somehow loses connection with a provisioner daemon,
upon the next connection the state will be properly reported.
