### PR TITLE
feat: arm(v7/64) builds for releases and agent scripts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,12 @@ builds:
     goos: [darwin, linux, windows]
     goarch: [amd64, arm, arm64]
     goarm: ["7"]
+    # Only build arm 7 for Linux
+    ignore:
+      - goos: windows
+        goarm: '7'
+      - goos: darwin
+        goarm: '7'
     hooks:
       # The "trimprefix" appends ".exe" on Windows.
       post: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,8 @@ builds:
       ["-s -w -X github.com/coder/coder/buildinfo.tag={{ .Version }}"]
     env: [CGO_ENABLED=0]
     goos: [darwin, linux, windows]
-    goarch: [amd64]
+    goarch: [amd64, arm, arm64]
+    goarm: ["7"]
     hooks:
       # The "trimprefix" appends ".exe" on Windows.
       post: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,8 @@ builds:
       ["-s -w -X github.com/coder/coder/buildinfo.tag={{ .Version }}"]
     env: [CGO_ENABLED=0]
     goos: [linux]
-    goarch: [amd64, arm64]
+    goarch: [amd64, arm, arm64]
+    goarm: ["7"]
 
   - id: coder-windows
     dir: cmd/coder

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,7 +43,7 @@ builds:
     hooks:
       # The "trimprefix" appends ".exe" on Windows.
       post: |
-        cp {{.Path}} site/out/bin/coder-{{ .Os }}-{{ .Arch }}{{ trimprefix .Name "coder" }}
+        cp {{.Path}} site/out/bin/coder-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ trimprefix .Name "coder" }}
 
   - id: coder-linux
     dir: cmd/coder

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -17,6 +17,12 @@ Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.
 $env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
 $env:CODER_AGENT_URL = "${ACCESS_URL}"
 Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`,
+			"arm64": `$ProgressPreference = "SilentlyContinue"
+Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-arm64.exe -OutFile $env:TEMP\sshd.exe
+Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
+$env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
+$env:CODER_AGENT_URL = "${ACCESS_URL}"
+Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`,
 		},
 		"linux": {
 			"amd64": `#!/usr/bin/env sh
@@ -27,12 +33,36 @@ chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
 exec $BINARY_LOCATION agent`,
+			"arm64": `#!/usr/bin/env sh
+set -eu pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
+curl -fsSL ${ACCESS_URL}bin/coder-linux-arm64 -o $BINARY_LOCATION
+chmod +x $BINARY_LOCATION
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec $BINARY_LOCATION agent`,
+			"arm": `#!/usr/bin/env sh
+set -eu pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
+curl -fsSL ${ACCESS_URL}bin/coder-linux-arm -o $BINARY_LOCATION
+chmod +x $BINARY_LOCATION
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec $BINARY_LOCATION agent`,
 		},
 		"darwin": {
 			"amd64": `#!/usr/bin/env sh
 set -eu pipefail
 export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
 curl -fsSL ${ACCESS_URL}bin/coder-darwin-amd64 -o $BINARY_LOCATION
+chmod +x $BINARY_LOCATION
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec $BINARY_LOCATION agent`,
+			"arm64": `#!/usr/bin/env sh
+set -eu pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
+curl -fsSL ${ACCESS_URL}bin/coder-darwin-arm64 -o $BINARY_LOCATION
 chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -1,72 +1,56 @@
 package provisionersdk
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var (
+	// On Windows, VS Code Remote requires a parent process of the
+	// executing shell to be named "sshd", otherwise it fails. See:
+	// https://github.com/microsoft/vscode-remote-release/issues/5699
+	windowsScript = `$ProgressPreference = "SilentlyContinue"
+Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-${ARCH}.exe -OutFile $env:TEMP\sshd.exe
+Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
+$env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
+$env:CODER_AGENT_URL = "${ACCESS_URL}"
+Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
+
+	linuxScript = `#!/usr/bin/env sh
+set -eu pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
+curl -fsSL ${ACCESS_URL}bin/coder-linux-${ARCH} -o $BINARY_LOCATION
+chmod +x $BINARY_LOCATION
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec $BINARY_LOCATION agent`
+
+	darwinScript = `#!/usr/bin/env sh
+set -eu pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
+curl -fsSL ${ACCESS_URL}bin/coder-darwin-${ARCH} -o $BINARY_LOCATION
+chmod +x $BINARY_LOCATION
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec $BINARY_LOCATION agent`
+
 	// A mapping of operating-system ($GOOS) to architecture ($GOARCH)
 	// to agent install and run script. ${DOWNLOAD_URL} is replaced
-	// with strings.ReplaceAll() when being consumed.
+	// with strings.ReplaceAll() when being consumed. ${ARCH} is replaced
+	// with the architecture when being provided.
 	agentScripts = map[string]map[string]string{
-		// On Windows, VS Code Remote requires a parent process of the
-		// executing shell to be named "sshd", otherwise it fails. See:
-		// https://github.com/microsoft/vscode-remote-release/issues/5699
 		"windows": {
-			"amd64": `$ProgressPreference = "SilentlyContinue"
-Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-amd64.exe -OutFile $env:TEMP\sshd.exe
-Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
-$env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
-$env:CODER_AGENT_URL = "${ACCESS_URL}"
-Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`,
-			"arm64": `$ProgressPreference = "SilentlyContinue"
-Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-arm64.exe -OutFile $env:TEMP\sshd.exe
-Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
-$env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
-$env:CODER_AGENT_URL = "${ACCESS_URL}"
-Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`,
+			"amd64": windowsScript,
+			"arm64": windowsScript,
 		},
 		"linux": {
-			"amd64": `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-linux-amd64 -o $BINARY_LOCATION
-chmod +x $BINARY_LOCATION
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`,
-			"arm64": `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-linux-arm64 -o $BINARY_LOCATION
-chmod +x $BINARY_LOCATION
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`,
-			"armv7": `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-linux-armv7 -o $BINARY_LOCATION
-chmod +x $BINARY_LOCATION
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`,
+			"amd64": linuxScript,
+			"arm64": linuxScript,
+			"armv7": linuxScript,
 		},
 		"darwin": {
-			"amd64": `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-darwin-amd64 -o $BINARY_LOCATION
-chmod +x $BINARY_LOCATION
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`,
-			"arm64": `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-darwin-arm64 -o $BINARY_LOCATION
-chmod +x $BINARY_LOCATION
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`,
+			"amd64": darwinScript,
+			"arm64": darwinScript,
 		},
 	}
 )
@@ -78,6 +62,7 @@ func AgentScriptEnv() map[string]string {
 	env := map[string]string{}
 	for operatingSystem, scripts := range agentScripts {
 		for architecture, script := range scripts {
+			script := strings.ReplaceAll(script, "${ARCH}", architecture)
 			env[fmt.Sprintf("CODER_AGENT_SCRIPT_%s_%s", operatingSystem, architecture)] = script
 		}
 	}

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -41,7 +41,7 @@ chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
 exec $BINARY_LOCATION agent`,
-			"arm": `#!/usr/bin/env sh
+			"armv7": `#!/usr/bin/env sh
 set -eu pipefail
 export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
 curl -fsSL ${ACCESS_URL}bin/coder-linux-arm -o $BINARY_LOCATION

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -44,7 +44,7 @@ exec $BINARY_LOCATION agent`,
 			"armv7": `#!/usr/bin/env sh
 set -eu pipefail
 export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-linux-arm -o $BINARY_LOCATION
+curl -fsSL ${ACCESS_URL}bin/coder-linux-armv7 -o $BINARY_LOCATION
 chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"


### PR DESCRIPTION
This PR adds builds armv7 Linux releases. Most notably, this will improve support for Raspberry Pi operating systems

Fixes #1336 

```sh
benpotter@elijo:~ $ cat /proc/cpuinfo
processor	: 0
model name	: ARMv7 Processor rev 3 (v7l)
BogoMIPS	: 108.00
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

... processors 1, 2, 3

Hardware	: BCM2711
Revision	: c03111
Serial		: 10000000e67636d1
Model		: Raspberry Pi 4 Model B Rev 1.1
benpotter@elijo:~ $ coder --version
Coder v0.5.4-devel+ad8d9dd Fri May  6 20:45:18 UTC 2022
https://github.com/coder/coder/commit/ad8d9dd71a3e3672e78d48058f29bbe5b251bdfb
benpotter@elijo:~ $ 

```