### PR TITLE
fix: Deadlock and race in `peer`, test improvements

### DIFF
--- a/peer/channel.go
+++ b/peer/channel.go
@@ -306,6 +306,7 @@ func (c *Channel) isClosed() bool {
 func (c *Channel) waitOpened() error {
 	select {
 	case <-c.opened:
+		// Re-check the closed channel to prioritize closure.
 		if c.isClosed() {
 			return c.closeError
 		}

--- a/peer/channel.go
+++ b/peer/channel.go
@@ -306,13 +306,10 @@ func (c *Channel) isClosed() bool {
 func (c *Channel) waitOpened() error {
 	select {
 	case <-c.opened:
-		// Re-check to prioritize the closed channel.
-		select {
-		case <-c.closed:
+		if c.isClosed() {
 			return c.closeError
-		default:
-			return nil
 		}
+		return nil
 	case <-c.closed:
 		return c.closeError
 	}

--- a/peer/channel.go
+++ b/peer/channel.go
@@ -106,6 +106,10 @@ func (c *Channel) init() {
 	// write operations to block once the threshold is set.
 	c.dc.SetBufferedAmountLowThreshold(bufferedAmountLowThreshold)
 	c.dc.OnBufferedAmountLow(func() {
+		// Grab the lock to protect the sendMore channel from being
+		// closed in between the isClosed check and the send.
+		c.closeMutex.Lock()
+		defer c.closeMutex.Unlock()
 		if c.isClosed() {
 			return
 		}

--- a/peer/channel.go
+++ b/peer/channel.go
@@ -115,7 +115,6 @@ func (c *Channel) init() {
 		}
 		select {
 		case <-c.closed:
-			return
 		case c.sendMore <- struct{}{}:
 		default:
 		}

--- a/peer/conn.go
+++ b/peer/conn.go
@@ -3,7 +3,6 @@ package peer
 import (
 	"bytes"
 	"context"
-
 	"crypto/rand"
 	"io"
 	"sync"
@@ -256,7 +255,6 @@ func (c *Conn) init() error {
 			c.logger().Debug(context.Background(), "sending local candidate", slog.F("candidate", iceCandidate.ToJSON().Candidate))
 			select {
 			case <-c.closed:
-				break
 			case c.localCandidateChannel <- iceCandidate.ToJSON():
 			}
 		}()
@@ -265,7 +263,6 @@ func (c *Conn) init() error {
 		go func() {
 			select {
 			case <-c.closed:
-				return
 			case c.dcOpenChannel <- dc:
 			}
 		}()
@@ -435,9 +432,6 @@ func (c *Conn) pingEchoChannel() (*Channel, error) {
 				data := make([]byte, pingDataLength)
 				bytesRead, err := c.pingEchoChan.Read(data)
 				if err != nil {
-					if c.isClosed() {
-						return
-					}
 					_ = c.CloseWithError(xerrors.Errorf("read ping echo channel: %w", err))
 					return
 				}

--- a/peer/conn_test.go
+++ b/peer/conn_test.go
@@ -91,6 +91,8 @@ func TestConn(t *testing.T) {
 		// Create a channel that closes on disconnect.
 		channel, err := server.CreateChannel(context.Background(), "wow", nil)
 		assert.NoError(t, err)
+		defer channel.Close()
+
 		err = wan.Stop()
 		require.NoError(t, err)
 		// Once the connection is marked as disconnected, this
@@ -107,10 +109,13 @@ func TestConn(t *testing.T) {
 		t.Parallel()
 		client, server, _ := createPair(t)
 		exchange(t, client, server)
-		cch, err := client.CreateChannel(context.Background(), "hello", &peer.ChannelOptions{})
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		cch, err := client.CreateChannel(ctx, "hello", &peer.ChannelOptions{})
 		require.NoError(t, err)
+		defer cch.Close()
 
-		sch, err := server.Accept(context.Background())
+		sch, err := server.Accept(ctx)
 		require.NoError(t, err)
 		defer sch.Close()
 
@@ -123,9 +128,12 @@ func TestConn(t *testing.T) {
 		t.Parallel()
 		client, server, wan := createPair(t)
 		exchange(t, client, server)
-		cch, err := client.CreateChannel(context.Background(), "hello", &peer.ChannelOptions{})
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		cch, err := client.CreateChannel(ctx, "hello", &peer.ChannelOptions{})
 		require.NoError(t, err)
-		sch, err := server.Accept(context.Background())
+		defer cch.Close()
+		sch, err := server.Accept(ctx)
 		require.NoError(t, err)
 		defer sch.Close()
 
@@ -170,13 +178,29 @@ func TestConn(t *testing.T) {
 		srv, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		defer srv.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 		go func() {
-			sch, err := server.Accept(context.Background())
-			assert.NoError(t, err)
+			sch, err := server.Accept(ctx)
+			if err != nil {
+				assert.NoError(t, err)
+				return
+			}
+			defer sch.Close()
+
 			nc2 := sch.NetConn()
+			defer nc2.Close()
+
 			nc1, err := net.Dial("tcp", srv.Addr().String())
-			assert.NoError(t, err)
+			if err != nil {
+				assert.NoError(t, err)
+				return
+			}
+			defer nc1.Close()
+
 			go func() {
+				defer nc1.Close()
+				defer nc2.Close()
 				_, _ = io.Copy(nc1, nc2)
 			}()
 			_, _ = io.Copy(nc2, nc1)
@@ -204,7 +228,7 @@ func TestConn(t *testing.T) {
 		c := http.Client{
 			Transport: defaultTransport,
 		}
-		req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost/", nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost/", nil)
 		require.NoError(t, err)
 		resp, err := c.Do(req)
 		require.NoError(t, err)
@@ -272,14 +296,21 @@ func TestConn(t *testing.T) {
 		t.Parallel()
 		client, server, _ := createPair(t)
 		exchange(t, client, server)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 		go func() {
-			channel, err := client.CreateChannel(context.Background(), "test", nil)
-			assert.NoError(t, err)
+			channel, err := client.CreateChannel(ctx, "test", nil)
+			if err != nil {
+				assert.NoError(t, err)
+				return
+			}
+			defer channel.Close()
 			_, err = channel.Write([]byte{1, 2})
 			assert.NoError(t, err)
 		}()
-		channel, err := server.Accept(context.Background())
+		channel, err := server.Accept(ctx)
 		require.NoError(t, err)
+		defer channel.Close()
 		data := make([]byte, 1)
 		_, err = channel.Read(data)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR fixes a few edge cases that I noticed whilst combing over the `peer` package. Some of the tests were also updated in an attempt to increase robustness and improve cleanup (e.g. closing channels and connections).

- fix: Potential deadlock in peer.Channel dc.OnOpen
- fix: Potential send on closed channel
- fix: Improve robustness of waitOpened during close
- chore: Simplify statements
- fix: Improve teardown and timeout of peer tests
- fix: Improve robustness of TestConn/Buffering test

After a while, I noticed what I was really debugging was the resurfacing of https://github.com/coder/coder/issues/1644 (I believe). These changes **do not** fix that issue.

