### PR TITLE
fix: Update icon when metadata is changed

### DIFF
--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -431,7 +431,7 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 			desc = template.Description
 		}
 		if icon == "" {
-			name = template.Icon
+			icon = template.Icon
 		}
 		if maxTTL == 0 {
 			maxTTL = time.Duration(template.MaxTtl)


### PR DESCRIPTION
This was causing names to become empty! Fixes #3586.
