### PR TITLE
fix: Allow coderd to exit on error channel

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -361,6 +361,7 @@ func server() *cobra.Command {
 					return err
 				}
 			case err := <-errCh:
+				shutdownConns()
 				closeCoderd()
 				return err
 			case <-stopChan:


### PR DESCRIPTION
coderd would fail silently if this was called, because connections
would never drain. HashiCorp's hc-install package broke today,
and we couldn't notice because this was hanging!
