### PR TITLE
feat: enforce min and max bounds on workspace TTL and Deadline

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -605,36 +605,29 @@ func (api *API) putExtendWorkspace(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var code = http.StatusOK
+	code := http.StatusOK
+	resp := httpapi.Response{}
 
 	err := api.Database.InTx(func(s database.Store) error {
 		build, err := s.GetLatestWorkspaceBuildByWorkspaceID(r.Context(), workspace.ID)
 		if err != nil {
 			code = http.StatusInternalServerError
+			resp.Message = "workspace not found"
 			return xerrors.Errorf("get latest workspace build: %w", err)
 		}
 
 		if build.Transition != database.WorkspaceTransitionStart {
 			code = http.StatusConflict
+			resp.Message = "workspace must be started, current status: " + string(build.Transition)
 			return xerrors.Errorf("workspace must be started, current status: %s", build.Transition)
 		}
 
 		newDeadline := req.Deadline.UTC()
-		if newDeadline.IsZero() {
-			// This should not be possible because the struct validation field enforces a non-zero value.
+		if err := validWorkspaceDeadline(build.Deadline, newDeadline); err != nil {
 			code = http.StatusBadRequest
-			return xerrors.New("new deadline cannot be zero")
-		}
-
-		if newDeadline.Before(build.Deadline) || newDeadline.Before(time.Now()) {
-			code = http.StatusBadRequest
-			return xerrors.Errorf("new deadline %q must be after existing deadline %q", newDeadline.Format(time.RFC3339), build.Deadline.Format(time.RFC3339))
-		}
-
-		// Disallow updates within less than one minute
-		if withinDuration(newDeadline, build.Deadline, time.Minute) {
-			code = http.StatusNotModified
-			return nil
+			resp.Message = "bad extend workspace request"
+			resp.Errors = append(resp.Errors, httpapi.Error{Field: "deadline", Detail: err.Error()})
+			return err
 		}
 
 		if err := s.UpdateWorkspaceBuildByID(r.Context(), database.UpdateWorkspaceBuildByIDParams{
@@ -643,15 +636,17 @@ func (api *API) putExtendWorkspace(rw http.ResponseWriter, r *http.Request) {
 			ProvisionerState: build.ProvisionerState,
 			Deadline:         newDeadline,
 		}); err != nil {
+			code = http.StatusInternalServerError
+			resp.Message = "failed to extend workspace deadline"
 			return xerrors.Errorf("update workspace build: %w", err)
 		}
+		resp.Message = "deadline updated to " + newDeadline.Format(time.RFC3339)
 
 		return nil
 	})
 
-	var resp = httpapi.Response{}
 	if err != nil {
-		resp.Message = err.Error()
+		api.Logger.Info(r.Context(), "extending workspace", slog.Error(err))
 	}
 	httpapi.Write(rw, code, resp)
 }
@@ -865,15 +860,6 @@ func convertSQLNullInt64(i sql.NullInt64) *time.Duration {
 	return (*time.Duration)(&i.Int64)
 }
 
-func withinDuration(t1, t2 time.Time, d time.Duration) bool {
-	dt := t1.Sub(t2)
-	if dt < -d || dt > d {
-		return false
-	}
-
-	return true
-}
-
 func validWorkspaceTTL(ttl *time.Duration) (sql.NullInt64, error) {
 	if ttl == nil {
 		return sql.NullInt64{}, nil
@@ -892,4 +878,26 @@ func validWorkspaceTTL(ttl *time.Duration) (sql.NullInt64, error) {
 		Valid: true,
 		Int64: int64(truncated),
 	}, nil
+}
+
+func validWorkspaceDeadline(old, new time.Time) error {
+	if old.IsZero() {
+		return xerrors.New("nothing to do: no existing deadline set")
+	}
+
+	now := time.Now()
+	if new.Before(now) {
+		return xerrors.New("new deadline must be in the future")
+	}
+
+	delta := new.Sub(old)
+	if delta < time.Minute {
+		return xerrors.New("minimum extension is one minute")
+	}
+
+	if delta > 24*time.Hour {
+		return xerrors.New("maximum extension is 24 hours")
+	}
+
+	return nil
 }

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -715,7 +715,13 @@ func TestWorkspaceExtend(t *testing.T) {
 	err = client.PutExtendWorkspace(ctx, workspace.ID, codersdk.PutExtendWorkspaceRequest{
 		Deadline: oldDeadline,
 	})
-	require.ErrorContains(t, err, "must be after existing deadline", "setting an earlier deadline should fail")
+	require.ErrorContains(t, err, "deadline: minimum extension is one minute", "setting an earlier deadline should fail")
+
+	// Updating with a time far in the future should also fail
+	err = client.PutExtendWorkspace(ctx, workspace.ID, codersdk.PutExtendWorkspaceRequest{
+		Deadline: oldDeadline.AddDate(1, 0, 0),
+	})
+	require.ErrorContains(t, err, "deadline: maximum extension is 24 hours", "setting an earlier deadline should fail")
 
 	// Ensure deadline still set correctly
 	updated, err = client.Workspace(ctx, workspace.ID)


### PR DESCRIPTION
This adds enforcement for both workspace TTL and deadline:
* Workspace TTL must be at least one minute and at most 7 days
* Delta between requested workspace deadline and now must be positive, at lest one minute, and at most 24 hours.

**NOTE:** These upper bounds are chosen arbitrarily; then can be changed later. The main takeaway here is that it is easier to *modify* an existing upper bound than it is to add a new one.

Closes https://github.com/coder/coder/issues/1758