### PR TITLE
fix: Use WebSockets to stream workspace build logs

### DIFF
--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -6,11 +6,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+	"nhooyr.io/websocket"
+
+	"github.com/coder/coder/coderd/httpmw"
 )
 
 type LogSource string
@@ -106,17 +111,30 @@ func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after
 	if !after.IsZero() {
 		afterQuery = fmt.Sprintf("&after=%d", after.UTC().UnixMilli())
 	}
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("%s?follow%s", path, afterQuery), nil)
+	followURL, err := c.URL.Parse(fmt.Sprintf("%s?follow%s", path, afterQuery))
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode != http.StatusOK {
-		defer res.Body.Close()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, xerrors.Errorf("create cookie jar: %w", err)
+	}
+	jar.SetCookies(followURL, []*http.Cookie{{
+		Name:  httpmw.SessionTokenKey,
+		Value: c.SessionToken,
+	}})
+	httpClient := &http.Client{
+		Jar: jar,
+	}
+	conn, res, err := websocket.Dial(ctx, followURL.String(), &websocket.DialOptions{
+		HTTPClient:      httpClient,
+		CompressionMode: websocket.CompressionDisabled,
+	})
+	if err != nil {
 		return nil, readBodyAsError(res)
 	}
-
 	logs := make(chan ProvisionerJobLog)
-	decoder := json.NewDecoder(res.Body)
+	decoder := json.NewDecoder(websocket.NetConn(ctx, conn, websocket.MessageText))
 	go func() {
 		defer close(logs)
 		var log ProvisionerJobLog

--- a/scripts/build_go_matrix.sh
+++ b/scripts/build_go_matrix.sh
@@ -193,7 +193,7 @@ for spec in "${specs[@]}"; do
 		--os "$spec_os" \
 		--arch "$spec_arch" \
 		--output "$spec_output_binary" \
-		"${build_args[@]}"
+		"${build_args[@]}" &
 	log
 	log
 
@@ -227,3 +227,5 @@ for spec in "${specs[@]}"; do
 		log
 	fi
 done
+
+wait

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -19,16 +19,16 @@ echo '== Without these binaries, workspaces will fail to start!'
 	cd "${PROJECT_ROOT}"
 
 	trap 'kill 0' SIGINT
-	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
+	CODER_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
 	go run -tags embed cmd/coder/main.go server --in-memory --tunnel &
 
 	# Just a minor sleep to ensure the first user was created to make the member.
-	sleep 2
+	sleep 5
 
 	#  create the first user, the admin
 	go run cmd/coder/main.go login http://127.0.0.1:3000 --username=admin --email=admin@coder.com --password=password || true
 
 	# || yes to always exit code 0. If this fails, whelp.
-	go run cmd/coder/main.go users create --email=member@coder.com --username=member --password="${CODER_DEV_ADMIN_PASSWORD}" || true
+	go run cmd/coder/main.go users create --email=member@coder.com --username=member --password=password || true
 	wait
 )

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -280,7 +280,7 @@ export const getWorkspaceBuildByNumber = async (
 }
 
 export const getWorkspaceBuildLogs = async (buildname: string, before: Date): Promise<TypesGen.ProvisionerJobLog[]> => {
-  const response = await axios.get<TypesGen.ProvisionerJobLog[]>(`/api/v2/workspacebuilds/${buildname}/logs?before=`+before.getTime())
+  const response = await axios.get<TypesGen.ProvisionerJobLog[]>(`/api/v2/workspacebuilds/${buildname}/logs?before=${before.getTime()}`)
   return response.data
 }
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosRequestHeaders } from "axios"
-import ndjsonStream from "can-ndjson-stream"
 import * as Types from "./types"
 import { WorkspaceBuildTransition } from "./types"
 import * as TypesGen from "./typesGenerated"
@@ -280,23 +279,9 @@ export const getWorkspaceBuildByNumber = async (
   return response.data
 }
 
-export const getWorkspaceBuildLogs = async (buildname: string): Promise<TypesGen.ProvisionerJobLog[]> => {
-  const response = await axios.get<TypesGen.ProvisionerJobLog[]>(`/api/v2/workspacebuilds/${buildname}/logs`)
+export const getWorkspaceBuildLogs = async (buildname: string, before: Date): Promise<TypesGen.ProvisionerJobLog[]> => {
+  const response = await axios.get<TypesGen.ProvisionerJobLog[]>(`/api/v2/workspacebuilds/${buildname}/logs?before=`+before.getTime())
   return response.data
-}
-
-export const streamWorkspaceBuildLogs = async (
-  buildname: string,
-): Promise<ReadableStreamDefaultReader<TypesGen.ProvisionerJobLog>> => {
-  // Axios does not support HTTP stream in the browser
-  // https://github.com/axios/axios/issues/1474
-  // So we are going to use window.fetch and return a "stream" reader
-  const reader = await window
-    .fetch(`/api/v2/workspacebuilds/${buildname}/logs?follow=true`)
-    .then((res) => ndjsonStream<TypesGen.ProvisionerJobLog>(res.body))
-    .then((stream) => stream.getReader())
-
-  return reader
 }
 
 export const putWorkspaceExtension = async (

--- a/site/src/components/WorkspaceBuildLogs/WorkspaceBuildLogs.stories.tsx
+++ b/site/src/components/WorkspaceBuildLogs/WorkspaceBuildLogs.stories.tsx
@@ -13,9 +13,3 @@ export const Example = Template.bind({})
 Example.args = {
   logs: MockWorkspaceBuildLogs,
 }
-
-export const Loading = Template.bind({})
-Loading.args = {
-  logs: MockWorkspaceBuildLogs,
-  isWaitingForLogs: true,
-}

--- a/site/src/components/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/components/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -1,4 +1,3 @@
-import CircularProgress from "@material-ui/core/CircularProgress"
 import { makeStyles } from "@material-ui/core/styles"
 import dayjs from "dayjs"
 import { FC } from "react"
@@ -40,17 +39,16 @@ const getStageDurationInSeconds = (logs: ProvisionerJobLog[]) => {
 
 export interface WorkspaceBuildLogsProps {
   logs: ProvisionerJobLog[]
-  isWaitingForLogs: boolean
 }
 
-export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({ logs, isWaitingForLogs }) => {
+export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({ logs }) => {
   const groupedLogsByStage = groupLogsByStage(logs)
   const stages = Object.keys(groupedLogsByStage)
   const styles = useStyles()
 
   return (
     <div className={styles.logs}>
-      {stages.map((stage, stageIndex) => {
+      {stages.map((stage) => {
         const logs = groupedLogsByStage[stage]
         const isEmpty = logs.every((log) => log.output === "")
         const lines = logs.map((log) => ({
@@ -58,15 +56,12 @@ export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({ logs, isWaitin
           output: log.output,
         }))
         const duration = getStageDurationInSeconds(logs)
-        const isLastStage = stageIndex === stages.length - 1
-        const shouldDisplaySpinner = isWaitingForLogs && isLastStage
-        const shouldDisplayDuration = !isWaitingForLogs && duration
+        const shouldDisplayDuration = duration !== undefined
 
         return (
           <div key={stage}>
             <div className={styles.header}>
               <div>{stage}</div>
-              {shouldDisplaySpinner && <CircularProgress size={14} className={styles.spinner} />}
               {shouldDisplayDuration && (
                 <div className={styles.duration}>
                   {duration} {Language.seconds}
@@ -108,9 +103,5 @@ const useStyles = makeStyles((theme) => ({
   codeBlock: {
     padding: theme.spacing(2),
     paddingLeft: theme.spacing(4),
-  },
-
-  spinner: {
-    marginLeft: "auto",
   },
 }))

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
@@ -1,26 +1,31 @@
 import { screen } from "@testing-library/react"
-import * as API from "../../api/api"
-import { MockWorkspace, MockWorkspaceBuild, renderWithAuth } from "../../testHelpers/renderHelpers"
+import WS from "jest-websocket-mock"
+import {
+  MockWorkspace,
+  MockWorkspaceBuild,
+  renderWithAuth,
+} from "../../testHelpers/renderHelpers"
 import { WorkspaceBuildPage } from "./WorkspaceBuildPage"
 
 describe("WorkspaceBuildPage", () => {
   it("renders the stats and logs", async () => {
-    jest.spyOn(API, "streamWorkspaceBuildLogs").mockResolvedValueOnce({
-      read() {
-        return Promise.resolve({
-          value: undefined,
-          done: true,
-        })
-      },
-      releaseLock: jest.fn(),
-      closed: Promise.resolve(undefined),
-      cancel: jest.fn(),
-    })
+    const server = new WS("ws://localhost/api/v2/workspacebuilds/" + MockWorkspaceBuild.id + "/logs")
     renderWithAuth(<WorkspaceBuildPage />, {
       route: `/@${MockWorkspace.owner_name}/${MockWorkspace.name}/builds/${MockWorkspace.latest_build.build_number}`,
       path: "/@:username/:workspace/builds/:buildNumber",
     })
-
+    await server.connected
+    const log = {
+      id: "70459334-4878-4bda-a546-98eee166c4c6",
+      created_at: "2022-05-19T16:46:02.283Z",
+      log_source: "provisioner_daemon",
+      log_level: "info",
+      stage: "Another stage",
+      output: "",
+    }
+    server.send(JSON.stringify(log))
     await screen.findByText(MockWorkspaceBuild.workspace_name)
+    await screen.findByText(log.stage)
+    server.close()
   })
 })

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.test.tsx
@@ -9,7 +9,7 @@ import { WorkspaceBuildPage } from "./WorkspaceBuildPage"
 
 describe("WorkspaceBuildPage", () => {
   it("renders the stats and logs", async () => {
-    const server = new WS("ws://localhost/api/v2/workspacebuilds/" + MockWorkspaceBuild.id + "/logs")
+    const server = new WS(`ws://localhost/api/v2/workspacebuilds/${MockWorkspaceBuild.id}/logs`)
     renderWithAuth(<WorkspaceBuildPage />, {
       route: `/@${MockWorkspace.owner_name}/${MockWorkspace.name}/builds/${MockWorkspace.latest_build.build_number}`,
       path: "/@:username/:workspace/builds/:buildNumber",

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.tsx
@@ -8,9 +8,10 @@ import { WorkspaceBuildPageView } from "./WorkspaceBuildPageView"
 
 export const WorkspaceBuildPage: FC = () => {
   const { username, workspace: workspaceName, buildNumber } = useParams()
-  const [buildState] = useMachine(workspaceBuildMachine, { context: { username, workspaceName, buildNumber, timeCursor: new Date() } })
+  const [buildState] = useMachine(workspaceBuildMachine, {
+    context: { username, workspaceName, buildNumber, timeCursor: new Date() },
+  })
   const { logs, build } = buildState.context
-  const isWaitingForLogs = !buildState.matches("logs.loaded")
 
   return (
     <>
@@ -18,7 +19,7 @@ export const WorkspaceBuildPage: FC = () => {
         <title>{build ? pageTitle(`Build #${build.build_number} · ${build.workspace_name}`) : ""}</title>
       </Helmet>
 
-      <WorkspaceBuildPageView logs={logs} build={build} isWaitingForLogs={isWaitingForLogs} />
+      <WorkspaceBuildPageView logs={logs} build={build} />
     </>
   )
 }

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPage.tsx
@@ -8,7 +8,7 @@ import { WorkspaceBuildPageView } from "./WorkspaceBuildPageView"
 
 export const WorkspaceBuildPage: FC = () => {
   const { username, workspace: workspaceName, buildNumber } = useParams()
-  const [buildState] = useMachine(workspaceBuildMachine, { context: { username, workspaceName, buildNumber } })
+  const [buildState] = useMachine(workspaceBuildMachine, { context: { username, workspaceName, buildNumber, timeCursor: new Date() } })
   const { logs, build } = buildState.context
   const isWaitingForLogs = !buildState.matches("logs.loaded")
 

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -14,7 +14,6 @@ const sortLogsByCreatedAt = (logs: ProvisionerJobLog[]) => {
 export interface WorkspaceBuildPageViewProps {
   logs: ProvisionerJobLog[] | undefined
   build: WorkspaceBuild | undefined
-  isWaitingForLogs: boolean
 }
 
 export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({ logs, build }) => {
@@ -27,7 +26,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({ logs, 
       <Stack>
         {build && <WorkspaceBuildStats build={build} />}
         {!logs && <Loader />}
-        {logs && <WorkspaceBuildLogs logs={sortLogsByCreatedAt(logs)} isWaitingForLogs={false} />}
+        {logs && <WorkspaceBuildLogs logs={sortLogsByCreatedAt(logs)} />}
       </Stack>
     </Margins>
   )

--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -17,7 +17,7 @@ export interface WorkspaceBuildPageViewProps {
   isWaitingForLogs: boolean
 }
 
-export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({ logs, build, isWaitingForLogs }) => {
+export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({ logs, build }) => {
   return (
     <Margins>
       <PageHeader>
@@ -27,7 +27,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({ logs, 
       <Stack>
         {build && <WorkspaceBuildStats build={build} />}
         {!logs && <Loader />}
-        {logs && <WorkspaceBuildLogs logs={sortLogsByCreatedAt(logs)} isWaitingForLogs={isWaitingForLogs} />}
+        {logs && <WorkspaceBuildLogs logs={sortLogsByCreatedAt(logs)} isWaitingForLogs={false} />}
       </Stack>
     </Margins>
   )

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -124,4 +124,7 @@ export const handlers = [
   rest.patch("/api/v2/workspacebuilds/:workspaceBuildId/cancel", (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(M.MockCancellationMessage))
   }),
+  rest.get("/api/v2/workspacebuilds/:workspaceBuildId/logs", (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(M.MockWorkspaceBuildLogs))
+  }),
 ]

--- a/site/src/xServices/workspaceBuild/workspaceBuildXService.ts
+++ b/site/src/xServices/workspaceBuild/workspaceBuildXService.ts
@@ -21,9 +21,6 @@ type LogsEvent =
       type: "ADD_LOG"
       log: ProvisionerJobLog
     }
-  | {
-      type: "NO_MORE_LOGS"
-    }
 
 export const workspaceBuildMachine = createMachine(
   {
@@ -86,9 +83,6 @@ export const workspaceBuildMachine = createMachine(
           ADD_LOG: {
             actions: "addLog",
           },
-          NO_MORE_LOGS: {
-            target: "logs.loaded",
-          },
         },
       },
     },
@@ -141,7 +135,6 @@ export const workspaceBuildMachine = createMachine(
           })
           socket.addEventListener("close", () => {
             // When the socket closes, logs have finished streaming!
-            callback("NO_MORE_LOGS")
             resolve()
           })
         })

--- a/site/src/xServices/workspaceBuild/workspaceBuildXService.ts
+++ b/site/src/xServices/workspaceBuild/workspaceBuildXService.ts
@@ -127,8 +127,7 @@ export const workspaceBuildMachine = createMachine(
         return new Promise<void>((resolve, reject) => {
           const proto = location.protocol === "https:" ? "wss:" : "ws:"
           const socket = new WebSocket(
-            `${proto}//${location.host}/api/v2/workspacebuilds/${ctx.buildId}/logs?follow=true&after=` +
-              ctx.timeCursor.getTime(),
+            `${proto}//${location.host}/api/v2/workspacebuilds/${ctx.buildId}/logs?follow=true&after=${ctx.timeCursor.getTime()}`,
           )
           socket.binaryType = "blob"
           socket.addEventListener("message", (event) => {


### PR DESCRIPTION
This was using a streaming HTTP request before, which didn't work
on my version of Chrome. This method seemed less reliable and standard
than a WebSocket, so figured switching would be best.


Fixes #2570 