### PR TITLE
fix: Avoid dirtying stdout/stderr in test

### DIFF
--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -25,6 +25,12 @@ func New(t *testing.T, args ...string) (*cobra.Command, config.Root) {
 	dir := t.TempDir()
 	root := config.Root(dir)
 	cmd.SetArgs(append([]string{"--global-config", dir}, args...))
+
+	// We could consider using writers
+	// that log via t.Log here instead.
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
 	return cmd, root
 }
 

--- a/cli/cliui/prompt_test.go
+++ b/cli/cliui/prompt_test.go
@@ -185,7 +185,7 @@ func TestPasswordTerminalState(t *testing.T) {
 	// connect the child process's stdio to the PTY directly, not via a pipe
 	cmd.Stdin = ptty.Input().Reader
 	cmd.Stdout = ptty.Output().Writer
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = ptty.Output().Writer
 	err := cmd.Start()
 	require.NoError(t, err)
 	process := cmd.Process

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -173,9 +173,10 @@ func TestConfigSSH(t *testing.T) {
 	home := filepath.Dir(filepath.Dir(sshConfigFile))
 	// #nosec
 	sshCmd := exec.Command("ssh", "-F", sshConfigFile, "coder."+workspace.Name, "echo", "test")
+	pty = ptytest.New(t)
 	// Set HOME because coder config is included from ~/.ssh/coder.
 	sshCmd.Env = append(sshCmd.Env, fmt.Sprintf("HOME=%s", home))
-	sshCmd.Stderr = os.Stderr
+	sshCmd.Stderr = pty.Output()
 	data, err := sshCmd.Output()
 	require.NoError(t, err)
 	require.Equal(t, "test", strings.TrimSpace(string(data)))

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -158,7 +157,7 @@ func TestPortForward(t *testing.T) {
 				cmd, root := clitest.New(t, "port-forward", workspace.Name, flag)
 				clitest.SetupConfig(t, client, root)
 				buf := newThreadSafeBuffer()
-				cmd.SetOut(io.MultiWriter(buf, os.Stderr))
+				cmd.SetOut(buf)
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				errC := make(chan error)
@@ -204,7 +203,7 @@ func TestPortForward(t *testing.T) {
 				cmd, root := clitest.New(t, "port-forward", workspace.Name, flag1, flag2)
 				clitest.SetupConfig(t, client, root)
 				buf := newThreadSafeBuffer()
-				cmd.SetOut(io.MultiWriter(buf, os.Stderr))
+				cmd.SetOut(buf)
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				errC := make(chan error)
@@ -257,7 +256,7 @@ func TestPortForward(t *testing.T) {
 		cmd, root := clitest.New(t, "port-forward", workspace.Name, flag)
 		clitest.SetupConfig(t, client, root)
 		buf := newThreadSafeBuffer()
-		cmd.SetOut(io.MultiWriter(buf, os.Stderr))
+		cmd.SetOut(buf)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		errC := make(chan error)
@@ -317,7 +316,7 @@ func TestPortForward(t *testing.T) {
 		cmd, root := clitest.New(t, append([]string{"port-forward", workspace.Name}, flags...)...)
 		clitest.SetupConfig(t, client, root)
 		buf := newThreadSafeBuffer()
-		cmd.SetOut(io.MultiWriter(buf, os.Stderr))
+		cmd.SetOut(buf)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		errC := make(chan error)


### PR DESCRIPTION
- fix: Default all clitest commands to io.Discard stdout/err
- fix: Never write to stdout or stderr in tests

