### PR TITLE
chore: add a unit test to ensure correct behaviour with multiple replicas and rename LifecycleTicker to AutobuildTicker

### DIFF
--- a/coderd/autobuild/executor/lifecycle_executor_test.go
+++ b/coderd/autobuild/executor/lifecycle_executor_test.go
@@ -26,7 +26,7 @@ func TestExecutorAutostartOK(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -66,7 +66,7 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -118,7 +118,7 @@ func TestExecutorAutostartAlreadyRunning(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -156,7 +156,7 @@ func TestExecutorAutostartNotEnabled(t *testing.T) {
 	var (
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -189,7 +189,7 @@ func TestExecutorAutostopOK(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -229,7 +229,7 @@ func TestExecutorAutostopAlreadyStopped(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -267,7 +267,7 @@ func TestExecutorAutostopNotEnabled(t *testing.T) {
 	var (
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -300,7 +300,7 @@ func TestExecutorWorkspaceDeleted(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -340,7 +340,7 @@ func TestExecutorWorkspaceTooEarly(t *testing.T) {
 		err    error
 		tickCh = make(chan time.Time)
 		client = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -384,10 +384,10 @@ func TestExecutorAutostartMultipleOK(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		tickCh2 = make(chan time.Time)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh,
+			AutobuildTicker: tickCh,
 		})
 		_ = coderdtest.New(t, &coderdtest.Options{
-			LifecycleTicker: tickCh2,
+			AutobuildTicker: tickCh2,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -61,7 +61,7 @@ type Options struct {
 	GoogleTokenValidator *idtoken.Validator
 	SSHKeygenAlgorithm   gitsshkey.Algorithm
 	APIRateLimit         int
-	LifecycleTicker      <-chan time.Time
+	AutobuildTicker      <-chan time.Time
 }
 
 // New constructs an in-memory coderd instance and returns
@@ -77,9 +77,9 @@ func New(t *testing.T, options *Options) *codersdk.Client {
 		options.GoogleTokenValidator, err = idtoken.NewValidator(ctx, option.WithoutAuthentication())
 		require.NoError(t, err)
 	}
-	if options.LifecycleTicker == nil {
+	if options.AutobuildTicker == nil {
 		ticker := make(chan time.Time)
-		options.LifecycleTicker = ticker
+		options.AutobuildTicker = ticker
 		t.Cleanup(func() { close(ticker) })
 	}
 
@@ -111,7 +111,7 @@ func New(t *testing.T, options *Options) *codersdk.Client {
 		ctx,
 		db,
 		slogtest.Make(t, nil).Named("autobuild.executor").Leveled(slog.LevelDebug),
-		options.LifecycleTicker,
+		options.AutobuildTicker,
 	)
 	lifecycleExecutor.Run()
 


### PR DESCRIPTION
This PR adds another unit test to `autobuild/executor` to validate the correct behaviour when multiple coderd instances run in parallel.

**Note:** this only works if you use a "real" database, as `coderdtest.New` by default uses a separate fake database instance per coderd.