### PR TITLE
fix: fix deleted workspace banner 404

### DIFF
--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -77,7 +77,7 @@ export const Workspace: FC<WorkspaceProps> = ({
             workspace={workspace}
           />
 
-          <WorkspaceDeletedBanner workspace={workspace} handleClick={() => navigate(`/workspaces/new`)} />
+          <WorkspaceDeletedBanner workspace={workspace} handleClick={() => navigate(`/templates`)} />
 
           <WorkspaceStats workspace={workspace} />
 


### PR DESCRIPTION
- When a workspace is deleted the user is nudged
  to create a new workspace. The page to which they
  are routed 404s. This PR simply routes them to the
  /templates page where they can pick a template for their
  new workspace.

