### PR TITLE
fix: flaky install.sh upgrade on OSX (zsh killed)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -397,7 +397,7 @@ install_standalone() {
 	# Remove the file if it already exists to
 	# avoid https://github.com/coder/coder/issues/2086
 	if [ -f "$COPY_LOCATION" ]; then
-    	"$sh_c" rm $COPY_LOCATION
+		"$sh_c" rm "$COPY_LOCATION"
 	fi
 
 	# Copy the binary to the correct location.

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,8 @@ echo_latest_version() {
 
 echo_standalone_postinstall() {
 	cath <<EOF
-	Standalone release has been installed into $STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME
+
+Standalone release has been installed into $STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME
 
 EOF
 
@@ -391,7 +392,16 @@ install_standalone() {
 		"$sh_c" unzip -d "$CACHE_DIR" -o "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.zip"
 	fi
 
-	"$sh_c" cp "$CACHE_DIR/coder" "$STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME"
+	COPY_LOCATION="$STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME"
+
+	# Remove the file if it already exists to
+	# avoid https://github.com/coder/coder/issues/2086
+	if [ -f "$COPY_LOCATION" ]; then
+    	"$sh_c" rm $COPY_LOCATION
+	fi
+
+	# Copy the binary to the correct location.
+	"$sh_c" cp "$CACHE_DIR/coder" "$COPY_LOCATION"
 
 	echo_standalone_postinstall
 }


### PR DESCRIPTION
Fixes #2086. This likely has something to do with how MacOS trusts binaries

## To test

@misskniss @mark-theshark - would appreciate if you could confirm this fixes it

Broken:
```sh
# see the current version
coder --version
# install a different version of Coder (n+1 or n-1)
curl -L https://raw.githubusercontent.com/coder/coder/main/install.sh | sh -s -- --version=0.6.6
# run the binary
coder version
# [1]    48010 killed     coder
```

Fixed:
```sh
# see the current version
coder --version
# install a different version of Coder (n+1 or n-1)
curl -L https://raw.githubusercontent.com/coder/coder/bpmct/install-fixes/install.sh | sh -s -- --version=0.6.6
# run the binary
coder
# Coder v0.6.6+cbde8e8 Mon Jun 13 14:16:26 UTC 2022
# https://github.com/coder/coder/commit/cbde8e8b91097412b2ae0daa72d1b698b61584bc!
```