### PR TITLE
fix: Protect circular buffer during close in reconnectingPTY

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -801,7 +801,9 @@ func (r *reconnectingPTY) Close() {
 		_ = conn.Close()
 	}
 	_ = r.ptty.Close()
+	r.circularBufferMutex.Lock()
 	r.circularBuffer.Reset()
+	r.circularBufferMutex.Unlock()
 	r.timeout.Stop()
 }
 


### PR DESCRIPTION
This PR fixes a data race during reconnectingPTY.Close.

Saw the race in CI: https://github.com/coder/coder/runs/7977030943?check_suite_focus=true

