### PR TITLE
feat: Unify cli behavior for templates create and update

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -27,7 +27,8 @@ func templateCreate() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "create [name]",
-		Short: "Create a template from the current directory",
+		Short: "Create a template from the current directory or as specified by flag",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := createClient(cmd)
 			if err != nil {
@@ -51,19 +52,10 @@ func templateCreate() *cobra.Command {
 				return xerrors.Errorf("A template already exists named %q!", templateName)
 			}
 
-			// Confirm upload of the users current directory.
-			// Truncate if in the home directory, because a shorter path looks nicer.
-			displayDirectory := directory
-			userHomeDir, err := os.UserHomeDir()
-			if err != nil {
-				return xerrors.Errorf("get home dir: %w", err)
-			}
-			if strings.HasPrefix(displayDirectory, userHomeDir) {
-				displayDirectory = strings.TrimPrefix(displayDirectory, userHomeDir)
-				displayDirectory = "~" + displayDirectory
-			}
+			// Confirm upload of the directory.
+			prettyDir := prettyDirectoryPath(directory)
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
-				Text:      fmt.Sprintf("Create and upload %q?", displayDirectory),
+				Text:      fmt.Sprintf("Create and upload %q?", prettyDir),
 				IsConfirm: true,
 				Default:   "yes",
 			})
@@ -73,7 +65,7 @@ func templateCreate() *cobra.Command {
 
 			spin := spinner.New(spinner.CharSets[5], 100*time.Millisecond)
 			spin.Writer = cmd.OutOrStdout()
-			spin.Suffix = cliui.Styles.Keyword.Render(" Uploading current directory...")
+			spin.Suffix = cliui.Styles.Keyword.Render(" Uploading directory...")
 			spin.Start()
 			defer spin.Stop()
 			archive, err := provisionersdk.Tar(directory, provisionersdk.TemplateArchiveLimit)
@@ -123,9 +115,9 @@ func templateCreate() *cobra.Command {
 	}
 	currentDirectory, _ := os.Getwd()
 	cmd.Flags().StringVarP(&directory, "directory", "d", currentDirectory, "Specify the directory to create from")
-	cmd.Flags().StringVarP(&provisioner, "provisioner", "p", "terraform", "Customize the provisioner backend")
+	cmd.Flags().StringVarP(&provisioner, "test.provisioner", "", "terraform", "Customize the provisioner backend")
 	// This is for testing!
-	err := cmd.Flags().MarkHidden("provisioner")
+	err := cmd.Flags().MarkHidden("test.provisioner")
 	if err != nil {
 		panic(err)
 	}
@@ -227,4 +219,20 @@ func createValidTemplateVersion(cmd *cobra.Command, client *codersdk.Client, org
 	}
 
 	return &version, parameters, nil
+}
+
+// prettyDirectoryPath returns a prettified path when inside the users
+// home directory. Falls back to dir if the users home directory cannot
+// discerned.
+func prettyDirectoryPath(dir string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return dir
+	}
+	pretty := dir
+	if strings.HasPrefix(pretty, homeDir) {
+		pretty = strings.TrimPrefix(pretty, homeDir)
+		pretty = "~" + pretty
+	}
+	return pretty
 }

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -223,8 +223,9 @@ func createValidTemplateVersion(cmd *cobra.Command, client *codersdk.Client, org
 
 // prettyDirectoryPath returns a prettified path when inside the users
 // home directory. Falls back to dir if the users home directory cannot
-// discerned.
+// discerned. This function calls filepath.Clean on the result.
 func prettyDirectoryPath(dir string) string {
+	dir = filepath.Clean(dir)
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return dir

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -22,7 +22,7 @@ func TestTemplateCreate(t *testing.T) {
 			Parse:     echo.ParseComplete,
 			Provision: echo.ProvisionComplete,
 		})
-		cmd, root := clitest.New(t, "templates", "create", "my-template", "--directory", source, "--provisioner", string(database.ProvisionerTypeEcho))
+		cmd, root := clitest.New(t, "templates", "create", "my-template", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		_ = coderdtest.NewProvisionerDaemon(t, client)
 		doneChan := make(chan struct{})

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -25,25 +25,27 @@ func TestTemplateCreate(t *testing.T) {
 		cmd, root := clitest.New(t, "templates", "create", "my-template", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		_ = coderdtest.NewProvisionerDaemon(t, client)
-		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
 		cmd.SetOut(pty.Output())
+
+		execDone := make(chan error)
 		go func() {
-			defer close(doneChan)
-			err := cmd.Execute()
-			require.NoError(t, err)
+			execDone <- cmd.Execute()
 		}()
-		matches := []string{
-			"Create and upload", "yes",
-			"Confirm create?", "yes",
+
+		matches := []struct {
+			match string
+			write string
+		}{
+			{match: "Create and upload", write: "yes"},
+			{match: "Confirm create?", write: "yes"},
 		}
-		for i := 0; i < len(matches); i += 2 {
-			match := matches[i]
-			value := matches[i+1]
-			pty.ExpectMatch(match)
-			pty.WriteLine(value)
+		for _, m := range matches {
+			pty.ExpectMatch(m.match)
+			pty.WriteLine(m.write)
 		}
-		<-doneChan
+
+		require.NoError(t, <-execDone)
 	})
 }

--- a/cli/templateupdate_test.go
+++ b/cli/templateupdate_test.go
@@ -1,0 +1,62 @@
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/coderd/database"
+	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/provisioner/echo"
+	"github.com/coder/coder/pty/ptytest"
+)
+
+func TestTemplateUpdate(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+	_ = coderdtest.NewProvisionerDaemon(t, client)
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+	_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+
+	// Test the cli command.
+	source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+		Parse:     echo.ParseComplete,
+		Provision: echo.ProvisionComplete,
+	})
+	cmd, root := clitest.New(t, "templates", "update", template.Name, "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
+	clitest.SetupConfig(t, client, root)
+	pty := ptytest.New(t)
+	cmd.SetIn(pty.Input())
+	cmd.SetOut(pty.Output())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err := cmd.Execute()
+		require.NoError(t, err)
+	}()
+	matches := []string{
+		"Upload", "yes",
+	}
+	for i := 0; i < len(matches); i += 2 {
+		match := matches[i]
+		value := matches[i+1]
+		pty.ExpectMatch(match)
+		pty.WriteLine(value)
+	}
+	<-done
+
+	// Assert that the template version changed.
+	templateVersions, err := client.TemplateVersionsByTemplate(context.Background(), codersdk.TemplateVersionsByTemplateRequest{
+		TemplateID: template.ID,
+	})
+	require.NoError(t, err)
+	assert.Len(t, templateVersions, 2)
+	assert.NotEqual(t, template.ActiveVersionID, templateVersions[1].ID)
+}


### PR DESCRIPTION
This PR changes the `templates update` command to be more in line with `templates create`.

Changes:

- The directory is either cwd or provided via the `-d` flag, same as `create`
- A confirmation prompt is now shown to confirm the `update` directory, same as `create`
- For both `create` and `update` the `--provider` flag is now called `--test.provider` and has no shorthand to improve clarity
- A test was added for `update`

Other considerations:
- I considered turning dir into a mandatory arg and name into an optional flag as it would be quite low effor to do `templates create .`, `tempaltes update .` and by default infer the `name` from the provided directory. Ultimately decided to keep the behavior as-is but am open to make the change if it seems like a good idea

Fixes #565

---

Observations:

- While trying to get the spinner to show, I tried dumping a few MB of data into the folder, only to notice there's a 1MB limit. This does seem a bit conservative?

