### PR TITLE
chore: remove duplicative kube config info in projector section

### DIFF
--- a/docs/ides/configuring-web-ides.md
+++ b/docs/ides/configuring-web-ides.md
@@ -214,8 +214,6 @@ You can also reference/use to these pre-built templates with JetBrains projector
 
 ![PyCharm in Coder](../images/projector-pycharm.png)
 
-> You need to have a valid `~/.kube/config` on your Coder host and a namespace on a Kubernetes cluster to use the Kubernetes pod template examples.
-
 > Coder OSS currently does not perform a health check([#2662](https://github.com/coder/coder/issues/2662)) that any IDE or commands in the `startup_script` have completed, so wait a minute or so before opening the JetBrains or code-server icons. As a precaution, you can open Terminal and run `htop` to see if the processes have completed.
 
 ## JupyterLab


### PR DESCRIPTION
This PR removes duplicate kube config text discovered in [issue 3288](https://github.com/coder/coder/issues/3288)

[ci-skip test/go/postgres]