### PR TITLE
test: Fix log output after closing peer conn

### DIFF
--- a/peer/conn.go
+++ b/peer/conn.go
@@ -230,6 +230,9 @@ func (c *Conn) init() error {
 			slog.F("state", dtlsTransportState))
 	})
 	c.rtc.SCTP().Transport().ICETransport().OnSelectedCandidatePairChange(func(candidatePair *webrtc.ICECandidatePair) {
+		if c.isClosed() {
+			return
+		}
 		c.opts.Logger.Debug(context.Background(), "selected candidate pair changed",
 			slog.F("local", candidatePair.Local), slog.F("remote", candidatePair.Remote))
 	})


### PR DESCRIPTION
This caused a few flakes. Here's one:
https://github.com/coder/coder/runs/6218716724?check_suite_focus=true
