### PR TITLE
feat: Add helper output on failed gitssh

### DIFF
--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -1,14 +1,16 @@
 package cli
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 
+	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/codersdk"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
-
-	"github.com/coder/coder/codersdk"
 )
 
 func gitssh() *cobra.Command {
@@ -55,12 +57,25 @@ func gitssh() *cobra.Command {
 				return xerrors.Errorf("close temp gitsshkey file: %w", err)
 			}
 
-			a := append([]string{"-i", privateKeyFile.Name()}, args...)
-			c := exec.CommandContext(cmd.Context(), "ssh", a...)
+			args = append([]string{"-i", privateKeyFile.Name()}, args...)
+			c := exec.CommandContext(cmd.Context(), "ssh", args...)
+			c.Stderr = cmd.ErrOrStderr()
 			c.Stdout = cmd.OutOrStdout()
 			c.Stdin = cmd.InOrStdin()
 			err = c.Run()
 			if err != nil {
+				exitErr := &exec.ExitError{}
+				if xerrors.As(err, &exitErr) && exitErr.ExitCode() == 255 {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+						"\n"+cliui.Styles.Wrap.Render("Coder authenticates with "+cliui.Styles.Field.Render("git")+
+							" using the public key below. All clones with SSH are authenticated automatically 🪄.")+"\n")
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), cliui.Styles.Code.Render(strings.TrimSpace(key.PublicKey))+"\n")
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Add to GitHub and GitLab:")
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), cliui.Styles.Prompt.String()+"https://github.com/settings/ssh/new")
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), cliui.Styles.Prompt.String()+"https://gitlab.com/-/profile/keys")
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+					return err
+				}
 				return xerrors.Errorf("run ssh command: %w", err)
 			}
 

--- a/cli/publickey.go
+++ b/cli/publickey.go
@@ -30,11 +30,11 @@ func publickey() *cobra.Command {
 					"Coder. All clones with SSH will be authenticated automatically 🪄.",
 			))
 			cmd.Println()
+			cmd.Println(cliui.Styles.Code.Render(strings.TrimSpace(key.PublicKey)))
+			cmd.Println()
 			cmd.Println("Add to GitHub and GitLab:")
 			cmd.Println(cliui.Styles.Prompt.String() + "https://github.com/settings/ssh/new")
 			cmd.Println(cliui.Styles.Prompt.String() + "https://gitlab.com/-/profile/keys")
-			cmd.Println()
-			cmd.Println(cliui.Styles.Code.Render(strings.TrimSpace(key.PublicKey)))
 
 			return nil
 		},

--- a/coderd/gitsshkey.go
+++ b/coderd/gitsshkey.go
@@ -105,6 +105,7 @@ func (api *api) agentGitSSHKey(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	httpapi.Write(rw, http.StatusOK, codersdk.AgentGitSSHKey{
+		PublicKey:  gitSSHKey.PublicKey,
 		PrivateKey: gitSSHKey.PrivateKey,
 	})
 }

--- a/codersdk/gitsshkey.go
+++ b/codersdk/gitsshkey.go
@@ -19,6 +19,7 @@ type GitSSHKey struct {
 }
 
 type AgentGitSSHKey struct {
+	PublicKey  string `json:"public_key"`
 	PrivateKey string `json:"private_key"`
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -16,6 +16,7 @@ export interface GitSSHKey {
 
 // From codersdk/gitsshkey.go:21:6.
 export interface AgentGitSSHKey {
+  readonly public_key: string
   readonly private_key: string
 }
 


### PR DESCRIPTION
This guides the user to adding their Coder keys
to GitHub/GitLab.

It outputs to stderr, so it doesn't interfere with
any Git operations.

Because this hooks with gitssh, once we add a disable
it won't appear anymore!

![image](https://user-images.githubusercontent.com/7122116/165024255-73fdd3af-04d7-4317-9a4e-edb5641d99e5.png)

This is my first contribution from dogfooding v2 👀👀👀👀👀