### PR TITLE
feat: add template version creator

### DIFF
--- a/coderd/audit/diff_test.go
+++ b/coderd/audit/diff_test.go
@@ -114,7 +114,7 @@ func TestDiff(t *testing.T) {
 				UpdatedAt:      time.Now(),
 				OrganizationID: uuid.UUID{3},
 				Name:           "rust",
-				CreatedBy:      uuid.UUID{4},
+				CreatedBy:      uuid.NullUUID{UUID: uuid.UUID{4}, Valid: true},
 			},
 			exp: audit.Map{
 				"id":              uuid.UUID{1}.String(),
@@ -134,7 +134,7 @@ func TestDiff(t *testing.T) {
 				UpdatedAt:      time.Now(),
 				OrganizationID: uuid.UUID{3},
 				Name:           "rust",
-				CreatedBy:      uuid.UUID{4},
+				CreatedBy:      uuid.NullUUID{UUID: uuid.UUID{4}, Valid: true},
 			},
 			exp: audit.Map{
 				"id":              uuid.UUID{1}.String(),

--- a/coderd/audit/diff_test.go
+++ b/coderd/audit/diff_test.go
@@ -114,12 +114,14 @@ func TestDiff(t *testing.T) {
 				UpdatedAt:      time.Now(),
 				OrganizationID: uuid.UUID{3},
 				Name:           "rust",
+				CreatedBy:      uuid.UUID{4},
 			},
 			exp: audit.Map{
 				"id":              uuid.UUID{1}.String(),
 				"template_id":     uuid.UUID{2}.String(),
 				"organization_id": uuid.UUID{3}.String(),
 				"name":            "rust",
+				"created_by":      uuid.UUID{4}.String(),
 			},
 		},
 		{
@@ -132,11 +134,13 @@ func TestDiff(t *testing.T) {
 				UpdatedAt:      time.Now(),
 				OrganizationID: uuid.UUID{3},
 				Name:           "rust",
+				CreatedBy:      uuid.UUID{4},
 			},
 			exp: audit.Map{
 				"id":              uuid.UUID{1}.String(),
 				"organization_id": uuid.UUID{3}.String(),
 				"name":            "rust",
+				"created_by":      uuid.UUID{4}.String(),
 			},
 		},
 	})

--- a/coderd/audit/table.go
+++ b/coderd/audit/table.go
@@ -83,6 +83,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 		"name":            ActionTrack,
 		"readme":          ActionTrack,
 		"job_id":          ActionIgnore, // Not helpful in a diff because jobs aren't tracked in audit logs.
+		"created_by":      ActionTrack,
 	},
 	&database.User{}: {
 		"id":              ActionTrack,

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1511,6 +1511,7 @@ func (q *fakeQuerier) InsertTemplateVersion(_ context.Context, arg database.Inse
 		Name:           arg.Name,
 		Readme:         arg.Readme,
 		JobID:          arg.JobID,
+		CreatedBy:      arg.CreatedBy,
 	}
 	q.templateVersions = append(q.templateVersions, version)
 	return version, nil

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -248,7 +248,7 @@ CREATE TABLE template_versions (
     name character varying(64) NOT NULL,
     readme character varying(1048576) NOT NULL,
     job_id uuid NOT NULL,
-    created_by uuid NOT NULL
+    created_by uuid
 );
 
 CREATE TABLE templates (

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -247,7 +247,8 @@ CREATE TABLE template_versions (
     updated_at timestamp with time zone NOT NULL,
     name character varying(64) NOT NULL,
     readme character varying(1048576) NOT NULL,
-    job_id uuid NOT NULL
+    job_id uuid NOT NULL,
+    created_by uuid NOT NULL
 );
 
 CREATE TABLE templates (
@@ -485,6 +486,9 @@ ALTER TABLE ONLY provisioner_job_logs
 
 ALTER TABLE ONLY provisioner_jobs
     ADD CONSTRAINT provisioner_jobs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY template_versions
+    ADD CONSTRAINT template_versions_created_by_fkey FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE RESTRICT;
 
 ALTER TABLE ONLY template_versions
     ADD CONSTRAINT template_versions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE;

--- a/coderd/database/migrations/000030_template_version_created_by.down.sql
+++ b/coderd/database/migrations/000030_template_version_created_by.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ONLY template_versions DROP COLUMN IF EXISTS created_by;

--- a/coderd/database/migrations/000030_template_version_created_by.up.sql
+++ b/coderd/database/migrations/000030_template_version_created_by.up.sql
@@ -1,14 +1,18 @@
+BEGIN;
+
 ALTER TABLE ONLY template_versions ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES users (id) ON DELETE RESTRICT;
 
 UPDATE
     template_versions
 SET
-    created_by = (
-        SELECT created_by FROM templates
+    template_versions.created_by = (
+        SELECT templates.created_by FROM templates
         WHERE template_versions.template_id = templates.id
         LIMIT 1
     )
 WHERE
-    created_by IS NULL;
+    template_versions.created_by IS NULL;
 
 ALTER TABLE ONLY template_versions ALTER COLUMN created_by SET NOT NULL;
+
+COMMIT;

--- a/coderd/database/migrations/000030_template_version_created_by.up.sql
+++ b/coderd/database/migrations/000030_template_version_created_by.up.sql
@@ -13,6 +13,4 @@ SET
 WHERE
     created_by IS NULL;
 
-ALTER TABLE ONLY template_versions ALTER COLUMN created_by SET NOT NULL;
-
 COMMIT;

--- a/coderd/database/migrations/000030_template_version_created_by.up.sql
+++ b/coderd/database/migrations/000030_template_version_created_by.up.sql
@@ -5,13 +5,13 @@ ALTER TABLE ONLY template_versions ADD COLUMN IF NOT EXISTS created_by uuid REFE
 UPDATE
     template_versions
 SET
-    template_versions.created_by = (
-        SELECT templates.created_by FROM templates
+    created_by = (
+        SELECT created_by FROM templates
         WHERE template_versions.template_id = templates.id
         LIMIT 1
     )
 WHERE
-    template_versions.created_by IS NULL;
+    created_by IS NULL;
 
 ALTER TABLE ONLY template_versions ALTER COLUMN created_by SET NOT NULL;
 

--- a/coderd/database/migrations/000030_template_version_created_by.up.sql
+++ b/coderd/database/migrations/000030_template_version_created_by.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE ONLY template_versions ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES users (id) ON DELETE RESTRICT;
+
+UPDATE
+    template_versions
+SET
+    created_by = (
+        SELECT created_by FROM templates
+        WHERE template_versions.template_id = templates.id
+        LIMIT 1
+    )
+WHERE
+    created_by IS NULL;
+
+ALTER TABLE ONLY template_versions ALTER COLUMN created_by SET NOT NULL;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -478,6 +478,7 @@ type TemplateVersion struct {
 	Name           string        `db:"name" json:"name"`
 	Readme         string        `db:"readme" json:"readme"`
 	JobID          uuid.UUID     `db:"job_id" json:"job_id"`
+	CreatedBy      uuid.UUID     `db:"created_by" json:"created_by"`
 }
 
 type User struct {

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -478,7 +478,7 @@ type TemplateVersion struct {
 	Name           string        `db:"name" json:"name"`
 	Readme         string        `db:"readme" json:"readme"`
 	JobID          uuid.UUID     `db:"job_id" json:"job_id"`
-	CreatedBy      uuid.UUID     `db:"created_by" json:"created_by"`
+	CreatedBy      uuid.NullUUID `db:"created_by" json:"created_by"`
 }
 
 type User struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2370,7 +2370,7 @@ type InsertTemplateVersionParams struct {
 	Name           string        `db:"name" json:"name"`
 	Readme         string        `db:"readme" json:"readme"`
 	JobID          uuid.UUID     `db:"job_id" json:"job_id"`
-	CreatedBy      uuid.UUID     `db:"created_by" json:"created_by"`
+	CreatedBy      uuid.NullUUID `db:"created_by" json:"created_by"`
 }
 
 func (q *sqlQuerier) InsertTemplateVersion(ctx context.Context, arg InsertTemplateVersionParams) (TemplateVersion, error) {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2145,7 +2145,7 @@ func (q *sqlQuerier) UpdateTemplateMetaByID(ctx context.Context, arg UpdateTempl
 
 const getTemplateVersionByID = `-- name: GetTemplateVersionByID :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by
 FROM
 	template_versions
 WHERE
@@ -2164,13 +2164,14 @@ func (q *sqlQuerier) GetTemplateVersionByID(ctx context.Context, id uuid.UUID) (
 		&i.Name,
 		&i.Readme,
 		&i.JobID,
+		&i.CreatedBy,
 	)
 	return i, err
 }
 
 const getTemplateVersionByJobID = `-- name: GetTemplateVersionByJobID :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by
 FROM
 	template_versions
 WHERE
@@ -2189,13 +2190,14 @@ func (q *sqlQuerier) GetTemplateVersionByJobID(ctx context.Context, jobID uuid.U
 		&i.Name,
 		&i.Readme,
 		&i.JobID,
+		&i.CreatedBy,
 	)
 	return i, err
 }
 
 const getTemplateVersionByTemplateIDAndName = `-- name: GetTemplateVersionByTemplateIDAndName :one
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by
 FROM
 	template_versions
 WHERE
@@ -2220,13 +2222,14 @@ func (q *sqlQuerier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, 
 		&i.Name,
 		&i.Readme,
 		&i.JobID,
+		&i.CreatedBy,
 	)
 	return i, err
 }
 
 const getTemplateVersionsByTemplateID = `-- name: GetTemplateVersionsByTemplateID :many
 SELECT
-	id, template_id, organization_id, created_at, updated_at, name, readme, job_id
+	id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by
 FROM
 	template_versions
 WHERE
@@ -2289,6 +2292,7 @@ func (q *sqlQuerier) GetTemplateVersionsByTemplateID(ctx context.Context, arg Ge
 			&i.Name,
 			&i.Readme,
 			&i.JobID,
+			&i.CreatedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -2304,7 +2308,7 @@ func (q *sqlQuerier) GetTemplateVersionsByTemplateID(ctx context.Context, arg Ge
 }
 
 const getTemplateVersionsCreatedAfter = `-- name: GetTemplateVersionsCreatedAfter :many
-SELECT id, template_id, organization_id, created_at, updated_at, name, readme, job_id FROM template_versions WHERE created_at > $1
+SELECT id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by FROM template_versions WHERE created_at > $1
 `
 
 func (q *sqlQuerier) GetTemplateVersionsCreatedAfter(ctx context.Context, createdAt time.Time) ([]TemplateVersion, error) {
@@ -2325,6 +2329,7 @@ func (q *sqlQuerier) GetTemplateVersionsCreatedAfter(ctx context.Context, create
 			&i.Name,
 			&i.Readme,
 			&i.JobID,
+			&i.CreatedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -2349,10 +2354,11 @@ INSERT INTO
 		updated_at,
 		"name",
 		readme,
-		job_id
+		job_id,
+		created_by
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, template_id, organization_id, created_at, updated_at, name, readme, job_id
+	($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id, template_id, organization_id, created_at, updated_at, name, readme, job_id, created_by
 `
 
 type InsertTemplateVersionParams struct {
@@ -2364,6 +2370,7 @@ type InsertTemplateVersionParams struct {
 	Name           string        `db:"name" json:"name"`
 	Readme         string        `db:"readme" json:"readme"`
 	JobID          uuid.UUID     `db:"job_id" json:"job_id"`
+	CreatedBy      uuid.UUID     `db:"created_by" json:"created_by"`
 }
 
 func (q *sqlQuerier) InsertTemplateVersion(ctx context.Context, arg InsertTemplateVersionParams) (TemplateVersion, error) {
@@ -2376,6 +2383,7 @@ func (q *sqlQuerier) InsertTemplateVersion(ctx context.Context, arg InsertTempla
 		arg.Name,
 		arg.Readme,
 		arg.JobID,
+		arg.CreatedBy,
 	)
 	var i TemplateVersion
 	err := row.Scan(
@@ -2387,6 +2395,7 @@ func (q *sqlQuerier) InsertTemplateVersion(ctx context.Context, arg InsertTempla
 		&i.Name,
 		&i.Readme,
 		&i.JobID,
+		&i.CreatedBy,
 	)
 	return i, err
 }

--- a/coderd/database/queries/templateversions.sql
+++ b/coderd/database/queries/templateversions.sql
@@ -70,10 +70,11 @@ INSERT INTO
 		updated_at,
 		"name",
 		readme,
-		job_id
+		job_id,
+		created_by
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *;
+	($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *;
 
 -- name: UpdateTemplateVersionByID :exec
 UPDATE

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -209,6 +209,7 @@ func (api *API) postTemplateByOrganization(rw http.ResponseWriter, r *http.Reque
 				UUID:  dbTemplate.ID,
 				Valid: true,
 			},
+			UpdatedAt: database.Now(),
 		})
 		if err != nil {
 			return xerrors.Errorf("insert template version: %s", err)

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -37,7 +37,7 @@ func (api *API) templateVersion(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, templateVersion)
+	createdByName, err := getUsernameByUserID(r.Context(), api.Database, templateVersion.CreatedBy)
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching creator name.",
@@ -486,10 +486,11 @@ func (api *API) templateVersionsByTemplate(rw http.ResponseWriter, r *http.Reque
 				})
 				return err
 			}
-			createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, version)
+			createdByName, err := getUsernameByUserID(r.Context(), api.Database, version.CreatedBy)
 			if err != nil {
 				httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
-					Message: fmt.Sprintf("Internal error fetching creator name (user %q) for version %q.", version.CreatedBy, version.ID),
+					Message: "Internal error fetching creator name.",
+					Detail:  err.Error(),
 				})
 				return err
 			}
@@ -542,7 +543,7 @@ func (api *API) templateVersionByName(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, templateVersion)
+	createdByName, err := getUsernameByUserID(r.Context(), api.Database, templateVersion.CreatedBy)
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching creator name.",
@@ -775,7 +776,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		return
 	}
 
-	createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, templateVersion)
+	createdByName, err := getUsernameByUserID(r.Context(), api.Database, templateVersion.CreatedBy)
 	if err != nil {
 		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching creator name.",
@@ -832,12 +833,12 @@ func (api *API) templateVersionLogs(rw http.ResponseWriter, r *http.Request) {
 	api.provisionerJobLogs(rw, r, job)
 }
 
-func getCreatedByNameByTemplateVersionID(ctx context.Context, db database.Store, templateVersion database.TemplateVersion) (string, error) {
-	creator, err := db.GetUserByID(ctx, templateVersion.CreatedBy)
+func getUsernameByUserID(ctx context.Context, db database.Store, userID uuid.UUID) (string, error) {
+	user, err := db.GetUserByID(ctx, userID)
 	if err != nil {
 		return "", err
 	}
-	return creator.Username, nil
+	return user.Username, nil
 }
 
 func convertTemplateVersion(version database.TemplateVersion, job codersdk.ProvisionerJob, createdByName string) codersdk.TemplateVersion {

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1,6 +1,7 @@
 package coderd
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -36,7 +37,16 @@ func (api *API) templateVersion(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(job)))
+	createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, templateVersion)
+	if err != nil {
+		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching creator name.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(job), createdByName))
 }
 
 func (api *API) patchCancelTemplateVersion(rw http.ResponseWriter, r *http.Request) {
@@ -476,7 +486,14 @@ func (api *API) templateVersionsByTemplate(rw http.ResponseWriter, r *http.Reque
 				})
 				return err
 			}
-			apiVersions = append(apiVersions, convertTemplateVersion(version, convertProvisionerJob(job)))
+			createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, version)
+			if err != nil {
+				httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
+					Message: fmt.Sprintf("Internal error fetching creator name (user %q) for version %q.", version.CreatedBy, version.ID),
+				})
+				return err
+			}
+			apiVersions = append(apiVersions, convertTemplateVersion(version, convertProvisionerJob(job), createdByName))
 		}
 
 		return nil
@@ -525,7 +542,16 @@ func (api *API) templateVersionByName(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(job)))
+	createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, templateVersion)
+	if err != nil {
+		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching creator name.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(rw, http.StatusOK, convertTemplateVersion(templateVersion, convertProvisionerJob(job), createdByName))
 }
 
 func (api *API) patchActiveTemplateVersion(rw http.ResponseWriter, r *http.Request) {
@@ -735,6 +761,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 			Name:           namesgenerator.GetRandomName(1),
 			Readme:         "",
 			JobID:          provisionerJob.ID,
+			CreatedBy:      apiKey.UserID,
 		})
 		if err != nil {
 			return xerrors.Errorf("insert template version: %w", err)
@@ -748,7 +775,16 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		return
 	}
 
-	httpapi.Write(rw, http.StatusCreated, convertTemplateVersion(templateVersion, convertProvisionerJob(provisionerJob)))
+	createdByName, err := getCreatedByNameByTemplateVersionID(r.Context(), api.Database, templateVersion)
+	if err != nil {
+		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching creator name.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(rw, http.StatusCreated, convertTemplateVersion(templateVersion, convertProvisionerJob(provisionerJob), createdByName))
 }
 
 // templateVersionResources returns the workspace agent resources associated
@@ -796,7 +832,15 @@ func (api *API) templateVersionLogs(rw http.ResponseWriter, r *http.Request) {
 	api.provisionerJobLogs(rw, r, job)
 }
 
-func convertTemplateVersion(version database.TemplateVersion, job codersdk.ProvisionerJob) codersdk.TemplateVersion {
+func getCreatedByNameByTemplateVersionID(ctx context.Context, db database.Store, templateVersion database.TemplateVersion) (string, error) {
+	creator, err := db.GetUserByID(ctx, templateVersion.CreatedBy)
+	if err != nil {
+		return "", err
+	}
+	return creator.Username, nil
+}
+
+func convertTemplateVersion(version database.TemplateVersion, job codersdk.ProvisionerJob, createdByName string) codersdk.TemplateVersion {
 	return codersdk.TemplateVersion{
 		ID:             version.ID,
 		TemplateID:     &version.TemplateID.UUID,
@@ -806,5 +850,7 @@ func convertTemplateVersion(version database.TemplateVersion, job codersdk.Provi
 		Name:           version.Name,
 		Job:            job,
 		Readme:         version.Readme,
+		CreatedByID:    version.CreatedBy,
+		CreatedByName:  createdByName,
 	}
 }

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -486,7 +486,7 @@ func (api *API) templateVersionsByTemplate(rw http.ResponseWriter, r *http.Reque
 				})
 				return err
 			}
-			createdByName, err := getUsernameByUserID(r.Context(), api.Database, version.CreatedBy)
+			createdByName, err := getUsernameByUserID(r.Context(), store, version.CreatedBy)
 			if err != nil {
 				httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 					Message: "Internal error fetching creator name.",

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -20,6 +20,8 @@ type TemplateVersion struct {
 	Name           string         `json:"name"`
 	Job            ProvisionerJob `json:"job"`
 	Readme         string         `json:"readme"`
+	CreatedByID    uuid.UUID      `json:"created_by_id"`
+	CreatedByName  string         `json:"created_by_name"`
 }
 
 // TemplateVersion returns a template version by ID.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -87,7 +87,7 @@ export interface CreateTemplateRequest {
   readonly min_autostart_interval_ms?: number
 }
 
-// From codersdk/templateversions.go:106:6
+// From codersdk/templateversions.go:108:6
 export interface CreateTemplateVersionDryRunRequest {
   readonly WorkspaceName: string
   readonly ParameterValues: CreateParameterRequest[]
@@ -290,6 +290,8 @@ export interface TemplateVersion {
   readonly name: string
   readonly job: ProvisionerJob
   readonly readme: string
+  readonly created_by_id: string
+  readonly created_by_name: string
 }
 
 // From codersdk/templates.go:100:6

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -112,6 +112,8 @@ name:Template test
 You can add instructions here
 
 [Some link info](https://coder.com)`,
+  created_by_id: "test-creator-id",
+  created_by_name: "test_creator",
 }
 
 export const MockTemplate: TypesGen.Template = {


### PR DESCRIPTION
This PR adds a created_by field to the template version table and returns the relevant data with the API calls.

## Subtasks

- [x] add a created_by field to the template version table
- [x] populate the default value of the field from the created_by field from the corresponding template
- [x] populate the field on insertion
- [x] return the field via the API

This will enable us to show the template version history (who created it and when) on the Template page for #2876.

## Example API Call
### Request
```
http://localhost:8080/api/v2/templateversions/be409505-f1cd-40ac-8c2d-364c27469681
```
### Response
```json
{
    "id": "be409505-f1cd-40ac-8c2d-364c27469681",
    "template_id": "790457b4-bd93-43dc-9c76-cf43c7251448",
    "organization_id": "8668a031-d228-4773-abb2-bc8ac2f39716",
    "created_at": "2022-07-14T16:43:45.993399969Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "name": "elastic_leavitt4",
    "job": {
        "id": "bd08dbcf-5274-49b7-bfe5-a1c4ee259cd5",
        "created_at": "2022-07-14T16:43:45.993396474Z",
        "started_at": "2022-07-14T16:43:46.172760057Z",
        "completed_at": "2022-07-14T16:43:52.543660466Z",
        "status": "succeeded",
        "worker_id": "3f74d616-df83-4557-9fd0-d31a863ed0d8",
        "storage_source": "6c621616837cca443cf54c9445c8986527e24ee12a09c3c51ffa98c3abf743be"
    },
    "readme": "---\nname: Develop code-server in Docker\ndescription: Run code-server in a Docker development environment\ntags: [local, docker]\n---\n\n# code-server in Docker\n\n## Getting started\n\nRun `coder templates init` and select this template. Follow the instructions that appear.\n\n## Supported Parameters\n\nYou can create a file containing parameters and pass the argument\n`--parameter-file` to `coder templates create`.\nSee `params.sample.yaml` for more information.\n\nThis template has the following predefined parameters:\n\n- `docker_host`: Path to (or address of) the Docker socket.\n  \u003e You can determine the correct value for this by runnning\n  \u003e `docker context ls`.\n- `docker_arch`: Architecture of the host running Docker.\n  This can be `amd64`, `arm64`, or `armv7`.\n",
    "created_by_id": "6d17ede3-bf5d-4bb9-b1c3-5dbcf8cfc13a",
    "created_by_name": "admin"
}
```