### PR TITLE
fix: Decrease postgres test timeout (`make test-postgres`)

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -233,7 +233,10 @@ jobs:
   test-go-postgres:
     name: "test/go/postgres"
     runs-on: ubuntu-latest
-    # This timeout must be greater than go test -timeout.
+    # This timeout must be greater than the timeout set by `go test` in
+    # `make test-postgres` to ensure we receive a trace of running
+    # goroutines. Setting this to the timeout +5m should work quite well
+    # even if some of the preceding steps are slow.
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,11 @@ test: test-clean
 	gotestsum -- -v -short ./...
 .PHONY: test
 
+# When updating -timeout for this test, keep in sync with
+# test-go-postgres (.github/workflows/coder.yaml).
 test-postgres: test-clean test-postgres-docker
 	DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum --junitfile="gotests.xml" --packages="./..." -- \
-		-covermode=atomic -coverprofile="gotests.coverage" -timeout=30m \
+		-covermode=atomic -coverprofile="gotests.coverage" -timeout=20m \
 		-coverpkg=./...,github.com/coder/coder/codersdk \
 		-count=1 -race -failfast
 .PHONY: test-postgres


### PR DESCRIPTION
This commit lowers the postgres test timeout from 30m to 20m, currently
our postgres tests seem to take 8-10m, a 2x factor should suffice.
Comments were updated in both places to reflect the reasoning and
necessity of keeping these values in sync.

They used to take longer but the `count` was lowered in
3d40cb85b7e875cd8677d5c857db25351b514a84.

The actual timeout value of `make test-postgres` got overlooked in
https://github.com/coder/coder/pull/3079.

