### PR TITLE
fix: remove system user highlighting

### DIFF
--- a/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
+++ b/site/src/components/WorkspaceBuildStats/WorkspaceBuildStats.tsx
@@ -19,7 +19,7 @@ export const WorkspaceBuildStats: FC<WorkspaceBuildStatsProps> = ({ build }) => 
   const styles = useStyles()
   const theme = useTheme()
   const status = getDisplayWorkspaceBuildStatus(theme, build)
-  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(theme, build)
+  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(build)
 
   return (
     <div className={styles.stats}>
@@ -61,9 +61,7 @@ export const WorkspaceBuildStats: FC<WorkspaceBuildStatsProps> = ({ build }) => 
       <div className={styles.statsDivider} />
       <div className={styles.statItem}>
         <span className={styles.statsLabel}>Initiated by</span>
-        <span className={styles.statsValue}>
-          <span style={{ color: initiatedBy.color }}>{initiatedBy.initiatedBy}</span>
-        </span>
+        <span className={styles.statsValue}>{initiatedBy}</span>
       </div>
     </div>
   )

--- a/site/src/components/WorkspaceStats/WorkspaceStats.tsx
+++ b/site/src/components/WorkspaceStats/WorkspaceStats.tsx
@@ -28,7 +28,7 @@ export const WorkspaceStats: FC<WorkspaceStatsProps> = ({ workspace }) => {
   const styles = useStyles()
   const theme = useTheme()
   const status = getDisplayStatus(theme, workspace.latest_build)
-  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(theme, workspace.latest_build)
+  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(workspace.latest_build)
 
   return (
     <WorkspaceSection title={Language.workspaceDetails} contentsProps={{ className: styles.stats }}>
@@ -63,9 +63,7 @@ export const WorkspaceStats: FC<WorkspaceStatsProps> = ({ workspace }) => {
       <div className={styles.statsDivider} />
       <div className={styles.statItem}>
         <span className={styles.statsLabel}>{Language.byLabel}</span>
-        <span className={styles.statsValue}>
-          <span style={{ color: initiatedBy.color }}>{initiatedBy.initiatedBy}</span>
-        </span>
+        <span className={styles.statsValue}>{initiatedBy}</span>
       </div>
       <div className={styles.statsDivider} />
       <div className={styles.statItem}>

--- a/site/src/components/WorkspacesTable/WorkspacesRow.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesRow.tsx
@@ -27,7 +27,7 @@ export const WorkspacesRow: FC<{ workspaceRef: WorkspaceItemMachineRef }> = ({ w
   const [workspaceState, send] = useActor(workspaceRef)
   const { data: workspace } = workspaceState.context
   const status = getDisplayStatus(theme, workspace.latest_build)
-  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(theme, workspace.latest_build)
+  const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(workspace.latest_build)
   const workspacePageLink = `/@${workspace.owner_name}/${workspace.name}`
 
   return (
@@ -47,7 +47,7 @@ export const WorkspacesRow: FC<{ workspaceRef: WorkspaceItemMachineRef }> = ({ w
       </TableCellLink>
       <TableCellLink to={workspacePageLink}>
         <AvatarData
-          title={initiatedBy.initiatedBy}
+          title={initiatedBy}
           subtitle={dayjs().to(dayjs(workspace.latest_build.created_at))}
         />
       </TableCellLink>

--- a/site/src/util/workspace.test.ts
+++ b/site/src/util/workspace.test.ts
@@ -1,7 +1,6 @@
 import dayjs from "dayjs"
 import * as TypesGen from "../api/typesGenerated"
 import * as Mocks from "../testHelpers/entities"
-import { dark } from "../theme/theme"
 import {
   defaultWorkspaceExtension,
   getDisplayWorkspaceBuildInitiatedBy,
@@ -109,14 +108,13 @@ describe("util > workspace", () => {
   })
 
   describe("getDisplayWorkspaceBuildInitiatedBy", () => {
-    it.each<[TypesGen.WorkspaceBuild, string, string]>([
-      [Mocks.MockWorkspaceBuild, "#C1C1C1", "TestUser"],
+    it.each<[TypesGen.WorkspaceBuild, string]>([
+      [Mocks.MockWorkspaceBuild, "TestUser"],
       [
         {
           ...Mocks.MockWorkspaceBuild,
           reason: "autostart",
         },
-        "#7057FF",
         "system/autostart",
       ],
       [
@@ -124,17 +122,10 @@ describe("util > workspace", () => {
           ...Mocks.MockWorkspaceBuild,
           reason: "autostop",
         },
-        "#7057FF",
         "system/autostop",
       ],
-    ])(
-      `getDisplayWorkspaceBuildInitiatedBy(%p) returns color: %p, initiatedBy: %p`,
-      (build, color, initiatedBy) => {
-        expect(getDisplayWorkspaceBuildInitiatedBy(dark, build)).toEqual({
-          color: color,
-          initiatedBy: initiatedBy,
-        })
-      },
-    )
+    ])(`getDisplayWorkspaceBuildInitiatedBy(%p) returns %p`, (build, initiatedBy) => {
+      expect(getDisplayWorkspaceBuildInitiatedBy(build)).toEqual(initiatedBy)
+    })
   })
 })

--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -191,29 +191,14 @@ export const DisplayWorkspaceBuildInitiatedByLanguage = {
   autostop: "system/autostop",
 }
 
-export const getDisplayWorkspaceBuildInitiatedBy = (
-  theme: Theme,
-  build: TypesGen.WorkspaceBuild,
-): {
-  color: string
-  initiatedBy: string
-} => {
+export const getDisplayWorkspaceBuildInitiatedBy = (build: TypesGen.WorkspaceBuild): string => {
   switch (build.reason) {
     case "initiator":
-      return {
-        color: theme.palette.text.secondary,
-        initiatedBy: build.initiator_name,
-      }
+      return build.initiator_name
     case "autostart":
-      return {
-        color: theme.palette.secondary.dark,
-        initiatedBy: DisplayWorkspaceBuildInitiatedByLanguage.autostart,
-      }
+      return DisplayWorkspaceBuildInitiatedByLanguage.autostart
     case "autostop":
-      return {
-        color: theme.palette.secondary.dark,
-        initiatedBy: DisplayWorkspaceBuildInitiatedByLanguage.autostop,
-      }
+      return DisplayWorkspaceBuildInitiatedByLanguage.autostop
   }
 }
 


### PR DESCRIPTION
This PR removes the highlighting from the system user for workspace build initiators on the Workspace and Workspace Build pages.

## Subtasks

- [x] Stop using the highlight color on the Workspace page.
- [x] Stop using the highlight color on the Workspace Build page.
- [x] Refactor code to stop returning color for the build initiator.
- [x] Update unit tests.

## Screenshots

### Workspace page
<img width="1147" alt="Screen Shot 2022-07-13 at 11 25 46 AM" src="https://user-images.githubusercontent.com/7511231/178804805-935c51a8-9305-4a3c-be2a-8b5cd21c09db.png">

### Workspace Build page
<img width="1214" alt="Screen Shot 2022-07-13 at 11 26 09 AM" src="https://user-images.githubusercontent.com/7511231/178804830-80a1078c-19da-44a4-89e1-2b1cde311658.png">

Fixes #2972 