### PR TITLE
fix: use hardcoded "coder" user for AWS and Azure

### DIFF
--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -138,8 +138,7 @@ sudo shutdown -h now
 --//--
 EOT
 
-  # Ensure Coder username is a valid Linux username
-  linux_user = lower(substr(data.coder_workspace.me.owner, 0, 32))
+  linux_user = "coder" # Ensure this user/group does not exist in your VM image
 
 }
 

--- a/examples/templates/azure-linux/main.tf
+++ b/examples/templates/azure-linux/main.tf
@@ -228,12 +228,3 @@ resource "coder_metadata" "home_info" {
     value = "${var.home_size} GiB"
   }
 }
-
-resource "coder_metadata" "private_key" {
-  resource_id = tls_private_key.dummy
-  item {
-    key       = "key"
-    value     = tls_private_key.dummy.private_key_pem
-    sensitive = true
-  }
-}

--- a/examples/templates/azure-linux/main.tf
+++ b/examples/templates/azure-linux/main.tf
@@ -89,7 +89,7 @@ locals {
   prefix = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
 
   userdata = templatefile("cloud-config.yaml.tftpl", {
-    username    = lower(substr(data.coder_workspace.me.owner, 0, 32))
+    username    = "coder" # Ensure this user/group does not exist in your VM image
     init_script = base64encode(coder_agent.main.init_script)
     hostname    = lower(data.coder_workspace.me.name)
   })
@@ -226,5 +226,14 @@ resource "coder_metadata" "home_info" {
   item {
     key   = "size"
     value = "${var.home_size} GiB"
+  }
+}
+
+resource "coder_metadata" "private_key" {
+  resource_id = tls_private_key.dummy
+  item {
+    key       = "key"
+    value     = tls_private_key.dummy.private_key_pem
+    sensitive = true
   }
 }


### PR DESCRIPTION
fixes #3611 #3511

@spikecurtis explains the problem well:
> Ok, we've chased this down. The issue is when the Coder user is named admin, the cloud-init fails because it tries to create user=admin group=admin, but admin is the name of a builtin group.
> 
> We could just hardcode the username "coder" in our templates, or possibly hardcode just the group "coder" (rather than the default of creating a group with the same name as the user).

I tested manually on both templates and confirmed the templates now work with an `admin` username in Coder, where they previously didn't before.