### PR TITLE
feat: link to timezone database spells out timezone

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -186,9 +186,9 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
             {...formHelpers(
               "timezone",
               <>
-                Timezone must be a valid{" "}
+                Timezone must be a valid name from the{" "}
                 <Link href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List" target="_blank">
-                  tz database name
+                  timezone database
                 </Link>
               </>,
             )}


### PR DESCRIPTION
This PR spells out timezone instead of tz database when linking to tz database.

## Subtasks

- [x] update the link from tz to spell timezone

Fixes #2024 
