### PR TITLE
develop.sh: attempt to create a Docker template automatically

### DIFF
--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -97,13 +97,16 @@ provision:
     # Set up initial user
     [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --username admin --email admin@coder.com --password $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8 | tee ${HOME}/.config/coderv2/password)
     # Create an initial template
-    cd ${HOME}
-    echo code-server | coder templates init
-    cd ./docker-code-server
-    if [ $(arch) = "aarch64" ]; then
-        sed -i 's/arch.*=.*"amd64"/arch = "arm64"/' ./main.tf
+    temp_template_dir=$(mktemp -d)
+    echo code-server | coder templates init "${temp_template_dir}"
+    DOCKER_ARCH="amd64"
+    if [ "$(arch)" = "aarch64" ]; then
+      DOCKER_ARCH="arm64"
     fi
-    coder templates create docker-code-server -y -d .
+    DOCKER_HOST=$(docker context inspect --format '{{.Endpoints.docker.Host}}')
+    printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${DOCKER_ARCH}" "${DOCKER_HOST}" | tee "${temp_template_dir}/params.yaml"
+    coder templates create "docker-code-server-${DOCKER_ARCH}" --directory "${temp_template_dir}" --parameter-file "${temp_template_dir}/params.yaml" --yes
+    rm -rfv "${temp_template_dir}"
 probes:
 - description: "docker to be installed"
   script: |
@@ -127,7 +130,7 @@ probes:
     See "/var/log/cloud-init-output.log" in the guest.
 message: |
   All Done! Your Coder instance is accessible at http://localhost:3000
-  
+
   Username: "admin@coder.com"
   Password: Run `LIMA_INSTANCE=coder lima cat /home/${USER}.linux/.config/coderv2/password` 🤫
 

--- a/examples/templates/docker-code-server/README.md
+++ b/examples/templates/docker-code-server/README.md
@@ -8,4 +8,18 @@ tags: [local, docker]
 
 ## Getting started
 
-Run `coder templates init` and select this template. Follow the instructions that appear. 
+Run `coder templates init` and select this template. Follow the instructions that appear.
+
+## Supported Parameters
+
+You can create a file containing parameters and pass the argument
+`--parameter-file` to `coder templates create`.
+See `params.sample.yaml` for more information.
+
+This template has the following predefined parameters:
+
+- `docker_host`: Path to (or address of) the Docker socket.
+  > You can determine the correct value for this by runnning
+  > `docker context ls`.
+- `docker_arch`: Architecture of the host running Docker.
+  This can be `amd64`, `arm64`, or `armv7`.

--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -13,7 +13,7 @@ terraform {
 
 variable "docker_host" {
   description = "Specify location of Docker socket (check `docker context ls` if you're not sure)"
-  sensitive = true
+  sensitive   = true
 }
 
 variable "docker_arch" {

--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -11,14 +11,32 @@ terraform {
   }
 }
 
+variable "docker_host" {
+  description = "Specify location of Docker socket (check `docker context ls` if you're not sure)"
+  sensitive = true
+}
+
+variable "docker_arch" {
+  description = "Specify architecture of docker host (amd64, arm64, or armv7)"
+  validation {
+    condition     = contains(["amd64", "arm64", "armv7"], var.docker_arch)
+    error_message = "Value must be amd64, arm64, or armv7."
+  }
+  sensitive = true
+}
+
 provider "coder" {
+}
+
+provider "docker" {
+  host = var.docker_host
 }
 
 data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "dev" {
-  arch           = "amd64"
+  arch           = var.docker_arch
   os             = "linux"
   startup_script = "code-server --auth none"
 }

--- a/examples/templates/docker-code-server/params.sample.yaml
+++ b/examples/templates/docker-code-server/params.sample.yaml
@@ -1,0 +1,2 @@
+docker_host: "unix:///var/run/docker.sock"
+docker_arch: "amd64"

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -75,8 +75,8 @@ variable "docker_image" {
   # The codercom/enterprise-* images are only built for amd64
   default = "codercom/enterprise-base:ubuntu"
   validation {
-    condition     = contains(["codercom/enterprise-base:ubuntu", "codercom/enterprise-node:ubuntu",
-                              "codercom/enterprise-intellij:ubuntu", "codercom/enterprise-golang:ubuntu"], var.docker_image)
+    condition = contains(["codercom/enterprise-base:ubuntu", "codercom/enterprise-node:ubuntu",
+    "codercom/enterprise-intellij:ubuntu", "codercom/enterprise-golang:ubuntu"], var.docker_image)
     error_message = "Invalid Docker image!"
   }
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -53,7 +53,7 @@ fi
 		echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
 
 	# If we have docker available, then let's try to create a template!
-	if docker run --rm hello-world >/dev/null 2>&1; then
+	if docker info >/dev/null 2>&1; then
 		temp_template_dir=$(mktemp -d)
 		echo code-server | go run "${PROJECT_ROOT}/cmd/coder/main.go" templates init "${temp_template_dir}"
 		# shellcheck disable=SC1090

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -53,6 +53,7 @@ fi
 		echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
 
 	# If we have docker available, then let's try to create a template!
+	template_name=""
 	if docker info >/dev/null 2>&1; then
 		temp_template_dir=$(mktemp -d)
 		echo code-server | go run "${PROJECT_ROOT}/cmd/coder/main.go" templates init "${temp_template_dir}"
@@ -60,15 +61,22 @@ fi
 		source <(go env | grep GOARCH)
 		DOCKER_HOST=$(docker context inspect --format '{{.Endpoints.docker.Host}}')
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" | tee "${temp_template_dir}/params.yaml"
-		go run "${PROJECT_ROOT}/cmd/coder/main.go" templates create "docker-${GOARCH}" --directory "${temp_template_dir}" --parameter-file "${temp_template_dir}/params.yaml" --yes
+		template_name="docker-${GOARCH}"
+		go run "${PROJECT_ROOT}/cmd/coder/main.go" templates create "${template_name}" --directory "${temp_template_dir}" --parameter-file "${temp_template_dir}/params.yaml" --yes
 		rm -rfv "${temp_template_dir}"
 	fi
 
 	log
 	log "======================================================================="
+	log "==                                                                   =="
 	log "==               Coder is now running in development mode.           =="
 	log "==                    API   : http://localhost:3000                  =="
 	log "==                    Web UI: http://localhost:8080                  =="
+	if [[ -n "${template_name}" ]]; then
+		log "==                                                                   =="
+		log "==            Docker template ${template_name} is ready to use!          =="
+		log "==                                                                   =="
+	fi
 	log "======================================================================="
 	log
 	# Wait for both frontend and backend to exit.

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -12,6 +12,9 @@ set +u
 CODER_DEV_ADMIN_PASSWORD="${CODER_DEV_ADMIN_PASSWORD:-password}"
 set -u
 
+# shellcheck disable=SC1090
+source <(go env)
+
 # Preflight checks: ensure we have our required dependencies, and make sure nothing is listening on port 3000 or 8080
 dependencies curl git go make yarn
 curl --fail http://127.0.0.1:3000 >/dev/null 2>&1 && echo '== ERROR: something is listening on port 3000. Kill it and re-run this script.' && exit 1
@@ -34,10 +37,12 @@ fi
 # to kill both at the same time. For more details, see:
 # https://stackoverflow.com/questions/3004811/how-do-you-run-multiple-programs-in-parallel-from-a-bash-script
 (
-	SCRIPT_PID=$$
+	# If something goes wrong, just bail and tear everything down
+	# rather than leaving things in an inconsistent state.
+	trap 'kill -INT -$$' ERR
 	cdroot
-	CODERV2_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT -${SCRIPT_PID} &
-	go run -tags embed cmd/coder/main.go server --address 127.0.0.1:3000 --in-memory --tunnel || kill -INT -${SCRIPT_PID} &
+	CODER_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT -$$ &
+	go run -tags embed cmd/coder/main.go server --address 127.0.0.1:3000 --in-memory --tunnel || kill -INT -$$ &
 
 	echo '== Waiting for Coder to become ready'
 	timeout 60s bash -c 'until curl -s --fail http://localhost:3000 > /dev/null 2>&1; do sleep 0.5; done'
@@ -49,5 +54,31 @@ fi
 	# || true to always exit code 0. If this fails, whelp.
 	go run cmd/coder/main.go users create --email=member@coder.com --username=member --password="${CODER_DEV_ADMIN_PASSWORD}" ||
 		echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
+
+	# If we have docker available, then let's try to create a template!
+	if docker run --rm hello-world >/dev/null 2>&1; then
+		temp_template_dir=$(mktemp -d)
+		# cd "${temp_template_dir}"
+		echo code-server | go run "${PROJECT_ROOT}/cmd/coder/main.go" templates init "${temp_template_dir}"
+		if [[ "$GOARCH" = "arm64" ]]; then
+			# MacOS sed expects an argument to -i.
+			sed_ext_arg=""
+			if [[ "$GOOS" = "darwin" ]]; then
+				sed_ext_arg="''"
+			fi
+			sed -i "$sed_ext_arg" 's/arch.*=.*"amd64"/arch = "arm64"/' "${temp_template_dir}/main.tf"
+		fi
+		go run "${PROJECT_ROOT}/cmd/coder/main.go" templates create "docker-${GOARCH}" -d "${temp_template_dir}" -y
+		rm -rfv "${temp_template_dir}"
+	fi
+
+	log
+	log "======================================================================="
+	log "==               Coder is now running in development mode.           =="
+	log "==                    API   : http://localhost:3000                  =="
+	log "==                    Web UI: http://localhost:8080                  =="
+	log "======================================================================="
+	log
+	# Wait for both frontend and backend to exit.
 	wait
 )


### PR DESCRIPTION
This PR makes the following changes:
- Adds two variables `docker_host` and `docker_arch` to the example `docker-code-server` template
- Adds an example `params.yaml` to `docker-code-server` and updates the `README.md` to reference these parameters
- `scripts/develop.sh` will now attempt to create a template using `docker-code-server` with the appropriate parameters for the environment
- Updated Lima example to make use of the template parameters for `docker-code-server`

Additional drive-bys:
- `webpack.dev.ts` references `CODER_HOST` and not `CODERV2_HOST`; updated `develop.sh` accordingly
- `develop.sh` should now terminate child processes upon error.

Tested on:
- MacOS 12.4 (arm64, colima)
- Ubuntu 20.04 (v1 dogfood image)
- Ubuntu 20.04 (v2 dogfood template)

