### PR TITLE
fix: use absolute path for config-ssh coder binary

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -546,7 +546,7 @@ func currentBinPath(w io.Writer) (string, error) {
 		_, _ = fmt.Fprint(w, "\n")
 	}
 
-	return binName, nil
+	return exePath, nil
 }
 
 // diffBytes takes two byte slices and diffs them as if they were in a


### PR DESCRIPTION
fixes #2528