### PR TITLE
fix: Add a slightly better error message for dropped SSH connection

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -36,8 +36,6 @@ import (
 var workspacePollInterval = time.Minute
 var autostopNotifyCountdown = []time.Duration{30 * time.Minute}
 
-var errConnectionDropped = xerrors.New("SSH connection ended unexpectedly")
-
 func ssh() *cobra.Command {
 	var (
 		stdio          bool
@@ -237,7 +235,7 @@ func ssh() *cobra.Command {
 				// If the connection drops unexpectedly, we get an ExitMissingError but no other
 				// error details, so try to at least give the user a better message
 				if errors.Is(err, &gossh.ExitMissingError{}) {
-					return errConnectionDropped
+					return xerrors.New("SSH connection ended unexpectedly")
 				}
 				return err
 			}


### PR DESCRIPTION
If an SSH connection drops, we typically get an `ssh.ExitMissingError` from the client, which doesn't have a very user-friendly error message:

```wait: remote command exited without exit status or exit signal```

This PR looks for that error type and replaces it with message that, while not necessarily more helpful, at least doesn't incorrectly state the problem is on the remote side:

```SSH connection ended unexpectedly```

Partial fix for #1369
