### PR TITLE
fix: Increase CI timeout for postgres test

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -230,7 +230,7 @@ jobs:
   test-go-postgres:
     name: "test/go/postgres"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -230,6 +230,7 @@ jobs:
   test-go-postgres:
     name: "test/go/postgres"
     runs-on: ubuntu-latest
+    # This timeout must be greater than go test -timeout.
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The Go test timeout uses 20m, if we want to get a stack trace, we must
allow the actions worker to run longer than that.

Fail in CI: https://github.com/coder/coder/runs/7434700524?check_suite_focus=true
