### PR TITLE
fix: correct localhost url in dev webpack

### DIFF
--- a/site/webpack.dev.ts
+++ b/site/webpack.dev.ts
@@ -63,7 +63,7 @@ const config: Configuration = {
     port: process.env.PORT || 8080,
     proxy: {
       "/api": {
-        target: "https://dev.coder.com",
+        target: "http://localhost:3000",
         ws: true,
         secure: false,
       },


### PR DESCRIPTION
Fixes an issue where you cannot login with `make dev`, introduced https://github.com/coder/coder/commit/0ac37b146d52b73d31f26a79e7a5c3bb178075de#diff-b17823d590cbd82b7f4b0a4f646ed90083d0009fafdf34a4b4d7d24fa2750208L66