### PR TITLE
fix: Add sync.Once to prevent double close in test

### DIFF
--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -310,12 +310,15 @@ func TestProvisionerd(t *testing.T) {
 			didLog        atomic.Bool
 			didAcquireJob atomic.Bool
 		)
+		var complete sync.Once
 		completeChan := make(chan struct{})
 		closer := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
 			return createProvisionerDaemonClient(t, provisionerDaemonTestServer{
 				acquireJob: func(ctx context.Context, _ *proto.Empty) (*proto.AcquiredJob, error) {
 					if didAcquireJob.Load() {
-						close(completeChan)
+						complete.Do(func() {
+							close(completeChan)
+						})
 						return &proto.AcquiredJob{}, nil
 					}
 					didAcquireJob.Store(true)


### PR DESCRIPTION
https://github.com/coder/coder/runs/6151451291?check_suite_focus=true
