### PR TITLE
feat: Make workspace timeline rows obviously clickable

### DIFF
--- a/site/src/components/BuildsTable/BuildsTable.tsx
+++ b/site/src/components/BuildsTable/BuildsTable.tsx
@@ -42,6 +42,7 @@ export const BuildsTable: FC<BuildsTableProps> = ({ builds, className }) => {
           <TableCell width="20%">{Language.durationLabel}</TableCell>
           <TableCell width="40%">{Language.startedAtLabel}</TableCell>
           <TableCell width="20%">{Language.statusLabel}</TableCell>
+          <TableCell></TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -78,8 +79,10 @@ export const BuildsTable: FC<BuildsTableProps> = ({ builds, className }) => {
                   </span>
                 </TableCell>
                 <TableCell>
-                  <div className={styles.statusCell}>
-                    <span style={{ color: status.color }}>{status.status}</span>
+                  <span style={{ color: status.color }}>{status.status}</span>
+                </TableCell>
+                <TableCell>
+                  <div className={styles.arrowCell}>
                     <KeyboardArrowRight className={styles.arrowRight} />
                   </div>
                 </TableCell>
@@ -122,8 +125,7 @@ const useStyles = makeStyles((theme) => ({
     width: 20,
     height: 20,
   },
-  statusCell: {
+  arrowCell: {
     display: "flex",
-    justifyContent: "space-between",
   },
 }))

--- a/site/src/components/BuildsTable/BuildsTable.tsx
+++ b/site/src/components/BuildsTable/BuildsTable.tsx
@@ -1,10 +1,11 @@
 import Box from "@material-ui/core/Box"
-import { makeStyles, Theme } from "@material-ui/core/styles"
+import { fade, makeStyles, Theme } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import useTheme from "@material-ui/styles/useTheme"
 import { FC } from "react"
 import { useNavigate } from "react-router-dom"
@@ -77,7 +78,10 @@ export const BuildsTable: FC<BuildsTableProps> = ({ builds, className }) => {
                   </span>
                 </TableCell>
                 <TableCell>
-                  <span style={{ color: status.color }}>{status.status}</span>
+                  <div className={styles.statusCell}>
+                    <span style={{ color: status.color }}>{status.status}</span>
+                    <KeyboardArrowRight className={styles.arrowRight} />
+                  </div>
                 </TableCell>
               </TableRow>
             )
@@ -102,11 +106,24 @@ const useStyles = makeStyles((theme) => ({
     cursor: "pointer",
 
     "&:hover td": {
-      backgroundColor: theme.palette.background.default,
+      backgroundColor: fade(theme.palette.primary.light, 0.1),
     },
 
     "&:focus": {
       outline: `1px solid ${theme.palette.secondary.dark}`,
     },
+
+    "& .MuiTableCell-root:last-child": {
+      paddingRight: theme.spacing(2),
+    },
+  },
+  arrowRight: {
+    color: fade(theme.palette.primary.contrastText, 0.7),
+    width: 20,
+    height: 20,
+  },
+  statusCell: {
+    display: "flex",
+    justifyContent: "space-between",
   },
 }))

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -1,13 +1,15 @@
 import Link from "@material-ui/core/Link"
-import { makeStyles } from "@material-ui/core/styles"
+import { fade, makeStyles } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import { FC } from "react"
+import { useNavigate } from "react-router-dom"
 import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { CodeExample } from "../../components/CodeExample/CodeExample"
@@ -71,6 +73,8 @@ export interface TemplatesPageViewProps {
 
 export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
   const styles = useStyles()
+  const navigate = useNavigate()
+
   return (
     <Margins>
       <PageHeader>
@@ -85,9 +89,10 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>{Language.nameLabel}</TableCell>
-            <TableCell>{Language.usedByLabel}</TableCell>
-            <TableCell>{Language.lastUpdatedLabel}</TableCell>
+            <TableCell width="33%">{Language.nameLabel}</TableCell>
+            <TableCell width="33%">{Language.usedByLabel}</TableCell>
+            <TableCell width="33%">{Language.lastUpdatedLabel}</TableCell>
+            <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -104,21 +109,39 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
               </TableCell>
             </TableRow>
           )}
-          {props.templates?.map((template) => (
-            <TableRow key={template.id}>
-              <TableCell>
-                <AvatarData
-                  title={template.name}
-                  subtitle={template.description}
-                  link={`/templates/${template.name}`}
-                />
-              </TableCell>
+          {props.templates?.map((template) => {
+            const navigateToTemplatePage = () => {
+              navigate(`/templates/${template.name}`)
+            }
+            return (
+              <TableRow
+                key={template.id}
+                hover
+                data-testid={`template-${template.id}`}
+                tabIndex={0}
+                onClick={navigateToTemplatePage}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    navigateToTemplatePage()
+                  }
+                }}
+                className={styles.clickableTableRow}
+              >
+                <TableCell>
+                  <AvatarData title={template.name} subtitle={template.description} />
+                </TableCell>
 
-              <TableCell>{Language.developerCount(template.workspace_owner_count)}</TableCell>
+                <TableCell>{Language.developerCount(template.workspace_owner_count)}</TableCell>
 
-              <TableCell data-chromatic="ignore">{dayjs().to(dayjs(template.updated_at))}</TableCell>
-            </TableRow>
-          ))}
+                <TableCell data-chromatic="ignore">{dayjs().to(dayjs(template.updated_at))}</TableCell>
+                <TableCell>
+                  <div className={styles.arrowCell}>
+                    <KeyboardArrowRight className={styles.arrowRight} />
+                  </div>
+                </TableCell>
+              </TableRow>
+              )
+            })}
         </TableBody>
       </Table>
     </Margins>
@@ -128,5 +151,28 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
 const useStyles = makeStyles((theme) => ({
   emptyDescription: {
     maxWidth: theme.spacing(62),
+  },
+  clickableTableRow: {
+    cursor: "pointer",
+
+    "&:hover td": {
+      backgroundColor: fade(theme.palette.primary.light, 0.1),
+    },
+
+    "&:focus": {
+      outline: `1px solid ${theme.palette.secondary.dark}`,
+    },
+
+    "& .MuiTableCell-root:last-child": {
+      paddingRight: theme.spacing(2),
+    },
+  },
+  arrowRight: {
+    color: fade(theme.palette.primary.contrastText, 0.7),
+    width: 20,
+    height: 20,
+  },
+  arrowCell: {
+    display: "flex",
   },
 }))

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -89,10 +89,10 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell width="33%">{Language.nameLabel}</TableCell>
-            <TableCell width="33%">{Language.usedByLabel}</TableCell>
-            <TableCell width="33%">{Language.lastUpdatedLabel}</TableCell>
-            <TableCell></TableCell>
+            <TableCell>{Language.nameLabel}</TableCell>
+            <TableCell>{Language.usedByLabel}</TableCell>
+            <TableCell>{Language.lastUpdatedLabel}</TableCell>
+            <TableCell width="1%"></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -140,8 +140,8 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
                   </div>
                 </TableCell>
               </TableRow>
-              )
-            })}
+            )
+          })}
         </TableBody>
       </Table>
     </Margins>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -4,7 +4,7 @@ import InputAdornment from "@material-ui/core/InputAdornment"
 import Link from "@material-ui/core/Link"
 import Menu from "@material-ui/core/Menu"
 import MenuItem from "@material-ui/core/MenuItem"
-import { makeStyles, Theme } from "@material-ui/core/styles"
+import { fade, makeStyles, Theme } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
@@ -12,13 +12,14 @@ import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
 import TextField from "@material-ui/core/TextField"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import SearchIcon from "@material-ui/icons/Search"
 import useTheme from "@material-ui/styles/useTheme"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import { FormikErrors, useFormik } from "formik"
 import { FC, useState } from "react"
-import { Link as RouterLink } from "react-router-dom"
+import { Link as RouterLink, useNavigate } from "react-router-dom"
 import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { CloseDropdown, OpenDropdown } from "../../components/DropdownArrows/DropdownArrows"
@@ -90,6 +91,7 @@ export interface WorkspacesPageViewProps {
 
 export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaces, filter, onFilter }) => {
   const styles = useStyles()
+  const navigate = useNavigate()
   const theme: Theme = useTheme()
 
   const form = useFormik<FilterFormValues>({
@@ -190,11 +192,12 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Template</TableCell>
-            <TableCell>Version</TableCell>
-            <TableCell>Last Built</TableCell>
-            <TableCell>Status</TableCell>
+            <TableCell width="20%">Name</TableCell>
+            <TableCell width="20%">Template</TableCell>
+            <TableCell width="20%">Version</TableCell>
+            <TableCell width="20%">Last Built</TableCell>
+            <TableCell width="20%">Status</TableCell>
+            <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -217,14 +220,25 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
           {workspaces &&
             workspaces.map((workspace) => {
               const status = getDisplayStatus(theme, workspace.latest_build)
+              const navigateToWorkspacePage = () => {
+                navigate(`/@${workspace.owner_name}/${workspace.name}`)
+              }
               return (
-                <TableRow key={workspace.id}>
+                <TableRow
+                  key={workspace.id}
+                  hover
+                  data-testid={`workspace-${workspace.id}`}
+                  tabIndex={0}
+                  onClick={navigateToWorkspacePage}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      navigateToWorkspacePage()
+                    }
+                  }}
+                  className={styles.clickableTableRow}
+                >
                   <TableCell>
-                    <AvatarData
-                      title={workspace.name}
-                      subtitle={workspace.owner_name}
-                      link={`/@${workspace.owner_name}/${workspace.name}`}
-                    />
+                    <AvatarData title={workspace.name} subtitle={workspace.owner_name} />
                   </TableCell>
                   <TableCell>{workspace.template_name}</TableCell>
                   <TableCell>
@@ -241,6 +255,11 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
                   </TableCell>
                   <TableCell>
                     <span style={{ color: status.color }}>{status.status}</span>
+                  </TableCell>
+                  <TableCell>
+                    <div className={styles.arrowCell}>
+                      <KeyboardArrowRight className={styles.arrowRight} />
+                    </div>
                   </TableCell>
                 </TableRow>
               )
@@ -285,5 +304,28 @@ const useStyles = makeStyles((theme) => ({
     "& fieldset": {
       border: "none",
     },
+  },
+  clickableTableRow: {
+    cursor: "pointer",
+
+    "&:hover td": {
+      backgroundColor: fade(theme.palette.primary.light, 0.1),
+    },
+
+    "&:focus": {
+      outline: `1px solid ${theme.palette.secondary.dark}`,
+    },
+
+    "& .MuiTableCell-root:last-child": {
+      paddingRight: theme.spacing(2),
+    },
+  },
+  arrowRight: {
+    color: fade(theme.palette.primary.contrastText, 0.7),
+    width: 20,
+    height: 20,
+  },
+  arrowCell: {
+    display: "flex",
   },
 }))

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -192,12 +192,12 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell width="20%">Name</TableCell>
-            <TableCell width="20%">Template</TableCell>
-            <TableCell width="20%">Version</TableCell>
-            <TableCell width="20%">Last Built</TableCell>
-            <TableCell width="20%">Status</TableCell>
-            <TableCell></TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Template</TableCell>
+            <TableCell>Version</TableCell>
+            <TableCell>Last Built</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell width="1%"></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>


### PR DESCRIPTION
This PR make workspace timeline rows obviously clickable.

## Subtasks

- [x] added the right arrow
- [x] update the hover background color
- [x] apply the same to workspace list
- [x] remove existing link on the workspace name 
- [x] apply the same to templates list 
- [x] remove existing link on the template name 

Fixes #2021 
Fixes #2058

## Screenshot

### Timeline (with hover)
![Screen Shot 2022-06-03 at 4 19 19 PM](https://user-images.githubusercontent.com/7511231/171945847-7184fd0d-2a5a-42fa-bcf3-5e4c8ec5925e.png)

### Templates list
<img width="1351" alt="Screen Shot 2022-06-06 at 9 42 56 PM" src="https://user-images.githubusercontent.com/7511231/172277684-4ec5665c-798a-45a7-9dd0-3a30e14f6ece.png">

### Workspaces list
<img width="1347" alt="Screen Shot 2022-06-06 at 9 42 46 PM" src="https://user-images.githubusercontent.com/7511231/172277725-100309f2-fc6c-4af0-93d8-e4cc4b75ce76.png">




