### PR TITLE
fix(devtunnel): use 1280 mtu

### DIFF
--- a/coderd/devtunnel/tunnel.go
+++ b/coderd/devtunnel/tunnel.go
@@ -59,7 +59,7 @@ func NewWithConfig(ctx context.Context, logger slog.Logger, cfg Config) (*Tunnel
 	tun, tnet, err := netstack.CreateNetTUN(
 		[]netip.Addr{netip.AddrFrom16(cfg.ID)},
 		[]netip.Addr{netip.AddrFrom4([4]byte{1, 1, 1, 1})},
-		1420,
+		1280,
 	)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("create net TUN: %w", err)


### PR DESCRIPTION
This should be more compatible with cloud VMs and VPNs.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
