### PR TITLE
feat: Show template description in `coder template init`

### DIFF
--- a/cli/templateinit.go
+++ b/cli/templateinit.go
@@ -24,7 +24,11 @@ func templateInit() *cobra.Command {
 			exampleNames := []string{}
 			exampleByName := map[string]examples.Example{}
 			for _, example := range exampleList {
-				name := fmt.Sprintf("%s\n      %s", example.Name, example.Description)
+				name := fmt.Sprintf(
+					"%s\n%s\n",
+					cliui.Styles.Bold.Render(example.Name),
+					cliui.Styles.Wrap.Copy().PaddingLeft(6).Render(example.Description),
+				)
 				exampleNames = append(exampleNames, name)
 				exampleByName[name] = example
 			}

--- a/cli/templateinit.go
+++ b/cli/templateinit.go
@@ -24,8 +24,9 @@ func templateInit() *cobra.Command {
 			exampleNames := []string{}
 			exampleByName := map[string]examples.Example{}
 			for _, example := range exampleList {
-				exampleNames = append(exampleNames, example.Name)
-				exampleByName[example.Name] = example
+				name := fmt.Sprintf("%s\n      %s", example.Name, example.Description)
+				exampleNames = append(exampleNames, name)
+				exampleByName[name] = example
 			}
 
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), cliui.Styles.Wrap.Render(


### PR DESCRIPTION
This change shows the template description as part of the select output.

Bonus feature: Select search now also searches the description.

Fixes #1904

![image](https://user-images.githubusercontent.com/147409/173070816-dbbfc864-fe93-4692-a486-cfad937cbde6.png)
