### PR TITLE
test: Regenerate GitSSHKey flake when comparing times

### DIFF
--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -70,7 +70,7 @@ func TestGitSSHKey(t *testing.T) {
 		require.NotEmpty(t, key1.PublicKey)
 		key2, err := client.RegenerateGitSSHKey(ctx, res.UserID)
 		require.NoError(t, err)
-		require.Greater(t, key2.UpdatedAt, key1.UpdatedAt)
+		require.GreaterOrEqual(t, key2.UpdatedAt, key1.UpdatedAt)
 		require.NotEmpty(t, key2.PublicKey)
 		require.NotEqual(t, key2.PublicKey, key1.PublicKey)
 	})


### PR DESCRIPTION
This is a crazy one! The in-memory DB is fast, which allows the same
exact timestamp to occur for regenerating the key!

See: https://github.com/coder/coder/runs/6234173911?check_suite_focus=true#step:9:82
