### PR TITLE
fix: Add test for wrapping init script with single quotes

### DIFF
--- a/provisionersdk/agent_test.go
+++ b/provisionersdk/agent_test.go
@@ -46,7 +46,10 @@ func TestAgentScript(t *testing.T) {
 		}
 		script = strings.ReplaceAll(script, "${ACCESS_URL}", srvURL.String()+"/")
 		script = strings.ReplaceAll(script, "${AUTH_TYPE}", "token")
-		output, err := exec.Command("sh", "-c", script).CombinedOutput()
+		// This is intentionally ran in single quotes to mimic how a customer may
+		// embed our script. Our scripts should not include any single quotes.
+		// nolint:gosec
+		output, err := exec.Command("sh", "-c", "sh -c '"+script+"'").CombinedOutput()
 		t.Log(string(output))
 		require.NoError(t, err)
 		// Ignore debug output from `set -x`, we're only interested in the last line.

--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -16,8 +16,8 @@ cd "$BINARY_DIR"
 # This could fail for a number of reasons, many of which are likely transient.
 # So just keep trying!
 while :; do
-	# Try a number of different download tools, as we don't know what we'll
-	# have available
+	# Try a number of different download tools, as we don not know what we
+	# will have available.
 	status=""
 	if command -v curl >/dev/null 2>&1; then
 		curl -fsSL --compressed "${BINARY_URL}" -o "${BINARY_NAME}" && break

--- a/provisionersdk/scripts/bootstrap_windows.ps1
+++ b/provisionersdk/scripts/bootstrap_windows.ps1
@@ -1,6 +1,6 @@
 # Sleep for a while in case the underlying provider deletes the resource on error.
 trap {
-	Write-Error '=== Agent script exited with non-zero code. Sleeping 24h to preserve logs...'
+	Write-Error "=== Agent script exited with non-zero code. Sleeping 24h to preserve logs..."
 	Start-Sleep -Seconds 86400
 }
 
@@ -25,7 +25,7 @@ while ($true) {
 	}
 }
 
-# If the below fails, retrying probably won't help.
+# If the below fails, retrying probably will not help.
 Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
 $env:CODER_AGENT_AUTH = "${AUTH_TYPE}"
 $env:CODER_AGENT_URL = "${ACCESS_URL}"


### PR DESCRIPTION
This ensures our initialization script works with single quotes.
