### PR TITLE
fix: template: enforce bounds of template max_ttl

### DIFF
--- a/cli/templateedit.go
+++ b/cli/templateedit.go
@@ -59,8 +59,8 @@ func templateEdit() *cobra.Command {
 	cmd.Flags().StringVarP(&name, "name", "", "", "Edit the template name")
 	cmd.Flags().StringVarP(&description, "description", "", "", "Edit the template description")
 	cmd.Flags().StringVarP(&icon, "icon", "", "", "Edit the template icon path")
-	cmd.Flags().DurationVarP(&maxTTL, "max-ttl", "", 0, "Edit the template maximum time before shutdown")
-	cmd.Flags().DurationVarP(&minAutostartInterval, "min-autostart-interval", "", 0, "Edit the template minimum autostart interval")
+	cmd.Flags().DurationVarP(&maxTTL, "max-ttl", "", 0, "Edit the template maximum time before shutdown - workspaces created from this template cannot stay running longer than this.")
+	cmd.Flags().DurationVarP(&minAutostartInterval, "min-autostart-interval", "", 0, "Edit the template minimum autostart interval - workspaces created from this template must wait at least this long between autostarts.")
 	cliui.AllowSkipPrompt(cmd)
 
 	return cmd

--- a/coderd/authorize.go
+++ b/coderd/authorize.go
@@ -49,6 +49,7 @@ func (api *API) Authorize(r *http.Request, action rbac.Action, object rbac.Objec
 // This function will log appropriately, but the caller must return an
 // error to the api client.
 // Eg:
+//
 //	if !h.Authorize(...) {
 //		httpapi.Forbidden(rw)
 //		return

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1564,10 +1564,6 @@ func (q *fakeQuerier) InsertTemplate(_ context.Context, arg database.InsertTempl
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	// default values
-	if arg.MaxTtl == 0 {
-		arg.MaxTtl = int64(168 * time.Hour)
-	}
 	if arg.MinAutostartInterval == 0 {
 		arg.MinAutostartInterval = int64(time.Hour)
 	}

--- a/coderd/database/migrations/000038_template_max_ttl_cap_7_days.down.sql
+++ b/coderd/database/migrations/000038_template_max_ttl_cap_7_days.down.sql
@@ -1,0 +1,1 @@
+-- this is a no-op

--- a/coderd/database/migrations/000038_template_max_ttl_cap_7_days.up.sql
+++ b/coderd/database/migrations/000038_template_max_ttl_cap_7_days.up.sql
@@ -1,0 +1,2 @@
+-- Set a cap of 7 days on template max_ttl
+UPDATE templates SET max_ttl = 604800000000000 WHERE max_ttl > 604800000000000;

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -173,7 +173,7 @@ func (api *API) postTemplateByOrganization(rw http.ResponseWriter, r *http.Reque
 	}
 
 	maxTTL := maxTTLDefault
-	if !ptr.NilOrZero(createTemplate.MaxTTLMillis) {
+	if createTemplate.MaxTTLMillis != nil {
 		maxTTL = time.Duration(*createTemplate.MaxTTLMillis) * time.Millisecond
 	}
 	if maxTTL < 0 {

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -461,9 +461,6 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 		if icon == "" {
 			icon = template.Icon
 		}
-		if maxTTL == 0 {
-			maxTTL = time.Duration(template.MaxTtl)
-		}
 		if minAutostartInterval == 0 {
 			minAutostartInterval = time.Duration(template.MinAutostartInterval)
 		}

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -148,6 +148,24 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		require.Contains(t, err.Error(), "max_ttl_ms: Cannot be greater than")
 	})
 
+	t.Run("NoMaxTTL", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		got, err := client.CreateTemplate(ctx, user.OrganizationID, codersdk.CreateTemplateRequest{
+			Name:         "testing",
+			VersionID:    version.ID,
+			MaxTTLMillis: ptr.Ref(int64(0)),
+		})
+		require.NoError(t, err)
+		require.Zero(t, got.MaxTTLMillis)
+	})
+
 	t.Run("Unauthorized", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -342,6 +342,9 @@ func TestPatchTemplateMeta(t *testing.T) {
 			MaxTTLMillis: 0,
 		}
 
+		// We're too fast! Sleep so we can be sure that updatedAt is greater
+		time.Sleep(time.Millisecond * 5)
+
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -108,6 +108,46 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		require.Equal(t, http.StatusConflict, apiErr.StatusCode())
 	})
 
+	t.Run("MaxTTLTooLow", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.CreateTemplate(ctx, user.OrganizationID, codersdk.CreateTemplateRequest{
+			Name:         "testing",
+			VersionID:    version.ID,
+			MaxTTLMillis: ptr.Ref(int64(-1)),
+		})
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+		require.Contains(t, err.Error(), "max_ttl_ms: Must be a positive integer")
+	})
+
+	t.Run("MaxTTLTooHigh", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.CreateTemplate(ctx, user.OrganizationID, codersdk.CreateTemplateRequest{
+			Name:         "testing",
+			VersionID:    version.ID,
+			MaxTTLMillis: ptr.Ref(365 * 24 * time.Hour.Milliseconds()),
+		})
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+		require.Contains(t, err.Error(), "max_ttl_ms: Cannot be greater than")
+	})
+
 	t.Run("Unauthorized", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
@@ -269,6 +309,58 @@ func TestPatchTemplateMeta(t *testing.T) {
 		assert.Equal(t, req.Icon, updated.Icon)
 		assert.Equal(t, req.MaxTTLMillis, updated.MaxTTLMillis)
 		assert.Equal(t, req.MinAutostartIntervalMillis, updated.MinAutostartIntervalMillis)
+	})
+
+	t.Run("MaxTTLTooLow", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+			ctr.MaxTTLMillis = ptr.Ref(24 * time.Hour.Milliseconds())
+		})
+		req := codersdk.UpdateTemplateMeta{
+			MaxTTLMillis: -1,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.UpdateTemplateMeta(ctx, template.ID, req)
+		require.ErrorContains(t, err, "max_ttl_ms: Must be a positive integer")
+
+		// Ensure no update occurred
+		updated, err := client.Template(ctx, template.ID)
+		require.NoError(t, err)
+		assert.Equal(t, updated.UpdatedAt, template.UpdatedAt)
+		assert.Equal(t, updated.MaxTTLMillis, template.MaxTTLMillis)
+	})
+
+	t.Run("MaxTTLTooHigh", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+			ctr.MaxTTLMillis = ptr.Ref(24 * time.Hour.Milliseconds())
+		})
+		req := codersdk.UpdateTemplateMeta{
+			MaxTTLMillis: 365 * 24 * time.Hour.Milliseconds(),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.UpdateTemplateMeta(ctx, template.ID, req)
+		require.ErrorContains(t, err, "max_ttl_ms: Cannot be greater than")
+
+		// Ensure no update occurred
+		updated, err := client.Template(ctx, template.ID)
+		require.NoError(t, err)
+		assert.Equal(t, updated.UpdatedAt, template.UpdatedAt)
+		assert.Equal(t, updated.MaxTTLMillis, template.MaxTTLMillis)
 	})
 
 	t.Run("NotModified", func(t *testing.T) {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -310,10 +310,6 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// if !dbTTL.Valid {
-	// Default to min(12 hours, template maximum). Just defaulting to template maximum can be surprising.
-	// dbTTL = sql.NullInt64{Valid: true, Int64: min(template.MaxTtl, int64(workspaceDefaultTTL))}
-	// }
 
 	workspace, err := api.Database.GetWorkspaceByOwnerIDAndName(r.Context(), database.GetWorkspaceByOwnerIDAndNameParams{
 		OwnerID: apiKey.UserID,

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -310,7 +310,6 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
-
 	workspace, err := api.Database.GetWorkspaceByOwnerIDAndName(r.Context(), database.GetWorkspaceByOwnerIDAndNameParams{
 		OwnerID: apiKey.UserID,
 		Name:    createWorkspace.Name,

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -32,8 +32,6 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-const workspaceDefaultTTL = 12 * time.Hour
-
 var (
 	ttlMin = time.Minute //nolint:revive // min here means 'minimum' not 'minutes'
 	ttlMax = 7 * 24 * time.Hour
@@ -312,10 +310,10 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if !dbTTL.Valid {
-		// Default to min(12 hours, template maximum). Just defaulting to template maximum can be surprising.
-		dbTTL = sql.NullInt64{Valid: true, Int64: min(template.MaxTtl, int64(workspaceDefaultTTL))}
-	}
+	// if !dbTTL.Valid {
+	// Default to min(12 hours, template maximum). Just defaulting to template maximum can be surprising.
+	// dbTTL = sql.NullInt64{Valid: true, Int64: min(template.MaxTtl, int64(workspaceDefaultTTL))}
+	// }
 
 	workspace, err := api.Database.GetWorkspaceByOwnerIDAndName(r.Context(), database.GetWorkspaceByOwnerIDAndNameParams{
 		OwnerID: apiKey.UserID,
@@ -923,7 +921,8 @@ func validWorkspaceTTLMillis(millis *int64, max time.Duration) (sql.NullInt64, e
 		return sql.NullInt64{}, errTTLMax
 	}
 
-	if truncated > max {
+	// template level
+	if max > 0 && truncated > max {
 		return sql.NullInt64{}, xerrors.Errorf("time until shutdown must be below template maximum %s", max.String())
 	}
 
@@ -1049,11 +1048,4 @@ func splitQueryParameterByDelimiter(query string, delimiter rune, maintainQuotes
 	}
 
 	return parts
-}
-
-func min(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
 }

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -191,6 +191,26 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 		_ = coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 	})
 
+	t.Run("TemplateNoTTL", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+			ctr.MaxTTLMillis = ptr.Ref(int64(0))
+		})
+		// Given: the template has no max TTL set
+		require.Zero(t, template.MaxTTLMillis)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+
+		// When: we create a workspace with autostop not enabled
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.TTLMillis = ptr.Ref(int64(0))
+		})
+		// Then: No TTL should be set by the template
+		require.Nil(t, workspace.TTLMillis)
+	})
+
 	t.Run("TemplateCustomTTL", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
@@ -1050,6 +1070,17 @@ func TestWorkspaceUpdateTTL(t *testing.T) {
 			ttlMillis:      ptr.Ref((12 * time.Hour).Milliseconds()),
 			expectedError:  "ttl_ms: time until shutdown must be below template maximum 8h0m0s",
 			modifyTemplate: func(ctr *codersdk.CreateTemplateRequest) { ctr.MaxTTLMillis = ptr.Ref((8 * time.Hour).Milliseconds()) },
+		},
+		{
+			name:           "no template maximum ttl",
+			ttlMillis:      ptr.Ref((7 * 24 * time.Hour).Milliseconds()),
+			modifyTemplate: func(ctr *codersdk.CreateTemplateRequest) { ctr.MaxTTLMillis = ptr.Ref(int64(0)) },
+		},
+		{
+			name:           "above maximum ttl even with no template max",
+			ttlMillis:      ptr.Ref((365 * 24 * time.Hour).Milliseconds()),
+			expectedError:  "ttl_ms: time until shutdown must be less than 7 days",
+			modifyTemplate: func(ctr *codersdk.CreateTemplateRequest) { ctr.MaxTTLMillis = ptr.Ref(int64(0)) },
 		},
 	}
 


### PR DESCRIPTION
This PR makes the following changes:

- enforces lower and upper limits on template `max_ttl_ms`
- adds a migration to enforce 7-day cap on `max_ttl`
- allows setting template `max_ttl` to 0
- updates template edit CLI help to be clearer

Partially fixes https://github.com/coder/coder/issues/3640