### PR TITLE
feat: add 'coder upgrade' cmd

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -130,6 +130,7 @@ func Root() *cobra.Command {
 		stop(),
 		templates(),
 		update(),
+		upgrade(),
 		users(),
 		versionCmd(),
 		wireguardPortForward(),

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func upgrade() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade coder CLI to server version.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			client, err := createClient(cmd)
+			if err != nil {
+				return xerrors.Errorf("create client: %w", err)
+			}
+
+			bin, err := client.Upgrade(ctx)
+			if err != nil {
+				return xerrors.Errorf("download binary: %w", err)
+			}
+			defer bin.Close()
+
+			exe, err := os.Executable()
+			if err != nil {
+				return xerrors.Errorf("get local executable: %w", err)
+			}
+
+			stat, err := os.Stat(exe)
+			if err != nil {
+				return xerrors.Errorf("stat %q: %w", exe, err)
+			}
+
+			// We intentionally do not use os.TmpDir here since it may
+			// give us an 'invalid cross-device link' error.
+			dir := filepath.Dir(exe)
+			tmpPath := filepath.Join(dir, fmt.Sprintf(".coder-%v", time.Now().Unix()))
+			tmpFi, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, stat.Mode().Perm())
+			if err != nil {
+				return xerrors.Errorf("create temp file %q: %w", tmpPath, err)
+			}
+			defer tmpFi.Close()
+
+			_, err = io.Copy(tmpFi, bin)
+			if err != nil {
+				return xerrors.Errorf("copy binary: %w", err)
+			}
+
+			err = tmpFi.Close()
+			if err != nil {
+				return xerrors.Errorf("close temp file %q: %w", tmpPath, err)
+			}
+
+			err = os.Rename(tmpPath, exe)
+			if err != nil {
+				return xerrors.Errorf("rename %q to %q: %w", tmpPath, exe, err)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/cli/cliui"
 )
 
 func upgrade() *cobra.Command {
@@ -46,6 +49,9 @@ func upgrade() *cobra.Command {
 			dir := filepath.Dir(exe)
 			tmpPath := filepath.Join(dir, fmt.Sprintf(".coder-%v", time.Now().Unix()))
 			tmpFi, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, stat.Mode().Perm())
+			if xerrors.Is(err, fs.ErrPermission) {
+				fmt.Fprintf(cmd.ErrOrStderr(), cliui.Styles.Warn.Render("Unable to write to directory %v, try running "))
+			}
 			if err != nil {
 				return xerrors.Errorf("create temp file %q: %w", tmpPath, err)
 			}

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -6,16 +6,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
-
-	"github.com/coder/coder/cli/cliui"
 )
 
 func upgrade() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade coder CLI to server version.",
@@ -28,7 +26,7 @@ func upgrade() *cobra.Command {
 				return xerrors.Errorf("create client: %w", err)
 			}
 
-			bin, err := client.Upgrade(ctx)
+			bin, err := client.FetchCLI(ctx, runtime.GOOS, runtime.GOARCH)
 			if err != nil {
 				return xerrors.Errorf("download binary: %w", err)
 			}
@@ -50,7 +48,7 @@ func upgrade() *cobra.Command {
 			tmpPath := filepath.Join(dir, fmt.Sprintf(".coder-%v", time.Now().Unix()))
 			tmpFi, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, stat.Mode().Perm())
 			if xerrors.Is(err, fs.ErrPermission) {
-				fmt.Fprintf(cmd.ErrOrStderr(), cliui.Styles.Warn.Render("Unable to write to directory %v, try running "))
+				return xerrors.Errorf("Unable to write to directory %q try rerunning command with 'sudo': %w", err)
 			}
 			if err != nil {
 				return xerrors.Errorf("create temp file %q: %w", tmpPath, err)

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -53,6 +53,7 @@ func upgrade() *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("create temp file %q: %w", tmpPath, err)
 			}
+			defer os.Remove(tmpPath)
 			defer tmpFi.Close()
 
 			_, err = io.Copy(tmpFi, bin)

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -24,6 +24,10 @@ func TestUpgrade(t *testing.T) {
 		binPath = filepath.Join(tmpDir, binName)
 	)
 
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+
 	// Build a binary. We have to do this because 'coder upgrade'
 	// replaces the running binary with the one pulled from the server.
 	buildCoder(t, binPath)
@@ -93,9 +97,14 @@ func copyFile(t *testing.T, from, to string) {
 // newUpgradeServer starts a server with just the routes necessary
 // to complete the 'coder upgrade' path.
 func newUpgradeServer(t *testing.T, binPath string) *httptest.Server {
+	path := fmt.Sprintf("/bin/coder-%s-%s", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		path += ".exe"
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc(
-		fmt.Sprintf("/bin/coder-%s-%s", runtime.GOOS, runtime.GOARCH),
+		path,
 		func(w http.ResponseWriter, r *http.Request) {
 			http.ServeFile(w, r, binPath)
 		})

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -1,8 +1,14 @@
 package cli_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,22 +20,89 @@ func TestUpgrade(t *testing.T) {
 
 	var (
 		tmpDir  = t.TempDir()
-		binPath = filepath.Join(tmpDir, "coder")
+		binName = "coder"
+		binPath = filepath.Join(tmpDir, binName)
 	)
 
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
-	require.NoError(t, err)
-
-	cliDir := filepath.Join(string(out), "cmd/coder")
-
-	now := time.Now()
-	out, err = exec.Command("go", "build", "-o", binPath, cliDir).CombinedOutput()
-	require.NoError(t, err, "failed to compile (%s): %v", out, err)
-	t.Logf("compilation took %v", time.Since(now))
+	// Build a binary. We have to do this because 'coder upgrade'
+	// replaces the running binary with the one pulled from the server.
+	buildCoder(t, binPath)
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
+		var (
+			dir       = t.TempDir()
+			coderPath = filepath.Join(dir, binName)
+			server    = newUpgradeServer(t, binPath)
+		)
+
+		copyFile(t, binPath, coderPath)
+
+		stat, err := os.Stat(coderPath)
+		require.NoError(t, err)
+
+		cmd := exec.Command(coderPath, "--url", server.URL, "upgrade")
+		t.Log("Running command " + strings.Join(cmd.Args, " "))
+
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "output: %s", out)
+
+		newStat, err := os.Stat(coderPath)
+		require.NoError(t, err)
+
+		require.True(t, newStat.ModTime().After(stat.ModTime()), "mod time should update")
+
+		// Validate that the new binary is still executable.
+		out, err = exec.Command(binPath, "version").CombinedOutput()
+		require.NoError(t, err, "output: %s", out)
+	})
+}
+
+// buildCoder build coder/cmd/coder.
+func buildCoder(t *testing.T, dest string) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	require.NoError(t, err)
+
+	t.Logf("top level: %s", out)
+
+	cliDir := filepath.Join(strings.TrimSpace(string(out)), "cmd/coder")
+
+	t.Logf("cliDir: %s", cliDir)
+
+	now := time.Now()
+	out, err = exec.Command("go", "build", "-o", dest, cliDir).CombinedOutput()
+	require.NoError(t, err, "failed to compile (%s): %v", out, err)
+	t.Logf("compilation took %v", time.Since(now))
+}
+
+func copyFile(t *testing.T, from, to string) {
+	b, err := os.ReadFile(from)
+	require.NoError(t, err)
+
+	err = os.WriteFile(to, b, 0755)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.Remove(to)
+	})
+}
+
+// newUpgradeServer starts a server with just the routes necessary
+// to complete the 'coder upgrade' path.
+func newUpgradeServer(t *testing.T, binPath string) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		fmt.Sprintf("/bin/coder-%s-%s", runtime.GOOS, runtime.GOARCH),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, binPath)
+		})
+
+	server := httptest.NewServer(mux)
+
+	t.Cleanup(func() {
+		server.Close()
 	})
 
+	return server
 }

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -42,7 +42,8 @@ func TestUpgrade(t *testing.T) {
 		stat, err := os.Stat(coderPath)
 		require.NoError(t, err)
 
-		cmd := exec.Command(coderPath, "--url", server.URL, "upgrade")
+		//nolint
+		cmd := exec.Command(coderPath, "--url", server.URL, "--token", "fake", "upgrade")
 		t.Log("Running command " + strings.Join(cmd.Args, " "))
 
 		out, err := cmd.CombinedOutput()
@@ -80,6 +81,7 @@ func copyFile(t *testing.T, from, to string) {
 	b, err := os.ReadFile(from)
 	require.NoError(t, err)
 
+	//nolint
 	err = os.WriteFile(to, b, 0755)
 	require.NoError(t, err)
 

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -1,0 +1,35 @@
+package cli_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgrade(t *testing.T) {
+	t.Parallel()
+
+	var (
+		tmpDir  = t.TempDir()
+		binPath = filepath.Join(tmpDir, "coder")
+	)
+
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	require.NoError(t, err)
+
+	cliDir := filepath.Join(string(out), "cmd/coder")
+
+	now := time.Now()
+	out, err = exec.Command("go", "build", "-o", binPath, cliDir).CombinedOutput()
+	require.NoError(t, err, "failed to compile (%s): %v", out, err)
+	t.Logf("compilation took %v", time.Since(now))
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+	})
+
+}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -131,6 +132,19 @@ func New(options *Options) *API {
 	// other applications might not as well.
 	r.Route("/%40{user}/{workspacename}/apps/{workspaceapp}", apps)
 	r.Route("/@{user}/{workspacename}/apps/{workspaceapp}", apps)
+
+	r.Get("/upgrade", func(w http.ResponseWriter, r *http.Request) {
+		exe, err := os.Executable()
+		if err != nil {
+			httpapi.Write(w, http.StatusInternalServerError, httpapi.Response{
+				Message: "Unable to locate coder.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+
+		http.ServeFile(w, r, exe)
+	})
 
 	r.Route("/api/v2", func(r chi.Router) {
 		r.NotFound(func(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -132,19 +131,6 @@ func New(options *Options) *API {
 	// other applications might not as well.
 	r.Route("/%40{user}/{workspacename}/apps/{workspaceapp}", apps)
 	r.Route("/@{user}/{workspacename}/apps/{workspaceapp}", apps)
-
-	r.Get("/upgrade", func(w http.ResponseWriter, r *http.Request) {
-		exe, err := os.Executable()
-		if err != nil {
-			httpapi.Write(w, http.StatusInternalServerError, httpapi.Response{
-				Message: "Unable to locate coder.",
-				Detail:  err.Error(),
-			})
-			return
-		}
-
-		http.ServeFile(w, r, exe)
-	})
 
 	r.Route("/api/v2", func(r chi.Router) {
 		r.NotFound(func(rw http.ResponseWriter, r *http.Request) {

--- a/codersdk/upgrade.go
+++ b/codersdk/upgrade.go
@@ -1,0 +1,23 @@
+package codersdk
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"golang.org/x/xerrors"
+)
+
+func (c *Client) Upgrade(ctx context.Context) (io.ReadCloser, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/upgrade", nil)
+	if err != nil {
+		_ = res.Body.Close()
+		return nil, xerrors.Errorf("do request: %w", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		_ = res.Body.Close()
+		return nil, readBodyAsError(res)
+	}
+
+	return res.Body, nil
+}

--- a/codersdk/upgrade.go
+++ b/codersdk/upgrade.go
@@ -13,6 +13,10 @@ import (
 
 func (c *Client) FetchCLI(ctx context.Context, os, arch string) (io.ReadCloser, error) {
 	binName := fmt.Sprintf("coder-%s-%s", os, arch)
+	if os == "windows" {
+		binName += ".exe"
+	}
+
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/bin/%s", binName), nil)
 	if err != nil {
 		return nil, xerrors.Errorf("do request: %w", err)

--- a/codersdk/upgrade.go
+++ b/codersdk/upgrade.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Client) Upgrade(ctx context.Context) (io.ReadCloser, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/upgrade", nil)
+	res, err := c.Request(ctx, http.MethodGet, "/bin", nil)
 	if err != nil {
 		_ = res.Body.Close()
 		return nil, xerrors.Errorf("do request: %w", err)

--- a/codersdk/upgrade.go
+++ b/codersdk/upgrade.go
@@ -1,17 +1,20 @@
 package codersdk
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"golang.org/x/xerrors"
 )
 
-func (c *Client) Upgrade(ctx context.Context) (io.ReadCloser, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/bin", nil)
+func (c *Client) FetchCLI(ctx context.Context, os, arch string) (io.ReadCloser, error) {
+	binName := fmt.Sprintf("coder-%s-%s", os, arch)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/bin/%s", binName), nil)
 	if err != nil {
-		_ = res.Body.Close()
 		return nil, xerrors.Errorf("do request: %w", err)
 	}
 	if res.StatusCode != http.StatusOK {
@@ -20,4 +23,52 @@ func (c *Client) Upgrade(ctx context.Context) (io.ReadCloser, error) {
 	}
 
 	return res.Body, nil
+}
+
+type CLIChecksums map[string]string
+
+func (c CLIChecksums) Checksum(os, arch string) string {
+	key := fmt.Sprintf("coder-%s-%s", os, arch)
+	if os == "windows" {
+		key += ".exe"
+	}
+
+	return c[key]
+}
+
+func (c *Client) CLIChecksums(ctx context.Context) (CLIChecksums, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/bin/coder.sha1", nil)
+	if err != nil {
+		return nil, xerrors.Errorf("do request: %w", err)
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, readBodyAsError(res)
+	}
+
+	return parseChecksumFile(res.Body)
+}
+
+func parseChecksumFile(rd io.Reader) (CLIChecksums, error) {
+	var (
+		scan = bufio.NewScanner(rd)
+		sums = map[string]string{}
+	)
+
+	for scan.Scan() {
+		fields := strings.Fields(scan.Text())
+		if len(fields) != 2 {
+			return nil, xerrors.Errorf("malformed checksum file")
+		}
+
+		var (
+			binary   = fields[1]
+			checksum = fields[0]
+		)
+
+		sums[binary] = checksum
+	}
+
+	return sums, nil
 }

--- a/codersdk/upgrade.go
+++ b/codersdk/upgrade.go
@@ -63,7 +63,7 @@ func parseChecksumFile(rd io.Reader) (CLIChecksums, error) {
 		}
 
 		var (
-			binary   = fields[1]
+			binary   = strings.TrimPrefix(fields[1], "*")
 			checksum = fields[0]
 		)
 


### PR DESCRIPTION
- Added a command to allow a user to upgrade their 'coder' binary
  directly from their coderd deployment. This allows users to easily
  swap out coder binaries as they work across deployments.