### PR TITLE
Check AGPL code doesn't import enterprise

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -102,6 +102,15 @@ jobs:
         with:
           version: v1.46.0
 
+  check-enterprise-imports:
+    name: check/enterprise-imports
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check imports of enterprise code
+        run: ./scripts/check_enterprise_imports.sh
+
   style-lint-shellcheck:
     name: style/lint/shellcheck
     timeout-minutes: 5

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ lint: lint/shellcheck lint/go
 .PHONY: lint
 
 lint/go:
+	./scripts/check_enterprise_imports.sh
 	golangci-lint run
 .PHONY: lint/go
 

--- a/scripts/check_enterprise_imports.sh
+++ b/scripts/check_enterprise_imports.sh
@@ -14,8 +14,6 @@ find . -regex ".*\.go" | grep -v "./enterprise" | xargs grep -n "github.com/code
 status=$?
 set -e
 if [ $status -eq 0 ]; then
-	echo "AGPL code cannot import enterprise!"
-	exit 1
+	error "AGPL code cannot import enterprise!"
 fi
-echo "AGPL imports OK"
-exit 0
+log "AGPL imports OK"

--- a/scripts/check_enterprise_imports.sh
+++ b/scripts/check_enterprise_imports.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This file checks all our AGPL licensed source files to be sure they don't
+# import any enterprise licensed packages (the inverse is fine).
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cdroot
+
+set +e
+find . -regex ".*\.go" | grep -v "./enterprise" | xargs grep -n "github.com/coder/coder/enterprise"
+# reverse the exit code because we want this script to fail if grep finds anything.
+status=$?
+set -e
+if [ $status -eq 0 ]; then
+	echo "AGPL code cannot import enterprise!"
+	exit 1
+fi
+echo "AGPL imports OK"
+exit 0


### PR DESCRIPTION
This adds a check to ensure we don't accidentally import enterprise code from AGPL code, which would cause "AGPL" builds to not really be AGPL.

Oh, and if you are wondering, "can ruleguard do this?," the answer is [no](https://github.com/quasilyte/go-ruleguard/issues/78)