### PR TITLE
Update template users language

### DIFF
--- a/site/src/components/TemplateStats/TemplateStats.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.tsx
@@ -11,8 +11,8 @@ const Language = {
   usedByLabel: "Used by",
   activeVersionLabel: "Active version",
   lastUpdateLabel: "Last updated",
-  userPlural: "users",
-  userSingular: "user",
+  developerPlural: "developers",
+  developerSingular: "developer",
   createdByLabel: "Created by",
 }
 
@@ -31,7 +31,7 @@ export const TemplateStats: FC<TemplateStatsProps> = ({ template, activeVersion 
 
         <span className={styles.statsValue}>
           {template.workspace_owner_count}{" "}
-          {template.workspace_owner_count === 1 ? Language.userSingular : Language.userPlural}
+          {template.workspace_owner_count === 1 ? Language.developerSingular : Language.developerPlural}
         </span>
       </div>
       <div className={styles.statsDivider} />


### PR DESCRIPTION
This PR updates the language used to communicate the number of developers using a template on the Template page. Makes it consistent with the Templates list page.

## Subtasks

- [x] updated the language to use `developers` in place of `users`.

Fixes #2469 

## Screenshot
<img width="1144" alt="Screen Shot 2022-06-20 at 10 42 25 AM" src="https://user-images.githubusercontent.com/7511231/174626712-f51f83f2-40d1-4fa1-af73-241ec33ea6f6.png">
<img width="1157" alt="Screen Shot 2022-06-20 at 10 43 00 AM" src="https://user-images.githubusercontent.com/7511231/174626786-22928d5d-0ad3-4489-8a5b-1fdda683c57b.png">

