### PR TITLE
fix: allow admins to reset their own pass without old_password

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -384,7 +384,6 @@ func (api *API) putUserStatus(status database.UserStatus) func(rw http.ResponseW
 func (api *API) putUserPassword(rw http.ResponseWriter, r *http.Request) {
 	var (
 		user   = httpmw.UserParam(r)
-		apiKey = httpmw.APIKey(r)
 		params codersdk.UpdateUserPasswordRequest
 	)
 
@@ -410,10 +409,13 @@ func (api *API) putUserPassword(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// we want to require old_password field if the user is changing their
-	// own password. This is to prevent a compromised session from being able
-	// to change password and lock out the user.
-	if user.ID == apiKey.UserID {
+	// admins can change passwords without sending old_password
+	if params.OldPassword == "" {
+		if !api.Authorize(rw, r, rbac.ActionUpdate, rbac.ResourceUser.WithID(user.ID.String())) {
+			return
+		}
+	} else {
+		// if they send something let's validate it
 		ok, err := userpassword.Compare(string(user.HashedPassword), params.OldPassword)
 		if err != nil {
 			httpapi.Write(rw, http.StatusInternalServerError, httpapi.Response{

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -480,14 +480,14 @@ func TestUpdateUserPassword(t *testing.T) {
 		})
 		require.Error(t, err, "member should not be able to update own password without providing old password")
 	})
-	t.Run("AdminCantUpdateOwnPasswordWithoutOldPassword", func(t *testing.T) {
+	t.Run("AdminCanUpdateOwnPasswordWithoutOldPassword", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		_ = coderdtest.CreateFirstUser(t, client)
 		err := client.UpdateUserPassword(context.Background(), "me", codersdk.UpdateUserPasswordRequest{
 			Password: "newpassword",
 		})
-		require.Error(t, err, "admin should not be able to update own password without providing old password")
+		require.NoError(t, err, "admin should be able to update own password without providing old password")
 	})
 }
 


### PR DESCRIPTION
Fixes issue where you cannot reset your own password as an admin.
