### PR TITLE
fix: Adjust pagination limit to be zero-based

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -396,7 +396,7 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 			}
 		}
 		return true
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 15*time.Second, 50*time.Millisecond)
 	return resources
 }
 

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1360,10 +1360,10 @@ func (q *fakeQuerier) GetProvisionerLogsByIDBetween(_ context.Context, arg datab
 		if jobLog.JobID.String() != arg.JobID.String() {
 			continue
 		}
-		if jobLog.CreatedAt.After(arg.CreatedBefore) {
+		if !arg.CreatedBefore.IsZero() && jobLog.CreatedAt.After(arg.CreatedBefore) {
 			continue
 		}
-		if jobLog.CreatedAt.Before(arg.CreatedAfter) {
+		if !arg.CreatedAfter.IsZero() && jobLog.CreatedAt.Before(arg.CreatedAfter) {
 			continue
 		}
 		logs = append(logs, jobLog)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2242,8 +2242,8 @@ ORDER BY
     -- a timestamp. This is to ensure consistent pagination.
 	(created_at, id) ASC OFFSET $3
 LIMIT
-	-- A null limit means "no limit", so -1 means return all
-	NULLIF($4 :: int, -1)
+	-- A null limit means "no limit", so 0 means return all
+	NULLIF($4 :: int, 0)
 `
 
 type GetTemplateVersionsByTemplateIDParams struct {
@@ -2590,8 +2590,8 @@ ORDER BY
     -- a timestamp. This is to ensure consistent pagination.
 	(created_at, id) ASC OFFSET $5
 LIMIT
-	-- A null limit means "no limit", so -1 means return all
-	NULLIF($6 :: int, -1)
+	-- A null limit means "no limit", so 0 means return all
+	NULLIF($6 :: int, 0)
 `
 
 type GetUsersParams struct {
@@ -3573,8 +3573,8 @@ END
 ORDER BY
     build_number desc OFFSET $3
 LIMIT
-    -- A null limit means "no limit", so -1 means return all
-    NULLIF($4 :: int, -1)
+    -- A null limit means "no limit", so 0 means return all
+    NULLIF($4 :: int, 0)
 `
 
 type GetWorkspaceBuildByWorkspaceIDParams struct {

--- a/coderd/database/queries/templateversions.sql
+++ b/coderd/database/queries/templateversions.sql
@@ -29,8 +29,8 @@ ORDER BY
     -- a timestamp. This is to ensure consistent pagination.
 	(created_at, id) ASC OFFSET @offset_opt
 LIMIT
-	-- A null limit means "no limit", so -1 means return all
-	NULLIF(@limit_opt :: int, -1);
+	-- A null limit means "no limit", so 0 means return all
+	NULLIF(@limit_opt :: int, 0);
 
 -- name: GetTemplateVersionByJobID :one
 SELECT

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -126,8 +126,8 @@ ORDER BY
     -- a timestamp. This is to ensure consistent pagination.
 	(created_at, id) ASC OFFSET @offset_opt
 LIMIT
-	-- A null limit means "no limit", so -1 means return all
-	NULLIF(@limit_opt :: int, -1);
+	-- A null limit means "no limit", so 0 means return all
+	NULLIF(@limit_opt :: int, 0);
 
 -- name: UpdateUserStatus :one
 UPDATE

--- a/coderd/database/queries/workspacebuilds.sql
+++ b/coderd/database/queries/workspacebuilds.sql
@@ -68,8 +68,8 @@ END
 ORDER BY
     build_number desc OFFSET @offset_opt
 LIMIT
-    -- A null limit means "no limit", so -1 means return all
-    NULLIF(@limit_opt :: int, -1);
+    -- A null limit means "no limit", so 0 means return all
+    NULLIF(@limit_opt :: int, 0);
 
 -- name: GetLatestWorkspaceBuildByWorkspaceID :one
 SELECT

--- a/coderd/pagination.go
+++ b/coderd/pagination.go
@@ -17,7 +17,7 @@ func parsePagination(w http.ResponseWriter, r *http.Request) (p codersdk.Paginat
 	params := codersdk.Pagination{
 		AfterID: parser.UUID(queryParams, uuid.Nil, "after_id"),
 		// Limit default to "-1" which returns all results
-		Limit:  parser.Int(queryParams, -1, "limit"),
+		Limit:  parser.Int(queryParams, 0, "limit"),
 		Offset: parser.Int(queryParams, 0, "offset"),
 	}
 	if len(parser.Errors) > 0 {

--- a/coderd/pagination_internal_test.go
+++ b/coderd/pagination_internal_test.go
@@ -77,7 +77,6 @@ func TestPagination(t *testing.T) {
 			ExpectedParams: codersdk.Pagination{
 				AfterID: uuid.Nil,
 				Offset:  150,
-				Limit:   -1,
 			},
 		},
 		{
@@ -85,7 +84,6 @@ func TestPagination(t *testing.T) {
 			AfterID: "5f2005fc-acc4-4e5e-a7fa-be017359c60b",
 			ExpectedParams: codersdk.Pagination{
 				AfterID: uuid.MustParse("5f2005fc-acc4-4e5e-a7fa-be017359c60b"),
-				Limit:   -1,
 			},
 		},
 	}


### PR DESCRIPTION
There isn't a use-case for querying a limit of zero. Using
-1 led to issues when using default parameters for querying.
