### PR TITLE
fix: show --help message for CLI errors, add tests for delete

### DIFF
--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -1,0 +1,38 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/pty/ptytest"
+)
+
+func TestDelete(t *testing.T) {
+	t.Run("WithParameter", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		coderdtest.NewProvisionerDaemon(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+		cmd, root := clitest.New(t, "delete", workspace.Name)
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			require.NoError(t, err)
+		}()
+		pty.ExpectMatch("Cleaning Up")
+		<-doneChan
+	})
+}

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -35,4 +35,12 @@ func TestDelete(t *testing.T) {
 		pty.ExpectMatch("Cleaning Up")
 		<-doneChan
 	})
+	t.Run("WithoutParameters", func(t *testing.T) {
+		t.Parallel()
+
+		cmd, _ := clitest.New(t, "delete")
+
+		err := cmd.Execute()
+		require.ErrorContains(t, err, "Run 'coder workspaces delete --help' for usage.")
+	})
 }

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/pty/ptytest"
@@ -35,14 +34,5 @@ func TestDelete(t *testing.T) {
 		}()
 		pty.ExpectMatch("Cleaning Up")
 		<-doneChan
-	})
-	t.Run("WithoutParameters/FormatCobraError", func(t *testing.T) {
-		t.Parallel()
-
-		cmd, _ := clitest.New(t, "delete")
-
-		cmd, err := cmd.ExecuteC()
-		errStr := cli.FormatCobraError(err, cmd)
-		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
 	})
 }

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/pty/ptytest"
@@ -35,12 +36,13 @@ func TestDelete(t *testing.T) {
 		pty.ExpectMatch("Cleaning Up")
 		<-doneChan
 	})
-	t.Run("WithoutParameters", func(t *testing.T) {
+	t.Run("WithoutParameters/FormatCobraError", func(t *testing.T) {
 		t.Parallel()
 
 		cmd, _ := clitest.New(t, "delete")
 
-		err := cmd.Execute()
-		require.ErrorContains(t, err, "Run 'coder delete --help' for usage.")
+		cmd, err := cmd.ExecuteC()
+		errStr := cli.FormatCobraError(err, cmd)
+		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
 	})
 }

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -41,6 +41,6 @@ func TestDelete(t *testing.T) {
 		cmd, _ := clitest.New(t, "delete")
 
 		err := cmd.Execute()
-		require.ErrorContains(t, err, "Run 'coder workspaces delete --help' for usage.")
+		require.ErrorContains(t, err, "Run 'coder delete --help' for usage.")
 	})
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"time"
@@ -258,4 +259,10 @@ func versionTemplate() string {
 	template += "\r\n" + buildinfo.ExternalURL()
 	template += "\r\n"
 	return template
+}
+
+// FormatCobraError colorizes and adds "--help" docs to cobra commands.
+func FormatCobraError(err error, cmd *cobra.Command) string {
+	helpErrMsg := fmt.Sprintf("Run '%s %s --help' for usage.", cmd.Root().Name(), cmd.Name())
+	return cliui.Styles.Error.Render(err.Error() + "\n" + helpErrMsg)
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,0 +1,22 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli"
+	"github.com/coder/coder/cli/clitest"
+)
+
+func TestRoot(t *testing.T) {
+	t.Run("FormatCobraError", func(t *testing.T) {
+		t.Parallel()
+
+		cmd, _ := clitest.New(t, "delete")
+
+		cmd, err := cmd.ExecuteC()
+		errStr := cli.FormatCobraError(err, cmd)
+		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
+	})
+}

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	dadjoke()
-	err := cli.Root().Execute()
+	_, err := cli.Root().ExecuteC()
 	if err != nil {
 		if errors.Is(err, cliui.Canceled) {
 			os.Exit(1)

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -14,12 +14,13 @@ import (
 
 func main() {
 	dadjoke()
-	_, err := cli.Root().ExecuteC()
+	cmd, err := cli.Root().ExecuteC()
 	if err != nil {
 		if errors.Is(err, cliui.Canceled) {
 			os.Exit(1)
 		}
-		_, _ = fmt.Fprintln(os.Stderr, cliui.Styles.Error.Render(err.Error()))
+		helpErrMsg := fmt.Sprintf("Run '%s %s --help' for usage.", cmd.Root().Name(), cmd.Name())
+		_, _ = fmt.Fprintln(os.Stderr, cliui.Styles.Error.Render(err.Error()+"/n"+helpErrMsg))
 		os.Exit(1)
 	}
 }

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -19,8 +19,8 @@ func main() {
 		if errors.Is(err, cliui.Canceled) {
 			os.Exit(1)
 		}
-		helpErrMsg := fmt.Sprintf("Run '%s %s --help' for usage.", cmd.Root().Name(), cmd.Name())
-		_, _ = fmt.Fprintln(os.Stderr, cliui.Styles.Error.Render(err.Error()+"/n"+helpErrMsg))
+		cobraErr := cli.FormatCobraError(err, cmd)
+		_, _ = fmt.Fprintln(os.Stderr, cobraErr)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR shows a more helpful error message when calling `coder delete`.

## Subtasks

- [x] added tests

Fixes #1233

H/T to @mafredri for pointers & suggestions 🎉

_First time actually working in Go so please give any and all suggestions_