### PR TITLE
fix: Order database queries for templates

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -895,8 +895,8 @@ func (q *fakeQuerier) GetTemplatesWithFilter(_ context.Context, arg database.Get
 	}
 	if len(templates) > 0 {
 		slices.SortFunc(templates, func(i, j database.Template) bool {
-			if i.CreatedAt.Before(j.CreatedAt) {
-				return true
+			if !i.CreatedAt.Before(j.CreatedAt) {
+				return false
 			}
 			return i.ID.String() < j.ID.String()
 		})
@@ -1078,8 +1078,8 @@ func (q *fakeQuerier) GetTemplates(_ context.Context) ([]database.Template, erro
 
 	templates := slices.Clone(q.templates)
 	slices.SortFunc(templates, func(i, j database.Template) bool {
-		if i.CreatedAt.Before(j.CreatedAt) {
-			return true
+		if !i.CreatedAt.Before(j.CreatedAt) {
+			return false
 		}
 		return i.ID.String() < j.ID.String()
 	})

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -626,7 +626,8 @@ func (q *fakeQuerier) GetLatestWorkspaceBuildsByWorkspaceIDs(_ context.Context, 
 }
 
 func (q *fakeQuerier) GetWorkspaceBuildByWorkspaceID(_ context.Context,
-	params database.GetWorkspaceBuildByWorkspaceIDParams) ([]database.WorkspaceBuild, error) {
+	params database.GetWorkspaceBuildByWorkspaceIDParams,
+) ([]database.WorkspaceBuild, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
@@ -893,6 +894,9 @@ func (q *fakeQuerier) GetTemplatesWithFilter(_ context.Context, arg database.Get
 		templates = append(templates, template)
 	}
 	if len(templates) > 0 {
+		slices.SortFunc(templates, func(i, j database.Template) bool {
+			return i.CreatedAt.Before(j.CreatedAt) && i.ID.String() < j.ID.String()
+		})
 		return templates, nil
 	}
 
@@ -1069,7 +1073,12 @@ func (q *fakeQuerier) GetTemplates(_ context.Context) ([]database.Template, erro
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
-	return q.templates[:], nil
+	templates := slices.Clone(q.templates)
+	slices.SortFunc(templates, func(i, j database.Template) bool {
+		return i.CreatedAt.Before(j.CreatedAt) && i.ID.String() < j.ID.String()
+	})
+
+	return templates, nil
 }
 
 func (q *fakeQuerier) GetOrganizationMemberByUserID(_ context.Context, arg database.GetOrganizationMemberByUserIDParams) (database.OrganizationMember, error) {

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -895,7 +895,10 @@ func (q *fakeQuerier) GetTemplatesWithFilter(_ context.Context, arg database.Get
 	}
 	if len(templates) > 0 {
 		slices.SortFunc(templates, func(i, j database.Template) bool {
-			return i.CreatedAt.Before(j.CreatedAt) && i.ID.String() < j.ID.String()
+			if i.CreatedAt.Before(j.CreatedAt) {
+				return true
+			}
+			return i.ID.String() < j.ID.String()
 		})
 		return templates, nil
 	}
@@ -1075,7 +1078,10 @@ func (q *fakeQuerier) GetTemplates(_ context.Context) ([]database.Template, erro
 
 	templates := slices.Clone(q.templates)
 	slices.SortFunc(templates, func(i, j database.Template) bool {
-		return i.CreatedAt.Before(j.CreatedAt) && i.ID.String() < j.ID.String()
+		if i.CreatedAt.Before(j.CreatedAt) {
+			return true
+		}
+		return i.ID.String() < j.ID.String()
 	})
 
 	return templates, nil

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1889,6 +1889,7 @@ func (q *sqlQuerier) GetTemplateByOrganizationAndName(ctx context.Context, arg G
 
 const getTemplates = `-- name: GetTemplates :many
 SELECT id, created_at, updated_at, organization_id, deleted, name, provisioner, active_version_id, description, max_ttl, min_autostart_interval, created_by FROM templates
+ORDER BY (created_at, id) ASC
 `
 
 func (q *sqlQuerier) GetTemplates(ctx context.Context) ([]Template, error) {
@@ -1953,6 +1954,7 @@ WHERE
 			id = ANY($4)
 		ELSE true
 	END
+ORDER BY (created_at, id) ASC
 `
 
 type GetTemplatesWithFilterParams struct {

--- a/coderd/database/queries/templates.sql
+++ b/coderd/database/queries/templates.sql
@@ -34,6 +34,7 @@ WHERE
 			id = ANY(@ids)
 		ELSE true
 	END
+ORDER BY (created_at, id) ASC
 ;
 
 -- name: GetTemplateByOrganizationAndName :one
@@ -49,7 +50,9 @@ LIMIT
 	1;
 
 -- name: GetTemplates :many
-SELECT * FROM templates;
+SELECT * FROM templates
+ORDER BY (created_at, id) ASC
+;
 
 -- name: InsertTemplate :one
 INSERT INTO


### PR DESCRIPTION
Fixes a race in a test where the order of templates varies.

```
    ptytest.go:50: cmd: stdout: "NAME              LAST UPDATED   USED BY       "
372
    ptytest.go:50: cmd: stdout: "pedantic-galois4  July 27, 2022  0 developers  "
373
    ptytest.go:50: cmd: stdout: "strange-booth8    July 27, 2022  0 developers  "
374
    templatelist_test.go:41: 2022-07-27 13:39:37.097225345 +0000 UTC m=+89.235838173: matched "strange-booth8" = "NAME              LAST UPDATED   USED BY       \r\npedantic-galois4  July 27, 2022  0 developers  \r\nstrange-booth8"
375
    t.go:81: 2022-07-27 13:39:39.140 [DEBUG]	<github.com/coder/coder/coderd/provisionerdaemons.go:98>	(*API).ListenProvisionerDaemon.func2	drpc server error ...
376
        "error": stream closed
377
                 	storj.io/drpc/drpcstream.(*Stream).sendPacket:268
378
                 	storj.io/drpc/drpcstream.(*Stream).CloseSend:501
379
                 	storj.io/drpc/drpcserver.(*Server).handleRPC:126
380
                 	storj.io/drpc/drpcserver.(*Server).ServeOne:66
381
                 	storj.io/drpc/drpcserver.(*Server).Serve.func2:112
382
                 	storj.io/drpc/drpcctx.(*Tracker).track:52
383
    t.go:81: 2022-07-27 13:39:41.144 [DEBUG]	<github.com/coder/coder/coderd/provisionerdaemons.go:98>	(*API).ListenProvisionerDaemon.func2	drpc server error ...
384
        "error": stream closed
385
                 	storj.io/drpc/drpcstream.(*Stream).sendPacket:268
386
                 	storj.io/drpc/drpcstream.(*Stream).CloseSend:501
387
                 	storj.io/drpc/drpcserver.(*Server).handleRPC:126
388
                 	storj.io/drpc/drpcserver.(*Server).ServeOne:66
389
                 	storj.io/drpc/drpcserver.(*Server).Serve.func2:112
390
                 	storj.io/drpc/drpcctx.(*Tracker).track:52
391
    templatelist_test.go:42: 2022-07-27 13:39:47.110267312 +0000 UTC m=+99.248880040: match exceeded deadline: wanted "pedantic-galois4"; got "    July 27, 2022  0 developers  \r\n"
392
    t.go:81: 2022-07-27 13:39:47.133 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:369>	(*Server).closeWithError	closing server with error	{"error": null}
393
    --- FAIL: TestTemplateList/ListTemplates (13.96s)
```
