### PR TITLE
chore: add testutil.Eventually and friends

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -411,9 +411,9 @@ func AwaitTemplateVersionJob(t *testing.T, client *codersdk.Client, version uuid
 
 	t.Logf("waiting for template version job %s", version)
 	var templateVersion codersdk.TemplateVersion
-	require.True(t, testutil.EventuallyShort(t, func() bool {
+	require.True(t, testutil.EventuallyShort(t, func(ctx context.Context) bool {
 		var err error
-		templateVersion, err = client.TemplateVersion(context.Background(), version)
+		templateVersion, err = client.TemplateVersion(ctx, version)
 		return assert.NoError(t, err) && templateVersion.Job.CompletedAt != nil
 	}))
 	return templateVersion
@@ -425,8 +425,8 @@ func AwaitWorkspaceBuildJob(t *testing.T, client *codersdk.Client, build uuid.UU
 
 	t.Logf("waiting for workspace build job %s", build)
 	var workspaceBuild codersdk.WorkspaceBuild
-	require.True(t, testutil.EventuallyShort(t, func() bool {
-		workspaceBuild, err := client.WorkspaceBuild(context.Background(), build)
+	require.True(t, testutil.EventuallyShort(t, func(ctx context.Context) bool {
+		workspaceBuild, err := client.WorkspaceBuild(ctx, build)
 		return assert.NoError(t, err) && workspaceBuild.Job.CompletedAt != nil
 	}))
 	return workspaceBuild
@@ -438,9 +438,9 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 
 	t.Logf("waiting for workspace agents (build %s)", build)
 	var resources []codersdk.WorkspaceResource
-	require.True(t, testutil.EventuallyLong(t, func() bool {
+	require.True(t, testutil.EventuallyLong(t, func(ctx context.Context) bool {
 		var err error
-		resources, err = client.WorkspaceResourcesByBuild(context.Background(), build)
+		resources, err = client.WorkspaceResourcesByBuild(ctx, build)
 		if !assert.NoError(t, err) {
 			return false
 		}

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -411,11 +411,11 @@ func AwaitTemplateVersionJob(t *testing.T, client *codersdk.Client, version uuid
 
 	t.Logf("waiting for template version job %s", version)
 	var templateVersion codersdk.TemplateVersion
-	require.Eventually(t, func() bool {
+	require.True(t, testutil.EventuallyShort(t, func() bool {
 		var err error
 		templateVersion, err = client.TemplateVersion(context.Background(), version)
 		return assert.NoError(t, err) && templateVersion.Job.CompletedAt != nil
-	}, testutil.WaitShort, testutil.IntervalFast)
+	}))
 	return templateVersion
 }
 
@@ -425,11 +425,10 @@ func AwaitWorkspaceBuildJob(t *testing.T, client *codersdk.Client, build uuid.UU
 
 	t.Logf("waiting for workspace build job %s", build)
 	var workspaceBuild codersdk.WorkspaceBuild
-	require.Eventually(t, func() bool {
-		var err error
-		workspaceBuild, err = client.WorkspaceBuild(context.Background(), build)
+	require.True(t, testutil.EventuallyShort(t, func() bool {
+		workspaceBuild, err := client.WorkspaceBuild(context.Background(), build)
 		return assert.NoError(t, err) && workspaceBuild.Job.CompletedAt != nil
-	}, testutil.WaitShort, testutil.IntervalFast)
+	}))
 	return workspaceBuild
 }
 
@@ -439,7 +438,7 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 
 	t.Logf("waiting for workspace agents (build %s)", build)
 	var resources []codersdk.WorkspaceResource
-	require.Eventually(t, func() bool {
+	require.True(t, testutil.EventuallyShort(t, func() bool {
 		var err error
 		resources, err = client.WorkspaceResourcesByBuild(context.Background(), build)
 		if !assert.NoError(t, err) {
@@ -448,12 +447,13 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 		for _, resource := range resources {
 			for _, agent := range resource.Agents {
 				if agent.Status != codersdk.WorkspaceAgentConnected {
+					t.Logf("agent %s not connected yet", agent.Name)
 					return false
 				}
 			}
 		}
 		return true
-	}, testutil.WaitLong, testutil.IntervalMedium)
+	}))
 	return resources
 }
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -438,7 +438,7 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 
 	t.Logf("waiting for workspace agents (build %s)", build)
 	var resources []codersdk.WorkspaceResource
-	require.True(t, testutil.EventuallyShort(t, func() bool {
+	require.True(t, testutil.EventuallyLong(t, func() bool {
 		var err error
 		resources, err = client.WorkspaceResourcesByBuild(context.Background(), build)
 		if !assert.NoError(t, err) {

--- a/coderd/coderdtest/coderdtest_test.go
+++ b/coderd/coderdtest/coderdtest_test.go
@@ -19,7 +19,7 @@ func TestNew(t *testing.T) {
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
-	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+	_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -91,7 +91,7 @@ func useStandardTimeoutsAndDelaysInTests(m dsl.Matcher) {
 	m.Import("github.com/coder/coder/testutil")
 
 	m.Match(`context.WithTimeout($ctx, $duration)`).
-		Where(m.File().Imports("testing") && !m["duration"].Text.Matches("^testutil\\.")).
+		Where(m.File().Imports("testing") && !m.File().PkgPath.Matches("testutil$") && !m["duration"].Text.Matches("^testutil\\.")).
 		At(m["duration"]).
 		Report("Do not use magic numbers in test timeouts and delays. Use the standard testutil.Wait* or testutil.Interval* constants instead.")
 

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -39,7 +39,6 @@ func Eventually(ctx context.Context, t testing.TB, condition func() bool, tick t
 // EventuallyShort is a convenience function that runs Eventually with
 // IntervalFast and times out after WaitShort.
 func EventuallyShort(t testing.TB, condition func() bool) bool {
-	//nolint: gocritic
 	ctx, cancel := context.WithTimeout(context.Background(), WaitShort)
 	defer cancel()
 	return Eventually(ctx, t, condition, IntervalFast)
@@ -48,7 +47,6 @@ func EventuallyShort(t testing.TB, condition func() bool) bool {
 // EventuallyMedium is a convenience function that runs Eventually with
 // IntervalMedium and times out after WaitMedium.
 func EventuallyMedium(t testing.TB, condition func() bool) bool {
-	//nolint: gocritic
 	ctx, cancel := context.WithTimeout(context.Background(), WaitMedium)
 	defer cancel()
 	return Eventually(ctx, t, condition, IntervalMedium)
@@ -57,7 +55,6 @@ func EventuallyMedium(t testing.TB, condition func() bool) bool {
 // EventuallyLong is a convenience function that runs Eventually with
 // IntervalSlow and times out after WaitLong.
 func EventuallyLong(t testing.TB, condition func() bool) bool {
-	//nolint: gocritic
 	ctx, cancel := context.WithTimeout(context.Background(), WaitLong)
 	defer cancel()
 	return Eventually(ctx, t, condition, IntervalSlow)

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -35,6 +35,7 @@ func Eventually(ctx context.Context, t testing.TB, condition func(context.Contex
 			assert.NoError(t, ctx.Err(), "Eventually timed out")
 			return false
 		case <-tick:
+			assert.NoError(t, ctx.Err(), "Eventually timed out")
 			if condition(ctx) {
 				return true
 			}

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -38,7 +38,6 @@ func Eventually(ctx context.Context, t testing.TB, condition func(context.Contex
 			if condition(ctx) {
 				return true
 			}
-			tick = ticker.C
 		}
 	}
 }

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -27,7 +27,6 @@ func Eventually(ctx context.Context, t testing.TB, condition func(context.Contex
 		panic("developer error: must set deadline or timeout on ctx")
 	}
 
-	ch := make(chan bool, 1)
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 	for tick := ticker.C; ; {
@@ -36,11 +35,7 @@ func Eventually(ctx context.Context, t testing.TB, condition func(context.Contex
 			assert.NoError(t, ctx.Err(), "Eventually timed out")
 			return false
 		case <-tick:
-			tick = nil
-			ch <- condition(ctx)
-		case v := <-ch:
-			if v {
-				close(ch)
+			if condition(ctx) {
 				return true
 			}
 			tick = ticker.C

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Eventually is like require.Eventually except it takes a context.
+// If ctx times out, the test will fail.
+// ctx must have a deadline set or this will panic.
+func Eventually(ctx context.Context, t testing.TB, condition func() bool, tick time.Duration) bool {
+	t.Helper()
+
+	if _, ok := ctx.Deadline(); !ok {
+		panic("developer error: must set deadline on ctx")
+	}
+
+	ch := make(chan bool, 1)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+	for tick := ticker.C; ; {
+		select {
+		case <-ctx.Done():
+			t.Errorf("Await timed out")
+			return false
+		case <-tick:
+			tick = nil
+			go func() { ch <- condition() }()
+		case v := <-ch:
+			if v {
+				return true
+			}
+			tick = ticker.C
+		}
+	}
+}
+
+// EventuallyShort is a convenience function that runs Eventually with
+// IntervalFast and times out after WaitShort.
+func EventuallyShort(t testing.TB, condition func() bool) bool {
+	//nolint: gocritic
+	ctx, cancel := context.WithTimeout(context.Background(), WaitShort)
+	defer cancel()
+	return Eventually(ctx, t, condition, IntervalFast)
+}
+
+// EventuallyMedium is a convenience function that runs Eventually with
+// IntervalMedium and times out after WaitMedium.
+func EventuallyMedium(t testing.TB, condition func() bool) bool {
+	//nolint: gocritic
+	ctx, cancel := context.WithTimeout(context.Background(), WaitMedium)
+	defer cancel()
+	return Eventually(ctx, t, condition, IntervalMedium)
+}
+
+// EventuallyLong is a convenience function that runs Eventually with
+// IntervalSlow and times out after WaitLong.
+func EventuallyLong(t testing.TB, condition func() bool) bool {
+	//nolint: gocritic
+	ctx, cancel := context.WithTimeout(context.Background(), WaitLong)
+	defer cancel()
+	return Eventually(ctx, t, condition, IntervalSlow)
+}

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -4,16 +4,27 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// Eventually is like require.Eventually except it takes a context.
-// If ctx times out, the test will fail.
-// ctx must have a deadline set or this will panic.
-func Eventually(ctx context.Context, t testing.TB, condition func() bool, tick time.Duration) bool {
+// Eventually is like require.Eventually except it allows passing
+// a context into the condition. It is safe to use with `require.*`.
+//
+// If ctx times out, the test will fail, but not immediately.
+// It is the caller's responsibility to exit early if required.
+//
+// It is the caller's responsibility to ensure that ctx has a
+// deadline or timeout set. Eventually will panic if this is not
+// the case in order to avoid potentially waiting forever.
+//
+// condition is not run in a goroutine; use the provided
+// context argument for cancellation if required.
+func Eventually(ctx context.Context, t testing.TB, condition func(context.Context) bool, tick time.Duration) bool {
 	t.Helper()
 
 	if _, ok := ctx.Deadline(); !ok {
-		panic("developer error: must set deadline on ctx")
+		panic("developer error: must set deadline or timeout on ctx")
 	}
 
 	ch := make(chan bool, 1)
@@ -22,13 +33,14 @@ func Eventually(ctx context.Context, t testing.TB, condition func() bool, tick t
 	for tick := ticker.C; ; {
 		select {
 		case <-ctx.Done():
-			t.Errorf("Await timed out")
+			assert.NoError(t, ctx.Err(), "Eventually timed out")
 			return false
 		case <-tick:
 			tick = nil
-			go func() { ch <- condition() }()
+			ch <- condition(ctx)
 		case v := <-ch:
 			if v {
+				close(ch)
 				return true
 			}
 			tick = ticker.C
@@ -38,7 +50,7 @@ func Eventually(ctx context.Context, t testing.TB, condition func() bool, tick t
 
 // EventuallyShort is a convenience function that runs Eventually with
 // IntervalFast and times out after WaitShort.
-func EventuallyShort(t testing.TB, condition func() bool) bool {
+func EventuallyShort(t testing.TB, condition func(context.Context) bool) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), WaitShort)
 	defer cancel()
 	return Eventually(ctx, t, condition, IntervalFast)
@@ -46,7 +58,7 @@ func EventuallyShort(t testing.TB, condition func() bool) bool {
 
 // EventuallyMedium is a convenience function that runs Eventually with
 // IntervalMedium and times out after WaitMedium.
-func EventuallyMedium(t testing.TB, condition func() bool) bool {
+func EventuallyMedium(t testing.TB, condition func(context.Context) bool) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), WaitMedium)
 	defer cancel()
 	return Eventually(ctx, t, condition, IntervalMedium)
@@ -54,7 +66,7 @@ func EventuallyMedium(t testing.TB, condition func() bool) bool {
 
 // EventuallyLong is a convenience function that runs Eventually with
 // IntervalSlow and times out after WaitLong.
-func EventuallyLong(t testing.TB, condition func() bool) bool {
+func EventuallyLong(t testing.TB, condition func(context.Context) bool) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), WaitLong)
 	defer cancel()
 	return Eventually(ctx, t, condition, IntervalSlow)

--- a/testutil/eventually_test.go
+++ b/testutil/eventually_test.go
@@ -19,7 +19,7 @@ func TestEventually(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 		state := 0
-		condition := func() bool {
+		condition := func(_ context.Context) bool {
 			defer func() {
 				state++
 			}()
@@ -27,18 +27,18 @@ func TestEventually(t *testing.T) {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
-		assert.True(t, testutil.Eventually(ctx, t, condition, testutil.IntervalFast))
+		testutil.Eventually(ctx, t, condition, testutil.IntervalFast)
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
 		t.Parallel()
-		condition := func() bool {
+		condition := func(_ context.Context) bool {
 			return false
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
 		mockT := new(testing.T)
-		assert.False(t, testutil.Eventually(ctx, mockT, condition, testutil.IntervalFast))
+		testutil.Eventually(ctx, mockT, condition, testutil.IntervalFast)
 		assert.True(t, mockT.Failed())
 	})
 
@@ -47,24 +47,24 @@ func TestEventually(t *testing.T) {
 
 		panicky := func() {
 			mockT := new(testing.T)
-			condition := func() bool { return true }
-			assert.False(t, testutil.Eventually(context.Background(), mockT, condition, testutil.IntervalFast))
+			condition := func(_ context.Context) bool { return true }
+			testutil.Eventually(context.Background(), mockT, condition, testutil.IntervalFast)
 		}
 		assert.Panics(t, panicky)
 	})
 
 	t.Run("Short", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, testutil.EventuallyShort(t, func() bool { return true }))
+		testutil.EventuallyShort(t, func(_ context.Context) bool { return true })
 	})
 
 	t.Run("Medium", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, testutil.EventuallyMedium(t, func() bool { return true }))
+		testutil.EventuallyMedium(t, func(_ context.Context) bool { return true })
 	})
 
 	t.Run("Long", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, testutil.EventuallyLong(t, func() bool { return true }))
+		testutil.EventuallyLong(t, func(_ context.Context) bool { return true })
 	})
 }

--- a/testutil/eventually_test.go
+++ b/testutil/eventually_test.go
@@ -1,0 +1,70 @@
+package testutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+
+	"github.com/coder/coder/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestEventually(t *testing.T) {
+	t.Parallel()
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		state := 0
+		condition := func() bool {
+			defer func() {
+				state++
+			}()
+			return state > 2
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+		assert.True(t, testutil.Eventually(ctx, t, condition, testutil.IntervalFast))
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		t.Parallel()
+		condition := func() bool {
+			return false
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+		mockT := new(testing.T)
+		assert.False(t, testutil.Eventually(ctx, mockT, condition, testutil.IntervalFast))
+		assert.True(t, mockT.Failed())
+	})
+
+	t.Run("Panic", func(t *testing.T) {
+		t.Parallel()
+
+		panicky := func() {
+			mockT := new(testing.T)
+			condition := func() bool { return true }
+			assert.False(t, testutil.Eventually(context.Background(), mockT, condition, testutil.IntervalFast))
+		}
+		assert.Panics(t, panicky)
+	})
+
+	t.Run("Short", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, testutil.EventuallyShort(t, func() bool { return true }))
+	})
+
+	t.Run("Medium", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, testutil.EventuallyMedium(t, func() bool { return true }))
+	})
+
+	t.Run("Long", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, testutil.EventuallyLong(t, func() bool { return true }))
+	})
+}


### PR DESCRIPTION
This PR adds a `testutil` function aimed to replace `require.Eventually`.
Should be useful in conjunction with https://github.com/coder/coder/pull/3381

Before:
```go
require.Eventually(t, func() bool { ... }, testutil.WaitShort, testutil.IntervalFast)
```

After:
```go
require.True(t, testutil.EventuallyShort(t, func(ctx context.Context) bool { ... }))

// or the full incantation if you need more control
ctx, cancel := context.WithTimeout(ctx.Background(), testutil.WaitLong)
require.True(t, testutil.Eventually(t, ctx, func(ctx context.Context) bool { ... }, testutil.IntervalSlow))
```