### PR TITLE
fix: flake in setup-docker in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       # Docker is not included on macos-latest
-      - uses: docker-practice/actions-setup-docker@v1
+      - uses: docker-practice/actions-setup-docker@v1.0.8
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
During a release, the `setup-docker` sometimes flakes on the latest version. See docker-practice/actions-setup-docker#18
