### PR TITLE
fix: derive running ws stop time from deadline

### DIFF
--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -41,25 +41,49 @@ Starting.args = {
 }
 
 export const Stopped = Template.bind({})
-Stopped.args = { ...Started.args, workspace: MockStoppedWorkspace }
+Stopped.args = {
+  ...Started.args,
+  workspace: MockStoppedWorkspace,
+}
 
 export const Stopping = Template.bind({})
-Stopping.args = { ...Started.args, workspace: MockStoppingWorkspace }
+Stopping.args = {
+  ...Started.args,
+  workspace: MockStoppingWorkspace,
+}
 
 export const Error = Template.bind({})
-Error.args = { ...Started.args, workspace: MockFailedWorkspace }
+Error.args = {
+  ...Started.args,
+  workspace: MockFailedWorkspace,
+}
 
 export const Deleting = Template.bind({})
-Deleting.args = { ...Started.args, workspace: MockDeletingWorkspace }
+Deleting.args = {
+  ...Started.args,
+  workspace: MockDeletingWorkspace,
+}
 
 export const Deleted = Template.bind({})
-Deleted.args = { ...Started.args, workspace: MockDeletedWorkspace }
+Deleted.args = {
+  ...Started.args,
+  workspace: MockDeletedWorkspace,
+}
 
 export const Canceling = Template.bind({})
-Canceling.args = { ...Started.args, workspace: MockCancelingWorkspace }
+Canceling.args = {
+  ...Started.args,
+  workspace: MockCancelingWorkspace,
+}
 
 export const Canceled = Template.bind({})
-Canceled.args = { ...Started.args, workspace: MockCanceledWorkspace }
+Canceled.args = {
+  ...Started.args,
+  workspace: MockCanceledWorkspace,
+}
 
 export const Outdated = Template.bind({})
-Outdated.args = { ...Started.args, workspace: MockOutdatedWorkspace }
+Outdated.args = {
+  ...Started.args,
+  workspace: MockOutdatedWorkspace,
+}

--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -1,20 +1,6 @@
 import { action } from "@storybook/addon-actions"
 import { Story } from "@storybook/react"
-import {
-  MockCanceledWorkspace,
-  MockCancelingWorkspace,
-  MockDeletedWorkspace,
-  MockDeletingWorkspace,
-  MockFailedWorkspace,
-  MockOutdatedWorkspace,
-  MockStartingWorkspace,
-  MockStoppedWorkspace,
-  MockStoppingWorkspace,
-  MockWorkspace,
-  MockWorkspaceBuild,
-  MockWorkspaceResource,
-  MockWorkspaceResource2,
-} from "../../testHelpers/renderHelpers"
+import * as Mocks from "../../testHelpers/entities"
 import { Workspace, WorkspaceProps } from "./Workspace"
 
 export default {
@@ -27,63 +13,73 @@ const Template: Story<WorkspaceProps> = (args) => <Workspace {...args} />
 
 export const Started = Template.bind({})
 Started.args = {
-  workspace: MockWorkspace,
+  workspace: Mocks.MockWorkspace,
   handleStart: action("start"),
   handleStop: action("stop"),
-  resources: [MockWorkspaceResource, MockWorkspaceResource2],
-  builds: [MockWorkspaceBuild],
+  resources: [Mocks.MockWorkspaceResource, Mocks.MockWorkspaceResource2],
+  builds: [Mocks.MockWorkspaceBuild],
 }
 
 export const Starting = Template.bind({})
 Starting.args = {
   ...Started.args,
-  workspace: MockStartingWorkspace,
+  workspace: Mocks.MockStartingWorkspace,
 }
 
 export const Stopped = Template.bind({})
 Stopped.args = {
   ...Started.args,
-  workspace: MockStoppedWorkspace,
+  workspace: Mocks.MockStoppedWorkspace,
 }
 
 export const Stopping = Template.bind({})
 Stopping.args = {
   ...Started.args,
-  workspace: MockStoppingWorkspace,
+  workspace: Mocks.MockStoppingWorkspace,
 }
 
 export const Error = Template.bind({})
 Error.args = {
   ...Started.args,
-  workspace: MockFailedWorkspace,
+  workspace: {
+    ...Mocks.MockFailedWorkspace,
+    latest_build: {
+      ...Mocks.MockWorkspaceBuild,
+      job: {
+        ...Mocks.MockProvisionerJob,
+        status: "failed",
+      },
+      transition: "start",
+    },
+  },
 }
 
 export const Deleting = Template.bind({})
 Deleting.args = {
   ...Started.args,
-  workspace: MockDeletingWorkspace,
+  workspace: Mocks.MockDeletingWorkspace,
 }
 
 export const Deleted = Template.bind({})
 Deleted.args = {
   ...Started.args,
-  workspace: MockDeletedWorkspace,
+  workspace: Mocks.MockDeletedWorkspace,
 }
 
 export const Canceling = Template.bind({})
 Canceling.args = {
   ...Started.args,
-  workspace: MockCancelingWorkspace,
+  workspace: Mocks.MockCancelingWorkspace,
 }
 
 export const Canceled = Template.bind({})
 Canceled.args = {
   ...Started.args,
-  workspace: MockCanceledWorkspace,
+  workspace: Mocks.MockCanceledWorkspace,
 }
 
 export const Outdated = Template.bind({})
 Outdated.args = {
   ...Started.args,
-  workspace: MockOutdatedWorkspace,
+  workspace: Mocks.MockOutdatedWorkspace,
 }

--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -35,7 +35,10 @@ Started.args = {
 }
 
 export const Starting = Template.bind({})
-Starting.args = { ...Started.args, workspace: MockStartingWorkspace }
+Starting.args = {
+  ...Started.args,
+  workspace: MockStartingWorkspace,
+}
 
 export const Stopped = Template.bind({})
 Stopped.args = { ...Started.args, workspace: MockStoppedWorkspace }

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
@@ -6,10 +6,15 @@ import { WorkspaceSchedule, WorkspaceScheduleProps } from "./WorkspaceSchedule"
 
 dayjs.extend(utc)
 
+// REMARK: There's a known problem with storybook and using date libraries that
+//         call string.toLowerCase
+// SEE: https:github.com/storybookjs/storybook/issues/12208#issuecomment-697044557
+const ONE = 1
+const SEVEN = 7
+
 export default {
   title: "components/WorkspaceSchedule",
   component: WorkspaceSchedule,
-  argTypes: {},
 }
 
 const Template: Story<WorkspaceScheduleProps> = (args) => <WorkspaceSchedule {...args} />
@@ -32,13 +37,9 @@ export const ShutdownSoon = Template.bind({})
 ShutdownSoon.args = {
   workspace: {
     ...Mocks.MockWorkspace,
-
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().utc().add(1, "hour").toString(), // in 1 hour ago
-      job: {
-        ...Mocks.MockProvisionerJob,
-      },
+      deadline: dayjs().add(ONE, "hour").utc().format(),
       transition: "start",
     },
     ttl: 2 * 60 * 60 * 1000 * 1_000_000, // 2 hours
@@ -52,7 +53,7 @@ ShutdownLong.args = {
 
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().utc().add(7, "days").toString(), // in 7 days
+      deadline: dayjs().add(SEVEN, "days").utc().format(),
       transition: "start",
     },
     ttl: 7 * 24 * 60 * 60 * 1000 * 1_000_000, // 7 days
@@ -67,7 +68,6 @@ WorkspaceOffShort.args = {
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
       transition: "stop",
-      updated_at: dayjs().subtract(2, "days").toString(),
     },
     ttl: 2 * 60 * 60 * 1000 * 1_000_000, // 2 hours
   },
@@ -81,7 +81,6 @@ WorkspaceOffLong.args = {
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
       transition: "stop",
-      updated_at: dayjs().subtract(2, "days").toString(),
     },
     ttl: 2 * 365 * 24 * 60 * 60 * 1000 * 1_000_000, // 2 years
   },

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
@@ -1,7 +1,10 @@
 import { Story } from "@storybook/react"
 import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
 import * as Mocks from "../../testHelpers/entities"
 import { WorkspaceSchedule, WorkspaceScheduleProps } from "./WorkspaceSchedule"
+
+dayjs.extend(utc)
 
 export default {
   title: "components/WorkspaceSchedule",
@@ -15,6 +18,12 @@ export const NoTTL = Template.bind({})
 NoTTL.args = {
   workspace: {
     ...Mocks.MockWorkspace,
+    latest_build: {
+      ...Mocks.MockWorkspaceBuild,
+      // a mannual shutdown has a deadline of '"0001-01-01T00:00:00Z"'
+      // SEE: #1834
+      deadline: "0001-01-01T00:00:00Z",
+    },
     ttl: undefined,
   },
 }
@@ -26,8 +35,11 @@ ShutdownSoon.args = {
 
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
+      deadline: dayjs().utc().add(1, "hour").toString(), // in 1 hour ago
+      job: {
+        ...Mocks.MockProvisionerJob,
+      },
       transition: "start",
-      updated_at: dayjs().subtract(1, "hour").toString(), // 1 hour ago
     },
     ttl: 2 * 60 * 60 * 1000 * 1_000_000, // 2 hours
   },
@@ -40,8 +52,8 @@ ShutdownLong.args = {
 
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
+      deadline: dayjs().utc().add(7, "days").toString(), // in 7 days
       transition: "start",
-      updated_at: dayjs().toString(),
     },
     ttl: 7 * 24 * 60 * 60 * 1000 * 1_000_000, // 7 days
   },

--- a/site/src/components/WorkspaceScheduleBanner/WorkspaceScheduleBanner.test.tsx
+++ b/site/src/components/WorkspaceScheduleBanner/WorkspaceScheduleBanner.test.tsx
@@ -91,7 +91,6 @@ describe("WorkspaceScheduleBanner", () => {
         latest_build: {
           ...Mocks.MockWorkspaceBuild,
           deadline: dayjs().add(27, "minutes").utc().format(),
-          job: Mocks.MockRunningProvisionerJob,
           transition: "start",
         },
       }

--- a/site/src/components/WorkspaceScheduleBanner/WorkspaceScheduleBanner.tsx
+++ b/site/src/components/WorkspaceScheduleBanner/WorkspaceScheduleBanner.tsx
@@ -5,6 +5,7 @@ import isSameOrBefore from "dayjs/plugin/isSameOrBefore"
 import utc from "dayjs/plugin/utc"
 import { FC } from "react"
 import * as TypesGen from "../../api/typesGenerated"
+import { isWorkspaceOn } from "../../util/workspace"
 
 dayjs.extend(utc)
 dayjs.extend(isSameOrBefore)
@@ -18,12 +19,7 @@ export interface WorkspaceScheduleBannerProps {
 }
 
 export const shouldDisplay = (workspace: TypesGen.Workspace): boolean => {
-  const transition = workspace.latest_build.transition
-  const status = workspace.latest_build.job.status
-
-  if (transition !== "start") {
-    return false
-  } else if (status === "canceled" || status === "canceling" || status === "failed") {
+  if (!isWorkspaceOn(workspace)) {
     return false
   } else {
     // a mannual shutdown has a deadline of '"0001-01-01T00:00:00Z"'

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -182,10 +182,7 @@ export const MockStartingWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,
   latest_build: {
     ...MockWorkspaceBuild,
-    job: {
-      ...MockProvisionerJob,
-      status: "succeeded",
-    },
+    job: MockRunningProvisionerJob,
     transition: "start",
   },
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -196,7 +196,10 @@ export const MockCanceledWorkspace: TypesGen.Workspace = {
 }
 export const MockFailedWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,
-  latest_build: { ...MockWorkspaceBuild, job: MockFailedProvisionerJob },
+  latest_build: {
+    ...MockWorkspaceBuild,
+    job: MockFailedProvisionerJob,
+  },
 }
 export const MockDeletingWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -162,10 +162,16 @@ export const MockWorkspace: TypesGen.Workspace = {
   latest_build: MockWorkspaceBuild,
 }
 
-export const MockStoppedWorkspace: TypesGen.Workspace = { ...MockWorkspace, latest_build: MockWorkspaceBuildStop }
+export const MockStoppedWorkspace: TypesGen.Workspace = {
+  ...MockWorkspace,
+  latest_build: MockWorkspaceBuildStop,
+}
 export const MockStoppingWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,
-  latest_build: { ...MockWorkspaceBuildStop, job: MockRunningProvisionerJob },
+  latest_build: {
+    ...MockWorkspaceBuildStop,
+    job: MockRunningProvisionerJob,
+  },
 }
 export const MockStartingWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -169,7 +169,14 @@ export const MockStoppingWorkspace: TypesGen.Workspace = {
 }
 export const MockStartingWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,
-  latest_build: { ...MockWorkspaceBuild, job: MockRunningProvisionerJob },
+  latest_build: {
+    ...MockWorkspaceBuild,
+    job: {
+      ...MockProvisionerJob,
+      status: "succeeded",
+    },
+    transition: "start",
+  },
 }
 export const MockCancelingWorkspace: TypesGen.Workspace = {
   ...MockWorkspace,

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -1,0 +1,43 @@
+import * as TypesGen from "../api/typesGenerated"
+import * as Mocks from "../testHelpers/entities"
+import { isWorkspaceOn } from "./workspace"
+
+describe("util > workspace", () => {
+  describe("isWorkspaceOn", () => {
+    it.each<[TypesGen.WorkspaceTransition, TypesGen.ProvisionerJobStatus, boolean]>([
+      ["delete", "canceled", false],
+      ["delete", "canceling", false],
+      ["delete", "failed", false],
+      ["delete", "pending", false],
+      ["delete", "running", false],
+      ["delete", "succeeded", false],
+
+      ["stop", "canceled", false],
+      ["stop", "canceling", false],
+      ["stop", "failed", false],
+      ["stop", "pending", false],
+      ["stop", "running", false],
+      ["stop", "succeeded", false],
+
+      ["start", "canceled", false],
+      ["start", "canceling", false],
+      ["start", "failed", false],
+      ["start", "pending", false],
+      ["start", "running", false],
+      ["start", "succeeded", true],
+    ])(`transition=%p, status=%p, isWorkspaceOn=%p`, (transition, status, isOn) => {
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          job: {
+            ...Mocks.MockProvisionerJob,
+            status,
+          },
+          transition,
+        },
+      }
+      expect(isWorkspaceOn(workspace)).toBe(isOn)
+    })
+  })
+})

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -1,7 +1,7 @@
 import { Theme } from "@material-ui/core/styles"
 import dayjs from "dayjs"
 import { WorkspaceBuildTransition } from "../api/types"
-import { WorkspaceAgent, WorkspaceBuild } from "../api/typesGenerated"
+import { Workspace, WorkspaceAgent, WorkspaceBuild } from "../api/typesGenerated"
 
 export type WorkspaceStatus =
   | "queued"
@@ -184,4 +184,10 @@ export const getDisplayAgentStatus = (
         status: DisplayAgentStatusLanguage["disconnected"],
       }
   }
+}
+
+export const isWorkspaceOn = (workspace: Workspace): boolean => {
+  const transition = workspace.latest_build.transition
+  const status = workspace.latest_build.job.status
+  return transition === "start" && status === "succeeded"
 }


### PR DESCRIPTION
Summary:

When a workspace is on, the remaining time until shutdown needs to be
derived from the deadline timestamp, not implied from the TTL. A utility is
function is added that answers the question if a workspace is on.

Impact:

This is a shared piece of logic in workspace scheduling presentations.
In particular it unblocks work in 1779, or at least allows an
implementation that shares details with the WorkspaceScheduleBanner.

Notes:

We could possibly instead return whether the workspace is "ON",
"UNKNOWN", or "OFF". Maybe a future improvement for that could be made
as the neds arrises.