### PR TITLE
Wrap code text in readme files on template page

### DIFF
--- a/site/src/pages/TemplatePage/TemplatePageView.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageView.stories.tsx
@@ -19,7 +19,19 @@ Example.args = {
 export const SmallViewport = Template.bind({})
 SmallViewport.args = {
   template: Mocks.MockTemplate,
-  activeTemplateVersion: Mocks.MockTemplateVersion,
+  activeTemplateVersion: {
+    ...Mocks.MockTemplateVersion,
+    readme: `---
+name:Template test
+---
+## Instructions
+You can add instructions here
+
+[Some link info](https://coder.com)
+\`\`\`
+# This is a really long sentence to test that the code block wraps into a new line properly.
+\`\`\``,
+  },
   templateResources: [Mocks.MockWorkspaceResource, Mocks.MockWorkspaceResource2],
 }
 SmallViewport.parameters = {

--- a/site/src/pages/TemplatePage/TemplatePageView.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageView.tsx
@@ -83,6 +83,12 @@ export const useStyles = makeStyles((theme) => {
     markdownWrapper: {
       background: theme.palette.background.paper,
       padding: theme.spacing(3.5),
+
+      // Adds text wrapping to <pre> tag added by ReactMarkdown
+      "& pre": {
+        whiteSpace: "pre-wrap",
+        wordWrap: "break-word",
+      },
     },
     resourcesTableContents: {
       margin: 0,


### PR DESCRIPTION
This PR wraps the code portion in template README files.

## Subtasks

- [x] add relevant CSS
- [x] add story

Fixes #2298
Fixes #2385 

## Screenshot
![Screen Shot 2022-06-21 at 3 58 12 PM](https://user-images.githubusercontent.com/7511231/174887038-001dcc91-16bb-437d-983b-c8df0354c5ac.png)

