### PR TITLE
fix: Ensure terraform tests have a cache path and logger

### DIFF
--- a/provisioner/terraform/parse_test.go
+++ b/provisioner/terraform/parse_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+
 	"github.com/coder/coder/provisioner/terraform"
 	"github.com/coder/coder/provisionersdk"
 	"github.com/coder/coder/provisionersdk/proto"
@@ -33,6 +36,8 @@ func TestParse(t *testing.T) {
 			ServeOptions: &provisionersdk.ServeOptions{
 				Listener: server,
 			},
+			CachePath: t.TempDir(),
+			Logger:    slogtest.Make(t, nil).Leveled(slog.LevelDebug),
 		})
 		assert.NoError(t, err)
 	}()
@@ -175,7 +180,8 @@ func TestParse(t *testing.T) {
 								DefaultDestination: &proto.ParameterDestination{
 									Scheme: proto.ParameterDestination_PROVISIONER_VARIABLE,
 								},
-							}},
+							},
+						},
 					},
 				},
 			},

--- a/provisioner/terraform/parse_test.go
+++ b/provisioner/terraform/parse_test.go
@@ -3,45 +3,20 @@
 package terraform_test
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog"
-	"cdr.dev/slog/sloggers/slogtest"
-
-	"github.com/coder/coder/provisioner/terraform"
-	"github.com/coder/coder/provisionersdk"
 	"github.com/coder/coder/provisionersdk/proto"
 )
 
 func TestParse(t *testing.T) {
 	t.Parallel()
 
-	// Create an in-memory provisioner to communicate with.
-	client, server := provisionersdk.TransportPipe()
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(func() {
-		_ = client.Close()
-		_ = server.Close()
-		cancelFunc()
-	})
-	go func() {
-		err := terraform.Serve(ctx, &terraform.ServeOptions{
-			ServeOptions: &provisionersdk.ServeOptions{
-				Listener: server,
-			},
-			CachePath: t.TempDir(),
-			Logger:    slogtest.Make(t, nil).Leveled(slog.LevelDebug),
-		})
-		assert.NoError(t, err)
-	}()
-	api := proto.NewDRPCProvisionerClient(provisionersdk.Conn(client))
+	ctx, api := setupProvisioner(t)
 
 	testCases := []struct {
 		Name     string

--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -35,7 +35,8 @@ func setupProvisioner(t *testing.T) (context.Context, proto.DRPCProvisionerClien
 			ServeOptions: &provisionersdk.ServeOptions{
 				Listener: server,
 			},
-			Logger: slogtest.Make(t, nil).Leveled(slog.LevelDebug),
+			CachePath: t.TempDir(),
+			Logger:    slogtest.Make(t, nil).Leveled(slog.LevelDebug),
 		})
 		assert.NoError(t, err)
 	}()


### PR DESCRIPTION
This PR sets cache path for terraform in tests.

However, for some reason this does not work.

Related: #3159
