### PR TITLE
fix: ensure correct version of sqlc is executed

### DIFF
--- a/coderd/database/generate.sh
+++ b/coderd/database/generate.sh
@@ -11,8 +11,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 # The logic below depends on the exact version being correct :(
-[[ $(sqlc version) != "v1.13.0" ]] && go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.13.0
-sqlc generate
+go run github.com/kyleconroy/sqlc/cmd/sqlc@v1.13.0 generate
 
 first=true
 for fi in queries/*.sql.go; do


### PR DESCRIPTION
If `/usr/local/bin` is searched before `$GOPATH/bin` in your `$PATH` the wrong
version of `sqlc` can be executed.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
