### PR TITLE
chore: apply non-durability settings to test postgres container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,13 +127,17 @@ test-postgres-docker:
 		--env POSTGRES_USER=postgres \
 		--env POSTGRES_DB=postgres \
 		--env PGDATA=/tmp \
+		--tmpfs /tmp \
 		--publish 5432:5432 \
 		--name test-postgres-docker \
-		--restart unless-stopped \
+		--restart no \
 		--detach \
 		postgres:11 \
 		-c shared_buffers=1GB \
-		-c max_connections=1000
+		-c max_connections=1000 \
+		-c fsync=off \
+		-c synchronous_commit=off \
+		-c full_page_writes=off
 
 .PHONY: test-clean
 test-clean:


### PR DESCRIPTION
This commit applies some recommended settings to sacrifice durability
for speed for our testing database:
  - Mount PGDATA dir in RAM (--tmpfs /tmp)
  - Turn off fsync
  - Turn off synchronous_commit
  - Turn off full_page_writes

  Ref: https://www.postgresql.org/docs/current/non-durability.html

You can argue that if we are already storing the tmpfs in memory, why do we want the other stuff to avoid disk I/O?
My response is:
- What if we're swapping
- Why not just do it anyway

I tested this out in my v2 workspace (template=coder)
Before: average runtime = 146.6s (N=3)
After: average runtime = 106.4s (N=3)
