### PR TITLE
fix: (Re-)enable TestPasswordTerminalState test

### DIFF
--- a/cli/cliui/prompt_test.go
+++ b/cli/cliui/prompt_test.go
@@ -165,9 +165,6 @@ func newPrompt(ptty *ptytest.PTY, opts cliui.PromptOptions, cmdOpt func(cmd *cob
 }
 
 func TestPasswordTerminalState(t *testing.T) {
-	// TODO: fix this test so that it runs reliably
-	t.Skip()
-
 	if os.Getenv("TEST_SUBPROCESS") == "1" {
 		passwordHelper()
 		return
@@ -192,20 +189,21 @@ func TestPasswordTerminalState(t *testing.T) {
 	defer process.Kill()
 
 	ptty.ExpectMatch("Password: ")
-	time.Sleep(100 * time.Millisecond) // wait for child process to turn off echo and start reading input
 
-	echo, err := ptyWithFlags.EchoEnabled()
-	require.NoError(t, err)
-	require.False(t, echo, "echo is on while reading password")
+	require.Eventually(t, func() bool {
+		echo, err := ptyWithFlags.EchoEnabled()
+		return err == nil && !echo
+	}, 5*time.Second, 50*time.Millisecond, "echo is on while reading password")
 
 	err = process.Signal(os.Interrupt)
 	require.NoError(t, err)
 	_, err = process.Wait()
 	require.NoError(t, err)
 
-	echo, err = ptyWithFlags.EchoEnabled()
-	require.NoError(t, err)
-	require.True(t, echo, "echo is off after reading password")
+	require.Eventually(t, func() bool {
+		echo, err := ptyWithFlags.EchoEnabled()
+		return err == nil && echo
+	}, 5*time.Second, 50*time.Millisecond, "echo is off after reading password")
 }
 
 // nolint:unused


### PR DESCRIPTION
Noticed this one was disabled when changing command outputs, thought it could be re-enabled with a `require.Eventually`.
