### PR TITLE
fix: remove string TTL from workspace error responses

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -547,19 +547,18 @@ func (api *API) putWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
+		resp := codersdk.Response{
+			Message: "Error updating workspace time until shutdown.",
+		}
 		var validErr codersdk.ValidationError
 		if errors.As(err, &validErr) {
-			httpapi.Write(rw, http.StatusBadRequest, codersdk.Response{
-				Message:     "Error updating workspace time until shutdown!",
-				Validations: []codersdk.ValidationError{validErr},
-			})
+			resp.Validations = []codersdk.ValidationError{validErr}
+			httpapi.Write(rw, http.StatusBadRequest, resp)
 			return
 		}
 
-		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Error updating workspace time until shutdown!",
-			Detail:  err.Error(),
-		})
+		resp.Detail = err.Error()
+		httpapi.Write(rw, http.StatusInternalServerError, resp)
 		return
 	}
 

--- a/codersdk/error.go
+++ b/codersdk/error.go
@@ -1,6 +1,7 @@
 package codersdk
 
 import (
+	"fmt"
 	"net"
 
 	"golang.org/x/xerrors"
@@ -31,6 +32,12 @@ type ValidationError struct {
 	Field  string `json:"field" validate:"required"`
 	Detail string `json:"detail" validate:"required"`
 }
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("field: %s detail: %s", e.Field, e.Detail)
+}
+
+var _ error = (*ValidationError)(nil)
 
 // IsConnectionErr is a convenience function for checking if the source of an
 // error is due to a 'connection refused', 'no such host', etc.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -192,7 +192,7 @@ func (c *Client) UpdateWorkspaceTTL(ctx context.Context, id uuid.UUID, req Updat
 	path := fmt.Sprintf("/api/v2/workspaces/%s/ttl", id.String())
 	res, err := c.Request(ctx, http.MethodPut, path, req)
 	if err != nil {
-		return xerrors.Errorf("update workspace ttl: %w", err)
+		return xerrors.Errorf("update workspace time until shutdown: %w", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
@@ -212,7 +212,7 @@ func (c *Client) PutExtendWorkspace(ctx context.Context, id uuid.UUID, req PutEx
 	path := fmt.Sprintf("/api/v2/workspaces/%s/extend", id.String())
 	res, err := c.Request(ctx, http.MethodPut, path, req)
 	if err != nil {
-		return xerrors.Errorf("extend workspace ttl: %w", err)
+		return xerrors.Errorf("extend workspace time until shutdown: %w", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNotModified {

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -146,7 +146,7 @@ EOT
 resource "aws_instance" "dev" {
   ami               = data.aws_ami.ubuntu.id
   availability_zone = "${var.region}a"
-  instance_type     = "${var.instance_type}"
+  instance_type     = var.instance_type
 
   user_data = data.coder_workspace.me.transition == "start" ? local.user_data_start : local.user_data_end
   tags = {

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -146,7 +146,7 @@ EOT
 resource "aws_instance" "dev" {
   ami               = data.aws_ami.ubuntu.id
   availability_zone = "${var.region}a"
-  instance_type     = var.instance_type
+  instance_type     = "${var.instance_type}"
 
   user_data = data.coder_workspace.me.transition == "start" ? local.user_data_start : local.user_data_end
   tags = {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -250,7 +250,7 @@ export interface PutExtendWorkspaceRequest {
   readonly deadline: string
 }
 
-// From codersdk/error.go:10:6
+// From codersdk/error.go:11:6
 export interface Response {
   readonly message: string
   readonly detail?: string
@@ -386,7 +386,7 @@ export interface UsersRequest extends Pagination {
   readonly q?: string
 }
 
-// From codersdk/error.go:30:6
+// From codersdk/error.go:31:6
 export interface ValidationError {
   readonly field: string
   readonly detail: string


### PR DESCRIPTION
This PR:
- Rewrites some error messages to better integrate with the frontend (ttl_ms -> time until shutdown)
- Makes `codersdk.ValidationError` implement the `error` interface
- only return validations if the error was a validation error, return detail otherwise (e.g. database error)