### PR TITLE
fix: Add resource icons into template page

### DIFF
--- a/site/src/components/TemplateResourcesTable/TemplateResourcesTable.tsx
+++ b/site/src/components/TemplateResourcesTable/TemplateResourcesTable.tsx
@@ -4,6 +4,8 @@ import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import { AvatarData } from "components/AvatarData/AvatarData"
+import { ResourceAvatar } from "components/Resources/ResourceAvatar"
 import { FC } from "react"
 import { WorkspaceResource } from "../../api/typesGenerated"
 import { Stack } from "../Stack/Stack"
@@ -51,8 +53,12 @@ export const TemplateResourcesTable: FC<TemplateResourcesProps> = ({ resources }
               return (
                 <TableRow>
                   <TableCell className={styles.resourceNameCell}>
-                    {resource.name}
-                    <span className={styles.resourceType}>{resource.type}</span>
+                    <AvatarData
+                      title={resource.name}
+                      subtitle={resource.type}
+                      highlightTitle
+                      avatar={<ResourceAvatar type={resource.type} />}
+                    />
                   </TableCell>
                   <TableCell colSpan={3}></TableCell>
                 </TableRow>
@@ -65,8 +71,12 @@ export const TemplateResourcesTable: FC<TemplateResourcesProps> = ({ resources }
                 {/* The rowspan should be the same than the number of agents */}
                 {agentIndex === 0 && (
                   <TableCell className={styles.resourceNameCell} rowSpan={agents.length}>
-                    {resource.name}
-                    <span className={styles.resourceType}>{resource.type}</span>
+                    <AvatarData
+                      title={resource.name}
+                      subtitle={resource.type}
+                      highlightTitle
+                      avatar={<ResourceAvatar type={resource.type} />}
+                    />
                   </TableCell>
                 )}
 


### PR DESCRIPTION
Fix #3122 
<img width="1792" alt="Screen Shot 2022-07-22 at 12 57 31" src="https://user-images.githubusercontent.com/3165839/180477959-b8f35e82-3063-4652-bb30-4a75d964a0c5.png">

