### PR TITLE
fix: coderd: dev mode should show verbose output by default

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/coder/coder/buildinfo"
 	"github.com/coder/coder/provisioner/echo"
 
 	"github.com/briandowns/spinner"
@@ -29,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"
 	xgithub "golang.org/x/oauth2/github"
 	"golang.org/x/xerrors"
@@ -98,7 +100,8 @@ func server() *cobra.Command {
 		Short: "Start a Coder server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := slog.Make(sloghuman.Sink(os.Stderr))
-			if verbose || dev {
+			buildModeDev := semver.Prerelease(buildinfo.Version()) == "-devel"
+			if verbose || buildModeDev {
 				logger = logger.Leveled(slog.LevelDebug)
 			}
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -98,7 +98,7 @@ func server() *cobra.Command {
 		Short: "Start a Coder server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := slog.Make(sloghuman.Sink(os.Stderr))
-			if verbose {
+			if verbose || dev {
 				logger = logger.Leveled(slog.LevelDebug)
 			}
 


### PR DESCRIPTION
This fixes a pet peeve of mine -- development mode should show verbose output by default.

EDIT: Per Kyle's suggestion, only doing this if buildmode is dev.