### PR TITLE
fix: Add redirect for OAuth from /login

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -34,7 +34,14 @@ export const AppRouter: React.FC = () => (
 
       <Route path="login" element={<LoginPage />} />
       <Route path="healthz" element={<HealthzPage />} />
-      <Route path="cli-auth" element={<CliAuthenticationPage />} />
+      <Route
+        path="cli-auth"
+        element={
+          <RequireAuth>
+            <CliAuthenticationPage />
+          </RequireAuth>
+        }
+      />
 
       <Route path="templates">
         <Route

--- a/site/src/components/SignInForm/SignInForm.tsx
+++ b/site/src/components/SignInForm/SignInForm.tsx
@@ -53,6 +53,7 @@ const useStyles = makeStyles((theme) => ({
 
 export interface SignInFormProps {
   isLoading: boolean
+  redirectTo: string
   authErrorMessage?: string
   methodsErrorMessage?: string
   authMethods?: AuthMethods
@@ -61,6 +62,7 @@ export interface SignInFormProps {
 
 export const SignInForm: React.FC<SignInFormProps> = ({
   authMethods,
+  redirectTo,
   isLoading,
   authErrorMessage,
   methodsErrorMessage,
@@ -113,7 +115,7 @@ export const SignInForm: React.FC<SignInFormProps> = ({
       </form>
       {authMethods?.github && (
         <div className={styles.submitBtn}>
-          <Link href="/api/v2/users/oauth2/github/callback">
+          <Link href={`/api/v2/users/oauth2/github/callback?redirect=${encodeURIComponent(redirectTo)}`}>
             <Button color="primary" disabled={isLoading} fullWidth type="submit" variant="contained">
               {Language.githubSignIn}
             </Button>

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -52,6 +52,7 @@ export const LoginPage: React.FC = () => {
           <div className={styles.container}>
             <SignInForm
               authMethods={authState.context.methods}
+              redirectTo={redirectTo}
               isLoading={isLoading}
               authErrorMessage={authErrorMessage}
               methodsErrorMessage={getMethodsError}


### PR DESCRIPTION
This allows for a complete sign-up flow:
1. coder login https://dev.coder.com
2. Navigates to /cli-auth
3. Redirects to /login?redirect=%2Fcli-auth
4. User signs in with GitHub
5. User is redirected back to /cli-auth
