### PR TITLE
Show build initiator on Workspace Build page

### DIFF
--- a/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.stories.tsx
+++ b/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.stories.tsx
@@ -13,3 +13,19 @@ export const Example = Template.bind({})
 Example.args = {
   build: MockWorkspaceBuild,
 }
+
+export const Autostart = Template.bind({})
+Autostart.args = {
+  build: {
+    ...MockWorkspaceBuild,
+    reason: "autostart",
+  },
+}
+
+export const Autostop = Template.bind({})
+Autostop.args = {
+  build: {
+    ...MockWorkspaceBuild,
+    reason: "autostop",
+  },
+}

--- a/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.stories.tsx
+++ b/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.stories.tsx
@@ -26,6 +26,7 @@ export const Autostop = Template.bind({})
 Autostop.args = {
   build: {
     ...MockWorkspaceBuild,
+    transition: "stop",
     reason: "autostop",
   },
 }

--- a/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
+++ b/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
@@ -5,7 +5,11 @@ import { Link as RouterLink } from "react-router-dom"
 import { WorkspaceBuild } from "../../api/typesGenerated"
 import { CardRadius, MONOSPACE_FONT_FAMILY } from "../../theme/constants"
 import { combineClasses } from "../../util/combineClasses"
-import { displayWorkspaceBuildDuration, getDisplayWorkspaceBuildStatus } from "../../util/workspace"
+import {
+  displayWorkspaceBuildDuration,
+  getDisplayWorkspaceBuildInitiatedBy,
+  getDisplayWorkspaceBuildStatus,
+} from "../../util/workspace"
 
 export interface WorkspaceBuildStatsProps {
   build: WorkspaceBuild
@@ -15,6 +19,7 @@ export const WorkspaceBuildStats: FC<WorkspaceBuildStatsProps> = ({ build }) => 
   const styles = useStyles()
   const theme = useTheme()
   const status = getDisplayWorkspaceBuildStatus(theme, build)
+  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(theme, build)
 
   return (
     <div className={styles.stats}>
@@ -51,6 +56,13 @@ export const WorkspaceBuildStats: FC<WorkspaceBuildStatsProps> = ({ build }) => 
         <span className={styles.statsLabel}>Action</span>
         <span className={combineClasses([styles.statsValue, styles.capitalize])}>{build.transition}</span>
       </div>
+      <div className={styles.statsDivider} />
+      <div className={styles.statItem}>
+        <span className={styles.statsLabel}>Initiated by</span>
+        <span className={styles.statsValue}>
+          <span style={{ color: initiatedBy.color }}>{initiatedBy.initiatedBy}</span>
+        </span>
+      </div>
     </div>
   )
 }
@@ -72,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
   },
 
   statItem: {
-    minWidth: "16%",
+    minWidth: "13%",
     padding: theme.spacing(2),
     paddingTop: theme.spacing(1.75),
   },

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -186,6 +186,37 @@ export const getDisplayWorkspaceBuildStatus = (
   }
 }
 
+export const DisplayWorkspaceBuildInitiatedByLanguage = {
+  autostart: "system/autostart",
+  autostop: "system/autostop",
+}
+
+export const getDisplayWorkspaceBuildInitiatedBy = (
+  theme: Theme,
+  build: TypesGen.WorkspaceBuild,
+): {
+  color: string
+  initiatedBy: string
+} => {
+  switch (build.reason) {
+    case "initiator":
+      return {
+        color: theme.palette.text.secondary,
+        initiatedBy: build.initiator_name,
+      }
+    case "autostart":
+      return {
+        color: theme.palette.secondary.dark,
+        initiatedBy: DisplayWorkspaceBuildInitiatedByLanguage.autostart,
+      }
+    case "autostop":
+      return {
+        color: theme.palette.secondary.dark,
+        initiatedBy: DisplayWorkspaceBuildInitiatedByLanguage.autostop,
+      }
+  }
+}
+
 export const getWorkspaceBuildDurationInSeconds = (build: TypesGen.WorkspaceBuild): number | undefined => {
   const isCompleted = build.job.started_at && build.job.completed_at
 


### PR DESCRIPTION
This PR builds on #2438 and shows the workspace build initiator on the Workspace Build page.

## Subtasks

- [x] add a column in the stats to show build initiator
- [x] format the initiator based on reason
- [x] add stories

Fixes #2029 
Fixes #2410 

## Screenshots

<img width="1162" alt="Screen Shot 2022-06-16 at 7 27 50 PM" src="https://user-images.githubusercontent.com/7511231/174194430-47106b7e-b46c-4a1b-af42-89c23f934139.png">

<img width="1170" alt="Screen Shot 2022-06-16 at 7 20 28 PM" src="https://user-images.githubusercontent.com/7511231/174193800-bf26721e-b1c0-4f66-9cd9-63f5de46b829.png">

<img width="1168" alt="Screen Shot 2022-06-16 at 7 20 49 PM" src="https://user-images.githubusercontent.com/7511231/174193836-af2856ae-5e49-434b-87bc-c403106b7915.png">

