### PR TITLE
fix: Confirm password in cli create first user step

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -117,6 +117,19 @@ func login() *cobra.Command {
 				if err != nil {
 					return xerrors.Errorf("specify password prompt: %w", err)
 				}
+				_, err = cliui.Prompt(cmd, cliui.PromptOptions{
+					Text:   "Confirm " + cliui.Styles.Field.Render("password") + ":",
+					Secret: true,
+					Validate: func(s string) error {
+						if s != password {
+							return xerrors.Errorf("Passwords do not match")
+						}
+						return nil
+					},
+				})
+				if err != nil {
+					return xerrors.Errorf("confirm password prompt: %w", err)
+				}
 
 				_, err = client.CreateFirstUser(cmd.Context(), codersdk.CreateFirstUserRequest{
 					Email:            email,


### PR DESCRIPTION
This PR asks the user to confirm the password during the create first user step (cli).

Fixes #1182

Example:

```console
❯ coder login http://127.0.0.1:3000
> Your Coder deployment hasn't been set up!
> Would you like to create the first user? (yes/no) yes
> What  username  would you like? (coder) 
> What's your  email ? mathias@coder.com
> Enter a  password : 
> Confirm  password : 
Passwords do not match
> Confirm  password : 
                                                            
  Welcome to Coder, coder! You're authenticated.            
```