### PR TITLE
provisionerd sends failed or complete last

### DIFF
--- a/agent/reaper/reaper_stub.go
+++ b/agent/reaper/reaper_stub.go
@@ -7,6 +7,6 @@ func IsInitProcess() bool {
 	return false
 }
 
-func ForkReap(opt ...Option) error {
+func ForkReap(_ ...Option) error {
 	return nil
 }

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -383,6 +383,7 @@ func UpdateTemplateVersion(t *testing.T, client *codersdk.Client, organizationID
 
 // AwaitTemplateImportJob awaits for an import job to reach completed status.
 func AwaitTemplateVersionJob(t *testing.T, client *codersdk.Client, version uuid.UUID) codersdk.TemplateVersion {
+	t.Logf("waiting for template version job %s", version)
 	var templateVersion codersdk.TemplateVersion
 	require.Eventually(t, func() bool {
 		var err error

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -331,6 +331,7 @@ func (server *provisionerdServer) UpdateJob(ctx context.Context, request *proto.
 	if err != nil {
 		return nil, xerrors.Errorf("parse job id: %w", err)
 	}
+	server.Logger.Debug(ctx, "UpdateJob starting", slog.F("job_id", parsedID))
 	job, err := server.Database.GetProvisionerJobByID(ctx, parsedID)
 	if err != nil {
 		return nil, xerrors.Errorf("get job: %w", err)
@@ -368,19 +369,27 @@ func (server *provisionerdServer) UpdateJob(ctx context.Context, request *proto.
 			insertParams.Stage = append(insertParams.Stage, log.Stage)
 			insertParams.Source = append(insertParams.Source, logSource)
 			insertParams.Output = append(insertParams.Output, log.Output)
+			server.Logger.Debug(ctx, "job log",
+				slog.F("job_id", parsedID),
+				slog.F("stage", log.Stage),
+				slog.F("output", log.Output))
 		}
 		logs, err := server.Database.InsertProvisionerJobLogs(context.Background(), insertParams)
 		if err != nil {
+			server.Logger.Error(ctx, "failed to insert job logs", slog.F("job_id", parsedID), slog.Error(err))
 			return nil, xerrors.Errorf("insert job logs: %w", err)
 		}
+		server.Logger.Debug(ctx, "inserted job logs", slog.F("job_id", parsedID))
 		data, err := json.Marshal(logs)
 		if err != nil {
 			return nil, xerrors.Errorf("marshal job log: %w", err)
 		}
 		err = server.Pubsub.Publish(provisionerJobLogsChannel(parsedID), data)
 		if err != nil {
+			server.Logger.Error(ctx, "failed to publish job logs", slog.F("job_id", parsedID), slog.Error(err))
 			return nil, xerrors.Errorf("publish job log: %w", err)
 		}
+		server.Logger.Debug(ctx, "published job logs", slog.F("job_id", parsedID))
 	}
 
 	if len(request.Readme) > 0 {
@@ -488,6 +497,7 @@ func (server *provisionerdServer) FailJob(ctx context.Context, failJob *proto.Fa
 	if err != nil {
 		return nil, xerrors.Errorf("parse job id: %w", err)
 	}
+	server.Logger.Debug(ctx, "FailJob starting", slog.F("job_id", jobID))
 	job, err := server.Database.GetProvisionerJobByID(ctx, jobID)
 	if err != nil {
 		return nil, xerrors.Errorf("get provisioner job: %w", err)
@@ -547,6 +557,7 @@ func (server *provisionerdServer) CompleteJob(ctx context.Context, completed *pr
 	if err != nil {
 		return nil, xerrors.Errorf("parse job id: %w", err)
 	}
+	server.Logger.Debug(ctx, "CompleteJob starting", slog.F("job_id", jobID))
 	job, err := server.Database.GetProvisionerJobByID(ctx, jobID)
 	if err != nil {
 		return nil, xerrors.Errorf("get job by id: %w", err)
@@ -699,6 +710,7 @@ func (server *provisionerdServer) CompleteJob(ctx context.Context, completed *pr
 			reflect.TypeOf(completed.Type).String())
 	}
 
+	server.Logger.Debug(ctx, "CompleteJob done", slog.F("job_id", jobID))
 	return &proto.Empty{}, nil
 }
 

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -9,11 +9,12 @@ import (
 	"sync"
 	"time"
 
-	"cdr.dev/slog"
 	"github.com/hashicorp/yamux"
 	"github.com/spf13/afero"
 	"go.uber.org/atomic"
 	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
 
 	"github.com/coder/coder/provisionerd/proto"
 	"github.com/coder/coder/provisionerd/runner"
@@ -235,7 +236,7 @@ func (p *Server) acquireJob(ctx context.Context) {
 	}
 	p.activeJob = runner.NewRunner(job, p, p.opts.Logger, p.opts.Filesystem, p.opts.WorkDirectory, provisioner,
 		p.opts.UpdateInterval, p.opts.ForceCancelInterval)
-	go p.activeJob.Start()
+	go p.activeJob.Run()
 }
 
 func retryable(err error) bool {

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -9,26 +9,23 @@ import (
 	"sync"
 	"time"
 
+	"cdr.dev/slog"
 	"github.com/hashicorp/yamux"
 	"github.com/spf13/afero"
 	"go.uber.org/atomic"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog"
 	"github.com/coder/coder/provisionerd/proto"
+	"github.com/coder/coder/provisionerd/runner"
 	sdkproto "github.com/coder/coder/provisionersdk/proto"
 	"github.com/coder/retry"
-)
-
-const (
-	missingParameterErrorText = "missing parameter"
 )
 
 // IsMissingParameterError returns whether the error message provided
 // is a missing parameter error. This can indicate to consumers that
 // they should check parameters.
 func IsMissingParameterError(err string) bool {
-	return strings.Contains(err, missingParameterErrorText)
+	return strings.Contains(err, runner.MissingParameterErrorText)
 }
 
 // Dialer represents the function to create a daemon client connection.
@@ -90,7 +87,7 @@ type Server struct {
 	closeCancel  context.CancelFunc
 	closeError   error
 	shutdown     chan struct{}
-	activeJob    jobRunner
+	activeJob    runner.jobRunner
 }
 
 // Connect establishes a connection to coderd.
@@ -236,7 +233,7 @@ func (p *Server) acquireJob(ctx context.Context) {
 		}
 		return
 	}
-	p.activeJob = newRunner(job, p, p.opts.Logger, p.opts.Filesystem, p.opts.WorkDirectory, provisioner,
+	p.activeJob = runner.newRunner(job, p, p.opts.Logger, p.opts.Filesystem, p.opts.WorkDirectory, provisioner,
 		p.opts.UpdateInterval, p.opts.ForceCancelInterval)
 	go p.activeJob.start()
 }

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
@@ -30,6 +32,18 @@ import (
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
+}
+
+func closedWithin(c chan struct{}, d time.Duration) func() bool {
+	return func() bool {
+		pop := time.After(d)
+		select {
+		case <-c:
+			return true
+		case <-pop:
+			return false
+		}
+	}
 }
 
 func TestProvisionerd(t *testing.T) {
@@ -54,7 +68,7 @@ func TestProvisionerd(t *testing.T) {
 			defer close(completeChan)
 			return nil, xerrors.New("an error")
 		}, provisionerd.Provisioners{})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, closer.Close())
 	})
 
@@ -77,7 +91,7 @@ func TestProvisionerd(t *testing.T) {
 				updateJob: noopUpdateJob,
 			}), nil
 		}, provisionerd.Provisioners{})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, closer.Close())
 	})
 
@@ -122,7 +136,7 @@ func TestProvisionerd(t *testing.T) {
 			}),
 		})
 		closerMutex.Unlock()
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, closer.Close())
 	})
 
@@ -160,7 +174,7 @@ func TestProvisionerd(t *testing.T) {
 		}, provisionerd.Provisioners{
 			"someprovisioner": createProvisionerClient(t, provisionerTestServer{}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, closer.Close())
 	})
 
@@ -203,7 +217,7 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, closer.Close())
 	})
 
@@ -308,7 +322,7 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.True(t, didLog.Load())
 		require.True(t, didComplete.Load())
 		require.True(t, didDryRun.Load())
@@ -388,7 +402,7 @@ func TestProvisionerd(t *testing.T) {
 			}),
 		})
 
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.True(t, didLog.Load())
 		require.True(t, didComplete.Load())
 		require.NoError(t, closer.Close())
@@ -459,7 +473,7 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.True(t, didLog.Load())
 		require.True(t, didComplete.Load())
 		require.NoError(t, closer.Close())
@@ -514,7 +528,7 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.True(t, didFail.Load())
 		require.NoError(t, closer.Close())
 	})
@@ -587,10 +601,10 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-updateChan
+		require.Condition(t, closedWithin(updateChan, 5*time.Second))
 		err := server.Shutdown(context.Background())
 		require.NoError(t, err)
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, server.Close())
 	})
 
@@ -617,15 +631,21 @@ func TestProvisionerd(t *testing.T) {
 					}, nil
 				},
 				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
+					resp := &proto.UpdateJobResponse{}
 					if len(update.Logs) > 0 && update.Logs[0].Source == proto.LogSource_PROVISIONER {
 						// Close on a log so we know when the job is in progress!
 						updated.Do(func() {
 							close(updateChan)
 						})
 					}
-					return &proto.UpdateJobResponse{
-						Canceled: true,
-					}, nil
+					// start returning Canceled once we've gotten at least one log.
+					select {
+					case <-updateChan:
+						resp.Canceled = true
+					default:
+						// pass
+					}
+					return resp, nil
 				},
 				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
 					completed.Do(func() {
@@ -664,8 +684,8 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-updateChan
-		<-completeChan
+		require.Condition(t, closedWithin(updateChan, 5*time.Second))
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, server.Close())
 	})
 
@@ -703,6 +723,7 @@ func TestProvisionerd(t *testing.T) {
 					return &proto.UpdateJobResponse{}, nil
 				},
 				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
+					assert.Equal(t, job.JobId, "test")
 					if second.Load() {
 						completeOnce.Do(func() { close(completeChan) })
 						return &proto.Empty{}, nil
@@ -736,7 +757,7 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
 		require.NoError(t, server.Close())
 	})
 
@@ -808,7 +829,96 @@ func TestProvisionerd(t *testing.T) {
 				},
 			}),
 		})
-		<-completeChan
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
+		require.NoError(t, server.Close())
+	})
+
+	t.Run("UpdatesBeforeComplete", func(t *testing.T) {
+		t.Parallel()
+		logger := slogtest.Make(t, nil)
+		m := sync.Mutex{}
+		var ops []string
+		completeChan := make(chan struct{})
+		completeOnce := sync.Once{}
+
+		server := createProvisionerd(t, func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error) {
+			return createProvisionerDaemonClient(t, provisionerDaemonTestServer{
+				acquireJob: func(ctx context.Context, _ *proto.Empty) (*proto.AcquiredJob, error) {
+					m.Lock()
+					defer m.Unlock()
+					logger.Info(ctx, "AcquiredJob called.")
+					if len(ops) > 0 {
+						return &proto.AcquiredJob{}, nil
+					}
+					ops = append(ops, "AcquireJob")
+
+					return &proto.AcquiredJob{
+						JobId:       "test",
+						Provisioner: "someprovisioner",
+						TemplateSourceArchive: createTar(t, map[string]string{
+							"test.txt": "content",
+						}),
+						Type: &proto.AcquiredJob_WorkspaceBuild_{
+							WorkspaceBuild: &proto.AcquiredJob_WorkspaceBuild{
+								Metadata: &sdkproto.Provision_Metadata{},
+							},
+						},
+					}, nil
+				},
+				updateJob: func(ctx context.Context, update *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
+					m.Lock()
+					defer m.Unlock()
+					logger.Info(ctx, "UpdateJob called.")
+					ops = append(ops, "UpdateJob")
+					for _, log := range update.Logs {
+						ops = append(ops, fmt.Sprintf("Log: %s | %s", log.Stage, log.Output))
+					}
+					return &proto.UpdateJobResponse{}, nil
+				},
+				completeJob: func(ctx context.Context, job *proto.CompletedJob) (*proto.Empty, error) {
+					m.Lock()
+					defer m.Unlock()
+					logger.Info(ctx, "CompleteJob called.")
+					ops = append(ops, "CompleteJob")
+					completeOnce.Do(func() { close(completeChan) })
+					return &proto.Empty{}, nil
+				},
+				failJob: func(ctx context.Context, job *proto.FailedJob) (*proto.Empty, error) {
+					m.Lock()
+					defer m.Unlock()
+					logger.Info(ctx, "FailJob called.")
+					ops = append(ops, "FailJob")
+					return &proto.Empty{}, nil
+				},
+			}), nil
+		}, provisionerd.Provisioners{
+			"someprovisioner": createProvisionerClient(t, provisionerTestServer{
+				provision: func(stream sdkproto.DRPCProvisioner_ProvisionStream) error {
+					err := stream.Send(&sdkproto.Provision_Response{
+						Type: &sdkproto.Provision_Response_Log{
+							Log: &sdkproto.Log{
+								Level:  sdkproto.LogLevel_DEBUG,
+								Output: "wow",
+							},
+						},
+					})
+					require.NoError(t, err)
+
+					err = stream.Send(&sdkproto.Provision_Response{
+						Type: &sdkproto.Provision_Response_Complete{
+							Complete: &sdkproto.Provision_Complete{},
+						},
+					})
+					require.NoError(t, err)
+					return nil
+				},
+			}),
+		})
+		require.Condition(t, closedWithin(completeChan, 5*time.Second))
+		m.Lock()
+		defer m.Unlock()
+		require.Equal(t, ops[len(ops)-1], "CompleteJob")
+		require.Contains(t, ops[0:len(ops)-1], "Log: Cleaning Up | ")
 		require.NoError(t, server.Close())
 	})
 }

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/coder/provisionerd/runner"
+
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,8 +247,8 @@ func TestProvisionerd(t *testing.T) {
 						JobId:       "test",
 						Provisioner: "someprovisioner",
 						TemplateSourceArchive: createTar(t, map[string]string{
-							"test.txt":              "content",
-							provisionerd.ReadmeFile: "# A cool template 😎\n",
+							"test.txt":        "content",
+							runner.ReadmeFile: "# A cool template 😎\n",
 						}),
 						Type: &proto.AcquiredJob_TemplateImport_{
 							TemplateImport: &proto.AcquiredJob_TemplateImport{

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -38,11 +38,10 @@ func TestMain(m *testing.M) {
 
 func closedWithin(c chan struct{}, d time.Duration) func() bool {
 	return func() bool {
-		pop := time.After(d)
 		select {
 		case <-c:
 			return true
-		case <-pop:
+		case <-time.After(d):
 			return false
 		}
 	}

--- a/provisionerd/runner.go
+++ b/provisionerd/runner.go
@@ -1,0 +1,872 @@
+package provisionerd
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+
+	"github.com/coder/coder/provisionerd/proto"
+	sdkproto "github.com/coder/coder/provisionersdk/proto"
+)
+
+type jobRunner interface {
+	start()
+	cancel()
+	isDone() <-chan any
+	fail(ctx context.Context, f *proto.FailedJob) error
+	forceStop()
+}
+
+type runner struct {
+	job                 *proto.AcquiredJob
+	sender              messageSender
+	logger              slog.Logger
+	filesystem          afero.Fs
+	workDirectory       string
+	provisioner         sdkproto.DRPCProvisionerClient
+	updateInterval      time.Duration
+	forceCancelInterval time.Duration
+
+	// mutex controls access to all the following variables.
+	mutex *sync.Mutex
+	// used to wait for the failedJob or completedJob to be populated
+	cond *sync.Cond
+	// closed when the job ends.
+	done         chan any
+	failedJob    *proto.FailedJob
+	completedJob *proto.CompletedJob
+	// active as long as we are not canceled
+	gracefulContext context.Context
+	cancelFunc      context.CancelFunc
+	// active as long as we haven't been force stopped
+	forceStopContext context.Context
+	forceStopFunc    context.CancelFunc
+	// setting this false signals that no more messages about this job should be sent.  Usually this means that a
+	// terminal message like FailedJob or CompletedJob has been sent, but if we are force canceled, we may set this
+	// false and not send one.
+	okToSend bool
+}
+
+type messageSender interface {
+	updateJob(ctx context.Context, in *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error)
+	failJob(ctx context.Context, in *proto.FailedJob) error
+	completeJob(ctx context.Context, in *proto.CompletedJob) error
+}
+
+func newRunner(
+	job *proto.AcquiredJob,
+	sender messageSender,
+	logger slog.Logger,
+	filesystem afero.Fs,
+	workDirectory string,
+	provisioner sdkproto.DRPCProvisionerClient,
+	updateInterval time.Duration,
+	forceCancelInterval time.Duration) jobRunner {
+	m := new(sync.Mutex)
+
+	// we need to create our contexts here in case a call to cancel() comes immediately.
+	logCtx := slog.With(context.Background(), slog.F("job_id", job.JobId))
+	forceStopContext, forceStopFunc := context.WithCancel(logCtx)
+	gracefulContext, cancelFunc := context.WithCancel(forceStopContext)
+
+	return &runner{
+		job:                 job,
+		sender:              sender,
+		logger:              logger,
+		filesystem:          filesystem,
+		workDirectory:       workDirectory,
+		provisioner:         provisioner,
+		updateInterval:      updateInterval,
+		forceCancelInterval: forceCancelInterval,
+		mutex:               m,
+		cond:                sync.NewCond(m),
+		done:                make(chan any),
+		okToSend:            true,
+		forceStopContext:    forceStopContext,
+		forceStopFunc:       forceStopFunc,
+		gracefulContext:     gracefulContext,
+		cancelFunc:          cancelFunc,
+	}
+}
+
+func (r *runner) start() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	defer r.forceStopFunc()
+
+	// the idea here is to run two goroutines to work on the job: run and heartbeat, then use the `r.cond` to wait until
+	// the job is either complete or failed.  This function then sends the complete or failed message --- the exception
+	// to this is if something calls fail() on the runner; either something external, like the server getting closed,
+	// or the heartbeat goroutine timing out after attempting to gracefully cancel.  If something calls fail(), then
+	// the failure is sent on that goroutine on the context passed into fail(), and it marks okToSend false to signal
+	// us here that this function should not also send a terminal message.
+	go r.run()
+	go r.heartbeat()
+	for r.failedJob == nil && r.completedJob == nil {
+		r.cond.Wait()
+	}
+	if !r.okToSend {
+		// nothing else to do.
+		return
+	}
+	if r.failedJob != nil {
+		r.logger.Debug(r.forceStopContext, "sending FailedJob")
+		err := r.sender.failJob(r.forceStopContext, r.failedJob)
+		if err != nil {
+			r.logger.Error(r.forceStopContext, "send FailJob", slog.Error(err))
+		}
+		r.logger.Info(r.forceStopContext, "sent FailedJob")
+	} else {
+		r.logger.Debug(r.forceStopContext, "sending CompletedJob")
+		err := r.sender.completeJob(r.forceStopContext, r.completedJob)
+		if err != nil {
+			r.logger.Error(r.forceStopContext, "send CompletedJob", slog.Error(err))
+		}
+		r.logger.Info(r.forceStopContext, "sent CompletedJob")
+	}
+	close(r.done)
+	r.okToSend = false
+}
+
+// cancel initiates a cancel on the job, but allows it to keep running to do so gracefully.  Read from isDone() to
+// be notified when the job completes.
+func (r *runner) cancel() {
+	r.cancelFunc()
+}
+
+func (r *runner) isDone() <-chan any {
+	return r.done
+}
+
+// fail immediately halts updates and, if the job is not complete sends FailJob to the coder server.  Running goroutines
+// are canceled but complete asynchronously (although they are prevented from further updating the job to the coder
+// server).  The provided context sets how long to keep trying to send the FailJob.
+func (r *runner) fail(ctx context.Context, f *proto.FailedJob) error {
+	f.JobId = r.job.JobId
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.okToSend {
+		return nil // already done
+	}
+	r.cancel()
+	if r.failedJob == nil {
+		r.failedJob = f
+		r.cond.Signal()
+	}
+	// here we keep the original failed reason if there already was one, but we hadn't yet sent it.  It is likely more
+	// informative of the job failing due to some problem running it, whereas this function is used to externally
+	// force a fail.
+	err := r.sender.failJob(ctx, r.failedJob)
+	r.okToSend = false
+	r.forceStopFunc()
+	close(r.done)
+	return err
+}
+
+// setComplete is an internal function to set the job to completed.  This does not send the completedJob.
+func (r *runner) setComplete(c *proto.CompletedJob) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.completedJob == nil {
+		r.completedJob = c
+		r.cond.Signal()
+	}
+}
+
+// setFail is an internal function to set the job to failed.  This does not send the failedJob.
+func (r *runner) setFail(f *proto.FailedJob) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.failedJob == nil {
+		f.JobId = r.job.GetJobId()
+		r.failedJob = f
+		r.cond.Signal()
+	}
+}
+
+// forceStop signals all goroutines to stop and prevents any further API calls back to coder server for this job
+func (r *runner) forceStop() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.forceStopFunc()
+	if !r.okToSend {
+		return
+	}
+	r.okToSend = false
+	close(r.done)
+	// doesn't matter what we put here, since it won't get sent! Just need something to satisfy the condition in
+	// start()
+	r.failedJob = &proto.FailedJob{}
+	r.cond.Signal()
+}
+
+func (r *runner) update(ctx context.Context, u *proto.UpdateJobRequest) (*proto.UpdateJobResponse, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.okToSend {
+		return nil, xerrors.New("update skipped; job complete or failed")
+	}
+	return r.sender.updateJob(ctx, u)
+}
+
+func (r *runner) run() {
+	// push the fail/succeed write onto the defer stack before the cleanup, so that cleanup happens before this.
+	// Failures during this function should write to the _local_ failedJob variable, then return.
+	var failedJob *proto.FailedJob
+	var completedJob *proto.CompletedJob
+	defer func() {
+		if failedJob != nil {
+			r.setFail(failedJob)
+			return
+		}
+		r.setComplete(completedJob)
+	}()
+
+	defer func() {
+		r.logCleanup(r.forceStopContext)
+
+		// Cleanup the work directory after execution.
+		for attempt := 0; attempt < 5; attempt++ {
+			err := r.filesystem.RemoveAll(r.workDirectory)
+			if err != nil {
+				// On Windows, open files cannot be removed.
+				// When the provisioner daemon is shutting down,
+				// it may take a few milliseconds for processes to exit.
+				// See: https://github.com/golang/go/issues/50510
+				r.logger.Debug(r.forceStopContext, "failed to clean work directory; trying again", slog.Error(err))
+				time.Sleep(250 * time.Millisecond)
+				continue
+			}
+			r.logger.Debug(r.forceStopContext, "cleaned up work directory", slog.Error(err))
+			break
+		}
+	}()
+
+	err := r.filesystem.MkdirAll(r.workDirectory, 0700)
+	if err != nil {
+		failedJob = r.failedJobf("create work directory %q: %s", r.workDirectory, err)
+		return
+	}
+
+	_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     "Setting up",
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+	})
+	if err != nil {
+		failedJob = r.failedJobf("write log: %s", err)
+		return
+	}
+
+	r.logger.Info(r.forceStopContext, "unpacking template source archive",
+		slog.F("size_bytes", len(r.job.TemplateSourceArchive)))
+	reader := tar.NewReader(bytes.NewBuffer(r.job.TemplateSourceArchive))
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			failedJob = r.failedJobf("read template source archive: %s", err)
+			return
+		}
+		// #nosec
+		headerPath := filepath.Join(r.workDirectory, header.Name)
+		if !strings.HasPrefix(headerPath, filepath.Clean(r.workDirectory)) {
+			failedJob = r.failedJobf("tar attempts to target relative upper directory")
+			return
+		}
+		mode := header.FileInfo().Mode()
+		if mode == 0 {
+			mode = 0600
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			err = r.filesystem.MkdirAll(headerPath, mode)
+			if err != nil {
+				failedJob = r.failedJobf("mkdir %q: %s", headerPath, err)
+				return
+			}
+			r.logger.Debug(context.Background(), "extracted directory", slog.F("path", headerPath))
+		case tar.TypeReg:
+			file, err := r.filesystem.OpenFile(headerPath, os.O_CREATE|os.O_RDWR, mode)
+			if err != nil {
+				failedJob = r.failedJobf("create file %q (mode %s): %s", headerPath, mode, err)
+				return
+			}
+			// Max file size of 10MiB.
+			size, err := io.CopyN(file, reader, 10<<20)
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+			if err != nil {
+				_ = file.Close()
+				failedJob = r.failedJobf("copy file %q: %s", headerPath, err)
+				return
+			}
+			err = file.Close()
+			if err != nil {
+				failedJob = r.failedJobf("close file %q: %s", headerPath, err)
+				return
+			}
+			r.logger.Debug(context.Background(), "extracted file",
+				slog.F("size_bytes", size),
+				slog.F("path", headerPath),
+				slog.F("mode", mode),
+			)
+		}
+	}
+
+	switch jobType := r.job.Type.(type) {
+	case *proto.AcquiredJob_TemplateImport_:
+		r.logger.Debug(context.Background(), "acquired job is template import")
+
+		failedJob = r.runReadmeParse()
+		if failedJob == nil {
+			completedJob, failedJob = r.runTemplateImport()
+		}
+	case *proto.AcquiredJob_TemplateDryRun_:
+		r.logger.Debug(context.Background(), "acquired job is template dry-run",
+			slog.F("workspace_name", jobType.TemplateDryRun.Metadata.WorkspaceName),
+			slog.F("parameters", jobType.TemplateDryRun.ParameterValues),
+		)
+		completedJob, failedJob = r.runTemplateDryRun()
+	case *proto.AcquiredJob_WorkspaceBuild_:
+		r.logger.Debug(context.Background(), "acquired job is workspace provision",
+			slog.F("workspace_name", jobType.WorkspaceBuild.WorkspaceName),
+			slog.F("state_length", len(jobType.WorkspaceBuild.State)),
+			slog.F("parameters", jobType.WorkspaceBuild.ParameterValues),
+		)
+
+		completedJob, failedJob = r.runWorkspaceBuild()
+	default:
+		failedJob = r.failedJobf("unknown job type %q; ensure your provisioner daemon is up-to-date",
+			reflect.TypeOf(r.job.Type).String())
+	}
+}
+
+func (r *runner) heartbeat() {
+	ticker := time.NewTicker(r.updateInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.gracefulContext.Done():
+			return
+		case <-ticker.C:
+		}
+
+		resp, err := r.update(r.forceStopContext, &proto.UpdateJobRequest{
+			JobId: r.job.JobId,
+		})
+		if err != nil {
+			err = r.fail(r.forceStopContext, r.failedJobf("send periodic update: %s", err))
+			if err != nil {
+				r.logger.Error(r.forceStopContext, "failed to call FailJob", slog.Error(err))
+			}
+			return
+		}
+		if !resp.Canceled {
+			continue
+		}
+		r.logger.Info(r.forceStopContext, "attempting graceful cancelation")
+		r.cancel()
+		// Hard-cancel the job after a minute of pending cancelation.
+		timer := time.NewTimer(r.forceCancelInterval)
+		select {
+		case <-timer.C:
+			r.logger.Warn(r.forceStopContext, "cancel timed out")
+			err := r.fail(r.forceStopContext, r.failedJobf("cancel timed out"))
+			if err != nil {
+				r.logger.Warn(r.forceStopContext, "failed to call FailJob", slog.Error(err))
+			}
+			return
+		case <-r.isDone():
+			timer.Stop()
+			return
+		case <-r.forceStopContext.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func (r *runner) logCleanup(ctx context.Context) {
+	_, err := r.update(ctx, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     "Cleaning Up",
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+	})
+	if err != nil {
+		r.logger.Warn(ctx, "failed to log cleanup")
+		return
+	}
+}
+
+// ReadmeFile is the location we look for to extract documentation from template
+// versions.
+const ReadmeFile = "README.md"
+
+func (r *runner) runReadmeParse() *proto.FailedJob {
+	fi, err := afero.ReadFile(r.filesystem, path.Join(r.workDirectory, ReadmeFile))
+	if err != nil {
+		_, err := r.update(r.forceStopContext, &proto.UpdateJobRequest{
+			JobId: r.job.JobId,
+			Logs: []*proto.Log{{
+				Source:    proto.LogSource_PROVISIONER_DAEMON,
+				Level:     sdkproto.LogLevel_DEBUG,
+				Stage:     "No README.md provided",
+				CreatedAt: time.Now().UTC().UnixMilli(),
+			}},
+		})
+		if err != nil {
+			return r.failedJobf("write log: %s", err)
+		}
+
+		return nil
+	}
+
+	_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     "Adding README.md...",
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+		Readme: fi,
+	})
+	if err != nil {
+		return r.failedJobf("write log: %s", err)
+	}
+	return nil
+}
+
+func (r *runner) runTemplateImport() (*proto.CompletedJob, *proto.FailedJob) {
+	// Parse parameters and update the job with the parameter specs
+	_, err := r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     "Parsing template parameters",
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+	})
+	if err != nil {
+		return nil, r.failedJobf("write log: %s", err)
+	}
+	parameterSchemas, err := r.runTemplateImportParse()
+	if err != nil {
+		return nil, r.failedJobf("run parse: %s", err)
+	}
+	updateResponse, err := r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId:            r.job.JobId,
+		ParameterSchemas: parameterSchemas,
+	})
+	if err != nil {
+		return nil, r.failedJobf("update job: %s", err)
+	}
+
+	valueByName := map[string]*sdkproto.ParameterValue{}
+	for _, parameterValue := range updateResponse.ParameterValues {
+		valueByName[parameterValue.Name] = parameterValue
+	}
+	for _, parameterSchema := range parameterSchemas {
+		_, ok := valueByName[parameterSchema.Name]
+		if !ok {
+			return nil, r.failedJobf("%s: %s", missingParameterErrorText, parameterSchema.Name)
+		}
+	}
+
+	// Determine persistent resources
+	_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     "Detecting persistent resources",
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+	})
+	if err != nil {
+		return nil, r.failedJobf("write log: %s", err)
+	}
+	startResources, err := r.runTemplateImportProvision(updateResponse.ParameterValues, &sdkproto.Provision_Metadata{
+		CoderUrl:            r.job.GetTemplateImport().Metadata.CoderUrl,
+		WorkspaceTransition: sdkproto.WorkspaceTransition_START,
+	})
+	if err != nil {
+		return nil, r.failedJobf("template import provision for start: %s", err)
+	}
+
+	// Determine ephemeral resources.
+	_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     "Detecting ephemeral resources",
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+	})
+	if err != nil {
+		return nil, r.failedJobf("write log: %s", err)
+	}
+	stopResources, err := r.runTemplateImportProvision(updateResponse.ParameterValues, &sdkproto.Provision_Metadata{
+		CoderUrl:            r.job.GetTemplateImport().Metadata.CoderUrl,
+		WorkspaceTransition: sdkproto.WorkspaceTransition_STOP,
+	})
+	if err != nil {
+		return nil, r.failedJobf("template import provision for stop: %s", err)
+	}
+
+	return &proto.CompletedJob{
+		JobId: r.job.JobId,
+		Type: &proto.CompletedJob_TemplateImport_{
+			TemplateImport: &proto.CompletedJob_TemplateImport{
+				StartResources: startResources,
+				StopResources:  stopResources,
+			},
+		},
+	}, nil
+}
+
+// Parses parameter schemas from source.
+func (r *runner) runTemplateImportParse() ([]*sdkproto.ParameterSchema, error) {
+	stream, err := r.provisioner.Parse(r.forceStopContext, &sdkproto.Parse_Request{
+		Directory: r.workDirectory,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("parse source: %w", err)
+	}
+	defer stream.Close()
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			return nil, xerrors.Errorf("recv parse source: %w", err)
+		}
+		switch msgType := msg.Type.(type) {
+		case *sdkproto.Parse_Response_Log:
+			r.logger.Debug(context.Background(), "parse job logged",
+				slog.F("level", msgType.Log.Level),
+				slog.F("output", msgType.Log.Output),
+			)
+
+			_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+				JobId: r.job.JobId,
+				Logs: []*proto.Log{{
+					Source:    proto.LogSource_PROVISIONER,
+					Level:     msgType.Log.Level,
+					CreatedAt: time.Now().UTC().UnixMilli(),
+					Output:    msgType.Log.Output,
+					Stage:     "Parse parameters",
+				}},
+			})
+			if err != nil {
+				return nil, xerrors.Errorf("update job: %w", err)
+			}
+		case *sdkproto.Parse_Response_Complete:
+			r.logger.Info(context.Background(), "parse complete",
+				slog.F("parameter_schemas", msgType.Complete.ParameterSchemas))
+
+			return msgType.Complete.ParameterSchemas, nil
+		default:
+			return nil, xerrors.Errorf("invalid message type %q received from provisioner",
+				reflect.TypeOf(msg.Type).String())
+		}
+	}
+}
+
+// Performs a dry-run provision when importing a template.
+// This is used to detect resources that would be provisioned
+// for a workspace in various states.
+func (r *runner) runTemplateImportProvision(values []*sdkproto.ParameterValue, metadata *sdkproto.Provision_Metadata) ([]*sdkproto.Resource, error) {
+	var stage string
+	switch metadata.WorkspaceTransition {
+	case sdkproto.WorkspaceTransition_START:
+		stage = "Detecting persistent resources"
+	case sdkproto.WorkspaceTransition_STOP:
+		stage = "Detecting ephemeral resources"
+	}
+	// use the forceStopContext so that if we attempt to gracefully cancel, the stream will still be available for us
+	// to send the cancel to the provisioner
+	stream, err := r.provisioner.Provision(r.forceStopContext)
+	if err != nil {
+		return nil, xerrors.Errorf("provision: %w", err)
+	}
+	defer stream.Close()
+	go func() {
+		select {
+		case <-r.forceStopContext.Done():
+			return
+		case <-r.gracefulContext.Done():
+			_ = stream.Send(&sdkproto.Provision_Request{
+				Type: &sdkproto.Provision_Request_Cancel{
+					Cancel: &sdkproto.Provision_Cancel{},
+				},
+			})
+		}
+	}()
+	err = stream.Send(&sdkproto.Provision_Request{
+		Type: &sdkproto.Provision_Request_Start{
+			Start: &sdkproto.Provision_Start{
+				Directory:       r.workDirectory,
+				ParameterValues: values,
+				DryRun:          true,
+				Metadata:        metadata,
+			},
+		},
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("start provision: %w", err)
+	}
+
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			return nil, xerrors.Errorf("recv import provision: %w", err)
+		}
+		switch msgType := msg.Type.(type) {
+		case *sdkproto.Provision_Response_Log:
+			r.logger.Debug(context.Background(), "template import provision job logged",
+				slog.F("level", msgType.Log.Level),
+				slog.F("output", msgType.Log.Output),
+			)
+			_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+				JobId: r.job.JobId,
+				Logs: []*proto.Log{{
+					Source:    proto.LogSource_PROVISIONER,
+					Level:     msgType.Log.Level,
+					CreatedAt: time.Now().UTC().UnixMilli(),
+					Output:    msgType.Log.Output,
+					Stage:     stage,
+				}},
+			})
+			if err != nil {
+				return nil, xerrors.Errorf("send job update: %w", err)
+			}
+		case *sdkproto.Provision_Response_Complete:
+			if msgType.Complete.Error != "" {
+				r.logger.Info(context.Background(), "dry-run provision failure",
+					slog.F("error", msgType.Complete.Error),
+				)
+
+				return nil, xerrors.New(msgType.Complete.Error)
+			}
+
+			r.logger.Info(context.Background(), "parse dry-run provision successful",
+				slog.F("resource_count", len(msgType.Complete.Resources)),
+				slog.F("resources", msgType.Complete.Resources),
+				slog.F("state_length", len(msgType.Complete.State)),
+			)
+
+			return msgType.Complete.Resources, nil
+		default:
+			return nil, xerrors.Errorf("invalid message type %q received from provisioner",
+				reflect.TypeOf(msg.Type).String())
+		}
+	}
+}
+
+func (r *runner) runTemplateDryRun() (
+	*proto.CompletedJob, *proto.FailedJob) {
+	// Ensure all metadata fields are set as they are all optional for dry-run.
+	metadata := r.job.GetTemplateDryRun().GetMetadata()
+	metadata.WorkspaceTransition = sdkproto.WorkspaceTransition_START
+	if metadata.CoderUrl == "" {
+		metadata.CoderUrl = "http://localhost:3000"
+	}
+	if metadata.WorkspaceName == "" {
+		metadata.WorkspaceName = "dryrun"
+	}
+	metadata.WorkspaceOwner = r.job.UserName
+	if metadata.WorkspaceOwner == "" {
+		metadata.WorkspaceOwner = "dryrunner"
+	}
+	if metadata.WorkspaceId == "" {
+		id, err := uuid.NewRandom()
+		if err != nil {
+			return nil, r.failedJobf("generate random ID: %s", err)
+		}
+		metadata.WorkspaceId = id.String()
+	}
+	if metadata.WorkspaceOwnerId == "" {
+		id, err := uuid.NewRandom()
+		if err != nil {
+			return nil, r.failedJobf("generate random ID: %s", err)
+		}
+		metadata.WorkspaceOwnerId = id.String()
+	}
+
+	// Run the template import provision task since it's already a dry run.
+	resources, err := r.runTemplateImportProvision(
+		r.job.GetTemplateDryRun().GetParameterValues(),
+		metadata,
+	)
+	if err != nil {
+		return nil, r.failedJobf("run dry-run provision job: %s", err)
+	}
+
+	return &proto.CompletedJob{
+		JobId: r.job.JobId,
+		Type: &proto.CompletedJob_TemplateDryRun_{
+			TemplateDryRun: &proto.CompletedJob_TemplateDryRun{
+				Resources: resources,
+			},
+		},
+	}, nil
+}
+
+func (r *runner) runWorkspaceBuild() (
+	*proto.CompletedJob, *proto.FailedJob) {
+	var stage string
+	switch r.job.GetWorkspaceBuild().Metadata.WorkspaceTransition {
+	case sdkproto.WorkspaceTransition_START:
+		stage = "Starting workspace"
+	case sdkproto.WorkspaceTransition_STOP:
+		stage = "Stopping workspace"
+	case sdkproto.WorkspaceTransition_DESTROY:
+		stage = "Destroying workspace"
+	}
+
+	_, err := r.update(r.forceStopContext, &proto.UpdateJobRequest{
+		JobId: r.job.JobId,
+		Logs: []*proto.Log{{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			Stage:     stage,
+			CreatedAt: time.Now().UTC().UnixMilli(),
+		}},
+	})
+	if err != nil {
+		return nil, r.failedJobf("write log: %s", err)
+	}
+
+	// use the forceStopContext so that if we attempt to gracefully cancel, the stream will still be available for us
+	// to send the cancel to the provisioner
+	stream, err := r.provisioner.Provision(r.forceStopContext)
+	if err != nil {
+		return nil, r.failedJobf("provision: %s", err)
+	}
+	defer stream.Close()
+	go func() {
+		select {
+		case <-r.forceStopContext.Done():
+			return
+		case <-r.gracefulContext.Done():
+			_ = stream.Send(&sdkproto.Provision_Request{
+				Type: &sdkproto.Provision_Request_Cancel{
+					Cancel: &sdkproto.Provision_Cancel{},
+				},
+			})
+		}
+	}()
+	err = stream.Send(&sdkproto.Provision_Request{
+		Type: &sdkproto.Provision_Request_Start{
+			Start: &sdkproto.Provision_Start{
+				Directory:       r.workDirectory,
+				ParameterValues: r.job.GetWorkspaceBuild().ParameterValues,
+				Metadata:        r.job.GetWorkspaceBuild().Metadata,
+				State:           r.job.GetWorkspaceBuild().State,
+			},
+		},
+	})
+	if err != nil {
+		return nil, r.failedJobf("start provision: %s", err)
+	}
+
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			return nil, r.failedJobf("recv workspace provision: %s", err)
+		}
+		switch msgType := msg.Type.(type) {
+		case *sdkproto.Provision_Response_Log:
+			r.logger.Debug(context.Background(), "workspace provision job logged",
+				slog.F("level", msgType.Log.Level),
+				slog.F("output", msgType.Log.Output),
+				slog.F("workspace_build_id", r.job.GetWorkspaceBuild().WorkspaceBuildId),
+			)
+
+			_, err = r.update(r.forceStopContext, &proto.UpdateJobRequest{
+				JobId: r.job.JobId,
+				Logs: []*proto.Log{{
+					Source:    proto.LogSource_PROVISIONER,
+					Level:     msgType.Log.Level,
+					CreatedAt: time.Now().UTC().UnixMilli(),
+					Output:    msgType.Log.Output,
+					Stage:     stage,
+				}},
+			})
+			if err != nil {
+				return nil, r.failedJobf("send job update: %s", err)
+			}
+		case *sdkproto.Provision_Response_Complete:
+			if msgType.Complete.Error != "" {
+				r.logger.Info(context.Background(), "provision failed; updating state",
+					slog.F("state_length", len(msgType.Complete.State)),
+				)
+
+				return nil, &proto.FailedJob{
+					JobId: r.job.JobId,
+					Error: msgType.Complete.Error,
+					Type: &proto.FailedJob_WorkspaceBuild_{
+						WorkspaceBuild: &proto.FailedJob_WorkspaceBuild{
+							State: msgType.Complete.State,
+						},
+					},
+				}
+			}
+
+			r.logger.Debug(context.Background(), "provision complete no error")
+			r.logger.Info(context.Background(), "provision successful; marked job as complete",
+				slog.F("resource_count", len(msgType.Complete.Resources)),
+				slog.F("resources", msgType.Complete.Resources),
+				slog.F("state_length", len(msgType.Complete.State)),
+			)
+			// Stop looping!
+			return &proto.CompletedJob{
+				JobId: r.job.JobId,
+				Type: &proto.CompletedJob_WorkspaceBuild_{
+					WorkspaceBuild: &proto.CompletedJob_WorkspaceBuild{
+						State:     msgType.Complete.State,
+						Resources: msgType.Complete.Resources,
+					},
+				},
+			}, nil
+		default:
+			return nil, r.failedJobf("invalid message type %T received from provisioner", msg.Type)
+		}
+	}
+}
+
+func (r *runner) failedJobf(format string, args ...interface{}) *proto.FailedJob {
+	return &proto.FailedJob{
+		JobId: r.job.JobId,
+		Error: fmt.Sprintf(format, args...),
+	}
+}

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -1,4 +1,4 @@
-package provisionerd
+package runner
 
 import (
 	"archive/tar"
@@ -23,6 +23,10 @@ import (
 
 	"github.com/coder/coder/provisionerd/proto"
 	sdkproto "github.com/coder/coder/provisionersdk/proto"
+)
+
+const (
+	MissingParameterErrorText = "missing parameter"
 )
 
 type jobRunner interface {
@@ -498,7 +502,7 @@ func (r *runner) runTemplateImport() (*proto.CompletedJob, *proto.FailedJob) {
 	for _, parameterSchema := range parameterSchemas {
 		_, ok := valueByName[parameterSchema.Name]
 		if !ok {
-			return nil, r.failedJobf("%s: %s", missingParameterErrorText, parameterSchema.Name)
+			return nil, r.failedJobf("%s: %s", provisionerd.missingParameterErrorText, parameterSchema.Name)
 		}
 	}
 

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -54,9 +54,10 @@ type Runner struct {
 	cond         *sync.Cond
 	failedJob    *proto.FailedJob
 	completedJob *proto.CompletedJob
-	// setting this false signals that no more messages about this job should be sent.  Usually this means that a
-	// terminal message like FailedJob or CompletedJob has been sent, but if we are force canceled, we may set this
-	// false and not send one.
+	// setting this false signals that no more messages about this job should be sent.  Usually this
+	// means that a terminal message like FailedJob or CompletedJob has been sent, even in the case
+	// of a Cancel().  However, when someone calls Fail() or ForceStop(), we might not send the
+	// terminal message, but okToSend is set to false regardless.
 	okToSend bool
 }
 

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -89,7 +89,7 @@ func (p *PTY) ExpectMatch(str string) string {
 		case <-timer.C:
 		}
 		_ = p.Close()
-		p.t.Errorf("match exceeded deadline: wanted %q; got %q", str, buffer.String())
+		p.t.Errorf("%s match exceeded deadline: wanted %q; got %q", time.Now(), str, buffer.String())
 	}()
 	for {
 		var r rune


### PR DESCRIPTION
Substantially narrows the race window on #2603 but doesn't close it.

This PR refactors provisionerd to include a job runner that is designed to ensure that we get at most 1 FailedJob or CompletedJob message per job, and that we cease any updates for jobs once this is sent.

It uses unexported interfaces to distinguish between methods that can be called by things like the main provisionerd goroutines (things like canceling the current job), and methods internal to the runner.  Similarly, we abstract the provisionerd server from the runner so that we ensure that sending messages about jobs happens with consistent code.
