### PR TITLE
feat: Update TTL language to Time until shutdown

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -40,8 +40,8 @@ export const Language = {
   startTimeLabel: "Start time",
   startTimeHelperText: "Your workspace will automatically start at this time.",
   timezoneLabel: "Timezone",
-  ttlLabel: "TTL (hours)",
-  ttlHelperText: "Your workspace will automatically shutdown after the TTL.",
+  ttlLabel: "Time until shutdown (hours)",
+  ttlHelperText: "Your workspace will automatically shutdown after this much time.",
 }
 
 export interface WorkspaceScheduleFormProps {

--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -41,7 +41,7 @@ export const Language = {
   startTimeHelperText: "Your workspace will automatically start at this time.",
   timezoneLabel: "Timezone",
   ttlLabel: "Time until shutdown (hours)",
-  ttlHelperText: "Your workspace will automatically shut down after this much time.",
+  ttlHelperText: "Your workspace will automatically shut down after this amount of time has elapsed.",
 }
 
 export interface WorkspaceScheduleFormProps {

--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -41,7 +41,7 @@ export const Language = {
   startTimeHelperText: "Your workspace will automatically start at this time.",
   timezoneLabel: "Timezone",
   ttlLabel: "Time until shutdown (hours)",
-  ttlHelperText: "Your workspace will automatically shutdown after this much time.",
+  ttlHelperText: "Your workspace will automatically shut down after this much time.",
 }
 
 export interface WorkspaceScheduleFormProps {


### PR DESCRIPTION
This PR updates the copy of TTL in frontend to Time until shutdown.

## Subtasks

- [x] update the language of the label and helptext.

Fixes #1784 

## Screenshot

![image](https://user-images.githubusercontent.com/7511231/171492913-7c3c7099-5b38-48b2-bd00-3bc82d9a47f6.png)
