### PR TITLE
fix: Remove alternative image architectures until we virtualize

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
 
           # build and (maybe) push Docker images for each architecture
           images=()
-          for arch in amd64 armv7 arm64; do
+          for arch in amd64; do
             img="$(
               ./scripts/build_docker.sh \
                 ${{ (!github.event.inputs.dry_run && !github.event.inputs.snapshot) && '--push' || '' }} \


### PR DESCRIPTION
With the addition of a command being executed inside the Docker build,
we could no longer build non-amd64 images on amd64. They will be added
back, but to allow for releases this temporarily removes them.

An issue tracking the addition has been added here: https://github.com/coder/coder/issues/3337