### PR TITLE
improve develop.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,9 @@ coderd/database/dump.sql: $(wildcard coderd/database/migrations/*.sql)
 coderd/database/querier.go: coderd/database/dump.sql $(wildcard coderd/database/queries/*.sql)
 	coderd/database/generate.sh
 
+# This target is deprecated, as GNU make has issues passing signals to subprocesses.
 dev:
-	./scripts/develop.sh
+	@echo Please run ./scripts/develop.sh manually.
 .PHONY: dev
 
 fmt/prettier:

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib.sh"
 PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 set +u
@@ -12,9 +13,9 @@ CODER_DEV_ADMIN_PASSWORD="${CODER_DEV_ADMIN_PASSWORD:-password}"
 set -u
 
 # Preflight checks: ensure we have our required dependencies, and make sure nothing is listening on port 3000 or 8080
-dependencies git make nc go yarn
-nc -z 127.0.0.1 3000 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
-nc -z 127.0.0.1 8080 && echo '== ERROR: something is listening on port 8080. Kill it and re-run this script.' && exit 1
+dependencies curl git go make nc yarn
+nc -z localhost 3000 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
+nc -z localhost 8080 && echo '== ERROR: something is listening on port 8080. Kill it and re-run this script.' && exit 1
 
 echo '== Run "make build" before running this command to build binaries.'
 echo '== Without these binaries, workspaces will fail to start!'
@@ -26,20 +27,20 @@ echo '== Without these binaries, workspaces will fail to start!'
 # to kill both at the same time. For more details, see:
 # https://stackoverflow.com/questions/3004811/how-do-you-run-multiple-programs-in-parallel-from-a-bash-script
 (
+	SCRIPT_PID=$$
 	cd "${PROJECT_ROOT}"
-	# Send an interrupt signal to all processes in this subshell on exit
-	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev &
-	go run -tags embed cmd/coder/main.go server --in-memory --tunnel &
+	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT ${SCRIPT_PID} &
+	go run -tags embed cmd/coder/main.go server --in-memory --tunnel || kill -INT ${SCRIPT_PID} &
 
 	echo '== Waiting for Coder to become ready'
-	timeout 60s bash -c 'until nc -z 127.0.0.1 3000 > /dev/null 2>&1; do sleep 1; done'
+	timeout 60s bash -c 'until curl -s --fail http://localhost:3000 > /dev/null 2>&1; do sleep 0.5; done'
 
 	#  create the first user, the admin
-	go run cmd/coder/main.go login http://127.0.0.1:3000 --username=admin --email=admin@coder.com --password=password \
-		|| echo 'Failed to create admin user. To troubleshoot, try running this command manually.'
+	go run cmd/coder/main.go login http://127.0.0.1:3000 --username=admin --email=admin@coder.com --password="${CODER_DEV_ADMIN_PASSWORD}" ||
+		echo 'Failed to create admin user. To troubleshoot, try running this command manually.'
 
 	# || true to always exit code 0. If this fails, whelp.
-	go run cmd/coder/main.go users create --email=member@coder.com --username=member --password="${CODER_DEV_ADMIN_PASSWORD}" \
-		|| echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
+	go run cmd/coder/main.go users create --email=member@coder.com --username=member --password="${CODER_DEV_ADMIN_PASSWORD}" ||
+		echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
 	wait
 )

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -14,8 +14,8 @@ set -u
 
 # Preflight checks: ensure we have our required dependencies, and make sure nothing is listening on port 3000 or 8080
 dependencies curl git go make nc yarn
-nc -z localhost 3000 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
-nc -z localhost 8080 && echo '== ERROR: something is listening on port 8080. Kill it and re-run this script.' && exit 1
+nc -z 127.0.0.1 3000 >/dev/null 2>&1 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
+nc -z 127.0.0.1 8080 >/dev/null 2>&1 && echo '== ERROR: something is listening on port 8080. Kill it and re-run this script.' && exit 1
 
 echo '== Run "make build" before running this command to build binaries.'
 echo '== Without these binaries, workspaces will fail to start!'
@@ -29,8 +29,8 @@ echo '== Without these binaries, workspaces will fail to start!'
 (
 	SCRIPT_PID=$$
 	cd "${PROJECT_ROOT}"
-	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT ${SCRIPT_PID} &
-	go run -tags embed cmd/coder/main.go server --in-memory --tunnel || kill -INT ${SCRIPT_PID} &
+	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT -${SCRIPT_PID} &
+	go run -tags embed cmd/coder/main.go server --address 127.0.0.1:3000 --in-memory --tunnel || kill -INT -${SCRIPT_PID} &
 
 	echo '== Waiting for Coder to become ready'
 	timeout 60s bash -c 'until curl -s --fail http://localhost:3000 > /dev/null 2>&1; do sleep 0.5; done'

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Allow toggling verbose output
-[[ ! -z ${VERBOSE:-""} ]] && set -x
+[[ -n ${VERBOSE:-""} ]] && set -x
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
+# Allow toggling verbose output
+[[ ! -z ${VERBOSE:-""} ]] && set -x
 set -euo pipefail
-set -x
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source "${SCRIPT_DIR}/lib.sh"
 PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
 set +u
 CODER_DEV_ADMIN_PASSWORD="${CODER_DEV_ADMIN_PASSWORD:-password}"
 set -u
 
-# Preflight check: make sure nothing is listening on port 3000 or 8080
+# Preflight checks: ensure we have our required dependencies, and make sure nothing is listening on port 3000 or 8080
+dependencies git make nc go yarn
 nc -z 127.0.0.1 3000 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
 nc -z 127.0.0.1 8080 && echo '== ERROR: something is listening on port 8080. Kill it and re-run this script.' && exit 1
 


### PR DESCRIPTION
Partially addresses #2560.

* Running `make dev` now prompts you to run `./scripts/develop.sh` manually, as GNU make does not appear to pass SIGINT to subprocesses.
* Added checks to `develop.sh` to ensure that coderd is listening before running our initial setup steps
* Add some more troubleshooting/debugging output to `develop.sh`