### PR TITLE
feat: Add support for json omitempty and embedded structs in apitypings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,9 @@ site/out/index.html: $(shell find ./site -not -path './site/node_modules/*' -typ
 	# Restores GITKEEP files!
 	git checkout HEAD site/out
 
-site/src/api/typesGenerated.ts: $(shell find codersdk -type f -name '*.go')
+site/src/api/typesGenerated.ts: scripts/apitypings/main.go $(shell find codersdk -type f -name '*.go')
 	go run scripts/apitypings/main.go > site/src/api/typesGenerated.ts
 	cd site && yarn run format:types
-.PHONY: site/src/api/typesGenerated.ts
 
 test:
 	gotestsum -- -v -short ./...

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ site/out/index.html: $(shell find ./site -not -path './site/node_modules/*' -typ
 site/src/api/typesGenerated.ts: $(shell find codersdk -type f -name '*.go')
 	go run scripts/apitypings/main.go > site/src/api/typesGenerated.ts
 	cd site && yarn run format:types
+.PHONY: site/src/api/typesGenerated.ts
 
 test:
 	gotestsum -- -v -short ./...

--- a/codersdk/pagination.go
+++ b/codersdk/pagination.go
@@ -14,16 +14,16 @@ type Pagination struct {
 	// Offset for better performance. To use it as an alternative,
 	// set AfterID to the last UUID returned by the previous
 	// request.
-	AfterID uuid.UUID `json:"after_id"`
+	AfterID uuid.UUID `json:"after_id,omitempty"`
 	// Limit sets the maximum number of users to be returned
 	// in a single page. If the limit is <= 0, there is no limit
 	// and all users are returned.
-	Limit int `json:"limit"`
+	Limit int `json:"limit,omitempty"`
 	// Offset is used to indicate which page to return. An offset of 0
 	// returns the first 'limit' number of users.
 	// To get the next page, use offset=<limit>*<page_number>.
 	// Offset is 0 indexed, so the first record sits at offset 0.
-	Offset int `json:"offset"`
+	Offset int `json:"offset,omitempty"`
 }
 
 // asRequestOption returns a function that can be used in (*Client).request.

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -244,7 +244,10 @@ func (g *Generator) buildStruct(obj types.Object, st *types.Struct) (string, err
 	extendedFields := make(map[int]bool)
 	for i := 0; i < st.NumFields(); i++ {
 		field := st.Field(i)
-		if field.Embedded() && field.Pkg().Name() == "codersdk" {
+		tag := reflect.StructTag(st.Tag(i))
+		// Adding a json struct tag causes the json package to consider
+		// the field unembedded.
+		if field.Embedded() && tag.Get("json") == "" && field.Pkg().Name() == "codersdk" {
 			extendedFields[i] = true
 			extends = append(extends, field.Name())
 		}

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -251,6 +251,10 @@ func (g *Generator) buildStruct(obj types.Object, st *types.Struct) (string, err
 		if jsonName == "" {
 			jsonName = field.Name()
 		}
+		jsonOptional := false
+		if len(arr) > 1 && arr[1] == "omitempty" {
+			jsonOptional = true
+		}
 
 		var tsType TypescriptType
 		// If a `typescript:"string"` exists, we take this, and do not try to infer.
@@ -273,7 +277,7 @@ func (g *Generator) buildStruct(obj types.Object, st *types.Struct) (string, err
 			_, _ = s.WriteRune('\n')
 		}
 		optional := ""
-		if tsType.Optional {
+		if jsonOptional || tsType.Optional {
 			optional = "?"
 		}
 		_, _ = s.WriteString(fmt.Sprintf("%sreadonly %s%s: %s\n", indent, jsonName, optional, tsType.ValueType))

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -91,7 +91,7 @@ export interface CreateWorkspaceBuildRequest {
   // This is likely an enum in an external package ("github.com/coder/coder/coderd/database.WorkspaceTransition")
   readonly transition: string
   readonly dry_run: boolean
-  readonly state: string
+  readonly state?: string
 }
 
 // From codersdk/organizations.go:52:6
@@ -149,9 +149,9 @@ export interface OrganizationMember {
 
 // From codersdk/pagination.go:11:6
 export interface Pagination {
-  readonly after_id: string
-  readonly limit: number
-  readonly offset: number
+  readonly after_id?: string
+  readonly limit?: number
+  readonly offset?: number
 }
 
 // From codersdk/parameters.go:26:6
@@ -185,7 +185,7 @@ export interface ProvisionerJob {
   readonly created_at: string
   readonly started_at?: string
   readonly completed_at?: string
-  readonly error: string
+  readonly error?: string
   readonly status: ProvisionerJobStatus
   readonly worker_id?: string
 }
@@ -355,12 +355,12 @@ export interface WorkspaceAgent {
   readonly status: WorkspaceAgentStatus
   readonly name: string
   readonly resource_id: string
-  readonly instance_id: string
+  readonly instance_id?: string
   readonly architecture: string
   readonly environment_variables: Record<string, string>
   readonly operating_system: string
-  readonly startup_script: string
-  readonly directory: string
+  readonly startup_script?: string
+  readonly directory?: string
 }
 
 // From codersdk/workspaceagents.go:47:6
@@ -415,7 +415,7 @@ export interface WorkspaceResource {
   readonly workspace_transition: string
   readonly type: string
   readonly name: string
-  readonly agents: WorkspaceAgent[]
+  readonly agents?: WorkspaceAgent[]
 }
 
 // From codersdk/parameters.go:16:6

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -264,9 +264,8 @@ export interface TemplateVersionParameterSchema {
 }
 
 // From codersdk/templates.go:74:6
-export interface TemplateVersionsByTemplateRequest {
+export interface TemplateVersionsByTemplateRequest extends Pagination {
   readonly template_id: string
-  readonly Pagination: Pagination
 }
 
 // From codersdk/templates.go:28:6
@@ -323,10 +322,9 @@ export interface UserRoles {
 }
 
 // From codersdk/users.go:23:6
-export interface UsersRequest {
+export interface UsersRequest extends Pagination {
   readonly search: string
   readonly status: string
-  readonly Pagination: Pagination
 }
 
 // From codersdk/workspaces.go:18:6


### PR DESCRIPTION
Note: This PR targets https://github.com/coder/coder/pull/1308, it is a continuation but I felt it warranted a separate PR.

This PR adds support for the JSON `omitempty` tag (reflected as a TypeScript optional) and embedded structs in the `codersdk` package. The properties of embedded structs now appear directly on the struct that embeds them via TypeScript `interface .. extends`. This behaves the same way as the Go `json.Marshal` and `json.Unmarshal` do when a struct is embedded ([example playground](https://go.dev/play/p/azJL-Wl6ka0)).

As discussed in https://github.com/coder/coder/pull/1308#discussion_r865994793, the generated typings are not ideal for comfortable use in the frontend, this tries to amend that.

If we don't want the above behavior, the field can either be named or a have `json` tag added.

Do these changes seem reasonable/are they helpful @presleyp @BrunoQuaresma?
