### PR TITLE
Automatically configure user.name and user.email in .gitconfig

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -216,6 +216,25 @@ func TestAgent(t *testing.T) {
 		require.Equal(t, content, strings.TrimSpace(gotContent))
 	})
 
+	t.Run("GitAutoconfig", func(t *testing.T) {
+		t.Parallel()
+		configPath := filepath.Join(os.TempDir(), "gitconfig")
+
+		initialContent := "[user]\nemail = elmo@example.com\n"
+		err := os.WriteFile(configPath, []byte(initialContent), 0600)
+		require.NoError(t, err)
+
+		setupAgent(t, agent.Metadata{
+			OwnerUsername: "Kermit the Frog",
+			OwnerEmail:    "kermit@example.com",
+			GitConfigPath: configPath,
+		}, 0)
+
+		gotContent := readFileContents(t, configPath)
+		require.Contains(t, gotContent, "name = Kermit the Frog")
+		require.Contains(t, gotContent, "email = elmo@example.com")
+	})
+
 	t.Run("ReconnectingPTY", func(t *testing.T) {
 		t.Parallel()
 		if runtime.GOOS == "windows" {

--- a/agent/gitconfig.go
+++ b/agent/gitconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -20,7 +21,7 @@ func setupGitconfig(ctx context.Context, configPath string, params map[string]st
 		if err != nil {
 			return xerrors.Errorf("get current user: %w", err)
 		}
-		configPath = currentUser.HomeDir + "/" + configPath[2:]
+		configPath = filepath.Join(currentUser.HomeDir, configPath[2:])
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "--version")

--- a/agent/gitconfig.go
+++ b/agent/gitconfig.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+	"os/exec"
+	"os/user"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+var errNoGitAvailable = xerrors.New("Git does not seem to be installed")
+
+func setupGitconfig(ctx context.Context, configPath string, params map[string]string) error {
+	if configPath == "" {
+		return nil
+	}
+	if strings.HasPrefix(configPath, "~/") {
+		currentUser, err := user.Current()
+		if err != nil {
+			return xerrors.Errorf("get current user: %w", err)
+		}
+		configPath = currentUser.HomeDir + "/" + configPath[2:]
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "--version")
+	err := cmd.Run()
+	if err != nil {
+		return errNoGitAvailable
+	}
+
+	for name, value := range params {
+		err = setGitConfigIfUnset(ctx, configPath, name, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setGitConfigIfUnset(ctx context.Context, configPath, name, value string) error {
+	cmd := exec.CommandContext(ctx, "git", "config", "--file", configPath, "--get", name)
+	err := cmd.Run()
+	if err == nil {
+		// an exit status of 0 means the value exists, so there's nothing to do
+		return nil
+	}
+	// an exit status of 1 means the value is unset
+	if cmd.ProcessState.ExitCode() != 1 {
+		return xerrors.Errorf("getting %s: %w", name, err)
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "config", "--file", configPath, "--add", name, value)
+	_, err = cmd.Output()
+	if err != nil {
+		return xerrors.Errorf("setting %s=%s: %w", name, value, err)
+	}
+	return nil
+}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -178,6 +178,7 @@ func (api *API) workspaceAgentMetadata(rw http.ResponseWriter, r *http.Request) 
 		EnvironmentVariables: apiAgent.EnvironmentVariables,
 		StartupScript:        apiAgent.StartupScript,
 		Directory:            apiAgent.Directory,
+		GitConfigPath:        "~/.gitconfig",
 	})
 }
 


### PR DESCRIPTION
This PR removes the existing functionality in the agent that was setting `GIT_*` environment variables, and instead automatically configures the `user.name` and `user.email` global config settings so that users can customize the values.

Making this testable required a bit more complexity than one might have expected. For one thing, we want to modify the actual `~/.gitconfig` file when running a real agent but not when running tests, so I added a `GitConfigPath` field to the agent metadata object. For another, the test case covers modification of an existing Git config file, so `agent.New` now returns an interface that allows detecting when the agent has initialized itself, and `agent_test.setupAgent` waits for that condition.

Fixes #2665, obsoletes #2980