### PR TITLE
fix: Reduce count to 1 for PostgreSQL tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ test-postgres: test-clean test-postgres-docker
 	DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum --junitfile="gotests.xml" --packages="./..." -- \
 		-covermode=atomic -coverprofile="gotests.coverage" -timeout=30m \
 		-coverpkg=./...,github.com/coder/coder/codersdk \
-		-count=2 -race -failfast
+		-count=1 -race -failfast
 .PHONY: test-postgres
 
 test-postgres-docker:


### PR DESCRIPTION
It's unnecessary for these to run twice. It increases CI times  without
providing much additional assurance tests don't have race conditions.
This already runs with `-race` too.
