### PR TITLE
feat: Log API requests made by CLI

### DIFF
--- a/cli/requestlogging.go
+++ b/cli/requestlogging.go
@@ -1,27 +1,34 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 type loggingRoundTripper struct {
 	http.RoundTripper
 	io.Writer
-}
 
-func newLoggingRoundTripper(writer io.Writer) http.RoundTripper {
-	return &loggingRoundTripper{
-		Writer: writer,
-	}
+	logRequestBodies  bool
+	logResponseBodies bool
 }
 
 func (lrt loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	inner := lrt.RoundTripper
 	if inner == nil {
 		inner = http.DefaultTransport
+	}
+
+	var requestBody bytes.Buffer
+	if lrt.logRequestBodies {
+		teeReader := io.TeeReader(request.Body, &requestBody)
+		wrappedBody := &readCloser{teeReader, request.Body}
+		request = request.Clone(request.Context())
+		request.Body = wrappedBody
 	}
 
 	response, err := inner.RoundTrip(request)
@@ -32,7 +39,74 @@ func (lrt loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 	} else {
 		displayedStatusCode = strconv.Itoa(response.StatusCode)
 	}
+	_, _ = fmt.Fprintf(lrt.Writer, "sending request: %s %s status: %s\n", request.Method, request.URL.String(), displayedStatusCode)
 
-	_, _ = fmt.Fprintf(lrt.Writer, "%s %s %s\n", request.Method, request.URL.String(), displayedStatusCode)
+	if lrt.logRequestBodies {
+		printRequestBodyLog(lrt.Writer, request, &requestBody)
+	}
+
+	if lrt.logResponseBodies {
+		response = wrapResponse(lrt.Writer, response)
+	}
+
 	return response, err
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func formatBody(contentType string, body *bytes.Buffer) string {
+	bareType, _, _ := strings.Cut(contentType, ";")
+	if bareType == "application/json" || strings.HasPrefix(bareType, "text/") {
+		return fmt.Sprintf("%s: %s", contentType, body.Bytes())
+	}
+	return fmt.Sprintf("%s, %d bytes", contentType, body.Len())
+}
+
+func printRequestBodyLog(writer io.Writer, request *http.Request, body *bytes.Buffer) {
+	// omit bodies that are empty and expected to be empty
+	if body.Len() == 0 && emptyRequestExpected(request.Method) {
+		return
+	}
+
+	message := formatBody(request.Header.Get("Content-Type"), body)
+	_, _ = fmt.Fprintf(writer, "\trequest body: %s\n", message)
+}
+
+func emptyRequestExpected(method string) bool {
+	return !(method == "POST" || method == "PUT" || method == "PATCH")
+}
+
+type responseBodyLogger struct {
+	writer io.Writer
+
+	body        io.ReadCloser
+	bodyContent bytes.Buffer
+	contentType string
+}
+
+func wrapResponse(writer io.Writer, response *http.Response) *http.Response {
+	newResponse := new(http.Response)
+	*newResponse = *response
+
+	logger := responseBodyLogger{
+		writer:      writer,
+		contentType: response.Header.Get("Content-Type"),
+	}
+	logger.body = &readCloser{io.TeeReader(response.Body, &logger.bodyContent), response.Body}
+	newResponse.Body = &logger
+
+	return newResponse
+}
+
+func (logger *responseBodyLogger) Read(p []byte) (int, error) {
+	return logger.body.Read(p)
+}
+
+func (logger *responseBodyLogger) Close() error {
+	message := formatBody(logger.contentType, &logger.bodyContent)
+	_, _ = fmt.Fprintf(logger.writer, "\tresponse body: %s\n", message)
+	return logger.body.Close()
 }

--- a/cli/requestlogging.go
+++ b/cli/requestlogging.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+type loggingRoundTripper struct {
+	http.RoundTripper
+	io.Writer
+}
+
+func newLoggingRoundTripper(writer io.Writer) http.RoundTripper {
+	return &loggingRoundTripper{
+		Writer: writer,
+	}
+}
+
+func (lrt loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	inner := lrt.RoundTripper
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+
+	response, err := inner.RoundTrip(request)
+
+	var displayedStatusCode string
+	if err != nil {
+		displayedStatusCode = "(err)"
+	} else {
+		displayedStatusCode = strconv.Itoa(response.StatusCode)
+	}
+
+	_, _ = fmt.Fprintf(lrt.Writer, "%s %s %s\n", request.Method, request.URL.String(), displayedStatusCode)
+	return response, err
+}

--- a/cli/requestlogging_test.go
+++ b/cli/requestlogging_test.go
@@ -1,0 +1,40 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/pty/ptytest"
+)
+
+func TestRequestLogging(t *testing.T) {
+	t.Parallel()
+	t.Run("List", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+		cmd, root := clitest.New(t, "ls", "--log-requests")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			require.NoError(t, err)
+		}()
+		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces 200")
+		pty.ExpectMatch(workspace.Name)
+		pty.ExpectMatch("Running")
+		<-doneChan
+	})
+}

--- a/cli/requestlogging_test.go
+++ b/cli/requestlogging_test.go
@@ -18,7 +18,7 @@ func TestRequestLogging(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		_ = coderdtest.CreateFirstUser(t, client)
-		cmd, root := clitest.New(t, "ls", "--log-requests")
+		cmd, root := clitest.New(t, "ls", "--verbose")
 		clitest.SetupConfig(t, client, root)
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
@@ -29,14 +29,14 @@ func TestRequestLogging(t *testing.T) {
 			err := cmd.Execute()
 			require.NoError(t, err)
 		}()
-		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces 200")
+		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces status: 200")
 		<-doneChan
 	})
 
 	t.Run("NoAuthentication", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
-		cmd, root := clitest.New(t, "ls", "--log-requests")
+		cmd, root := clitest.New(t, "ls", "--verbose")
 		clitest.SetupConfig(t, client, root)
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
@@ -47,7 +47,7 @@ func TestRequestLogging(t *testing.T) {
 			err := cmd.Execute()
 			require.Error(t, err)
 		}()
-		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces 401")
+		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces status: 401")
 		<-doneChan
 	})
 
@@ -56,7 +56,7 @@ func TestRequestLogging(t *testing.T) {
 		parsedURL, err := url.Parse("invalidprotocol://foobar")
 		require.NoError(t, err)
 		client := codersdk.New(parsedURL)
-		cmd, root := clitest.New(t, "ls", "--log-requests")
+		cmd, root := clitest.New(t, "ls", "--verbose")
 		clitest.SetupConfig(t, client, root)
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
@@ -67,7 +67,7 @@ func TestRequestLogging(t *testing.T) {
 			err := cmd.Execute()
 			require.Error(t, err)
 		}()
-		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces (err)")
+		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces status: (err)")
 		<-doneChan
 	})
 }

--- a/cli/requestlogging_test.go
+++ b/cli/requestlogging_test.go
@@ -1,12 +1,14 @@
 package cli_test
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/pty/ptytest"
 )
 
@@ -15,12 +17,7 @@ func TestRequestLogging(t *testing.T) {
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
-		user := coderdtest.CreateFirstUser(t, client)
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
-		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+		_ = coderdtest.CreateFirstUser(t, client)
 		cmd, root := clitest.New(t, "ls", "--log-requests")
 		clitest.SetupConfig(t, client, root)
 		doneChan := make(chan struct{})
@@ -33,8 +30,44 @@ func TestRequestLogging(t *testing.T) {
 			require.NoError(t, err)
 		}()
 		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces 200")
-		pty.ExpectMatch(workspace.Name)
-		pty.ExpectMatch("Running")
+		<-doneChan
+	})
+
+	t.Run("NoAuthentication", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		cmd, root := clitest.New(t, "ls", "--log-requests")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			require.Error(t, err)
+		}()
+		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces 401")
+		<-doneChan
+	})
+
+	t.Run("InvalidUrl", func(t *testing.T) {
+		t.Parallel()
+		parsedURL, err := url.Parse("invalidprotocol://foobar")
+		require.NoError(t, err)
+		client := codersdk.New(parsedURL)
+		cmd, root := clitest.New(t, "ls", "--log-requests")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			require.Error(t, err)
+		}()
+		pty.ExpectMatch("GET " + client.URL.String() + "/api/v2/workspaces (err)")
 		<-doneChan
 	})
 }

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -26,6 +26,16 @@ func New(serverURL *url.URL) *Client {
 	}
 }
 
+// NewWithRoundTripper behaves like New, but allows specifying a custom implementation of http.RoundTripper.
+func NewWithRoundTripper(serverURL *url.URL, roundTripper http.RoundTripper) *Client {
+	return &Client{
+		URL: serverURL,
+		HTTPClient: &http.Client{
+			Transport: roundTripper,
+		},
+	}
+}
+
 // Client is an HTTP caller for methods to the Coder API.
 // @typescript-ignore Client
 type Client struct {


### PR DESCRIPTION
Basic support for logging API request URLs, behind a `--log-requests` flag.

Sample usage:

```
coder@my-dev:~/coder$ ./coder --log-requests show dev
GET http://localhost:3000/api/v2/users/me/organizations 200
GET http://localhost:3000/api/v2/organizations/529f78a9-2413-4ca3-80a3-f4d46ba2f663/workspaces/me/dev 200
GET http://localhost:3000/api/v2/workspacebuilds/82f5c5b4-7a83-4154-a225-a54c74d3e185/resources 200
┌──────────────────────────────────────────────────────────┐
│ RESOURCE                    STATUS       ACCESS          │
├──────────────────────────────────────────────────────────┤
│ docker_container.workspace  ephemeral                    │
│ └─ dev (linux, amd64)       ⦿ connected   coder ssh dev  │
├──────────────────────────────────────────────────────────┤
│ docker_volume.home_volume   ephemeral                    │
└──────────────────────────────────────────────────────────┘
```

Fixes #1565