### PR TITLE
fix: Add --yes and --use-previous-options to config-ssh

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -138,6 +138,7 @@ func configSSH() *cobra.Command {
 	var (
 		sshConfigFile    string
 		sshConfigOpts    sshConfigOptions
+		usePreviousOpts  bool
 		coderConfigFile  string
 		showDiff         bool
 		skipProxyCommand bool
@@ -218,7 +219,9 @@ func configSSH() *cobra.Command {
 
 			// Avoid prompting in diff mode (unexpected behavior)
 			// or when a previous config does not exist.
-			if !showDiff && lastConfig != nil && !sshConfigOpts.equal(*lastConfig) {
+			if usePreviousOpts && lastConfig != nil {
+				sshConfigOpts = *lastConfig
+			} else if !showDiff && lastConfig != nil && !sshConfigOpts.equal(*lastConfig) {
 				newOpts := sshConfigOpts.asList()
 				newOptsMsg := "\n\n  New options: none"
 				if len(newOpts) > 0 {
@@ -394,10 +397,13 @@ func configSSH() *cobra.Command {
 	cmd.Flags().BoolVarP(&showDiff, "diff", "D", false, "Show diff of changes that will be made.")
 	cmd.Flags().BoolVarP(&skipProxyCommand, "skip-proxy-command", "", false, "Specifies whether the ProxyCommand option should be skipped. Useful for testing.")
 	_ = cmd.Flags().MarkHidden("skip-proxy-command")
+	cliflag.BoolVarP(cmd.Flags(), &usePreviousOpts, "use-previous-options", "", "CODER_SSH_USE_PREVIOUS_OPTIONS", false, "Specifies whether or not to keep options from previous run of config-ssh.")
 
 	// Deprecated: Remove after migration period.
 	cmd.Flags().StringVar(&coderConfigFile, "test.ssh-coder-config-file", sshDefaultCoderConfigFileName, "Specifies the path to an Coder SSH config file. Useful for testing.")
 	_ = cmd.Flags().MarkHidden("test.ssh-coder-config-file")
+
+	cliui.AllowSkipPrompt(cmd)
 
 	return cmd
 }

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -446,6 +446,54 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 				{match: "Continue?", write: "no"},
 			},
 		},
+		{
+			name: "Do not prompt when using --yes",
+			writeConfig: writeConfig{
+				ssh: strings.Join([]string{
+					headerStart,
+					"# Last config-ssh options:",
+					"# :ssh-option=ForwardAgent=yes",
+					"#",
+					headerEnd,
+					"",
+				}, "\n"),
+			},
+			wantConfig: wantConfig{
+				ssh: strings.Join([]string{
+					// Last options overwritten.
+					baseHeader,
+					"",
+				}, "\n"),
+			},
+			args: []string{"--yes"},
+		},
+		{
+			name: "Do not prompt for new options when prev opts flag is set",
+			writeConfig: writeConfig{
+				ssh: strings.Join([]string{
+					headerStart,
+					"# Last config-ssh options:",
+					"# :ssh-option=ForwardAgent=yes",
+					"#",
+					headerEnd,
+					"",
+				}, "\n"),
+			},
+			wantConfig: wantConfig{
+				ssh: strings.Join([]string{
+					headerStart,
+					"# Last config-ssh options:",
+					"# :ssh-option=ForwardAgent=yes",
+					"#",
+					headerEnd,
+					"",
+				}, "\n"),
+			},
+			args: []string{
+				"--use-previous-options",
+				"--yes",
+			},
+		},
 
 		// Tests for deprecated split coder config.
 		{


### PR DESCRIPTION
This PR adds support for `--yes` to `coder config-ssh` and `--use-previous-options`. The latter is needed for automations to avoid overwriting the users settings (e.g. `--ssh-option ForwardAgent=yes`).

See https://github.com/coder/coder-jetbrains/issues/11.
