### PR TITLE
chore: Add .editorconfig, subshell dir changes in scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+
+[*.{md,json,yaml}]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
 
-[*.{md,json,yaml}]
+[*.{md,json,yaml,tf,tfvars}]
 indent_style = space
 indent_size = 2
+
+[*.sql]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,6 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.sql]
+[coderd/database/dump.sql]
 indent_style = space
 indent_size = 4

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -147,7 +147,9 @@ jobs:
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0
 
-      - run: "make --output-sync -j -B fmt"
+      - run: |
+          export PATH=${PATH}:$(go env GOPATH)/bin
+          make --output-sync -j -B fmt
 
   test-go:
     name: "test/go"

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -44,6 +44,17 @@ jobs:
         with:
           version: v1.46.0
 
+  style-lint-shellcheck:
+    name: style/lint/shellcheck
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@1.1.0
+        with:
+          ignore: node_modules
+
   style-lint-typescript:
     name: "style/lint/typescript"
     timeout-minutes: 5
@@ -132,6 +143,9 @@ jobs:
 
       - name: Install node_modules
         run: ./scripts/yarn_install.sh
+
+      - name: Install shfmt
+        run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0
 
       - run: "make --output-sync -j -B fmt"
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ fmt: fmt/prettier fmt/terraform
 gen: coderd/database/querier.go peerbroker/proto/peerbroker.pb.go provisionersdk/proto/provisioner.pb.go provisionerd/proto/provisionerd.pb.go site/src/api/typesGenerated.ts
 
 install: build
+	mkdir -p $(INSTALL_DIR)
 	@echo "--- Copying from bin to $(INSTALL_DIR)"
 	cp -r ./dist/coder-$(GOOS)_$(GOOS)_$(GOARCH)*/* $(INSTALL_DIR)
 	@echo "-- CLI available at $(shell ls $(INSTALL_DIR)/coder*)"

--- a/coderd/audit/generate.sh
+++ b/coderd/audit/generate.sh
@@ -8,8 +8,12 @@
 # Usage:
 # ./generate.sh <database type> <database type> ...
 
-
 set -euo pipefail
 
-cd "$(dirname "$0")" && cd "$(git rev-parse --show-toplevel)"
-go run ./scripts/auditgen ./coderd/database "$@"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+PROJECT_ROOT=${SCRIPT_DIR}/..
+
+(
+	cd "$PROJECT_ROOT"
+	go run ./scripts/auditgen ./coderd/database "$@"
+)

--- a/coderd/audit/generate.sh
+++ b/coderd/audit/generate.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-PROJECT_ROOT=${SCRIPT_DIR}/..
+PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 
 (
 	cd "$PROJECT_ROOT"

--- a/coderd/database/migrations/create_migration.sh
+++ b/coderd/database/migrations/create_migration.sh
@@ -7,14 +7,17 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+(
+	cd "$SCRIPT_DIR"
 
-# if migration name is an empty string exit
-[[ -z "${*}" ]] && (echo "Must provide a migration name" && exit 1)
+	# if migration name is an empty string exit
+	[[ -z "${*}" ]] && (echo "Must provide a migration name" && exit 1)
 
-# " " && "-" -> "_"
-title="$(echo "${@}" | tr "[:upper:]" "[:lower:]" | sed -E -e "s/( |-)/_/g")"
+	# " " && "-" -> "_"
+	title="$(echo "${@}" | tr "[:upper:]" "[:lower:]" | sed -E -e "s/( |-)/_/g")"
 
-migrate create -ext sql -dir . -seq "$title"
+	migrate create -ext sql -dir . -seq "$title"
 
-echo "Run \"make gen\" to generate models."
+	echo "Run \"make gen\" to generate models."
+)

--- a/scripts/check_unstaged.sh
+++ b/scripts/check_unstaged.sh
@@ -2,23 +2,29 @@
 
 set -euo pipefail
 
-FILES="$(git ls-files --other --modified --exclude-standard)"
-if [[ "$FILES" != "" ]]; then
-    mapfile -t files <<<"$FILES"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+PROJECT_ROOT=${SCRIPT_DIR}/..
 
-    echo "The following files contain unstaged changes:"
-    echo
-    for file in "${files[@]}"; do
-        echo "  - $file"
-    done
-    echo
+(
+	cd "${PROJECT_ROOT}"
 
-    echo "These are the changes:"
-    echo
-    for file in "${files[@]}"; do
-        git --no-pager diff "$file"
-    done
-    exit 1
-fi
+	FILES="$(git ls-files --other --modified --exclude-standard)"
+	if [[ "$FILES" != "" ]]; then
+		mapfile -t files <<<"$FILES"
 
+		echo "The following files contain unstaged changes:"
+		echo
+		for file in "${files[@]}"; do
+			echo "  - $file"
+		done
+		echo
+
+		echo "These are the changes:"
+		echo
+		for file in "${files[@]}"; do
+			git --no-pager diff "$file"
+		done
+		exit 1
+	fi
+)
 exit 0

--- a/scripts/check_unstaged.sh
+++ b/scripts/check_unstaged.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-PROJECT_ROOT=${SCRIPT_DIR}/..
+PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 
 (
 	cd "${PROJECT_ROOT}"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-cd "${PROJECT_ROOT}"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+PROJECT_ROOT=${SCRIPT_DIR}/..
 
 echo '== Run "make build" before running this command to build binaries.'
 echo '== Without these binaries, workspaces will fail to start!'
@@ -19,8 +19,10 @@ export CODER_DEV_ADMIN_PASSWORD=password
 # to kill both at the same time. For more details, see:
 # https://stackoverflow.com/questions/3004811/how-do-you-run-multiple-programs-in-parallel-from-a-bash-script
 (
-  trap 'kill 0' SIGINT
-  CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
-  go run -tags embed cmd/coder/main.go server --dev --tunnel=true &
-  wait
+	cd "${PROJECT_ROOT}"
+
+	trap 'kill 0' SIGINT
+	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
+	go run -tags embed cmd/coder/main.go server --dev --tunnel=true &
+	wait
 )

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-PROJECT_ROOT=${SCRIPT_DIR}/..
+PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 
 echo '== Run "make build" before running this command to build binaries.'
 echo '== Without these binaries, workspaces will fail to start!'

--- a/scripts/sign_macos.sh
+++ b/scripts/sign_macos.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
 
-codesign -s $AC_APPLICATION_IDENTITY -f -v --timestamp --options runtime $1 
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+PROJECT_ROOT=${SCRIPT_DIR}/..
 
-config="$(mktemp -d)/gon.json" 
-jq -r --null-input --arg path "$(pwd)/$1" '{
-    "notarize": [
-        {
-            "path": $path,
-            "bundle_id": "com.coder.cli"
-        }
-    ]
-}' > $config
-gon $config
+(
+	cd "${PROJECT_ROOT}"
+
+	codesign -s "$AC_APPLICATION_IDENTITY" -f -v --timestamp --options runtime "$1"
+
+	config=$(mktemp -d)/gon.json
+	jq -r --null-input --arg path "$(pwd)/$1" '{
+		"notarize": [
+			{
+				"path": $path,
+				"bundle_id": "com.coder.cli"
+			}
+		]
+	}' >"$config"
+	gon "$config"
+)

--- a/scripts/sign_macos.sh
+++ b/scripts/sign_macos.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-PROJECT_ROOT=${SCRIPT_DIR}/..
+PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 
 (
 	cd "${PROJECT_ROOT}"

--- a/scripts/yarn_install.sh
+++ b/scripts/yarn_install.sh
@@ -7,33 +7,37 @@
 
 set -euo pipefail
 
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/site"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+PROJECT_ROOT=${SCRIPT_DIR}/..
 
-yarn_flags=(
-  # Do not execute install scripts
-  # TODO: check if build works properly with this enabled
-  # --ignore-scripts
+(
+	cd "$PROJECT_ROOT/site"
 
-  # Check if existing node_modules are valid
-  # TODO: determine if this is necessary
-  # --check-files
+	yarn_flags=(
+		# Do not execute install scripts
+		# TODO: check if build works properly with this enabled
+		# --ignore-scripts
+
+		# Check if existing node_modules are valid
+		# TODO: determine if this is necessary
+		# --check-files
+	)
+
+	if [ -n "${CI:-}" ]; then
+		yarn_flags+=(
+			# Install dependencies from lockfile, ensuring builds are fully
+			# reproducible
+			--frozen-lockfile
+			# Suppress progress information
+			--silent
+			# Disable interactive prompts for build
+			--non-interactive
+		)
+	fi
+
+	# Append whatever is specified on the command line
+	yarn_flags+=("$@")
+
+	echo "+ yarn install ${yarn_flags[*]}"
+	yarn install "${yarn_flags[@]}"
 )
-
-if [ -n "${CI:-}" ]; then
-  yarn_flags+=(
-    # Install dependencies from lockfile, ensuring builds are fully
-    # reproducible
-    --frozen-lockfile
-    # Suppress progress information
-    --silent
-    # Disable interactive prompts for build
-    --non-interactive
-  )
-fi
-
-# Append whatever is specified on the command line
-yarn_flags+=("$@")
-
-echo "+ yarn install ${yarn_flags[*]}"
-yarn install "${yarn_flags[@]}"

--- a/scripts/yarn_install.sh
+++ b/scripts/yarn_install.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-PROJECT_ROOT=${SCRIPT_DIR}/..
+PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 
 (
 	cd "$PROJECT_ROOT/site"

--- a/site/.editorconfig
+++ b/site/.editorconfig
@@ -5,3 +5,6 @@ indent_size = 2
 [*.go]
 indent_style = tab
 indent_size = unset
+
+[node_modules/**]
+ignore = true

--- a/site/.editorconfig
+++ b/site/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab
+indent_size = unset


### PR DESCRIPTION
This PR adds a `.editorconfig` file to the project root to help contributors ensure they have the correct editor settings when contributing to the project.

It also updates all `.sh` scripts to perform dir changes inside subshells since calling the script directly could change the callers `pwd`.

I opted to not specify specific `.sh` settings in `.editorconfig`, this means tabs will be the preferred indentation as with our `.go` files.

- fix: Ensure ~/go/bin dir exists during make install
- chore: Add .editorconfig to project root
- chore: Perform dir changes in subshell and run shfmt

PS. I recommend ignoring whitespace when reviewing.

PPS. Should we also move the `generate.sh` scripts to `scripts/` folder?
