### PR TITLE
chore: executor_test: reduce test execution time

### DIFF
--- a/coderd/autobuild/executor/lifecycle_executor.go
+++ b/coderd/autobuild/executor/lifecycle_executor.go
@@ -21,11 +21,11 @@ type Executor struct {
 	db      database.Store
 	log     slog.Logger
 	tick    <-chan time.Time
-	statsCh chan<- RunStats
+	statsCh chan<- Stats
 }
 
-// RunStats contains information about one run of Executor.
-type RunStats struct {
+// Stats contains information about one run of Executor.
+type Stats struct {
 	Transitions map[uuid.UUID]database.WorkspaceTransition
 	Elapsed     time.Duration
 	Error       error
@@ -44,7 +44,7 @@ func New(ctx context.Context, db database.Store, log slog.Logger, tick <-chan ti
 
 // WithStatsChannel will cause Executor to push a RunStats to ch after
 // every tick.
-func (e *Executor) WithStatsChannel(ch chan<- RunStats) *Executor {
+func (e *Executor) WithStatsChannel(ch chan<- Stats) *Executor {
 	e.statsCh = ch
 	return e
 }
@@ -67,9 +67,9 @@ func (e *Executor) Run() {
 	}()
 }
 
-func (e *Executor) runOnce(t time.Time) RunStats {
+func (e *Executor) runOnce(t time.Time) Stats {
 	var err error
-	stats := RunStats{
+	stats := Stats{
 		Transitions: make(map[uuid.UUID]database.WorkspaceTransition),
 	}
 	defer func() {

--- a/coderd/autobuild/executor/lifecycle_executor.go
+++ b/coderd/autobuild/executor/lifecycle_executor.go
@@ -17,10 +17,18 @@ import (
 
 // Executor automatically starts or stops workspaces.
 type Executor struct {
-	ctx  context.Context
-	db   database.Store
-	log  slog.Logger
-	tick <-chan time.Time
+	ctx     context.Context
+	db      database.Store
+	log     slog.Logger
+	tick    <-chan time.Time
+	statsCh chan<- RunStats
+}
+
+// RunStats contains information about one run of Executor.
+type RunStats struct {
+	Transitions map[uuid.UUID]database.WorkspaceTransition
+	Elapsed     time.Duration
+	Error       error
 }
 
 // New returns a new autobuild executor.
@@ -34,22 +42,42 @@ func New(ctx context.Context, db database.Store, log slog.Logger, tick <-chan ti
 	return le
 }
 
+// WithStatsChannel will cause Executor to push a RunStats to ch after
+// every tick.
+func (e *Executor) WithStatsChannel(ch chan<- RunStats) *Executor {
+	e.statsCh = ch
+	return e
+}
+
 // Run will cause executor to start or stop workspaces on every
 // tick from its channel. It will stop when its context is Done, or when
 // its channel is closed.
 func (e *Executor) Run() {
 	go func() {
 		for t := range e.tick {
-			if err := e.runOnce(t); err != nil {
-				e.log.Error(e.ctx, "error running once", slog.Error(err))
+			stats := e.runOnce(t)
+			if stats.Error != nil {
+				e.log.Error(e.ctx, "error running once", slog.Error(stats.Error))
 			}
+			if e.statsCh != nil {
+				e.statsCh <- stats
+			}
+			e.log.Debug(e.ctx, "run stats", slog.F("elapsed", stats.Elapsed), slog.F("transitions", stats.Transitions))
 		}
 	}()
 }
 
-func (e *Executor) runOnce(t time.Time) error {
+func (e *Executor) runOnce(t time.Time) RunStats {
+	var err error
+	stats := RunStats{
+		Transitions: make(map[uuid.UUID]database.WorkspaceTransition),
+	}
+	defer func() {
+		stats.Elapsed = time.Since(t)
+		stats.Error = err
+	}()
 	currentTick := t.Truncate(time.Minute)
-	return e.db.InTx(func(db database.Store) error {
+	err = e.db.InTx(func(db database.Store) error {
 		// TTL is set at the workspace level, and deadline at the workspace build level.
 		// When a workspace build is created, its deadline initially starts at zero.
 		// When provisionerd successfully completes a provision job, the deadline is
@@ -146,6 +174,7 @@ func (e *Executor) runOnce(t time.Time) error {
 				slog.F("transition", validTransition),
 			)
 
+			stats.Transitions[ws.ID] = validTransition
 			if err := build(e.ctx, db, ws, validTransition, priorHistory, priorJob); err != nil {
 				e.log.Error(e.ctx, "unable to transition workspace",
 					slog.F("workspace_id", ws.ID),
@@ -156,6 +185,7 @@ func (e *Executor) runOnce(t time.Time) error {
 		}
 		return nil
 	})
+	return stats
 }
 
 // TODO(cian): this function duplicates most of api.postWorkspaceBuilds. Refactor.

--- a/coderd/autobuild/executor/lifecycle_executor_test.go
+++ b/coderd/autobuild/executor/lifecycle_executor_test.go
@@ -503,6 +503,7 @@ func mustTransitionWorkspace(t *testing.T, client *codersdk.Client, workspaceID 
 }
 
 func mustWorkspace(t *testing.T, client *codersdk.Client, workspaceID uuid.UUID) codersdk.Workspace {
+	t.Helper()
 	ctx := context.Background()
 	ws, err := client.Workspace(ctx, workspaceID)
 	if err != nil && strings.Contains(err.Error(), "status code 410") {
@@ -513,6 +514,7 @@ func mustWorkspace(t *testing.T, client *codersdk.Client, workspaceID uuid.UUID)
 }
 
 func assertLatestTransitionWithEventualBuild(t *testing.T, client *codersdk.Client, workspace codersdk.Workspace, expected codersdk.WorkspaceTransition) {
+	t.Helper()
 	assert.Eventually(t, func() bool {
 		ws := mustWorkspace(t, client, workspace.ID)
 		if ws.LatestBuild.ID == workspace.LatestBuild.ID {
@@ -523,10 +525,11 @@ func assertLatestTransitionWithEventualBuild(t *testing.T, client *codersdk.Clie
 		}
 		// At this point a build has happened. Is it what we want?
 		return assert.Equal(t, expected, ws.LatestBuild.Transition)
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 3*time.Second, 25*time.Millisecond)
 }
 
 func assertLatestTransitionWithNoEventualBuild(t *testing.T, client *codersdk.Client, workspace codersdk.Workspace, expected codersdk.WorkspaceTransition) {
+	t.Helper()
 	assert.Never(t, func() bool {
 		ws := mustWorkspace(t, client, workspace.ID)
 		if ws.LatestBuild.ID == workspace.LatestBuild.ID {
@@ -537,7 +540,7 @@ func assertLatestTransitionWithNoEventualBuild(t *testing.T, client *codersdk.Cl
 		}
 		// At this point a build should not have happened. Is the state still as expected?
 		return assert.Equal(t, expected, ws.LatestBuild.Transition)
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 3*time.Second, 25*time.Millisecond)
 }
 
 func TestMain(m *testing.M) {

--- a/coderd/autobuild/executor/lifecycle_executor_test.go
+++ b/coderd/autobuild/executor/lifecycle_executor_test.go
@@ -28,11 +28,11 @@ func TestExecutorAutostartOK(t *testing.T) {
 		ctx     = context.Background()
 		err     error
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -68,11 +68,11 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 		ctx     = context.Background()
 		err     error
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -121,11 +121,11 @@ func TestExecutorAutostartAlreadyRunning(t *testing.T) {
 		ctx     = context.Background()
 		err     error
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -158,11 +158,11 @@ func TestExecutorAutostartNotEnabled(t *testing.T) {
 
 	var (
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -193,11 +193,11 @@ func TestExecutorAutostopOK(t *testing.T) {
 
 	var (
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -226,11 +226,11 @@ func TestExecutorAutostopExtend(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace        = mustProvisionWorkspace(t, client)
@@ -276,11 +276,11 @@ func TestExecutorAutostopAlreadyStopped(t *testing.T) {
 
 	var (
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace (disabling autostart)
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -308,11 +308,11 @@ func TestExecutorAutostopNotEnabled(t *testing.T) {
 
 	var (
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace that has no TTL set
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -345,11 +345,11 @@ func TestExecutorWorkspaceDeleted(t *testing.T) {
 		ctx     = context.Background()
 		err     error
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -384,11 +384,11 @@ func TestExecutorWorkspaceAutostartTooEarly(t *testing.T) {
 		ctx     = context.Background()
 		err     error
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		futureTime     = time.Now().Add(time.Hour)
 		futureTimeCron = fmt.Sprintf("%d %d * * *", futureTime.Minute(), futureTime.Hour())
@@ -422,11 +422,11 @@ func TestExecutorWorkspaceAutostopBeforeDeadline(t *testing.T) {
 
 	var (
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -450,11 +450,11 @@ func TestExecutorWorkspaceAutostopNoWaitChangedMyMind(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		tickCh  = make(chan time.Time)
-		statsCh = make(chan executor.RunStats)
+		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -488,17 +488,17 @@ func TestExecutorAutostartMultipleOK(t *testing.T) {
 	var (
 		tickCh   = make(chan time.Time)
 		tickCh2  = make(chan time.Time)
-		statsCh1 = make(chan executor.RunStats)
-		statsCh2 = make(chan executor.RunStats)
+		statsCh1 = make(chan executor.Stats)
+		statsCh2 = make(chan executor.Stats)
 		client   = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh1,
+			AutobuildTicker:     tickCh,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh1,
 		})
 		_ = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:       tickCh2,
-			IncludeProvisionerD:   true,
-			AutobuildStatsChannel: statsCh2,
+			AutobuildTicker:     tickCh2,
+			IncludeProvisionerD: true,
+			AutobuildStats:      statsCh2,
 		})
 		// Given: we have a user with a workspace that has autostart enabled (default)
 		workspace = mustProvisionWorkspace(t, client)

--- a/coderd/autobuild/executor/lifecycle_executor_test.go
+++ b/coderd/autobuild/executor/lifecycle_executor_test.go
@@ -515,6 +515,7 @@ func mustWorkspace(t *testing.T, client *codersdk.Client, workspaceID uuid.UUID)
 
 func assertLatestTransitionWithEventualBuild(t *testing.T, client *codersdk.Client, workspace codersdk.Workspace, expected codersdk.WorkspaceTransition) {
 	t.Helper()
+	// assert.Eventually appears to have concurrency issues
 	assert.Eventually(t, func() bool {
 		ws := mustWorkspace(t, client, workspace.ID)
 		if ws.LatestBuild.ID == workspace.LatestBuild.ID {
@@ -524,7 +525,8 @@ func assertLatestTransitionWithEventualBuild(t *testing.T, client *codersdk.Clie
 			return false
 		}
 		// At this point a build has happened. Is it what we want?
-		return assert.Equal(t, expected, ws.LatestBuild.Transition)
+		// return assert.Equal(t, expected, ws.LatestBuild.Transition)
+		return expected == ws.LatestBuild.Transition
 	}, 3*time.Second, 25*time.Millisecond)
 }
 
@@ -539,7 +541,8 @@ func assertLatestTransitionWithNoEventualBuild(t *testing.T, client *codersdk.Cl
 			return false
 		}
 		// At this point a build should not have happened. Is the state still as expected?
-		return assert.Equal(t, expected, ws.LatestBuild.Transition)
+		// return assert.Equal(t, expected, ws.LatestBuild.Transition)
+		return expected == ws.LatestBuild.Transition
 	}, 3*time.Second, 25*time.Millisecond)
 }
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -56,15 +56,15 @@ import (
 )
 
 type Options struct {
-	AWSCertificates       awsidentity.Certificates
-	Authorizer            rbac.Authorizer
-	AzureCertificates     x509.VerifyOptions
-	GithubOAuth2Config    *coderd.GithubOAuth2Config
-	GoogleTokenValidator  *idtoken.Validator
-	SSHKeygenAlgorithm    gitsshkey.Algorithm
-	APIRateLimit          int
-	AutobuildTicker       <-chan time.Time
-	AutobuildStatsChannel chan<- executor.RunStats
+	AWSCertificates      awsidentity.Certificates
+	Authorizer           rbac.Authorizer
+	AzureCertificates    x509.VerifyOptions
+	GithubOAuth2Config   *coderd.GithubOAuth2Config
+	GoogleTokenValidator *idtoken.Validator
+	SSHKeygenAlgorithm   gitsshkey.Algorithm
+	APIRateLimit         int
+	AutobuildTicker      <-chan time.Time
+	AutobuildStats       chan<- executor.Stats
 
 	// IncludeProvisionerD when true means to start an in-memory provisionerD
 	IncludeProvisionerD bool
@@ -93,9 +93,9 @@ func NewWithAPI(t *testing.T, options *Options) (*codersdk.Client, *coderd.API) 
 		options.AutobuildTicker = ticker
 		t.Cleanup(func() { close(ticker) })
 	}
-	if options.AutobuildStatsChannel != nil {
+	if options.AutobuildStats != nil {
 		t.Cleanup(func() {
-			close(options.AutobuildStatsChannel)
+			close(options.AutobuildStats)
 		})
 	}
 
@@ -128,7 +128,7 @@ func NewWithAPI(t *testing.T, options *Options) (*codersdk.Client, *coderd.API) 
 		db,
 		slogtest.Make(t, nil).Named("autobuild.executor").Leveled(slog.LevelDebug),
 		options.AutobuildTicker,
-	).WithStatsChannel(options.AutobuildStatsChannel)
+	).WithStatsChannel(options.AutobuildStats)
 	lifecycleExecutor.Run()
 
 	srv := httptest.NewUnstartedServer(nil)


### PR DESCRIPTION
This PR removes 5-second wait in `autobuild.executor` unit tests (now approx. 1.6s on my machine):
* Adds a write-only channel to Executor and plumbs through to unit tests
* Modifies `runOnce` to return an `executor.RunStats` struct and write to `statsCh` if not nil

Closes https://github.com/coder/coder/issues/1859