### PR TITLE
fix: Publish Linux releases in tar.gz archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 archives:
   - id: coder-linux
     builds: [coder-linux]
-    format: tar
+    format: tar.gz
     files:
       - src: docs/README.md
         dst: README.md


### PR DESCRIPTION
This reduces download size by ~70%.
