### PR TITLE
fix: Fix workspace count to exclude deleted workspaces

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -527,7 +527,7 @@ func (q *fakeQuerier) GetWorkspaceOwnerCountsByTemplateIDs(_ context.Context, te
 
 	counts := map[uuid.UUID]map[uuid.UUID]struct{}{}
 	for _, templateID := range templateIDs {
-		found := false
+		counts[templateID] = map[uuid.UUID]struct{}{}
 		for _, workspace := range q.workspaces {
 			if workspace.TemplateID != templateID {
 				continue
@@ -541,11 +541,6 @@ func (q *fakeQuerier) GetWorkspaceOwnerCountsByTemplateIDs(_ context.Context, te
 			}
 			countByOwnerID[workspace.OwnerID] = struct{}{}
 			counts[templateID] = countByOwnerID
-			found = true
-			break
-		}
-		if !found {
-			counts[templateID] = map[uuid.UUID]struct{}{}
 		}
 	}
 	res := make([]database.GetWorkspaceOwnerCountsByTemplateIDsRow, 0)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4058,6 +4058,8 @@ FROM
 	workspaces
 WHERE
 	template_id = ANY($1 :: uuid [ ])
+    -- Ignore deleted workspaces
+	AND deleted != true
 GROUP BY
 	template_id
 `

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4058,7 +4058,7 @@ FROM
 	workspaces
 WHERE
 	template_id = ANY($1 :: uuid [ ])
-    -- Ignore deleted workspaces
+	-- Ignore deleted workspaces
 	AND deleted != true
 GROUP BY
 	template_id

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -83,6 +83,8 @@ FROM
 	workspaces
 WHERE
 	template_id = ANY(@ids :: uuid [ ])
+    -- Ignore deleted workspaces
+	AND deleted != true
 GROUP BY
 	template_id;
 

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -83,7 +83,7 @@ FROM
 	workspaces
 WHERE
 	template_id = ANY(@ids :: uuid [ ])
-    -- Ignore deleted workspaces
+	-- Ignore deleted workspaces
 	AND deleted != true
 GROUP BY
 	template_id;

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -52,6 +52,7 @@ func TestTemplate(t *testing.T) {
 		build, err := client.CreateWorkspaceBuild(ctx, deletedWorkspace.ID, codersdk.CreateWorkspaceBuildRequest{
 			Transition: codersdk.WorkspaceTransitionDelete,
 		})
+		require.NoError(t, err)
 		coderdtest.AwaitWorkspaceBuildJob(t, client, build.ID)
 
 		template, err = client.Template(context.Background(), template.ID)


### PR DESCRIPTION
- Fake database was also not counting correctly. It only counted the first user, then a `break` stopped further counting

Fixes: https://github.com/coder/coder/issues/1830