### PR TITLE
fix: Use GoReleaser Action in deploy script

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -355,7 +355,10 @@ jobs:
             js-${{ runner.os }}-
 
       - name: Build Release
-        run: make build
+        uses: goreleaser/goreleaser-action@v2.9.1
+        with:
+          version: latest
+          args: release --snapshot --rm-dist --skip-sign
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This reduces conflictions with our Makefile, which is presently
primarily a user script.
