### PR TITLE
fix: missing return when template version is not found

### DIFF
--- a/coderd/organizations.go
+++ b/coderd/organizations.go
@@ -180,6 +180,7 @@ func (api *api) postTemplatesByOrganization(rw http.ResponseWriter, r *http.Requ
 		httpapi.Write(rw, http.StatusNotFound, httpapi.Response{
 			Message: "template version does not exist",
 		})
+		return
 	}
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, httpapi.Response{


### PR DESCRIPTION
Split out from https://github.com/coder/coder/pull/1394 for changelog purposes