### PR TITLE
fix: Check for job status on another incoming

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -166,7 +166,7 @@ func (api *api) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	priorHistory, err := api.Database.GetWorkspaceBuildByWorkspaceIDWithoutAfter(r.Context(), workspace.ID)
 	if err == nil {
 		priorJob, err := api.Database.GetProvisionerJobByID(r.Context(), priorHistory.JobID)
-		if err == nil && !priorJob.CompletedAt.Valid {
+		if err == nil && convertProvisionerJob(priorJob).Status.Active() {
 			httpapi.Write(rw, http.StatusConflict, httpapi.Response{
 				Message: "a workspace build is already active",
 			})

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -25,6 +25,15 @@ type ProvisionerDaemon database.ProvisionerDaemon
 // ProvisionerJobStaus represents the at-time state of a job.
 type ProvisionerJobStatus string
 
+// Active returns whether the job is still active or not.
+// It returns true if canceling as well, since the job isn't
+// in an entirely inactive state yet.
+func (p ProvisionerJobStatus) Active() bool {
+	return p == ProvisionerJobPending ||
+		p == ProvisionerJobRunning ||
+		p == ProvisionerJobCanceling
+}
+
 const (
 	ProvisionerJobPending   ProvisionerJobStatus = "pending"
 	ProvisionerJobRunning   ProvisionerJobStatus = "running"

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -46,13 +46,13 @@ export interface CreateParameterRequest {
   readonly source_value: string
 }
 
-// From codersdk/provisionerdaemons.go:37:6.
+// From codersdk/provisionerdaemons.go:46:6.
 export interface ProvisionerJob {
   readonly error: string
   readonly status: ProvisionerJobStatus
 }
 
-// From codersdk/provisionerdaemons.go:47:6.
+// From codersdk/provisionerdaemons.go:56:6.
 export interface ProvisionerJobLog {
   readonly stage: string
   readonly output: string


### PR DESCRIPTION
If a job silently failed, it wasn't possible for another one
to execute. This fixes it by using the API status to return
active state.
