### PR TITLE
fix: set a failed canceled job status correctly

### DIFF
--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -312,7 +312,11 @@ func convertProvisionerJob(provisionerJob database.ProvisionerJob) codersdk.Prov
 	switch {
 	case provisionerJob.CanceledAt.Valid:
 		if provisionerJob.CompletedAt.Valid {
-			job.Status = codersdk.ProvisionerJobCanceled
+			if job.Error == "" {
+				job.Status = codersdk.ProvisionerJobCanceled
+			} else {
+				job.Status = codersdk.ProvisionerJobFailed
+			}
 		} else {
 			job.Status = codersdk.ProvisionerJobCanceling
 		}

--- a/coderd/provisionerjobs_internal_test.go
+++ b/coderd/provisionerjobs_internal_test.go
@@ -3,6 +3,7 @@ package coderd
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/json"
 	"net/http/httptest"
 	"net/url"
@@ -144,6 +145,111 @@ func TestProvisionerJobLogs_Unit(t *testing.T) {
 		}
 		assert.False(t, fPubsub.closed)
 	})
+}
+
+func TestConvertProvisionerJob_Unit(t *testing.T) {
+	t.Parallel()
+	validNullTimeMock := sql.NullTime{
+		Time:  database.Now(),
+		Valid: true,
+	}
+	invalidNullTimeMock := sql.NullTime{
+		Valid: false,
+	}
+	errorMock := sql.NullString{
+		String: "error",
+		Valid:  true,
+	}
+	testCases := []struct {
+		name     string
+		input    database.ProvisionerJob
+		expected codersdk.ProvisionerJob
+	}{
+		{
+			name:  "empty",
+			input: database.ProvisionerJob{},
+			expected: codersdk.ProvisionerJob{
+				Status: codersdk.ProvisionerJobPending,
+			},
+		},
+		{
+			name: "cancellation pending",
+			input: database.ProvisionerJob{
+				CanceledAt:  validNullTimeMock,
+				CompletedAt: invalidNullTimeMock,
+			},
+			expected: codersdk.ProvisionerJob{
+				Status: codersdk.ProvisionerJobCanceling,
+			},
+		},
+		{
+			name: "cancellation failed",
+			input: database.ProvisionerJob{
+				CanceledAt:  validNullTimeMock,
+				CompletedAt: validNullTimeMock,
+				Error:       errorMock,
+			},
+			expected: codersdk.ProvisionerJob{
+				CompletedAt: &validNullTimeMock.Time,
+				Status:      codersdk.ProvisionerJobFailed,
+				Error:       errorMock.String,
+			},
+		},
+		{
+			name: "cancellation succeeded",
+			input: database.ProvisionerJob{
+				CanceledAt:  validNullTimeMock,
+				CompletedAt: validNullTimeMock,
+			},
+			expected: codersdk.ProvisionerJob{
+				CompletedAt: &validNullTimeMock.Time,
+				Status:      codersdk.ProvisionerJobCanceled,
+			},
+		},
+		{
+			name: "job pending",
+			input: database.ProvisionerJob{
+				StartedAt: invalidNullTimeMock,
+			},
+			expected: codersdk.ProvisionerJob{
+				Status: codersdk.ProvisionerJobPending,
+			},
+		},
+		{
+			name: "job failed",
+			input: database.ProvisionerJob{
+				CompletedAt: validNullTimeMock,
+				StartedAt:   validNullTimeMock,
+				Error:       errorMock,
+			},
+			expected: codersdk.ProvisionerJob{
+				CompletedAt: &validNullTimeMock.Time,
+				StartedAt:   &validNullTimeMock.Time,
+				Error:       errorMock.String,
+				Status:      codersdk.ProvisionerJobFailed,
+			},
+		},
+		{
+			name: "job succeeded",
+			input: database.ProvisionerJob{
+				CompletedAt: validNullTimeMock,
+				StartedAt:   validNullTimeMock,
+			},
+			expected: codersdk.ProvisionerJob{
+				CompletedAt: &validNullTimeMock.Time,
+				StartedAt:   &validNullTimeMock.Time,
+				Status:      codersdk.ProvisionerJobSucceeded,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			actual := convertProvisionerJob(testCase.input)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
 }
 
 type fakePubSub struct {

--- a/coderd/provisionerjobs_internal_test.go
+++ b/coderd/provisionerjobs_internal_test.go
@@ -153,9 +153,7 @@ func TestConvertProvisionerJob_Unit(t *testing.T) {
 		Time:  database.Now(),
 		Valid: true,
 	}
-	invalidNullTimeMock := sql.NullTime{
-		Valid: false,
-	}
+	invalidNullTimeMock := sql.NullTime{}
 	errorMock := sql.NullString{
 		String: "error",
 		Valid:  true,

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -128,8 +128,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		require.Eventually(t, func() bool {
 			var err error
 			version, err = client.TemplateVersion(context.Background(), version.ID)
-			require.NoError(t, err)
-			return version.Job.Status == codersdk.ProvisionerJobFailed
+			return assert.NoError(t, err) && version.Job.Status == codersdk.ProvisionerJobFailed
 		}, 5*time.Second, 25*time.Millisecond)
 	})
 	// TODO(Cian): until we are able to test cancellation properly, validating

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -125,6 +125,12 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Eventually(t, func() bool {
+			var err error
+			version, err = client.TemplateVersion(context.Background(), version.ID)
+			require.NoError(t, err)
+			return version.Job.Status == codersdk.ProvisionerJobFailed
+		}, 5*time.Second, 25*time.Millisecond)
 	})
 	// TODO(Cian): until we are able to test cancellation properly, validating
 	// Running -> Canceling is the best we can do for now.


### PR DESCRIPTION
Using in favor of #3061
resolves https://github.com/coder/coder/issues/1374

When a previous job was canceled and that cancellation was unsuccessful, we incorrectly set the job status as canceled. This fix remedies that issue by setting the status as Failed.
