### PR TITLE
fix: Disallow args for config-ssh subcommand in cli

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -156,7 +156,8 @@ func configSSH() *cobra.Command {
 				Command:     "coder config-ssh --dry-run",
 			},
 		),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := createClient(cmd)
 			if err != nil {
 				return err


### PR DESCRIPTION
Args are not used in `coder config-ssh`, this change prevents their use:

```
❯ go run ./cmd/coder config-ssh yes
accepts 0 arg(s), received 1
Run 'coder config-ssh --help' for usage.
exit status 1
```
