### PR TITLE
chore: Increase style/gen CI test timeout

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -148,7 +148,7 @@ jobs:
 
   gen:
     name: "style/gen"
-    timeout-minutes: 5
+    timeout-minutes: 8
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.docs-only == 'false'


### PR DESCRIPTION
Last week this test took ~4m, now I'm running into timeout at 5 minutes multiple times.

Bumping this to 8m so it's 2x what is used to take, should allow to account for CI fluctuations.
