### PR TITLE
fix: Improve friendly validation error messages

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -14,9 +14,7 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-var (
-	validate *validator.Validate
-)
+var validate *validator.Validate
 
 // This init is used to create a validator and register validation-specific
 // functionality for the HTTP API.
@@ -31,16 +29,19 @@ func init() {
 		}
 		return name
 	})
-	err := validate.RegisterValidation("username", func(fl validator.FieldLevel) bool {
+	nameValidator := func(fl validator.FieldLevel) bool {
 		f := fl.Field().Interface()
 		str, ok := f.(string)
 		if !ok {
 			return false
 		}
 		return UsernameValid(str)
-	})
-	if err != nil {
-		panic(err)
+	}
+	for _, tag := range []string{"username", "template_name", "workspace_name"} {
+		err := validate.RegisterValidation(tag, nameValidator)
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -186,7 +186,12 @@ func (e *Error) StatusCode() int {
 }
 
 func (e *Error) Friendly() string {
-	return fmt.Sprintf("%s. %s", strings.TrimSuffix(e.Message, "."), e.Helper)
+	var sb strings.Builder
+	_, _ = fmt.Fprintf(&sb, "%s. %s", strings.TrimSuffix(e.Message, "."), e.Helper)
+	for _, err := range e.Validations {
+		_, _ = fmt.Fprintf(&sb, "\n- %s: %s", err.Field, err.Detail)
+	}
+	return sb.String()
 }
 
 func (e *Error) Error() string {

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -48,7 +48,7 @@ type CreateTemplateVersionRequest struct {
 // CreateTemplateRequest provides options when creating a template.
 type CreateTemplateRequest struct {
 	// Name is the name of the template.
-	Name string `json:"name" validate:"username,required"`
+	Name string `json:"name" validate:"template_name,required"`
 	// Description is a description of what the template contains. It must be
 	// less than 128 bytes.
 	Description string `json:"description,omitempty" validate:"lt=128"`
@@ -75,7 +75,7 @@ type CreateTemplateRequest struct {
 // CreateWorkspaceRequest provides options for creating a new workspace.
 type CreateWorkspaceRequest struct {
 	TemplateID        uuid.UUID `json:"template_id" validate:"required"`
-	Name              string    `json:"name" validate:"username,required"`
+	Name              string    `json:"name" validate:"workspace_name,required"`
 	AutostartSchedule *string   `json:"autostart_schedule"`
 	TTLMillis         *int64    `json:"ttl_ms,omitempty"`
 	// ParameterValues allows for additional parameters to be provided


### PR DESCRIPTION
This PR adds the validation errors to the friendly error message.

I found it confusing when working on #3000 and all I got was `Validation failed.`.

Before:

```
❯ go run ./cmd/coder rename testy user/tester
Validation failed.
Run 'coder rename --help' for usage.
```

After:

```
❯ go run ./cmd/coder rename testy user/tester
Validation failed.
- name: Validation failed for tag "workspace_name" with value: "user/tester"
Run 'coder rename --help' for usage.
```

The original `Validation failed for tag "username"` was also confusing, so new validators were registered.

- fix: Add validations to `(*codersdk.Error).Friendly`
- fix: Add named validators for template and workspace name

---

Fixes #1673