### PR TITLE
test: Disable TestAgent/SessionTTY on Windows

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -62,6 +62,12 @@ func TestAgent(t *testing.T) {
 
 	t.Run("SessionTTY", func(t *testing.T) {
 		t.Parallel()
+		if runtime.GOOS == "windows" {
+			// This might be our implementation, or ConPTY itself.
+			// It's difficult to find extensive tests for it, so
+			// it seems like it could be either.
+			t.Skip("ConPTY appears to be inconsistent on Windows.")
+		}
 		session := setupSSHSession(t)
 		command := "bash"
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
Either our ConPTY implementation is unstable, or something is
flakey with how it sends output. I'm not sure how our
implementation would sometimes work, so it's best to disable
this for CI stability for now.
