### PR TITLE
fix: remove access column header

### DIFF
--- a/site/src/components/Resources/Resources.tsx
+++ b/site/src/components/Resources/Resources.tsx
@@ -22,7 +22,6 @@ const Language = {
   resourceLabel: "Resource",
   agentsLabel: "Agents",
   agentLabel: "Agent",
-  accessLabel: "Access",
 }
 
 interface ResourcesProps {
@@ -64,7 +63,7 @@ export const Resources: FC<ResourcesProps> = ({
                   <AgentHelpTooltip />
                 </Stack>
               </TableCell>
-              {canUpdateWorkspace && <TableCell>{Language.accessLabel}</TableCell>}
+              {canUpdateWorkspace && <TableCell></TableCell>}
             </TableHeaderRow>
           </TableHead>
           <TableBody>
@@ -80,7 +79,7 @@ export const Resources: FC<ResourcesProps> = ({
                 if (!agent) {
                   return (
                     <TableRow key={`${resource.id}-${agentIndex}`}>
-                      <TableCell className={styles.resourceNameCell}>
+                      <TableCell>
                         {resource.name}
                         <span className={styles.resourceType}>{resource.type}</span>
                       </TableCell>
@@ -184,5 +183,6 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     gap: theme.spacing(0.5),
     flexWrap: "wrap",
+    justifyContent: "right",
   },
 }))

--- a/site/src/components/Resources/Resources.tsx
+++ b/site/src/components/Resources/Resources.tsx
@@ -163,7 +163,7 @@ const useStyles = makeStyles((theme) => ({
 
   // Adds some left spacing
   agentColumn: {
-    paddingLeft: `${theme.spacing(2)}px !important`,
+    paddingLeft: `${theme.spacing(4)}px !important`,
   },
 
   agentInfo: {
@@ -183,6 +183,6 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     gap: theme.spacing(0.5),
     flexWrap: "wrap",
-    justifyContent: "right",
+    justifyContent: "flex-end",
   },
 }))


### PR DESCRIPTION
This PR removes the Access column header on the workspace page and aligns the access buttons to the right of the table row.

Additionally, we also remove the table column border when the resource does not have an agent.

## Subtasks

- [x] Remove Access table heading
- [x] Right align access buttons
- [x] Remove border from table column when no agents are present

## Screenshot
<img width="1040" alt="Screen Shot 2022-07-13 at 12 23 26 PM" src="https://user-images.githubusercontent.com/7511231/178814909-631c0d2b-e1c3-48c4-a343-61c419b8975e.png">



Fixes #2974 
