### PR TITLE
feat: set $HOME for coder agent in aws-linux template

### DIFF
--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -101,7 +101,7 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash
-sudo -E -u ubuntu sh -c '${coder_agent.dev.init_script}'
+sudo -u ubuntu sh -c '${coder_agent.dev.init_script}'
 --//--
 EOT
 


### PR DESCRIPTION
Second PR for #1386 --- still left is Digital Ocean.

It's unclear to me why we used `-E` in the first place; it doesn't make sense to me to pass the environment vars from the startup script (presumably running as root) to the agent script.  Perhaps just mistakenly thinking we needed variables from provisioner/terraform to get passed---but these get substituted by terraform before the script is set in the metadata.