### PR TITLE
chore: renamed `coder template edit` flags in coder CLI 

### DIFF
--- a/cli/templateedit.go
+++ b/cli/templateedit.go
@@ -53,8 +53,8 @@ func templateEdit() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&description, "description", "", "", "Edit the template description")
-	cmd.Flags().DurationVarP(&maxTTL, "max_ttl", "", 0, "Edit the template maximum time before shutdown")
-	cmd.Flags().DurationVarP(&minAutostartInterval, "min_autostart_interval", "", 0, "Edit the template minimum autostart interval")
+	cmd.Flags().DurationVarP(&maxTTL, "max-ttl", "", 0, "Edit the template maximum time before shutdown")
+	cmd.Flags().DurationVarP(&minAutostartInterval, "min-autostart-interval", "", 0, "Edit the template minimum autostart interval")
 	cliui.AllowSkipPrompt(cmd)
 
 	return cmd

--- a/cli/templateedit_test.go
+++ b/cli/templateedit_test.go
@@ -38,8 +38,8 @@ func TestTemplateEdit(t *testing.T) {
 			"edit",
 			template.Name,
 			"--description", desc,
-			"--max_ttl", maxTTL.String(),
-			"--min_autostart_interval", minAutostartInterval.String(),
+			"--max-ttl", maxTTL.String(),
+			"--min-autostart-interval", minAutostartInterval.String(),
 		}
 		cmd, root := clitest.New(t, cmdArgs...)
 		clitest.SetupConfig(t, client, root)
@@ -74,8 +74,8 @@ func TestTemplateEdit(t *testing.T) {
 			"edit",
 			template.Name,
 			"--description", template.Description,
-			"--max_ttl", (time.Duration(template.MaxTTLMillis) * time.Millisecond).String(),
-			"--min_autostart_interval", (time.Duration(template.MinAutostartIntervalMillis) * time.Millisecond).String(),
+			"--max-ttl", (time.Duration(template.MaxTTLMillis) * time.Millisecond).String(),
+			"--min-autostart-interval", (time.Duration(template.MinAutostartIntervalMillis) * time.Millisecond).String(),
 		}
 		cmd, root := clitest.New(t, cmdArgs...)
 		clitest.SetupConfig(t, client, root)


### PR DESCRIPTION
This PR renames `coder template edit` flags to adopt `-` inplca eof `_` for 
`--max_ttl`
`--min_autostart_interval`