### PR TITLE
fix: include architecture and version information in linux packages

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -75,7 +75,8 @@ formats=(apk deb rpm)
 for format in "${formats[@]}"; do
 	output_path="$input_file.$format"
 	log "--- Building $format package ($output_path)"
-	nfpm package \
+
+	GOARCH="$arch" CODER_VERSION="$version" nfpm package \
 		-f nfpm.yaml \
 		-p "$format" \
 		-t "$output_path"


### PR DESCRIPTION
The `nfpm.yaml` correctly has environment variable templates for the architecture and version fields, but the `package.sh` script was never setting those environment variables. This resulted in `nfpm` defaulting the packages to the default arch `amd64`

tl;dr: the `arm64` packages were incorrectly marked as `amd64` packages so they couldn't be installed on `arm64` 🤦 

Updates `package.sh` to set `GOARCH` and `CODER_VERSION` which are consumed by `nfpm`.