### PR TITLE
fix: use armhf architecture in linux packages

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -59,6 +59,11 @@ if [[ "$version" == "" ]]; then
 	version="$(execrelative ./version.sh)"
 fi
 
+# armv7 isn't a real architecture, so we need to remap it to armhf.
+if [[ "$arch" == "arm" ]] || [[ "$arch" == "armv7" ]]; then
+	arch="armhf"
+fi
+
 # Make temporary dir where all source files intended to be in the package will
 # be hardlinked from.
 cdroot


### PR DESCRIPTION
New `armv7` package incorrectly has the architecture set to `armv7`, the old packages have it set to `armhf` so lets emulate that.