### PR TITLE
fix: Await workspace build job before waiting for CLI output

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -170,7 +170,7 @@ func TestServer(t *testing.T) {
 		require.Eventually(t, func() bool {
 			var err error
 			accessURLRaw, err = cfg.URL().Read()
-			return err == nil
+			return accessURLRaw != "" && err == nil
 		}, 15*time.Second, 25*time.Millisecond)
 		accessURL, err := url.Parse(accessURLRaw)
 		require.NoError(t, err)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -68,6 +68,7 @@ func TestSSH(t *testing.T) {
 	t.Run("ImmediateExit", func(t *testing.T) {
 		t.Parallel()
 		client, workspace, agentToken := setupWorkspaceForSSH(t)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 		cmd, root := clitest.New(t, "ssh", workspace.Name)
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
@@ -79,7 +80,6 @@ func TestSSH(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		pty.ExpectMatch("Waiting")
-		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 		agentClient := codersdk.New(client.URL)
 		agentClient.SessionToken = agentToken
 		agentCloser := agent.New(agentClient.ListenWorkspaceAgent, &agent.Options{


### PR DESCRIPTION
This was causing occasional flakes seen here:
https://github.com/coder/coder/runs/7063142245?check_suite_focus=true
