### PR TITLE
fix: fix ERRPIPE in build scripts, fix deploy

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -372,7 +372,23 @@ jobs:
         run: make -B site/out/index.html
 
       - name: Build Release
-        run: make build
+        run: |
+          set -euo pipefail
+          go mod download
+
+          mkdir -p ./dist
+          # build slim binaries
+          ./scripts/build_go_slim.sh \
+            --output ./dist/ \
+            linux:amd64,armv7,arm64 \
+            windows:amd64,arm64 \
+            darwin:amd64,arm64
+
+          # build linux amd64 packages
+          ./scripts/build_go_matrix.sh \
+            --output ./dist/ \
+            --package-linux \
+            linux:amd64
 
       - name: Install Release
         run: |

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -35,13 +35,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR" && realpath "$(git rev-parse --show-toplevel)")
 
 # pushd is a silent alternative to the real pushd shell command.
 pushd() {
-	command pushd "$@" >/dev/null
+	command pushd "$@" >/dev/null || error "Could not pushd to '$*'"
 }
 
 # popd is a silent alternative to the real popd shell command.
 # shellcheck disable=SC2120
 popd() {
-	command popd "$@" >/dev/null
+	command popd >/dev/null || error "Could not restore directory with popd"
 }
 
 # cdself changes directory to the directory of the current script. This should
@@ -116,51 +116,62 @@ isdarwin() {
 	[[ "${OSTYPE:-darwin}" == *darwin* ]]
 }
 
-libsh_bad_dependencies=0
+# We don't need to check dependencies more than once per script, but some
+# scripts call other scripts that also `source lib.sh`, so we set an environment
+# variable after successfully checking dependencies once.
+if [[ "${CODER_LIBSH_NO_CHECK_DEPENDENCIES:-}" != *t* ]]; then
+	libsh_bad_dependencies=0
 
-if ((BASH_VERSINFO[0] < 4)); then
-	libsh_bad_dependencies=1
-	log "ERROR: You need at least bash 4.0 to run the scripts in the Coder repo."
-	if isdarwin; then
-		log "On darwin:"
-		log "- brew install bash"
-		log "- Restart your terminal"
+	if ((BASH_VERSINFO[0] < 4)); then
+		libsh_bad_dependencies=1
+		log "ERROR: You need at least bash 4.0 to run the scripts in the Coder repo."
+		if isdarwin; then
+			log "On darwin:"
+			log "- brew install bash"
+			log "- Restart your terminal"
+		fi
+		log
 	fi
-	log
-fi
 
-# BSD getopt (which is installed by default on Macs) is not supported.
-if [[ "$(getopt --version)" == *--* ]]; then
-	libsh_bad_dependencies=1
-	log "ERROR: You need GNU getopt to run the scripts in the Coder repo."
-	if isdarwin; then
-		log "On darwin:"
-		log "- brew install gnu-getopt"
-		# shellcheck disable=SC2016
-		log '- Add "$(brew --prefix)/opt/gnu-getopt/bin" to your PATH'
-		log "- Restart your terminal"
+	# BSD getopt (which is installed by default on Macs) is not supported.
+	if [[ "$(getopt --version)" == *--* ]]; then
+		libsh_bad_dependencies=1
+		log "ERROR: You need GNU getopt to run the scripts in the Coder repo."
+		if isdarwin; then
+			log "On darwin:"
+			log "- brew install gnu-getopt"
+			# shellcheck disable=SC2016
+			log '- Add "$(brew --prefix)/opt/gnu-getopt/bin" to your PATH'
+			log "- Restart your terminal"
+		fi
+		log
 	fi
-	log
-fi
 
-# The bash scripts don't call Make directly, but we want to make (ha ha) sure
-# that make supports the features the repo uses. Notably, Macs have an old
-# version of Make installed out of the box that doesn't support new features
-# like ONESHELL.
-make_version="$(make --version 2>/dev/null | head -n1 | grep -oE '([[:digit:]]+\.){1,2}[[:digit:]]+')"
-if [ "${make_version//.*/}" -lt 4 ]; then
-	libsh_bad_dependencies=1
-	log "ERROR: You need at least make 4.0 to run the scripts in the Coder repo."
-	if isdarwin; then
-		log "On darwin:"
-		log "- brew install make"
-		# shellcheck disable=SC2016
-		log '- Add "$(brew --prefix)/opt/make/libexec/gnubin" to your PATH (you should Google this first)'
-		log "- Restart your terminal"
+	# The bash scripts don't call Make directly, but we want to make (ha ha)
+	# sure that make supports the features the repo uses. Notably, Macs have an
+	# old version of Make installed out of the box that doesn't support new
+	# features like ONESHELL.
+	#
+	# Piping commands directly into `head -n1` may result in ERRPIPE errors, so
+	# we capture the version output first before
+	make_version_raw="$(make --version 2>/dev/null)"
+	make_version="$(echo "$make_version_raw" | head -n1 | grep -oE '([[:digit:]]+\.){1,2}[[:digit:]]+')"
+	if [ "${make_version//.*/}" -lt 4 ]; then
+		libsh_bad_dependencies=1
+		log "ERROR: You need at least make 4.0 to run the scripts in the Coder repo."
+		if isdarwin; then
+			log "On darwin:"
+			log "- brew install make"
+			# shellcheck disable=SC2016
+			log '- Add "$(brew --prefix)/opt/make/libexec/gnubin" to your PATH (you should Google this first)'
+			log "- Restart your terminal"
+		fi
+		log
 	fi
-	log
-fi
 
-if [[ "$libsh_bad_dependencies" == 1 ]]; then
-	error "Invalid dependencies, see above for more details."
+	if [[ "$libsh_bad_dependencies" == 1 ]]; then
+		error "Invalid dependencies, see above for more details."
+	fi
+
+	export CODER_LIBSH_NO_CHECK_DEPENDENCIES=true
 fi


### PR DESCRIPTION
- Fixes an ERRPIPE error that occurs occasionally during the `make` version check in `scripts/lib.sh` (sometimes when you pipe a program into `head -n1` you get an ERRPIPE error because `head` immediately exits after printing the first line)
- Avoids checking dependencies twice by setting an environment variable after the first check
- Calls build scripts directly instead of `make build` in deploy job because `make build` will try to generate files and depends on tools to do so