### PR TITLE
fix: Subtract a second when listening in TestWorkspaceBuildLogs

### DIFF
--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -325,7 +325,7 @@ func TestWorkspaceBuildLogs(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
-	logs, err := client.WorkspaceBuildLogsAfter(ctx, workspace.LatestBuild.ID, before)
+	logs, err := client.WorkspaceBuildLogsAfter(ctx, workspace.LatestBuild.ID, before.Add(-time.Second))
 	require.NoError(t, err)
 	for {
 		log, ok := <-logs


### PR DESCRIPTION
This allowed a test flake seen here:
https://github.com/coder/coder/runs/7009119403?check_suite_focus=true#step:9:151
