### PR TITLE
fix: Write agent URL to file for gitssh

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -120,6 +120,10 @@ func workspaceAgent() *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("writing agent session token to config: %w", err)
 			}
+			err = cfg.URL().Write(client.URL.String())
+			if err != nil {
+				return xerrors.Errorf("writing agent url to config: %w", err)
+			}
 
 			closer := agent.New(client.ListenWorkspaceAgent, logger)
 			<-cmd.Context().Done()


### PR DESCRIPTION
This was broken because gitssh couldn't find the URL.
Now it can, and SSH is confirmed to work on dogfood! 🥳
