### PR TITLE
fix: ensure gcp resource names are lowercase

### DIFF
--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -36,7 +36,7 @@ data "coder_workspace" "me" {
 }
 
 resource "google_compute_disk" "root" {
-  name  = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  name  = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
   type  = "pd-ssd"
   zone  = var.zone
   image = "debian-cloud/debian-9"
@@ -54,7 +54,7 @@ resource "coder_agent" "dev" {
 resource "google_compute_instance" "dev" {
   zone         = var.zone
   count        = data.coder_workspace.me.start_count
-  name         = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+  name         = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
   machine_type = "e2-medium"
   network_interface {
     network = "default"

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -58,7 +58,7 @@ module "gce-container" {
 resource "google_compute_instance" "dev" {
   zone         = var.zone
   count        = data.coder_workspace.me.start_count
-  name         = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+  name         = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   machine_type = "e2-medium"
   network_interface {
     network = "default"

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -36,7 +36,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 resource "google_compute_disk" "root" {
-  name  = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  name  = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
   type  = "pd-ssd"
   zone  = var.zone
   image = "projects/windows-cloud/global/images/windows-server-2022-dc-core-v20220215"
@@ -54,7 +54,7 @@ resource "coder_agent" "dev" {
 resource "google_compute_instance" "dev" {
   zone         = var.zone
   count        = data.coder_workspace.me.start_count
-  name         = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+  name         = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   machine_type = "e2-medium"
   network_interface {
     network = "default"


### PR DESCRIPTION
Our example templates do not ensure that resource names are lowercase. This means that if the workspace or user names have uppercase letters, workspace creation will fail - this PR should address that.

This isn't noted in any issue, but fixes an issue I ran into while using GCP VMs on dev.