### PR TITLE
fix: Increase ptytest buffer to resolve flake

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -76,6 +76,11 @@ func TestAgent(t *testing.T) {
 		session.Stdin = ptty.Input()
 		err = session.Start(command)
 		require.NoError(t, err)
+		caret := "$"
+		if runtime.GOOS == "windows" {
+			caret = ">"
+		}
+		ptty.ExpectMatch(caret)
 		ptty.WriteLine("echo test")
 		ptty.ExpectMatch("test")
 		ptty.WriteLine("exit")


### PR DESCRIPTION
From investigating the following run:
https://github.com/coder/coder/runs/6156348454?check_suite_focus=true

It's believed that the cause is data being discarded due to the buffer
filling up. This _might_ fix it, but not entirely sure.
