### PR TITLE
fix: Use the cobra CommandPath for usage to avoid duplication

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -264,6 +264,6 @@ func versionTemplate() string {
 
 // FormatCobraError colorizes and adds "--help" docs to cobra commands.
 func FormatCobraError(err error, cmd *cobra.Command) string {
-	helpErrMsg := fmt.Sprintf("Run '%s %s --help' for usage.", cmd.Root().Name(), cmd.Name())
+	helpErrMsg := fmt.Sprintf("Run '%s --help' for usage.", cmd.CommandPath())
 	return cliui.Styles.Error.Render(err.Error() + "\n" + helpErrMsg)
 }


### PR DESCRIPTION
This PR fixes duplicated command path when errors happen on the root command.

See screenshot in https://github.com/coder/coder/issues/1616 (otherwise unrelated issue)
