### PR TITLE
fix: Use proper shutdown signal for systemd

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -318,8 +318,8 @@ func (a *agent) handleSSHSession(session ssh.Session) error {
 	executablePath = strings.ReplaceAll(executablePath, "\\", "/")
 	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_SSH_COMMAND=%s gitssh --`, executablePath))
 	// These prevent the user from having to specify _anything_ to successfully commit.
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_COMMITTER_EMAIL=%s`, a.ownerEmail.Load()))
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_COMMITTER_NAME=%s`, a.ownerUsername.Load()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_AUTHOR_EMAIL=%s`, a.ownerEmail.Load()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_AUTHOR_NAME=%s`, a.ownerUsername.Load()))
 
 	// Load environment variables passed via the agent.
 	// These should override all variables we manually specify.

--- a/coder.service
+++ b/coder.service
@@ -18,6 +18,7 @@ SecureBits=keep-caps
 AmbientCapabilities=CAP_IPC_LOCK
 CacheDirectory=coder
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+KillSignal=SIGINT
 NoNewPrivileges=yes
 ExecStart=/usr/bin/coder server
 Restart=on-failure


### PR DESCRIPTION
Coder was being killed instantly, which caused builds
to randomly fail!
