### PR TITLE
fix: Show schedule commands in help, improve template

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -335,7 +335,7 @@ func usageTemplate() string {
 {{- if .HasAvailableSubCommands}}
 {{usageHeader "Commands:"}}
   {{- range .Commands}}
-    {{- $hasRootAnnotations := (and $isRootHelp (eq (len .Annotations) 0))}}
+    {{- $hasRootAnnotations := (and $isRootHelp (gt (len .Annotations) 0))}}
     {{- if (or (and .IsAvailableCommand (not $hasRootAnnotations)) (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}
     {{- end}}

--- a/cli/root.go
+++ b/cli/root.go
@@ -367,12 +367,12 @@ func usageTemplate() string {
 
 {{- if .HasAvailableLocalFlags}}
 {{usageHeader "Flags:"}}
-{{.LocalFlags.FlagUsagesWrapped 100}}
+{{.LocalFlags.FlagUsagesWrapped 100 | trimTrailingWhitespaces}}
 {{end}}
 
 {{- if .HasAvailableInheritedFlags}}
 {{usageHeader "Global Flags:"}}
-{{.InheritedFlags.FlagUsagesWrapped 100}}
+{{.InheritedFlags.FlagUsagesWrapped 100 | trimTrailingWhitespaces}}
 {{end}}
 
 {{- if .HasHelpSubCommands}}

--- a/cli/root.go
+++ b/cli/root.go
@@ -331,16 +331,18 @@ func usageTemplate() string {
 {{.Example}}
 {{end}}
 
+{{- $isRootHelp := (not .HasParent)}}
 {{- if .HasAvailableSubCommands}}
 {{usageHeader "Commands:"}}
   {{- range .Commands}}
-    {{- if (or (and .IsAvailableCommand (eq (len .Annotations) 0)) (eq .Name "help"))}}
+    {{- $hasRootAnnotations := (and $isRootHelp (eq (len .Annotations) 0))}}
+    {{- if (or (and .IsAvailableCommand (not $hasRootAnnotations)) (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}
     {{- end}}
   {{- end}}
 {{end}}
 
-{{- if and (not .HasParent) .HasAvailableSubCommands}}
+{{- if (and $isRootHelp .HasAvailableSubCommands)}}
 {{usageHeader "Workspace Commands:"}}
   {{- range .Commands}}
     {{- if (and .IsAvailableCommand (ne (index .Annotations "workspaces") ""))}}

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -17,12 +17,6 @@ import (
 )
 
 const (
-	scheduleDescriptionLong = `Modify scheduled stop and start times for your workspace:
-  * schedule show: show workspace schedule
-  * schedule start: edit workspace start schedule
-  * schedule stop: edit workspace stop schedule
-  * schedule override-stop: edit stop time of active workspace
-`
 	scheduleShowDescriptionLong = `Shows the following information for the given workspace:
   * The automatic start schedule
   * The next scheduled start time
@@ -64,7 +58,6 @@ func schedules() *cobra.Command {
 		Annotations: workspaceCommand,
 		Use:         "schedule { show | start | stop | override } <workspace>",
 		Short:       "Modify scheduled stop and start times for your workspace",
-		Long:        scheduleDescriptionLong,
 	}
 
 	scheduleCmd.AddCommand(

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -67,21 +67,22 @@ func schedules() *cobra.Command {
 		Long:        scheduleDescriptionLong,
 	}
 
-	scheduleCmd.AddCommand(scheduleShow())
-	scheduleCmd.AddCommand(scheduleStart())
-	scheduleCmd.AddCommand(scheduleStop())
-	scheduleCmd.AddCommand(scheduleOverride())
+	scheduleCmd.AddCommand(
+		scheduleShow(),
+		scheduleStart(),
+		scheduleStop(),
+		scheduleOverride(),
+	)
 
 	return scheduleCmd
 }
 
 func scheduleShow() *cobra.Command {
 	showCmd := &cobra.Command{
-		Annotations: workspaceCommand,
-		Use:         "show <workspace-name>",
-		Short:       "Show workspace schedule",
-		Long:        scheduleShowDescriptionLong,
-		Args:        cobra.ExactArgs(1),
+		Use:   "show <workspace-name>",
+		Short: "Show workspace schedule",
+		Long:  scheduleShowDescriptionLong,
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := createClient(cmd)
 			if err != nil {
@@ -101,8 +102,7 @@ func scheduleShow() *cobra.Command {
 
 func scheduleStart() *cobra.Command {
 	cmd := &cobra.Command{
-		Annotations: workspaceCommand,
-		Use:         "start <workspace-name> { <start-time> [day-of-week] [location] | manual }",
+		Use: "start <workspace-name> { <start-time> [day-of-week] [location] | manual }",
 		Example: formatExamples(
 			example{
 				Description: "Set the workspace to start at 9:30am (in Dublin) from Monday to Friday",
@@ -153,9 +153,8 @@ func scheduleStart() *cobra.Command {
 
 func scheduleStop() *cobra.Command {
 	return &cobra.Command{
-		Annotations: workspaceCommand,
-		Args:        cobra.ExactArgs(2),
-		Use:         "stop <workspace-name> { <duration> | manual }",
+		Args: cobra.ExactArgs(2),
+		Use:  "stop <workspace-name> { <duration> | manual }",
 		Example: formatExamples(
 			example{
 				Command: "coder schedule stop my-workspace 2h30m",
@@ -200,9 +199,8 @@ func scheduleStop() *cobra.Command {
 
 func scheduleOverride() *cobra.Command {
 	overrideCmd := &cobra.Command{
-		Args:        cobra.ExactArgs(2),
-		Annotations: workspaceCommand,
-		Use:         "override-stop <workspace-name> <duration from now>",
+		Args: cobra.ExactArgs(2),
+		Use:  "override-stop <workspace-name> <duration from now>",
 		Example: formatExamples(
 			example{
 				Command: "coder schedule override-stop my-workspace 90m",


### PR DESCRIPTION
The subcommands in `coder schedule --help` were not being shown due to annotations being present, this PR removes the annotations and permanently fixes the issue by only using the annotations for the root command in the help template.
