### PR TITLE
Log provisioner outputs from TestProvision_ExtraEnv

### DIFF
--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -325,6 +325,7 @@ func TestProvision_ExtraEnv(t *testing.T) {
 		require.NoError(t, err)
 
 		if log := msg.GetLog(); log != nil {
+			t.Log(log.Level.String(), log.Output)
 			if strings.Contains(log.Output, "TF_LOG") {
 				found = true
 			}


### PR DESCRIPTION
I got a strange error here in another unrelated PR: https://github.com/coder/coder/actions/runs/2510850193/attempts/1

Log what terraform is complaining about to the test log so we can fix it if it comes up again.