### PR TITLE
fix: Skip waiting for exit output in SSH test

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -86,6 +86,7 @@ func TestSSH(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		pty.ExpectMatch("Waiting")
+
 		agentClient := codersdk.New(client.URL)
 		agentClient.SessionToken = agentToken
 		agentCloser := agent.New(agentClient.ListenWorkspaceAgent, &agent.Options{
@@ -97,9 +98,6 @@ func TestSSH(t *testing.T) {
 
 		// Shells on Mac, Windows, and Linux all exit shells with the "exit" command.
 		pty.WriteLine("exit")
-		// Read output to prevent hang on macOS, see:
-		// https://github.com/coder/coder/issues/2122
-		pty.ExpectMatch("exit")
 		<-cmdDone
 	})
 	t.Run("Stdio", func(t *testing.T) {


### PR DESCRIPTION
This seems to have caused flakes on Windows, the reason could be that
the input is lost due to writing to stdin before the shell is ready, or
simply that the command wasn't echoed (for the same reason).

We no longer need to consume the output since #2122 has been fixed, so
this might remove the flake in the latter case.

Ideally we would wait for the prompt to be present, but since we are
spawning the users shell, we have no control of what the prompt looks
like. In CI we can make assumption but even then it could change in the
future.

