### PR TITLE
feat: Add initiator_username to workspace builds in apis

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -912,3 +912,12 @@ func userOrganizationIDs(ctx context.Context, api *API, user database.User) ([]u
 	member := organizationIDsByMemberIDsRows[0]
 	return member.OrganizationIDs, nil
 }
+
+func findUser(id uuid.UUID, users []database.User) *database.User {
+	for _, u := range users {
+		if u.ID == id {
+			return &u
+		}
+	}
+	return nil
+}

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -33,15 +33,18 @@ func TestWorkspaceBuilds(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
-		user := coderdtest.CreateFirstUser(t, client)
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
-		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		first := coderdtest.CreateFirstUser(t, client)
+		user, err := client.User(context.Background(), codersdk.Me)
+		require.NoError(t, err, "fetch me")
+		version := coderdtest.CreateTemplateVersion(t, client, first.OrganizationID, nil)
+		template := coderdtest.CreateTemplate(t, client, first.OrganizationID, version.ID)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
-		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, first.OrganizationID, template.ID)
 		builds, err := client.WorkspaceBuilds(context.Background(),
 			codersdk.WorkspaceBuildsRequest{WorkspaceID: workspace.ID})
 		require.Len(t, builds, 1)
 		require.Equal(t, int32(1), builds[0].BuildNumber)
+		require.Equal(t, user.Username, builds[0].InitiatorUsername)
 		require.NoError(t, err)
 	})
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -73,7 +73,7 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 		group    errgroup.Group
 		job      database.ProvisionerJob
 		template database.Template
-		owner    database.User
+		users    []database.User
 	)
 	group.Go(func() (err error) {
 		job, err = api.Database.GetProvisionerJobByID(r.Context(), build.JobID)
@@ -84,7 +84,7 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	group.Go(func() (err error) {
-		owner, err = api.Database.GetUserByID(r.Context(), workspace.OwnerID)
+		users, err = api.Database.GetUsersByIDs(r.Context(), []uuid.UUID{workspace.OwnerID, build.InitiatorID})
 		return err
 	})
 	err = group.Wait()
@@ -96,7 +96,8 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(rw, http.StatusOK, convertWorkspace(workspace, build, job, template, owner))
+	httpapi.Write(rw, http.StatusOK, convertWorkspace(workspace, build, job, template,
+		findUser(workspace.OwnerID, users), findUser(build.InitiatorID, users)))
 }
 
 // workspaces returns all workspaces a user can read.
@@ -210,7 +211,16 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	httpapi.Write(rw, http.StatusOK, convertWorkspace(workspace, build, job, template, owner))
+	initiator, err := api.Database.GetUserByID(r.Context(), build.InitiatorID)
+	if err != nil {
+		httpapi.Write(rw, http.StatusInternalServerError, httpapi.Response{
+			Message: "Internal error fetching template.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(rw, http.StatusOK, convertWorkspace(workspace, build, job, template, &owner, &initiator))
 }
 
 // Create a new workspace for the currently authenticated user.
@@ -443,7 +453,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		})
 		return
 	}
-	user, err := api.Database.GetUserByID(r.Context(), apiKey.UserID)
+	users, err := api.Database.GetUsersByIDs(r.Context(), []uuid.UUID{apiKey.UserID, workspaceBuild.InitiatorID})
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, httpapi.Response{
 			Message: "Internal error fetching user.",
@@ -452,7 +462,8 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
-	httpapi.Write(rw, http.StatusCreated, convertWorkspace(workspace, workspaceBuild, templateVersionJob, template, user))
+	httpapi.Write(rw, http.StatusCreated, convertWorkspace(workspace, workspaceBuild, templateVersionJob, template,
+		findUser(apiKey.UserID, users), findUser(workspaceBuild.InitiatorID, users)))
 }
 
 func (api *API) putWorkspaceAutostart(rw http.ResponseWriter, r *http.Request) {
@@ -669,7 +680,7 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 				group    errgroup.Group
 				job      database.ProvisionerJob
 				template database.Template
-				owner    database.User
+				users    []database.User
 			)
 			group.Go(func() (err error) {
 				job, err = api.Database.GetProvisionerJobByID(r.Context(), build.JobID)
@@ -680,7 +691,7 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 				return err
 			})
 			group.Go(func() (err error) {
-				owner, err = api.Database.GetUserByID(r.Context(), workspace.OwnerID)
+				users, err = api.Database.GetUsersByIDs(r.Context(), []uuid.UUID{workspace.OwnerID, build.InitiatorID})
 				return err
 			})
 			err = group.Wait()
@@ -692,7 +703,8 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			_ = wsjson.Write(ctx, c, convertWorkspace(workspace, build, job, template, owner))
+			_ = wsjson.Write(ctx, c, convertWorkspace(workspace, build, job, template,
+				findUser(workspace.OwnerID, users), findUser(build.InitiatorID, users)))
 		case <-ctx.Done():
 			return
 		}
@@ -785,11 +797,15 @@ func convertWorkspaces(ctx context.Context, db database.Store, workspaces []data
 		if !exists {
 			return nil, xerrors.Errorf("build job not found for workspace: %w", err)
 		}
-		user, exists := userByID[workspace.OwnerID]
+		owner, exists := userByID[workspace.OwnerID]
 		if !exists {
 			return nil, xerrors.Errorf("owner not found for workspace: %q", workspace.Name)
 		}
-		apiWorkspaces = append(apiWorkspaces, convertWorkspace(workspace, build, job, template, user))
+		initiator, exists := userByID[build.InitiatorID]
+		if !exists {
+			return nil, xerrors.Errorf("build initiator not found for workspace: %q", workspace.Name)
+		}
+		apiWorkspaces = append(apiWorkspaces, convertWorkspace(workspace, build, job, template, &owner, &initiator))
 	}
 	return apiWorkspaces, nil
 }
@@ -798,7 +814,9 @@ func convertWorkspace(
 	workspaceBuild database.WorkspaceBuild,
 	job database.ProvisionerJob,
 	template database.Template,
-	owner database.User) codersdk.Workspace {
+	owner *database.User,
+	initiator *database.User,
+) codersdk.Workspace {
 	var autostartSchedule *string
 	if workspace.AutostartSchedule.Valid {
 		autostartSchedule = &workspace.AutostartSchedule.String
@@ -812,7 +830,7 @@ func convertWorkspace(
 		OwnerID:           workspace.OwnerID,
 		OwnerName:         owner.Username,
 		TemplateID:        workspace.TemplateID,
-		LatestBuild:       convertWorkspaceBuild(owner, workspace, workspaceBuild, job),
+		LatestBuild:       convertWorkspaceBuild(owner, initiator, workspace, workspaceBuild, job),
 		TemplateName:      template.Name,
 		Outdated:          workspaceBuild.TemplateVersionID.String() != template.ActiveVersionID.String(),
 		Name:              workspace.Name,

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -34,6 +34,7 @@ type WorkspaceBuild struct {
 	Name               string              `json:"name"`
 	Transition         WorkspaceTransition `json:"transition"`
 	InitiatorID        uuid.UUID           `json:"initiator_id"`
+	InitiatorUsername  string              `json:"initiator_name"`
 	Job                ProvisionerJob      `json:"job"`
 	Deadline           time.Time           `json:"deadline"`
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -454,6 +454,7 @@ export interface WorkspaceBuild {
   readonly name: string
   readonly transition: WorkspaceTransition
   readonly initiator_id: string
+  readonly initiator_name: string
   readonly job: ProvisionerJob
   readonly deadline: string
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -131,6 +131,7 @@ export const MockWorkspaceBuild: TypesGen.WorkspaceBuild = {
   created_at: "2022-05-17T17:39:01.382927298Z",
   id: "1",
   initiator_id: "",
+  initiator_name: "",
   job: MockProvisionerJob,
   name: "a-workspace-build",
   template_version_id: "",


### PR DESCRIPTION
# What this does

Returns the username of the initiator in workspace builds.

# Implementation notes

The `GetUsersByIDs` call I use to fetch the usernames might not return the full set requested. For this reason `convertWorkspaceBuild` now takes a `*database.User` to handle the `nil` case. I handle the nil case in the convert for a consistent message of "unknown". In practice, this _**should never actually happen**_ as our users should always exist.