### PR TITLE
fix: provide environment variable for CLI session token

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -39,6 +39,8 @@ const (
 	varNoOpen          = "no-open"
 	varForceTty        = "force-tty"
 	notLoggedInMessage = "You are not logged in. Try logging in using 'coder login <url>'."
+
+	envSessionToken = "CODER_SESSION_TOKEN"
 )
 
 func init() {
@@ -95,7 +97,7 @@ func Root() *cobra.Command {
 	cmd.SetUsageTemplate(usageTemplate())
 
 	cmd.PersistentFlags().String(varURL, "", "Specify the URL to your deployment.")
-	cmd.PersistentFlags().String(varToken, "", "Specify an authentication token.")
+	cliflag.String(cmd.PersistentFlags(), varToken, "", envSessionToken, "", fmt.Sprintf("Specify an authentication token. For security reasons setting %s is preferred.", envSessionToken))
 	cliflag.String(cmd.PersistentFlags(), varAgentToken, "", "CODER_AGENT_TOKEN", "", "Specify an agent authentication token.")
 	_ = cmd.PersistentFlags().MarkHidden(varAgentToken)
 	cliflag.String(cmd.PersistentFlags(), varAgentURL, "", "CODER_AGENT_URL", "", "Specify the URL for an agent to access your deployment.")


### PR DESCRIPTION
fixes #2418