### PR TITLE
fix: cleanup reaper implementation

### DIFF
--- a/agent/reaper/reaper.go
+++ b/agent/reaper/reaper.go
@@ -1,0 +1,28 @@
+package reaper
+
+import "github.com/hashicorp/go-reap"
+
+type Option func(o *options)
+
+// WithExecArgs specifies the exec arguments for the fork exec call.
+// By default the same arguments as the parent are used as dictates by
+// os.Args. Since ForkReap calls a fork-exec it is the responsibility of
+// the caller to avoid fork-bombing oneself.
+func WithExecArgs(args ...string) Option {
+	return func(o *options) {
+		o.ExecArgs = args
+	}
+}
+
+// WithPIDCallback sets the channel that reaped child process PIDs are pushed
+// onto.
+func WithPIDCallback(ch reap.PidCh) Option {
+	return func(o *options) {
+		o.PIDs = ch
+	}
+}
+
+type options struct {
+	ExecArgs []string
+	PIDs     reap.PidCh
+}

--- a/agent/reaper/reaper.go
+++ b/agent/reaper/reaper.go
@@ -5,7 +5,7 @@ import "github.com/hashicorp/go-reap"
 type Option func(o *options)
 
 // WithExecArgs specifies the exec arguments for the fork exec call.
-// By default the same arguments as the parent are used as dictates by
+// By default the same arguments as the parent are used as dictated by
 // os.Args. Since ForkReap calls a fork-exec it is the responsibility of
 // the caller to avoid fork-bombing oneself.
 func WithExecArgs(args ...string) Option {

--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -4,16 +4,11 @@ package reaper
 
 import "github.com/hashicorp/go-reap"
 
-// IsChild returns true if we're the forked process.
-func IsChild() bool {
-	return false
-}
-
 // IsInitProcess returns true if the current process's PID is 1.
 func IsInitProcess() bool {
 	return false
 }
 
-func ForkReap(_ reap.PidCh) error {
+func ForkReap(opt ...Option) error {
 	return nil
 }

--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -2,8 +2,6 @@
 
 package reaper
 
-import "github.com/hashicorp/go-reap"
-
 // IsInitProcess returns true if the current process's PID is 1.
 func IsInitProcess() bool {
 	return false

--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -24,17 +24,16 @@ func TestReap(t *testing.T) {
 		t.Skip("Detected CI, skipping reaper tests")
 	}
 
-	// Because we're forkexecing these tests will try to run twice...
-	if reaper.IsChild() {
-		t.Skip("I'm a child!")
-	}
-
 	// OK checks that's the reaper is successfully reaping
 	// exited processes and passing the PIDs through the shared
 	// channel.
 	t.Run("OK", func(t *testing.T) {
 		pids := make(reap.PidCh, 1)
-		err := reaper.ForkReap(pids)
+		err := reaper.ForkReap(
+			reaper.WithPIDCallback(pids),
+			// Provide some argument that immediately exits.
+			reaper.WithExecArgs("/bin/sh", "-c", "exit 0"),
+		)
 		require.NoError(t, err)
 
 		cmd := exec.Command("tail", "-f", "/dev/null")

--- a/agent/reaper/reaper_unix.go
+++ b/agent/reaper/reaper_unix.go
@@ -3,24 +3,12 @@
 package reaper
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 
 	"github.com/hashicorp/go-reap"
 	"golang.org/x/xerrors"
 )
-
-// agentEnvMark is a simple environment variable that we use as a marker
-// to indicated that the process is a child as opposed to the reaper.
-// Since we are forkexec'ing we need to be able to differentiate between
-// the two to avoid fork bombing ourselves.
-const agentEnvMark = "CODER_DO_NOT_REAP"
-
-// IsChild returns true if we're the forked process.
-func IsChild() bool {
-	return os.Getenv(agentEnvMark) != ""
-}
 
 // IsInitProcess returns true if the current process's PID is 1.
 func IsInitProcess() bool {
@@ -33,19 +21,16 @@ func IsInitProcess() bool {
 // the reaper and an exec.Command waiting for its process to complete.
 // The provided 'pids' channel may be nil if the caller does not care about the
 // reaped children PIDs.
-func ForkReap(pids reap.PidCh) error {
-	// Check if the process is the parent or the child.
-	// If it's the child we want to skip attempting to reap.
-	if IsChild() {
-		return nil
+func ForkReap(opt ...Option) error {
+	opts := &options{
+		ExecArgs: os.Args,
 	}
 
-	go reap.ReapChildren(pids, nil, nil, nil)
+	for _, o := range opt {
+		o(opts)
+	}
 
-	args := os.Args
-	// This is simply done to help identify the real agent process
-	// when viewing in something like 'ps'.
-	args = append(args, "#Agent")
+	go reap.ReapChildren(opts.PIDs, nil, nil, nil)
 
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -54,8 +39,7 @@ func ForkReap(pids reap.PidCh) error {
 
 	pattrs := &syscall.ProcAttr{
 		Dir: pwd,
-		// Add our marker for identifying the child process.
-		Env: append(os.Environ(), fmt.Sprintf("%s=true", agentEnvMark)),
+		Env: os.Environ(),
 		Sys: &syscall.SysProcAttr{
 			Setsid: true,
 		},
@@ -67,7 +51,7 @@ func ForkReap(pids reap.PidCh) error {
 	}
 
 	//#nosec G204
-	pid, _ := syscall.ForkExec(args[0], args, pattrs)
+	pid, _ := syscall.ForkExec(opts.ExecArgs[0], opts.ExecArgs, pattrs)
 
 	var wstatus syscall.WaitStatus
 	_, err = syscall.Wait4(pid, &wstatus, 0, nil)


### PR DESCRIPTION
- Clean up the agent/reaper API to be a more isolated and reusable package.

Primarily removes env var pollution (`CODER_DO_NOT_REAP`) and cleans up the API a little bit.
