### PR TITLE
fix: increase default extension time

### DIFF
--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -47,7 +47,7 @@ describe("util > workspace", () => {
       [
         "2022-06-02T14:56:34Z",
         {
-          deadline: "2022-06-02T16:26:34Z",
+          deadline: "2022-06-02T18:56:34Z",
         },
       ],
 
@@ -56,7 +56,7 @@ describe("util > workspace", () => {
       [
         "2022-06-02T10:56:20-04:00",
         {
-          deadline: "2022-06-02T16:26:20Z",
+          deadline: "2022-06-02T18:56:20Z",
         },
       ],
     ])(`defaultWorkspaceExtension(%p) returns %p`, (startTime, request) => {

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -251,10 +251,10 @@ export const isWorkspaceOn = (workspace: TypesGen.Workspace): boolean => {
 
 export const defaultWorkspaceExtension = (__startDate?: dayjs.Dayjs): TypesGen.PutExtendWorkspaceRequest => {
   const now = __startDate ? dayjs(__startDate) : dayjs()
-  const NinetyMinutesFromNow = now.add(90, "minutes").utc()
+  const fourHoursFromNow = now.add(4, "hours").utc()
 
   return {
-    deadline: NinetyMinutesFromNow.format(),
+    deadline: fourHoursFromNow.format(),
   }
 }
 


### PR DESCRIPTION
This does not fully close #2141, but builds upon #2171 to fulfill each
of the UX requests.

A next step (probably as a separate ticket) is to allow customizing
extension time pre-emptively.
