### PR TITLE
test: Using local time in unit test fails in certain time zones

### DIFF
--- a/coderd/autobuild/schedule/schedule_test.go
+++ b/coderd/autobuild/schedule/schedule_test.go
@@ -12,31 +12,34 @@ import (
 func Test_Weekly(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		name          string
-		spec          string
-		at            time.Time
-		expectedNext  time.Time
-		expectedError string
-		expectedCron  string
-		expectedTz    string
+		name           string
+		spec           string
+		at             time.Time
+		expectedNext   time.Time
+		expectedError  string
+		expectedCron   string
+		expectedTz     string
+		expectedString string
 	}{
 		{
-			name:          "with timezone",
-			spec:          "CRON_TZ=US/Central 30 9 * * 1-5",
-			at:            time.Date(2022, 4, 1, 14, 29, 0, 0, time.UTC),
-			expectedNext:  time.Date(2022, 4, 1, 14, 30, 0, 0, time.UTC),
-			expectedError: "",
-			expectedCron:  "30 9 * * 1-5",
-			expectedTz:    "US/Central",
+			name:           "with timezone",
+			spec:           "CRON_TZ=US/Central 30 9 * * 1-5",
+			at:             time.Date(2022, 4, 1, 14, 29, 0, 0, time.UTC),
+			expectedNext:   time.Date(2022, 4, 1, 14, 30, 0, 0, time.UTC),
+			expectedError:  "",
+			expectedCron:   "30 9 * * 1-5",
+			expectedTz:     "US/Central",
+			expectedString: "CRON_TZ=US/Central 30 9 * * 1-5",
 		},
 		{
-			name:          "without timezone",
-			spec:          "CRON_TZ=UTC 30 9 * * 1-5",
-			at:            time.Date(2022, 4, 1, 9, 29, 0, 0, time.UTC),
-			expectedNext:  time.Date(2022, 4, 1, 9, 30, 0, 0, time.UTC),
-			expectedError: "",
-			expectedCron:  "30 9 * * 1-5",
-			expectedTz:    "UTC",
+			name:           "without timezone",
+			spec:           "30 9 * * 1-5",
+			at:             time.Date(2022, 4, 1, 9, 29, 0, 0, time.UTC),
+			expectedNext:   time.Date(2022, 4, 1, 9, 30, 0, 0, time.UTC),
+			expectedError:  "",
+			expectedCron:   "30 9 * * 1-5",
+			expectedTz:     "UTC",
+			expectedString: "CRON_TZ=UTC 30 9 * * 1-5",
 		},
 		{
 			name:          "invalid schedule",
@@ -91,9 +94,9 @@ func Test_Weekly(t *testing.T) {
 				nextTime := actual.Next(testCase.at)
 				require.NoError(t, err)
 				require.Equal(t, testCase.expectedNext, nextTime)
-				require.Equal(t, testCase.spec, actual.String())
 				require.Equal(t, testCase.expectedCron, actual.Cron())
 				require.Equal(t, testCase.expectedTz, actual.Timezone())
+				require.Equal(t, testCase.expectedString, actual.String())
 			} else {
 				require.EqualError(t, err, testCase.expectedError)
 				require.Nil(t, actual)

--- a/coderd/autobuild/schedule/schedule_test.go
+++ b/coderd/autobuild/schedule/schedule_test.go
@@ -32,8 +32,8 @@ func Test_Weekly(t *testing.T) {
 		{
 			name:          "without timezone",
 			spec:          "CRON_TZ=UTC 30 9 * * 1-5",
-			at:            time.Date(2022, 4, 1, 9, 29, 0, 0, time.Local),
-			expectedNext:  time.Date(2022, 4, 1, 9, 30, 0, 0, time.Local),
+			at:            time.Date(2022, 4, 1, 9, 29, 0, 0, time.UTC),
+			expectedNext:  time.Date(2022, 4, 1, 9, 30, 0, 0, time.UTC),
 			expectedError: "",
 			expectedCron:  "30 9 * * 1-5",
 			expectedTz:    "UTC",


### PR DESCRIPTION
This test was failing when running in CST (GMT-5) timezone.
My local timezone pushed the next to the upcoming monday

@johnstcn Is this change to the test ok? I was not really sure what it was testing. The CI says "Without timezone", but the spec does include the timezone as UTC.