### PR TITLE
chore: Add watch workspace endpoint

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -311,7 +311,7 @@ func New(options *Options) (http.Handler, func()) {
 					r.Put("/", api.putWorkspaceAutostop)
 				})
 			})
-			r.HandleFunc("/watch", api.watchWorkspace)
+			r.Get("/watch", api.watchWorkspace)
 		})
 		r.Route("/workspacebuilds/{workspacebuild}", func(r chi.Router) {
 			r.Use(

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -310,8 +310,8 @@ func New(options *Options) (http.Handler, func()) {
 				r.Route("/autostop", func(r chi.Router) {
 					r.Put("/", api.putWorkspaceAutostop)
 				})
+				r.Get("/watch", api.watchWorkspace)
 			})
-			r.Get("/watch", api.watchWorkspace)
 		})
 		r.Route("/workspacebuilds/{workspacebuild}", func(r chi.Router) {
 			r.Use(

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -311,6 +311,7 @@ func New(options *Options) (http.Handler, func()) {
 					r.Put("/", api.putWorkspaceAutostop)
 				})
 			})
+			r.HandleFunc("/watch", api.watchWorkspace)
 		})
 		r.Route("/workspacebuilds/{workspacebuild}", func(r chi.Router) {
 			r.Use(

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -128,7 +128,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 		"PUT:/api/v2/workspaces/{workspace}/autostop":  {NoAuthorize: true},
 		"GET:/api/v2/workspaces/{workspace}/builds":    {NoAuthorize: true},
 		"POST:/api/v2/workspaces/{workspace}/builds":   {NoAuthorize: true},
-		"POST:/api/v2/workspaces/{workspace}/watch":    {NoAuthorize: true},
+		"CONNECT:/api/v2/workspaces/{workspace}/watch": {NoAuthorize: true},
 
 		"POST:/api/v2/files":       {NoAuthorize: true},
 		"GET:/api/v2/files/{hash}": {NoAuthorize: true},

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -128,6 +128,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 		"PUT:/api/v2/workspaces/{workspace}/autostop":  {NoAuthorize: true},
 		"GET:/api/v2/workspaces/{workspace}/builds":    {NoAuthorize: true},
 		"POST:/api/v2/workspaces/{workspace}/builds":   {NoAuthorize: true},
+		"POST:/api/v2/workspaces/{workspace}/watch":    {NoAuthorize: true},
 
 		"POST:/api/v2/files":       {NoAuthorize: true},
 		"GET:/api/v2/files/{hash}": {NoAuthorize: true},

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -128,7 +128,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 		"PUT:/api/v2/workspaces/{workspace}/autostop":  {NoAuthorize: true},
 		"GET:/api/v2/workspaces/{workspace}/builds":    {NoAuthorize: true},
 		"POST:/api/v2/workspaces/{workspace}/builds":   {NoAuthorize: true},
-		"CONNECT:/api/v2/workspaces/{workspace}/watch": {NoAuthorize: true},
+		"GET:/api/v2/workspaces/{workspace}/watch":     {NoAuthorize: true},
 
 		"POST:/api/v2/files":       {NoAuthorize: true},
 		"GET:/api/v2/files/{hash}": {NoAuthorize: true},

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -17,8 +17,8 @@ import (
 	"github.com/coder/coder/coderd/httpapi"
 )
 
-// AuthCookie represents the name of the cookie the API key is stored in.
-const AuthCookie = "session_token"
+// SessionTokenKey represents the name of the cookie or query paramater the API key is stored in.
+const SessionTokenKey = "session_token"
 
 type apiKeyContextKey struct{}
 
@@ -44,15 +44,15 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs) func(http.Handler) h
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			var cookieValue string
-			cookie, err := r.Cookie(AuthCookie)
+			cookie, err := r.Cookie(SessionTokenKey)
 			if err != nil {
-				cookieValue = r.URL.Query().Get(AuthCookie)
+				cookieValue = r.URL.Query().Get(SessionTokenKey)
 			} else {
 				cookieValue = cookie.Value
 			}
 			if cookieValue == "" {
 				httpapi.Write(rw, http.StatusUnauthorized, httpapi.Response{
-					Message: fmt.Sprintf("%q cookie or query parameter must be provided", AuthCookie),
+					Message: fmt.Sprintf("%q cookie or query parameter must be provided", SessionTokenKey),
 				})
 				return
 			}
@@ -60,7 +60,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs) func(http.Handler) h
 			// APIKeys are formatted: ID-SECRET
 			if len(parts) != 2 {
 				httpapi.Write(rw, http.StatusUnauthorized, httpapi.Response{
-					Message: fmt.Sprintf("invalid %q cookie api key format", AuthCookie),
+					Message: fmt.Sprintf("invalid %q cookie api key format", SessionTokenKey),
 				})
 				return
 			}
@@ -69,13 +69,13 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs) func(http.Handler) h
 			// Ensuring key lengths are valid.
 			if len(keyID) != 10 {
 				httpapi.Write(rw, http.StatusUnauthorized, httpapi.Response{
-					Message: fmt.Sprintf("invalid %q cookie api key id", AuthCookie),
+					Message: fmt.Sprintf("invalid %q cookie api key id", SessionTokenKey),
 				})
 				return
 			}
 			if len(keySecret) != 22 {
 				httpapi.Write(rw, http.StatusUnauthorized, httpapi.Response{
-					Message: fmt.Sprintf("invalid %q cookie api key secret", AuthCookie),
+					Message: fmt.Sprintf("invalid %q cookie api key secret", SessionTokenKey),
 				})
 				return
 			}

--- a/coderd/httpmw/authorize_test.go
+++ b/coderd/httpmw/authorize_test.go
@@ -94,7 +94,7 @@ func TestExtractUserRoles(t *testing.T) {
 
 			req := httptest.NewRequest("GET", "/", nil)
 			req.AddCookie(&http.Cookie{
-				Name:  httpmw.AuthCookie,
+				Name:  httpmw.SessionTokenKey,
 				Value: token,
 			})
 

--- a/coderd/httpmw/organizationparam_test.go
+++ b/coderd/httpmw/organizationparam_test.go
@@ -29,7 +29,7 @@ func TestOrganizationParam(t *testing.T) {
 			hashed     = sha256.Sum256([]byte(secret))
 		)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/httpmw/templateparam_test.go
+++ b/coderd/httpmw/templateparam_test.go
@@ -29,7 +29,7 @@ func TestTemplateParam(t *testing.T) {
 		)
 		r := httptest.NewRequest("GET", "/", nil)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/httpmw/templateversionparam_test.go
+++ b/coderd/httpmw/templateversionparam_test.go
@@ -29,7 +29,7 @@ func TestTemplateVersionParam(t *testing.T) {
 		)
 		r := httptest.NewRequest("GET", "/", nil)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/httpmw/userparam_test.go
+++ b/coderd/httpmw/userparam_test.go
@@ -29,7 +29,7 @@ func TestUserParam(t *testing.T) {
 			rw         = httptest.NewRecorder()
 		)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/httpmw/workspaceagent.go
+++ b/coderd/httpmw/workspaceagent.go
@@ -28,10 +28,10 @@ func WorkspaceAgent(r *http.Request) database.WorkspaceAgent {
 func ExtractWorkspaceAgent(db database.Store) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			cookie, err := r.Cookie(AuthCookie)
+			cookie, err := r.Cookie(SessionTokenKey)
 			if err != nil {
 				httpapi.Write(rw, http.StatusUnauthorized, httpapi.Response{
-					Message: fmt.Sprintf("%q cookie must be provided", AuthCookie),
+					Message: fmt.Sprintf("%q cookie must be provided", SessionTokenKey),
 				})
 				return
 			}

--- a/coderd/httpmw/workspaceagent_test.go
+++ b/coderd/httpmw/workspaceagent_test.go
@@ -22,7 +22,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		token := uuid.New()
 		r := httptest.NewRequest("GET", "/", nil)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: token.String(),
 		})
 		return r, token

--- a/coderd/httpmw/workspaceagentparam_test.go
+++ b/coderd/httpmw/workspaceagentparam_test.go
@@ -29,7 +29,7 @@ func TestWorkspaceAgentParam(t *testing.T) {
 		)
 		r := httptest.NewRequest("GET", "/", nil)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/httpmw/workspacebuildparam_test.go
+++ b/coderd/httpmw/workspacebuildparam_test.go
@@ -29,7 +29,7 @@ func TestWorkspaceBuildParam(t *testing.T) {
 		)
 		r := httptest.NewRequest("GET", "/", nil)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/httpmw/workspaceparam_test.go
+++ b/coderd/httpmw/workspaceparam_test.go
@@ -29,7 +29,7 @@ func TestWorkspaceParam(t *testing.T) {
 		)
 		r := httptest.NewRequest("GET", "/", nil)
 		r.AddCookie(&http.Cookie{
-			Name:  httpmw.AuthCookie,
+			Name:  httpmw.SessionTokenKey,
 			Value: fmt.Sprintf("%s-%s", id, secret),
 		})
 

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -690,7 +690,7 @@ func (*api) postLogout(rw http.ResponseWriter, _ *http.Request) {
 	cookie := &http.Cookie{
 		// MaxAge < 0 means to delete the cookie now
 		MaxAge: -1,
-		Name:   httpmw.AuthCookie,
+		Name:   httpmw.SessionTokenKey,
 		Path:   "/",
 	}
 
@@ -748,7 +748,7 @@ func (api *api) createAPIKey(rw http.ResponseWriter, r *http.Request, params dat
 	// This format is consumed by the APIKey middleware.
 	sessionToken := fmt.Sprintf("%s-%s", keyID, keySecret)
 	http.SetCookie(rw, &http.Cookie{
-		Name:     httpmw.AuthCookie,
+		Name:     httpmw.SessionTokenKey,
 		Value:    sessionToken,
 		Path:     "/",
 		HttpOnly: true,

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -122,7 +122,7 @@ func TestPostLogout(t *testing.T) {
 		cookies := response.Cookies()
 		require.Len(t, cookies, 1, "Exactly one cookie should be returned")
 
-		require.Equal(t, cookies[0].Name, httpmw.AuthCookie, "Cookie should be the auth cookie")
+		require.Equal(t, cookies[0].Name, httpmw.SessionTokenKey, "Cookie should be the auth cookie")
 		require.Equal(t, cookies[0].MaxAge, -1, "Cookie should be set to delete")
 	})
 }

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"cdr.dev/slog"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/moby/moby/pkg/namesgenerator"
@@ -17,6 +16,8 @@ import (
 	"golang.org/x/xerrors"
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
+
+	"cdr.dev/slog"
 
 	"github.com/coder/coder/coderd/autobuild/schedule"
 	"github.com/coder/coder/coderd/database"

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -589,7 +589,7 @@ func (api *api) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
-			build, err := api.Database.GetWorkspaceBuildByWorkspaceIDWithoutAfter(r.Context(), workspace.ID)
+			build, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(r.Context(), workspace.ID)
 			if err != nil {
 				_ = wsjson.Write(ctx, c, httpapi.Response{
 					Message: fmt.Sprintf("get workspace build: %s", err),

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -7,12 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
+	"cdr.dev/slog"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/moby/moby/pkg/namesgenerator"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
 
 	"github.com/coder/coder/coderd/autobuild/schedule"
 	"github.com/coder/coder/coderd/database"
@@ -532,6 +536,94 @@ func (api *api) putWorkspaceAutostop(rw http.ResponseWriter, r *http.Request) {
 			Message: fmt.Sprintf("update workspace autostop schedule: %s", err),
 		})
 		return
+	}
+}
+
+func (api *api) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
+	workspace := httpmw.WorkspaceParam(r)
+
+	c, err := websocket.Accept(rw, r, &websocket.AcceptOptions{
+		// Fix for Safari 15.1:
+		// There is a bug in latest Safari in which compressed web socket traffic
+		// isn't handled correctly. Turning off compression is a workaround:
+		// https://github.com/nhooyr/websocket/issues/218
+		CompressionMode: websocket.CompressionDisabled,
+	})
+	if err != nil {
+		api.Logger.Warn(r.Context(), "accept websocket connection", slog.Error(err))
+		return
+	}
+	defer c.Close(websocket.StatusInternalError, "internal error")
+
+	ctx := c.CloseRead(r.Context())
+
+	// Send a heartbeat every 15 seconds to avoid the websocket being killed.
+	go func() {
+		ticker := time.NewTicker(time.Second * 15)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				err := c.Ping(ctx)
+				if err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	t := time.NewTicker(time.Second * 1)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			workspace, err := api.Database.GetWorkspaceByID(r.Context(), workspace.ID)
+			if err != nil {
+				_ = wsjson.Write(ctx, c, httpapi.Response{
+					Message: fmt.Sprintf("get workspace: %s", err),
+				})
+				return
+			}
+			build, err := api.Database.GetWorkspaceBuildByWorkspaceIDWithoutAfter(r.Context(), workspace.ID)
+			if err != nil {
+				_ = wsjson.Write(ctx, c, httpapi.Response{
+					Message: fmt.Sprintf("get workspace build: %s", err),
+				})
+				return
+			}
+			var (
+				group    errgroup.Group
+				job      database.ProvisionerJob
+				template database.Template
+				owner    database.User
+			)
+			group.Go(func() (err error) {
+				job, err = api.Database.GetProvisionerJobByID(r.Context(), build.JobID)
+				return err
+			})
+			group.Go(func() (err error) {
+				template, err = api.Database.GetTemplateByID(r.Context(), workspace.TemplateID)
+				return err
+			})
+			group.Go(func() (err error) {
+				owner, err = api.Database.GetUserByID(r.Context(), workspace.OwnerID)
+				return err
+			})
+			err = group.Wait()
+			if err != nil {
+				_ = wsjson.Write(ctx, c, httpapi.Response{
+					Message: fmt.Sprintf("fetch resource: %s", err),
+				})
+				return
+			}
+
+			_ = wsjson.Write(ctx, c, convertWorkspace(workspace, convertWorkspaceBuild(build, convertProvisionerJob(job)), template, owner))
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -555,6 +555,7 @@ func (api *api) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 	}
 	defer c.Close(websocket.StatusInternalError, "internal error")
 
+	// Makes the websocket connection write-only
 	ctx := c.CloseRead(r.Context())
 
 	// Send a heartbeat every 15 seconds to avoid the websocket being killed.

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -81,9 +81,9 @@ func (c *Client) Request(ctx context.Context, method, path string, body interfac
 	return resp, err
 }
 
-// websocket opens a websocket connection on that path provided.
-// The caller is responsible for closing the websocket.Conn.
-func (c *Client) websocket(ctx context.Context, path string) (*websocket.Conn, error) {
+// dialWebsocket opens a dialWebsocket connection on that path provided.
+// The caller is responsible for closing the dialWebsocket.Conn.
+func (c *Client) dialWebsocket(ctx context.Context, path string) (*websocket.Conn, error) {
 	serverURL, err := c.URL.Parse(path)
 	if err != nil {
 		return nil, xerrors.Errorf("parse path: %w", err)

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -64,7 +64,7 @@ func (c *Client) Request(ctx context.Context, method, path string, body interfac
 		return nil, xerrors.Errorf("create request: %w", err)
 	}
 	req.AddCookie(&http.Cookie{
-		Name:  httpmw.AuthCookie,
+		Name:  httpmw.SessionTokenKey,
 		Value: c.SessionToken,
 	})
 	if body != nil {
@@ -99,7 +99,7 @@ func (c *Client) websocket(ctx context.Context, path string) (*websocket.Conn, e
 	}
 	apiURL.Path = path
 	q := apiURL.Query()
-	q.Add(httpmw.AuthCookie, c.SessionToken)
+	q.Add(httpmw.SessionTokenKey, c.SessionToken)
 	apiURL.RawQuery = q.Encode()
 
 	//nolint:bodyclose

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -86,10 +86,13 @@ func (c *Client) Request(ctx context.Context, method, path string, body interfac
 func (c *Client) websocket(ctx context.Context, path string) (*websocket.Conn, error) {
 	serverURL, err := c.URL.Parse(path)
 	if err != nil {
-		return nil, xerrors.Errorf("parse url: %w", err)
+		return nil, xerrors.Errorf("parse path: %w", err)
 	}
 
 	apiURL, err := url.Parse(serverURL.String())
+	if err != nil {
+		return nil, xerrors.Errorf("parse server url: %w", err)
+	}
 	apiURL.Scheme = "ws"
 	if serverURL.Scheme == "https" {
 		apiURL.Scheme = "wss"
@@ -100,7 +103,7 @@ func (c *Client) websocket(ctx context.Context, path string) (*websocket.Conn, e
 	apiURL.RawQuery = q.Encode()
 
 	//nolint:bodyclose
-	conn, _, err := websocket.Dial(context.Background(), apiURL.String(), &websocket.DialOptions{
+	conn, _, err := websocket.Dial(ctx, apiURL.String(), &websocket.DialOptions{
 		HTTPClient: c.HTTPClient,
 	})
 	if err != nil {

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -188,7 +188,7 @@ func (c *Client) ListenWorkspaceAgent(ctx context.Context, logger slog.Logger) (
 		return agent.Metadata{}, nil, xerrors.Errorf("create cookie jar: %w", err)
 	}
 	jar.SetCookies(serverURL, []*http.Cookie{{
-		Name:  httpmw.AuthCookie,
+		Name:  httpmw.SessionTokenKey,
 		Value: c.SessionToken,
 	}})
 	httpClient := &http.Client{
@@ -263,7 +263,7 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 		return nil, xerrors.Errorf("create cookie jar: %w", err)
 	}
 	jar.SetCookies(serverURL, []*http.Cookie{{
-		Name:  httpmw.AuthCookie,
+		Name:  httpmw.SessionTokenKey,
 		Value: c.SessionToken,
 	}})
 	httpClient := &http.Client{
@@ -351,7 +351,7 @@ func (c *Client) WorkspaceAgentReconnectingPTY(ctx context.Context, agentID, rec
 		return nil, xerrors.Errorf("create cookie jar: %w", err)
 	}
 	jar.SetCookies(serverURL, []*http.Cookie{{
-		Name:  httpmw.AuthCookie,
+		Name:  httpmw.SessionTokenKey,
 		Value: c.SessionToken,
 	}})
 	httpClient := &http.Client{

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -123,7 +123,7 @@ func (w *WorkspaceWatcher) Close() error {
 	return nil
 }
 
-func (c *Client) WorkspaceWatcher(ctx context.Context, id uuid.UUID) (*WorkspaceWatcher, error) {
+func (c *Client) WatchWorkspace(ctx context.Context, id uuid.UUID) (*WorkspaceWatcher, error) {
 	conn, err := c.websocket(ctx, fmt.Sprintf("/api/v2/workspaces/%s/watch", id))
 	if err != nil {
 		return nil, err

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -108,7 +108,7 @@ func (w *WorkspaceWatcher) Read(ctx context.Context) (Workspace, error) {
 	var ws Workspace
 	err := wsjson.Read(ctx, w.conn, &ws)
 	if err != nil {
-		return ws, xerrors.Errorf("read workspace: %w")
+		return ws, xerrors.Errorf("read workspace: %w", err)
 	}
 
 	return ws, nil

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -124,7 +124,7 @@ func (w *WorkspaceWatcher) Close() error {
 }
 
 func (c *Client) WatchWorkspace(ctx context.Context, id uuid.UUID) (*WorkspaceWatcher, error) {
-	conn, err := c.websocket(ctx, fmt.Sprintf("/api/v2/workspaces/%s/watch", id))
+	conn, err := c.dialWebsocket(ctx, fmt.Sprintf("/api/v2/workspaces/%s/watch", id))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To avoid polling frequently I'm adding a `/watch` endpoint to workspaces that will pump the data we currently poll for over a one-way websocket. 

Changes:
- Added support for `session_token` query parameter on authenticated calls
- Changed `httpmw.AuthCookie` to `httpmw.SessionTokeyKey` since we now use it for query parameters
- Added watch workspace endpoint
- Added `dialWebsocket` method to `codersdk.Client`