### PR TITLE
fix: More robust provisionersdk agent init scripts

### DIFF
--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -18,7 +18,7 @@ Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 
 	linuxScript = `#!/usr/bin/env sh
 set -eux pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
+BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
 if which curl >/dev/null 2>&1; then
 	curl -fsSL "${BINARY_URL}" -o "${BINARY_LOCATION}"
@@ -37,7 +37,7 @@ exec $BINARY_LOCATION agent`
 
 	darwinScript = `#!/usr/bin/env sh
 set -eux pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
+BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
 curl -fsSL "${ACCESS_URL}bin/coder-darwin-${ARCH}" -o "${BINARY_LOCATION}"
 chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -19,13 +19,13 @@ Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 	linuxScript = `#!/usr/bin/env sh
 set -eux pipefail
 export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
-export BINARY_URL="${ACCESS_URL}bin/coder-linux-${ARCH}"
+BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
 if which curl >/dev/null 2>&1; then
 	curl -fsSL "${BINARY_URL}" -o "${BINARY_LOCATION}"
 elif which wget >/dev/null 2>&1; then
-	wget -q "${BINARY_URL}" -O $BINARY_LOCATION
+	wget -q "${BINARY_URL}" -O "${BINARY_LOCATION}"
 elif which busybox >/dev/null 2>&1; then
-	busybox wget -q "${BINARY_URL}" -O $BINARY_LOCATION
+	busybox wget -q "${BINARY_URL}" -O "${BINARY_LOCATION}"
 else
 	echo "error: no download tool found, please install curl, wget or busybox wget"
 	exit 1
@@ -38,7 +38,7 @@ exec $BINARY_LOCATION agent`
 	darwinScript = `#!/usr/bin/env sh
 set -eux pipefail
 export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-darwin-${ARCH} -o $BINARY_LOCATION
+curl -fsSL "${ACCESS_URL}bin/coder-darwin-${ARCH}" -o "${BINARY_LOCATION}"
 chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -21,7 +21,7 @@ set -eux pipefail
 export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
 export BINARY_URL="${ACCESS_URL}bin/coder-linux-${ARCH}"
 if which curl >/dev/null 2>&1; then
-	curl -fsSL "${BINARY_URL}" -o $BINARY_LOCATION
+	curl -fsSL "${BINARY_URL}" -o "${BINARY_LOCATION}"
 elif which wget >/dev/null 2>&1; then
 	wget -q "${BINARY_URL}" -O $BINARY_LOCATION
 elif which busybox >/dev/null 2>&1; then

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -17,17 +17,27 @@ $env:CODER_AGENT_URL = "${ACCESS_URL}"
 Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 
 	linuxScript = `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
-curl -fsSL ${ACCESS_URL}bin/coder-linux-${ARCH} -o $BINARY_LOCATION
+set -eux pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
+export BINARY_URL="${ACCESS_URL}bin/coder-linux-${ARCH}"
+if which curl >/dev/null 2>&1; then
+	curl -fsSL "${BINARY_URL}" -o $BINARY_LOCATION
+elif which wget >/dev/null 2>&1; then
+	wget -q "${BINARY_URL}" -O $BINARY_LOCATION
+elif which busybox >/dev/null 2>&1; then
+	busybox wget -q "${BINARY_URL}" -O $BINARY_LOCATION
+else
+	echo "error: no download tool found, please install curl, wget or busybox wget"
+	exit 1
+fi
 chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
 exec $BINARY_LOCATION agent`
 
 	darwinScript = `#!/usr/bin/env sh
-set -eu pipefail
-export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXX)/coder
+set -eux pipefail
+export BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
 curl -fsSL ${ACCESS_URL}bin/coder-darwin-${ARCH} -o $BINARY_LOCATION
 chmod +x $BINARY_LOCATION
 export CODER_AGENT_AUTH="${AUTH_TYPE}"

--- a/provisionersdk/agent_test.go
+++ b/provisionersdk/agent_test.go
@@ -49,8 +49,11 @@ func TestAgentScript(t *testing.T) {
 		output, err := exec.Command("sh", "-c", script).CombinedOutput()
 		t.Log(string(output))
 		require.NoError(t, err)
+		// Ignore debug output from `set -x`, we're only interested in the last line.
+		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+		lastLine := lines[len(lines)-1]
 		// Because we use the "echo" binary, we should expect the arguments provided
 		// as the response to executing our script.
-		require.Equal(t, "agent", strings.TrimSpace(string(output)))
+		require.Equal(t, "agent", lastLine)
 	})
 }


### PR DESCRIPTION
This PR makes the provisionersdk agent init scripts a bit more robust (mostly on Linux).

- Try `wget` and `busybox wget` instead of just `curl`
- More verbose shell output via `-x`
- Handle `mktemp` limitation on `busybox` by adding one `X` in template

Related #1544

Tested on:
- `alpine:latest`
- `codercom/enterprise-base:ubuntu`