### PR TITLE
chore: unconditionally run all `make` cmds in CI

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -133,8 +133,7 @@ jobs:
       - name: Install node_modules
         run: ./scripts/yarn_install.sh
 
-      - name: "make fmt"
-        run: "make --output-sync -j fmt"
+      - run: "make --output-sync -j -B fmt"
 
   test-go:
     name: "test/go"
@@ -355,7 +354,7 @@ jobs:
             js-${{ runner.os }}-
 
       - name: Build site
-        run: make site/out/index.html
+        run: make -B site/out/index.html
 
       - name: Build Release
         uses: goreleaser/goreleaser-action@v2.9.1
@@ -488,7 +487,7 @@ jobs:
 
       - name: Build
         run: |
-          make site/out/index.html
+          make -B site/out/index.html
 
       - run: yarn playwright:install
         working-directory: site

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -483,3 +483,4 @@ ALTER TABLE ONLY workspaces
 
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_template_id_fkey FOREIGN KEY (template_id) REFERENCES templates(id) ON DELETE RESTRICT;
+


### PR DESCRIPTION
Skips the `-B` added in https://github.com/coder/coder/pull/1607
