### PR TITLE
chore: Add (skipped) `ptytest` test that hangs on Intel Mac (and Windows)

### DIFF
--- a/pty/ptytest/ptytest_test.go
+++ b/pty/ptytest/ptytest_test.go
@@ -20,7 +20,7 @@ func TestPtytest(t *testing.T) {
 	})
 	// nolint:paralleltest
 	t.Run("Do not hang on Intel macOS", func(t *testing.T) {
-		cmd := exec.Command("sh", "-c", "for i in $(seq 1 1000); do echo $i; done")
+		cmd := exec.Command("sh", "-c", "echo hi, I will cause a hang")
 		pty := ptytest.New(t)
 		cmd.Stdin = pty.Input()
 		cmd.Stdout = pty.Output()

--- a/pty/ptytest/ptytest_test.go
+++ b/pty/ptytest/ptytest_test.go
@@ -1,7 +1,10 @@
 package ptytest_test
 
 import (
+	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/pty/ptytest"
 )
@@ -14,5 +17,14 @@ func TestPtytest(t *testing.T) {
 		pty.Output().Write([]byte("write"))
 		pty.ExpectMatch("write")
 		pty.WriteLine("read")
+	})
+	// nolint:paralleltest
+	t.Run("Do not hang on Intel macOS", func(t *testing.T) {
+		cmd := exec.Command("sh", "-c", "for i in $(seq 1 1000); do echo $i; done")
+		pty := ptytest.New(t)
+		cmd.Stdin = pty.Input()
+		cmd.Stdout = pty.Output()
+		err := cmd.Run()
+		require.NoError(t, err)
 	})
 }

--- a/pty/ptytest/ptytest_test.go
+++ b/pty/ptytest/ptytest_test.go
@@ -1,9 +1,11 @@
 package ptytest_test
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/pty/ptytest"
@@ -18,6 +20,7 @@ func TestPtytest(t *testing.T) {
 		pty.ExpectMatch("write")
 		pty.WriteLine("read")
 	})
+
 	// nolint:paralleltest
 	t.Run("Do not hang on Intel macOS", func(t *testing.T) {
 		cmd := exec.Command("sh", "-c", "echo hi, I will cause a hang")
@@ -25,6 +28,25 @@ func TestPtytest(t *testing.T) {
 		cmd.Stdin = pty.Input()
 		cmd.Stdout = pty.Output()
 		err := cmd.Run()
+		require.NoError(t, err)
+	})
+
+	// nolint:paralleltest
+	t.Run("CobraCommandWorksLinux", func(t *testing.T) {
+		// Example with cobra command instead of exec. More abstractions, but
+		// for some reason works on linux.
+		cmd := cobra.Command{
+			Use: "test",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				fmt.Println("Hello world")
+				return nil
+			},
+		}
+
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		err := cmd.Execute()
 		require.NoError(t, err)
 	})
 }

--- a/pty/ptytest/ptytest_test.go
+++ b/pty/ptytest/ptytest_test.go
@@ -30,6 +30,7 @@ func TestPtytest(t *testing.T) {
 		}{
 			{name: "1024 is safe (does not exceed macOS buffer)", output: strings.Repeat(".", 1024)},
 			{name: "1025 exceeds macOS buffer (must not hang)", output: strings.Repeat(".", 1025)},
+			{name: "10241 large output", output: strings.Repeat(".", 10241)}, // 1024 * 10 + 1
 		}
 		for _, tt := range tests {
 			tt := tt

--- a/pty/ptytest/ptytest_test.go
+++ b/pty/ptytest/ptytest_test.go
@@ -28,7 +28,7 @@ func TestPtytest(t *testing.T) {
 		tests := []struct {
 			name          string
 			output        string
-			isPlatformBug bool // See https://github.com/coder/coder/issues/2122.
+			isPlatformBug bool // See https://github.com/coder/coder/issues/2122 for more info.
 		}{
 			{name: "1024 is safe (does not exceed macOS buffer)", output: strings.Repeat(".", 1024)},
 			{name: "1025 exceeds macOS buffer (must not hang)", output: strings.Repeat(".", 1025), isPlatformBug: true},
@@ -39,7 +39,7 @@ func TestPtytest(t *testing.T) {
 			// nolint:paralleltest // Avoid parallel test to more easily identify the issue.
 			t.Run(tt.name, func(t *testing.T) {
 				if tt.isPlatformBug && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
-					t.Skip("This test does not (currently) work on macOS or Windows")
+					t.Skip("This test hangs on macOS and Windows, see https://github.com/coder/coder/issues/2122")
 				}
 
 				cmd := cobra.Command{


### PR DESCRIPTION
This (draft) PR adds a test that breaks `ptytest` with unconsumed output on Intel Macs.

This is left open to inform / opportunity to investigate.

To reproduce: `go test ./pty/ptytest -v -run=TestPtytest/Do_not_hang -timeout=5s`

Here is the trace: [trace.txt](https://github.com/coder/coder/files/8741887/trace.txt)

// @coder/backend @Emyrk
