### PR TITLE
chore: clean up scripts for internal godoc site that's no longer used

### DIFF
--- a/scripts/internal-docs/README.md
+++ b/scripts/internal-docs/README.md
@@ -1,3 +1,0 @@
-Configuration for automatically building and hosting an internal godoc site.
-This will become obsolete once we make the repo public and can use
-https://pkg.go.dev/.

--- a/scripts/internal-docs/cloudbuild.yaml
+++ b/scripts/internal-docs/cloudbuild.yaml
@@ -1,8 +1,0 @@
-steps:
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/coder-devrel/internal-docs', '-f', 'scripts/internal-docs/docker/Dockerfile', '.']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/coder-devrel/internal-docs']
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  entrypoint: gcloud
-  args: ['run', 'deploy', 'internal-docs', '--image', 'gcr.io/coder-devrel/internal-docs', '--region', 'us-central1']

--- a/scripts/internal-docs/docker/Dockerfile
+++ b/scripts/internal-docs/docker/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.18-alpine
-
-RUN go install github.com/dwahler/go-tools/cmd/godoc@v0.1.1
-
-WORKDIR /go/src/github.com/coder/coder
-ADD . .
-
-EXPOSE 6060
-CMD godoc -http :6060


### PR DESCRIPTION
This PR removes the internal godoc container configurations that were added in #1415, and which are no longer necessary now that our docs are hosted at https://pkg.go.dev/.