### PR TITLE
fix: Fetch GitHub teams by name for performance

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -770,24 +770,9 @@ func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, al
 			})
 			return memberships, err
 		},
-		ListTeams: func(ctx context.Context, client *http.Client, org string) ([]*github.Team, error) {
-			opt := &github.ListOptions{
-				// This is the maximum amount per-page that GitHub allows.
-				PerPage: 100,
-			}
-			var allTeams []*github.Team
-			for {
-				teams, resp, err := github.NewClient(client).Teams.ListTeams(ctx, org, opt)
-				if err != nil {
-					return nil, err
-				}
-				allTeams = append(allTeams, teams...)
-				if resp.NextPage == 0 {
-					break
-				}
-				opt.Page = resp.NextPage
-			}
-			return allTeams, nil
+		Team: func(ctx context.Context, client *http.Client, org, teamSlug string) (*github.Team, error) {
+			team, _, err := github.NewClient(client).Teams.GetTeamBySlug(ctx, org, teamSlug)
+			return team, err
 		},
 	}, nil
 }

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-github/v43/github"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/coderd"
 	"github.com/coder/coder/coderd/coderdtest"
@@ -87,10 +88,8 @@ func TestUserOAuth2Github(t *testing.T) {
 						},
 					}}, nil
 				},
-				ListTeams: func(ctx context.Context, client *http.Client, org string) ([]*github.Team, error) {
-					return []*github.Team{{
-						Slug: github.String("nope"),
-					}}, nil
+				Team: func(ctx context.Context, client *http.Client, org, team string) (*github.Team, error) {
+					return nil, xerrors.New("no perms")
 				},
 			},
 		})
@@ -223,10 +222,8 @@ func TestUserOAuth2Github(t *testing.T) {
 						},
 					}}, nil
 				},
-				ListTeams: func(ctx context.Context, client *http.Client, org string) ([]*github.Team, error) {
-					return []*github.Team{{
-						Slug: github.String("frontend"),
-					}}, nil
+				Team: func(ctx context.Context, client *http.Client, org, team string) (*github.Team, error) {
+					return &github.Team{}, nil
 				},
 				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
 					return &github.User{

--- a/go.sum
+++ b/go.sum
@@ -1880,8 +1880,6 @@ github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
-github.com/zeebo/errs v1.2.2 h1:5NFypMTuSdoySVTqlNs1dEoU21QVamMQJxW/Fii5O7g=
-github.com/zeebo/errs v1.2.2/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/errs v1.3.0 h1:hmiaKqgYZzcVgRL1Vkc1Mn2914BbzB0IBxs+ebeutGs=
 github.com/zeebo/errs v1.3.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -2912,10 +2910,6 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZa
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 software.sslmate.com/src/go-pkcs12 v0.0.0-20210415151418-c5206de65a78 h1:SqYE5+A2qvRhErbsXFfUEUmpWEKxxRSMgGLkvRAFOV4=
-storj.io/drpc v0.0.30 h1:jqPe4T9KEu3CDBI05A2hCMgMSHLtd/E0N0yTF9QreIE=
-storj.io/drpc v0.0.30/go.mod h1:6rcOyR/QQkSTX/9L5ZGtlZaE2PtXTTZl8d+ulSeeYEg=
-storj.io/drpc v0.0.32 h1:5p5ZwsK/VOgapaCu+oxaPVwO6UwIs+iwdMiD50+R4PI=
-storj.io/drpc v0.0.32/go.mod h1:6rcOyR/QQkSTX/9L5ZGtlZaE2PtXTTZl8d+ulSeeYEg=
 storj.io/drpc v0.0.33-0.20220622181519-9206537a4db7 h1:6jIp39oQGZMjfrG3kiafK2tcL0Fbprh2kvaoJNfhvuM=
 storj.io/drpc v0.0.33-0.20220622181519-9206537a4db7/go.mod h1:6rcOyR/QQkSTX/9L5ZGtlZaE2PtXTTZl8d+ulSeeYEg=
 tailscale.com v1.26.2 h1:EBR0DXblI2Rx3mPe/YU29oZbQLnC8BtJYUTufmEygUY=


### PR DESCRIPTION
In large organizations with thousands of teams, looping took >5s.
This fetches organizations by team name, which should be very fast!
