### PR TITLE
feat: Update success confirmation dialog and snackbar

### DIFF
--- a/site/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -36,3 +36,10 @@ InfoDialog.args = {
   hideCancel: true,
   type: "info",
 }
+
+export const InfoDialogWithCancel = Template.bind({})
+InfoDialog.args = {
+  description: "Information can be cool!",
+  hideCancel: false,
+  type: "info",
+}

--- a/site/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -38,8 +38,22 @@ InfoDialog.args = {
 }
 
 export const InfoDialogWithCancel = Template.bind({})
-InfoDialog.args = {
+InfoDialogWithCancel.args = {
   description: "Information can be cool!",
   hideCancel: false,
   type: "info",
+}
+
+export const SuccessDialog = Template.bind({})
+SuccessDialog.args = {
+  description: "I am successful.",
+  hideCancel: true,
+  type: "success",
+}
+
+export const SuccessDialogWithCancel = Template.bind({})
+SuccessDialog.args = {
+  description: "I may be successful.",
+  hideCancel: false,
+  type: "success",
 }

--- a/site/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -52,7 +52,7 @@ SuccessDialog.args = {
 }
 
 export const SuccessDialogWithCancel = Template.bind({})
-SuccessDialog.args = {
+SuccessDialogWithCancel.args = {
   description: "I may be successful.",
   hideCancel: false,
   type: "success",

--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -19,6 +19,10 @@ const CONFIRM_DIALOG_DEFAULTS: Record<ConfirmDialogType, ConfirmDialogTypeConfig
     confirmText: "OK",
     hideCancel: true,
   },
+  success: {
+    confirmText: "OK",
+    hideCancel: true,
+  },
 }
 
 export interface ConfirmDialogProps extends Omit<DialogActionButtonsProps, "color" | "confirmDialog" | "onCancel"> {

--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -41,40 +41,32 @@ export interface ConfirmDialogProps extends Omit<DialogActionButtonsProps, "colo
   readonly title: string
 }
 
-interface StyleProps {
-  type: ConfirmDialogType
-}
-
 const useStyles = makeStyles((theme) => ({
-  dialogWrapper: (props: StyleProps) => ({
+  dialogWrapper: {
     "& .MuiPaper-root": {
-      background: props.type === "info" ? theme.palette.primary.main : theme.palette.background.paper,
+      background: theme.palette.background.paper,
       border: `1px solid ${theme.palette.divider}`,
     },
     "& .MuiDialogActions-spacing": {
       padding: `0 ${theme.spacing(3.75)}px ${theme.spacing(3.75)}px`,
     },
-  }),
-  dialogContent: (props: StyleProps) => ({
-    color: props.type === "info" ? theme.palette.primary.contrastText : theme.palette.text.secondary,
+  },
+  dialogContent: {
+    color: theme.palette.text.secondary,
     padding: theme.spacing(6),
     textAlign: "center",
-  }),
+  },
   titleText: {
     marginBottom: theme.spacing(3),
   },
-  description: (props: StyleProps) => ({
-    color:
-      props.type === "info" ? fade(theme.palette.primary.contrastText, 0.75) : fade(theme.palette.text.secondary, 0.75),
+  description: {
+    color: fade(theme.palette.text.secondary, 0.75),
     lineHeight: "160%",
 
     "& strong": {
-      color:
-        props.type === "info"
-          ? fade(theme.palette.primary.contrastText, 0.95)
-          : fade(theme.palette.text.secondary, 0.95),
+      color: fade(theme.palette.text.secondary, 0.95),
     },
-  }),
+  },
 }))
 
 /**

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -126,11 +126,12 @@ export const DialogActionButtons: React.FC<DialogActionButtonsProps> = ({
           color={typeToColor(type)}
           loading={confirmLoading}
           type="submit"
-          className={combineClasses([
-            styles.dialogButton,
-            styles.submitButton,
-            type === "delete" ? styles.errorButton : "",
-          ])}
+          className={combineClasses({
+            [styles.dialogButton]: true,
+            [styles.submitButton]: true,
+            [styles.errorButton]: type === "delete",
+            [styles.successButton]: type === "success",
+          })}
         >
           {confirmText}
         </LoadingButton>
@@ -180,7 +181,7 @@ const useButtonStyles = makeStyles((theme) => ({
     // Override disabled to keep background color, change loading spinner to contrast color
     "&.Mui-disabled": {
       "&.MuiButton-containedPrimary": {
-        background: theme.palette.success.main,
+        background: theme.palette.primary.dark,
 
         "& .MuiCircularProgress-root": {
           color: theme.palette.primary.contrastText,
@@ -237,6 +238,56 @@ const useButtonStyles = makeStyles((theme) => ({
       color: theme.palette.error.main,
       "&:hover": {
         backgroundColor: fade(theme.palette.error.main, theme.palette.action.hoverOpacity),
+        "@media (hover: none)": {
+          backgroundColor: "transparent",
+        },
+      },
+      "&.Mui-disabled": {
+        color: fade(theme.palette.text.disabled, 0.5),
+      },
+    },
+  },
+  successButton: {
+    "&.MuiButton-contained": {
+      backgroundColor: theme.palette.success.main,
+      color: theme.palette.primary.contrastText,
+      "&:hover": {
+        backgroundColor: darken(theme.palette.success.main, 0.3),
+        "@media (hover: none)": {
+          backgroundColor: "transparent",
+        },
+        "&.Mui-disabled": {
+          backgroundColor: "transparent",
+        },
+      },
+      "&.Mui-disabled": {
+        backgroundColor: theme.palette.action.disabledBackground,
+        color: fade(theme.palette.text.disabled, 0.5),
+      },
+    },
+
+    "&.MuiButton-outlined": {
+      color: theme.palette.success.main,
+      borderColor: theme.palette.success.main,
+      "&:hover": {
+        backgroundColor: fade(theme.palette.success.main, theme.palette.action.hoverOpacity),
+        "@media (hover: none)": {
+          backgroundColor: "transparent",
+        },
+        "&.Mui-disabled": {
+          backgroundColor: "transparent",
+        },
+      },
+      "&.Mui-disabled": {
+        color: fade(theme.palette.text.disabled, 0.5),
+        borderColor: theme.palette.action.disabled,
+      },
+    },
+
+    "&.MuiButton-text": {
+      color: theme.palette.success.main,
+      "&:hover": {
+        backgroundColor: fade(theme.palette.success.main, theme.palette.action.hoverOpacity),
         "@media (hover: none)": {
           backgroundColor: "transparent",
         },

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -180,7 +180,7 @@ const useButtonStyles = makeStyles((theme) => ({
     // Override disabled to keep background color, change loading spinner to contrast color
     "&.Mui-disabled": {
       "&.MuiButton-containedPrimary": {
-        background: theme.palette.primary.dark,
+        background: theme.palette.success.main,
 
         "& .MuiCircularProgress-root": {
           color: theme.palette.primary.contrastText,

--- a/site/src/components/Dialog/types.ts
+++ b/site/src/components/Dialog/types.ts
@@ -1,1 +1,1 @@
-export type ConfirmDialogType = "delete" | "info"
+export type ConfirmDialogType = "delete" | "info" | "success"

--- a/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.stories.tsx
+++ b/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.stories.tsx
@@ -21,3 +21,10 @@ Info.args = {
   open: true,
   message: "Hey, something happened.",
 }
+
+export const Success = Template.bind({})
+Success.args = {
+  variant: "success",
+  open: true,
+  message: "Hey, something good happened.",
+}

--- a/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.tsx
+++ b/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.tsx
@@ -5,7 +5,7 @@ import CloseIcon from "@material-ui/icons/Close"
 import { FC } from "react"
 import { combineClasses } from "../../util/combineClasses"
 
-type EnterpriseSnackbarVariant = "error" | "info"
+type EnterpriseSnackbarVariant = "error" | "info" | "success"
 
 export interface EnterpriseSnackbarProps extends MuiSnackbarProps {
   /** Called when the snackbar should close, either from timeout or clicking close */
@@ -45,7 +45,7 @@ export const EnterpriseSnackbar: FC<EnterpriseSnackbarProps> = ({
         <div className={styles.actionWrapper}>
           {action}
           <IconButton onClick={onClose} className={styles.iconButton}>
-            <CloseIcon className={variant === "info" ? styles.closeIcon : styles.closeIconError} />
+            <CloseIcon className={styles.closeIcon} />
           </IconButton>
         </div>
       }
@@ -55,6 +55,7 @@ export const EnterpriseSnackbar: FC<EnterpriseSnackbarProps> = ({
           [styles.snackbarContent]: true,
           [styles.snackbarContentInfo]: variant === "info",
           [styles.snackbarContentError]: variant === "error",
+          [styles.snackbarContentSuccess]: variant === "success",
         }),
       }}
       onClose={onClose}
@@ -73,12 +74,7 @@ const useStyles = makeStyles((theme) => ({
   closeIcon: {
     width: 25,
     height: 25,
-    color: theme.palette.info.contrastText,
-  },
-  closeIconError: {
-    width: 25,
-    height: 25,
-    color: theme.palette.error.contrastText,
+    color: theme.palette.primary.contrastText,
   },
   snackbarContent: {
     border: `1px solid ${theme.palette.divider}`,
@@ -92,9 +88,12 @@ const useStyles = makeStyles((theme) => ({
   },
   snackbarContentInfo: {
     // Use success color as a highlight
-    borderLeftColor: theme.palette.success.main,
+    borderLeftColor: theme.palette.primary.main,
   },
   snackbarContentError: {
     borderLeftColor: theme.palette.error.main,
+  },
+  snackbarContentSuccess: {
+    borderLeftColor: theme.palette.success.main,
   },
 }))

--- a/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.tsx
+++ b/site/src/components/EnterpriseSnackbar/EnterpriseSnackbar.tsx
@@ -87,16 +87,14 @@ const useStyles = makeStyles((theme) => ({
     padding: `${theme.spacing(1)}px ${theme.spacing(3)}px ${theme.spacing(1)}px ${theme.spacing(2)}px`,
     boxShadow: theme.shadows[6],
     alignItems: "inherit",
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.secondary,
   },
   snackbarContentInfo: {
-    backgroundColor: theme.palette.info.main,
-    // Use primary color as a highlight
-    borderLeftColor: theme.palette.primary.main,
-    color: theme.palette.info.contrastText,
+    // Use success color as a highlight
+    borderLeftColor: theme.palette.success.main,
   },
   snackbarContentError: {
-    backgroundColor: theme.palette.background.paper,
     borderLeftColor: theme.palette.error.main,
-    color: theme.palette.text.secondary,
   },
 }))

--- a/site/src/components/GlobalSnackbar/GlobalSnackbar.tsx
+++ b/site/src/components/GlobalSnackbar/GlobalSnackbar.tsx
@@ -15,6 +15,16 @@ import {
   SnackbarEventType,
 } from "./utils"
 
+const variantFromMsgType = (type: MsgType) => {
+  if (type === MsgType.Error) {
+    return "error"
+  } else if (type === MsgType.Success) {
+    return "success"
+  } else {
+    return "info"
+  }
+}
+
 export const GlobalSnackbar: React.FC = () => {
   const styles = useStyles()
   const [open, setOpen] = useState<boolean>(false)
@@ -63,7 +73,7 @@ export const GlobalSnackbar: React.FC = () => {
   return (
     <EnterpriseSnackbar
       open={open}
-      variant={notification.msgType === MsgType.Error ? "error" : "info"}
+      variant={variantFromMsgType(notification.msgType)}
       message={
         <div className={styles.messageWrapper}>
           {notification.msgType === MsgType.Error && <ErrorIcon className={styles.errorIcon} />}


### PR DESCRIPTION
This PR updates the UI for success confirmation dialog and snackbar.

## Subtasks

- [x] add the UI for success confirmation dialog
- [x] add the UI for success snackbar
- [x] update the UI for info to be consistent with error and success
- [x] update and add corresponding stories
- [x] update the usages of snackbar and confirm dialog to success type wherever applicable. 

Fixes #1984 

## Screenshots
### Success snackbar
![Screen Shot 2022-06-03 at 11 24 00 AM](https://user-images.githubusercontent.com/7511231/171884123-6165b7c7-7a9e-49e1-9559-0983b79109b0.png)

### Info snackbar
![Screen Shot 2022-06-03 at 11 24 16 AM](https://user-images.githubusercontent.com/7511231/171884102-9dbe1bad-4917-4c25-8939-5b5ddfd714d8.png)

### Info confirm dialogs
![Screen Shot 2022-06-03 at 11 26 39 AM](https://user-images.githubusercontent.com/7511231/171884505-94e4345a-df3b-4cf7-aa30-e9eac43ca234.png)
![Screen Shot 2022-06-03 at 11 23 37 AM](https://user-images.githubusercontent.com/7511231/171884290-7ae60644-5044-430a-a28d-0d58047ce94c.png)

### Success confirm dialogs
![Screen Shot 2022-06-03 at 11 23 52 AM](https://user-images.githubusercontent.com/7511231/171884413-851b8d0e-2102-4924-87f3-c039ef6c5b7f.png)

![Screen Shot 2022-06-03 at 11 23 44 AM](https://user-images.githubusercontent.com/7511231/171884393-db15d389-c361-4a75-b3bf-99e6cad8fab1.png)




