### PR TITLE
chore: increase dependabot interval frequency and disregard patches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
       timezone: "America/Chicago"
     labels: []
@@ -28,17 +28,20 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
       timezone: "America/Chicago"
     commit-message:
       prefix: "chore"
     labels: []
+    ignore:
+      update-types:
+      - version-update:semver-patch
 
   - package-ecosystem: "npm"
     directory: "/site/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
       timezone: "America/Chicago"
     commit-message:
@@ -50,11 +53,12 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
+          - version-update:semver-patch
 
   - package-ecosystem: "terraform"
     directory: "/examples/templates"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
       timezone: "America/Chicago"
     commit-message:


### PR DESCRIPTION
As discussed in FE and BE varieties, Dependabot has been pretty noisy lately (especially for npm). As an initial step toward solving the problem, we have increased the interval after which Dependabot looks for updates from weekly to monthly for all package ecosystems. For the Go and NPM package ecosystems only, we are no longer taking patch updates.