### PR TITLE
feat: Set SSH env vars: `SSH_CLIENT`, `SSH_CONNECTION` and `SSH_TTY`

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -428,8 +428,12 @@ func (a *agent) handleSSHSession(session ssh.Session) (retErr error) {
 		return err
 	}
 	// Set SSH connection environment variables, from the clients perspective.
-	srcAddr, srcPort := addrToSSHEnvAddr(session.RemoteAddr())
-	dstAddr, dstPort := addrToSSHEnvAddr(session.LocalAddr())
+	// Set SSH connection environment variables (these are also set by OpenSSH
+	// and thus expected to be present by SSH clients). Since the agent does
+	// networking in-memory, trying to provide accurate values here would be
+	// nonsensical. For now, we hard code these values so that they're present.
+	srcAddr, srcPort := "0.0.0.0", "0"
+	dstAddr, dstPort := "0.0.0.0", "0"
 	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_CLIENT=%s %s %s", srcAddr, srcPort, dstPort))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_CONNECTION=%s %s %s %s", srcAddr, srcPort, dstAddr, dstPort))
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -404,6 +404,15 @@ func (a *agent) createCommand(ctx context.Context, rawCommand string, env []stri
 	unixExecutablePath := strings.ReplaceAll(executablePath, "\\", "/")
 	cmd.Env = append(cmd.Env, fmt.Sprintf(`GIT_SSH_COMMAND=%s gitssh --`, unixExecutablePath))
 
+	// Set SSH connection environment variables (these are also set by OpenSSH
+	// and thus expected to be present by SSH clients). Since the agent does
+	// networking in-memory, trying to provide accurate values here would be
+	// nonsensical. For now, we hard code these values so that they're present.
+	srcAddr, srcPort := "0.0.0.0", "0"
+	dstAddr, dstPort := "0.0.0.0", "0"
+	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_CLIENT=%s %s %s", srcAddr, srcPort, dstPort))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_CONNECTION=%s %s %s %s", srcAddr, srcPort, dstAddr, dstPort))
+
 	// Load environment variables passed via the agent.
 	// These should override all variables we manually specify.
 	for envKey, value := range metadata.EnvironmentVariables {
@@ -427,15 +436,6 @@ func (a *agent) handleSSHSession(session ssh.Session) (retErr error) {
 	if err != nil {
 		return err
 	}
-	// Set SSH connection environment variables, from the clients perspective.
-	// Set SSH connection environment variables (these are also set by OpenSSH
-	// and thus expected to be present by SSH clients). Since the agent does
-	// networking in-memory, trying to provide accurate values here would be
-	// nonsensical. For now, we hard code these values so that they're present.
-	srcAddr, srcPort := "0.0.0.0", "0"
-	dstAddr, dstPort := "0.0.0.0", "0"
-	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_CLIENT=%s %s %s", srcAddr, srcPort, dstPort))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_CONNECTION=%s %s %s %s", srcAddr, srcPort, dstAddr, dstPort))
 
 	if ssh.AgentRequested(session) {
 		l, err := ssh.NewAgentListener()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -706,19 +706,6 @@ func (a *agent) handleReconnectingPTY(ctx context.Context, rawID string, conn ne
 	}
 }
 
-// addrToSSHEnvAddr turns the address and port into space-separated values,
-// works with IPv4, IPv6 and invalid addresses (such as [peer/unknown-addr]).
-func addrToSSHEnvAddr(a net.Addr) (addr string, port string) {
-	addr = a.String()
-	port = "0"
-	li := strings.LastIndex(addr, ":")
-	if li != -1 {
-		port = addr[li+1:]
-		addr = addr[:li]
-	}
-	return addr, port
-}
-
 // dialResponse is written to datachannels with protocol "dial" by the agent as
 // the first packet to signify whether the dial succeeded or failed.
 type dialResponse struct {

--- a/pty/start_other.go
+++ b/pty/start_other.go
@@ -4,6 +4,7 @@
 package pty
 
 import (
+	"fmt"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -18,6 +19,8 @@ func startPty(cmd *exec.Cmd) (PTY, Process, error) {
 	if err != nil {
 		return nil, nil, xerrors.Errorf("open: %w", err)
 	}
+
+	cmd.Env = append(cmd.Env, fmt.Sprintf("SSH_PTY=%s", tty.Name()))
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid:  true,
 		Setctty: true,

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -43,7 +43,7 @@ func TestStart(t *testing.T) {
 	t.Run("SSH_PTY", func(t *testing.T) {
 		t.Parallel()
 		pty, ps := ptytest.Start(t, exec.Command("env"))
-		pty.ExpectMatch("SSH_PTY=/dev/pts/")
+		pty.ExpectMatch("SSH_PTY=/dev/")
 		err := ps.Wait()
 		require.NoError(t, err)
 	})

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package pty_test
 
@@ -39,5 +38,13 @@ func TestStart(t *testing.T) {
 		var exitErr *exec.ExitError
 		require.True(t, xerrors.As(err, &exitErr))
 		assert.NotEqual(t, 0, exitErr.ExitCode())
+	})
+
+	t.Run("SSH_PTY", func(t *testing.T) {
+		t.Parallel()
+		pty, ps := ptytest.Start(t, exec.Command("env"))
+		pty.ExpectMatch("SSH_PTY=/dev/pts/")
+		err := ps.Wait()
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
With out current webrtc connections, the result is not ideal:

```shell
# env | grep ^SSH_
SSH_CONNECTION=peer/unknown-addr 0 peer/unknown-addr 0
SSH_PTY=/dev/pts/0
SSH_CLIENT=peer/unknown-addr 0 0
```

It seems like it would be possible to extract some sensible information from the peer negotiation process.

```
selected candidate pair changed	{"local": {"foundation": "", "priority": 0, "address": "172.17.0.2", "protocol": 1, "port": 33555, "type": 1, "component": 1, "relatedAddress": "", "relatedPort": 0, "tcpType": ""}, "remote": {"foundation": "", "priority": 0, "address": "192.168.32.120", "protocol": 1, "port": 56627, "type": 1, "component": 1, "relatedAddress": "", "relatedPort": 0, "tcpType": ""}}
```

But since we're moving towards WireGuard, I don't think it's worth it.

Using WireGuard though (`coder config-ssh --wireguard`), we actually get some more sensible output:

```shell
env | grep ^SSH_
SSH_CONNECTION=[66b0:b5ee:5a5f:62ec:3f95:e1ff:526c:38e4] 23171 [6a58:41de:9543:ec22:2692:f500:4768:861b] 12212
SSH_PTY=/dev/pts/0
SSH_CLIENT=[66b0:b5ee:5a5f:62ec:3f95:e1ff:526c:38e4] 23171 12212
```

Fixes #2339

We may want to re-consider the `pty` package we currently have as well, it's a bit weird we set `SSH_TTY` in it now, without being more explicit about it being tied to SSH. Relevant for #3473 as well.
