### PR TITLE
fix: use CODER_AGENT_TOKEN for docker example

### DIFF
--- a/examples/docker-local/main.tf
+++ b/examples/docker-local/main.tf
@@ -42,7 +42,7 @@ resource "docker_container" "workspace" {
   name    = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
   dns     = ["1.1.1.1"]
   command = ["sh", "-c", coder_agent.dev.init_script]
-  env     = ["CODER_TOKEN=${coder_agent.dev.token}"]
+  env     = ["CODER_AGENT_TOKEN=${coder_agent.dev.token}"]
   volumes {
     container_path = "/home/coder/"
     volume_name    = docker_volume.coder_volume.name


### PR DESCRIPTION
Since #1238 we are using CODER_AGENT_TOKEN instead of token. I think we're going to set up automated tests for all examples in the future.