### PR TITLE
chore: add template length restriction in troubleshooting

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -293,6 +293,12 @@ practices:
   - The Coder agent logs are typically stored in `/var/log/coder-agent.log`
   - The Coder agent startup script logs are typically stored in `/var/log/coder-startup-script.log`
 
+### Template name length limits 
+
+Templates cannot exceed 32 characters. If your local template directory name or
+name given in `coder templates create` is greater than 32 characters, the
+template will fail to upload and give a validation error.
+
 ## Change Management
 
 We recommend source controlling your templates as you would other code.


### PR DESCRIPTION
This PR explains that there is a character length limit to templates.

I am documenting this because the validation error that a user receives when running `coder templates create` does identify the template length limit as the cause.
