### PR TITLE
Expand stalebot to issues

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,9 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 14
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 5
-# Only apply the stale logic to pulls, since we are using issues to manage work
-only: pulls
+daysUntilClose: 7
 # Label to apply when stale.
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Removing old, stale issues is essential to keeping a workable tracker.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
