### PR TITLE
chore: Prefer `[[` over `[` in bash build scripts

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -156,7 +156,7 @@ if [[ "${CODER_LIBSH_NO_CHECK_DEPENDENCIES:-}" != *t* ]]; then
 	# we capture the version output first before
 	make_version_raw="$(make --version 2>/dev/null)"
 	make_version="$(echo "$make_version_raw" | head -n1 | grep -oE '([[:digit:]]+\.){1,2}[[:digit:]]+')"
-	if [ "${make_version//.*/}" -lt 4 ]; then
+	if [[ ${make_version//.*/} -lt 4 ]]; then
 		libsh_bad_dependencies=1
 		log "ERROR: You need at least make 4.0 to run the scripts in the Coder repo."
 		if isdarwin; then

--- a/scripts/sign_darwin.sh
+++ b/scripts/sign_darwin.sh
@@ -48,7 +48,7 @@ rc=0
 for i in $(seq 1 2); do
 	gon "$config" && rc=0 && break || rc=$?
 	log "gon exit code: $rc"
-	if [ "$i" -lt 5 ]; then
+	if [[ $i -lt 5 ]]; then
 		log
 		log "Retrying notarization in 60 seconds"
 		log

--- a/scripts/yarn_install.sh
+++ b/scripts/yarn_install.sh
@@ -23,7 +23,7 @@ PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 		# --check-files
 	)
 
-	if [ -n "${CI:-}" ]; then
+	if [[ -n ${CI:-} ]]; then
 		yarn_flags+=(
 			# Install dependencies from lockfile, ensuring builds are fully
 			# reproducible


### PR DESCRIPTION
As discussed in https://github.com/coder/coder/pull/2533#discussion_r901886315 this PR removes the (mixed) use of `[` and `[[`, prefering `[[`.

Portable scripts like `install.sh` were not touched so as to support `/bin/sh` interpreters.
