### PR TITLE
docs: fix: use absolute link for examples

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -9,7 +9,7 @@ to everybody. Users can also manually update their workspaces.
 
 ## Manage templates
 
-Coder provides production-ready [sample templates]([../examples/templates/](https://github.com/coder/coder/tree/main/examples/templates)),
+Coder provides production-ready [sample templates](https://github.com/coder/coder/tree/main/examples/templates),
 but you can modify the templates with Terraform.
 
 ```sh

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -9,8 +9,8 @@ to everybody. Users can also manually update their workspaces.
 
 ## Manage templates
 
-Coder provides production-ready [sample templates](../examples/templates/), but you can
-modify the templates with Terraform.
+Coder provides production-ready [sample templates]([../examples/templates/](https://github.com/coder/coder/tree/main/examples/templates)),
+but you can modify the templates with Terraform.
 
 ```sh
 # start from an example


### PR DESCRIPTION
this 404s on the hosted docs
