### PR TITLE
fix: Increase wait time for agent connection tests

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -396,7 +396,7 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 			}
 		}
 		return true
-	}, 5*time.Second, 25*time.Millisecond)
+	}, 15*time.Second, 50*time.Millisecond)
 	return resources
 }
 


### PR DESCRIPTION
This was causing a test flake seen here:
https://github.com/coder/coder/runs/7063032150?check_suite_focus=true
