### PR TITLE
feat: (idea) link to templates page from workspaces page

### DIFF
--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -1,3 +1,4 @@
+import Button from "@material-ui/core/Button"
 import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
@@ -5,6 +6,7 @@ import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import { FC } from "react"
@@ -15,6 +17,7 @@ import { EmptyState } from "../../components/EmptyState/EmptyState"
 import { Margins } from "../../components/Margins/Margins"
 import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
+import { Link as RouterLink } from "react-router-dom"
 
 dayjs.extend(relativeTime)
 
@@ -22,6 +25,7 @@ export const Language = {
   developerCount: (ownerCount: number): string => {
     return `${ownerCount} developer${ownerCount !== 1 ? "s" : ""}`
   },
+  createButton: "Create workspace",
   nameLabel: "Name",
   usedByLabel: "Used by",
   lastUpdatedLabel: "Last updated",
@@ -55,6 +59,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
               <TableCell>{Language.nameLabel}</TableCell>
               <TableCell>{Language.usedByLabel}</TableCell>
               <TableCell>{Language.lastUpdatedLabel}</TableCell>
+              <TableCell> </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -84,6 +89,12 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
                 <TableCell>{Language.developerCount(template.workspace_owner_count)}</TableCell>
 
                 <TableCell data-chromatic="ignore">{dayjs().to(dayjs(template.updated_at))}</TableCell>
+
+                <TableCell data-chromatic="ignore">
+                  <Link underline="none" component={RouterLink} to={`/workspaces/new?template=${template.name}`}>
+                    <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
+                  </Link>
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -6,7 +6,7 @@ import Menu from "@material-ui/core/Menu"
 import MenuItem from "@material-ui/core/MenuItem"
 import { makeStyles } from "@material-ui/core/styles"
 import TextField from "@material-ui/core/TextField"
-import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
+import ReplyIcon from '@material-ui/icons/Reply';
 import SearchIcon from "@material-ui/icons/Search"
 import { useMachine } from "@xstate/react"
 import { FormikErrors, useFormik } from "formik"
@@ -25,7 +25,7 @@ interface FilterFormValues {
 
 const Language = {
   filterName: "Filters",
-  createWorkspaceButton: "Create workspace",
+  createWorkspaceButton: "Create from template",
   yourWorkspacesButton: "Your workspaces",
   allWorkspacesButton: "All workspaces",
 }
@@ -125,8 +125,8 @@ const WorkspacesPage: FC = () => {
           </Stack>
         </Stack>
 
-        <Link underline="none" component={RouterLink} to="/workspaces/new">
-          <Button startIcon={<AddCircleOutline />} style={{ height: "44px" }}>
+        <Link underline="none" component={RouterLink} to="/templates">
+          <Button startIcon={<ReplyIcon style={{ transform: "scaleX(-1)" }}/>} style={{ height: "44px" }}>
             {Language.createWorkspaceButton}
           </Button>
         </Link>


### PR DESCRIPTION
This is an experiment, looking for feedback and ideas. 

![chrome_Nj5ZrqcJej](https://user-images.githubusercontent.com/19379394/171924116-fec2ea68-304c-4f51-9069-002a3814851f.gif)

## Issue
The current "New Workspace" button on the workspace is awkward because it forces users into a view that asks them to select a template with no context. I think we should move this button to each template on the templates page and just direct users there. 

## Styling
I'm only doing a proof of concept on the functionality and flow, design and styling will come later if we want to continue with this change. 

I know the new workspaces button is bad and the table looks jank. 
