### PR TITLE
fix: Associate spot instances with their instance IDs for auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.2
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -310,6 +310,7 @@ func applyAutomaticInstanceID(resource *tfjson.StateResource, agents []*proto.Ag
 	key, isValid := map[string]string{
 		"google_compute_instance":         "instance_id",
 		"aws_instance":                    "id",
+		"aws_spot_instance_request":       "spot_instance_id",
 		"azurerm_linux_virtual_machine":   "virtual_machine_id",
 		"azurerm_windows_virtual_machine": "virtual_machine_id",
 	}[resource.Type]

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -220,6 +220,10 @@ func TestInstanceIDAssociation(t *testing.T) {
 		ResourceType:  "aws_instance",
 		InstanceIDKey: "id",
 	}, {
+		Auth:          "aws-instance-identity",
+		ResourceType:  "aws_spot_instance_request",
+		InstanceIDKey: "spot_instance_id",
+	}, {
 		Auth:          "azure-instance-identity",
 		ResourceType:  "azurerm_linux_virtual_machine",
 		InstanceIDKey: "virtual_machine_id",


### PR DESCRIPTION
Fixes #2162.
