### PR TITLE
Make `coder bump` idempotent

### DIFF
--- a/cli/bump.go
+++ b/cli/bump.go
@@ -12,55 +12,55 @@ import (
 )
 
 const (
-	bumpDescriptionLong = `To extend the autostop deadline for a workspace.
-If no unit is specified in the duration, we assume minutes.`
-	defaultBumpDuration = 90 * time.Minute
+	bumpDescriptionLong = `To extend the autostop deadline for a workspace.`
 )
 
 func bump() *cobra.Command {
 	bumpCmd := &cobra.Command{
 		Args:        cobra.RangeArgs(1, 2),
 		Annotations: workspaceCommand,
-		Use:         "bump <workspace-name> [duration]",
+		Use:         "bump <workspace-name> <duration>",
 		Short:       "Extend the autostop deadline for a workspace.",
 		Long:        bumpDescriptionLong,
 		Example:     "coder bump my-workspace 90m",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bumpDuration := defaultBumpDuration
-			if len(args) > 1 {
-				d, err := tryParseDuration(args[1])
-				if err != nil {
-					return err
-				}
-				bumpDuration = d
-			}
-
-			if bumpDuration < time.Minute {
-				return xerrors.New("minimum bump duration is 1 minute")
+			bumpDuration, err := tryParseDuration(args[1])
+			if err != nil {
+				return err
 			}
 
 			client, err := createClient(cmd)
 			if err != nil {
 				return xerrors.Errorf("create client: %w", err)
 			}
+
 			workspace, err := namedWorkspace(cmd, client, args[0])
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}
 
-			if workspace.LatestBuild.Deadline.IsZero() {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "no deadline set\n")
+			newDeadline := time.Now().Add(bumpDuration)
+
+			if newDeadline.Before(workspace.LatestBuild.Deadline) {
+				_, _ = fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"The proposed deadline is %s before the current deadline.\n",
+					workspace.LatestBuild.Deadline.Sub(newDeadline).Round(time.Minute),
+				)
 				return nil
 			}
 
-			newDeadline := workspace.LatestBuild.Deadline.Add(bumpDuration)
 			if err := client.PutExtendWorkspace(cmd.Context(), workspace.ID, codersdk.PutExtendWorkspaceRequest{
 				Deadline: newDeadline,
 			}); err != nil {
 				return err
 			}
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Workspace %q will now stop at %s\n", workspace.Name, newDeadline.Format(time.RFC3339))
+			_, _ = fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"Workspace %q will now stop at %s\n", workspace.Name,
+				newDeadline.Format(time.RFC822),
+			)
 
 			return nil
 		},


### PR DESCRIPTION
Resolves #2223

In addition to solving what's outlined in the issue,
I remove the client-side minute check because it had no
clear purpose when the API already returns an error.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
