### PR TITLE
fix: hide New user button if no permission

### DIFF
--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -23,6 +23,7 @@ export const UsersPage: React.FC = () => {
   const userToResetPassword = users?.find((u) => u.id === userIdToResetPassword)
   const permissions = useSelector(xServices.authXService, selectPermissions)
   const canEditUsers = permissions && permissions.updateUsers
+  const canCreateUser = permissions && permissions.createUser
   const { roles } = rolesState.context
   // Is loading if
   // - permissions are not loaded or
@@ -70,6 +71,7 @@ export const UsersPage: React.FC = () => {
         isUpdatingUserRoles={usersState.matches("updatingUserRoles")}
         isLoading={isLoading}
         canEditUsers={canEditUsers}
+        canCreateUser={canCreateUser}
       />
 
       <ConfirmDialog

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -10,13 +10,16 @@ export default {
 
 const Template: Story<UsersPageViewProps> = (args) => <UsersPageView {...args} />
 
-export const Ready = Template.bind({})
-Ready.args = {
+export const Admin = Template.bind({})
+Admin.args = {
   users: [MockUser, MockUser2],
   roles: MockSiteRoles,
+  canCreateUser: true,
+  canEditUsers: true,
 }
+
+export const Member = Template.bind({})
+Member.args = { ...Admin.args, canCreateUser: false, canEditUsers: false }
+
 export const Empty = Template.bind({})
-Empty.args = {
-  users: [],
-  roles: MockSiteRoles,
-}
+Empty.args = { ...Admin.args, users: [] }

--- a/site/src/pages/UsersPage/UsersPageView.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.tsx
@@ -17,6 +17,7 @@ export interface UsersPageViewProps {
   error?: unknown
   isUpdatingUserRoles?: boolean
   canEditUsers?: boolean
+  canCreateUser?: boolean
   isLoading?: boolean
   openUserCreationDialog: () => void
   onSuspendUser: (user: TypesGen.User) => void
@@ -34,11 +35,13 @@ export const UsersPageView: React.FC<UsersPageViewProps> = ({
   error,
   isUpdatingUserRoles,
   canEditUsers,
+  canCreateUser,
   isLoading,
 }) => {
+  const newUserAction = canCreateUser ? { text: Language.newUserButton, onClick: openUserCreationDialog } : undefined
   return (
     <Stack spacing={4}>
-      <Header title={Language.pageTitle} action={{ text: Language.newUserButton, onClick: openUserCreationDialog }} />
+      <Header title={Language.pageTitle} action={newUserAction} />
       <Margins>
         {error ? (
           <ErrorSummary error={error} />

--- a/site/src/xServices/auth/authXService.ts
+++ b/site/src/xServices/auth/authXService.ts
@@ -12,6 +12,7 @@ export const Language = {
 export const checks = {
   readAllUsers: "readAllUsers",
   updateUsers: "updateUsers",
+  createUser: "createUser",
   createTemplates: "createTemplates",
 } as const
 
@@ -27,6 +28,12 @@ export const permissionsToCheck = {
       resource_type: "user",
     },
     action: "update",
+  },
+  [checks.createUser]: {
+    object: {
+      resource_type: "user",
+    },
+    action: "create",
   },
   [checks.createTemplates]: {
     object: {


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
Fixes #1742 
Storybook now shows the UserPageView with and without create and update permissions