### PR TITLE
fix: Wait for workspace build to complete before running SSH tests

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -59,6 +59,7 @@ func setupWorkspaceForSSH(t *testing.T) (*codersdk.Client, codersdk.Workspace, s
 	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 	return client, workspace, agentToken
 }
@@ -68,7 +69,6 @@ func TestSSH(t *testing.T) {
 	t.Run("ImmediateExit", func(t *testing.T) {
 		t.Parallel()
 		client, workspace, agentToken := setupWorkspaceForSSH(t)
-		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 		cmd, root := clitest.New(t, "ssh", workspace.Name)
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
@@ -96,11 +96,9 @@ func TestSSH(t *testing.T) {
 	t.Run("Stdio", func(t *testing.T) {
 		t.Parallel()
 		client, workspace, agentToken := setupWorkspaceForSSH(t)
-
 		_, _ = tGoContext(t, func(ctx context.Context) {
 			// Run this async so the SSH command has to wait for
 			// the build and agent to connect!
-			coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 			agentClient := codersdk.New(client.URL)
 			agentClient.SessionToken = agentToken
 			agentCloser := agent.New(agentClient.ListenWorkspaceAgent, &agent.Options{
@@ -154,11 +152,9 @@ func TestSSH(t *testing.T) {
 		t.Parallel()
 
 		client, workspace, agentToken := setupWorkspaceForSSH(t)
-
 		_, _ = tGoContext(t, func(ctx context.Context) {
 			// Run this async so the SSH command has to wait for
 			// the build and agent to connect!
-			coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 			agentClient := codersdk.New(client.URL)
 			agentClient.SessionToken = agentToken
 			agentCloser := agent.New(agentClient.ListenWorkspaceAgent, &agent.Options{


### PR DESCRIPTION
This was causing a race shown here:
https://github.com/coder/coder/runs/7063713786?check_suite_focus=true
