### PR TITLE
chore: Reduce deployment times by excluding Docker images

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -371,16 +371,11 @@ jobs:
       - name: Build site
         run: make -B site/out/index.html
 
-      - name: Build Linux Release
-        run: |
-          goreleaser build --snapshot --rm-dist --id coder-slim
-          goreleaser build --snapshot --rm-dist --id coder-linux
-
-      - uses: actions/upload-artifact@v3
+      - name: Build Release
+        uses: goreleaser/goreleaser-action@v3
         with:
-          name: coder_linux_amd64.tar.gz
-          path: ./dist/coder_*_linux_amd64.tar.gz
-          retention-days: 7
+          version: latest
+          args: release --snapshot --rm-dist --skip-sign
 
       - name: Install Release
         run: |
@@ -393,9 +388,11 @@ jobs:
       - name: Start
         run: gcloud compute ssh coder -- sudo service coder restart
 
-      - name: Build Windows Release
-        run: |
-          goreleaser build --snapshot --rm-dist --id coder-windows
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coder_linux_amd64.tar.gz
+          path: ./dist/coder_*_linux_amd64.tar.gz
+          retention-days: 7
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -315,7 +315,7 @@ jobs:
     name: "deploy"
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+    if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -353,10 +353,6 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-release-go-mod-${{ hashFiles('**/go.sum') }}
 
-      - uses: goreleaser/goreleaser-action@v3
-        with:
-          install-only: true
-
       - name: Cache Node
         id: cache-node
         uses: actions/cache@v3
@@ -364,9 +360,13 @@ jobs:
           path: |
             **/node_modules
             .eslintcache
-          key: js-${{ runner.os }}-test-${{ hashFiles('**/yarn.lock') }}
+          key: js-${{ runner.os }}-release-node-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             js-${{ runner.os }}-
+
+      - uses: goreleaser/goreleaser-action@v3
+        with:
+          install-only: true
 
       - name: Build site
         run: make -B site/out/index.html
@@ -390,14 +390,10 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: coder_linux_amd64.tar.gz
-          path: ./dist/coder_*_linux_amd64.tar.gz
-          retention-days: 7
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: coder_windows_amd64.zip
-          path: ./dist/coder_*_windows_amd64.zip
+          name: coder
+          path: |
+            ./dist/coder_*_linux_amd64.tar.gz
+            ./dist/coder_*_windows_amd64.zip
           retention-days: 7
 
   test-js:

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -315,7 +315,7 @@ jobs:
     name: "deploy"
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+    # if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
     permissions:
       contents: read
       id-token: write
@@ -371,17 +371,10 @@ jobs:
       - name: Build site
         run: make -B site/out/index.html
 
-      - name: Build Release
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          version: latest
-          args: release --snapshot --rm-dist --skip-sign
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: coder_windows_amd64.zip
-          path: ./dist/coder_*_windows_amd64.zip
-          retention-days: 7
+      - name: Build Linux Release
+        run: |
+          goreleaser build --snapshot --rm-dist --id coder-slim
+          goreleaser build --snapshot --rm-dist --id coder-linux
 
       - uses: actions/upload-artifact@v3
         with:
@@ -399,6 +392,16 @@ jobs:
 
       - name: Start
         run: gcloud compute ssh coder -- sudo service coder restart
+
+      - name: Build Windows Release
+        run: |
+          goreleaser build --snapshot --rm-dist --id coder-windows
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coder_windows_amd64.zip
+          path: ./dist/coder_*_windows_amd64.zip
+          retention-days: 7
 
   test-js:
     name: "test/js"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,8 +94,9 @@ nfpms:
       - src: coder.service
         dst: /usr/lib/systemd/system/coder.service
 
+# Image templates are empty on snapshots to avoid lengthy builds for development.
 dockers:
-  - image_templates: ["ghcr.io/coder/coder:{{ .Tag }}-amd64"]
+  - image_templates: ["{{ if not .IsSnapshot }}ghcr.io/coder/coder:{{ .Tag }}-amd64{{ end }}"]
     id: coder-linux
     dockerfile: Dockerfile
     use: buildx
@@ -108,7 +109,7 @@ dockers:
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=AGPL-3.0
-  - image_templates: ["ghcr.io/coder/coder:{{ .Tag }}-arm64"]
+  - image_templates: ["{{ if not .IsSnapshot }}ghcr.io/coder/coder:{{ .Tag }}-arm64{{ end }}"]
     goarch: arm64
     dockerfile: Dockerfile
     use: buildx
@@ -121,7 +122,7 @@ dockers:
       - --label=org.opencontainers.image.version={{ .Tag }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=AGPL-3.0
-  - image_templates: ["ghcr.io/coder/coder:{{ .Tag }}-armv7"]
+  - image_templates: ["{{ if not .IsSnapshot }}ghcr.io/coder/coder:{{ .Tag }}-armv7{{ end }}"]
     goarch: arm
     goarm: "7"
     dockerfile: Dockerfile

--- a/site/webpack.common.ts
+++ b/site/webpack.common.ts
@@ -38,7 +38,7 @@ const dashboardHTMLPluginConfig = new HtmlWebpackPlugin({
   template: path.join(templatePath, "index.html"),
 })
 
-export const commonWebpackConfig: Configuration = {
+export const createCommonWebpackConfig = (options?: { skipTypecheck: boolean }): Configuration => ({
   // entry defines each "page" or "chunk". In v1, we have two "pages":
   // dashboard and terminal. This is desired because the terminal has the xterm
   // vendor, and it is undesireable to load all of xterm on a dashboard
@@ -78,6 +78,7 @@ export const commonWebpackConfig: Configuration = {
             loader: "ts-loader",
             options: {
               configFile: "tsconfig.prod.json",
+              transpileOnly: options?.skipTypecheck,
             },
           },
         ],
@@ -106,4 +107,4 @@ export const commonWebpackConfig: Configuration = {
 
   // plugins customize the build process
   plugins: [environmentPlugin, dashboardHTMLPluginConfig],
-}
+})

--- a/site/webpack.dev.ts
+++ b/site/webpack.dev.ts
@@ -5,14 +5,16 @@
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin"
 import { Configuration } from "webpack"
 import "webpack-dev-server"
-import { commonWebpackConfig } from "./webpack.common"
+import { createCommonWebpackConfig } from "./webpack.common"
+
+const commonWebpackConfig = createCommonWebpackConfig()
 
 const commonPlugins = commonWebpackConfig.plugins || []
 
 const commonRules = commonWebpackConfig.module?.rules || []
 
 const config: Configuration = {
-  ...commonWebpackConfig,
+  ...createCommonWebpackConfig,
 
   // devtool controls how source maps are generated. In development, we want
   // more details (less optimized) for more readability and an easier time

--- a/site/webpack.prod.ts
+++ b/site/webpack.prod.ts
@@ -6,7 +6,13 @@ import CopyWebpackPlugin from "copy-webpack-plugin"
 import CSSMinimizerPlugin from "css-minimizer-webpack-plugin"
 import MiniCSSExtractPlugin from "mini-css-extract-plugin"
 import { Configuration } from "webpack"
-import { commonWebpackConfig } from "./webpack.common"
+import { createCommonWebpackConfig } from "./webpack.common"
+
+const commonWebpackConfig = createCommonWebpackConfig({
+  // This decreases compilation time when publishing releases.
+  // The "test/js" step will already catch any TypeScript compilation errors.
+  skipTypecheck: true,
+})
 
 const commonPlugins = commonWebpackConfig.plugins || []
 


### PR DESCRIPTION
Only the Windows and Linux binaries are built during deploy, so we
can save many minutes by excluding Docker images.
