### PR TITLE
fix: User's should be able to read what roles available

### DIFF
--- a/coderd/rbac/builtin.go
+++ b/coderd/rbac/builtin.go
@@ -66,7 +66,8 @@ var (
 				DisplayName: "Member",
 				Site: permissions(map[Object][]Action{
 					// All users can read all other users and know they exist.
-					ResourceUser: {ActionRead},
+					ResourceUser:           {ActionRead},
+					ResourceRoleAssignment: {ActionRead},
 				}),
 				User: permissions(map[Object][]Action{
 					ResourceWildcard: {WildcardSymbol},

--- a/coderd/rbac/builtin_internal_test.go
+++ b/coderd/rbac/builtin_internal_test.go
@@ -34,7 +34,7 @@ func TestRoleByName(t *testing.T) {
 			t.Run(c.Role.Name, func(t *testing.T) {
 				role, err := RoleByName(c.Role.Name)
 				require.NoError(t, err, "role exists")
-				require.Equal(t, c.Role, role)
+				equalRoles(t, c.Role, role)
 			})
 		}
 	})
@@ -52,4 +52,19 @@ func TestRoleByName(t *testing.T) {
 		_, err = RoleByName(orgMember)
 		require.Error(t, err, "expect orgID")
 	})
+}
+
+// SameAs compares 2 roles for equality.
+func equalRoles(t *testing.T, a, b Role) {
+	require.Equal(t, a.Name, b.Name, "role names")
+	require.Equal(t, a.DisplayName, b.DisplayName, "role display names")
+	require.ElementsMatch(t, a.Site, b.Site, "site permissions")
+	require.ElementsMatch(t, a.User, b.User, "user permissions")
+	require.Equal(t, len(a.Org), len(b.Org), "same number of org roles")
+
+	for ak, av := range a.Org {
+		bv, ok := b.Org[ak]
+		require.True(t, ok, "org permissions missing: %s", ak)
+		require.ElementsMatchf(t, av, bv, "org %s permissions", ak)
+	}
 }

--- a/coderd/roles_test.go
+++ b/coderd/roles_test.go
@@ -112,7 +112,6 @@ func TestListRoles(t *testing.T) {
 	})
 	require.NoError(t, err, "create org")
 
-	const unauth = "forbidden"
 	const notMember = "not a member of the organization"
 
 	testCases := []struct {

--- a/coderd/roles_test.go
+++ b/coderd/roles_test.go
@@ -128,14 +128,14 @@ func TestListRoles(t *testing.T) {
 				x, err := member.ListSiteRoles(ctx)
 				return x, err
 			},
-			AuthorizedError: unauth,
+			ExpectedRoles: convertRoles(rbac.SiteRoles()),
 		},
 		{
 			Name: "OrgMemberListOrg",
 			APICall: func() ([]codersdk.Role, error) {
 				return member.ListOrganizationRoles(ctx, admin.OrganizationID)
 			},
-			AuthorizedError: unauth,
+			ExpectedRoles: convertRoles(rbac.OrganizationRoles(admin.OrganizationID)),
 		},
 		{
 			Name: "NonOrgMemberListOrg",
@@ -150,7 +150,7 @@ func TestListRoles(t *testing.T) {
 			APICall: func() ([]codersdk.Role, error) {
 				return orgAdmin.ListSiteRoles(ctx)
 			},
-			AuthorizedError: unauth,
+			ExpectedRoles: convertRoles(rbac.SiteRoles()),
 		},
 		{
 			Name: "OrgAdminListOrg",


### PR DESCRIPTION
Users cannot read the possible roles. This lets them read roles, not assign them. Which is correct!