### PR TITLE
fix: ensure config dir exists before reading tunnel config

### DIFF
--- a/coderd/devtunnel/tunnel.go
+++ b/coderd/devtunnel/tunnel.go
@@ -177,7 +177,13 @@ func cfgPath() (string, error) {
 		return "", xerrors.Errorf("get user config dir: %w", err)
 	}
 
-	return filepath.Join(cfgDir, "coderv2", "devtunnel"), nil
+	cfgDir = filepath.Join(cfgDir, "coderv2")
+	err = os.MkdirAll(cfgDir, 0750)
+	if err != nil {
+		return "", xerrors.Errorf("mkdirall config dir %q: %w", cfgDir, err)
+	}
+
+	return filepath.Join(cfgDir, "devtunnel"), nil
 }
 
 func readOrGenerateConfig() (Config, error) {


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
