### PR TITLE
feat: Clean up coder agent path in `ps` listing

### DIFF
--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -18,31 +18,35 @@ Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 
 	linuxScript = `#!/usr/bin/env sh
 set -eux pipefail
-BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
+BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
+BINARY_NAME=coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
+cd $BINARY_DIR
 if command -v curl >/dev/null 2>&1; then
-	curl -fsSL --compressed "${BINARY_URL}" -o "${BINARY_LOCATION}"
+	curl -fsSL --compressed "${BINARY_URL}" -o "${BINARY_NAME}"
 elif command -v wget >/dev/null 2>&1; then
-	wget -q "${BINARY_URL}" -O "${BINARY_LOCATION}"
+	wget -q "${BINARY_URL}" -O "${BINARY_NAME}"
 elif command -v busybox >/dev/null 2>&1; then
-	busybox wget -q "${BINARY_URL}" -O "${BINARY_LOCATION}"
+	busybox wget -q "${BINARY_URL}" -O "${BINARY_NAME}"
 else
 	echo "error: no download tool found, please install curl, wget or busybox wget"
 	exit 1
 fi
-chmod +x $BINARY_LOCATION
+chmod +x $BINARY_NAME
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`
+exec ./$BINARY_NAME agent`
 
 	darwinScript = `#!/usr/bin/env sh
 set -eux pipefail
-BINARY_LOCATION=$(mktemp -d -t tmp.coderXXXXXX)/coder
-curl -fsSL --compressed "${ACCESS_URL}bin/coder-darwin-${ARCH}" -o "${BINARY_LOCATION}"
-chmod +x $BINARY_LOCATION
+BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
+BINARY_NAME=coder
+cd $BINARY_DIR
+curl -fsSL --compressed "${ACCESS_URL}bin/coder-darwin-${ARCH}" -o "${BINARY_NAME}"
+chmod +x $BINARY_NAME
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
-exec $BINARY_LOCATION agent`
+exec ./$BINARY_NAME agent`
 
 	// A mapping of operating-system ($GOOS) to architecture ($GOARCH)
 	// to agent install and run script. ${DOWNLOAD_URL} is replaced


### PR DESCRIPTION
This commit changes the `coder agent` path in `ps` listing from
`/tmp/tmp.coderwWs87Y/coder agent` to `./coder agent`.

The path is also updated to `/tmp/coder.wWs87Y`.

There were two options considered for turning `./coder agent` into
`coder agent`:

1. Run `exec -a coder /path/to/coder agent`
2. Run `PATH=/path/to:$PATH exec coder agent`

Option 1 is not supported by `dash`, and thus discarded.

Option 2 duplicates functionality in `coder agent` which _appends_ the
path, here we would want to _prepend_ it to ensure we're starting the
downloaded `coder` binary in case there is a binary with a conflicting
name on the system.

Fixes #2407
