### PR TITLE
fix: Update CLI Placeholder color to have a dark theme alternative

### DIFF
--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -48,7 +48,7 @@ var Styles = struct {
 	Field:         defaultStyles.Code.Copy().Foreground(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"}),
 	Keyword:       defaultStyles.Keyword,
 	Paragraph:     defaultStyles.Paragraph,
-	Placeholder:   lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+	Placeholder:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#585858", Dark: "#005fff"}),
 	Prompt:        defaultStyles.Prompt.Foreground(lipgloss.AdaptiveColor{Light: "#9B9B9B", Dark: "#5C5C5C"}),
 	FocusedPrompt: defaultStyles.FocusedPrompt.Foreground(lipgloss.Color("#651fff")),
 	Fuschia:       defaultStyles.SelectedMenuItem.Copy(),


### PR DESCRIPTION
Fixes #3293 

The light color is still ANSI 256 color `240`, but in hex code.

![image](https://user-images.githubusercontent.com/86365960/181783721-c6dbd10d-4afe-4273-a962-f7f390866d7f.png)

![image](https://user-images.githubusercontent.com/86365960/181783989-620a2e95-735f-456b-bd19-fe5e9a8944ce.png)

Up to y'all regarding if this is the right color. Not sure if this meets any branding Coder might have, but I tried picking something sort of similar to the ascent colors on the website.