### PR TITLE
fix: restrict edit schedule access

### DIFF
--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -64,6 +64,7 @@ export const Workspace: FC<WorkspaceProps> = ({
               workspace={workspace}
               onDeadlineMinus={scheduleProps.onDeadlineMinus}
               onDeadlinePlus={scheduleProps.onDeadlinePlus}
+              canUpdateWorkspace={canUpdateWorkspace}
             />
             <WorkspaceActions
               workspace={workspace}

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
@@ -16,6 +16,11 @@ const THIRTY = 30
 export default {
   title: "components/WorkspaceSchedule",
   component: WorkspaceSchedule,
+  argTypes: {
+    canUpdateWorkspace: {
+      defaultValue: true,
+    },
+  },
 }
 
 const Template: Story<WorkspaceScheduleProps> = (args) => <WorkspaceSchedule {...args} />
@@ -40,7 +45,7 @@ NoTTL.args = {
     ...Mocks.MockWorkspace,
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
-      // a mannual shutdown has a deadline of '"0001-01-01T00:00:00Z"'
+      // a manual shutdown has a deadline of '"0001-01-01T00:00:00Z"'
       // SEE: #1834
       deadline: "0001-01-01T00:00:00Z",
     },
@@ -112,4 +117,18 @@ WorkspaceOffLong.args = {
     },
     ttl_ms: 2 * 365 * 24 * 60 * 60 * 1000, // 2 years
   },
+}
+
+export const CannotEdit = Template.bind({})
+CannotEdit.args = {
+  workspace: {
+    ...Mocks.MockWorkspace,
+
+    latest_build: {
+      ...Mocks.MockWorkspaceBuild,
+      transition: "stop",
+    },
+    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
+  },
+  canUpdateWorkspace: false,
 }

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -36,7 +36,10 @@ export interface WorkspaceScheduleProps {
   canUpdateWorkspace: boolean
 }
 
-export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace, canUpdateWorkspace }) => {
+export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
+  workspace,
+  canUpdateWorkspace,
+}) => {
   const styles = useStyles()
   const timezone = workspace.autostart_schedule
     ? extractTimezone(workspace.autostart_schedule)

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -33,9 +33,10 @@ export const Language = {
 
 export interface WorkspaceScheduleProps {
   workspace: Workspace
+  canUpdateWorkspace: boolean
 }
 
-export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace }) => {
+export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace, canUpdateWorkspace }) => {
   const styles = useStyles()
   const timezone = workspace.autostart_schedule
     ? extractTimezone(workspace.autostart_schedule)
@@ -62,15 +63,17 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace }) => 
             </span>
           </Stack>
         </div>
-        <div>
-          <Link
-            className={styles.scheduleAction}
-            component={RouterLink}
-            to={`/@${workspace.owner_name}/${workspace.name}/schedule`}
-          >
-            {Language.editScheduleLink}
-          </Link>
-        </div>
+        {canUpdateWorkspace && (
+          <div>
+            <Link
+              className={styles.scheduleAction}
+              component={RouterLink}
+              to={`/@${workspace.owner_name}/${workspace.name}/schedule`}
+            >
+              {Language.editScheduleLink}
+            </Link>
+          </div>
+        )}
       </Stack>
     </div>
   )

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
@@ -115,3 +115,17 @@ WorkspaceOffLong.args = {
     ttl_ms: 2 * 365 * 24 * 60 * 60 * 1000, // 2 years
   },
 }
+
+export const CannotEdit = Template.bind({})
+CannotEdit.args = {
+  workspace: {
+    ...Mocks.MockWorkspace,
+
+    latest_build: {
+      ...Mocks.MockWorkspaceBuild,
+      transition: "stop",
+    },
+    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
+  },
+  canUpdateWorkspace: false,
+}

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
@@ -16,6 +16,11 @@ const THIRTY = 30
 export default {
   title: "components/WorkspaceScheduleButton",
   component: WorkspaceScheduleButton,
+  argTypes: {
+    canUpdateWorkspace: {
+      defaultValue: true,
+    },
+  },
 }
 
 const Template: Story<WorkspaceScheduleButtonProps> = (args) => (

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
@@ -54,12 +54,14 @@ export interface WorkspaceScheduleButtonProps {
   workspace: Workspace
   onDeadlinePlus: () => void
   onDeadlineMinus: () => void
+  canUpdateWorkspace: boolean
 }
 
 export const WorkspaceScheduleButton: React.FC<WorkspaceScheduleButtonProps> = ({
   workspace,
   onDeadlinePlus,
   onDeadlineMinus,
+  canUpdateWorkspace,
 }) => {
   const anchorRef = useRef<HTMLButtonElement>(null)
   const [isOpen, setIsOpen] = useState(false)
@@ -74,7 +76,7 @@ export const WorkspaceScheduleButton: React.FC<WorkspaceScheduleButtonProps> = (
     <div className={styles.wrapper}>
       <div className={styles.label}>
         <WorkspaceScheduleLabel workspace={workspace} />
-        {shouldDisplayPlusMinus(workspace) && (
+        {canUpdateWorkspace && shouldDisplayPlusMinus(workspace) && (
           <Stack direction="row" spacing={0}>
             <IconButton
               className={styles.iconButton}
@@ -124,7 +126,7 @@ export const WorkspaceScheduleButton: React.FC<WorkspaceScheduleButtonProps> = (
             horizontal: "right",
           }}
         >
-          <WorkspaceSchedule workspace={workspace} />
+          <WorkspaceSchedule workspace={workspace} canUpdateWorkspace={canUpdateWorkspace} />
         </Popover>
       </div>
     </div>

--- a/site/src/pages/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -27,7 +27,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 
 const Language = {
-  forbiddenError: "403: Workspace schedule update forbidden.",
+  forbiddenError: "You don't have permissions to update the schedule for this workspace.",
 }
 
 export const formValuesToAutoStartRequest = (

--- a/site/src/pages/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -168,23 +168,31 @@ export const WorkspaceSchedulePage: React.FC = () => {
   if (!username || !workspaceName) {
     navigate("/workspaces")
     return null
-  } else if (
+  }
+
+  if (
     scheduleState.matches("idle") ||
     scheduleState.matches("gettingWorkspace") ||
     scheduleState.matches("gettingPermissions") ||
     !workspace
   ) {
     return <FullScreenLoader />
-  } else if (scheduleState.matches("error")) {
+  }
+
+  if (scheduleState.matches("error")) {
     return (
       <ErrorSummary
         error={getWorkspaceError || checkPermissionsError}
         retry={() => scheduleSend({ type: "GET_WORKSPACE", username, workspaceName })}
       />
     )
-  } else if (!permissions?.updateWorkspace) {
+  }
+
+  if (!permissions?.updateWorkspace) {
     return <ErrorSummary error={Error(Language.forbiddenError)} />
-  } else if (scheduleState.matches("presentForm") || scheduleState.matches("submittingSchedule")) {
+  }
+
+  if (scheduleState.matches("presentForm") || scheduleState.matches("submittingSchedule")) {
     return (
       <WorkspaceScheduleForm
         fieldErrors={formErrors}
@@ -202,13 +210,15 @@ export const WorkspaceSchedulePage: React.FC = () => {
         }}
       />
     )
-  } else if (scheduleState.matches("submitSuccess")) {
+  }
+
+  if (scheduleState.matches("submitSuccess")) {
     navigate(`/@${username}/${workspaceName}`)
     return <FullScreenLoader />
-  } else {
-    // Theoretically impossible - log and bail
-    console.error("WorkspaceSchedulePage: unknown state :: ", scheduleState)
-    navigate("/")
-    return null
   }
+
+  // Theoretically impossible - log and bail
+  console.error("WorkspaceSchedulePage: unknown state :: ", scheduleState)
+  navigate("/")
+  return null
 }


### PR DESCRIPTION
This PR restricts the link to editing workspace schedule and the actual page access to users with update access to the workspace.

## Subtasks

- [x] hide the `Edit schedule` link for users without update access.
- [x] hide the plus-minus buttons for users without update access.
- [x] add relevant story
- [x] fetch permissions on workspace schedule page
- [x] display error in case access is forbidden

Fixes #2655 

## Screenshots
![Screen Shot 2022-07-01 at 3 34 43 PM](https://user-images.githubusercontent.com/7511231/176958638-b301543e-0aad-4ce1-a6f5-b78b47435517.png)


<img width="784" alt="Screen Shot 2022-07-01 at 4 45 40 AM" src="https://user-images.githubusercontent.com/7511231/176859883-441dcdc4-9038-47d1-813d-27136e5edab9.png">


