### PR TITLE
fix: add workspace option 'deleted' to options type

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -60,12 +60,6 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if !workspace.Deleted && showDeleted {
-		httpapi.Write(rw, http.StatusBadRequest, httpapi.Response{
-			Message: fmt.Sprintf("Workspace %q is not deleted, please remove '?deleted=true' and try again", workspace.ID.String()),
-		})
-		return
-	}
 
 	build, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(r.Context(), workspace.ID)
 	if err != nil {

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -46,10 +46,9 @@ func TestWorkspace(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
-		// Getting with deleted=true should fail.
+		// Getting with deleted=true should still work.
 		_, err := client.DeletedWorkspace(context.Background(), workspace.ID)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "400") // bad request
+		require.NoError(t, err)
 
 		// Delete the workspace
 		build, err := client.CreateWorkspaceBuild(context.Background(), workspace.ID, codersdk.CreateWorkspaceBuildRequest{

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -36,14 +36,6 @@ type Client struct {
 
 type requestOption func(*http.Request)
 
-func queryParam(k, v string) requestOption {
-	return func(r *http.Request) {
-		q := r.URL.Query()
-		q.Set(k, v)
-		r.URL.RawQuery = q.Encode()
-	}
-}
-
 // Request performs an HTTP request with the body provided.
 // The caller is responsible for closing the response body.
 func (c *Client) Request(ctx context.Context, method, path string, body interface{}, opts ...requestOption) (*http.Response, error) {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -221,7 +221,7 @@ export interface ProvisionerJobLog {
   readonly output: string
 }
 
-// From codersdk/workspaces.go:182:6
+// From codersdk/workspaces.go:201:6
 export interface PutExtendWorkspaceRequest {
   readonly deadline: string
 }
@@ -298,12 +298,12 @@ export interface UpdateUserProfileRequest {
   readonly username: string
 }
 
-// From codersdk/workspaces.go:141:6
+// From codersdk/workspaces.go:160:6
 export interface UpdateWorkspaceAutostartRequest {
   readonly schedule?: string
 }
 
-// From codersdk/workspaces.go:161:6
+// From codersdk/workspaces.go:180:6
 export interface UpdateWorkspaceTTLRequest {
   readonly ttl_ms?: number
 }
@@ -445,16 +445,21 @@ export interface WorkspaceBuild {
   readonly deadline: string
 }
 
-// From codersdk/workspaces.go:64:6
+// From codersdk/workspaces.go:83:6
 export interface WorkspaceBuildsRequest extends Pagination {
   readonly WorkspaceID: string
 }
 
-// From codersdk/workspaces.go:200:6
+// From codersdk/workspaces.go:219:6
 export interface WorkspaceFilter {
   readonly organization_id?: string
   readonly owner?: string
   readonly name?: string
+}
+
+// From codersdk/workspaces.go:41:6
+export interface WorkspaceOptions {
+  readonly deleted?: boolean
 }
 
 // From codersdk/workspaceresources.go:21:6


### PR DESCRIPTION
We were not generating the `deleted` query param option for the frontend to consume, so this changes that.

I've also removed the 400 error code if you provide `?deleted=true` but the workspace isn't in a deleted state. I think it's easier for the frontend to provide this unconditionally for some pages and not need to juggle the changing error states. 