### PR TITLE
feat: add coder logout command

### DIFF
--- a/cli/logout.go
+++ b/cli/logout.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func logout() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Remove local autheticated session",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := createConfig(cmd)
+			err := os.RemoveAll(string(config))
+			if err != nil {
+				return xerrors.Errorf("remove files at %s: %w", config, err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), caret+"Successfully logged out.\n")
+			return nil
+		},
+	}
+}

--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -1,0 +1,44 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/pty/ptytest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogout(t *testing.T) {
+	t.Parallel()
+
+	// login
+	client := coderdtest.New(t, nil)
+	coderdtest.CreateFirstUser(t, client)
+
+	doneChan := make(chan struct{})
+	root, config := clitest.New(t, "login", "--force-tty", client.URL.String(), "--no-open")
+	pty := ptytest.New(t)
+	root.SetIn(pty.Input())
+	root.SetOut(pty.Output())
+	go func() {
+		defer close(doneChan)
+		err := root.Execute()
+		require.NoError(t, err)
+	}()
+
+	pty.ExpectMatch("Paste your token here:")
+	pty.WriteLine(client.SessionToken)
+	pty.ExpectMatch("Welcome to Coder")
+	<-doneChan
+
+	// ensure session files exist
+	require.FileExists(t, string(config.URL()))
+	require.FileExists(t, string(config.Session()))
+
+	logout, _ := clitest.New(t, "logout", "--global-config", string(config))
+	err := logout.Execute()
+	require.NoError(t, err)
+	require.NoFileExists(t, string(config.URL()))
+	require.NoFileExists(t, string(config.Session()))
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -68,6 +68,7 @@ func Root() *cobra.Command {
 		gitssh(),
 		list(),
 		login(),
+		logout(),
 		publickey(),
 		resetPassword(),
 		server(),


### PR DESCRIPTION
A `coder logout` command is useful so users do not have to find and delete the session files manually. 
