### PR TITLE
feat: port forwarding dropdown

### DIFF
--- a/agent/conn.go
+++ b/agent/conn.go
@@ -112,6 +112,17 @@ func (c *Conn) DialContext(ctx context.Context, network string, addr string) (ne
 	return channel.NetConn(), nil
 }
 
+// Netstat returns a connection that serves a list of listening ports.
+func (c *Conn) Netstat(ctx context.Context) (net.Conn, error) {
+	channel, err := c.CreateChannel(ctx, "netstat", &peer.ChannelOptions{
+		Protocol: ProtocolNetstat,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("netsat: %w", err)
+	}
+	return channel.NetConn(), nil
+}
+
 func (c *Conn) Close() error {
 	_ = c.Negotiator.DRPCConn().Close()
 	return c.Conn.Close()

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -285,6 +285,7 @@ func New(options *Options) *API {
 				r.Get("/", api.workspaceAgent)
 				r.Get("/dial", api.workspaceAgentDial)
 				r.Get("/turn", api.workspaceAgentTurn)
+				r.Get("/netstat", api.workspaceAgentNetstat)
 				r.Get("/pty", api.workspaceAgentPTY)
 				r.Get("/iceservers", api.workspaceAgentICEServers)
 			})

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -139,6 +139,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 		"GET:/api/v2/workspaceagents/{workspaceagent}":            {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/{workspaceagent}/dial":       {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/{workspaceagent}/iceservers": {NoAuthorize: true},
+		"GET:/api/v2/workspaceagents/{workspaceagent}/netstat":    {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/{workspaceagent}/pty":        {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/{workspaceagent}/turn":       {NoAuthorize: true},
 

--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,8 @@ require (
 	storj.io/drpc v0.0.30
 )
 
+require github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bytecodealliance/wasmtime-go v0.35.0 h1:VZjaZ0XOY0qp9TQfh0CQj9zl/AbdeXePVTALy8V1sKs=
 github.com/bytecodealliance/wasmtime-go v0.35.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=

--- a/site/src/api/types.ts
+++ b/site/src/api/types.ts
@@ -14,3 +14,14 @@ export interface ReconnectingPTYRequest {
 export type WorkspaceBuildTransition = "start" | "stop" | "delete"
 
 export type Message = { message: string }
+
+export interface NetstatPort {
+  name: string
+  port: number
+}
+
+export interface NetstatResponse {
+  readonly ports?: NetstatPort[]
+  readonly error?: string
+  readonly took?: number
+}

--- a/site/src/components/PortForwardDropdown/PortForwardDropdown.stories.tsx
+++ b/site/src/components/PortForwardDropdown/PortForwardDropdown.stories.tsx
@@ -1,0 +1,85 @@
+import { Story } from "@storybook/react"
+import React from "react"
+import { PortForwardDropdown, PortForwardDropdownProps } from "./PortForwardDropdown"
+
+export default {
+  title: "components/PortForwardDropdown",
+  component: PortForwardDropdown,
+}
+
+const Template: Story<PortForwardDropdownProps> = (args: PortForwardDropdownProps) => (
+  <PortForwardDropdown anchorEl={document.body} urlFormatter={urlFormatter} open {...args} />
+)
+
+const urlFormatter = (port: number | string): string => {
+  return `https://${port}--user--workspace.coder.com`
+}
+
+export const Error = Template.bind({})
+Error.args = {
+  netstat: {
+    error: "Unable to get listening ports",
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.args = {}
+
+export const None = Template.bind({})
+None.args = {
+  netstat: {
+    ports: [],
+  },
+}
+
+export const Excluded = Template.bind({})
+Excluded.args = {
+  netstat: {
+    ports: [
+      {
+        name: "sshd",
+        port: 22,
+      },
+    ],
+  },
+}
+
+export const Single = Template.bind({})
+Single.args = {
+  netstat: {
+    ports: [
+      {
+        name: "code-server",
+        port: 8080,
+      },
+    ],
+  },
+}
+
+export const Multiple = Template.bind({})
+Multiple.args = {
+  netstat: {
+    ports: [
+      {
+        name: "code-server",
+        port: 8080,
+      },
+      {
+        name: "coder",
+        port: 8000,
+      },
+      {
+        name: "coder",
+        port: 3000,
+      },
+      {
+        name: "node",
+        port: 8001,
+      },
+      {
+        name: "sshd",
+        port: 22,
+      },
+    ],
+  },
+}

--- a/site/src/components/PortForwardDropdown/PortForwardDropdown.test.tsx
+++ b/site/src/components/PortForwardDropdown/PortForwardDropdown.test.tsx
@@ -1,0 +1,33 @@
+import { screen } from "@testing-library/react"
+import React from "react"
+import { render } from "../../testHelpers/renderHelpers"
+import { Language, PortForwardDropdown } from "./PortForwardDropdown"
+
+const urlFormatter = (port: number | string): string => {
+  return `https://${port}--user--workspace.coder.com`
+}
+
+describe("PortForwardDropdown", () => {
+  it("skips known non-http ports", async () => {
+    // When
+    const netstat = {
+      ports: [
+        {
+          name: "sshd",
+          port: 22,
+        },
+        {
+          name: "code-server",
+          port: 8080,
+        },
+      ],
+    }
+    render(<PortForwardDropdown urlFormatter={urlFormatter} open netstat={netstat} anchorEl={document.body} />)
+
+    // Then
+    let portNameElement = await screen.queryByText(Language.portListing(22, "sshd"))
+    expect(portNameElement).toBeNull()
+    portNameElement = await screen.findByText(Language.portListing(8080, "code-server"))
+    expect(portNameElement).toBeDefined()
+  })
+})

--- a/site/src/components/PortForwardDropdown/PortForwardDropdown.tsx
+++ b/site/src/components/PortForwardDropdown/PortForwardDropdown.tsx
@@ -1,0 +1,162 @@
+import Button from "@material-ui/core/Button"
+import CircularProgress from "@material-ui/core/CircularProgress"
+import Link from "@material-ui/core/Link"
+import Popover, { PopoverProps } from "@material-ui/core/Popover"
+import { makeStyles } from "@material-ui/core/styles"
+import TextField from "@material-ui/core/TextField"
+import Typography from "@material-ui/core/Typography"
+import OpenInNewIcon from "@material-ui/icons/OpenInNew"
+import Alert from "@material-ui/lab/Alert"
+import React, { useState } from "react"
+import { NetstatPort, NetstatResponse } from "../../api/types"
+import { CodeExample } from "../CodeExample/CodeExample"
+import { Stack } from "../Stack/Stack"
+
+export const Language = {
+  title: "Port forward",
+  automaticPortText:
+    "Here are the applications we detected are listening on ports in this resource. Click to open them in a new tab.",
+  manualPortText:
+    "You can manually port forward this resource by typing the port and your username in the URL like below.",
+  formPortText: "Or you can use the following form to open the port in a new tab.",
+  portListing: (port: number, name: string): string => `${port} (${name})`,
+  portInputLabel: "Port",
+  formButtonText: "Open URL",
+}
+
+export type PortForwardDropdownProps = Pick<PopoverProps, "onClose" | "open" | "anchorEl"> & {
+  /**
+   * The netstat response to render.  Undefined is taken to mean "loading".
+   */
+  netstat?: NetstatResponse
+  /**
+   * Given a port return the URL for accessing that port.
+   */
+  urlFormatter: (port: number | string) => string
+}
+
+const portFilter = ({ port }: NetstatPort): boolean => {
+  if (port === 443 || port === 80) {
+    // These are standard HTTP ports.
+    return true
+  } else if (port <= 1023) {
+    // Assume a privileged port is probably not being used for HTTP.  This will
+    // catch things like sshd.
+    return false
+  }
+  return true
+}
+
+export const PortForwardDropdown: React.FC<PortForwardDropdownProps> = ({ netstat, open, urlFormatter, ...rest }) => {
+  const styles = useStyles()
+  const [port, setPort] = useState<number | string>(3000)
+  const ports = netstat?.ports?.filter(portFilter)
+
+  return (
+    <Popover
+      open={!!open}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "center",
+      }}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "center",
+      }}
+      {...rest}
+    >
+      <div className={styles.root}>
+        <Typography variant="h6" className={styles.title}>
+          {Language.title}
+        </Typography>
+
+        <Typography className={styles.paragraph}>{Language.automaticPortText}</Typography>
+
+        {typeof netstat === "undefined" && (
+          <div className={styles.loader}>
+            <CircularProgress size="1rem" />
+          </div>
+        )}
+
+        {netstat?.error && <Alert severity="error">{netstat.error}</Alert>}
+
+        {ports && ports.length > 0 && (
+          <div className={styles.ports}>
+            {ports.map(({ port, name }) => (
+              <Link className={styles.portLink} key={port} href={urlFormatter(port)} target="_blank">
+                <OpenInNewIcon />
+                {Language.portListing(port, name)}
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {ports && ports.length === 0 && <Alert severity="info">No HTTP ports were detected.</Alert>}
+
+        <Typography className={styles.paragraph}>{Language.manualPortText}</Typography>
+
+        <CodeExample code={urlFormatter(port)} />
+
+        <Typography className={styles.paragraph}>{Language.formPortText}</Typography>
+
+        <Stack direction="row">
+          <TextField
+            className={styles.textField}
+            onChange={(event) => setPort(event.target.value)}
+            value={port}
+            autoFocus
+            label={Language.portInputLabel}
+            variant="outlined"
+          />
+          <Button component={Link} href={urlFormatter(port)} target="_blank" className={styles.linkButton}>
+            {Language.formButtonText}
+          </Button>
+        </Stack>
+      </div>
+    </Popover>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: `${theme.spacing(3)}px`,
+    maxWidth: 500,
+  },
+  title: {
+    fontWeight: 600,
+  },
+  ports: {
+    margin: `${theme.spacing(2)}px 0`,
+  },
+  portLink: {
+    alignItems: "center",
+    color: theme.palette.text.secondary,
+    display: "flex",
+
+    "& svg": {
+      width: 16,
+      height: 16,
+      marginRight: theme.spacing(1.5),
+    },
+  },
+  loader: {
+    margin: `${theme.spacing(2)}px 0`,
+    textAlign: "center",
+  },
+  paragraph: {
+    color: theme.palette.text.secondary,
+    margin: `${theme.spacing(2)}px 0`,
+  },
+  textField: {
+    flex: 1,
+    margin: 0,
+  },
+  linkButton: {
+    color: "inherit",
+    flex: 1,
+
+    "&:hover": {
+      textDecoration: "none",
+    },
+  },
+}))

--- a/site/src/components/Resources/Resources.tsx
+++ b/site/src/components/Resources/Resources.tsx
@@ -1,18 +1,21 @@
+import Button from "@material-ui/core/Button"
 import { makeStyles, Theme } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import CompareArrowsIcon from "@material-ui/icons/CompareArrows"
 import useTheme from "@material-ui/styles/useTheme"
 import React from "react"
-import { Workspace, WorkspaceResource } from "../../api/typesGenerated"
+import { Workspace, WorkspaceAgent, WorkspaceResource } from "../../api/typesGenerated"
 import { getDisplayAgentStatus } from "../../util/workspace"
 import { TableHeaderRow } from "../TableHeaders/TableHeaders"
 import { TerminalLink } from "../TerminalLink/TerminalLink"
 import { WorkspaceSection } from "../WorkspaceSection/WorkspaceSection"
 
 const Language = {
+  portForwardLabel: "Port forward",
   resources: "Resources",
   resourceLabel: "Resource",
   agentsLabel: "Agents",
@@ -22,12 +25,18 @@ const Language = {
 }
 
 interface ResourcesProps {
+  handleOpenPortForward: (agent: WorkspaceAgent, anchorEl: HTMLElement) => void
   resources?: WorkspaceResource[]
   getResourcesError?: Error
   workspace: Workspace
 }
 
-export const Resources: React.FC<ResourcesProps> = ({ resources, getResourcesError, workspace }) => {
+export const Resources: React.FC<ResourcesProps> = ({
+  handleOpenPortForward,
+  resources,
+  getResourcesError,
+  workspace,
+}) => {
   const styles = useStyles()
   const theme: Theme = useTheme()
 
@@ -89,12 +98,22 @@ export const Resources: React.FC<ResourcesProps> = ({ resources, getResourcesErr
                     </TableCell>
                     <TableCell>
                       {agent.status === "connected" && (
-                        <TerminalLink
-                          className={styles.accessLink}
-                          workspaceName={workspace.name}
-                          agentName={agent.name}
-                          userName={workspace.owner_name}
-                        />
+                        <>
+                          <TerminalLink
+                            className={styles.accessLink}
+                            workspaceName={workspace.name}
+                            agentName={agent.name}
+                            userName={workspace.owner_name}
+                          />
+                          <Button
+                            variant="text"
+                            className={styles.accessLink}
+                            onClick={(event) => handleOpenPortForward(agent, event.currentTarget)}
+                          >
+                            <CompareArrowsIcon />
+                            {Language.portForwardLabel}
+                          </Button>
+                        </>
                       )}
                     </TableCell>
                   </TableRow>
@@ -134,9 +153,16 @@ const useStyles = makeStyles((theme) => ({
   },
 
   accessLink: {
+    alignItems: "center",
     color: theme.palette.text.secondary,
     display: "flex",
-    alignItems: "center",
+    border: 0,
+    padding: 0,
+
+    "&:hover": {
+      backgroundColor: "unset",
+      textDecoration: "underline",
+    },
 
     "& svg": {
       width: 16,

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -17,6 +17,7 @@ export interface WorkspaceProps {
   handleStop: () => void
   handleUpdate: () => void
   handleCancel: () => void
+  handleOpenPortForward: (agent: TypesGen.WorkspaceAgent, anchorEl: HTMLElement) => void
   workspace: TypesGen.Workspace
   resources?: TypesGen.WorkspaceResource[]
   getResourcesError?: Error
@@ -31,6 +32,7 @@ export const Workspace: React.FC<WorkspaceProps> = ({
   handleStop,
   handleUpdate,
   handleCancel,
+  handleOpenPortForward,
   workspace,
   resources,
   getResourcesError,
@@ -68,7 +70,12 @@ export const Workspace: React.FC<WorkspaceProps> = ({
 
           <WorkspaceStats workspace={workspace} />
 
-          <Resources resources={resources} getResourcesError={getResourcesError} workspace={workspace} />
+          <Resources
+            handleOpenPortForward={handleOpenPortForward}
+            resources={resources}
+            getResourcesError={getResourcesError}
+            workspace={workspace}
+          />
 
           <WorkspaceSection title="Timeline" contentsProps={{ className: styles.timelineContents }}>
             <BuildsTable builds={builds} className={styles.timelineTable} />

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -1,12 +1,14 @@
 import { useMachine } from "@xstate/react"
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 import { ErrorSummary } from "../../components/ErrorSummary/ErrorSummary"
 import { FullScreenLoader } from "../../components/Loader/FullScreenLoader"
 import { Margins } from "../../components/Margins/Margins"
+import { PortForwardDropdown } from "../../components/PortForwardDropdown/PortForwardDropdown"
 import { Stack } from "../../components/Stack/Stack"
 import { Workspace } from "../../components/Workspace/Workspace"
 import { firstOrItem } from "../../util/array"
+import { agentMachine } from "../../xServices/agent/agentXService"
 import { workspaceMachine } from "../../xServices/workspace/workspaceXService"
 
 export const WorkspacePage: React.FC = () => {
@@ -15,6 +17,10 @@ export const WorkspacePage: React.FC = () => {
 
   const [workspaceState, workspaceSend] = useMachine(workspaceMachine)
   const { workspace, resources, getWorkspaceError, getResourcesError, builds } = workspaceState.context
+
+  const [agentState, agentSend] = useMachine(agentMachine)
+  const { netstat } = agentState.context
+  const [portForwardAnchorEl, setPortForwardAnchorEl] = useState<HTMLElement>()
 
   /**
    * Get workspace, template, and organization on mount and whenever workspaceId changes.
@@ -38,9 +44,23 @@ export const WorkspacePage: React.FC = () => {
             handleStop={() => workspaceSend("STOP")}
             handleUpdate={() => workspaceSend("UPDATE")}
             handleCancel={() => workspaceSend("CANCEL")}
+            handleOpenPortForward={(agent, anchorEl) => {
+              agentSend("CONNECT", { agentId: agent.id })
+              setPortForwardAnchorEl(anchorEl)
+            }}
             resources={resources}
             getResourcesError={getResourcesError instanceof Error ? getResourcesError : undefined}
             builds={builds}
+          />
+          <PortForwardDropdown
+            open={!!portForwardAnchorEl}
+            anchorEl={portForwardAnchorEl}
+            netstat={netstat}
+            onClose={() => {
+              agentSend("DISCONNECT")
+              setPortForwardAnchorEl(undefined)
+            }}
+            urlFormatter={(port) => `${location.protocol}//${port}--${workspace.owner_name}--${location.host}`}
           />
         </Stack>
       </Margins>

--- a/site/src/util/error.test.ts
+++ b/site/src/util/error.test.ts
@@ -1,0 +1,20 @@
+import { errorString, Language } from "./error"
+
+describe("error", () => {
+  describe("errorStr", () => {
+    it("returns message if error", () => {
+      expect(errorString(new Error("foobar"))).toBe("foobar")
+    })
+    it("returns message if string", () => {
+      expect(errorString("bazzle")).toBe("bazzle")
+    })
+    it("returns message if undefined or empty", () => {
+      expect(errorString(undefined)).toBe(Language.noError)
+      expect(errorString("")).toBe(Language.noError)
+    })
+    it("returns message if anything else", () => {
+      expect(errorString({ qux: "fred" })).toBe(Language.unexpectedError)
+      expect(errorString({ qux: 1 })).toBe(Language.unexpectedError)
+    })
+  })
+})

--- a/site/src/util/error.ts
+++ b/site/src/util/error.ts
@@ -1,0 +1,20 @@
+export const Language = {
+  unexpectedError: "Unexpected error: see console for details",
+  noError: "No error provided",
+}
+
+/**
+ * Best effort to get a string from what could be an error or anything else.
+ */
+export const errorString = (error: Error | unknown): string | undefined => {
+  if (error instanceof Error) {
+    return error.message
+  } else if (typeof error === "string") {
+    return error || Language.noError
+  } else if (typeof error !== "undefined") {
+    console.warn(error)
+    return Language.unexpectedError
+  } else {
+    return Language.noError
+  }
+}

--- a/site/src/xServices/agent/agentXService.ts
+++ b/site/src/xServices/agent/agentXService.ts
@@ -1,0 +1,133 @@
+import { assign, createMachine } from "xstate"
+import * as Types from "../../api/types"
+import { errorString } from "../../util/error"
+
+export interface AgentContext {
+  agentId?: string
+  netstat?: Types.NetstatResponse
+  websocket?: WebSocket
+}
+
+export type AgentEvent =
+  | { type: "CONNECT"; agentId: string }
+  | { type: "STAT"; data: Types.NetstatResponse }
+  | { type: "DISCONNECT" }
+
+export const agentMachine = createMachine(
+  {
+    tsTypes: {} as import("./agentXService.typegen").Typegen0,
+    schema: {
+      context: {} as AgentContext,
+      events: {} as AgentEvent,
+      services: {} as {
+        connect: {
+          data: WebSocket
+        }
+      },
+    },
+    id: "agentState",
+    initial: "disconnected",
+    states: {
+      connecting: {
+        invoke: {
+          src: "connect",
+          id: "connect",
+          onDone: [
+            {
+              actions: ["assignWebsocket", "clearNetstat"],
+              target: "connected",
+            },
+          ],
+          onError: [
+            {
+              actions: "assignWebsocketError",
+              target: "disconnected",
+            },
+          ],
+        },
+      },
+      connected: {
+        on: {
+          STAT: {
+            actions: "assignNetstat",
+          },
+          DISCONNECT: {
+            actions: ["disconnect", "clearNetstat"],
+            target: "disconnected",
+          },
+        },
+      },
+      disconnected: {
+        on: {
+          CONNECT: {
+            actions: "assignConnection",
+            target: "connecting",
+          },
+        },
+      },
+    },
+  },
+  {
+    services: {
+      connect: (context) => (send) => {
+        return new Promise<WebSocket>((resolve, reject) => {
+          if (!context.agentId) {
+            return reject("agent ID is not set")
+          }
+          const proto = location.protocol === "https:" ? "wss:" : "ws:"
+          const socket = new WebSocket(`${proto}//${location.host}/api/v2/workspaceagents/${context.agentId}/netstat`)
+          socket.binaryType = "arraybuffer"
+          socket.addEventListener("open", () => {
+            resolve(socket)
+          })
+          socket.addEventListener("error", (error) => {
+            reject(error)
+          })
+          socket.addEventListener("close", () => {
+            send({
+              type: "DISCONNECT",
+            })
+          })
+          socket.addEventListener("message", (event) => {
+            try {
+              send({
+                type: "STAT",
+                data: JSON.parse(new TextDecoder().decode(event.data)),
+              })
+            } catch (error) {
+              send({
+                type: "STAT",
+                data: {
+                  error: errorString(error),
+                },
+              })
+            }
+          })
+        })
+      },
+    },
+    actions: {
+      assignConnection: assign((context, event) => ({
+        ...context,
+        agentId: event.agentId,
+      })),
+      assignWebsocket: assign({
+        websocket: (_, event) => event.data,
+      }),
+      assignWebsocketError: assign({
+        netstat: (_, event) => ({ error: errorString(event.data) }),
+      }),
+      clearNetstat: assign((context: AgentContext) => ({
+        ...context,
+        netstat: undefined,
+      })),
+      assignNetstat: assign({
+        netstat: (_, event) => event.data,
+      }),
+      disconnect: (context: AgentContext) => {
+        // Code 1000 is a successful exit!
+        context.websocket?.close(1000)
+      },
+    },
+  },
+)


### PR DESCRIPTION
What this does:

- Adds a web socket to the agent that scans for listening ports on an interval
- Displays those ports in a popup when you open said popup
- The popup also lets you manually open ports in case the detection is not working

Todo:

- [ ] Fails on darwin, I think because the `netstat` package does not support darwin.  Not sure how to fix this yet.
- [ ] Add comprehensive frontend test similar to the terminal test (only the individual parts are tested right now).
- [x] Probably need to filter out some ports like 22.
- [ ] Not sure if the proxy backend is built out yet so the ports link to a temporary non-working URL right now.

Closes #1624


https://user-images.githubusercontent.com/45609798/182719293-2e7c619a-d778-4f26-9620-4843c1fe7c52.mp4