### PR TITLE
alias users as user

### DIFF
--- a/cli/users.go
+++ b/cli/users.go
@@ -12,8 +12,9 @@ import (
 
 func users() *cobra.Command {
 	cmd := &cobra.Command{
-		Short: "Create, remove, and list users",
-		Use:   "users",
+		Short:   "Create, remove, and list users",
+		Use:     "users",
+		Aliases: []string{"user"},
 	}
 	cmd.AddCommand(
 		userCreate(),


### PR DESCRIPTION
This PR adds an alias `user` to the subcommand `users`.

## Subtasks

- [x] added an alias to the `users` subcommand.

Fixes #2506 

## Screenshot
<img width="412" alt="Screen Shot 2022-06-20 at 10 14 51 AM" src="https://user-images.githubusercontent.com/7511231/174621348-4fe08118-38db-479c-b9c2-34b1b979514d.png">

