### PR TITLE
chore: Enable comments for database dump / models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build: site/out/index.html $(shell find . -not -path './vendor/*' -type f -name 
 .PHONY: build
 
 # Runs migrations to output a dump of the database.
-coderd/database/dump.sql: $(wildcard coderd/database/migrations/*.sql)
+coderd/database/dump.sql: coderd/database/dump/main.go $(wildcard coderd/database/migrations/*.sql)
 	go run coderd/database/dump/main.go
 
 # Generates Go code for querying the database.

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -138,6 +138,8 @@ CREATE TABLE licenses (
     exp timestamp with time zone NOT NULL
 );
 
+COMMENT ON COLUMN licenses.exp IS 'exp tracks the claim of the same name in the JWT, and we include it here so that we can easily query for licenses that have not yet expired.';
+
 CREATE SEQUENCE licenses_id_seq
     AS integer
     START WITH 1

--- a/coderd/database/dump/main.go
+++ b/coderd/database/dump/main.go
@@ -41,7 +41,6 @@ func main() {
 		connection,
 		"--no-privileges",
 		"--no-owner",
-		"--no-comments",
 
 		// We never want to manually generate
 		// queries executing against this table.

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -360,7 +360,8 @@ type License struct {
 	ID         int32     `db:"id" json:"id"`
 	UploadedAt time.Time `db:"uploaded_at" json:"uploaded_at"`
 	JWT        string    `db:"jwt" json:"jwt"`
-	Exp        time.Time `db:"exp" json:"exp"`
+	// exp tracks the claim of the same name in the JWT, and we include it here so that we can easily query for licenses that have not yet expired.
+	Exp time.Time `db:"exp" json:"exp"`
 }
 
 type Organization struct {


### PR DESCRIPTION
I'm not sure what the initial intent behind `--no-comments` was, but I think we should remove it and make it favorable to document database fields via `COMMENT ON`.

This came up in https://github.com/coder/coder/pull/3570#discussion_r951952010
