### PR TITLE
fix: Check if an API error has data before checking the message

### DIFF
--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -25,6 +25,9 @@ export type ApiError = AxiosError<ApiErrorResponse> & { response: AxiosResponse<
 export const isApiError = (err: any): err is ApiError => {
   if (axios.isAxiosError(err)) {
     const response = err.response?.data
+    if (!response) {
+      return false
+    }
 
     return (
       typeof response.message === "string" &&


### PR DESCRIPTION
This was causing the app to crash with an error. I found this manually
by looking through the obfuscated sources in DevTools. It's a
data-point for #3425 though!
