### PR TITLE
fix: ci uses a migrated DB template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test: test-clean
 .PHONY: test
 
 test-postgres: test-clean test-postgres-docker
-	DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum --junitfile="gotests.xml" --packages="./..." -- \
+	DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum --junitfile="gotests.xml" --packages="./..." -- \
 		-covermode=atomic -coverprofile="gotests.coverage" -timeout=30m \
 		-coverpkg=./...,github.com/coder/coder/codersdk \
 		-count=2 -race -failfast

--- a/scripts/migrate-ci/main.go
+++ b/scripts/migrate-ci/main.go
@@ -27,7 +27,14 @@ func main() {
 		panic(err)
 	}
 
-	err = database.MigrateUp(db)
+	targetURL := fmt.Sprintf("postgres://postgres:postgres@127.0.0.1:5432/%s?sslmode=disable", dbName)
+	target, err := sql.Open("postgres", targetURL)
+	if err != nil {
+		panic(err)
+	}
+	defer target.Close()
+
+	err = database.MigrateUp(target)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Noticed anomalously low postgres CPU utilization during tests...  turns out it wasn't using it at all!

