### PR TITLE
Return proper exit code on ssh with TTY

### DIFF
--- a/pty/pty.go
+++ b/pty/pty.go
@@ -29,6 +29,16 @@ type PTY interface {
 	Resize(height uint16, width uint16) error
 }
 
+// Process represents a process running in a PTY
+type Process interface {
+
+	// Wait for the command to complete.  Returned error is as for exec.Cmd.Wait()
+	Wait() error
+
+	// Kill the command process.  Returned error is as for os.Process.Kill()
+	Kill() error
+}
+
 // WithFlags represents a PTY whose flags can be inspected, in particular
 // to determine whether local echo is enabled.
 type WithFlags interface {

--- a/pty/pty_windows.go
+++ b/pty/pty_windows.go
@@ -5,6 +5,7 @@ package pty
 
 import (
 	"os"
+	"os/exec"
 	"sync"
 	"unsafe"
 
@@ -66,6 +67,13 @@ type ptyWindows struct {
 	closed     bool
 }
 
+type windowsProcess struct {
+	// cmdDone protects access to cmdErr: anything reading cmdErr should read from cmdDone first.
+	cmdDone chan any
+	cmdErr  error
+	proc    *os.Process
+}
+
 func (p *ptyWindows) Output() ReadWriter {
 	return ReadWriter{
 		Reader: p.outputRead,
@@ -110,4 +118,26 @@ func (p *ptyWindows) Close() error {
 	}
 
 	return nil
+}
+
+func (p *windowsProcess) waitInternal() {
+	defer close(p.cmdDone)
+	state, err := p.proc.Wait()
+	if err != nil {
+		p.cmdErr = err
+		return
+	}
+	if !state.Success() {
+		p.cmdErr = &exec.ExitError{ProcessState: state}
+		return
+	}
+}
+
+func (p *windowsProcess) Wait() error {
+	<-p.cmdDone
+	return p.cmdErr
+}
+
+func (p *windowsProcess) Kill() error {
+	return p.proc.Kill()
 }

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -27,7 +26,7 @@ func New(t *testing.T) *PTY {
 	return create(t, ptty, "cmd")
 }
 
-func Start(t *testing.T, cmd *exec.Cmd) (*PTY, *os.Process) {
+func Start(t *testing.T, cmd *exec.Cmd) (*PTY, pty.Process) {
 	ptty, ps, err := pty.Start(cmd)
 	require.NoError(t, err)
 	return create(t, ptty, cmd.Args[0]), ps

--- a/pty/start.go
+++ b/pty/start.go
@@ -1,10 +1,11 @@
 package pty
 
 import (
-	"os"
 	"os/exec"
 )
 
-func Start(cmd *exec.Cmd) (PTY, *os.Process, error) {
+// Start the command in a TTY.  The calling code must not use cmd after passing it to the PTY, and
+// instead rely on the returned Process to manage the command/process.
+func Start(cmd *exec.Cmd) (PTY, Process, error) {
 	return startPty(cmd)
 }

--- a/pty/start_other.go
+++ b/pty/start_other.go
@@ -4,7 +4,6 @@
 package pty
 
 import (
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -14,7 +13,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func startPty(cmd *exec.Cmd) (PTY, *os.Process, error) {
+func startPty(cmd *exec.Cmd) (PTY, Process, error) {
 	ptty, tty, err := pty.Open()
 	if err != nil {
 		return nil, nil, xerrors.Errorf("open: %w", err)
@@ -37,16 +36,15 @@ func startPty(cmd *exec.Cmd) (PTY, *os.Process, error) {
 		}
 		return nil, nil, xerrors.Errorf("start: %w", err)
 	}
-	go func() {
-		// The GC can garbage collect the TTY FD before the command
-		// has finished running. See:
-		// https://github.com/creack/pty/issues/127#issuecomment-932764012
-		_ = cmd.Wait()
-		runtime.KeepAlive(ptty)
-	}()
 	oPty := &otherPty{
 		pty: ptty,
 		tty: tty,
 	}
-	return oPty, cmd.Process, nil
+	oProcess := &otherProcess{
+		pty:     ptty,
+		cmd:     cmd,
+		cmdDone: make(chan any),
+	}
+	go oProcess.waitInternal()
+	return oPty, oProcess, nil
 }

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -38,6 +38,6 @@ func TestStart(t *testing.T) {
 		err = ps.Wait()
 		var exitErr *exec.ExitError
 		require.True(t, xerrors.As(err, &exitErr))
-		assert.Equal(t, -1, exitErr.ExitCode())
+		assert.NotEqual(t, 0, exitErr.ExitCode())
 	})
 }

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -7,6 +7,10 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
 	"go.uber.org/goleak"
 
 	"github.com/coder/coder/pty/ptytest"
@@ -20,7 +24,20 @@ func TestStart(t *testing.T) {
 	t.Parallel()
 	t.Run("Echo", func(t *testing.T) {
 		t.Parallel()
-		pty, _ := ptytest.Start(t, exec.Command("echo", "test"))
+		pty, ps := ptytest.Start(t, exec.Command("echo", "test"))
 		pty.ExpectMatch("test")
+		err := ps.Wait()
+		require.NoError(t, err)
+	})
+
+	t.Run("Kill", func(t *testing.T) {
+		t.Parallel()
+		_, ps := ptytest.Start(t, exec.Command("sleep", "30"))
+		err := ps.Kill()
+		assert.NoError(t, err)
+		err = ps.Wait()
+		var exitErr *exec.ExitError
+		require.True(t, xerrors.As(err, &exitErr))
+		assert.Equal(t, -1, exitErr.ExitCode())
 	})
 }

--- a/pty/start_windows_test.go
+++ b/pty/start_windows_test.go
@@ -29,13 +29,13 @@ func TestStart(t *testing.T) {
 	})
 	t.Run("Resize", func(t *testing.T) {
 		t.Parallel()
-		pty := ptytest.Start(t, exec.Command("cmd.exe"))
+		pty, _ := ptytest.Start(t, exec.Command("cmd.exe"))
 		err := pty.Resize(100, 50)
 		require.NoError(t, err)
 	})
 	t.Run("Kill", func(t *testing.T) {
 		t.Parallel()
-		pty := ptytest.Start(t, exec.Command("cmd.exe"))
+		pty, ps := ptytest.Start(t, exec.Command("cmd.exe"))
 		err := ps.Kill()
 		assert.NoError(t, err)
 		err = ps.Wait()

--- a/pty/start_windows_test.go
+++ b/pty/start_windows_test.go
@@ -35,7 +35,7 @@ func TestStart(t *testing.T) {
 	})
 	t.Run("Kill", func(t *testing.T) {
 		t.Parallel()
-		pty, ps := ptytest.Start(t, exec.Command("cmd.exe"))
+		_, ps := ptytest.Start(t, exec.Command("cmd.exe"))
 		err := ps.Kill()
 		assert.NoError(t, err)
 		err = ps.Wait()

--- a/pty/start_windows_test.go
+++ b/pty/start_windows_test.go
@@ -41,6 +41,6 @@ func TestStart(t *testing.T) {
 		err = ps.Wait()
 		var exitErr *exec.ExitError
 		require.True(t, xerrors.As(err, &exitErr))
-		assert.Equal(t, -1, exitErr.ExitCode())
+		assert.NotEqual(t, 0, exitErr.ExitCode())
 	})
 }

--- a/pty/start_windows_test.go
+++ b/pty/start_windows_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/coder/coder/pty/ptytest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"golang.org/x/xerrors"
 )
 
 func TestMain(m *testing.M) {
@@ -20,13 +22,25 @@ func TestStart(t *testing.T) {
 	t.Parallel()
 	t.Run("Echo", func(t *testing.T) {
 		t.Parallel()
-		pty, _ := ptytest.Start(t, exec.Command("cmd.exe", "/c", "echo", "test"))
+		pty, ps := ptytest.Start(t, exec.Command("cmd.exe", "/c", "echo", "test"))
 		pty.ExpectMatch("test")
+		err := ps.Wait()
+		require.NoError(t, err)
 	})
 	t.Run("Resize", func(t *testing.T) {
 		t.Parallel()
-		pty, _ := ptytest.Start(t, exec.Command("cmd.exe"))
+		pty := ptytest.Start(t, exec.Command("cmd.exe"))
 		err := pty.Resize(100, 50)
 		require.NoError(t, err)
+	})
+	t.Run("Kill", func(t *testing.T) {
+		t.Parallel()
+		pty := ptytest.Start(t, exec.Command("cmd.exe"))
+		err := ps.Kill()
+		assert.NoError(t, err)
+		err = ps.Wait()
+		var exitErr *exec.ExitError
+		require.True(t, xerrors.As(err, &exitErr))
+		assert.Equal(t, -1, exitErr.ExitCode())
 	})
 }


### PR DESCRIPTION
Related to #3125  - JetBrains use the exit code of commands they run over SSH for logic, so it is important that we report them correctly.  They also request a TTY so they can send interrupt signals.

This PR updates our SSH agent to correctly return exit codes from SSH commands when a TTY is requested.  Previously, we ignored errors from the TTY entirely.

It fixes a previously ignored error where both the PTY code and the Agent code would `Wait()` on the command process, resulting in a race where one waiter would get a SystemCallError instead of the exit status.  Now only the PTY waits on the actual command.  Users can now Wait() on the PTY to get the results of the inner command running in it.

It also corrects an issue for non-TTY commands where we return exit code 1 any time the command returned non-zero: we now correctly return the actual exit code.

