### PR TITLE
fix: clarify AWS access key ID vs secret

### DIFF
--- a/examples/aws-linux/main.tf
+++ b/examples/aws-linux/main.tf
@@ -12,7 +12,7 @@ variable "access_key" {
 Create an AWS access key to provision resources with Coder:
 - https://console.aws.amazon.com/iam/home#/users
   
-AWS Access Key
+AWS Access Key ID
 EOT
   sensitive   = true
 }


### PR DESCRIPTION
This is how AWS differentiates access key vs secret