### PR TITLE
chore: Deploy internally accessible godoc container

### DIFF
--- a/scripts/internal-docs/README.md
+++ b/scripts/internal-docs/README.md
@@ -1,0 +1,3 @@
+Configuration for automatically building and hosting an internal godoc site.
+This will become obsolete once we make the repo public and can use
+https://pkg.go.dev/.

--- a/scripts/internal-docs/cloudbuild.yaml
+++ b/scripts/internal-docs/cloudbuild.yaml
@@ -1,0 +1,8 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/coder-devrel/internal-docs', '-f', 'scripts/internal-docs/docker/Dockerfile', '.']
+- name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/coder-devrel/internal-docs']
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args: ['run', 'deploy', 'internal-docs', '--image', 'gcr.io/coder-devrel/internal-docs', '--region', 'us-central1']

--- a/scripts/internal-docs/docker/Dockerfile
+++ b/scripts/internal-docs/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.18-alpine
 
-RUN go install golang.org/x/tools/cmd/godoc@v0.1.10
+RUN go install github.com/dwahler/go-tools/cmd/godoc@v0.1.0
 
 WORKDIR /go/src/github.com/coder/coder
 ADD . .

--- a/scripts/internal-docs/docker/Dockerfile
+++ b/scripts/internal-docs/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.18-alpine
+
+RUN go install golang.org/x/tools/cmd/godoc@v0.1.10
+
+WORKDIR /go/src/github.com/coder/coder
+ADD . .
+
+EXPOSE 6060
+CMD godoc -http :6060

--- a/scripts/internal-docs/docker/Dockerfile
+++ b/scripts/internal-docs/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.18-alpine
 
-RUN go install github.com/dwahler/go-tools/cmd/godoc@v0.1.0
+RUN go install github.com/dwahler/go-tools/cmd/godoc@v0.1.1
 
 WORKDIR /go/src/github.com/coder/coder
 ADD . .


### PR DESCRIPTION
Build a container image that runs `godoc` on our source code, and deploy it to Cloud Run for internal use.

The Cloud Run/Build configurations are currently manually configured, but the important settings are:

* Cloud Build config path: `/scripts/internal-docs/cloudbuild.yaml`
* Container image: `gcr.io/coder-devrel/internal-docs`
* Port: 6060
* Container resources: 2 vCPU, 2GB RAM
* Execution environment: Second generation
 * Not sure why this is crucial, but the container consistently fails to start without it

The container uses https://github.com/dwahler/go-tools, which is a fork of golang.org/x/tools that doesn't serve traffic until it's finished scanning the repository, which is necessary to play nicely with Cloud Run's traffic balancing.

Fixes #1398