### PR TITLE
fix: Workspace schedule button on responsive

### DIFF
--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
@@ -87,3 +87,9 @@ CannotEdit.args = {
   },
   canUpdateWorkspace: false,
 }
+
+export const SmallViewport = Template.bind({})
+SmallViewport.args = WorkspaceOffShort.args
+SmallViewport.parameters = {
+  chromatic: { viewports: [320] },
+}

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
@@ -89,7 +89,9 @@ CannotEdit.args = {
 }
 
 export const SmallViewport = Template.bind({})
-SmallViewport.args = WorkspaceOffShort.args
+SmallViewport.args = {
+   ...WorkspaceOffShort.args,
+}
 SmallViewport.parameters = {
   chromatic: { viewports: [320] },
 }

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.stories.tsx
@@ -90,7 +90,7 @@ CannotEdit.args = {
 
 export const SmallViewport = Template.bind({})
 SmallViewport.args = {
-   ...WorkspaceOffShort.args,
+  ...WorkspaceOffShort.args,
 }
 SmallViewport.parameters = {
   chromatic: { viewports: [320] },

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
@@ -154,12 +154,15 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
       display: "flex",
       alignItems: "center",
-      padding: theme.spacing(1, 2),
+      padding: theme.spacing(1.5, 2),
     },
   },
   actions: {
     [theme.breakpoints.down("sm")]: {
       marginLeft: "auto",
+      display: "flex",
+      paddingLeft: theme.spacing(1),
+      marginRight: -theme.spacing(1),
     },
   },
   scheduleButton: {

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
@@ -140,6 +140,10 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: `${theme.shape.borderRadius}px`,
+
+    [theme.breakpoints.down("sm")]: {
+      flexDirection: "column",
+    },
   },
   label: {
     borderRight: 0,
@@ -150,6 +154,7 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
       display: "flex",
       alignItems: "center",
+      padding: theme.spacing(1, 2),
     },
   },
   actions: {
@@ -162,6 +167,13 @@ const useStyles = makeStyles((theme) => ({
     borderLeft: `1px solid ${theme.palette.divider}`,
     borderRadius: `0px ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0px`,
     flexShrink: 0,
+
+    [theme.breakpoints.down("sm")]: {
+      width: "100%",
+      borderLeft: 0,
+      borderTop: `1px solid ${theme.palette.divider}`,
+      borderRadius: `0 0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
+    },
   },
   iconButton: {
     borderRadius: 2,

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleLabel.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleLabel.tsx
@@ -14,18 +14,16 @@ export const WorkspaceScheduleLabel: React.FC<{ workspace: Workspace }> = ({ wor
     // If it is shutting down, we don't need to display the auto stop label
     return (
       <span className={combineClasses([styles.labelText, "chromatic-ignore"])}>
-        {shouldDisplayStrongLabel && (
-          <strong className={styles.labelStrong}>{Language.autoStopLabel}</strong>
-        )}
-        {stopLabel}
+        {shouldDisplayStrongLabel && <strong>{Language.autoStopLabel}</strong>}{" "}
+        <span className={styles.value}>{stopLabel}</span>
       </span>
     )
   }
 
   return (
     <span className={combineClasses([styles.labelText, "chromatic-ignore"])}>
-      <strong className={styles.labelStrong}>{Language.autoStartLabel}</strong>
-      {autoStartDisplay(workspace.autostart_schedule)}
+      <strong>{Language.autoStartLabel}</strong>{" "}
+      <span className={styles.value}>{autoStartDisplay(workspace.autostart_schedule)}</span>
     </span>
   )
 }
@@ -33,13 +31,17 @@ export const WorkspaceScheduleLabel: React.FC<{ workspace: Workspace }> = ({ wor
 const useStyles = makeStyles((theme) => ({
   labelText: {
     marginRight: theme.spacing(2),
+    lineHeight: "160%",
 
     [theme.breakpoints.down("sm")]: {
       marginRight: 0,
+      width: "100%",
     },
   },
 
-  labelStrong: {
-    marginRight: theme.spacing(0.5),
+  value: {
+    [theme.breakpoints.down("sm")]: {
+      whiteSpace: "nowrap",
+    },
   },
 }))

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleLabel.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleLabel.tsx
@@ -33,6 +33,10 @@ export const WorkspaceScheduleLabel: React.FC<{ workspace: Workspace }> = ({ wor
 const useStyles = makeStyles((theme) => ({
   labelText: {
     marginRight: theme.spacing(2),
+
+    [theme.breakpoints.down("sm")]: {
+      marginRight: 0,
+    },
   },
 
   labelStrong: {


### PR DESCRIPTION
After:
<img width="323" alt="Screen Shot 2022-07-28 at 11 21 44" src="https://user-images.githubusercontent.com/3165839/181545744-5b808631-6867-4059-9aed-472b447dbe90.png">

With + and - buttons:
<img width="319" alt="Screen Shot 2022-07-28 at 11 53 43" src="https://user-images.githubusercontent.com/3165839/181568593-38e61420-3e80-46bb-b9dd-9d244eae3f07.png">


Before:
<img width="360" alt="Screen Shot 2022-07-28 at 11 02 34" src="https://user-images.githubusercontent.com/3165839/181545768-dc803032-365b-4622-8ba8-6d31cc16f1d6.png">
