### PR TITLE
chore: ignore artifacts dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ site/build-storybook.log
 # Build
 dist/
 site/out/
+artifacts
 
 *.tfstate
 *.tfplan

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ site/build-storybook.log
 # Build
 dist/
 site/out/
+# used by release CI for downloaded artifacts
 artifacts
 
 *.tfstate


### PR DESCRIPTION
used by release CI