### PR TITLE
feat: Implement parameters list + more template list columns

### DIFF
--- a/cli/parameters.go
+++ b/cli/parameters.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/codersdk"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+func parameters() *cobra.Command {
+	cmd := &cobra.Command{
+		Short:   "List parameters for a given scope",
+		Use:     "parameters",
+		Aliases: []string{"params"},
+	}
+	cmd.AddCommand(
+		parameterList(),
+	)
+	return cmd
+}
+
+// displayParameters will return a table displaying all parameters passed in.
+// filterColumns must be a subset of the parameter fields and will determine which
+// columns to display
+func displayParameters(filterColumns []string, params ...codersdk.Parameter) string {
+	tableWriter := cliui.Table()
+	header := table.Row{"id", "scope", "scope id", "name", "source scheme", "destination scheme", "created at", "updated at"}
+	tableWriter.AppendHeader(header)
+	tableWriter.SetColumnConfigs(cliui.FilterTableColumns(header, filterColumns))
+	tableWriter.SortBy([]table.SortBy{{
+		Name: "name",
+	}})
+	for _, param := range params {
+		//fmt.Println(param, filterColumns)
+		tableWriter.AppendRow(table.Row{
+			param.ID.String(),
+			param.Scope,
+			param.ScopeID.String(),
+			param.Name,
+			param.SourceScheme,
+			param.DestinationScheme,
+			param.CreatedAt,
+			param.UpdatedAt,
+		})
+	}
+	return tableWriter.Render()
+}

--- a/cli/parameters.go
+++ b/cli/parameters.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
-	"github.com/coder/coder/cli/cliui"
-	"github.com/coder/coder/codersdk"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
+
+	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/codersdk"
 )
 
 func parameters() *cobra.Command {
@@ -33,7 +34,6 @@ func displayParameters(filterColumns []string, params ...codersdk.Parameter) str
 		Name: "name",
 	}})
 	for _, param := range params {
-		//fmt.Println(param, filterColumns)
 		tableWriter.AppendRow(table.Row{
 			param.ID.String(),
 			param.Scope,

--- a/cli/parameters.go
+++ b/cli/parameters.go
@@ -10,7 +10,9 @@ import (
 func parameters() *cobra.Command {
 	cmd := &cobra.Command{
 		Short:   "List parameters for a given scope",
+		Example: "coder parameters list workspace my-workspace",
 		Use:     "parameters",
+		Hidden:  true,
 		Aliases: []string{"params"},
 	}
 	cmd.AddCommand(

--- a/cli/parameters.go
+++ b/cli/parameters.go
@@ -13,6 +13,11 @@ func parameters() *cobra.Command {
 		Short:   "List parameters for a given scope",
 		Example: "coder parameters list workspace my-workspace",
 		Use:     "parameters",
+		// Currently hidden as this shows parameter values, not parameter
+		// schemes. Until we have a good way to distinguish the two, it's better
+		// not to add confusion or lock ourselves into a certain api.
+		// This cmd is still valuable debugging tool for devs to avoid
+		// constructing curl requests.
 		Hidden:  true,
 		Aliases: []string{"params"},
 	}

--- a/cli/parameterslist.go
+++ b/cli/parameterslist.go
@@ -6,8 +6,9 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/codersdk"
 	"github.com/spf13/cobra"
+
+	"github.com/coder/coder/codersdk"
 )
 
 func parameterList() *cobra.Command {
@@ -58,7 +59,7 @@ func parameterList() *cobra.Command {
 				})
 			}
 
-			params, err := client.Parameters(cmd.Context(), codersdk.ParameterScope(args[0]), scopeID)
+			params, err := client.Parameters(cmd.Context(), codersdk.ParameterScope(scope), scopeID)
 			if err != nil {
 				return xerrors.Errorf("fetch params: %w", err)
 			}

--- a/cli/parameterslist.go
+++ b/cli/parameterslist.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"golang.org/x/xerrors"
-
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/codersdk"
 )

--- a/cli/parameterslist.go
+++ b/cli/parameterslist.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/codersdk"
+	"github.com/spf13/cobra"
+)
+
+func parameterList() *cobra.Command {
+	var (
+		columns []string
+	)
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scope, name := args[0], args[1]
+
+			client, err := createClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			organization, err := currentOrganization(cmd, client)
+			if err != nil {
+				return xerrors.Errorf("get current organization: %w", err)
+			}
+
+			var scopeID uuid.UUID
+			switch codersdk.ParameterScope(scope) {
+			case codersdk.ParameterWorkspace:
+				workspace, err := namedWorkspace(cmd, client, name)
+				if err != nil {
+					return err
+				}
+				scopeID = workspace.ID
+			case codersdk.ParameterTemplate:
+				template, err := client.TemplateByName(cmd.Context(), organization.ID, name)
+				if err != nil {
+					return xerrors.Errorf("get workspace template: %w", err)
+				}
+				scopeID = template.ID
+
+			case codersdk.ParameterScopeImportJob, "template_version":
+				scope = string(codersdk.ParameterScopeImportJob)
+				scopeID, err = uuid.Parse(name)
+				if err != nil {
+					return xerrors.Errorf("%q must be a uuid for this scope type", name)
+				}
+			default:
+				return xerrors.Errorf("%q is an unsupported scope, use %v", scope, []codersdk.ParameterScope{
+					codersdk.ParameterWorkspace, codersdk.ParameterTemplate, codersdk.ParameterScopeImportJob,
+				})
+			}
+
+			params, err := client.Parameters(cmd.Context(), codersdk.ParameterScope(args[0]), scopeID)
+			if err != nil {
+				return xerrors.Errorf("fetch params: %w", err)
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), displayParameters(columns, params...))
+			return err
+		},
+	}
+	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"name", "source_scheme", "destination_scheme"},
+		"Specify a column to filter in the table.")
+	return cmd
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -90,6 +90,7 @@ func Root() *cobra.Command {
 		portForward(),
 		workspaceAgent(),
 		versionCmd(),
+		parameters(),
 	)
 
 	cmd.SetUsageTemplate(usageTemplate())

--- a/cli/templatelist.go
+++ b/cli/templatelist.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-
-	"github.com/coder/coder/cli/cliui"
 )
 
 func templateList() *cobra.Command {
-	return &cobra.Command{
+	var (
+		columns []string
+	)
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -34,22 +34,11 @@ func templateList() *cobra.Command {
 				return nil
 			}
 
-			tableWriter := cliui.Table()
-			tableWriter.AppendHeader(table.Row{"Name", "Last updated", "Used by"})
-
-			for _, template := range templates {
-				suffix := ""
-				if template.WorkspaceOwnerCount != 1 {
-					suffix = "s"
-				}
-				tableWriter.AppendRow(table.Row{
-					template.Name,
-					template.UpdatedAt.Format("January 2, 2006"),
-					cliui.Styles.Fuschia.Render(fmt.Sprintf("%d developer%s", template.WorkspaceOwnerCount, suffix)),
-				})
-			}
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), tableWriter.Render())
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), displayTemplates(columns, templates...))
 			return err
 		},
 	}
+	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"name", "last_updated", "used_by"},
+		"Specify a column to filter in the table.")
+	return cmd
 }

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -1,9 +1,14 @@
 package cli
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 
 	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/codersdk"
 )
 
 func templates() *cobra.Command {
@@ -17,7 +22,7 @@ func templates() *cobra.Command {
     ` + cliui.Styles.Code.Render("$ coder templates create") + `
 
   - Make changes to your template, and plan the changes
- 
+
     ` + cliui.Styles.Code.Render("$ coder templates plan <name>") + `
 
   - Update the template. Your developers can update their workspaces
@@ -36,4 +41,37 @@ func templates() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// displayTemplates will return a table displaying all templates passed in.
+// filterColumns must be a subset of the template fields and will determine which
+// columns to display
+func displayTemplates(filterColumns []string, templates ...codersdk.Template) string {
+	tableWriter := cliui.Table()
+	header := table.Row{
+		"Name", "Created At", "Last Updated", "Organization ID", "Provisioner",
+		"Active Version ID", "Used By", "Max TTL", "Min Autostart"}
+	tableWriter.AppendHeader(header)
+	tableWriter.SetColumnConfigs(cliui.FilterTableColumns(header, filterColumns))
+	tableWriter.SortBy([]table.SortBy{{
+		Name: "name",
+	}})
+	for _, template := range templates {
+		suffix := ""
+		if template.WorkspaceOwnerCount != 1 {
+			suffix = "s"
+		}
+		tableWriter.AppendRow(table.Row{
+			template.Name,
+			template.CreatedAt.Format("January 2, 2006"),
+			template.UpdatedAt.Format("January 2, 2006"),
+			template.OrganizationID.String(),
+			template.Provisioner,
+			template.ActiveVersionID.String(),
+			cliui.Styles.Fuschia.Render(fmt.Sprintf("%d developer%s", template.WorkspaceOwnerCount, suffix)),
+			fmt.Sprintf("%s", time.Duration(template.MaxTTLMillis)*time.Millisecond),
+			fmt.Sprintf("%s", time.Duration(template.MinAutostartIntervalMillis)*time.Millisecond),
+		})
+	}
+	return tableWriter.Render()
 }

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -69,8 +69,8 @@ func displayTemplates(filterColumns []string, templates ...codersdk.Template) st
 			template.Provisioner,
 			template.ActiveVersionID.String(),
 			cliui.Styles.Fuschia.Render(fmt.Sprintf("%d developer%s", template.WorkspaceOwnerCount, suffix)),
-			fmt.Sprintf("%s", time.Duration(template.MaxTTLMillis)*time.Millisecond),
-			fmt.Sprintf("%s", time.Duration(template.MinAutostartIntervalMillis)*time.Millisecond),
+			(time.Duration(template.MaxTTLMillis) * time.Millisecond).String(),
+			(time.Duration(template.MinAutostartIntervalMillis) * time.Millisecond).String(),
 		})
 	}
 	return tableWriter.Render()

--- a/cli/users.go
+++ b/cli/users.go
@@ -30,7 +30,7 @@ func users() *cobra.Command {
 // columns to display
 func displayUsers(filterColumns []string, users ...codersdk.User) string {
 	tableWriter := cliui.Table()
-	header := table.Row{"id", "username", "email", "created_at", "status"}
+	header := table.Row{"id", "username", "email", "created at", "status"}
 	tableWriter.AppendHeader(header)
 	tableWriter.SetColumnConfigs(cliui.FilterTableColumns(header, filterColumns))
 	tableWriter.SortBy([]table.SortBy{{

--- a/codersdk/parameters.go
+++ b/codersdk/parameters.go
@@ -14,8 +14,9 @@ import (
 type ParameterScope string
 
 const (
-	ParameterTemplate  ParameterScope = "template"
-	ParameterWorkspace ParameterScope = "workspace"
+	ParameterTemplate       ParameterScope = "template"
+	ParameterWorkspace      ParameterScope = "workspace"
+	ParameterScopeImportJob ParameterScope = "import_job"
 )
 
 type ParameterSourceScheme string

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -49,7 +49,7 @@ export interface CreateOrganizationRequest {
   readonly name: string
 }
 
-// From codersdk/parameters.go:79:6
+// From codersdk/parameters.go:80:6
 export interface CreateParameterRequest {
   readonly name: string
   readonly source_value: string
@@ -160,7 +160,7 @@ export interface Pagination {
   readonly offset?: number
 }
 
-// From codersdk/parameters.go:44:6
+// From codersdk/parameters.go:45:6
 export interface Parameter {
   readonly id: string
   readonly created_at: string
@@ -172,7 +172,7 @@ export interface Parameter {
   readonly destination_scheme: ParameterDestinationScheme
 }
 
-// From codersdk/parameters.go:55:6
+// From codersdk/parameters.go:56:6
 export interface ParameterSchema {
   readonly id: string
   readonly created_at: string
@@ -493,16 +493,16 @@ export type LogLevel = "debug" | "error" | "info" | "trace" | "warn"
 // From codersdk/provisionerdaemons.go:16:6
 export type LogSource = "provisioner" | "provisioner_daemon"
 
-// From codersdk/parameters.go:28:6
+// From codersdk/parameters.go:29:6
 export type ParameterDestinationScheme = "environment_variable" | "none" | "provisioner_variable"
 
 // From codersdk/parameters.go:14:6
-export type ParameterScope = "template" | "workspace"
+export type ParameterScope = "import_job" | "template" | "workspace"
 
-// From codersdk/parameters.go:21:6
+// From codersdk/parameters.go:22:6
 export type ParameterSourceScheme = "data" | "none"
 
-// From codersdk/parameters.go:36:6
+// From codersdk/parameters.go:37:6
 export type ParameterTypeSystem = "hcl" | "none"
 
 // From codersdk/provisionerdaemons.go:42:6


### PR DESCRIPTION
I am using this for debugging, figured I'd throw it in a quick branch.

# What this does

Adds a way to list parameter values for a scope. Really helpful for debugging the param things I am messing with. **I hide the cmd by default right now,** as it lists the **parameter_values**, not **parameter_schemes**.. I think the cli should somehow distinguish the two, but don't know at the moment.

No actual values are returned from the cli, just the name + meta data.


I also added more columns templates list if they specify the columns. I needed this for debugging too.



## Param list (hidden by default)

```
$ coder parameters list workspace my-workspace
NAME          SOURCE SCHEME  DESTINATION SCHEME    
docker_image  data           provisioner_variable 
```

## Template columns

```
$ ./coder templates list -c name -c active_version_id                                                                                                                                                                                              
NAME    ACTIVE VERSION ID                     
docker  8898efde-8f95-4cdd-8ea8-fee121510361 
```

