### PR TITLE
feature: allow editing workspace deadline in UI

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1,8 +1,8 @@
 import axios, { AxiosRequestHeaders } from "axios"
+import dayjs from "dayjs"
 import * as Types from "./types"
 import { WorkspaceBuildTransition } from "./types"
 import * as TypesGen from "./typesGenerated"
-import dayjs from "dayjs"
 
 const CONTENT_TYPE_JSON: AxiosRequestHeaders = {
   "Content-Type": "application/json",

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2,6 +2,7 @@ import axios, { AxiosRequestHeaders } from "axios"
 import * as Types from "./types"
 import { WorkspaceBuildTransition } from "./types"
 import * as TypesGen from "./typesGenerated"
+import dayjs from "dayjs"
 
 const CONTENT_TYPE_JSON: AxiosRequestHeaders = {
   "Content-Type": "application/json",
@@ -339,7 +340,7 @@ export const getWorkspaceBuildLogs = async (
 
 export const putWorkspaceExtension = async (
   workspaceId: string,
-  extendWorkspaceRequest: TypesGen.PutExtendWorkspaceRequest,
+  newDeadline: dayjs.Dayjs,
 ): Promise<void> => {
-  await axios.put(`/api/v2/workspaces/${workspaceId}/extend`, extendWorkspaceRequest)
+  await axios.put(`/api/v2/workspaces/${workspaceId}/extend`, { deadline: newDeadline })
 }

--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -17,6 +17,14 @@ Started.args = {
     isLoading: false,
     onExtend: action("extend"),
   },
+  scheduleProps: {
+    onDeadlineMinus: () => {
+      // do nothing, this is just for storybook
+    },
+    onDeadlinePlus: () => {
+      // do nothing, this is just for storybook
+    },
+  },
   workspace: Mocks.MockWorkspace,
   handleStart: action("start"),
   handleStop: action("stop"),

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -19,6 +19,10 @@ export interface WorkspaceProps {
     isLoading?: boolean
     onExtend: () => void
   }
+  scheduleProps: {
+    onDeadlinePlus: () => void
+    onDeadlineMinus: () => void
+  }
   handleStart: () => void
   handleStop: () => void
   handleDelete: () => void
@@ -36,6 +40,7 @@ export interface WorkspaceProps {
  */
 export const Workspace: FC<WorkspaceProps> = ({
   bannerProps,
+  scheduleProps,
   handleStart,
   handleStop,
   handleDelete,
@@ -99,7 +104,11 @@ export const Workspace: FC<WorkspaceProps> = ({
         </Stack>
 
         <Stack direction="column" className={styles.secondColumnSpacer} spacing={3}>
-          <WorkspaceSchedule workspace={workspace} />
+          <WorkspaceSchedule
+            workspace={workspace}
+            onDeadlineMinus={scheduleProps.onDeadlineMinus}
+            onDeadlinePlus={scheduleProps.onDeadlinePlus}
+          />
         </Stack>
       </Stack>
     </Margins>

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
@@ -11,6 +11,7 @@ dayjs.extend(utc)
 // SEE: https:github.com/storybookjs/storybook/issues/12208#issuecomment-697044557
 const ONE = 1
 const SEVEN = 7
+const THIRTY = 30
 
 export default {
   title: "components/WorkspaceSchedule",
@@ -44,6 +45,19 @@ NoTTL.args = {
       deadline: "0001-01-01T00:00:00Z",
     },
     ttl_ms: undefined,
+  },
+}
+
+export const ShutdownRealSoon = Template.bind({})
+ShutdownRealSoon.args = {
+  workspace: {
+    ...Mocks.MockWorkspace,
+    latest_build: {
+      ...Mocks.MockWorkspaceBuild,
+      deadline: dayjs().add(THIRTY, "minute").utc().format(),
+      transition: "start",
+    },
+    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
   },
 }
 

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.test.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.test.tsx
@@ -58,6 +58,20 @@ describe("WorkspaceSchedule", () => {
       // Then: deadlineMinusDisabled should be truthy
       expect(deadlineMinusDisabled(workspace, now)).toBeTruthy()
     })
+
+    it("should be true if the deadline is in the past", () => {
+      // Given: a workspace with a deadline set to 1 minute in the past
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          deadline: now.add(-1, "minutes").utc().format(),
+        },
+      }
+
+      // Then: deadlineMinusDisabled should be truthy
+      expect(deadlineMinusDisabled(workspace, now)).toBeTruthy()
+    })
   })
 
   describe("deadlinePlusDisabled", () => {
@@ -87,6 +101,20 @@ describe("WorkspaceSchedule", () => {
 
       // Then: deadlinePlusDisabled should be truthy
       expect(deadlinePlusDisabled(workspace, now)).toBeTruthy()
+    })
+
+    it("should be false if the deadline is in the past", () => {
+      // Given: a workspace with a deadline set to 1 minute in the past
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          deadline: now.add(-1, "minute").utc().format(),
+        },
+      }
+
+      // Then: deadlinePlusDisabled should be falsy
+      expect(deadlinePlusDisabled(workspace, now)).toBeFalsy()
     })
   })
 })

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.test.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.test.tsx
@@ -1,0 +1,92 @@
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+import * as TypesGen from "../../api/typesGenerated"
+import * as Mocks from "../../testHelpers/entities"
+import {
+  deadlineMinusDisabled,
+  deadlinePlusDisabled,
+  shouldDisplayPlusMinus,
+} from "./WorkspaceSchedule"
+
+dayjs.extend(utc)
+const now = dayjs()
+
+describe("WorkspaceSchedule", () => {
+  describe("shouldDisplayPlusMinus", () => {
+    it("should not display if the workspace is not running", () => {
+      // Given: a stopped workspace
+      const workspace: TypesGen.Workspace = Mocks.MockStoppedWorkspace
+
+      // Then: shouldDisplayPlusMinus should be false
+      expect(shouldDisplayPlusMinus(workspace)).toBeFalsy()
+    })
+
+    it("should display if the workspace is running", () => {
+      // Given: a stopped workspace
+      const workspace: TypesGen.Workspace = Mocks.MockWorkspace
+
+      // Then: shouldDisplayPlusMinus should be false
+      expect(shouldDisplayPlusMinus(workspace)).toBeTruthy()
+    })
+  })
+
+  describe("deadlineMinusDisabled", () => {
+    it("should be false if the deadline is more than 30 minutes in the future", () => {
+      // Given: a workspace with a deadline set to 31 minutes in the future
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          deadline: now.add(31, "minutes").utc().format(),
+        },
+      }
+
+      // Then: deadlineMinusDisabled should be falsy
+      expect(deadlineMinusDisabled(workspace, now)).toBeFalsy()
+    })
+
+    it("should be true if the deadline is 30 minutes or less in the future", () => {
+      // Given: a workspace with a deadline set to 30 minutes in the future
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          deadline: now.add(30, "minutes").utc().format(),
+        },
+      }
+
+      // Then: deadlineMinusDisabled should be truthy
+      expect(deadlineMinusDisabled(workspace, now)).toBeTruthy()
+    })
+  })
+
+  describe("deadlinePlusDisabled", () => {
+    it("should be false if the deadline is less than 24 hours in the future", () => {
+      // Given: a workspace with a deadline set to 23 hours in the future
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          deadline: now.add(23, "hours").utc().format(),
+        },
+      }
+
+      // Then: deadlinePlusDisabled should be falsy
+      expect(deadlinePlusDisabled(workspace, now)).toBeFalsy()
+    })
+
+    it("should be true if the deadline is 24 hours or more in the future", () => {
+      // Given: a workspace with a deadline set to 25 hours in the future
+      const workspace: TypesGen.Workspace = {
+        ...Mocks.MockWorkspace,
+        latest_build: {
+          ...Mocks.MockWorkspaceBuild,
+          deadline: now.add(25, "hours").utc().format(),
+        },
+      }
+
+      // Then: deadlinePlusDisabled should be truthy
+      expect(deadlinePlusDisabled(workspace, now)).toBeTruthy()
+    })
+  })
+})

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -1,3 +1,4 @@
+import Button from "@material-ui/core/Button"
 import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
 import Typography from "@material-ui/core/Typography"
@@ -66,6 +67,8 @@ export const Language = {
     }
   },
   editScheduleLink: "Edit schedule",
+  editDeadlineMinus: "[-1 hour]",
+  editDeadlinePlus: "[+1 hour]",
   scheduleHeader: (workspace: Workspace): string => {
     const tz = workspace.autostart_schedule
       ? extractTimezone(workspace.autostart_schedule)
@@ -76,6 +79,16 @@ export const Language = {
 
 export interface WorkspaceScheduleProps {
   workspace: Workspace
+  onDeadlinePlus: () => void
+  onDeadlineMinus: () => void
+}
+
+export const shouldDisplayPlusMins = (workspace: Workspace): boolean => {
+  if (!isWorkspaceOn(workspace)) {
+    return false
+  }
+  const deadline = dayjs(workspace.latest_build.deadline).utc()
+  return deadline.year() > 1
 }
 
 export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace }) => {
@@ -99,6 +112,16 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace }) => 
           <span className={[styles.scheduleValue, "chromatic-ignore"].join(" ")}>
             {Language.autoStopDisplay(workspace)}
           </span>
+        </div>
+        <div>
+          <Stack direction="row">
+            <Button className={styles.editDeadline}>
+              <span className={styles.scheduleLabel}>{Language.editDeadlineMinus}</span>
+            </Button>
+            <Button className={styles.editDeadline}>
+              <span className={styles.scheduleLabel}>{Language.editDeadlinePlus}</span>
+            </Button>
+          </Stack>
         </div>
         <div>
           <Link
@@ -145,5 +168,13 @@ const useStyles = makeStyles((theme) => ({
   },
   scheduleAction: {
     cursor: "pointer",
+  },
+  editDeadline: {
+    fontSize: 12,
+    textTransform: "uppercase",
+    display: "inline-block",
+    fontWeight: 600,
+    color: theme.palette.text.secondary,
+    margin: theme.spacing(0),
   },
 }))

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -97,12 +97,12 @@ export const shouldDisplayPlusMinus = (workspace: Workspace): boolean => {
 
 export const deadlineMinusDisabled = (workspace: Workspace, now: dayjs.Dayjs): boolean => {
   const delta = dayjs(workspace.latest_build.deadline).diff(now)
-  return Math.abs(delta) <= 30 * 60 * 1000 // 30 minutes
+  return delta <= 30 * 60 * 1000 // 30 minutes
 }
 
 export const deadlinePlusDisabled = (workspace: Workspace, now: dayjs.Dayjs): boolean => {
   const delta = dayjs(workspace.latest_build.deadline).diff(now)
-  return Math.abs(delta) >= 24 * 60 * 60 * 1000 // 24 hours
+  return delta >= 24 * 60 * 60 * 1000 // 24 hours
 }
 
 export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -1,7 +1,10 @@
-import Button from "@material-ui/core/Button"
+import IconButton from "@material-ui/core/IconButton"
 import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
+import Tooltip from "@material-ui/core/Tooltip"
 import Typography from "@material-ui/core/Typography"
+import AddBoxIcon from "@material-ui/icons/AddBox"
+import IndeterminateCheckBoxIcon from "@material-ui/icons/IndeterminateCheckBox"
 import ScheduleIcon from "@material-ui/icons/Schedule"
 import cronstrue from "cronstrue"
 import dayjs from "dayjs"
@@ -67,8 +70,8 @@ export const Language = {
     }
   },
   editScheduleLink: "Edit schedule",
-  editDeadlineMinus: "[-1 hour]",
-  editDeadlinePlus: "[+1 hour]",
+  editDeadlineMinus: "Subtract one hour",
+  editDeadlinePlus: "Add one hour",
   scheduleHeader: (workspace: Workspace): string => {
     const tz = workspace.autostart_schedule
       ? extractTimezone(workspace.autostart_schedule)
@@ -98,16 +101,18 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
 }) => {
   const styles = useStyles()
   const editDeadlineButtons = shouldDisplayPlusMins(workspace) ? (
-    <div>
-      <Stack direction="row">
-        <Button className={styles.editDeadline} onClick={onDeadlineMinus}>
-          <span className={styles.scheduleLabel}>{Language.editDeadlineMinus}</span>
-        </Button>
-        <Button className={styles.editDeadline} onClick={onDeadlinePlus}>
-          <span className={styles.scheduleLabel}>{Language.editDeadlinePlus}</span>
-        </Button>
-      </Stack>
-    </div>
+    <Stack direction="row" spacing={0}>
+      <IconButton size="small" className={styles.editDeadline} onClick={onDeadlineMinus}>
+        <Tooltip title={Language.editDeadlineMinus}>
+          <IndeterminateCheckBoxIcon />
+        </Tooltip>
+      </IconButton>
+      <IconButton size="small" className={styles.editDeadline} onClick={onDeadlinePlus}>
+        <Tooltip title={Language.editDeadlinePlus}>
+          <AddBoxIcon />
+        </Tooltip>
+      </IconButton>
+    </Stack>
   ) : null
 
   return (
@@ -125,11 +130,13 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
         </div>
         <div>
           <span className={styles.scheduleLabel}>{Language.autoStopLabel}</span>
-          <span className={[styles.scheduleValue, "chromatic-ignore"].join(" ")}>
-            {Language.autoStopDisplay(workspace)}
-          </span>
+          <Stack direction="row">
+            <span className={[styles.scheduleValue, "chromatic-ignore"].join(" ")}>
+              {Language.autoStopDisplay(workspace)}
+            </span>
+            {editDeadlineButtons}
+          </Stack>
         </div>
-        {editDeadlineButtons}
         <div>
           <Link
             className={styles.scheduleAction}
@@ -168,8 +175,8 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
   },
   scheduleValue: {
-    fontSize: 16,
-    marginTop: theme.spacing(0.25),
+    fontSize: 14,
+    marginTop: theme.spacing(0.75),
     display: "inline-block",
     color: theme.palette.text.secondary,
   },
@@ -177,11 +184,6 @@ const useStyles = makeStyles((theme) => ({
     cursor: "pointer",
   },
   editDeadline: {
-    fontSize: 12,
-    textTransform: "uppercase",
-    display: "inline-block",
-    fontWeight: 600,
     color: theme.palette.text.secondary,
-    margin: theme.spacing(0),
   },
 }))

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -97,6 +97,18 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
   onDeadlinePlus,
 }) => {
   const styles = useStyles()
+  const editDeadlineButtons = shouldDisplayPlusMins(workspace) ? (
+    <div>
+      <Stack direction="row">
+        <Button className={styles.editDeadline} onClick={onDeadlineMinus}>
+          <span className={styles.scheduleLabel}>{Language.editDeadlineMinus}</span>
+        </Button>
+        <Button className={styles.editDeadline} onClick={onDeadlinePlus}>
+          <span className={styles.scheduleLabel}>{Language.editDeadlinePlus}</span>
+        </Button>
+      </Stack>
+    </div>
+  ) : null
 
   return (
     <div className={styles.schedule}>
@@ -117,16 +129,7 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
             {Language.autoStopDisplay(workspace)}
           </span>
         </div>
-        <div>
-          <Stack direction="row">
-            <Button className={styles.editDeadline} onClick={onDeadlineMinus}>
-              <span className={styles.scheduleLabel}>{Language.editDeadlineMinus}</span>
-            </Button>
-            <Button className={styles.editDeadline} onClick={onDeadlinePlus}>
-              <span className={styles.scheduleLabel}>{Language.editDeadlinePlus}</span>
-            </Button>
-          </Stack>
-        </div>
+        {editDeadlineButtons}
         <div>
           <Link
             className={styles.scheduleAction}

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -87,7 +87,7 @@ export interface WorkspaceScheduleProps {
   onDeadlineMinus: () => void
 }
 
-export const shouldDisplayPlusMins = (workspace: Workspace): boolean => {
+export const shouldDisplayPlusMinus = (workspace: Workspace): boolean => {
   if (!isWorkspaceOn(workspace)) {
     return false
   }
@@ -97,12 +97,12 @@ export const shouldDisplayPlusMins = (workspace: Workspace): boolean => {
 
 export const deadlineMinusDisabled = (workspace: Workspace, now: dayjs.Dayjs): boolean => {
   const delta = dayjs(workspace.latest_build.deadline).diff(now)
-  return delta <= 30 * 60 * 1000
+  return Math.abs(delta) <= 30 * 60 * 1000 // 30 minutes
 }
 
 export const deadlinePlusDisabled = (workspace: Workspace, now: dayjs.Dayjs): boolean => {
   const delta = dayjs(workspace.latest_build.deadline).diff(now)
-  return delta > 23 * 59 * 59 * 1000
+  return Math.abs(delta) >= 24 * 60 * 60 * 1000 // 24 hours
 }
 
 export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
@@ -112,7 +112,7 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
   onDeadlinePlus,
 }) => {
   const styles = useStyles()
-  const editDeadlineButtons = shouldDisplayPlusMins(workspace) ? (
+  const editDeadlineButtons = shouldDisplayPlusMinus(workspace) ? (
     <Stack direction="row" spacing={0}>
       <IconButton
         size="small"

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -91,7 +91,11 @@ export const shouldDisplayPlusMins = (workspace: Workspace): boolean => {
   return deadline.year() > 1
 }
 
-export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace }) => {
+export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
+  workspace,
+  onDeadlineMinus,
+  onDeadlinePlus,
+}) => {
   const styles = useStyles()
 
   return (
@@ -115,10 +119,10 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({ workspace }) => 
         </div>
         <div>
           <Stack direction="row">
-            <Button className={styles.editDeadline}>
+            <Button className={styles.editDeadline} onClick={onDeadlineMinus}>
               <span className={styles.scheduleLabel}>{Language.editDeadlineMinus}</span>
             </Button>
-            <Button className={styles.editDeadline}>
+            <Button className={styles.editDeadline} onClick={onDeadlinePlus}>
               <span className={styles.scheduleLabel}>{Language.editDeadlinePlus}</span>
             </Button>
           </Stack>

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -116,7 +116,7 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
     <Stack direction="row" spacing={0}>
       <IconButton
         size="small"
-        disabled={deadlineMinusDisabled(workspace, now ? now : dayjs())}
+        disabled={deadlineMinusDisabled(workspace, now ?? dayjs())}
         className={styles.editDeadline}
         onClick={onDeadlineMinus}
       >
@@ -126,7 +126,7 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
       </IconButton>
       <IconButton
         size="small"
-        disabled={deadlinePlusDisabled(workspace, now ? now : dayjs())}
+        disabled={deadlinePlusDisabled(workspace, now ?? dayjs())}
         className={styles.editDeadline}
         onClick={onDeadlinePlus}
       >

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -81,6 +81,7 @@ export const Language = {
 }
 
 export interface WorkspaceScheduleProps {
+  now?: dayjs.Dayjs
   workspace: Workspace
   onDeadlinePlus: () => void
   onDeadlineMinus: () => void
@@ -94,7 +95,18 @@ export const shouldDisplayPlusMins = (workspace: Workspace): boolean => {
   return deadline.year() > 1
 }
 
+export const deadlineMinusDisabled = (workspace: Workspace, now: dayjs.Dayjs): boolean => {
+  const delta = dayjs(workspace.latest_build.deadline).diff(now)
+  return delta <= 30 * 60 * 1000
+}
+
+export const deadlinePlusDisabled = (workspace: Workspace, now: dayjs.Dayjs): boolean => {
+  const delta = dayjs(workspace.latest_build.deadline).diff(now)
+  return delta > 23 * 59 * 59 * 1000
+}
+
 export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
+  now,
   workspace,
   onDeadlineMinus,
   onDeadlinePlus,
@@ -102,12 +114,22 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
   const styles = useStyles()
   const editDeadlineButtons = shouldDisplayPlusMins(workspace) ? (
     <Stack direction="row" spacing={0}>
-      <IconButton size="small" className={styles.editDeadline} onClick={onDeadlineMinus}>
+      <IconButton
+        size="small"
+        disabled={deadlineMinusDisabled(workspace, now ? now : dayjs())}
+        className={styles.editDeadline}
+        onClick={onDeadlineMinus}
+      >
         <Tooltip title={Language.editDeadlineMinus}>
           <IndeterminateCheckBoxIcon />
         </Tooltip>
       </IconButton>
-      <IconButton size="small" className={styles.editDeadline} onClick={onDeadlinePlus}>
+      <IconButton
+        size="small"
+        disabled={deadlinePlusDisabled(workspace, now ? now : dayjs())}
+        className={styles.editDeadline}
+        onClick={onDeadlinePlus}
+      >
         <Tooltip title={Language.editDeadlinePlus}>
           <AddBoxIcon />
         </Tooltip>

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -59,6 +59,14 @@ export const WorkspacePage: React.FC = () => {
               bannerSend({ type: "EXTEND_DEADLINE_DEFAULT", workspaceId: workspace.id })
             },
           }}
+          scheduleProps={{
+            onDeadlineMinus: () => {
+              console.log("not implemented")
+            },
+            onDeadlinePlus: () => {
+              console.log("not implemented")
+            },
+          }}
           workspace={workspace}
           handleStart={() => workspaceSend("START")}
           handleStop={() => workspaceSend("STOP")}

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -63,7 +63,7 @@ export const WorkspacePage: React.FC = () => {
               bannerSend({
                 type: "UPDATE_DEADLINE",
                 workspaceId: workspace.id,
-                newDeadline: dayjs().utc().add(4, "hours"),
+                newDeadline: dayjs(workspace.latest_build.deadline).utc().add(4, "hours"),
               })
             },
           }}

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -8,8 +8,8 @@ import * as API from "../../api/api"
 import { displayError, displaySuccess } from "../../components/GlobalSnackbar/utils"
 
 export const Language = {
-  errorExtension: "Failed to extend workspace deadline.",
-  successExtension: "Successfully extended workspace deadline.",
+  errorExtension: "Failed to update workspace shutdown time.",
+  successExtension: "Updated workspace shutdown time.",
 }
 
 export type WorkspaceScheduleBannerEvent = {

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -1,18 +1,18 @@
 /**
  * @fileoverview workspaceScheduleBanner is an xstate machine backing a form,
- * presented as an Alert/banner, for reactively extending a workspace schedule.
+ * presented as an Alert/banner, for reactively updating a workspace schedule.
  */
 import { createMachine } from "xstate"
 import * as API from "../../api/api"
+import dayjs from "dayjs"
 import { displayError, displaySuccess } from "../../components/GlobalSnackbar/utils"
-import { defaultWorkspaceExtension } from "../../util/workspace"
 
 export const Language = {
   errorExtension: "Failed to extend workspace deadline.",
   successExtension: "Successfully extended workspace deadline.",
 }
 
-export type WorkspaceScheduleBannerEvent = { type: "EXTEND_DEADLINE_DEFAULT"; workspaceId: string }
+export type WorkspaceScheduleBannerEvent = { type: "UPDATE_DEADLINE"; workspaceId: string, newDeadline: dayjs.Dayjs }
 
 export const workspaceScheduleBannerMachine = createMachine(
   {
@@ -25,13 +25,13 @@ export const workspaceScheduleBannerMachine = createMachine(
     states: {
       idle: {
         on: {
-          EXTEND_DEADLINE_DEFAULT: "extendingDeadline",
+          UPDATE_DEADLINE: "updatingDeadline",
         },
       },
-      extendingDeadline: {
+      updatingDeadline: {
         invoke: {
-          src: "extendDeadlineDefault",
-          id: "extendDeadlineDefault",
+          src: "updateDeadline",
+          id: "updateDeadline",
           onDone: {
             target: "idle",
             actions: "displaySuccessMessage",
@@ -56,8 +56,8 @@ export const workspaceScheduleBannerMachine = createMachine(
     },
 
     services: {
-      extendDeadlineDefault: async (_, event) => {
-        await API.putWorkspaceExtension(event.workspaceId, defaultWorkspaceExtension())
+      updateDeadline: async (_, event) => {
+        await API.putWorkspaceExtension(event.workspaceId, event.newDeadline )
       },
     },
   },

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -2,9 +2,9 @@
  * @fileoverview workspaceScheduleBanner is an xstate machine backing a form,
  * presented as an Alert/banner, for reactively updating a workspace schedule.
  */
+import dayjs from "dayjs"
 import { createMachine } from "xstate"
 import * as API from "../../api/api"
-import dayjs from "dayjs"
 import { displayError, displaySuccess } from "../../components/GlobalSnackbar/utils"
 
 export const Language = {
@@ -12,7 +12,11 @@ export const Language = {
   successExtension: "Successfully extended workspace deadline.",
 }
 
-export type WorkspaceScheduleBannerEvent = { type: "UPDATE_DEADLINE"; workspaceId: string, newDeadline: dayjs.Dayjs }
+export type WorkspaceScheduleBannerEvent = {
+  type: "UPDATE_DEADLINE"
+  workspaceId: string
+  newDeadline: dayjs.Dayjs
+}
 
 export const workspaceScheduleBannerMachine = createMachine(
   {
@@ -57,7 +61,7 @@ export const workspaceScheduleBannerMachine = createMachine(
 
     services: {
       updateDeadline: async (_, event) => {
-        await API.putWorkspaceExtension(event.workspaceId, event.newDeadline )
+        await API.putWorkspaceExtension(event.workspaceId, event.newDeadline)
       },
     },
   },


### PR DESCRIPTION
This PR adds two buttons to edit the workspace deadline.
- These buttons only appear when a workspace is running and has a non-zero deadline
- Clicking the ➕  button increases the deadline by one hour, to a max of 24 hours in the future
- Clicking the ➖  button decreases the deadline by one hour, to a minimum of 30 minutes in the future (when the warning banner appears)