### PR TITLE
fix: Add `trap` to agent startup script to sleep on failure

### DIFF
--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -18,6 +18,7 @@ Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 
 	linuxScript = `#!/usr/bin/env sh
 set -eux pipefail
+trap 'echo === Agent script exited with non-zero code. Sleeping infinitely to preserve logs... && sleep 86400' EXIT
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
@@ -39,6 +40,7 @@ exec ./$BINARY_NAME agent`
 
 	darwinScript = `#!/usr/bin/env sh
 set -eux pipefail
+trap 'echo === Agent script exited with non-zero code. Sleeping infinitely to preserve logs... && sleep 86400' EXIT
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 cd $BINARY_DIR

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -18,7 +18,7 @@ Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
 
 	linuxScript = `#!/usr/bin/env sh
 set -eux pipefail
-trap 'echo === Agent script exited with non-zero code. Sleeping infinitely to preserve logs... && sleep 86400' EXIT
+trap 'echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400' EXIT
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}

--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -40,7 +40,7 @@ exec ./$BINARY_NAME agent`
 
 	darwinScript = `#!/usr/bin/env sh
 set -eux pipefail
-trap 'echo === Agent script exited with non-zero code. Sleeping infinitely to preserve logs... && sleep 86400' EXIT
+trap 'echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400' EXIT
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 cd $BINARY_DIR


### PR DESCRIPTION
The Docker Terraform provider removes containers immediately on exit, making
it difficult to debug a failed container start with Coder. This will sleep on
exit and output a friendly log, which should assist with debugging failures.
