### PR TITLE
fix: change color of time icon for dark mode

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -243,6 +243,10 @@ const useStyles = makeStyles({
   form: {
     display: "flex",
     justifyContent: "center",
+
+    "& input": {
+      colorScheme: "dark",
+    },
   },
   stack: {
     // REMARK: 360 is 'arbitrary' in that it gives the helper text enough room


### PR DESCRIPTION
resolves #1791

Instead of replacing the timepicker, we are adjusting the color of the icon.
Here is the fix on Chrome:
![Screen Shot 2022-05-31 at 12 00 14 PM](https://user-images.githubusercontent.com/19142439/171222684-37842aac-2651-4c55-9421-ce8ea6c6511d.png)

Interestingly Firefox doesn't give us the time icon. Instead, it gives us a close icon, which clears the field:
![Screen Shot 2022-05-31 at 11 58 34 AM](https://user-images.githubusercontent.com/19142439/171222621-3774924b-a565-4c87-b868-e8c1b08591f8.png)

And Safari doesn't have an icon at all.

The latter two browsers might warrant different design down the road but I would say the bug itself is resolved.
