### PR TITLE
Lock the fake database during transactions

### DIFF
--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -14,6 +14,6 @@ func IsInitProcess() bool {
 	return false
 }
 
-func ForkReap(pids reap.PidCh) error {
+func ForkReap(_ reap.PidCh) error {
 	return nil
 }

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -54,10 +54,10 @@ type rwMutex interface {
 // inTxMutex is a no op, since inside a transaction we are already locked.
 type inTxMutex struct{}
 
-func (_ *inTxMutex) Lock()    {}
-func (_ *inTxMutex) RLock()   {}
-func (_ *inTxMutex) Unlock()  {}
-func (_ *inTxMutex) RUnlock() {}
+func (inTxMutex) Lock()    {}
+func (inTxMutex) RLock()   {}
+func (inTxMutex) Unlock()  {}
+func (inTxMutex) RUnlock() {}
 
 // fakeQuerier replicates database functionality to enable quick testing.
 type fakeQuerier struct {
@@ -96,7 +96,7 @@ type data struct {
 func (q *fakeQuerier) InTx(fn func(database.Store) error) error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
-	return fn(&fakeQuerier{mutex: &inTxMutex{}, data: q.data})
+	return fn(&fakeQuerier{mutex: inTxMutex{}, data: q.data})
 }
 
 func (q *fakeQuerier) AcquireProvisionerJob(_ context.Context, arg database.AcquireProvisionerJobParams) (database.ProvisionerJob, error) {

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -18,33 +18,54 @@ import (
 // New returns an in-memory fake of the database.
 func New() database.Store {
 	return &fakeQuerier{
-		apiKeys:             make([]database.APIKey, 0),
-		organizationMembers: make([]database.OrganizationMember, 0),
-		organizations:       make([]database.Organization, 0),
-		users:               make([]database.User, 0),
+		mutex: &sync.RWMutex{},
+		data: &data{
+			apiKeys:             make([]database.APIKey, 0),
+			organizationMembers: make([]database.OrganizationMember, 0),
+			organizations:       make([]database.Organization, 0),
+			users:               make([]database.User, 0),
 
-		auditLogs:               make([]database.AuditLog, 0),
-		files:                   make([]database.File, 0),
-		gitSSHKey:               make([]database.GitSSHKey, 0),
-		parameterSchemas:        make([]database.ParameterSchema, 0),
-		parameterValues:         make([]database.ParameterValue, 0),
-		provisionerDaemons:      make([]database.ProvisionerDaemon, 0),
-		provisionerJobAgents:    make([]database.WorkspaceAgent, 0),
-		provisionerJobLogs:      make([]database.ProvisionerJobLog, 0),
-		provisionerJobResources: make([]database.WorkspaceResource, 0),
-		provisionerJobs:         make([]database.ProvisionerJob, 0),
-		templateVersions:        make([]database.TemplateVersion, 0),
-		templates:               make([]database.Template, 0),
-		workspaceBuilds:         make([]database.WorkspaceBuild, 0),
-		workspaceApps:           make([]database.WorkspaceApp, 0),
-		workspaces:              make([]database.Workspace, 0),
+			auditLogs:               make([]database.AuditLog, 0),
+			files:                   make([]database.File, 0),
+			gitSSHKey:               make([]database.GitSSHKey, 0),
+			parameterSchemas:        make([]database.ParameterSchema, 0),
+			parameterValues:         make([]database.ParameterValue, 0),
+			provisionerDaemons:      make([]database.ProvisionerDaemon, 0),
+			provisionerJobAgents:    make([]database.WorkspaceAgent, 0),
+			provisionerJobLogs:      make([]database.ProvisionerJobLog, 0),
+			provisionerJobResources: make([]database.WorkspaceResource, 0),
+			provisionerJobs:         make([]database.ProvisionerJob, 0),
+			templateVersions:        make([]database.TemplateVersion, 0),
+			templates:               make([]database.Template, 0),
+			workspaceBuilds:         make([]database.WorkspaceBuild, 0),
+			workspaceApps:           make([]database.WorkspaceApp, 0),
+			workspaces:              make([]database.Workspace, 0),
+		},
 	}
 }
 
+type rwMutex interface {
+	Lock()
+	RLock()
+	Unlock()
+	RUnlock()
+}
+
+// inTxMutex is a no op, since inside a transaction we are already locked.
+type inTxMutex struct{}
+
+func (_ *inTxMutex) Lock()    {}
+func (_ *inTxMutex) RLock()   {}
+func (_ *inTxMutex) Unlock()  {}
+func (_ *inTxMutex) RUnlock() {}
+
 // fakeQuerier replicates database functionality to enable quick testing.
 type fakeQuerier struct {
-	mutex sync.RWMutex
+	mutex rwMutex
+	*data
+}
 
+type data struct {
 	// Legacy tables
 	apiKeys             []database.APIKey
 	organizations       []database.Organization
@@ -73,7 +94,9 @@ type fakeQuerier struct {
 
 // InTx doesn't rollback data properly for in-memory yet.
 func (q *fakeQuerier) InTx(fn func(database.Store) error) error {
-	return fn(q)
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	return fn(&fakeQuerier{mutex: &inTxMutex{}, data: q.data})
 }
 
 func (q *fakeQuerier) AcquireProvisionerJob(_ context.Context, arg database.AcquireProvisionerJobParams) (database.ProvisionerJob, error) {


### PR DESCRIPTION
Might fix https://github.com/coder/coder/issues/2436 entirely, but definitely will fix in the fake db case.

There are additional bugs lurking around basically every use of InTx() in our tests that this fixes, because until this PR, transactions exposed intermediate state to other goroutines with the fake database.