### PR TITLE
chore: update link to go to Coder docs instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Use `coder --help` to get a complete list of flags and environment variables. Us
 
 ## Documentation
 
-Visit our docs [here](./docs/index.md).
+Visit our docs [here](https://coder.com/docs/coder-oss).
 
 ## Comparison
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Coder creates remote development machines so your team can develop from anywhere
 > **Note**:
 > Coder is in an alpha state. [Report issues here](https://github.com/coder/coder/issues/new).
 
-There are a few ways to install Coder: [install script](./docs/install.md#installsh) (macOS, Linux), [docker-compose](./docs/install.md#docker-compose), or [manually](./docs/install.md#manual) via the latest release (macOS, Windows, and Linux).
+There are a few ways to install Coder: [install script](https://coder.com/docs/coder-oss/latest/install#installsh) (macOS, Linux), [docker-compose](https://coder.com/docs/coder-oss/latest/install#docker-compose), or [manually](https://coder.com/docs/coder-oss/latest/install#manual) via the latest release (macOS, Windows, and Linux).
 
 If you use the install script, you can preview what occurs during the install process:
 
@@ -53,7 +53,7 @@ Once installed, you can run a temporary deployment in dev mode (all data is in-m
 coder server --dev
 ```
 
-Use `coder --help` to get a complete list of flags and environment variables. Use our [quickstart guide](./docs/quickstart.md) for a full walkthrough.
+Use `coder --help` to get a complete list of flags and environment variables. Use our [quickstart guide](https://coder.com/docs/coder-oss/latest/quickstart) for a full walkthrough.
 
 ## Documentation
 
@@ -61,7 +61,7 @@ Visit our docs [here](https://coder.com/docs/coder-oss).
 
 ## Comparison
 
-Please file [an issue](https://github.com/coder/coder/issues/new) if any information is out of date. Also refer to: [What Coder is not](./docs/about.md#what-coder-is-not).
+Please file [an issue](https://github.com/coder/coder/issues/new) if any information is out of date. Also refer to: [What Coder is not](https://coder.com/docs/coder-oss/latest/about#what-coder-is-not).
 
 | Tool                                                        | Type     | Delivery Model     | Cost                          | Environments                                                                                                                                               |
 | :---------------------------------------------------------- | :------- | :----------------- | :---------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -82,6 +82,6 @@ Join our community on [Discord](https://discord.gg/coder) and [Twitter](https://
 
 ## Contributing
 
-Read the [contributing docs](./docs/CONTRIBUTING.md).
+Read the [contributing docs](https://coder.com/docs/coder-oss/latest/CONTRIBUTING).
 
 Find our list of contributors [here](./docs/CONTRIBUTORS.md).


### PR DESCRIPTION
The README link to the docs goes to the GH folder instead of the docs site; this PR fixes this.

fixes https://github.com/coder/coder/issues/2325