### PR TITLE
fix: Parse 24h time format from schedule cron in CLI

### DIFF
--- a/coderd/autobuild/schedule/schedule.go
+++ b/coderd/autobuild/schedule/schedule.go
@@ -144,7 +144,7 @@ func (s Schedule) Time() string {
 	minute := strings.Fields(s.cronStr)[0]
 	hour := strings.Fields(s.cronStr)[1]
 	maybeTime := fmt.Sprintf("%s:%s", hour, minute)
-	t, err := time.ParseInLocation("3:4", maybeTime, s.sched.Location)
+	t, err := time.ParseInLocation("15:4", maybeTime, s.sched.Location)
 	if err != nil {
 		// return the original cronspec for minute and hour, who knows what's in there!
 		return fmt.Sprintf("cron(%s %s)", minute, hour)

--- a/coderd/autobuild/schedule/schedule_test.go
+++ b/coderd/autobuild/schedule/schedule_test.go
@@ -51,6 +51,19 @@ func Test_Weekly(t *testing.T) {
 			expectedTime:       "9:30AM",
 		},
 		{
+			name:               "24h format",
+			spec:               "30 13 * * 1-5",
+			at:                 time.Date(2022, 4, 1, 13, 29, 0, 0, time.UTC),
+			expectedNext:       time.Date(2022, 4, 1, 13, 30, 0, 0, time.UTC),
+			expectedMin:        24 * time.Hour,
+			expectedDaysOfWeek: "Mon-Fri",
+			expectedError:      "",
+			expectedCron:       "30 13 * * 1-5",
+			expectedLocation:   time.UTC,
+			expectedString:     "CRON_TZ=UTC 30 13 * * 1-5",
+			expectedTime:       "1:30PM",
+		},
+		{
 			name:               "convoluted with timezone",
 			spec:               "CRON_TZ=US/Central */5 12-18 * * 1,3,6",
 			at:                 time.Date(2022, 4, 1, 14, 29, 0, 0, time.UTC),
@@ -141,6 +154,7 @@ func Test_Weekly(t *testing.T) {
 				require.Equal(t, testCase.expectedString, actual.String())
 				require.Equal(t, testCase.expectedMin, actual.Min())
 				require.Equal(t, testCase.expectedDaysOfWeek, actual.DaysOfWeek())
+				require.Equal(t, testCase.expectedTime, actual.Time())
 			} else {
 				require.EqualError(t, err, testCase.expectedError)
 				require.Nil(t, actual)


### PR DESCRIPTION
This PR updates the time format layout used to parse the hour value from the cron schedule.

## Subtasks

- [x] update the layout from `stdHour12` (3) to `stdHour` (15)

Fixes #2579 

## Screenshot
![Screen Shot 2022-06-22 at 1 04 44 PM](https://user-images.githubusercontent.com/7511231/175096277-88b3ed1d-1340-4714-9c25-d6f4376d1696.png)


