### PR TITLE
fix: Wrap help flags at 100 chars

### DIFF
--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -102,9 +102,14 @@ func DurationVarP(flagset *pflag.FlagSet, ptr *time.Duration, name string, short
 }
 
 func fmtUsage(u string, env string) string {
-	if env == "" {
-		return fmt.Sprintf("%s.", u)
+	if env != "" {
+		// Avoid double dotting.
+		dot := "."
+		if strings.HasSuffix(u, ".") {
+			dot = ""
+		}
+		u = fmt.Sprintf("%s%s\nConsumes $%s", u, dot, env)
 	}
 
-	return fmt.Sprintf("%s - consumes $%s.", u, env)
+	return u
 }

--- a/cli/cliflag/cliflag_test.go
+++ b/cli/cliflag/cliflag_test.go
@@ -24,7 +24,7 @@ func TestCliflag(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, def, got)
 		require.Contains(t, flagset.FlagUsages(), usage)
-		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf(" - consumes $%s", env))
+		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf("Consumes $%s", env))
 	})
 
 	t.Run("StringEnvVar", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestCliflag(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, def, got)
 		require.Contains(t, flagset.FlagUsages(), usage)
-		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf(" - consumes $%s", env))
+		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf("Consumes $%s", env))
 	})
 
 	t.Run("StringVarPEnvVar", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestCliflag(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, def, got)
 		require.Contains(t, flagset.FlagUsages(), usage)
-		require.NotContains(t, flagset.FlagUsages(), " - consumes")
+		require.NotContains(t, flagset.FlagUsages(), "Consumes")
 	})
 
 	t.Run("StringArrayDefault", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestCliflag(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint8(def), got)
 		require.Contains(t, flagset.FlagUsages(), usage)
-		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf(" - consumes $%s", env))
+		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf("Consumes $%s", env))
 	})
 
 	t.Run("IntEnvVar", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestCliflag(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, def, got)
 		require.Contains(t, flagset.FlagUsages(), usage)
-		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf(" - consumes $%s", env))
+		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf("Consumes $%s", env))
 	})
 
 	t.Run("BoolEnvVar", func(t *testing.T) {
@@ -195,7 +195,7 @@ func TestCliflag(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, def, got)
 		require.Contains(t, flagset.FlagUsages(), usage)
-		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf(" - consumes $%s", env))
+		require.Contains(t, flagset.FlagUsages(), fmt.Sprintf("Consumes $%s", env))
 	})
 
 	t.Run("DurationEnvVar", func(t *testing.T) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -348,12 +348,12 @@ func usageTemplate() string {
 
 {{- if .HasAvailableLocalFlags}}
 {{usageHeader "Flags:"}}
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{.LocalFlags.FlagUsagesWrapped 100}}
 {{end}}
 
 {{- if .HasAvailableInheritedFlags}}
 {{usageHeader "Global Flags:"}}
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{.InheritedFlags.FlagUsagesWrapped 100}}
 {{end}}
 
 {{- if .HasHelpSubCommands}}


### PR DESCRIPTION
Because the actual flags take quite a bit of space, wrapping at 80
characters creates a very cramped output for e.g. `coder server`, for
this reasons, flags are wrapped at 100 chars (vs. standard 80).

The `Consumes $ENV_FLAG` message was put on a newline for consistency,
this should allow users to learn where to look for the informations.

Side note: we should perhaps stop adding period (`.`) at the end of flag
descriptions to be consistent, for instance, command helps usually don't
have one.

This change fixes the biggest issue in #2363, but not all `--help`
output is guaranteed (yet) to wrap at 80-100 chars.

Fixes #2363
