### PR TITLE
Disable skipping job acquire log

### DIFF
--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -190,7 +190,6 @@ func (p *Server) acquireJob(ctx context.Context) {
 		return
 	}
 	if p.isRunningJob() {
-		p.opts.Logger.Debug(context.Background(), "skipping acquire; job is already running")
 		return
 	}
 	if p.isShutdown() {


### PR DESCRIPTION
This log line accounts for 90-95% of logs in tests that include provisionerd, which means its usefulness is eclipsed by how difficult it makes it to read the other logs.
