### PR TITLE
chore: Ignore scripts from code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -29,6 +29,6 @@ ignore:
   - peerbroker/proto
   - provisionerd/proto
   - provisionersdk/proto
-  - scripts/datadog-cireport
+  - scripts
   - site/.storybook
   - rules.go


### PR DESCRIPTION
Our CI scripts don't need to have thorough tests, and aren't
in the hot path of the product.
