### PR TITLE
example: aws-linux: resize and use non-root user

### DIFF
--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -82,7 +82,7 @@ cloud_final_modules:
 - [scripts-user, always]
 hostname: ${lower(data.coder_workspace.me.name)}
 users:
-- name: ${lower(data.coder_workspace.me.owner)}
+- name: ${local.linux_user}
   sudo: ALL=(ALL) NOPASSWD:ALL
   shell: /bin/bash
 
@@ -93,7 +93,7 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash
-sudo -u ${lower(data.coder_workspace.me.owner)} sh -c '${coder_agent.dev.init_script}'
+sudo -u ${local.linux_user} sh -c '${coder_agent.dev.init_script}'
 --//--
 EOT
 
@@ -121,6 +121,10 @@ Content-Disposition: attachment; filename="userdata.txt"
 sudo shutdown -h now
 --//--
 EOT
+
+  # Ensure Coder username is a valid Linux username
+  linux_user = lower(substr(data.coder_workspace.me.owner, 0, 32))
+
 }
 
 resource "aws_instance" "dev" {

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -126,7 +126,7 @@ EOT
 resource "aws_instance" "dev" {
   ami               = data.aws_ami.ubuntu.id
   availability_zone = "${var.region}a"
-  instance_type     = "t3.medium"
+  instance_type     = "t3.xlarge"
 
   user_data = data.coder_workspace.me.transition == "start" ? local.user_data_start : local.user_data_end
   tags = {

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -36,19 +36,6 @@ variable "region" {
   }
 }
 
-variable "disk_size" {
-  description = "Specify your disk size (GiBs)"
-  default     = "20"
-  type        = number
-  validation {
-    condition = (
-      var.disk_size >= 8 &&
-      var.disk_size <= 256
-    )
-    error_message = "Disk size must be between 8 and 256."
-  }
-}
-
 provider "aws" {
   region = var.region
 }
@@ -93,6 +80,11 @@ Content-Disposition: attachment; filename="cloud-config.txt"
 #cloud-config
 cloud_final_modules:
 - [scripts-user, always]
+hostname: ${lower(data.coder_workspace.me.name)}
+users:
+- name: ${lower(data.coder_workspace.me.owner)}
+  sudo: ALL=(ALL) NOPASSWD:ALL
+  shell: /bin/bash
 
 --//
 Content-Type: text/x-shellscript; charset="us-ascii"
@@ -101,7 +93,7 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash
-sudo -u ubuntu sh -c '${coder_agent.dev.init_script}'
+sudo -u ${lower(data.coder_workspace.me.owner)} sh -c '${coder_agent.dev.init_script}'
 --//--
 EOT
 
@@ -134,7 +126,7 @@ EOT
 resource "aws_instance" "dev" {
   ami               = data.aws_ami.ubuntu.id
   availability_zone = "${var.region}a"
-  instance_type     = "t3.micro"
+  instance_type     = "t3.medium"
 
   user_data = data.coder_workspace.me.transition == "start" ? local.user_data_start : local.user_data_end
   tags = {


### PR DESCRIPTION
This runs the aws-linux template as a non-root user and resizes to support JetBrains Gateway.

50% of the way there for #2179.

code-server support is trivial (I have done it in https://github.com/bpmct/coder-templates/tree/main/aws-spot), but we need to host the IDE icon statically as well, like this example: https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#example-usage