### PR TITLE
fix: reprompt for matching passwords on mismatch

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -131,26 +131,29 @@ func login() *cobra.Command {
 				}
 
 				if password == "" {
-					password, err = cliui.Prompt(cmd, cliui.PromptOptions{
-						Text:     "Enter a " + cliui.Styles.Field.Render("password") + ":",
-						Secret:   true,
-						Validate: cliui.ValidateNotEmpty,
-					})
-					if err != nil {
-						return xerrors.Errorf("specify password prompt: %w", err)
-					}
-					_, err = cliui.Prompt(cmd, cliui.PromptOptions{
-						Text:   "Confirm " + cliui.Styles.Field.Render("password") + ":",
-						Secret: true,
-						Validate: func(s string) error {
-							if s != password {
-								return xerrors.Errorf("Passwords do not match")
-							}
-							return nil
-						},
-					})
-					if err != nil {
-						return xerrors.Errorf("confirm password prompt: %w", err)
+					var matching bool
+
+					for !matching {
+						password, err = cliui.Prompt(cmd, cliui.PromptOptions{
+							Text:     "Enter a " + cliui.Styles.Field.Render("password") + ":",
+							Secret:   true,
+							Validate: cliui.ValidateNotEmpty,
+						})
+						if err != nil {
+							return xerrors.Errorf("specify password prompt: %w", err)
+						}
+						confirm, err := cliui.Prompt(cmd, cliui.PromptOptions{
+							Text:   "Confirm " + cliui.Styles.Field.Render("password") + ":",
+							Secret: true,
+						})
+						if err != nil {
+							return xerrors.Errorf("confirm password prompt: %w", err)
+						}
+
+						matching = confirm == password
+						if !matching {
+							_, _ = fmt.Fprintln(cmd.OutOrStdout(), cliui.Styles.Error.Render("Passwords do not match"))
+						}
 					}
 				}
 


### PR DESCRIPTION
fixes #2626

![image](https://user-images.githubusercontent.com/4856196/176739858-6ae375e8-7f55-48cc-afee-5e2570944fc2.png)
