### PR TITLE
feat: Add SSH agent forwarding support to coder agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -380,6 +380,16 @@ func (a *agent) handleSSHSession(session ssh.Session) error {
 		return err
 	}
 
+	if ssh.AgentRequested(session) {
+		l, err := ssh.NewAgentListener()
+		if err != nil {
+			return xerrors.Errorf("new agent listener: %w", err)
+		}
+		defer l.Close()
+		go ssh.ForwardAgentConnections(l, session)
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", "SSH_AUTH_SOCK", l.Addr().String()))
+	}
+
 	sshPty, windowSize, isPty := session.Pty()
 	if isPty {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", sshPty.Term))

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -38,6 +38,11 @@ func configSSH() *cobra.Command {
 		Annotations: workspaceCommand,
 		Use:         "config-ssh",
 		Short:       "Populate your SSH config with Host entries for all of your workspaces",
+		Example: `
+  - You can use -o (or --ssh-option) so set SSH options to be used for all your
+    workspaces.
+
+    ` + cliui.Styles.Code.Render("$ coder config-ssh -o ForwardAgent=yes"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := createClient(cmd)
 			if err != nil {

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -170,7 +170,7 @@ func ssh() *cobra.Command {
 	cliflag.BoolVarP(cmd.Flags(), &stdio, "stdio", "", "CODER_SSH_STDIO", false, "Specifies whether to emit SSH output over stdin/stdout.")
 	cliflag.BoolVarP(cmd.Flags(), &shuffle, "shuffle", "", "CODER_SSH_SHUFFLE", false, "Specifies whether to choose a random workspace")
 	_ = cmd.Flags().MarkHidden("shuffle")
-	cliflag.BoolVarP(cmd.Flags(), &forwardAgent, "forward-agent", "", "CODER_SSH_FORWARD_AGENT", false, "Specifies whether to forward the SSH agent specified in $SSH_AUTH_SOCK")
+	cliflag.BoolVarP(cmd.Flags(), &forwardAgent, "forward-agent", "A", "CODER_SSH_FORWARD_AGENT", false, "Specifies whether to forward the SSH agent specified in $SSH_AUTH_SOCK")
 	cliflag.DurationVarP(cmd.Flags(), &wsPollInterval, "workspace-poll-interval", "", "CODER_WORKSPACE_POLL_INTERVAL", workspacePollInterval, "Specifies how often to poll for workspace automated shutdown.")
 
 	return cmd

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	gossh "golang.org/x/crypto/ssh"
+	gosshagent "golang.org/x/crypto/ssh/agent"
 	"golang.org/x/term"
 	"golang.org/x/xerrors"
 
@@ -32,6 +33,7 @@ func ssh() *cobra.Command {
 	var (
 		stdio          bool
 		shuffle        bool
+		forwardAgent   bool
 		wsPollInterval time.Duration
 	)
 	cmd := &cobra.Command{
@@ -108,6 +110,17 @@ func ssh() *cobra.Command {
 				return err
 			}
 
+			if forwardAgent && os.Getenv("SSH_AUTH_SOCK") != "" {
+				err = gosshagent.ForwardToRemote(sshClient, os.Getenv("SSH_AUTH_SOCK"))
+				if err != nil {
+					return xerrors.Errorf("forward agent failed: %w", err)
+				}
+				err = gosshagent.RequestAgentForwarding(sshSession)
+				if err != nil {
+					return xerrors.Errorf("request agent forwarding failed: %w", err)
+				}
+			}
+
 			stdoutFile, valid := cmd.OutOrStdout().(*os.File)
 			if valid && isatty.IsTerminal(stdoutFile.Fd()) {
 				state, err := term.MakeRaw(int(os.Stdin.Fd()))
@@ -156,8 +169,9 @@ func ssh() *cobra.Command {
 	}
 	cliflag.BoolVarP(cmd.Flags(), &stdio, "stdio", "", "CODER_SSH_STDIO", false, "Specifies whether to emit SSH output over stdin/stdout.")
 	cliflag.BoolVarP(cmd.Flags(), &shuffle, "shuffle", "", "CODER_SSH_SHUFFLE", false, "Specifies whether to choose a random workspace")
-	cliflag.DurationVarP(cmd.Flags(), &wsPollInterval, "workspace-poll-interval", "", "CODER_WORKSPACE_POLL_INTERVAL", workspacePollInterval, "Specifies how often to poll for workspace automated shutdown.")
 	_ = cmd.Flags().MarkHidden("shuffle")
+	cliflag.BoolVarP(cmd.Flags(), &forwardAgent, "forward-agent", "", "CODER_SSH_FORWARD_AGENT", false, "Specifies whether to forward the SSH agent specified in $SSH_AUTH_SOCK")
+	cliflag.DurationVarP(cmd.Flags(), &wsPollInterval, "workspace-poll-interval", "", "CODER_WORKSPACE_POLL_INTERVAL", workspacePollInterval, "Specifies how often to poll for workspace automated shutdown.")
 
 	return cmd
 }

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -211,15 +211,17 @@ func TestSSH(t *testing.T) {
 		})
 
 		// Ensure that SSH_AUTH_SOCK is set.
+		// Linux: /tmp/auth-agent3167016167/listener.sock
+		// macOS: /var/folders/ng/m1q0wft14hj0t3rtjxrdnzsr0000gn/T/auth-agent3245553419/listener.sock
 		pty.WriteLine("env")
-		pty.ExpectMatch("SSH_AUTH_SOCK=/tmp") // E.g. /tmp/auth-agent3167016167/listener.sock
+		pty.ExpectMatch("SSH_AUTH_SOCK=")
 		// Ensure that ssh-add lists our key.
 		pty.WriteLine("ssh-add -L")
 		keys, err := kr.List()
 		require.NoError(t, err)
 		pty.ExpectMatch(keys[0].String())
 
-		// kthxbye
+		// And we're done.
 		pty.WriteLine("exit")
 	})
 }

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -87,8 +87,11 @@ func TestSSH(t *testing.T) {
 		t.Cleanup(func() {
 			_ = agentCloser.Close()
 		})
+
 		// Shells on Mac, Windows, and Linux all exit shells with the "exit" command.
 		pty.WriteLine("exit")
+		// Wait before closing agent to give `coder ssh` time to exit cleanly.
+		time.Sleep(3 * time.Second)
 	})
 	t.Run("Stdio", func(t *testing.T) {
 		t.Parallel()

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -184,7 +184,9 @@ func TestSSH(t *testing.T) {
 			for {
 				fd, err := l.Accept()
 				if err != nil {
-					t.Logf("accept error: %v", err)
+					if !errors.Is(err, net.ErrClosed) {
+						t.Logf("accept error: %v", err)
+					}
 					return
 				}
 

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func setupWorkspaceForSSH(t *testing.T) (*codersdk.Client, codersdk.Workspace, string) {
+	t.Helper()
 	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	agentToken := uuid.NewString()


### PR DESCRIPTION
This PR adds support for SSH agent forwarding.

~~This simple change can support SSH agent forwarding but requires extra steps:~~

As Kyle pointed out, this works fine with the `coder gitssh` command so the extra steps are not necessary, we only need to make sure the `ssh` `ForwardAgent` setting is enabled:


```shell
coder config-ssh
ssh -o ForwardAgent=yes coder.mydev
# Inside workspace:
git clone git@github.com:private/repo.git
```

### Checklist

- [x] Add basic forward agent support
- [ ] ~~Add support for using the forwarded agent to `GIT_SSH_COMMAND` (i.e. `coder gitssh`)?~~
- [x] Add forward agent support to `coder ssh` too

Fixes #1549.