### PR TITLE
chore: Make member role struct match site roles

### DIFF
--- a/coderd/members.go
+++ b/coderd/members.go
@@ -105,11 +105,17 @@ func (api *API) updateOrganizationMemberRoles(ctx context.Context, args database
 }
 
 func convertOrganizationMember(mem database.OrganizationMember) codersdk.OrganizationMember {
-	return codersdk.OrganizationMember{
+	convertedMember := codersdk.OrganizationMember{
 		UserID:         mem.UserID,
 		OrganizationID: mem.OrganizationID,
 		CreatedAt:      mem.CreatedAt,
 		UpdatedAt:      mem.UpdatedAt,
-		Roles:          mem.Roles,
+		Roles:          make([]codersdk.Role, 0, len(mem.Roles)),
 	}
+
+	for _, roleName := range mem.Roles {
+		rbacRole, _ := rbac.RoleByName(roleName)
+		convertedMember.Roles = append(convertedMember.Roles, convertRole(rbacRole))
+	}
+	return convertedMember
 }

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1000,7 +1000,7 @@ func convertUser(user database.User, organizationIDs []uuid.UUID) codersdk.User 
 		Username:        user.Username,
 		Status:          codersdk.UserStatus(user.Status),
 		OrganizationIDs: organizationIDs,
-		Roles:           make([]codersdk.Role, 0),
+		Roles:           make([]codersdk.Role, 0, len(user.RBACRoles)),
 	}
 
 	for _, roleName := range user.RBACRoles {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -489,17 +489,19 @@ func TestGrantSiteRoles(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, randOrgUser := coderdtest.CreateAnotherUserWithUser(t, admin, randOrg.ID, rbac.RoleOrgAdmin(randOrg.ID))
+	userAdmin := coderdtest.CreateAnotherUser(t, admin, first.OrganizationID, rbac.RoleUserAdmin())
 
 	const newUser = "newUser"
 
 	testCases := []struct {
-		Name         string
-		Client       *codersdk.Client
-		OrgID        uuid.UUID
-		AssignToUser string
-		Roles        []string
-		Error        bool
-		StatusCode   int
+		Name          string
+		Client        *codersdk.Client
+		OrgID         uuid.UUID
+		AssignToUser  string
+		Roles         []string
+		ExpectedRoles []string
+		Error         bool
+		StatusCode    int
 	}{
 		{
 			Name:         "OrgRoleInSite",
@@ -576,7 +578,22 @@ func TestGrantSiteRoles(t *testing.T) {
 			OrgID:        first.OrganizationID,
 			AssignToUser: newUser,
 			Roles:        []string{rbac.RoleOrgAdmin(first.OrganizationID)},
-			Error:        false,
+			ExpectedRoles: []string{
+				rbac.RoleOrgMember(first.OrganizationID),
+				rbac.RoleOrgAdmin(first.OrganizationID),
+				rbac.RoleMember(),
+			},
+			Error: false,
+		},
+		{
+			Name:         "UserAdminMakeMember",
+			Client:       userAdmin,
+			AssignToUser: newUser,
+			Roles:        []string{rbac.RoleMember()},
+			ExpectedRoles: []string{
+				rbac.RoleMember(),
+			},
+			Error: false,
 		},
 	}
 
@@ -597,16 +614,21 @@ func TestGrantSiteRoles(t *testing.T) {
 				c.AssignToUser = newUser.ID.String()
 			}
 
+			var newRoles []codersdk.Role
 			if c.OrgID != uuid.Nil {
 				// Org assign
-				_, err = c.Client.UpdateOrganizationMemberRoles(ctx, c.OrgID, c.AssignToUser, codersdk.UpdateRoles{
+				var mem codersdk.OrganizationMember
+				mem, err = c.Client.UpdateOrganizationMemberRoles(ctx, c.OrgID, c.AssignToUser, codersdk.UpdateRoles{
 					Roles: c.Roles,
 				})
+				newRoles = mem.Roles
 			} else {
 				// Site assign
-				_, err = c.Client.UpdateUserRoles(ctx, c.AssignToUser, codersdk.UpdateRoles{
+				var user codersdk.User
+				user, err = c.Client.UpdateUserRoles(ctx, c.AssignToUser, codersdk.UpdateRoles{
 					Roles: c.Roles,
 				})
+				newRoles = user.Roles
 			}
 
 			if c.Error {
@@ -614,6 +636,11 @@ func TestGrantSiteRoles(t *testing.T) {
 				requireStatusCode(t, err, c.StatusCode)
 			} else {
 				require.NoError(t, err)
+				roles := make([]string, 0, len(newRoles))
+				for _, r := range newRoles {
+					roles = append(roles, r.Name)
+				}
+				require.ElementsMatch(t, roles, c.ExpectedRoles)
 			}
 		})
 	}

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -579,9 +579,7 @@ func TestGrantSiteRoles(t *testing.T) {
 			AssignToUser: newUser,
 			Roles:        []string{rbac.RoleOrgAdmin(first.OrganizationID)},
 			ExpectedRoles: []string{
-				rbac.RoleOrgMember(first.OrganizationID),
 				rbac.RoleOrgAdmin(first.OrganizationID),
-				rbac.RoleMember(),
 			},
 			Error: false,
 		},

--- a/codersdk/organizationmember.go
+++ b/codersdk/organizationmember.go
@@ -11,5 +11,5 @@ type OrganizationMember struct {
 	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id"`
 	CreatedAt      time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt      time.Time `db:"updated_at" json:"updated_at"`
-	Roles          []string  `db:"roles" json:"roles"`
+	Roles          []Role    `db:"roles" json:"roles"`
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -206,7 +206,7 @@ export interface OrganizationMember {
   readonly organization_id: string
   readonly created_at: string
   readonly updated_at: string
-  readonly roles: string[]
+  readonly roles: Role[]
 }
 
 // From codersdk/pagination.go


### PR DESCRIPTION
The response struct now matches, and I added some more test assertions.

Site roles were returned as `[]codersdk.Role`. Org roles now return the same