### PR TITLE
fix: Use relative timestamp for workspaces page Storybook

### DIFF
--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -112,7 +112,7 @@ export const MockWorkspaceAutostopEnabled: TypesGen.UpdateWorkspaceAutostartRequ
 export const MockWorkspaceBuild: TypesGen.WorkspaceBuild = {
   after_id: "",
   before_id: "",
-  created_at: new Date().toDateString(),
+  created_at: new Date().toString(),
   id: "test-workspace-build",
   initiator_id: "",
   job: MockProvisionerJob,


### PR DESCRIPTION
This was causing random time changes on every PR, requiring
approval on storybook!
