### PR TITLE
chore: `version` sub command remove `--version` and `-v` flag

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -90,6 +90,7 @@ func Root() *cobra.Command {
 		users(),
 		portForward(),
 		workspaceAgent(),
+		versionCmd(),
 	)
 
 	cmd.SetUsageTemplate(usageTemplate())
@@ -107,7 +108,30 @@ func Root() *cobra.Command {
 	cmd.PersistentFlags().Bool(varNoOpen, false, "Block automatically opening URLs in the browser.")
 	_ = cmd.PersistentFlags().MarkHidden(varNoOpen)
 
+	// Cobra automatically uses "-v" and "--version" for printing the version on
+	// the root cmd. If we decide to use "-v" as a verbose flag on the root,
+	// then that will be a behavior change. So we should just reserve "-v"
+	// and make users use "coder --version" or "coder version"
+	cmd.Flags().BoolP("placeholder", "v", false, "This flag is a placeholder to make the cobra version flag work appropriately")
+	_ = cmd.Flags().MarkHidden("placeholder")
+
 	return cmd
+}
+
+// versionCmd comes from example in cobra issue.
+//	https://github.com/spf13/cobra/issues/724
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "version",
+		Short:   "Version for coder",
+		Example: "coder version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Use "--version" behavior on root.
+			root := cmd.Root()
+			root.SetArgs([]string{"--version"})
+			return root.Execute()
+		},
+	}
 }
 
 // createClient returns a new client from the command context.

--- a/cli/root.go
+++ b/cli/root.go
@@ -117,12 +117,12 @@ func versionCmd() *cobra.Command {
 		Example: "coder version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var str strings.Builder
-			str.WriteString(fmt.Sprintf("Coder %s", buildinfo.Version()))
+			_, _ = str.WriteString(fmt.Sprintf("Coder %s", buildinfo.Version()))
 			buildTime, valid := buildinfo.Time()
 			if valid {
-				str.WriteString(" " + buildTime.Format(time.UnixDate))
+				_, _ = str.WriteString(" " + buildTime.Format(time.UnixDate))
 			}
-			str.WriteString("\r\n" + buildinfo.ExternalURL() + "\r\n")
+			_, _ = str.WriteString("\r\n" + buildinfo.ExternalURL() + "\r\n")
 
 			_, _ = fmt.Fprint(cmd.OutOrStdout(), str.String())
 			return nil

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,7 +1,10 @@
 package cli_test
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/coder/coder/buildinfo"
 
 	"github.com/stretchr/testify/require"
 
@@ -15,8 +18,43 @@ func TestRoot(t *testing.T) {
 
 		cmd, _ := clitest.New(t, "delete")
 
-		cmd, err := cmd.ExecuteC()
+		err := cmd.Execute()
 		errStr := cli.FormatCobraError(err, cmd)
 		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
+	})
+
+	// The "-v" short flag should return the usage output, not a version output
+	t.Run("TestVShortFlag", func(t *testing.T) {
+		t.Parallel()
+
+		buf := new(bytes.Buffer)
+		cmd, _ := clitest.New(t, "-v")
+		cmd.SetOut(buf)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		// Check the usage string is the output when using "-v"
+		require.Contains(t, buf.String(), cmd.UsageString())
+		require.Contains(t, buf.String(), cmd.Root().Long)
+	})
+
+	t.Run("TestVersion", func(t *testing.T) {
+		t.Parallel()
+
+		bufFlag := new(bytes.Buffer)
+		cmd, _ := clitest.New(t, "--version")
+		cmd.SetOut(bufFlag)
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		bufCmd := new(bytes.Buffer)
+		cmd, _ = clitest.New(t, "version")
+		cmd.SetOut(bufCmd)
+		err = cmd.Execute()
+		require.NoError(t, err)
+
+		require.Equal(t, bufFlag.String(), bufCmd.String(), "cmd and flag identical output")
+		require.Contains(t, bufFlag.String(), buildinfo.Version(), "has version")
+		require.Contains(t, bufFlag.String(), buildinfo.ExternalURL(), "has url")
 	})
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -23,38 +23,17 @@ func TestRoot(t *testing.T) {
 		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
 	})
 
-	// The "-v" short flag should return the usage output, not a version output
-	t.Run("TestVShortFlag", func(t *testing.T) {
-		t.Parallel()
-
-		buf := new(bytes.Buffer)
-		cmd, _ := clitest.New(t, "-v")
-		cmd.SetOut(buf)
-
-		err := cmd.Execute()
-		require.NoError(t, err)
-		// Check the usage string is the output when using "-v"
-		require.Contains(t, buf.String(), cmd.UsageString())
-		require.Contains(t, buf.String(), cmd.Root().Long)
-	})
-
 	t.Run("TestVersion", func(t *testing.T) {
 		t.Parallel()
 
-		bufFlag := new(bytes.Buffer)
-		cmd, _ := clitest.New(t, "--version")
-		cmd.SetOut(bufFlag)
+		buf := new(bytes.Buffer)
+		cmd, _ := clitest.New(t, "version")
+		cmd.SetOut(buf)
 		err := cmd.Execute()
 		require.NoError(t, err)
 
-		bufCmd := new(bytes.Buffer)
-		cmd, _ = clitest.New(t, "version")
-		cmd.SetOut(bufCmd)
-		err = cmd.Execute()
-		require.NoError(t, err)
-
-		require.Equal(t, bufFlag.String(), bufCmd.String(), "cmd and flag identical output")
-		require.Contains(t, bufFlag.String(), buildinfo.Version(), "has version")
-		require.Contains(t, bufFlag.String(), buildinfo.ExternalURL(), "has url")
+		output := buf.String()
+		require.Contains(t, output, buildinfo.Version(), "has version")
+		require.Contains(t, output, buildinfo.ExternalURL(), "has url")
 	})
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -18,7 +18,7 @@ func TestRoot(t *testing.T) {
 
 		cmd, _ := clitest.New(t, "delete")
 
-		err := cmd.Execute()
+		cmd, err := cmd.ExecuteC()
 		errStr := cli.FormatCobraError(err, cmd)
 		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
 	})

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -23,7 +23,7 @@ func TestRoot(t *testing.T) {
 		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
 	})
 
-	t.Run("TestVersion", func(t *testing.T) {
+	t.Run("Version", func(t *testing.T) {
 		t.Parallel()
 
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
# What this does (https://github.com/coder/coder/issues/1543)

Removes `coder -v` and `coder --version`.

Now do `coder version` to see coder version.

```bash
$ coder version
Coder v0.0.0-devel+ae779c6 Mon Jun  6 15:18:00 UTC 2022
https://github.com/coder/coder/commit/ae779c6276a5f305273343c3d5d4836d6a16c890
```