### PR TITLE
fix: Add coder user to docker group on installation

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -11,4 +11,14 @@ if ! id -u $USER >/dev/null 2>&1; then
 		--user-group \
 		--shell /bin/false \
 		$USER
+
+	# Add the Coder user to the Docker group.
+	# Coder is frequently used with Docker, so
+	# this prevents failures when building.
+	#
+	# It's fine if this fails!
+	usermod \
+		--append \
+		--groups docker \
+		$USER 2>/dev/null || true
 fi


### PR DESCRIPTION
This makes for a simpler setup and reduces the likelihood
a user runs into a strange issue.
