### PR TITLE
feat: Use consistent colors for links and highlighting

### DIFF
--- a/site/src/components/BorderedMenu/BorderedMenu.tsx
+++ b/site/src/components/BorderedMenu/BorderedMenu.tsx
@@ -31,8 +31,8 @@ const useStyles = makeStyles((theme) => ({
   },
   paperRoot: {
     width: "292px",
-    border: `2px solid ${theme.palette.primary.main}`,
+    border: `2px solid ${theme.palette.secondary.dark}`,
     borderRadius: 7,
-    boxShadow: `4px 4px 0px ${fade(theme.palette.primary.main, 0.2)}`,
+    boxShadow: `4px 4px 0px ${fade(theme.palette.secondary.dark, 0.2)}`,
   },
 }))

--- a/site/src/components/BorderedMenuRow/BorderedMenuRow.tsx
+++ b/site/src/components/BorderedMenuRow/BorderedMenuRow.tsx
@@ -78,12 +78,12 @@ const useStyles = makeStyles((theme) => ({
     },
 
     "&[data-status='active']": {
-      color: theme.palette.primary.main,
+      color: theme.palette.secondary.dark,
       "& .BorderedMenuRow-description": {
         color: theme.palette.text.primary,
       },
       "& .BorderedMenuRow-icon": {
-        color: theme.palette.primary.main,
+        color: theme.palette.secondary.dark,
       },
     },
   },

--- a/site/src/components/BuildsTable/BuildsTable.tsx
+++ b/site/src/components/BuildsTable/BuildsTable.tsx
@@ -106,7 +106,7 @@ const useStyles = makeStyles((theme) => ({
     },
 
     "&:focus": {
-      outline: `1px solid ${theme.palette.primary.dark}`,
+      outline: `1px solid ${theme.palette.secondary.dark}`,
     },
   },
 }))

--- a/site/src/components/NavbarView/NavbarView.tsx
+++ b/site/src/components/NavbarView/NavbarView.tsx
@@ -116,7 +116,7 @@ const useStyles = makeStyles((theme) => ({
         content: `" "`,
         bottom: 0,
         left: theme.spacing(3),
-        background: "#C16800",
+        background: theme.palette.secondary.dark,
         right: theme.spacing(3),
         height: 2,
         position: "absolute",

--- a/site/src/components/TabSidebar/TabSidebar.tsx
+++ b/site/src/components/TabSidebar/TabSidebar.tsx
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.text.primary,
     },
     "&.active": {
-      color: theme.palette.primary.dark,
+      color: theme.palette.secondary.dark,
     },
 
     "&.active, &:hover": {

--- a/site/src/components/UserDropdownContent/UserDropdownContent.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.tsx
@@ -127,7 +127,7 @@ const useStyles = makeStyles((theme) => ({
     margin: theme.spacing(0.5),
   },
   chipRoot: {
-    backgroundColor: "#7057FF",
+    backgroundColor: theme.palette.secondary.dark,
   },
   link: {
     textDecoration: "none",

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -11,6 +11,7 @@ export const darkPalette: PaletteOptions = {
   secondary: {
     main: "#008510",
     contrastText: "#f8f8f8",
+    dark: "#7057FF",
   },
   background: {
     default: "#1F1F1F",


### PR DESCRIPTION
This PR uses the new purple color for highlighting links and other focus elements.

## Subtasks

- [x] move the chip color from user roles to the palette.
- [x] use the palette color in places we need to update.

Fixes #1940 

## Screenshots
### User roles
![Screen Shot 2022-06-02 at 11 56 02 AM](https://user-images.githubusercontent.com/7511231/171672598-5b334a43-33b2-4790-8418-be54ebc7de8b.png)

### Side-navbar
![Screen Shot 2022-06-02 at 11 55 48 AM](https://user-images.githubusercontent.com/7511231/171672626-81166ce0-c365-4990-9595-9495b3eec676.png)

### Navbar
![Screen Shot 2022-06-02 at 11 55 37 AM](https://user-images.githubusercontent.com/7511231/171672646-dbe7db10-1399-4385-98f7-05ce7d01a697.png)

### Builds table
![Screen Shot 2022-06-02 at 11 58 08 AM](https://user-images.githubusercontent.com/7511231/171673265-593a11ad-87f0-48fb-82b9-0ff0ddd7c1ec.png)

### User dropdown menu
![Screen Shot 2022-06-02 at 12 08 53 PM](https://user-images.githubusercontent.com/7511231/171675587-4e9562cc-1748-47c8-8926-c369100c0329.png)

This one is probably unused, but it was part of a story so updated it in case we end up using the component in the future:
![Screen Shot 2022-06-02 at 12 19 55 PM](https://user-images.githubusercontent.com/7511231/171677249-1802d1c5-61c0-4885-945f-fae6aa05dd5c.png)

