### PR TITLE
fix: add missing key to resource row

### DIFF
--- a/site/src/components/Resources/Resources.tsx
+++ b/site/src/components/Resources/Resources.tsx
@@ -57,7 +57,7 @@ export const Resources: React.FC<ResourcesProps> = ({ resources, getResourcesErr
                 }
                 if (!agent) {
                   return (
-                    <TableRow>
+                    <TableRow key={`${resource.id}-${agentIndex}`}>
                       <TableCell className={styles.resourceNameCell}>
                         {resource.name}
                         <span className={styles.resourceType}>{resource.type}</span>


### PR DESCRIPTION
This just clears out the React error complaining about this. 