### PR TITLE
example: docker: support Windows hosts

### DIFF
--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -38,9 +38,20 @@ variable "step2_arch" {
   }
   sensitive = true
 }
+variable "step3_OS" {
+  description = <<-EOF
+  What operating system is your Coder host on?
+  EOF
+
+  validation {
+    condition     = contains(["MacOS", "Windows", "Linux"], var.step3_OS)
+    error_message = "Value must be MacOS, Windows, or Linux."
+  }
+  sensitive = true
+}
 
 provider "docker" {
-  host = "unix:///var/run/docker.sock"
+  host = var.step3_OS == "Windows" ? "npipe:////.//pipe//docker_engine" : "unix:///var/run/docker.sock"
 }
 
 provider "coder" {

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -32,7 +32,7 @@ variable "step1_docker_host_warning" {
 }
 variable "step2_arch" {
   description = <<-EOF
-  arch: What archicture is your Docker host on?
+  arch: What architecture is your Docker host on?
 
   note: codercom/enterprise-* images are only built for amd64
   EOF

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -17,8 +17,6 @@ terraform {
 # host on the "docker" provider below.
 variable "step1_docker_host_warning" {
   description = <<-EOF
-  Is Docker running on the Coder host?
-
   This template will use the Docker socket present on
   the Coder host, which is not necessarily your local machine.
 
@@ -34,7 +32,7 @@ variable "step1_docker_host_warning" {
 }
 variable "step2_arch" {
   description = <<-EOF
-  arch: What architecture is your Docker host on?
+  arch: What archicture is your Docker host on?
 
   note: codercom/enterprise-* images are only built for amd64
   EOF
@@ -45,10 +43,22 @@ variable "step2_arch" {
   }
   sensitive = true
 }
+variable "step3_OS" {
+  description = <<-EOF
+  What operating system is your Coder host on?
+  EOF
+
+  validation {
+    condition     = contains(["MacOS", "Windows", "Linux"], var.step3_OS)
+    error_message = "Value must be MacOS, Windows, or Linux."
+  }
+  sensitive = true
+}
 
 provider "docker" {
-  host = "unix:///var/run/docker.sock"
+  host = var.step3_OS == "Windows" ? "npipe:////.//pipe//docker_engine" : "unix:///var/run/docker.sock"
 }
+
 provider "coder" {
 }
 


### PR DESCRIPTION
This adds support for using the Docker example on WIndows, as long as Docker is installed, of course. Works for both WSL and Hyper-V versions of Docker Desktop.

See: https://github.com/hashicorp/terraform-provider-docker/issues/180#issuecomment-594680623. 

Alternatives:
- Use a [Terraform exec hack](https://aws-blog.de/2021/05/terraform-os-detection.html) to detect the OS automatically
    - Downside: added complexity to template, less clear what behavior is
- #1879 (no steps required for Docker provider)

Closes #1789