### PR TITLE
fix: Fix dangling references in provisioner/terraform/testdata

### DIFF
--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -31,7 +31,7 @@ func TestConvertResources(t *testing.T) {
 			Name: "b",
 			Type: "null_resource",
 			Agents: []*proto.Agent{{
-				Name:            "dev",
+				Name:            "main",
 				OperatingSystem: "linux",
 				Architecture:    "amd64",
 				Auth:            &proto.Agent_Token{},
@@ -44,7 +44,7 @@ func TestConvertResources(t *testing.T) {
 			Name: "first",
 			Type: "null_resource",
 			Agents: []*proto.Agent{{
-				Name:            "dev",
+				Name:            "main",
 				OperatingSystem: "linux",
 				Architecture:    "amd64",
 				Auth:            &proto.Agent_Token{},
@@ -55,10 +55,10 @@ func TestConvertResources(t *testing.T) {
 		}},
 		// Ensures the instance ID authentication type surfaces.
 		"instance-id": {{
-			Name: "dev",
+			Name: "main",
 			Type: "null_resource",
 			Agents: []*proto.Agent{{
-				Name:            "dev",
+				Name:            "main",
 				OperatingSystem: "linux",
 				Architecture:    "amd64",
 				Auth:            &proto.Agent_InstanceId{},
@@ -70,7 +70,7 @@ func TestConvertResources(t *testing.T) {
 			Name: "example",
 			Type: "null_resource",
 			Agents: []*proto.Agent{{
-				Name:            "dev",
+				Name:            "main",
 				OperatingSystem: "linux",
 				Architecture:    "amd64",
 				Auth:            &proto.Agent_Token{},

--- a/provisioner/terraform/testdata/calling-module/calling-module.tf
+++ b/provisioner/terraform/testdata/calling-module/calling-module.tf
@@ -14,5 +14,5 @@ resource "coder_agent" "main" {
 
 module "module" {
   source = "./module"
-  script = coder_agent.dev.init_script
+  script = coder_agent.main.init_script
 }

--- a/provisioner/terraform/testdata/calling-module/calling-module.tfplan.dot
+++ b/provisioner/terraform/testdata/calling-module/calling-module.tfplan.dot
@@ -2,19 +2,19 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
 		"[root] module.module.data.null_data_source.script (expand)" [label = "module.module.data.null_data_source.script", shape = "box"]
 		"[root] module.module.null_resource.example (expand)" [label = "module.module.null_resource.example", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] module.module (close)" -> "[root] module.module.null_resource.example (expand)"
 		"[root] module.module.data.null_data_source.script (expand)" -> "[root] module.module.var.script (expand)"
 		"[root] module.module.data.null_data_source.script (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
 		"[root] module.module.null_resource.example (expand)" -> "[root] module.module.data.null_data_source.script (expand)"
-		"[root] module.module.var.script (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] module.module.var.script (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] module.module.var.script (expand)" -> "[root] module.module (expand)"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.main (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] module.module.null_resource.example (expand)"
 		"[root] root" -> "[root] module.module (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"

--- a/provisioner/terraform/testdata/calling-module/calling-module.tfplan.json
+++ b/provisioner/terraform/testdata/calling-module/calling-module.tfplan.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.1",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "planned_values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -60,10 +60,10 @@
   },
   "resource_changes": [
     {
-      "address": "coder_agent.dev",
+      "address": "coder_agent.main",
       "mode": "managed",
       "type": "coder_agent",
-      "name": "dev",
+      "name": "main",
       "provider_name": "registry.terraform.io/coder/coder",
       "change": {
         "actions": [
@@ -158,10 +158,10 @@
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_config_key": "coder",
           "expressions": {
             "arch": {
@@ -180,8 +180,8 @@
           "expressions": {
             "script": {
               "references": [
-                "coder_agent.dev.init_script",
-                "coder_agent.dev"
+                "coder_agent.main.init_script",
+                "coder_agent.main"
               ]
             }
           },
@@ -224,7 +224,7 @@
   },
   "relevant_attributes": [
     {
-      "resource": "coder_agent.dev",
+      "resource": "coder_agent.main",
       "attribute": [
         "init_script"
       ]

--- a/provisioner/terraform/testdata/calling-module/calling-module.tfstate.dot
+++ b/provisioner/terraform/testdata/calling-module/calling-module.tfstate.dot
@@ -2,19 +2,19 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
 		"[root] module.module.data.null_data_source.script (expand)" [label = "module.module.data.null_data_source.script", shape = "box"]
 		"[root] module.module.null_resource.example (expand)" [label = "module.module.null_resource.example", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] module.module (close)" -> "[root] module.module.null_resource.example (expand)"
 		"[root] module.module.data.null_data_source.script (expand)" -> "[root] module.module.var.script (expand)"
 		"[root] module.module.data.null_data_source.script (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
 		"[root] module.module.null_resource.example (expand)" -> "[root] module.module.data.null_data_source.script (expand)"
-		"[root] module.module.var.script (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] module.module.var.script (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] module.module.var.script (expand)" -> "[root] module.module (expand)"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.main (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] module.module.null_resource.example (expand)"
 		"[root] root" -> "[root] module.module (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"

--- a/provisioner/terraform/testdata/calling-module/calling-module.tfstate.json
+++ b/provisioner/terraform/testdata/calling-module/calling-module.tfstate.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.0",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -16,11 +16,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "66fed4b4-2246-4c0f-8e55-74e109ee0603",
+            "id": "78098841-3d6c-4aa7-9d3c-6e4c9be7e2df",
             "init_script": "",
             "os": "linux",
             "startup_script": null,
-            "token": "c7f7d527-3eab-4f77-8c0f-05f543bce5c1"
+            "token": "605d8d2c-a720-4422-9410-62b41e3e6565"
           },
           "sensitive_values": {}
         }
@@ -44,7 +44,7 @@
                 "outputs": {
                   "script": ""
                 },
-                "random": "2465369318401710566"
+                "random": "3340396623875729305"
               },
               "sensitive_values": {
                 "inputs": {},
@@ -59,12 +59,12 @@
               "provider_name": "registry.terraform.io/hashicorp/null",
               "schema_version": 0,
               "values": {
-                "id": "354396519773748320",
+                "id": "831556400374221454",
                 "triggers": null
               },
               "sensitive_values": {},
               "depends_on": [
-                "coder_agent.dev",
+                "coder_agent.main",
                 "module.module.data.null_data_source.script"
               ]
             }

--- a/provisioner/terraform/testdata/chaining-resources/chaining-resources.tf
+++ b/provisioner/terraform/testdata/chaining-resources/chaining-resources.tf
@@ -14,7 +14,7 @@ resource "coder_agent" "main" {
 
 resource "null_resource" "b" {
   depends_on = [
-    coder_agent.dev
+    coder_agent.main
   ]
 }
 

--- a/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfplan.dot
+++ b/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfplan.dot
@@ -2,16 +2,16 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
 		"[root] null_resource.a (expand)" [label = "null_resource.a", shape = "box"]
 		"[root] null_resource.b (expand)" [label = "null_resource.b", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] null_resource.a (expand)" -> "[root] null_resource.b (expand)"
-		"[root] null_resource.b (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] null_resource.b (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] null_resource.b (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.main (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.a (expand)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"

--- a/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfplan.json
+++ b/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfplan.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.1",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "planned_values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -50,10 +50,10 @@
   },
   "resource_changes": [
     {
-      "address": "coder_agent.dev",
+      "address": "coder_agent.main",
       "mode": "managed",
       "type": "coder_agent",
-      "name": "dev",
+      "name": "main",
       "provider_name": "registry.terraform.io/coder/coder",
       "change": {
         "actions": [
@@ -135,10 +135,10 @@
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_config_key": "coder",
           "expressions": {
             "arch": {
@@ -169,7 +169,7 @@
           "provider_config_key": "null",
           "schema_version": 0,
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         }
       ]

--- a/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfstate.dot
+++ b/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfstate.dot
@@ -2,16 +2,16 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
 		"[root] null_resource.a (expand)" [label = "null_resource.a", shape = "box"]
 		"[root] null_resource.b (expand)" [label = "null_resource.b", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] null_resource.a (expand)" -> "[root] null_resource.b (expand)"
-		"[root] null_resource.b (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] null_resource.b (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] null_resource.b (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.main (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.a (expand)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"

--- a/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfstate.json
+++ b/provisioner/terraform/testdata/chaining-resources/chaining-resources.tfstate.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.0",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -16,11 +16,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "44e31a74-646f-4f29-a979-ff0da7108ed6",
+            "id": "79e7cbba-c238-47f1-aec2-eb816385595d",
             "init_script": "",
             "os": "linux",
             "startup_script": null,
-            "token": "3c011212-912c-45f5-8cdb-84b7e03a8d44"
+            "token": "96cc0f63-c65b-4fea-90bb-073e57ddc766"
           },
           "sensitive_values": {}
         },
@@ -32,12 +32,12 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "5747685929405905376",
+            "id": "6159719504309004303",
             "triggers": null
           },
           "sensitive_values": {},
           "depends_on": [
-            "coder_agent.dev",
+            "coder_agent.main",
             "null_resource.b"
           ]
         },
@@ -49,12 +49,12 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "4234681175686342228",
+            "id": "5246585857846899839",
             "triggers": null
           },
           "sensitive_values": {},
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         }
       ]

--- a/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tf
+++ b/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tf
@@ -14,12 +14,12 @@ resource "coder_agent" "main" {
 
 resource "null_resource" "first" {
   depends_on = [
-    coder_agent.dev
+    coder_agent.main
   ]
 }
 
 resource "null_resource" "second" {
   depends_on = [
-    coder_agent.dev
+    coder_agent.main
   ]
 }

--- a/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfplan.dot
+++ b/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfplan.dot
@@ -2,17 +2,17 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
 		"[root] null_resource.first (expand)" [label = "null_resource.first", shape = "box"]
 		"[root] null_resource.second (expand)" [label = "null_resource.second", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
-		"[root] null_resource.first (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] null_resource.first (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] null_resource.first (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] null_resource.second (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] null_resource.second (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] null_resource.second (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.main (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.first (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.second (expand)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"

--- a/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfplan.json
+++ b/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfplan.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.1",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "planned_values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -50,10 +50,10 @@
   },
   "resource_changes": [
     {
-      "address": "coder_agent.dev",
+      "address": "coder_agent.main",
       "mode": "managed",
       "type": "coder_agent",
-      "name": "dev",
+      "name": "main",
       "provider_name": "registry.terraform.io/coder/coder",
       "change": {
         "actions": [
@@ -135,10 +135,10 @@
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_config_key": "coder",
           "expressions": {
             "arch": {
@@ -158,7 +158,7 @@
           "provider_config_key": "null",
           "schema_version": 0,
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         },
         {
@@ -169,7 +169,7 @@
           "provider_config_key": "null",
           "schema_version": 0,
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         }
       ]

--- a/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfstate.dot
+++ b/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfstate.dot
@@ -2,17 +2,17 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
 		"[root] null_resource.first (expand)" [label = "null_resource.first", shape = "box"]
 		"[root] null_resource.second (expand)" [label = "null_resource.second", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
-		"[root] null_resource.first (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] null_resource.first (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] null_resource.first (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] null_resource.second (expand)" -> "[root] coder_agent.dev (expand)"
+		"[root] null_resource.second (expand)" -> "[root] coder_agent.main (expand)"
 		"[root] null_resource.second (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.main (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.first (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.second (expand)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"

--- a/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfstate.json
+++ b/provisioner/terraform/testdata/conflicting-resources/conflicting-resources.tfstate.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.0",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -16,11 +16,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "99a85fe5-719f-4d20-8dd9-d02e7d477c45",
+            "id": "1c27d2eb-c2e3-4391-b3a2-5e3f57ae9ec6",
             "init_script": "",
             "os": "linux",
             "startup_script": null,
-            "token": "7bdf3592-b3d0-42f8-8e81-132903f28614"
+            "token": "c0dbedc7-fb3d-4b77-a3f8-6c84c688db57"
           },
           "sensitive_values": {}
         },
@@ -32,12 +32,12 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "5367760563120181345",
+            "id": "2210256189362430895",
             "triggers": null
           },
           "sensitive_values": {},
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         },
         {
@@ -48,12 +48,12 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "3224902069148001434",
+            "id": "7017926349421667565",
             "triggers": null
           },
           "sensitive_values": {},
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         }
       ]

--- a/provisioner/terraform/testdata/instance-id/instance-id.tf
+++ b/provisioner/terraform/testdata/instance-id/instance-id.tf
@@ -13,13 +13,13 @@ resource "coder_agent" "main" {
   auth = "google-instance-identity"
 }
 
-resource "null_resource" "dev" {
+resource "null_resource" "main" {
   depends_on = [
-    coder_agent.dev
+    coder_agent.main
   ]
 }
 
-resource "coder_agent_instance" "dev" {
-  agent_id    = coder_agent.dev.id
+resource "coder_agent_instance" "main" {
+  agent_id    = coder_agent.main.id
   instance_id = "example"
 }

--- a/provisioner/terraform/testdata/instance-id/instance-id.tfplan.dot
+++ b/provisioner/terraform/testdata/instance-id/instance-id.tfplan.dot
@@ -2,17 +2,17 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
-		"[root] coder_agent_instance.dev (expand)" [label = "coder_agent_instance.dev", shape = "box"]
-		"[root] null_resource.dev (expand)" [label = "null_resource.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
+		"[root] coder_agent_instance.main (expand)" [label = "coder_agent_instance.main", shape = "box"]
+		"[root] null_resource.main (expand)" [label = "null_resource.main", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
-		"[root] coder_agent_instance.dev (expand)" -> "[root] coder_agent.dev (expand)"
-		"[root] null_resource.dev (expand)" -> "[root] coder_agent.dev (expand)"
-		"[root] null_resource.dev (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent_instance.dev (expand)"
-		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.dev (expand)"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent_instance.main (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] null_resource.main (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] null_resource.main (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent_instance.main (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.main (expand)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
 	}

--- a/provisioner/terraform/testdata/instance-id/instance-id.tfplan.json
+++ b/provisioner/terraform/testdata/instance-id/instance-id.tfplan.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.1",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "planned_values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -22,10 +22,10 @@
           "sensitive_values": {}
         },
         {
-          "address": "coder_agent_instance.dev",
+          "address": "coder_agent_instance.main",
           "mode": "managed",
           "type": "coder_agent_instance",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -34,10 +34,10 @@
           "sensitive_values": {}
         },
         {
-          "address": "null_resource.dev",
+          "address": "null_resource.main",
           "mode": "managed",
           "type": "null_resource",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
@@ -50,10 +50,10 @@
   },
   "resource_changes": [
     {
-      "address": "coder_agent.dev",
+      "address": "coder_agent.main",
       "mode": "managed",
       "type": "coder_agent",
-      "name": "dev",
+      "name": "main",
       "provider_name": "registry.terraform.io/coder/coder",
       "change": {
         "actions": [
@@ -78,10 +78,10 @@
       }
     },
     {
-      "address": "coder_agent_instance.dev",
+      "address": "coder_agent_instance.main",
       "mode": "managed",
       "type": "coder_agent_instance",
-      "name": "dev",
+      "name": "main",
       "provider_name": "registry.terraform.io/coder/coder",
       "change": {
         "actions": [
@@ -100,10 +100,10 @@
       }
     },
     {
-      "address": "null_resource.dev",
+      "address": "null_resource.main",
       "mode": "managed",
       "type": "null_resource",
-      "name": "dev",
+      "name": "main",
       "provider_name": "registry.terraform.io/hashicorp/null",
       "change": {
         "actions": [
@@ -136,10 +136,10 @@
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_config_key": "coder",
           "expressions": {
             "arch": {
@@ -155,16 +155,16 @@
           "schema_version": 0
         },
         {
-          "address": "coder_agent_instance.dev",
+          "address": "coder_agent_instance.main",
           "mode": "managed",
           "type": "coder_agent_instance",
-          "name": "dev",
+          "name": "main",
           "provider_config_key": "coder",
           "expressions": {
             "agent_id": {
               "references": [
-                "coder_agent.dev.id",
-                "coder_agent.dev"
+                "coder_agent.main.id",
+                "coder_agent.main"
               ]
             },
             "instance_id": {
@@ -174,14 +174,14 @@
           "schema_version": 0
         },
         {
-          "address": "null_resource.dev",
+          "address": "null_resource.main",
           "mode": "managed",
           "type": "null_resource",
-          "name": "dev",
+          "name": "main",
           "provider_config_key": "null",
           "schema_version": 0,
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         }
       ]
@@ -189,7 +189,7 @@
   },
   "relevant_attributes": [
     {
-      "resource": "coder_agent.dev",
+      "resource": "coder_agent.main",
       "attribute": [
         "id"
       ]

--- a/provisioner/terraform/testdata/instance-id/instance-id.tfstate.dot
+++ b/provisioner/terraform/testdata/instance-id/instance-id.tfstate.dot
@@ -2,17 +2,17 @@ digraph {
 	compound = "true"
 	newrank = "true"
 	subgraph "root" {
-		"[root] coder_agent.dev (expand)" [label = "coder_agent.dev", shape = "box"]
-		"[root] coder_agent_instance.dev (expand)" [label = "coder_agent_instance.dev", shape = "box"]
-		"[root] null_resource.dev (expand)" [label = "null_resource.dev", shape = "box"]
+		"[root] coder_agent.main (expand)" [label = "coder_agent.main", shape = "box"]
+		"[root] coder_agent_instance.main (expand)" [label = "coder_agent_instance.main", shape = "box"]
+		"[root] null_resource.main (expand)" [label = "null_resource.main", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
-		"[root] coder_agent.dev (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
-		"[root] coder_agent_instance.dev (expand)" -> "[root] coder_agent.dev (expand)"
-		"[root] null_resource.dev (expand)" -> "[root] coder_agent.dev (expand)"
-		"[root] null_resource.dev (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
-		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent_instance.dev (expand)"
-		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.dev (expand)"
+		"[root] coder_agent.main (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] coder_agent_instance.main (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] null_resource.main (expand)" -> "[root] coder_agent.main (expand)"
+		"[root] null_resource.main (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent_instance.main (expand)"
+		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.main (expand)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
 	}

--- a/provisioner/terraform/testdata/instance-id/instance-id.tfstate.json
+++ b/provisioner/terraform/testdata/instance-id/instance-id.tfstate.json
@@ -1,14 +1,14 @@
 {
   "format_version": "1.0",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "values": {
     "root_module": {
       "resources": [
         {
-          "address": "coder_agent.dev",
+          "address": "coder_agent.main",
           "mode": "managed",
           "type": "coder_agent",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
@@ -16,45 +16,45 @@
             "auth": "google-instance-identity",
             "dir": null,
             "env": null,
-            "id": "af919173-b148-4852-9552-453c5665efc4",
+            "id": "0c214e55-a886-4b2b-a3b5-a3eaf55be2f4",
             "init_script": "",
             "os": "linux",
             "startup_script": null,
-            "token": "06bcca4d-b37f-4f82-8fcb-f3c00387748a"
+            "token": "afeac870-ff84-4bd9-952b-0325f8e4266a"
           },
           "sensitive_values": {}
         },
         {
-          "address": "coder_agent_instance.dev",
+          "address": "coder_agent_instance.main",
           "mode": "managed",
           "type": "coder_agent_instance",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
-            "agent_id": "af919173-b148-4852-9552-453c5665efc4",
-            "id": "f90a6c0f-11c1-4737-982f-e54590c46cea",
+            "agent_id": "0c214e55-a886-4b2b-a3b5-a3eaf55be2f4",
+            "id": "e48f98eb-6d1a-4fe9-8526-3ad92ac54dc9",
             "instance_id": "example"
           },
           "sensitive_values": {},
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         },
         {
-          "address": "null_resource.dev",
+          "address": "null_resource.main",
           "mode": "managed",
           "type": "null_resource",
-          "name": "dev",
+          "name": "main",
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "4993832153889617160",
+            "id": "565648463520883027",
             "triggers": null
           },
           "sensitive_values": {},
           "depends_on": [
-            "coder_agent.dev"
+            "coder_agent.main"
           ]
         }
       ]

--- a/provisioner/terraform/testdata/multiple-agents/multiple-agents.tfplan.json
+++ b/provisioner/terraform/testdata/multiple-agents/multiple-agents.tfplan.json
@@ -1,6 +1,6 @@
 {
   "format_version": "1.1",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "planned_values": {
     "root_module": {
       "resources": [

--- a/provisioner/terraform/testdata/multiple-agents/multiple-agents.tfstate.json
+++ b/provisioner/terraform/testdata/multiple-agents/multiple-agents.tfstate.json
@@ -1,6 +1,6 @@
 {
   "format_version": "1.0",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "values": {
     "root_module": {
       "resources": [
@@ -16,11 +16,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "521a6bee-1193-468f-bbe9-4a25a870a9f0",
+            "id": "7a5de656-7e69-4cb2-9ae1-8bed34e62f13",
             "init_script": "",
             "os": "linux",
             "startup_script": null,
-            "token": "ee0452e2-7efe-4a84-9407-e871c7c4f4c4"
+            "token": "03d9d621-c589-4b89-8bc1-07acb60c4c4d"
           },
           "sensitive_values": {}
         },
@@ -36,11 +36,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "f1c2eb3a-2303-4499-8cfc-5a63f5d57def",
+            "id": "8dadb875-f4af-4827-b701-5e22815cbd72",
             "init_script": "",
             "os": "darwin",
             "startup_script": null,
-            "token": "15ea44b7-acd7-41d5-98a3-93ac23bd2b84"
+            "token": "b431714b-b2e9-45d7-969f-bf93f5cc0dab"
           },
           "sensitive_values": {}
         },
@@ -56,11 +56,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "445a229e-6886-46ba-9947-94d39b90b941",
+            "id": "7947e78a-70b6-4fed-aa0e-5b262cf531dc",
             "init_script": "",
             "os": "windows",
             "startup_script": null,
-            "token": "26a999c8-d281-46da-a296-15318d4c0998"
+            "token": "93b837fb-0676-4d52-a343-b6668adeb733"
           },
           "sensitive_values": {}
         },
@@ -72,7 +72,7 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "6903043049471472110",
+            "id": "2338175068284005953",
             "triggers": null
           },
           "sensitive_values": {},

--- a/provisioner/terraform/testdata/multiple-apps/multiple-apps.tfplan.json
+++ b/provisioner/terraform/testdata/multiple-apps/multiple-apps.tfplan.json
@@ -1,6 +1,6 @@
 {
   "format_version": "1.1",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "planned_values": {
     "root_module": {
       "resources": [

--- a/provisioner/terraform/testdata/multiple-apps/multiple-apps.tfstate.json
+++ b/provisioner/terraform/testdata/multiple-apps/multiple-apps.tfstate.json
@@ -1,6 +1,6 @@
 {
   "format_version": "1.0",
-  "terraform_version": "1.2.2",
+  "terraform_version": "1.2.5",
   "values": {
     "root_module": {
       "resources": [
@@ -16,11 +16,11 @@
             "auth": "token",
             "dir": null,
             "env": null,
-            "id": "d613fec9-933b-490f-97c7-7e6527e02a91",
+            "id": "7ad4fa50-dc01-49dc-ac83-8ad5740aa0cb",
             "init_script": "",
             "os": "linux",
             "startup_script": null,
-            "token": "564c308a-5d9e-42f9-b2a5-da28d3c04a90"
+            "token": "eafde061-9020-409c-b258-bde0a8d05075"
           },
           "sensitive_values": {}
         },
@@ -32,10 +32,10 @@
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
-            "agent_id": "d613fec9-933b-490f-97c7-7e6527e02a91",
+            "agent_id": "7ad4fa50-dc01-49dc-ac83-8ad5740aa0cb",
             "command": null,
             "icon": null,
-            "id": "2b92ebdb-1169-4247-b039-87aeaeaf55b3",
+            "id": "9cea1631-c146-4996-9e29-7977cfe62a23",
             "name": null,
             "relative_path": null,
             "url": null
@@ -53,10 +53,10 @@
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 0,
           "values": {
-            "agent_id": "d613fec9-933b-490f-97c7-7e6527e02a91",
+            "agent_id": "7ad4fa50-dc01-49dc-ac83-8ad5740aa0cb",
             "command": null,
             "icon": null,
-            "id": "80eedec0-8816-4c8d-96b7-3aa3d5b5cef8",
+            "id": "4d9b0721-3630-4807-b3f6-0114a9ccd938",
             "name": null,
             "relative_path": null,
             "url": null
@@ -74,7 +74,7 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "3551148082877575423",
+            "id": "4241115483797204647",
             "triggers": null
           },
           "sensitive_values": {},


### PR DESCRIPTION
A recent PR (#3150) updated several of the Terraform test data files in `provisioner/terraform/testdata` to rename agent resources from `dev` to `main`. However, some references to those resources were still using the old names, causing the Terraform modules to fail to compile. This wasn't caught in CI because the test suite is still using plan/state files that were generated before the change.

This PR fixes those references, regenerates the Terraform plan/state output files so that they match the .tf files they're derived from (using `provisioner/terraform/testdata/generate.sh`), and updates the Go test cases to expect the new names.

The changes to the generated .tfplan/.tfstate files are a bit verbose, but they consist entirely of:
* Replacing `dev` to `main`
* Bumping the `terraform-provider-coder` version in the state from 1.2.2 to 1.2.5
* Random values (e.g. UUIDs) that were regenerated