### PR TITLE
fix: Stop showing resources after `coder create`

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -242,19 +242,7 @@ func create() *cobra.Command {
 				return err
 			}
 
-			resources, err = client.WorkspaceResourcesByBuild(cmd.Context(), workspace.LatestBuild.ID)
-			if err != nil {
-				return err
-			}
-
-			err = cliui.WorkspaceResources(cmd.OutOrStdout(), resources, cliui.WorkspaceResourcesOptions{
-				WorkspaceName: workspaceName,
-			})
-			if err != nil {
-				return err
-			}
-
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "The %s workspace has been created!\n", cliui.Styles.Keyword.Render(workspace.Name))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nThe %s workspace has been created!\n", cliui.Styles.Keyword.Render(workspace.Name))
 			return nil
 		},
 	}


### PR DESCRIPTION
This change avoids a confusing UX where the workspace agent shows "connecting" after create has completed.

Fixes #1036

---

Output:

```
Select a template below to preview the provisioned
infrastructure:

  This template has customizable parameters. Values can be
  changed after create, but may have unintended side effects
  (like data loss).

var.docker_image
  Which Docker image would you like to use for your workspace?

  >  codercom/enterprise-base:ubuntu

Planning workspace...
✔ Queued [15ms]
✔ Setting up [500ms]
✔ Detecting persistent resources [1431ms]
✔ Cleaning Up [0ms]
┌──────────────────────────────────────────────────────────┐
│ Workspace Preview                                        │
├──────────────────────────────────────────────────────────┤
│ RESOURCE                    STATUS     ACCESS            │
├──────────────────────────────────────────────────────────┤
│ docker_container.workspace  ephemeral                    │
│ └─ dev (linux, )                        coder ssh test2  │
├──────────────────────────────────────────────────────────┤
│ docker_volume.home_volume   ephemeral                    │
└──────────────────────────────────────────────────────────┘
> Confirm create? (yes/no)
✔ Queued [136ms]
✔ Setting up [6ms]
⧗  Starting workspace
  Terraform 1.1.9
  coder_agent.dev: Plan to create
  docker_volume.home_volume: Plan to create
  docker_container.workspace[0]: Plan to create
  Plan: 3 to add, 0 to change, 0 to destroy.
  coder_agent.dev: Creating...
  coder_agent.dev: Creation complete after 0s [id=a76f21f8-1fc8-4990-b498-70dd97da2563]
  docker_volume.home_volume: Creating...
  docker_volume.home_volume: Creation complete after 0s [id=coder-maf-test2-root]
  docker_container.workspace[0]: Creating...
  docker_container.workspace[0]: Creation complete after 1s [id=a9ac14a867d28bcace2fe1b3c2eb747dda33994b6a586b2e9ab30b18250a776e]
  Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
  Outputs: 0
✔ Starting workspace [2916ms]
✔ Cleaning Up [-5ms]

The test2 workspace has been created!
```