### PR TITLE
fix: Handle all method types for app proxying

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -124,7 +124,7 @@ func New(options *Options) *API {
 			apiKeyMiddleware,
 			httpmw.ExtractUserParam(api.Database),
 		)
-		r.Get("/*", api.workspaceAppsProxyPath)
+		r.HandleFunc("/*", api.workspaceAppsProxyPath)
 	}
 	// %40 is the encoded character of the @ symbol. VS Code Web does
 	// not handle character encoding properly, so it's safe to assume


### PR DESCRIPTION
All methods need to be accepted on app routes. Some apps
may POST (like Jupyter).

