### PR TITLE
chore: upload playwright videos on failure

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -661,6 +661,14 @@ jobs:
           DEBUG: pw:api
         working-directory: site
 
+      - name: Upload Playwright Failed Tests
+        if: always() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
+        uses: actions/upload-artifact@v3
+        with:
+          name: failed-test-videos
+          path: ./site/test-results/**/*.webm
+          retention:days: 7
+
       - name: Upload DataDog Trace
         if: always() && github.actor != 'dependabot[bot]' && runner.os == 'Linux' && !github.event.pull_request.head.repo.fork
         env:


### PR DESCRIPTION
This will upload failed e2e test videos as an artifact. Example: https://github.com/coder/coder/actions/runs/2921348579#artifacts

Fixes https://github.com/coder/coder/issues/2740