### PR TITLE
fix: make text colors legible

### DIFF
--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@ import MuiDialog, { DialogProps as MuiDialogProps } from "@material-ui/core/Dial
 import MuiDialogTitle from "@material-ui/core/DialogTitle"
 import InputAdornment from "@material-ui/core/InputAdornment"
 import OutlinedInput, { OutlinedInputProps } from "@material-ui/core/OutlinedInput"
-import { darken, lighten, fade, makeStyles } from "@material-ui/core/styles"
+import { darken, fade, lighten, makeStyles } from "@material-ui/core/styles"
 import SvgIcon from "@material-ui/core/SvgIcon"
 import * as React from "react"
 import { combineClasses } from "../../util/combineClasses"

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@ import MuiDialog, { DialogProps as MuiDialogProps } from "@material-ui/core/Dial
 import MuiDialogTitle from "@material-ui/core/DialogTitle"
 import InputAdornment from "@material-ui/core/InputAdornment"
 import OutlinedInput, { OutlinedInputProps } from "@material-ui/core/OutlinedInput"
-import { darken, fade, makeStyles } from "@material-ui/core/styles"
+import { darken, lighten, fade, makeStyles } from "@material-ui/core/styles"
 import SvgIcon from "@material-ui/core/SvgIcon"
 import * as React from "react"
 import { combineClasses } from "../../util/combineClasses"
@@ -200,10 +200,10 @@ const useButtonStyles = makeStyles((theme) => ({
   },
   errorButton: {
     "&.MuiButton-contained": {
-      backgroundColor: theme.palette.error.main,
+      backgroundColor: lighten(theme.palette.error.dark, 0.15),
       color: theme.palette.error.contrastText,
       "&:hover": {
-        backgroundColor: darken(theme.palette.error.main, 0.3),
+        backgroundColor: theme.palette.error.dark,
         "@media (hover: none)": {
           backgroundColor: "transparent",
         },

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -104,7 +104,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   },
   detailsLink: {
     cursor: "pointer",
-    color: `${lighten(theme.palette.primary.light, 0.2)}`
+    color: `${lighten(theme.palette.primary.light, 0.2)}`,
   },
   details: {
     marginTop: `${theme.spacing(2)}px`,

--- a/site/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/site/src/components/ErrorSummary/ErrorSummary.tsx
@@ -2,7 +2,7 @@ import Button from "@material-ui/core/Button"
 import Collapse from "@material-ui/core/Collapse"
 import IconButton from "@material-ui/core/IconButton"
 import Link from "@material-ui/core/Link"
-import { darken, makeStyles, Theme } from "@material-ui/core/styles"
+import { darken, lighten, makeStyles, Theme } from "@material-ui/core/styles"
 import CloseIcon from "@material-ui/icons/Close"
 import RefreshIcon from "@material-ui/icons/Refresh"
 import { ApiError, getErrorDetail, getErrorMessage } from "api/errors"
@@ -104,6 +104,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   },
   detailsLink: {
     cursor: "pointer",
+    color: `${lighten(theme.palette.primary.light, 0.2)}`
   },
   details: {
     marginTop: `${theme.spacing(2)}px`,

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -6,7 +6,7 @@ export const darkPalette: PaletteOptions = {
   primary: {
     main: colors.blue[7],
     contrastText: colors.gray[3],
-    light: colors.blue[6],
+    light: colors.blue[5],
     dark: colors.blue[9],
   },
   secondary: {

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -34,11 +34,11 @@ export const darkPalette: PaletteOptions = {
   info: {
     main: colors.blue[11],
     dark: colors.blue[15],
-    contrastText: colors.gray[3]
+    contrastText: colors.gray[3],
   },
   error: {
     main: colors.red[5],
     dark: colors.red[15],
-    contrastText: colors.gray[3]
+    contrastText: colors.gray[3],
   },
 }

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -6,7 +6,7 @@ export const darkPalette: PaletteOptions = {
   primary: {
     main: colors.blue[7],
     contrastText: colors.gray[3],
-    light: colors.blue[5],
+    light: colors.blue[6],
     dark: colors.blue[9],
   },
   secondary: {

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -34,9 +34,11 @@ export const darkPalette: PaletteOptions = {
   info: {
     main: colors.blue[11],
     dark: colors.blue[15],
+    contrastText: colors.gray[3]
   },
   error: {
-    main: colors.red[11],
+    main: colors.red[5],
     dark: colors.red[15],
+    contrastText: colors.gray[3]
   },
 }


### PR DESCRIPTION
Fixes #3222 
Fixes #3230 

- [x] changed `error.main` color to a lighter one for legible color contrast in validation error messages
- [x] added `contrastText` to more parts of the palette so we use it instead of defaulting to illegible near-black
- [x] changed Dialog styles to use `error.dark` as the button background instead of `error.main`. Hover styles darken a color, and `error.dark` is VERY dark currently, so I had it start at a lightened version and darken to the standard.

The color palette will need more work - the color contrast between button background and text doesn't pass accessibility tests on other buttons (the blue ones). But this PR improves the most egregious places I had seen.

<img width="211" alt="Screen Shot 2022-07-27 at 11 01 59 AM" src="https://user-images.githubusercontent.com/1290996/181281205-691d82e4-a7c2-4223-980b-c4a9a1a03e37.png">
<img width="445" alt="Screen Shot 2022-07-27 at 11 01 37 AM" src="https://user-images.githubusercontent.com/1290996/181281232-36acbf6d-ca04-4bac-a2a5-eb53103eb46c.png">

## Testing
### Validation messages
Given I am logged out,
When I type a letter in the email field and then click on the password field,
Then I see a legible validation message 

### Dialogs
Given I have created a new user,
When I suspend that user,
Then I see a confirmation dialog with legible buttons

