### PR TITLE
feat: add tag and value in validation error details

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -104,7 +104,7 @@ func Read(rw http.ResponseWriter, r *http.Request, value interface{}) bool {
 		for _, validationError := range validationErrors {
 			apiErrors = append(apiErrors, Error{
 				Field:  validationError.Field(),
-				Detail: fmt.Sprintf("Validation failed for tag \"%s\" with value: %v", validationError.Tag(), validationError.Value()),
+				Detail: fmt.Sprintf("Validation failed for tag %q with value: %v", validationError.Tag(), validationError.Value()),
 			})
 		}
 		Write(rw, http.StatusBadRequest, Response{

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -104,7 +104,7 @@ func Read(rw http.ResponseWriter, r *http.Request, value interface{}) bool {
 		for _, validationError := range validationErrors {
 			apiErrors = append(apiErrors, Error{
 				Field:  validationError.Field(),
-				Detail: fmt.Sprintf("Validation failed for tag %q with value: %v", validationError.Tag(), validationError.Value()),
+				Detail: fmt.Sprintf("Validation failed for tag %q with value: \"%v\"", validationError.Tag(), validationError.Value()),
 			})
 		}
 		Write(rw, http.StatusBadRequest, Response{

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -104,7 +104,7 @@ func Read(rw http.ResponseWriter, r *http.Request, value interface{}) bool {
 		for _, validationError := range validationErrors {
 			apiErrors = append(apiErrors, Error{
 				Field:  validationError.Field(),
-				Detail: validationError.Tag(),
+				Detail: fmt.Sprintf("Validation failed for tag \"%s\" with value: %v", validationError.Tag(), validationError.Value()),
 			})
 		}
 		Write(rw, http.StatusBadRequest, Response{

--- a/coderd/httpapi/httpapi_test.go
+++ b/coderd/httpapi/httpapi_test.go
@@ -58,7 +58,7 @@ func TestRead(t *testing.T) {
 
 		var validate toValidate
 		require.True(t, httpapi.Read(rw, r, &validate))
-		require.Equal(t, validate.Value, "hi")
+		require.Equal(t, "hi", validate.Value)
 	})
 
 	t.Run("ValidateFailure", func(t *testing.T) {
@@ -75,8 +75,8 @@ func TestRead(t *testing.T) {
 		err := json.NewDecoder(rw.Body).Decode(&v)
 		require.NoError(t, err)
 		require.Len(t, v.Errors, 1)
-		require.Equal(t, v.Errors[0].Field, "value")
-		require.Equal(t, v.Errors[0].Detail, "required")
+		require.Equal(t, "value", v.Errors[0].Field)
+		require.Equal(t, "Validation failed for tag \"required\" with value: ", v.Errors[0].Detail)
 	})
 }
 
@@ -140,7 +140,7 @@ func TestReadUsername(t *testing.T) {
 			r := httptest.NewRequest("POST", "/", bytes.NewBuffer(data))
 
 			var validate toValidate
-			require.Equal(t, httpapi.Read(rw, r, &validate), testCase.Valid)
+			require.Equal(t, testCase.Valid, httpapi.Read(rw, r, &validate))
 		})
 	}
 }

--- a/coderd/httpapi/httpapi_test.go
+++ b/coderd/httpapi/httpapi_test.go
@@ -76,7 +76,7 @@ func TestRead(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, v.Errors, 1)
 		require.Equal(t, "value", v.Errors[0].Field)
-		require.Equal(t, "Validation failed for tag \"required\" with value: ", v.Errors[0].Detail)
+		require.Equal(t, "Validation failed for tag \"required\" with value: \"\"", v.Errors[0].Detail)
 	})
 }
 


### PR DESCRIPTION


This PR adds a more details to validation errors from the API.

## Subtasks

- [x] update the error details to include value and tag
- [x] update test

Fixes #1757 
