### PR TITLE
fix: Disable telemetry by default in tests

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -176,8 +176,8 @@ func versionCmd() *cobra.Command {
 }
 
 // setCliTest in TestMain to convey we are running in a test.
-func setCliTest() {
-	os.Setenv("CODER_TEST_CLI", "true")
+func setCliTest() error {
+	return os.Setenv("CODER_TEST_CLI", "true")
 }
 
 func isCliTest() bool {

--- a/cli/root.go
+++ b/cli/root.go
@@ -175,6 +175,15 @@ func versionCmd() *cobra.Command {
 	}
 }
 
+// setCliTest in TestMain to convey we are running in a test.
+func setCliTest() {
+	os.Setenv("CODER_TEST_CLI", "true")
+}
+
+func isCliTest() bool {
+	return os.Getenv("CODER_TEST_CLI") != ""
+}
+
 // createClient returns a new client from the command context.
 // It reads from global configuration files if flags are not set.
 func createClient(cmd *cobra.Command) (*codersdk.Client, error) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"net/url"
 	"os"
@@ -175,13 +176,8 @@ func versionCmd() *cobra.Command {
 	}
 }
 
-// setCliTest in TestMain to convey we are running in a test.
-func setCliTest() error {
-	return os.Setenv("CODER_TEST_CLI", "true")
-}
-
-func isCliTest() bool {
-	return os.Getenv("CODER_TEST_CLI") != ""
+func isTest() bool {
+	return flag.Lookup("test.v") != nil
 }
 
 // createClient returns a new client from the command context.

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -64,3 +64,8 @@ func Test_formatExamples(t *testing.T) {
 		})
 	}
 }
+
+func TestMain(m *testing.M) {
+	setCliTest()
+	// goleak.VerifyTestMain(m)
+}

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -68,10 +68,6 @@ func Test_formatExamples(t *testing.T) {
 
 //nolint:unused-parameter // We want to enable goleak at some point.
 func TestMain(m *testing.M) {
-	err := setCliTest()
-	if err != nil {
-		panic(err)
-	}
 	// Replace with goleak.VerifyTestMain(m) when we enable goleak.
 	os.Exit(m.Run())
 	// goleak.VerifyTestMain(m)

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -66,7 +66,6 @@ func Test_formatExamples(t *testing.T) {
 	}
 }
 
-//nolint:unused-parameter // We want to enable goleak at some point.
 func TestMain(m *testing.M) {
 	// Replace with goleak.VerifyTestMain(m) when we enable goleak.
 	os.Exit(m.Run())

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,13 @@ func Test_formatExamples(t *testing.T) {
 	}
 }
 
+//nolint:unused-parameter // We want to enable goleak at some point.
 func TestMain(m *testing.M) {
-	setCliTest()
+	err := setCliTest()
+	if err != nil {
+		panic(err)
+	}
+	// Replace with goleak.VerifyTestMain(m) when we enable goleak.
+	os.Exit(m.Run())
 	// goleak.VerifyTestMain(m)
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -566,7 +566,11 @@ func server() *cobra.Command {
 		"Specifies teams inside organizations the user must be a member of to authenticate with GitHub. Formatted as: <organization-name>/<team-slug>.")
 	cliflag.BoolVarP(root.Flags(), &oauth2GithubAllowSignups, "oauth2-github-allow-signups", "", "CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS", false,
 		"Specifies whether new users can sign up with GitHub.")
-	cliflag.BoolVarP(root.Flags(), &telemetryEnable, "telemetry", "", "CODER_TELEMETRY", true, "Specifies whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.")
+	enableTelemetryByDefault := true
+	if isCliTest() {
+		enableTelemetryByDefault = false
+	}
+	cliflag.BoolVarP(root.Flags(), &telemetryEnable, "telemetry", "", "CODER_TELEMETRY", enableTelemetryByDefault, "Specifies whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.")
 	cliflag.StringVarP(root.Flags(), &telemetryURL, "telemetry-url", "", "CODER_TELEMETRY_URL", "https://telemetry.coder.com", "Specifies a URL to send telemetry to.")
 	_ = root.Flags().MarkHidden("telemetry-url")
 	cliflag.BoolVarP(root.Flags(), &tlsEnable, "tls-enable", "", "CODER_TLS_ENABLE", false, "Specifies if TLS will be enabled")

--- a/cli/server.go
+++ b/cli/server.go
@@ -567,7 +567,7 @@ func server() *cobra.Command {
 	cliflag.BoolVarP(root.Flags(), &oauth2GithubAllowSignups, "oauth2-github-allow-signups", "", "CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS", false,
 		"Specifies whether new users can sign up with GitHub.")
 	enableTelemetryByDefault := true
-	if isCliTest() {
+	if isTest() {
 		enableTelemetryByDefault = false
 	}
 	cliflag.BoolVarP(root.Flags(), &telemetryEnable, "telemetry", "", "CODER_TELEMETRY", enableTelemetryByDefault, "Specifies whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.")

--- a/cli/server.go
+++ b/cli/server.go
@@ -566,10 +566,7 @@ func server() *cobra.Command {
 		"Specifies teams inside organizations the user must be a member of to authenticate with GitHub. Formatted as: <organization-name>/<team-slug>.")
 	cliflag.BoolVarP(root.Flags(), &oauth2GithubAllowSignups, "oauth2-github-allow-signups", "", "CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS", false,
 		"Specifies whether new users can sign up with GitHub.")
-	enableTelemetryByDefault := true
-	if isTest() {
-		enableTelemetryByDefault = false
-	}
+	enableTelemetryByDefault := !isTest()
 	cliflag.BoolVarP(root.Flags(), &telemetryEnable, "telemetry", "", "CODER_TELEMETRY", enableTelemetryByDefault, "Specifies whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.")
 	cliflag.StringVarP(root.Flags(), &telemetryURL, "telemetry-url", "", "CODER_TELEMETRY_URL", "https://telemetry.coder.com", "Specifies a URL to send telemetry to.")
 	_ = root.Flags().MarkHidden("telemetry-url")


### PR DESCRIPTION
~~Telemetry reporting for coder server tests were slowing down the tests
by 60x using `-race` (100s vs 1.5s on my machine).~~

~~Arguably, we should make this change even if it didn't speed up the
tests.~~

**Edit:** I thought this was more impressive but I should've been more suspicious, with `TestMain` present and `goleak` disabled we were not calling `m.Run()`.

Still a change we should make IMO.

---

I also noticed we don't have `goleak` enabled for CLI tests, this commit
adds it, but commented out. The reason being that we're nowhere near
being able to enable it yet.
