### PR TITLE
Add helper text to unauthorized error messages

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -116,7 +116,7 @@ func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
 		if err != nil {
 			// If the configuration files are absent, the user is logged out
 			if os.IsNotExist(err) {
-				return nil, xerrors.New("You are not logged in. Try logging in using 'coder login [url]'.")
+				return nil, xerrors.New("You are not logged in. Try logging in using 'coder login <url>'.")
 			}
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
 		if err != nil {
 			// If the configuration files are absent, the user is logged out
 			if os.IsNotExist(err) {
-				return nil, xerrors.New("You are not logged in. Try logging in using 'coder login [url]'.")
+				return nil, xerrors.New("You are not logged in. Try logging in using 'coder login <url>'.")
 			}
 			return nil, err
 		}

--- a/cli/root.go
+++ b/cli/root.go
@@ -104,6 +104,15 @@ func Root() *cobra.Command {
 	return cmd
 }
 
+type Error struct {
+	Err    error
+	Helper string
+}
+
+func (w *Error) Error() string {
+	return fmt.Sprintf("%v: %s", w.Err, w.Helper)
+}
+
 // createClient returns a new client from the command context.
 // It reads from global configuration files if flags are not set.
 func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
@@ -112,6 +121,10 @@ func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
 	if err != nil || rawURL == "" {
 		rawURL, err = root.URL().Read()
 		if err != nil {
+			err = &Error{
+				Err:    err,
+				Helper: "Try running \"coder login [url]\".",
+			}
 			return nil, err
 		}
 	}
@@ -123,6 +136,10 @@ func createClient(cmd *cobra.Command) (*codersdk.Client, error) {
 	if err != nil || token == "" {
 		token, err = root.Session().Read()
 		if err != nil {
+			err = &Error{
+				Err:    err,
+				Helper: "Try running \"coder login [url]\".",
+			}
 			return nil, err
 		}
 	}

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -35,7 +35,7 @@ func TestUserList(t *testing.T) {
 
 		_, err := cmd.ExecuteC()
 
-		require.Contains(t, err.Error(), "Try logging in using 'coder login [url]'.")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login <url>'.")
 	})
 	t.Run("SessionAuthErrorHasHelperText", func(t *testing.T) {
 		t.Parallel()
@@ -48,6 +48,6 @@ func TestUserList(t *testing.T) {
 
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Contains(t, err.Error(), "Try logging in using 'coder login [url]'.")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login <url>'.")
 	})
 }

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -38,7 +38,7 @@ func TestUserList(t *testing.T) {
 
 		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
 	})
-	t.Run("NoSessionAuthErrorHasHelperText", func(t *testing.T) {
+	t.Run("SessionAuthErrorHasHelperText", func(t *testing.T) {
 		t.Parallel()
 
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -11,20 +11,42 @@ import (
 )
 
 func TestUserList(t *testing.T) {
-	t.Parallel()
-	client := coderdtest.New(t, nil)
-	coderdtest.CreateFirstUser(t, client)
-	cmd, root := clitest.New(t, "users", "list")
-	clitest.SetupConfig(t, client, root)
-	doneChan := make(chan struct{})
-	pty := ptytest.New(t)
-	cmd.SetIn(pty.Input())
-	cmd.SetOut(pty.Output())
-	go func() {
-		defer close(doneChan)
-		err := cmd.Execute()
-		require.NoError(t, err)
-	}()
-	pty.ExpectMatch("coder.com")
-	<-doneChan
+	t.Run("FormatCobraError", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		coderdtest.CreateFirstUser(t, client)
+		cmd, root := clitest.New(t, "users", "list")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			require.NoError(t, err)
+		}()
+		pty.ExpectMatch("coder.com")
+		<-doneChan
+	})
+	t.Run("NoURLFileErrorHasHelperText", func(t *testing.T) {
+		t.Parallel()
+
+		cmd, _ := clitest.New(t, "users", "list")
+
+		cmd, err := cmd.ExecuteC()
+
+		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
+	})
+	t.Run("NoSessionAuthErrorHasHelperText", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		cmd, root := clitest.New(t, "users", "list")
+		clitest.SetupConfig(t, client, root)
+
+		cmd, err := cmd.ExecuteC()
+
+		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
+	})
 }

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/pty/ptytest"
 )
 
@@ -34,7 +35,7 @@ func TestUserList(t *testing.T) {
 
 		_, err := cmd.ExecuteC()
 
-		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login [url]'.")
 	})
 	t.Run("SessionAuthErrorHasHelperText", func(t *testing.T) {
 		t.Parallel()
@@ -45,6 +46,8 @@ func TestUserList(t *testing.T) {
 
 		_, err := cmd.ExecuteC()
 
-		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Contains(t, err.Error(), "Try logging in using 'coder login [url]'.")
 	})
 }

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUserList(t *testing.T) {
-	t.Run("FormatCobraError", func(t *testing.T) {
+	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		coderdtest.CreateFirstUser(t, client)

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -34,7 +34,7 @@ func TestUserList(t *testing.T) {
 
 		cmd, _ := clitest.New(t, "users", "list")
 
-		cmd, err := cmd.ExecuteC()
+		_, err := cmd.ExecuteC()
 
 		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
 	})
@@ -45,7 +45,7 @@ func TestUserList(t *testing.T) {
 		cmd, root := clitest.New(t, "users", "list")
 		clitest.SetupConfig(t, client, root)
 
-		cmd, err := cmd.ExecuteC()
+		_, err := cmd.ExecuteC()
 
 		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
 	})

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -70,7 +70,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
-		require.Contains(t, err.Error(), "Try logging in using 'coder login [url]'.")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login <url>'.")
 	})
 
 	t.Run("NoVersion", func(t *testing.T) {

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -59,6 +59,21 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		require.Equal(t, http.StatusConflict, apiErr.StatusCode())
 	})
 
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		organizationID := uuid.New()
+		_, err := client.CreateTemplate(context.Background(), organizationID, codersdk.CreateTemplateRequest{
+			Name:      "test",
+			VersionID: uuid.New(),
+		})
+
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
+		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
+	})
+
 	t.Run("NoVersion", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -62,8 +62,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 	t.Run("Unauthorized", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
-		organizationID := uuid.New()
-		_, err := client.CreateTemplate(context.Background(), organizationID, codersdk.CreateTemplateRequest{
+		_, err := client.CreateTemplate(context.Background(), uuid.New(), codersdk.CreateTemplateRequest{
 			Name:      "test",
 			VersionID: uuid.New(),
 		})

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -70,7 +70,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
-		require.Contains(t, err.Error(), "Try running \"coder login [url]\"")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login [url]'.")
 	})
 
 	t.Run("NoVersion", func(t *testing.T) {

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -127,8 +127,7 @@ func readBodyAsError(res *http.Response) error {
 	contentType := res.Header.Get("Content-Type")
 
 	var helper string
-	switch res.StatusCode {
-	case http.StatusUnauthorized:
+	if res.StatusCode == http.StatusUnauthorized {
 		helper = "Try running \"coder login [url]\"."
 	}
 

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -130,7 +130,7 @@ func readBodyAsError(res *http.Response) error {
 	if res.StatusCode == http.StatusUnauthorized {
 		// 401 means the user is not logged in
 		// 403 would mean that the user is not authorized
-		helper = "Try logging in using 'coder login [url]'."
+		helper = "Try logging in using 'coder login <url>'."
 	}
 
 	if strings.HasPrefix(contentType, "text/plain") {

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -125,6 +125,13 @@ func (c *Client) dialWebsocket(ctx context.Context, path string) (*websocket.Con
 // wraps it in a codersdk.Error type for easy marshaling.
 func readBodyAsError(res *http.Response) error {
 	contentType := res.Header.Get("Content-Type")
+
+	var helper string
+	switch res.StatusCode {
+	case http.StatusUnauthorized:
+		helper = "Try running \"coder login [url]\"."
+	}
+
 	if strings.HasPrefix(contentType, "text/plain") {
 		resp, err := io.ReadAll(res.Body)
 		if err != nil {
@@ -135,6 +142,7 @@ func readBodyAsError(res *http.Response) error {
 			Response: httpapi.Response{
 				Message: string(resp),
 			},
+			Helper: helper,
 		}
 	}
 
@@ -153,6 +161,7 @@ func readBodyAsError(res *http.Response) error {
 	return &Error{
 		Response:   m,
 		statusCode: res.StatusCode,
+		Helper:     helper,
 	}
 }
 
@@ -162,6 +171,8 @@ type Error struct {
 	httpapi.Response
 
 	statusCode int
+
+	Helper string
 }
 
 func (e *Error) StatusCode() int {
@@ -173,6 +184,9 @@ func (e *Error) Error() string {
 	_, _ = fmt.Fprintf(&builder, "status code %d: %s", e.statusCode, e.Message)
 	for _, err := range e.Errors {
 		_, _ = fmt.Fprintf(&builder, "\n\t%s: %s", err.Field, err.Detail)
+	}
+	if e.Helper != "" {
+		_, _ = fmt.Fprintf(&builder, ": %s", e.Helper)
 	}
 	return builder.String()
 }


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->

Adds a suggestion to login in the error messages for users when receiving unauthorized errors.

Subtasks:

- [x] Handle authorization errors due to the absence of url/session files
- [x] Handle authorization errors due to incorrect session key
- [x] Add unit tests

Fixes #917 
