### PR TITLE
fix: Remove unexpected break lines when copy logs

### DIFF
--- a/site/src/components/Logs/Logs.tsx
+++ b/site/src/components/Logs/Logs.tsx
@@ -21,8 +21,9 @@ export const Logs: FC<LogsProps> = ({ lines, className = "" }) => {
     <div className={combineClasses([className, styles.root])}>
       {lines.map((line, idx) => (
         <div className={styles.line} key={idx}>
-          <div className={styles.time}>{dayjs(line.time).format(`HH:mm:ss.SSS`)}</div>
-          <div>{line.output}</div>
+          <span className={styles.time}>{dayjs(line.time).format(`HH:mm:ss.SSS`)}</span>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span>{line.output}</span>
         </div>
       ))}
     </div>
@@ -42,12 +43,10 @@ const useStyles = makeStyles((theme) => ({
     overflowX: "auto",
   },
   line: {
-    display: "flex",
-    alignItems: "baseline",
+    whiteSpace: "nowrap",
   },
   time: {
     width: theme.spacing(12.5),
-    marginRight: theme.spacing(3),
-    flexShrink: 0,
+    display: "inline-block",
   },
 }))


### PR DESCRIPTION
Closes #3475 

Previously:
```
17:15:52.139
Initializing the backend...
17:15:52.192
17:15:52.245
Initializing provider plugins...
17:15:52.298
- Finding coder/coder versions matching "~> 0.4.4"...
17:15:52.540
- Finding latest version of hashicorp/aws...
17:15:52.766
- Finding latest version of hashicorp/null...
17:15:53.002
- Using coder/coder v0.4.5 from the shared cache directory
17:15:53.055
- Using hashicorp/aws v4.25.0 from the shared cache directory
17:15:53.756
- Using hashicorp/null v3.1.1 from the shared cache directory
```

Now:
```
09:30:10.447    
09:30:10.591    
09:30:10.651    Initializing the backend...
09:30:10.712    
09:30:10.771    Initializing provider plugins...
09:30:10.830    - Finding coder/coder versions matching "0.4.4"...
09:30:10.888    - Finding latest version of hashicorp/kubernetes...
09:30:11.002    - Finding latest version of hashicorp/google...
09:30:11.059    - Using coder/coder v0.4.4 from the shared cache directory
09:30:11.116    - Using hashicorp/kubernetes v2.12.1 from the shared cache directory
09:30:11.376    - Using hashicorp/google v4.31.0 from the shared cache directory
09:30:11.916    
09:30:11.995    Terraform has created a lock file .terraform.lock.hcl to record the provider
09:30:12.052    selections it made above. Include this file in your version control repository
09:30:12.111    so that Terraform can guarantee to make the same selections by default when
09:30:12.170    you run "terraform init" in the future.
09:30:12.227    
09:30:12.285    Terraform has been successfully initialized!
09:30:12.364    
09:30:12.422    You may now begin working with Terraform. Try running "terraform plan" to see
09:30:12.482    any changes that are required for your infrastructure. All Terraform commands
09:30:12.601    should now work.
09:30:12.663    
09:30:12.737    If you ever set or change modules or backend configuration for Terraform,
09:30:12.795    rerun this command to reinitialize your working directory. If you forget, other
09:30:12.852    commands will detect it and remind you to do so if necessary.
09:30:12.910    Terraform 1.1.9
09:30:14.051    coder_agent.coder: Refreshing state... [id=71e2eb87-53bd-44e9-a10c-f75e4bfb1900]
09:30:14.109    coder_agent.coder: Refresh complete [id=71e2eb87-53bd-44e9-a10c-f75e4bfb1900]
09:30:14.166    coder_app.code-server: Refreshing state... [id=63ca944f-b851-4aa5-adff-c1f304c91d7f]
09:30:14.223    coder_app.code-server: Refresh complete [id=63ca944f-b851-4aa5-adff-c1f304c91d7f]
09:30:15.771    kubernetes_persistent_volume_claim.root: Refreshing state... [id=default/home-af657bc3-6949-4b1b-bc2d-d41a40b546a4-84431a75-46f0-431e-a401-629f7f272e85]
09:30:16.383    kubernetes_persistent_volume_claim.root: Refresh complete [id=default/home-af657bc3-6949-4b1b-bc2d-d41a40b546a4-84431a75-46f0-431e-a401-629f7f272e85]
09:30:16.497    coder_metadata.pvc: Refreshing state... [id=533b69e6-30b1-4b50-aee2-4032f8cab0bc]
09:30:16.556    coder_metadata.pvc: Refresh complete [id=533b69e6-30b1-4b50-aee2-4032f8cab0bc]
```