### PR TITLE
fix: prepend scheme to access url

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -229,7 +229,7 @@ func server() *cobra.Command {
 				if isLocal {
 					reason = "isn't externally reachable"
 				}
-				cmd.Printf("%s The access URL %s %s, this may cause unexpected problems when creating workspaces. Generate a unique *.try.coder.app URL with:\n", cliui.Styles.Warn.Render("Warning:"), cliui.Styles.Field.Render(accessURL), reason)
+				cmd.Printf("%s The access URL %s %s, this may cause unexpected problems when creating workspaces. Generate a unique *.try.coder.app URL with:\n", cliui.Styles.Warn.Render("Warning:"), cliui.Styles.Field.Render(accessURLParsed.String()), reason)
 				cmd.Println(cliui.Styles.Code.Render(strings.Join(os.Args, " ") + " --tunnel"))
 			}
 
@@ -678,7 +678,7 @@ func server() *cobra.Command {
 // exist so that the URL does not get parsed improprely.
 func parseURL(ctx context.Context, u string) (*url.URL, error) {
 	var (
-		hasScheme = strings.HasPrefix(u, "http") || strings.HasPrefix(u, "https")
+		hasScheme = strings.HasPrefix(u, "http:") || strings.HasPrefix(u, "https:")
 	)
 
 	if !hasScheme {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -148,7 +148,7 @@ func TestServer(t *testing.T) {
 	})
 
 	// Validate that an https scheme is prepended to a remote access URL
-	// and that a warning is not printed about it not being externally reachable.
+	// and that a warning is printed about it not being externally reachable.
 	t.Run("NoSchemeRemoteAccessURL", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancelFunc := context.WithCancel(context.Background())
@@ -158,7 +158,7 @@ func TestServer(t *testing.T) {
 			"server",
 			"--in-memory",
 			"--address", ":0",
-			"--access-url", "1.2.3.4:3000/",
+			"--access-url", "foobarbaz.mydomain",
 			"--cache-dir", t.TempDir(),
 		)
 		buf := newThreadSafeBuffer()
@@ -177,8 +177,8 @@ func TestServer(t *testing.T) {
 
 		cancelFunc()
 		require.ErrorIs(t, <-errC, context.Canceled)
-		require.NotContains(t, buf.String(), "this may cause unexpected problems when creating workspaces")
-		require.Contains(t, buf.String(), "View the Web UI: https://1.2.3.4:3000/\n")
+		require.Contains(t, buf.String(), "this may cause unexpected problems when creating workspaces")
+		require.Contains(t, buf.String(), "View the Web UI: https://foobarbaz.mydomain\n")
 	})
 
 	t.Run("NoWarningWithRemoteAccessURL", func(t *testing.T) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -148,7 +148,7 @@ func TestServer(t *testing.T) {
 	})
 
 	// Validate that an https scheme is prepended to a remote access URL
-	// and that a warning is printed about it not being externally reachable.
+	// and that a warning is printed for a host that cannot be resolved.
 	t.Run("NoSchemeRemoteAccessURL", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancelFunc := context.WithCancel(context.Background())


### PR DESCRIPTION
- Problems can arise spawning workspaces if a scheme-less URL is passed
  as the access URL.

  If an access URL is detected to not have an "http" or "https" scheme
  then it is prepended with "https". If the hostname is detected
  to be a loopback device then "http" is preferred.

fixes #2874
