### PR TITLE
test: Unit test to assert role capabilities

### DIFF
--- a/coderd/rbac/builtin_test.go
+++ b/coderd/rbac/builtin_test.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/google/uuid"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/rbac"

--- a/coderd/rbac/builtin_test.go
+++ b/coderd/rbac/builtin_test.go
@@ -1,8 +1,11 @@
 package rbac_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"
 
@@ -10,6 +13,234 @@ import (
 
 	"github.com/coder/coder/coderd/rbac"
 )
+
+type authSubject struct {
+	// Name is helpful for test assertions
+	Name   string
+	UserID string
+	Roles  []string
+}
+
+func TestRolePermissions(t *testing.T) {
+	t.Parallel()
+
+	auth, err := rbac.NewAuthorizer()
+	require.NoError(t, err, "new rego authorizer")
+
+	meID := uuid.New()
+	adminID := uuid.New()
+	orgID := uuid.New()
+	otherOrg := uuid.New()
+
+	// Subjects to user
+	member := authSubject{Name: "member", UserID: meID.String(), Roles: []string{rbac.RoleMember()}}
+	admin := authSubject{Name: "admin", UserID: adminID.String(), Roles: []string{rbac.RoleMember(), rbac.RoleAdmin()}}
+
+	orgMember := authSubject{Name: "org_member", UserID: meID.String(), Roles: []string{rbac.RoleMember(), rbac.RoleOrgMember(orgID)}}
+	orgAdmin := authSubject{Name: "org_admin", UserID: adminID.String(), Roles: []string{rbac.RoleMember(), rbac.RoleOrgMember(orgID), rbac.RoleOrgAdmin(orgID)}}
+	otherOrgMember := authSubject{Name: "other_org_member", UserID: uuid.NewString(), Roles: []string{rbac.RoleMember(), rbac.RoleOrgMember(otherOrg)}}
+	otherOrgAdmin := authSubject{Name: "other_org_admin", UserID: uuid.NewString(), Roles: []string{rbac.RoleMember(), rbac.RoleOrgMember(otherOrg), rbac.RoleOrgAdmin(otherOrg)}}
+
+	allSubj := []authSubject{member, admin, orgMember, orgAdmin, otherOrgAdmin, otherOrgMember}
+
+	testCases := []struct {
+		Name       string
+		Resource   rbac.Object
+		Actions    []rbac.Action
+		Assertions map[bool][]authSubject
+	}{
+		{
+			Name:     "MyUser",
+			Actions:  []rbac.Action{rbac.ActionRead},
+			Resource: rbac.ResourceUser.WithID(meID.String()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, member, orgMember, orgAdmin, otherOrgMember, otherOrgAdmin},
+				false: {},
+			},
+		},
+		{
+			Name:     "AUser",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceUser,
+			Assertions: map[bool][]authSubject{
+				true:  {admin},
+				false: {member, orgMember, orgAdmin, otherOrgMember, otherOrgAdmin},
+			},
+		},
+		{
+			Name: "MyWorkspaceInOrg",
+			// When creating the WithID won't be set, but it does not change the result.
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceWorkspace.InOrg(orgID).WithOwner(meID.String()).WithID(uuid.NewString()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgMember, orgAdmin},
+				false: {member, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "Templates",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceTemplate.InOrg(orgID).WithID(uuid.NewString()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin},
+				false: {member, orgMember, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "ReadTemplates",
+			Actions:  []rbac.Action{rbac.ActionRead},
+			Resource: rbac.ResourceTemplate.InOrg(orgID).WithID(uuid.NewString()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgMember, orgAdmin},
+				false: {member, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "Files",
+			Actions:  []rbac.Action{rbac.ActionCreate},
+			Resource: rbac.ResourceFile,
+			Assertions: map[bool][]authSubject{
+				true:  {admin},
+				false: {orgMember, orgAdmin, member, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "MyFile",
+			Actions:  []rbac.Action{rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceFile.WithID(uuid.NewString()).WithOwner(meID.String()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, member, orgMember},
+				false: {orgAdmin, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "CreateOrganizations",
+			Actions:  []rbac.Action{rbac.ActionCreate},
+			Resource: rbac.ResourceOrganization,
+			Assertions: map[bool][]authSubject{
+				true:  {admin},
+				false: {orgAdmin, otherOrgAdmin, otherOrgMember, member, orgMember},
+			},
+		},
+		{
+			Name:     "Organizations",
+			Actions:  []rbac.Action{rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceOrganization.InOrg(orgID).WithID(orgID.String()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin},
+				false: {otherOrgAdmin, otherOrgMember, member, orgMember},
+			},
+		},
+		{
+			Name:     "ReadOrganizations",
+			Actions:  []rbac.Action{rbac.ActionRead},
+			Resource: rbac.ResourceOrganization.InOrg(orgID).WithID(orgID.String()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin, orgMember},
+				false: {otherOrgAdmin, otherOrgMember, member},
+			},
+		},
+		{
+			Name:     "RoleAssignment",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceRoleAssignment,
+			Assertions: map[bool][]authSubject{
+				true:  {admin},
+				false: {orgAdmin, orgMember, otherOrgAdmin, otherOrgMember, member},
+			},
+		},
+		{
+			Name:     "ReadRoleAssignment",
+			Actions:  []rbac.Action{rbac.ActionRead},
+			Resource: rbac.ResourceRoleAssignment,
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin, orgMember, otherOrgAdmin, otherOrgMember, member},
+				false: {},
+			},
+		},
+		{
+			Name:     "OrgRoleAssignment",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceOrgRoleAssignment.InOrg(orgID),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin},
+				false: {orgMember, otherOrgAdmin, otherOrgMember, member},
+			},
+		},
+		{
+			Name:     "ReadOrgRoleAssignment",
+			Actions:  []rbac.Action{rbac.ActionRead},
+			Resource: rbac.ResourceOrgRoleAssignment.InOrg(orgID),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin, orgMember},
+				false: {otherOrgAdmin, otherOrgMember, member},
+			},
+		},
+		{
+			Name:     "APIKey",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceAPIKey.WithOwner(meID.String()).WithID(uuid.NewString()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgMember, member},
+				false: {orgAdmin, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "UserData",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceUserData.WithOwner(meID.String()).WithID(meID.String()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgMember, member},
+				false: {orgAdmin, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "ManageOrgMember",
+			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
+			Resource: rbac.ResourceOrganizationMember.InOrg(orgID).WithID(uuid.NewString()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin},
+				false: {orgMember, member, otherOrgAdmin, otherOrgMember},
+			},
+		},
+		{
+			Name:     "ReadOrgMember",
+			Actions:  []rbac.Action{rbac.ActionRead},
+			Resource: rbac.ResourceOrganizationMember.InOrg(orgID).WithID(uuid.NewString()),
+			Assertions: map[bool][]authSubject{
+				true:  {admin, orgAdmin, orgMember},
+				false: {member, otherOrgAdmin, otherOrgMember},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			remainingSubjs := make(map[string]struct{})
+			for _, subj := range allSubj {
+				remainingSubjs[subj.Name] = struct{}{}
+			}
+
+			for _, action := range c.Actions {
+				for result, subjs := range c.Assertions {
+					for _, subj := range subjs {
+						delete(remainingSubjs, subj.Name)
+						msg := fmt.Sprintf("%s as %q doing %q on %q", c.Name, subj.Name, action, c.Resource.Type)
+						err := auth.ByRoleName(context.Background(), subj.UserID, subj.Roles, action, c.Resource)
+						if result {
+							assert.NoError(t, err, fmt.Sprintf("Should pass: %s", msg))
+						} else {
+							assert.ErrorContains(t, err, "forbidden", fmt.Sprintf("Should fail: %s", msg))
+						}
+					}
+				}
+			}
+			require.Empty(t, remainingSubjs, "test should cover all subjects")
+		})
+	}
+}
 
 func TestIsOrgRole(t *testing.T) {
 	t.Parallel()

--- a/coderd/rbac/builtin_test.go
+++ b/coderd/rbac/builtin_test.go
@@ -39,12 +39,16 @@ func TestRolePermissions(t *testing.T) {
 	otherOrgMember := authSubject{Name: "other_org_member", UserID: uuid.NewString(), Roles: []string{rbac.RoleMember(), rbac.RoleOrgMember(otherOrg)}}
 	otherOrgAdmin := authSubject{Name: "other_org_admin", UserID: uuid.NewString(), Roles: []string{rbac.RoleMember(), rbac.RoleOrgMember(otherOrg), rbac.RoleOrgAdmin(otherOrg)}}
 
-	allSubj := []authSubject{member, admin, orgMember, orgAdmin, otherOrgAdmin, otherOrgMember}
+	// requiredSubjects are required to be asserted in each test case. This is
+	// to make sure one is not forgotten.
+	requiredSubjects := []authSubject{member, admin, orgMember, orgAdmin, otherOrgAdmin, otherOrgMember}
 
 	testCases := []struct {
-		Name       string
-		Resource   rbac.Object
-		Actions    []rbac.Action
+		// Name the test case to better locate the failing test case.
+		Name     string
+		Resource rbac.Object
+		Actions  []rbac.Action
+		// Assertions must cover all subjects in 'requiredSubjects'
 		Assertions map[bool][]authSubject
 	}{
 		{
@@ -217,7 +221,7 @@ func TestRolePermissions(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
 			remainingSubjs := make(map[string]struct{})
-			for _, subj := range allSubj {
+			for _, subj := range requiredSubjects {
 				remainingSubjs[subj.Name] = struct{}{}
 			}
 


### PR DESCRIPTION
This unit test allows for asserting which roles can perform
actions on various objects. This is much easier than making
unit tests to hit the api.
