### PR TITLE
fix: remove pipefail from standard shell options

### DIFF
--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -75,7 +75,7 @@ resource "google_compute_instance" "dev" {
   # it.
   metadata_startup_script = <<EOMETA
 #!/usr/bin/env sh
-set -eux pipefail
+set -eux
 
 mkdir /root || true
 cat <<'EOCODER' > /root/coder_agent.sh

--- a/provisionersdk/scripts/bootstrap_darwin.sh
+++ b/provisionersdk/scripts/bootstrap_darwin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eux pipefail
+set -eux
 # Sleep for a good long while before exiting.
 # This is to allow folks to exec into a failed workspace and poke around to
 # troubleshoot.

--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eux pipefail
+set -eux
 # Sleep for a good long while before exiting.
 # This is to allow folks to exec into a failed workspace and poke around to
 # troubleshoot.


### PR DESCRIPTION
Small one I found while checking out the OSS product.

Setting `pipefail` requires the `-o` flag, otherwise it has no effect.

Validation:
```
$ sh
sh-5.1$ set -eux pipefail
sh-5.1$ false | echo 'hello'
+ echo hello
hello
+ false
sh-5.1$ echo $?
+ echo 0
0
```

```
$ sh
sh-5.1$ set -eux -o pipefail
sh-5.1$ false | echo 'hello'
+ echo hello
hello
+ false

[sh exits, parent shell]

$ echo $?
1
```