### PR TITLE
chore: Update `coder/coder` provider in example templates

### DIFF
--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
   }
 }

--- a/examples/templates/aws-windows/main.tf
+++ b/examples/templates/aws-windows/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
   }
 }

--- a/examples/templates/azure-linux/main.tf
+++ b/examples/templates/azure-linux/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/templates/do-linux/main.tf
+++ b/examples/templates/do-linux/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     digitalocean = {
       source  = "digitalocean/digitalocean"

--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "0.4.5"
+      version = "0.4.9"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/templates/kubernetes-multi-service/main.tf
+++ b/examples/templates/kubernetes-multi-service/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     coder = {
       source  = "coder/coder"
-      version = "~> 0.4.3"
+      version = "0.4.9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/update_template_versions.sh
+++ b/examples/update_template_versions.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+EXAMPLES_DIR=$(dirname "${BASH_SOURCE[0]}")
+PROJECT_ROOT=$(cd "$EXAMPLES_DIR" && git rev-parse --show-toplevel)
+
+# shellcheck source=scripts/lib.sh
+source "$PROJECT_ROOT/scripts/lib.sh"
+
+dependencies curl jq sed
+
+sed_args=(-i)
+if isdarwin; then
+	sed_args=(-i '')
+fi
+
+main() {
+	pushd "$EXAMPLES_DIR/templates"
+
+	# Fetch the latest release of terraform-provider-coder from GitHub.
+	latest_provider_coder="$(curl --fail -sSL https://api.github.com/repos/coder/terraform-provider-coder/releases/latest | jq -r .tag_name)"
+	latest_provider_coder=${latest_provider_coder#v}
+
+	# Update all terraform files that contain ~ the following lines:
+	#   source  = "coder/coder"
+	#   version = "[version]"
+	find . -type f -name "*.tf" -print0 | while read -r -d $'\0' f; do
+		current_version_raw="$(grep -n -A 1 'source *= *"coder/coder"' "$f" | tail -n 1)"
+		if [[ $current_version_raw = *version* ]]; then
+			line="${current_version_raw%%-*}"
+			sed "${sed_args[@]}" "$line s/\".*\"/\"$latest_provider_coder\"/" "$f"
+		fi
+	done
+}
+
+# Wrap the main function in a subshell to restore the working directory.
+(main)


### PR DESCRIPTION
Additionally, a convenience script was added to `examples/update_template_versions.sh` to keep the templates up-to-date.

Fixes #2966
