### PR TITLE
fix: Unskip SuspendAnotherUser test

### DIFF
--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -528,7 +528,6 @@ func TestPutUserSuspend(t *testing.T) {
 	t.Parallel()
 
 	t.Run("SuspendAnotherUser", func(t *testing.T) {
-		t.Skip()
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		me := coderdtest.CreateFirstUser(t, client)


### PR DESCRIPTION
It wasn't clear why this was skipped, it seems accidental.
