### PR TITLE
fix: Add "GIT_COMMITTER_*" to remove Git prompt

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -343,8 +343,11 @@ func (a *agent) createCommand(ctx context.Context, rawCommand string, env []stri
 	executablePath = strings.ReplaceAll(executablePath, "\\", "/")
 	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_SSH_COMMAND=%s gitssh --`, executablePath))
 	// These prevent the user from having to specify _anything_ to successfully commit.
+	// Both author and committer must be set!
 	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_AUTHOR_EMAIL=%s`, a.ownerEmail.Load()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_COMMITTER_EMAIL=%s`, a.ownerEmail.Load()))
 	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_AUTHOR_NAME=%s`, a.ownerUsername.Load()))
+	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_COMMITTER_NAME=%s`, a.ownerEmail.Load()))
 
 	// Load environment variables passed via the agent.
 	// These should override all variables we manually specify.


### PR DESCRIPTION
A prompt would appear to globally configure the email or name
before. We already have this information, so we can set the
environment variables!
