### PR TITLE
fix: Monitor TTY size when using SSH

### DIFF
--- a/cli/ssh_other.go
+++ b/cli/ssh_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+// +build !windows
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"golang.org/x/sys/unix"
+)
+
+func listenWindowSize(ctx context.Context) <-chan os.Signal {
+	windowSize := make(chan os.Signal, 1)
+	signal.Notify(windowSize, unix.SIGWINCH)
+	go func() {
+		<-ctx.Done()
+		signal.Stop(windowSize)
+	}()
+	return windowSize
+}

--- a/cli/ssh_windows.go
+++ b/cli/ssh_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+package cli
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+func listenWindowSize(ctx context.Context) <-chan os.Signal {
+	windowSize := make(chan os.Signal, 3)
+	ticker := time.NewTicker(time.Second)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			windowSize <- nil
+		}
+	}()
+	return windowSize
+}


### PR DESCRIPTION
The TTY wasn't resizing properly, and reasonably so considering
we weren't updating it 🤦.
