### PR TITLE
fix: Remove grouping for workspace owner counts

### DIFF
--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -65,8 +65,7 @@ FROM
 WHERE
 	template_id = ANY(@ids :: uuid [ ])
 GROUP BY
-	template_id,
-	owner_id;
+	template_id;
 
 -- name: InsertWorkspace :one
 INSERT INTO


### PR DESCRIPTION
This caused templates to show max ownership of one developer!
