### PR TITLE
fix: Force keeping old files to prevent dpkg failure on update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -329,7 +329,7 @@ install_deb() {
 
 	fetch "https://github.com/coder/coder/releases/download/v$VERSION/coder_${VERSION}_${OS}_${ARCH}.deb" \
 		"$CACHE_DIR/coder_${VERSION}_$ARCH.deb"
-	sudo_sh_c dpkg -i "$CACHE_DIR/coder_${VERSION}_$ARCH.deb"
+	sudo_sh_c dpkg --force-confdef --force-confold -i "$CACHE_DIR/coder_${VERSION}_$ARCH.deb"
 
 	echo_systemd_postinstall deb
 }

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -6,6 +6,7 @@ USER="coder"
 # Add a Coder user to run as in systemd.
 if ! id -u $USER >/dev/null 2>&1; then
 	useradd \
+		--create-home \
 		--system \
 		--user-group \
 		--shell /bin/false \


### PR DESCRIPTION
Updating a release if system files failed would result in failure from
the install script. This fixes it!
