### PR TITLE
fix: Use stdin/out defined in command

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -106,7 +106,7 @@ func server() *cobra.Command {
 		Short: "Start a Coder server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printLogo(cmd, spooky)
-			logger := slog.Make(sloghuman.Sink(os.Stderr))
+			logger := slog.Make(sloghuman.Sink(cmd.ErrOrStderr()))
 			if verbose {
 				logger = logger.Leveled(slog.LevelDebug)
 			}
@@ -348,7 +348,7 @@ func server() *cobra.Command {
 			}
 
 			// This prevents the pprof import from being accidentally deleted.
-			var _ = pprof.Handler
+			_ = pprof.Handler
 			if pprofEnabled {
 				//nolint:revive
 				defer serveHandler(cmd.Context(), logger, nil, pprofAddress, "pprof")()
@@ -516,7 +516,7 @@ func server() *cobra.Command {
 		Short: "Run the built-in PostgreSQL deployment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := createConfig(cmd)
-			logger := slog.Make(sloghuman.Sink(os.Stderr))
+			logger := slog.Make(sloghuman.Sink(cmd.ErrOrStderr()))
 			if verbose {
 				logger = logger.Leveled(slog.LevelDebug)
 			}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -192,9 +192,9 @@ func ssh() *cobra.Command {
 				}
 			}
 
-			stdoutFile, valid := cmd.OutOrStdout().(*os.File)
-			stdinFile, valid2 := cmd.InOrStdin().(*os.File)
-			if valid && valid2 && isatty.IsTerminal(stdoutFile.Fd()) {
+			stdoutFile, validOut := cmd.OutOrStdout().(*os.File)
+			stdinFile, validIn := cmd.InOrStdin().(*os.File)
+			if validOut && validIn && isatty.IsTerminal(stdoutFile.Fd()) {
 				state, err := term.MakeRaw(int(stdinFile.Fd()))
 				if err != nil {
 					return err

--- a/cli/state_test.go
+++ b/cli/state_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,8 +96,6 @@ func TestStatePush(t *testing.T) {
 		err = stateFile.Close()
 		require.NoError(t, err)
 		cmd, root := clitest.New(t, "state", "push", workspace.Name, stateFile.Name())
-		cmd.SetErr(io.Discard)
-		cmd.SetOut(io.Discard)
 		clitest.SetupConfig(t, client, root)
 		err = cmd.Execute()
 		require.NoError(t, err)

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"io"
 	"os"
 	"testing"
 
@@ -219,8 +218,6 @@ func TestTemplateCreate(t *testing.T) {
 			}
 			cmd, root := clitest.New(t, args...)
 			clitest.SetupConfig(t, client, root)
-			cmd.SetOut(io.Discard)
-			cmd.SetErr(io.Discard)
 
 			return cmd.Execute()
 		}
@@ -233,8 +230,6 @@ func TestTemplateCreate(t *testing.T) {
 			}
 			cmd, root := clitest.New(t, args...)
 			clitest.SetupConfig(t, client, root)
-			cmd.SetOut(io.Discard)
-			cmd.SetErr(io.Discard)
 
 			return cmd.Execute()
 		}

--- a/cli/templateedit.go
+++ b/cli/templateedit.go
@@ -47,7 +47,7 @@ func templateEdit() *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("update template metadata: %w", err)
 			}
-			_, _ = fmt.Printf("Updated template metadata at %s!\n", cliui.Styles.DateTimeStamp.Render(time.Now().Format(time.Stamp)))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated template metadata at %s!\n", cliui.Styles.DateTimeStamp.Render(time.Now().Format(time.Stamp)))
 			return nil
 		},
 	}

--- a/cli/templateupdate.go
+++ b/cli/templateupdate.go
@@ -98,7 +98,7 @@ func templateUpdate() *cobra.Command {
 				return err
 			}
 
-			_, _ = fmt.Printf("Updated version at %s!\n", cliui.Styles.DateTimeStamp.Render(time.Now().Format(time.Stamp)))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updated version at %s!\n", cliui.Styles.DateTimeStamp.Render(time.Now().Format(time.Stamp)))
 			return nil
 		},
 	}

--- a/cli/update.go
+++ b/cli/update.go
@@ -30,7 +30,7 @@ func update() *cobra.Command {
 				return err
 			}
 			if !workspace.Outdated && !alwaysPrompt {
-				_, _ = fmt.Printf("Workspace isn't outdated!\n")
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Workspace isn't outdated!\n")
 				return nil
 			}
 			template, err := client.Template(cmd.Context(), workspace.TemplateID)
@@ -74,7 +74,7 @@ func update() *cobra.Command {
 				if !ok {
 					break
 				}
-				_, _ = fmt.Printf("Output: %s\n", log.Output)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Output: %s\n", log.Output)
 			}
 			return nil
 		},

--- a/cli/wireguardtunnel.go
+++ b/cli/wireguardtunnel.go
@@ -95,7 +95,7 @@ func wireguardPortForward() *cobra.Command {
 
 			ipv6 := peerwg.UUIDToNetaddr(uuid.New())
 			wgn, err := peerwg.New(
-				slog.Make(sloghuman.Sink(os.Stderr)),
+				slog.Make(sloghuman.Sink(cmd.ErrOrStderr())),
 				[]netaddr.IPPrefix{netaddr.IPPrefixFrom(ipv6, 128)},
 			)
 			if err != nil {


### PR DESCRIPTION
This was causing dirty test output.
