### PR TITLE
fix: Guard pty window resize after close

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -457,7 +457,7 @@ func (a *agent) handleSSHSession(session ssh.Session) (retErr error) {
 			for win := range windowSize {
 				resizeErr := ptty.Resize(uint16(win.Height), uint16(win.Width))
 				if resizeErr != nil {
-					a.logger.Warn(context.Background(), "failed to resize tty", slog.Error(err))
+					a.logger.Warn(context.Background(), "failed to resize tty", slog.Error(resizeErr))
 				}
 			}
 		}()

--- a/pty/pty_other.go
+++ b/pty/pty_other.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/creack/pty"
+	"golang.org/x/xerrors"
 )
 
 func newPty() (PTY, error) {
@@ -26,6 +27,8 @@ func newPty() (PTY, error) {
 
 type otherPty struct {
 	mutex    sync.Mutex
+	closed   bool
+	err      error
 	pty, tty *os.File
 }
 
@@ -55,6 +58,9 @@ func (p *otherPty) Output() ReadWriter {
 func (p *otherPty) Resize(height uint16, width uint16) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+	if p.closed {
+		return p.err
+	}
 	return pty.Setsize(p.pty, &pty.Winsize{
 		Rows: height,
 		Cols: width,
@@ -65,17 +71,24 @@ func (p *otherPty) Close() error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
+	if p.closed {
+		return p.err
+	}
+	p.closed = true
+
 	err := p.pty.Close()
+	err2 := p.tty.Close()
 	if err != nil {
-		_ = p.tty.Close()
-		return err
+		err = err2
 	}
 
-	err = p.tty.Close()
 	if err != nil {
-		return err
+		p.err = err
+	} else {
+		p.err = xerrors.New("pty: closed")
 	}
-	return nil
+
+	return err
 }
 
 func (p *otherProcess) Wait() error {


### PR DESCRIPTION
A bit of a shot in the dark, but I'm thinking this could help help alleviate #3236.

We're seeing a lot of CI failures because of it currently.
