### PR TITLE
fix: Always show clear API error in CLI

### DIFF
--- a/cli/autostart_test.go
+++ b/cli/autostart_test.go
@@ -77,7 +77,7 @@ func TestAutostart(t *testing.T) {
 		clitest.SetupConfig(t, client, root)
 
 		err := cmd.Execute()
-		require.ErrorContains(t, err, "status code 404: no workspace found by name", "unexpected error")
+		require.ErrorContains(t, err, "status code 404", "unexpected error")
 	})
 
 	t.Run("Disable_NotFound", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestAutostart(t *testing.T) {
 		clitest.SetupConfig(t, client, root)
 
 		err := cmd.Execute()
-		require.ErrorContains(t, err, "status code 404: no workspace found by name", "unexpected error")
+		require.ErrorContains(t, err, "status code 404", "unexpected error")
 	})
 
 	t.Run("Enable_DefaultSchedule", func(t *testing.T) {

--- a/cli/autostop_test.go
+++ b/cli/autostop_test.go
@@ -76,7 +76,7 @@ func TestAutostop(t *testing.T) {
 		clitest.SetupConfig(t, client, root)
 
 		err := cmd.Execute()
-		require.ErrorContains(t, err, "status code 404: no workspace found by name", "unexpected error")
+		require.ErrorContains(t, err, "status code 404", "unexpected error")
 	})
 
 	t.Run("Disable_NotFound", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestAutostop(t *testing.T) {
 		clitest.SetupConfig(t, client, root)
 
 		err := cmd.Execute()
-		require.ErrorContains(t, err, "status code 404: no workspace found by name", "unexpected error")
+		require.ErrorContains(t, err, "status code 404", "unexpected error")
 	})
 
 	t.Run("Enable_DefaultSchedule", func(t *testing.T) {

--- a/coderd/roles_test.go
+++ b/coderd/roles_test.go
@@ -119,7 +119,7 @@ func TestListRoles(t *testing.T) {
 				var apiErr *codersdk.Error
 				require.ErrorAs(t, err, &apiErr)
 				require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
-				require.Contains(t, apiErr.Message, c.AuthorizedError)
+				require.Contains(t, string(apiErr.Body), c.AuthorizedError)
 			} else {
 				require.NoError(t, err)
 				require.ElementsMatch(t, c.ExpectedRoles, roles)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -263,17 +263,17 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 		{
 			name:          "invalid location",
 			schedule:      "CRON_TZ=Imaginary/Place 30 9 * * 1-5",
-			expectedError: "status code 500: invalid autostart schedule: parse schedule: provided bad location Imaginary/Place: unknown time zone Imaginary/Place",
+			expectedError: "status code 500",
 		},
 		{
 			name:          "invalid schedule",
 			schedule:      "asdf asdf asdf ",
-			expectedError: `status code 500: invalid autostart schedule: validate weekly schedule: expected schedule to consist of 5 fields with an optional CRON_TZ=<timezone> prefix`,
+			expectedError: `status code 500`,
 		},
 		{
 			name:          "only 3 values",
 			schedule:      "CRON_TZ=Europe/Dublin 30 9 *",
-			expectedError: `status code 500: invalid autostart schedule: validate weekly schedule: expected schedule to consist of 5 fields with an optional CRON_TZ=<timezone> prefix`,
+			expectedError: `status code 500`,
 		},
 	}
 
@@ -300,7 +300,7 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 			})
 
 			if testCase.expectedError != "" {
-				require.EqualError(t, err, testCase.expectedError, "unexpected error when setting workspace autostart schedule")
+				require.Contains(t, err.Error(), testCase.expectedError, "unexpected error when setting workspace autostart schedule")
 				return
 			}
 
@@ -339,7 +339,7 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 		require.IsType(t, err, &codersdk.Error{}, "expected codersdk.Error")
 		coderSDKErr, _ := err.(*codersdk.Error) //nolint:errorlint
 		require.Equal(t, coderSDKErr.StatusCode(), 404, "expected status code 404")
-		require.Equal(t, fmt.Sprintf("workspace %q does not exist", wsid), coderSDKErr.Message, "unexpected response code")
+		require.Contains(t, string(coderSDKErr.Body), fmt.Sprintf("does not exist"), "unexpected response code")
 	})
 }
 
@@ -397,17 +397,17 @@ func TestWorkspaceUpdateAutostop(t *testing.T) {
 		{
 			name:          "invalid location",
 			schedule:      "CRON_TZ=Imaginary/Place 30 17 * * 1-5",
-			expectedError: "status code 500: invalid autostop schedule: parse schedule: provided bad location Imaginary/Place: unknown time zone Imaginary/Place",
+			expectedError: "status code 500",
 		},
 		{
 			name:          "invalid schedule",
 			schedule:      "asdf asdf asdf ",
-			expectedError: `status code 500: invalid autostop schedule: validate weekly schedule: expected schedule to consist of 5 fields with an optional CRON_TZ=<timezone> prefix`,
+			expectedError: `status code 500`,
 		},
 		{
 			name:          "only 3 values",
 			schedule:      "CRON_TZ=Europe/Dublin 30 9 *",
-			expectedError: `status code 500: invalid autostop schedule: validate weekly schedule: expected schedule to consist of 5 fields with an optional CRON_TZ=<timezone> prefix`,
+			expectedError: `status code 500`,
 		},
 	}
 
@@ -434,7 +434,7 @@ func TestWorkspaceUpdateAutostop(t *testing.T) {
 			})
 
 			if testCase.expectedError != "" {
-				require.EqualError(t, err, testCase.expectedError, "unexpected error when setting workspace autostop schedule")
+				require.Contains(t, err.Error(), testCase.expectedError, "unexpected error when setting workspace autostop schedule")
 				return
 			}
 
@@ -473,7 +473,7 @@ func TestWorkspaceUpdateAutostop(t *testing.T) {
 		require.IsType(t, err, &codersdk.Error{}, "expected codersdk.Error")
 		coderSDKErr, _ := err.(*codersdk.Error) //nolint:errorlint
 		require.Equal(t, coderSDKErr.StatusCode(), 404, "expected status code 404")
-		require.Equal(t, fmt.Sprintf("workspace %q does not exist", wsid), coderSDKErr.Message, "unexpected response code")
+		require.Contains(t, string(coderSDKErr.Body), "does not exist", "unexpected response code")
 	})
 }
 


### PR DESCRIPTION
In the case where the response was json, but not in the expected format, we would just show the status code and no other information, leaving the user in the dark.

## Before
[![asciicast](https://asciinema.org/a/boZ9c4DYPp1qRGX4UtaK1tYxS.svg)](https://asciinema.org/a/boZ9c4DYPp1qRGX4UtaK1tYxS)

## After
[![asciicast](https://asciinema.org/a/AFTFmwldz09kfROQ55Y028Xjg.svg)](https://asciinema.org/a/AFTFmwldz09kfROQ55Y028Xjg)
