### PR TITLE
added a default app icon

### DIFF
--- a/site/src/components/AppLink/AppLink.tsx
+++ b/site/src/components/AppLink/AppLink.tsx
@@ -1,6 +1,7 @@
 import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
-import React, { FC } from "react"
+import ComputerIcon from "@material-ui/icons/Computer"
+import { FC } from "react"
 import * as TypesGen from "../../api/typesGenerated"
 import { combineClasses } from "../../util/combineClasses"
 
@@ -8,7 +9,7 @@ export interface AppLinkProps {
   userName: TypesGen.User["username"]
   workspaceName: TypesGen.Workspace["name"]
   appName: TypesGen.WorkspaceApp["name"]
-  appIcon: TypesGen.WorkspaceApp["icon"]
+  appIcon?: TypesGen.WorkspaceApp["icon"]
 }
 
 export const AppLink: FC<AppLinkProps> = ({ userName, workspaceName, appName, appIcon }) => {
@@ -25,11 +26,15 @@ export const AppLink: FC<AppLinkProps> = ({ userName, workspaceName, appName, ap
         window.open(href, appName, "width=900,height=600")
       }}
     >
-      <img
-        className={combineClasses([styles.icon, appIcon === "" ? "empty" : ""])}
-        alt={`${appName} Icon`}
-        src={appIcon || ""}
-      />
+      {appIcon ? (
+        <img
+          className={combineClasses([styles.icon, appIcon === "" ? "empty" : ""])}
+          alt={`${appName} Icon`}
+          src={appIcon || ""}
+        />
+      ) : (
+        <ComputerIcon className={styles.icon} />
+      )}
       {appName}
     </Link>
   )


### PR DESCRIPTION
resolves #2268
![Screen Shot 2022-06-22 at 3 47 39 PM](https://user-images.githubusercontent.com/19142439/175129466-334ce84b-5cdb-4070-8f9a-ce20fc7a0667.png)


Added a default icon for apps without icons. I figured this should be the same as terminal - we don't need to clog up our page with a bunch of icons yet  - but let me know if you feel differently.
There was actually already a story for this case, as you see if you look at Chromatic.

**NOTE**: I would love to add the appropriate code-server icon to the app as mentioned in the ticket, but I'm unsure where to do this. If someone points me in the right direction, I will def update.