### PR TITLE
docs: slim down readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Coder creates remote development machines so you can develop your code from anyw
 - Automatically shut down expensive cloud resources
 - Keep your source code and data behind your firewall
 
-
 ## Installing Coder
 
 There are a few ways to install Coder: [install script](./docs/install.md#installsh) (macOS, Linux), [docker-compose](./docs/install.md#docker-compose), or [manually](./docs/install.md#manual) via the latest release (macOS, Windows, and Linux).
@@ -62,49 +61,9 @@ coder server --dev
 
 Use `coder --help` to get a complete list of flags and environment variables.
 
-## Creating your first template and workspace
-
-In a new terminal window, run the following to copy a sample template:
-
-```bash
-coder templates init
-```
-
-Follow the CLI instructions to modify and create the template specific for your
-usage (e.g., a template to **Develop in Linux on Google Cloud**).
-
-Create a workspace using your template:
-
-```bash
-coder create --template="yourTemplate" <workspaceName>
-```
-
-Connect to your workspace via SSH:
-
-```bash
-coder ssh <workspaceName>
-```
-
-## Modifying templates
-
-You can edit the Terraform template using a sample template:
-
-```sh
-coder templates init
-cd gcp-linux/
-vim main.tf
-coder templates update gcp-linux
-```
-
 ## Documentation
 
 Visit our docs [here](./docs/index.md).
-
-## Community
-
-Join the community on [Discord](https://discord.gg/coder) and [Twitter](https://twitter.com/coderhq) #coder!
-
-[Suggest improvements and report problems](https://github.com/coder/coder/issues/new/choose)
 
 ## Comparison
 
@@ -119,7 +78,13 @@ Please file [an issue](https://github.com/coder/coder/issues/new) if any informa
 
 ---
 
-_As of 5/27/22_
+_Last updated: 5/27/22_
+
+## Community
+
+Join the community on [Discord](https://discord.gg/coder) and [Twitter](https://twitter.com/coderhq) #coder!
+
+[Suggest improvements and report problems](https://github.com/coder/coder/issues/new/choose)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once installed, you can run a temporary deployment in dev mode (all data is in-m
 coder server --dev
 ```
 
-Use `coder --help` to get a complete list of flags and environment variables. For a full walkthrough, follow [this guide](./docs/walkthrough.md).
+Use `coder --help` to get a complete list of flags and environment variables follow our [quickstart guide](./docs/quickstart.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once installed, you can run a temporary deployment in dev mode (all data is in-m
 coder server --dev
 ```
 
-Use `coder --help` to get a complete list of flags and environment variables follow our [quickstart guide](./docs/quickstart.md).
+Use `coder --help` to get a complete list of flags and environment variables. Use our [quickstart guide](./docs/quickstart.md) for a full walkthrough.
 
 ## Documentation
 
@@ -74,7 +74,7 @@ Please file [an issue](https://github.com/coder/coder/issues/new) if any informa
 
 _Last updated: 5/27/22_
 
-## Community
+## Community and Support
 
 Join our community on [Discord](https://discord.gg/coder) and [Twitter](https://twitter.com/coderhq)!
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Discord"](https://img.shields.io/badge/join-us%20on%20Discord-gray.svg?longCache
 Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 [![codecov](https://codecov.io/gh/coder/coder/branch/main/graph/badge.svg?token=TNLW3OAP6G)](https://codecov.io/gh/coder/coder)
 
-## Run Coder *now*
+## Run Coder _now_
 
-```curl -L https://coder.com/install.sh | sh```
+`curl -L https://coder.com/install.sh | sh`
 
 ## What Coder does
+
 Coder creates remote development machines so you can develop your code from anywhere. #coder
 
 > **Note**:
@@ -119,22 +120,7 @@ coder templates update gcp-linux
 
 ## Documentation
 
-- [About Coder](./docs/about.md#about-coder)
-  - [Why remote development](./docs/about.md#why-remote-development)
-  - [Why Coder](./docs/about.md#why-coder)
-  - [What Coder is not](./docs/about.md#what-coder-is-not)
-  - [Comparison: Coder vs. [product]](./docs/about.md#comparison)
-- [Templates](./docs/templates.md)
-  - [Manage templates](./docs/templates.md#manage-templates)
-  - [Persistent and ephemeral
-    resources](./docs/templates.md#persistent-and-ephemeral-resources)
-  - [Parameters](./docs/templates.md#parameters)
-- [Workspaces](./docs/workspaces.md)
-  - [Create workspaces](./docs/workspaces.md#create-workspaces)
-  - [Connect with SSH](./docs/workspaces.md#connect-with-ssh)
-  - [Editors and IDEs](./docs/workspaces.md#editors-and-ides)
-  - [Workspace lifecycle](./docs/workspaces.md#workspace-lifecycle)
-  - [Updating workspaces](./docs/workspaces.md#updating-workspaces)
+Visit our docs [here](./docs/index.md).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -37,28 +37,6 @@ Coder creates remote development machines so you can develop your code from anyw
 - Automatically shut down expensive cloud resources
 - Keep your source code and data behind your firewall
 
-## How it works
-
-Coder workspaces are represented with Terraform. But, no Terraform knowledge is
-required to get started. We have a database of pre-made templates built into the
-product.
-
-<p align="center">
-  <img src="./docs/images/providers-compute.png">
-</p>
-
-Coder workspaces don't stop at compute. You can add storage buckets, secrets, sidecars
-and whatever else Terraform lets you dream up.
-
-[Learn more about managing infrastructure.](./docs/templates.md)
-
-## IDE Support
-
-You can use any Web IDE ([code-server](https://github.com/coder/code-server), [projector](https://github.com/JetBrains/projector-server), [Jupyter](https://jupyter.org/), etc.), [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/), [VS Code Remote](https://code.visualstudio.com/docs/remote/ssh-tutorial) or even a file sync such as [mutagen](https://mutagen.io/).
-
-<p align="center">
-  <img src="./docs/images/ide-icons.svg" height=72>
-</p>
 
 ## Installing Coder
 

--- a/README.md
+++ b/README.md
@@ -8,27 +8,11 @@ Discord"](https://img.shields.io/badge/join-us%20on%20Discord-gray.svg?longCache
 Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 [![codecov](https://codecov.io/gh/coder/coder/branch/main/graph/badge.svg?token=TNLW3OAP6G)](https://codecov.io/gh/coder/coder)
 
-## Run Coder _now_
-
-`curl -L https://coder.com/install.sh | sh`
-
-## What Coder does
-
-Coder creates remote development machines so you can develop your code from anywhere. #coder
-
-> **Note**:
-> Coder is in an alpha state, but any serious bugs are P1 for us so [please report them](https://github.com/coder/coder/issues/new/choose).
+Coder creates remote development machines so your team can develop from anywhere.
 
 <p align="center">
   <img src="./docs/images/hero-image.png">
 </p>
-
-**Code more**
-
-- Build and test faster
-  - Leveraging cloud CPUs, RAM, network speeds, etc.
-- Access your environment from any place on any client (even an iPad)
-- Onboard instantly then stay up to date continuously
 
 **Manage less**
 
@@ -37,7 +21,17 @@ Coder creates remote development machines so you can develop your code from anyw
 - Automatically shut down expensive cloud resources
 - Keep your source code and data behind your firewall
 
-## Installing Coder
+**Code more**
+
+- Build and test faster
+  - Leveraging cloud CPUs, RAM, network speeds, etc.
+- Access your environment from any place on any client (even an iPad)
+- Onboard instantly then stay up to date continuously
+
+## Getting Started
+
+> **Note**:
+> Coder is in an alpha state. [Report issues here](https://github.com/coder/coder/issues/new).
 
 There are a few ways to install Coder: [install script](./docs/install.md#installsh) (macOS, Linux), [docker-compose](./docs/install.md#docker-compose), or [manually](./docs/install.md#manual) via the latest release (macOS, Windows, and Linux).
 
@@ -59,7 +53,7 @@ Once installed, you can run a temporary deployment in dev mode (all data is in-m
 coder server --dev
 ```
 
-Use `coder --help` to get a complete list of flags and environment variables.
+Use `coder --help` to get a complete list of flags and environment variables. For a full walkthrough, follow [this guide](./docs/walkthrough.md).
 
 ## Documentation
 
@@ -82,7 +76,7 @@ _Last updated: 5/27/22_
 
 ## Community
 
-Join the community on [Discord](https://discord.gg/coder) and [Twitter](https://twitter.com/coderhq) #coder!
+Join our community on [Discord](https://discord.gg/coder) and [Twitter](https://twitter.com/coderhq)!
 
 [Suggest improvements and report problems](https://github.com/coder/coder/issues/new/choose)
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -9,6 +9,29 @@ By building on top of common development interfaces (SSH) and infrastructure too
 > production environments, please consider [Coder v1](https://coder.com/docs) or
 > [code-server](https://github.com/cdr/code-server).
 
+## How it works
+
+Coder workspaces are represented with Terraform. But, no Terraform knowledge is
+required to get started. We have a database of pre-made templates built into the
+product.
+
+<p align="center">
+  <img src="./images/providers-compute.png">
+</p>
+
+Coder workspaces don't stop at compute. You can add storage buckets, secrets, sidecars
+and whatever else Terraform lets you dream up.
+
+[Learn more about managing infrastructure.](./templates.md)
+
+## IDE Support
+
+You can use any Web IDE ([code-server](https://github.com/coder/code-server), [projector](https://github.com/JetBrains/projector-server), [Jupyter](https://jupyter.org/), etc.), [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/), [VS Code Remote](https://code.visualstudio.com/docs/remote/ssh-tutorial) or even a file sync such as [mutagen](https://mutagen.io/).
+
+<p align="center">
+  <img src="./images/ide-icons.svg" height=72>
+</p>
+
 ## Why remote development
 
 Migrating from local developer machines to workspaces hosted by cloud services

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@
   - [Why Coder](./about.md#why-coder)
   - [What Coder is not](./about.md#what-coder-is-not)
   - [Comparison: Coder vs. [product]](./about.md#comparison)
+- [Quickstart](./quickstart.md)
+  - [Creating your first template and workspace](./quickstart.md#creating-your-first-template-and-workspace)
+  - [Modifying templates](./quickstart.md#modifying-templates)
 - [Templates](./templates.md)
   - [Manage templates](./templates.md#manage-templates)
   - [Persistent and ephemeral

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# Coder Documentation
+
+## Table of Contents
+
+- [About Coder](./about.md#about-coder)
+  - [Why remote development](./about.md#why-remote-development)
+  - [Why Coder](./about.md#why-coder)
+  - [What Coder is not](./about.md#what-coder-is-not)
+  - [Comparison: Coder vs. [product]](./about.md#comparison)
+- [Templates](./templates.md)
+  - [Manage templates](./templates.md#manage-templates)
+  - [Persistent and ephemeral
+    resources](./templates.md#persistent-and-ephemeral-resources)
+  - [Parameters](./templates.md#parameters)
+- [Workspaces](./workspaces.md)
+  - [Create workspaces](./workspaces.md#create-workspaces)
+  - [Connect with SSH](./workspaces.md#connect-with-ssh)
+  - [Editors and IDEs](./workspaces.md#editors-and-ides)
+  - [Workspace lifecycle](./workspaces.md#workspace-lifecycle)
+  - [Updating workspaces](./workspaces.md#updating-workspaces)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# Walkthrough
+# Quickstart
 
 This guide will walk you through creating your first template and workspace. If you haven't already installed `coder`, do that first [here](./install.md).
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,0 +1,37 @@
+# Walkthrough
+
+This guide will walk you through creating your first template and workspace. If you haven't already installed `coder`, do that first [here](./install.md).
+
+## Creating your first template and workspace
+
+In a new terminal window, run the following to copy a sample template:
+
+```bash
+coder templates init
+```
+
+Follow the CLI instructions to modify and create the template specific for your
+usage (e.g., a template to **Develop in Linux on Google Cloud**).
+
+Create a workspace using your template:
+
+```bash
+coder create --template="yourTemplate" <workspaceName>
+```
+
+Connect to your workspace via SSH:
+
+```bash
+coder ssh <workspaceName>
+```
+
+## Modifying templates
+
+If needed, you can edit the Terraform template using a sample template:
+
+```sh
+coder templates init
+cd gcp-linux/
+vim main.tf
+coder templates update gcp-linux
+```


### PR DESCRIPTION
## Description

This PR refactors the `README.md` to be more slim and concise with the goal of making it less overwhelming when someone lands on the repo page. 

I also moved the Documentation Table of Contents to `./docs/index.md` and some getting started information to `./docs/walkthrough.md`. Open to suggestions!

🖼️ [Rendered](https://github.com/coder/coder/blob/jsjoeio/slim-readme/README.md)