### PR TITLE
feat: Set `CODER=true` in workspaces

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -394,6 +394,10 @@ func (a *agent) createCommand(ctx context.Context, rawCommand string, env []stri
 	if err != nil {
 		return nil, xerrors.Errorf("getting os executable: %w", err)
 	}
+	// Set environment variables reliable detection of being inside a
+	// Coder workspace.
+	cmd.Env = append(cmd.Env, "CODER=true")
+
 	cmd.Env = append(cmd.Env, fmt.Sprintf("USER=%s", username))
 	// Git on Windows resolves with UNIX-style paths.
 	// If using backslashes, it's unable to find the executable.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -232,6 +232,26 @@ func TestAgent(t *testing.T) {
 		require.Equal(t, expect, strings.TrimSpace(string(output)))
 	})
 
+	t.Run("Coder env vars", func(t *testing.T) {
+		t.Parallel()
+
+		for _, key := range []string{"CODER"} {
+			key := key
+			t.Run(key, func(t *testing.T) {
+				t.Parallel()
+
+				session := setupSSHSession(t, agent.Metadata{})
+				command := "sh -c 'echo $" + key + "'"
+				if runtime.GOOS == "windows" {
+					command = "cmd.exe /c echo %" + key + "%"
+				}
+				output, err := session.Output(command)
+				require.NoError(t, err)
+				require.NotEmpty(t, strings.TrimSpace(string(output)))
+			})
+		}
+	})
+
 	t.Run("StartupScript", func(t *testing.T) {
 		t.Parallel()
 		tempPath := filepath.Join(t.TempDir(), "content.txt")


### PR DESCRIPTION
For now, we only set `CODER=true` as discussed in #2340.

The documentation already mentions how templates can configure env vars (https://coder.com/docs/coder-oss/latest/templates#data-source) so I don't think we need to expand on that or make it more obvious.

Fixes #2340

