### PR TITLE
fix: Add default created_by in templates and not null constraint

### DIFF
--- a/coderd/audit/diff_test.go
+++ b/coderd/audit/diff_test.go
@@ -88,7 +88,7 @@ func TestDiff(t *testing.T) {
 				ActiveVersionID:      uuid.UUID{3},
 				MaxTtl:               int64(time.Hour),
 				MinAutostartInterval: int64(time.Minute),
-				CreatedBy:            uuid.NullUUID{UUID: uuid.UUID{4}, Valid: true},
+				CreatedBy:            uuid.UUID{4},
 			},
 			exp: audit.Map{
 				"id":                     uuid.UUID{1}.String(),

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -249,7 +249,7 @@ CREATE TABLE templates (
     description character varying(128) DEFAULT ''::character varying NOT NULL,
     max_ttl bigint DEFAULT '604800000000000'::bigint NOT NULL,
     min_autostart_interval bigint DEFAULT '3600000000000'::bigint NOT NULL,
-    created_by uuid
+    created_by uuid NOT NULL
 );
 
 CREATE TABLE users (

--- a/coderd/database/migrations/000023_template_created_by_not_null.down.sql
+++ b/coderd/database/migrations/000023_template_created_by_not_null.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ONLY templates ALTER COLUMN created_by DROP NOT NULL;

--- a/coderd/database/migrations/000023_template_created_by_not_null.up.sql
+++ b/coderd/database/migrations/000023_template_created_by_not_null.up.sql
@@ -1,0 +1,14 @@
+UPDATE
+    templates
+SET
+    created_by = (
+        SELECT user_id FROM organization_members
+        WHERE organization_members.organization_id = templates.organization_id
+        ORDER BY created_at
+        LIMIT 1
+    )
+WHERE
+    created_by IS NULL;
+
+
+ALTER TABLE ONLY templates ALTER COLUMN created_by SET NOT NULL;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -438,7 +438,7 @@ type Template struct {
 	Description          string          `db:"description" json:"description"`
 	MaxTtl               int64           `db:"max_ttl" json:"max_ttl"`
 	MinAutostartInterval int64           `db:"min_autostart_interval" json:"min_autostart_interval"`
-	CreatedBy            uuid.NullUUID   `db:"created_by" json:"created_by"`
+	CreatedBy            uuid.UUID       `db:"created_by" json:"created_by"`
 }
 
 type TemplateVersion struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1797,7 +1797,7 @@ type InsertTemplateParams struct {
 	Description          string          `db:"description" json:"description"`
 	MaxTtl               int64           `db:"max_ttl" json:"max_ttl"`
 	MinAutostartInterval int64           `db:"min_autostart_interval" json:"min_autostart_interval"`
-	CreatedBy            uuid.NullUUID   `db:"created_by" json:"created_by"`
+	CreatedBy            uuid.UUID       `db:"created_by" json:"created_by"`
 }
 
 func (q *sqlQuerier) InsertTemplate(ctx context.Context, arg InsertTemplateParams) (Template, error) {

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -186,10 +186,7 @@ func (api *API) postTemplateByOrganization(rw http.ResponseWriter, r *http.Reque
 			Description:          createTemplate.Description,
 			MaxTtl:               int64(maxTTL),
 			MinAutostartInterval: int64(minAutostartInterval),
-			CreatedBy: uuid.NullUUID{
-				UUID:  apiKey.UserID,
-				Valid: true,
-			},
+			CreatedBy:            apiKey.UserID,
 		})
 		if err != nil {
 			return xerrors.Errorf("insert template: %s", err)
@@ -453,15 +450,11 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 func getCreatedByNamesByTemplateIDs(ctx context.Context, db database.Store, templates []database.Template) (map[string]string, error) {
 	creators := make(map[string]string, len(templates))
 	for _, template := range templates {
-		if template.CreatedBy.Valid {
-			creator, err := db.GetUserByID(ctx, template.CreatedBy.UUID)
-			if err != nil {
-				return map[string]string{}, err
-			}
-			creators[template.ID.String()] = creator.Username
-		} else {
-			creators[template.ID.String()] = ""
+		creator, err := db.GetUserByID(ctx, template.CreatedBy)
+		if err != nil {
+			return map[string]string{}, err
 		}
+		creators[template.ID.String()] = creator.Username
 	}
 	return creators, nil
 }

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -25,7 +25,7 @@ type Template struct {
 	Description                string          `json:"description"`
 	MaxTTLMillis               int64           `json:"max_ttl_ms"`
 	MinAutostartIntervalMillis int64           `json:"min_autostart_interval_ms"`
-	CreatedByID                uuid.NullUUID   `json:"created_by_id"`
+	CreatedByID                uuid.UUID       `json:"created_by_id"`
 	CreatedByName              string          `json:"created_by_name"`
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -247,7 +247,7 @@ export interface Template {
   readonly description: string
   readonly max_ttl_ms: number
   readonly min_autostart_interval_ms: number
-  readonly created_by_id?: string
+  readonly created_by_id: string
   readonly created_by_name: string
 }
 

--- a/site/src/components/TemplateStats/TemplateStats.stories.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.stories.tsx
@@ -23,12 +23,3 @@ UsedByMany.args = {
   },
   activeVersion: Mocks.MockTemplateVersion,
 }
-
-export const UnknownCreator = Template.bind({})
-UnknownCreator.args = {
-  template: {
-    ...Mocks.MockTemplate,
-    created_by_name: "",
-  },
-  activeVersion: Mocks.MockTemplateVersion,
-}

--- a/site/src/components/TemplateStats/TemplateStats.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.tsx
@@ -14,7 +14,6 @@ const Language = {
   userPlural: "users",
   userSingular: "user",
   createdByLabel: "Created by",
-  defaultTemplateCreator: "<unknown>",
 }
 
 export interface TemplateStatsProps {
@@ -50,7 +49,7 @@ export const TemplateStats: FC<TemplateStatsProps> = ({ template, activeVersion 
       <div className={styles.statsDivider} />
       <div className={styles.statItem}>
         <span className={styles.statsLabel}>{Language.createdByLabel}</span>
-        <span className={styles.statsValue}>{template.created_by_name || Language.defaultTemplateCreator}</span>
+        <span className={styles.statsValue}>{template.created_by_name}</span>
       </div>
     </div>
   )

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -50,7 +50,6 @@ export const Language = {
   templateTooltipText: "With templates you can create a common configuration for your workspaces using Terraform.",
   templateTooltipLink: "Manage templates",
   createdByLabel: "Created by",
-  defaultTemplateCreator: "<unknown>",
 }
 
 const TemplateHelpTooltip: React.FC = () => {
@@ -140,7 +139,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = (props) => {
                 <TableCell>{Language.developerCount(template.workspace_owner_count)}</TableCell>
 
                 <TableCell data-chromatic="ignore">{dayjs().to(dayjs(template.updated_at))}</TableCell>
-                <TableCell>{template.created_by_name || Language.defaultTemplateCreator}</TableCell>
+                <TableCell>{template.created_by_name}</TableCell>
                 <TableCell>
                   <div className={styles.arrowCell}>
                     <KeyboardArrowRight className={styles.arrowRight} />


### PR DESCRIPTION
This PR populates the `created_by` field wherever `null` with the first-created user in the organization and adds a non-nullable constraint.

## Subtasks

- [x] create migration with populating the default value and adding the not null constraint
- [x] update usages of `NullUUID` to `UUID`
- [x] remove default `<unknown>` behavior in frontend for unknown creators.

Fixes #2283 
