### PR TITLE
fix: Use Terraform address to index resource + agent association

### DIFF
--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -206,6 +206,7 @@ provider "coder" {
 		Name: "dryrun-resource-associated-with-agent",
 		Files: map[string]string{
 			"main.tf": provider + `
+			data "coder_workspace" "me" {}
 			resource "coder_agent" "A" {
 				count = 1
 				os = "linux"
@@ -216,7 +217,10 @@ provider "coder" {
 				startup_script = "code-server"
 			}
 			resource "null_resource" "A" {
-				count = length(coder_agent.A)
+				depends_on = [
+					coder_agent.A[0]
+				]
+				count = data.coder_workspace.me.start_count
 			}`,
 		},
 		Request: &proto.Provision_Request{


### PR DESCRIPTION
Closes #1705.

There was an issue in the implementation brought by #1577 by not trimming
the array value when resources use counts. This should fix it, and adds
a test to be sure!