### PR TITLE
example: fix: properly tag aws-windows workspaces

### DIFF
--- a/examples/templates/aws-windows/main.tf
+++ b/examples/templates/aws-windows/main.tf
@@ -88,6 +88,8 @@ resource "aws_instance" "dev" {
   user_data = data.coder_workspace.me.transition == "start" ? local.user_data_start : local.user_data_end
   tags = {
     Name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+    # Required if you are using our example policy, see template README
+    Coder_Provisioned = "true"
   }
 
 }


### PR DESCRIPTION
The `Coder_Provisioned` tag allows for use with a more restrictive policy, limiting Coder to only modify/delete instances it created. 

See: https://github.com/coder/coder/tree/main/examples/templates/aws-linux#required-permissions--policy