### PR TITLE
feat: improve coder users show output, add json format

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -471,8 +471,8 @@ download the server version with: 'curl -L https://coder.com/install.sh | sh -s 
 	if !buildinfo.VersionsMatch(clientVersion, info.Version) {
 		warn := cliui.Styles.Warn.Copy().Align(lipgloss.Left)
 		// Trim the leading 'v', our install.sh script does not handle this case well.
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), warn.Render(fmtWarningText), clientVersion, info.Version, strings.TrimPrefix(info.CanonicalVersion(), "v"))
-		_, _ = fmt.Fprintln(cmd.OutOrStdout())
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), warn.Render(fmtWarningText), clientVersion, info.Version, strings.TrimPrefix(info.CanonicalVersion(), "v"))
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 	}
 
 	return nil

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -1,15 +1,27 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/codersdk"
 )
 
 func userList() *cobra.Command {
-	var columns []string
+	var (
+		columns      []string
+		outputFormat string
+	)
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -23,17 +35,34 @@ func userList() *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), displayUsers(columns, users...))
+			out := ""
+			switch outputFormat {
+			case "table", "":
+				out = displayUsers(columns, users...)
+			case "json":
+				outBytes, err := json.Marshal(users)
+				if err != nil {
+					return xerrors.Errorf("marshal users to JSON: %w", err)
+				}
+
+				out = string(outBytes)
+			default:
+				return xerrors.Errorf(`unknown output format %q, only "table" and "json" are supported`, outputFormat)
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), out)
 			return err
 		},
 	}
-	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"username", "email", "created_at"},
-		"Specify a column to filter in the table.")
+
+	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"username", "email", "created_at", "status"},
+		"Specify a column to filter in the table. Available columns are: id, username, email, created_at, status.")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format. Available formats are: table, json.")
 	return cmd
 }
 
 func userSingle() *cobra.Command {
-	var columns []string
+	var outputFormat string
 	cmd := &cobra.Command{
 		Use:   "show <username|user_id|'me'>",
 		Short: "Show a single user. Use 'me' to indicate the currently authenticated user.",
@@ -54,11 +83,89 @@ func userSingle() *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), displayUsers(columns, user))
+			out := ""
+			switch outputFormat {
+			case "table", "":
+				out = displayUser(cmd.Context(), cmd.ErrOrStderr(), client, user)
+			case "json":
+				outBytes, err := json.Marshal(user)
+				if err != nil {
+					return xerrors.Errorf("marshal user to JSON: %w", err)
+				}
+
+				out = string(outBytes)
+			default:
+				return xerrors.Errorf(`unknown output format %q, only "table" and "json" are supported`, outputFormat)
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), out)
 			return err
 		},
 	}
-	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"username", "email", "created_at"},
-		"Specify a column to filter in the table.")
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format. Available formats are: table, json.")
 	return cmd
+}
+
+func displayUser(ctx context.Context, stderr io.Writer, client *codersdk.Client, user codersdk.User) string {
+	tableWriter := cliui.Table()
+	addRow := func(name string, value interface{}) {
+		key := ""
+		if name != "" {
+			key = name + ":"
+		}
+		tableWriter.AppendRow(table.Row{
+			key, value,
+		})
+	}
+
+	// Add rows for each of the user's fields.
+	addRow("ID", user.ID.String())
+	addRow("Username", user.Username)
+	addRow("Email", user.Email)
+	addRow("Status", user.Status)
+	addRow("Created At", user.CreatedAt.Format(time.Stamp))
+
+	addRow("", "")
+	firstRole := true
+	for _, role := range user.Roles {
+		if role.DisplayName == "" {
+			// Skip roles with no display name.
+			continue
+		}
+
+		key := ""
+		if firstRole {
+			key = "Roles"
+			firstRole = false
+		}
+		addRow(key, role.DisplayName)
+	}
+	if firstRole {
+		addRow("Roles", "(none)")
+	}
+
+	addRow("", "")
+	firstOrg := true
+	for _, orgID := range user.OrganizationIDs {
+		org, err := client.Organization(ctx, orgID)
+		if err != nil {
+			warn := cliui.Styles.Warn.Copy().Align(lipgloss.Left)
+			_, _ = fmt.Fprintf(stderr, warn.Render("Could not fetch organization %s: %+v"), orgID, err)
+			continue
+		}
+
+		key := ""
+		if firstOrg {
+			key = "Organizations"
+			firstOrg = false
+		}
+
+		addRow(key, org.Name)
+	}
+	if firstOrg {
+		addRow("Organizations", "(none)")
+	}
+
+	return tableWriter.Render()
 }

--- a/cli/users.go
+++ b/cli/users.go
@@ -35,7 +35,7 @@ func displayUsers(filterColumns []string, users ...codersdk.User) string {
 	tableWriter.AppendHeader(header)
 	tableWriter.SetColumnConfigs(cliui.FilterTableColumns(header, filterColumns))
 	tableWriter.SortBy([]table.SortBy{{
-		Name: "Username",
+		Name: "username",
 	}})
 	for _, user := range users {
 		tableWriter.AppendRow(table.Row{


### PR DESCRIPTION
Improves the output of `coder users show <username>` to be kinda similar to `kubectl describe` and show more information.

<img width="441" alt="image" src="https://user-images.githubusercontent.com/11241812/180821528-d00d4255-0228-4c98-8c4d-18ee5c99c1cc.png">

Adds `-o json` to both `coder users list` and `coder users show <username>` which will output the user(s) as JSON instead of a pretty printed table.

Fixes #2376 
Fixes #2369 
