### PR TITLE
fix: handle `getUser` error

### DIFF
--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -51,7 +51,7 @@ type OAuth2Configs struct {
 	Github OAuth2Config
 }
 
-const loggedOutErrorMessage string = "You are logged out. Please log in to continue."
+const signedOutErrorMessage string = "You are signed out. Please sign in to continue."
 
 // ExtractAPIKey requires authentication using a valid API key.
 // It handles extending an API key if it comes close to expiry,
@@ -85,7 +85,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 			}
 			if cookieValue == "" {
 				write(http.StatusUnauthorized, codersdk.Response{
-					Message: loggedOutErrorMessage,
+					Message: signedOutErrorMessage,
 					Detail:  fmt.Sprintf("Cookie %q or query parameter must be provided.", codersdk.SessionTokenKey),
 				})
 				return
@@ -94,7 +94,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 			// APIKeys are formatted: ID-SECRET
 			if len(parts) != 2 {
 				write(http.StatusUnauthorized, codersdk.Response{
-					Message: loggedOutErrorMessage,
+					Message: signedOutErrorMessage,
 					Detail:  fmt.Sprintf("Invalid %q cookie API key format.", codersdk.SessionTokenKey),
 				})
 				return
@@ -104,14 +104,14 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 			// Ensuring key lengths are valid.
 			if len(keyID) != 10 {
 				write(http.StatusUnauthorized, codersdk.Response{
-					Message: loggedOutErrorMessage,
+					Message: signedOutErrorMessage,
 					Detail:  fmt.Sprintf("Invalid %q cookie API key id.", codersdk.SessionTokenKey),
 				})
 				return
 			}
 			if len(keySecret) != 22 {
 				write(http.StatusUnauthorized, codersdk.Response{
-					Message: loggedOutErrorMessage,
+					Message: signedOutErrorMessage,
 					Detail:  fmt.Sprintf("Invalid %q cookie API key secret.", codersdk.SessionTokenKey),
 				})
 				return
@@ -120,7 +120,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
 					write(http.StatusUnauthorized, codersdk.Response{
-						Message: loggedOutErrorMessage,
+						Message: signedOutErrorMessage,
 						Detail:  "API key is invalid.",
 					})
 					return
@@ -136,7 +136,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 			// Checking to see if the secret is valid.
 			if subtle.ConstantTimeCompare(key.HashedSecret, hashed[:]) != 1 {
 				write(http.StatusUnauthorized, codersdk.Response{
-					Message: loggedOutErrorMessage,
+					Message: signedOutErrorMessage,
 					Detail:  "API key secret is invalid.",
 				})
 				return
@@ -182,7 +182,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 			// Checking if the key is expired.
 			if key.ExpiresAt.Before(now) {
 				write(http.StatusUnauthorized, codersdk.Response{
-					Message: loggedOutErrorMessage,
+					Message: signedOutErrorMessage,
 					Detail:  fmt.Sprintf("API key expired at %q.", key.ExpiresAt.String()),
 				})
 				return
@@ -225,7 +225,7 @@ func ExtractAPIKey(db database.Store, oauth *OAuth2Configs, redirectToLogin bool
 				})
 				if err != nil {
 					write(http.StatusInternalServerError, codersdk.Response{
-						Message: loggedOutErrorMessage,
+						Message: signedOutErrorMessage,
 						Detail:  fmt.Sprintf("API key couldn't update: %s.", err.Error()),
 					})
 					return

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -51,7 +51,7 @@ type OAuth2Configs struct {
 	Github OAuth2Config
 }
 
-const signedOutErrorMessage string = "You are signed out. Please sign in to continue."
+const signedOutErrorMessage string = "You are signed out or your session has expired. Please sign in again to continue."
 
 // ExtractAPIKey requires authentication using a valid API key.
 // It handles extending an API key if it comes close to expiry,

--- a/site/src/components/RequireAuth/RequireAuth.tsx
+++ b/site/src/components/RequireAuth/RequireAuth.tsx
@@ -13,9 +13,10 @@ export const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
   const xServices = useContext(XServiceContext)
   const [authState] = useActor(xServices.authXService)
   const location = useLocation()
-  const navigateTo = location.pathname === "/" ? "/login" : embedRedirect(location.pathname)
+  const isHomePage = location.pathname === "/"
+  const navigateTo = isHomePage ? "/login" : embedRedirect(location.pathname)
   if (authState.matches("signedOut")) {
-    return <Navigate to={navigateTo} />
+    return <Navigate to={navigateTo} state={{ isRedirect: !isHomePage }} />
   } else if (authState.hasTag("loading")) {
     return <FullScreenLoader />
   } else {

--- a/site/src/components/SignInForm/SignInForm.stories.tsx
+++ b/site/src/components/SignInForm/SignInForm.stories.tsx
@@ -51,6 +51,17 @@ WithLoginError.args = {
   },
 }
 
+export const WithGetUserError = Template.bind({})
+WithGetUserError.args = {
+  ...SignedOut.args,
+  loginErrors: {
+    [LoginErrors.GET_USER_ERROR]: makeMockApiError({
+      message: "You are logged out. Please log in to continue.",
+      detail: "API Key is invalid.",
+    }),
+  },
+}
+
 export const WithCheckPermissionsError = Template.bind({})
 WithCheckPermissionsError.args = {
   ...SignedOut.args,
@@ -66,6 +77,18 @@ export const WithAuthMethodsError = Template.bind({})
 WithAuthMethodsError.args = {
   ...SignedOut.args,
   loginErrors: {
+    [LoginErrors.GET_METHODS_ERROR]: new Error("Failed to fetch auth methods"),
+  },
+}
+
+export const WithGetUserAndAuthMethodsError = Template.bind({})
+WithGetUserAndAuthMethodsError.args = {
+  ...SignedOut.args,
+  loginErrors: {
+    [LoginErrors.GET_USER_ERROR]: makeMockApiError({
+      message: "You are logged out. Please log in to continue.",
+      detail: "API Key is invalid.",
+    }),
     [LoginErrors.GET_METHODS_ERROR]: new Error("Failed to fetch auth methods"),
   },
 }

--- a/site/src/components/SignInForm/SignInForm.tsx
+++ b/site/src/components/SignInForm/SignInForm.tsx
@@ -25,6 +25,7 @@ interface BuiltInAuthFormValues {
 
 export enum LoginErrors {
   AUTH_ERROR = "authError",
+  GET_USER_ERROR = "getUserError",
   CHECK_PERMISSIONS_ERROR = "checkPermissionsError",
   GET_METHODS_ERROR = "getMethodsError",
 }
@@ -36,6 +37,7 @@ export const Language = {
   emailRequired: "Please enter an email address.",
   errorMessages: {
     [LoginErrors.AUTH_ERROR]: "Incorrect email or password.",
+    [LoginErrors.GET_USER_ERROR]: "Failed to fetch user details.",
     [LoginErrors.CHECK_PERMISSIONS_ERROR]: "Unable to fetch user permissions.",
     [LoginErrors.GET_METHODS_ERROR]: "Unable to fetch auth methods.",
   },

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -40,7 +40,7 @@ export const LoginPage: React.FC = () => {
   const isLoading = authState.hasTag("loading")
   const redirectTo = retrieveRedirect(location.search)
   const locationState = location.state ? (location.state as LocationState) : null
-  const isRedirected = locationState !== null ? locationState.isRedirect : false
+  const isRedirected = locationState ? locationState.isRedirect : false
 
   const onSubmit = async ({ email, password }: { email: string; password: string }) => {
     authSend({ type: "SIGN_IN", email, password })

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -4,7 +4,7 @@ import React, { useContext } from "react"
 import { Helmet } from "react-helmet"
 import { Navigate, useLocation } from "react-router-dom"
 import { Footer } from "../../components/Footer/Footer"
-import { SignInForm } from "../../components/SignInForm/SignInForm"
+import { LoginErrors, SignInForm } from "../../components/SignInForm/SignInForm"
 import { pageTitle } from "../../util/page"
 import { retrieveRedirect } from "../../util/redirect"
 import { XServiceContext } from "../../xServices/StateContext"
@@ -28,6 +28,10 @@ export const useStyles = makeStyles((theme) => ({
   },
 }))
 
+interface LocationState {
+  isRedirect: boolean
+}
+
 export const LoginPage: React.FC = () => {
   const styles = useStyles()
   const location = useLocation()
@@ -35,12 +39,14 @@ export const LoginPage: React.FC = () => {
   const [authState, authSend] = useActor(xServices.authXService)
   const isLoading = authState.hasTag("loading")
   const redirectTo = retrieveRedirect(location.search)
+  const locationState = location.state ? (location.state as LocationState) : null
+  const isRedirected = locationState !== null ? locationState.isRedirect : false
 
   const onSubmit = async ({ email, password }: { email: string; password: string }) => {
     authSend({ type: "SIGN_IN", email, password })
   }
 
-  const { authError, checkPermissionsError, getMethodsError } = authState.context
+  const { authError, getUserError, checkPermissionsError, getMethodsError } = authState.context
 
   if (authState.matches("signedIn")) {
     return <Navigate to={redirectTo} replace />
@@ -57,9 +63,10 @@ export const LoginPage: React.FC = () => {
               redirectTo={redirectTo}
               isLoading={isLoading}
               loginErrors={{
-                authError,
-                checkPermissionsError,
-                getMethodsError,
+                [LoginErrors.AUTH_ERROR]: authError,
+                [LoginErrors.GET_USER_ERROR]: isRedirected ? getUserError : null,
+                [LoginErrors.CHECK_PERMISSIONS_ERROR]: checkPermissionsError,
+                [LoginErrors.GET_METHODS_ERROR]: getMethodsError,
               }}
               onSubmit={onSubmit}
             />


### PR DESCRIPTION
Building on #3241, this PR handles the `getUser` error from `authXService`.

Special criteria: The error is only shown when redirecting to the `/login` page from a page other than `/`. It is also not shown when loading the `/login` page directly. 

## Subtasks

- [x] show `getUser` error above the Sign-in form
- [x] restrict showing the error only when redirecting (except redirecting from `/`)
- [x] added stories
- [x] update relevant backend API middleware errors to have the a `You are signed out.` or `An internal error occurred` message and move the details in the error details section.

Fixes #3088 

## Screenshot

<img width="422" alt="Screen Shot 2022-07-28 at 11 14 29 PM" src="https://user-images.githubusercontent.com/7511231/181675381-1f083bb4-5193-405a-a4dc-328018b46c59.png">

