### PR TITLE
chore: update docs manifest to reflect current Coder version number

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "versions": ["0.6.2"],
+  "versions": ["0.6.6"],
   "routes": [
     {
       "title": "Home",


### PR DESCRIPTION
Updates `manifest.json` with the current release number (this is what's displayed on the docs site)

fixes https://github.com/coder/coder/issues/2280