### PR TITLE
fix: Remove reference to `coder rebuild` command

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -79,7 +79,7 @@ func Agent(ctx context.Context, writer io.Writer, opts AgentOptions) error {
 		defer resourceMutex.Unlock()
 		message := "Don't panic, your workspace is booting up!"
 		if agent.Status == codersdk.WorkspaceAgentDisconnected {
-			message = "The workspace agent lost connection! Wait for it to reconnect or run: " + Styles.Code.Render("coder rebuild "+opts.WorkspaceName)
+			message = "The workspace agent lost connection! Wait for it to reconnect or restart your workspace."
 		}
 		// This saves the cursor position, then defers clearing from the cursor
 		// position to the end of the screen.


### PR DESCRIPTION
Closes #2464.
