### PR TITLE
feat: Generate random admin user password in dev mode

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -81,9 +82,10 @@ func TestServer(t *testing.T) {
 		root, cfg := clitest.New(t, "server", "--dev", "--skip-tunnel", "--address", ":0")
 		var buf strings.Builder
 		root.SetOutput(&buf)
-		done := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
 		go func() {
-			defer close(done)
+			defer wg.Done()
 
 			err := root.ExecuteContext(ctx)
 			require.ErrorIs(t, err, context.Canceled)
@@ -116,7 +118,7 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 
 		cancelFunc()
-		<-done
+		wg.Wait()
 	})
 	// Duplicated test from "Development" above to test setting email/password via env.
 	// Cannot run parallel due to os.Setenv.
@@ -133,9 +135,10 @@ func TestServer(t *testing.T) {
 		root, cfg := clitest.New(t, "server", "--dev", "--skip-tunnel", "--address", ":0")
 		var buf strings.Builder
 		root.SetOutput(&buf)
-		done := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
 		go func() {
-			defer close(done)
+			defer wg.Done()
 
 			err := root.ExecuteContext(ctx)
 			require.ErrorIs(t, err, context.Canceled)
@@ -161,7 +164,7 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 
 		cancelFunc()
-		<-done
+		wg.Wait()
 	})
 	t.Run("TLSBadVersion", func(t *testing.T) {
 		t.Parallel()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -81,7 +81,10 @@ func TestServer(t *testing.T) {
 		root, cfg := clitest.New(t, "server", "--dev", "--skip-tunnel", "--address", ":0")
 		var buf strings.Builder
 		root.SetOutput(&buf)
+		done := make(chan struct{})
 		go func() {
+			defer close(done)
+
 			err := root.ExecuteContext(ctx)
 			require.ErrorIs(t, err, context.Canceled)
 
@@ -111,6 +114,9 @@ func TestServer(t *testing.T) {
 		client.SessionToken = token
 		_, err = client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
+
+		cancelFunc()
+		<-done
 	})
 	t.Run("TLSBadVersion", func(t *testing.T) {
 		t.Parallel()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -120,7 +120,7 @@ func TestServer(t *testing.T) {
 	})
 	// Duplicated test from "Development" above to test setting email/password via env.
 	t.Run("Development with email and password from env", func(t *testing.T) {
-		// Cannot run parallell due to os.Setenv.
+		// Cannot run parallel due to os.Setenv.
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
 

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -127,10 +127,8 @@ func TestServer(t *testing.T) {
 
 		wantEmail := "myadmin@coder.com"
 		wantPassword := "testpass42"
-		os.Setenv("CODER_DEV_ADMIN_EMAIL", wantEmail)
-		defer os.Unsetenv("CODER_DEV_ADMIN_EMAIL")
-		os.Setenv("CODER_DEV_ADMIN_PASSWORD", wantPassword)
-		defer os.Unsetenv("CODER_DEV_ADMIN_PASSWORD")
+		t.Setenv("CODER_DEV_ADMIN_EMAIL", wantEmail)
+		t.Setenv("CODER_DEV_ADMIN_PASSWORD", wantPassword)
 
 		root, cfg := clitest.New(t, "server", "--dev", "--skip-tunnel", "--address", ":0")
 		var buf strings.Builder

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -119,8 +119,9 @@ func TestServer(t *testing.T) {
 		<-done
 	})
 	// Duplicated test from "Development" above to test setting email/password via env.
+	// Cannot run parallel due to os.Setenv.
+	//nolint:paralleltest
 	t.Run("Development with email and password from env", func(t *testing.T) {
-		// Cannot run parallel due to os.Setenv.
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
 

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -1,6 +1,6 @@
 import { PlaywrightTestConfig } from "@playwright/test"
 import * as path from "path"
-import * as constants from './constants';
+import * as constants from "./constants"
 
 const config: PlaywrightTestConfig = {
   testDir: "tests",
@@ -18,7 +18,10 @@ const config: PlaywrightTestConfig = {
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests
   webServer: {
     // Run the coder daemon directly.
-    command: `go run -tags embed ${path.join(__dirname, "../../cmd/coder/main.go")} server --dev --skip-tunnel --dev-admin-email ${constants.email} --dev-admin-password ${constants.password}`,
+    command: `go run -tags embed ${path.join(
+      __dirname,
+      "../../cmd/coder/main.go",
+    )} server --dev --skip-tunnel --dev-admin-email ${constants.email} --dev-admin-password ${constants.password}`,
     port: 3000,
     timeout: 120 * 10000,
     reuseExistingServer: false,

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -1,5 +1,6 @@
 import { PlaywrightTestConfig } from "@playwright/test"
 import * as path from "path"
+import * as constants from './constants';
 
 const config: PlaywrightTestConfig = {
   testDir: "tests",
@@ -17,7 +18,7 @@ const config: PlaywrightTestConfig = {
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests
   webServer: {
     // Run the coder daemon directly.
-    command: `go run -tags embed ${path.join(__dirname, "../../cmd/coder/main.go")} server --dev --skip-tunnel`,
+    command: `go run -tags embed ${path.join(__dirname, "../../cmd/coder/main.go")} server --dev --skip-tunnel --dev-admin-email ${constants.email} --dev-admin-password ${constants.password}`,
     port: 3000,
     timeout: 120 * 10000,
     reuseExistingServer: false,


### PR DESCRIPTION
This PR replaces the static dev mode admin password with a randomly generated one. It allows both email and password to be set either via environment or command line flags.

Normally passwords as cli flags is suboptimal, but considering the use case I think it's acceptable and may be nicer for the developer.

This PR also fixes a flake in the TestServer/Development test.

Closes #825

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
