### PR TITLE
feat: Output username and password for `code server --dev`

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -47,6 +47,13 @@ import (
 	"github.com/coder/coder/provisionersdk/proto"
 )
 
+var defaultDevUser = codersdk.CreateFirstUserRequest{
+	Email:            "admin@coder.com",
+	Username:         "developer",
+	Password:         "password",
+	OrganizationName: "acme-corp",
+}
+
 // nolint:gocyclo
 func server() *cobra.Command {
 	var (
@@ -275,6 +282,9 @@ func server() *cobra.Command {
 				if err != nil {
 					return xerrors.Errorf("create first user: %w", err)
 				}
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "email: %s\n", defaultDevUser.Email)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "password: %s\n", defaultDevUser.Password)
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), cliui.Styles.Wrap.Render(`Started in dev mode. All data is in-memory! `+cliui.Styles.Bold.Render("Do not use in production")+`. Press `+
 					cliui.Styles.Field.Render("ctrl+c")+` to clean up provisioned infrastructure.`)+"\n\n")
@@ -441,18 +451,13 @@ func server() *cobra.Command {
 }
 
 func createFirstUser(cmd *cobra.Command, client *codersdk.Client, cfg config.Root) error {
-	_, err := client.CreateFirstUser(cmd.Context(), codersdk.CreateFirstUserRequest{
-		Email:            "admin@coder.com",
-		Username:         "developer",
-		Password:         "password",
-		OrganizationName: "acme-corp",
-	})
+	_, err := client.CreateFirstUser(cmd.Context(), defaultDevUser)
 	if err != nil {
 		return xerrors.Errorf("create first user: %w", err)
 	}
 	token, err := client.LoginWithPassword(cmd.Context(), codersdk.LoginWithPasswordRequest{
-		Email:    "admin@coder.com",
-		Password: "password",
+		Email:    defaultDevUser.Email,
+		Password: defaultDevUser.Password,
 	})
 	if err != nil {
 		return xerrors.Errorf("login with first user: %w", err)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -75,12 +75,12 @@ func TestServer(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
 		root, cfg := clitest.New(t, "server", "--dev", "--skip-tunnel", "--address", ":0")
+		var stdoutBuf bytes.Buffer
+		root.SetOutput(&stdoutBuf)
 		go func() {
 			err := root.ExecuteContext(ctx)
 			require.ErrorIs(t, err, context.Canceled)
 		}()
-		var stdoutBuf bytes.Buffer
-		root.SetOutput(&stdoutBuf)
 		var token string
 		require.Eventually(t, func() bool {
 			var err error

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -93,8 +93,10 @@ func TestServer(t *testing.T) {
 		parsed, err := url.Parse(accessURL)
 		require.NoError(t, err)
 		// Verify that credentials were output to the terminal.
-		assert.Contains(t, stdoutBuf.String(), "email: admin@coder.com", "unexpected output")
-		assert.Contains(t, stdoutBuf.String(), "password: password", "unexpected output")
+		wantEmail := "email: admin@coder.com"
+		wantPassword := "password: password"
+		assert.Contains(t, stdoutBuf.String(), wantEmail, "expected output %q; got no match", wantEmail)
+		assert.Contains(t, stdoutBuf.String(), wantPassword, "expected output %q; got no match", wantPassword)
 		client := codersdk.New(parsed)
 		client.SessionToken = token
 		_, err = client.User(ctx, codersdk.Me)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -80,6 +80,12 @@ func TestServer(t *testing.T) {
 		go func() {
 			err := root.ExecuteContext(ctx)
 			require.ErrorIs(t, err, context.Canceled)
+
+			// Verify that credentials were output to the terminal.
+			wantEmail := "email: admin@coder.com"
+			wantPassword := "password: password"
+			assert.Contains(t, stdoutBuf.String(), wantEmail, "expected output %q; got no match", wantEmail)
+			assert.Contains(t, stdoutBuf.String(), wantPassword, "expected output %q; got no match", wantPassword)
 		}()
 		var token string
 		require.Eventually(t, func() bool {
@@ -92,11 +98,6 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 		parsed, err := url.Parse(accessURL)
 		require.NoError(t, err)
-		// Verify that credentials were output to the terminal.
-		wantEmail := "email: admin@coder.com"
-		wantPassword := "password: password"
-		assert.Contains(t, stdoutBuf.String(), wantEmail, "expected output %q; got no match", wantEmail)
-		assert.Contains(t, stdoutBuf.String(), wantPassword, "expected output %q; got no match", wantPassword)
 		client := codersdk.New(parsed)
 		client.SessionToken = token
 		_, err = client.User(ctx, codersdk.Me)


### PR DESCRIPTION
This PR allows the dev mode credentials (email and password) to be output to the terminal.

Fixes #825

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
