### PR TITLE
fix: use fmt.Fprintln to print workspaces table

### DIFF
--- a/cli/workspacelist.go
+++ b/cli/workspacelist.go
@@ -71,7 +71,7 @@ func workspaceList() *cobra.Command {
 					workspace.Outdated,
 				})
 			}
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), tableWriter.Render())
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), tableWriter.Render())
 			return err
 		},
 	}


### PR DESCRIPTION
It was missing a newline
