### PR TITLE
feat: Longer lived api keys for cli

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1126,6 +1126,10 @@ func (q *fakeQuerier) InsertAPIKey(_ context.Context, arg database.InsertAPIKeyP
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
+	if arg.LifetimeSeconds == 0 {
+		arg.LifetimeSeconds = 86400
+	}
+
 	//nolint:gosimple
 	key := database.APIKey{
 		ID:                arg.ID,

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1129,6 +1129,7 @@ func (q *fakeQuerier) InsertAPIKey(_ context.Context, arg database.InsertAPIKeyP
 	//nolint:gosimple
 	key := database.APIKey{
 		ID:                arg.ID,
+		LifetimeSeconds:   arg.LifetimeSeconds,
 		HashedSecret:      arg.HashedSecret,
 		UserID:            arg.UserID,
 		ExpiresAt:         arg.ExpiresAt,

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -93,7 +93,8 @@ CREATE TABLE api_keys (
     oauth_access_token text DEFAULT ''::text NOT NULL,
     oauth_refresh_token text DEFAULT ''::text NOT NULL,
     oauth_id_token text DEFAULT ''::text NOT NULL,
-    oauth_expiry timestamp with time zone DEFAULT '0001-01-01 00:00:00+00'::timestamp with time zone NOT NULL
+    oauth_expiry timestamp with time zone DEFAULT '0001-01-01 00:00:00+00'::timestamp with time zone NOT NULL,
+    lifetime_seconds bigint DEFAULT 86400 NOT NULL
 );
 
 CREATE TABLE audit_logs (

--- a/coderd/database/migrations/000016_api_key_lifetime.down.sql
+++ b/coderd/database/migrations/000016_api_key_lifetime.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE api_keys DROP COLUMN lifetime_seconds;

--- a/coderd/database/migrations/000016_api_key_lifetime.up.sql
+++ b/coderd/database/migrations/000016_api_key_lifetime.up.sql
@@ -1,0 +1,2 @@
+-- Default lifetime is 24hours.
+ALTER TABLE api_keys ADD COLUMN lifetime_seconds bigint default 86400 NOT NULL;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -304,6 +304,7 @@ type APIKey struct {
 	OAuthRefreshToken string    `db:"oauth_refresh_token" json:"oauth_refresh_token"`
 	OAuthIDToken      string    `db:"oauth_id_token" json:"oauth_id_token"`
 	OAuthExpiry       time.Time `db:"oauth_expiry" json:"oauth_expiry"`
+	LifetimeSeconds   int64     `db:"lifetime_seconds" json:"lifetime_seconds"`
 }
 
 type AuditLog struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -30,7 +30,7 @@ func (q *sqlQuerier) DeleteAPIKeyByID(ctx context.Context, id string) error {
 
 const getAPIKeyByID = `-- name: GetAPIKeyByID :one
 SELECT
-	id, hashed_secret, user_id, last_used, expires_at, created_at, updated_at, login_type, oauth_access_token, oauth_refresh_token, oauth_id_token, oauth_expiry
+	id, hashed_secret, user_id, last_used, expires_at, created_at, updated_at, login_type, oauth_access_token, oauth_refresh_token, oauth_id_token, oauth_expiry, lifetime_seconds
 FROM
 	api_keys
 WHERE
@@ -55,6 +55,7 @@ func (q *sqlQuerier) GetAPIKeyByID(ctx context.Context, id string) (APIKey, erro
 		&i.OAuthRefreshToken,
 		&i.OAuthIDToken,
 		&i.OAuthExpiry,
+		&i.LifetimeSeconds,
 	)
 	return i, err
 }
@@ -66,6 +67,7 @@ INSERT INTO
 		hashed_secret,
 		user_id,
 		last_used,
+	    lifetime_seconds,
 		expires_at,
 		created_at,
 		updated_at,
@@ -76,7 +78,7 @@ INSERT INTO
 		oauth_expiry
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id, hashed_secret, user_id, last_used, expires_at, created_at, updated_at, login_type, oauth_access_token, oauth_refresh_token, oauth_id_token, oauth_expiry
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id, hashed_secret, user_id, last_used, expires_at, created_at, updated_at, login_type, oauth_access_token, oauth_refresh_token, oauth_id_token, oauth_expiry, lifetime_seconds
 `
 
 type InsertAPIKeyParams struct {
@@ -84,6 +86,7 @@ type InsertAPIKeyParams struct {
 	HashedSecret      []byte    `db:"hashed_secret" json:"hashed_secret"`
 	UserID            uuid.UUID `db:"user_id" json:"user_id"`
 	LastUsed          time.Time `db:"last_used" json:"last_used"`
+	LifetimeSeconds   int64     `db:"lifetime_seconds" json:"lifetime_seconds"`
 	ExpiresAt         time.Time `db:"expires_at" json:"expires_at"`
 	CreatedAt         time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt         time.Time `db:"updated_at" json:"updated_at"`
@@ -100,6 +103,7 @@ func (q *sqlQuerier) InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (
 		arg.HashedSecret,
 		arg.UserID,
 		arg.LastUsed,
+		arg.LifetimeSeconds,
 		arg.ExpiresAt,
 		arg.CreatedAt,
 		arg.UpdatedAt,
@@ -123,6 +127,7 @@ func (q *sqlQuerier) InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (
 		&i.OAuthRefreshToken,
 		&i.OAuthIDToken,
 		&i.OAuthExpiry,
+		&i.LifetimeSeconds,
 	)
 	return i, err
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -64,10 +64,10 @@ const insertAPIKey = `-- name: InsertAPIKey :one
 INSERT INTO
 	api_keys (
 		id,
+		lifetime_seconds,
 		hashed_secret,
 		user_id,
 		last_used,
-	    lifetime_seconds,
 		expires_at,
 		created_at,
 		updated_at,
@@ -78,15 +78,21 @@ INSERT INTO
 		oauth_expiry
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id, hashed_secret, user_id, last_used, expires_at, created_at, updated_at, login_type, oauth_access_token, oauth_refresh_token, oauth_id_token, oauth_expiry, lifetime_seconds
+	($1,
+	 -- If the lifetime is set to 0, default to 24hrs
+	 CASE $2::bigint
+	     WHEN 0 THEN 86400
+		 ELSE $2::bigint
+	 END
+	 , $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id, hashed_secret, user_id, last_used, expires_at, created_at, updated_at, login_type, oauth_access_token, oauth_refresh_token, oauth_id_token, oauth_expiry, lifetime_seconds
 `
 
 type InsertAPIKeyParams struct {
 	ID                string    `db:"id" json:"id"`
+	LifetimeSeconds   int64     `db:"lifetime_seconds" json:"lifetime_seconds"`
 	HashedSecret      []byte    `db:"hashed_secret" json:"hashed_secret"`
 	UserID            uuid.UUID `db:"user_id" json:"user_id"`
 	LastUsed          time.Time `db:"last_used" json:"last_used"`
-	LifetimeSeconds   int64     `db:"lifetime_seconds" json:"lifetime_seconds"`
 	ExpiresAt         time.Time `db:"expires_at" json:"expires_at"`
 	CreatedAt         time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt         time.Time `db:"updated_at" json:"updated_at"`
@@ -100,10 +106,10 @@ type InsertAPIKeyParams struct {
 func (q *sqlQuerier) InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (APIKey, error) {
 	row := q.db.QueryRowContext(ctx, insertAPIKey,
 		arg.ID,
+		arg.LifetimeSeconds,
 		arg.HashedSecret,
 		arg.UserID,
 		arg.LastUsed,
-		arg.LifetimeSeconds,
 		arg.ExpiresAt,
 		arg.CreatedAt,
 		arg.UpdatedAt,

--- a/coderd/database/queries/apikeys.sql
+++ b/coderd/database/queries/apikeys.sql
@@ -12,10 +12,10 @@ LIMIT
 INSERT INTO
 	api_keys (
 		id,
+		lifetime_seconds,
 		hashed_secret,
 		user_id,
 		last_used,
-	    lifetime_seconds,
 		expires_at,
 		created_at,
 		updated_at,
@@ -26,7 +26,13 @@ INSERT INTO
 		oauth_expiry
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING *;
+	(@id,
+	 -- If the lifetime is set to 0, default to 24hrs
+	 CASE @lifetime_seconds::bigint
+	     WHEN 0 THEN 86400
+		 ELSE @lifetime_seconds::bigint
+	 END
+	 , @hashed_secret, @user_id, @last_used, @expires_at, @created_at, @updated_at, @login_type, @oauth_access_token, @oauth_refresh_token, @oauth_id_token, @oauth_expiry) RETURNING *;
 
 -- name: UpdateAPIKeyByID :exec
 UPDATE

--- a/coderd/database/queries/apikeys.sql
+++ b/coderd/database/queries/apikeys.sql
@@ -15,6 +15,7 @@ INSERT INTO
 		hashed_secret,
 		user_id,
 		last_used,
+	    lifetime_seconds,
 		expires_at,
 		created_at,
 		updated_at,
@@ -25,7 +26,7 @@ INSERT INTO
 		oauth_expiry
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *;
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING *;
 
 -- name: UpdateAPIKeyByID :exec
 UPDATE

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -154,10 +154,6 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs) func(http.Handler) h
 			// Only update the ExpiresAt once an hour to prevent database spam.
 			// We extend the ExpiresAt to reduce re-authentication.
 			apiKeyLifetime := time.Duration(key.LifetimeSeconds) * time.Second
-			if apiKeyLifetime == 0 {
-				// Default to 24 hours if it is not set
-				apiKeyLifetime = time.Hour * 24
-			}
 			if key.ExpiresAt.Sub(now) <= apiKeyLifetime-time.Hour {
 				key.ExpiresAt = now.Add(apiKeyLifetime)
 				changed = true

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -153,7 +153,11 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs) func(http.Handler) h
 			}
 			// Only update the ExpiresAt once an hour to prevent database spam.
 			// We extend the ExpiresAt to reduce re-authentication.
-			apiKeyLifetime := 24 * time.Hour
+			apiKeyLifetime := time.Duration(key.LifetimeSeconds) * time.Second
+			if apiKeyLifetime == 0 {
+				// Default to 24 hours if it is not set
+				apiKeyLifetime = time.Hour * 24
+			}
 			if key.ExpiresAt.Sub(now) <= apiKeyLifetime-time.Hour {
 				key.ExpiresAt = now.Add(apiKeyLifetime)
 				changed = true

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -726,8 +726,13 @@ func (api *API) createAPIKey(rw http.ResponseWriter, r *http.Request, params dat
 	}
 	hashed := sha256.Sum256([]byte(keySecret))
 
+	// Default expires at to now+lifetime, or just 24hrs if not set
 	if params.ExpiresAt.IsZero() {
-		params.ExpiresAt = database.Now().Add(24 * time.Hour)
+		if params.LifetimeSeconds != 0 {
+			params.ExpiresAt = database.Now().Add(time.Duration(params.LifetimeSeconds) * time.Second)
+		} else {
+			params.ExpiresAt = database.Now().Add(24 * time.Hour)
+		}
 	}
 
 	_, err = api.Database.InsertAPIKey(r.Context(), database.InsertAPIKeyParams{

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coder/coder/coderd/database"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/databasefake"
 	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/coderd/rbac"


### PR DESCRIPTION
#1269

# What this does

Cli auth now lasts 1 week. Token refreshes use `lifetime_seconds` column on the api key to know how long to refresh