### PR TITLE
feat: default confirm to no for safety

### DIFF
--- a/cli/cliui/prompt.go
+++ b/cli/cliui/prompt.go
@@ -41,8 +41,17 @@ func Prompt(cmd *cobra.Command, opts PromptOptions) (string, error) {
 
 	_, _ = fmt.Fprint(cmd.OutOrStdout(), Styles.FocusedPrompt.String()+opts.Text+" ")
 	if opts.IsConfirm {
-		opts.Default = "yes"
-		_, _ = fmt.Fprint(cmd.OutOrStdout(), Styles.Placeholder.Render("("+Styles.Bold.Render("yes")+Styles.Placeholder.Render("/no) ")))
+		if len(opts.Default) == 0 {
+			opts.Default = "yes"
+		}
+		renderedYes := Styles.Placeholder.Render("yes")
+		renderedNo := Styles.Placeholder.Render("no")
+		if opts.Default == "yes" {
+			renderedYes = Styles.Bold.Render("yes")
+		} else {
+			renderedNo = Styles.Bold.Render("no")
+		}
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), Styles.Placeholder.Render("("+renderedYes+Styles.Placeholder.Render("/"+renderedNo+Styles.Placeholder.Render(") "))))
 	} else if opts.Default != "" {
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), Styles.Placeholder.Render("("+opts.Default+") "))
 	}

--- a/cli/cliui/prompt.go
+++ b/cli/cliui/prompt.go
@@ -24,32 +24,39 @@ type PromptOptions struct {
 	Validate  func(string) error
 }
 
+const skipPromptFlag = "yes"
+
 func AllowSkipPrompt(cmd *cobra.Command) {
-	cmd.Flags().BoolP("yes", "y", false, "Bypass prompts")
+	cmd.Flags().BoolP(skipPromptFlag, "y", false, "Bypass prompts")
 }
+
+const (
+	ConfirmYes = "yes"
+	ConfirmNo  = "no"
+)
 
 // Prompt asks the user for input.
 func Prompt(cmd *cobra.Command, opts PromptOptions) (string, error) {
 	// If the cmd has a "yes" flag for skipping confirm prompts, honor it.
 	// If it's not a "Confirm" prompt, then don't skip. As the default value of
 	// "yes" makes no sense.
-	if opts.IsConfirm && cmd.Flags().Lookup("yes") != nil {
-		if skip, _ := cmd.Flags().GetBool("yes"); skip {
-			return "yes", nil
+	if opts.IsConfirm && cmd.Flags().Lookup(skipPromptFlag) != nil {
+		if skip, _ := cmd.Flags().GetBool(skipPromptFlag); skip {
+			return ConfirmYes, nil
 		}
 	}
 
 	_, _ = fmt.Fprint(cmd.OutOrStdout(), Styles.FocusedPrompt.String()+opts.Text+" ")
 	if opts.IsConfirm {
 		if len(opts.Default) == 0 {
-			opts.Default = "yes"
+			opts.Default = ConfirmYes
 		}
-		renderedYes := Styles.Placeholder.Render("yes")
-		renderedNo := Styles.Placeholder.Render("no")
-		if opts.Default == "yes" {
-			renderedYes = Styles.Bold.Render("yes")
+		renderedYes := Styles.Placeholder.Render(ConfirmYes)
+		renderedNo := Styles.Placeholder.Render(ConfirmNo)
+		if opts.Default == ConfirmYes {
+			renderedYes = Styles.Bold.Render(ConfirmYes)
 		} else {
-			renderedNo = Styles.Bold.Render("no")
+			renderedNo = Styles.Bold.Render(ConfirmNo)
 		}
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), Styles.Placeholder.Render("("+renderedYes+Styles.Placeholder.Render("/"+renderedNo+Styles.Placeholder.Render(") "))))
 	} else if opts.Default != "" {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -22,6 +22,7 @@ func deleteWorkspace() *cobra.Command {
 			_, err := cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Confirm delete workspace?",
 				IsConfirm: true,
+				Default:   "no",
 			})
 			if err != nil {
 				return err

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -22,7 +22,7 @@ func deleteWorkspace() *cobra.Command {
 			_, err := cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Confirm delete workspace?",
 				IsConfirm: true,
-				Default:   "no",
+				Default:   cliui.ConfirmNo,
 			})
 			if err != nil {
 				return err

--- a/cli/login.go
+++ b/cli/login.go
@@ -89,7 +89,7 @@ func login() *cobra.Command {
 					}
 					_, err := cliui.Prompt(cmd, cliui.PromptOptions{
 						Text:      "Would you like to create the first user?",
-						Default:   "yes",
+						Default:   cliui.ConfirmYes,
 						IsConfirm: true,
 					})
 					if errors.Is(err, cliui.Canceled) {

--- a/cli/logout.go
+++ b/cli/logout.go
@@ -28,7 +28,7 @@ func logout() *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Are you sure you want to log out?",
 				IsConfirm: true,
-				Default:   "no",
+				Default:   cliui.ConfirmYes,
 			})
 			if err != nil {
 				return err

--- a/cli/logout.go
+++ b/cli/logout.go
@@ -28,7 +28,7 @@ func logout() *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Are you sure you want to log out?",
 				IsConfirm: true,
-				Default:   "yes",
+				Default:   "no",
 			})
 			if err != nil {
 				return err

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -20,7 +20,6 @@ func stop() *cobra.Command {
 			_, err := cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Confirm stop workspace?",
 				IsConfirm: true,
-				Default:   "no",
 			})
 			if err != nil {
 				return err

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -20,6 +20,7 @@ func stop() *cobra.Command {
 			_, err := cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Confirm stop workspace?",
 				IsConfirm: true,
+				Default:   "no",
 			})
 			if err != nil {
 				return err

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -60,7 +60,7 @@ func templateCreate() *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      fmt.Sprintf("Create and upload %q?", prettyDir),
 				IsConfirm: true,
-				Default:   "yes",
+				Default:   cliui.ConfirmYes,
 			})
 			if err != nil {
 				return err

--- a/cli/templatedelete.go
+++ b/cli/templatedelete.go
@@ -76,7 +76,7 @@ func templateDelete() *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      fmt.Sprintf("Delete these templates: %s?", cliui.Styles.Code.Render(strings.Join(templateNames, ", "))),
 				IsConfirm: true,
-				Default:   "no",
+				Default:   cliui.ConfirmNo,
 			})
 			if err != nil {
 				return err

--- a/cli/templateupdate.go
+++ b/cli/templateupdate.go
@@ -53,7 +53,7 @@ func templateUpdate() *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      fmt.Sprintf("Upload %q?", prettyDir),
 				IsConfirm: true,
-				Default:   "yes",
+				Default:   cliui.ConfirmYes,
 			})
 			if err != nil {
 				return err

--- a/cli/userstatus.go
+++ b/cli/userstatus.go
@@ -16,20 +16,17 @@ func createUserStatusCommand(sdkStatus codersdk.UserStatus) *cobra.Command {
 	var pastVerb string
 	var aliases []string
 	var short string
-	var defaultConfirm string
 	switch sdkStatus {
 	case codersdk.UserStatusActive:
 		verb = "activate"
 		pastVerb = "activated"
 		aliases = []string{"active"}
 		short = "Update a user's status to 'active'. Active users can fully interact with the platform"
-		defaultConfirm = "yes"
 	case codersdk.UserStatusSuspended:
 		verb = "suspend"
 		pastVerb = "suspended"
 		aliases = []string{"rm", "delete"}
 		short = "Update a user's status to 'suspended'. A suspended user cannot log into the platform"
-		defaultConfirm = "no"
 	default:
 		panic(fmt.Sprintf("%s is not supported", sdkStatus))
 	}
@@ -74,7 +71,7 @@ func createUserStatusCommand(sdkStatus codersdk.UserStatus) *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      fmt.Sprintf("Are you sure you want to %s this user?", verb),
 				IsConfirm: true,
-				Default:   defaultConfirm,
+				Default:   cliui.ConfirmYes,
 			})
 			if err != nil {
 				return err

--- a/cli/userstatus.go
+++ b/cli/userstatus.go
@@ -16,17 +16,20 @@ func createUserStatusCommand(sdkStatus codersdk.UserStatus) *cobra.Command {
 	var pastVerb string
 	var aliases []string
 	var short string
+	var defaultConfirm string
 	switch sdkStatus {
 	case codersdk.UserStatusActive:
 		verb = "activate"
 		pastVerb = "activated"
 		aliases = []string{"active"}
 		short = "Update a user's status to 'active'. Active users can fully interact with the platform"
+		defaultConfirm = "yes"
 	case codersdk.UserStatusSuspended:
 		verb = "suspend"
 		pastVerb = "suspended"
 		aliases = []string{"rm", "delete"}
 		short = "Update a user's status to 'suspended'. A suspended user cannot log into the platform"
+		defaultConfirm = "no"
 	default:
 		panic(fmt.Sprintf("%s is not supported", sdkStatus))
 	}
@@ -71,7 +74,7 @@ func createUserStatusCommand(sdkStatus codersdk.UserStatus) *cobra.Command {
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      fmt.Sprintf("Are you sure you want to %s this user?", verb),
 				IsConfirm: true,
-				Default:   "yes",
+				Default:   defaultConfirm,
 			})
 			if err != nil {
 				return err

--- a/cmd/cliui/main.go
+++ b/cmd/cliui/main.go
@@ -43,7 +43,7 @@ func main() {
 			}
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text:      "Do you want to accept?",
-				Default:   "yes",
+				Default:   cliui.ConfirmYes,
 				IsConfirm: true,
 			})
 			if errors.Is(err, cliui.Canceled) {


### PR DESCRIPTION
This PR sets the default confirmation to `no` for the following cases:
 - Deleting a template
 - Deleting a workspace

## Subtasks

- [x] render yes/no as bolded for default choice
- [x] update default choice for the two cases mentioned above
- [x] refactor other code to use the new yes/no constants

Fixes #2878 

## Screenshot
<img width="557" alt="Screen Shot 2022-07-11 at 3 29 24 PM" src="https://user-images.githubusercontent.com/7511231/178369470-0c832391-632b-4585-bf76-67995297f754.png">


