### PR TITLE
feat: Add "Outdated" tooltip and "Update version" button in the Workspaces page

### DIFF
--- a/site/src/components/GlobalSnackbar/GlobalSnackbar.tsx
+++ b/site/src/components/GlobalSnackbar/GlobalSnackbar.tsx
@@ -72,6 +72,7 @@ export const GlobalSnackbar: React.FC = () => {
 
   return (
     <EnterpriseSnackbar
+      key={notification.msg}
       open={open}
       variant={variantFromMsgType(notification.msgType)}
       message={

--- a/site/src/components/HelpTooltip/HelpTooltip.tsx
+++ b/site/src/components/HelpTooltip/HelpTooltip.tsx
@@ -3,8 +3,10 @@ import Popover from "@material-ui/core/Popover"
 import { makeStyles } from "@material-ui/core/styles"
 import HelpIcon from "@material-ui/icons/HelpOutline"
 import OpenInNewIcon from "@material-ui/icons/OpenInNew"
-import { useState } from "react"
+import React, { useState } from "react"
 import { Stack } from "../Stack/Stack"
+
+type Icon = typeof HelpIcon
 
 type Size = "small" | "medium"
 export interface HelpTooltipProps {
@@ -70,6 +72,17 @@ export const HelpTooltipLink: React.FC<{ href: string }> = ({ children, href }) 
   )
 }
 
+export const HelpTooltipAction: React.FC<{ icon: Icon; onClick: () => void }> = ({ children, icon: Icon, onClick }) => {
+  const styles = useStyles()
+
+  return (
+    <button className={styles.action} onClick={onClick}>
+      <Icon className={styles.actionIcon} />
+      {children}
+    </button>
+  )
+}
+
 export const HelpTooltipLinksGroup: React.FC = ({ children }) => {
   const styles = useStyles()
 
@@ -110,11 +123,12 @@ const useStyles = makeStyles((theme) => ({
     padding: 0,
     border: 0,
     background: "transparent",
-    color: theme.palette.text.secondary,
+    color: theme.palette.text.primary,
+    opacity: 0.5,
     cursor: "pointer",
 
     "&:hover": {
-      color: theme.palette.text.primary,
+      opacity: 0.75,
     },
   },
 
@@ -155,5 +169,23 @@ const useStyles = makeStyles((theme) => ({
 
   linksGroup: {
     marginTop: theme.spacing(2),
+  },
+
+  action: {
+    display: "flex",
+    alignItems: "center",
+    background: "none",
+    border: 0,
+    color: theme.palette.primary.light,
+    padding: 0,
+    cursor: "pointer",
+    fontSize: 14,
+  },
+
+  actionIcon: {
+    color: "inherit",
+    width: 14,
+    height: 14,
+    marginRight: theme.spacing(1),
   },
 }))

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -17,7 +17,7 @@ const WorkspacesPage: FC = () => {
     const query = filter !== null ? filter : workspaceFilterQuery.me
 
     send({
-      type: "SET_FILTER",
+      type: "GET_WORKSPACES",
       query,
     })
   }, [searchParams, send])

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -10,6 +10,7 @@ import { WorkspacesPageView } from "./WorkspacesPageView"
 const WorkspacesPage: FC = () => {
   const [workspacesState, send] = useMachine(workspacesMachine)
   const [searchParams, setSearchParams] = useSearchParams()
+  const { workspaceRefs } = workspacesState.context
 
   useEffect(() => {
     const filter = searchParams.get("filter")
@@ -30,7 +31,7 @@ const WorkspacesPage: FC = () => {
       <WorkspacesPageView
         filter={workspacesState.context.filter}
         loading={workspacesState.hasTag("loading")}
-        workspaces={workspacesState.context.workspaces}
+        workspaceRefs={workspaceRefs}
         onFilter={(query) => {
           searchParams.set("filter", query)
           setSearchParams(searchParams)

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -14,9 +14,11 @@ const Template: Story<WorkspacesPageViewProps> = (args) => <WorkspacesPageView {
 const createWorkspaceWithStatus = (
   status: ProvisionerJobStatus,
   transition: WorkspaceTransition = "start",
+  outdated = false,
 ): Workspace => {
   return {
     ...MockWorkspace,
+    outdated,
     latest_build: {
       ...MockWorkspace.latest_build,
       transition,
@@ -47,6 +49,11 @@ AllStates.args = {
     createWorkspaceWithStatus("succeeded", "stop"),
     createWorkspaceWithStatus("running", "delete"),
   ],
+}
+
+export const Outdated = Template.bind({})
+Outdated.args = {
+  workspaces: [createWorkspaceWithStatus("running", "stop", true)],
 }
 
 export const OwnerHasNoWorkspaces = Template.bind({})

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -1,7 +1,9 @@
 import { ComponentMeta, Story } from "@storybook/react"
+import { spawn } from "xstate"
 import { ProvisionerJobStatus, Workspace, WorkspaceTransition } from "../../api/typesGenerated"
 import { MockWorkspace } from "../../testHelpers/entities"
 import { workspaceFilterQuery } from "../../util/workspace"
+import { workspaceItemMachine } from "../../xServices/workspaces/workspacesXService"
 import { WorkspacesPageView, WorkspacesPageViewProps } from "./WorkspacesPageView"
 
 export default {
@@ -43,27 +45,29 @@ const workspaces: { [key in ProvisionerJobStatus]: Workspace } = {
 
 export const AllStates = Template.bind({})
 AllStates.args = {
-  workspaces: [
+  workspaceRefs: [
     ...Object.values(workspaces),
     createWorkspaceWithStatus("running", "stop"),
     createWorkspaceWithStatus("succeeded", "stop"),
     createWorkspaceWithStatus("running", "delete"),
-  ],
+  ].map((data) => spawn(workspaceItemMachine.withContext({ data }))),
 }
 
 export const Outdated = Template.bind({})
 Outdated.args = {
-  workspaces: [createWorkspaceWithStatus("running", "stop", true)],
+  workspaceRefs: [createWorkspaceWithStatus("running", "stop", true)].map((data) =>
+    spawn(workspaceItemMachine.withContext({ data })),
+  ),
 }
 
 export const OwnerHasNoWorkspaces = Template.bind({})
 OwnerHasNoWorkspaces.args = {
-  workspaces: [],
+  workspaceRefs: [],
   filter: workspaceFilterQuery.me,
 }
 
 export const NoResults = Template.bind({})
 NoResults.args = {
-  workspaces: [],
+  workspaceRefs: [],
   filter: "searchtearmwithnoresults",
 }

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -60,7 +60,7 @@ export const Language = {
   outdatedLabel: "Outdated",
   upToDateLabel: "Up to date",
   versionTooltipText:
-    "Looks like the version you are using for this workspace is outdated and there is a newest version that you could use.",
+    "This workspace version is outdated and a newer version is available.",
   updateVersionLabel: "Update version",
 }
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -59,8 +59,7 @@ export const Language = {
   workspaceTooltipLink3: "Editors and IDEs",
   outdatedLabel: "Outdated",
   upToDateLabel: "Up to date",
-  versionTooltipText:
-    "This workspace version is outdated and a newer version is available.",
+  versionTooltipText: "This workspace version is outdated and a newer version is available.",
   updateVersionLabel: "Update version",
 }
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -16,12 +16,12 @@ import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import RefreshIcon from "@material-ui/icons/Refresh"
 import SearchIcon from "@material-ui/icons/Search"
 import useTheme from "@material-ui/styles/useTheme"
+import { useActor } from "@xstate/react"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import { FormikErrors, useFormik } from "formik"
 import { FC, useState } from "react"
 import { Link as RouterLink, useNavigate } from "react-router-dom"
-import * as TypesGen from "../../api/typesGenerated"
 import { AvatarData } from "../../components/AvatarData/AvatarData"
 import { CloseDropdown, OpenDropdown } from "../../components/DropdownArrows/DropdownArrows"
 import { EmptyState } from "../../components/EmptyState/EmptyState"
@@ -39,6 +39,7 @@ import { Stack } from "../../components/Stack/Stack"
 import { TableLoader } from "../../components/TableLoader/TableLoader"
 import { getFormHelpers, onChangeTrimmed } from "../../util/formUtils"
 import { getDisplayStatus, workspaceFilterQuery } from "../../util/workspace"
+import { WorkspaceItemMachineRef } from "../../xServices/workspaces/workspacesXService"
 
 dayjs.extend(relativeTime)
 
@@ -97,6 +98,64 @@ const OutdatedHelpTooltip: React.FC<{ onUpdateVersion: () => void }> = ({ onUpda
   )
 }
 
+const WorkspaceRow: React.FC<{ workspaceRef: WorkspaceItemMachineRef }> = ({ workspaceRef }) => {
+  const styles = useStyles()
+  const navigate = useNavigate()
+  const theme: Theme = useTheme()
+  const [workspaceState, send] = useActor(workspaceRef)
+  const { data: workspace } = workspaceState.context
+  const status = getDisplayStatus(theme, workspace.latest_build)
+  const navigateToWorkspacePage = () => {
+    navigate(`/@${workspace.owner_name}/${workspace.name}`)
+  }
+  return (
+    <TableRow
+      hover
+      data-testid={`workspace-${workspace.id}`}
+      tabIndex={0}
+      onClick={navigateToWorkspacePage}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          navigateToWorkspacePage()
+        }
+      }}
+      className={styles.clickableTableRow}
+    >
+      <TableCell>
+        <AvatarData title={workspace.name} subtitle={workspace.owner_name} />
+      </TableCell>
+      <TableCell>{workspace.template_name}</TableCell>
+      <TableCell>
+        {workspace.outdated ? (
+          <span className={styles.outdatedLabel}>
+            {Language.outdatedLabel}
+            <OutdatedHelpTooltip
+              onUpdateVersion={() => {
+                send("UPDATE_VERSION")
+              }}
+            />
+          </span>
+        ) : (
+          <span style={{ color: theme.palette.text.secondary }}>{Language.upToDateLabel}</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <span data-chromatic="ignore" style={{ color: theme.palette.text.secondary }}>
+          {dayjs().to(dayjs(workspace.latest_build.created_at))}
+        </span>
+      </TableCell>
+      <TableCell>
+        <span style={{ color: status.color }}>{status.status}</span>
+      </TableCell>
+      <TableCell>
+        <div className={styles.arrowCell}>
+          <KeyboardArrowRight className={styles.arrowRight} />
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
 interface FilterFormValues {
   query: string
 }
@@ -105,15 +164,13 @@ export type FilterFormErrors = FormikErrors<FilterFormValues>
 
 export interface WorkspacesPageViewProps {
   loading?: boolean
-  workspaces?: TypesGen.Workspace[]
+  workspaceRefs?: WorkspaceItemMachineRef[]
   filter?: string
   onFilter: (query: string) => void
 }
 
-export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaces, filter, onFilter }) => {
+export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, workspaceRefs, filter, onFilter }) => {
   const styles = useStyles()
-  const navigate = useNavigate()
-  const theme: Theme = useTheme()
 
   const form = useFormik<FilterFormValues>({
     enableReinitialize: true,
@@ -216,17 +273,17 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell>Template</TableCell>
-            <TableCell>Version</TableCell>
-            <TableCell>Last Built</TableCell>
-            <TableCell>Status</TableCell>
+            <TableCell width="35%">Name</TableCell>
+            <TableCell width="15%">Template</TableCell>
+            <TableCell width="15%">Version</TableCell>
+            <TableCell width="20%">Last Built</TableCell>
+            <TableCell width="15%">Status</TableCell>
             <TableCell width="1%"></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {!workspaces && loading && <TableLoader />}
-          {workspaces && workspaces.length === 0 && (
+          {!workspaceRefs && loading && <TableLoader />}
+          {workspaceRefs && workspaceRefs.length === 0 && (
             <>
               {filter === workspaceFilterQuery.me || filter === workspaceFilterQuery.all ? (
                 <TableRow>
@@ -251,60 +308,8 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
               )}
             </>
           )}
-          {workspaces &&
-            workspaces.map((workspace) => {
-              const status = getDisplayStatus(theme, workspace.latest_build)
-              const navigateToWorkspacePage = () => {
-                navigate(`/@${workspace.owner_name}/${workspace.name}`)
-              }
-              return (
-                <TableRow
-                  key={workspace.id}
-                  hover
-                  data-testid={`workspace-${workspace.id}`}
-                  tabIndex={0}
-                  onClick={navigateToWorkspacePage}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      navigateToWorkspacePage()
-                    }
-                  }}
-                  className={styles.clickableTableRow}
-                >
-                  <TableCell>
-                    <AvatarData title={workspace.name} subtitle={workspace.owner_name} />
-                  </TableCell>
-                  <TableCell>{workspace.template_name}</TableCell>
-                  <TableCell>
-                    {workspace.outdated ? (
-                      <span className={styles.outdatedLabel}>
-                        {Language.outdatedLabel}
-                        <OutdatedHelpTooltip
-                          onUpdateVersion={() => {
-                            console.log("UPDATE!!")
-                          }}
-                        />
-                      </span>
-                    ) : (
-                      <span style={{ color: theme.palette.text.secondary }}>{Language.upToDateLabel}</span>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <span data-chromatic="ignore" style={{ color: theme.palette.text.secondary }}>
-                      {dayjs().to(dayjs(workspace.latest_build.created_at))}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    <span style={{ color: status.color }}>{status.status}</span>
-                  </TableCell>
-                  <TableCell>
-                    <div className={styles.arrowCell}>
-                      <KeyboardArrowRight className={styles.arrowRight} />
-                    </div>
-                  </TableCell>
-                </TableRow>
-              )
-            })}
+          {workspaceRefs &&
+            workspaceRefs.map((workspaceRef) => <WorkspaceRow workspaceRef={workspaceRef} key={workspaceRef.id} />)}
         </TableBody>
       </Table>
     </Margins>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -13,6 +13,7 @@ import TableRow from "@material-ui/core/TableRow"
 import TextField from "@material-ui/core/TextField"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
+import RefreshIcon from "@material-ui/icons/Refresh"
 import SearchIcon from "@material-ui/icons/Search"
 import useTheme from "@material-ui/styles/useTheme"
 import dayjs from "dayjs"
@@ -26,6 +27,7 @@ import { CloseDropdown, OpenDropdown } from "../../components/DropdownArrows/Dro
 import { EmptyState } from "../../components/EmptyState/EmptyState"
 import {
   HelpTooltip,
+  HelpTooltipAction,
   HelpTooltipLink,
   HelpTooltipLinksGroup,
   HelpTooltipText,
@@ -54,6 +56,11 @@ export const Language = {
   workspaceTooltipLink1: "Create workspaces",
   workspaceTooltipLink2: "Connect with SSH",
   workspaceTooltipLink3: "Editors and IDEs",
+  outdatedLabel: "Outdated",
+  upToDateLabel: "Up to date",
+  versionTooltipText:
+    "Looks like the version you are using for this workspace is outdated and there is a newest version that you could use.",
+  updateVersionLabel: "Update version",
 }
 
 const WorkspaceHelpTooltip: React.FC = () => {
@@ -71,6 +78,20 @@ const WorkspaceHelpTooltip: React.FC = () => {
         <HelpTooltipLink href="https://github.com/coder/coder/blob/main/docs/workspaces.md#editors-and-ides">
           {Language.workspaceTooltipLink3}
         </HelpTooltipLink>
+      </HelpTooltipLinksGroup>
+    </HelpTooltip>
+  )
+}
+
+const OutdatedHelpTooltip: React.FC<{ onUpdateVersion: () => void }> = ({ onUpdateVersion }) => {
+  return (
+    <HelpTooltip size="small">
+      <HelpTooltipTitle>{Language.outdatedLabel}</HelpTooltipTitle>
+      <HelpTooltipText>{Language.versionTooltipText}</HelpTooltipText>
+      <HelpTooltipLinksGroup>
+        <HelpTooltipAction icon={RefreshIcon} onClick={onUpdateVersion}>
+          {Language.updateVersionLabel}
+        </HelpTooltipAction>
       </HelpTooltipLinksGroup>
     </HelpTooltip>
   )
@@ -256,9 +277,16 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({ loading, works
                   <TableCell>{workspace.template_name}</TableCell>
                   <TableCell>
                     {workspace.outdated ? (
-                      <span style={{ color: theme.palette.error.main }}>outdated</span>
+                      <span className={styles.outdatedLabel}>
+                        {Language.outdatedLabel}
+                        <OutdatedHelpTooltip
+                          onUpdateVersion={() => {
+                            console.log("UPDATE!!")
+                          }}
+                        />
+                      </span>
                     ) : (
-                      <span style={{ color: theme.palette.text.secondary }}>up to date</span>
+                      <span style={{ color: theme.palette.text.secondary }}>{Language.upToDateLabel}</span>
                     )}
                   </TableCell>
                   <TableCell>
@@ -340,5 +368,11 @@ const useStyles = makeStyles((theme) => ({
   },
   arrowCell: {
     display: "flex",
+  },
+  outdatedLabel: {
+    color: theme.palette.error.main,
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(0.5),
   },
 }))

--- a/site/src/xServices/workspaces/workspacesXService.ts
+++ b/site/src/xServices/workspaces/workspacesXService.ts
@@ -275,6 +275,7 @@ export const workspacesMachine = createMachine(
 
         workspaceRef.send("UPDATE_VERSION")
       },
+      // Opened discussion on XState https://github.com/statelyai/xstate/discussions/3406
       updateWorkspaceRefs: assign({
         workspaceRefs: (context, event) => {
           let workspaceRefs = context.workspaceRefs

--- a/site/src/xServices/workspaces/workspacesXService.ts
+++ b/site/src/xServices/workspaces/workspacesXService.ts
@@ -33,6 +33,9 @@ export const workspaceItemMachine = createMachine(
         startWorkspace: {
           data: TypesGen.WorkspaceBuild
         }
+        getWorkspace: {
+          data: TypesGen.Workspace
+        }
       },
     },
     tsTypes: {} as import("./workspacesXService.typegen").Typegen0,
@@ -93,10 +96,11 @@ export const workspaceItemMachine = createMachine(
                 {
                   target: "waitingToBeUpdated",
                   cond: "isOutdated",
+                  actions: ["assignUpdatedData"],
                 },
                 {
                   target: "success",
-                  actions: "displayUpdatedSuccessMessage",
+                  actions: ["assignUpdatedData", "displayUpdatedSuccessMessage"],
                 },
               ],
             },
@@ -113,7 +117,7 @@ export const workspaceItemMachine = createMachine(
   },
   {
     guards: {
-      isOutdated: (ctx) => !ctx.data.outdated,
+      isOutdated: (_, event) => event.data.outdated,
     },
     services: {
       getTemplate: (context) => API.getTemplate(context.data.template_id),
@@ -124,6 +128,7 @@ export const workspaceItemMachine = createMachine(
 
         return API.startWorkspace(context.data.id, context.updatedTemplate.active_version_id)
       },
+      getWorkspace: (context) => API.getWorkspace(context.data.id),
     },
     actions: {
       assignUpdatedTemplate: assign({
@@ -142,7 +147,7 @@ export const workspaceItemMachine = createMachine(
         displayError(message)
       },
       displayUpdatingVersionMessage: () => {
-        displayMsg("Updating your workspace", "It will be running in a few seconds.")
+        displayMsg("Updating workspace...")
       },
       assignQueuedStatus: assign({
         data: (ctx) => {
@@ -161,6 +166,9 @@ export const workspaceItemMachine = createMachine(
       displayUpdatedSuccessMessage: () => {
         displaySuccess("Workspace updated successfully.")
       },
+      assignUpdatedData: assign({
+        data: (_, event) => event.data,
+      }),
     },
   },
 )


### PR DESCRIPTION
Demo:
https://user-images.githubusercontent.com/3165839/173636455-33c83eb3-2525-46cd-a198-6d9ec785eb81.mov

**Important things:**
- Each workspace/row is a machine so each workspace can execute your actions and handle your own state.
- We added polling in the workspaces machine, so the list is updated automatically.
- We are using an optimistic update to set the workspace into the "Queued" state. I think this is way better than having a spinner inside of the tooltip and tracking it down in the component.
- To update the workspaces machines I had to code some "complex" logic because:
  - If we just recreate all the machines, we would lose the workspace state. Eg. Let's say one workspace is updating the version and after polling the new workspace data we recreate it. It will lose all the previous states because it will be a new instance.
  - To avoid that, I had to verify if new items were created and spawning, update the ones with new data and stop and remove the actors that are not present anymore.
  - You can see that in the action `updateWorkspaceRefs`
- I'm not adding tests right now because it will take some time and I have to jump into other priority website tasks. Knowing that, is ok we open an exception and merge this if the current tests are ok? I promise to add the tests when I finish the website priority stuff. 🤞

Closes #2001 
