### PR TITLE
fix: Use verified and primary email for GitHub signup

### DIFF
--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -142,11 +142,14 @@ func TestUserOAuth2Github(t *testing.T) {
 				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
 					return &github.User{
 						Login: github.String("kyle"),
-						Email: github.String("kyle@coder.com"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
-					return []*github.UserEmail{}, nil
+					return []*github.UserEmail{{
+						Email:    github.String("kyle@coder.com"),
+						Verified: github.Bool(true),
+						Primary:  github.Bool(true),
+					}}, nil
 				},
 			},
 		})


### PR DESCRIPTION
This was causing a panic due to nil pointer dereference.
It required all users signing up had a public email,
which is an unreasonable requirement!
