### PR TITLE
fix: develop.sh: do not clobber existing login, pre-build coder binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ site/out/
 
 .vscode/*.log
 **/*.swp
+.coderv2/*

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This is a shim for developing and dogfooding Coder so that we don't
+# overwrite an existing session in ~/.config/coderv2
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
+
+CODER_DEV_DIR="$PROJECT_ROOT/.coderv2/"
+CODER_DEV_BIN="${CODER_DEV_DIR}/coder"
+if [[ ! -d "${CODER_DEV_DIR}" ]]; then
+	mkdir -p "${CODER_DEV_DIR}"
+fi
+
+if [[ ! -x "${CODER_DEV_BIN}" ]]; then
+	echo "Run this command first:"
+	echo "go build -o ${CODER_DEV_BIN} ${PROJECT_ROOT}/cmd/coder"
+	exit 1
+fi
+
+exec "${CODER_DEV_BIN}" --global-config "${CODER_DEV_DIR}" "$@"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib.sh"
 PROJECT_ROOT=$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)
+CODER_DEV_BIN="${PROJECT_ROOT}/.coderv2/coder"
 set +u
 CODER_DEV_ADMIN_PASSWORD="${CODER_DEV_ADMIN_PASSWORD:-password}"
 set -u
@@ -27,6 +28,11 @@ if [[ ! -e ./site/out/bin/coder.sha1 && ! -e ./site/out/bin/coder.tar.zst ]]; th
 	exit 1
 fi
 
+# Compile the CLI binary once just so we don't waste time compiling things multiple times
+go build -o "${CODER_DEV_BIN}" "${PROJECT_ROOT}/cmd/coder"
+# Use the coder dev shim so we don't overwrite the user's existing Coder config.
+CODER_DEV_SHIM="${PROJECT_ROOT}/scripts/coder-dev.sh"
+
 # Run yarn install, to make sure node_modules are ready to go
 "$PROJECT_ROOT/scripts/yarn_install.sh"
 
@@ -36,33 +42,33 @@ fi
 (
 	# If something goes wrong, just bail and tear everything down
 	# rather than leaving things in an inconsistent state.
-	trap 'kill -INT -$$' ERR
+	trap 'kill -TERM -$$' ERR
 	cdroot
 	CODER_HOST=http://127.0.0.1:3000 INSPECT_XSTATE=true yarn --cwd=./site dev || kill -INT -$$ &
-	go run -tags embed cmd/coder/main.go server --address 127.0.0.1:3000 --in-memory --tunnel || kill -INT -$$ &
+	"${CODER_DEV_SHIM}" server --address 127.0.0.1:3000 --in-memory --tunnel || kill -INT -$$ &
 
 	echo '== Waiting for Coder to become ready'
 	timeout 60s bash -c 'until curl -s --fail http://localhost:3000 > /dev/null 2>&1; do sleep 0.5; done'
 
 	#  create the first user, the admin
-	go run cmd/coder/main.go login http://127.0.0.1:3000 --username=admin --email=admin@coder.com --password="${CODER_DEV_ADMIN_PASSWORD}" ||
+	"${CODER_DEV_SHIM}" login http://127.0.0.1:3000 --username=admin --email=admin@coder.com --password="${CODER_DEV_ADMIN_PASSWORD}" ||
 		echo 'Failed to create admin user. To troubleshoot, try running this command manually.'
 
 	# || true to always exit code 0. If this fails, whelp.
-	go run cmd/coder/main.go users create --email=member@coder.com --username=member --password="${CODER_DEV_ADMIN_PASSWORD}" ||
+	"${CODER_DEV_SHIM}" users create --email=member@coder.com --username=member --password="${CODER_DEV_ADMIN_PASSWORD}" ||
 		echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
 
 	# If we have docker available, then let's try to create a template!
 	template_name=""
 	if docker info >/dev/null 2>&1; then
 		temp_template_dir=$(mktemp -d)
-		echo code-server | go run "${PROJECT_ROOT}/cmd/coder/main.go" templates init "${temp_template_dir}"
+		echo code-server | "${CODER_DEV_SHIM}" templates init "${temp_template_dir}"
 		# shellcheck disable=SC1090
 		source <(go env | grep GOARCH)
 		DOCKER_HOST=$(docker context inspect --format '{{.Endpoints.docker.Host}}')
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" | tee "${temp_template_dir}/params.yaml"
 		template_name="docker-${GOARCH}"
-		go run "${PROJECT_ROOT}/cmd/coder/main.go" templates create "${template_name}" --directory "${temp_template_dir}" --parameter-file "${temp_template_dir}/params.yaml" --yes
+		"${CODER_DEV_SHIM}" templates create "${template_name}" --directory "${temp_template_dir}" --parameter-file "${temp_template_dir}/params.yaml" --yes
 		rm -rfv "${temp_template_dir}"
 	fi
 
@@ -75,6 +81,7 @@ fi
 	if [[ -n "${template_name}" ]]; then
 		log "==                                                                   =="
 		log "==            Docker template ${template_name} is ready to use!          =="
+		log "==            Use ./scripts/coder-dev.sh to talk to this instance!   =="
 		log "==                                                                   =="
 	fi
 	log "======================================================================="

--- a/site/.eslintignore
+++ b/site/.eslintignore
@@ -11,3 +11,4 @@ storybook-static
 test-results
 **/*.typegen.ts
 **/*.swp
+.coderv2/*

--- a/site/.prettierignore
+++ b/site/.prettierignore
@@ -19,3 +19,4 @@ storybook-static/
 test-results/
 
 **/*.swp
+.coderv2/*


### PR DESCRIPTION
I found that the `develop.sh` script can clobber your existing Coder login, so I made a `.coderv2` directory to hold the 'development' config directory, and added a shim to run an existing coder binary with that specific config dir.

I also figured it makes sense to build the Coder binary once instead of using `go run` a bunch of times in `develop.sh`, which makes it a bit faster.

Comments, suggestions, etc. welcome!