### PR TITLE
fix: Move timeout ctx closer to use in tests, increase timeout

### DIFF
--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -16,8 +16,6 @@ func TestList(t *testing.T) {
 	t.Parallel()
 	t.Run("Single", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancelFunc()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -30,6 +28,9 @@ func TestList(t *testing.T) {
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
 		cmd.SetOut(pty.Output())
+
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelFunc()
 		done := make(chan any)
 		go func() {
 			errC := cmd.ExecuteContext(ctx)

--- a/coderd/provisionerjobs_internal_test.go
+++ b/coderd/provisionerjobs_internal_test.go
@@ -27,8 +27,6 @@ func TestProvisionerJobLogs_Unit(t *testing.T) {
 	t.Parallel()
 
 	t.Run("QueryPubSubDupes", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		t.Cleanup(cancel)
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		// mDB := mocks.NewStore(t)
 		fDB := databasefake.New()
@@ -64,6 +62,9 @@ func TestProvisionerJobLogs_Unit(t *testing.T) {
 			{ID: uuid.New(), JobID: jobID, Stage: "Stage2"},
 			{ID: uuid.New(), JobID: jobID, Stage: "Stage3"},
 		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 
 		// wow there are a lot of DB rows we touch...
 		_, err = fDB.InsertAPIKey(ctx, database.InsertAPIKeyParams{

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -48,7 +48,7 @@ func TestCaching(t *testing.T) {
 	defer srv.Close()
 
 	// Create a context
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFunc()
 
 	testCases := []struct {
@@ -108,7 +108,7 @@ func TestServingFiles(t *testing.T) {
 	defer srv.Close()
 
 	// Create a context
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFunc()
 
 	testCases := []struct {
@@ -337,7 +337,7 @@ func TestServingBin(t *testing.T) {
 			defer srv.Close()
 
 			// Create a context
-			ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancelFunc()
 
 			for _, tr := range tt.reqs {


### PR DESCRIPTION
Some contexts were moved closer to use so that test setup doesn't affect
timeout. And timeout was increased for some others to avoid flakyness
due to slow test runners.

This CI run ran into context deadline exceeded:
https://github.com/coder/coder/runs/7456533733?check_suite_focus=true

