### PR TITLE
fix: Improve TestSSH reliability on macOS

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -91,6 +91,9 @@ func TestSSH(t *testing.T) {
 
 		// Shells on Mac, Windows, and Linux all exit shells with the "exit" command.
 		pty.WriteLine("exit")
+		// Read output to prevent hang on macOS, see:
+		// https://github.com/coder/coder/issues/2122
+		pty.ExpectMatch("exit")
 		<-cmdDone
 	})
 	t.Run("Stdio", func(t *testing.T) {
@@ -224,6 +227,9 @@ func TestSSH(t *testing.T) {
 
 		// And we're done.
 		pty.WriteLine("exit")
+		// Read output to prevent hang on macOS, see:
+		// https://github.com/coder/coder/issues/2122
+		pty.ExpectMatch("exit")
 		<-cmdDone
 	})
 }


### PR DESCRIPTION
This PR fixes TestSSH flakes on macOS, it's a band-aid fix.

Related issue: https://github.com/coder/coder/issues/2122

Recent failure: https://github.com/coder/coder/runs/7432289508?check_suite_focus=true

The proper fix is to always buffer `ptytest` output but requires a little refactoring.
