### PR TITLE
fix: Use membership endpoint to ensure user exists in a GitHub team

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -796,8 +796,8 @@ func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, al
 			})
 			return memberships, err
 		},
-		Team: func(ctx context.Context, client *http.Client, org, teamSlug string) (*github.Team, error) {
-			team, _, err := github.NewClient(client).Teams.GetTeamBySlug(ctx, org, teamSlug)
+		TeamMembership: func(ctx context.Context, client *http.Client, org, teamSlug, username string) (*github.Membership, error) {
+			team, _, err := github.NewClient(client).Teams.GetTeamMembershipBySlug(ctx, org, teamSlug, username)
 			return team, err
 		},
 	}, nil

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -88,7 +88,12 @@ func TestUserOAuth2Github(t *testing.T) {
 						},
 					}}, nil
 				},
-				Team: func(ctx context.Context, client *http.Client, org, team string) (*github.Team, error) {
+				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
+					return &github.User{
+						Login: github.String("kyle"),
+					}, nil
+				},
+				TeamMembership: func(ctx context.Context, client *http.Client, org, team, username string) (*github.Membership, error) {
 					return nil, xerrors.New("no perms")
 				},
 			},
@@ -222,8 +227,8 @@ func TestUserOAuth2Github(t *testing.T) {
 						},
 					}}, nil
 				},
-				Team: func(ctx context.Context, client *http.Client, org, team string) (*github.Team, error) {
-					return &github.Team{}, nil
+				TeamMembership: func(ctx context.Context, client *http.Client, org, team, username string) (*github.Membership, error) {
+					return &github.Membership{}, nil
 				},
 				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
 					return &github.User{


### PR DESCRIPTION
This was using the incorrect GitHub endpoint prior, which fetched a team
by slug. Any user in a GitHub organization can view all teams, so this
didn't block signups like intended.

I've verified this API returns an error when the calling user is not a
member of the team requested.

Fixes #3105.
