### PR TITLE
fix: break word to wrap long strings in stats, add media query

### DIFF
--- a/site/src/components/TemplateStats/TemplateStats.stories.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.stories.tsx
@@ -32,6 +32,9 @@ LongTemplateVersion.args = {
     name: "thisisareallyreallylongnamefortesting",
   },
 }
+LongTemplateVersion.parameters = {
+  chromatic: { viewports: [960] },
+}
 
 export const SmallViewport = Template.bind({})
 SmallViewport.args = {
@@ -39,5 +42,5 @@ SmallViewport.args = {
   activeVersion: Mocks.MockTemplateVersion,
 }
 SmallViewport.parameters = {
-  chromatic: { viewports: [480, 1200] },
+  chromatic: { viewports: [600] },
 }

--- a/site/src/components/TemplateStats/TemplateStats.stories.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.stories.tsx
@@ -23,3 +23,21 @@ UsedByMany.args = {
   },
   activeVersion: Mocks.MockTemplateVersion,
 }
+
+export const LongTemplateVersion = Template.bind({})
+LongTemplateVersion.args = {
+  template: Mocks.MockTemplate,
+  activeVersion: {
+    ...Mocks.MockTemplateVersion,
+    name: "thisisareallyreallylongnamefortesting",
+  },
+}
+
+export const SmallViewport = Template.bind({})
+SmallViewport.args = {
+  template: Mocks.MockTemplate,
+  activeVersion: Mocks.MockTemplateVersion,
+}
+SmallViewport.parameters = {
+  chromatic: { viewports: [480, 1200] },
+}

--- a/site/src/components/TemplateStats/TemplateStats.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.tsx
@@ -66,6 +66,9 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     fontFamily: MONOSPACE_FONT_FAMILY,
     border: `1px solid ${theme.palette.divider}`,
+    [theme.breakpoints.down("sm")]: {
+      display: "block",
+    },
   },
 
   statItem: {
@@ -79,12 +82,14 @@ const useStyles = makeStyles((theme) => ({
     textTransform: "uppercase",
     display: "block",
     fontWeight: 600,
+    wordWrap: "break-word",
   },
 
   statsValue: {
     fontSize: 16,
     marginTop: theme.spacing(0.25),
-    display: "inline-block",
+    display: "block",
+    wordWrap: "break-word",
   },
 
   statsDivider: {
@@ -92,5 +97,8 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(5),
     backgroundColor: theme.palette.divider,
     marginRight: theme.spacing(2),
+    [theme.breakpoints.down("sm")]: {
+      display: "none",
+    },
   },
 }))

--- a/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
+++ b/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
@@ -66,6 +66,9 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     fontFamily: MONOSPACE_FONT_FAMILY,
     border: `1px solid ${theme.palette.divider}`,
+    [theme.breakpoints.down("sm")]: {
+      display: "block",
+    },
   },
 
   statItem: {
@@ -79,12 +82,14 @@ const useStyles = makeStyles((theme) => ({
     textTransform: "uppercase",
     display: "block",
     fontWeight: 600,
+    wordWrap: "break-word",
   },
 
   statsValue: {
     fontSize: 16,
     marginTop: theme.spacing(0.25),
-    display: "inline-block",
+    display: "block",
+    wordWrap: "break-word",
   },
 
   statsDivider: {
@@ -92,6 +97,9 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(5),
     backgroundColor: theme.palette.divider,
     marginRight: theme.spacing(2),
+    [theme.breakpoints.down("sm")]: {
+      display: "none",
+    },
   },
 
   capitalize: {

--- a/site/src/components/WorkspaceStats/WorkspaceStats.tsx
+++ b/site/src/components/WorkspaceStats/WorkspaceStats.tsx
@@ -82,6 +82,9 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     fontFamily: MONOSPACE_FONT_FAMILY,
     margin: "0px",
+    [theme.breakpoints.down("sm")]: {
+      display: "block",
+    },
   },
 
   statItem: {
@@ -95,12 +98,14 @@ const useStyles = makeStyles((theme) => ({
     textTransform: "uppercase",
     display: "block",
     fontWeight: 600,
+    wordWrap: "break-word",
   },
 
   statsValue: {
     fontSize: 16,
     marginTop: theme.spacing(0.25),
-    display: "inline-block",
+    display: "block",
+    wordWrap: "break-word",
   },
 
   statsDivider: {
@@ -108,6 +113,9 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(5),
     backgroundColor: theme.palette.divider,
     marginRight: theme.spacing(2),
+    [theme.breakpoints.down("sm")]: {
+      display: "none",
+    },
   },
 
   capitalize: {

--- a/site/src/pages/TemplatePage/TemplatePageView.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageView.stories.tsx
@@ -15,3 +15,13 @@ Example.args = {
   activeTemplateVersion: Mocks.MockTemplateVersion,
   templateResources: [Mocks.MockWorkspaceResource, Mocks.MockWorkspaceResource2],
 }
+
+export const SmallViewport = Template.bind({})
+SmallViewport.args = {
+  template: Mocks.MockTemplate,
+  activeTemplateVersion: Mocks.MockTemplateVersion,
+  templateResources: [Mocks.MockWorkspaceResource, Mocks.MockWorkspaceResource2],
+}
+SmallViewport.parameters = {
+  chromatic: { viewports: [600] },
+}


### PR DESCRIPTION
This PR wraps long strings in stats label and value by breaking the word. Also adds a media query to arrange the stats vertically without the divider.

## Subtasks

- [x] add media query for size below 960px to arrange the stats vertically
- [x] update styles to break long words to wrap them
- [x] added story for small screen
- [x] added story for long active version name

Fixes #2300 

## Screenshots

### Small screens (<960px)
![Screen Shot 2022-06-13 at 8 10 25 PM](https://user-images.githubusercontent.com/7511231/173467171-3f6cbd39-9d8f-46b3-bfff-147a93500515.png)

### Long names
![image](https://user-images.githubusercontent.com/7511231/173467238-c6a0512a-82cb-4a17-b871-66c00ba9f47d.png)


