### PR TITLE
chore: update tsconfig target to es2018

### DIFF
--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -13,7 +13,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5"
+    "target": "es2018"
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "_jest"]


### PR DESCRIPTION
This PR changes the tsconfig target to ES2018, which is supported by [all major current browsers](
https://kangax.github.io/compat-table/es2016plus/). (The only unsupported feature is RegEx lookbehind assertions, which is not polyfilled anyway.)

This stops us from having to transpile lots of promise code for legacy browsers (IE!), which makes the resulting sources in `eval-source-map` view much easier to read.

Hopefully, all tests pass!