### PR TITLE
cli: remove confirm prompt when starting a workspace

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -17,14 +17,6 @@ func start() *cobra.Command {
 		Short:       "Build a workspace with the start state",
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := cliui.Prompt(cmd, cliui.PromptOptions{
-				Text:      "Confirm start workspace?",
-				IsConfirm: true,
-			})
-			if err != nil {
-				return err
-			}
-
 			client, err := createClient(cmd)
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR removes the CLI confirmation prompt when starting a workspace.
I find it annoying to have to confirm this for a start operation. For stop / delete operations, it makes more sense.