### PR TITLE
Revert "fix: Use Terraform address to index resource + agent associat…

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -357,10 +357,11 @@ func parseTerraformPlan(ctx context.Context, terraform *tfexec.Terraform, planfi
 		if resource.Type == "coder_agent" || resource.Type == "coder_agent_instance" {
 			continue
 		}
+		resourceKey := strings.Join([]string{resource.Type, resource.Name}, ".")
 		resources = append(resources, &proto.Resource{
 			Name:   resource.Name,
 			Type:   resource.Type,
-			Agents: findAgents(resourceDependencies, agents, resource.Address),
+			Agents: findAgents(resourceDependencies, agents, resourceKey),
 		})
 	}
 
@@ -497,7 +498,8 @@ func parseTerraformApply(ctx context.Context, terraform *tfexec.Terraform, state
 			if resource.Type == "coder_agent" || resource.Type == "coder_agent_instance" {
 				continue
 			}
-			resourceAgents := findAgents(resourceDependencies, agents, resource.Address)
+			resourceKey := strings.Join([]string{resource.Type, resource.Name}, ".")
+			resourceAgents := findAgents(resourceDependencies, agents, resourceKey)
 			for _, agent := range resourceAgents {
 				// Didn't use instance identity.
 				if agent.GetToken() != "" {


### PR DESCRIPTION
…ion (#1577)"

This reverts commit f3fe2a08cefcdc203590df3778d354c360b733ef.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->

Newly-created workspaces from docker example template on c034e83 are missing agents:
```
[...]
  coder_agent.dev: Creation complete after 0s [id=950e2365-5e24-43a5-8537-14368f195e92]
[...]
The test4 workspace has been created!
$ coderv2 ssh test4 
workspace "test4" has no agents
$ docker logs coder-cian-test4 
2022-05-19 10:31:52.734 [WARN]  <agent.go:112>  failed to dial  {"error": "status code 401: agent token is invalid"}
$ docker exec -it coder-database-1 psql -U username coder
coder=# select count(1) from workspace_agents where id = '950e2365-5e24-43a5-8537-14368f195e92';
 count 
-------
     0
(1 row)
```