### PR TITLE
fix: replace broken link with Github contributors graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ Join our community on [Discord](https://discord.gg/coder) and [Twitter](https://
 
 Read the [contributing docs](https://coder.com/docs/coder-oss/latest/CONTRIBUTING).
 
-Find our list of contributors [here](./docs/CONTRIBUTORS.md).
+Find our list of contributors [here](https://github.com/coder/coder/graphs/contributors).


### PR DESCRIPTION
This PR improves README by replacing a broken link.

Alternatively, we can simply remove the line.