### PR TITLE
fix: Swap height and width for TTY size

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -333,7 +333,7 @@ func (a *agent) handleSSHSession(session ssh.Session) error {
 		}
 		go func() {
 			for win := range windowSize {
-				err = ptty.Resize(uint16(win.Width), uint16(win.Height))
+				err = ptty.Resize(uint16(win.Height), uint16(win.Width))
 				if err != nil {
 					a.logger.Warn(context.Background(), "failed to resize tty", slog.Error(err))
 				}

--- a/pty/pty.go
+++ b/pty/pty.go
@@ -25,7 +25,7 @@ type PTY interface {
 	Input() io.ReadWriter
 
 	// Resize sets the size of the PTY.
-	Resize(cols uint16, rows uint16) error
+	Resize(height uint16, width uint16) error
 }
 
 // New constructs a new Pty.

--- a/pty/pty_other.go
+++ b/pty/pty_other.go
@@ -42,12 +42,12 @@ func (p *otherPty) Output() io.ReadWriter {
 	}
 }
 
-func (p *otherPty) Resize(cols uint16, rows uint16) error {
+func (p *otherPty) Resize(height uint16, width uint16) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	return pty.Setsize(p.pty, &pty.Winsize{
-		Rows: rows,
-		Cols: cols,
+		Rows: width,
+		Cols: height,
 	})
 }
 

--- a/pty/pty_windows.go
+++ b/pty/pty_windows.go
@@ -81,11 +81,11 @@ func (p *ptyWindows) Input() io.ReadWriter {
 	}
 }
 
-func (p *ptyWindows) Resize(cols uint16, rows uint16) error {
+func (p *ptyWindows) Resize(height uint16, width uint16) error {
 	// Taken from: https://github.com/microsoft/hcsshim/blob/54a5ad86808d761e3e396aff3e2022840f39f9a8/internal/winapi/zsyscall_windows.go#L144
 	ret, _, err := procResizePseudoConsole.Call(uintptr(p.console), uintptr(*((*uint32)(unsafe.Pointer(&windows.Coord{
-		X: int16(rows),
-		Y: int16(cols),
+		Y: int16(height),
+		X: int16(width),
 	})))))
 	if ret != 0 {
 		return err


### PR DESCRIPTION
This was causing the TTY to be real wonky on Windows.
It didn't seem to have an effect on Linux, but I suspect
that's because of escape codes.
