### PR TITLE
feat: make it harder to skip graceful shutdown accidentally

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -348,7 +348,7 @@ func server() *cobra.Command {
 			// signal.Stop() until graceful shutdown finished--this means we swallow additional
 			// SIGINT after the first.  To get out of a graceful shutdown, the user can send SIGQUIT
 			// with ctrl+\ or SIGTERM with `kill`.
-			stopChan := make(chan os.Signal)
+			stopChan := make(chan os.Signal, 1)
 			defer signal.Stop(stopChan)
 			signal.Notify(stopChan, os.Interrupt)
 			select {

--- a/cli/server.go
+++ b/cli/server.go
@@ -342,7 +342,13 @@ func server() *cobra.Command {
 				return xerrors.Errorf("notify systemd: %w", err)
 			}
 
-			stopChan := make(chan os.Signal, 1)
+			// Because the graceful shutdown includes cleaning up workspaces in dev mode, we're
+			// going to make it harder to accidentally skip the graceful shutdown by hitting ctrl+c
+			// two or more times.  So the stopChan is unlimited in size and we don't call
+			// signal.Stop() until graceful shutdown finished--this means we swallow additional
+			// SIGINT after the first.  To get out of a graceful shutdown, the user can send SIGQUIT
+			// with ctrl+\ or SIGTERM with `kill`.
+			stopChan := make(chan os.Signal)
 			defer signal.Stop(stopChan)
 			signal.Notify(stopChan, os.Interrupt)
 			select {
@@ -358,12 +364,13 @@ func server() *cobra.Command {
 				return err
 			case <-stopChan:
 			}
-			signal.Stop(stopChan)
 			_, err = daemon.SdNotify(false, daemon.SdNotifyStopping)
 			if err != nil {
 				return xerrors.Errorf("notify systemd: %w", err)
 			}
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\n\n"+cliui.Styles.Bold.Render("Interrupt caught. Gracefully exiting..."))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\n\n"+
+				cliui.Styles.Bold.Render(
+					"Interrupt caught, gracefully exiting.  Use ctrl+\\ to force quit"))
 
 			if dev {
 				organizations, err := client.OrganizationsByUser(cmd.Context(), codersdk.Me)

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -271,7 +271,10 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 		err = currentProcess.Signal(os.Interrupt)
 		require.NoError(t, err)
-		// Send a second signal, which should be ignored
+		// Send a two more signal, which should be ignored.  Send 2 because the channel has a buffer
+		// of 1 and we want to make sure that nothing strange happens if we exceed the buffer.
+		err = currentProcess.Signal(os.Interrupt)
+		require.NoError(t, err)
 		err = currentProcess.Signal(os.Interrupt)
 		require.NoError(t, err)
 		<-done

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -271,6 +271,9 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 		err = currentProcess.Signal(os.Interrupt)
 		require.NoError(t, err)
+		// Send a second signal, which should be ignored
+		err = currentProcess.Signal(os.Interrupt)
+		require.NoError(t, err)
 		<-done
 	})
 	t.Run("DatadogTracerNoLeak", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@coder.com>

Makes it harder to accidentally skip graceful shutdown (which, in `--dev` mode includes cleaning up workspaces) by not allowing a second ctrl+C to kill the program.  If you really want to kill graceful shutdown, you can use ctrl+\ (SIGQUIT).

## Subtasks

- [x] added a test for feature

Fixes #631


