### PR TITLE
docs: remove configuring prefix from IDEs

### DIFF
--- a/docs/ides.md
+++ b/docs/ides.md
@@ -4,7 +4,7 @@ The following desktop IDEs have been tested with Coder, though any IDE with SSH
 support should work:
 
 - [VS Code Remote SSH](#vs-code-remote)
-- [JetBrains with Gateway](./ides/configuring-gateway.md)
+- [JetBrains with Gateway](./ides/gateway.md)
   - IntelliJ IDEA
   - CLion
   - GoLand
@@ -13,8 +13,8 @@ support should work:
   - RubyMine
   - WebStorm
 - Web IDEs (code-server, JupyterLab, JetBrains Projector)
-  - Note: These are [configured in the template](./ides/configuring-web-ides.md)
-- [Emacs](./ides/configuring-emacs-tramp.md)
+  - Note: These are [configured in the template](./ides/web-ides.md)
+- [Emacs](./ides/emacs-tramp.md)
 
 ## SSH configuration
 
@@ -67,7 +67,7 @@ already done so, you may wish to open a terminal on your Coder workspace and
 check out a copy of the project you intend to work on.
 
 After installing Gateway on your local system, [follow these steps to create a
-Connection and connect to your Coder workspace.](./ides/configuring-gateway.md)
+Connection and connect to your Coder workspace.](./ides/gateway.md)
 
 | Version   | Status  | Notes                                                    |
 | --------- | ------- | -------------------------------------------------------- |
@@ -77,7 +77,7 @@ Connection and connect to your Coder workspace.](./ides/configuring-gateway.md)
 
 ## Web IDEs (Jupyter, code-server, JetBrains Projector)
 
-Web IDEs (code-server, JetBrains Projector, VNC, etc.) are defined in the template. See [configuring IDEs](./ides/configuring-web-ides.md).
+Web IDEs (code-server, JetBrains Projector, VNC, etc.) are defined in the template. See [IDEs](./ides/web-ides.md).
 
 ## Up next
 

--- a/docs/ides/emacs-tramp.md
+++ b/docs/ides/emacs-tramp.md
@@ -1,4 +1,4 @@
-# Configuring Emacs TRAMP
+# Emacs TRAMP
 
 [Emacs TRAMP](https://www.emacswiki.org/emacs/TrampMode) is a method of running editing operations on a remote server.
 

--- a/docs/ides/gateway.md
+++ b/docs/ides/gateway.md
@@ -1,4 +1,4 @@
-# Configuring JetBrains Gateway
+# JetBrains Gateway
 
 The following walkthrough details how to connect JetBrains Gateway to
 Coder.

--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -1,4 +1,4 @@
-# Configuring web IDEs
+# Web IDEs
 
 By default, Coder workspaces allow connections via:
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -78,19 +78,19 @@
       "icon_path": "./images/icons/terminal.svg",
       "children": [
         {
-          "title": "Configuring Web IDEs",
+          "title": "Web IDEs",
           "description": "Learn how to configure web IDEs in your templates",
-          "path": "./ides/configuring-web-ides.md"
+          "path": "./ides/web-ides.md"
         },
         {
-          "title": "Configuring JetBrains Gateway",
+          "title": "JetBrains Gateway",
           "description": "Learn how to configure JetBrains Gateway for your workspaces",
-          "path": "./ides/configuring-gateway.md"
+          "path": "./ides/gateway.md"
         },
         {
-          "title": "Configuring Emacs",
+          "title": "Emacs",
           "description": "Learn how to configure Emacs with TRAMP in Coder",
-          "path": "./ides/configuring-emacs-tramp.md"
+          "path": "./ides/emacs-tramp.md"
         }
       ]
     },

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -84,4 +84,4 @@ Coder with Docker has the following advantages:
 ## Next Steps
 
 - [Learn more about template configuration](../templates.md)
-- [Configure more IDEs](../ides/configuring-web-ides.md)
+- [Configure more IDEs](../ides/web-ides.md)

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -238,7 +238,7 @@ resources associated with the workspace.
 ### Coder apps
 
 By default, all templates allow developers to connect over SSH and a web
-terminal. See [Configuring Web IDEs](./ides/configuring-web-ides.md) to
+terminal. See [Configuring Web IDEs](./ides/web-ides.md) to
 learn how to give users access to additional web applications.
 
 ### Data source


### PR DESCRIPTION
The Configuring prefix was cluttering the UI.

Before:
<img width="271" alt="Screen Shot 2022-08-09 at 7 04 22 PM" src="https://user-images.githubusercontent.com/7416144/183782289-dc783036-8c35-4566-b122-5c402b7c7fd1.png">

After:
<img width="322" alt="Screen Shot 2022-08-09 at 7 04 30 PM" src="https://user-images.githubusercontent.com/7416144/183782301-be0f8215-dd64-4f7a-bafa-1117c9b295d1.png">


