### PR TITLE
Make builds in build_go_matrix.sh run serially

### DIFF
--- a/scripts/build_go_matrix.sh
+++ b/scripts/build_go_matrix.sh
@@ -193,7 +193,7 @@ for spec in "${specs[@]}"; do
 		--os "$spec_os" \
 		--arch "$spec_arch" \
 		--output "$spec_output_binary" \
-		"${build_args[@]}" &
+		"${build_args[@]}"
 	log
 	log
 
@@ -227,5 +227,3 @@ for spec in "${specs[@]}"; do
 		log
 	fi
 done
-
-wait


### PR DESCRIPTION
This fixes a race condition that is causing the `deploy.yaml` workflow to fail, e.g. https://github.com/coder/coder/runs/7005930277?check_suite_focus=true