### PR TITLE
feat: Workspaces filtering

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -328,6 +328,9 @@ func (q *fakeQuerier) GetWorkspacesWithFilter(_ context.Context, arg database.Ge
 		if !arg.Deleted && workspace.Deleted {
 			continue
 		}
+		if arg.Name != "" && workspace.Name != arg.Name {
+			continue
+		}
 		workspaces = append(workspaces, workspace)
 	}
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3512,7 +3512,7 @@ WHERE
 	-- Filter by name
 	AND CASE
 		  WHEN $4 :: text != '' THEN
-				name = LOWER($4)
+				LOWER(name) = LOWER($4)
 		  ELSE true
 	END
 `

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3509,16 +3509,28 @@ WHERE
 				owner_id = $3
 		  ELSE true
 	END
+	-- Filter by name
+	AND CASE
+		  WHEN $4 :: string != '' THEN
+				name = LOWER($4)
+		  ELSE true
+	END
 `
 
 type GetWorkspacesWithFilterParams struct {
 	Deleted        bool      `db:"deleted" json:"deleted"`
 	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id"`
 	OwnerID        uuid.UUID `db:"owner_id" json:"owner_id"`
+	Name           string    `db:"name" json:"name"`
 }
 
 func (q *sqlQuerier) GetWorkspacesWithFilter(ctx context.Context, arg GetWorkspacesWithFilterParams) ([]Workspace, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspacesWithFilter, arg.Deleted, arg.OrganizationID, arg.OwnerID)
+	rows, err := q.db.QueryContext(ctx, getWorkspacesWithFilter,
+		arg.Deleted,
+		arg.OrganizationID,
+		arg.OwnerID,
+		arg.Name,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3511,7 +3511,7 @@ WHERE
 	END
 	-- Filter by name
 	AND CASE
-		  WHEN $4 :: string != '' THEN
+		  WHEN $4 :: text != '' THEN
 				name = LOWER($4)
 		  ELSE true
 	END

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -30,7 +30,7 @@ WHERE
 	END
 	-- Filter by name
 	AND CASE
-		  WHEN @name :: string != '' THEN
+		  WHEN @name :: text != '' THEN
 				name = LOWER(@name)
 		  ELSE true
 	END

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -28,6 +28,12 @@ WHERE
 				owner_id = @owner_id
 		  ELSE true
 	END
+	-- Filter by name
+	AND CASE
+		  WHEN @name :: string != '' THEN
+				name = LOWER(@name)
+		  ELSE true
+	END
 ;
 
 -- name: GetWorkspacesByOrganizationIDs :many

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -31,7 +31,7 @@ WHERE
 	-- Filter by name
 	AND CASE
 		  WHEN @name :: text != '' THEN
-				name = LOWER(@name)
+				LOWER(name) = LOWER(@name)
 		  ELSE true
 	END
 ;

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -137,6 +137,7 @@ func (api *API) workspaces(rw http.ResponseWriter, r *http.Request) {
 	// Empty strings mean no filter
 	orgFilter := r.URL.Query().Get("organization_id")
 	ownerFilter := r.URL.Query().Get("owner")
+	nameFilter := r.URL.Query().Get("name")
 
 	filter := database.GetWorkspacesWithFilterParams{Deleted: false}
 	if orgFilter != "" {
@@ -169,6 +170,9 @@ func (api *API) workspaces(rw http.ResponseWriter, r *http.Request) {
 			userID = user.ID
 		}
 		filter.OwnerID = userID
+	}
+	if nameFilter != "" {
+		filter.Name = nameFilter
 	}
 
 	workspaces, err := api.Database.GetWorkspacesWithFilter(r.Context(), filter)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -142,13 +142,9 @@ func (api *API) workspaces(rw http.ResponseWriter, r *http.Request) {
 	filter := database.GetWorkspacesWithFilterParams{Deleted: false}
 	if orgFilter != "" {
 		orgID, err := uuid.Parse(orgFilter)
-		if err != nil {
-			httpapi.Write(rw, http.StatusBadRequest, httpapi.Response{
-				Message: fmt.Sprintf("organization_id must be a uuid: %s", err.Error()),
-			})
-			return
+		if err == nil {
+			filter.OrganizationID = orgID
 		}
-		filter.OrganizationID = orgID
 	}
 	if ownerFilter == "me" {
 		filter.OwnerID = apiKey.UserID
@@ -161,15 +157,12 @@ func (api *API) workspaces(rw http.ResponseWriter, r *http.Request) {
 				Username: ownerFilter,
 				Email:    ownerFilter,
 			})
-			if err != nil {
-				httpapi.Write(rw, http.StatusBadRequest, httpapi.Response{
-					Message: "owner must be a uuid or username",
-				})
-				return
+			if err == nil {
+				filter.OwnerID = user.ID
 			}
-			userID = user.ID
+		} else {
+			filter.OwnerID = userID
 		}
-		filter.OwnerID = userID
 	}
 	if nameFilter != "" {
 		filter.Name = nameFilter

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -290,7 +290,8 @@ func TestWorkspacesByOwner(t *testing.T) {
 		require.Len(t, workspaces, 1)
 
 		// Create same name workspace that should be included
-		_ = coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) { cwr.Name = w.Name })
+		other := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
+		_ = coderdtest.CreateWorkspace(t, other, user.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) { cwr.Name = w.Name })
 
 		workspaces, err = client.Workspaces(context.Background(), codersdk.WorkspaceFilter{
 			Name: w.Name,

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -200,7 +201,9 @@ func (c *Client) PutExtendWorkspace(ctx context.Context, id uuid.UUID, req PutEx
 type WorkspaceFilter struct {
 	OrganizationID uuid.UUID
 	// Owner can be a user_id (uuid), "me", or a username
-	Owner string
+	Owner   string
+	Name    string
+	Deleted bool
 }
 
 // asRequestOption returns a function that can be used in (*Client).Request.
@@ -213,6 +216,12 @@ func (f WorkspaceFilter) asRequestOption() requestOption {
 		}
 		if f.Owner != "" {
 			q.Set("owner", f.Owner)
+		}
+		if f.Name != "" {
+			q.Set("name", f.Name)
+		}
+		if f.Deleted {
+			q.Set("deleted", strconv.FormatBool(f.Deleted))
 		}
 		r.URL.RawQuery = q.Encode()
 	}

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -199,11 +198,10 @@ func (c *Client) PutExtendWorkspace(ctx context.Context, id uuid.UUID, req PutEx
 }
 
 type WorkspaceFilter struct {
-	OrganizationID uuid.UUID
+	OrganizationID uuid.UUID `json:"organization_id,omitempty"`
 	// Owner can be a user_id (uuid), "me", or a username
-	Owner   string
-	Name    string
-	Deleted bool
+	Owner string `json:"owner,omitempty"`
+	Name  string `json:"name,omitempty"`
 }
 
 // asRequestOption returns a function that can be used in (*Client).Request.
@@ -219,9 +217,6 @@ func (f WorkspaceFilter) asRequestOption() requestOption {
 		}
 		if f.Name != "" {
 			q.Set("name", f.Name)
-		}
-		if f.Deleted {
-			q.Set("deleted", strconv.FormatBool(f.Deleted))
 		}
 		r.URL.RawQuery = q.Encode()
 	}

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -118,10 +118,10 @@ describe("api.ts", () => {
     it.each<[TypesGen.WorkspaceFilter | undefined, string]>([
       [undefined, "/api/v2/workspaces"],
 
-      [{ OrganizationID: "1", Owner: "" }, "/api/v2/workspaces?organization_id=1"],
-      [{ OrganizationID: "", Owner: "1" }, "/api/v2/workspaces?owner=1"],
+      [{ organization_id: "1", owner: "" }, "/api/v2/workspaces?organization_id=1"],
+      [{ organization_id: "", owner: "1" }, "/api/v2/workspaces?owner=1"],
 
-      [{ OrganizationID: "1", Owner: "me" }, "/api/v2/workspaces?organization_id=1&owner=me"],
+      [{ organization_id: "1", owner: "me" }, "/api/v2/workspaces?organization_id=1&owner=me"],
     ])(`getWorkspacesURL(%p) returns %p`, (filter, expected) => {
       expect(getWorkspacesURL(filter)).toBe(expected)
     })

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -116,11 +116,14 @@ export const getWorkspacesURL = (filter?: TypesGen.WorkspaceFilter): string => {
   const basePath = "/api/v2/workspaces"
   const searchParams = new URLSearchParams()
 
-  if (filter?.OrganizationID) {
-    searchParams.append("organization_id", filter.OrganizationID)
+  if (filter?.organization_id) {
+    searchParams.append("organization_id", filter.organization_id)
   }
-  if (filter?.Owner) {
-    searchParams.append("owner", filter.Owner)
+  if (filter?.owner) {
+    searchParams.append("owner", filter.owner)
+  }
+  if (filter?.name) {
+    searchParams.append("name", filter.name)
   }
 
   const searchString = searchParams.toString()

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -443,10 +443,9 @@ export interface WorkspaceBuildsRequest extends Pagination {
 
 // From codersdk/workspaces.go:201:6
 export interface WorkspaceFilter {
-  readonly OrganizationID: string
-  readonly Owner: string
-  readonly Name: string
-  readonly Deleted: boolean
+  readonly organization_id?: string
+  readonly owner?: string
+  readonly name?: string
 }
 
 // From codersdk/workspaceresources.go:21:6

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -88,7 +88,7 @@ export interface CreateUserRequest {
   readonly organization_id: string
 }
 
-// From codersdk/workspaces.go:34:6
+// From codersdk/workspaces.go:35:6
 export interface CreateWorkspaceBuildRequest {
   readonly template_version_id?: string
   readonly transition: WorkspaceTransition
@@ -221,7 +221,7 @@ export interface ProvisionerJobLog {
   readonly output: string
 }
 
-// From codersdk/workspaces.go:182:6
+// From codersdk/workspaces.go:183:6
 export interface PutExtendWorkspaceRequest {
   readonly deadline: string
 }
@@ -298,12 +298,12 @@ export interface UpdateUserProfileRequest {
   readonly username: string
 }
 
-// From codersdk/workspaces.go:141:6
+// From codersdk/workspaces.go:142:6
 export interface UpdateWorkspaceAutostartRequest {
   readonly schedule?: string
 }
 
-// From codersdk/workspaces.go:161:6
+// From codersdk/workspaces.go:162:6
 export interface UpdateWorkspaceTTLRequest {
   readonly ttl_ms?: number
 }
@@ -358,7 +358,7 @@ export interface UsersRequest extends Pagination {
   readonly status?: string
 }
 
-// From codersdk/workspaces.go:18:6
+// From codersdk/workspaces.go:19:6
 export interface Workspace {
   readonly id: string
   readonly created_at: string
@@ -436,15 +436,17 @@ export interface WorkspaceBuild {
   readonly deadline: string
 }
 
-// From codersdk/workspaces.go:64:6
+// From codersdk/workspaces.go:65:6
 export interface WorkspaceBuildsRequest extends Pagination {
   readonly WorkspaceID: string
 }
 
-// From codersdk/workspaces.go:200:6
+// From codersdk/workspaces.go:201:6
 export interface WorkspaceFilter {
   readonly OrganizationID: string
   readonly Owner: string
+  readonly Name: string
+  readonly Deleted: boolean
 }
 
 // From codersdk/workspaceresources.go:21:6

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -88,7 +88,7 @@ export interface CreateUserRequest {
   readonly organization_id: string
 }
 
-// From codersdk/workspaces.go:35:6
+// From codersdk/workspaces.go:34:6
 export interface CreateWorkspaceBuildRequest {
   readonly template_version_id?: string
   readonly transition: WorkspaceTransition
@@ -221,7 +221,7 @@ export interface ProvisionerJobLog {
   readonly output: string
 }
 
-// From codersdk/workspaces.go:183:6
+// From codersdk/workspaces.go:182:6
 export interface PutExtendWorkspaceRequest {
   readonly deadline: string
 }
@@ -298,12 +298,12 @@ export interface UpdateUserProfileRequest {
   readonly username: string
 }
 
-// From codersdk/workspaces.go:142:6
+// From codersdk/workspaces.go:141:6
 export interface UpdateWorkspaceAutostartRequest {
   readonly schedule?: string
 }
 
-// From codersdk/workspaces.go:162:6
+// From codersdk/workspaces.go:161:6
 export interface UpdateWorkspaceTTLRequest {
   readonly ttl_ms?: number
 }
@@ -358,7 +358,7 @@ export interface UsersRequest extends Pagination {
   readonly status?: string
 }
 
-// From codersdk/workspaces.go:19:6
+// From codersdk/workspaces.go:18:6
 export interface Workspace {
   readonly id: string
   readonly created_at: string
@@ -436,12 +436,12 @@ export interface WorkspaceBuild {
   readonly deadline: string
 }
 
-// From codersdk/workspaces.go:65:6
+// From codersdk/workspaces.go:64:6
 export interface WorkspaceBuildsRequest extends Pagination {
   readonly WorkspaceID: string
 }
 
-// From codersdk/workspaces.go:201:6
+// From codersdk/workspaces.go:200:6
 export interface WorkspaceFilter {
   readonly organization_id?: string
   readonly owner?: string

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -10,6 +10,7 @@ import { FormikContextType, FormikErrors, useFormik } from "formik"
 import { FC, useState } from "react"
 import { Link as RouterLink } from "react-router-dom"
 import { Margins } from "../../components/Margins/Margins"
+import { Stack } from "../../components/Stack/Stack"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { workspacesMachine } from "../../xServices/workspaces/workspacesXService"
 import { Language, WorkspacesPageView } from "./WorkspacesPageView"
@@ -58,16 +59,19 @@ const WorkspacesPage: FC = () => {
     <>
       <Margins>
         <div className={styles.actions}>
-          <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
-            Filter
-          </Button>
-          <Menu id="simple-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
-            <MenuItem onClick={setYourWorkspaces}>Your workspaces</MenuItem>
-            <MenuItem onClick={setAllWorkspaces}>All workspaces</MenuItem>
-          </Menu>
-          <form onSubmit={form.handleSubmit}>
-            <TextField {...getFieldHelpers("query")} onChange={onChangeTrimmed(form)} fullWidth variant="outlined" />
-          </form>
+          <Stack direction="row">
+            <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
+              Filter
+            </Button>
+            <Menu id="simple-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+              <MenuItem onClick={setYourWorkspaces}>Your workspaces</MenuItem>
+              <MenuItem onClick={setAllWorkspaces}>All workspaces</MenuItem>
+            </Menu>
+            <form onSubmit={form.handleSubmit}>
+              <TextField {...getFieldHelpers("query")} onChange={onChangeTrimmed(form)} fullWidth variant="outlined" />
+            </form>
+          </Stack>
+
           <Link underline="none" component={RouterLink} to="/workspaces/new">
             <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
           </Link>

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -13,10 +13,16 @@ import { Margins } from "../../components/Margins/Margins"
 import { Stack } from "../../components/Stack/Stack"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { workspacesMachine } from "../../xServices/workspaces/workspacesXService"
-import { Language, WorkspacesPageView } from "./WorkspacesPageView"
+import { WorkspacesPageView } from "./WorkspacesPageView"
 
 interface FilterFormValues {
   query: string
+}
+
+const Language = {
+  createWorkspaceButton: "Create workspace",
+  yourWorkspacesButton: "Your workspaces",
+  allWorkspacesButton: "All workspaces"
 }
 
 export type FilterFormErrors = FormikErrors<FilterFormValues>
@@ -71,8 +77,8 @@ const WorkspacesPage: FC = () => {
             </Button>
 
             <Menu id="filter-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
-              <MenuItem onClick={setYourWorkspaces}>Your workspaces</MenuItem>
-              <MenuItem onClick={setAllWorkspaces}>All workspaces</MenuItem>
+              <MenuItem onClick={setYourWorkspaces}>{Language.yourWorkspacesButton}</MenuItem>
+              <MenuItem onClick={setAllWorkspaces}>{Language.allWorkspacesButton}</MenuItem>
             </Menu>
 
             <form onSubmit={form.handleSubmit}>
@@ -81,7 +87,7 @@ const WorkspacesPage: FC = () => {
           </Stack>
 
           <Link underline="none" component={RouterLink} to="/workspaces/new">
-            <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
+            <Button startIcon={<AddCircleOutline />}>{Language.createWorkspaceButton}</Button>
           </Link>
         </div>
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from "@material-ui/core/styles"
 import TextField from "@material-ui/core/TextField"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import { useMachine } from "@xstate/react"
-import { FormikContextType, FormikErrors, useFormik } from "formik"
+import { FormikErrors, useFormik } from "formik"
 import { FC, useState } from "react"
 import { Link as RouterLink } from "react-router-dom"
 import { Margins } from "../../components/Margins/Margins"
@@ -25,7 +25,7 @@ const WorkspacesPage: FC = () => {
   const styles = useStyles()
   const [workspacesState, send] = useMachine(workspacesMachine)
 
-const form = useFormik<FilterFormValues>({
+  const form = useFormik<FilterFormValues>({
     initialValues: {
       query: workspacesState.context.filter || "",
     },
@@ -50,13 +50,13 @@ const form = useFormik<FilterFormValues>({
   }
 
   const setYourWorkspaces = () => {
-    form.setFieldValue("query", "owner:me")
+    void form.setFieldValue("query", "owner:me")
     void form.submitForm()
     handleClose()
   }
 
   const setAllWorkspaces = () => {
-    form.setFieldValue("query", "")
+    void form.setFieldValue("query", "")
     void form.submitForm()
     handleClose()
   }
@@ -88,7 +88,6 @@ const form = useFormik<FilterFormValues>({
         <WorkspacesPageView
           loading={workspacesState.hasTag("loading")}
           workspaces={workspacesState.context.workspaces}
-          error={workspacesState.context.getWorkspacesError}
         />
       </Margins>
     </>

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -14,12 +14,14 @@ import { Stack } from "../../components/Stack/Stack"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { workspacesMachine } from "../../xServices/workspaces/workspacesXService"
 import { WorkspacesPageView } from "./WorkspacesPageView"
+import { CloseDropdown, OpenDropdown } from "../../components/DropdownArrows/DropdownArrows"
 
 interface FilterFormValues {
   query: string
 }
 
 const Language = {
+  filterName: "Filters",
   createWorkspaceButton: "Create workspace",
   yourWorkspacesButton: "Your workspaces",
   allWorkspacesButton: "All workspaces"
@@ -73,10 +75,15 @@ const WorkspacesPage: FC = () => {
         <div className={styles.actions}>
           <Stack direction="row">
             <Button aria-controls="filter-menu" aria-haspopup="true" onClick={handleClick}>
-              Filter
+              {Language.filterName} {anchorEl ? <CloseDropdown /> : <OpenDropdown />}
             </Button>
 
-            <Menu id="filter-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+            <Menu id="filter-menu"
+              anchorEl={anchorEl} 
+              keepMounted 
+              open={Boolean(anchorEl)} 
+              onClose={handleClose}
+            >
               <MenuItem onClick={setYourWorkspaces}>{Language.yourWorkspacesButton}</MenuItem>
               <MenuItem onClick={setAllWorkspaces}>{Language.allWorkspacesButton}</MenuItem>
             </Menu>

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -9,12 +9,12 @@ import { useMachine } from "@xstate/react"
 import { FormikErrors, useFormik } from "formik"
 import { FC, useState } from "react"
 import { Link as RouterLink } from "react-router-dom"
+import { CloseDropdown, OpenDropdown } from "../../components/DropdownArrows/DropdownArrows"
 import { Margins } from "../../components/Margins/Margins"
 import { Stack } from "../../components/Stack/Stack"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { workspacesMachine } from "../../xServices/workspaces/workspacesXService"
 import { WorkspacesPageView } from "./WorkspacesPageView"
-import { CloseDropdown, OpenDropdown } from "../../components/DropdownArrows/DropdownArrows"
 
 interface FilterFormValues {
   query: string
@@ -24,7 +24,7 @@ const Language = {
   filterName: "Filters",
   createWorkspaceButton: "Create workspace",
   yourWorkspacesButton: "Your workspaces",
-  allWorkspacesButton: "All workspaces"
+  allWorkspacesButton: "All workspaces",
 }
 
 export type FilterFormErrors = FormikErrors<FilterFormValues>
@@ -78,12 +78,7 @@ const WorkspacesPage: FC = () => {
               {Language.filterName} {anchorEl ? <CloseDropdown /> : <OpenDropdown />}
             </Button>
 
-            <Menu id="filter-menu"
-              anchorEl={anchorEl} 
-              keepMounted 
-              open={Boolean(anchorEl)} 
-              onClose={handleClose}
-            >
+            <Menu id="filter-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
               <MenuItem onClick={setYourWorkspaces}>{Language.yourWorkspacesButton}</MenuItem>
               <MenuItem onClick={setAllWorkspaces}>{Language.allWorkspacesButton}</MenuItem>
             </Menu>

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -1,20 +1,95 @@
+import Button from "@material-ui/core/Button"
+import Link from "@material-ui/core/Link"
+import Menu from "@material-ui/core/Menu"
+import MenuItem from "@material-ui/core/MenuItem"
+import { makeStyles } from "@material-ui/core/styles"
+import TextField from "@material-ui/core/TextField"
+import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import { useMachine } from "@xstate/react"
-import { FC } from "react"
+import { FormikContextType, FormikErrors, useFormik } from "formik"
+import { FC, useState } from "react"
+import { Link as RouterLink } from "react-router-dom"
+import { Margins } from "../../components/Margins/Margins"
+import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { workspacesMachine } from "../../xServices/workspaces/workspacesXService"
-import { WorkspacesPageView } from "./WorkspacesPageView"
+import { Language, WorkspacesPageView } from "./WorkspacesPageView"
+
+interface FilterFormValues {
+  query: string
+}
+
+export type FilterFormErrors = FormikErrors<FilterFormValues>
 
 const WorkspacesPage: FC = () => {
-  const [workspacesState] = useMachine(workspacesMachine)
+  const styles = useStyles()
+  const [workspacesState, send] = useMachine(workspacesMachine)
+
+  const form: FormikContextType<FilterFormValues> = useFormik<FilterFormValues>({
+    initialValues: { query: workspacesState.context.filter || "" },
+    onSubmit: (data) => {
+      send({
+        type: "SET_FILTER",
+        query: data.query,
+      })
+    },
+  })
+
+  const getFieldHelpers = getFormHelpers<FilterFormValues>(form, {})
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+  const setYourWorkspaces = () => {
+    form.setFieldValue("query", "owner:me")
+    void form.submitForm()
+    handleClose()
+  }
+  const setAllWorkspaces = () => {
+    form.setFieldValue("query", "")
+    void form.submitForm()
+    handleClose()
+  }
 
   return (
     <>
-      <WorkspacesPageView
-        loading={workspacesState.hasTag("loading")}
-        workspaces={workspacesState.context.workspaces}
-        error={workspacesState.context.getWorkspacesError}
-      />
+      <Margins>
+        <div className={styles.actions}>
+          <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
+            Filter
+          </Button>
+          <Menu id="simple-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+            <MenuItem onClick={setYourWorkspaces}>Your workspaces</MenuItem>
+            <MenuItem onClick={setAllWorkspaces}>All workspaces</MenuItem>
+          </Menu>
+          <form onSubmit={form.handleSubmit}>
+            <TextField {...getFieldHelpers("query")} onChange={onChangeTrimmed(form)} fullWidth variant="outlined" />
+          </form>
+          <Link underline="none" component={RouterLink} to="/workspaces/new">
+            <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
+          </Link>
+        </div>
+        <WorkspacesPageView
+          loading={workspacesState.hasTag("loading")}
+          workspaces={workspacesState.context.workspaces}
+          error={workspacesState.context.getWorkspacesError}
+        />
+      </Margins>
     </>
   )
 }
+
+const useStyles = makeStyles((theme) => ({
+  actions: {
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(3),
+    display: "flex",
+    justifyContent: "space-between",
+    height: theme.spacing(6),
+  },
+}))
 
 export default WorkspacesPage

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -25,30 +25,36 @@ const WorkspacesPage: FC = () => {
   const styles = useStyles()
   const [workspacesState, send] = useMachine(workspacesMachine)
 
-  const form: FormikContextType<FilterFormValues> = useFormik<FilterFormValues>({
-    initialValues: { query: workspacesState.context.filter || "" },
-    onSubmit: (data) => {
+const form = useFormik<FilterFormValues>({
+    initialValues: {
+      query: workspacesState.context.filter || "",
+    },
+    onSubmit: (values) => {
       send({
         type: "SET_FILTER",
-        query: data.query,
+        query: values.query,
       })
     },
   })
 
-  const getFieldHelpers = getFormHelpers<FilterFormValues>(form, {})
+  const getFieldHelpers = getFormHelpers<FilterFormValues>(form)
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
   }
+
   const handleClose = () => {
     setAnchorEl(null)
   }
+
   const setYourWorkspaces = () => {
     form.setFieldValue("query", "owner:me")
     void form.submitForm()
     handleClose()
   }
+
   const setAllWorkspaces = () => {
     form.setFieldValue("query", "")
     void form.submitForm()
@@ -60,13 +66,15 @@ const WorkspacesPage: FC = () => {
       <Margins>
         <div className={styles.actions}>
           <Stack direction="row">
-            <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
+            <Button aria-controls="filter-menu" aria-haspopup="true" onClick={handleClick}>
               Filter
             </Button>
-            <Menu id="simple-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+
+            <Menu id="filter-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
               <MenuItem onClick={setYourWorkspaces}>Your workspaces</MenuItem>
               <MenuItem onClick={setAllWorkspaces}>All workspaces</MenuItem>
             </Menu>
+
             <form onSubmit={form.handleSubmit}>
               <TextField {...getFieldHelpers("query")} onChange={onChangeTrimmed(form)} fullWidth variant="outlined" />
             </form>
@@ -76,6 +84,7 @@ const WorkspacesPage: FC = () => {
             <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
           </Link>
         </div>
+
         <WorkspacesPageView
           loading={workspacesState.hasTag("loading")}
           workspaces={workspacesState.context.workspaces}

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -1,10 +1,13 @@
 import Button from "@material-ui/core/Button"
+import Fade from "@material-ui/core/Fade"
+import InputAdornment from "@material-ui/core/InputAdornment"
 import Link from "@material-ui/core/Link"
 import Menu from "@material-ui/core/Menu"
 import MenuItem from "@material-ui/core/MenuItem"
 import { makeStyles } from "@material-ui/core/styles"
 import TextField from "@material-ui/core/TextField"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
+import SearchIcon from "@material-ui/icons/Search"
 import { useMachine } from "@xstate/react"
 import { FormikErrors, useFormik } from "formik"
 import { FC, useState } from "react"
@@ -70,45 +73,96 @@ const WorkspacesPage: FC = () => {
   }
 
   return (
-    <>
-      <Margins>
-        <div className={styles.actions}>
-          <Stack direction="row">
-            <Button aria-controls="filter-menu" aria-haspopup="true" onClick={handleClick}>
+    <Margins>
+      <Stack direction="row" className={styles.workspacesHeaderContainer}>
+        <Stack direction="column" className={styles.filterColumn}>
+          <Stack direction="row" spacing={0} className={styles.filterContainer}>
+            <Button
+              aria-controls="filter-menu"
+              aria-haspopup="true"
+              onClick={handleClick}
+              className={styles.buttonRoot}
+            >
               {Language.filterName} {anchorEl ? <CloseDropdown /> : <OpenDropdown />}
             </Button>
 
-            <Menu id="filter-menu" anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleClose}>
+            <form onSubmit={form.handleSubmit} className={styles.filterForm}>
+              <TextField
+                {...getFieldHelpers("query")}
+                className={styles.textFieldRoot}
+                onChange={onChangeTrimmed(form)}
+                fullWidth
+                variant="outlined"
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </form>
+
+            <Menu
+              id="filter-menu"
+              anchorEl={anchorEl}
+              keepMounted
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
+              TransitionComponent={Fade}
+              anchorOrigin={{
+                vertical: "bottom",
+                horizontal: "left",
+              }}
+              transformOrigin={{
+                vertical: "top",
+                horizontal: "left",
+              }}
+            >
               <MenuItem onClick={setYourWorkspaces}>{Language.yourWorkspacesButton}</MenuItem>
               <MenuItem onClick={setAllWorkspaces}>{Language.allWorkspacesButton}</MenuItem>
             </Menu>
-
-            <form onSubmit={form.handleSubmit}>
-              <TextField {...getFieldHelpers("query")} onChange={onChangeTrimmed(form)} fullWidth variant="outlined" />
-            </form>
           </Stack>
+        </Stack>
 
-          <Link underline="none" component={RouterLink} to="/workspaces/new">
-            <Button startIcon={<AddCircleOutline />}>{Language.createWorkspaceButton}</Button>
-          </Link>
-        </div>
-
-        <WorkspacesPageView
-          loading={workspacesState.hasTag("loading")}
-          workspaces={workspacesState.context.workspaces}
-        />
-      </Margins>
-    </>
+        <Link underline="none" component={RouterLink} to="/workspaces/new">
+          <Button startIcon={<AddCircleOutline />} style={{ height: "44px" }}>
+            {Language.createWorkspaceButton}
+          </Button>
+        </Link>
+      </Stack>
+      <WorkspacesPageView loading={workspacesState.hasTag("loading")} workspaces={workspacesState.context.workspaces} />
+    </Margins>
   )
 }
 
 const useStyles = makeStyles((theme) => ({
-  actions: {
+  workspacesHeaderContainer: {
     marginTop: theme.spacing(3),
     marginBottom: theme.spacing(3),
-    display: "flex",
     justifyContent: "space-between",
-    height: theme.spacing(6),
+  },
+  filterColumn: {
+    width: "60%",
+    cursor: "text",
+  },
+  filterContainer: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: "6px",
+  },
+  filterForm: {
+    width: "100%",
+  },
+  buttonRoot: {
+    border: "none",
+    borderRight: `1px solid ${theme.palette.divider}`,
+    borderRadius: "6px 0px 0px 6px",
+  },
+  textFieldRoot: {
+    margin: "0px",
+    "& fieldset": {
+      border: "none",
+    },
   },
 }))
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -30,7 +30,6 @@ export const Language = {
 export interface WorkspacesPageViewProps {
   loading?: boolean
   workspaces?: TypesGen.Workspace[]
-  error?: unknown
 }
 
 export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaces }) => {

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -15,7 +15,7 @@ import { Link as RouterLink } from "react-router-dom"
 import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { EmptyState } from "../../components/EmptyState/EmptyState"
-import { Margins } from "../../components/Margins/Margins"
+import { ErrorSummary } from "../../components/ErrorSummary/ErrorSummary"
 import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getDisplayStatus } from "../../util/workspace"
@@ -34,93 +34,78 @@ export interface WorkspacesPageViewProps {
   error?: unknown
 }
 
-export const WorkspacesPageView: FC<WorkspacesPageViewProps> = (props) => {
-  const styles = useStyles()
+export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaces, error }) => {
+  useStyles()
   const theme: Theme = useTheme()
+
   return (
     <Stack spacing={4}>
-      <Margins>
-        <div className={styles.actions}>
-          <Link underline="none" component={RouterLink} to="/workspaces/new">
-            <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
-          </Link>
-        </div>
-        <Table>
-          <TableHead>
+      {error && <ErrorSummary error={error} />}
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Template</TableCell>
+            <TableCell>Version</TableCell>
+            <TableCell>Last Built</TableCell>
+            <TableCell>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {loading && <TableLoader />}
+          {workspaces && workspaces.length === 0 && (
             <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Template</TableCell>
-              <TableCell>Version</TableCell>
-              <TableCell>Last Built</TableCell>
-              <TableCell>Status</TableCell>
+              <TableCell colSpan={999}>
+                <EmptyState
+                  message={Language.emptyMessage}
+                  description={Language.emptyDescription}
+                  cta={
+                    <Link underline="none" component={RouterLink} to="/workspaces/new">
+                      <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
+                    </Link>
+                  }
+                />
+              </TableCell>
             </TableRow>
-          </TableHead>
-          <TableBody>
-            {props.loading && <TableLoader />}
-            {props.workspaces && props.workspaces.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={999}>
-                  <EmptyState
-                    message={Language.emptyMessage}
-                    description={Language.emptyDescription}
-                    cta={
-                      <Link underline="none" component={RouterLink} to="/workspaces/new">
-                        <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
-                      </Link>
-                    }
-                  />
-                </TableCell>
-              </TableRow>
-            )}
-            {props.workspaces &&
-              props.workspaces.map((workspace) => {
-                const status = getDisplayStatus(theme, workspace.latest_build)
-                return (
-                  <TableRow key={workspace.id}>
-                    <TableCell>
-                      <AvatarData
-                        title={workspace.name}
-                        subtitle={workspace.owner_name}
-                        link={`/workspaces/${workspace.id}`}
-                      />
-                    </TableCell>
-                    <TableCell>{workspace.template_name}</TableCell>
-                    <TableCell>
-                      {workspace.outdated ? (
-                        <span style={{ color: theme.palette.error.main }}>outdated</span>
-                      ) : (
-                        <span style={{ color: theme.palette.text.secondary }}>up to date</span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <span data-chromatic="ignore" style={{ color: theme.palette.text.secondary }}>
-                        {dayjs().to(dayjs(workspace.latest_build.created_at))}
-                      </span>
-                    </TableCell>
-                    <TableCell>
-                      <span style={{ color: status.color }}>{status.status}</span>
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-          </TableBody>
-        </Table>
-      </Margins>
+          )}
+          {workspaces &&
+            workspaces.map((workspace) => {
+              const status = getDisplayStatus(theme, workspace.latest_build)
+              return (
+                <TableRow key={workspace.id}>
+                  <TableCell>
+                    <AvatarData
+                      title={workspace.name}
+                      subtitle={workspace.owner_name}
+                      link={`/workspaces/${workspace.id}`}
+                    />
+                  </TableCell>
+                  <TableCell>{workspace.template_name}</TableCell>
+                  <TableCell>
+                    {workspace.outdated ? (
+                      <span style={{ color: theme.palette.error.main }}>outdated</span>
+                    ) : (
+                      <span style={{ color: theme.palette.text.secondary }}>up to date</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <span data-chromatic="ignore" style={{ color: theme.palette.text.secondary }}>
+                      {dayjs().to(dayjs(workspace.latest_build.created_at))}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <span style={{ color: status.color }}>{status.status}</span>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+        </TableBody>
+      </Table>
     </Stack>
   )
 }
 
 const useStyles = makeStyles((theme) => ({
-  actions: {
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(3),
-    display: "flex",
-    height: theme.spacing(6),
-
-    "& > *": {
-      marginLeft: "auto",
-    },
-  },
   welcome: {
     paddingTop: theme.spacing(12),
     paddingBottom: theme.spacing(12),

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -49,7 +49,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
           </TableRow>
         </TableHead>
         <TableBody>
-          {loading && <TableLoader />}
+          {!workspaces && loading && <TableLoader />}
           {workspaces && workspaces.length === 0 && (
             <TableRow>
               <TableCell colSpan={999}>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -15,7 +15,6 @@ import { Link as RouterLink } from "react-router-dom"
 import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { EmptyState } from "../../components/EmptyState/EmptyState"
-import { ErrorSummary } from "../../components/ErrorSummary/ErrorSummary"
 import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getDisplayStatus } from "../../util/workspace"
@@ -34,13 +33,12 @@ export interface WorkspacesPageViewProps {
   error?: unknown
 }
 
-export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaces, error }) => {
+export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaces }) => {
   useStyles()
   const theme: Theme = useTheme()
 
   return (
     <Stack spacing={4}>
-      {error && <ErrorSummary error={error} />}
       <Table>
         <TableHead>
           <TableRow>

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -65,11 +65,12 @@ describe("util > workspace", () => {
     })
   describe("workspaceQueryToFilter", () => {
     it.each<[string | undefined, TypesGen.WorkspaceFilter]>([
-      [undefined, { Owner: "", OrganizationID: "" }],
-      ["", { Owner: "", OrganizationID: "" }],
-      ["asdkfvjn", { Owner: "", OrganizationID: "" }],
-      ["owner:me", { Owner: "me", OrganizationID: "" }],
-      ["owner:me owner:me2", { Owner: "me", OrganizationID: "" }],
+      [undefined, {}],
+      ["", {}],
+      ["asdkfvjn", { name: "asdkfvjn" }],
+      ["owner:me", { owner: "me" }],
+      ["owner:me owner:me2", { owner: "me" }],
+      ["me/dev", { owner: "me", name: "dev" }],
     ])(`query=%p, filter=%p`, (query, filter) => {
       expect(workspaceQueryToFilter(query)).toEqual(filter)
     })

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -69,9 +69,9 @@ describe("util > workspace", () => {
       ["", { Owner: "", OrganizationID: "" }],
       ["asdkfvjn", { Owner: "", OrganizationID: "" }],
       ["owner:me", { Owner: "me", OrganizationID: "" }],
-      ["owner:me owner:me2", { Owner: "me2", OrganizationID: "" }],
+      ["owner:me owner:me2", { Owner: "me", OrganizationID: "" }],
     ])(`query=%p, filter=%p`, (query, filter) => {
-      expect(workspaceQueryToFilter(query)).toBe(filter)
+      expect(workspaceQueryToFilter(query)).toEqual(filter)
     })
   })
 })

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs"
 import * as TypesGen from "../api/typesGenerated"
 import * as Mocks from "../testHelpers/entities"
-import { defaultWorkspaceExtension, isWorkspaceOn } from "./workspace"
+import { isWorkspaceOn, workspaceQueryToFilter, defaultWorkspaceExtension } from "./workspace"
 
 describe("util > workspace", () => {
   describe("isWorkspaceOn", () => {
@@ -61,6 +61,17 @@ describe("util > workspace", () => {
       ],
     ])(`defaultWorkspaceExtension(%p) returns %p`, (startTime, request) => {
       expect(defaultWorkspaceExtension(dayjs(startTime))).toEqual(request)
+      })
+    })
+  describe("workspaceQueryToFilter", () => {
+    it.each<[string | undefined, TypesGen.WorkspaceFilter]>([
+      [undefined, { Owner: "", OrganizationID: "" }],
+      ["", { Owner: "", OrganizationID: "" }],
+      ["asdkfvjn", { Owner: "", OrganizationID: "" }],
+      ["owner:me", { Owner: "me", OrganizationID: "" }],
+      ["owner:me owner:me2", { Owner: "me2", OrganizationID: "" }],
+    ])(`query=%p, filter=%p`, (query, filter) => {
+      expect(workspaceQueryToFilter(query)).toBe(filter)
     })
   })
 })

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs"
 import * as TypesGen from "../api/typesGenerated"
 import * as Mocks from "../testHelpers/entities"
-import { isWorkspaceOn, workspaceQueryToFilter, defaultWorkspaceExtension } from "./workspace"
+import { defaultWorkspaceExtension, isWorkspaceOn, workspaceQueryToFilter } from "./workspace"
 
 describe("util > workspace", () => {
   describe("isWorkspaceOn", () => {
@@ -61,8 +61,8 @@ describe("util > workspace", () => {
       ],
     ])(`defaultWorkspaceExtension(%p) returns %p`, (startTime, request) => {
       expect(defaultWorkspaceExtension(dayjs(startTime))).toEqual(request)
-      })
     })
+  })
   describe("workspaceQueryToFilter", () => {
     it.each<[string | undefined, TypesGen.WorkspaceFilter]>([
       [undefined, {}],

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -71,6 +71,7 @@ describe("util > workspace", () => {
       ["owner:me", { owner: "me" }],
       ["owner:me owner:me2", { owner: "me" }],
       ["me/dev", { owner: "me", name: "dev" }],
+      ["    key:val      owner:me       ", { owner: "me" }],
     ])(`query=%p, filter=%p`, (query, filter) => {
       expect(workspaceQueryToFilter(query)).toEqual(filter)
     })

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -219,10 +219,14 @@ export const workspaceQueryToFilter = (query?: string): TypesGen.WorkspaceFilter
 
     for (const part of parts) {
       const [key, val] = part.split(":")
-      if (key === "owner") {
-        return {
-          owner: val,
+      if (key && val) {
+        if (key === "owner") {
+          return {
+            owner: val,
+          }
         }
+        // skip invalid key pairs
+        continue
       }
 
       const [username, name] = part.split("/")

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -207,3 +207,25 @@ export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.P
     deadline: NinetyMinutesFromNow.format(),
   }
 }
+
+export const workspaceQueryToFilter = (query?: string): WorkspaceFilter => {
+  let filter: WorkspaceFilter = {
+    Owner: "",
+    OrganizationID: "",
+  }
+
+  if (query) {
+    const parts = query.split(" ")
+
+    parts.map((part) => {
+      if (part.startsWith("owner:")) {
+        filter = {
+          Owner: part.slice("owner:".length),
+          OrganizationID: "",
+        }
+      }
+    })
+  }
+
+  return filter
+}

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -199,8 +199,6 @@ export const isWorkspaceOn = (workspace: TypesGen.Workspace): boolean => {
   return transition === "start" && status === "succeeded"
 }
 
-<<<<<<< HEAD
-
 export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.PutExtendWorkspaceRequest => {
   const now = __startDate ? dayjs(__startDate) : dayjs()
   const NinetyMinutesFromNow = now.add(90, "minutes").utc()

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -199,6 +199,7 @@ export const isWorkspaceOn = (workspace: TypesGen.Workspace): boolean => {
   return transition === "start" && status === "succeeded"
 }
 
+
 export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.PutExtendWorkspaceRequest => {
   const now = __startDate ? dayjs(__startDate) : dayjs()
   const NinetyMinutesFromNow = now.add(90, "minutes").utc()

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -210,7 +210,7 @@ export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.P
 
 export const workspaceQueryToFilter = (query?: string): TypesGen.WorkspaceFilter => {
   const defaultFilter: TypesGen.WorkspaceFilter = {}
-  const preparedQuery = query?.replace(/  +/g, " ")
+  const preparedQuery = query?.trim().replace(/  +/g, " ")
 
   if (!preparedQuery) {
     return defaultFilter

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -209,23 +209,28 @@ export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.P
 }
 
 export const workspaceQueryToFilter = (query?: string): WorkspaceFilter => {
-  let filter: WorkspaceFilter = {
+  const defaultFilter: WorkspaceFilter = {
     Owner: "",
     OrganizationID: "",
   }
 
-  if (query) {
-    const parts = query.split(" ")
+  const preparedQuery = query?.replace(/  +/g, " ")
 
-    parts.map((part) => {
-      if (part.startsWith("owner:")) {
-        filter = {
-          Owner: part.slice("owner:".length),
+  if (!preparedQuery) {
+    return defaultFilter
+  } else {
+    const parts = preparedQuery.split(" ")
+
+    for (const part of parts) {
+      const [key, val] = part.split(":")
+      if (key === "owner") {
+        return {
+          Owner: val,
           OrganizationID: "",
         }
       }
-    })
-  }
+    }
 
-  return filter
+    return defaultFilter
+  }
 }

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -199,6 +199,7 @@ export const isWorkspaceOn = (workspace: TypesGen.Workspace): boolean => {
   return transition === "start" && status === "succeeded"
 }
 
+<<<<<<< HEAD
 
 export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.PutExtendWorkspaceRequest => {
   const now = __startDate ? dayjs(__startDate) : dayjs()
@@ -209,12 +210,8 @@ export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.P
   }
 }
 
-export const workspaceQueryToFilter = (query?: string): WorkspaceFilter => {
-  const defaultFilter: WorkspaceFilter = {
-    Owner: "",
-    OrganizationID: "",
-  }
-
+export const workspaceQueryToFilter = (query?: string): TypesGen.WorkspaceFilter => {
+  const defaultFilter: TypesGen.WorkspaceFilter = {}
   const preparedQuery = query?.replace(/  +/g, " ")
 
   if (!preparedQuery) {
@@ -226,9 +223,19 @@ export const workspaceQueryToFilter = (query?: string): WorkspaceFilter => {
       const [key, val] = part.split(":")
       if (key === "owner") {
         return {
-          Owner: val,
-          OrganizationID: "",
+          owner: val,
         }
+      }
+
+      const [username, name] = part.split("/")
+      if (username && name) {
+        return {
+          owner: username,
+          name: name,
+        }
+      }
+      return {
+        name: part,
       }
     }
 

--- a/site/src/xServices/workspaces/workspacesXService.ts
+++ b/site/src/xServices/workspaces/workspacesXService.ts
@@ -51,7 +51,7 @@ export const workspacesMachine = createMachine(
           },
           onError: {
             target: "ready",
-            actions: "assignGetWorkspacesError",
+            actions: ["assignGetWorkspacesError", "clearWorkspaces"],
           },
         },
         tags: "loading",
@@ -70,6 +70,7 @@ export const workspacesMachine = createMachine(
         getWorkspacesError: (_, event) => event.data,
       }),
       clearGetWorkspacesError: (context) => assign({ ...context, getWorkspacesError: undefined }),
+      clearWorkspaces: (context) => assign({ ...context, workspaces: undefined }),
     },
     services: {
       getWorkspaces: (context) => API.getWorkspaces(workspaceQueryToFilter(context.filter)),


### PR DESCRIPTION
Okay third time is the charm. This one I'd actually like to get merged. 

Discussion at https://github.com/coder/coder/issues/1820

This PR adds a workspace filter to the workspaces page. It uses the backend and it defaults to the workspaces you own, and there's buttons to see all workspaces and a filter bar. Right now the filter bar only functions with the `owner:` query filter. 

![chrome_zNVFzNQXaq](https://user-images.githubusercontent.com/19379394/171518676-70c1e8c9-52a0-48d4-9b41-ca0873cad1e8.gif)

Next steps:
- Work with / hand off to a frontend person to help with styling issues
- Correctly handle 400 error cases where we should show no workspaces 
- Support plain words as a workspace name filter (requires backend changes, probably different PR)