### PR TITLE
fix: Rename `NewMemoryCoderd` to `NewWithServer`

### DIFF
--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -35,7 +35,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 	t.Parallel()
 
 	authorizer := &fakeAuthorizer{}
-	srv, client := coderdtest.NewMemoryCoderd(t, &coderdtest.Options{
+	srv, client := coderdtest.NewWithServer(t, &coderdtest.Options{
 		Authorizer: authorizer,
 	})
 	admin := coderdtest.CreateFirstUser(t, client)

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -67,7 +67,14 @@ type Options struct {
 
 // New constructs an in-memory coderd instance and returns
 // the connected client.
-func NewMemoryCoderd(t *testing.T, options *Options) (*httptest.Server, *codersdk.Client) {
+func New(t *testing.T, options *Options) *codersdk.Client {
+	_, cli := NewWithServer(t, options)
+	return cli
+}
+
+// NewWithServer returns an in-memory coderd instance and
+// the HTTP server it started with.
+func NewWithServer(t *testing.T, options *Options) (*httptest.Server, *codersdk.Client) {
 	if options == nil {
 		options = &Options{}
 	}
@@ -158,13 +165,6 @@ func NewMemoryCoderd(t *testing.T, options *Options) (*httptest.Server, *codersd
 	})
 
 	return srv, codersdk.New(serverURL)
-}
-
-// New constructs an in-memory coderd instance and returns
-// the connected client.
-func New(t *testing.T, options *Options) *codersdk.Client {
-	_, cli := NewMemoryCoderd(t, options)
-	return cli
 }
 
 // NewProvisionerDaemon launches a provisionerd instance configured to work


### PR DESCRIPTION
This name felt invalid, because `New` was also in memory.
