### PR TITLE
fix: Rewrite ptytest to buffer stdout

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -245,9 +245,10 @@ func (b *stdbuf) closeErr(err error) error {
 		return err
 	}
 	if err == nil {
-		err = io.EOF
+		b.err = io.EOF
+	} else {
+		b.err = err
 	}
-	b.err = err
 	close(b.more)
-	return b.err
+	return err
 }

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -171,7 +171,7 @@ func newStdbuf() *stdbuf {
 
 func (b *stdbuf) Read(p []byte) (int, error) {
 	if b.r == nil {
-		return b.read(p)
+		return b.readOrWaitForMore(p)
 	}
 
 	n, err := b.r.Read(p)
@@ -179,13 +179,13 @@ func (b *stdbuf) Read(p []byte) (int, error) {
 		b.r = nil
 		err = nil
 		if n == 0 {
-			return b.read(p)
+			return b.readOrWaitForMore(p)
 		}
 	}
 	return n, err
 }
 
-func (b *stdbuf) read(p []byte) (int, error) {
+func (b *stdbuf) readOrWaitForMore(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -120,7 +120,10 @@ func (p *PTY) ExpectMatch(str string) string {
 		p.t.Logf("%s: matched %q = %q", time.Now(), str, buffer.String())
 		return buffer.String()
 	case <-timeout.Done():
+		// Ensure goroutine is cleaned up before test exit.
 		_ = p.out.closeErr(p.Close())
+		<-match
+
 		p.t.Fatalf("%s: match exceeded deadline: wanted %q; got %q", time.Now(), str, buffer.String())
 		return ""
 	}

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -93,22 +93,21 @@ func (p *PTY) ExpectMatch(str string) string {
 	match := make(chan error, 1)
 	go func() {
 		defer close(match)
-		for {
-			r, _, err := p.runeReader.ReadRune()
-			if err != nil {
-				match <- err
-				return
+		match <- func() error {
+			for {
+				r, _, err := p.runeReader.ReadRune()
+				if err != nil {
+					return err
+				}
+				_, err = buffer.WriteRune(r)
+				if err != nil {
+					return err
+				}
+				if strings.Contains(buffer.String(), str) {
+					return nil
+				}
 			}
-			_, err = buffer.WriteRune(r)
-			if err != nil {
-				match <- err
-				return
-			}
-			if strings.Contains(buffer.String(), str) {
-				match <- nil
-				return
-			}
-		}
+		}()
 	}()
 
 	select {

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -86,7 +86,7 @@ type PTY struct {
 func (p *PTY) ExpectMatch(str string) string {
 	p.t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var buffer bytes.Buffer
@@ -119,7 +119,7 @@ func (p *PTY) ExpectMatch(str string) string {
 		}
 		p.t.Logf("%s: matched %q = %q", time.Now(), str, buffer.String())
 		return buffer.String()
-	case <-ctx.Done():
+	case <-timeout.Done():
 		_ = p.out.closeErr(p.Close())
 		p.t.Fatalf("%s: match exceeded deadline: wanted %q; got %q", time.Now(), str, buffer.String())
 		return ""

--- a/pty/ptytest/ptytest_internal_test.go
+++ b/pty/ptytest/ptytest_internal_test.go
@@ -1,0 +1,31 @@
+package ptytest
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStdbuf(t *testing.T) {
+	t.Parallel()
+
+	var got bytes.Buffer
+
+	b := newStdbuf()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		io.Copy(&got, b)
+	}()
+
+	b.Write([]byte("hello "))
+	b.Write([]byte("world\n"))
+	b.Write([]byte("bye\n"))
+
+	b.Close()
+	<-done
+
+	assert.Equal(t, "hello world\nbye\n", got.String())
+}

--- a/pty/ptytest/ptytest_internal_test.go
+++ b/pty/ptytest/ptytest_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStdbuf(t *testing.T) {
@@ -17,14 +18,19 @@ func TestStdbuf(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		io.Copy(&got, b)
+		_, err := io.Copy(&got, b)
+		assert.NoError(t, err)
 	}()
 
-	b.Write([]byte("hello "))
-	b.Write([]byte("world\n"))
-	b.Write([]byte("bye\n"))
+	_, err := b.Write([]byte("hello "))
+	require.NoError(t, err)
+	_, err = b.Write([]byte("world\n"))
+	require.NoError(t, err)
+	_, err = b.Write([]byte("bye\n"))
+	require.NoError(t, err)
 
-	b.Close()
+	err = b.Close()
+	require.NoError(t, err)
 	<-done
 
 	assert.Equal(t, "hello world\nbye\n", got.String())

--- a/pty/ptytest/ptytest_test.go
+++ b/pty/ptytest/ptytest_test.go
@@ -2,7 +2,6 @@ package ptytest_test
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -22,26 +21,24 @@ func TestPtytest(t *testing.T) {
 		pty.WriteLine("read")
 	})
 
+	// See https://github.com/coder/coder/issues/2122 for the motivation
+	// behind this test.
 	t.Run("Cobra ptytest should not hang when output is not consumed", func(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
 			name          string
 			output        string
-			isPlatformBug bool // See https://github.com/coder/coder/issues/2122 for more info.
+			isPlatformBug bool
 		}{
 			{name: "1024 is safe (does not exceed macOS buffer)", output: strings.Repeat(".", 1024)},
-			{name: "1025 exceeds macOS buffer (must not hang)", output: strings.Repeat(".", 1025), isPlatformBug: true},
-			{name: "10241 large output", output: strings.Repeat(".", 10241), isPlatformBug: true}, // 1024 * 10 + 1
+			{name: "1025 exceeds macOS buffer (must not hang)", output: strings.Repeat(".", 1025)},
+			{name: "10241 large output", output: strings.Repeat(".", 10241)}, // 1024 * 10 + 1
 		}
 		for _, tt := range tests {
 			tt := tt
 			// nolint:paralleltest // Avoid parallel test to more easily identify the issue.
 			t.Run(tt.name, func(t *testing.T) {
-				if tt.isPlatformBug && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
-					t.Skip("This test hangs on macOS and Windows, see https://github.com/coder/coder/issues/2122")
-				}
-
 				cmd := cobra.Command{
 					Use: "test",
 					RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
With this PR we now always buffer command output.

The `ExpectMatch` function was also refactored a bit to avoid a race where a timeout could fire whilst writing to buffer (concurrent read/write), or a timeout could fail the test just as it succeeds.

Fixes #2122
