### PR TITLE
feat: Warn on coderd startup if access URL is localhost

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -203,6 +203,28 @@ func server() *cobra.Command {
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 			}
 
+			// Warn the user if the access URL appears to be a loopback address.
+			isLocal, err := isLocalURL(cmd.Context(), accessURL)
+			if isLocal || err != nil {
+				var reason string
+				if isLocal {
+					reason = "appears to be a loopback address"
+				} else {
+					reason = "could not be resolved"
+				}
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), cliui.Styles.Wrap.Render(
+					cliui.Styles.Warn.Render("Warning:")+" The current access URL:")+"\n\n")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  "+cliui.Styles.Field.Render(accessURL)+"\n\n")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), cliui.Styles.Wrap.Render(
+					reason+". Provisioned workspaces are unlikely to be able to "+
+						"connect to Coder. Please consider changing your "+
+						"access URL using the --access-url option, or directly "+
+						"specifying access URLs on templates.",
+				)+"\n\n")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "For more information, see "+
+					"https://github.com/coder/coder/issues/1528\n\n")
+			}
+
 			validator, err := idtoken.NewValidator(cmd.Context(), option.WithoutAuthentication())
 			if err != nil {
 				return err
@@ -802,4 +824,25 @@ func serveHandler(ctx context.Context, logger slog.Logger, handler http.Handler,
 	}()
 
 	return func() { _ = srv.Close() }
+}
+
+// isLocalURL returns true if the hostname of the provided URL appears to
+// resolve to a loopback address.
+func isLocalURL(ctx context.Context, urlString string) (bool, error) {
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return false, err
+	}
+	resolver := &net.Resolver{}
+	ips, err := resolver.LookupIPAddr(ctx, url.Hostname())
+	if err != nil {
+		return false, err
+	}
+
+	for _, ip := range ips {
+		if ip.IP.IsLoopback() {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -829,12 +829,12 @@ func serveHandler(ctx context.Context, logger slog.Logger, handler http.Handler,
 // isLocalURL returns true if the hostname of the provided URL appears to
 // resolve to a loopback address.
 func isLocalURL(ctx context.Context, urlString string) (bool, error) {
-	url, err := url.Parse(urlString)
+	parsedURL, err := url.Parse(urlString)
 	if err != nil {
 		return false, err
 	}
 	resolver := &net.Resolver{}
-	ips, err := resolver.LookupIPAddr(ctx, url.Hostname())
+	ips, err := resolver.LookupIPAddr(ctx, parsedURL.Hostname())
 	if err != nil {
 		return false, err
 	}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -186,10 +186,10 @@ func TestServer(t *testing.T) {
 			return err == nil
 		}, 15*time.Second, 25*time.Millisecond)
 
-		assert.NotContains(t, buf.String(), "coder/coder/issues/1528")
-
 		cancelFunc()
 		require.ErrorIs(t, <-errC, context.Canceled)
+
+		assert.NotContains(t, buf.String(), "coder/coder/issues/1528")
 	})
 
 	t.Run("TLSBadVersion", func(t *testing.T) {


### PR DESCRIPTION
This PR adds a warning to `coder server` if the access URL appears to be (or resolve to) a loopback address, or if it can't be resolved.

Fixes #1528 