### PR TITLE
examples/docker-local: add explanatory comment

### DIFF
--- a/examples/docker-local/main.tf
+++ b/examples/docker-local/main.tf
@@ -16,6 +16,8 @@ provider "docker" {
 }
 
 provider "coder" {
+  # The below assumes your Coder deployment is running in docker-compose.
+  # If this is not the case, either comment or edit the below.
   url = "http://host.docker.internal:7080"
 }
 


### PR DESCRIPTION
Adds a comment to the `docker-local` example template regarding `coder.url` and pointing users to edit the URL to their environment.