### PR TITLE
chore: add hero image to OSS docs homepage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Coder Documentation
 
+<p align="center">
+  <img src="images/hero-image.png">
+</p>
+
 ## Table of Contents
 
 - [About Coder](./about.md#about-coder)


### PR DESCRIPTION
added the hero image from the repo's README to the homepage of the docs page:

<img width="577" alt="image" src="https://user-images.githubusercontent.com/16521651/173096420-46e570a7-4990-4d0b-8e67-9764e20f8d25.png">
