### PR TITLE
feat: Support reading from token flag on coder login

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -168,28 +168,31 @@ func login() *cobra.Command {
 				return nil
 			}
 
-			authURL := *serverURL
-			authURL.Path = serverURL.Path + "/cli-auth"
-			if err := openURL(cmd, authURL.String()); err != nil {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open the following in your browser:\n\n\t%s\n\n", authURL.String())
-			} else {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Your browser has been opened to visit:\n\n\t%s\n\n", authURL.String())
-			}
+			sessionToken, _ := cmd.Flags().GetString(varToken)
+			if sessionToken == "" {
+				authURL := *serverURL
+				authURL.Path = serverURL.Path + "/cli-auth"
+				if err := openURL(cmd, authURL.String()); err != nil {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Open the following in your browser:\n\n\t%s\n\n", authURL.String())
+				} else {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Your browser has been opened to visit:\n\n\t%s\n\n", authURL.String())
+				}
 
-			sessionToken, err := cliui.Prompt(cmd, cliui.PromptOptions{
-				Text:   "Paste your token here:",
-				Secret: true,
-				Validate: func(token string) error {
-					client.SessionToken = token
-					_, err := client.User(cmd.Context(), codersdk.Me)
-					if err != nil {
-						return xerrors.New("That's not a valid token!")
-					}
-					return err
-				},
-			})
-			if err != nil {
-				return xerrors.Errorf("paste token prompt: %w", err)
+				sessionToken, err = cliui.Prompt(cmd, cliui.PromptOptions{
+					Text:   "Paste your token here:",
+					Secret: true,
+					Validate: func(token string) error {
+						client.SessionToken = token
+						_, err := client.User(cmd.Context(), codersdk.Me)
+						if err != nil {
+							return xerrors.New("That's not a valid token!")
+						}
+						return err
+					},
+				})
+				if err != nil {
+					return xerrors.Errorf("paste token prompt: %w", err)
+				}
 			}
 
 			// Login to get user data - verify it is OK before persisting

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -140,4 +140,16 @@ func TestLogin(t *testing.T) {
 		cancelFunc()
 		<-doneChan
 	})
+
+	t.Run("TokenFlag", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		coderdtest.CreateFirstUser(t, client)
+		root, cfg := clitest.New(t, "login", client.URL.String(), "--token", client.SessionToken)
+		err := root.Execute()
+		require.NoError(t, err)
+		sessionFile, err := cfg.Session().Read()
+		require.NoError(t, err)
+		require.Equal(t, client.SessionToken, sessionFile)
+	})
 }


### PR DESCRIPTION
This PR adds the ability to skip the login prompt by providing a valid token using the global `token` flag. This enables users to automate logins in scripts easier if they already have a valid session token. 