### PR TITLE
Fix bug in Workspace Schedule Form's deadline

### DIFF
--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -50,7 +50,7 @@ export const Language = {
       if (now.isAfter(deadline)) {
         return "Workspace is shutting down"
       } else {
-        return deadline.tz(dayjs.tz.guess()).format("hh:mm A")
+        return "At " + deadline.tz(dayjs.tz.guess()).format("dddd, MMMM D, hh:mm A")
       }
     } else if (!ttl || ttl < 1) {
       // If the workspace is not on, and the ttl is 0 or undefined, then the

--- a/site/src/components/WorkspaceScheduleBanner/WorkspaceScheduleBanner.tsx
+++ b/site/src/components/WorkspaceScheduleBanner/WorkspaceScheduleBanner.tsx
@@ -30,8 +30,8 @@ export const shouldDisplay = (workspace: TypesGen.Workspace): boolean => {
     // SEE: #1834
     const deadline = dayjs(workspace.latest_build.deadline).utc()
     const hasDeadline = deadline.year() > 1
-    const thirtyMinutesFromNow = dayjs().add(30, "minutes").utc()
-    return hasDeadline && deadline.isSameOrBefore(thirtyMinutesFromNow)
+    const showThreshold = dayjs().add(30, "minutes").utc()
+    return hasDeadline && deadline.isSameOrBefore(showThreshold)
   }
 }
 

--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.test.ts
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.test.ts
@@ -168,21 +168,7 @@ describe("ttlShutdownAt", () => {
       Mocks.MockWorkspace,
       "America/Chicago",
       1,
-      `${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownAt} 01:39 PM CDT.`,
-    ],
-    [
-      dayjs("2022-05-17T18:10:00Z"),
-      Mocks.MockWorkspace,
-      "America/Chicago",
-      1,
-      `⚠️ ${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownSoon} ⚠️`,
-    ],
-    [
-      dayjs("2022-05-17T18:40:00Z"),
-      Mocks.MockWorkspace,
-      "America/Chicago",
-      1,
-      `⚠️ ${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownImmediately} ⚠️`,
+      `${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownAt} Tuesday, May 17, 07:39 PM CDT.`,
     ],
   ])("ttlShutdownAt(%p, %p, %p, %p) returns %p", (now, workspace, timezone, ttlHours, expected) => {
     expect(ttlShutdownAt(now, workspace, timezone, ttlHours)).toEqual(expected)

--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -50,8 +50,6 @@ export const Language = {
   ttlHelperText: "Your workspace will automatically shut down after this amount of time has elapsed.",
   ttlCausesShutdownHelperText: "Your workspace will shut down",
   ttlCausesShutdownAt: "at",
-  ttlCausesShutdownImmediately: "immediately!",
-  ttlCausesShutdownSoon: "within 30 minutes.",
   ttlCausesNoShutdownHelperText: "Your workspace will not automatically shut down.",
 }
 
@@ -283,17 +281,13 @@ export const WorkspaceScheduleForm: FC<WorkspaceScheduleFormProps> = ({
 }
 
 export const ttlShutdownAt = (now: dayjs.Dayjs, workspace: Workspace, tz: string, newTTL: number): string => {
-  const newDeadline = dayjs(workspace.latest_build.updated_at).add(newTTL, "hour")
+  const newDeadline = dayjs(workspace.latest_build.deadline).add(newTTL, "hour")
   if (!isWorkspaceOn(workspace)) {
     return Language.ttlHelperText
   } else if (newTTL === 0) {
     return Language.ttlCausesNoShutdownHelperText
-  } else if (newDeadline.isBefore(now)) {
-    return `⚠️ ${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownImmediately} ⚠️`
-  } else if (newDeadline.isBefore(now.add(30, "minute"))) {
-    return `⚠️ ${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownSoon} ⚠️`
   } else {
-    const newDeadlineString = newDeadline.tz(tz).format("hh:mm A z")
+    const newDeadlineString = newDeadline.tz(tz).format("dddd, MMMM D, hh:mm A z")
     return `${Language.ttlCausesShutdownHelperText} ${Language.ttlCausesShutdownAt} ${newDeadlineString}.`
   }
 }


### PR DESCRIPTION
- We were using UpdatedAt instead of Deadline, which is only right
  sometimes. Other operations may update the build beyond TTL changes.
- Show the date of the next shutdown instead of just the time since it
can be far out in the future.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
