### PR TITLE
fix: Open csp-images to allow external

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -101,7 +101,6 @@ func New(options *Options) *API {
 				Message: "Route not found.",
 			})
 		})
-
 		r.Use(
 			// Specific routes can specify smaller limits.
 			httpmw.RateLimitPerMinute(options.APIRateLimit),
@@ -112,6 +111,9 @@ func New(options *Options) *API {
 				Message: "👋",
 			})
 		})
+		// All CSP errors will be logged
+		r.Post("/csp/reports", api.logReportCSPViolations)
+
 		r.Route("/buildinfo", func(r chi.Router) {
 			r.Get("/", func(rw http.ResponseWriter, r *http.Request) {
 				httpapi.Write(rw, http.StatusOK, codersdk.BuildInfoResponse{

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -119,6 +119,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 		"POST:/api/v2/users/login":      {NoAuthorize: true},
 		"POST:/api/v2/users/logout":     {NoAuthorize: true},
 		"GET:/api/v2/users/authmethods": {NoAuthorize: true},
+		"POST:/api/v2/csp/reports":      {NoAuthorize: true},
 
 		// Has it's own auth
 		"GET:/api/v2/users/oauth2/github/callback": {NoAuthorize: true},

--- a/coderd/csp.go
+++ b/coderd/csp.go
@@ -1,0 +1,38 @@
+package coderd
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/coder/coder/coderd/httpapi"
+
+	"cdr.dev/slog"
+)
+
+type cspViolation struct {
+	Report map[string]interface{} `json:"csp-report"`
+}
+
+// logReportCSPViolations will log all reported csp violations.
+func (api *API) logReportCSPViolations(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var v cspViolation
+
+	dec := json.NewDecoder(r.Body)
+	err := dec.Decode(&v)
+	if err != nil {
+		api.Logger.Warn(ctx, "csp violation", slog.Error(err))
+		httpapi.Write(rw, http.StatusBadRequest, httpapi.Response{
+			Message: "failed to read body",
+		})
+		return
+	}
+
+	fields := make([]slog.Field, 0, len(v.Report))
+	for k, v := range v.Report {
+		fields = append(fields, slog.F(k, v))
+	}
+	api.Logger.Warn(ctx, "csp violation", fields...)
+
+	httpapi.Write(rw, http.StatusOK, "ok")
+}

--- a/site/embed.go
+++ b/site/embed.go
@@ -261,11 +261,14 @@ func secureHeaders(next http.Handler) http.Handler {
 		CSPDirectiveManifestSrc: {"'self' blob:"},
 		CSPDirectiveFrameSrc:    {"'self'"},
 		// data: for loading base64 encoded icons for generic applications.
-		CSPDirectiveImgSrc:     {"'self' https://cdn.coder.com data:"},
+		// https: allows loading images from external sources. This is not ideal
+		// 	but is required for the templates page that renders readmes.
+		//	We should find a better solution in the future.
+		CSPDirectiveImgSrc:     {"'self' https: https://cdn.coder.com data:"},
 		CSPDirectiveFormAction: {"'self'"},
 		CSPDirectiveMediaSrc:   {"'self'"},
 		// Report all violations back to the server to log
-		CSPDirectiveReportURI: {"/api/private/csp/reports"},
+		CSPDirectiveReportURI: {"/api/v2/csp/reports"},
 		CSPFrameAncestors:     {"'none'"},
 
 		// Only scripts can manipulate the dom. This prevents someone from


### PR DESCRIPTION
External images are required for the README parts of templates.
Only allowing https right now


![Screenshot from 2022-05-27 09-32-15](https://user-images.githubusercontent.com/5446298/170720983-e0c4493e-61d6-4d86-adb1-21840683e412.png)

