### PR TITLE
fix: Check if start is nil before consuming in echo provisioner

### DIFF
--- a/provisioner/echo/serve.go
+++ b/provisioner/echo/serve.go
@@ -82,6 +82,10 @@ func (e *echo) Provision(stream proto.DRPCProvisioner_ProvisionStream) error {
 		return err
 	}
 	request := msg.GetStart()
+	if request == nil {
+		// A cancel could occur here!
+		return nil
+	}
 	for index := 0; ; index++ {
 		extension := ".protobuf"
 		if request.DryRun {


### PR DESCRIPTION
This caused a race seen here:
https://github.com/coder/coder/runs/7074123929?check_suite_focus=true#step:10:217
