### PR TITLE
feat: force legacy tunnels to new version

### DIFF
--- a/coderd/devtunnel/servers.go
+++ b/coderd/devtunnel/servers.go
@@ -20,6 +20,7 @@ type Region struct {
 
 type Node struct {
 	ID                int    `json:"id"`
+	RegionID          int    `json:"region_id"`
 	HostnameHTTPS     string `json:"hostname_https"`
 	HostnameWireguard string `json:"hostname_wireguard"`
 	WireguardPort     uint16 `json:"wireguard_port"`
@@ -29,11 +30,12 @@ type Node struct {
 
 var Regions = []Region{
 	{
-		ID:           1,
+		ID:           0,
 		LocationName: "US East Pittsburgh",
 		Nodes: []Node{
 			{
 				ID:                1,
+				RegionID:          0,
 				HostnameHTTPS:     "pit-1.try.coder.app",
 				HostnameWireguard: "pit-1.try.coder.app",
 				WireguardPort:     55551,

--- a/coderd/devtunnel/tunnel.go
+++ b/coderd/devtunnel/tunnel.go
@@ -3,7 +3,6 @@ package devtunnel
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -311,17 +310,4 @@ func writeConfig(cfg Config) error {
 	}
 
 	return nil
-}
-
-func encodeBase64ToHex(key string) string {
-	decoded, err := base64.StdEncoding.DecodeString(key)
-	if err != nil {
-		panic(err)
-	}
-
-	if len(decoded) != 32 {
-		panic((xerrors.New("key should be 32 bytes: " + key)))
-	}
-
-	return hex.EncodeToString(decoded)
 }

--- a/coderd/devtunnel/tunnel.go
+++ b/coderd/devtunnel/tunnel.go
@@ -277,7 +277,7 @@ func readOrGenerateConfig() (Config, error) {
 	if cfg.Version == 0 {
 		_, _ = fmt.Println()
 		_, _ = fmt.Println(cliui.Styles.Error.Render("You're running a deprecated tunnel version!"))
-		_, _ = fmt.Println(cliui.Styles.Error.Render("Upgrading you to the new version now. You may need to rebuild running workspaces."))
+		_, _ = fmt.Println(cliui.Styles.Error.Render("Upgrading you to the new version now. You will need to rebuild running workspaces."))
 		_, _ = fmt.Println()
 
 		cfg, err := GenerateConfig()

--- a/coderd/devtunnel/tunnel.go
+++ b/coderd/devtunnel/tunnel.go
@@ -280,7 +280,7 @@ func GenerateConfig() (Config, error) {
 	}
 
 	spin.Stop()
-	_, _ = fmt.Printf("Found closest tunnel region %s with latency %s.\n",
+	_, _ = fmt.Printf("Using tunnel in %s with latency %s.\n",
 		cliui.Styles.Keyword.Render(Regions[node.RegionID].LocationName),
 		cliui.Styles.Code.Render(node.AvgLatency.String()),
 	)


### PR DESCRIPTION
On startup, legacy tunnels will automatically be upgraded to v1. It'll require users to rebuild workspaces for them to reconnect again.