### PR TITLE
Open a new window for each click on `Open terminal`

### DIFF
--- a/site/src/components/TerminalLink/TerminalLink.tsx
+++ b/site/src/components/TerminalLink/TerminalLink.tsx
@@ -4,10 +4,11 @@ import ComputerIcon from "@material-ui/icons/Computer"
 import { FC } from "react"
 import * as TypesGen from "../../api/typesGenerated"
 import { combineClasses } from "../../util/combineClasses"
+import { generateRandomString } from "../../util/random"
 
 export const Language = {
   linkText: "Open terminal",
-  terminalTitle: "Terminal",
+  terminalTitle: (identifier: string): string => `Terminal - ${identifier}`,
 }
 
 export interface TerminalLinkProps {
@@ -35,7 +36,7 @@ export const TerminalLink: FC<TerminalLinkProps> = ({ agentName, userName = "me"
       target="_blank"
       onClick={(event) => {
         event.preventDefault()
-        window.open(href, Language.terminalTitle, "width=900,height=600")
+        window.open(href, Language.terminalTitle(generateRandomString(12)), "width=900,height=600")
       }}
     >
       <ComputerIcon className={styles.icon} />


### PR DESCRIPTION
This PR makes sure that a new window is open when clicking on `Open terminal` on the workspaces page. This allows the user to open multiple terminals, for the same or different workspaces.

## Subtasks

- [x] update the name of the window using a random string identifier.

Fixes #2542 
