### PR TITLE
chore: avoid concurrent usage of t.FailNow

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -201,6 +201,8 @@ run:
   concurrency: 4
   skip-dirs:
     - node_modules
+  skip-files:
+    - scripts/rules.go
   timeout: 5m
 
 # Over time, add more and more linters from

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pion/udp"
 	"github.com/pion/webrtc/v3"
 	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"golang.org/x/crypto/ssh"
@@ -119,7 +120,7 @@ func TestAgent(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			conn, err := local.Accept()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_ = conn.Close()
 			close(done)
 		}()
@@ -367,7 +368,7 @@ func setupSSHCommand(t *testing.T, beforeArgs []string, afterArgs []string) *exe
 				return
 			}
 			ssh, err := agentConn.SSH()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			go io.Copy(conn, ssh)
 			go io.Copy(ssh, conn)
 		}
@@ -409,7 +410,7 @@ func setupAgent(t *testing.T, metadata agent.Metadata, ptyTimeout time.Duration)
 	})
 	api := proto.NewDRPCPeerBrokerClient(provisionersdk.Conn(client))
 	stream, err := api.NegotiateConnection(context.Background())
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	conn, err := peerbroker.Dial(stream, []webrtc.ICEServer{}, &peer.ConnOptions{
 		Logger: slogtest.Make(t, nil),
 	})
@@ -444,13 +445,13 @@ func testAccept(t *testing.T, c net.Conn) {
 func assertReadPayload(t *testing.T, r io.Reader, payload []byte) {
 	b := make([]byte, len(payload)+16)
 	n, err := r.Read(b)
-	require.NoError(t, err, "read payload")
-	require.Equal(t, len(payload), n, "read payload length does not match")
-	require.Equal(t, payload, b[:n])
+	assert.NoError(t, err, "read payload")
+	assert.Equal(t, len(payload), n, "read payload length does not match")
+	assert.Equal(t, payload, b[:n])
 }
 
 func assertWritePayload(t *testing.T, w io.Writer, payload []byte) {
 	n, err := w.Write(payload)
-	require.NoError(t, err, "write payload")
-	require.Equal(t, len(payload), n, "payload length does not match")
+	assert.NoError(t, err, "write payload")
+	assert.Equal(t, len(payload), n, "payload length does not match")
 }

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 
 	"github.com/coder/coder/cli/cliui"
@@ -43,7 +43,7 @@ func TestAgent(t *testing.T) {
 	go func() {
 		defer close(done)
 		err := cmd.Execute()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	ptty.ExpectMatch("lost connection")
 	disconnected.Store(true)

--- a/cli/cliui/prompt_test.go
+++ b/cli/cliui/prompt_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/cliui"
@@ -27,7 +28,7 @@ func TestPrompt(t *testing.T) {
 			resp, err := newPrompt(ptty, cliui.PromptOptions{
 				Text: "Example",
 			}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			msgChan <- resp
 		}()
 		ptty.ExpectMatch("Example")
@@ -44,7 +45,7 @@ func TestPrompt(t *testing.T) {
 				Text:      "Example",
 				IsConfirm: true,
 			}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			doneChan <- resp
 		}()
 		ptty.ExpectMatch("Example")
@@ -80,7 +81,7 @@ func TestPrompt(t *testing.T) {
 				cliui.AllowSkipPrompt(cmd)
 				cmd.SetArgs([]string{"-y"})
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			doneChan <- resp
 		}()
 
@@ -101,7 +102,7 @@ func TestPrompt(t *testing.T) {
 			resp, err := newPrompt(ptty, cliui.PromptOptions{
 				Text: "Example",
 			}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			doneChan <- resp
 		}()
 		ptty.ExpectMatch("Example")
@@ -117,7 +118,7 @@ func TestPrompt(t *testing.T) {
 			resp, err := newPrompt(ptty, cliui.PromptOptions{
 				Text: "Example",
 			}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			doneChan <- resp
 		}()
 		ptty.ExpectMatch("Example")
@@ -133,7 +134,7 @@ func TestPrompt(t *testing.T) {
 			resp, err := newPrompt(ptty, cliui.PromptOptions{
 				Text: "Example",
 			}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			doneChan <- resp
 		}()
 		ptty.ExpectMatch("Example")

--- a/cli/cliui/provisionerjob_test.go
+++ b/cli/cliui/provisionerjob_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/coderd/database"
@@ -90,9 +90,9 @@ func TestProvisionerJob(t *testing.T) {
 		go func() {
 			<-test.Next
 			currentProcess, err := os.FindProcess(os.Getpid())
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			err = currentProcess.Signal(os.Interrupt)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			<-test.Next
 			test.JobMutex.Lock()
 			test.Job.Status = codersdk.ProvisionerJobCanceled
@@ -150,7 +150,7 @@ func newProvisionerJob(t *testing.T) provisionerJobTest {
 		defer close(done)
 		err := cmd.ExecuteContext(context.Background())
 		if err != nil {
-			require.ErrorIs(t, err, cliui.Canceled)
+			assert.ErrorIs(t, err, cliui.Canceled)
 		}
 	}()
 	t.Cleanup(func() {

--- a/cli/cliui/resources_test.go
+++ b/cli/cliui/resources_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/coderd/database"
@@ -32,7 +32,7 @@ func TestWorkspaceResources(t *testing.T) {
 			}}, cliui.WorkspaceResourcesOptions{
 				WorkspaceName: "example",
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			close(done)
 		}()
 		ptty.ExpectMatch("coder ssh example")
@@ -85,7 +85,7 @@ func TestWorkspaceResources(t *testing.T) {
 				HideAgentState: false,
 				HideAccess:     false,
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			close(done)
 		}()
 		ptty.ExpectMatch("google_compute_disk.root")

--- a/cli/cliui/select_test.go
+++ b/cli/cliui/select_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/cliui"
@@ -21,7 +22,7 @@ func TestSelect(t *testing.T) {
 			resp, err := newSelect(ptty, cliui.SelectOptions{
 				Options: []string{"First", "Second"},
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			msgChan <- resp
 		}()
 		require.Equal(t, "First", <-msgChan)

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/sloggers/slogtest"
@@ -96,7 +97,7 @@ func TestConfigSSH(t *testing.T) {
 				return
 			}
 			ssh, err := agentConn.SSH()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			go io.Copy(conn, ssh)
 			go io.Copy(ssh, conn)
 		}
@@ -120,7 +121,7 @@ func TestConfigSSH(t *testing.T) {
 	go func() {
 		defer close(doneChan)
 		err := cmd.Execute()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	<-doneChan
 

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
@@ -34,7 +35,7 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		matches := []string{
 			"Confirm create", "yes",
@@ -61,7 +62,7 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer done()
 			err := cmd.ExecuteContext(cmdCtx)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		// No pty interaction needed since we use the -y skip prompt flag
 		<-cmdCtx.Done()
@@ -84,7 +85,7 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		matches := []string{
 			"Specify a name", "my-workspace",
@@ -122,7 +123,7 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		matches := []string{
@@ -166,7 +167,7 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		matches := []string{
@@ -207,7 +208,7 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.EqualError(t, err, "Parameter value absent in parameter file for \"region\"!")
+			assert.EqualError(t, err, "Parameter value absent in parameter file for \"region\"!")
 		}()
 		<-doneChan
 		removeTmpDirUntilSuccess(t, tempDir)

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -1,9 +1,10 @@
 package cli_test
 
 import (
+	"io"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
@@ -29,7 +30,10 @@ func TestDelete(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			// When running with the race detector on, we sometimes get an EOF.
+			if err != nil {
+				assert.ErrorIs(t, err, io.EOF)
+			}
 		}()
 		pty.ExpectMatch("Cleaning Up")
 		<-doneChan

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
@@ -35,7 +36,7 @@ func TestLogin(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := root.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		matches := []string{
@@ -71,7 +72,7 @@ func TestLogin(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := root.ExecuteContext(ctx)
-			require.ErrorIs(t, err, context.Canceled)
+			assert.ErrorIs(t, err, context.Canceled)
 		}()
 
 		matches := []string{
@@ -106,7 +107,7 @@ func TestLogin(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := root.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		pty.ExpectMatch("Paste your token here:")
@@ -131,7 +132,7 @@ func TestLogin(t *testing.T) {
 			defer close(doneChan)
 			err := root.ExecuteContext(ctx)
 			// An error is expected in this case, since the login wasn't successful:
-			require.Error(t, err)
+			assert.Error(t, err)
 		}()
 
 		pty.ExpectMatch("Paste your token here:")

--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
@@ -25,7 +26,7 @@ func TestLogout(t *testing.T) {
 	go func() {
 		defer close(doneChan)
 		err := root.Execute()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	pty.ExpectMatch("Paste your token here:")

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pion/udp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
@@ -172,8 +173,7 @@ func TestPortForward(t *testing.T) {
 				defer cancel()
 				go func() {
 					err := cmd.ExecuteContext(ctx)
-					require.Error(t, err)
-					require.ErrorIs(t, err, context.Canceled)
+					assert.ErrorIs(t, err, context.Canceled)
 				}()
 				waitForPortForwardReady(t, buf)
 
@@ -220,8 +220,7 @@ func TestPortForward(t *testing.T) {
 				defer cancel()
 				go func() {
 					err := cmd.ExecuteContext(ctx)
-					require.Error(t, err)
-					require.ErrorIs(t, err, context.Canceled)
+					assert.ErrorIs(t, err, context.Canceled)
 				}()
 				waitForPortForwardReady(t, buf)
 
@@ -275,8 +274,7 @@ func TestPortForward(t *testing.T) {
 		defer cancel()
 		go func() {
 			err := cmd.ExecuteContext(ctx)
-			require.Error(t, err)
-			require.ErrorIs(t, err, context.Canceled)
+			assert.ErrorIs(t, err, context.Canceled)
 		}()
 		waitForPortForwardReady(t, buf)
 
@@ -336,8 +334,8 @@ func TestPortForward(t *testing.T) {
 		defer cancel()
 		go func() {
 			err := cmd.ExecuteContext(ctx)
-			require.Error(t, err)
-			require.ErrorIs(t, err, context.Canceled)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, context.Canceled)
 		}()
 		waitForPortForwardReady(t, buf)
 
@@ -406,7 +404,7 @@ func runAgent(t *testing.T, client *codersdk.Client, userID uuid.UUID) ([]coders
 	t.Cleanup(agentCancel)
 	go func() {
 		err := cmd.ExecuteContext(agentCtx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	coderdtest.AwaitWorkspaceAgents(t, client, workspace.LatestBuild.ID)
@@ -463,15 +461,15 @@ func testAccept(t *testing.T, c net.Conn) {
 func assertReadPayload(t *testing.T, r io.Reader, payload []byte) {
 	b := make([]byte, len(payload)+16)
 	n, err := r.Read(b)
-	require.NoError(t, err, "read payload")
-	require.Equal(t, len(payload), n, "read payload length does not match")
-	require.Equal(t, payload, b[:n])
+	assert.NoError(t, err, "read payload")
+	assert.Equal(t, len(payload), n, "read payload length does not match")
+	assert.Equal(t, payload, b[:n])
 }
 
 func assertWritePayload(t *testing.T, w io.Writer, payload []byte) {
 	n, err := w.Write(payload)
-	require.NoError(t, err, "write payload")
-	require.Equal(t, len(payload), n, "payload length does not match")
+	assert.NoError(t, err, "write payload")
+	assert.Equal(t, len(payload), n, "payload length does not match")
 }
 
 func waitForPortForwardReady(t *testing.T, output *threadSafeBuffer) {

--- a/cli/resetpassword_test.go
+++ b/cli/resetpassword_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
@@ -41,7 +42,7 @@ func TestResetPassword(t *testing.T) {
 	go func() {
 		defer close(serverDone)
 		err = serverCmd.ExecuteContext(ctx)
-		require.ErrorIs(t, err, context.Canceled)
+		assert.ErrorIs(t, err, context.Canceled)
 	}()
 	var client *codersdk.Client
 	require.Eventually(t, func() bool {
@@ -73,7 +74,7 @@ func TestResetPassword(t *testing.T) {
 	go func() {
 		defer close(cmdDone)
 		err = resetCmd.Execute()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	matches := []struct {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -57,7 +57,7 @@ func TestServer(t *testing.T) {
 				return false
 			}
 			accessURL, err := url.Parse(rawURL)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			client = codersdk.New(accessURL)
 			return true
 		}, 15*time.Second, 25*time.Millisecond)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
@@ -63,7 +64,7 @@ func TestSSH(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		pty.ExpectMatch("Waiting")
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
@@ -133,7 +134,7 @@ func TestSSH(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		conn, channels, requests, err := ssh.NewClientConn(&stdioConn{

--- a/cli/usercreate_test.go
+++ b/cli/usercreate_test.go
@@ -3,7 +3,7 @@ package cli_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
@@ -25,7 +25,7 @@ func TestUserCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		matches := []string{
 			"Username", "dean",

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"github.com/moby/moby/pkg/namesgenerator"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/idtoken"
 	"google.golang.org/api/option"
@@ -188,7 +189,7 @@ func NewProvisionerDaemon(t *testing.T, coderDaemon coderd.CoderD) io.Closer {
 		err := echo.Serve(ctx, &provisionersdk.ServeOptions{
 			Listener: echoServer,
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	closer := provisionerd.New(coderDaemon.ListenProvisionerDaemon, &provisionerd.Options{

--- a/coderd/database/pubsub_memory_test.go
+++ b/coderd/database/pubsub_memory_test.go
@@ -27,7 +27,7 @@ func TestPubsubMemory(t *testing.T) {
 		defer cancelFunc()
 		go func() {
 			err = pubsub.Publish(event, []byte(data))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		message := <-messageChannel
 		assert.Equal(t, string(message), data)

--- a/coderd/database/pubsub_test.go
+++ b/coderd/database/pubsub_test.go
@@ -48,7 +48,7 @@ func TestPubsub(t *testing.T) {
 		defer cancelFunc()
 		go func() {
 			err = pubsub.Publish(event, []byte(data))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		message := <-messageChannel
 		assert.Equal(t, string(message), data)

--- a/peer/conn_test.go
+++ b/peer/conn_test.go
@@ -174,10 +174,10 @@ func TestConn(t *testing.T) {
 		defer srv.Close()
 		go func() {
 			sch, err := server.Accept(context.Background())
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			nc2 := sch.NetConn()
 			nc1, err := net.Dial("tcp", srv.Addr().String())
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			go func() {
 				_, _ = io.Copy(nc1, nc2)
 			}()
@@ -248,12 +248,12 @@ func TestConn(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_, err := client.Ping()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		go func() {
 			defer wg.Done()
 			_, err := server.Ping()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		wg.Wait()
 	})
@@ -276,9 +276,9 @@ func TestConn(t *testing.T) {
 		exchange(t, client, server)
 		go func() {
 			channel, err := client.CreateChannel(context.Background(), "test", nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			_, err = channel.Write([]byte{1, 2})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 		channel, err := server.Accept(context.Background())
 		require.NoError(t, err)

--- a/peerbroker/proxy_test.go
+++ b/peerbroker/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pion/webrtc/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog"
@@ -55,7 +56,7 @@ func TestProxy(t *testing.T) {
 			Logger:    slogtest.Make(t, nil).Named("proxy-dial").Leveled(slog.LevelDebug),
 			Pubsub:    pubsub,
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	api := proto.NewDRPCPeerBrokerClient(provisionersdk.Conn(dialerClient))

--- a/provisioner/echo/serve_test.go
+++ b/provisioner/echo/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/provisioner/echo"
@@ -31,7 +32,7 @@ func TestEcho(t *testing.T) {
 		err := echo.Serve(ctx, &provisionersdk.ServeOptions{
 			Listener: server,
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	api := proto.NewDRPCProvisionerClient(provisionersdk.Conn(client))
 

--- a/provisioner/terraform/parse_test.go
+++ b/provisioner/terraform/parse_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/provisioner/terraform"
@@ -33,7 +34,7 @@ func TestParse(t *testing.T) {
 				Listener: server,
 			},
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	api := proto.NewDRPCProvisionerClient(provisionersdk.Conn(client))
 

--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog"
@@ -53,7 +54,7 @@ provider "coder" {
 			},
 			Logger: slogtest.Make(t, nil).Leveled(slog.LevelDebug),
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	api := proto.NewDRPCProvisionerClient(provisionersdk.Conn(client))
 

--- a/provisionersdk/serve_test.go
+++ b/provisionersdk/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"storj.io/drpc/drpcerr"
@@ -30,7 +31,7 @@ func TestProvisionerSDK(t *testing.T) {
 			err := provisionersdk.Serve(ctx, &proto.DRPCProvisionerUnimplementedServer{}, &provisionersdk.ServeOptions{
 				Listener: server,
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		api := proto.NewDRPCProvisionerClient(provisionersdk.Conn(client))

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -10,6 +10,7 @@
 // You run one of the following commands to execute your go rules only:
 //   golangci-lint run
 //   golangci-lint run --disable-all --enable=gocritic
+// Note: don't forget to run `golangci-lint cache clean`!
 package gorules
 
 import (
@@ -40,4 +41,31 @@ func databaseImport(m dsl.Matcher) {
 	m.Match("database.$_").
 		Report("Do not import any database types into codersdk").
 		Where(m.File().PkgPath.Matches("github.com/coder/coder/codersdk"))
+}
+
+// doNotCallTFailNowInsideGoroutine enforces not calling t.FailNow or
+// functions that may themselves call t.FailNow in goroutines outside
+// the main test goroutine. See testing.go:834 for why.
+//nolint:unused,deadcode,varnamelen
+func doNotCallTFailNowInsideGoroutine(m dsl.Matcher) {
+	m.Import("testing")
+	m.Match(`
+	go func($*_){
+		$*_
+		$require.$_($*_)
+		$*_
+	}($*_)`).
+		At(m["require"]).
+		Where(m["require"].Text == "require" || m["require"].Text == "assert").
+		Report("Do not call functions that may call t.Fail or t.FailNow in a goroutine, as this can cause data races (see testing.go:834)")
+
+	m.Match(`
+	go func($*_){
+		$*_
+		$t.$fail($*_)
+		$*_
+	}($*_)`).
+		At(m["fail"]).
+		Where(m["t"].Type.Implements("testing.TB") && m["fail"].Text.Matches("^(FailNow|Fatal|Error)$")).
+		Report("Do not call functions that may call t.Fail or t.FailNow in a goroutine, as this can cause data races (see testing.go:834)")
 }

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -56,8 +56,8 @@ func doNotCallTFailNowInsideGoroutine(m dsl.Matcher) {
 		$*_
 	}($*_)`).
 		At(m["require"]).
-		Where(m["require"].Text == "require" || m["require"].Text == "assert").
-		Report("Do not call functions that may call t.Fail or t.FailNow in a goroutine, as this can cause data races (see testing.go:834)")
+		Where(m["require"].Text == "require").
+		Report("Do not call functions that may call t.FailNow in a goroutine, as this can cause data races (see testing.go:834)")
 
 	m.Match(`
 	go func($*_){
@@ -66,6 +66,6 @@ func doNotCallTFailNowInsideGoroutine(m dsl.Matcher) {
 		$*_
 	}($*_)`).
 		At(m["fail"]).
-		Where(m["t"].Type.Implements("testing.TB") && m["fail"].Text.Matches("^(FailNow|Fatal|Error)$")).
-		Report("Do not call functions that may call t.Fail or t.FailNow in a goroutine, as this can cause data races (see testing.go:834)")
+		Where(m["t"].Type.Implements("testing.TB") && m["fail"].Text.Matches("^(FailNow|Fatal|Fatalf)$")).
+		Report("Do not call functions that may call t.FailNow in a goroutine, as this can cause data races (see testing.go:834)")
 }


### PR DESCRIPTION
# Context

https://pkg.go.dev/testing#T.FailNow
```
FailNow marks the function as having failed and stops its execution by calling runtime.Goexit
(which then runs all deferred calls in the current goroutine). Execution will continue at the
next test or benchmark. FailNow must be called from the goroutine running the test or
benchmark function, not from other goroutines created during the test. Calling FailNow
does not stop those other goroutines.
```

# Problem

We make heavy use of `github.com/stretchr/testify/require` in our unit test code. However, one "gotcha" about every method in the `require` package is that it will call `t.FailNow` under the hood if any assertion fails. This is _unsafe_ to do outside of the main testing goroutine. There's actually an [open issue](https://github.com/golang/go/issues/15758) about this behaviour.

For example, the following code can trigger a data race:
```
func Test_SomeOperationThatMightFail(t *testing.T) {
    c := make(chan struct{})
    go func() { 
        err := someOperationThatMightFail()
        require.NoError(t, err)
        c <- struct{}{}
    }()
    <-c
}
```

# Solution

1) Replace existing concurrent usages of `require` with the equivalent `assert` function (`github.com/stretchr/testify/assert`)
2) Add a Ruleguard rule to detect concurrent usage of `github.com/stretchr/testify/assert.*` or `t.FailNow` 

(Explicitly tagging @Emyrk as our resident Ruleguard laywer)