### PR TITLE
fix: checkout tags in deploy job

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -322,6 +322,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0


### PR DESCRIPTION
The deploy job does a shallow clone without fetching tags, which are required for `version.sh`.
