### PR TITLE
fix: removing noisy shutdown snapshots

### DIFF
--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.stories.tsx
@@ -6,13 +6,6 @@ import { WorkspaceSchedule, WorkspaceScheduleProps } from "./WorkspaceSchedule"
 
 dayjs.extend(utc)
 
-// REMARK: There's a known problem with storybook and using date libraries that
-//         call string.toLowerCase
-// SEE: https:github.com/storybookjs/storybook/issues/12208#issuecomment-697044557
-const ONE = 1
-const SEVEN = 7
-const THIRTY = 30
-
 export default {
   title: "components/WorkspaceSchedule",
   component: WorkspaceSchedule,
@@ -50,46 +43,6 @@ NoTTL.args = {
       deadline: "0001-01-01T00:00:00Z",
     },
     ttl_ms: undefined,
-  },
-}
-
-export const ShutdownRealSoon = Template.bind({})
-ShutdownRealSoon.args = {
-  workspace: {
-    ...Mocks.MockWorkspace,
-    latest_build: {
-      ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().add(THIRTY, "minute").utc().format(),
-      transition: "start",
-    },
-    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
-  },
-}
-
-export const ShutdownSoon = Template.bind({})
-ShutdownSoon.args = {
-  workspace: {
-    ...Mocks.MockWorkspace,
-    latest_build: {
-      ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().add(ONE, "hour").utc().format(),
-      transition: "start",
-    },
-    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
-  },
-}
-
-export const ShutdownLong = Template.bind({})
-ShutdownLong.args = {
-  workspace: {
-    ...Mocks.MockWorkspace,
-
-    latest_build: {
-      ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().add(SEVEN, "days").utc().format(),
-      transition: "start",
-    },
-    ttl_ms: 7 * 24 * 60 * 60 * 1000, // 7 days
   },
 }
 

--- a/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
+++ b/site/src/components/WorkspaceSchedule/WorkspaceSchedule.tsx
@@ -54,16 +54,14 @@ export const WorkspaceSchedule: FC<WorkspaceScheduleProps> = ({
         </div>
         <div>
           <span className={styles.scheduleLabel}>{ScheduleLanguage.autoStartLabel}</span>
-          <span className={[styles.scheduleValue, "chromatic-ignore"].join(" ")}>
+          <span className={styles.scheduleValue}>
             {autoStartDisplay(workspace.autostart_schedule)}
           </span>
         </div>
         <div>
           <span className={styles.scheduleLabel}>{ScheduleLanguage.autoStopLabel}</span>
           <Stack direction="row">
-            <span className={[styles.scheduleValue, "chromatic-ignore"].join(" ")}>
-              {autoStopDisplay(workspace)}
-            </span>
+            <span className={styles.scheduleValue}>{autoStopDisplay(workspace)}</span>
           </Stack>
         </div>
         {canUpdateWorkspace && (

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
@@ -6,13 +6,6 @@ import { WorkspaceScheduleButton, WorkspaceScheduleButtonProps } from "./Workspa
 
 dayjs.extend(utc)
 
-// REMARK: There's a known problem with storybook and using date libraries that
-//         call string.toLowerCase
-// SEE: https:github.com/storybookjs/storybook/issues/12208#issuecomment-697044557
-const ONE = 1
-const SEVEN = 7
-const THIRTY = 30
-
 export default {
   title: "components/WorkspaceScheduleButton",
   component: WorkspaceScheduleButton,
@@ -52,46 +45,6 @@ NoTTL.args = {
       deadline: "0001-01-01T00:00:00Z",
     },
     ttl_ms: undefined,
-  },
-}
-
-export const ShutdownRealSoon = Template.bind({})
-ShutdownRealSoon.args = {
-  workspace: {
-    ...Mocks.MockWorkspace,
-    latest_build: {
-      ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().add(THIRTY, "minute").utc().format(),
-      transition: "start",
-    },
-    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
-  },
-}
-
-export const ShutdownSoon = Template.bind({})
-ShutdownSoon.args = {
-  workspace: {
-    ...Mocks.MockWorkspace,
-    latest_build: {
-      ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().add(ONE, "hour").utc().format(),
-      transition: "start",
-    },
-    ttl_ms: 2 * 60 * 60 * 1000, // 2 hours
-  },
-}
-
-export const ShutdownLong = Template.bind({})
-ShutdownLong.args = {
-  workspace: {
-    ...Mocks.MockWorkspace,
-
-    latest_build: {
-      ...Mocks.MockWorkspaceBuild,
-      deadline: dayjs().add(SEVEN, "days").utc().format(),
-      transition: "start",
-    },
-    ttl_ms: 7 * 24 * 60 * 60 * 1000, // 7 days
   },
 }
 


### PR DESCRIPTION
resolves #2685

I'm just taking these snapshots out for now. They are causing noise on every PR and the `chromatic-ignore` attribute isn't solving our issue. In addition, I'm not sure these were good candidates for stories - I would argue these tests aren't visual.
![Screen Shot 2022-07-11 at 8 51 10 AM](https://user-images.githubusercontent.com/19142439/178288529-c58f12ab-66e8-4d53-a698-58dbfcfb401c.png)

