### PR TITLE
chore: k8s example persistence & coder images

### DIFF
--- a/examples/templates/kubernetes-multi-service/README.md
+++ b/examples/templates/kubernetes-multi-service/README.md
@@ -72,3 +72,7 @@ roleRef:
 
 Then start the Coder host with `serviceAccountName: coder` in the pod spec.
 
+## Persistence
+
+Each container in this Kubernetes pod example will have their `/home/coder` directory
+persisted via the attached PersistentVolumeClaim.

--- a/examples/templates/kubernetes-multi-service/README.md
+++ b/examples/templates/kubernetes-multi-service/README.md
@@ -74,5 +74,5 @@ Then start the Coder host with `serviceAccountName: coder` in the pod spec.
 
 ## Persistence
 
-Each container in this Kubernetes pod example will have their `/home/coder` directory
-persisted via the attached PersistentVolumeClaim.
+The `/home/coder` directory in this example is persisted via the attached PersistentVolumeClaim.
+Any data saved outside of this directory will be wiped when the workspace stops.

--- a/examples/templates/kubernetes-multi-service/main.tf
+++ b/examples/templates/kubernetes-multi-service/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.10"
+      version = "~> 2.12.1"
     }
   }
 }
@@ -29,7 +29,7 @@ variable "workspaces_namespace" {
   type        = string
   sensitive   = true
   description = "The namespace to create workspaces in (must exist prior to creating workspaces)"
-  default     = "coder-workspaces"
+  default     = "coder-workspace"
 }
 
 variable "disk_size" {
@@ -45,19 +45,25 @@ provider "kubernetes" {
 
 data "coder_workspace" "me" {}
 
-resource "coder_agent" "go" {
+resource "coder_agent" "main" {
   os   = "linux"
   arch = "amd64"
+  startup_script = <<EOT
+    #!/bin/bash
+
+    # install and start code-server
+    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    code-server --auth none --port 13337 | tee code-server-install.log &
+  EOT
 }
 
-resource "coder_agent" "java" {
-  os   = "linux"
-  arch = "amd64"
-}
-
-resource "coder_agent" "ubuntu" {
-  os   = "linux"
-  arch = "amd64"
+# code-server
+resource "coder_app" "code-server" {
+  agent_id      = coder_agent.main.id
+  name          = "code-server"
+  icon          = "/icon/code.svg"
+  url           = "http://localhost:13337?folder=/home/coder"
+  relative_path = true
 }
 
 resource "kubernetes_pod" "main" {
@@ -67,109 +73,38 @@ resource "kubernetes_pod" "main" {
     namespace = var.workspaces_namespace
   }
   spec {
-    container {
-      name    = "go"
-      image   = "codercom/enterprise-golang:ubuntu"
-      command = ["sh", "-c", coder_agent.go.init_script]
-      security_context {
-        run_as_user = "1000"
-      }
-      env {
-        name  = "CODER_AGENT_TOKEN"
-        value = coder_agent.go.token
-      }
-      volume_mount {
-        mount_path = "/home/coder"
-        name       = "go-home-directory"
-      }
-    }
-    volume {
-      name = "go-home-directory"
-      persistent_volume_claim {
-        claim_name = kubernetes_persistent_volume_claim.go-home-directory.metadata.0.name
-      }
+    security_context {
+      run_as_user = "1000"
+      fs_group    = "1000"
     }
     container {
-      name    = "java"
-      image   = "codercom/enterprise-java:ubuntu"
-      command = ["sh", "-c", coder_agent.java.init_script]
-      security_context {
-        run_as_user = "1000"
-      }
-      env {
-        name  = "CODER_AGENT_TOKEN"
-        value = coder_agent.java.token
-      }
-      volume_mount {
-        mount_path = "/home/coder"
-        name       = "java-home-directory"
-      }
-    }
-    volume {
-      name = "java-home-directory"
-      persistent_volume_claim {
-        claim_name = kubernetes_persistent_volume_claim.java-home-directory.metadata.0.name
-      }
-    }
-    container {
-      name    = "ubuntu"
+      name    = "dev"
       image   = "codercom/enterprise-base:ubuntu"
-      command = ["sh", "-c", coder_agent.ubuntu.init_script]
+      command = ["sh", "-c", coder_agent.main.init_script]
       security_context {
         run_as_user = "1000"
       }
       env {
         name  = "CODER_AGENT_TOKEN"
-        value = coder_agent.ubuntu.token
+        value = coder_agent.main.token
       }
       volume_mount {
         mount_path = "/home/coder"
-        name       = "ubuntu-home-directory"
+        name       = "home-directory"
       }
     }
     volume {
-      name = "ubuntu-home-directory"
+      name = "home-directory"
       persistent_volume_claim {
-        claim_name = kubernetes_persistent_volume_claim.ubuntu-home-directory.metadata.0.name
-      }
-    }
-
-  }
-}
-
-resource "kubernetes_persistent_volume_claim" "go-home-directory" {
-  metadata {
-    name      = "home-coder-go-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
-    namespace = var.workspaces_namespace
-  }
-  spec {
-    access_modes = ["ReadWriteOnce"]
-    resources {
-      requests = {
-        storage = "${var.disk_size}Gi"
+        claim_name = kubernetes_persistent_volume_claim.home-directory.metadata.0.name
       }
     }
   }
 }
 
-resource "kubernetes_persistent_volume_claim" "java-home-directory" {
+resource "kubernetes_persistent_volume_claim" "home-directory" {
   metadata {
     name      = "home-coder-java-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
-    namespace = var.workspaces_namespace
-  }
-  spec {
-    access_modes = ["ReadWriteOnce"]
-    resources {
-      requests = {
-        storage = "${var.disk_size}Gi"
-      }
-    }
-  }
-}
-
-resource "kubernetes_persistent_volume_claim" "ubuntu-home-directory" {
-  metadata {
-    name      = "home-coder-ubuntu-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
     namespace = var.workspaces_namespace
   }
   spec {

--- a/examples/templates/kubernetes-pod/README.md
+++ b/examples/templates/kubernetes-pod/README.md
@@ -72,7 +72,18 @@ roleRef:
 
 Then start the Coder host with `serviceAccountName: coder` in the pod spec.
 
+## Namespace
+
+The target namespace in which the pod will be deployed is defined via the `coder_workspace`
+variable. The namespace must exist prior to creating workspaces.
+
 ## Persistence
 
 The `/home/coder` directory in this example is persisted via the attached PersistentVolumeClaim.
 Any data saved outside of this directory will be wiped when the workspace stops.
+
+## code-server
+
+`code-server` is installed via the `startup_script` argument in the `coder_agent`
+resource block. The `coder_app` resource is defined to access `code-server` through
+the dashboard UI over `localhost:13337`.

--- a/examples/templates/kubernetes-pod/README.md
+++ b/examples/templates/kubernetes-pod/README.md
@@ -82,6 +82,28 @@ variable. The namespace must exist prior to creating workspaces.
 The `/home/coder` directory in this example is persisted via the attached PersistentVolumeClaim.
 Any data saved outside of this directory will be wiped when the workspace stops.
 
+Since most binary installations and environment configurations live outside of
+the `/home` directory, we suggest including these in the `startup_script` argument
+of the `coder_agent` resource block, which will run each time the workspace starts up.
+
+For example, when installing the `aws` CLI, the install script will place the
+`aws` binary in `/usr/local/bin/aws`. To ensure the `aws` CLI is persisted across
+workspace starts/stops, include the following code in the `coder_agent` resource
+block of your workspace template:
+
+```terraform
+resource "coder_agent" "main" {
+  startup_script = <<EOT
+    #!/bin/bash
+
+    # install AWS CLI
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    sudo ./aws/install
+  EOT
+}
+```
+
 ## code-server
 
 `code-server` is installed via the `startup_script` argument in the `coder_agent`

--- a/examples/templates/kubernetes-pod/main.tf
+++ b/examples/templates/kubernetes-pod/main.tf
@@ -25,11 +25,11 @@ variable "use_kubeconfig" {
   EOF
 }
 
-variable "workspaces_namespace" {
+variable "coder_namespace" {
   type        = string
   sensitive   = true
   description = "The namespace to create workspaces in (must exist prior to creating workspaces)"
-  default     = "coder-workspace"
+  default     = "coder-namespace"
 }
 
 variable "disk_size" {
@@ -70,7 +70,7 @@ resource "kubernetes_pod" "main" {
   count = data.coder_workspace.me.start_count
   metadata {
     name      = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
-    namespace = var.workspaces_namespace
+    namespace = var.coder_namespace
   }
   spec {
     security_context {
@@ -105,7 +105,7 @@ resource "kubernetes_pod" "main" {
 resource "kubernetes_persistent_volume_claim" "home-directory" {
   metadata {
     name      = "home-coder-java-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
-    namespace = var.workspaces_namespace
+    namespace = var.coder_namespace
   }
   spec {
     access_modes = ["ReadWriteOnce"]


### PR DESCRIPTION
this PR looks to address @ammario's feedback in #3588 by adding persistence to our k8s example template.

it also removes the VS Code dev container images in favor of [Coder's enterprise images](https://github.com/coder/enterprise-images). The dev container images used `/home/vscode`, which contained shell scripts/customizations that would be wiped with a `/home/vscode` volume mount.

open to thoughts/feedback on removing the dev container images.