### PR TITLE
chore: remove docker host from docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
       - "7080:7080"
     environment:
       CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
-      CODER_ADDRESS: "0.0.0.0:7080"
-      # You'll need to set CODER_ACCESS_URL to an
-      # externally-reachable IP to use non-Docker examples!
-      CODER_ACCESS_URL: "${CODER_ACCESS_URL:-http://host.docker.internal:7080}"
+      # You'll need to set CODER_ACCESS_URL to an IP or domain
+      # that workspaces can reach. This cannot be localhost
+      # or 127.0.0.1!
+      CODER_ACCESS_URL: "${CODER_ACCESS_URL}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,8 @@ services:
       CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
       # You'll need to set CODER_ACCESS_URL to an IP or domain
       # that workspaces can reach. This cannot be localhost
-      # or 127.0.0.1!
+      # or 127.0.0.1 for non-Docker templates!
+      CODER_ADDRESS: "0.0.0.0:7080"
       CODER_ACCESS_URL: "${CODER_ACCESS_URL}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/examples/docker-image-builds/main.tf
+++ b/examples/docker-image-builds/main.tf
@@ -94,8 +94,9 @@ resource "docker_container" "workspace" {
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = lower(data.coder_workspace.me.name)
   dns      = ["1.1.1.1"]
-  command  = ["sh", "-c", coder_agent.dev.init_script]
-  env      = ["CODER_AGENT_TOKEN=${coder_agent.dev.token}"]
+  # Use the docker gateway if the access URL is 127.0.0.1 
+  command = ["sh", "-c", replace(coder_agent.dev.init_script, "127.0.0.1", "host.docker.internal")]
+  env     = ["CODER_AGENT_TOKEN=${coder_agent.dev.token}"]
   host {
     host = "host.docker.internal"
     ip   = "host-gateway"

--- a/examples/docker/main.tf
+++ b/examples/docker/main.tf
@@ -48,10 +48,10 @@ provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
 
-provider "coder" {
+data "coder_workspace" "me" {
 }
 
-data "coder_workspace" "me" {
+provider "coder" {
 }
 
 resource "coder_agent" "dev" {
@@ -82,8 +82,9 @@ resource "docker_container" "workspace" {
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = lower(data.coder_workspace.me.name)
   dns      = ["1.1.1.1"]
-  command  = ["sh", "-c", coder_agent.dev.init_script]
-  env      = ["CODER_AGENT_TOKEN=${coder_agent.dev.token}"]
+  # Use the docker gateway if the access URL is 127.0.0.1
+  command = ["sh", "-c", replace(coder_agent.dev.init_script, "127.0.0.1", "host.docker.internal")]
+  env     = ["CODER_AGENT_TOKEN=${coder_agent.dev.token}"]
   host {
     host = "host.docker.internal"
     ip   = "host-gateway"

--- a/examples/docker/main.tf
+++ b/examples/docker/main.tf
@@ -47,11 +47,10 @@ variable "step2_arch" {
 provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
-
-data "coder_workspace" "me" {
+provider "coder" {
 }
 
-provider "coder" {
+data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "dev" {


### PR DESCRIPTION
There isn't really a great solution to get docker-compose working locally:

- ❌ use 127.0.0.1 as access URL for docker
  - containers dial themselves instead of the Coder control panel
- ❌ use `--network=host` on containers in the template
   - no network isolation for workspaces. two workspaces can't have apps on `:8080`
- ❌ add host.docker.internal to docker-compose:
  - wrong URL on `coder server` command

  <img width="1018" alt="Screen Shot 2022-05-19 at 12 18 48 PM" src="https://user-images.githubusercontent.com/22407953/169359616-697f38a8-06f9-4668-a321-51f85f519bc9.png">
- ❌ add host.docker.internal to the Docker templates.
   - breaks for non-compose workflows: https://github.com/coder/coder/pull/1545#issuecomment-1130399811
- 🤔 admin parameter for access URL in Docker templates
  - only relevant if running on localhost
- ✅ this hack (override and replace localhost access URL in Docker start script)