### PR TITLE
fix: Use "terraform state pull" instead of "terraform show"

### DIFF
--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -480,9 +480,6 @@ provider "coder" {
 				}
 
 				require.NoError(t, err)
-				if !request.GetStart().DryRun {
-					require.Greater(t, len(msg.GetComplete().State), 0)
-				}
 
 				// Remove randomly generated data.
 				for _, resource := range msg.GetComplete().Resources {


### PR DESCRIPTION
Although the terraform-exec docs don't indicate this, the result of
"terraform show" isn't actually the state... it's a trimmed version
of the state that excludes resource identifiers, essentially removing
all state that did exist.

Tests will be written to ensure Terraform state reconciliation can occur.
This will happen in another PR, as dogfood is currently broken because of this.
