### PR TITLE
feat: add verbose error messaging

### DIFF
--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -17,8 +17,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+func IsSet(cmd *cobra.Command, name string) (string, bool) {
+	flag := cmd.Flag(name)
+	if flag == nil {
+		return "", false
+	}
+
+	return flag.Value.String(), flag.Changed
+}
 
 // String sets a string flag on the given flag set.
 func String(flagset *pflag.FlagSet, name, shorthand, env, def, usage string) {

--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -21,6 +21,20 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// IsSetBool returns the value of the boolean flag if it is set.
+// It returns false if the flag isn't set or if any error occurs attempting
+// to parse the value of the flag.
+func IsSetBool(cmd *cobra.Command, name string) bool {
+	val, ok := IsSet(cmd, name)
+	if !ok {
+		return false
+	}
+
+	b, err := strconv.ParseBool(val)
+	return err == nil && b
+}
+
+// IsSet returns the string value of the flag and whether it was set.
 func IsSet(cmd *cobra.Command, name string) (string, bool) {
 	flag := cmd.Flag(name)
 	if flag == nil {
@@ -75,6 +89,22 @@ func Uint8VarP(flagset *pflag.FlagSet, ptr *uint8, name string, shorthand string
 	}
 
 	flagset.Uint8VarP(ptr, name, shorthand, uint8(vi64), fmtUsage(usage, env))
+}
+
+func Bool(flagset *pflag.FlagSet, name, shorthand, env string, def bool, usage string) {
+	val, ok := os.LookupEnv(env)
+	if !ok || val == "" {
+		flagset.BoolP(name, shorthand, def, fmtUsage(usage, env))
+		return
+	}
+
+	valb, err := strconv.ParseBool(val)
+	if err != nil {
+		flagset.BoolP(name, shorthand, def, fmtUsage(usage, env))
+		return
+	}
+
+	flagset.BoolP(name, shorthand, valb, fmtUsage(usage, env))
 }
 
 // BoolVarP sets a bool flag on the given flag set.

--- a/cli/login.go
+++ b/cli/login.go
@@ -73,7 +73,9 @@ func login() *cobra.Command {
 			// on a very old client.
 			err = checkVersions(cmd, client)
 			if err != nil {
-				return xerrors.Errorf("check versions: %w", err)
+				// Checking versions isn't a fatal error so we print a warning
+				// and proceed.
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), cliui.Styles.Warn.Render(err.Error()))
 			}
 
 			hasInitialUser, err := client.HasFirstUser(cmd.Context())

--- a/cli/root.go
+++ b/cli/root.go
@@ -437,7 +437,9 @@ func FormatCobraError(err error, cmd *cobra.Command) string {
 		_, _ = fmt.Fprintln(&output, httpErr.Friendly())
 	}
 
-	if cliflag.IsSetBool(cmd, varVerbose) {
+	// If the httpErr is nil then we just have a regular error in which
+	// case we want to print out what's happening.
+	if httpErr == nil || cliflag.IsSetBool(cmd, varVerbose) {
 		_, _ = fmt.Fprintln(&output, err.Error())
 	}
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -449,8 +448,7 @@ func FormatCobraError(err error, cmd *cobra.Command) string {
 }
 
 func checkVersions(cmd *cobra.Command, client *codersdk.Client) error {
-	flag := cmd.Flag("no-version-warning")
-	if suppress, _ := strconv.ParseBool(flag.Value.String()); suppress {
+	if cliflag.IsSetBool(cmd, varNoVersionCheck) {
 		return nil
 	}
 

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -4,22 +4,53 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/buildinfo"
 	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/codersdk"
 )
 
 func TestRoot(t *testing.T) {
 	t.Run("FormatCobraError", func(t *testing.T) {
 		t.Parallel()
 
-		cmd, _ := clitest.New(t, "delete")
+		t.Run("OK", func(t *testing.T) {
+			t.Parallel()
 
-		cmd, err := cmd.ExecuteC()
-		errStr := cli.FormatCobraError(err, cmd)
-		require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
+			cmd, _ := clitest.New(t, "delete")
+
+			cmd, err := cmd.ExecuteC()
+			errStr := cli.FormatCobraError(err, cmd)
+			require.Contains(t, errStr, "Run 'coder delete --help' for usage.")
+		})
+
+		t.Run("Verbose", func(t *testing.T) {
+			t.Parallel()
+
+			cmd, _ := clitest.New(t, "--verbose")
+
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				var err error = &codersdk.Error{
+					Response: codersdk.Response{
+						Message: "This is a message.",
+					},
+					Helper: "Try this instead.",
+				}
+
+				err = xerrors.Errorf("wrap me: %w", err)
+
+				return err
+			}
+
+			cmd, err := cmd.ExecuteC()
+			errStr := cli.FormatCobraError(err, cmd)
+			require.Contains(t, errStr, "This is a message. Try this instead.")
+			require.Contains(t, errStr, err.Error())
+		})
 	})
 
 	t.Run("Version", func(t *testing.T) {

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -31,25 +31,87 @@ func TestRoot(t *testing.T) {
 		t.Run("Verbose", func(t *testing.T) {
 			t.Parallel()
 
-			cmd, _ := clitest.New(t, "--verbose")
+			// Test that the verbose error is masked without verbose flag.
+			t.Run("NoVerboseAPIError", func(t *testing.T) {
+				t.Parallel()
 
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				var err error = &codersdk.Error{
-					Response: codersdk.Response{
-						Message: "This is a message.",
-					},
-					Helper: "Try this instead.",
+				cmd, _ := clitest.New(t)
+
+				cmd.RunE = func(cmd *cobra.Command, args []string) error {
+					var err error = &codersdk.Error{
+						Response: codersdk.Response{
+							Message: "This is a message.",
+						},
+						Helper: "Try this instead.",
+					}
+
+					err = xerrors.Errorf("wrap me: %w", err)
+
+					return err
 				}
 
-				err = xerrors.Errorf("wrap me: %w", err)
+				cmd, err := cmd.ExecuteC()
+				errStr := cli.FormatCobraError(err, cmd)
+				require.Contains(t, errStr, "This is a message. Try this instead.")
+				require.NotContains(t, errStr, err.Error())
+			})
 
-				return err
-			}
+			// Assert that a regular error is not masked when verbose is not
+			// specified.
+			t.Run("NoVerboseRegularError", func(t *testing.T) {
+				t.Parallel()
 
-			cmd, err := cmd.ExecuteC()
-			errStr := cli.FormatCobraError(err, cmd)
-			require.Contains(t, errStr, "This is a message. Try this instead.")
-			require.Contains(t, errStr, err.Error())
+				cmd, _ := clitest.New(t)
+
+				cmd.RunE = func(cmd *cobra.Command, args []string) error {
+					return xerrors.Errorf("this is a non-codersdk error: %w", xerrors.Errorf("a wrapped error"))
+				}
+
+				cmd, err := cmd.ExecuteC()
+				errStr := cli.FormatCobraError(err, cmd)
+				require.Contains(t, errStr, err.Error())
+			})
+
+			// Test that both the friendly error and the verbose error are
+			// displayed when verbose is passed.
+			t.Run("APIError", func(t *testing.T) {
+				t.Parallel()
+
+				cmd, _ := clitest.New(t, "--verbose")
+
+				cmd.RunE = func(cmd *cobra.Command, args []string) error {
+					var err error = &codersdk.Error{
+						Response: codersdk.Response{
+							Message: "This is a message.",
+						},
+						Helper: "Try this instead.",
+					}
+
+					err = xerrors.Errorf("wrap me: %w", err)
+
+					return err
+				}
+
+				cmd, err := cmd.ExecuteC()
+				errStr := cli.FormatCobraError(err, cmd)
+				require.Contains(t, errStr, "This is a message. Try this instead.")
+				require.Contains(t, errStr, err.Error())
+			})
+
+			// Assert that a regular error is not masked when verbose specified.
+			t.Run("RegularError", func(t *testing.T) {
+				t.Parallel()
+
+				cmd, _ := clitest.New(t, "--verbose")
+
+				cmd.RunE = func(cmd *cobra.Command, args []string) error {
+					return xerrors.Errorf("this is a non-codersdk error: %w", xerrors.Errorf("a wrapped error"))
+				}
+
+				cmd, err := cmd.ExecuteC()
+				errStr := cli.FormatCobraError(err, cmd)
+				require.Contains(t, errStr, err.Error())
+			})
 		})
 	})
 

--- a/coderd/database/postgres/postgres.go
+++ b/coderd/database/postgres/postgres.go
@@ -75,7 +75,7 @@ func Open() (string, func(), error) {
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
-		Tag:        "13",
+		Tag:        "11",
 		Env: []string{
 			"POSTGRES_PASSWORD=postgres",
 			"POSTGRES_USER=postgres",

--- a/coderd/database/postgres/postgres.go
+++ b/coderd/database/postgres/postgres.go
@@ -75,7 +75,7 @@ func Open() (string, func(), error) {
 
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
-		Tag:        "11",
+		Tag:        "13",
 		Env: []string{
 			"POSTGRES_PASSWORD=postgres",
 			"POSTGRES_USER=postgres",

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -185,6 +185,10 @@ func (e *Error) StatusCode() int {
 	return e.statusCode
 }
 
+func (e *Error) Friendly() string {
+	return fmt.Sprintf("%s. %s", strings.TrimSuffix(e.Message, "."), e.Helper)
+}
+
 func (e *Error) Error() string {
 	var builder strings.Builder
 	if e.method != "" && e.url != "" {


### PR DESCRIPTION
- fix an issue where `login` fatally errored when checking versions.

Regular output: 

![image](https://user-images.githubusercontent.com/4856196/179868439-74ce4471-4493-489f-acb1-7763a01c7bef.png)

Verbose output:

![image](https://user-images.githubusercontent.com/4856196/179868486-ed95f828-3f65-4937-bd86-7c17b9399c87.png)
