### PR TITLE
Bump version number for coder terraform provider

### DIFF
--- a/examples/templates/do-linux/main.tf
+++ b/examples/templates/do-linux/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     digitalocean = {
       source  = "digitalocean/digitalocean"

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
I ran into an issue while I was working through the Quickstart and some of the documentation. Specifically, when I tried to install `code-server` as a `coder_app` in the `docker` example using the [docs](https://coder.com/docs/coder-oss/latest/ides/configuring-web-ides) I got an error that `url` was unexpected. It looks like in versions [0.4.0 and 0.4.1](https://registry.terraform.io/providers/coder/coder/0.4.1/docs/resources/app) of the Terraform spec, `target` was used in place of `url`, which is used in [0.4.2](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)

I didn't bump any of the examples that used versions <0.4.0, because I wasn't sure what effect that might have on them
