### PR TITLE
chore: configure absolute paths with webpack

### DIFF
--- a/site/jest.config.js
+++ b/site/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
       testEnvironment: "jsdom",
       testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
       testPathIgnorePatterns: ["/node_modules/", "/__tests__/fakes", "/e2e/"],
-      moduleDirectories: ["node_modules", "<rootDir>"],
+      moduleDirectories: ["node_modules", "<rootDir>/src"],
       moduleNameMapper: {
         "\\.css$": "<rootDir>/src/testHelpers/styleMock.ts",
       },

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -2,9 +2,9 @@ import { useMachine } from "@xstate/react"
 import { FC, useEffect } from "react"
 import { Helmet } from "react-helmet"
 import { useSearchParams } from "react-router-dom"
-import { workspaceFilterQuery } from "../../util/filters"
-import { pageTitle } from "../../util/page"
-import { workspacesMachine } from "../../xServices/workspaces/workspacesXService"
+import { workspaceFilterQuery } from "util/filters"
+import { pageTitle } from "util/page"
+import { workspacesMachine } from "xServices/workspaces/workspacesXService"
 import { WorkspacesPageView } from "./WorkspacesPageView"
 
 const WorkspacesPage: FC = () => {

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2018"
+    "target": "es2018",
+    "baseUrl": "./src"
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "_jest"]

--- a/site/webpack.common.ts
+++ b/site/webpack.common.ts
@@ -103,6 +103,7 @@ export const createCommonWebpackConfig = (options?: { skipTypecheck: boolean }):
     //
     // See: https://webpack.js.org/guides/typescript/
     extensions: [".tsx", ".ts", ".js"],
+    modules: [path.resolve(__dirname, "src"), "node_modules"],
   },
 
   // plugins customize the build process


### PR DESCRIPTION
resolves #1855

We can now use absolute paths on the FE.
Before:
![Screen Shot 2022-07-15 at 4 22 57 PM](https://user-images.githubusercontent.com/19142439/179310239-51610392-ae6d-4f3e-98ee-85128521d9c0.png)

After:
![Screen Shot 2022-07-15 at 5 02 18 PM](https://user-images.githubusercontent.com/19142439/179310253-d29b3491-0c33-4641-8774-65f3eda404be.png)

