### PR TITLE
test: Loop if content length is zero for Windows

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -175,6 +175,9 @@ func TestAgent(t *testing.T) {
 			if err != nil {
 				return false
 			}
+			if len(content) == 0 {
+				return false
+			}
 			if runtime.GOOS == "windows" {
 				// Windows uses UTF16! 🪟🪟🪟
 				content, _, err = transform.Bytes(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder(), content)


### PR DESCRIPTION
On Windows it seems the file can be created before the
content has been written, which results in comparing
an empty string.
