### PR TITLE
fix: Increase test timeout for TestCreate/CreateFromListWithSkip

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -88,7 +88,7 @@ func TestCreate(t *testing.T) {
 
 		member := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
 		clitest.SetupConfig(t, member, root)
-		cmdCtx, done := context.WithTimeout(context.Background(), time.Second*3)
+		cmdCtx, done := context.WithTimeout(context.Background(), 10*time.Second)
 		go func() {
 			defer done()
 			err := cmd.ExecuteContext(cmdCtx)


### PR DESCRIPTION
Considering database load and CI performance during testing, we should
avoid failing too early.

Three seconds isn't enough to tell if CI was just being slow here: https://github.com/coder/coder/runs/7434469515?check_suite_focus=true
