### PR TITLE
fix: use valid ip mask in api keys when remote address is ipv6

### DIFF
--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -172,10 +172,11 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs) func(http.Handler) h
 				if remoteIP == nil {
 					remoteIP = net.IPv4(0, 0, 0, 0)
 				}
+				bitlen := len(remoteIP) * 8
 				key.IPAddress = pqtype.Inet{
 					IPNet: net.IPNet{
 						IP:   remoteIP,
-						Mask: remoteIP.DefaultMask(),
+						Mask: net.CIDRMask(bitlen, bitlen),
 					},
 					Valid: true,
 				}

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -815,6 +815,7 @@ func (api *API) createAPIKey(rw http.ResponseWriter, r *http.Request, params dat
 	if ip == nil {
 		ip = net.IPv4(0, 0, 0, 0)
 	}
+	bitlen := len(ip) * 8
 	key, err := api.Database.InsertAPIKey(r.Context(), database.InsertAPIKeyParams{
 		ID:              keyID,
 		UserID:          params.UserID,
@@ -822,7 +823,7 @@ func (api *API) createAPIKey(rw http.ResponseWriter, r *http.Request, params dat
 		IPAddress: pqtype.Inet{
 			IPNet: net.IPNet{
 				IP:   ip,
-				Mask: ip.DefaultMask(),
+				Mask: net.CIDRMask(bitlen, bitlen),
 			},
 			Valid: true,
 		},


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
