### PR TITLE
fix: chromatic workflow filter

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -68,10 +68,7 @@ jobs:
             sh:
               - "**.sh"
             ts:
-              - "**.tsx?"
-              - "**.jsx?"
-              - "**.lock"
-              - "**.json"
+              - 'site/**'
       - id: debug
         run: |
           echo "${{ toJSON(steps.filter )}}"


### PR DESCRIPTION
This PR fixes the workflow filter for checking when to run the Chromatic job. Currently, the Chromatic job is being skipped even for TypeScript changes.