### PR TITLE
docs: fix missing word for "coder workspaces create" command

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -10,7 +10,7 @@ templates](./templates.md):
 
 ```sh
 # create a workspace from the template; specify any variables
-create --template="<templateName>" <workspaceName>
+coder create --template="<templateName>" <workspaceName>
 
 # show the resources behind the workspace and how to connect
 coder show <workspace-name>


### PR DESCRIPTION

Going through starting documentation, noticed a word missing from the command, so creating a PR to get this fixed. 