### PR TITLE
fix: Force trap to always succeed due to incompatibility

### DIFF
--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 set -eux pipefail
-trap 'echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400' EXIT
+# Not all instances of "trap" support ERR SIGNAL_SPEC. See: https://github.com/bmizerany/roundup/issues/25
+trap 'echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400' EXIT || true
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}


### PR DESCRIPTION
There are some instances of Linux that don't support trap. We should
ignore the failure in those cases.
