### PR TITLE
provisionersdk: extract and embed agent bootstrap scripts

### DIFF
--- a/provisionersdk/agent.go
+++ b/provisionersdk/agent.go
@@ -1,52 +1,20 @@
 package provisionersdk
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 )
 
 var (
-	// On Windows, VS Code Remote requires a parent process of the
-	// executing shell to be named "sshd", otherwise it fails. See:
-	// https://github.com/microsoft/vscode-remote-release/issues/5699
-	windowsScript = `$ProgressPreference = "SilentlyContinue"
-Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-${ARCH}.exe -OutFile $env:TEMP\sshd.exe
-Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
-$env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
-$env:CODER_AGENT_URL = "${ACCESS_URL}"
-Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru`
-
-	linuxScript = `#!/usr/bin/env sh
-set -eux pipefail
-BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
-BINARY_NAME=coder
-BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
-cd $BINARY_DIR
-if command -v curl >/dev/null 2>&1; then
-	curl -fsSL --compressed "${BINARY_URL}" -o "${BINARY_NAME}"
-elif command -v wget >/dev/null 2>&1; then
-	wget -q "${BINARY_URL}" -O "${BINARY_NAME}"
-elif command -v busybox >/dev/null 2>&1; then
-	busybox wget -q "${BINARY_URL}" -O "${BINARY_NAME}"
-else
-	echo "error: no download tool found, please install curl, wget or busybox wget"
-	exit 1
-fi
-chmod +x $BINARY_NAME
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec ./$BINARY_NAME agent`
-
-	darwinScript = `#!/usr/bin/env sh
-set -eux pipefail
-BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
-BINARY_NAME=coder
-cd $BINARY_DIR
-curl -fsSL --compressed "${ACCESS_URL}bin/coder-darwin-${ARCH}" -o "${BINARY_NAME}"
-chmod +x $BINARY_NAME
-export CODER_AGENT_AUTH="${AUTH_TYPE}"
-export CODER_AGENT_URL="${ACCESS_URL}"
-exec ./$BINARY_NAME agent`
+	// These used to be hard-coded, but after growing significantly more complex
+	// it made sense to put them in their own files (e.g. for linting).
+	//go:embed scripts/bootstrap_windows.ps1
+	windowsScript string
+	//go:embed scripts/bootstrap_linux.sh
+	linuxScript string
+	//go:embed scripts/bootstrap_darwin.sh
+	darwinScript string
 
 	// A mapping of operating-system ($GOOS) to architecture ($GOARCH)
 	// to agent install and run script. ${DOWNLOAD_URL} is replaced

--- a/provisionersdk/scripts/bootstrap_darwin.sh
+++ b/provisionersdk/scripts/bootstrap_darwin.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eux pipefail
+BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
+BINARY_NAME=coder
+cd "$BINARY_DIR"
+curl -fsSL --compressed "${ACCESS_URL}bin/coder-darwin-${ARCH}" -o "${BINARY_NAME}"
+chmod +x $BINARY_NAME
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec ./$BINARY_NAME agent

--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eux pipefail
+BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
+BINARY_NAME=coder
+BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}
+cd "$BINARY_DIR"
+if command -v curl >/dev/null 2>&1; then
+	curl -fsSL --compressed "${BINARY_URL}" -o "${BINARY_NAME}"
+elif command -v wget >/dev/null 2>&1; then
+	wget -q "${BINARY_URL}" -O "${BINARY_NAME}"
+elif command -v busybox >/dev/null 2>&1; then
+	busybox wget -q "${BINARY_URL}" -O "${BINARY_NAME}"
+else
+	echo "error: no download tool found, please install curl, wget or busybox wget"
+	exit 1
+fi
+chmod +x $BINARY_NAME
+export CODER_AGENT_AUTH="${AUTH_TYPE}"
+export CODER_AGENT_URL="${ACCESS_URL}"
+exec ./$BINARY_NAME agent

--- a/provisionersdk/scripts/bootstrap_windows.ps1
+++ b/provisionersdk/scripts/bootstrap_windows.ps1
@@ -1,0 +1,9 @@
+# On Windows, VS Code Remote requires a parent process of the
+## executing shell to be named "sshd", otherwise it fails. See:
+# https://github.com/microsoft/vscode-remote-release/issues/5699
+$ProgressPreference = "SilentlyContinue"
+Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-${ARCH}.exe -OutFile $env:TEMP\sshd.exe
+Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
+$env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
+$env:CODER_AGENT_URL = "${ACCESS_URL}"
+Start-Process -FilePath $env:TEMP\sshd.exe -ArgumentList "agent" -PassThru

--- a/provisionersdk/scripts/bootstrap_windows.ps1
+++ b/provisionersdk/scripts/bootstrap_windows.ps1
@@ -1,5 +1,5 @@
 # On Windows, VS Code Remote requires a parent process of the
-## executing shell to be named "sshd", otherwise it fails. See:
+# executing shell to be named "sshd", otherwise it fails. See:
 # https://github.com/microsoft/vscode-remote-release/issues/5699
 $ProgressPreference = "SilentlyContinue"
 Invoke-WebRequest -Uri ${ACCESS_URL}bin/coder-windows-${ARCH}.exe -OutFile $env:TEMP\sshd.exe


### PR DESCRIPTION
This commit extracts the existing hard-coded agent scripts to their own files and embeds them using  `go:embed`.
We can more easily use e.g. shellcheck to validate our agent scripts