### PR TITLE
chore: Add some more error context in cli

### DIFF
--- a/cli/templateupdate.go
+++ b/cli/templateupdate.go
@@ -91,7 +91,7 @@ func templateUpdate() *cobra.Command {
 			}
 
 			if templateVersion.Job.Status != codersdk.ProvisionerJobSucceeded {
-				return xerrors.New("job failed")
+				return xerrors.Errorf("job failed: %s", templateVersion.Job.Error)
 			}
 
 			err = client.UpdateActiveTemplateVersion(cmd.Context(), template.ID, codersdk.UpdateActiveTemplateVersion{


### PR DESCRIPTION
We probably need to revisit our errors more generally.
This is better than the status quo.

## Before

```
> Upload "../../examples/templates/docker"? (yes/no) yes
terraform (info): 
terraform (info): 
terraform (info): 
job failed
```

## After

```
> Upload "../../examples/templates/docker"? (yes/no) yes
terraform (info): 
terraform (info): 
terraform (info): 
job failed: missing parameter: new_var
```