### PR TITLE
fix: coderdtest: increase ForceCancelInterval

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -230,7 +230,7 @@ func NewProvisionerDaemon(t *testing.T, coderAPI *coderd.API) io.Closer {
 		Logger:              slogtest.Make(t, nil).Named("provisionerd").Leveled(slog.LevelDebug),
 		PollInterval:        10 * time.Millisecond,
 		UpdateInterval:      25 * time.Millisecond,
-		ForceCancelInterval: 25 * time.Millisecond,
+		ForceCancelInterval: time.Second,
 		Provisioners: provisionerd.Provisioners{
 			string(database.ProvisionerTypeEcho): proto.NewDRPCProvisionerClient(provisionersdk.Conn(echoClient)),
 		},

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -126,7 +126,9 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
 	})
-	t.Run("Success", func(t *testing.T) {
+	// TODO(Cian): until we are able to test cancellation properly, validating
+	// Running -> Canceling is the best we can do for now.
+	t.Run("Canceling", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		user := coderdtest.CreateFirstUser(t, client)

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -150,8 +150,11 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		require.Eventually(t, func() bool {
 			var err error
 			version, err = client.TemplateVersion(context.Background(), version.ID)
-			require.NoError(t, err)
-			return version.Job.Status == codersdk.ProvisionerJobCanceled
+			return assert.NoError(t, err) &&
+				// The job will never actually cancel successfully because it will never send a
+				// provision complete response.
+				assert.Empty(t, version.Job.Error) &&
+				version.Job.Status == codersdk.ProvisionerJobCanceling
 		}, 5*time.Second, 25*time.Millisecond)
 	})
 }

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/coderdtest"
@@ -228,8 +229,11 @@ func TestPatchCancelWorkspaceBuild(t *testing.T) {
 	require.Eventually(t, func() bool {
 		var err error
 		build, err = client.WorkspaceBuild(context.Background(), build.ID)
-		require.NoError(t, err)
-		return build.Job.Status == codersdk.ProvisionerJobCanceled
+		return assert.NoError(t, err) &&
+			// The job will never actually cancel successfully because it will never send a
+			// provision complete response.
+			assert.Empty(t, build.Job.Error) &&
+			build.Job.Status == codersdk.ProvisionerJobCanceling
 	}, 5*time.Second, 25*time.Millisecond)
 }
 


### PR DESCRIPTION
Two `coderd` unit tests (`TestPatchCancelTemplateVersion/Success` and `TestPatchCancelWorkspaceBuild`) implied erroneously that the job was canceled successfully.

This is not the case, as these unit tests do not include a Provision_Complete response in the input to the
echo provisioner. Now explicitly checking the job error and bumping the force cancel interval to be longer.

I'm not sure if this is the "correct" fix here; I'm mainly unblocking https://github.com/coder/coder/pull/3061.
It seems that the "right" way would be to allow some way of modifying the contents of the test provisioner's job in-flight. 
For example in this use-case, we want to have the job initially returning only logs (implying in progress), and then also returning a complete after we cancel. 
There's another use case where we want the status quo, e.g. to test the force cancelation logic.

Fixes https://github.com/coder/coder/issues/3083.