### PR TITLE
fix: push create workspace UX to templates page

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -56,15 +56,6 @@ export const AppRouter: FC = () => (
             </AuthAndFrame>
           }
         />
-
-        <Route
-          path="new"
-          element={
-            <RequireAuth>
-              <CreateWorkspacePage />
-            </RequireAuth>
-          }
-        />
       </Route>
 
       <Route path="templates">
@@ -77,14 +68,24 @@ export const AppRouter: FC = () => (
           }
         />
 
-        <Route
-          path=":template"
-          element={
-            <AuthAndFrame>
-              <TemplatePage />
-            </AuthAndFrame>
-          }
-        />
+        <Route path=":template">
+          <Route
+            index
+            element={
+              <AuthAndFrame>
+                <TemplatePage />
+              </AuthAndFrame>
+            }
+          />
+          <Route
+            path="workspace"
+            element={
+              <RequireAuth>
+                <CreateWorkspacePage />
+              </RequireAuth>
+            }
+          />
+        </Route>
       </Route>
 
       <Route path="users">

--- a/site/src/components/PageHeader/PageHeader.tsx
+++ b/site/src/components/PageHeader/PageHeader.tsx
@@ -32,6 +32,12 @@ export const PageHeaderSubtitle: React.FC = ({ children }) => {
   return <h2 className={styles.subtitle}>{children}</h2>
 }
 
+export const PageHeaderText: React.FC = ({ children }) => {
+  const styles = useStyles()
+
+  return <h3 className={styles.text}>{children}</h3>
+}
+
 const useStyles = makeStyles((theme) => ({
   root: {
     display: "flex",
@@ -51,6 +57,15 @@ const useStyles = makeStyles((theme) => ({
 
   subtitle: {
     fontSize: theme.spacing(2.5),
+    color: theme.palette.text.secondary,
+    fontWeight: 400,
+    display: "block",
+    margin: 0,
+    marginTop: theme.spacing(1),
+  },
+
+  text: {
+    fontSize: theme.spacing(2),
     color: theme.palette.text.secondary,
     fontWeight: 400,
     display: "block",

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -4,7 +4,6 @@ import * as API from "../../api/api"
 import { Language as FooterLanguage } from "../../components/FormFooter/FormFooter"
 import { MockTemplate, MockWorkspace } from "../../testHelpers/entities"
 import { renderWithAuth } from "../../testHelpers/renderHelpers"
-import { Language as FormLanguage } from "../../util/formUtils"
 import CreateWorkspacePage from "./CreateWorkspacePage"
 import { Language } from "./CreateWorkspacePageView"
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -10,8 +10,8 @@ import { Language } from "./CreateWorkspacePageView"
 
 const renderCreateWorkspacePage = () => {
   return renderWithAuth(<CreateWorkspacePage />, {
-    route: "/workspaces/new?template=" + MockTemplate.name,
-    path: "/workspaces/new",
+    route: "/templates/" + MockTemplate.name + "/workspace",
+    path: "/templates/:template/workspace",
   })
 }
 
@@ -27,13 +27,6 @@ describe("CreateWorkspacePage", () => {
     renderCreateWorkspacePage()
     const element = await screen.findByText("Create workspace")
     expect(element).toBeDefined()
-  })
-
-  it("shows validation error message", async () => {
-    renderCreateWorkspacePage()
-    await fillForm({ name: "$$$" })
-    const errorMessage = await screen.findByText(FormLanguage.nameInvalidChars(Language.nameLabel))
-    expect(errorMessage).toBeDefined()
   })
 
   it("succeeds", async () => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -2,7 +2,6 @@ import { useMachine } from "@xstate/react"
 import { FC } from "react"
 import { Helmet } from "react-helmet"
 import { useNavigate, useSearchParams } from "react-router-dom"
-import { Template } from "../../api/typesGenerated"
 import { useOrganizationId } from "../../hooks/useOrganizationId"
 import { pageTitle } from "../../util/page"
 import { createWorkspaceMachine } from "../../xServices/createWorkspace/createWorkspaceXService"
@@ -11,10 +10,11 @@ import { CreateWorkspacePageView } from "./CreateWorkspacePageView"
 const CreateWorkspacePage: FC = () => {
   const organizationId = useOrganizationId()
   const [searchParams] = useSearchParams()
-  const preSelectedTemplateName = searchParams.get("template")
+  const templateParam = searchParams.get("template")
+  const templateName = templateParam ? templateParam : ""
   const navigate = useNavigate()
   const [createWorkspaceState, send] = useMachine(createWorkspaceMachine, {
-    context: { organizationId, preSelectedTemplateName },
+    context: { organizationId, templateName },
     actions: {
       onCreateWorkspace: (_, event) => {
         navigate(`/@${event.data.owner_name}/${event.data.name}`)
@@ -31,6 +31,7 @@ const CreateWorkspacePage: FC = () => {
         loadingTemplates={createWorkspaceState.matches("gettingTemplates")}
         loadingTemplateSchema={createWorkspaceState.matches("gettingTemplateSchema")}
         creatingWorkspace={createWorkspaceState.matches("creatingWorkspace")}
+        templateName={createWorkspaceState.context.templateName}
         templates={createWorkspaceState.context.templates}
         selectedTemplate={createWorkspaceState.context.selectedTemplate}
         templateSchema={createWorkspaceState.context.templateSchema}
@@ -41,12 +42,6 @@ const CreateWorkspacePage: FC = () => {
           send({
             type: "CREATE_WORKSPACE",
             request,
-          })
-        }}
-        onSelectTemplate={(template: Template) => {
-          send({
-            type: "SELECT_TEMPLATE",
-            template,
           })
         }}
       />

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -1,7 +1,7 @@
 import { useMachine } from "@xstate/react"
 import { FC } from "react"
 import { Helmet } from "react-helmet"
-import { useNavigate, useSearchParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 import { useOrganizationId } from "../../hooks/useOrganizationId"
 import { pageTitle } from "../../util/page"
 import { createWorkspaceMachine } from "../../xServices/createWorkspace/createWorkspaceXService"
@@ -9,9 +9,8 @@ import { CreateWorkspacePageView } from "./CreateWorkspacePageView"
 
 const CreateWorkspacePage: FC = () => {
   const organizationId = useOrganizationId()
-  const [searchParams] = useSearchParams()
-  const templateParam = searchParams.get("template")
-  const templateName = templateParam ? templateParam : ""
+  const { template } = useParams()
+  const templateName = template ? template : ""
   const navigate = useNavigate()
   const [createWorkspaceState, send] = useMachine(createWorkspaceMachine, {
     context: { organizationId, templateName },

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -35,7 +35,7 @@ const CreateWorkspacePage: FC = () => {
         selectedTemplate={createWorkspaceState.context.selectedTemplate}
         templateSchema={createWorkspaceState.context.templateSchema}
         onCancel={() => {
-          navigate(preSelectedTemplateName ? "/templates" : "/workspaces")
+          navigate("/templates")
         }}
         onSubmit={(request) => {
           send({

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -33,11 +33,6 @@ export default {
 
 const Template: Story<CreateWorkspacePageViewProps> = (args) => <CreateWorkspacePageView {...args} />
 
-export const NoTemplates = Template.bind({})
-NoTemplates.args = {
-  templates: [],
-}
-
 export const NoParameters = Template.bind({})
 NoParameters.args = {
   templates: [MockTemplate],

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -1,4 +1,3 @@
-import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
 import TextField from "@material-ui/core/TextField"
 import { FormikContextType, useFormik } from "formik"
@@ -76,13 +75,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props)
         {props.loadingTemplates && <Loader />}
 
         <Stack>
-          <TextField
-            disabled
-            fullWidth
-            label={Language.templateLabel}
-            value={props.templateName}
-            variant="outlined"
-          />
+          <TextField disabled fullWidth label={Language.templateLabel} value={props.templateName} variant="outlined" />
 
           {props.selectedTemplate && props.templateSchema && (
             <>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -72,11 +72,10 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props)
   return (
     <FullPageForm title="Create workspace" onCancel={props.onCancel}>
       <form onSubmit={form.handleSubmit}>
-        {props.loadingTemplates && <Loader />}
-
         <Stack>
           <TextField disabled fullWidth label={Language.templateLabel} value={props.templateName} variant="outlined" />
 
+          {props.loadingTemplateSchema && <Loader />}
           {props.selectedTemplate && props.templateSchema && (
             <>
               <TextField

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -73,7 +73,13 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props)
     <FullPageForm title="Create workspace" onCancel={props.onCancel}>
       <form onSubmit={form.handleSubmit}>
         <Stack>
-          <TextField disabled fullWidth label={Language.templateLabel} value={props.selectedTemplate?.name || props.templateName} variant="outlined" />
+          <TextField
+            disabled
+            fullWidth
+            label={Language.templateLabel}
+            value={props.selectedTemplate?.name || props.templateName}
+            variant="outlined"
+          />
 
           {props.loadingTemplateSchema && <Loader />}
           {props.selectedTemplate && props.templateSchema && (

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -73,7 +73,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props)
     <FullPageForm title="Create workspace" onCancel={props.onCancel}>
       <form onSubmit={form.handleSubmit}>
         <Stack>
-          <TextField disabled fullWidth label={Language.templateLabel} value={props.templateName} variant="outlined" />
+          <TextField disabled fullWidth label={Language.templateLabel} value={props.selectedTemplate?.name || props.templateName} variant="outlined" />
 
           {props.loadingTemplateSchema && <Loader />}
           {props.selectedTemplate && props.templateSchema && (

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -1,15 +1,10 @@
 import Link from "@material-ui/core/Link"
-import MenuItem from "@material-ui/core/MenuItem"
 import { makeStyles } from "@material-ui/core/styles"
-import TextField, { TextFieldProps } from "@material-ui/core/TextField"
-import OpenInNewIcon from "@material-ui/icons/OpenInNew"
+import TextField from "@material-ui/core/TextField"
 import { FormikContextType, useFormik } from "formik"
 import { FC, useState } from "react"
-import { Link as RouterLink } from "react-router-dom"
 import * as Yup from "yup"
 import * as TypesGen from "../../api/typesGenerated"
-import { CodeExample } from "../../components/CodeExample/CodeExample"
-import { EmptyState } from "../../components/EmptyState/EmptyState"
 import { FormFooter } from "../../components/FormFooter/FormFooter"
 import { FullPageForm } from "../../components/FullPageForm/FullPageForm"
 import { Loader } from "../../components/Loader/Loader"
@@ -20,29 +15,18 @@ import { getFormHelpers, nameValidator, onChangeTrimmed } from "../../util/formU
 export const Language = {
   templateLabel: "Template",
   nameLabel: "Name",
-  emptyMessage: "Let's create your first template",
-  emptyDescription: (
-    <>
-      To create a workspace you need to have a template. You can{" "}
-      <Link target="_blank" href="https://github.com/coder/coder/blob/main/docs/templates.md">
-        create one from scratch
-      </Link>{" "}
-      or use a built-in template by typing the following Coder CLI command:
-    </>
-  ),
-  templateLink: "Read more about this template",
 }
 
 export interface CreateWorkspacePageViewProps {
   loadingTemplates: boolean
   loadingTemplateSchema: boolean
   creatingWorkspace: boolean
+  templateName: string
   templates?: TypesGen.Template[]
   selectedTemplate?: TypesGen.Template
   templateSchema?: TypesGen.ParameterSchema[]
   onCancel: () => void
   onSubmit: (req: TypesGen.CreateWorkspaceRequest) => void
-  onSelectTemplate: (template: TypesGen.Template) => void
 }
 
 export const validationSchema = Yup.object({
@@ -51,7 +35,8 @@ export const validationSchema = Yup.object({
 
 export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props) => {
   const [parameterValues, setParameterValues] = useState<Record<string, string>>({})
-  const styles = useStyles()
+  useStyles()
+
   const form: FormikContextType<TypesGen.CreateWorkspaceRequest> = useFormik<TypesGen.CreateWorkspaceRequest>({
     initialValues: {
       name: "",
@@ -84,26 +69,6 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props)
     },
   })
   const getFieldHelpers = getFormHelpers<TypesGen.CreateWorkspaceRequest>(form)
-  const selectedTemplate =
-    props.templates &&
-    form.values.template_id &&
-    props.templates.find((template) => template.id === form.values.template_id)
-
-  const handleTemplateChange: TextFieldProps["onChange"] = (event) => {
-    if (!props.templates) {
-      throw new Error("Templates are not loaded")
-    }
-
-    const templateId = event.target.value
-    const selectedTemplate = props.templates.find((template) => template.id === templateId)
-
-    if (!selectedTemplate) {
-      throw new Error(`Template ${templateId} not found`)
-    }
-
-    form.setFieldValue("template_id", selectedTemplate.id)
-    props.onSelectTemplate(selectedTemplate)
-  }
 
   return (
     <FullPageForm title="Create workspace" onCancel={props.onCancel}>
@@ -111,47 +76,13 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = (props)
         {props.loadingTemplates && <Loader />}
 
         <Stack>
-          {props.templates && props.templates.length === 0 && (
-            <EmptyState
-              className={styles.emptyState}
-              message={Language.emptyMessage}
-              description={Language.emptyDescription}
-              descriptionClassName={styles.emptyStateDescription}
-              cta={
-                <CodeExample className={styles.code} buttonClassName={styles.codeButton} code="coder template init" />
-              }
-            />
-          )}
-          {props.templates && props.templates.length > 0 && (
-            <TextField
-              {...getFieldHelpers("template_id")}
-              disabled={form.isSubmitting}
-              onChange={handleTemplateChange}
-              autoFocus
-              fullWidth
-              label={Language.templateLabel}
-              variant="outlined"
-              select
-              helperText={
-                selectedTemplate && (
-                  <Link
-                    className={styles.readMoreLink}
-                    component={RouterLink}
-                    to={`/templates/${selectedTemplate.name}`}
-                    target="_blank"
-                  >
-                    {Language.templateLink} <OpenInNewIcon />
-                  </Link>
-                )
-              }
-            >
-              {props.templates.map((template) => (
-                <MenuItem key={template.id} value={template.id}>
-                  {template.name}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
+          <TextField
+            disabled
+            fullWidth
+            label={Language.templateLabel}
+            value={props.templateName}
+            variant="outlined"
+          />
 
           {props.selectedTemplate && props.templateSchema && (
             <>

--- a/site/src/pages/TemplatePage/TemplatePageView.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageView.tsx
@@ -39,7 +39,7 @@ export const TemplatePageView: FC<TemplatePageViewProps> = ({ template, activeTe
     <Margins>
       <PageHeader
         actions={
-          <Link underline="none" component={RouterLink} to={`/workspaces/new?template=${template.name}`}>
+          <Link underline="none" component={RouterLink} to={`/templates/${template.name}/workspace`}>
             <Button startIcon={<AddCircleOutline />}>{Language.createButton}</Button>
           </Link>
         }

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -9,7 +9,7 @@ import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import { FC } from "react"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, Link as RouterLink } from "react-router-dom"
 import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { CodeExample } from "../../components/CodeExample/CodeExample"
@@ -22,7 +22,7 @@ import {
   HelpTooltipTitle,
 } from "../../components/HelpTooltip/HelpTooltip"
 import { Margins } from "../../components/Margins/Margins"
-import { PageHeader, PageHeaderTitle } from "../../components/PageHeader/PageHeader"
+import { PageHeader, PageHeaderText, PageHeaderTitle } from "../../components/PageHeader/PageHeader"
 import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 
@@ -84,6 +84,12 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
             <TemplateHelpTooltip />
           </Stack>
         </PageHeaderTitle>
+        {props.templates && props.templates.length > 0 && (
+          <PageHeaderText>
+              Choose a template to create a new workspace.
+          </PageHeaderText>
+        )}
+
       </PageHeader>
 
       <Table>

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -9,7 +9,7 @@ import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import { FC } from "react"
-import { useNavigate, Link as RouterLink } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
 import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { CodeExample } from "../../components/CodeExample/CodeExample"
@@ -85,11 +85,8 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
           </Stack>
         </PageHeaderTitle>
         {props.templates && props.templates.length > 0 && (
-          <PageHeaderText>
-              Choose a template to create a new workspace.
-          </PageHeaderText>
+          <PageHeaderText>Choose a template to create a new workspace.</PageHeaderText>
         )}
-
       </PageHeader>
 
       <Table>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -37,11 +37,12 @@ import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { getDisplayStatus, workspaceFilterQuery } from "../../util/workspace"
+import ReplyIcon from '@material-ui/icons/Reply';
 
 dayjs.extend(relativeTime)
 
 export const Language = {
-  createWorkspaceButton: "Create workspace",
+  createFromTemplateButton: "Create from template",
   emptyCreateWorkspaceMessage: "Create your first workspace",
   emptyCreateWorkspaceDescription: "Start editing your source code and building your software",
   emptyResultsMessage: "No results matched your search",
@@ -132,9 +133,9 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
     <Margins>
       <PageHeader
         actions={
-          <Link underline="none" component={RouterLink} to="/workspaces/new">
-            <Button startIcon={<AddCircleOutline />} style={{ height: "44px" }}>
-              {Language.createWorkspaceButton}
+          <Link underline="none" component={RouterLink} to="/templates">
+            <Button startIcon={<ReplyIcon style={{ transform: "scaleX(-1)" }}/>} style={{ height: "44px" }}>
+              {Language.createFromTemplateButton}
             </Button>
           </Link>
         }
@@ -213,7 +214,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
                       description={Language.emptyCreateWorkspaceDescription}
                       cta={
                         <Link underline="none" component={RouterLink} to="/workspaces/new">
-                          <Button startIcon={<AddCircleOutline />}>{Language.createWorkspaceButton}</Button>
+                          <Button startIcon={<AddCircleOutline />}>{Language.createFromTemplateButton}</Button>
                         </Link>
                       }
                     />

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -33,7 +33,7 @@ import {
   HelpTooltipTitle,
 } from "../../components/HelpTooltip/HelpTooltip"
 import { Margins } from "../../components/Margins/Margins"
-import { PageHeader, PageHeaderTitle } from "../../components/PageHeader/PageHeader"
+import { PageHeader, PageHeaderTitle, PageHeaderText } from "../../components/PageHeader/PageHeader"
 import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
@@ -133,11 +133,14 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
     <Margins>
       <PageHeader
         actions={
-          <Link underline="none" component={RouterLink} to="/templates">
-            <Button startIcon={<ReplyIcon style={{ transform: "scaleX(-1)" }} />} style={{ height: "44px" }}>
-              {Language.createFromTemplateButton}
-            </Button>
-          </Link>
+          <PageHeaderText>
+            Create a new workspace from a <Link
+              component={RouterLink}
+              to="/templates"
+            >
+              Template
+            </Link>.
+          </PageHeaderText>
         }
       >
         <PageHeaderTitle>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -13,6 +13,7 @@ import TableRow from "@material-ui/core/TableRow"
 import TextField from "@material-ui/core/TextField"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
+import ReplyIcon from "@material-ui/icons/Reply"
 import SearchIcon from "@material-ui/icons/Search"
 import useTheme from "@material-ui/styles/useTheme"
 import dayjs from "dayjs"
@@ -37,7 +38,6 @@ import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { getDisplayStatus, workspaceFilterQuery } from "../../util/workspace"
-import ReplyIcon from '@material-ui/icons/Reply';
 
 dayjs.extend(relativeTime)
 
@@ -134,7 +134,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
       <PageHeader
         actions={
           <Link underline="none" component={RouterLink} to="/templates">
-            <Button startIcon={<ReplyIcon style={{ transform: "scaleX(-1)" }}/>} style={{ height: "44px" }}>
+            <Button startIcon={<ReplyIcon style={{ transform: "scaleX(-1)" }} />} style={{ height: "44px" }}>
               {Language.createFromTemplateButton}
             </Button>
           </Link>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -13,7 +13,6 @@ import TableRow from "@material-ui/core/TableRow"
 import TextField from "@material-ui/core/TextField"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
-import ReplyIcon from "@material-ui/icons/Reply"
 import SearchIcon from "@material-ui/icons/Search"
 import useTheme from "@material-ui/styles/useTheme"
 import dayjs from "dayjs"
@@ -33,7 +32,7 @@ import {
   HelpTooltipTitle,
 } from "../../components/HelpTooltip/HelpTooltip"
 import { Margins } from "../../components/Margins/Margins"
-import { PageHeader, PageHeaderTitle, PageHeaderText } from "../../components/PageHeader/PageHeader"
+import { PageHeader, PageHeaderText, PageHeaderTitle } from "../../components/PageHeader/PageHeader"
 import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
@@ -134,12 +133,11 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
       <PageHeader
         actions={
           <PageHeaderText>
-            Create a new workspace from a <Link
-              component={RouterLink}
-              to="/templates"
-            >
+            Create a new workspace from a{" "}
+            <Link component={RouterLink} to="/templates">
               Template
-            </Link>.
+            </Link>
+            .
           </PageHeaderText>
         }
       >

--- a/site/src/xServices/createWorkspace/createWorkspaceXService.ts
+++ b/site/src/xServices/createWorkspace/createWorkspaceXService.ts
@@ -125,11 +125,8 @@ export const createWorkspaceMachine = createMachine(
       }),
       assignSelectedTemplate: assign({
         selectedTemplate: (ctx, event) => {
-          for (const template of event.data) {
-            if (template.name === ctx.templateName) {
-              return template
-            }
-          }
+          const templates = event.data.filter((template) => template.name === ctx.templateName)
+          return templates.length ? templates[0] : undefined
         },
       }),
       assignTemplateSchema: assign({

--- a/site/src/xServices/createWorkspace/createWorkspaceXService.ts
+++ b/site/src/xServices/createWorkspace/createWorkspaceXService.ts
@@ -12,11 +12,10 @@ type CreateWorkspaceContext = {
   createdWorkspace?: Workspace
 }
 
-type CreateWorkspaceEvent =
-  | {
-      type: "CREATE_WORKSPACE"
-      request: CreateWorkspaceRequest
-    }
+type CreateWorkspaceEvent = {
+  type: "CREATE_WORKSPACE"
+  request: CreateWorkspaceRequest
+}
 
 export const createWorkspaceMachine = createMachine(
   {


### PR DESCRIPTION
@kylecarbs and I have discussed wanting to clean up this flow. The main driver is that Users should have more context than just a template name, and we must provide that flow naturally in the product. The flow now becomes:
- Land on workspaces page
- Click "Create from template" and be brought to the templates page
- Select the template
- Click "Create New Workspace" button
- See template already selected for you and no longer a selector

Example:

![chrome_Dvgpap4BzV](https://user-images.githubusercontent.com/19379394/172501221-be63c741-b8eb-43d2-928f-870c5a746eee.gif)
