### PR TITLE
fix: CreateWorkspaceForm name validation

### DIFF
--- a/site/src/forms/CreateWorkspaceForm.test.tsx
+++ b/site/src/forms/CreateWorkspaceForm.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react"
 import React from "react"
+import { reach, StringSchema } from "yup"
 import { MockOrganization, MockTemplate, MockWorkspace } from "../testHelpers/renderHelpers"
-import { CreateWorkspaceForm } from "./CreateWorkspaceForm"
+import { CreateWorkspaceForm, validationSchema } from "./CreateWorkspaceForm"
+
+const nameSchema = reach(validationSchema, "name") as StringSchema
 
 describe("CreateWorkspaceForm", () => {
   it("renders", async () => {
@@ -23,5 +26,39 @@ describe("CreateWorkspaceForm", () => {
     // Simple smoke test to verify form renders
     const element = await screen.findByText("Create Workspace")
     expect(element).toBeDefined()
+  })
+
+  describe("validationSchema", () => {
+    it("allows a 1-letter name", () => {
+      const validate = () => nameSchema.validateSync("t")
+      expect(validate).not.toThrow()
+    })
+
+    it("allows a 32-letter name", () => {
+      const input = Array(32).fill("a").join("")
+      const validate = () => nameSchema.validateSync(input)
+      expect(validate).not.toThrow()
+    })
+
+    it("allows 'test-3' to be used as name", () => {
+      const validate = () => nameSchema.validateSync("test-3")
+      expect(validate).not.toThrow()
+    })
+
+    it("allows '3-test' to be used as a name", () => {
+      const validate = () => nameSchema.validateSync("3-test")
+      expect(validate).not.toThrow()
+    })
+
+    it("disallows a 33-letter name", () => {
+      const input = Array(33).fill("a").join("")
+      const validate = () => nameSchema.validateSync(input)
+      expect(validate).toThrow()
+    })
+
+    it("disallows a space", () => {
+      const validate = () => nameSchema.validateSync("test 3")
+      expect(validate).toThrow()
+    })
   })
 })

--- a/site/src/util/formUtils.ts
+++ b/site/src/util/formUtils.ts
@@ -13,7 +13,7 @@ interface FormHelpers {
 
 export const getFormHelpers =
   <T>(form: FormikContextType<T>, formErrors?: FormikErrors<T>) =>
-  (name: keyof T): FormHelpers => {
+  (name: keyof T, helperText = ""): FormHelpers => {
     if (typeof name !== "string") {
       throw new Error(`name must be type of string, instead received '${typeof name}'`)
     }
@@ -28,7 +28,7 @@ export const getFormHelpers =
       ...form.getFieldProps(name),
       id: name,
       error: touched && Boolean(error),
-      helperText: touched && error,
+      helperText: touched ? error : helperText,
     }
   }
 


### PR DESCRIPTION
Resolves: #1421 

- adjust `getFormHelpers` to allow `helperText`
- refactor `CreateWorkspaceForm` to have `Language`, remove `FormTextField` and meet conventions
- add missing validations to Workspace name
- make Workspace name auto-focused

![validation](https://user-images.githubusercontent.com/11184711/168438930-71b419ad-ea3b-4454-99db-6d6b7cdd474f.png)
