### PR TITLE
fix: avoid processing updates to usernames

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -235,7 +235,7 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "A database error occurred.",
-				Detail:  xerrors.Errorf("update user link: %w", err.Error).Error(),
+				Detail:  fmt.Sprintf("update user link: %s", err.Error()),
 			})
 			return
 		}
@@ -443,7 +443,7 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "A database error occurred.",
-				Detail:  xerrors.Errorf("update user link: %w", err.Error).Error(),
+				Detail:  fmt.Sprintf("update user link: %s", err.Error()),
 			})
 			return
 		}
@@ -479,7 +479,8 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		user, err = api.Database.UpdateUserProfile(ctx, database.UpdateUserProfileParams{
 			ID:        user.ID,
 			Email:     claims.Email,
-			Username:  claims.Username,
+			// TODO: This should run in a transaction.
+			Username:  user.Username,
 			UpdatedAt: database.Now(),
 		})
 		if err != nil {

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -229,8 +229,8 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 	if link.LinkedID == "" {
 		link, err = api.Database.UpdateUserLinkedID(ctx, database.UpdateUserLinkedIDParams{
 			UserID:    user.ID,
-			LinkedID:  githubLinkedID(ghUser),
 			LoginType: database.LoginTypeGithub,
+			LinkedID:  githubLinkedID(ghUser),
 		})
 		if err != nil {
 			httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
@@ -437,8 +437,8 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 	if link.LinkedID == "" {
 		link, err = api.Database.UpdateUserLinkedID(ctx, database.UpdateUserLinkedIDParams{
 			UserID:    user.ID,
+			LoginType: database.LoginTypeOIDC,
 			LinkedID:  oidcLinkedID(idToken),
-			LoginType: database.LoginTypeGithub,
 		})
 		if err != nil {
 			httpapi.Write(rw, http.StatusInternalServerError, codersdk.Response{
@@ -477,8 +477,8 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		// longer sign in until an administrator finds the offending built-in
 		// user and changes their username.
 		user, err = api.Database.UpdateUserProfile(ctx, database.UpdateUserProfileParams{
-			ID:        user.ID,
-			Email:     claims.Email,
+			ID:    user.ID,
+			Email: claims.Email,
 			// TODO: This should run in a transaction.
 			Username:  user.Username,
 			UpdatedAt: database.Now(),


### PR DESCRIPTION
- With the support of OIDC we began processing updates to a user's
  email and username to stay in sync with the upstream provider. This
  can cause issues in templates that use the user's username as a stable
  identifier, potentially causing the deletion of user's home volumes.
- Fix some faulty error wrapping.
