### PR TITLE
fix: Use Terraform address to index resource + agent association

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -357,11 +357,10 @@ func parseTerraformPlan(ctx context.Context, terraform *tfexec.Terraform, planfi
 		if resource.Type == "coder_agent" || resource.Type == "coder_agent_instance" {
 			continue
 		}
-		resourceKey := strings.Join([]string{resource.Type, resource.Name}, ".")
 		resources = append(resources, &proto.Resource{
 			Name:   resource.Name,
 			Type:   resource.Type,
-			Agents: findAgents(resourceDependencies, agents, resourceKey),
+			Agents: findAgents(resourceDependencies, agents, resource.Address),
 		})
 	}
 
@@ -498,8 +497,7 @@ func parseTerraformApply(ctx context.Context, terraform *tfexec.Terraform, state
 			if resource.Type == "coder_agent" || resource.Type == "coder_agent_instance" {
 				continue
 			}
-			resourceKey := strings.Join([]string{resource.Type, resource.Name}, ".")
-			resourceAgents := findAgents(resourceDependencies, agents, resourceKey)
+			resourceAgents := findAgents(resourceDependencies, agents, resource.Address)
 			for _, agent := range resourceAgents {
 				// Didn't use instance identity.
 				if agent.GetToken() != "" {


### PR DESCRIPTION
This fixes resources created from Terraform modules not
properly being associated with an agent.

By not using the address, and resource identifiers prefixed
with `module.<name>` would be missed!
