### PR TITLE
fix: update template updated_at value

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1830,6 +1830,7 @@ func (q *fakeQuerier) UpdateTemplateActiveVersionByID(_ context.Context, arg dat
 			continue
 		}
 		template.ActiveVersionID = arg.ActiveVersionID
+		template.UpdatedAt = arg.UpdatedAt
 		q.templates[index] = template
 		return nil
 	}
@@ -1845,6 +1846,7 @@ func (q *fakeQuerier) UpdateTemplateDeletedByID(_ context.Context, arg database.
 			continue
 		}
 		template.Deleted = arg.Deleted
+		template.UpdatedAt = arg.UpdatedAt
 		q.templates[index] = template
 		return nil
 	}

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1878,7 +1878,7 @@ func (q *fakeQuerier) UpdateTemplateVersionDescriptionByJobID(_ context.Context,
 			continue
 		}
 		templateVersion.Readme = arg.Readme
-		templateVersion.UpdatedAt = database.Now()
+		templateVersion.UpdatedAt = arg.UpdatedAt
 		q.templateVersions[index] = templateVersion
 		return nil
 	}
@@ -1912,6 +1912,7 @@ func (q *fakeQuerier) UpdateWorkspaceAgentConnectionByID(_ context.Context, arg 
 		agent.FirstConnectedAt = arg.FirstConnectedAt
 		agent.LastConnectedAt = arg.LastConnectedAt
 		agent.DisconnectedAt = arg.DisconnectedAt
+		agent.UpdatedAt = arg.UpdatedAt
 		q.provisionerJobAgents[index] = agent
 		return nil
 	}
@@ -1929,7 +1930,7 @@ func (q *fakeQuerier) UpdateWorkspaceAgentKeysByID(_ context.Context, arg databa
 
 		agent.WireguardNodePublicKey = arg.WireguardNodePublicKey
 		agent.WireguardDiscoPublicKey = arg.WireguardDiscoPublicKey
-		agent.UpdatedAt = database.Now()
+		agent.UpdatedAt = arg.UpdatedAt
 		q.provisionerJobAgents[index] = agent
 		return nil
 	}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2063,7 +2063,8 @@ const updateTemplateActiveVersionByID = `-- name: UpdateTemplateActiveVersionByI
 UPDATE
 	templates
 SET
-	active_version_id = $2
+	active_version_id = $2,
+	updated_at = $3
 WHERE
 	id = $1
 `
@@ -2071,10 +2072,11 @@ WHERE
 type UpdateTemplateActiveVersionByIDParams struct {
 	ID              uuid.UUID `db:"id" json:"id"`
 	ActiveVersionID uuid.UUID `db:"active_version_id" json:"active_version_id"`
+	UpdatedAt       time.Time `db:"updated_at" json:"updated_at"`
 }
 
 func (q *sqlQuerier) UpdateTemplateActiveVersionByID(ctx context.Context, arg UpdateTemplateActiveVersionByIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateTemplateActiveVersionByID, arg.ID, arg.ActiveVersionID)
+	_, err := q.db.ExecContext(ctx, updateTemplateActiveVersionByID, arg.ID, arg.ActiveVersionID, arg.UpdatedAt)
 	return err
 }
 
@@ -2082,18 +2084,20 @@ const updateTemplateDeletedByID = `-- name: UpdateTemplateDeletedByID :exec
 UPDATE
 	templates
 SET
-	deleted = $2
+	deleted = $2,
+	updated_at = $3
 WHERE
 	id = $1
 `
 
 type UpdateTemplateDeletedByIDParams struct {
-	ID      uuid.UUID `db:"id" json:"id"`
-	Deleted bool      `db:"deleted" json:"deleted"`
+	ID        uuid.UUID `db:"id" json:"id"`
+	Deleted   bool      `db:"deleted" json:"deleted"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
 }
 
 func (q *sqlQuerier) UpdateTemplateDeletedByID(ctx context.Context, arg UpdateTemplateDeletedByIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateTemplateDeletedByID, arg.ID, arg.Deleted)
+	_, err := q.db.ExecContext(ctx, updateTemplateDeletedByID, arg.ID, arg.Deleted, arg.UpdatedAt)
 	return err
 }
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2408,18 +2408,19 @@ UPDATE
 	template_versions
 SET
 	readme = $2,
-	updated_at = now()
+	updated_at = $3
 WHERE
 	job_id = $1
 `
 
 type UpdateTemplateVersionDescriptionByJobIDParams struct {
-	JobID  uuid.UUID `db:"job_id" json:"job_id"`
-	Readme string    `db:"readme" json:"readme"`
+	JobID     uuid.UUID `db:"job_id" json:"job_id"`
+	Readme    string    `db:"readme" json:"readme"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
 }
 
 func (q *sqlQuerier) UpdateTemplateVersionDescriptionByJobID(ctx context.Context, arg UpdateTemplateVersionDescriptionByJobIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateTemplateVersionDescriptionByJobID, arg.JobID, arg.Readme)
+	_, err := q.db.ExecContext(ctx, updateTemplateVersionDescriptionByJobID, arg.JobID, arg.Readme, arg.UpdatedAt)
 	return err
 }
 
@@ -3164,10 +3165,10 @@ const updateWorkspaceAgentConnectionByID = `-- name: UpdateWorkspaceAgentConnect
 UPDATE
 	workspace_agents
 SET
-	updated_at = now(),
 	first_connected_at = $2,
 	last_connected_at = $3,
-	disconnected_at = $4
+	disconnected_at = $4,
+	updated_at = $5
 WHERE
 	id = $1
 `
@@ -3177,6 +3178,7 @@ type UpdateWorkspaceAgentConnectionByIDParams struct {
 	FirstConnectedAt sql.NullTime `db:"first_connected_at" json:"first_connected_at"`
 	LastConnectedAt  sql.NullTime `db:"last_connected_at" json:"last_connected_at"`
 	DisconnectedAt   sql.NullTime `db:"disconnected_at" json:"disconnected_at"`
+	UpdatedAt        time.Time    `db:"updated_at" json:"updated_at"`
 }
 
 func (q *sqlQuerier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error {
@@ -3185,6 +3187,7 @@ func (q *sqlQuerier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg
 		arg.FirstConnectedAt,
 		arg.LastConnectedAt,
 		arg.DisconnectedAt,
+		arg.UpdatedAt,
 	)
 	return err
 }
@@ -3193,9 +3196,9 @@ const updateWorkspaceAgentKeysByID = `-- name: UpdateWorkspaceAgentKeysByID :exe
 UPDATE
 	workspace_agents
 SET
-	updated_at = now(),
 	wireguard_node_public_key = $2,
-	wireguard_disco_public_key = $3
+	wireguard_disco_public_key = $3,
+	updated_at = $4
 WHERE
 	id = $1
 `
@@ -3204,10 +3207,16 @@ type UpdateWorkspaceAgentKeysByIDParams struct {
 	ID                      uuid.UUID           `db:"id" json:"id"`
 	WireguardNodePublicKey  dbtypes.NodePublic  `db:"wireguard_node_public_key" json:"wireguard_node_public_key"`
 	WireguardDiscoPublicKey dbtypes.DiscoPublic `db:"wireguard_disco_public_key" json:"wireguard_disco_public_key"`
+	UpdatedAt               time.Time           `db:"updated_at" json:"updated_at"`
 }
 
 func (q *sqlQuerier) UpdateWorkspaceAgentKeysByID(ctx context.Context, arg UpdateWorkspaceAgentKeysByIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateWorkspaceAgentKeysByID, arg.ID, arg.WireguardNodePublicKey, arg.WireguardDiscoPublicKey)
+	_, err := q.db.ExecContext(ctx, updateWorkspaceAgentKeysByID,
+		arg.ID,
+		arg.WireguardNodePublicKey,
+		arg.WireguardDiscoPublicKey,
+		arg.UpdatedAt,
+	)
 	return err
 }
 

--- a/coderd/database/queries/templates.sql
+++ b/coderd/database/queries/templates.sql
@@ -73,7 +73,8 @@ VALUES
 UPDATE
 	templates
 SET
-	active_version_id = $2
+	active_version_id = $2,
+	updated_at = $3
 WHERE
 	id = $1;
 
@@ -81,7 +82,8 @@ WHERE
 UPDATE
 	templates
 SET
-	deleted = $2
+	deleted = $2,
+	updated_at = $3
 WHERE
 	id = $1;
 

--- a/coderd/database/queries/templateversions.sql
+++ b/coderd/database/queries/templateversions.sql
@@ -89,6 +89,6 @@ UPDATE
 	template_versions
 SET
 	readme = $2,
-	updated_at = now()
+	updated_at = $3
 WHERE
 	job_id = $1;

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -65,10 +65,10 @@ VALUES
 UPDATE
 	workspace_agents
 SET
-	updated_at = now(),
 	first_connected_at = $2,
 	last_connected_at = $3,
-	disconnected_at = $4
+	disconnected_at = $4,
+	updated_at = $5
 WHERE
 	id = $1;
 
@@ -76,8 +76,8 @@ WHERE
 UPDATE
 	workspace_agents
 SET
-	updated_at = now(),
 	wireguard_node_public_key = $2,
-	wireguard_disco_public_key = $3
+	wireguard_disco_public_key = $3,
+	updated_at = $4
 WHERE
 	id = $1;

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -385,8 +385,9 @@ func (server *provisionerdServer) UpdateJob(ctx context.Context, request *proto.
 
 	if len(request.Readme) > 0 {
 		err := server.Database.UpdateTemplateVersionDescriptionByJobID(ctx, database.UpdateTemplateVersionDescriptionByJobIDParams{
-			JobID:  job.ID,
-			Readme: string(request.Readme),
+			JobID:     job.ID,
+			Readme:    string(request.Readme),
+			UpdatedAt: database.Now(),
 		})
 		if err != nil {
 			return nil, xerrors.Errorf("update template version description: %w", err)

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -96,8 +96,9 @@ func (api *API) deleteTemplate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	err = api.Database.UpdateTemplateDeletedByID(r.Context(), database.UpdateTemplateDeletedByIDParams{
-		ID:      template.ID,
-		Deleted: true,
+		ID:        template.ID,
+		Deleted:   true,
+		UpdatedAt: database.Now(),
 	})
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, httpapi.Response{

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -564,6 +564,7 @@ func (api *API) patchActiveTemplateVersion(rw http.ResponseWriter, r *http.Reque
 		err = store.UpdateTemplateActiveVersionByID(r.Context(), database.UpdateTemplateActiveVersionByIDParams{
 			ID:              template.ID,
 			ActiveVersionID: req.ID,
+			UpdatedAt:       database.Now(),
 		})
 		if err != nil {
 			return xerrors.Errorf("update active version: %w", err)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -282,6 +282,7 @@ func (api *API) workspaceAgentListen(rw http.ResponseWriter, r *http.Request) {
 			FirstConnectedAt: firstConnectedAt,
 			LastConnectedAt:  lastConnectedAt,
 			DisconnectedAt:   disconnectedAt,
+			UpdatedAt:        database.Now(),
 		})
 		if err != nil {
 			return err
@@ -491,6 +492,7 @@ func (api *API) postWorkspaceAgentKeys(rw http.ResponseWriter, r *http.Request) 
 		ID:                      workspaceAgent.ID,
 		WireguardNodePublicKey:  dbtypes.NodePublic(keys.Public),
 		WireguardDiscoPublicKey: dbtypes.DiscoPublic(keys.Disco),
+		UpdatedAt:               database.Now(),
 	})
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, httpapi.Response{


### PR DESCRIPTION
This PR fixes the template update time not reflecting on updating the template version.

## Subtasks

- [x] change the query that updates the active version to set updated_at.
- [x] change the query that marks the template as deleted to set updated_at.
- [x] pass in current UTC Go time as updated_at when calling these queries.
- [x] update instances of updated_at using SQL now() time.

Fixes #2720


## Demo

https://user-images.githubusercontent.com/7511231/176500356-6e1269ea-9552-4532-91f1-766cb65cb802.mov

