### PR TITLE
refactor: rename errors to validations

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -67,7 +67,7 @@ type Response struct {
 	// Validations are form field-specific friendly error messages. They will be
 	// shown on a form field in the UI. These can also be used to add additional
 	// context if there is a set of errors in the primary 'Message'.
-	Validations []Error `json:"errors,omitempty"`
+	Validations []Error `json:"validations,omitempty"`
 }
 
 // Error represents a scoped error to a user input.

--- a/site/src/api/errors.test.ts
+++ b/site/src/api/errors.test.ts
@@ -29,7 +29,7 @@ describe("mapApiErrorToFieldErrors", () => {
     expect(
       mapApiErrorToFieldErrors({
         message: "Invalid entry",
-        errors: [{ detail: "Username is already in use", field: "username" }],
+        validations: [{ detail: "Username is already in use", field: "username" }],
       }),
     ).toEqual({
       username: "Username is already in use",

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -15,7 +15,8 @@ export type FieldErrors = Record<FieldError["field"], FieldError["detail"]>
 
 export interface ApiErrorResponse {
   message: string
-  errors?: FieldError[]
+  detail?: string
+  validations?: FieldError[]
 }
 
 export type ApiError = AxiosError<ApiErrorResponse> & { response: AxiosResponse<ApiErrorResponse> }
@@ -39,13 +40,13 @@ export const isApiError = (err: any): err is ApiError => {
  * @param error ApiError
  * @returns true if the ApiError contains error messages for specific form fields.
  */
-export const hasApiFieldErrors = (error: ApiError): boolean => Array.isArray(error.response.data.errors)
+export const hasApiFieldErrors = (error: ApiError): boolean => Array.isArray(error.response.data.validations)
 
 export const mapApiErrorToFieldErrors = (apiErrorResponse: ApiErrorResponse): FieldErrors => {
   const result: FieldErrors = {}
 
-  if (apiErrorResponse.errors) {
-    for (const error of apiErrorResponse.errors) {
+  if (apiErrorResponse.validations) {
+    for (const error of apiErrorResponse.validations) {
       result[error.field] = error.detail || Language.errorsByCode.defaultErrorCode
     }
   }

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.test.tsx
@@ -54,7 +54,7 @@ describe("AccountPage", () => {
       jest.spyOn(API, "updateProfile").mockRejectedValueOnce({
         isAxiosError: true,
         response: {
-          data: { message: "Invalid profile", errors: [{ detail: "Username is already in use", field: "username" }] },
+          data: { message: "Invalid profile", validations: [{ detail: "Username is already in use", field: "username" }] },
         },
       })
 

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.test.tsx
@@ -54,7 +54,10 @@ describe("AccountPage", () => {
       jest.spyOn(API, "updateProfile").mockRejectedValueOnce({
         isAxiosError: true,
         response: {
-          data: { message: "Invalid profile", validations: [{ detail: "Username is already in use", field: "username" }] },
+          data: {
+            message: "Invalid profile",
+            validations: [{ detail: "Username is already in use", field: "username" }],
+          },
         },
       })
 

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
@@ -49,7 +49,7 @@ describe("SecurityPage", () => {
       jest.spyOn(API, "updateUserPassword").mockRejectedValueOnce({
         isAxiosError: true,
         response: {
-          data: { message: "Incorrect password.", errors: [{ detail: "Incorrect password.", field: "old_password" }] },
+          data: { message: "Incorrect password.", validations: [{ detail: "Incorrect password.", field: "old_password" }] },
         },
       })
 
@@ -68,7 +68,7 @@ describe("SecurityPage", () => {
       jest.spyOn(API, "updateUserPassword").mockRejectedValueOnce({
         isAxiosError: true,
         response: {
-          data: { message: "Invalid password.", errors: [{ detail: "Invalid password.", field: "password" }] },
+          data: { message: "Invalid password.", validations: [{ detail: "Invalid password.", field: "password" }] },
         },
       })
 

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
@@ -49,7 +49,10 @@ describe("SecurityPage", () => {
       jest.spyOn(API, "updateUserPassword").mockRejectedValueOnce({
         isAxiosError: true,
         response: {
-          data: { message: "Incorrect password.", validations: [{ detail: "Incorrect password.", field: "old_password" }] },
+          data: {
+            message: "Incorrect password.",
+            validations: [{ detail: "Incorrect password.", field: "old_password" }],
+          },
         },
       })
 

--- a/site/src/pages/UsersPage/CreateUserPage/CreateUserPage.test.tsx
+++ b/site/src/pages/UsersPage/CreateUserPage/CreateUserPage.test.tsx
@@ -58,7 +58,7 @@ describe("Create User Page", () => {
           ctx.status(400),
           ctx.json({
             message: "invalid field",
-            errors: [
+            validations: [
               {
                 detail: fieldErrorMessage,
                 field: "username",


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
When the backend sends per-field validation errors, they will be called `validations` instead of `errors`. Fixes #2120.