### PR TITLE
example: ec2: document "minimal" policy

### DIFF
--- a/examples/aws-linux/README.md
+++ b/examples/aws-linux/README.md
@@ -23,11 +23,9 @@ This example policy allows Coder to create EC2 instances and modify instances pr
             "Effect": "Allow",
             "Action": [
                 "ec2:GetDefaultCreditSpecification",
-                "ec2:DescribeInstances",
                 "ec2:DescribeIamInstanceProfileAssociations",
                 "ec2:DescribeTags",
                 "ec2:CreateTags",
-                "ec2:DescribeInstanceAttribute",
                 "ec2:RunInstances",
                 "ec2:DescribeInstanceCreditSpecifications",
                 "ec2:DescribeImages",
@@ -42,6 +40,7 @@ This example policy allows Coder to create EC2 instances and modify instances pr
             "Effect": "Allow",
             "Action": [
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceAttribute",
                 "ec2:UnmonitorInstances",
                 "ec2:TerminateInstances",
                 "ec2:StartInstances",

--- a/examples/aws-linux/README.md
+++ b/examples/aws-linux/README.md
@@ -3,3 +3,63 @@ name: Develop in Linux on AWS EC2
 description: Get started with Linux development on AWS EC2.
 tags: [cloud, aws]
 ---
+
+# aws-linux
+
+## Getting started
+
+Pick this template in `coder templates init` and follow instructions.
+
+## Required permissions / policy
+
+This example policy allows Coder to create EC2 instances and modify instances provisioned by Coder.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:GetDefaultCreditSpecification",
+                "ec2:DescribeInstances",
+                "ec2:DescribeIamInstanceProfileAssociations",
+                "ec2:DescribeTags",
+                "ec2:CreateTags",
+                "ec2:DescribeInstanceAttribute",
+                "ec2:RunInstances",
+                "ec2:DescribeInstanceCreditSpecifications",
+                "ec2:DescribeImages",
+                "ec2:ModifyInstanceCreditSpecification",
+                "ec2:ModifyDefaultCreditSpecification",
+                "ec2:DescribeVolumes"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "CoderResouces",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:UnmonitorInstances",
+                "ec2:TerminateInstances",
+                "ec2:StartInstances",
+                "ec2:StopInstances",
+                "ec2:DeleteTags",
+                "ec2:MonitorInstances",
+                "ec2:CreateTags",
+                "ec2:RunInstances",
+                "ec2:ModifyInstanceAttribute"
+            ],
+            "Resource": "arn:aws:ec2:*:*:instance/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/Coder_Provisioned": "true"
+                }
+            }
+        }
+    ]
+}
+```
+

--- a/examples/aws-linux/README.md
+++ b/examples/aws-linux/README.md
@@ -29,7 +29,6 @@ This example policy allows Coder to create EC2 instances and modify instances pr
                 "ec2:RunInstances",
                 "ec2:DescribeInstanceCreditSpecifications",
                 "ec2:DescribeImages",
-                "ec2:ModifyInstanceCreditSpecification",
                 "ec2:ModifyDefaultCreditSpecification",
                 "ec2:DescribeVolumes"
             ],
@@ -49,7 +48,8 @@ This example policy allows Coder to create EC2 instances and modify instances pr
                 "ec2:MonitorInstances",
                 "ec2:CreateTags",
                 "ec2:RunInstances",
-                "ec2:ModifyInstanceAttribute"
+                "ec2:ModifyInstanceAttribute",
+                "ec2:ModifyInstanceCreditSpecification"
             ],
             "Resource": "arn:aws:ec2:*:*:instance/*",
             "Condition": {

--- a/examples/aws-linux/main.tf
+++ b/examples/aws-linux/main.tf
@@ -11,6 +11,9 @@ variable "access_key" {
   description = <<EOT
 Create an AWS access key to provision resources with Coder:
 - https://console.aws.amazon.com/iam/home#/users
+
+See the template README for an example permissions policy,
+if needed.
   
 AWS Access Key ID
 EOT
@@ -138,5 +141,7 @@ resource "aws_instance" "dev" {
   user_data = data.coder_workspace.me.transition == "start" ? local.user_data_start : local.user_data_end
   tags = {
     Name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+    # Required if you are using our example policy, see template README
+    Coder_Provisioned = "true"
   }
 }


### PR DESCRIPTION
I'm not an expert on AWS permissions, but this seems to be a same policy for Coder. I tested with workspaces and it can CRUD successfully. It also fails to delete non-Coder tagged resources, which is a good thing :) 