### PR TITLE
feat: added include_deleted to getWorkspaceByOwnerAndName

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,6 +83,7 @@
     "workspaceapp",
     "workspaceapps",
     "workspacebuilds",
+    "workspacename",
     "wsconncache",
     "xerrors",
     "xstate",

--- a/cli/create.go
+++ b/cli/create.go
@@ -49,7 +49,7 @@ func create() *cobra.Command {
 				workspaceName, err = cliui.Prompt(cmd, cliui.PromptOptions{
 					Text: "Specify a name for your workspace:",
 					Validate: func(workspaceName string) error {
-						_, err = client.WorkspaceByOwnerAndName(cmd.Context(), codersdk.Me, workspaceName)
+						_, err = client.WorkspaceByOwnerAndName(cmd.Context(), codersdk.Me, workspaceName, codersdk.WorkspaceByOwnerAndNameParams{})
 						if err == nil {
 							return xerrors.Errorf("A workspace already exists named %q!", workspaceName)
 						}
@@ -61,7 +61,7 @@ func create() *cobra.Command {
 				}
 			}
 
-			_, err = client.WorkspaceByOwnerAndName(cmd.Context(), codersdk.Me, workspaceName)
+			_, err = client.WorkspaceByOwnerAndName(cmd.Context(), codersdk.Me, workspaceName, codersdk.WorkspaceByOwnerAndNameParams{})
 			if err == nil {
 				return xerrors.Errorf("A workspace already exists named %q!", workspaceName)
 			}

--- a/cli/root.go
+++ b/cli/root.go
@@ -214,7 +214,7 @@ func namedWorkspace(cmd *cobra.Command, client *codersdk.Client, identifier stri
 		return codersdk.Workspace{}, xerrors.Errorf("invalid workspace name: %q", identifier)
 	}
 
-	return client.WorkspaceByOwnerAndName(cmd.Context(), owner, name)
+	return client.WorkspaceByOwnerAndName(cmd.Context(), owner, name, codersdk.WorkspaceByOwnerAndNameParams{})
 }
 
 // createConfig consumes the global configuration flag to produce a config root.

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -191,7 +191,6 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 			Deleted: includeDeleted,
 		})
 	}
-
 	if errors.Is(err, sql.ErrNoRows) {
 		// Do not leak information if the workspace exists or not
 		httpapi.Forbidden(rw)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -165,13 +165,10 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 	owner := httpmw.UserParam(r)
 	workspaceName := chi.URLParam(r, "workspacename")
 
-	var (
-		includeDeletedStr = r.URL.Query().Get("include_deleted")
-		includeDeleted    = false
-	)
-	if includeDeletedStr != "" {
+	includeDeleted := false
+	if s := r.URL.Query().Get("include_deleted"); s != "" {
 		var err error
-		includeDeleted, err = strconv.ParseBool(includeDeletedStr)
+		includeDeleted, err = strconv.ParseBool(s)
 		if err != nil {
 			httpapi.Write(rw, http.StatusBadRequest, httpapi.Response{
 				Message: fmt.Sprintf("Invalid boolean value %q for \"include_deleted\" query param.", includeDeletedStr),

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -171,7 +171,7 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 		includeDeleted, err = strconv.ParseBool(s)
 		if err != nil {
 			httpapi.Write(rw, http.StatusBadRequest, httpapi.Response{
-				Message: fmt.Sprintf("Invalid boolean value %q for \"include_deleted\" query param.", includeDeletedStr),
+				Message: fmt.Sprintf("Invalid boolean value %q for \"include_deleted\" query param.", s),
 				Validations: []httpapi.Error{
 					{Field: "include_deleted", Detail: "Must be a valid boolean"},
 				},

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -184,7 +184,6 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 		OwnerID: owner.ID,
 		Name:    workspaceName,
 	})
-
 	if includeDeleted && errors.Is(err, sql.ErrNoRows) {
 		workspace, err = api.Database.GetWorkspaceByOwnerIDAndName(r.Context(), database.GetWorkspaceByOwnerIDAndNameParams{
 			OwnerID: owner.ID,

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -293,7 +293,7 @@ func TestWorkspaceByOwnerAndName(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, build.ID)
 
 		// Then:
-		// when we call without includes_deleted, we don't expect to get the workspace back
+		// When we call without includes_deleted, we don't expect to get the workspace back
 		_, err = client.WorkspaceByOwnerAndName(context.Background(), workspace.OwnerName, workspace.Name, codersdk.WorkspaceByOwnerAndNameParams{})
 		require.ErrorContains(t, err, "403")
 

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -274,7 +274,7 @@ func TestWorkspaceByOwnerAndName(t *testing.T) {
 		_, err := client.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, workspace.Name, codersdk.WorkspaceByOwnerAndNameParams{})
 		require.NoError(t, err)
 	})
-	t.Run("deletedGetWorkspaceByOwnerAndName", func(t *testing.T) {
+	t.Run("Deleted", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		user := coderdtest.CreateFirstUser(t, client)

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -258,9 +258,17 @@ func (c *Client) Workspaces(ctx context.Context, filter WorkspaceFilter) ([]Work
 	return workspaces, json.NewDecoder(res.Body).Decode(&workspaces)
 }
 
+type WorkspaceByOwnerAndNameParams struct {
+	IncludeDeleted bool `json:"include_deleted,omitempty"`
+}
+
 // WorkspaceByOwnerAndName returns a workspace by the owner's UUID and the workspace's name.
-func (c *Client) WorkspaceByOwnerAndName(ctx context.Context, owner string, name string) (Workspace, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/workspace/%s", owner, name), nil)
+func (c *Client) WorkspaceByOwnerAndName(ctx context.Context, owner string, name string, params WorkspaceByOwnerAndNameParams) (Workspace, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/workspace/%s", owner, name), nil, func(r *http.Request) {
+		q := r.URL.Query()
+		q.Set("include_deleted", fmt.Sprintf("%t", params.IncludeDeleted))
+		r.URL.RawQuery = q.Encode()
+	})
 	if err != nil {
 		return Workspace{}, err
 	}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -142,7 +142,9 @@ export const getWorkspaceByOwnerAndName = async (
   username = "me",
   workspaceName: string,
 ): Promise<TypesGen.Workspace> => {
-  const response = await axios.get<TypesGen.Workspace>(`/api/v2/users/${username}/workspace/${workspaceName}`)
+  const response = await axios.get<TypesGen.Workspace>(`/api/v2/users/${username}/workspace/${workspaceName}`, {
+    params: { include_deleted: true },
+  })
   return response.data
 }
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -142,9 +142,7 @@ export const getWorkspaceByOwnerAndName = async (
   username = "me",
   workspaceName: string,
 ): Promise<TypesGen.Workspace> => {
-  const response = await axios.get<TypesGen.Workspace>(`/api/v2/users/${username}/workspace/${workspaceName}`, {
-    params: { include_deleted: true },
-  })
+  const response = await axios.get<TypesGen.Workspace>(`/api/v2/users/${username}/workspace/${workspaceName}`)
   return response.data
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -456,6 +456,11 @@ export interface WorkspaceBuildsRequest extends Pagination {
   readonly WorkspaceID: string
 }
 
+// From codersdk/workspaces.go:261:6
+export interface WorkspaceByOwnerAndNameParams {
+  readonly include_deleted?: boolean
+}
+
 // From codersdk/workspaces.go:219:6
 export interface WorkspaceFilter {
   readonly organization_id?: string


### PR DESCRIPTION
relates to #1955

I'm working on #1955: a ticket that will show deleted workspaces in our UI. 
@f0ssel made some helpful changes to `getWorkspaces` in #2095 to help support the aforementioned UI change.
However, @BrunoQuaresma recently updated the Workspace page so that it no longer uses the `getWorkspace` route, instead favoring `getWorkspaceByOwnerAndName`. 

This PR attempts to add an `include_deleted` param to `getWorkspaceByOwnerAndName` so I can continue work on #1955. I've never touched Go before so please let me know what I've broken 🧹 

P.S. It would be great to generate a type for this addition but idk how to do that. 