### PR TITLE
fix: Guard against CLI cmd running after test exit

### DIFF
--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -49,13 +49,12 @@ func TestWorkspaceAgent(t *testing.T) {
 		cmd, _ := clitest.New(t, "agent", "--auth", "azure-instance-identity", "--agent-url", client.URL.String())
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
+		errC := make(chan error)
 		go func() {
-			// A linting error occurs for weakly typing the context value here,
-			// but it seems reasonable for a one-off test.
-			// nolint
-			ctx = context.WithValue(ctx, "azure-client", metadataClient)
-			err := cmd.ExecuteContext(ctx)
-			require.NoError(t, err)
+			// A linting error occurs for weakly typing the context value here.
+			//nolint // The above seems reasonable for a one-off test.
+			ctx := context.WithValue(ctx, "azure-client", metadataClient)
+			errC <- cmd.ExecuteContext(ctx)
 		}()
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.LatestBuild.ID)
 		resources, err := client.WorkspaceResourcesByBuild(ctx, workspace.LatestBuild.ID)
@@ -66,6 +65,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		_, err = dialer.Ping()
 		require.NoError(t, err)
 		cancelFunc()
+		err = <-errC
+		require.NoError(t, err)
 	})
 
 	t.Run("AWS", func(t *testing.T) {
@@ -103,13 +104,12 @@ func TestWorkspaceAgent(t *testing.T) {
 		cmd, _ := clitest.New(t, "agent", "--auth", "aws-instance-identity", "--agent-url", client.URL.String())
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
+		errC := make(chan error)
 		go func() {
-			// A linting error occurs for weakly typing the context value here,
-			// but it seems reasonable for a one-off test.
-			// nolint
-			ctx = context.WithValue(ctx, "aws-client", metadataClient)
-			err := cmd.ExecuteContext(ctx)
-			require.NoError(t, err)
+			// A linting error occurs for weakly typing the context value here.
+			//nolint // The above seems reasonable for a one-off test.
+			ctx := context.WithValue(ctx, "aws-client", metadataClient)
+			errC <- cmd.ExecuteContext(ctx)
 		}()
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.LatestBuild.ID)
 		resources, err := client.WorkspaceResourcesByBuild(ctx, workspace.LatestBuild.ID)
@@ -120,6 +120,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		_, err = dialer.Ping()
 		require.NoError(t, err)
 		cancelFunc()
+		err = <-errC
+		require.NoError(t, err)
 	})
 
 	t.Run("GoogleCloud", func(t *testing.T) {
@@ -157,13 +159,12 @@ func TestWorkspaceAgent(t *testing.T) {
 		cmd, _ := clitest.New(t, "agent", "--auth", "google-instance-identity", "--agent-url", client.URL.String())
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
+		errC := make(chan error)
 		go func() {
-			// A linting error occurs for weakly typing the context value here,
-			// but it seems reasonable for a one-off test.
-			// nolint
-			ctx = context.WithValue(ctx, "gcp-client", metadata)
-			err := cmd.ExecuteContext(ctx)
-			require.NoError(t, err)
+			// A linting error occurs for weakly typing the context value here.
+			//nolint // The above seems reasonable for a one-off test.
+			ctx := context.WithValue(ctx, "gcp-client", metadata)
+			errC <- cmd.ExecuteContext(ctx)
 		}()
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.LatestBuild.ID)
 		resources, err := client.WorkspaceResourcesByBuild(ctx, workspace.LatestBuild.ID)
@@ -174,5 +175,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		_, err = dialer.Ping()
 		require.NoError(t, err)
 		cancelFunc()
+		err = <-errC
+		require.NoError(t, err)
 	})
 }

--- a/cli/clitest/clitest_test.go
+++ b/cli/clitest/clitest_test.go
@@ -1,11 +1,8 @@
 package clitest_test
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/coder/coder/cli/clitest"
@@ -19,8 +16,6 @@ func TestMain(m *testing.M) {
 
 func TestCli(t *testing.T) {
 	t.Parallel()
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancelFunc()
 	clitest.CreateTemplateVersionSource(t, nil)
 	client := coderdtest.New(t, nil)
 	cmd, config := clitest.New(t)
@@ -28,11 +23,8 @@ func TestCli(t *testing.T) {
 	pty := ptytest.New(t)
 	cmd.SetIn(pty.Input())
 	cmd.SetOut(pty.Output())
-	errC := make(chan error)
 	go func() {
-		errC <- cmd.ExecuteContext(ctx)
+		_ = cmd.Execute()
 	}()
 	pty.ExpectMatch("coder")
-	cancelFunc()
-	require.NoError(t, <-errC)
 }

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -63,9 +63,9 @@ func TestGitSSH(t *testing.T) {
 		clitest.SetupConfig(t, agentClient, root)
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
+		errC := make(chan error)
 		go func() {
-			err := cmd.ExecuteContext(ctx)
-			require.NoError(t, err)
+			errC <- cmd.ExecuteContext(ctx)
 		}()
 
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.LatestBuild.ID)
@@ -103,5 +103,8 @@ func TestGitSSH(t *testing.T) {
 		err = cmd.ExecuteContext(context.Background())
 		require.NoError(t, err)
 		require.EqualValues(t, 1, inc)
+
+		err = <-errC
+		require.NoError(t, err)
 	})
 }

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -104,6 +104,7 @@ func TestGitSSH(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 1, inc)
 
+		cancelFunc()
 		err = <-errC
 		require.NoError(t, err)
 	})

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -99,7 +99,7 @@ func TestGitSSH(t *testing.T) {
 		addr, ok := l.Addr().(*net.TCPAddr)
 		require.True(t, ok)
 		// set to agent config dir
-		gitsshCmd, _ := clitest.New(t, "gitssh", "--agent-url", agentClient.URL.String(), "--agent-token", agentToken, "--", fmt.Sprintf("-p%d", addr.Port), "-o", "StrictHostKeyChecking=no", "127.0.0.1")
+		gitsshCmd, _ := clitest.New(t, "gitssh", "--agent-url", agentClient.URL.String(), "--agent-token", agentToken, "--", fmt.Sprintf("-p%d", addr.Port), "-o", "StrictHostKeyChecking=no", "-o", "IdentitiesOnly=yes", "127.0.0.1")
 		err = gitsshCmd.ExecuteContext(context.Background())
 		require.NoError(t, err)
 		require.EqualValues(t, 1, inc)

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -63,9 +63,9 @@ func TestGitSSH(t *testing.T) {
 		clitest.SetupConfig(t, agentClient, root)
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
-		errC := make(chan error)
+		agentErrC := make(chan error)
 		go func() {
-			errC <- cmd.ExecuteContext(ctx)
+			agentErrC <- cmd.ExecuteContext(ctx)
 		}()
 
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.LatestBuild.ID)
@@ -85,13 +85,13 @@ func TestGitSSH(t *testing.T) {
 			return ssh.KeysEqual(publicKey, key)
 		})
 		var inc int64
+		sshErrC := make(chan error)
 		go func() {
 			// as long as we get a successful session we don't care if the server errors
 			_ = ssh.Serve(l, func(s ssh.Session) {
 				atomic.AddInt64(&inc, 1)
 				t.Log("got authenticated session")
-				err := s.Exit(0)
-				require.NoError(t, err)
+				sshErrC <- s.Exit(0)
 			}, publicKeyOption)
 		}()
 
@@ -99,13 +99,16 @@ func TestGitSSH(t *testing.T) {
 		addr, ok := l.Addr().(*net.TCPAddr)
 		require.True(t, ok)
 		// set to agent config dir
-		cmd, _ = clitest.New(t, "gitssh", "--agent-url", agentClient.URL.String(), "--agent-token", agentToken, "--", fmt.Sprintf("-p%d", addr.Port), "-o", "StrictHostKeyChecking=no", "127.0.0.1")
-		err = cmd.ExecuteContext(context.Background())
+		gitsshCmd, _ := clitest.New(t, "gitssh", "--agent-url", agentClient.URL.String(), "--agent-token", agentToken, "--", fmt.Sprintf("-p%d", addr.Port), "-o", "StrictHostKeyChecking=no", "127.0.0.1")
+		err = gitsshCmd.ExecuteContext(context.Background())
 		require.NoError(t, err)
 		require.EqualValues(t, 1, inc)
 
+		err = <-sshErrC
+		require.NoError(t, err, "error in ssh session exit")
+
 		cancelFunc()
-		err = <-errC
-		require.NoError(t, err)
+		err = <-agentErrC
+		require.NoError(t, err, "error in agent execute")
 	})
 }

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -1,7 +1,9 @@
 package cli_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +16,8 @@ func TestList(t *testing.T) {
 	t.Parallel()
 	t.Run("Single", func(t *testing.T) {
 		t.Parallel()
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelFunc()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -23,17 +27,16 @@ func TestList(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 		cmd, root := clitest.New(t, "ls")
 		clitest.SetupConfig(t, client, root)
-		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
 		cmd.SetOut(pty.Output())
+		errC := make(chan error)
 		go func() {
-			defer close(doneChan)
-			err := cmd.Execute()
-			require.NoError(t, err)
+			errC <- cmd.ExecuteContext(ctx)
 		}()
 		pty.ExpectMatch(workspace.Name)
 		pty.ExpectMatch("Running")
-		<-doneChan
+		cancelFunc()
+		require.NoError(t, <-errC)
 	})
 }

--- a/cli/templateinit_test.go
+++ b/cli/templateinit_test.go
@@ -16,16 +16,11 @@ func TestTemplateInit(t *testing.T) {
 		t.Parallel()
 		tempDir := t.TempDir()
 		cmd, _ := clitest.New(t, "templates", "init", tempDir)
-		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
 		cmd.SetOut(pty.Output())
-		go func() {
-			defer close(doneChan)
-			err := cmd.Execute()
-			require.NoError(t, err)
-		}()
-		<-doneChan
+		err := cmd.Execute()
+		require.NoError(t, err)
 		files, err := os.ReadDir(tempDir)
 		require.NoError(t, err)
 		require.Greater(t, len(files), 0)

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -16,15 +16,13 @@ func TestUserList(t *testing.T) {
 	coderdtest.CreateFirstUser(t, client)
 	cmd, root := clitest.New(t, "users", "list")
 	clitest.SetupConfig(t, client, root)
-	doneChan := make(chan struct{})
 	pty := ptytest.New(t)
 	cmd.SetIn(pty.Input())
 	cmd.SetOut(pty.Output())
+	errC := make(chan error)
 	go func() {
-		defer close(doneChan)
-		err := cmd.Execute()
-		require.NoError(t, err)
+		errC <- cmd.Execute()
 	}()
+	require.NoError(t, <-errC)
 	pty.ExpectMatch("coder.com")
-	<-doneChan
 }


### PR DESCRIPTION
This PR fixes a few cases of command potentially running after test exit. The require on test object can result in data race.
