### PR TITLE
add lima template for coder

### DIFF
--- a/examples/lima/README.md
+++ b/examples/lima/README.md
@@ -4,9 +4,9 @@ description: Quickly stand up Coder using Lima
 tags: [local, docker, vm, lima]
 ---
 
-# Lima VM Template
+# Run Coder in Lima
 
-This provides a [Lima](https://github.com/lima-vm/lima) template for Coder.
+This provides a sample [Lima](https://github.com/lima-vm/lima) configuration for Coder.
 This lets you quickly test out Coder in a self-contained environment.
 
 > Prerequisite: You must have `lima` installed and available to use this.
@@ -18,7 +18,7 @@ This lets you quickly test out Coder in a self-contained environment.
 
 This will:
 - Start an Ubuntu 22.04 VM
-- Install Docker from the official repos
+- Install Docker and Terraform from the official repos
 - Install Coder using the [installation script](https://coder.com/docs/coder-oss/latest/install#installsh)
 - Generates an initial user account `admin@coder.com` with a randomly generated password (stored in the VM under `/home/${USER}.linux/.config/coderv2/password`)
 - Initializes a [sample Docker template](https://github.com/coder/coder/tree/main/examples/templates/docker-code-server) for creating workspaces

--- a/examples/lima/README.md
+++ b/examples/lima/README.md
@@ -1,0 +1,32 @@
+---
+name: Run Coder in Lima
+description: Quickly stand up Coder using Lima
+tags: [local, docker, vm, lima]
+---
+
+# Lima VM Template
+
+This provides a [Lima](https://github.com/lima-vm/lima) template for Coder.
+This lets you quickly test out Coder in a self-contained environment.
+
+> Prerequisite: You must have `lima` installed and available to use this.
+
+## Getting Started
+
+- Run `limactl start --name=coder https://raw.githubusercontent.com/coder/coder/main/examples/lima/coder.yaml`
+- You can use the configuration as-is, or edit it to your liking.
+
+This will:
+- Start an Ubuntu 22.04 VM
+- Install Docker from the official repos
+- Install Coder using the [installation script](https://coder.com/docs/coder-oss/latest/install#installsh)
+- Generates an initial user account `admin@coder.com` with a randomly generated password (stored in the VM under `/home/${USER}.linux/.config/coderv2/password`)
+- Initializes a [sample Docker template](https://github.com/coder/coder/tree/main/examples/templates/docker-code-server) for creating workspaces
+
+Once this completes, you can visit `http://localhost:3000` and start creating workspaces!
+
+Alternatively, enter the VM with `limactl shell coder` and run `coder template init` to start creating your own templates!
+
+## Further Information
+
+- To learn more about Lima, [visit the the project's GitHub page](https://github.com/lima-vm/lima/).

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -112,7 +112,7 @@ probes:
       exit 1
     fi
   hint: |
-    See "/var/log/cloud-init-output.log". in the guest
+    See "/var/log/cloud-init-output.log" in the guest.
 - description: "coder to be installed"
   script: |
     #!/bin/bash
@@ -122,12 +122,12 @@ probes:
       exit 1
     fi
   hint: |
-    See "/var/log/cloud-init-output.log". in the guest
+    See "/var/log/cloud-init-output.log" in the guest.
 message: |
   All Done! Your Coder instance is accessible at http://localhost:3000
   
   Username: "admin@coder.com"
-  Password: `LIMA_INSTANCE=coder lima cat /home/${USER}.linux/.config/coderv2/password` 🤫
+  Password: Run `LIMA_INSTANCE=coder lima cat /home/${USER}.linux/.config/coderv2/password` 🤫
 
   Get started creating your own template now:
   ------

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -84,14 +84,16 @@ provision:
     # Ensure coder starts on boot
     systemctl enable coder
     systemctl start coder
+    # Wait for Coder to have downloaded Terraform
+    timeout 60s bash -c 'until /var/cache/coder/terraform version >/dev/null 2>&1; do sleep 1; done'
+    # Coder restarts after downloading Terraform, wait for it to become available
+    timeout 60s bash -c 'until nc -z localhost 3000 > /dev/null 2>&1; do sleep 1; done'
 - mode: user
   script: |
     #!/bin/bash
     set -eux -o pipefail
     # If we are already logged in, nothing to do
     coder templates list >/dev/null 2>&1 && exit 0
-    # Wait for Coder to become available
-    timeout 30s bash -c 'until nc -z localhost 3000; do sleep 1; done'
     # Set up initial user
     [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --username admin --email admin@coder.com --password $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8 | tee ${HOME}/.config/coderv2/password)
     # Create an initial template

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -62,6 +62,17 @@ provision:
   script: |
     #!/bin/bash
     set -eux -o pipefail
+    command -v terraform >/dev/null 2>&1 && exit 0
+    wget -qO - terraform.gpg https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/terraform-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/terraform.list
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -y
+    apt-get install terraform=1.1.9
+    apt-mark hold terraform
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
     command -v coder >/dev/null 2>&1 && exit 0
     export DEBIAN_FRONTEND=noninteractive
     export HOME=/root
@@ -79,8 +90,18 @@ provision:
     set -eux -o pipefail
     # If we are already logged in, nothing to do
     coder templates list >/dev/null 2>&1 && exit 0
+    # Wait for Coder to become available
+    timeout 30s bash -c 'until nc -z localhost 3000; do sleep 1; done'
     # Set up initial user
-    [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --username admin --email admin@coder.com --password password
+    [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --username admin --email admin@coder.com --password $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8 | tee ${HOME}/.config/coderv2/password)
+    # Create an initial template
+    cd ${HOME}
+    echo code-server | coder templates init
+    cd ./docker-code-server
+    if [ $(arch) = "aarch64" ]; then
+        sed -i 's/arch.*=.*"amd64"/arch = "arm64"/' ./main.tf
+    fi
+    coder templates create docker-code-server -y -d .
 probes:
 - description: "docker to be installed"
   script: |
@@ -102,25 +123,15 @@ probes:
     fi
   hint: |
     See "/var/log/cloud-init-output.log". in the guest
-- description: "terraform to be fully downloaded"
-  script: |
-    #!/bin/bash
-    set -eux -o pipefail
-    if ! timeout 30s bash -c "until [ $(du /var/cache/coder/terraform | awk '{print $1}') -ge 62784 ] >/dev/null 2>&1; do sleep 3; done"; then
-      echo >&2 "terraform is not fully downloaded yet"
-      exit 1
-    fi
-  hint: |
-    Check "/var/cache/coder/terraform" in the guest
 message: |
   All Done! Your Coder instance is accessible at http://localhost:3000
+  
   Username: "admin@coder.com"
-  Password: "password" 🤫
-  Start a workspace now by running the following commands:
+  Password: `LIMA_INSTANCE=coder lima cat /home/${USER}.linux/.config/coderv2/password` 🤫
+
+  Get started creating your own template now:
   ------
   limactl shell coder
-  cd && echo code-server | coder templates init
-  cd ./docker-code-server && coder templates create -y
-  coder create -t docker-code-server my-workspace -y
+  cd && coder templates init
   ------
 

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -1,0 +1,126 @@
+# Deploy Coder in Lima via the install script
+# See: https://coder.com/docs/coder-oss/latest/install
+# $ limactl start ./coder.yaml
+# $ limactl shell coder
+# The web UI is accessible on http://localhost:3000 -- ports are forwarded automatically by lima:
+# $ coder login http://localhost:3000
+
+# This example requires Lima v0.8.3 or later.
+images:
+# Try to use release-yyyyMMdd image if available. Note that release-yyyyMMdd will be removed after several months.
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220420/ubuntu-22.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release-20220420/ubuntu-22.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+  digest: "sha256:66224c7fed99ff5a5539eda406c87bbfefe8af6ff6b47d92df3187832b5b5d4f"
+# Fallback to the latest release image.
+# Hint: run `limactl prune` to invalidate the cache
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+- location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
+# Your home directory is mounted read-only
+mounts:
+  - location: "~"
+containerd:
+  system: false
+  user: false
+hostResolver:
+  # hostResolver.hosts requires lima 0.8.3 or later. Names defined here will also
+  # resolve inside containers, and not just inside the VM itself.
+  hosts:
+    host.docker.internal: host.lima.internal
+provision:
+- mode: system
+  # This script defines the host.docker.internal hostname when hostResolver is disabled.
+  # It is also needed for lima 0.8.2 and earlier, which does not support hostResolver.hosts.
+  # Names defined in /etc/hosts inside the VM are not resolved inside containers when
+  # using the hostResolver; use hostResolver.hosts instead (requires lima 0.8.3 or later).
+  script: |
+    #!/bin/sh
+    set -eux -o pipefail
+    sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v docker >/dev/null 2>&1 && exit 0
+    export DEBIAN_FRONTEND=noninteractive
+    curl -fsSL https://get.docker.com | sh
+    # Ensure we have a decent logging driver set up for Docker, for debugging.
+    cat > /etc/docker/daemon.json << EOF
+    {
+            "log-driver": "journald"
+    }
+    EOF
+    systemctl restart docker
+    # In case a user forgets to set the arch correctly, just install binfmt
+    docker run --privileged --rm tonistiigi/binfmt --install all
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    command -v coder >/dev/null 2>&1 && exit 0
+    export DEBIAN_FRONTEND=noninteractive
+    export HOME=/root
+    curl -fsSL https://coder.com/install.sh | sh
+    # Ensure Coder has permissions on /var/run/docker.socket
+    usermod -aG docker coder
+    # Ensure coder listens on all interfaces
+    sed -i 's/CODER_ADDRESS=.*/CODER_ADDRESS=0.0.0.0:3000/' /etc/coder.d/coder.env
+    # Ensure coder starts on boot
+    systemctl enable coder
+    systemctl start coder
+- mode: user
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    # If we are already logged in, nothing to do
+    coder templates list >/dev/null 2>&1 && exit 0
+    # Set up initial user
+    [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --username admin --email admin@coder.com --password password
+probes:
+- description: "docker to be installed"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v docker >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "docker is not installed yet"
+      exit 1
+    fi
+  hint: |
+    See "/var/log/cloud-init-output.log". in the guest
+- description: "coder to be installed"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until command -v coder >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "coder is not installed yet"
+      exit 1
+    fi
+  hint: |
+    See "/var/log/cloud-init-output.log". in the guest
+- description: "terraform to be fully downloaded"
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until [ $(du /var/cache/coder/terraform | awk '{print $1}') -ge 62784 ] >/dev/null 2>&1; do sleep 3; done"; then
+      echo >&2 "terraform is not fully downloaded yet"
+      exit 1
+    fi
+  hint: |
+    Check "/var/cache/coder/terraform" in the guest
+message: |
+  All Done! Your Coder instance is accessible at http://localhost:3000
+  Username: "admin@coder.com"
+  Password: "password" 🤫
+  Start a workspace now by running the following commands:
+  ------
+  limactl shell coder
+  cd && echo code-server | coder templates init
+  cd ./docker-code-server && coder templates create -y
+  coder create -t docker-code-server my-workspace -y
+  ------
+


### PR DESCRIPTION
This PR adds a [lima](https://github.com/lima-vm/lima) template for Coder.

You can now run `limactl start --name=coder ./examples/lima/coder.yaml` and have a "prod-like" Coder instance up and running within a minute or so.