### PR TITLE
fix: Accept CODER_CACHE_DIRECTORY with CACHE_DIRECTORY fallback

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -60,12 +60,6 @@ import (
 
 // nolint:gocyclo
 func server() *cobra.Command {
-	defaultCacheDir := filepath.Join(os.TempDir(), "coder-cache")
-	if dir := os.Getenv("CACHE_DIRECTORY"); dir != "" {
-		// For compatibility with systemd.
-		defaultCacheDir = dir
-	}
-
 	var (
 		accessURL             string
 		address               string
@@ -479,6 +473,11 @@ func server() *cobra.Command {
 	cliflag.StringVarP(root.Flags(), &promAddress, "prometheus-address", "", "CODER_PROMETHEUS_ADDRESS", "127.0.0.1:2112", "The address to serve prometheus metrics.")
 	cliflag.BoolVarP(root.Flags(), &pprofEnabled, "pprof-enable", "", "CODER_PPROF_ENABLE", false, "Enable serving pprof metrics on the address defined by --pprof-address.")
 	cliflag.StringVarP(root.Flags(), &pprofAddress, "pprof-address", "", "CODER_PPROF_ADDRESS", "127.0.0.1:6060", "The address to serve pprof.")
+	defaultCacheDir := filepath.Join(os.TempDir(), "coder-cache")
+	if dir := os.Getenv("CACHE_DIRECTORY"); dir != "" {
+		// For compatibility with systemd.
+		defaultCacheDir = dir
+	}
 	cliflag.StringVarP(root.Flags(), &cacheDir, "cache-dir", "", "CODER_CACHE_DIRECTORY", defaultCacheDir, "Specifies a directory to cache binaries for provision operations. If unspecified and $CACHE_DIRECTORY is set, it will be used for compatibility with systemd.")
 	cliflag.BoolVarP(root.Flags(), &dev, "dev", "", "CODER_DEV_MODE", false, "Serve Coder in dev mode for tinkering")
 	cliflag.StringVarP(root.Flags(), &devUserEmail, "dev-admin-email", "", "CODER_DEV_ADMIN_EMAIL", "admin@coder.com", "Specifies the admin email to be used in dev mode (--dev)")

--- a/cli/server.go
+++ b/cli/server.go
@@ -60,6 +60,12 @@ import (
 
 // nolint:gocyclo
 func server() *cobra.Command {
+	defaultCacheDir := filepath.Join(os.TempDir(), "coder-cache")
+	if dir := os.Getenv("CACHE_DIRECTORY"); dir != "" {
+		// For compatibility with systemd.
+		defaultCacheDir = dir
+	}
+
 	var (
 		accessURL             string
 		address               string
@@ -68,7 +74,6 @@ func server() *cobra.Command {
 		promAddress           string
 		pprofEnabled          bool
 		pprofAddress          string
-		defaultCacheDir       = filepath.Join(os.TempDir(), "coder-cache")
 		cacheDir              string
 		dev                   bool
 		devUserEmail          string
@@ -100,11 +105,6 @@ func server() *cobra.Command {
 		Use:   "server",
 		Short: "Start a Coder server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cacheDir == defaultCacheDir && os.Getenv("CACHE_DIRECTORY") != "" {
-				// For compatibility with systemd.
-				cacheDir = os.Getenv("CACHE_DIRECTORY")
-			}
-
 			logger := slog.Make(sloghuman.Sink(os.Stderr))
 			buildModeDev := semver.Prerelease(buildinfo.Version()) == "-devel"
 			if verbose || buildModeDev {

--- a/cli/server.go
+++ b/cli/server.go
@@ -68,6 +68,7 @@ func server() *cobra.Command {
 		promAddress           string
 		pprofEnabled          bool
 		pprofAddress          string
+		defaultCacheDir       = filepath.Join(os.TempDir(), "coder-cache")
 		cacheDir              string
 		dev                   bool
 		devUserEmail          string
@@ -99,6 +100,11 @@ func server() *cobra.Command {
 		Use:   "server",
 		Short: "Start a Coder server",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cacheDir == defaultCacheDir && os.Getenv("CACHE_DIRECTORY") != "" {
+				// For compatibility with systemd.
+				cacheDir = os.Getenv("CACHE_DIRECTORY")
+			}
+
 			logger := slog.Make(sloghuman.Sink(os.Stderr))
 			buildModeDev := semver.Prerelease(buildinfo.Version()) == "-devel"
 			if verbose || buildModeDev {
@@ -473,8 +479,7 @@ func server() *cobra.Command {
 	cliflag.StringVarP(root.Flags(), &promAddress, "prometheus-address", "", "CODER_PROMETHEUS_ADDRESS", "127.0.0.1:2112", "The address to serve prometheus metrics.")
 	cliflag.BoolVarP(root.Flags(), &pprofEnabled, "pprof-enable", "", "CODER_PPROF_ENABLE", false, "Enable serving pprof metrics on the address defined by --pprof-address.")
 	cliflag.StringVarP(root.Flags(), &pprofAddress, "pprof-address", "", "CODER_PPROF_ADDRESS", "127.0.0.1:6060", "The address to serve pprof.")
-	// systemd uses the CACHE_DIRECTORY environment variable!
-	cliflag.StringVarP(root.Flags(), &cacheDir, "cache-dir", "", "CACHE_DIRECTORY", filepath.Join(os.TempDir(), "coder-cache"), "Specifies a directory to cache binaries for provision operations.")
+	cliflag.StringVarP(root.Flags(), &cacheDir, "cache-dir", "", "CODER_CACHE_DIRECTORY", defaultCacheDir, "Specifies a directory to cache binaries for provision operations. If unspecified and $CACHE_DIRECTORY is set, it will be used for compatibility with systemd.")
 	cliflag.BoolVarP(root.Flags(), &dev, "dev", "", "CODER_DEV_MODE", false, "Serve Coder in dev mode for tinkering")
 	cliflag.StringVarP(root.Flags(), &devUserEmail, "dev-admin-email", "", "CODER_DEV_ADMIN_EMAIL", "admin@coder.com", "Specifies the admin email to be used in dev mode (--dev)")
 	cliflag.StringVarP(root.Flags(), &devUserPassword, "dev-admin-password", "", "CODER_DEV_ADMIN_PASSWORD", "", "Specifies the admin password to be used in dev mode (--dev) instead of a randomly generated one")


### PR DESCRIPTION
When I reported #2199, I didn't realize the naming was due to systemd compat.

I still think it'd be worthwile to be able to explicitly specify a directory for coder caches, as such this PR changes the behavior to use `CODER_CACHE_DIRECTORY` primarily, and `CACHE_DIRECTORY` as a fallback.

Fixes #2199

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
