### PR TITLE
fix: set autostop notify to t minus 30 minutes

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -27,7 +27,7 @@ import (
 )
 
 var autostopPollInterval = 30 * time.Second
-var autostopNotifyCountdown = []time.Duration{5 * time.Minute}
+var autostopNotifyCountdown = []time.Duration{30 * time.Minute}
 
 func ssh() *cobra.Command {
 	var (


### PR DESCRIPTION
5 minutes is a bit too late for a notification, update to 30 minutes before scheduled shutdown instead.