### PR TITLE
chore: rename to "template push" in docs

### DIFF
--- a/cli/templateplan.go
+++ b/cli/templateplan.go
@@ -8,7 +8,7 @@ func templatePlan() *cobra.Command {
 	return &cobra.Command{
 		Use:   "plan <directory>",
 		Args:  cobra.MinimumNArgs(1),
-		Short: "Plan a template update from the current directory",
+		Short: "Plan a template push from the current directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,7 +62,7 @@ You can edit the Terraform template as follows:
 coder templates init
 cd gcp-linux # modify this line as needed to access the template
 vim main.tf
-coder templates update gcp-linux # updates the template
+coder templates push gcp-linux # updates the template
 ```
 
 ## Up Next

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -297,7 +297,7 @@ practices:
 
 We recommend source controlling your templates as you would other code.
 
-CI is as simple as running `coder templates update` with the appropriate
+CI is as simple as running `coder templates push` with the appropriate
 credentials.
 
 ---

--- a/examples/templates/docker-image-builds/README.md
+++ b/examples/templates/docker-image-builds/README.md
@@ -88,7 +88,7 @@ resource "docker_image" "coder_image" {
 Update the template:
 
 ```sh
-coder template update docker-image-builds
+coder template push docker-image-builds
 ```
 
 You can also remove images from the validation list. Workspaces using older template versions will continue using
@@ -136,7 +136,7 @@ resource "docker_image" "coder_image" {
 Update the template:
 
 ```sh
-coder template update docker-image-builds
+coder template push docker-image-builds
 ```
 
 Optional: Update workspaces to the latest template version

--- a/examples/templates/docker/README.md
+++ b/examples/templates/docker/README.md
@@ -1,6 +1,6 @@
 ---
 name: Develop in Docker
-description: Run workspaces on a Docker host using registry images 
+description: Run workspaces on a Docker host using registry images
 tags: [local, docker]
 ---
 
@@ -37,7 +37,7 @@ variable "docker_image" {
 Update the template:
 
 ```sh
-coder template update docker
+coder template push docker
 ```
 
 You can also remove images from the validation list. Workspaces using older template versions will continue using


### PR DESCRIPTION
We changed the command to `coder template push` in #3307 but did not change the docs