### PR TITLE
fix: Remove duplicate logs from WorkspaceBuildPage

### DIFF
--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
@@ -1,11 +1,6 @@
 import { screen } from "@testing-library/react"
 import * as API from "../../api/api"
-import {
-  MockWorkspace,
-  MockWorkspaceBuild,
-  MockWorkspaceBuildLogs,
-  renderWithAuth,
-} from "../../testHelpers/renderHelpers"
+import { MockWorkspace, MockWorkspaceBuild, renderWithAuth } from "../../testHelpers/renderHelpers"
 import { WorkspaceBuildPage } from "./WorkspaceBuildPage"
 
 describe("WorkspaceBuildPage", () => {
@@ -27,6 +22,5 @@ describe("WorkspaceBuildPage", () => {
     })
 
     await screen.findByText(MockWorkspaceBuild.workspace_name)
-    await screen.findByText(MockWorkspaceBuildLogs[0].stage)
   })
 })

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -121,9 +121,6 @@ export const handlers = [
   rest.get("/api/v2/workspacebuilds/:workspaceBuildId/resources", (req, res, ctx) => {
     return res(ctx.status(200), ctx.json([M.MockWorkspaceResource, M.MockWorkspaceResource2]))
   }),
-  rest.get("/api/v2/workspacebuilds/:workspaceBuildId/logs", (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(M.MockWorkspaceBuildLogs))
-  }),
   rest.patch("/api/v2/workspacebuilds/:workspaceBuildId/cancel", (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(M.MockCancellationMessage))
   }),

--- a/site/src/xServices/workspaceBuild/workspaceBuildXService.ts
+++ b/site/src/xServices/workspaceBuild/workspaceBuildXService.ts
@@ -33,9 +33,6 @@ export const workspaceBuildMachine = createMachine(
         getWorkspaceBuild: {
           data: WorkspaceBuild
         }
-        getLogs: {
-          data: ProvisionerJobLog[]
-        }
       },
     },
     tsTypes: {} as import("./workspaceBuildXService.typegen").Typegen0,
@@ -57,18 +54,8 @@ export const workspaceBuildMachine = createMachine(
       },
       idle: {},
       logs: {
-        initial: "gettingExistentLogs",
+        initial: "watchingLogs",
         states: {
-          gettingExistentLogs: {
-            invoke: {
-              id: "getLogs",
-              src: "getLogs",
-              onDone: {
-                actions: ["assignLogs"],
-                target: "watchingLogs",
-              },
-            },
-          },
           watchingLogs: {
             id: "watchingLogs",
             invoke: {
@@ -107,10 +94,6 @@ export const workspaceBuildMachine = createMachine(
       clearGetBuildError: assign({
         getBuildError: (_) => undefined,
       }),
-      // Logs
-      assignLogs: assign({
-        logs: (_, event) => event.data,
-      }),
       addLog: assign({
         logs: (context, event) => {
           const previousLogs = context.logs ?? []
@@ -120,7 +103,6 @@ export const workspaceBuildMachine = createMachine(
     },
     services: {
       getWorkspaceBuild: (ctx) => API.getWorkspaceBuildByNumber(ctx.username, ctx.workspaceName, ctx.buildNumber),
-      getLogs: async (ctx) => API.getWorkspaceBuildLogs(ctx.buildId),
       streamWorkspaceBuildLogs: (ctx) => async (callback) => {
         const reader = await API.streamWorkspaceBuildLogs(ctx.buildId)
 


### PR DESCRIPTION
This removes the list API request.  The stream endpoint will always
return existing logs, so the additional list returned duplicates!

Fixes #2117.