### PR TITLE
Rename `template update` to `template push`

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -16,7 +16,7 @@ import (
 	"github.com/coder/coder/provisionersdk"
 )
 
-func templateUpdate() *cobra.Command {
+func templatePush() *cobra.Command {
 	var (
 		directory     string
 		provisioner   string
@@ -25,9 +25,9 @@ func templateUpdate() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "update [template]",
+		Use:   "push [template]",
 		Args:  cobra.MaximumNArgs(1),
-		Short: "Update the source-code of a template from the current directory or as specified by flag",
+		Short: "Push a new template version from the current directory or as specified by flag",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := createClient(cmd)
 			if err != nil {

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/coder/coder/pty/ptytest"
 )
 
-func TestTemplateUpdate(t *testing.T) {
+func TestTemplatePush(t *testing.T) {
 	t.Parallel()
 	// NewParameter will:
 	//	1. Create a template version with 0 params
@@ -43,7 +43,7 @@ func TestTemplateUpdate(t *testing.T) {
 			Parse:     createTestParseResponse(),
 			Provision: echo.ProvisionComplete,
 		})
-		cmd, root := clitest.New(t, "templates", "update", template.Name, "-y", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
+		cmd, root := clitest.New(t, "templates", "push", template.Name, "-y", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
@@ -76,7 +76,7 @@ func TestTemplateUpdate(t *testing.T) {
 
 		// Second update of the same source requires no prompt since the params
 		// are carried over.
-		cmd, root = clitest.New(t, "templates", "update", template.Name, "-y", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
+		cmd, root = clitest.New(t, "templates", "push", template.Name, "-y", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		go func() {
 			execDone <- cmd.Execute()
@@ -95,7 +95,7 @@ func TestTemplateUpdate(t *testing.T) {
 			Provision: echo.ProvisionComplete,
 		})
 
-		cmd, root = clitest.New(t, "templates", "update", template.Name, "-y", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
+		cmd, root = clitest.New(t, "templates", "push", template.Name, "-y", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		go func() {
 			execDone <- cmd.Execute()
@@ -122,7 +122,7 @@ func TestTemplateUpdate(t *testing.T) {
 			Parse:     echo.ParseComplete,
 			Provision: echo.ProvisionComplete,
 		})
-		cmd, root := clitest.New(t, "templates", "update", template.Name, "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
+		cmd, root := clitest.New(t, "templates", "push", template.Name, "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
@@ -175,7 +175,7 @@ func TestTemplateUpdate(t *testing.T) {
 
 		// Don't pass the name of the template, it should use the
 		// directory of the source.
-		cmd, root := clitest.New(t, "templates", "update", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
+		cmd, root := clitest.New(t, "templates", "push", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -26,8 +26,8 @@ func templates() *cobra.Command {
 				Command:     "coder templates plan my-template",
 			},
 			example{
-				Description: "Update the template. Your developers can update their workspaces",
-				Command:     "coder templates update my-template",
+				Description: "Push an update to the template. Your developers can update their workspaces",
+				Command:     "coder templates push my-template",
 			},
 		),
 	}
@@ -37,7 +37,7 @@ func templates() *cobra.Command {
 		templateInit(),
 		templateList(),
 		templatePlan(),
-		templateUpdate(),
+		templatePush(),
 		templateVersions(),
 		templateDelete(),
 		templatePull(),


### PR DESCRIPTION
Before, there was a `template edit` AND a `template update`. The
distinction between both commands was easy to forget. `push` more
clearly indicates that the template's source code is being updated.

It is also complimentary to existing `template pull`.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
