### PR TITLE
fix: Downgrade embedded PostgreSQL

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1153,7 +1153,7 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 	stdlibLogger := slog.Stdlib(ctx, logger.Named("postgres"), slog.LevelDebug)
 	ep := embeddedpostgres.NewDatabase(
 		embeddedpostgres.DefaultConfig().
-			Version(embeddedpostgres.V14).
+			Version(embeddedpostgres.V13).
 			BinariesPath(filepath.Join(cfg.PostgresPath(), "bin")).
 			DataPath(filepath.Join(cfg.PostgresPath(), "data")).
 			RuntimePath(filepath.Join(cfg.PostgresPath(), "runtime")).


### PR DESCRIPTION
This was causing a new data path to occur, which broke existing installs.
It needs to use the same path and upgrade instead.
