### PR TITLE
feat: Update UI for error dialog and snackbar

### DIFF
--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -51,6 +51,9 @@ const useStyles = makeStyles((theme) => ({
       background: props.type === "info" ? theme.palette.primary.main : theme.palette.background.paper,
       border: `1px solid ${theme.palette.divider}`,
     },
+    "& .MuiDialogActions-spacing": {
+      padding: `0 ${theme.spacing(3.75)}px ${theme.spacing(3.75)}px`,
+    },
   }),
   dialogContent: (props: StyleProps) => ({
     color: props.type === "info" ? theme.palette.primary.contrastText : theme.palette.text.secondary,

--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -48,11 +48,12 @@ interface StyleProps {
 const useStyles = makeStyles((theme) => ({
   dialogWrapper: (props: StyleProps) => ({
     "& .MuiPaper-root": {
-      background: props.type === "info" ? theme.palette.primary.main : theme.palette.error.dark,
+      background: props.type === "info" ? theme.palette.primary.main : theme.palette.background.paper,
+      border: `1px solid ${theme.palette.divider}`,
     },
   }),
   dialogContent: (props: StyleProps) => ({
-    color: props.type === "info" ? theme.palette.primary.contrastText : theme.palette.error.contrastText,
+    color: props.type === "info" ? theme.palette.primary.contrastText : theme.palette.text.secondary,
     padding: theme.spacing(6),
     textAlign: "center",
   }),
@@ -61,16 +62,14 @@ const useStyles = makeStyles((theme) => ({
   },
   description: (props: StyleProps) => ({
     color:
-      props.type === "info"
-        ? fade(theme.palette.primary.contrastText, 0.75)
-        : fade(theme.palette.error.contrastText, 0.75),
+      props.type === "info" ? fade(theme.palette.primary.contrastText, 0.75) : fade(theme.palette.text.secondary, 0.75),
     lineHeight: "160%",
 
     "& strong": {
       color:
         props.type === "info"
           ? fade(theme.palette.primary.contrastText, 0.95)
-          : fade(theme.palette.error.contrastText, 0.95),
+          : fade(theme.palette.text.secondary, 0.95),
     },
   }),
 }))

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -148,7 +148,7 @@ const useButtonStyles = makeStyles((theme) => ({
     borderRadius: theme.shape.borderRadius,
     fontSize: theme.typography.h6.fontSize,
     fontWeight: theme.typography.h5.fontWeight,
-    padding: theme.spacing(2.25),
+    padding: `${theme.spacing(0.75)}px ${theme.spacing(2)}px`,
     width: "100%",
     boxShadow: "none",
   },

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -114,7 +114,7 @@ export const DialogActionButtons: React.FC<DialogActionButtonsProps> = ({
           })}
           disabled={confirmLoading}
           onClick={onCancel}
-          variant="contained"
+          variant="outlined"
         >
           {cancelText}
         </LoadingButton>
@@ -145,7 +145,7 @@ interface StyleProps {
 
 const useButtonStyles = makeStyles((theme) => ({
   dialogButton: {
-    borderRadius: 0,
+    borderRadius: theme.shape.borderRadius,
     fontSize: theme.typography.h6.fontSize,
     fontWeight: theme.typography.h5.fontWeight,
     padding: theme.spacing(2.25),

--- a/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.tsx
+++ b/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.tsx
@@ -81,8 +81,9 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.error.contrastText,
   },
   snackbarContent: {
+    border: `1px solid ${theme.palette.divider}`,
     borderLeft: `4px solid ${theme.palette.primary.main}`,
-    borderRadius: 0,
+    borderRadius: theme.shape.borderRadius,
     padding: `${theme.spacing(1)}px ${theme.spacing(3)}px ${theme.spacing(1)}px ${theme.spacing(2)}px`,
     boxShadow: theme.shadows[6],
     alignItems: "inherit",
@@ -94,8 +95,8 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.info.contrastText,
   },
   snackbarContentError: {
-    backgroundColor: theme.palette.error.dark,
+    backgroundColor: theme.palette.background.paper,
     borderLeftColor: theme.palette.error.main,
-    color: theme.palette.error.contrastText,
+    color: theme.palette.text.secondary,
   },
 }))


### PR DESCRIPTION
This PR updates the alarmingly red UI for error dialog and snackbars.

## Subtasks

- [x] update the UI for error type dialog box
- [x] update the UI for error type snackbar

Fixes #1832 

## Screenshot

![image](https://user-images.githubusercontent.com/7511231/171524169-32688767-94d7-4b0c-a615-3c5fd2fc4d09.png)

![image](https://user-images.githubusercontent.com/7511231/171518990-faceee40-5b01-47e7-b9c8-020ca30ff834.png)
