### PR TITLE
example: added hetzner cloud workspace

### DIFF
--- a/examples/hetzner-linux/README.md
+++ b/examples/hetzner-linux/README.md
@@ -1,0 +1,5 @@
+---
+name: Develop in Linux on Hetzner Cloud
+description: Get started with Linux development on Hetzner Cloud.
+tags: [cloud, hetzner]
+---

--- a/examples/hetzner-linux/cloud-config.yaml.tftpl
+++ b/examples/hetzner-linux/cloud-config.yaml.tftpl
@@ -1,0 +1,46 @@
+#cloud-config
+users:
+  - name: ${username}
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    groups: sudo
+    shell: /bin/bash
+packages:
+  - git
+mounts:
+  - [
+      "${volume_path}",
+      "/home/${username}",
+      ext4,
+      "discard,defaults",
+    ]
+write_files:
+  - path: /opt/coder/init
+    permissions: "0755"
+    encoding: b64
+    content: ${init_script}
+  - path: /etc/systemd/system/coder-agent.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Coder Agent
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      User=${username}
+      ExecStart=/opt/coder/init
+      Environment=CODER_AGENT_TOKEN=${coder_agent_token}
+      Restart=always
+      RestartSec=10
+      TimeoutStopSec=90
+      KillMode=process
+
+      OOMScoreAdjust=-900
+      SyslogIdentifier=coder-agent
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - chown ${username}:${username} /home/${username}
+  - systemctl enable coder-agent
+  - systemctl start coder-agent

--- a/examples/hetzner-linux/cloud-config.yaml.tftpl
+++ b/examples/hetzner-linux/cloud-config.yaml.tftpl
@@ -6,6 +6,8 @@ users:
     shell: /bin/bash
 packages:
   - git
+  - curl
+  - jq
 mounts:
   - [
       "${volume_path}",
@@ -40,7 +42,31 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+%{ if code_server_setup ~}
+  - path: /tmp/install_code_server.sh
+    permissions: "0777"
+    content: |
+      #!/bin/bash
+      CODE_SERVER_DOWNLOAD_URL=$(curl -sL https://api.github.com/repos/coder/code-server/releases/latest | jq -r '.assets[].browser_download_url' | grep "amd64.deb")
+      curl -fL $CODE_SERVER_DOWNLOAD_URL -o /tmp/code_server.deb
+      dpkg -i /tmp/code_server.deb
+      systemctl enable --now code-server@${username}
+      rm /tmp/code_server.deb
+  - path: /tmp/install_code_server.sh
+    permissions: "0777"
+    content: |
+  - path: /home/${username}/.config/code-server/config.yaml
+    permissions: "0644"
+    content: |
+      bind-addr: 127.0.0.1:8080
+      auth: none
+      cert: false
+%{ endif ~}
 runcmd:
   - chown ${username}:${username} /home/${username}
   - systemctl enable coder-agent
   - systemctl start coder-agent
+%{ if code_server_setup ~}
+  - /tmp/install_code_server.sh
+  - rm /tmp/install_code_server.sh
+%{ endif }

--- a/examples/hetzner-linux/main.tf
+++ b/examples/hetzner-linux/main.tf
@@ -1,0 +1,120 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "0.4.2"
+    }
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "1.33.2"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+provider "coder" {
+}
+
+variable "hcloud_token" {
+  description = <<EOF
+Coder requires a Hetzner Cloud token to provision workspaces.
+EOF
+  sensitive   = true
+  validation {
+    condition     = length(var.hcloud_token) == 64
+    error_message = "Please provide a valid Hetzner Cloud API token."
+  }
+}
+
+variable "instance_location" {
+  description = "What region should your workspace live in?"
+  default     = "nbg1"
+  validation {
+    condition     = contains(["nbg1", "fsn1", "hel1"], var.instance_location)
+    error_message = "Invalid zone!"
+  }
+}
+
+variable "instance_type" {
+  description = "What instance type should your workspace use?"
+  default     = "cx11"
+  validation {
+    condition     = contains(["cx11", "cx21", "cx31", "cx41", "cx51"], var.instance_type)
+    error_message = "Invalid instance type!"
+  }
+}
+
+variable "instance_os" {
+  description = "Which operating system should your workspace use?"
+  default     = "ubuntu-20.04"
+  validation {
+    condition     = contains(["ubuntu-22.04","ubuntu-20.04", "ubuntu-18.04", "debian-11", "debian-10", "fedora-35"], var.instance_os)
+    error_message = "Invalid OS!"
+  }
+}
+
+variable "volume_size" {
+  description = "How much storage space do you need?"
+  default     = "50"
+  validation {
+    condition     = contains(["50","100","150"], var.volume_size)
+    error_message = "Invalid volume size!"
+  }
+}
+
+data "coder_workspace" "me" {
+}
+
+resource "coder_agent" "dev" {
+  arch = "amd64"
+  os   = "linux"
+}
+
+resource "hcloud_server" "root" {
+  count = data.coder_workspace.me.start_count
+  name        = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  server_type = var.instance_type
+  location    = var.instance_location
+  image       = var.instance_os
+  user_data = templatefile("cloud-config.yaml.tftpl", {
+    username          = data.coder_workspace.me.owner
+    volume_path       = "/dev/disk/by-id/scsi-0HC_Volume_${hcloud_volume.root.id}"
+    init_script       = base64encode(coder_agent.dev.init_script)
+    coder_agent_token = coder_agent.dev.token
+  })
+}
+
+resource "hcloud_volume" "root" {
+  name         = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  size         = var.volume_size
+  format       = "ext4"
+  location     = var.instance_location
+}
+
+resource "hcloud_volume_attachment" "root" {
+  count     = data.coder_workspace.me.start_count
+  volume_id = hcloud_volume.root.id
+  server_id = hcloud_server.root[count.index].id
+  automount = false
+}
+
+resource "hcloud_firewall" "root" {
+  name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  rule {
+    direction = "in"
+    protocol  = "icmp"
+    source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+    ]
+  }
+}
+
+resource "hcloud_firewall_attachment" "root_fw_attach" {
+    count = data.coder_workspace.me.start_count
+    firewall_id = hcloud_firewall.root.id
+    server_ids  = [hcloud_server.root[count.index].id]
+}

--- a/examples/hetzner-linux/main.tf
+++ b/examples/hetzner-linux/main.tf
@@ -51,7 +51,7 @@ variable "instance_os" {
   description = "Which operating system should your workspace use?"
   default     = "ubuntu-20.04"
   validation {
-    condition     = contains(["ubuntu-22.04","ubuntu-20.04", "ubuntu-18.04", "debian-11", "debian-10", "fedora-35"], var.instance_os)
+    condition     = contains(["ubuntu-22.04","ubuntu-20.04", "ubuntu-18.04", "debian-11", "debian-10"], var.instance_os)
     error_message = "Invalid OS!"
   }
 }


### PR DESCRIPTION
This PR adds an example for [Hetzner Cloud](https://hetzner.com/).
The general idea is to let the user create a cloud instance and mount a persistent volume to it. And when the workspace is stopped to unmount the volume and delete the instance to save costs (only the volume will be paid during the stopped time).

In summary this template does:
- Creates a Hetzner Cloud instance
- Create a Hetzner Cloud volume
- Create a default block inbound firewall policy
- Add volumes and firewall policy to the instance
- Ask the user if code-server should be installed and if so installs it

Note: I had to create a new PR because the fork relation of my fork from #1044 broke.
