### PR TITLE
chore: use docker host in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       - "7080:7080"
     environment:
       CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
-      CODER_ADDRESS: "${CODER_ADDRESS:-0.0.0.0:7080}"
+      CODER_ADDRESS: "0.0.0.0:7080"
       # You'll need to set CODER_ACCESS_URL to an
       # externally-reachable IP to use non-Docker examples!
       CODER_ACCESS_URL: "${CODER_ACCESS_URL:-http://host.docker.internal:7080}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,15 @@
 version: "3.9"
 services:
   coder:
-    image: ghcr.io/coder/coder:v${CODER_VERSION:-0.5.6}-${ARCH:-amd64}
+    image: ghcr.io/coder/coder:v${CODER_VERSION:-0.5.10}-${ARCH:-amd64}
     ports:
       - "7080:7080"
     environment:
       CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
-      CODER_ADDRESS: "0.0.0.0:7080"
+      CODER_ADDRESS: "${CODER_ADDRESS:-0.0.0.0:7080}"
+      # You'll need to set CODER_ACCESS_URL to an
+      # externally-reachable IP to use non-Docker examples!
+      CODER_ACCESS_URL: "${CODER_ACCESS_URL:-http://host.docker.internal:7080}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/examples/docker-image-builds/main.tf
+++ b/examples/docker-image-builds/main.tf
@@ -42,9 +42,6 @@ provider "docker" {
 }
 
 provider "coder" {
-  # The below assumes your Coder deployment is running in docker-compose.
-  # If this is not the case, either comment or edit the below.
-  url = "http://host.docker.internal:7080"
 }
 
 data "coder_workspace" "me" {

--- a/examples/docker/main.tf
+++ b/examples/docker/main.tf
@@ -49,9 +49,6 @@ provider "docker" {
 }
 
 provider "coder" {
-  # The below assumes your Coder deployment is running in docker-compose.
-  # If this is not the case, either comment or edit the below.
-  url = "http://host.docker.internal:7080"
 }
 
 data "coder_workspace" "me" {


### PR DESCRIPTION
This PR adds support for passing through `CODER_ACCESS_URL` in docker-compose, and also defaults to the docker host.

This is somewhat a revert of #1507, but it was also its initial implementation. I think this is an acceptable standard for the following reasons:
- The absence of an access URL in docker-compose results in 0 functioning example templates
- The docker host as an access URL in docker-compose results in 2 functioning example templates (docker, docker-builds)
- Users will be required to set an access URL anyways to use all other example templates. #1528 proposes a warning for this anyways
- Docker template users will not experience breaking changes if they have a functional access URL (this already happened!)

Related discussions: #1545, #1528, #1345, #1545