### PR TITLE
fix: Build site in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,9 @@ jobs:
           restore-keys: |
             js-${{ runner.os }}-
 
+      - name: Install make
+        run: brew install make
+
       - name: Build Site
         run: make site/out
 


### PR DESCRIPTION
This was using Mac Make, which is missing some options:
https://github.com/coder/coder/runs/6265845123?check_suite_focus=true#step:10:6
