### PR TITLE
fix: remove unused pages from Admin dropdown (org and settings)

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -8,7 +8,6 @@ import { NotFoundPage } from "./pages/404Page/404Page"
 import { CliAuthenticationPage } from "./pages/CliAuthPage/CliAuthPage"
 import { HealthzPage } from "./pages/HealthzPage/HealthzPage"
 import { LoginPage } from "./pages/LoginPage/LoginPage"
-import { SettingsPage } from "./pages/SettingsPage/SettingsPage"
 import { AccountPage } from "./pages/SettingsPages/AccountPage/AccountPage"
 import { SSHKeysPage } from "./pages/SettingsPages/SSHKeysPage/SSHKeysPage"
 import { TemplatePage } from "./pages/TemplatePage/TemplatePage"
@@ -133,14 +132,6 @@ export const AppRouter: React.FC = () => (
             }
           />
         </Route>
-        <Route
-          path="settings"
-          element={
-            <AuthAndFrame>
-              <SettingsPage />
-            </AuthAndFrame>
-          }
-        />
 
         <Route path="settings" element={<SettingsLayout />}>
           <Route path="account" element={<AccountPage />} />

--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -8,7 +8,6 @@ import { NotFoundPage } from "./pages/404Page/404Page"
 import { CliAuthenticationPage } from "./pages/CliAuthPage/CliAuthPage"
 import { HealthzPage } from "./pages/HealthzPage/HealthzPage"
 import { LoginPage } from "./pages/LoginPage/LoginPage"
-import { OrgsPage } from "./pages/OrgsPage/OrgsPage"
 import { SettingsPage } from "./pages/SettingsPage/SettingsPage"
 import { AccountPage } from "./pages/SettingsPages/AccountPage/AccountPage"
 import { SSHKeysPage } from "./pages/SettingsPages/SSHKeysPage/SSHKeysPage"
@@ -134,14 +133,6 @@ export const AppRouter: React.FC = () => (
             }
           />
         </Route>
-        <Route
-          path="orgs"
-          element={
-            <AuthAndFrame>
-              <OrgsPage />
-            </AuthAndFrame>
-          }
-        />
         <Route
           path="settings"
           element={

--- a/site/src/components/AdminDropdown/AdminDropdown.test.tsx
+++ b/site/src/components/AdminDropdown/AdminDropdown.test.tsx
@@ -14,7 +14,6 @@ describe("AdminDropdown", () => {
     it("opens the menu", async () => {
       await renderAndClick()
       expect(screen.getByText(Language.usersLabel)).toBeDefined()
-      expect(screen.getByText(Language.settingsLabel)).toBeDefined()
     })
   })
 
@@ -25,14 +24,5 @@ describe("AdminDropdown", () => {
     usersLink?.click()
 
     expect(history.location.pathname).toEqual("/users")
-  })
-
-  it("links to the settings page", async () => {
-    await renderAndClick()
-
-    const usersLink = screen.getByText(Language.settingsLabel).closest("a")
-    usersLink?.click()
-
-    expect(history.location.pathname).toEqual("/settings")
   })
 })

--- a/site/src/components/AdminDropdown/AdminDropdown.test.tsx
+++ b/site/src/components/AdminDropdown/AdminDropdown.test.tsx
@@ -14,7 +14,6 @@ describe("AdminDropdown", () => {
     it("opens the menu", async () => {
       await renderAndClick()
       expect(screen.getByText(Language.usersLabel)).toBeDefined()
-      expect(screen.getByText(Language.orgsLabel)).toBeDefined()
       expect(screen.getByText(Language.settingsLabel)).toBeDefined()
     })
   })
@@ -26,15 +25,6 @@ describe("AdminDropdown", () => {
     usersLink?.click()
 
     expect(history.location.pathname).toEqual("/users")
-  })
-
-  it("links to the orgs page", async () => {
-    await renderAndClick()
-
-    const usersLink = screen.getByText(Language.orgsLabel).closest("a")
-    usersLink?.click()
-
-    expect(history.location.pathname).toEqual("/orgs")
   })
 
   it("links to the settings page", async () => {

--- a/site/src/components/AdminDropdown/AdminDropdown.tsx
+++ b/site/src/components/AdminDropdown/AdminDropdown.tsx
@@ -7,15 +7,12 @@ import { navHeight } from "../../theme/constants"
 import { BorderedMenu } from "../BorderedMenu/BorderedMenu"
 import { BorderedMenuRow } from "../BorderedMenuRow/BorderedMenuRow"
 import { CloseDropdown, OpenDropdown } from "../DropdownArrows/DropdownArrows"
-import { BuildingIcon } from "../Icons/BuildingIcon"
 import { UsersOutlinedIcon } from "../Icons/UsersOutlinedIcon"
 
 export const Language = {
   menuTitle: "Admin",
   usersLabel: "Users",
   usersDescription: "Manage users, roles, and permissions.",
-  orgsLabel: "Organizations",
-  orgsDescription: "Manage organizations.",
   settingsLabel: "Settings",
   settingsDescription: "Configure authentication and more.",
 }
@@ -26,12 +23,6 @@ const entries = [
     description: Language.usersDescription,
     path: "/users",
     Icon: UsersOutlinedIcon,
-  },
-  {
-    label: Language.orgsLabel,
-    description: Language.orgsDescription,
-    path: "/orgs",
-    Icon: BuildingIcon,
   },
   {
     label: Language.settingsLabel,

--- a/site/src/components/AdminDropdown/AdminDropdown.tsx
+++ b/site/src/components/AdminDropdown/AdminDropdown.tsx
@@ -1,7 +1,6 @@
 import ListItem from "@material-ui/core/ListItem"
 import ListItemText from "@material-ui/core/ListItemText"
 import { fade, makeStyles, Theme } from "@material-ui/core/styles"
-import AdminIcon from "@material-ui/icons/SettingsOutlined"
 import React, { useState } from "react"
 import { navHeight } from "../../theme/constants"
 import { BorderedMenu } from "../BorderedMenu/BorderedMenu"
@@ -13,8 +12,6 @@ export const Language = {
   menuTitle: "Admin",
   usersLabel: "Users",
   usersDescription: "Manage users, roles, and permissions.",
-  settingsLabel: "Settings",
-  settingsDescription: "Configure authentication and more.",
 }
 
 const entries = [
@@ -23,12 +20,6 @@ const entries = [
     description: Language.usersDescription,
     path: "/users",
     Icon: UsersOutlinedIcon,
-  },
-  {
-    label: Language.settingsLabel,
-    description: Language.settingsDescription,
-    path: "/settings",
-    Icon: AdminIcon,
   },
 ]
 

--- a/site/src/pages/OrgsPage/OrgsPage.tsx
+++ b/site/src/pages/OrgsPage/OrgsPage.tsx
@@ -1,5 +1,0 @@
-import React from "react"
-
-export const OrgsPage: React.FC = () => {
-  return <div>Coming soon!</div>
-}

--- a/site/src/pages/SettingsPage/SettingsPage.tsx
+++ b/site/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,5 +1,0 @@
-import React from "react"
-
-export const SettingsPage: React.FC = () => {
-  return <div>Coming soon!</div>
-}


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
Fixes #1741 
I went ahead and removed both the pages and the nav links to them, even though the whole Admin menu is going to be deleted soon, just so everything stays working at all times.