### PR TITLE
fix: remove outdated doc paths in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,23 +2,14 @@ archives:
   - id: coder-linux
     builds: [coder-linux]
     format: tar.gz
-    files:
-      - src: docs/README.md
-        dst: README.md
 
   - id: coder-darwin
     builds: [coder-darwin]
     format: zip
-    files:
-      - src: docs/README.md
-        dst: README.md
 
   - id: coder-windows
     builds: [coder-windows]
     format: zip
-    files:
-      - src: docs/README.md
-        dst: README.md
 
 before:
   hooks:


### PR DESCRIPTION
It appears we were manually moving the `README.md`. This should have been updated in https://github.com/coder/coder/pull/1630 but slipped through CI

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
