### PR TITLE
example(k8s): clarify kubeconfig location

### DIFF
--- a/examples/kubernetes-multi-service/main.tf
+++ b/examples/kubernetes-multi-service/main.tf
@@ -14,7 +14,15 @@ terraform {
 variable "step1_use_kubeconfig" {
   type        = bool
   sensitive   = true
-  description = "Use local ~/.kube/config? (true/false)"
+  description = <<-EOF
+  Use host kubeconfig? (true/false)
+
+  If true, a valid "~/.kube/config" must be present on the Coder host. This
+  is likely not your local machine unless you are using `coder server --dev.`
+
+  If false, proceed for instructions creating a ServiceAccount on your existing
+  Kubernetes cluster.
+  EOF
 }
 
 variable "step2_cluster_host" {


### PR DESCRIPTION
Quick fix to explain that `~/.kube/config` must be present on the host (where the provisioner is), not the local machine.