### PR TITLE
agent: Don't set GIT_* environment variables

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -386,12 +386,6 @@ func (a *agent) createCommand(ctx context.Context, rawCommand string, env []stri
 	// If using backslashes, it's unable to find the executable.
 	unixExecutablePath := strings.ReplaceAll(executablePath, "\\", "/")
 	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_SSH_COMMAND=%s gitssh --`, unixExecutablePath))
-	// These prevent the user from having to specify _anything_ to successfully commit.
-	// Both author and committer must be set!
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_AUTHOR_EMAIL=%s`, metadata.OwnerEmail))
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_COMMITTER_EMAIL=%s`, metadata.OwnerEmail))
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_AUTHOR_NAME=%s`, metadata.OwnerUsername))
-	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_COMMITTER_NAME=%s`, metadata.OwnerUsername))
 
 	// Load environment variables passed via the agent.
 	// These should override all variables we manually specify.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -56,8 +56,6 @@ type Options struct {
 
 type Metadata struct {
 	WireguardAddresses   []netaddr.IPPrefix `json:"addresses"`
-	OwnerEmail           string             `json:"owner_email"`
-	OwnerUsername        string             `json:"owner_username"`
 	EnvironmentVariables map[string]string  `json:"environment_variables"`
 	StartupScript        string             `json:"startup_script"`
 	Directory            string             `json:"directory"`

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -129,38 +129,6 @@ func (api *API) workspaceAgentMetadata(rw http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
-	resource, err := api.Database.GetWorkspaceResourceByID(r.Context(), workspaceAgent.ResourceID)
-	if err != nil {
-		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching workspace resources.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	build, err := api.Database.GetWorkspaceBuildByJobID(r.Context(), resource.JobID)
-	if err != nil {
-		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching workspace build.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	workspace, err := api.Database.GetWorkspaceByID(r.Context(), build.WorkspaceID)
-	if err != nil {
-		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching workspace.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	owner, err := api.Database.GetUserByID(r.Context(), workspace.OwnerID)
-	if err != nil {
-		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching workspace owner.",
-			Detail:  err.Error(),
-		})
-		return
-	}
 
 	ipp, ok := netaddr.FromStdIPNet(&workspaceAgent.WireguardNodeIPv6.IPNet)
 	if !ok {
@@ -173,8 +141,6 @@ func (api *API) workspaceAgentMetadata(rw http.ResponseWriter, r *http.Request) 
 
 	httpapi.Write(rw, http.StatusOK, agent.Metadata{
 		WireguardAddresses:   []netaddr.IPPrefix{ipp},
-		OwnerEmail:           owner.Email,
-		OwnerUsername:        owner.Username,
 		EnvironmentVariables: apiAgent.EnvironmentVariables,
 		StartupScript:        apiAgent.StartupScript,
 		Directory:            apiAgent.Directory,


### PR DESCRIPTION
These variables take precedence over settings in the user's .gitconfig, which leads to surprising behavior, as described in #2665.