### PR TITLE
fix: Use "virtual_machine_id" for instance identity with Azure

### DIFF
--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -310,8 +310,8 @@ func applyAutomaticInstanceID(resource *tfjson.StateResource, agents []*proto.Ag
 	key, isValid := map[string]string{
 		"google_compute_instance":         "instance_id",
 		"aws_instance":                    "id",
-		"azurerm_linux_virtual_machine":   "id",
-		"azurerm_windows_virtual_machine": "id",
+		"azurerm_linux_virtual_machine":   "virtual_machine_id",
+		"azurerm_windows_virtual_machine": "virtual_machine_id",
 	}[resource.Type]
 	if !isValid {
 		return

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -222,11 +222,11 @@ func TestInstanceIDAssociation(t *testing.T) {
 	}, {
 		Auth:          "azure-instance-identity",
 		ResourceType:  "azurerm_linux_virtual_machine",
-		InstanceIDKey: "id",
+		InstanceIDKey: "virtual_machine_id",
 	}, {
 		Auth:          "azure-instance-identity",
 		ResourceType:  "azurerm_windows_virtual_machine",
-		InstanceIDKey: "id",
+		InstanceIDKey: "virtual_machine_id",
 	}} {
 		tc := tc
 		t.Run(tc.ResourceType, func(t *testing.T) {


### PR DESCRIPTION
This was using the wrong property, causing automatic auth to break.

Fixes #3315.