### PR TITLE
fix: Make TestAgent and TestWorkspaceAgentPTY less flaky

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -207,6 +207,10 @@ func TestAgent(t *testing.T) {
 		require.NoError(t, err)
 		bufRead := bufio.NewReader(netConn)
 
+		// Brief pause to reduce the likelihood that we send keystrokes while
+		// the shell is simultaneously sending a prompt.
+		time.Sleep(100 * time.Millisecond)
+
 		data, err := json.Marshal(agent.ReconnectingPTYRequest{
 			Data: "echo test\r\n",
 		})

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1,11 +1,13 @@
 package coderd_test
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/pion/webrtc/v3"
@@ -230,6 +232,11 @@ func TestWorkspaceAgentPTY(t *testing.T) {
 	require.NoError(t, err)
 	_, err = conn.Write(data)
 	require.NoError(t, err)
+	bufRead := bufio.NewReader(conn)
+
+	// Brief pause to reduce the likelihood that we send keystrokes while
+	// the shell is simultaneously sending a prompt.
+	time.Sleep(100 * time.Millisecond)
 
 	data, err = json.Marshal(agent.ReconnectingPTYRequest{
 		Data: "echo test\r\n",
@@ -238,16 +245,22 @@ func TestWorkspaceAgentPTY(t *testing.T) {
 	_, err = conn.Write(data)
 	require.NoError(t, err)
 
-	findEcho := func() {
+	expectLine := func(matcher func(string) bool) {
 		for {
-			read, err := conn.Read(data)
+			line, err := bufRead.ReadString('\n')
 			require.NoError(t, err)
-			if strings.Contains(string(data[:read]), "test") {
-				return
+			if matcher(line) {
+				break
 			}
 		}
 	}
+	matchEchoCommand := func(line string) bool {
+		return strings.Contains(line, "echo test")
+	}
+	matchEchoOutput := func(line string) bool {
+		return strings.Contains(line, "test") && !strings.Contains(line, "echo")
+	}
 
-	findEcho()
-	findEcho()
+	expectLine(matchEchoCommand)
+	expectLine(matchEchoOutput)
 }


### PR DESCRIPTION
TestAgent/ReconnectingPTY was making some fragile assumptions about the data returned from a `net.Conn`. This PR makes it a bit more robust.

The previous version was sending `echo test` via a PTY, and then expecting to see the string `test` in the output twice: once from the echoed command line, and once from the command output itself. But it was expecting them to be returned by two different calls to `Read()`, and there's no guarantee of that. 

The new version uses buffered I/O to read one line at a time, and expects to see at least one line that contains `echo test`, followed by at least one line that contains `test` but not `echo`. It also sleeps for 100ms to reduce the likelihood that the shell prompt test will be interleaved with the local echo of the command.

There's still some room for improvement here, because ideally the test would be controlling both ends of the PTY, instead of just assuming the user's shell behaves predictably.

Fixes #1348, fixes #1368
