### PR TITLE
fix: sort time zones

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/zones.ts
+++ b/site/src/components/WorkspaceScheduleForm/zones.ts
@@ -1,3 +1,3 @@
 import tzData from "tzdata"
 
-export const zones: string[] = Object.keys(tzData.zones)
+export const zones: string[] = Object.keys(tzData.zones).sort()


### PR DESCRIPTION
Summary:

The list of time zones in the edit workspace schedule form is not sorted
alphabetically.