### PR TITLE
fix: example: update docker-local to use host-gateway

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     ports:
       - "7080:7080"
     environment:
-      CODER_PG_CONNECTION_URL: "postgresql://username:password@database/coder?sslmode=disable"
+      CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
       CODER_ADDRESS: "0.0.0.0:7080"
       CODER_ACCESS_URL: "http://host.docker.internal:7080"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,9 @@ services:
     environment:
       CODER_PG_CONNECTION_URL: "postgresql://username:password@database/coder?sslmode=disable"
       CODER_ADDRESS: "0.0.0.0:7080"
+      CODER_ACCESS_URL: "http://host.docker.internal:7080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       database:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,6 @@ services:
     environment:
       CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
       CODER_ADDRESS: "0.0.0.0:7080"
-      CODER_ACCESS_URL: "http://host.docker.internal:7080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/examples/docker-local/main.tf
+++ b/examples/docker-local/main.tf
@@ -15,6 +15,10 @@ provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
 
+provider "coder" {
+  url = "http://host.docker.internal:7080"
+}
+
 data "coder_workspace" "me" {
 }
 

--- a/examples/docker-local/main.tf
+++ b/examples/docker-local/main.tf
@@ -43,6 +43,10 @@ resource "docker_container" "workspace" {
   dns     = ["1.1.1.1"]
   command = ["sh", "-c", coder_agent.dev.init_script]
   env     = ["CODER_AGENT_TOKEN=${coder_agent.dev.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
   volumes {
     container_path = "/home/coder/"
     volume_name    = docker_volume.coder_volume.name


### PR DESCRIPTION
This PR attempts to reduce the friction to getting a workspace up and running in docker when running Coder via `docker-compose` using the example `docker-local` template:
* `docker-compose.yaml`: pass through docker socket and set CODER_ACCESS_URL env 
*  `examples/docker-local`: add host.docker.internal to containers 

See: https://github.com/coder/coder/issues/1345