### PR TITLE
fix: Avoid use of r.Context() after r.Hijack()

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -388,7 +388,6 @@ func (api *API) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Accept text connections, because it's more developer friendly.
 	ctx, wsNetConn := websocketNetConn(r.Context(), conn, websocket.MessageBinary)
 	defer wsNetConn.Close() // Also closes conn.
 


### PR DESCRIPTION
This PR changes how we initialize `websocket.NetConn`s so that we have a context that emits connection closure.

Fixes #1508

- fix: Fix goroutine leak by propagating websocket closure
- fix: Use of r.Context() in workspaceAgentDial
- fix: Use of rw and r.Context() in workspaceAgentListen
- fix: Use of r.Context() in workspaceAgentPTY

This is version 2. Initially I implemented `io.EOF` closure propagation in `coderd/turnconn.Conn`, while I do think it may be a good idea, it's not necessary to fix #1508. I implemented it this way so that the fix can be utilized in the other handlers as well.
