### PR TITLE
fix(ui): decrease WorkspaceActions popover padding

### DIFF
--- a/site/src/components/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/components/WorkspaceActions/WorkspaceActions.tsx
@@ -171,6 +171,6 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   popoverPaper: {
-    padding: `${theme.spacing(2)}px ${theme.spacing(3)}px ${theme.spacing(3)}px`,
+    padding: `${theme.spacing(1)}px ${theme.spacing(2)}px ${theme.spacing(1)}px`,
   },
 }))


### PR DESCRIPTION
There was too much padding on the WorkspaceActions dropdown. This fixes
that.

## Before

![before](https://user-images.githubusercontent.com/3806031/185450867-188f4180-7582-4ee4-b87c-b0fb0a53985c.jpg)

## After

![after](https://user-images.githubusercontent.com/3806031/185451209-2609c2ef-6352-4b5a-bd60-ceb9005d788e.jpg)

