### PR TITLE
fix: Avoid double escaping of ProxyCommand on Windows

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -280,10 +280,16 @@ func configSSH() *cobra.Command {
 						"\tLogLevel ERROR",
 					)
 					if !skipProxyCommand {
+						// In SSH configs, strings inside "" are interpreted literally and there
+						// is no need to e.g. escape backslashes (common on Windows platforms).
+						// We will escape the quotes, though.
+						escapedBinaryFile := strings.ReplaceAll(binaryFile, "\"", "\\\"")
 						if !wireguard {
-							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand %q --global-config %q ssh --stdio %s", binaryFile, root, hostname))
+							//nolint:gocritic // We don't want to use %q here, see above.
+							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand \"%s\" --global-config \"%s\" ssh --stdio %s", escapedBinaryFile, root, hostname))
 						} else {
-							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand %q --global-config %q ssh --wireguard --stdio %s", binaryFile, root, hostname))
+							//nolint:gocritic // We don't want to use %q here, see above.
+							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand \"%s\" --global-config \"%s\" ssh --wireguard --stdio %s", escapedBinaryFile, root, hostname))
 						}
 					}
 


### PR DESCRIPTION
I don't have a Windows setup, but I tested this on Linux with the following:

Binary name:

```
❯ ls coder*
coder\test\n"
```

SSH Config:

```
ProxyCommand "/home/maf/src/coder/coder\test\n\"" --global-config "/home/maf/.config/coderv2" ssh --stdio test
```

This shows that neither `\t`, nor `\n` are interpreted as tab or newline, so `\` doesn't seem to have special meaning when inside `""`, but `\"` seems necessary to avoid it being interpreted as literal `"`.

Without `\"` in the ProxyCommand, we get: `zsh: unmatched "`.

I tried looking through OpenSSH documentation, but could not find specifics as to what happens inside `""`, it simply mentions that `""` must be used when there is whitespace in the name.

Fixes #2853

