### PR TITLE
Remove set -u on yarn_install.sh to allow it to run on macos default bash

### DIFF
--- a/scripts/yarn_install.sh
+++ b/scripts/yarn_install.sh
@@ -5,7 +5,7 @@
 #
 # Usage: yarn_install.sh [optional extra flags]
 
-set -euo pipefail
+set -eo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)


### PR DESCRIPTION
On zsh (default on macos) yarn_install.sh fails like:

```
./scripts/yarn_install.sh: line 41: yarn_flags[*]: unbound variable
```

It seems that zsh is refusing to expand an empty array with `set -u` enabled, while bash happily does so.  We could add an explicit if test, but that seems complex for such a short script.
