### PR TITLE
test: Write URL after signal listen to fix flake

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -403,11 +403,6 @@ func server() *cobra.Command {
 				errCh <- wg.Wait()
 			}()
 
-			// This is helpful for tests, but can be silently ignored.
-			// Coder may be ran as users that don't have permission to write in the homedir,
-			// such as via the systemd service.
-			_ = config.URL().Write(client.URL.String())
-
 			hasFirstUser, err := client.HasFirstUser(cmd.Context())
 			if !hasFirstUser && err == nil {
 				cmd.Println()
@@ -437,6 +432,12 @@ func server() *cobra.Command {
 			stopChan := make(chan os.Signal, 1)
 			defer signal.Stop(stopChan)
 			signal.Notify(stopChan, os.Interrupt)
+
+			// This is helpful for tests, but can be silently ignored.
+			// Coder may be ran as users that don't have permission to write in the homedir,
+			// such as via the systemd service.
+			_ = config.URL().Write(client.URL.String())
+
 			select {
 			case <-cmd.Context().Done():
 				coderAPI.Close()

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -96,7 +96,7 @@ func (api *API) ListenProvisionerDaemon(ctx context.Context) (client proto.DRPCP
 		},
 	})
 	go func() {
-		err = server.Serve(ctx, serverSession)
+		err := server.Serve(ctx, serverSession)
 		if err != nil && !xerrors.Is(err, io.EOF) {
 			api.Logger.Debug(ctx, "provisioner daemon disconnected", slog.Error(err))
 		}


### PR DESCRIPTION
The URL could be read before the signal was listening, causing
this test to flake: https://github.com/coder/coder/runs/6936820170?check_suite_focus=true
