### PR TITLE
feat: Add success messages for CLI commands

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -41,7 +42,14 @@ func delete() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
+
+			err = cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nThe %s workspace has been deleted!\n", cliui.Styles.Keyword.Render(workspace.Name))
+			return nil
 		},
 	}
 	cliui.AllowSkipPrompt(cmd)

--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -80,6 +81,7 @@ func resetPassword() *cobra.Command {
 				return xerrors.Errorf("updating password: %w", err)
 			}
 
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nPassword has been reset for user %s!\n", cliui.Styles.Keyword.Render(user.Username))
 			return nil
 		},
 	}

--- a/cli/start.go
+++ b/cli/start.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -39,7 +40,14 @@ func start() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
+
+			err = cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nThe %s workspace has been started!\n", cliui.Styles.Keyword.Render(workspace.Name))
+			return nil
 		},
 	}
 	cliui.AllowSkipPrompt(cmd)

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -39,7 +40,14 @@ func stop() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
+
+			err = cliui.WorkspaceBuild(cmd.Context(), cmd.OutOrStdout(), client, build.ID, before)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nThe %s workspace has been stopped!\n", cliui.Styles.Keyword.Render(workspace.Name))
+			return nil
 		},
 	}
 	cliui.AllowSkipPrompt(cmd)

--- a/cli/userstatus.go
+++ b/cli/userstatus.go
@@ -13,15 +13,18 @@ import (
 // createUserStatusCommand sets a user status.
 func createUserStatusCommand(sdkStatus codersdk.UserStatus) *cobra.Command {
 	var verb string
+	var pastVerb string
 	var aliases []string
 	var short string
 	switch sdkStatus {
 	case codersdk.UserStatusActive:
 		verb = "activate"
+		pastVerb = "activated"
 		aliases = []string{"active"}
 		short = "Update a user's status to 'active'. Active users can fully interact with the platform"
 	case codersdk.UserStatusSuspended:
 		verb = "suspend"
+		pastVerb = "suspended"
 		aliases = []string{"rm", "delete"}
 		short = "Update a user's status to 'suspended'. A suspended user cannot log into the platform"
 	default:
@@ -76,6 +79,8 @@ func createUserStatusCommand(sdkStatus codersdk.UserStatus) *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("%s user: %w", verb, err)
 			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nUser %s has been %s!\n", cliui.Styles.Keyword.Render(user.Username), pastVerb)
 			return nil
 		},
 	}


### PR DESCRIPTION
This PR adds success messages for CLI commands: workspace start, stop, delete; users: suspend, activate, resetpassword.

## Subtasks

- [x] Added success messages for CLI commands missing them.

Fixes #1976 
Fixes #2316 

## Screenshot
### suspend, activate
![Screen Shot 2022-06-24 at 11 32 04 AM](https://user-images.githubusercontent.com/7511231/175568496-ede23e39-785f-441f-ad9a-6d78eabb2265.png)

### start
![Screen Shot 2022-06-24 at 11 34 01 AM](https://user-images.githubusercontent.com/7511231/175568917-6552f397-9c94-4a85-903c-3499335b89be.png)

### stop
![Screen Shot 2022-06-24 at 11 34 11 AM](https://user-images.githubusercontent.com/7511231/175568923-8f8a28b2-8e5d-4c30-bb44-e6bc99777ffe.png)

### delete
![Screen Shot 2022-06-24 at 11 37 57 AM](https://user-images.githubusercontent.com/7511231/175569451-ae77dcc5-75e3-46c6-873a-abae325c718c.png)


