### PR TITLE
feat: New static error summary component

### DIFF
--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -83,3 +83,6 @@ export const getValidationErrorMessage = (error: Error | ApiError | unknown): st
     isApiError(error) && error.response.data.validations ? error.response.data.validations : []
   return validationErrors.map((error) => error.detail).join("\n")
 }
+
+export const getErrorDetail = (error: Error | ApiError | unknown): string | undefined | null =>
+  isApiError(error) ? error.response.data.detail : error instanceof Error ? error.stack : null

--- a/site/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -23,3 +23,39 @@ WithRetry.args = {
 }
 
 export const WithUndefined = Template.bind({})
+
+export const WithDefaultMessage = Template.bind({})
+WithDefaultMessage.args = {
+  // Unknown error type
+  error: {
+    message: "Failed to fetch something!",
+  },
+  defaultMessage: "This is a default error message",
+}
+
+export const WithDismissible = Template.bind({})
+WithDismissible.args = {
+  error: {
+    response: {
+      data: {
+        message: "Failed to fetch something!",
+      },
+    },
+    isAxiosError: true,
+  },
+  dismissible: true,
+}
+
+export const WithDetails = Template.bind({})
+WithDetails.args = {
+  error: {
+    response: {
+      data: {
+        message: "Failed to fetch something!",
+        detail: "The resource you requested does not exist in the database.",
+      },
+    },
+    isAxiosError: true,
+  },
+  dismissible: true,
+}

--- a/site/src/components/ErrorSummary/ErrorSummary.test.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { ErrorSummary } from "./ErrorSummary"
 
 describe("ErrorSummary", () => {
@@ -8,7 +8,67 @@ describe("ErrorSummary", () => {
     render(<ErrorSummary error={error} />)
 
     // Then
-    const element = await screen.findByText("test error message", { exact: false })
+    const element = await screen.findByText("test error message")
     expect(element).toBeDefined()
+  })
+
+  it("shows details on More click", async () => {
+    // When
+    const error = {
+      response: {
+        data: {
+          message: "Failed to fetch something!",
+          detail: "The resource you requested does not exist in the database.",
+        },
+      },
+      isAxiosError: true,
+    }
+    render(<ErrorSummary error={error} />)
+
+    // Then
+    fireEvent.click(screen.getByText("More"))
+    const element = await screen.findByText(
+      "The resource you requested does not exist in the database.",
+      { exact: false },
+    )
+    expect(element.closest(".MuiCollapse-entered")).toBeDefined()
+  })
+
+  it("hides details on Less click", async () => {
+    // When
+    const error = {
+      response: {
+        data: {
+          message: "Failed to fetch something!",
+          detail: "The resource you requested does not exist in the database.",
+        },
+      },
+      isAxiosError: true,
+    }
+    render(<ErrorSummary error={error} />)
+
+    // Then
+    fireEvent.click(screen.getByText("More"))
+    fireEvent.click(screen.getByText("Less"))
+    const element = await screen.findByText(
+      "The resource you requested does not exist in the database.",
+      { exact: false },
+    )
+    expect(element.closest(".MuiCollapse-hidden")).toBeDefined()
+  })
+
+  it("renders nothing on closing", async () => {
+    // When
+    const error = new Error("test error message")
+    render(<ErrorSummary error={error} dismissible />)
+
+    // Then
+    const element = await screen.findByText("test error message")
+    expect(element).toBeDefined()
+
+    const closeIcon = screen.getAllByRole("button")[0]
+    fireEvent.click(closeIcon)
+    const nullElement = screen.queryByText("test error message")
+    expect(nullElement).toBeNull()
   })
 })

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -1,32 +1,112 @@
 import Button from "@material-ui/core/Button"
+import Collapse from "@material-ui/core/Collapse"
+import IconButton from "@material-ui/core/IconButton"
+import Link from "@material-ui/core/Link"
+import { makeStyles, Theme } from "@material-ui/core/styles"
+import CloseIcon from "@material-ui/icons/Close"
 import RefreshIcon from "@material-ui/icons/Refresh"
-import { FC } from "react"
+import { ApiError, getErrorDetail, getErrorMessage } from "api/errors"
+import { FC, useState } from "react"
 import { Stack } from "../Stack/Stack"
 
 const Language = {
   retryMessage: "Retry",
   unknownErrorMessage: "An unknown error has occurred",
+  moreDetails: "More",
+  lessDetails: "Less",
 }
 
 export interface ErrorSummaryProps {
-  error: Error | unknown
+  error: ApiError | Error | unknown
   retry?: () => void
+  dismissible?: boolean
+  defaultMessage?: string
 }
 
-export const ErrorSummary: FC<ErrorSummaryProps> = ({ error, retry }) => (
-  <Stack>
-    {!(error instanceof Error) ? (
-      <div>{Language.unknownErrorMessage}</div>
-    ) : (
-      <div>{error.toString()}</div>
-    )}
+export const ErrorSummary: FC<ErrorSummaryProps> = ({
+  error,
+  retry,
+  dismissible,
+  defaultMessage,
+}) => {
+  const message = getErrorMessage(error, defaultMessage || Language.unknownErrorMessage)
+  const detail = getErrorDetail(error)
+  const [showDetails, setShowDetails] = useState(false)
+  const [isOpen, setOpen] = useState(true)
 
-    {retry && (
-      <div>
-        <Button onClick={retry} startIcon={<RefreshIcon />} variant="outlined">
-          {Language.retryMessage}
-        </Button>
-      </div>
-    )}
-  </Stack>
-)
+  const styles = useStyles({ showDetails })
+
+  const toggleShowDetails = () => {
+    setShowDetails(!showDetails)
+  }
+
+  const closeError = () => {
+    setOpen(false)
+  }
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <Stack>
+      <Stack className={styles.root}>
+        <Stack direction="row" alignItems="center" className={styles.message}>
+          <div>
+            <span className={styles.errorMessage}>{message}</span>
+            {!!detail && (
+              <Link onClick={toggleShowDetails} className={styles.detailsLink}>
+                {showDetails ? Language.lessDetails : Language.moreDetails}
+              </Link>
+            )}
+          </div>
+          {dismissible && (
+            <IconButton onClick={closeError} className={styles.iconButton}>
+              <CloseIcon className={styles.closeIcon} />
+            </IconButton>
+          )}
+        </Stack>
+        <Collapse in={showDetails}>{detail}</Collapse>
+      </Stack>
+
+      {retry && (
+        <div>
+          <Button onClick={retry} startIcon={<RefreshIcon />} variant="outlined">
+            {Language.retryMessage}
+          </Button>
+        </div>
+      )}
+    </Stack>
+  )
+}
+
+interface StyleProps {
+  showDetails?: boolean
+}
+
+const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
+  root: {
+    background: `${theme.palette.error.main}60`,
+    margin: `${theme.spacing(2)}px`,
+    padding: `${theme.spacing(2)}px`,
+    borderRadius: theme.shape.borderRadius,
+    gap: (props) => (props.showDetails ? `${theme.spacing(2)}px` : 0),
+  },
+  message: {
+    justifyContent: "space-between",
+  },
+  errorMessage: {
+    marginRight: `${theme.spacing(1)}px`,
+  },
+  detailsLink: {
+    cursor: "pointer",
+  },
+  iconButton: {
+    padding: 0,
+  },
+  closeIcon: {
+    width: 25,
+    height: 25,
+    color: theme.palette.primary.contrastText,
+  },
+}))

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -55,7 +55,11 @@ export const ErrorSummary: FC<ErrorSummaryProps> = ({
           <div>
             <span className={styles.errorMessage}>{message}</span>
             {!!detail && (
-              <Link onClick={toggleShowDetails} className={styles.detailsLink}>
+              <Link
+                aria-expanded={showDetails}
+                onClick={toggleShowDetails}
+                className={styles.detailsLink}
+              >
                 {showDetails ? Language.lessDetails : Language.moreDetails}
               </Link>
             )}

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -5,7 +5,7 @@ import Link from "@material-ui/core/Link"
 import { makeStyles, Theme } from "@material-ui/core/styles"
 import CloseIcon from "@material-ui/icons/Close"
 import RefreshIcon from "@material-ui/icons/Refresh"
-import { ApiError, getErrorDetail, getErrorMessage } from "api/errors"
+import { ApiError, getErrorDetail, getErrorMessage } from "../../api/errors"
 import { FC, useState } from "react"
 import { Stack } from "../Stack/Stack"
 

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -2,7 +2,7 @@ import Button from "@material-ui/core/Button"
 import Collapse from "@material-ui/core/Collapse"
 import IconButton from "@material-ui/core/IconButton"
 import Link from "@material-ui/core/Link"
-import { makeStyles, Theme } from "@material-ui/core/styles"
+import { darken, makeStyles, Theme } from "@material-ui/core/styles"
 import CloseIcon from "@material-ui/icons/Close"
 import RefreshIcon from "@material-ui/icons/Refresh"
 import { ApiError, getErrorDetail, getErrorMessage } from "api/errors"
@@ -49,33 +49,33 @@ export const ErrorSummary: FC<ErrorSummaryProps> = ({
   }
 
   return (
-    <Stack>
-      <Stack className={styles.root}>
-        <Stack direction="row" alignItems="center" className={styles.message}>
-          <div>
-            <span className={styles.errorMessage}>{message}</span>
-            {!!detail && (
-              <Link
-                aria-expanded={showDetails}
-                onClick={toggleShowDetails}
-                className={styles.detailsLink}
-              >
-                {showDetails ? Language.lessDetails : Language.moreDetails}
-              </Link>
-            )}
-          </div>
-          {dismissible && (
-            <IconButton onClick={closeError} className={styles.iconButton}>
-              <CloseIcon className={styles.closeIcon} />
-            </IconButton>
-          )}
-        </Stack>
-        <Collapse in={showDetails}>{detail}</Collapse>
-      </Stack>
-
-      {retry && (
+    <Stack className={styles.root}>
+      <Stack direction="row" alignItems="center" className={styles.messageBox}>
         <div>
-          <Button onClick={retry} startIcon={<RefreshIcon />} variant="outlined">
+          <span className={styles.errorMessage}>{message}</span>
+          {!!detail && (
+            <Link
+              aria-expanded={showDetails}
+              onClick={toggleShowDetails}
+              className={styles.detailsLink}
+              tabIndex={0}
+            >
+              {showDetails ? Language.lessDetails : Language.moreDetails}
+            </Link>
+          )}
+        </div>
+        {dismissible && (
+          <IconButton onClick={closeError} className={styles.iconButton}>
+            <CloseIcon className={styles.closeIcon} />
+          </IconButton>
+        )}
+      </Stack>
+      <Collapse in={showDetails}>
+        <div className={styles.details}>{detail}</div>
+      </Collapse>
+      {retry && (
+        <div className={styles.retry}>
+          <Button size="small" onClick={retry} startIcon={<RefreshIcon />} variant="outlined">
             {Language.retryMessage}
           </Button>
         </div>
@@ -90,13 +90,13 @@ interface StyleProps {
 
 const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   root: {
-    background: `${theme.palette.error.main}60`,
+    background: darken(theme.palette.error.main, 0.6),
     margin: `${theme.spacing(2)}px`,
     padding: `${theme.spacing(2)}px`,
     borderRadius: theme.shape.borderRadius,
-    gap: (props) => (props.showDetails ? `${theme.spacing(2)}px` : 0),
+    gap: 0,
   },
-  message: {
+  messageBox: {
     justifyContent: "space-between",
   },
   errorMessage: {
@@ -105,6 +105,12 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   detailsLink: {
     cursor: "pointer",
   },
+  details: {
+    marginTop: `${theme.spacing(2)}px`,
+    padding: `${theme.spacing(2)}px`,
+    background: darken(theme.palette.error.main, 0.7),
+    borderRadius: theme.shape.borderRadius,
+  },
   iconButton: {
     padding: 0,
   },
@@ -112,5 +118,8 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     width: 25,
     height: 25,
     color: theme.palette.primary.contrastText,
+  },
+  retry: {
+    marginTop: `${theme.spacing(2)}px`,
   },
 }))


### PR DESCRIPTION
This PR repurposes the existing ErrorSummary component to create a static component to display error messages with details from the backend.

We want to make the details section collapsible and the error summary optionally dismissible.

## Subtasks

- [x] create new component with collapsible details section
- [x] add an option to dismiss the component
- [x] add unit tests
- [x] add stories

Fixes #3106 

## Screenshots

<img width="696" alt="Screen Shot 2022-07-22 at 1 01 00 AM" src="https://user-images.githubusercontent.com/7511231/180366432-11b48103-a702-4bc4-9c71-8cc7ef36e5df.png">

### Dismissible

<img width="695" alt="Screen Shot 2022-07-22 at 1 01 35 AM" src="https://user-images.githubusercontent.com/7511231/180366447-821b2b80-4e3e-48fa-95f3-2a5347668c98.png">

### Collapsed details

<img width="693" alt="Screen Shot 2022-07-22 at 1 02 00 AM" src="https://user-images.githubusercontent.com/7511231/180366463-76db1b7a-e346-442b-848d-9dc52e64bd7f.png">

### With details

<img width="692" alt="Screen Shot 2022-07-22 at 1 02 09 AM" src="https://user-images.githubusercontent.com/7511231/180366479-766e0c4b-294f-49de-8814-3450243fdf8b.png">


