### PR TITLE
chore: propose coder dotfiles command

### DIFF
--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func dotfiles() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dotfiles [git_repo_url]",
+		Short: "Checkout and install a dotfiles repository.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// checkout git repo
+			// do install script if exists
+			// or symlink dotfiles if not
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/coder/coder/cli/cliui"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/cli/cliui"
 )
 
 func dotfiles() *cobra.Command {
@@ -123,6 +124,9 @@ func dotfiles() *cobra.Command {
 
 				for _, s := range scripts {
 					_, _ = fmt.Fprint(cmd.OutOrStdout(), fmt.Sprintf("\nRunning %s...\n", s))
+					// it is safe to use a variable command here because it's from
+					// a filtered list of pre-approved install scripts
+					// nolint:gosec
 					c := exec.CommandContext(cmd.Context(), fmt.Sprintf("./%s", s))
 					c.Dir = dotfilesDir
 					out, err := c.CombinedOutput()

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -22,8 +22,7 @@ func dotfiles() *cobra.Command {
 			var (
 				dotfilesRepoDir  = "dotfiles"
 				gitRepo          = args[0]
-				cfg              = createConfig(cmd)
-				cfgDir           = string(cfg)
+				cfgDir           = string(createConfig(cmd))
 				dotfilesDir      = filepath.Join(cfgDir, dotfilesRepoDir)
 				subcommands      = []string{"clone", args[0], dotfilesRepoDir}
 				gitCmdDir        = cfgDir
@@ -56,12 +55,6 @@ func dotfiles() *cobra.Command {
 				_, _ = fmt.Fprint(cmd.OutOrStdout(), fmt.Sprintf("Did not find dotfiles repository at %s\n", dotfilesDir))
 			}
 
-			// check if git ssh command already exists so we can just wrap it
-			gitsshCmd := os.Getenv("GIT_SSH_COMMAND")
-			if gitsshCmd == "" {
-				gitsshCmd = "ssh"
-			}
-
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      promtText,
 				IsConfirm: true,
@@ -74,6 +67,12 @@ func dotfiles() *cobra.Command {
 			err = os.MkdirAll(gitCmdDir, 0750)
 			if err != nil {
 				return xerrors.Errorf("ensuring dir at %s: %w", gitCmdDir, err)
+			}
+
+			// check if git ssh command already exists so we can just wrap it
+			gitsshCmd := os.Getenv("GIT_SSH_COMMAND")
+			if gitsshCmd == "" {
+				gitsshCmd = "ssh"
 			}
 
 			// clone or pull repo
@@ -161,6 +160,7 @@ func dotfiles() *cobra.Command {
 					to := filepath.Join(home, df)
 					_, _ = fmt.Fprintf(cmd.OutOrStdout(), fmt.Sprintf("Symlinking %s to %s...\n", from, to))
 					// if file already exists at destination remove it
+					// this behavior matches `ln -f`
 					_, err := os.Lstat(to)
 					if err == nil {
 						err := os.Remove(to)

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -1,15 +1,82 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/coder/coder/cli/cliui"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+const (
+	dotfilesRepoDir = "dotfiles"
 )
 
 func dotfiles() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dotfiles [git_repo_url]",
+		Args:  cobra.ExactArgs(1),
 		Short: "Checkout and install a dotfiles repository.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// checkout git repo
+			var (
+				gitRepo     = args[0]
+				cfg         = createConfig(cmd)
+				cfgDir      = string(cfg)
+				dotfilesDir = filepath.Join(cfgDir, dotfilesRepoDir)
+				subcommands = []string{"clone", args[0], dotfilesRepoDir}
+				gitCmdDir   = cfgDir
+				promtText   = fmt.Sprintf("Cloning %s into directory %s.\n  Continue?", gitRepo, dotfilesDir)
+			)
+
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Checking if dotfiles repository already exists...")
+			dotfilesExists, err := dirExists(dotfilesDir)
+			if err != nil {
+				return xerrors.Errorf("checking dir %s: %w", dotfilesDir, err)
+			}
+
+			// if repo exists already do a git pull instead of clone
+			if dotfilesExists {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), fmt.Sprintf("Found dotfiles repository at %s", dotfilesDir))
+				gitCmdDir = dotfilesDir
+				subcommands = []string{"pull", "--ff-only"}
+				promtText = fmt.Sprintf("Pulling latest from %s into directory %s.\n  Continue?", gitRepo, dotfilesDir)
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), fmt.Sprintf("Did not find dotfiles repository at %s", dotfilesDir))
+			}
+
+			// check if git ssh command already exists so we can just wrap it
+			gitsshCmd := os.Getenv("GIT_SSH_COMMAND")
+			if gitsshCmd == "" {
+				gitsshCmd = "ssh"
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), fmt.Sprintf("gitssh %s", gitsshCmd))
+
+			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
+				Text:      promtText,
+				IsConfirm: true,
+			})
+			if err != nil {
+				return err
+			}
+
+			err = os.MkdirAll(gitCmdDir, 0750)
+			if err != nil {
+				return xerrors.Errorf("ensuring dir at %s: %w", gitCmdDir, err)
+			}
+
+			c := exec.CommandContext(cmd.Context(), "git", subcommands...)
+			c.Dir = gitCmdDir
+			c.Env = append(os.Environ(), fmt.Sprintf(`GIT_SSH_COMMAND=%s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`, gitsshCmd))
+			out, err := c.CombinedOutput()
+			if err != nil {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cliui.Styles.Error.Render(string(out)))
+				return xerrors.Errorf("running git command: %w", err)
+			}
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), string(out))
+
 			// do install script if exists
 			// or symlink dotfiles if not
 
@@ -18,4 +85,17 @@ func dotfiles() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func dirExists(name string) (bool, error) {
+	_, err := os.Stat(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, xerrors.Errorf("stat dir: %w", err)
+	}
+
+	return true, nil
 }

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -5,14 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/coder/coder/cli/cliui"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
-)
-
-const (
-	dotfilesRepoDir = "dotfiles"
 )
 
 func dotfiles() *cobra.Command {
@@ -22,16 +19,27 @@ func dotfiles() *cobra.Command {
 		Short: "Checkout and install a dotfiles repository.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				gitRepo     = args[0]
-				cfg         = createConfig(cmd)
-				cfgDir      = string(cfg)
-				dotfilesDir = filepath.Join(cfgDir, dotfilesRepoDir)
-				subcommands = []string{"clone", args[0], dotfilesRepoDir}
-				gitCmdDir   = cfgDir
-				promtText   = fmt.Sprintf("Cloning %s into directory %s.\n  Continue?", gitRepo, dotfilesDir)
+				dotfilesRepoDir  = "dotfiles"
+				gitRepo          = args[0]
+				cfg              = createConfig(cmd)
+				cfgDir           = string(cfg)
+				dotfilesDir      = filepath.Join(cfgDir, dotfilesRepoDir)
+				subcommands      = []string{"clone", args[0], dotfilesRepoDir}
+				gitCmdDir        = cfgDir
+				promtText        = fmt.Sprintf("Cloning %s into directory %s.\n  Continue?", gitRepo, dotfilesDir)
+				installScriptSet = []string{
+					"install.sh",
+					"install",
+					"bootstrap.sh",
+					"bootstrap",
+					"script/bootstrap",
+					"setup.sh",
+					"setup",
+					"script/setup",
+				}
 			)
 
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Checking if dotfiles repository already exists...")
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), "Checking if dotfiles repository already exists...\n")
 			dotfilesExists, err := dirExists(dotfilesDir)
 			if err != nil {
 				return xerrors.Errorf("checking dir %s: %w", dotfilesDir, err)
@@ -39,12 +47,12 @@ func dotfiles() *cobra.Command {
 
 			// if repo exists already do a git pull instead of clone
 			if dotfilesExists {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), fmt.Sprintf("Found dotfiles repository at %s", dotfilesDir))
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), fmt.Sprintf("Found dotfiles repository at %s\n", dotfilesDir))
 				gitCmdDir = dotfilesDir
 				subcommands = []string{"pull", "--ff-only"}
 				promtText = fmt.Sprintf("Pulling latest from %s into directory %s.\n  Continue?", gitRepo, dotfilesDir)
 			} else {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), fmt.Sprintf("Did not find dotfiles repository at %s", dotfilesDir))
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), fmt.Sprintf("Did not find dotfiles repository at %s\n", dotfilesDir))
 			}
 
 			// check if git ssh command already exists so we can just wrap it
@@ -52,7 +60,6 @@ func dotfiles() *cobra.Command {
 			if gitsshCmd == "" {
 				gitsshCmd = "ssh"
 			}
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), fmt.Sprintf("gitssh %s", gitsshCmd))
 
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      promtText,
@@ -62,27 +69,117 @@ func dotfiles() *cobra.Command {
 				return err
 			}
 
+			// ensure config dir exists
 			err = os.MkdirAll(gitCmdDir, 0750)
 			if err != nil {
 				return xerrors.Errorf("ensuring dir at %s: %w", gitCmdDir, err)
 			}
 
+			// clone or pull repo
 			c := exec.CommandContext(cmd.Context(), "git", subcommands...)
 			c.Dir = gitCmdDir
 			c.Env = append(os.Environ(), fmt.Sprintf(`GIT_SSH_COMMAND=%s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`, gitsshCmd))
 			out, err := c.CombinedOutput()
 			if err != nil {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cliui.Styles.Error.Render(string(out)))
-				return xerrors.Errorf("running git command: %w", err)
+				return err
 			}
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), string(out))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 
-			// do install script if exists
-			// or symlink dotfiles if not
+			// check for install scripts
+			files, err := os.ReadDir(dotfilesDir)
+			if err != nil {
+				return xerrors.Errorf("reading files in dir %s: %w", dotfilesDir, err)
+			}
 
+			var scripts []string
+			var dotfiles []string
+			for _, f := range files {
+				for _, i := range installScriptSet {
+					if f.Name() == i {
+						scripts = append(scripts, f.Name())
+					}
+				}
+
+				if strings.HasPrefix(f.Name(), ".") {
+					dotfiles = append(dotfiles, f.Name())
+				}
+			}
+
+			// run found install scripts
+			if len(scripts) > 0 {
+				t := "Found install script(s). The following script(s) will be executed in order:\n\n"
+				for _, s := range scripts {
+					t = fmt.Sprintf("%s  - %s\n", t, s)
+				}
+				t = fmt.Sprintf("%s\n  Continue?", t)
+				_, err = cliui.Prompt(cmd, cliui.PromptOptions{
+					Text:      t,
+					IsConfirm: true,
+				})
+				if err != nil {
+					return err
+				}
+
+				for _, s := range scripts {
+					_, _ = fmt.Fprint(cmd.OutOrStdout(), fmt.Sprintf("\nRunning %s...\n", s))
+					c := exec.CommandContext(cmd.Context(), fmt.Sprintf("./%s", s))
+					c.Dir = dotfilesDir
+					out, err := c.CombinedOutput()
+					if err != nil {
+						_, _ = fmt.Fprintln(cmd.OutOrStdout(), cliui.Styles.Error.Render(string(out)))
+						return xerrors.Errorf("running %s: %w", s, err)
+					}
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+				}
+
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dotfiles installation complete.")
+				return nil
+			}
+
+			// otherwise symlink dotfiles
+			if len(dotfiles) > 0 {
+				_, err = cliui.Prompt(cmd, cliui.PromptOptions{
+					Text:      "No install scripts found, symlinking dotfiles to home directory.\n\n  Continue?",
+					IsConfirm: true,
+				})
+				if err != nil {
+					return err
+				}
+
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return xerrors.Errorf("getting user home: %w", err)
+				}
+
+				for _, df := range dotfiles {
+					from := filepath.Join(dotfilesDir, df)
+					to := filepath.Join(home, df)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), fmt.Sprintf("Symlinking %s to %s...\n", from, to))
+					// if file already exists at destination remove it
+					_, err := os.Lstat(to)
+					if err == nil {
+						err := os.Remove(to)
+						if err != nil {
+							return xerrors.Errorf("removing destination file %s: %w", to, err)
+						}
+					}
+
+					err = os.Symlink(from, to)
+					if err != nil {
+						return xerrors.Errorf("symlinking %s to %s: %w", from, to, err)
+					}
+				}
+
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dotfiles installation complete.")
+				return nil
+			}
+
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No install scripts or dotfiles found, nothing to do.")
 			return nil
 		},
 	}
+	cliui.AllowSkipPrompt(cmd)
 
 	return cmd
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -69,6 +69,7 @@ func Root() *cobra.Command {
 		configSSH(),
 		create(),
 		delete(),
+		dotfiles(),
 		gitssh(),
 		list(),
 		login(),

--- a/examples/docker/main.tf
+++ b/examples/docker/main.tf
@@ -43,6 +43,17 @@ variable "step2_arch" {
   }
   sensitive = true
 }
+variable "step3_dotfiles" {
+  description = <<-EOF
+  Dotfiles repository URL (example 'git@github.com:coder/dotfiles.git')
+  EOF
+
+  validation {
+    condition     = var.step3_dotfiles != "" ? regex([".git$"], var.step3_dotfiles) : true
+    error_message = "Value must end in '.git' extension"
+  }
+  sensitive = false
+}
 
 provider "docker" {
   host = "unix:///var/run/docker.sock"
@@ -56,6 +67,7 @@ data "coder_workspace" "me" {
 resource "coder_agent" "dev" {
   arch = var.step2_arch
   os   = "linux"
+  startup_script = var.step3_dotfiles != "" ? "coder dotfiles -y ${var.step3_dotfiles}": null
 }
 
 variable "docker_image" {

--- a/examples/docker/main.tf
+++ b/examples/docker/main.tf
@@ -44,14 +44,7 @@ variable "step2_arch" {
   sensitive = true
 }
 variable "step3_dotfiles" {
-  description = <<-EOF
-  Dotfiles repository URL (example 'git@github.com:coder/dotfiles.git')
-  EOF
-
-  validation {
-    condition     = var.step3_dotfiles != "" ? regex([".git$"], var.step3_dotfiles) : true
-    error_message = "Value must end in '.git' extension"
-  }
+  description = "Dotfiles repository URL (example 'git@github.com:coder/dotfiles.git')"
   sensitive = false
 }
 


### PR DESCRIPTION
This draft is an example of how a customer would interact with the coder dotfiles feature.

Talking with @jsjoeio and @bpmct we tried to come up with an ideal user experience for dotfiles. We want to support a simple dotfiles flow but don't want to require it on users or get in the way of them customizing the flow. 

What I'm proposing:
1. Hook into template `startup_script` variable to add a script that calls `coder dotfiles <url>`
2. Add a `coder dotfiles` command to our cli that follows the following algorithms:
  - https://docs.github.com/en/codespaces/customizing-your-codespace/personalizing-codespaces-for-your-account#dotfiles
  - https://www.gitpod.io/docs/config-dotfiles
  - By doing so we further solidify this pattern in the market and cooperate with the existing solutions by behaving how others will expect a command like this to behave. 
  - I feel like lowest maintenance burden is to ship our own cli command, as putting a bash script out there to be copied around everywhere seems like it will bite us later. 
3. Provide documentation that links out to usage examples in the `example` directory of a template using the `coder dotfiles` flow. 

The general flow of the `coder dotfiles` command will be:
1. Check out repo, deal with updating if already exists
2. Check for some type of init script, if exists then run it
3. if no script exists copy over the files starting with `.`

You would fill in the dotfiles url during workspace creation like we currently do with "region" in dogfood:
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/19379394/169912880-bede61d6-51f4-4aa3-a731-638c383340fe.png">
