### PR TITLE
fix: use `command -v ` instead of `which` in agent bootstrap

### DIFF
--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -20,11 +20,11 @@ Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 set -eux pipefail
 BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
-if which curl >/dev/null 2>&1; then
+if command -v curl >/dev/null 2>&1; then
 	curl -fsSL --compressed "${BINARY_URL}" -o "${BINARY_LOCATION}"
-elif which wget >/dev/null 2>&1; then
+elif command -v wget >/dev/null 2>&1; then
 	wget -q "${BINARY_URL}" -O "${BINARY_LOCATION}"
-elif which busybox >/dev/null 2>&1; then
+elif command -v busybox >/dev/null 2>&1; then
 	busybox wget -q "${BINARY_URL}" -O "${BINARY_LOCATION}"
 else
 	echo "error: no download tool found, please install curl, wget or busybox wget"


### PR DESCRIPTION
Certain distros don't ship with `which` (arch) and `command -v` is
built-in to the shell, so this is much more compatible.
