### PR TITLE
Fix: surface error when over-extending workspace

### DIFF
--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -2,6 +2,7 @@
  * @fileoverview workspaceScheduleBanner is an xstate machine backing a form,
  * presented as an Alert/banner, for reactively updating a workspace schedule.
  */
+import { getErrorMessage } from "api/errors"
 import dayjs from "dayjs"
 import { createMachine } from "xstate"
 import * as API from "../../api/api"
@@ -51,8 +52,9 @@ export const workspaceScheduleBannerMachine = createMachine(
   },
   {
     actions: {
-      displayFailureMessage: () => {
-        displayError(Language.errorExtension)
+      // This error does not have a detail, so using the snackbar is okay
+      displayFailureMessage: (_, event) => {
+        displayError(getErrorMessage(event.data, Language.errorExtension))
       },
       displaySuccessMessage: () => {
         displaySuccess(Language.successExtension)


### PR DESCRIPTION
Fixes #3097 

We were displaying a hard-coded error, and I changed it to display the error `message` from the backend. That message is currently not great in terms of specificity, but will improve with work @johnstcn is planning. It does not have a `detail` aspect, so there is no need to expand/collapse, and so I thought keeping the snackbar made sense.

<img width="372" alt="Screen Shot 2022-07-28 at 3 23 48 PM" src="https://user-images.githubusercontent.com/1290996/181626963-ffd59a07-901c-4612-98ea-b24b073bde59.png">

## Testing
When I click + on the Workspace Schedule button too many times,
Then I see an error snackbar that says "Bad extend workspace request"

Once the backend error is updated, the snackbar will say something like "New deadline is greater than workspace allows"

With future work, the + button will be disabled so that it's impossible to elicit this error. It's just here in case of frontend bugs.