### PR TITLE
fix: Specify number of builds before reporting status on codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   require_ci_to_pass: false
+  notify:
+    after_n_builds: 5
 
 comment: false
 


### PR DESCRIPTION
We sometimes flake on `main` and this will drop our code coverage drastically because it counts the coverage for the entire test as 0%. This will require that all expected tests pass before reporting coverage for the commit. 