### PR TITLE
chore: clarify install options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There are a few ways to run Coder:
   ```
 
   > macOS and Windows users: You'll need to write your own 
-  > configuration to run as a system service.
+  > configuration to run Coder as a system service.
 
 - See the [installation guide](./docs/install.md) for additional ways to run Coder (e.g docker-compose)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ There are a few ways to run Coder:
   sudo service coder restart
   ```
 
-  > OSX and Windows: You'll need to write your own 
+  > macOS and Windows users: You'll need to write your own 
   > configuration to run as a system service.
 
 - See the [installation guide](./docs/install.md) for additional ways to run Coder (e.g docker-compose)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ CPU core and 2 GB RAM:
     mv coder /usr/local/bin 
     ```
 
-    Windows: see [this guide](https://answers.microsoft.com/en-us/windows/forum/all/adding-path-variable/97300613-20cb-4d85-8d0e-cc9d3549ba23) to add a folder to `PATH`
+    Windows: see [this guide](https://answers.microsoft.com/en-us/windows/forum/all/adding-path-variable/97300613-20cb-4d85-8d0e-cc9d3549ba23) on adding a folder to `PATH`
 
 There are a few ways to run Coder:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ CPU core and 2 GB RAM:
 
 There are a few ways to run Coder:
 
-- To run a **temporary deployment**, start with dev mode (all data is in-memory and is destroyed on exit):
+- To run a **temporary deployment**, start with dev mode (all data is in-memory and destroyed on exit):
 
   ```bash
   coder server --dev

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ CPU core and 2 GB RAM:
 1. Unzip the folder you just downloaded, and move the `coder` executable to a location that's on your `PATH`
 
     ```sh
-    # MacOS and Linux
+    # ex. MacOS and Linux
     mv coder /usr/local/bin 
     ```
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,18 @@ release](https://github.com/coder/coder/releases) on a system with at least 1
 CPU core and 2 GB RAM:
 
 1. Download the [release asset](https://github.com/coder/coder/releases) appropriate for your operating system
-1. Unzip the folder you just downloaded, and move the `coder` executable to a
-   location that's on your `PATH`
+1. Unzip the folder you just downloaded, and move the `coder` executable to a location that's on your `PATH`
 
-> Make sure you have the appropriate credentials for your cloud provider (e.g.,
-> access key ID and secret access key for AWS).
+    ```sh
+    # MacOS and Linux
+    mv coder /usr/local/bin 
+    ```
 
-You can set up a temporary deployment, a production deployment, or a system service:
+    Windows: see [this guide](https://answers.microsoft.com/en-us/windows/forum/all/adding-path-variable/97300613-20cb-4d85-8d0e-cc9d3549ba23) to add a folder to `PATH`
 
-- To set up a **temporary deployment**, start with dev mode (all data is in-memory and is
-  destroyed on exit):
+There are a few ways to run Coder:
+
+- To run a **temporary deployment**, start with dev mode (all data is in-memory and is destroyed on exit):
 
   ```bash
   coder server --dev
@@ -82,8 +84,7 @@ You can set up a temporary deployment, a production deployment, or a system serv
       coder server
   ```
 
-- To run as a **system service**, install with `.deb` (Debian, Ubuntu) or `.rpm`
-  (Fedora, CentOS, RHEL, SUSE):
+- To run as a **system service**, install with `.deb` (Debian, Ubuntu) or `.rpm` (Fedora, CentOS, RHEL, SUSE):
 
   ```bash
   # Edit the configuration!
@@ -91,10 +92,12 @@ You can set up a temporary deployment, a production deployment, or a system serv
   sudo service coder restart
   ```
 
-> Use `coder --help` to get a complete list of flags and environment
-> variables.
+  > OSX and Windows: You'll need to write your own 
+  > configuration to run as a system service.
 
-See the [installation guide](./docs/install.md) for additional ways to deploy Coder.
+- See the [installation guide](./docs/install.md) for additional ways to run Coder (e.g docker-compose)
+
+Use `coder --help` to get a complete list of flags and environment variables.
 
 ## Creating your first template and workspace
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ There are a few ways to run Coder:
   > macOS and Windows users: You'll need to write your own 
   > configuration to run Coder as a system service.
 
-- See the [installation guide](./docs/install.md) for additional ways to run Coder (e.g docker-compose)
+- See the [installation guide](./docs/install.md) for additional ways to run Coder (e.g., docker-compose)
 
 Use `coder --help` to get a complete list of flags and environment variables.
 


### PR DESCRIPTION
Fixes #1810 and documents a quick way to add vars to PATH, inspired by the `kubectx` package
