### PR TITLE
fix: Use proper webpack config for dev mode

### DIFF
--- a/site/webpack.dev.ts
+++ b/site/webpack.dev.ts
@@ -14,7 +14,7 @@ const commonPlugins = commonWebpackConfig.plugins || []
 const commonRules = commonWebpackConfig.module?.rules || []
 
 const config: Configuration = {
-  ...createCommonWebpackConfig,
+  ...commonWebpackConfig,
 
   // devtool controls how source maps are generated. In development, we want
   // more details (less optimized) for more readability and an easier time


### PR DESCRIPTION
This was broken when improving the build times. The typechecker
unfortunately missed it!
