### PR TITLE
chore: docs: add port-forwarding options (CLI & ssh)

### DIFF
--- a/docs/ides.md
+++ b/docs/ides.md
@@ -78,3 +78,10 @@ Connection and connect to your Coder workspace.](./ides/configuring-gateway.md)
 ## Web IDEs (Jupyter, code-server, JetBrains Projector)
 
 Web IDEs (code-server, JetBrains Projector, VNC, etc.) are defined in the template. See [configuring IDEs](./ides/configuring-web-ides.md).
+
+## Port Forwarding
+
+Port Forwarding lets developers securely access processes on their Coder
+workspace from a local machine. A common use case is testing front-end
+applications in a browser at `http://localhost:<yourforwardedport>` See
+[configuring Port Forwarding](./ides/configuring-port-forwarding.md).

--- a/docs/ides/configuring-port-forwarding.md
+++ b/docs/ides/configuring-port-forwarding.md
@@ -1,0 +1,34 @@
+# Configuring Port Forwarding
+
+There are two ways to forward ports:
+
+- The Coder CLI port-forward command
+- SSH
+
+## The Coder CLI and port-forward
+
+For example:
+
+```hcl
+coder port-forward mycoderworkspacename --tcp 8000:8000
+```
+
+For more examples, type `coder port-forward --help`
+
+## SSH
+
+Use the Coder CLI to first [configure SSH](../ides.md#ssh-configuration) on your
+local machine. Then run `ssh`. For example:
+
+```hcl
+ssh -L 8000:localhost:8000 coder.mycoderworkspacename 
+```
+
+## Accessing the forwarded port
+
+After completing either Port Forwarding method, open a web browser on your local
+machine to access the Coder workspace process.
+
+```hcl
+http://localhost:<yourforwardedport>
+```

--- a/docs/ides/configuring-port-forwarding.md
+++ b/docs/ides/configuring-port-forwarding.md
@@ -9,7 +9,7 @@ There are two ways to forward ports:
 
 For example:
 
-```hcl
+```console
 coder port-forward mycoderworkspacename --tcp 8000:8000
 ```
 
@@ -20,7 +20,7 @@ For more examples, type `coder port-forward --help`
 Use the Coder CLI to first [configure SSH](../ides.md#ssh-configuration) on your
 local machine. Then run `ssh`. For example:
 
-```hcl
+```console
 ssh -L 8000:localhost:8000 coder.mycoderworkspacename 
 ```
 
@@ -29,6 +29,6 @@ ssh -L 8000:localhost:8000 coder.mycoderworkspacename
 After completing either Port Forwarding method, open a web browser on your local
 machine to access the Coder workspace process.
 
-```hcl
+```console
 http://localhost:<yourforwardedport>
 ```


### PR DESCRIPTION
This PR:

Documents the 2 ways to do port forwarding.

This is in response to [two, separate requests in the public Slack channel](https://coder-com.slack.com/archives/C01B9RR442F/p1659656630459259) for dev URLs in Coder OSS.  Port forwarding is an alternative method for the time being.

The Configuring web IDE docs mention this for a couple of IDE examples, but port forwarding should be a first-class citizen in the docs since web IDE access is not the only use case.
