### PR TITLE
Add terminal link component

### DIFF
--- a/site/src/components/TerminalLink/TerminalLink.stories.tsx
+++ b/site/src/components/TerminalLink/TerminalLink.stories.tsx
@@ -1,0 +1,16 @@
+import { Story } from "@storybook/react"
+import React from "react"
+import { MockWorkspace } from "../../testHelpers/renderHelpers"
+import { TerminalLink, TerminalLinkProps } from "./TerminalLink"
+
+export default {
+  title: "components/TerminalLink",
+  component: TerminalLink,
+}
+
+const Template: Story<TerminalLinkProps> = (args) => <TerminalLink {...args} />
+
+export const Example = Template.bind({})
+Example.args = {
+  workspaceName: MockWorkspace.name,
+}

--- a/site/src/components/TerminalLink/TerminalLink.tsx
+++ b/site/src/components/TerminalLink/TerminalLink.tsx
@@ -1,0 +1,28 @@
+import Link from "@material-ui/core/Link"
+import React from "react"
+import * as TypesGen from "../../api/typesGenerated"
+
+export const Language = {
+  linkText: "Open in terminal",
+}
+
+export interface TerminalLinkProps {
+  agentName?: TypesGen.WorkspaceAgent["name"]
+  userName?: TypesGen.User["username"]
+  workspaceName: TypesGen.Workspace["name"]
+}
+
+/**
+ * Generate a link to a terminal connected to the provided workspace agent.  If
+ * no agent is provided connect to the first agent.
+ *
+ * If no user name is provided "me" is used however it makes the link not
+ * shareable.
+ */
+export const TerminalLink: React.FC<TerminalLinkProps> = ({ agentName, userName = "me", workspaceName }) => {
+  return (
+    <Link href={`/${userName}/${workspaceName}${agentName ? `.${agentName}` : ""}/terminal`} target="_blank">
+      {Language.linkText}
+    </Link>
+  )
+}

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -34,10 +34,14 @@ const TerminalPage: React.FC<{
     const search = new URLSearchParams(location.search)
     return search.get("reconnect") ?? uuidv4()
   })
+  // The workspace name is in the format:
+  // <workspace name>[.<agent name>]
+  const workspaceNameParts = workspace?.split(".")
   const [terminalState, sendEvent] = useMachine(terminalMachine, {
     context: {
+      agentName: workspaceNameParts?.[1],
       reconnection: reconnectionToken,
-      workspaceName: workspace,
+      workspaceName: workspaceNameParts?.[0],
       username: username,
     },
     actions: {

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -77,7 +77,16 @@ export const handlers = [
 
   // workspaces
   rest.get("/api/v2/organizations/:organizationId/workspaces/:userName/:workspaceName", (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(M.MockWorkspace))
+    if (req.params.workspaceName !== M.MockWorkspace.name) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          message: "workspace not found",
+        }),
+      )
+    } else {
+      return res(ctx.status(200), ctx.json(M.MockWorkspace))
+    }
   }),
   rest.get("/api/v2/workspaces/:workspaceId", async (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(M.MockWorkspace))


### PR DESCRIPTION
I am not sure if the component is overkill or not but if so maybe we can pull it out once the resource card is ready?  But I could see it being used in multiple places.  I did not do anything with the styling so it is just a plain link right now.

Partially addresses #760 (we just need to drop it into the resources card once it is good to go).

Other than that the terminal already supported connecting to a specific workspace agent using a `workspaceName.agentName` syntax so all I had to do was fix a small bug with it (it only split it when fetching the agent and not when fetching the workspace so the workspace fetch would error; I just moved this logic out so it would apply to both calls).