### PR TITLE
chore: Fix broken build due to semantic merge conflict

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -103,7 +103,7 @@ func newRouter(options *Options, a *api) chi.Router {
 			})
 		},
 		httpmw.Prometheus,
-		tracing.HTTPMW(api.TracerProvider, "coderd.http"),
+		tracing.HTTPMW(a.TracerProvider, "coderd.http"),
 	)
 
 	r.Route("/api/v2", func(r chi.Router) {


### PR DESCRIPTION
The main branch currently doesn't build because of an incorrect automatic merge. 

The `api` local variable in `coderd.New` was effectively renamed to become a parameter to `coderd.newRouter` called `a` in #1568. #1567 passed its tests before this change, using the old name, but was merged afterwards without retesting.