### PR TITLE
fix: Properly remove non matched workspaces

### DIFF
--- a/site/src/xServices/workspaces/workspacesXService.ts
+++ b/site/src/xServices/workspaces/workspacesXService.ts
@@ -307,7 +307,7 @@ export const workspacesMachine = createMachine(
               }
 
               // Remove ref from the array
-              workspaceRefs = workspaceRefs.filter((oldRef) => oldRef.id === ref.id)
+              workspaceRefs = workspaceRefs.filter((oldRef) => oldRef.id !== ref.id)
             }
           }
 


### PR DESCRIPTION
Previously was not filtering workspaces from the result. Meaning existing workspaces would not be removed if you inputted a search query that returns a smaller set.

The 5s refresh or refreshing page was a required workaround before this 
