### PR TITLE
fix: Upload the Windows .exe in CI

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -388,6 +388,7 @@ jobs:
           name: coder
           path: |
             ./dist/*.zip
+            ./dist/*.exe
             ./dist/*.tar.gz
             ./dist/*.apk
             ./dist/*.deb


### PR DESCRIPTION
why aren't we getting a .zip?  a question for later.