### PR TITLE
chore: un-hide autostart and autostop commands

### DIFF
--- a/cli/autostart.go
+++ b/cli/autostart.go
@@ -23,7 +23,6 @@ func autostart() *cobra.Command {
 		Short:       "schedule a workspace to automatically start at a regular time",
 		Long:        autostartDescriptionLong,
 		Example:     "coder autostart enable my-workspace --minute 30 --hour 9 --days 1-5 --tz Europe/Dublin",
-		Hidden:      true,
 	}
 
 	autostartCmd.AddCommand(autostartEnable())

--- a/cli/autostop.go
+++ b/cli/autostop.go
@@ -22,7 +22,6 @@ func autostop() *cobra.Command {
 		Short:   "schedule a workspace to automatically stop at a regular time",
 		Long:    autostopDescriptionLong,
 		Example: "coder autostop enable my-workspace --minute 0 --hour 18 --days 1-5 -tz Europe/Dublin",
-		Hidden:  true,
 	}
 
 	autostopCmd.AddCommand(autostopEnable())


### PR DESCRIPTION
This commit un-hides the autostart and autostop commands.
Fixes #1069.