### PR TITLE
feat: use and display default template values when creating wkspc.

### DIFF
--- a/cli/cliui/parameter.go
+++ b/cli/cliui/parameter.go
@@ -30,6 +30,7 @@ func ParameterSchema(cmd *cobra.Command, parameterSchema codersdk.TemplateVersio
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[1A")
 		value, err = Select(cmd, SelectOptions{
 			Options:    options,
+			Default:    parameterSchema.DefaultSourceValue,
 			HideSearch: true,
 		})
 		if err == nil {
@@ -37,9 +38,24 @@ func ParameterSchema(cmd *cobra.Command, parameterSchema codersdk.TemplateVersio
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+Styles.Prompt.String()+Styles.Field.Render(value))
 		}
 	} else {
+		text := "Enter a value"
+		if parameterSchema.DefaultSourceValue != "" {
+			text += fmt.Sprintf(" (default: %q)", parameterSchema.DefaultSourceValue)
+		}
+		text += ":"
+
 		value, err = Prompt(cmd, PromptOptions{
-			Text: Styles.Bold.Render("Enter a value:"),
+			Text: Styles.Bold.Render(text),
 		})
 	}
-	return value, err
+	if err != nil {
+		return "", err
+	}
+
+	// If they didn't specify anything, use the default value if set.
+	if len(options) == 0 && value == "" {
+		value = parameterSchema.DefaultSourceValue
+	}
+
+	return value, nil
 }

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -35,7 +35,9 @@ func init() {
 }
 
 type SelectOptions struct {
-	Options    []string
+	Options []string
+	// Default will be highlighted first if it's a valid option.
+	Default    string
 	Size       int
 	HideSearch bool
 }
@@ -50,9 +52,16 @@ func Select(cmd *cobra.Command, opts SelectOptions) (string, error) {
 	if flag.Lookup("test.v") != nil {
 		return opts.Options[0], nil
 	}
+
+	var defaultOption interface{}
+	if opts.Default != "" {
+		defaultOption = opts.Default
+	}
+
 	var value string
 	err := survey.AskOne(&survey.Select{
 		Options:  opts.Options,
+		Default:  defaultOption,
 		PageSize: opts.Size,
 	}, &value, survey.WithIcons(func(is *survey.IconSet) {
 		is.Help.Text = "Type to search"

--- a/cli/login.go
+++ b/cli/login.go
@@ -164,7 +164,7 @@ func login() *cobra.Command {
 					cliui.Styles.Paragraph.Render(fmt.Sprintf("Welcome to Coder, %s! You're authenticated.", cliui.Styles.Keyword.Render(username)))+"\n")
 
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-					cliui.Styles.Paragraph.Render("Get started by creating a template: "+cliui.Styles.Code.Render("coder templates create"))+"\n")
+					cliui.Styles.Paragraph.Render("Get started by creating a template: "+cliui.Styles.Code.Render("coder templates init"))+"\n")
 				return nil
 			}
 


### PR DESCRIPTION
When creating a workspace using a template that has default values (that aren't empty strings) the default value will be displayed beside the prompt.

Before: `Enter a value:`
Now: `Enter a value (default: "20"):`

Also, select (e.g. used by region selectors) parameters will now have the default selected as the initial value.

Fixes #1499

![Code_i8QKeVCLlZ](https://user-images.githubusercontent.com/11241812/169245676-e9c178f4-cb16-4792-a025-4d546b7ccb9d.gif)