### PR TITLE
feat: improve terraform template parsing errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/lib/pq v1.10.6
 	github.com/mattn/go-isatty v0.0.14
+	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/moby v20.10.17+incompatible
 	github.com/open-policy-agent/opa v0.41.0
@@ -190,7 +191,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/miekg/dns v1.1.45 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -2,9 +2,13 @@ package terraform
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/mitchellh/go-wordwrap"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/provisionersdk/proto"
@@ -12,14 +16,12 @@ import (
 
 // Parse extracts Terraform variables from source-code.
 func (*terraform) Parse(request *proto.Parse_Request, stream proto.DRPCProvisioner_ParseStream) error {
-	defer func() {
-		_ = stream.CloseSend()
-	}()
-
+	// Load the module and print any parse errors.
 	module, diags := tfconfig.LoadModule(request.Directory)
 	if diags.HasErrors() {
-		return xerrors.Errorf("load module: %w", diags.Err())
+		return xerrors.Errorf("load module: %s", formatDiagnostics(request.Directory, diags))
 	}
+
 	parameters := make([]*proto.ParameterSchema, 0, len(module.Variables))
 	for _, v := range module.Variables {
 		schema, err := convertVariableToParameter(v)
@@ -82,4 +84,48 @@ func convertVariableToParameter(variable *tfconfig.Variable) (*proto.ParameterSc
 	}
 
 	return schema, nil
+}
+
+// formatDiagnostics returns a nicely formatted string containing all of the
+// error details within the tfconfig.Diagnostics. We need to use this because
+// the default format doesn't provide much useful information.
+func formatDiagnostics(baseDir string, diags tfconfig.Diagnostics) string {
+	var msgs strings.Builder
+	for _, d := range diags {
+		// Convert severity.
+		severity := "UNKNOWN SEVERITY"
+		switch {
+		case d.Severity == tfconfig.DiagError:
+			severity = "ERROR"
+		case d.Severity == tfconfig.DiagWarning:
+			severity = "WARN"
+		}
+
+		// Determine filepath and line
+		location := "unknown location"
+		if d.Pos != nil {
+			filename, err := filepath.Rel(baseDir, d.Pos.Filename)
+			if err != nil {
+				filename = d.Pos.Filename
+			}
+			location = fmt.Sprintf("%s:%d", filename, d.Pos.Line)
+		}
+
+		_, _ = msgs.WriteString(fmt.Sprintf("\n%s: %s (%s)\n", severity, d.Summary, location))
+
+		// Wrap the details to 80 characters and indent them.
+		if d.Detail != "" {
+			wrapped := wordwrap.WrapString(d.Detail, 78)
+			for _, line := range strings.Split(wrapped, "\n") {
+				_, _ = msgs.WriteString(fmt.Sprintf("> %s\n", line))
+			}
+		}
+	}
+
+	spacer := " "
+	if len(diags) > 1 {
+		spacer = "\n\n"
+	}
+
+	return spacer + strings.TrimSpace(msgs.String())
 }

--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -70,30 +70,6 @@ func (t *terraform) Provision(stream proto.DRPCProvisioner_ProvisionStream) erro
 		return xerrors.Errorf("terraform version %q is too old. required >= %q", version.String(), minimumTerraformVersion.String())
 	}
 
-	statefilePath := filepath.Join(start.Directory, "terraform.tfstate")
-	if len(start.State) > 0 {
-		err := os.WriteFile(statefilePath, start.State, 0600)
-		if err != nil {
-			return xerrors.Errorf("write statefile %q: %w", statefilePath, err)
-		}
-	}
-
-	reader, writer := io.Pipe()
-	defer reader.Close()
-	defer writer.Close()
-	go func() {
-		scanner := bufio.NewScanner(reader)
-		for scanner.Scan() {
-			_ = stream.Send(&proto.Provision_Response{
-				Type: &proto.Provision_Response_Log{
-					Log: &proto.Log{
-						Level:  proto.LogLevel_DEBUG,
-						Output: scanner.Text(),
-					},
-				},
-			})
-		}
-	}()
 	terraformEnv := map[string]string{}
 	// Required for "terraform init" to find "git" to
 	// clone Terraform modules.
@@ -113,15 +89,38 @@ func (t *terraform) Provision(stream proto.DRPCProvisioner_ProvisionStream) erro
 	if err != nil {
 		return xerrors.Errorf("set terraform env: %w", err)
 	}
-	terraform.SetStdout(writer)
-	t.logger.Debug(shutdown, "running initialization")
+
+	statefilePath := filepath.Join(start.Directory, "terraform.tfstate")
+	if len(start.State) > 0 {
+		err := os.WriteFile(statefilePath, start.State, 0600)
+		if err != nil {
+			return xerrors.Errorf("write statefile %q: %w", statefilePath, err)
+		}
+	}
+
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	go func() {
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() {
+			_ = stream.Send(&proto.Provision_Response{
+				Type: &proto.Provision_Response_Log{
+					Log: &proto.Log{
+						Level:  proto.LogLevel_ERROR,
+						Output: scanner.Text(),
+					},
+				},
+			})
+		}
+	}()
+	terraform.SetStderr(writer)
 	err = terraform.Init(shutdown)
 	if err != nil {
 		return xerrors.Errorf("initialize terraform: %w", err)
 	}
-	t.logger.Debug(shutdown, "ran initialization")
 	_ = reader.Close()
-	terraform.SetStdout(io.Discard)
+	terraform.SetStderr(io.Discard)
 
 	env := os.Environ()
 	env = append(env,


### PR DESCRIPTION
Improves error output from parsing errors (fig. 1) caused by invalid HCL syntax.

Fixes provision job to send error logs from `terraform init` so we can catch terraform config validation errors (fig. 2).

fig. 1
<img width="706" alt="Code_DB4Dt3ARkO" src="https://user-images.githubusercontent.com/11241812/173702815-cade5378-4702-4394-8aba-186ceb67e468.png">

fig. 2
<img width="702" alt="Code_UFwAaOTakJ" src="https://user-images.githubusercontent.com/11241812/173702824-311664e7-8bb2-40ff-9e16-80595c05eb5e.png">


Fixes #1583 
Fixes #2332 