### PR TITLE
chore: remove make build dep from make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ coderd/database/dump.sql: $(wildcard coderd/database/migrations/*.sql)
 coderd/database/querier.go: coderd/database/dump.sql $(wildcard coderd/database/queries/*.sql)
 	coderd/database/generate.sh
 
-dev: build
+dev:
 	./scripts/develop.sh
 .PHONY: dev
 


### PR DESCRIPTION
From our discord office hours conversation it seems we don't need to run make build every time
