### PR TITLE
feat: Compress and extract slim binaries with zstd

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -370,6 +370,9 @@ jobs:
       - name: Install nfpm
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.16.0
 
+      - name: Install zstd
+        run: sudo apt-get install -y zstd
+
       - name: Build site
         run: make -B site/out/index.html
 
@@ -382,6 +385,7 @@ jobs:
           # build slim binaries
           ./scripts/build_go_slim.sh \
             --output ./dist/ \
+            --compress 22 \
             linux:amd64,armv7,arm64 \
             windows:amd64,arm64 \
             darwin:amd64,arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,9 @@ jobs:
       - name: Install nfpm
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.16.0
 
+      - name: Install zstd
+        run: sudo apt-get install -y zstd
+
       - name: Build Site
         run: make site/out/index.html
 
@@ -80,6 +83,7 @@ jobs:
           # build slim binaries
           ./scripts/build_go_slim.sh \
             --output ./dist/ \
+            --compress 22 \
             linux:amd64,armv7,arm64 \
             windows:amd64,arm64 \
             darwin:amd64,arm64
@@ -198,6 +202,9 @@ jobs:
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
 
+          # Used for compressing embedded slim binaries
+          brew install zstd
+
       - name: Build Site
         run: make site/out/index.html
 
@@ -210,6 +217,7 @@ jobs:
           # build slim binaries
           ./scripts/build_go_slim.sh \
             --output ./dist/ \
+            --compress 22 \
             linux:amd64,armv7,arm64 \
             windows:amd64,arm64 \
             darwin:amd64,arm64

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build: site/out/index.html $(shell find . -not -path './vendor/*' -type f -name 
 	# build slim artifacts and copy them to the site output directory
 	./scripts/build_go_slim.sh \
 		--version "$(VERSION)" \
-		--compress 22 \
+		--compress 6 \
 		--output ./dist/ \
 		linux:amd64,armv7,arm64 \
 		windows:amd64,arm64 \

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ build: site/out/index.html $(shell find . -not -path './vendor/*' -type f -name 
 	# build slim artifacts and copy them to the site output directory
 	./scripts/build_go_slim.sh \
 		--version "$(VERSION)" \
+		--compress 22 \
 		--output ./dist/ \
 		linux:amd64,armv7,arm64 \
 		windows:amd64,arm64 \

--- a/cli/server.go
+++ b/cli/server.go
@@ -254,6 +254,7 @@ func server() *cobra.Command {
 				Logger:               logger.Named("coderd"),
 				Database:             databasefake.New(),
 				Pubsub:               database.NewPubsubInMemory(),
+				CacheDir:             cacheDir,
 				GoogleTokenValidator: googleTokenValidator,
 				SecureAuthCookie:     secureAuthCookie,
 				SSHKeygenAlgorithm:   sshKeygenAlgorithm,

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -23,7 +23,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 version=""
 output_path=""
-compress=""
+compress=0
 
 args="$(getopt -o "" -l version:,output:,compress: -- "$@")"
 eval set -- "$args"
@@ -53,10 +53,10 @@ done
 
 # Check dependencies
 dependencies go
-if [[ -n $compress ]]; then
+if [[ $compress != 0 ]]; then
 	dependencies tar zstd
 
-	if [[ ! $compress == [0-9]* ]] || ((compress > 22)) || ((compress < 1)); then
+	if [[ $compress != [0-9]* ]] || ((compress > 22)) || ((compress < 1)); then
 		error "Invalid value for compress, must in in the range of [1, 22]"
 	fi
 fi

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -106,6 +106,7 @@ for f in ./coder-slim_*; do
 done
 
 if [[ -n $compress ]]; then
+	log "--- Compressing coder-slim binaries using zstd level $compress ($dest_dir/coder.tar.zst)"
 	(
 		cd "$dest_dir"
 		tar cf coder.tar coder-*

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -114,6 +114,6 @@ if [[ $compress != 0 ]]; then
 	pushd "$dest_dir"
 	tar cf coder.tar coder-*
 	rm coder-*
-	zstd --ultra --long -"${compress}" --rm --no-progress coder.tar -o coder.tar.zst
+	zstd --force --ultra --long -"${compress}" --rm --no-progress coder.tar -o coder.tar.zst
 	popd
 fi

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -15,6 +15,10 @@
 #
 # The built binaries are additionally copied to the site output directory so
 # they can be packaged into non-slim binaries correctly.
+#
+# When the --compress <level> parameter is provided, the binaries in site/bin
+# will be compressed using zstd into site/bin/coder.tar.zst, this helps reduce
+# final binary size significantly.
 
 set -euo pipefail
 shopt -s nullglob

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -107,10 +107,9 @@ done
 
 if [[ $compress != 0 ]]; then
 	log "--- Compressing coder-slim binaries using zstd level $compress ($dest_dir/coder.tar.zst)"
-	(
-		cd "$dest_dir"
-		tar cf coder.tar coder-*
-		rm coder-*
-		zstd --ultra --long -"${compress}" --rm --no-progress coder.tar -o coder.tar.zst
-	)
+	pushd "$dest_dir"
+	tar cf coder.tar coder-*
+	rm coder-*
+	zstd --ultra --long -"${compress}" --rm --no-progress coder.tar -o coder.tar.zst
+	popd
 fi

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -56,7 +56,7 @@ dependencies go
 if [[ $compress != 0 ]]; then
 	dependencies tar zstd
 
-	if [[ $compress != [0-9]* ]] || ((compress > 22)) || ((compress < 1)); then
+	if [[ $compress != [0-9]* ]] || [[ $compress -gt 22 ]] || [[ $compress -lt 1 ]]; then
 		error "Invalid value for compress, must in in the range of [1, 22]"
 	fi
 fi

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -105,7 +105,7 @@ for f in ./coder-slim_*; do
 	cp "$f" "$dest"
 done
 
-if [[ -n $compress ]]; then
+if [[ $compress != 0 ]]; then
 	log "--- Compressing coder-slim binaries using zstd level $compress ($dest_dir/coder.tar.zst)"
 	(
 		cd "$dest_dir"

--- a/scripts/build_go_slim.sh
+++ b/scripts/build_go_slim.sh
@@ -3,7 +3,7 @@
 # This script builds multiple "slim" Go binaries for Coder with the given OS and
 # architecture combinations. This wraps ./build_go_matrix.sh.
 #
-# Usage: ./build_go_slim.sh [--version 1.2.3-devel+abcdef] [--output dist/] os1:arch1,arch2 os2:arch1 os1:arch3
+# Usage: ./build_go_slim.sh [--version 1.2.3-devel+abcdef] [--output dist/] [--compress 22] os1:arch1,arch2 os2:arch1 os1:arch3
 #
 # If no OS:arch combinations are provided, nothing will happen and no error will
 # be returned. If no version is specified, defaults to the version from

--- a/site/site.go
+++ b/site/site.go
@@ -386,10 +386,10 @@ func htmlFiles(files fs.FS) (*htmlTemplates, error) {
 // ${CODER_CACHE_DIRECTORY}/site/bin).
 func ExtractOrReadBinFS(dest string, siteFS fs.FS) (http.FileSystem, error) {
 	if dest == "" {
-		// No destionation on fs, embedd fs is the only option.
+		// No destination on fs, embedded fs is the only option.
 		binFS, err := fs.Sub(siteFS, "bin")
 		if err != nil {
-			return nil, xerrors.Errorf("cache path is empty and embedd fs does not have /bin: %w", err)
+			return nil, xerrors.Errorf("cache path is empty and embedded fs does not have /bin: %w", err)
 		}
 		return http.FS(binFS), nil
 	}

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -174,15 +173,6 @@ func TestShouldCacheFile(t *testing.T) {
 		got := site.ShouldCacheFile(testCase.reqFile)
 		require.Equal(t, testCase.expected, got, fmt.Sprintf("Expected ShouldCacheFile(%s) to be %t", testCase.reqFile, testCase.expected))
 	}
-}
-
-func readFile(t *testing.T, name string) []byte {
-	t.Helper()
-	b, err := os.ReadFile(name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
 }
 
 func TestServingBin(t *testing.T) {

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -322,11 +322,12 @@ func TestServingBin(t *testing.T) {
 					defer resp.Body.Close()
 
 					gotStatus := resp.StatusCode
+					gotBody, _ := io.ReadAll(resp.Body)
+
 					if tr.wantStatus > 0 {
 						assert.Equal(t, tr.wantStatus, gotStatus, "status did not match")
 					}
 					if tr.wantBody != nil {
-						gotBody, _ := io.ReadAll(resp.Body)
 						assert.Equal(t, string(tr.wantBody), string(gotBody), "body did not match")
 					}
 				})


### PR DESCRIPTION
This PR adds support for compressing coder slim binaries. The binaries will be embedded as `site/bin/coder.tar.zst` and unpacked on coder startup.

Cases:

1. The `bin/coder.tar.zst` archive is present -> extracted to `$CODER_CACHE_DIR/site/bin` and served via `http.Dir`
2. There are files other than `GITKEEP` in embedded fs under `bin/` -> serve from embedd fs
3. There is no `bin/` or only `bin/GITKEEP` in embedd fs -> serve from empty `$CODER_CACHE_DIR/site/bin` (allows manual placement)

- feat: Add support for zstd compression of slim binaries
- feat: Add support for extract and serve of zstd bins

Fixes #2202

Changes here may also affect #1547 (i.e. 404 for /bin won't return index.html).

## TODO:

- [x] Only use compression level 22 for releases, level 6 or 7 should suffice for quick builds
- ~~Only extract archive once (currently extracted on each startup)~~ (This will be a separate PR)

## Notes

Decompression is sufficiently fast at around 0.6 - 1 second and will not delay startup significantly.

The following results show that compression after level 6 or 7 show diminishing returns until "ultra" levels of 20+.

```shell
for threads in T1 T0; do
	for level in 3 5 7 9 12 15 16 17 18 19 20 21 22; do
		print "\nZstd ${level} ${threads}:"
		time zstd --ultra --long -$level -$threads -o coder-zstd-level-$level-$threads.tar.zst coder.tar
	done
done

Zstd 3 T1:
coder.tar            : 27.92%   (   271 MiB =>   75.6 MiB, coder-zstd-level-3-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  3.15s user 0.34s system 109% cpu 3.192 total

Zstd 5 T1:
coder.tar            : 27.16%   (   271 MiB =>   73.6 MiB, coder-zstd-level-5-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  4.96s user 0.31s system 106% cpu 4.946 total

Zstd 7 T1:
coder.tar            : 26.16%   (   271 MiB =>   70.9 MiB, coder-zstd-level-7-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  7.12s user 0.33s system 104% cpu 7.105 total

Zstd 9 T1:
coder.tar            : 25.66%   (   271 MiB =>   69.5 MiB, coder-zstd-level-9-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  9.25s user 0.28s system 103% cpu 9.233 total

Zstd 12 T1:
coder.tar            : 25.15%   (   271 MiB =>   68.1 MiB, coder-zstd-level-12-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  20.56s user 0.45s system 101% cpu 20.706 total

Zstd 15 T1:
coder.tar            : 24.91%   (   271 MiB =>   67.5 MiB, coder-zstd-level-15-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  51.20s user 0.47s system 100% cpu 51.433 total

Zstd 16 T1:
coder.tar            : 24.08%   (   271 MiB =>   65.2 MiB, coder-zstd-level-16-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  77.86s user 0.30s system 99% cpu 1:18.18 total

Zstd 17 T1:
coder.tar            : 23.59%   (   271 MiB =>   63.9 MiB, coder-zstd-level-17-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  98.41s user 0.34s system 99% cpu 1:38.88 total

Zstd 18 T1:
coder.tar            : 22.52%   (   271 MiB =>   61.0 MiB, coder-zstd-level-18-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  121.11s user 0.35s system 100% cpu 2:01.44 total

Zstd 19 T1:
coder.tar            : 22.22%   (   271 MiB =>   60.2 MiB, coder-zstd-level-19-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  144.87s user 0.46s system 100% cpu 2:25.16 total

Zstd 20 T1:
coder.tar            : 19.30%   (   271 MiB =>   52.3 MiB, coder-zstd-level-20-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  144.46s user 0.42s system 100% cpu 2:24.55 total

Zstd 21 T1:
coder.tar            : 18.09%   (   271 MiB =>   49.0 MiB, coder-zstd-level-21-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  161.54s user 0.51s system 99% cpu 2:42.07 total

Zstd 22 T1:
coder.tar            : 17.80%   (   271 MiB =>   48.2 MiB, coder-zstd-level-22-T1.tar.zst)
zstd --ultra --long -$level -$threads -o  coder.tar  144.54s user 0.89s system 100% cpu 2:25.36 total
```
