### PR TITLE
cli/templateinit: add links to template READMEs

### DIFF
--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -52,5 +52,5 @@ var Styles = struct {
 	Fuschia:       defaultStyles.SelectedMenuItem.Copy(),
 	Logo:          defaultStyles.Logo.SetString("Coder"),
 	Warn:          lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#04B575", Dark: "#ECFD65"}),
-	Wrap:          defaultStyles.Wrap,
+	Wrap:          lipgloss.NewStyle().Width(80),
 }

--- a/cli/templateinit.go
+++ b/cli/templateinit.go
@@ -25,9 +25,10 @@ func templateInit() *cobra.Command {
 			exampleByName := map[string]examples.Example{}
 			for _, example := range exampleList {
 				name := fmt.Sprintf(
-					"%s\n%s\n",
+					"%s\n%s\n%s\n",
 					cliui.Styles.Bold.Render(example.Name),
 					cliui.Styles.Wrap.Copy().PaddingLeft(6).Render(example.Description),
+					cliui.Styles.Keyword.PaddingLeft(6).Render(example.URL),
 				)
 				exampleNames = append(exampleNames, name)
 				exampleByName[name] = example

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -18,13 +18,15 @@ var (
 	//go:embed templates
 	files embed.FS
 
-	examples      = make([]Example, 0)
-	parseExamples sync.Once
-	archives      = singleflight.Group{}
+	exampleBasePath = "https://github.com/coder/coder/tree/main/examples/templates/"
+	examples        = make([]Example, 0)
+	parseExamples   sync.Once
+	archives        = singleflight.Group{}
 )
 
 type Example struct {
 	ID          string `json:"id"`
+	URL         string `json:"url"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Markdown    string `json:"markdown"`
@@ -52,6 +54,7 @@ func List() ([]Example, error) {
 				continue
 			}
 			exampleID := dir.Name()
+			exampleURL := exampleBasePath + exampleID
 			// Each one of these is a example!
 			readme, err := fs.ReadFile(files, path.Join(dir.Name(), "README.md"))
 			if err != nil {
@@ -91,6 +94,7 @@ func List() ([]Example, error) {
 
 			examples = append(examples, Example{
 				ID:          exampleID,
+				URL:         exampleURL,
 				Name:        name,
 				Description: description,
 				Markdown:    string(frontMatter.Content),

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -27,7 +27,7 @@ func TestTemplate(t *testing.T) {
 			assert.NotEmpty(t, eg.Name, "example name should not be empty")
 			assert.NotEmpty(t, eg.Description, "example description should not be empty")
 			assert.NotEmpty(t, eg.Markdown, "example markdown should not be empty")
-			_, err = examples.Archive(eg.ID)
+			_, err := examples.Archive(eg.ID)
 			assert.NoError(t, err, "error archiving example")
 		})
 	}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/examples"
@@ -16,10 +17,20 @@ func TestTemplate(t *testing.T) {
 	t.Parallel()
 	list, err := examples.List()
 	require.NoError(t, err)
-	require.Greater(t, len(list), 0)
-
-	_, err = examples.Archive(list[0].ID)
-	require.NoError(t, err)
+	require.NotEmpty(t, list)
+	for _, eg := range list {
+		eg := eg
+		t.Run(eg.ID, func(t *testing.T) {
+			t.Parallel()
+			assert.NotEmpty(t, eg.ID, "example ID should not be empty")
+			assert.NotEmpty(t, eg.URL, "example URL should not be empty")
+			assert.NotEmpty(t, eg.Name, "example name should not be empty")
+			assert.NotEmpty(t, eg.Description, "example description should not be empty")
+			assert.NotEmpty(t, eg.Markdown, "example markdown should not be empty")
+			_, err = examples.Archive(eg.ID)
+			assert.NoError(t, err, "error archiving example")
+		})
+	}
 }
 
 func TestSubdirs(t *testing.T) {


### PR DESCRIPTION
- template init: add links to template docs
- examples: add URL field to examples, ensure that example fields are always non-empty
- cliui: bump wrap width to 80 from 58 -- @kylecarbs hope this is OK!


Fixes #2368 