### PR TITLE
feat: cli configs should not be space sensitive

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kirsle/configdir"
@@ -115,7 +116,7 @@ func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
 			return nil, err
 		}
 	}
-	serverURL, err := url.Parse(rawURL)
+	serverURL, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
 		}
 	}
 	client := codersdk.New(serverURL)
-	client.SessionToken = token
+	client.SessionToken = strings.TrimSpace(token)
 	return client, nil
 }
 


### PR DESCRIPTION
If you edit the file and add a newline, it breaks. It should not matter. I manually edited the file and kept getting this error because my vim added a newline.

```
parse "https://dev.coder.com\n": net/url: invalid control character in URL
```

# To reproduce

```
echo "https://dev.coder.com" > ~/.config/coderv2/url
./coder users list
```