### PR TITLE
fix: use dir over full path for coder bin

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -359,7 +359,7 @@ func (a *agent) createCommand(ctx context.Context, rawCommand string, env []stri
 	if err != nil {
 		return nil, xerrors.Errorf("getting os executable: %w", err)
 	}
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`PATH=%s%c%s`, os.Getenv("PATH"), filepath.ListSeparator, executablePath))
+	cmd.Env = append(cmd.Env, fmt.Sprintf(`PATH=%s%c%s`, os.Getenv("PATH"), filepath.ListSeparator, filepath.Dir(executablePath)))
 	// Git on Windows resolves with UNIX-style paths.
 	// If using backslashes, it's unable to find the executable.
 	unixExecutablePath := strings.ReplaceAll(executablePath, "\\", "/")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -80,7 +80,7 @@ func TestAgent(t *testing.T) {
 		ex, err := os.Executable()
 		t.Log(ex)
 		require.NoError(t, err)
-		require.True(t, strings.Contains(strings.TrimSpace(string(output)), ex), string(output), ex)
+		require.True(t, strings.Contains(strings.TrimSpace(string(output)), filepath.Dir(ex)))
 	})
 
 	t.Run("SessionTTY", func(t *testing.T) {


### PR DESCRIPTION
This was an oversight on my part, I was injecting the full binary path but need to only provide the dir of the binary. 