### PR TITLE
feat: amend schedule form validation string

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -32,7 +32,7 @@ dayjs.extend(relativeTime)
 dayjs.extend(timezone)
 
 export const Language = {
-  errorNoDayOfWeek: "Must set at least one day of week",
+  errorNoDayOfWeek: "Must set at least one day of week if start time is set",
   errorNoTime: "Start time is required",
   errorTime: "Time must be in HH:mm format (24 hours)",
   errorTimezone: "Invalid timezone",


### PR DESCRIPTION
resolves #2792


The old validation string for the workspace schedule days of the week field was unclear. Users were unsure why that field was mandatory. The new string is a bit clearer.

Old:
<img width="458" alt="176956857-8b2295c8-8ae3-48df-9c29-b2f56e4c0f0d" src="https://user-images.githubusercontent.com/19142439/179791464-93079e29-6f90-46da-9f98-5344344246fa.png">

New:
![Screen Shot 2022-07-19 at 11 36 46 AM](https://user-images.githubusercontent.com/19142439/179791514-0826fb05-61f9-47b7-9550-3ed63c12facf.png)

