### PR TITLE
feat: clarify start time validation in schedule

### DIFF
--- a/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
+++ b/site/src/components/WorkspaceScheduleForm/WorkspaceScheduleForm.tsx
@@ -33,7 +33,7 @@ dayjs.extend(timezone)
 
 export const Language = {
   errorNoDayOfWeek: "Must set at least one day of week if start time is set",
-  errorNoTime: "Start time is required",
+  errorNoTime: "Start time is required when days of the week are selected",
   errorTime: "Time must be in HH:mm format (24 hours)",
   errorTimezone: "Invalid timezone",
   daysOfWeekLabel: "Days of Week",


### PR DESCRIPTION
resolves #2792
"Start time is required" >> "Start time is required when days of the week are selected"


