### PR TITLE
config-ssh: always support agent name in host alias

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -89,18 +89,23 @@ func sshFetchWorkspaceConfigs(ctx context.Context, client *codersdk.Client) ([]s
 			}
 
 			wc := sshWorkspaceConfig{Name: workspace.Name}
+			var agents []codersdk.WorkspaceAgent
 			for _, resource := range resources {
 				if resource.Transition != codersdk.WorkspaceTransitionStart {
 					continue
 				}
-				for _, agent := range resource.Agents {
-					hostname := workspace.Name
-					if len(resource.Agents) > 1 {
-						hostname += "." + agent.Name
-					}
-					wc.Hosts = append(wc.Hosts, hostname)
-				}
+				agents = append(agents, resource.Agents...)
 			}
+
+			// handle both WORKSPACE and WORKSPACE.AGENT syntax
+			if len(agents) == 1 {
+				wc.Hosts = append(wc.Hosts, workspace.Name)
+			}
+			for _, agent := range agents {
+				hostname := workspace.Name + "." + agent.Name
+				wc.Hosts = append(wc.Hosts, hostname)
+			}
+
 			workspaceConfigs[i] = wc
 
 			return nil


### PR DESCRIPTION
This PR adjusts the behavior of `coder config-ssh` so that it *always* creates aliases of the form `coder.<WORKSPACE_NAME>.<AGENT_NAME>`, and additionally creates an alias of the form `coder.<WORKSPACE_NAME>` if the workspace has exactly one agent. This is more consistent with the behavior of `coder ssh`, and prevents us from incorrectly rejecting commands that are suggested by UI tooltips.

I believe the original logic was subtly incorrect, because it only considered how many agents existed in each workspace resource, not the total number of agents in the workspace. So if a workspace had two resources with one agent each, it would have generated multiple invalid `coder.<WORKSPACE_NAME>` aliases, instead of the correct aliases with the agent name.

Fixes #2969 