### PR TITLE
fix: ws schedule top-down restriction

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.test.ts
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.test.ts
@@ -57,6 +57,22 @@ describe("validationSchema", () => {
     expect(validate).toThrowError(Language.errorNoDayOfWeek)
   })
 
+  it("disallows empty startTime when at least one day is set", () => {
+    const values: WorkspaceScheduleFormValues = {
+      ...valid,
+      sunday: false,
+      monday: true,
+      tuesday: false,
+      wednesday: false,
+      thursday: false,
+      friday: false,
+      saturday: false,
+      startTime: "",
+    }
+    const validate = () => validationSchema.validateSync(values)
+    expect(validate).toThrowError(Language.errorNoTime)
+  })
+
   it("allows startTime 16:20", () => {
     const values: WorkspaceScheduleFormValues = {
       ...valid,

--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -27,6 +27,7 @@ dayjs.extend(timezone)
 
 export const Language = {
   errorNoDayOfWeek: "Must set at least one day of week",
+  errorNoTime: "Start time is required",
   errorTime: "Time must be in HH:mm format (24 hours)",
   errorTimezone: "Invalid timezone",
   daysOfWeekLabel: "Days of Week",
@@ -93,6 +94,25 @@ export const validationSchema = Yup.object({
 
   startTime: Yup.string()
     .ensure()
+    .test("required-if-day-selected", Language.errorNoTime, function (value) {
+      const parent = this.parent as WorkspaceScheduleFormValues
+
+      const isDaySelected = [
+        parent.sunday,
+        parent.monday,
+        parent.tuesday,
+        parent.wednesday,
+        parent.thursday,
+        parent.friday,
+        parent.saturday,
+      ].some((day) => day)
+
+      if (isDaySelected) {
+        return value !== ""
+      } else {
+        return true
+      }
+    })
     .test("is-time-string", Language.errorTime, (value) => {
       if (value === "") {
         return true
@@ -192,7 +212,7 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
                 </Link>
               </>,
             )}
-            disabled={isLoading || !form.values.startTime}
+            disabled={isLoading}
             InputLabelProps={{
               shrink: true,
             }}
@@ -210,7 +230,7 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
                   control={
                     <Checkbox
                       checked={checkbox.value}
-                      disabled={!form.values.startTime || isLoading}
+                      disabled={isLoading}
                       onChange={form.handleChange}
                       name={checkbox.name}
                       color="primary"


### PR DESCRIPTION
Resolves: #1958

Summary:

The workspace schedule form no longer disables certain fields based on
whether or not a start time is filled out. Instead, we validate that a
start time is provided if any of the days are checked.