### PR TITLE
feat: Download default terraform version when minor version mismatches

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -197,7 +197,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.1.2
+          terraform_version: 1.1.9
           terraform_wrapper: false
 
       - name: Test with Mock Database
@@ -264,7 +264,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.1.2
+          terraform_version: 1.1.9
           terraform_wrapper: false
 
       - name: Start PostgreSQL Database
@@ -494,7 +494,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.1.2
+          terraform_version: 1.1.9
           terraform_wrapper: false
 
       - uses: actions/setup-node@v3

--- a/cli/server.go
+++ b/cli/server.go
@@ -376,7 +376,6 @@ func server() *cobra.Command {
 			shutdownConnsCtx, shutdownConns := context.WithCancel(cmd.Context())
 			defer shutdownConns()
 			go func() {
-				defer close(errCh)
 				server := http.Server{
 					// These errors are typically noise like "TLS: EOF". Vault does similar:
 					// https://github.com/hashicorp/vault/blob/e2490059d0711635e529a4efcbaa1b26998d6e1c/command/server.go#L2714
@@ -590,7 +589,7 @@ func newProvisionerDaemon(ctx context.Context, coderAPI *coderd.API,
 			CachePath: cacheDir,
 			Logger:    logger,
 		})
-		if err != nil {
+		if err != nil && !xerrors.Is(err, context.Canceled) {
 			errChan <- err
 		}
 	}()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -84,6 +84,7 @@ func TestServer(t *testing.T) {
 		}()
 		require.Eventually(t, func() bool {
 			_, err := cfg.URL().Read()
+			t.Log(err)
 			return err == nil
 		}, time.Minute, 25*time.Millisecond)
 		cancelFunc()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -84,7 +84,6 @@ func TestServer(t *testing.T) {
 		}()
 		require.Eventually(t, func() bool {
 			_, err := cfg.URL().Read()
-			t.Log(err)
 			return err == nil
 		}, time.Minute, 25*time.Millisecond)
 		cancelFunc()

--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -112,7 +112,12 @@ func versionFromBinaryPath(ctx context.Context, binaryPath string) (*version.Ver
 	cmd := exec.CommandContext(ctx, binaryPath, "version", "-json")
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return nil, err
+		}
 	}
 	vj := tfjson.VersionOutput{}
 	err = json.Unmarshal(out, &vj)

--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -112,12 +112,7 @@ func versionFromBinaryPath(ctx context.Context, binaryPath string) (*version.Ver
 	cmd := exec.CommandContext(ctx, binaryPath, "version", "-json")
 	out, err := cmd.Output()
 	if err != nil {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-			return nil, err
-		}
+		return nil, err
 	}
 	vj := tfjson.VersionOutput{}
 	err = json.Unmarshal(out, &vj)

--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -118,6 +118,21 @@ func (e executor) version(ctx context.Context) (*version.Version, error) {
 	return version.NewVersion(vj.Version)
 }
 
+func versionFromBinaryPath(ctx context.Context, binaryPath string) (*version.Version, error) {
+	// #nosec
+	cmd := exec.CommandContext(ctx, binaryPath, "version", "-json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	vj := tfjson.VersionOutput{}
+	err = json.Unmarshal(out, &vj)
+	if err != nil {
+		return nil, err
+	}
+	return version.NewVersion(vj.Version)
+}
+
 func (e executor) init(ctx context.Context, logr logger) error {
 	outWriter, doneOut := logWriter(logr, proto.LogLevel_DEBUG)
 	errWriter, doneErr := logWriter(logr, proto.LogLevel_ERROR)

--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -104,18 +104,7 @@ func (e executor) checkMinVersion(ctx context.Context) error {
 }
 
 func (e executor) version(ctx context.Context) (*version.Version, error) {
-	// #nosec
-	cmd := exec.CommandContext(ctx, e.binaryPath, "version", "-json")
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	vj := tfjson.VersionOutput{}
-	err = json.Unmarshal(out, &vj)
-	if err != nil {
-		return nil, err
-	}
-	return version.NewVersion(vj.Version)
+	return versionFromBinaryPath(ctx, e.binaryPath)
 }
 
 func versionFromBinaryPath(ctx context.Context, binaryPath string) (*version.Version, error) {

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -2,7 +2,10 @@ package terraform
 
 import (
 	"context"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/cli/safeexec"
 	"github.com/hashicorp/go-version"
@@ -17,6 +20,7 @@ import (
 // This is the exact version of Terraform used internally
 // when Terraform is missing on the system.
 const terraformVersion = "1.1.9"
+const versionDelimiter = "."
 
 var (
 	// The minimum version of Terraform supported by the provisioner.
@@ -45,7 +49,46 @@ type ServeOptions struct {
 func Serve(ctx context.Context, options *ServeOptions) error {
 	if options.BinaryPath == "" {
 		binaryPath, err := safeexec.LookPath("terraform")
+		var downloadTerraform bool
 		if err != nil {
+			downloadTerraform = true
+		} else {
+			// If the "coder" binary is in the same directory as
+			// the "terraform" binary, "terraform" is returned.
+			//
+			// We must resolve the absolute path for other processes
+			// to execute this properly!
+			absoluteBinary, err := filepath.Abs(binaryPath)
+			if err != nil {
+				return xerrors.Errorf("absolute: %w", err)
+			}
+			// Checking the installed version of Terraform.
+			output, err := exec.Command(absoluteBinary, "version").Output()
+			if err != nil {
+				return xerrors.Errorf("terraform version: %w", err)
+			}
+			// The output for `terraform version` is:
+			// Terraform v1.2.1
+			// on linux_amd64
+			versionRegex := regexp.MustCompile("Terraform v(.+)\n?.*")
+			match := versionRegex.FindStringSubmatch(string(output))
+			if match != nil {
+				// match[0] is the entire string.
+				// match[1] is the matched substring.
+				version := match[1]
+				terraformMinorVersion := strings.Join(strings.Split(terraformVersion, versionDelimiter)[:2], versionDelimiter)
+				if !strings.HasPrefix(version, terraformMinorVersion) {
+					downloadTerraform = true
+				}
+			} else {
+				// Download the required Terraform version when unable to determine the existing one.
+				downloadTerraform = true
+			}
+			if !downloadTerraform {
+				options.BinaryPath = absoluteBinary
+			}
+		}
+		if downloadTerraform {
 			installer := &releases.ExactVersion{
 				InstallDir: options.CachePath,
 				Product:    product.Terraform,
@@ -57,17 +100,6 @@ func Serve(ctx context.Context, options *ServeOptions) error {
 				return xerrors.Errorf("install terraform: %w", err)
 			}
 			options.BinaryPath = execPath
-		} else {
-			// If the "coder" binary is in the same directory as
-			// the "terraform" binary, "terraform" is returned.
-			//
-			// We must resolve the absolute path for other processes
-			// to execute this properly!
-			absoluteBinary, err := filepath.Abs(binaryPath)
-			if err != nil {
-				return xerrors.Errorf("absolute: %w", err)
-			}
-			options.BinaryPath = absoluteBinary
 		}
 	}
 	return provisionersdk.Serve(ctx, &server{

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -33,6 +33,8 @@ var (
 	}()
 )
 
+var terraformMinorVersionMismatch = xerrors.New("Terraform binary minor version mismatch.")
+
 type ServeOptions struct {
 	*provisionersdk.ServeOptions
 
@@ -66,7 +68,7 @@ func absoluteBinaryPath(ctx context.Context) (string, error) {
 	}
 
 	if version.LessThan(minTerraformVersion) || version.GreaterThanOrEqual(maxTerraformVersion) {
-		return "", xerrors.Errorf("Terraform binary minor version mismatch.")
+		return "", terraformMinorVersionMismatch
 	}
 
 	return absoluteBinary, nil

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -48,6 +48,7 @@ func getAbsoluteBinaryPath(ctx context.Context) (string, bool) {
 	if err != nil {
 		return "", false
 	}
+
 	// If the "coder" binary is in the same directory as
 	// the "terraform" binary, "terraform" is returned.
 	//
@@ -57,13 +58,17 @@ func getAbsoluteBinaryPath(ctx context.Context) (string, bool) {
 	if err != nil {
 		return "", false
 	}
+
 	// Checking the installed version of Terraform.
 	version, err := versionFromBinaryPath(ctx, absoluteBinary)
 	if err != nil {
 		return "", false
-	} else if version.LessThan(minTerraformVersion) || version.GreaterThanOrEqual(maxTerraformVersion) {
+	}
+
+	if version.LessThan(minTerraformVersion) || version.GreaterThanOrEqual(maxTerraformVersion) {
 		return "", false
 	}
+
 	return absoluteBinary, true
 }
 

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -76,8 +76,10 @@ func absoluteBinaryPath(ctx context.Context) (string, error) {
 func Serve(ctx context.Context, options *ServeOptions) error {
 	if options.BinaryPath == "" {
 		absoluteBinary, err := absoluteBinaryPath(ctx)
-
 		if err != nil {
+			// This is an early exit to prevent extra execution in case the context is canceled.
+			// It generally happens in unit tests since this method is asynchronous and
+			// the unit test kills the app before this is complete.
 			if xerrors.Is(err, context.Canceled) {
 				return xerrors.Errorf("absolute binary context canceled: %w", err)
 			}

--- a/provisioner/terraform/serve_internal_test.go
+++ b/provisioner/terraform/serve_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -55,6 +56,10 @@ func Test_getAbsoluteBinaryPath(t *testing.T) {
 	// nolint:paralleltest
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip("Dummy terraform executable on Windows requires sh which isn't very practical.")
+			}
+
 			// Create a temp dir with the binary
 			tempDir := t.TempDir()
 			terraformBinaryOutput := fmt.Sprintf(`#!/bin/sh

--- a/provisioner/terraform/serve_internal_test.go
+++ b/provisioner/terraform/serve_internal_test.go
@@ -90,6 +90,10 @@ func Test_getAbsoluteBinaryPath(t *testing.T) {
 			if actualOk != tt.expectedOk {
 				t.Errorf("getAbsoluteBinaryPath() ok, actual = %v, expected %v", actualOk, tt.expectedOk)
 			}
+
+			t.Cleanup(func() {
+				t.Setenv("PATH", pathVariable)
+			})
 		})
 	}
 }

--- a/provisioner/terraform/serve_internal_test.go
+++ b/provisioner/terraform/serve_internal_test.go
@@ -12,45 +12,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// nolint:paralleltest
 func Test_getAbsoluteBinaryPath(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		ctx context.Context
 	}
 	tests := []struct {
-		name                   string
-		args                   args
-		terraformVersion       string
-		expectedAbsoluteBinary string
-		expectedOk             bool
+		name             string
+		args             args
+		terraformVersion string
+		expectedOk       bool
 	}{
 		{
-			name:                   "TestCorrectVersion",
-			args:                   args{ctx: context.Background()},
-			terraformVersion:       "1.1.9",
-			expectedAbsoluteBinary: "",
-			expectedOk:             true,
+			name:             "TestCorrectVersion",
+			args:             args{ctx: context.Background()},
+			terraformVersion: "1.1.9",
+			expectedOk:       true,
 		},
 		{
-			name:                   "TestOldVersion",
-			args:                   args{ctx: context.Background()},
-			terraformVersion:       "1.0.9",
-			expectedAbsoluteBinary: "",
-			expectedOk:             false,
+			name:             "TestOldVersion",
+			args:             args{ctx: context.Background()},
+			terraformVersion: "1.0.9",
+			expectedOk:       false,
 		},
 		{
-			name:                   "TestNewVersion",
-			args:                   args{ctx: context.Background()},
-			terraformVersion:       "1.2.9",
-			expectedAbsoluteBinary: "",
-			expectedOk:             false,
+			name:             "TestNewVersion",
+			args:             args{ctx: context.Background()},
+			terraformVersion: "1.2.9",
+			expectedOk:       false,
 		},
 		{
-			name:                   "TestMalformedVersion",
-			args:                   args{ctx: context.Background()},
-			terraformVersion:       "version",
-			expectedAbsoluteBinary: "",
-			expectedOk:             false,
+			name:             "TestMalformedVersion",
+			args:             args{ctx: context.Background()},
+			terraformVersion: "version",
+			expectedOk:       false,
 		},
 	}
 	// nolint:paralleltest
@@ -84,21 +79,18 @@ func Test_getAbsoluteBinaryPath(t *testing.T) {
 			pathVariable := os.Getenv("PATH")
 			t.Setenv("PATH", strings.Join([]string{tempDir, pathVariable}, ":"))
 
+			var expectedAbsoluteBinary string
 			if tt.expectedOk {
-				tt.expectedAbsoluteBinary = filepath.Join(tempDir, "terraform")
+				expectedAbsoluteBinary = filepath.Join(tempDir, "terraform")
 			}
 
 			actualAbsoluteBinary, actualOk := getAbsoluteBinaryPath(tt.args.ctx)
-			if actualAbsoluteBinary != tt.expectedAbsoluteBinary {
-				t.Errorf("getAbsoluteBinaryPath() absoluteBinaryPath, actual = %v, expected %v", actualAbsoluteBinary, tt.expectedAbsoluteBinary)
+			if actualAbsoluteBinary != expectedAbsoluteBinary {
+				t.Errorf("getAbsoluteBinaryPath() absoluteBinaryPath, actual = %v, expected %v", actualAbsoluteBinary, expectedAbsoluteBinary)
 			}
 			if actualOk != tt.expectedOk {
 				t.Errorf("getAbsoluteBinaryPath() ok, actual = %v, expected %v", actualOk, tt.expectedOk)
 			}
-
-			t.Cleanup(func() {
-				t.Setenv("PATH", pathVariable)
-			})
 		})
 	}
 }

--- a/provisioner/terraform/serve_internal_test.go
+++ b/provisioner/terraform/serve_internal_test.go
@@ -1,0 +1,95 @@
+package terraform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getAbsoluteBinaryPath(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name                   string
+		args                   args
+		terraformVersion       string
+		expectedAbsoluteBinary string
+		expectedOk             bool
+	}{
+		{
+			name:                   "TestCorrectVersion",
+			args:                   args{ctx: context.Background()},
+			terraformVersion:       "1.1.9",
+			expectedAbsoluteBinary: "",
+			expectedOk:             true,
+		},
+		{
+			name:                   "TestOldVersion",
+			args:                   args{ctx: context.Background()},
+			terraformVersion:       "1.0.9",
+			expectedAbsoluteBinary: "",
+			expectedOk:             false,
+		},
+		{
+			name:                   "TestNewVersion",
+			args:                   args{ctx: context.Background()},
+			terraformVersion:       "1.2.9",
+			expectedAbsoluteBinary: "",
+			expectedOk:             false,
+		},
+		{
+			name:                   "TestMalformedVersion",
+			args:                   args{ctx: context.Background()},
+			terraformVersion:       "version",
+			expectedAbsoluteBinary: "",
+			expectedOk:             false,
+		},
+	}
+	// nolint:paralleltest
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temp dir with the binary
+			tempDir := t.TempDir()
+			terraformBinaryOutput := fmt.Sprintf(`#!/bin/sh
+			cat <<-EOF
+			{
+				"terraform_version": "%s",
+				"platform": "linux_amd64",
+				"provider_selections": {},
+				"terraform_outdated": false
+			}
+			EOF`, tt.terraformVersion)
+
+			// #nosec
+			err := os.WriteFile(
+				filepath.Join(tempDir, "terraform"),
+				[]byte(terraformBinaryOutput),
+				0770,
+			)
+			require.NoError(t, err)
+
+			// Add the binary to PATH
+			pathVariable := os.Getenv("PATH")
+			t.Setenv("PATH", strings.Join([]string{tempDir, pathVariable}, ":"))
+
+			if tt.expectedOk {
+				tt.expectedAbsoluteBinary = filepath.Join(tempDir, "terraform")
+			}
+
+			actualAbsoluteBinary, actualOk := getAbsoluteBinaryPath(tt.args.ctx)
+			if actualAbsoluteBinary != tt.expectedAbsoluteBinary {
+				t.Errorf("getAbsoluteBinaryPath() absoluteBinaryPath, actual = %v, expected %v", actualAbsoluteBinary, tt.expectedAbsoluteBinary)
+			}
+			if actualOk != tt.expectedOk {
+				t.Errorf("getAbsoluteBinaryPath() ok, actual = %v, expected %v", actualOk, tt.expectedOk)
+			}
+		})
+	}
+}

--- a/provisioner/terraform/serve_internal_test.go
+++ b/provisioner/terraform/serve_internal_test.go
@@ -34,13 +34,13 @@ func Test_absoluteBinaryPath(t *testing.T) {
 			name:             "TestOldVersion",
 			args:             args{ctx: context.Background()},
 			terraformVersion: "1.0.9",
-			expectedErr:      xerrors.Errorf("Terraform binary minor version mismatch."),
+			expectedErr:      terraformMinorVersionMismatch,
 		},
 		{
 			name:             "TestNewVersion",
 			args:             args{ctx: context.Background()},
 			terraformVersion: "1.2.9",
-			expectedErr:      xerrors.Errorf("Terraform binary minor version mismatch."),
+			expectedErr:      terraformMinorVersionMismatch,
 		},
 		{
 			name:             "TestMalformedVersion",
@@ -86,17 +86,12 @@ func Test_absoluteBinaryPath(t *testing.T) {
 			}
 
 			actualAbsoluteBinary, actualErr := absoluteBinaryPath(tt.args.ctx)
-			if actualAbsoluteBinary != expectedAbsoluteBinary {
-				t.Errorf("getAbsoluteBinaryPath() absoluteBinaryPath, actual = %v, expected %v", actualAbsoluteBinary, expectedAbsoluteBinary)
-			}
+
+			require.Equal(t, expectedAbsoluteBinary, actualAbsoluteBinary)
 			if tt.expectedErr == nil {
-				if actualErr != nil {
-					t.Errorf("getAbsoluteBinaryPath() error, actual = %v, expected %v", actualErr.Error(), tt.expectedErr)
-				}
+				require.NoError(t, actualErr)
 			} else {
-				if actualErr.Error() != tt.expectedErr.Error() {
-					t.Errorf("getAbsoluteBinaryPath() error, actual = %v, expected %v", actualErr.Error(), tt.expectedErr.Error())
-				}
+				require.EqualError(t, actualErr, tt.expectedErr.Error())
 			}
 		})
 	}


### PR DESCRIPTION
This PR downloads the default Terraform version when the minor version of the already installed Terraform is different.

## Subtasks

- [x] Identify the installed version by parsing `terraform version`.
- [x] Download the default version if there's a mismatch or we can't identify the version.
- [x] Add unit tests for the feature. 

Fixes #1743 