### PR TITLE
feat: add `coder server postgres-builtin-serve` to run the built-in DB

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -529,7 +529,11 @@ func server() *cobra.Command {
 
 			cmd.Println(cliui.Styles.Code.Render("psql \"" + url + "\""))
 
-			<-cmd.Context().Done()
+			stopChan := make(chan os.Signal, 1)
+			defer signal.Stop(stopChan)
+			signal.Notify(stopChan, os.Interrupt)
+
+			<-stopChan
 			return nil
 		},
 	})


### PR DESCRIPTION
In cases where `coder server` fails to start, you still need to be able
to access your database!

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
