### PR TITLE
Condense footer

### DIFF
--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
+import AccountTreeIcon from "@material-ui/icons/AccountTree"
 import AssistantIcon from "@material-ui/icons/Assistant"
 import * as TypesGen from "../../api/typesGenerated"
 
@@ -22,14 +23,15 @@ export const Footer: React.FC<FooterProps> = ({ buildInfo }) => {
 
   return (
     <div className={styles.root}>
-      <Link className={styles.link} variant="caption" target="_blank" href={githubUrl}>
-        <AssistantIcon className={styles.assistantIcon} /> {Language.reportBugLink}
-      </Link>
       <div className={styles.copyRight}>{Language.copyrightText}</div>
       {buildInfo && (
         <div className={styles.buildInfo}>
           <Link className={styles.link} variant="caption" target="_blank" href={buildInfo.external_url}>
-            {Language.buildInfoText(buildInfo)}
+            <AccountTreeIcon className={styles.icon} /> {Language.buildInfoText(buildInfo)}
+          </Link>
+          &nbsp;|&nbsp;
+          <Link className={styles.link} variant="caption" target="_blank" href={githubUrl}>
+            <AssistantIcon className={styles.icon} /> {Language.reportBugLink}
           </Link>
         </div>
       )}
@@ -51,6 +53,7 @@ const useFooterStyles = makeStyles((theme) => ({
   },
   buildInfo: {
     margin: theme.spacing(0.25),
+    display: "inline-flex",
   },
   link: {
     color: theme.palette.text.secondary,
@@ -59,7 +62,7 @@ const useFooterStyles = makeStyles((theme) => ({
     alignItems: "center",
     justifyContent: "center",
   },
-  assistantIcon: {
+  icon: {
     fontSize: 12,
     color: theme.palette.secondary.dark,
     marginRight: theme.spacing(0.5),


### PR DESCRIPTION
Since the footer is included in every page, we should try extra
hard to use little vertical space.

Also, I add an icon to the version text for balance.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->

---

Before:
<img width="514" alt="image" src="https://user-images.githubusercontent.com/7416144/174853325-ce5f014f-dc9d-499e-8230-d12f5e14a986.png">

After:
<img width="535" alt="image" src="https://user-images.githubusercontent.com/7416144/174853379-295a15c9-5670-4f2d-b3e3-91a402661b38.png">


