### PR TITLE
fix: incomplete message when intercepting console logger

### DIFF
--- a/site/jest.setup.ts
+++ b/site/jest.setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom"
 import crypto from "crypto"
+import * as util from "util"
 import { server } from "./src/testHelpers/server"
 
 // Polyfill the getRandomValues that is used on utils/random.ts
@@ -43,8 +44,9 @@ CONSOLE_FAIL_TYPES.forEach((logType: string) => {
   // Suppressing the no-explicit-any to override certain console functions for testing
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const consoleAsAny = global.console as any
-  consoleAsAny[logType] = (message: string): void => {
-    throw new Error(`Failing due to console.${logType} while running test!\n\n${message}`)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  consoleAsAny[logType] = (format: string, ...args: any[]): void => {
+    throw new Error(`Failing due to console.${logType} while running test!\n\n${util.format(format, ...args)}`)
   }
 })
 


### PR DESCRIPTION
I was getting a message like "Warning: Failed type %s: %s%s".