### PR TITLE
fix: Use double quotes for `trap` signal

### DIFF
--- a/provisionersdk/scripts/bootstrap_darwin.sh
+++ b/provisionersdk/scripts/bootstrap_darwin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 set -eux pipefail
-trap 'echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400' EXIT
+trap "echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400" EXIT
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 cd "$BINARY_DIR"

--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 set -eux pipefail
-# Not all instances of "trap" support ERR SIGNAL_SPEC. See: https://github.com/bmizerany/roundup/issues/25
-trap 'echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400' EXIT || true
+trap "echo === Agent script exited with non-zero code. Sleeping 24h to preserve logs... && sleep 86400" EXIT
 BINARY_DIR=$(mktemp -d -t coder.XXXXXX)
 BINARY_NAME=coder
 BINARY_URL=${ACCESS_URL}bin/coder-linux-${ARCH}


### PR DESCRIPTION
Frequently callers will wrap our shell script in `sh -c ''`.
Having single quotes on our `trap` led to a syntax error when
doing this.
