### PR TITLE
feat: Add support for renaming workspaces

### DIFF
--- a/cli/rename.go
+++ b/cli/rename.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/codersdk"
+)
+
+func rename() *cobra.Command {
+	return &cobra.Command{
+		Annotations: workspaceCommand,
+		Use:         "rename <workspace> <new name>",
+		Short:       "Rename a workspace",
+		Args:        cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := createClient(cmd)
+			if err != nil {
+				return err
+			}
+			workspace, err := namedWorkspace(cmd, client, args[0])
+			if err != nil {
+				return xerrors.Errorf("get workspace: %w", err)
+			}
+			err = client.UpdateWorkspace(cmd.Context(), workspace.ID, codersdk.UpdateWorkspaceRequest{
+				Name: args[1],
+			})
+			if err != nil {
+				return xerrors.Errorf("rename workspace: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/codersdk"
 )
 
@@ -14,7 +15,7 @@ func rename() *cobra.Command {
 		Short:       "Rename a workspace",
 		Args:        cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := createClient(cmd)
+			client, err := CreateClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -22,6 +23,15 @@ func rename() *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("get workspace: %w", err)
 			}
+
+			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
+				Text:      "WARNING: A rename can result in loss of home volume if the template references the workspace name. Continue?",
+				IsConfirm: true,
+			})
+			if err != nil {
+				return err
+			}
+
 			err = client.UpdateWorkspace(cmd.Context(), workspace.ID, codersdk.UpdateWorkspaceRequest{
 				Name: args[1],
 			})

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -9,7 +9,7 @@ import (
 )
 
 func rename() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "rename <workspace> <new name>",
 		Short:       "Rename a workspace",
@@ -41,4 +41,8 @@ func rename() *cobra.Command {
 			return nil
 		},
 	}
+
+	cliui.AllowSkipPrompt(cmd)
+
+	return cmd
 }

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -1,0 +1,44 @@
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/pty/ptytest"
+	"github.com/coder/coder/testutil"
+)
+
+func TestRename(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	user := coderdtest.CreateFirstUser(t, client)
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	want := workspace.Name + "-test"
+	cmd, root := clitest.New(t, "rename", workspace.Name, want)
+	clitest.SetupConfig(t, client, root)
+	pty := ptytest.New(t)
+	cmd.SetIn(pty.Input())
+	cmd.SetOut(pty.Output())
+
+	err := cmd.ExecuteContext(ctx)
+	assert.NoError(t, err)
+
+	ws, err := client.Workspace(ctx, workspace.ID)
+	assert.NoError(t, err)
+
+	got := ws.Name
+	assert.Equal(t, want, got, "workspace name did not change")
+}

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -27,7 +27,7 @@ func TestRename(t *testing.T) {
 	defer cancel()
 
 	want := workspace.Name + "-test"
-	cmd, root := clitest.New(t, "rename", workspace.Name, want)
+	cmd, root := clitest.New(t, "rename", workspace.Name, want, "--yes")
 	clitest.SetupConfig(t, client, root)
 	pty := ptytest.New(t)
 	cmd.SetIn(pty.Input())

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
@@ -33,8 +34,15 @@ func TestRename(t *testing.T) {
 	cmd.SetIn(pty.Input())
 	cmd.SetOut(pty.Output())
 
-	err := cmd.ExecuteContext(ctx)
-	assert.NoError(t, err)
+	errC := make(chan error, 1)
+	go func() {
+		errC <- cmd.ExecuteContext(ctx)
+	}()
+
+	pty.ExpectMatch("confirm rename:")
+	pty.WriteLine(workspace.Name)
+
+	require.NoError(t, <-errC)
 
 	ws, err := client.Workspace(ctx, workspace.ID)
 	assert.NoError(t, err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -79,6 +79,7 @@ func Core() []*cobra.Command {
 		start(),
 		state(),
 		stop(),
+		rename(),
 		templates(),
 		update(),
 		users(),

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -372,6 +372,7 @@ func New(options *Options) *API {
 					httpmw.ExtractWorkspaceParam(options.Database),
 				)
 				r.Get("/", api.workspace)
+				r.Patch("/", api.patchWorkspace)
 				r.Route("/builds", func(r chi.Router) {
 					r.Get("/", api.workspaceBuilds)
 					r.Post("/", api.postWorkspaceBuilds)

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -2091,7 +2091,7 @@ func (q *fakeQuerier) UpdateProvisionerJobWithCompleteByID(_ context.Context, ar
 	return sql.ErrNoRows
 }
 
-func (q *fakeQuerier) UpdateWorkspace(_ context.Context, arg database.UpdateWorkspaceParams) error {
+func (q *fakeQuerier) UpdateWorkspace(_ context.Context, arg database.UpdateWorkspaceParams) (database.Workspace, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
@@ -2104,17 +2104,17 @@ func (q *fakeQuerier) UpdateWorkspace(_ context.Context, arg database.UpdateWork
 				continue
 			}
 			if other.Name == arg.Name {
-				return &pq.Error{Code: "23505", Message: "duplicate key value violates unique constraint"}
+				return database.Workspace{}, &pq.Error{Code: "23505", Message: "duplicate key value violates unique constraint"}
 			}
 		}
 
 		workspace.Name = arg.Name
 		q.workspaces[i] = workspace
 
-		return nil
+		return workspace, nil
 	}
 
-	return sql.ErrNoRows
+	return database.Workspace{}, sql.ErrNoRows
 }
 
 func (q *fakeQuerier) UpdateWorkspaceAutostart(_ context.Context, arg database.UpdateWorkspaceAutostartParams) error {

--- a/coderd/database/errors.go
+++ b/coderd/database/errors.go
@@ -16,9 +16,9 @@ const (
 )
 
 // IsUniqueViolation checks if the error is due to a unique violation.
-// If specific cunique constraints are given as arguments, the error
-// must be caused by one of them. If no constraints are given, this
-// function returns true on any unique violation.
+// If one or more specific unique constraints are given as arguments,
+// the error must be caused by one of them. If no constraints are given,
+// this function returns true for any unique violation.
 func IsUniqueViolation(err error, uniqueConstraints ...UniqueConstraint) bool {
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {

--- a/coderd/database/errors.go
+++ b/coderd/database/errors.go
@@ -1,0 +1,30 @@
+package database
+
+import (
+	"errors"
+
+	"github.com/lib/pq"
+)
+
+// UniqueConstraint represents a named unique constraint on a table.
+type UniqueConstraint string
+
+// UniqueConstrain enums.
+// TODO(mafredri): Generate these from the database schema.
+const (
+	UniqueConstraintAny                       UniqueConstraint = ""
+	UniqueConstraintWorkspacesOwnerIDLowerIdx UniqueConstraint = "workspaces_owner_id_lower_idx"
+)
+
+func IsUniqueViolation(err error, uniqueConstraint UniqueConstraint) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		if pqErr.Code.Name() == "unique_violation" {
+			if pqErr.Constraint == string(uniqueConstraint) || uniqueConstraint == UniqueConstraintAny {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/coderd/database/errors.go
+++ b/coderd/database/errors.go
@@ -9,7 +9,7 @@ import (
 // UniqueConstraint represents a named unique constraint on a table.
 type UniqueConstraint string
 
-// UniqueConstrain enums.
+// UniqueConstraint enums.
 // TODO(mafredri): Generate these from the database schema.
 const (
 	UniqueConstraintAny                       UniqueConstraint = ""

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -137,7 +137,7 @@ type querier interface {
 	UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error)
 	UpdateUserRoles(ctx context.Context, arg UpdateUserRolesParams) (User, error)
 	UpdateUserStatus(ctx context.Context, arg UpdateUserStatusParams) (User, error)
-	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (int64, error)
+	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error
 	UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error
 	UpdateWorkspaceAgentKeysByID(ctx context.Context, arg UpdateWorkspaceAgentKeysByIDParams) error
 	UpdateWorkspaceAutostart(ctx context.Context, arg UpdateWorkspaceAutostartParams) error

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -137,7 +137,7 @@ type querier interface {
 	UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error)
 	UpdateUserRoles(ctx context.Context, arg UpdateUserRolesParams) (User, error)
 	UpdateUserStatus(ctx context.Context, arg UpdateUserStatusParams) (User, error)
-	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error
+	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (int64, error)
 	UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error
 	UpdateWorkspaceAgentKeysByID(ctx context.Context, arg UpdateWorkspaceAgentKeysByIDParams) error
 	UpdateWorkspaceAutostart(ctx context.Context, arg UpdateWorkspaceAutostartParams) error

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -137,6 +137,7 @@ type querier interface {
 	UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error)
 	UpdateUserRoles(ctx context.Context, arg UpdateUserRolesParams) (User, error)
 	UpdateUserStatus(ctx context.Context, arg UpdateUserStatusParams) (User, error)
+	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error
 	UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error
 	UpdateWorkspaceAgentKeysByID(ctx context.Context, arg UpdateWorkspaceAgentKeysByIDParams) error
 	UpdateWorkspaceAutostart(ctx context.Context, arg UpdateWorkspaceAutostartParams) error

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -137,7 +137,7 @@ type querier interface {
 	UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error)
 	UpdateUserRoles(ctx context.Context, arg UpdateUserRolesParams) (User, error)
 	UpdateUserStatus(ctx context.Context, arg UpdateUserStatusParams) (User, error)
-	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error
+	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (Workspace, error)
 	UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error
 	UpdateWorkspaceAgentKeysByID(ctx context.Context, arg UpdateWorkspaceAgentKeysByIDParams) error
 	UpdateWorkspaceAutostart(ctx context.Context, arg UpdateWorkspaceAutostartParams) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4685,6 +4685,26 @@ func (q *sqlQuerier) InsertWorkspace(ctx context.Context, arg InsertWorkspacePar
 	return i, err
 }
 
+const updateWorkspace = `-- name: UpdateWorkspace :exec
+UPDATE
+	workspaces
+SET
+	name = $2
+WHERE
+	id = $1
+	AND deleted = false
+`
+
+type UpdateWorkspaceParams struct {
+	ID   uuid.UUID `db:"id" json:"id"`
+	Name string    `db:"name" json:"name"`
+}
+
+func (q *sqlQuerier) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error {
+	_, err := q.db.ExecContext(ctx, updateWorkspace, arg.ID, arg.Name)
+	return err
+}
+
 const updateWorkspaceAutostart = `-- name: UpdateWorkspaceAutostart :exec
 UPDATE
 	workspaces

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4685,13 +4685,15 @@ func (q *sqlQuerier) InsertWorkspace(ctx context.Context, arg InsertWorkspacePar
 	return i, err
 }
 
-const updateWorkspace = `-- name: UpdateWorkspace :exec
+const updateWorkspace = `-- name: UpdateWorkspace :execrows
 UPDATE
 	workspaces
 SET
 	name = $2
 WHERE
 	id = $1
+	-- This can result in rows affected being zero, the caller should
+	-- handle this case.
 	AND deleted = false
 `
 
@@ -4700,9 +4702,12 @@ type UpdateWorkspaceParams struct {
 	Name string    `db:"name" json:"name"`
 }
 
-func (q *sqlQuerier) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error {
-	_, err := q.db.ExecContext(ctx, updateWorkspace, arg.ID, arg.Name)
-	return err
+func (q *sqlQuerier) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateWorkspace, arg.ID, arg.Name)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updateWorkspaceAutostart = `-- name: UpdateWorkspaceAutostart :exec

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4685,15 +4685,13 @@ func (q *sqlQuerier) InsertWorkspace(ctx context.Context, arg InsertWorkspacePar
 	return i, err
 }
 
-const updateWorkspace = `-- name: UpdateWorkspace :execrows
+const updateWorkspace = `-- name: UpdateWorkspace :exec
 UPDATE
 	workspaces
 SET
 	name = $2
 WHERE
 	id = $1
-	-- This can result in rows affected being zero, the caller should
-	-- handle this case.
 	AND deleted = false
 `
 
@@ -4702,12 +4700,9 @@ type UpdateWorkspaceParams struct {
 	Name string    `db:"name" json:"name"`
 }
 
-func (q *sqlQuerier) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, updateWorkspace, arg.ID, arg.Name)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+func (q *sqlQuerier) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) error {
+	_, err := q.db.ExecContext(ctx, updateWorkspace, arg.ID, arg.Name)
+	return err
 }
 
 const updateWorkspaceAutostart = `-- name: UpdateWorkspaceAutostart :exec

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -112,6 +112,15 @@ SET
 WHERE
 	id = $1;
 
+-- name: UpdateWorkspace :exec
+UPDATE
+	workspaces
+SET
+	name = $2
+WHERE
+	id = $1
+	AND deleted = false;
+
 -- name: UpdateWorkspaceAutostart :exec
 UPDATE
 	workspaces

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -112,15 +112,13 @@ SET
 WHERE
 	id = $1;
 
--- name: UpdateWorkspace :execrows
+-- name: UpdateWorkspace :exec
 UPDATE
 	workspaces
 SET
 	name = $2
 WHERE
 	id = $1
-	-- This can result in rows affected being zero, the caller should
-	-- handle this case.
 	AND deleted = false;
 
 -- name: UpdateWorkspaceAutostart :exec

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -112,13 +112,15 @@ SET
 WHERE
 	id = $1;
 
--- name: UpdateWorkspace :exec
+-- name: UpdateWorkspace :execrows
 UPDATE
 	workspaces
 SET
 	name = $2
 WHERE
 	id = $1
+	-- This can result in rows affected being zero, the caller should
+	-- handle this case.
 	AND deleted = false;
 
 -- name: UpdateWorkspaceAutostart :exec

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -112,14 +112,15 @@ SET
 WHERE
 	id = $1;
 
--- name: UpdateWorkspace :exec
+-- name: UpdateWorkspace :one
 UPDATE
 	workspaces
 SET
 	name = $2
 WHERE
 	id = $1
-	AND deleted = false;
+	AND deleted = false
+RETURNING *;
 
 -- name: UpdateWorkspaceAutostart :exec
 UPDATE

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 	"github.com/moby/moby/pkg/namesgenerator"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
@@ -520,10 +519,8 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		// Check if we triggered the one-unique-name-per-owner
-		// constraint.
-		var pqErr *pq.Error
-		if errors.As(err, &pqErr) && pqErr.Code.Name() == "unique_violation" {
+		// Check if the name was already in use.
+		if database.IsUniqueViolation(err, database.UniqueConstraintWorkspacesOwnerIDLowerIdx) {
 			httpapi.Write(rw, http.StatusConflict, codersdk.Response{
 				Message: fmt.Sprintf("Workspace %q already exists.", req.Name),
 				Validations: []codersdk.ValidationError{{
@@ -533,7 +530,6 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-
 		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating workspace.",
 			Detail:  err.Error(),

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -501,11 +501,24 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 		name = req.Name
 	}
 
-	n, err := api.Database.UpdateWorkspace(r.Context(), database.UpdateWorkspaceParams{
+	err := api.Database.UpdateWorkspace(r.Context(), database.UpdateWorkspaceParams{
 		ID:   workspace.ID,
 		Name: name,
 	})
 	if err != nil {
+		// The query protects against updating deleted workspaces and
+		// the existence of the workspace is checked in the request,
+		// the only conclusion we can make is that we're trying to
+		// update a deleted workspace.
+		//
+		// We could do this check earlier but since we're not in a
+		// transaction, it's pointless.
+		if errors.Is(err, sql.ErrNoRows) {
+			httpapi.Write(rw, http.StatusMethodNotAllowed, codersdk.Response{
+				Message: fmt.Sprintf("Workspace %q is deleted and cannot be updated.", workspace.Name),
+			})
+			return
+		}
 		// Check if the name was already in use.
 		if database.IsUniqueViolation(err, database.UniqueWorkspacesOwnerIDLowerIdx) {
 			httpapi.Write(rw, http.StatusConflict, codersdk.Response{
@@ -520,18 +533,6 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating workspace.",
 			Detail:  err.Error(),
-		})
-		return
-	}
-	// If no rows were affected, the workspace must have been deleted
-	// between the start of the request and the query updating the
-	// workspace name.
-	//
-	// We could do this check earlier but we'd have to start a
-	// transaction to ensure consistency.
-	if n == 0 {
-		httpapi.Write(rw, http.StatusMethodNotAllowed, codersdk.Response{
-			Message: fmt.Sprintf("Workspace %q is deleted and cannot be updated.", workspace.Name),
 		})
 		return
 	}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -520,7 +520,7 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Check if the name was already in use.
-		if database.IsUniqueViolation(err, database.UniqueConstraintWorkspacesOwnerIDLowerIdx) {
+		if database.IsUniqueViolation(err, database.UniqueWorkspacesOwnerIDLowerIdx) {
 			httpapi.Write(rw, http.StatusConflict, codersdk.Response{
 				Message: fmt.Sprintf("Workspace %q already exists.", req.Name),
 				Validations: []codersdk.ValidationError{{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -93,7 +93,7 @@ func TestWorkspace(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 		defer cancel()
 
-		want := ws1.Name + "_2"
+		want := ws1.Name + "-test"
 		err := client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
 			Name: want,
 		})

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -77,6 +77,37 @@ func TestWorkspace(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "410") // gone
 	})
+
+	t.Run("Rename", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		ws1 := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		ws2 := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, ws1.LatestBuild.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, ws2.LatestBuild.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+		defer cancel()
+
+		want := ws1.Name + "_2"
+		err := client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
+			Name: want,
+		})
+		require.NoError(t, err, "workspace rename failed")
+
+		ws, err := client.Workspace(ctx, ws1.ID)
+		require.NoError(t, err)
+		require.Equal(t, want, ws.Name, "workspace name not updated")
+
+		err = client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
+			Name: ws2.Name,
+		})
+		require.Error(t, err, "workspace rename should have failed")
+	})
 }
 
 func TestAdminViewAllWorkspaces(t *testing.T) {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -371,6 +371,11 @@ export interface UpdateWorkspaceAutostartRequest {
 }
 
 // From codersdk/workspaces.go
+export interface UpdateWorkspaceRequest {
+  readonly name?: string
+}
+
+// From codersdk/workspaces.go
 export interface UpdateWorkspaceTTLRequest {
   readonly ttl_ms?: number
 }


### PR DESCRIPTION
**WIP:** This PR adds support for renaming workspaces.

For now, only the `docker` template has been updated, more to follow.

#### TODO

- [x] Prevent/warn about data loss mentioned in #3000, #3386
	- The rename cli command now has a disclaimer
- [ ] ~~Update all templates to use workspace IDs instead of names~~ We will do this separately.

Fixes #3000

