### PR TITLE
fix: Remove unique index on auth tokens

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -339,9 +339,6 @@ ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY workspace_agents
-    ADD CONSTRAINT workspace_agents_auth_token_key UNIQUE (auth_token);
-
-ALTER TABLE ONLY workspace_agents
     ADD CONSTRAINT workspace_agents_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY workspace_builds

--- a/coderd/database/migrations/000004_jobs.up.sql
+++ b/coderd/database/migrations/000004_jobs.up.sql
@@ -80,7 +80,7 @@ CREATE TABLE workspace_agents (
     last_connected_at timestamptz,
     disconnected_at timestamptz,
     resource_id uuid NOT NULL REFERENCES workspace_resources (id) ON DELETE CASCADE,
-    auth_token uuid NOT NULL UNIQUE,
+    auth_token uuid NOT NULL,
     auth_instance_id varchar(64),
     architecture varchar(64) NOT NULL,
     environment_variables jsonb,


### PR DESCRIPTION
If a workspace is started multiple times, resources may
not be invalidated. This means an auth token can be
reused for a workspace.

coderd closes old agent connections, so this is expected
behavior and the agent will reconnect properly.
