### PR TITLE
fix: Add ps.Kill/Wait to test cleanup in `ptytest.Start`

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -35,6 +35,10 @@ func Start(t *testing.T, cmd *exec.Cmd) (*PTY, pty.Process) {
 
 	ptty, ps, err := pty.Start(cmd)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ps.Kill()
+		_ = ps.Wait()
+	})
 	return create(t, ptty, cmd.Args[0]), ps
 }
 


### PR DESCRIPTION
A quick fix to ensure `ptytest.Start` cleans up after itself.

Prompted by a flake seen here: https://github.com/coder/coder/runs/7687803809
