### PR TITLE
fix: simplify terminal link

### DIFF
--- a/site/src/components/TerminalLink/TerminalLink.tsx
+++ b/site/src/components/TerminalLink/TerminalLink.tsx
@@ -7,7 +7,7 @@ import { combineClasses } from "../../util/combineClasses"
 import { generateRandomString } from "../../util/random"
 
 export const Language = {
-  linkText: "terminal",
+  linkText: "Terminal",
   terminalTitle: (identifier: string): string => `Terminal - ${identifier}`,
 }
 

--- a/site/src/components/TerminalLink/TerminalLink.tsx
+++ b/site/src/components/TerminalLink/TerminalLink.tsx
@@ -7,7 +7,7 @@ import { combineClasses } from "../../util/combineClasses"
 import { generateRandomString } from "../../util/random"
 
 export const Language = {
-  linkText: "Open terminal",
+  linkText: "terminal",
   terminalTitle: (identifier: string): string => `Terminal - ${identifier}`,
 }
 


### PR DESCRIPTION
This is just a proposal - I think next to the `code-server` link it looks better. 

Currently - 

![image](https://user-images.githubusercontent.com/19379394/175141398-ec64f8a5-4fcd-4b60-b44a-af41ab042cba.png)


"terminal"

![image](https://user-images.githubusercontent.com/19379394/175141474-01640292-9e31-4402-9246-079ea89f7b73.png)


"web-terminal" (what we commonly call it internally)

![image](https://user-images.githubusercontent.com/19379394/175141580-d01df805-094c-4f88-a158-eff5cabd7c56.png)

"ssh" - this is what GCP uses for their web terminal

![image](https://user-images.githubusercontent.com/19379394/175141693-7018c915-bd3d-4b80-add5-b2781fa78c46.png)

We landed on "Terminal"

![image](https://user-images.githubusercontent.com/19379394/175144476-5f7bd18a-9dd3-4633-85dc-8bbebc378ec3.png)
