### PR TITLE
Use new table formatter everywhere

### DIFF
--- a/cli/cliui/table.go
+++ b/cli/cliui/table.go
@@ -90,7 +90,7 @@ func DisplayTable(out any, sort string, filterColumns []string) (string, error) 
 			sort = strings.ToLower(strings.ReplaceAll(sort, "_", " "))
 			h, ok := headersMap[sort]
 			if !ok {
-				return "", xerrors.Errorf("specified sort column %q not found in table headers, available columns are %q", sort, strings.Join(headersRaw, `", "`))
+				return "", xerrors.Errorf(`specified sort column %q not found in table headers, available columns are "%v"`, sort, strings.Join(headersRaw, `", "`))
 			}
 
 			// Autocorrect
@@ -101,7 +101,7 @@ func DisplayTable(out any, sort string, filterColumns []string) (string, error) 
 			column := strings.ToLower(strings.ReplaceAll(column, "_", " "))
 			h, ok := headersMap[column]
 			if !ok {
-				return "", xerrors.Errorf("specified filter column %q not found in table headers, available columns are %q", sort, strings.Join(headersRaw, `", "`))
+				return "", xerrors.Errorf(`specified filter column %q not found in table headers, available columns are "%v"`, sort, strings.Join(headersRaw, `", "`))
 			}
 
 			// Autocorrect
@@ -157,6 +157,10 @@ func DisplayTable(out any, sort string, filterColumns []string) (string, error) 
 			case *time.Time:
 				if val != nil {
 					v = val.Format(time.Stamp)
+				}
+			case fmt.Stringer:
+				if val != nil {
+					v = val.String()
 				}
 			}
 
@@ -300,20 +304,4 @@ func valueToTableMap(val reflect.Value) (map[string]any, error) {
 	}
 
 	return row, nil
-}
-
-func ValidateColumns(all, given []string) error {
-	for _, col := range given {
-		found := false
-		for _, c := range all {
-			if strings.EqualFold(strings.ReplaceAll(col, "_", " "), c) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("unknown column: %s", col)
-		}
-	}
-	return nil
 }

--- a/cli/cliui/table_test.go
+++ b/cli/cliui/table_test.go
@@ -1,6 +1,7 @@
 package cliui_test
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -11,6 +12,16 @@ import (
 
 	"github.com/coder/coder/cli/cliui"
 )
+
+type stringWrapper struct {
+	str string
+}
+
+var _ fmt.Stringer = stringWrapper{}
+
+func (s stringWrapper) String() string {
+	return s.str
+}
 
 type tableTest1 struct {
 	Name        string      `table:"name"`
@@ -28,9 +39,9 @@ type tableTest1 struct {
 }
 
 type tableTest2 struct {
-	Name        string `table:"name"`
-	Age         int    `table:"age"`
-	NotIncluded string `table:"-"`
+	Name        stringWrapper `table:"name"`
+	Age         int           `table:"age"`
+	NotIncluded string        `table:"-"`
 }
 
 type tableTest3 struct {
@@ -48,21 +59,21 @@ func Test_DisplayTable(t *testing.T) {
 			Age:   10,
 			Roles: []string{"a", "b", "c"},
 			Sub1: tableTest2{
-				Name: "foo1",
+				Name: stringWrapper{str: "foo1"},
 				Age:  11,
 			},
 			Sub2: &tableTest2{
-				Name: "foo2",
+				Name: stringWrapper{str: "foo2"},
 				Age:  12,
 			},
 			Sub3: tableTest3{
 				Sub: tableTest2{
-					Name: "foo3",
+					Name: stringWrapper{str: "foo3"},
 					Age:  13,
 				},
 			},
 			Sub4: tableTest2{
-				Name: "foo4",
+				Name: stringWrapper{str: "foo4"},
 				Age:  14,
 			},
 			Time:    someTime,
@@ -73,18 +84,18 @@ func Test_DisplayTable(t *testing.T) {
 			Age:   20,
 			Roles: []string{"a"},
 			Sub1: tableTest2{
-				Name: "bar1",
+				Name: stringWrapper{str: "bar1"},
 				Age:  21,
 			},
 			Sub2: nil,
 			Sub3: tableTest3{
 				Sub: tableTest2{
-					Name: "bar3",
+					Name: stringWrapper{str: "bar3"},
 					Age:  23,
 				},
 			},
 			Sub4: tableTest2{
-				Name: "bar4",
+				Name: stringWrapper{str: "bar4"},
 				Age:  24,
 			},
 			Time:    someTime,
@@ -95,18 +106,18 @@ func Test_DisplayTable(t *testing.T) {
 			Age:   30,
 			Roles: nil,
 			Sub1: tableTest2{
-				Name: "baz1",
+				Name: stringWrapper{str: "baz1"},
 				Age:  31,
 			},
 			Sub2: nil,
 			Sub3: tableTest3{
 				Sub: tableTest2{
-					Name: "baz3",
+					Name: stringWrapper{str: "baz3"},
 					Age:  33,
 				},
 			},
 			Sub4: tableTest2{
-				Name: "baz4",
+				Name: stringWrapper{str: "baz4"},
 				Age:  34,
 			},
 			Time:    someTime,

--- a/cli/parameters.go
+++ b/cli/parameters.go
@@ -1,11 +1,7 @@
 package cli
 
 import (
-	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-
-	"github.com/coder/coder/cli/cliui"
-	"github.com/coder/coder/codersdk"
 )
 
 func parameters() *cobra.Command {
@@ -29,30 +25,4 @@ func parameters() *cobra.Command {
 		parameterList(),
 	)
 	return cmd
-}
-
-// displayParameters will return a table displaying all parameters passed in.
-// filterColumns must be a subset of the parameter fields and will determine which
-// columns to display
-func displayParameters(filterColumns []string, params ...codersdk.Parameter) string {
-	tableWriter := cliui.Table()
-	header := table.Row{"id", "scope", "scope id", "name", "source scheme", "destination scheme", "created at", "updated at"}
-	tableWriter.AppendHeader(header)
-	tableWriter.SetColumnConfigs(cliui.FilterTableColumns(header, filterColumns))
-	tableWriter.SortBy([]table.SortBy{{
-		Name: "name",
-	}})
-	for _, param := range params {
-		tableWriter.AppendRow(table.Row{
-			param.ID.String(),
-			param.Scope,
-			param.ScopeID.String(),
-			param.Name,
-			param.SourceScheme,
-			param.DestinationScheme,
-			param.CreatedAt,
-			param.UpdatedAt,
-		})
-	}
-	return tableWriter.Render()
 }

--- a/cli/parameterslist.go
+++ b/cli/parameterslist.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/codersdk"
 )
 
@@ -70,11 +71,16 @@ func parameterList() *cobra.Command {
 				return xerrors.Errorf("fetch params: %w", err)
 			}
 
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), displayParameters(columns, params...))
+			out, err := cliui.DisplayTable(params, "name", columns)
+			if err != nil {
+				return xerrors.Errorf("render table: %w", err)
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), out)
 			return err
 		},
 	}
-	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"name", "scope", "destination_scheme"},
+	cmd.Flags().StringArrayVarP(&columns, "column", "c", []string{"name", "scope", "destination scheme"},
 		"Specify a column to filter in the table.")
 	return cmd
 }

--- a/cli/templatelist.go
+++ b/cli/templatelist.go
@@ -30,12 +30,17 @@ func templateList() *cobra.Command {
 			}
 
 			if len(templates) == 0 {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s No templates found in %s! Create one:\n\n", caret, color.HiWhiteString(organization.Name))
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), color.HiMagentaString("  $ coder templates create <directory>\n"))
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s No templates found in %s! Create one:\n\n", caret, color.HiWhiteString(organization.Name))
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), color.HiMagentaString("  $ coder templates create <directory>\n"))
 				return nil
 			}
 
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), displayTemplates(columns, templates...))
+			out, err := displayTemplates(columns, templates...)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), out)
 			return err
 		},
 	}

--- a/cli/templatelist_test.go
+++ b/cli/templatelist_test.go
@@ -57,7 +57,7 @@ func TestTemplateList(t *testing.T) {
 
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
-		cmd.SetOut(pty.Output())
+		cmd.SetErr(pty.Output())
 
 		errC := make(chan error)
 		go func() {

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -47,15 +47,15 @@ func templates() *cobra.Command {
 }
 
 type templateTableRow struct {
-	Name                 string        `table:"name"`
-	CreatedAt            string        `table:"created at"`
-	LastUpdated          string        `table:"last updated"`
-	OrganizationID       uuid.UUID     `table:"organization id"`
-	Provisioner          string        `table:"provisioner"`
-	ActiveVersionID      uuid.UUID     `table:"active version id"`
-	UsedBy               string        `table:"used by"`
-	MaxTTL               time.Duration `table:"max ttl"`
-	MinAutostartInterval time.Duration `table:"min autostart"`
+	Name                 string                   `table:"name"`
+	CreatedAt            string                   `table:"created at"`
+	LastUpdated          string                   `table:"last updated"`
+	OrganizationID       uuid.UUID                `table:"organization id"`
+	Provisioner          codersdk.ProvisionerType `table:"provisioner"`
+	ActiveVersionID      uuid.UUID                `table:"active version id"`
+	UsedBy               string                   `table:"used by"`
+	MaxTTL               time.Duration            `table:"max ttl"`
+	MinAutostartInterval time.Duration            `table:"min autostart"`
 }
 
 // displayTemplates will return a table displaying all templates passed in.
@@ -74,7 +74,7 @@ func displayTemplates(filterColumns []string, templates ...codersdk.Template) (s
 			CreatedAt:            template.CreatedAt.Format("January 2, 2006"),
 			LastUpdated:          template.UpdatedAt.Format("January 2, 2006"),
 			OrganizationID:       template.OrganizationID,
-			Provisioner:          string(template.Provisioner),
+			Provisioner:          template.Provisioner,
 			ActiveVersionID:      template.ActiveVersionID,
 			UsedBy:               cliui.Styles.Fuchsia.Render(fmt.Sprintf("%d developer%s", template.WorkspaceOwnerCount, suffix)),
 			MaxTTL:               (time.Duration(template.MaxTTLMillis) * time.Millisecond),

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/coder/coder/cli/cliui"
@@ -46,35 +46,41 @@ func templates() *cobra.Command {
 	return cmd
 }
 
+type templateTableRow struct {
+	Name                 string        `table:"name"`
+	CreatedAt            string        `table:"created at"`
+	LastUpdated          string        `table:"last updated"`
+	OrganizationID       uuid.UUID     `table:"organization id"`
+	Provisioner          string        `table:"provisioner"`
+	ActiveVersionID      uuid.UUID     `table:"active version id"`
+	UsedBy               string        `table:"used by"`
+	MaxTTL               time.Duration `table:"max ttl"`
+	MinAutostartInterval time.Duration `table:"min autostart"`
+}
+
 // displayTemplates will return a table displaying all templates passed in.
 // filterColumns must be a subset of the template fields and will determine which
 // columns to display
-func displayTemplates(filterColumns []string, templates ...codersdk.Template) string {
-	tableWriter := cliui.Table()
-	header := table.Row{
-		"Name", "Created At", "Last Updated", "Organization ID", "Provisioner",
-		"Active Version ID", "Used By", "Max TTL", "Min Autostart"}
-	tableWriter.AppendHeader(header)
-	tableWriter.SetColumnConfigs(cliui.FilterTableColumns(header, filterColumns))
-	tableWriter.SortBy([]table.SortBy{{
-		Name: "name",
-	}})
-	for _, template := range templates {
+func displayTemplates(filterColumns []string, templates ...codersdk.Template) (string, error) {
+	rows := make([]templateTableRow, len(templates))
+	for i, template := range templates {
 		suffix := ""
 		if template.WorkspaceOwnerCount != 1 {
 			suffix = "s"
 		}
-		tableWriter.AppendRow(table.Row{
-			template.Name,
-			template.CreatedAt.Format("January 2, 2006"),
-			template.UpdatedAt.Format("January 2, 2006"),
-			template.OrganizationID.String(),
-			template.Provisioner,
-			template.ActiveVersionID.String(),
-			cliui.Styles.Fuchsia.Render(fmt.Sprintf("%d developer%s", template.WorkspaceOwnerCount, suffix)),
-			(time.Duration(template.MaxTTLMillis) * time.Millisecond).String(),
-			(time.Duration(template.MinAutostartIntervalMillis) * time.Millisecond).String(),
-		})
+
+		rows[i] = templateTableRow{
+			Name:                 template.Name,
+			CreatedAt:            template.CreatedAt.Format("January 2, 2006"),
+			LastUpdated:          template.UpdatedAt.Format("January 2, 2006"),
+			OrganizationID:       template.OrganizationID,
+			Provisioner:          string(template.Provisioner),
+			ActiveVersionID:      template.ActiveVersionID,
+			UsedBy:               cliui.Styles.Fuchsia.Render(fmt.Sprintf("%d developer%s", template.WorkspaceOwnerCount, suffix)),
+			MaxTTL:               (time.Duration(template.MaxTTLMillis) * time.Millisecond),
+			MinAutostartInterval: (time.Duration(template.MinAutostartIntervalMillis) * time.Millisecond),
+		}
 	}
-	return tableWriter.Render()
+
+	return cliui.DisplayTable(rows, "name", filterColumns)
 }

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -111,13 +111,13 @@ func userSingle() *cobra.Command {
 }
 
 func displayUser(ctx context.Context, stderr io.Writer, client *codersdk.Client, user codersdk.User) string {
-	tableWriter := cliui.Table()
+	tw := cliui.Table()
 	addRow := func(name string, value interface{}) {
 		key := ""
 		if name != "" {
 			key = name + ":"
 		}
-		tableWriter.AppendRow(table.Row{
+		tw.AppendRow(table.Row{
 			key, value,
 		})
 	}
@@ -170,5 +170,5 @@ func displayUser(ctx context.Context, stderr io.Writer, client *codersdk.Client,
 		addRow("Organizations", "(none)")
 	}
 
-	return tableWriter.Render()
+	return tw.Render()
 }

--- a/codersdk/parameters.go
+++ b/codersdk/parameters.go
@@ -50,14 +50,14 @@ type ComputedParameter struct {
 
 // Parameter represents a set value for the scope.
 type Parameter struct {
-	ID                uuid.UUID                  `json:"id"`
-	CreatedAt         time.Time                  `json:"created_at"`
-	UpdatedAt         time.Time                  `json:"updated_at"`
-	Scope             ParameterScope             `json:"scope"`
-	ScopeID           uuid.UUID                  `json:"scope_id"`
-	Name              string                     `json:"name"`
-	SourceScheme      ParameterSourceScheme      `json:"source_scheme"`
-	DestinationScheme ParameterDestinationScheme `json:"destination_scheme"`
+	ID                uuid.UUID                  `json:"id" table:"id"`
+	Scope             ParameterScope             `json:"scope" table:"scope"`
+	ScopeID           uuid.UUID                  `json:"scope_id" table:"scope id"`
+	Name              string                     `json:"name" table:"name"`
+	SourceScheme      ParameterSourceScheme      `json:"source_scheme" table:"source scheme"`
+	DestinationScheme ParameterDestinationScheme `json:"destination_scheme" table:"destination scheme"`
+	CreatedAt         time.Time                  `json:"created_at" table:"created at"`
+	UpdatedAt         time.Time                  `json:"updated_at" table:"updated at"`
 }
 
 type ParameterSchema struct {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -205,13 +205,13 @@ export interface Pagination {
 // From codersdk/parameters.go
 export interface Parameter {
   readonly id: string
-  readonly created_at: string
-  readonly updated_at: string
   readonly scope: ParameterScope
   readonly scope_id: string
   readonly name: string
   readonly source_scheme: ParameterSourceScheme
   readonly destination_scheme: ParameterDestinationScheme
+  readonly created_at: string
+  readonly updated_at: string
 }
 
 // From codersdk/parameters.go


### PR DESCRIPTION
Uses the new table formatter introduced in #3415 everywhere across the CLI except for two places: `schedule show` and `users show` which don't use a traditional table format.