### PR TITLE
fix: Loading state in the workspaces page

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -32,7 +32,7 @@ const WorkspacesPage: FC = () => {
 
       <WorkspacesPageView
         filter={workspacesState.context.filter}
-        isLoading={workspacesState.hasTag("loading")}
+        isLoading={!workspaceRefs}
         workspaceRefs={workspaceRefs}
         onFilter={(query) => {
           setSearchParams({ filter: query })

--- a/site/src/xServices/workspaces/workspacesXService.ts
+++ b/site/src/xServices/workspaces/workspacesXService.ts
@@ -218,9 +218,7 @@ export const workspacesMachine = createMachine(
     },
     initial: "idle",
     states: {
-      idle: {
-        tags: ["loading"],
-      },
+      idle: {},
       gettingWorkspaces: {
         entry: "clearGetWorkspacesError",
         invoke: {


### PR DESCRIPTION
I noticed the loading state for the workspaces page was broken. 

**Before:**
You can notice it displays the empty state and right after, the workspace list.

https://user-images.githubusercontent.com/3165839/178744814-0139a197-f61d-48ee-afbd-00fa2a8e41d4.mov

**After:**
The loading state is displayed before showing the list

https://user-images.githubusercontent.com/3165839/178744935-c0d745ba-17e5-4e38-942b-0f4acf80a5c2.mov

**Why?**
We were using the loading tag to match the loading state but, we would also have to use it in the gettingWorkspace since it is also a "loading" state but, since we are using it for refreshing as well, the loading state would be displayed every 5 seconds. 

**Possible solutions**
- Check if there are workspaces or not
- Add a new state for refreshing so we could tag idle and gettingWorkspace as loading. Basically, the refreshing state would be identical to the gettingWorkspace but this would help us to better split the "responsibilities" even if in the implementation, they look the same

**What did I chose?**
I chose the first option because it is way more simple and I think it is easy enough to follow, but I'm open to suggestions.

