### PR TITLE
feat: Delete workspace

### DIFF
--- a/site/src/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.stories.tsx
+++ b/site/src/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, Story } from "@storybook/react"
+import React from "react"
+import { DeleteWorkspaceDialog, DeleteWorkspaceDialogProps } from "./DeleteWorkspaceDialog"
+
+export default {
+  title: "Components/DeleteWorkspaceDialog",
+  component: DeleteWorkspaceDialog,
+  argTypes: {
+    onClose: {
+      action: "onClose",
+    },
+    onConfirm: {
+      action: "onConfirm",
+    },
+    open: {
+      control: "boolean",
+      defaultValue: true,
+    },
+    title: {
+      defaultValue: "Confirm Dialog",
+    },
+  },
+} as ComponentMeta<typeof DeleteWorkspaceDialog>
+
+const Template: Story<DeleteWorkspaceDialogProps> = (args) => <DeleteWorkspaceDialog {...args} />
+
+export const Example = Template.bind({})
+Example.args = {
+  isOpen: true,
+}

--- a/site/src/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/site/src/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { ConfirmDialog } from "../ConfirmDialog/ConfirmDialog"
+
+const Language = {
+  deleteDialogTitle: "Delete workspace?",
+  deleteDialogMessage: "Deleting your workspace is irreversible. Are you sure?",
+}
+
+export interface DeleteWorkspaceDialogProps {
+  isOpen: boolean
+  handleConfirm: () => void
+  handleCancel: () => void
+}
+
+export const DeleteWorkspaceDialog: React.FC<DeleteWorkspaceDialogProps> = ({
+  isOpen,
+  handleCancel,
+  handleConfirm,
+}) => (
+  <ConfirmDialog
+    type="delete"
+    hideCancel={false}
+    open={isOpen}
+    title={Language.deleteDialogTitle}
+    onConfirm={handleConfirm}
+    onClose={handleCancel}
+    description={<>{Language.deleteDialogMessage}</>}
+  />
+)

--- a/site/src/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
+++ b/site/src/components/DeleteWorkspaceDialog/DeleteWorkspaceDialog.tsx
@@ -24,6 +24,6 @@ export const DeleteWorkspaceDialog: React.FC<DeleteWorkspaceDialogProps> = ({
     title={Language.deleteDialogTitle}
     onConfirm={handleConfirm}
     onClose={handleCancel}
-    description={<>{Language.deleteDialogMessage}</>}
+    description={Language.deleteDialogMessage}
   />
 )

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -14,6 +14,7 @@ import { WorkspaceStats } from "../WorkspaceStats/WorkspaceStats"
 export interface WorkspaceProps {
   handleStart: () => void
   handleStop: () => void
+  handleDelete: () => void
   handleUpdate: () => void
   handleCancel: () => void
   workspace: TypesGen.Workspace
@@ -28,6 +29,7 @@ export interface WorkspaceProps {
 export const Workspace: React.FC<WorkspaceProps> = ({
   handleStart,
   handleStop,
+  handleDelete,
   handleUpdate,
   handleCancel,
   workspace,
@@ -55,6 +57,7 @@ export const Workspace: React.FC<WorkspaceProps> = ({
             workspace={workspace}
             handleStart={handleStart}
             handleStop={handleStop}
+            handleDelete={handleDelete}
             handleUpdate={handleUpdate}
             handleCancel={handleCancel}
           />

--- a/site/src/components/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/components/WorkspaceActions/WorkspaceActions.tsx
@@ -2,6 +2,7 @@ import Button from "@material-ui/core/Button"
 import { makeStyles } from "@material-ui/core/styles"
 import CancelIcon from "@material-ui/icons/Cancel"
 import CloudDownloadIcon from "@material-ui/icons/CloudDownload"
+import DeleteIcon from "@material-ui/icons/Delete"
 import PlayArrowRoundedIcon from "@material-ui/icons/PlayArrowRounded"
 import StopIcon from "@material-ui/icons/Stop"
 import React from "react"
@@ -15,6 +16,8 @@ export const Language = {
   stopping: "Stopping workspace",
   start: "Start workspace",
   starting: "Starting workspace",
+  delete: "Delete workspace",
+  deleting: "Deleting workspace",
   cancel: "Cancel action",
   update: "Update workspace",
 }
@@ -38,10 +41,14 @@ const canStart = (workspaceStatus: WorkspaceStatus) => ["stopped", "canceled", "
 
 const canStop = (workspaceStatus: WorkspaceStatus) => ["started", "canceled", "error"].includes(workspaceStatus)
 
+const canDelete = (workspaceStatus: WorkspaceStatus) =>
+  ["started", "stopped", "canceled", "error"].includes(workspaceStatus)
+
 export interface WorkspaceActionsProps {
   workspace: Workspace
   handleStart: () => void
   handleStop: () => void
+  handleDelete: () => void
   handleUpdate: () => void
   handleCancel: () => void
 }
@@ -50,6 +57,7 @@ export const WorkspaceActions: React.FC<WorkspaceActionsProps> = ({
   workspace,
   handleStart,
   handleStop,
+  handleDelete,
   handleUpdate,
   handleCancel,
 }) => {
@@ -72,6 +80,14 @@ export const WorkspaceActions: React.FC<WorkspaceActionsProps> = ({
           icon={<StopIcon />}
           onClick={handleStop}
           label={Language.stop}
+        />
+      )}
+      {canDelete(workspaceStatus) && (
+        <WorkspaceActionButton
+          className={styles.actionButton}
+          icon={<DeleteIcon />}
+          onClick={handleDelete}
+          label={Language.delete}
         />
       )}
       {canCancelJobs(workspaceStatus) && (

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
 import { rest } from "msw"
 import React from "react"
 import * as api from "../../api/api"
@@ -76,9 +76,15 @@ describe("Workspace Page", () => {
     const stopWorkspaceMock = jest.spyOn(api, "stopWorkspace").mockResolvedValueOnce(MockWorkspaceBuild)
     await testButton(Language.stop, stopWorkspaceMock)
   })
-  it("requests a delete job when the user presses Delete", async () => {
+  it("requests a delete job when the user presses Delete and confirms", async () => {
     const deleteWorkspaceMock = jest.spyOn(api, "deleteWorkspace").mockResolvedValueOnce(MockWorkspaceBuild)
-    await testButton(Language.delete, deleteWorkspaceMock)
+    await renderWorkspacePage()
+    const button = await screen.findByText(Language.delete)
+    await waitFor(() => fireEvent.click(button))
+    const confirmDialog = await screen.findByRole("dialog")
+    const confirmButton = within(confirmDialog).getByText("Delete")
+    await waitFor(() => fireEvent.click(confirmButton))
+    expect(deleteWorkspaceMock).toBeCalled()
   })
   it("requests a start job when the user presses Start", async () => {
     server.use(

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -76,6 +76,10 @@ describe("Workspace Page", () => {
     const stopWorkspaceMock = jest.spyOn(api, "stopWorkspace").mockResolvedValueOnce(MockWorkspaceBuild)
     await testButton(Language.stop, stopWorkspaceMock)
   })
+  it("requests a delete job when the user presses Delete", async () => {
+    const deleteWorkspaceMock = jest.spyOn(api, "deleteWorkspace").mockResolvedValueOnce(MockWorkspaceBuild)
+    await testButton(Language.delete, deleteWorkspaceMock)
+  })
   it("requests a start job when the user presses Start", async () => {
     server.use(
       rest.get(`/api/v2/workspaces/${MockWorkspace.id}`, (req, res, ctx) => {

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -1,7 +1,7 @@
 import { useMachine } from "@xstate/react"
 import React, { useEffect } from "react"
 import { useParams } from "react-router-dom"
-import { ConfirmDialog } from "../../components/ConfirmDialog/ConfirmDialog"
+import { DeleteWorkspaceDialog } from "../../components/DeleteWorkspaceDialog/DeleteWorkspaceDialog"
 import { ErrorSummary } from "../../components/ErrorSummary/ErrorSummary"
 import { FullScreenLoader } from "../../components/Loader/FullScreenLoader"
 import { Margins } from "../../components/Margins/Margins"
@@ -9,12 +9,6 @@ import { Stack } from "../../components/Stack/Stack"
 import { Workspace } from "../../components/Workspace/Workspace"
 import { firstOrItem } from "../../util/array"
 import { workspaceMachine } from "../../xServices/workspace/workspaceXService"
-
-const Language = {
-  deleteDialogTitle: "Delete workspace?",
-  confirmDelete: "Yes, delete",
-  deleteDialogMessage: "Deleting your workspace is irreversible. Are you sure?"
-}
 
 export const WorkspacePage: React.FC = () => {
   const { workspace: workspaceQueryParam } = useParams()
@@ -40,31 +34,22 @@ export const WorkspacePage: React.FC = () => {
       <Margins>
         <Stack spacing={4}>
           <>
-          <Workspace
-            workspace={workspace}
-            handleStart={() => workspaceSend("START")}
-            handleStop={() => workspaceSend("STOP")}
-            handleDelete={() => workspaceSend("ASK_DELETE")}
-            handleUpdate={() => workspaceSend("UPDATE")}
-            handleCancel={() => workspaceSend("CANCEL")}
-            resources={resources}
-            getResourcesError={getResourcesError instanceof Error ? getResourcesError : undefined}
-            builds={builds}
-          />
-      <ConfirmDialog
-        type="delete"
-        hideCancel={false}
-        open={workspaceState.matches({ ready: { build: "askingDelete" } })}
-        title={Language.deleteDialogTitle}
-        confirmText={Language.confirmDelete}
-        onConfirm={() => {
-          workspaceSend({ type: "DELETE" })
-        }}
-        onClose={() => {
-          workspaceSend({ type: "CANCEL_DELETE" })
-        }}
-        description={<>{Language.deleteDialogMessage}</>}
-      />
+            <Workspace
+              workspace={workspace}
+              handleStart={() => workspaceSend("START")}
+              handleStop={() => workspaceSend("STOP")}
+              handleDelete={() => workspaceSend("ASK_DELETE")}
+              handleUpdate={() => workspaceSend("UPDATE")}
+              handleCancel={() => workspaceSend("CANCEL")}
+              resources={resources}
+              getResourcesError={getResourcesError instanceof Error ? getResourcesError : undefined}
+              builds={builds}
+            />
+            <DeleteWorkspaceDialog
+              isOpen={workspaceState.matches({ ready: { build: "askingDelete" } })}
+              handleCancel={() => workspaceSend("ASK_DELETE")}
+              handleConfirm={() => workspaceSend("DELETE")}
+            />
           </>
         </Stack>
       </Margins>

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -1,6 +1,6 @@
 import { useMachine } from "@xstate/react"
 import React, { useEffect } from "react"
-import { useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 import { DeleteWorkspaceDialog } from "../../components/DeleteWorkspaceDialog/DeleteWorkspaceDialog"
 import { ErrorSummary } from "../../components/ErrorSummary/ErrorSummary"
 import { FullScreenLoader } from "../../components/Loader/FullScreenLoader"
@@ -12,6 +12,7 @@ import { workspaceMachine } from "../../xServices/workspace/workspaceXService"
 
 export const WorkspacePage: React.FC = () => {
   const { workspace: workspaceQueryParam } = useParams()
+  const navigate = useNavigate()
   const workspaceId = firstOrItem(workspaceQueryParam, null)
 
   const [workspaceState, workspaceSend] = useMachine(workspaceMachine)
@@ -47,8 +48,11 @@ export const WorkspacePage: React.FC = () => {
             />
             <DeleteWorkspaceDialog
               isOpen={workspaceState.matches({ ready: { build: "askingDelete" } })}
-              handleCancel={() => workspaceSend("ASK_DELETE")}
-              handleConfirm={() => workspaceSend("DELETE")}
+              handleCancel={() => workspaceSend("CANCEL_DELETE")}
+              handleConfirm={() => {
+                workspaceSend("DELETE")
+                navigate("/workspaces")
+              }}
             />
           </>
         </Stack>

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -1,6 +1,7 @@
 import { useMachine } from "@xstate/react"
 import React, { useEffect } from "react"
 import { useParams } from "react-router-dom"
+import { ConfirmDialog } from "../../components/ConfirmDialog/ConfirmDialog"
 import { ErrorSummary } from "../../components/ErrorSummary/ErrorSummary"
 import { FullScreenLoader } from "../../components/Loader/FullScreenLoader"
 import { Margins } from "../../components/Margins/Margins"
@@ -8,6 +9,12 @@ import { Stack } from "../../components/Stack/Stack"
 import { Workspace } from "../../components/Workspace/Workspace"
 import { firstOrItem } from "../../util/array"
 import { workspaceMachine } from "../../xServices/workspace/workspaceXService"
+
+const Language = {
+  deleteDialogTitle: "Delete workspace?",
+  confirmDelete: "Yes, delete",
+  deleteDialogMessage: "Deleting your workspace is irreversible. Are you sure?"
+}
 
 export const WorkspacePage: React.FC = () => {
   const { workspace: workspaceQueryParam } = useParams()
@@ -32,17 +39,33 @@ export const WorkspacePage: React.FC = () => {
     return (
       <Margins>
         <Stack spacing={4}>
+          <>
           <Workspace
             workspace={workspace}
             handleStart={() => workspaceSend("START")}
             handleStop={() => workspaceSend("STOP")}
-            handleDelete={() => workspaceSend("DELETE")}
+            handleDelete={() => workspaceSend("ASK_DELETE")}
             handleUpdate={() => workspaceSend("UPDATE")}
             handleCancel={() => workspaceSend("CANCEL")}
             resources={resources}
             getResourcesError={getResourcesError instanceof Error ? getResourcesError : undefined}
             builds={builds}
           />
+      <ConfirmDialog
+        type="delete"
+        hideCancel={false}
+        open={workspaceState.matches({ ready: { build: "askingDelete" } })}
+        title={Language.deleteDialogTitle}
+        confirmText={Language.confirmDelete}
+        onConfirm={() => {
+          workspaceSend({ type: "DELETE" })
+        }}
+        onClose={() => {
+          workspaceSend({ type: "CANCEL_DELETE" })
+        }}
+        description={<>{Language.deleteDialogMessage}</>}
+      />
+          </>
         </Stack>
       </Margins>
     )

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -36,6 +36,7 @@ export const WorkspacePage: React.FC = () => {
             workspace={workspace}
             handleStart={() => workspaceSend("START")}
             handleStop={() => workspaceSend("STOP")}
+            handleDelete={() => workspaceSend("DELETE")}
             handleUpdate={() => workspaceSend("UPDATE")}
             handleCancel={() => workspaceSend("CANCEL")}
             resources={resources}

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -40,7 +40,9 @@ export type WorkspaceEvent =
   | { type: "GET_WORKSPACE"; workspaceId: string }
   | { type: "START" }
   | { type: "STOP" }
+  | { type: "ASK_DELETE" }
   | { type: "DELETE" }
+  | { type: "CANCEL_DELETE" }
   | { type: "UPDATE" }
   | { type: "CANCEL" }
   | { type: "LOAD_MORE_BUILDS" }
@@ -137,10 +139,16 @@ export const workspaceMachine = createMachine(
                 on: {
                   START: "requestingStart",
                   STOP: "requestingStop",
-                  DELETE: "requestingDelete",
+                  ASK_DELETE: "askingDelete",
                   UPDATE: "refreshingTemplate",
                   CANCEL: "requestingCancel",
                 },
+              },
+              askingDelete: {
+                on: {
+                  DELETE: "requestingDelete",
+                  CANCEL_DELETE: "idle"
+                }
               },
               requestingStart: {
                 entry: "clearBuildError",

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -147,8 +147,8 @@ export const workspaceMachine = createMachine(
               askingDelete: {
                 on: {
                   DELETE: "requestingDelete",
-                  CANCEL_DELETE: "idle"
-                }
+                  CANCEL_DELETE: "idle",
+                },
               },
               requestingStart: {
                 entry: "clearBuildError",


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
Closes #768 

I broke out the confirmation dialog so it can be in storybook.

I have it redirect to the workspaces page when you confirm deletion. The workspaces page doesn't poll I guess so you won't see the change happen there, but we can change that later. When deletion finishes, the workspace page doesn't get a workspace object with the property of being deleted, but an error, so redirection seemed like the way to go.