### PR TITLE
fix: log after test exit in `TestAgent/StartupScript`

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -36,6 +36,12 @@ import (
 	"github.com/coder/retry"
 )
 
+const (
+	ProtocolReconnectingPTY = "reconnecting-pty"
+	ProtocolSSH             = "ssh"
+	ProtocolDial            = "dial"
+)
+
 type Options struct {
 	ReconnectingPTYTimeout time.Duration
 	EnvironmentVariables   map[string]string
@@ -213,11 +219,11 @@ func (a *agent) handlePeerConn(ctx context.Context, conn *peer.Conn) {
 		}
 
 		switch channel.Protocol() {
-		case peer.ProtocolSSH:
+		case ProtocolSSH:
 			go a.sshServer.HandleConn(channel.NetConn())
-		case peer.ProtocolReconnectingPTY:
+		case ProtocolReconnectingPTY:
 			go a.handleReconnectingPTY(ctx, channel.Label(), channel.NetConn())
-		case peer.ProtocolDial:
+		case ProtocolDial:
 			go a.handleDial(ctx, channel.Label(), channel.NetConn())
 		default:
 			a.logger.Warn(ctx, "unhandled protocol from channel",

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -21,9 +21,12 @@ import (
 	"time"
 
 	"github.com/armon/circbuf"
+	"github.com/gliderlabs/ssh"
 	"github.com/google/uuid"
-
+	"github.com/pkg/sftp"
 	"go.uber.org/atomic"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/agent/usershell"
@@ -31,12 +34,6 @@ import (
 	"github.com/coder/coder/peerbroker"
 	"github.com/coder/coder/pty"
 	"github.com/coder/retry"
-
-	"github.com/pkg/sftp"
-
-	"github.com/gliderlabs/ssh"
-	gossh "golang.org/x/crypto/ssh"
-	"golang.org/x/xerrors"
 )
 
 type Options struct {
@@ -174,17 +171,25 @@ func (*agent) runStartupScript(ctx context.Context, script string) error {
 	defer func() {
 		_ = writer.Close()
 	}()
+
 	caller := "-c"
 	if runtime.GOOS == "windows" {
 		caller = "/c"
 	}
+
 	cmd := exec.CommandContext(ctx, shell, caller, script)
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	err = cmd.Run()
 	if err != nil {
+		// cmd.Run does not return a context canceled error, it returns "signal: killed".
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		return xerrors.Errorf("run: %w", err)
 	}
+
 	return nil
 }
 
@@ -208,11 +213,11 @@ func (a *agent) handlePeerConn(ctx context.Context, conn *peer.Conn) {
 		}
 
 		switch channel.Protocol() {
-		case "ssh":
+		case peer.ProtocolSSH:
 			go a.sshServer.HandleConn(channel.NetConn())
-		case "reconnecting-pty":
+		case peer.ProtocolReconnectingPTY:
 			go a.handleReconnectingPTY(ctx, channel.Label(), channel.NetConn())
-		case "dial":
+		case peer.ProtocolDial:
 			go a.handleDial(ctx, channel.Label(), channel.NetConn())
 		default:
 			a.logger.Warn(ctx, "unhandled protocol from channel",
@@ -478,8 +483,8 @@ func (a *agent) handleReconnectingPTY(ctx context.Context, rawID string, conn ne
 			a.logger.Warn(ctx, "start reconnecting pty command", slog.F("id", id))
 		}
 
-		// Default to buffer 64KB.
-		circularBuffer, err := circbuf.NewBuffer(64 * 1024)
+		// Default to buffer 64KiB.
+		circularBuffer, err := circbuf.NewBuffer(64 << 10)
 		if err != nil {
 			a.logger.Warn(ctx, "create circular buffer", slog.Error(err))
 			return

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -172,8 +172,9 @@ func TestAgent(t *testing.T) {
 		tempPath := filepath.Join(os.TempDir(), "content.txt")
 		content := "somethingnice"
 		setupAgent(t, agent.Metadata{
-			StartupScript: "echo " + content + " > " + tempPath,
+			StartupScript: fmt.Sprintf("echo %s > %s", content, tempPath),
 		}, 0)
+
 		var gotContent string
 		require.Eventually(t, func() bool {
 			content, err := os.ReadFile(tempPath)
@@ -202,6 +203,7 @@ func TestAgent(t *testing.T) {
 			// it seems like it could be either.
 			t.Skip("ConPTY appears to be inconsistent on Windows.")
 		}
+
 		conn := setupAgent(t, agent.Metadata{}, 0)
 		id := uuid.NewString()
 		netConn, err := conn.ReconnectingPTY(id, 100, 100)
@@ -228,6 +230,7 @@ func TestAgent(t *testing.T) {
 				}
 			}
 		}
+
 		matchEchoCommand := func(line string) bool {
 			return strings.Contains(line, "echo test")
 		}

--- a/agent/conn.go
+++ b/agent/conn.go
@@ -36,7 +36,7 @@ type Conn struct {
 // be reconnected to via ID.
 func (c *Conn) ReconnectingPTY(id string, height, width uint16) (net.Conn, error) {
 	channel, err := c.CreateChannel(context.Background(), fmt.Sprintf("%s:%d:%d", id, height, width), &peer.ChannelOptions{
-		Protocol: peer.ProtocolReconnectingPTY,
+		Protocol: ProtocolReconnectingPTY,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("pty: %w", err)
@@ -47,7 +47,7 @@ func (c *Conn) ReconnectingPTY(id string, height, width uint16) (net.Conn, error
 // SSH dials the built-in SSH server.
 func (c *Conn) SSH() (net.Conn, error) {
 	channel, err := c.CreateChannel(context.Background(), "ssh", &peer.ChannelOptions{
-		Protocol: peer.ProtocolSSH,
+		Protocol: ProtocolSSH,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("dial: %w", err)
@@ -87,7 +87,7 @@ func (c *Conn) DialContext(ctx context.Context, network string, addr string) (ne
 	}
 
 	channel, err := c.CreateChannel(ctx, u.String(), &peer.ChannelOptions{
-		Protocol:  peer.ProtocolDial,
+		Protocol:  ProtocolDial,
 		Unordered: strings.HasPrefix(network, "udp"),
 	})
 	if err != nil {

--- a/agent/conn.go
+++ b/agent/conn.go
@@ -36,7 +36,7 @@ type Conn struct {
 // be reconnected to via ID.
 func (c *Conn) ReconnectingPTY(id string, height, width uint16) (net.Conn, error) {
 	channel, err := c.CreateChannel(context.Background(), fmt.Sprintf("%s:%d:%d", id, height, width), &peer.ChannelOptions{
-		Protocol: "reconnecting-pty",
+		Protocol: peer.ProtocolReconnectingPTY,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("pty: %w", err)
@@ -47,7 +47,7 @@ func (c *Conn) ReconnectingPTY(id string, height, width uint16) (net.Conn, error
 // SSH dials the built-in SSH server.
 func (c *Conn) SSH() (net.Conn, error) {
 	channel, err := c.CreateChannel(context.Background(), "ssh", &peer.ChannelOptions{
-		Protocol: "ssh",
+		Protocol: peer.ProtocolSSH,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("dial: %w", err)
@@ -87,7 +87,7 @@ func (c *Conn) DialContext(ctx context.Context, network string, addr string) (ne
 	}
 
 	channel, err := c.CreateChannel(ctx, u.String(), &peer.ChannelOptions{
-		Protocol:  "dial",
+		Protocol:  peer.ProtocolDial,
 		Unordered: strings.HasPrefix(network, "udp"),
 	})
 	if err != nil {

--- a/peer/channel.go
+++ b/peer/channel.go
@@ -41,12 +41,6 @@ func newChannel(conn *Conn, dc *webrtc.DataChannel, opts *ChannelOptions) *Chann
 	return channel
 }
 
-const (
-	ProtocolReconnectingPTY = "reconnecting-pty"
-	ProtocolSSH             = "ssh"
-	ProtocolDial            = "dial"
-)
-
 type ChannelOptions struct {
 	// ID is a channel ID that should be used when `Negotiated`
 	// is true.

--- a/peer/channel.go
+++ b/peer/channel.go
@@ -41,6 +41,12 @@ func newChannel(conn *Conn, dc *webrtc.DataChannel, opts *ChannelOptions) *Chann
 	return channel
 }
 
+const (
+	ProtocolReconnectingPTY = "reconnecting-pty"
+	ProtocolSSH             = "ssh"
+	ProtocolDial            = "dial"
+)
+
 type ChannelOptions struct {
 	// ID is a channel ID that should be used when `Negotiated`
 	// is true.


### PR DESCRIPTION
```
$ go test ./agent/ -v -run TestAgent/StartupScript -count 1
=== RUN   TestAgent
=== PAUSE TestAgent
=== CONT  TestAgent
=== RUN   TestAgent/StartupScript
=== PAUSE TestAgent/StartupScript
=== CONT  TestAgent/StartupScript
    t.go:56: 2022-05-24 20:22:39.648 [INFO]	<agent.go:112>	connected
--- PASS: TestAgent (0.00s)
    --- PASS: TestAgent/StartupScript (0.17s)
PASS
panic: Log in goroutine after TestAgent/StartupScript has completed: 2022-05-24 20:22:39.651 [WARN]	<agent.go:130>	agent script failed ...
"error": run:
             github.com/coder/coder/agent.(*agent).runStartupScript
                 /home/colin/Projects/coder/coder/agent/agent.go:183
           - signal: killed
```