### PR TITLE
make agent 'connecting' visually different from 'connected'

### DIFF
--- a/site/src/util/workspace.ts
+++ b/site/src/util/workspace.ts
@@ -200,7 +200,7 @@ export const getDisplayAgentStatus = (
       }
     case "connecting":
       return {
-        color: theme.palette.success.main,
+        color: theme.palette.primary.main,
         status: DisplayAgentStatusLanguage["connecting"],
       }
     case "disconnected":


### PR DESCRIPTION
Since "Connected" status is green, I wanted to make "Connecting" distinct visually, so I used blue. 

Before:
<img width="169" alt="chrome_CEK7WnC6HD" src="https://user-images.githubusercontent.com/19379394/186487987-e4088cc2-08e0-448e-8eac-8a9e76a5ce4e.png">

After:
<img width="351" alt="chrome_HrpSZOUXB4" src="https://user-images.githubusercontent.com/19379394/186488114-346d8ca8-0a52-40a1-a8dc-d632fb8e958c.png">

Connected (for comparison):
![image](https://user-images.githubusercontent.com/19379394/186488170-ab61a9c4-5909-42b2-871e-3dbcf53cf077.png)

