### PR TITLE
chore: update terraform to 1.2.1

### DIFF
--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -16,9 +16,9 @@ import (
 
 // This is the exact version of Terraform used internally
 // when Terraform is missing on the system.
-var terraformVersion = version.Must(version.NewVersion("1.1.9"))
+var terraformVersion = version.Must(version.NewVersion("1.2.1"))
 var minTerraformVersion = version.Must(version.NewVersion("1.1.0"))
-var maxTerraformVersion = version.Must(version.NewVersion("1.2.0"))
+var maxTerraformVersion = version.Must(version.NewVersion("1.2.1"))
 
 var (
 	// The minimum version of Terraform supported by the provisioner.

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -67,7 +67,7 @@ func absoluteBinaryPath(ctx context.Context) (string, error) {
 		return "", xerrors.Errorf("Terraform binary get version failed: %w", err)
 	}
 
-	if version.LessThan(minTerraformVersion) || version.GreaterThanOrEqual(maxTerraformVersion) {
+	if version.LessThan(minTerraformVersion) || version.GreaterThan(maxTerraformVersion) {
 		return "", terraformMinorVersionMismatch
 	}
 


### PR DESCRIPTION
This commit updates the embedded Terraform to version 1.2.1 and updates the max Terraform version.
It also modfies the version check logic to allow terraform version equal to max.

For a list of changes, see [Terraform 1.2.1 Changelog](https://github.com/hashicorp/terraform/blob/v1.2/CHANGELOG.md#121-may-23-2022).

I tested locally with the docker provisioner and it was able to spin up and delete a workspace just fine.

Fixes #1777.