### PR TITLE
clean site/out and enforce make bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ bin: $(shell find . -not -path './vendor/*' -type f -name '*.go') go.mod go.sum 
 
 	mkdir -p ./dist
 	rm -rf ./dist/coder-slim_*
+	rm -f ./site/out/bin/coder*
 	./scripts/build_go_slim.sh \
+		--compress 6 \
 		--version "$(VERSION)" \
 		--output ./dist/ \
 		linux:amd64,armv7,arm64 \
@@ -31,6 +33,7 @@ bin: $(shell find . -not -path './vendor/*' -type f -name '*.go') go.mod go.sum 
 build: site/out/index.html $(shell find . -not -path './vendor/*' -type f -name '*.go') go.mod go.sum $(shell find ./examples/templates)
 	rm -rf ./dist
 	mkdir -p ./dist
+	rm -f ./site/out/bin/coder*
 
 	# build slim artifacts and copy them to the site output directory
 	./scripts/build_go_slim.sh \

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -17,8 +17,15 @@ dependencies curl git go make yarn
 curl --fail http://127.0.0.1:3000 >/dev/null 2>&1 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
 curl --fail http://127.0.0.1:8080 >/dev/null 2>&1 && echo '== ERROR: something is listening on port 8080. Kill it and re-run this script.' && exit 1
 
-echo '== Run "make build" before running this command to build binaries.'
-echo '== Without these binaries, workspaces will fail to start!'
+if [[ ! -e ./site/out/bin/coder.sha1 && ! -e ./site/out/bin/coder.tar.zst ]]; then
+	log
+	log "======================================================================="
+	log "==   Run 'make bin' before running this command to build binaries.   =="
+	log "==       Without these binaries, workspaces will fail to start!      =="
+	log "======================================================================="
+	log
+	exit 1
+fi
 
 # Run yarn install, to make sure node_modules are ready to go
 "$PROJECT_ROOT/scripts/yarn_install.sh"
@@ -28,7 +35,7 @@ echo '== Without these binaries, workspaces will fail to start!'
 # https://stackoverflow.com/questions/3004811/how-do-you-run-multiple-programs-in-parallel-from-a-bash-script
 (
 	SCRIPT_PID=$$
-	cd "${PROJECT_ROOT}"
+	cdroot
 	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT -${SCRIPT_PID} &
 	go run -tags embed cmd/coder/main.go server --address 127.0.0.1:3000 --in-memory --tunnel || kill -INT -${SCRIPT_PID} &
 


### PR DESCRIPTION
I got a panic this morning when running v2:

```
<i> [webpack-dev-server] On Your Network (IPv4): http://192.168.1.74:8080/
<i> [webpack-dev-server] On Your Network (IPv6): http://[fe80::1]:8080/
<i> [webpack-dev-server] Content not from webpack is served from './static' directory
<i> [webpack-dev-server] 404s will fallback to '/index.html'
Coder v0.0.0-devel - Remote development on your infrastucture
Opening tunnel so workspaces can connect to your deployment
View the Web UI: https://fcca3a71-871a-4663-a779-3f5795851b8c.wg-tunnel.coder.app/
panic: read site bin failed: verify coder binaries sha1 failed: read coder sha1 from embedded fs failed: open bin/coder.sha1: file does not exist

goroutine 1 [running]:
github.com/coder/coder/coderd.New(0x140006e4180)
        /Users/cian/src/cdr/coder/coderd/coderd.go:91 +0x708
github.com/coder/coder/cli.server.func1(0x1400083cf00, {0x1053c9ca0?, 0x4?, 0x4?})
        /Users/cian/src/cdr/coder/cli/server.go:338 +0x2c74
github.com/spf13/cobra.(*Command).execute(0x1400083cf00, {0x140008364c0, 0x4, 0x4})
        /Users/cian/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856 +0x4c4
github.com/spf13/cobra.(*Command).ExecuteC(0x14000830500)
        /Users/cian/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x354
main.main()
        /Users/cian/src/cdr/coder/cmd/coder/main.go:18 +0xa8
exit status 2
```

@mafredri  and I investigated and it looks like I had a dirty `site/out/bin` folder that was missing the shasums.
We should probably be clearing this out in between builds.

Also, the warning about `make bin` seems to be routinely ignored, so enforcing it.
I'm also open to just automatically running `make bin` if folks find the enforcement too aggressive.

Future work: serve current binary as agent if running via `develop.sh`.