### PR TITLE
fix: Add godoc badge to README

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,6 +9,9 @@ github_checks:
   annotations: false
 
 coverage:
+  range: 50..75
+  round: down
+  precision: 2
   status:
     patch:
       default:
@@ -16,7 +19,7 @@ coverage:
     project:
       default:
         target: 65%
-        informational: yes
+        informational: true
 
 ignore:
   # This is generated code.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [!["Join us on
 Discord"](https://img.shields.io/badge/join-us%20on%20Discord-gray.svg?longCache=true&logo=discord&colorB=green)](https://discord.gg/coder)
 [![codecov](https://codecov.io/gh/coder/coder/branch/main/graph/badge.svg?token=TNLW3OAP6G)](https://codecov.io/gh/coder/coder)
+[![Go Reference](https://pkg.go.dev/badge/github.com/coder/coder.svg)](https://pkg.go.dev/github.com/coder/coder)
 [![Twitter
 Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 


### PR DESCRIPTION
This helps allude to the idea that Coder provides an API as
seen in #3411.

This also fixes the codecov badge from always being red ;p
