### PR TITLE
chore: Improve test cleanup

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -206,7 +206,7 @@ func TestAgent(t *testing.T) {
 
 	t.Run("StartupScript", func(t *testing.T) {
 		t.Parallel()
-		tempPath := filepath.Join(os.TempDir(), "content.txt")
+		tempPath := filepath.Join(t.TempDir(), "content.txt")
 		content := "somethingnice"
 		setupAgent(t, agent.Metadata{
 			StartupScript: fmt.Sprintf("echo %s > %s", content, tempPath),
@@ -324,12 +324,7 @@ func TestAgent(t *testing.T) {
 						t.Skip("Unix socket forwarding isn't supported on Windows")
 					}
 
-					tmpDir, err := os.MkdirTemp("", "coderd_agent_test_")
-					require.NoError(t, err, "create temp dir for unix listener")
-					t.Cleanup(func() {
-						_ = os.RemoveAll(tmpDir)
-					})
-
+					tmpDir := t.TempDir()
 					l, err := net.Listen("unix", filepath.Join(tmpDir, "test.sock"))
 					require.NoError(t, err, "create UDP listener")
 					return l

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -192,6 +192,7 @@ func TestCreate(t *testing.T) {
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 		_ = coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 		tempDir := t.TempDir()
+		removeTmpDirUntilSuccessAfterTest(t, tempDir)
 		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
 		_, _ = parameterFile.WriteString("region: \"bingo\"\nusername: \"boingo\"")
 		cmd, root := clitest.New(t, "create", "", "--parameter-file", parameterFile.Name())
@@ -217,7 +218,6 @@ func TestCreate(t *testing.T) {
 			pty.WriteLine(value)
 		}
 		<-doneChan
-		removeTmpDirUntilSuccess(t, tempDir)
 	})
 
 	t.Run("WithParameterFileNotContainingTheValue", func(t *testing.T) {
@@ -234,6 +234,7 @@ func TestCreate(t *testing.T) {
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 		tempDir := t.TempDir()
+		removeTmpDirUntilSuccessAfterTest(t, tempDir)
 		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
 		_, _ = parameterFile.WriteString("zone: \"bananas\"")
 		cmd, root := clitest.New(t, "create", "my-workspace", "--template", template.Name, "--parameter-file", parameterFile.Name())
@@ -248,7 +249,6 @@ func TestCreate(t *testing.T) {
 			assert.EqualError(t, err, "Parameter value absent in parameter file for \"region\"!")
 		}()
 		<-doneChan
-		removeTmpDirUntilSuccess(t, tempDir)
 	})
 
 	t.Run("FailedDryRun", func(t *testing.T) {

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -119,23 +119,13 @@ func TestPortForward(t *testing.T) {
 					t.Skip("Unix socket forwarding isn't supported on Windows")
 				}
 
-				tmpDir, err := os.MkdirTemp("", "coderd_agent_test_")
-				require.NoError(t, err, "create temp dir for unix listener")
-				t.Cleanup(func() {
-					_ = os.RemoveAll(tmpDir)
-				})
-
+				tmpDir := t.TempDir()
 				l, err := net.Listen("unix", filepath.Join(tmpDir, "test.sock"))
 				require.NoError(t, err, "create UDP listener")
 				return l
 			},
 			setupLocal: func(t *testing.T) (string, string) {
-				tmpDir, err := os.MkdirTemp("", "coderd_agent_test_")
-				require.NoError(t, err, "create temp dir for unix listener")
-				t.Cleanup(func() {
-					_ = os.RemoveAll(tmpDir)
-				})
-
+				tmpDir := t.TempDir()
 				path := filepath.Join(tmpDir, "test.sock")
 				return path, path
 			},

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -132,6 +132,7 @@ func TestTemplateCreate(t *testing.T) {
 			ProvisionDryRun: echo.ProvisionComplete,
 		})
 		tempDir := t.TempDir()
+		removeTmpDirUntilSuccessAfterTest(t, tempDir)
 		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
 		_, _ = parameterFile.WriteString("region: \"bananas\"")
 		cmd, root := clitest.New(t, "templates", "create", "my-template", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho), "--parameter-file", parameterFile.Name())
@@ -158,7 +159,6 @@ func TestTemplateCreate(t *testing.T) {
 		}
 
 		require.NoError(t, <-execDone)
-		removeTmpDirUntilSuccess(t, tempDir)
 	})
 
 	t.Run("WithParameterFileNotContainingTheValue", func(t *testing.T) {
@@ -171,6 +171,7 @@ func TestTemplateCreate(t *testing.T) {
 			ProvisionDryRun: echo.ProvisionComplete,
 		})
 		tempDir := t.TempDir()
+		removeTmpDirUntilSuccessAfterTest(t, tempDir)
 		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
 		_, _ = parameterFile.WriteString("zone: \"bananas\"")
 		cmd, root := clitest.New(t, "templates", "create", "my-template", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho), "--parameter-file", parameterFile.Name())
@@ -196,7 +197,6 @@ func TestTemplateCreate(t *testing.T) {
 		}
 
 		require.EqualError(t, <-execDone, "Parameter value absent in parameter file for \"region\"!")
-		removeTmpDirUntilSuccess(t, tempDir)
 	})
 
 	t.Run("Recreate template with same name (create, delete, create)", func(t *testing.T) {
@@ -267,7 +267,7 @@ func createTestParseResponse() []*proto.Parse_Response {
 
 // Need this for Windows because of a known issue with Go:
 // https://github.com/golang/go/issues/52986
-func removeTmpDirUntilSuccess(t *testing.T, tempDir string) {
+func removeTmpDirUntilSuccessAfterTest(t *testing.T, tempDir string) {
 	t.Helper()
 	t.Cleanup(func() {
 		err := os.RemoveAll(tempDir)


### PR DESCRIPTION
This change slightly improves test cleanup and standardizes use around `t.TempDir()`.
