### PR TITLE
feat: Add support for pprof in `coder agent`

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"net/http"
+	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -25,7 +26,9 @@ import (
 
 func workspaceAgent() *cobra.Command {
 	var (
-		auth string
+		auth         string
+		pprofEnabled bool
+		pprofAddress string
 	)
 	cmd := &cobra.Command{
 		Use: "agent",
@@ -48,6 +51,11 @@ func workspaceAgent() *cobra.Command {
 			defer logWriter.Close()
 			logger := slog.Make(sloghuman.Sink(cmd.ErrOrStderr()), sloghuman.Sink(logWriter)).Leveled(slog.LevelDebug)
 			client := codersdk.New(coderURL)
+
+			if pprofEnabled {
+				//nolint:revive
+				defer serveHandler(cmd.Context(), logger, nil, pprofAddress, "pprof")()
+			}
 
 			// exchangeToken returns a session token.
 			// This is abstracted to allow for the same looping condition
@@ -139,5 +147,7 @@ func workspaceAgent() *cobra.Command {
 	}
 
 	cliflag.StringVarP(cmd.Flags(), &auth, "auth", "", "CODER_AGENT_AUTH", "token", "Specify the authentication type to use for the agent")
+	cliflag.BoolVarP(cmd.Flags(), &pprofEnabled, "pprof-enable", "", "CODER_AGENT_PPROF_ENABLE", false, "Enable serving pprof metrics on the address defined by --pprof-address.")
+	cliflag.StringVarP(cmd.Flags(), &pprofAddress, "pprof-address", "", "CODER_AGENT_PPROF_ADDRESS", "127.0.0.1:6060", "The address to serve pprof.")
 	return cmd
 }

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -6,9 +6,7 @@ import (
 	_ "net/http/pprof" //nolint: gosec
 	"net/url"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -54,29 +52,14 @@ func workspaceAgent() *cobra.Command {
 			logger := slog.Make(sloghuman.Sink(cmd.ErrOrStderr()), sloghuman.Sink(logWriter)).Leveled(slog.LevelDebug)
 			client := codersdk.New(coderURL)
 
-			usr1 := make(chan os.Signal, 1)
 			if pprofEnabled {
-				close(usr1)
 				srvClose := serveHandler(cmd.Context(), logger, nil, pprofAddress, "pprof")
 				defer srvClose()
 			} else {
 				// If pprof wasn't enabled at startup, allow a
 				// `kill -USR1 $agent_pid` to start it.
-				signal.Notify(usr1, syscall.SIGUSR1)
-				go func() {
-					defer close(usr1)
-					defer signal.Stop(usr1)
-
-					select {
-					case <-usr1:
-						signal.Stop(usr1)
-						srvClose := serveHandler(cmd.Context(), logger, nil, pprofAddress, "pprof")
-						defer srvClose()
-					case <-cmd.Context().Done():
-						return
-					}
-					<-cmd.Context().Done() // Prevent defer close until done.
-				}()
+				srvClose := agentPPROFStartOnUSR1(cmd.Context(), logger, pprofAddress)
+				defer srvClose()
 			}
 
 			// exchangeToken returns a session token.
@@ -164,7 +147,6 @@ func workspaceAgent() *cobra.Command {
 				},
 			})
 			<-cmd.Context().Done()
-			<-usr1 // Wait for server to close (if started).
 			return closer.Close()
 		},
 	}

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -57,8 +57,8 @@ func workspaceAgent() *cobra.Command {
 				defer srvClose()
 			} else {
 				// If pprof wasn't enabled at startup, allow a
-				// `kill -USR1 $agent_pid` to start it.
-				srvClose := agentPPROFStartOnUSR1(cmd.Context(), logger, pprofAddress)
+				// `kill -USR1 $agent_pid` to start it (on Unix).
+				srvClose := agentStartPPROFOnUSR1(cmd.Context(), logger, pprofAddress)
 				defer srvClose()
 			}
 

--- a/cli/agent_unix.go
+++ b/cli/agent_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cli
 
 import (

--- a/cli/agent_unix.go
+++ b/cli/agent_unix.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"cdr.dev/slog"
+)
+
+func agentPPROFStartOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
+	usr1 := make(chan os.Signal, 1)
+	signal.Notify(usr1, syscall.SIGUSR1)
+	go func() {
+		defer close(usr1)
+		defer signal.Stop(usr1)
+
+		select {
+		case <-usr1:
+			signal.Stop(usr1)
+			srvClose := serveHandler(ctx, logger, nil, pprofAddress, "pprof")
+			defer srvClose()
+		case <-ctx.Done():
+			return
+		}
+		<-ctx.Done() // Prevent defer close until done.
+	}()
+
+	return func() {
+		<-usr1 // Wait until usr1 is closed, ensures srvClose was run.
+	}
+}

--- a/cli/agent_unix.go
+++ b/cli/agent_unix.go
@@ -10,6 +10,8 @@ import (
 )
 
 func agentPPROFStartOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
+	ctx, cancel := context.WithCancel(ctx)
+
 	usr1 := make(chan os.Signal, 1)
 	signal.Notify(usr1, syscall.SIGUSR1)
 	go func() {
@@ -28,6 +30,7 @@ func agentPPROFStartOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress
 	}()
 
 	return func() {
+		cancel()
 		<-usr1 // Wait until usr1 is closed, ensures srvClose was run.
 	}
 }

--- a/cli/agent_unix.go
+++ b/cli/agent_unix.go
@@ -9,7 +9,7 @@ import (
 	"cdr.dev/slog"
 )
 
-func agentPPROFStartOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
+func agentStartPPROFOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	usr1 := make(chan os.Signal, 1)

--- a/cli/agent_windows.go
+++ b/cli/agent_windows.go
@@ -9,7 +9,7 @@ import (
 	"cdr.dev/slog"
 )
 
-// agentPPROFStartOnUSR1 is no-op on Windows (no SIGUSR1 signal).
-func agentPPROFStartOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
+// agentStartPPROFOnUSR1 is no-op on Windows (no SIGUSR1 signal).
+func agentStartPPROFOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
 	return func() {}
 }

--- a/cli/agent_windows.go
+++ b/cli/agent_windows.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"cdr.dev/slog"
+)
+
+// agentPPROFStartOnUSR1 is no-op on Windows (no SIGUSR1 signal).
+func agentPPROFStartOnUSR1(ctx context.Context, logger slog.Logger, pprofAddress string) (srvClose func()) {
+	return func() {}
+}

--- a/cli/agent_windows.go
+++ b/cli/agent_windows.go
@@ -2,9 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"cdr.dev/slog"
 )


### PR DESCRIPTION
This PR adds support for starting a pprof server in `coder agent`.

After #1978 I wanted this to analyze the agent for memory leaks, as mentioned in #1508.

