### PR TITLE
fix: Adjust Makefile tagets to use dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,21 @@ INSTALL_DIR=$(shell go env GOPATH)/bin
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 
-bin:
-	goreleaser build --snapshot --rm-dist
-.PHONY: bin
-
-build: site/out bin
+# First target is the default for `make`.
+build: dist
 .PHONY: build
 
 # Runs migrations to output a dump of the database.
 coderd/database/dump.sql: $(wildcard coderd/database/migrations/*.sql)
 	go run coderd/database/dump/main.go
-.PHONY: coderd/database/dump.sql
 
 # Generates Go code for querying the database.
-coderd/database/generate: coderd/database/dump.sql $(wildcard coderd/database/queries/*.sql)
+coderd/database/querier.go: coderd/database/dump.sql $(wildcard coderd/database/queries/*.sql)
 	coderd/database/generate.sh
-.PHONY: coderd/database/generate
 
-apitypings/generate: site/src/api/types.ts
-	go run scripts/apitypings/main.go > site/src/api/typesGenerated.ts
-	cd site && yarn run format:types
-.PHONY: apitypings/generate
+# This is called "dist" to target the output directory for binaries.
+dist: site/out $(find -not -path './vendor/*' -type f -name '*.go') go.mod go.sum
+	goreleaser build --snapshot --rm-dist
 
 fmt/prettier:
 	@echo "--- prettier"
@@ -40,8 +34,7 @@ fmt/terraform: $(wildcard *.tf)
 fmt: fmt/prettier fmt/terraform
 .PHONY: fmt
 
-gen: coderd/database/generate peerbroker/proto provisionersdk/proto provisionerd/proto apitypings/generate
-.PHONY: gen
+gen: coderd/database/querier.go peerbroker/proto/peerbroker.pb.go provisionersdk/proto/provisioner.pb.go provisionerd/proto/provisionerd.pb.go site/src/api/typesGenerated.ts
 
 install: build
 	@echo "--- Copying from bin to $(INSTALL_DIR)"
@@ -53,44 +46,40 @@ lint:
 	golangci-lint run
 .PHONY: lint
 
-peerbroker/proto: peerbroker/proto/peerbroker.proto
+peerbroker/proto/peerbroker.pb.go: peerbroker/proto/peerbroker.proto
 	protoc \
 		--go_out=. \
 		--go_opt=paths=source_relative \
 		--go-drpc_out=. \
 		--go-drpc_opt=paths=source_relative \
 		./peerbroker/proto/peerbroker.proto
-.PHONY: peerbroker/proto
 
-provisionerd/proto: provisionerd/proto/provisionerd.proto
+provisionerd/proto/provisionerd.pb.go: provisionerd/proto/provisionerd.proto
 	protoc \
 		--go_out=. \
 		--go_opt=paths=source_relative \
 		--go-drpc_out=. \
 		--go-drpc_opt=paths=source_relative \
 		./provisionerd/proto/provisionerd.proto
-.PHONY: provisionerd/proto
 
-provisionersdk/proto: provisionersdk/proto/provisioner.proto
+provisionersdk/proto/provisioner.pb.go: provisionersdk/proto/provisioner.proto
 	protoc \
 		--go_out=. \
 		--go_opt=paths=source_relative \
 		--go-drpc_out=. \
 		--go-drpc_opt=paths=source_relative \
 		./provisionersdk/proto/provisioner.proto
-.PHONY: provisionersdk/proto
 
-release: site/out
-	goreleaser release --snapshot --rm-dist --skip-sign
-.PHONY: release
-
-site/out:
+site/out: $(shell find ./site -not -path './site/node_modules/*' -type f -name '*.tsx') $(shell find ./site -not -path './site/node_modules/*' -type f -name '*.ts') site/package.json
 	./scripts/yarn_install.sh
 	cd site && yarn typegen
 	cd site && yarn build
 	# Restores GITKEEP files!
 	git checkout HEAD site/out
-.PHONY: site/out
+
+site/src/api/typesGenerated.ts: $(shell find codersdk -type f -name '*.go')
+	go run scripts/apitypings/main.go > site/src/api/typesGenerated.ts
+	cd site && yarn run format:types
 
 test:
 	gotestsum -- -v -short ./...


### PR DESCRIPTION
It was getting slow to run `make gen` and other operations,
but this resolves it by targeting files properly.
