### PR TITLE
feat: Add STUN servers to enable P2P

### DIFF
--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/coder/coder/codersdk"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/codersdk"
 )
 
 func gitssh() *cobra.Command {


### PR DESCRIPTION
This exposes a `--stun-server` option for listing
STUN servers. By default it uses the Google STUN
server, but this is not required.
