### PR TITLE
Show workspace name in WorkspaceBuildStats component

### DIFF
--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -26,6 +26,7 @@ type WorkspaceBuild struct {
 	CreatedAt         time.Time           `json:"created_at"`
 	UpdatedAt         time.Time           `json:"updated_at"`
 	WorkspaceID       uuid.UUID           `json:"workspace_id"`
+	WorkspaceName     string              `json:"workspace_name"`
 	TemplateVersionID uuid.UUID           `json:"template_version_id"`
 	BuildNumber       int32               `json:"build_number"`
 	Name              string              `json:"name"`

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -422,6 +422,7 @@ export interface WorkspaceBuild {
   readonly created_at: string
   readonly updated_at: string
   readonly workspace_id: string
+  readonly workspace_name: string
   readonly template_version_id: string
   readonly build_number: number
   readonly name: string

--- a/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
+++ b/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
@@ -19,13 +19,13 @@ export const WorkspaceBuildStats: FC<WorkspaceBuildStatsProps> = ({ build }) => 
   return (
     <div className={styles.stats}>
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>Workspace ID</span>
+        <span className={styles.statsLabel}>Workspace Name</span>
         <Link
           component={RouterLink}
           to={`/workspaces/${build.workspace_id}`}
           className={combineClasses([styles.statsValue, styles.link])}
         >
-          {build.workspace_id}
+          {build.workspace_name}
         </Link>
       </div>
       <div className={styles.statsDivider} />

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
@@ -6,7 +6,7 @@ describe("WorkspaceBuildPage", () => {
   it("renders the stats and logs", async () => {
     renderWithAuth(<WorkspaceBuildPage />, { route: `/builds/${MockWorkspaceBuild.id}`, path: "/builds/:buildId" })
 
-    await screen.findByText(MockWorkspaceBuild.workspace_id)
+    await screen.findByText(MockWorkspaceBuild.workspace_name)
     await screen.findByText(MockWorkspaceBuildLogs[0].stage)
   })
 })

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -134,7 +134,8 @@ export const MockWorkspaceBuild: TypesGen.WorkspaceBuild = {
   template_version_id: "",
   transition: "start",
   updated_at: "2022-05-17T17:39:01.382927298Z",
-  workspace_id: "test-workspace",
+  workspace_name: "test-workspace",
+  workspace_id: "759f1d46-3174-453d-aa60-980a9c1442f3",
   deadline: "2022-05-17T23:39:00.00Z",
 }
 


### PR DESCRIPTION
Fixes #1801 

Backend: Includes Workspace Name in returned object form WorkspaceBuild API queries --- we already get this info from the DB, so it adds negligible overhead.

Frontend: Modfies the WorkspaceBuildStats component to show the name