### PR TITLE
fix: Fix test flake based on same update time

### DIFF
--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -166,6 +166,9 @@ func TestPatchTemplateMeta(t *testing.T) {
 			MaxTTLMillis:               12 * time.Hour.Milliseconds(),
 			MinAutostartIntervalMillis: time.Minute.Milliseconds(),
 		}
+		// It is unfortunate we need to sleep, but the test can fail if the
+		// updatedAt is too close together.
+		time.Sleep(time.Millisecond * 5)
 		updated, err := client.UpdateTemplateMeta(ctx, template.ID, req)
 		require.NoError(t, err)
 		assert.Greater(t, updated.UpdatedAt, template.UpdatedAt)


### PR DESCRIPTION
Would be nice to somehow mock the clock, but in lieu of that, 5ms shouldn't kill us...

---

Fail logs on windows: https://github.com/coder/coder/runs/6941697979?check_suite_focus=true

```
2022-06-17T19:35:15.8288444Z === Failed
2022-06-17T19:35:15.8288771Z === FAIL: coderd TestPatchTemplateMeta/Modified (0.03s)
2022-06-17T19:35:15.8289561Z     t.go:81: 2022-06-17 19:32:21.754 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	POST /api/v2/users/first
2022-06-17T19:35:15.8290486Z     t.go:81: 2022-06-17 19:32:21.754 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	POST /api/v2/users/login
2022-06-17T19:35:15.8291284Z     t.go:81: 2022-06-17 19:32:21.754 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	POST /api/v2/files
2022-06-17T19:35:15.8292351Z     t.go:81: 2022-06-17 19:32:21.755 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	POST /api/v2/organizations/f12aef77-524c-4f6c-874a-064db00db801/templateversions
2022-06-17T19:35:15.8293460Z     t.go:81: 2022-06-17 19:32:21.756 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	POST /api/v2/organizations/f12aef77-524c-4f6c-874a-064db00db801/templates
2022-06-17T19:35:15.8294486Z     t.go:81: 2022-06-17 19:32:21.757 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	PATCH /api/v2/templates/994b8fd7-7240-42de-803c-20ee3e9309be
2022-06-17T19:35:15.8294967Z     templates_test.go:171: 
2022-06-17T19:35:15.8295405Z         	Error Trace:	templates_test.go:171
2022-06-17T19:35:15.8296234Z         	Error:      	"2022-06-17 19:32:21.7577165 +0000 UTC" is not greater than "2022-06-17 19:32:21.7577165 +0000 UTC"
2022-06-17T19:35:15.8296740Z         	Test:       	TestPatchTemplateMeta/Modified
2022-06-17T19:35:15.8297612Z     t.go:81: 2022-06-17 19:32:21.757 [DEBUG]	<github.com\coder\coder\coderd\coderd.go:384>	debugLogRequest.func1.1	GET /api/v2/templates/994b8fd7-7240-42de-803c-20ee3e9309be
2022-06-17T19:35:15.8298091Z     templates_test.go:179: 
2022-06-17T19:35:15.8298507Z         	Error Trace:	templates_test.go:179
2022-06-17T19:35:15.8299307Z         	Error:      	"2022-06-17 19:32:21.7577165 +0000 UTC" is not greater than "2022-06-17 19:32:21.7577165 +0000 UTC"
2022-06-17T19:35:15.8299809Z         	Test:       	TestPatchTemplateMeta/Modified
2022-06-17T19:35:15.8300330Z     --- FAIL: TestPatchTemplateMeta/Modified (0.03s)
2022-06-17T19:35:15.8300530Z 
2022-06-17T19:35:15.8300708Z === FAIL: coderd TestPatchTemplateMeta (0.00s)
```