### PR TITLE
Lift frontend CODEOWNERS requirement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-site/ @coder/frontend
 docs/ @ammario


### PR DESCRIPTION
* It's more difficult to get changes into the frontend during off hours (e.g weekend) due to the requirement. See https://github.com/coder/coder/pull/3151 for an example. That PR makes [a minor, uncontroversial change](https://github.com/coder/coder/pull/3151/files#diff-ee55791615389e50dd9deff7768932ea3185cac8804723817dc08f30682d85c0) to the frontend that may delay my merge by a day. I'm tempted to avoid improving the frontend in my free time, and perhaps other are too.
* Lifting the gate will help encourage our traditional Go developers to make more changes to the frontend, which is good for cross functional empathy and overall velocity.
* The backend doesn't have CODEOWNERS, and I don't get why we would want to be more protective about the frontend than the backend.