### PR TITLE
fix: show explicit schedule stop time

### DIFF
--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -33,9 +33,10 @@ export const Language = {
   },
   autoStartLabel: (schedule: string | undefined): string => {
     const prefix = "Start"
+    const timezone = schedule ? extractTimezone(schedule) : dayjs.tz.guess()
 
     if (schedule) {
-      return `${prefix} (${dayjs().tz(extractTimezone(schedule)).format("z")})`
+      return `${prefix} (${dayjs().tz(timezone).format("z")})`
     } else {
       return prefix
     }


### PR DESCRIPTION
This does not fully resolve all requests in #2141, but just the piece of
when the workspace is actually stopping.

Next, we will adjust the default extension from 90 minutes to 4 hours.
Lastly, we can look at customizing the extension time in the extension
flow or with a pre-emptive prompt next to the stop time.

![extend-example](https://user-images.githubusercontent.com/11184711/172657762-f9f0dae5-cf49-43ec-ac12-388d9a718c8a.PNG)
