### PR TITLE
fix: race panic in `test/go/postgres`

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -19,8 +19,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/coder/coder/provisioner/echo"
-
 	"github.com/briandowns/spinner"
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/google/go-github/v43/github"
@@ -50,6 +48,7 @@ import (
 	"github.com/coder/coder/coderd/turnconn"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/cryptorand"
+	"github.com/coder/coder/provisioner/echo"
 	"github.com/coder/coder/provisioner/terraform"
 	"github.com/coder/coder/provisionerd"
 	"github.com/coder/coder/provisionersdk"
@@ -229,10 +228,9 @@ func server() *cobra.Command {
 					URLs: []string{stunServer},
 				})
 			}
-			options := &coderd.Options{
+			options := (&coderd.Options{
 				AccessURL:            accessURLParsed,
 				ICEServers:           iceServers,
-				Logger:               logger.Named("coderd"),
 				Database:             databasefake.New(),
 				Pubsub:               database.NewPubsubInMemory(),
 				GoogleTokenValidator: validator,
@@ -240,7 +238,7 @@ func server() *cobra.Command {
 				SSHKeygenAlgorithm:   sshKeygenAlgorithm,
 				TURNServer:           turnServer,
 				TracerProvider:       tracerProvider,
-			}
+			}).SetLogger(logger.Named("coderd"))
 
 			if oauth2GithubClientSecret != "" {
 				options.GithubOAuth2Config, err = configureGithubOAuth2(accessURLParsed, oauth2GithubClientID, oauth2GithubClientSecret, oauth2GithubAllowSignups, oauth2GithubAllowedOrganizations)

--- a/coderd/authorize.go
+++ b/coderd/authorize.go
@@ -27,9 +27,9 @@ func (api *api) Authorize(rw http.ResponseWriter, r *http.Request, action rbac.A
 
 		// Log the errors for debugging
 		internalError := new(rbac.UnauthorizedError)
-		logger := api.Logger
+		logger := api.Logger()
 		if xerrors.As(err, internalError) {
-			logger = api.Logger.With(slog.F("internal", internalError.Internal()))
+			logger = api.Logger().With(slog.F("internal", internalError.Internal()))
 		}
 		// Log information for debugging. This will be very helpful
 		// in the early days

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -66,6 +66,10 @@ type fakeQuerier struct {
 	workspaces              []database.Workspace
 }
 
+func (*fakeQuerier) Close() error {
+	return nil
+}
+
 // InTx doesn't rollback data properly for in-memory yet.
 func (q *fakeQuerier) InTx(fn func(database.Store) error) error {
 	return fn(q)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -22,6 +22,7 @@ type Store interface {
 	querier
 
 	InTx(func(Store) error) error
+	Close() error
 }
 
 // DBTX represents a database connection or transaction.
@@ -43,6 +44,10 @@ func New(sdb *sql.DB) Store {
 type sqlQuerier struct {
 	sdb *sql.DB
 	db  DBTX
+}
+
+func (q *sqlQuerier) Close() error {
+	return q.sdb.Close()
 }
 
 // InTx performs database operations inside a transaction.

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -96,7 +96,7 @@ func (api *api) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 		var logs []database.ProvisionerJobLog
 		err := json.Unmarshal(message, &logs)
 		if err != nil {
-			api.Logger.Warn(r.Context(), fmt.Sprintf("invalid provisioner job log on channel %q: %s", provisionerJobLogsChannel(job.ID), err.Error()))
+			api.Logger().Warn(r.Context(), fmt.Sprintf("invalid provisioner job log on channel %q: %s", provisionerJobLogsChannel(job.ID), err.Error()))
 			return
 		}
 
@@ -106,7 +106,7 @@ func (api *api) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 			default:
 				// If this overflows users could miss logs streaming. This can happen
 				// if a database request takes a long amount of time, and we get a lot of logs.
-				api.Logger.Warn(r.Context(), "provisioner job log overflowing channel")
+				api.Logger().Warn(r.Context(), "provisioner job log overflowing channel")
 			}
 		}
 	})
@@ -168,7 +168,7 @@ func (api *api) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 		case <-ticker.C:
 			job, err := api.Database.GetProvisionerJobByID(r.Context(), job.ID)
 			if err != nil {
-				api.Logger.Warn(r.Context(), "streaming job logs; checking if completed", slog.Error(err), slog.F("job_id", job.ID.String()))
+				api.Logger().Warn(r.Context(), "streaming job logs; checking if completed", slog.Error(err), slog.F("job_id", job.ID.String()))
 				continue
 			}
 			if job.CompletedAt.Valid {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -81,7 +81,7 @@ func (api *api) workspaceAgentDial(rw http.ResponseWriter, r *http.Request) {
 	}
 	err = peerbroker.ProxyListen(r.Context(), session, peerbroker.ProxyOptions{
 		ChannelID: workspaceAgent.ID.String(),
-		Logger:    api.Logger.Named("peerbroker-proxy-dial"),
+		Logger:    api.Logger().Named("peerbroker-proxy-dial"),
 		Pubsub:    api.Pubsub,
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func (api *api) workspaceAgentListen(rw http.ResponseWriter, r *http.Request) {
 	closer, err := peerbroker.ProxyDial(proto.NewDRPCPeerBrokerClient(provisionersdk.Conn(session)), peerbroker.ProxyOptions{
 		ChannelID: workspaceAgent.ID.String(),
 		Pubsub:    api.Pubsub,
-		Logger:    api.Logger.Named("peerbroker-proxy-listen"),
+		Logger:    api.Logger().Named("peerbroker-proxy-listen"),
 	})
 	if err != nil {
 		_ = conn.Close(websocket.StatusAbnormalClosure, err.Error())
@@ -241,7 +241,7 @@ func (api *api) workspaceAgentListen(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.Logger.Info(r.Context(), "accepting agent", slog.F("resource", resource), slog.F("agent", workspaceAgent))
+	api.Logger().Info(r.Context(), "accepting agent", slog.F("resource", resource), slog.F("agent", workspaceAgent))
 
 	ticker := time.NewTicker(api.AgentConnectionUpdateFrequency)
 	defer ticker.Stop()
@@ -314,12 +314,12 @@ func (api *api) workspaceAgentTurn(rw http.ResponseWriter, r *http.Request) {
 		_ = wsConn.Close(websocket.StatusNormalClosure, "")
 	}()
 	netConn := websocket.NetConn(r.Context(), wsConn, websocket.MessageBinary)
-	api.Logger.Debug(r.Context(), "accepting turn connection", slog.F("remote-address", r.RemoteAddr), slog.F("local-address", localAddress))
+	api.Logger().Debug(r.Context(), "accepting turn connection", slog.F("remote-address", r.RemoteAddr), slog.F("local-address", localAddress))
 	select {
 	case <-api.TURNServer.Accept(netConn, remoteAddress, localAddress).Closed():
 	case <-r.Context().Done():
 	}
-	api.Logger.Debug(r.Context(), "completed turn connection", slog.F("remote-address", r.RemoteAddr), slog.F("local-address", localAddress))
+	api.Logger().Debug(r.Context(), "completed turn connection", slog.F("remote-address", r.RemoteAddr), slog.F("local-address", localAddress))
 }
 
 // workspaceAgentPTY spawns a PTY and pipes it over a WebSocket.
@@ -400,7 +400,7 @@ func (api *api) dialWorkspaceAgent(r *http.Request, agentID uuid.UUID) (*agent.C
 	go func() {
 		_ = peerbroker.ProxyListen(r.Context(), server, peerbroker.ProxyOptions{
 			ChannelID: agentID.String(),
-			Logger:    api.Logger.Named("peerbroker-proxy-dial"),
+			Logger:    api.Logger().Named("peerbroker-proxy-dial"),
 			Pubsub:    api.Pubsub,
 		})
 		_ = client.Close()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -581,7 +581,7 @@ func (api *api) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 		CompressionMode: websocket.CompressionDisabled,
 	})
 	if err != nil {
-		api.Logger.Warn(r.Context(), "accept websocket connection", slog.Error(err))
+		api.Logger().Warn(r.Context(), "accept websocket connection", slog.Error(err))
 		return
 	}
 	defer c.Close(websocket.StatusInternalError, "internal error")

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -168,6 +168,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 func TestWorkspacesByOrganization(t *testing.T) {
 	t.Parallel()
+
 	t.Run("ListEmpty", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
@@ -175,6 +176,7 @@ func TestWorkspacesByOrganization(t *testing.T) {
 		_, err := client.WorkspacesByOrganization(context.Background(), user.OrganizationID)
 		require.NoError(t, err)
 	})
+
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})


### PR DESCRIPTION
https://github.com/coder/coder/actions/runs/2359166491/attempts/1

The current race condition is caused by a call to `t.Log` at the same time a test is finishing. This PR changes the logger to be swapped out before tests exit, to avoid any logs that may race with a test finishing.