### PR TITLE
fix: allow setting workspace deadline as early as now plus 30 minutes

### DIFF
--- a/cli/bump.go
+++ b/cli/bump.go
@@ -5,16 +5,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coder/coder/coderd/util/tz"
-
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/coderd/util/tz"
 	"github.com/coder/coder/codersdk"
 )
 
 const (
-	bumpDescriptionLong = `Specify a duration from now when you would like your workspace to shut down.`
+	bumpDescriptionShort = `Shut your workspace down after a given duration has passed.`
+	bumpDescriptionLong  = `Modify the time at which your workspace will shut down automatically.
+* Provide a duration from now (for example, 1h30m).
+* The minimum duration is 30 minutes.
+* If the workspace template restricts the maximum runtime of a workspace, this will be enforced here.
+* If the workspace does not already have a shutdown scheduled, this does nothing.
+`
 )
 
 func bump() *cobra.Command {
@@ -22,7 +27,7 @@ func bump() *cobra.Command {
 		Args:        cobra.RangeArgs(1, 2),
 		Annotations: workspaceCommand,
 		Use:         "bump <workspace-name> <duration from now>",
-		Short:       "Specify a duration from now when you would like your workspace to shut down.",
+		Short:       bumpDescriptionShort,
 		Long:        bumpDescriptionLong,
 		Example:     "coder bump my-workspace 90m",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -43,7 +48,7 @@ func bump() *cobra.Command {
 
 			loc, err := tz.TimezoneIANA()
 			if err != nil {
-				loc = time.UTC // best guess
+				loc = time.UTC // best effort
 			}
 
 			if bumpDuration < 29*time.Minute {

--- a/cli/bump.go
+++ b/cli/bump.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	bumpDescriptionLong = `Make your workspace stop at a certain point in the future.`
+	bumpDescriptionLong = `Specify a duration from now when you would like your workspace to shut down.`
 )
 
 func bump() *cobra.Command {
@@ -22,7 +22,7 @@ func bump() *cobra.Command {
 		Args:        cobra.RangeArgs(1, 2),
 		Annotations: workspaceCommand,
 		Use:         "bump <workspace-name> <duration from now>",
-		Short:       "Make your workspace stop at a certain point in the future.",
+		Short:       "Specify a duration from now when you would like your workspace to shut down.",
 		Long:        bumpDescriptionLong,
 		Example:     "coder bump my-workspace 90m",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/bump_test.go
+++ b/cli/bump_test.go
@@ -124,8 +124,8 @@ func TestBump(t *testing.T) {
 		workspace, err = client.Workspace(ctx, workspace.ID)
 		require.NoError(t, err)
 
-		// TODO(cian): need to stop and start the workspace as we do not update the deadline yet
-		//             see: https://github.com/coder/coder/issues/1783
+		// NOTE(cian): need to stop and start the workspace as we do not update the deadline
+		//             see: https://github.com/coder/coder/issues/2224
 		coderdtest.MustTransitionWorkspace(t, client, workspace.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
 		coderdtest.MustTransitionWorkspace(t, client, workspace.ID, database.WorkspaceTransitionStop, database.WorkspaceTransitionStart)
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -883,18 +883,9 @@ func validWorkspaceDeadline(old, new time.Time) error {
 		return xerrors.New("nothing to do: no existing deadline set")
 	}
 
-	now := time.Now()
-	if new.Before(now) {
-		return xerrors.New("new deadline must be in the future")
-	}
-
-	delta := new.Sub(old)
-	if delta < time.Minute {
-		return xerrors.New("minimum extension is one minute")
-	}
-
-	if delta > 24*time.Hour {
-		return xerrors.New("maximum extension is 24 hours")
+	soon := time.Now().Add(29 * time.Minute)
+	if new.Before(soon) {
+		return xerrors.New("new deadline must be at least 30 minutes in the future")
 	}
 
 	return nil

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -974,22 +974,23 @@ func TestWorkspaceUpdateTTL(t *testing.T) {
 func TestWorkspaceExtend(t *testing.T) {
 	t.Parallel()
 	var (
+		ttl         = 8 * time.Hour
+		newDeadline = time.Now().Add(ttl + time.Hour).UTC()
 		ctx         = context.Background()
 		client      = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		user        = coderdtest.CreateFirstUser(t, client)
 		version     = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_           = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 		project     = coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		workspace   = coderdtest.CreateWorkspace(t, client, user.OrganizationID, project.ID)
-		extend      = 90 * time.Minute
-		_           = coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
-		oldDeadline = time.Now().Add(time.Duration(*workspace.TTLMillis) * time.Millisecond).UTC()
-		newDeadline = time.Now().Add(time.Duration(*workspace.TTLMillis)*time.Millisecond + extend).UTC()
+		workspace   = coderdtest.CreateWorkspace(t, client, user.OrganizationID, project.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.TTLMillis = ptr.Ref(ttl.Milliseconds())
+		})
+		_ = coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 	)
 
 	workspace, err := client.Workspace(ctx, workspace.ID)
 	require.NoError(t, err, "fetch provisioned workspace")
-	require.InDelta(t, oldDeadline.Unix(), workspace.LatestBuild.Deadline.Unix(), 60)
+	oldDeadline := workspace.LatestBuild.Deadline
 
 	// Updating the deadline should succeed
 	req := codersdk.PutExtendWorkspaceRequest{
@@ -1001,7 +1002,7 @@ func TestWorkspaceExtend(t *testing.T) {
 	// Ensure deadline set correctly
 	updated, err := client.Workspace(ctx, workspace.ID)
 	require.NoError(t, err, "failed to fetch updated workspace")
-	require.InDelta(t, newDeadline.Unix(), updated.LatestBuild.Deadline.Unix(), 60)
+	require.WithinDuration(t, newDeadline, updated.LatestBuild.Deadline, time.Minute)
 
 	// Zero time should fail
 	err = client.PutExtendWorkspace(ctx, workspace.ID, codersdk.PutExtendWorkspaceRequest{
@@ -1009,22 +1010,30 @@ func TestWorkspaceExtend(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "deadline: Validation failed for tag \"required\" with value: \"0001-01-01 00:00:00 +0000 UTC\"", "setting an empty deadline on a workspace should fail")
 
-	// Updating with an earlier time should also fail
+	// Updating with a deadline 29 minutes in the future should fail
+	deadlineTooSoon := time.Now().Add(29 * time.Minute)
 	err = client.PutExtendWorkspace(ctx, workspace.ID, codersdk.PutExtendWorkspaceRequest{
-		Deadline: oldDeadline,
+		Deadline: deadlineTooSoon,
 	})
-	require.ErrorContains(t, err, "deadline: minimum extension is one minute", "setting an earlier deadline should fail")
+	require.ErrorContains(t, err, "new deadline must be at least 30 minutes in the future", "setting a deadline less than 30 minutes in the future should fail")
 
-	// Updating with a time far in the future should also fail
+	// Updating with a deadline 30 minutes in the future should succeed
+	deadlineJustSoonEnough := time.Now().Add(30 * time.Minute)
 	err = client.PutExtendWorkspace(ctx, workspace.ID, codersdk.PutExtendWorkspaceRequest{
-		Deadline: oldDeadline.AddDate(1, 0, 0),
+		Deadline: deadlineJustSoonEnough,
 	})
-	require.ErrorContains(t, err, "deadline: maximum extension is 24 hours", "setting an earlier deadline should fail")
+	require.NoError(t, err, "setting a deadline at least 30 minutes in the future should succeed")
+
+	// Updating with a deadline an hour before the previous deadline should succeed
+	err = client.PutExtendWorkspace(ctx, workspace.ID, codersdk.PutExtendWorkspaceRequest{
+		Deadline: oldDeadline.Add(-time.Hour),
+	})
+	require.NoError(t, err, "setting an earlier deadline should not fail")
 
 	// Ensure deadline still set correctly
 	updated, err = client.Workspace(ctx, workspace.ID)
 	require.NoError(t, err, "failed to fetch updated workspace")
-	require.InDelta(t, newDeadline.Unix(), updated.LatestBuild.Deadline.Unix(), 60)
+	require.WithinDuration(t, oldDeadline.Add(-time.Hour), updated.LatestBuild.Deadline, time.Minute)
 }
 
 func TestWorkspaceWatcher(t *testing.T) {


### PR DESCRIPTION
This PR makes the following changes:
- coderd: `/api/v2/workspaces/:workspace/extend` now accepts any time at least 30 minutes in the future 
- `coder bump` command also allows the above. Some small copy changes to command.

UI changes to come later.