### PR TITLE
fix: Use `cliui.WorkspaceBuild` to prevent cancel of builds jobs

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -361,18 +361,7 @@ func server() *cobra.Command {
 						return xerrors.Errorf("delete workspace: %w", err)
 					}
 
-					err = cliui.ProvisionerJob(cmd.Context(), cmd.OutOrStdout(), cliui.ProvisionerJobOptions{
-						Fetch: func() (codersdk.ProvisionerJob, error) {
-							build, err := client.WorkspaceBuild(cmd.Context(), build.ID)
-							return build.Job, err
-						},
-						Cancel: func() error {
-							return client.CancelWorkspaceBuild(cmd.Context(), build.ID)
-						},
-						Logs: func() (<-chan codersdk.ProvisionerJobLog, error) {
-							return client.WorkspaceBuildLogsAfter(cmd.Context(), build.ID, before)
-						},
-					})
+					err = cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
 					if err != nil {
 						return xerrors.Errorf("delete workspace %s: %w", workspace.Name, err)
 					}

--- a/cli/workspacestart.go
+++ b/cli/workspacestart.go
@@ -35,19 +35,7 @@ func workspaceStart() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = cliui.ProvisionerJob(cmd.Context(), cmd.OutOrStdout(), cliui.ProvisionerJobOptions{
-				Fetch: func() (codersdk.ProvisionerJob, error) {
-					build, err := client.WorkspaceBuild(cmd.Context(), build.ID)
-					return build.Job, err
-				},
-				Cancel: func() error {
-					return client.CancelWorkspaceBuild(cmd.Context(), build.ID)
-				},
-				Logs: func() (<-chan codersdk.ProvisionerJobLog, error) {
-					return client.WorkspaceBuildLogsAfter(cmd.Context(), build.ID, before)
-				},
-			})
-			return err
+			return cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
 		},
 	}
 }

--- a/cli/workspacestop.go
+++ b/cli/workspacestop.go
@@ -35,22 +35,7 @@ func workspaceStop() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = cliui.ProvisionerJob(cmd.Context(), cmd.OutOrStdout(), cliui.ProvisionerJobOptions{
-				Fetch: func() (codersdk.ProvisionerJob, error) {
-					build, err := client.WorkspaceBuild(cmd.Context(), build.ID)
-					return build.Job, err
-				},
-				Cancel: func() error {
-					return client.CancelWorkspaceBuild(cmd.Context(), build.ID)
-				},
-				Logs: func() (<-chan codersdk.ProvisionerJobLog, error) {
-					return client.WorkspaceBuildLogsAfter(cmd.Context(), build.ID, before)
-				},
-			})
-			if err != nil {
-				return err
-			}
-			return nil
+			return cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
 		},
 	}
 }


### PR DESCRIPTION
Build jobs cannot gracefully terminate because Terraform generally
cannot gracefully terminate.
