### PR TITLE
fix: Add reaper to coder agent

### DIFF
--- a/agent/reaper/doc.go
+++ b/agent/reaper/doc.go
@@ -1,0 +1,4 @@
+// Package reaper contains logic for reaping subprocesses. It is
+// specifically used in the agent to avoid the accumulation of
+// zombie processes.
+package reaper

--- a/agent/reaper/reaper.go
+++ b/agent/reaper/reaper.go
@@ -20,6 +20,11 @@ func IsChild() bool {
 	return os.Getenv(agentEnvMark) != ""
 }
 
+// IsInitProcess returns true if the current process's PID is 1.
+func IsInitProcess() bool {
+	return os.Getpid() == 1
+}
+
 // ForkReap spawns a goroutine that reaps children. In order to avoid
 // complications with spawning `exec.Commands` in the same process that
 // is reaping, we forkexec a child process. This prevents a race between

--- a/agent/reaper/reaper.go
+++ b/agent/reaper/reaper.go
@@ -1,0 +1,68 @@
+package reaper
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/hashicorp/go-reap"
+	"golang.org/x/xerrors"
+)
+
+// agentEnvMark is a simple environment variable that we use as a marker
+// to indicated that the process is a child as opposed to the reaper.
+// Since we are forkexec'ing we need to be able to differentiate between
+// the two to avoid fork bombing ourselves.
+const agentEnvMark = "CODER_AGENT"
+
+// IsChild returns true if we're the forked process.
+func IsChild() bool {
+	return os.Getenv(agentEnvMark) != ""
+}
+
+// ForkReap spawns a goroutine that reaps children. In order to avoid
+// complications with spawning `exec.Commands` in the same process that
+// is reaping, we forkexec a child process. This prevents a race between
+// the reaper and an exec.Command waiting for its process to complete.
+func ForkReap(pids reap.PidCh) error {
+	// Check if the process is the parent or the child.
+	// If it's the child we want to skip attempting to reap.
+	if !IsChild() {
+		go reap.ReapChildren(pids, nil, nil, nil)
+
+		args := os.Args
+		// This is simply done to help identify the real agent process
+		// when viewing in something like 'ps'.
+		args = append(args, "#Agent")
+
+		pwd, err := os.Getwd()
+		if err != nil {
+			return xerrors.Errorf("get wd: %w", err)
+		}
+
+		pattrs := &syscall.ProcAttr{
+			Dir: pwd,
+			// Add our marker for identifying the child process.
+			Env: append(os.Environ(), fmt.Sprintf("%s=true", agentEnvMark)),
+			Sys: &syscall.SysProcAttr{
+				Setsid: true,
+			},
+			Files: []uintptr{
+				uintptr(syscall.Stdin),
+				uintptr(syscall.Stdout),
+				uintptr(syscall.Stderr),
+			},
+		}
+
+		pid, _ := syscall.ForkExec(args[0], args, pattrs)
+
+		var wstatus syscall.WaitStatus
+		_, err = syscall.Wait4(pid, &wstatus, 0, nil)
+		for xerrors.Is(err, syscall.EINTR) {
+			_, err = syscall.Wait4(pid, &wstatus, 0, nil)
+		}
+		return nil
+	}
+
+	return nil
+}

--- a/agent/reaper/reaper.go
+++ b/agent/reaper/reaper.go
@@ -13,7 +13,7 @@ import (
 // to indicated that the process is a child as opposed to the reaper.
 // Since we are forkexec'ing we need to be able to differentiate between
 // the two to avoid fork bombing ourselves.
-const agentEnvMark = "CODER_AGENT"
+const agentEnvMark = "CODER_REAPER_AGENT"
 
 // IsChild returns true if we're the forked process.
 func IsChild() bool {
@@ -29,6 +29,8 @@ func IsInitProcess() bool {
 // complications with spawning `exec.Commands` in the same process that
 // is reaping, we forkexec a child process. This prevents a race between
 // the reaper and an exec.Command waiting for its process to complete.
+// The provided 'pids' channel may be nil if the caller does not care about the
+// reaped children PIDs.
 func ForkReap(pids reap.PidCh) error {
 	// Check if the process is the parent or the child.
 	// If it's the child we want to skip attempting to reap.

--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package reaper
+
+import "github.com/hashicorp/go-reap"
+
+// IsChild returns true if we're the forked process.
+func IsChild() bool {
+	return false
+}
+
+// IsInitProcess returns true if the current process's PID is 1.
+func IsInitProcess() bool {
+	return false
+}
+
+func ForkReap(pids reap.PidCh) error {
+	return nil
+}

--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build !linux
 
 package reaper
 

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -2,6 +2,7 @@ package reaper_test
 
 import (
 	"os/exec"
+	"runtime"
 	"testing"
 	"time"
 
@@ -13,6 +14,10 @@ import (
 
 func TestReap(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skipf("Skipping non-Linux OS %q", runtime.GOOS)
+	}
 
 	// Because we're forkexecing these tests will try to run twice...
 	if reaper.IsChild() {

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -1,0 +1,51 @@
+package reaper_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-reap"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/agent/reaper"
+)
+
+func TestReap(t *testing.T) {
+	t.Parallel()
+
+	// Because we're forkexecing these tests will try to run twice...
+	if reaper.IsChild() {
+		t.Skip("I'm a child!")
+	}
+
+	t.Run("OK", func(t *testing.T) {
+		pids := make(reap.PidCh, 1)
+		err := reaper.ForkReap(pids)
+		require.NoError(t, err)
+
+		cmd := exec.Command("sleep", "5")
+		err = cmd.Start()
+		require.NoError(t, err)
+
+		cmd2 := exec.Command("sleep", "5")
+		err = cmd2.Start()
+		require.NoError(t, err)
+
+		err = cmd.Process.Kill()
+		require.NoError(t, err)
+
+		err = cmd2.Process.Kill()
+		require.NoError(t, err)
+
+		expectedPIDs := []int{cmd.Process.Pid, cmd2.Process.Pid}
+
+		deadline := time.NewTimer(time.Second * 5)
+		select {
+		case <-deadline.C:
+			t.Fatalf("Timed out waiting for process")
+		case pid := <-pids:
+			require.Contains(t, expectedPIDs, pid)
+		}
+	})
+}

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -3,6 +3,7 @@
 package reaper_test
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -15,6 +16,13 @@ import (
 
 func TestReap(t *testing.T) {
 	t.Parallel()
+
+	// Don't run the reaper test in CI. It does weird
+	// things like forkexecing which may have unintended
+	// consequences in CI.
+	if _, ok := os.LookupEnv("CI"); ok {
+		t.Skip("Detected CI, skipping reaper tests")
+	}
 
 	// Because we're forkexecing these tests will try to run twice...
 	if reaper.IsChild() {

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package reaper_test
 

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -1,7 +1,6 @@
 package reaper_test
 
 import (
-	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -28,11 +27,11 @@ func TestReap(t *testing.T) {
 		err := reaper.ForkReap(pids)
 		require.NoError(t, err)
 
-		cmd := exec.Command("sleep", "5")
+		cmd := exec.Command("tail", "-f", "/dev/null")
 		err = cmd.Start()
 		require.NoError(t, err)
 
-		cmd2 := exec.Command("sleep", "5")
+		cmd2 := exec.Command("tail", "-f", "/dev/null")
 		err = cmd2.Start()
 		require.NoError(t, err)
 
@@ -50,7 +49,6 @@ func TestReap(t *testing.T) {
 			case <-deadline.C:
 				t.Fatalf("Timed out waiting for process")
 			case pid := <-pids:
-				fmt.Println("pid: ", pid)
 				require.Contains(t, expectedPIDs, pid)
 			}
 		}

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -1,8 +1,9 @@
+//go:build !windows
+
 package reaper_test
 
 import (
 	"os/exec"
-	"runtime"
 	"testing"
 	"time"
 
@@ -14,10 +15,6 @@ import (
 
 func TestReap(t *testing.T) {
 	t.Parallel()
-
-	if runtime.GOOS != "linux" {
-		t.Skipf("Skipping non-Linux OS %q", runtime.GOOS)
-	}
 
 	// Because we're forkexecing these tests will try to run twice...
 	if reaper.IsChild() {

--- a/agent/reaper/reaper_unix.go
+++ b/agent/reaper/reaper_unix.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build linux
 
 package reaper
 

--- a/agent/reaper/reaper_unix.go
+++ b/agent/reaper/reaper_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build windows
 
 package reaper
 

--- a/agent/reaper/reaper_unix.go
+++ b/agent/reaper/reaper_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package reaper
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,10 @@ require (
 	storj.io/drpc v0.0.30
 )
 
-require github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+require (
+	github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+)
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/go-github/v43 v43.0.1-0.20220414155304-00e42332e405
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b
 	github.com/hashicorp/go-version v1.5.0
 	github.com/hashicorp/hc-install v0.3.2
 	github.com/hashicorp/hcl/v2 v2.12.0
@@ -132,11 +133,6 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	nhooyr.io/websocket v1.8.7
 	storj.io/drpc v0.0.30
-)
-
-require (
-	github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b // indirect
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 )
 
 require (
@@ -239,6 +235,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
 	github.com/yuin/goldmark v1.4.12 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -899,6 +899,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b h1:3GrpnZQBxcMj1gCXQLelfjCT1D5MPGTuGMKHVzSIH6A=
+github.com/hashicorp/go-reap v0.0.0-20170704170343-bf58d8a43e7b/go.mod h1:qIFzeFcJU3OIFk/7JreWXcUjFmcCaeHTH9KoNyHYVCs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=


### PR DESCRIPTION
- The coder agent runs as PID 1 in some of our Docker workspaces.
  In such cases it is the responsibility of the init process to
  reap dead processes. Failing to do so can result in an inability
  to create new processes by running out of PIDs.

  This PR adds a reaper to our agent that is only spawned if it
  detects that it is PID1.

resolves #2398