### PR TITLE
feat: use ConfirmDialog for ResetPasswordDialog

### DIFF
--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -105,7 +105,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         </Typography>
 
         {description && (
-          <Typography className={styles.description} variant="body2">
+          <Typography component="div" className={styles.description} variant="body2">
             {description}
           </Typography>
         )}

--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -105,7 +105,11 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         </Typography>
 
         {description && (
-          <Typography component={typeof description === "string" ? "p" : "div"} className={styles.description} variant="body2">
+          <Typography
+            component={typeof description === "string" ? "p" : "div"}
+            className={styles.description}
+            variant="body2"
+          >
             {description}
           </Typography>
         )}

--- a/site/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -105,7 +105,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         </Typography>
 
         {description && (
-          <Typography component="div" className={styles.description} variant="body2">
+          <Typography component={typeof description === "string" ? "p" : "div"} className={styles.description} variant="body2">
             {description}
           </Typography>
         )}

--- a/site/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
+++ b/site/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
@@ -1,11 +1,9 @@
-import DialogActions from "@material-ui/core/DialogActions"
-import DialogContent from "@material-ui/core/DialogContent"
 import DialogContentText from "@material-ui/core/DialogContentText"
 import { makeStyles } from "@material-ui/core/styles"
 import { FC } from "react"
 import * as TypesGen from "../../api/typesGenerated"
-import { CodeBlock } from "../CodeBlock/CodeBlock"
-import { Dialog, DialogActionButtons, DialogTitle } from "../Dialog/Dialog"
+import { CodeExample } from "../CodeExample/CodeExample"
+import { ConfirmDialog } from "../ConfirmDialog/ConfirmDialog"
 
 export interface ResetPasswordDialogProps {
   open: boolean
@@ -36,32 +34,34 @@ export const ResetPasswordDialog: FC<ResetPasswordDialogProps> = ({
 }) => {
   const styles = useStyles()
 
+  const description =
+    <>
+      <DialogContentText variant="subtitle2">{Language.message(user?.username)}</DialogContentText>
+      <DialogContentText component="div" className={styles.codeBlock}>
+        <CodeExample code={newPassword ?? ""} className={styles.codeExample} />
+      </DialogContentText>
+    </>
+
   return (
-    <Dialog open={open} onClose={onClose}>
-      <DialogTitle title={Language.title} />
-
-      <DialogContent>
-        <DialogContentText variant="subtitle2">{Language.message(user?.username)}</DialogContentText>
-
-        <DialogContentText component="div">
-          <CodeBlock lines={[newPassword ?? ""]} className={styles.codeBlock} />
-        </DialogContentText>
-      </DialogContent>
-
-      <DialogActions>
-        <DialogActionButtons
-          onCancel={onClose}
-          confirmText={Language.confirmText}
-          onConfirm={onConfirm}
-          confirmLoading={loading}
-        />
-      </DialogActions>
-    </Dialog>
+    <ConfirmDialog
+      type="info"
+      hideCancel={false}
+      open={open}
+      onConfirm={onConfirm}
+      onClose={onClose}
+      title={Language.title}
+      confirmLoading={loading}
+      confirmText={Language.confirmText}
+      description={description}
+    />
   )
 }
 
 const useStyles = makeStyles(() => ({
   codeBlock: {
+    marginBottom: 0,
+  },
+  codeExample: {
     minHeight: "auto",
     userSelect: "all",
     width: "100%",

--- a/site/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
+++ b/site/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
@@ -34,13 +34,14 @@ export const ResetPasswordDialog: FC<ResetPasswordDialogProps> = ({
 }) => {
   const styles = useStyles()
 
-  const description =
+  const description = (
     <>
       <DialogContentText variant="subtitle2">{Language.message(user?.username)}</DialogContentText>
       <DialogContentText component="div" className={styles.codeBlock}>
         <CodeExample code={newPassword ?? ""} className={styles.codeExample} />
       </DialogContentText>
     </>
+  )
 
   return (
     <ConfirmDialog


### PR DESCRIPTION
This PR updates the styles for ResetPassword Dialog box to the same as ConfirmDialog info style.

## Subtasks

- [x] use ConfirmDialog component for ResetPasswordDialog
- [x] use CodeExample instead of CodeBlock
- [x] fix unit tests

## Screenshot
![Screen Shot 2022-06-03 at 12 39 48 PM](https://user-images.githubusercontent.com/7511231/171908480-793d2d1f-077a-497e-a149-60fd75854dbe.png)


Fixes #2034 
