### PR TITLE
fix: missing spacing added; typo fix

### DIFF
--- a/examples/docker-image-builds/README.md
+++ b/examples/docker-image-builds/README.md
@@ -54,7 +54,7 @@ Edit the validation to include the new image:
 
 ```diff
 variable "docker_image" {
-    description = "What Docker imagewould you like to use for your workspace?"
+    description = "What Docker image would you like to use for your workspace?"
     default     = "base"
 
     # List of images available for the user to choose from.

--- a/examples/docker-image-builds/main.tf
+++ b/examples/docker-image-builds/main.tf
@@ -56,7 +56,7 @@ resource "coder_agent" "dev" {
 }
 
 variable "docker_image" {
-  description = "What Docker imagewould you like to use for your workspace?"
+  description = "What Docker image would you like to use for your workspace?"
   default     = "base"
 
   # List of images available for the user to choose from.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -20,7 +20,7 @@ Edit the template:
 vim main.tf
 ```
 variable "docker_image" {
-  description = "What Docker imagewould you like to use for your workspace?"
+  description = "What Docker image would you like to use for your workspace?"
   default     = "codercom/enterprise-base:ubuntu"
   validation {
 -    condition     = contains(["codercom/enterprise-base:ubuntu", "codercom/enterprise-node:ubuntu", "codercom/enterprise-intellij:ubuntu"], var.docker_image)
@@ -46,7 +46,7 @@ To reduce drift, we recommend versioning images in your registry by creating tag
 
 ```sh
 variable "docker_image" {
-  description = "What Docker imagewould you like to use for your workspace?"
+  description = "What Docker image would you like to use for your workspace?"
   default     = "codercom/enterprise-base:ubuntu"
   validation {
 -    condition     = contains(["my-org/base-development:v1.1", "myorg-java-development:v1.1"], var.docker_image)


### PR DESCRIPTION

This PR adds a minor(very minor) correction to the Docker Images example that was introduced by @bpmct. Looks like there was a missing space that got noticed only when I ran this on my RasPi.
## Subtasks
None

