### PR TITLE
feat: add retry to ErrorSummary

### DIFF
--- a/site/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions"
 import { ComponentMeta, Story } from "@storybook/react"
 import React from "react"
 import { ErrorSummary, ErrorSummaryProps } from "./ErrorSummary"
@@ -12,6 +13,14 @@ const Template: Story<ErrorSummaryProps> = (args) => <ErrorSummary {...args} />
 export const WithError = Template.bind({})
 WithError.args = {
   error: new Error("Something went wrong!"),
+}
+
+export const WithRetry = Template.bind({})
+WithRetry.args = {
+  error: new Error("Failed to fetch something!"),
+  retry: () => {
+    action("retry")
+  },
 }
 
 export const WithUndefined = Template.bind({})

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -1,19 +1,28 @@
+import Button from "@material-ui/core/Button"
+import RefreshIcon from "@material-ui/icons/Refresh"
 import React from "react"
+import { Stack } from "../Stack/Stack"
 
 const Language = {
-  unknownErrorMessage: "Unknown error",
+  retryMessage: "Retry",
+  unknownErrorMessage: "An unknown error has occurred",
 }
 
 export interface ErrorSummaryProps {
   error: Error | unknown
+  retry?: () => void
 }
 
-export const ErrorSummary: React.FC<ErrorSummaryProps> = ({ error }) => {
-  // TODO: More interesting error page
+export const ErrorSummary: React.FC<ErrorSummaryProps> = ({ error, retry }) => (
+  <Stack>
+    {!(error instanceof Error) ? <div>{Language.unknownErrorMessage}</div> : <div>{error.toString()}</div>}
 
-  if (!(error instanceof Error)) {
-    return <div>{Language.unknownErrorMessage}</div>
-  } else {
-    return <div>{error.toString()}</div>
-  }
-}
+    {retry && (
+      <div>
+        <Button onClick={retry} startIcon={<RefreshIcon />} variant="outlined">
+          {Language.retryMessage}
+        </Button>
+      </div>
+    )}
+  </Stack>
+)


### PR DESCRIPTION
Summary:

The ErrorSummary accepts a retry callback and received improvements to
style and product copy

Impact:

This allows xstate-controlled pages to send re-fetch events.

Plan:

I plan to use this in my work for presenting the workspace schedule as a fullscreen form, however it can
be applied to any situation like that.