### PR TITLE
fix: correctly link agent name in app urls

### DIFF
--- a/site/src/components/AppLink/AppLink.tsx
+++ b/site/src/components/AppLink/AppLink.tsx
@@ -13,6 +13,7 @@ export const Language = {
 export interface AppLinkProps {
   userName: TypesGen.User["username"]
   workspaceName: TypesGen.Workspace["name"]
+  agentName: TypesGen.WorkspaceAgent["name"]
   appName: TypesGen.WorkspaceApp["name"]
   appIcon?: TypesGen.WorkspaceApp["icon"]
 }
@@ -20,11 +21,12 @@ export interface AppLinkProps {
 export const AppLink: FC<PropsWithChildren<AppLinkProps>> = ({
   userName,
   workspaceName,
+  agentName,
   appName,
   appIcon,
 }) => {
   const styles = useStyles()
-  const href = `/@${userName}/${workspaceName}/apps/${appName}`
+  const href = `/@${userName}/${workspaceName}.${agentName}/apps/${appName}`
 
   return (
     <Link

--- a/site/src/components/Resources/Resources.tsx
+++ b/site/src/components/Resources/Resources.tsx
@@ -131,6 +131,7 @@ export const Resources: FC<React.PropsWithChildren<ResourcesProps>> = ({
                                   appName={app.name}
                                   userName={workspace.owner_name}
                                   workspaceName={workspace.name}
+                                  agentName={agent.name}
                                 />
                               ))}
                             </div>


### PR DESCRIPTION
Fixes #3643 , we were handling this properly in the terminal component but not the app link. The backend already supported the routing needed for this. 
