### PR TITLE
fix: Wait for TestServer/Telemetry to close before exit

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -267,6 +267,8 @@ func TestServer(t *testing.T) {
 
 		<-deployment
 		<-snapshot
+		cancelFunc()
+		<-errC
 	})
 }
 


### PR DESCRIPTION
This was causing occasional test failures due to leakage!
