### PR TITLE
fix: Resolve symlinks being written with size 0 in tar

### DIFF
--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -25,7 +25,14 @@ func Tar(directory string, limit int64) ([]byte, error) {
 		if err != nil {
 			return err
 		}
-		header, err := tar.FileInfoHeader(fileInfo, file)
+		var link string
+		if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+			link, err = os.Readlink(file)
+			if err != nil {
+				return err
+			}
+		}
+		header, err := tar.FileInfoHeader(fileInfo, link)
 		if err != nil {
 			return err
 		}
@@ -45,7 +52,7 @@ func Tar(directory string, limit int64) ([]byte, error) {
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}
-		if fileInfo.IsDir() {
+		if !fileInfo.Mode().IsRegular() {
 			return nil
 		}
 		data, err := os.Open(file)


### PR DESCRIPTION
Solution found here:
https://stackoverflow.com/questions/38454850/getting-write-too-long-error-when-trying-to-create-tar-gz-file-from-file-and-d

Symlink's were being written with a size of 0, which surfaced an error
for write too long.
