### PR TITLE
fix: allow server startup without tunnel

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -192,9 +192,13 @@ func server() *cobra.Command {
 						Text:      "Would you like to start a tunnel for simple setup?",
 						IsConfirm: true,
 					})
-					if errors.Is(err, cliui.Canceled) {
+
+					if err != nil && !errors.Is(err, cliui.Canceled) {
 						return err
 					}
+
+					// Don't tunnel if the user specifies no tunnel.
+					tunnel = !errors.Is(err, cliui.Canceled)
 				}
 				if err == nil {
 					devTunnel, devTunnelErrChan, err = devtunnel.New(ctxTunnel, logger.Named("devtunnel"))


### PR DESCRIPTION
- Previously, specifying 'no' to the tunnel prompt just killed
  the process. It should be possible to start the server without
  a tunnel and not have the process killed.
