### PR TITLE
feat: support fully-qualified workspace names in CLI

### DIFF
--- a/cli/autostart.go
+++ b/cli/autostart.go
@@ -46,7 +46,7 @@ func autostartShow() *cobra.Command {
 				return err
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}
@@ -104,7 +104,7 @@ func autostartEnable() *cobra.Command {
 				return err
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}
@@ -147,7 +147,7 @@ func autostartDisable() *cobra.Command {
 				return err
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/bump.go
+++ b/cli/bump.go
@@ -48,7 +48,7 @@ func bump() *cobra.Command {
 				return xerrors.Errorf("get current org: %w", err)
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -34,7 +34,7 @@ func delete() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -88,7 +88,7 @@ func TestDelete(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			assert.ErrorContains(t, err, "invalid workspace name")
+			assert.ErrorContains(t, err, "invalid workspace name: \"a/b/c\"")
 		}()
 		<-doneChan
 	})

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -1,13 +1,16 @@
 package cli_test
 
 import (
+	"context"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/pty/ptytest"
 )
 
@@ -36,6 +39,57 @@ func TestDelete(t *testing.T) {
 			}
 		}()
 		pty.ExpectMatch("Cleaning Up")
+		<-doneChan
+	})
+
+	t.Run("DifferentUser", func(t *testing.T) {
+		t.Parallel()
+		adminClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		adminUser := coderdtest.CreateFirstUser(t, adminClient)
+		orgID := adminUser.OrganizationID
+		client := coderdtest.CreateAnotherUser(t, adminClient, orgID)
+		user, err := client.User(context.Background(), codersdk.Me)
+		require.NoError(t, err)
+
+		version := coderdtest.CreateTemplateVersion(t, adminClient, orgID, nil)
+		coderdtest.AwaitTemplateVersionJob(t, adminClient, version.ID)
+		template := coderdtest.CreateTemplate(t, adminClient, orgID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, orgID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+
+		cmd, root := clitest.New(t, "delete", user.Username+"/"+workspace.Name, "-y")
+		clitest.SetupConfig(t, adminClient, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			// When running with the race detector on, we sometimes get an EOF.
+			if err != nil {
+				assert.ErrorIs(t, err, io.EOF)
+			}
+		}()
+
+		pty.ExpectMatch("Cleaning Up")
+		<-doneChan
+
+		workspace, err = client.Workspace(context.Background(), workspace.ID)
+		require.ErrorContains(t, err, "was deleted")
+	})
+
+	t.Run("InvalidWorkspaceIdentifier", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		cmd, root := clitest.New(t, "delete", "a/b/c", "-y")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			assert.ErrorContains(t, err, "invalid workspace name")
+		}()
 		<-doneChan
 	})
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -192,7 +192,7 @@ func namedWorkspace(cmd *cobra.Command, client *codersdk.Client, orgID uuid.UUID
 		owner = parts[0]
 		name = parts[1]
 	default:
-		return codersdk.Workspace{}, xerrors.New("invalid workspace name")
+		return codersdk.Workspace{}, xerrors.Errorf("invalid workspace name: %q", identifier)
 	}
 
 	return client.WorkspaceByOwnerAndName(cmd.Context(), orgID, owner, name)

--- a/cli/show.go
+++ b/cli/show.go
@@ -5,7 +5,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/cli/cliui"
-	"github.com/coder/coder/codersdk"
 )
 
 func show() *cobra.Command {
@@ -23,7 +22,7 @@ func show() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -207,7 +207,7 @@ func getWorkspaceAndAgent(cmd *cobra.Command, client *codersdk.Client, orgID uui
 			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, err
 		}
 	} else {
-		workspace, err = client.WorkspaceByOwnerAndName(cmd.Context(), orgID, userID, workspaceParts[0])
+		workspace, err = namedWorkspace(cmd, client, orgID, workspaceParts[0])
 		if err != nil {
 			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, err
 		}

--- a/cli/start.go
+++ b/cli/start.go
@@ -32,7 +32,7 @@ func start() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/state.go
+++ b/cli/state.go
@@ -35,7 +35,7 @@ func statePull() *cobra.Command {
 				return err
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}
@@ -81,7 +81,7 @@ func statePush() *cobra.Command {
 				return err
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -32,7 +32,7 @@ func stop() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/ttl.go
+++ b/cli/ttl.go
@@ -44,7 +44,7 @@ func ttlShow() *cobra.Command {
 				return xerrors.Errorf("get current org: %w", err)
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}
@@ -77,7 +77,7 @@ func ttlset() *cobra.Command {
 				return xerrors.Errorf("get current org: %w", err)
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}
@@ -125,7 +125,7 @@ func ttlunset() *cobra.Command {
 				return xerrors.Errorf("get current org: %w", err)
 			}
 
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}

--- a/cli/update.go
+++ b/cli/update.go
@@ -23,7 +23,7 @@ func update() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			workspace, err := client.WorkspaceByOwnerAndName(cmd.Context(), organization.ID, codersdk.Me, args[0])
+			workspace, err := namedWorkspace(cmd, client, organization.ID, args[0])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Allow passing either `workspace` or `username/workspace` to CLI commands such as `coder delete` that take a workspace name as argument. (Not including `coder create`, since our API currently doesn't support creating workspaces owned by other users.)

Fixes #1424 
