### PR TITLE
fix: Update cli usage template for cobra feature parity

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -183,19 +183,32 @@ func usageTemplate() string {
 	// more visually appealing.
 	header := cliui.Styles.Placeholder
 
-	return `{{if .HasExample}}` + header.Render("Get Started:") + `
-{{.Example}}
+	return header.Render("Usage:") + `{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
-{{end}}{{if .HasAvailableLocalFlags}}` + header.Render("Flags:") + `
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableSubCommands}}
+` + header.Render("Aliases:") + `
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
-` + header.Render("Commands:") + `{{range .Commands}}{{if and .IsAvailableCommand (eq (len .Annotations) 0)}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .HasParent }}
+` + header.Render("Get Started:") + `
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
-` + header.Render("Workspace Commands:") + `{{range .Commands}}{{if and .IsAvailableCommand (ne (index .Annotations "workspaces") "")}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+` + header.Render("Commands:") + `{{range .Commands}}{{if (or (and .IsAvailableCommand (eq (len .Annotations) 0)) (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if and (not .HasParent) .HasAvailableSubCommands}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.
+` + header.Render("Workspace Commands:") + `{{range .Commands}}{{if (and .IsAvailableCommand (ne (index .Annotations "workspaces") ""))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+` + header.Render("Flags:") + `
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+` + header.Render("Global Flags:") + `
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
 }
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -182,11 +182,11 @@ func usageTemplate() string {
 	// Customizes the color of headings to make subcommands
 	// more visually appealing.
 	header := cliui.Styles.Placeholder
-	cobra.AddTemplateFunc("header", func(s string) string {
+	cobra.AddTemplateFunc("usageHeader", func(s string) string {
 		return header.Render(s)
 	})
 
-	return `{{header "Usage:"}}
+	return `{{usageHeader "Usage:"}}
 {{- if .Runnable}}
   {{.UseLine}}
 {{end}}
@@ -195,17 +195,17 @@ func usageTemplate() string {
 {{end}}
 
 {{- if gt (len .Aliases) 0}}
-{{header "Aliases:"}}
+{{usageHeader "Aliases:"}}
   {{.NameAndAliases}}
 {{end}}
 
 {{- if .HasExample}}
-{{header "Get Started:"}}
+{{usageHeader "Get Started:"}}
 {{.Example}}
 {{end}}
 
 {{- if .HasAvailableSubCommands}}
-{{header "Commands:"}}
+{{usageHeader "Commands:"}}
   {{- range .Commands}}
     {{- if (or (and .IsAvailableCommand (eq (len .Annotations) 0)) (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}
@@ -214,7 +214,7 @@ func usageTemplate() string {
 {{end}}
 
 {{- if and (not .HasParent) .HasAvailableSubCommands}}
-{{header "Workspace Commands:"}}
+{{usageHeader "Workspace Commands:"}}
   {{- range .Commands}}
     {{- if (and .IsAvailableCommand (ne (index .Annotations "workspaces") ""))}}
   {{rpad .Name .NamePadding }} {{.Short}}
@@ -223,17 +223,17 @@ func usageTemplate() string {
 {{end}}
 
 {{- if .HasAvailableLocalFlags}}
-{{header "Flags:"}}
+{{usageHeader "Flags:"}}
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
 {{end}}
 
 {{- if .HasAvailableInheritedFlags}}
-{{header "Global Flags:"}}
+{{usageHeader "Global Flags:"}}
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
 {{end}}
 
 {{- if .HasHelpSubCommands}}
-{{header "Additional help topics:"}}
+{{usageHeader "Additional help topics:"}}
   {{- range .Commands}}
     {{- if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}

--- a/cli/root.go
+++ b/cli/root.go
@@ -183,33 +183,64 @@ func usageTemplate() string {
 	// more visually appealing.
 	header := cliui.Styles.Placeholder
 
-	return header.Render("Usage:") + `{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+	return header.Render("Usage:") + `
+{{- if .Runnable}}
+  {{.UseLine}}
+{{end}}
+{{- if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]
+{{end}}
 
+{{- if gt (len .Aliases) 0}}
 ` + header.Render("Aliases:") + `
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+  {{.NameAndAliases}}
+{{end}}
 
+{{- if .HasExample}}
 ` + header.Render("Get Started:") + `
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{.Example}}
+{{end}}
 
-` + header.Render("Commands:") + `{{range .Commands}}{{if (or (and .IsAvailableCommand (eq (len .Annotations) 0)) (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if and (not .HasParent) .HasAvailableSubCommands}}
+{{- if .HasAvailableSubCommands}}
+` + header.Render("Commands:") + `
+  {{- range .Commands}}
+    {{- if (or (and .IsAvailableCommand (eq (len .Annotations) 0)) (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}
+    {{- end}}
+  {{- end}}
+{{end}}
 
-` + header.Render("Workspace Commands:") + `{{range .Commands}}{{if (and .IsAvailableCommand (ne (index .Annotations "workspaces") ""))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{- if and (not .HasParent) .HasAvailableSubCommands}}
+` + header.Render("Workspace Commands:") + `
+  {{- range .Commands}}
+    {{- if (and .IsAvailableCommand (ne (index .Annotations "workspaces") ""))}}
+  {{rpad .Name .NamePadding }} {{.Short}}
+    {{- end}}
+  {{- end}}
+{{end}}
 
+{{- if .HasAvailableLocalFlags}}
 ` + header.Render("Flags:") + `
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{end}}
 
+{{- if .HasAvailableInheritedFlags}}
 ` + header.Render("Global Flags:") + `
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{end}}
 
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+{{- if .HasHelpSubCommands}}
+Additional help topics:
+  {{- range .Commands}}
+    {{- if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}
+    {{- end}}
+  {{- end}}
+{{end}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`
+{{- if .HasAvailableSubCommands}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.
+{{end}}`
 }
 
 func versionTemplate() string {

--- a/cli/root.go
+++ b/cli/root.go
@@ -230,7 +230,7 @@ func usageTemplate() string {
 {{end}}
 
 {{- if .HasHelpSubCommands}}
-Additional help topics:
+` + header.Render("Additional help topics:") + `
   {{- range .Commands}}
     {{- if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}

--- a/cli/root.go
+++ b/cli/root.go
@@ -182,8 +182,11 @@ func usageTemplate() string {
 	// Customizes the color of headings to make subcommands
 	// more visually appealing.
 	header := cliui.Styles.Placeholder
+	cobra.AddTemplateFunc("header", func(s string) string {
+		return header.Render(s)
+	})
 
-	return header.Render("Usage:") + `
+	return `{{header "Usage:"}}
 {{- if .Runnable}}
   {{.UseLine}}
 {{end}}
@@ -192,17 +195,17 @@ func usageTemplate() string {
 {{end}}
 
 {{- if gt (len .Aliases) 0}}
-` + header.Render("Aliases:") + `
+{{header "Aliases:"}}
   {{.NameAndAliases}}
 {{end}}
 
 {{- if .HasExample}}
-` + header.Render("Get Started:") + `
+{{header "Get Started:"}}
 {{.Example}}
 {{end}}
 
 {{- if .HasAvailableSubCommands}}
-` + header.Render("Commands:") + `
+{{header "Commands:"}}
   {{- range .Commands}}
     {{- if (or (and .IsAvailableCommand (eq (len .Annotations) 0)) (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}
@@ -211,7 +214,7 @@ func usageTemplate() string {
 {{end}}
 
 {{- if and (not .HasParent) .HasAvailableSubCommands}}
-` + header.Render("Workspace Commands:") + `
+{{header "Workspace Commands:"}}
   {{- range .Commands}}
     {{- if (and .IsAvailableCommand (ne (index .Annotations "workspaces") ""))}}
   {{rpad .Name .NamePadding }} {{.Short}}
@@ -220,17 +223,17 @@ func usageTemplate() string {
 {{end}}
 
 {{- if .HasAvailableLocalFlags}}
-` + header.Render("Flags:") + `
+{{header "Flags:"}}
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
 {{end}}
 
 {{- if .HasAvailableInheritedFlags}}
-` + header.Render("Global Flags:") + `
+{{header "Global Flags:"}}
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
 {{end}}
 
 {{- if .HasHelpSubCommands}}
-` + header.Render("Additional help topics:") + `
+{{header "Additional help topics:"}}
   {{- range .Commands}}
     {{- if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}


### PR DESCRIPTION
This PR updates the custom usage template for feature parity with the default template used in Cobra.

I've restored the custom heading names and colorization.

Changes:
- We now display Usage properly for subcommands
- We now display "Global Flags" for all commands
- We now display "Aliases" for aliased commands
- Flags moved below Commands as per standard Cobra template

This is partially related to #1233 and #1403, but as suggested by @jsjoeio, split into a separate PR.

Fixes #1423

Example:
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/147409/168552082-abd94534-95f2-4d11-bfc3-385c01b3834c.png">
