### PR TITLE
fix: update workspace form fields when switching templates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,6 +60,7 @@
     "TCGETS",
     "tcpip",
     "TCSETS",
+    "templateversions",
     "testid",
     "tfexec",
     "tfjson",

--- a/site/src/xServices/createWorkspace/createWorkspaceXService.ts
+++ b/site/src/xServices/createWorkspace/createWorkspaceXService.ts
@@ -45,6 +45,12 @@ export const createWorkspaceMachine = createMachine(
       },
     },
     tsTypes: {} as import("./createWorkspaceXService.typegen").Typegen0,
+    on: {
+      SELECT_TEMPLATE: {
+        actions: ["assignSelectedTemplate"],
+        target: "gettingTemplateSchema",
+      },
+    },
     states: {
       gettingTemplates: {
         invoke: {


### PR DESCRIPTION
resolves #1716

The fix took 10 minutes; trying to write a test took a lot longer and I finally gave up. How the heck do you switch the input in an MUI `TextField`? 

Given a `TextField` with `inputProps={{ "data-testid": "template-select" }}`

Something like: 
````
renderWithAuth(<CreateWorkspacePage />, {
  route: "/workspaces/new",
  path: "/workspaces/new",
})

const field = await screen.findByTestId("template-select")
expect(field).toBeInTheDocument()

fireEvent.change(field, { target: { value: MockTemplate.id } })
expect(field.value).toBe(MockTemplate.id)
````

seems to work - everything passes - but schema description text just doesn't show up, even with everything mocked out.
Also, is there a reason we aren't using [MUI Select](https://mui.com/material-ui/react-select/)? IDK if that would make this any easier; just curious.
