### PR TITLE
Return template parameters in consistent order

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -225,10 +224,6 @@ func createValidTemplateVersion(cmd *cobra.Command, args createValidTemplateVers
 		for _, parameterValue := range parameterValues {
 			valuesBySchemaID[parameterValue.SchemaID.String()] = parameterValue
 		}
-
-		sort.Slice(parameterSchemas, func(i, j int) bool {
-			return parameterSchemas[i].Name < parameterSchemas[j].Name
-		})
 
 		// parameterMapFromFile can be nil if parameter file is not specified
 		var parameterMapFromFile map[string]string

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1027,6 +1027,9 @@ func (q *fakeQuerier) GetParameterSchemasByJobID(_ context.Context, jobID uuid.U
 	if len(parameters) == 0 {
 		return nil, sql.ErrNoRows
 	}
+	sort.Slice(parameters, func(i, j int) bool {
+		return parameters[i].Index < parameters[j].Index
+	})
 	return parameters, nil
 }
 
@@ -1555,6 +1558,7 @@ func (q *fakeQuerier) InsertParameterSchema(_ context.Context, arg database.Inse
 		ValidationCondition:      arg.ValidationCondition,
 		ValidationTypeSystem:     arg.ValidationTypeSystem,
 		ValidationValueType:      arg.ValidationValueType,
+		Index:                    arg.Index,
 	}
 	q.parameterSchemas = append(q.parameterSchemas, param)
 	return param, nil

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -182,7 +182,8 @@ CREATE TABLE parameter_schemas (
     validation_error character varying(256) NOT NULL,
     validation_condition character varying(512) NOT NULL,
     validation_type_system parameter_type_system NOT NULL,
-    validation_value_type character varying(64) NOT NULL
+    validation_value_type character varying(64) NOT NULL,
+    index integer NOT NULL
 );
 
 CREATE TABLE parameter_values (

--- a/coderd/database/migrations/000029_variable_order.down.sql
+++ b/coderd/database/migrations/000029_variable_order.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE parameter_schemas DROP COLUMN index;

--- a/coderd/database/migrations/000029_variable_order.up.sql
+++ b/coderd/database/migrations/000029_variable_order.up.sql
@@ -1,0 +1,15 @@
+-- temporarily create index column as nullable
+ALTER TABLE parameter_schemas ADD COLUMN index integer;
+
+-- initialize ordering for existing parameters
+WITH tmp AS (
+	SELECT id, row_number() OVER (PARTITION BY job_id ORDER BY name) AS index
+	FROM parameter_schemas
+)
+UPDATE parameter_schemas
+SET index = tmp.index
+FROM tmp
+WHERE parameter_schemas.id = tmp.id;
+
+-- all rows should now be initialized
+ALTER TABLE parameter_schemas ALTER COLUMN index SET NOT NULL;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -398,6 +398,7 @@ type ParameterSchema struct {
 	ValidationCondition      string                     `db:"validation_condition" json:"validation_condition"`
 	ValidationTypeSystem     ParameterTypeSystem        `db:"validation_type_system" json:"validation_type_system"`
 	ValidationValueType      string                     `db:"validation_value_type" json:"validation_value_type"`
+	Index                    int32                      `db:"index" json:"index"`
 }
 
 type ParameterValue struct {

--- a/coderd/database/queries/parameterschemas.sql
+++ b/coderd/database/queries/parameterschemas.sql
@@ -4,7 +4,9 @@ SELECT
 FROM
 	parameter_schemas
 WHERE
-	job_id = $1;
+	job_id = $1
+ORDER BY
+	index;
 
 -- name: GetParameterSchemasCreatedAfter :many
 SELECT * FROM parameter_schemas WHERE created_at > $1;
@@ -27,7 +29,8 @@ INSERT INTO
 		validation_error,
 		validation_condition,
 		validation_type_system,
-		validation_value_type
+		validation_value_type,
+		index
 	)
 VALUES
 	(
@@ -46,5 +49,6 @@ VALUES
 		$13,
 		$14,
 		$15,
-		$16
+		$16,
+		$17
 	) RETURNING *;

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -405,7 +405,7 @@ func (server *provisionerdServer) UpdateJob(ctx context.Context, request *proto.
 	}
 
 	if len(request.ParameterSchemas) > 0 {
-		for _, protoParameter := range request.ParameterSchemas {
+		for index, protoParameter := range request.ParameterSchemas {
 			validationTypeSystem, err := convertValidationTypeSystem(protoParameter.ValidationTypeSystem)
 			if err != nil {
 				return nil, xerrors.Errorf("convert validation type system for %q: %w", protoParameter.Name, err)
@@ -428,6 +428,8 @@ func (server *provisionerdServer) UpdateJob(ctx context.Context, request *proto.
 
 				AllowOverrideDestination: protoParameter.AllowOverrideDestination,
 				AllowOverrideSource:      protoParameter.AllowOverrideSource,
+
+				Index: int32(index),
 			}
 
 			// It's possible a parameter doesn't define a default source!

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -244,17 +244,30 @@ func TestTemplateVersionParameters(t *testing.T) {
 			Parse: []*proto.Parse_Response{{
 				Type: &proto.Parse_Response_Complete{
 					Complete: &proto.Parse_Complete{
-						ParameterSchemas: []*proto.ParameterSchema{{
-							Name:           "example",
-							RedisplayValue: true,
-							DefaultSource: &proto.ParameterSource{
-								Scheme: proto.ParameterSource_DATA,
-								Value:  "hello",
+						ParameterSchemas: []*proto.ParameterSchema{
+							{
+								Name:           "example",
+								RedisplayValue: true,
+								DefaultSource: &proto.ParameterSource{
+									Scheme: proto.ParameterSource_DATA,
+									Value:  "hello",
+								},
+								DefaultDestination: &proto.ParameterDestination{
+									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+								},
 							},
-							DefaultDestination: &proto.ParameterDestination{
-								Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+							{
+								Name:           "abcd",
+								RedisplayValue: true,
+								DefaultSource: &proto.ParameterSource{
+									Scheme: proto.ParameterSource_DATA,
+									Value:  "world",
+								},
+								DefaultDestination: &proto.ParameterDestination{
+									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+								},
 							},
-						}},
+						},
 					},
 				},
 			}},
@@ -264,8 +277,9 @@ func TestTemplateVersionParameters(t *testing.T) {
 		params, err := client.TemplateVersionParameters(context.Background(), version.ID)
 		require.NoError(t, err)
 		require.NotNil(t, params)
-		require.Len(t, params, 1)
+		require.Len(t, params, 2)
 		require.Equal(t, "hello", params[0].SourceValue)
+		require.Equal(t, "world", params[1].SourceValue)
 	})
 }
 

--- a/provisioner/terraform/parse_test.go
+++ b/provisioner/terraform/parse_test.go
@@ -128,6 +128,58 @@ func TestParse(t *testing.T) {
 			},
 			ErrorContains: `The ";" character is not valid.`,
 		},
+		{
+			Name: "multiple-variables",
+			Files: map[string]string{
+				"main1.tf": `variable "foo" { }
+				variable "bar" { }`,
+				"main2.tf": `variable "baz" { }
+				variable "quux" { }`,
+			},
+			Response: &proto.Parse_Response{
+				Type: &proto.Parse_Response_Complete{
+					Complete: &proto.Parse_Complete{
+						ParameterSchemas: []*proto.ParameterSchema{
+							{
+								Name:                "foo",
+								RedisplayValue:      true,
+								AllowOverrideSource: true,
+								Description:         "",
+								DefaultDestination: &proto.ParameterDestination{
+									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+								},
+							},
+							{
+								Name:                "bar",
+								RedisplayValue:      true,
+								AllowOverrideSource: true,
+								Description:         "",
+								DefaultDestination: &proto.ParameterDestination{
+									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+								},
+							},
+							{
+								Name:                "baz",
+								RedisplayValue:      true,
+								AllowOverrideSource: true,
+								Description:         "",
+								DefaultDestination: &proto.ParameterDestination{
+									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+								},
+							},
+							{
+								Name:                "quux",
+								RedisplayValue:      true,
+								AllowOverrideSource: true,
+								Description:         "",
+								DefaultDestination: &proto.ParameterDestination{
+									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
+								},
+							}},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This PR makes the order in which we display and prompt for template parameters deterministic and consistent. It involves two different functional changes:

* The Terraform provisioner now sorts the returned list of `ParameterSchema` messages to match the order of their `variable` blocks in the template source (first lexicographically by filename, then by line number)
* coderd persists the variable ordering using a new `parameter_schemas.index` database column, and sorts by that column when querying for parameters

For template versions that existed prior to this change, the database migration initializes the index column by putting the variable names for each version in lexicographic order, since we don't know the original source order.

Fixes #2471 