### PR TITLE
Revert "feat: add version checking to CLI"

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -3,7 +3,6 @@ package buildinfo
 import (
 	"fmt"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"time"
 
@@ -25,11 +24,6 @@ var (
 	tag string
 )
 
-const (
-	// develPrefix is prefixed to developer versions of the application.
-	develPrefix = "v0.0.0-devel"
-)
-
 // Version returns the semantic version of the build.
 // Use golang.org/x/mod/semver to compare versions.
 func Version() string {
@@ -41,7 +35,7 @@ func Version() string {
 		if tag == "" {
 			// This occurs when the tag hasn't been injected,
 			// like when using "go run".
-			version = develPrefix + revision
+			version = "v0.0.0-devel" + revision
 			return
 		}
 		version = "v" + tag
@@ -52,20 +46,6 @@ func Version() string {
 		}
 	})
 	return version
-}
-
-// VersionsMatch compares the two versions. It assumes the versions match if
-// the major and the minor versions are equivalent. Patch versions are
-// disregarded. If it detects that either version is a developer build it
-// returns true.
-func VersionsMatch(v1, v2 string) bool {
-	// Developer versions are disregarded...hopefully they know what they are
-	// doing.
-	if strings.HasPrefix(v1, develPrefix) || strings.HasPrefix(v2, develPrefix) {
-		return true
-	}
-
-	return semver.MajorMinor(v1) == semver.MajorMinor(v2)
 }
 
 // ExternalURL returns a URL referencing the current Coder version.

--- a/buildinfo/buildinfo_test.go
+++ b/buildinfo/buildinfo_test.go
@@ -1,7 +1,6 @@
 package buildinfo_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,71 +28,5 @@ func TestBuildInfo(t *testing.T) {
 		t.Parallel()
 		_, valid := buildinfo.Time()
 		require.False(t, valid)
-	})
-
-	t.Run("VersionsMatch", func(t *testing.T) {
-		t.Parallel()
-
-		type testcase struct {
-			name        string
-			v1          string
-			v2          string
-			expectMatch bool
-		}
-
-		cases := []testcase{
-			{
-				name:        "OK",
-				v1:          "v1.2.3",
-				v2:          "v1.2.3",
-				expectMatch: true,
-			},
-			// Test that we return true if a developer version is detected.
-			// Developers do not need to be warned of mismatched versions.
-			{
-				name:        "DevelIgnored",
-				v1:          "v0.0.0-devel+123abac",
-				v2:          "v1.2.3",
-				expectMatch: true,
-			},
-			// Our CI instance uses a "-devel" prerelease
-			// flag. This is not the same as a developer WIP build.
-			{
-				name:        "DevelPreleaseNotIgnored",
-				v1:          "v1.1.1-devel+123abac",
-				v2:          "v1.2.3",
-				expectMatch: false,
-			},
-			{
-				name:        "MajorMismatch",
-				v1:          "v1.2.3",
-				v2:          "v0.1.2",
-				expectMatch: false,
-			},
-			{
-				name:        "MinorMismatch",
-				v1:          "v1.2.3",
-				v2:          "v1.3.2",
-				expectMatch: false,
-			},
-			// Different patches are ok, breaking changes are not allowed
-			// in patches.
-			{
-				name:        "PatchMismatch",
-				v1:          "v1.2.3+hash.whocares",
-				v2:          "v1.2.4+somestuff.hm.ok",
-				expectMatch: true,
-			},
-		}
-
-		for _, c := range cases {
-			c := c
-			t.Run(c.name, func(t *testing.T) {
-				t.Parallel()
-				require.Equal(t, c.expectMatch, buildinfo.VersionsMatch(c.v1, c.v2),
-					fmt.Sprintf("expected match=%v for version %s and %s", c.expectMatch, c.v1, c.v2),
-				)
-			})
-		}
 	})
 }

--- a/cli/login.go
+++ b/cli/login.go
@@ -67,15 +67,6 @@ func login() *cobra.Command {
 			}
 
 			client := codersdk.New(serverURL)
-
-			// Try to check the version of the server prior to logging in.
-			// It may be useful to warn the user if they are trying to login
-			// on a very old client.
-			err = checkVersions(cmd, client)
-			if err != nil {
-				return xerrors.Errorf("check versions: %w", err)
-			}
-
 			hasInitialUser, err := client.HasFirstUser(cmd.Context())
 			if err != nil {
 				return xerrors.Errorf("has initial user: %w", err)

--- a/codersdk/buildinfo.go
+++ b/codersdk/buildinfo.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
-
-	"golang.org/x/mod/semver"
 )
 
 // BuildInfoResponse contains build information for this instance of Coder.
@@ -17,15 +14,6 @@ type BuildInfoResponse struct {
 	ExternalURL string `json:"external_url"`
 	// Version returns the semantic version of the build.
 	Version string `json:"version"`
-}
-
-// CanonicalVersion trims build information from the version.
-// E.g. 'v0.7.4-devel+11573034' -> 'v0.7.4'.
-func (b BuildInfoResponse) CanonicalVersion() string {
-	// We do a little hack here to massage the string into a form
-	// that works well with semver.
-	trimmed := strings.ReplaceAll(b.Version, "-devel+", "+devel-")
-	return semver.Canonical(trimmed)
 }
 
 // BuildInfo returns build information for this instance of Coder.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -36,7 +36,7 @@ export interface AzureInstanceIdentityToken {
   readonly encoding: string
 }
 
-// From codersdk/buildinfo.go:13:6
+// From codersdk/buildinfo.go:10:6
 export interface BuildInfoResponse {
   readonly external_url: string
   readonly version: string


### PR DESCRIPTION
Reverts coder/coder#2643

Dev is currently down
```
Jun 29 02:02:02 coder systemd[1]: Starting "Coder - Self-hosted developer workspaces on your infra"...
Jun 29 02:02:02 coder coder[30940]: build info: do: Get "https://127.0.0.1:8443/api/v2/buildinfo": dial tcp 127.0.0.1:8443: connect: connection refused
Jun 29 02:02:02 coder coder[30940]: Run 'coder server --help' for usage.
Jun 29 02:02:02 coder systemd[1]: coder.service: Main process exited, code=exited, status=1/FAILURE
Jun 29 02:02:02 coder systemd[1]: coder.service: Failed with result 'exit-code'.
Jun 29 02:02:02 coder systemd[1]: Failed to start "Coder - Self-hosted developer workspaces on your infra".
```