### PR TITLE
fix: cli: prettify schedule when printing output

### DIFF
--- a/cli/autostart.go
+++ b/cli/autostart.go
@@ -63,7 +63,15 @@ func autostartShow() *cobra.Command {
 				return nil
 			}
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "schedule: %s\nnext: %s\n", workspace.AutostartSchedule, validSchedule.Next(time.Now()))
+			next := validSchedule.Next(time.Now())
+			loc, _ := time.LoadLocation(validSchedule.Timezone())
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"schedule: %s\ntimezone: %s\nnext:     %s\n",
+				validSchedule.Cron(),
+				validSchedule.Timezone(),
+				next.In(loc),
+			)
 
 			return nil
 		},

--- a/cli/autostart_test.go
+++ b/cli/autostart_test.go
@@ -45,7 +45,8 @@ func TestAutostart(t *testing.T) {
 
 		err = cmd.Execute()
 		require.NoError(t, err, "unexpected error")
-		require.Contains(t, stdoutBuf.String(), "schedule: "+sched)
+		// CRON_TZ gets stripped
+		require.Contains(t, stdoutBuf.String(), "schedule: 30 17 * * 1-5")
 	})
 
 	t.Run("EnableDisableOK", func(t *testing.T) {

--- a/cli/autostop.go
+++ b/cli/autostop.go
@@ -63,7 +63,15 @@ func autostopShow() *cobra.Command {
 				return nil
 			}
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "schedule: %s\nnext: %s\n", workspace.AutostopSchedule, validSchedule.Next(time.Now()))
+			next := validSchedule.Next(time.Now())
+			loc, _ := time.LoadLocation(validSchedule.Timezone())
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+				"schedule: %s\ntimezone: %s\nnext:     %s\n",
+				validSchedule.Cron(),
+				validSchedule.Timezone(),
+				next.In(loc),
+			)
 
 			return nil
 		},

--- a/cli/autostop_test.go
+++ b/cli/autostop_test.go
@@ -45,7 +45,8 @@ func TestAutostop(t *testing.T) {
 
 		err = cmd.Execute()
 		require.NoError(t, err, "unexpected error")
-		require.Contains(t, stdoutBuf.String(), "schedule: "+sched)
+		// CRON_TZ gets stripped
+		require.Contains(t, stdoutBuf.String(), "schedule: 30 17 * * 1-5")
 	})
 
 	t.Run("EnableDisableOK", func(t *testing.T) {

--- a/cli/list.go
+++ b/cli/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/coderd/autobuild/schedule"
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/codersdk"
 )
@@ -108,14 +109,18 @@ func list() *cobra.Command {
 					durationDisplay = durationDisplay[:len(durationDisplay)-2]
 				}
 
-				autostartDisplay := "not enabled"
+				autostartDisplay := "-"
 				if workspace.AutostartSchedule != "" {
-					autostartDisplay = workspace.AutostartSchedule
+					if sched, err := schedule.Weekly(workspace.AutostartSchedule); err == nil {
+						autostartDisplay = sched.Cron()
+					}
 				}
 
-				autostopDisplay := "not enabled"
+				autostopDisplay := "-"
 				if workspace.AutostopSchedule != "" {
-					autostopDisplay = workspace.AutostopSchedule
+					if sched, err := schedule.Weekly(workspace.AutostopSchedule); err == nil {
+						autostopDisplay = sched.Cron()
+					}
 				}
 
 				user := usersByID[workspace.OwnerID]

--- a/coderd/autobuild/schedule/schedule.go
+++ b/coderd/autobuild/schedule/schedule.go
@@ -78,7 +78,7 @@ type Schedule struct {
 }
 
 // String serializes the schedule to its original human-friendly format.
-// The leading CRON_TZ is stripped.
+// The leading CRON_TZ is maintained.
 func (s Schedule) String() string {
 	var sb strings.Builder
 	_, _ = sb.WriteString("CRON_TZ=")

--- a/coderd/autobuild/schedule/schedule_test.go
+++ b/coderd/autobuild/schedule/schedule_test.go
@@ -17,6 +17,8 @@ func Test_Weekly(t *testing.T) {
 		at            time.Time
 		expectedNext  time.Time
 		expectedError string
+		expectedCron  string
+		expectedTz    string
 	}{
 		{
 			name:          "with timezone",
@@ -24,6 +26,8 @@ func Test_Weekly(t *testing.T) {
 			at:            time.Date(2022, 4, 1, 14, 29, 0, 0, time.UTC),
 			expectedNext:  time.Date(2022, 4, 1, 14, 30, 0, 0, time.UTC),
 			expectedError: "",
+			expectedCron:  "30 9 * * 1-5",
+			expectedTz:    "US/Central",
 		},
 		{
 			name:          "without timezone",
@@ -31,6 +35,8 @@ func Test_Weekly(t *testing.T) {
 			at:            time.Date(2022, 4, 1, 9, 29, 0, 0, time.Local),
 			expectedNext:  time.Date(2022, 4, 1, 9, 30, 0, 0, time.Local),
 			expectedError: "",
+			expectedCron:  "30 9 * * 1-5",
+			expectedTz:    "UTC",
 		},
 		{
 			name:          "invalid schedule",
@@ -86,6 +92,8 @@ func Test_Weekly(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, testCase.expectedNext, nextTime)
 				require.Equal(t, testCase.spec, actual.String())
+				require.Equal(t, testCase.expectedCron, actual.Cron())
+				require.Equal(t, testCase.expectedTz, actual.Timezone())
 			} else {
 				require.EqualError(t, err, testCase.expectedError)
 				require.Nil(t, actual)

--- a/coderd/autobuild/schedule/schedule_test.go
+++ b/coderd/autobuild/schedule/schedule_test.go
@@ -31,7 +31,7 @@ func Test_Weekly(t *testing.T) {
 		},
 		{
 			name:          "without timezone",
-			spec:          "30 9 * * 1-5",
+			spec:          "CRON_TZ=UTC 30 9 * * 1-5",
 			at:            time.Date(2022, 4, 1, 9, 29, 0, 0, time.Local),
 			expectedNext:  time.Date(2022, 4, 1, 9, 30, 0, 0, time.Local),
 			expectedError: "",


### PR DESCRIPTION
Ref: https://github.com/coder/coder/issues/1431#issuecomment-1126366128

This PR does the following:

- Adds methods to `schedule.Schedule` to show the raw cron string and timezone
- Uses these methods to clean up output of `auto(start|stop) show` or `ls`
- (From PR comment) Defaults `CRON_TZ=UTC` if not provided