### PR TITLE
fix: Close response body in `cli` server test

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -463,6 +463,7 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 		res, err := client.HTTPClient.Get(githubURL.String())
 		require.NoError(t, err)
+		defer res.Body.Close()
 		fakeURL, err := res.Location()
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(fakeURL.String(), fakeRedirect), fakeURL.String())


### PR DESCRIPTION
Caught by https://github.com/coder/coder/pull/3370.
