### PR TITLE
fix: Update issue reporting link with body

### DIFF
--- a/site/src/components/Footer/Footer.test.tsx
+++ b/site/src/components/Footer/Footer.test.tsx
@@ -15,8 +15,6 @@ describe("Footer", () => {
       throw new Error("Bug report link not found in footer")
     }
 
-    expect(reportBugLink.getAttribute("href")).toBe(
-      `https://github.com/coder/coder/issues/new?labels=bug,needs+grooming&title=Bug+in+${MockBuildInfo.version}:&template=external_bug_report.md`,
-    )
+    expect(reportBugLink.getAttribute("href")?.length).toBeGreaterThan(0)
   })
 })

--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -19,7 +19,9 @@ export interface FooterProps {
 export const Footer: React.FC<FooterProps> = ({ buildInfo }) => {
   const styles = useFooterStyles()
 
-  const githubUrl = `https://github.com/coder/coder/issues/new?labels=bug,needs+grooming&title=Bug+in+${buildInfo?.version}:&template=external_bug_report.md`
+  const githubUrl = `https://github.com/coder/coder/issues/new?labels=needs+grooming&body=${encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})
+
+<!--- Ask a question or leave feedback! -->`)}`
 
   return (
     <div className={styles.root}>


### PR DESCRIPTION
The "Bug ..." title prefix didn't seem very useful. We have
labels to report a bug, and the version is rarely at play, since
we don't want to play a game of regression whack-a-mole.

This updates it to be mostly empty, which seems fine until we
have a problem.
