### PR TITLE
feat: condition Audit log on licensing

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -33,7 +33,7 @@
     "@material-ui/lab": "4.0.0-alpha.42",
     "@testing-library/react-hooks": "8.0.1",
     "@xstate/inspect": "0.6.5",
-    "@xstate/react": "3.0.0",
+    "@xstate/react": "3.0.1",
     "axios": "0.26.1",
     "can-ndjson-stream": "1.0.2",
     "cron-parser": "4.5.0",

--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -143,7 +143,11 @@ export const AppRouter: FC = () => {
                 <Navigate to="/workspaces" />
               ) : (
                 <AuthAndFrame>
-                  <RequirePermission isFeatureVisible={featureVisibility[FeatureNames.AuditLog] && !!permissions?.viewAuditLog}>
+                  <RequirePermission
+                    isFeatureVisible={
+                      featureVisibility[FeatureNames.AuditLog] && !!permissions?.viewAuditLog
+                    }
+                  >
                     <AuditPage />
                   </RequirePermission>
                 </AuthAndFrame>

--- a/site/src/api/types.ts
+++ b/site/src/api/types.ts
@@ -18,5 +18,5 @@ export type Message = { message: string }
 // Keep up to date with coder/codersdk/features.go
 export enum FeatureNames {
   AuditLog = "audit_log",
-  UserLimit = "user_limit"
+  UserLimit = "user_limit",
 }

--- a/site/src/api/types.ts
+++ b/site/src/api/types.ts
@@ -14,3 +14,9 @@ export interface ReconnectingPTYRequest {
 export type WorkspaceBuildTransition = "start" | "stop" | "delete"
 
 export type Message = { message: string }
+
+// Keep up to date with coder/codersdk/features.go
+export enum FeatureNames {
+  AuditLog = "audit_log",
+  UserLimit = "user_limit"
+}

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -1,40 +1,54 @@
-import { screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import { rest } from "msw"
 import {
   MockEntitlementsWithAuditLog,
   MockMemberPermissions,
   MockUser,
-  render,
 } from "testHelpers/renderHelpers"
 import { server } from "testHelpers/server"
-import { Navbar } from "./Navbar"
+import { App } from "app"
 
+/**
+ * The LicenseBanner, mounted above the AppRouter, fetches entitlements. Thus, to test their
+ * effects, we must test at the App level and `waitFor` the fetch to be done.
+ */
 describe("Navbar", () => {
   it("shows Audit Log link when permitted and entitled", async () => {
     server.use(
-      rest.get("/api/entitlements", (req, res, ctx) => {
+      rest.get("/api/v2/entitlements", (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockEntitlementsWithAuditLog))
       }),
     )
-    render(<Navbar />)
-    const link = await screen.findByText("Audit")
-    expect(link).toBeDefined()
+    render(<App />)
+    await waitFor(() => {
+      const link = screen.getByText("Audit")
+      expect(link).toBeDefined()
+    })
   })
 
-  it("does not show Audit Log link when not entitled", () => {
-    render(<Navbar />)
-    const link = screen.getByText("Audit")
-    expect(link).not.toBeDefined()
+  it("does not show Audit Log link when not entitled", async () => {
+    render(<App />)
+    await waitFor(() => {
+      const link = screen.queryByText("Audit")
+      expect(link).toBe(null)
+    })
   })
 
-  it("does not show Audit Log link when not permitted via role", () => {
+  it("does not show Audit Log link when not permitted via role", async () => {
     server.use(
       rest.post(`/api/v2/users/${MockUser.id}/authorization`, async (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockMemberPermissions))
       }),
     )
-    render(<Navbar />)
-    const link = screen.getByText("Audit")
-    expect(link).not.toBeDefined()
+    server.use(
+      rest.get("/api/v2/entitlements", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(MockEntitlementsWithAuditLog))
+      }),
+    )
+    render(<App />)
+    await waitFor(() => {
+      const link = screen.queryByText("Audit")
+      expect(link).toBe(null)
+    })
   })
 })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react"
+import { App } from "app"
 import { rest } from "msw"
 import {
   MockEntitlementsWithAuditLog,
@@ -6,7 +7,6 @@ import {
   MockUser,
 } from "testHelpers/renderHelpers"
 import { server } from "testHelpers/server"
-import { App } from "app"
 
 /**
  * The LicenseBanner, mounted above the AppRouter, fetches entitlements. Thus, to test their

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -27,7 +27,7 @@ describe("Navbar", () => {
         const link = screen.getByText(Language.audit)
         expect(link).toBeDefined()
       },
-      { timeout: 2500 },
+      { timeout: 2000 },
     )
   })
 
@@ -40,7 +40,7 @@ describe("Navbar", () => {
         const link = screen.queryByText(Language.audit)
         expect(link).toBe(null)
       },
-      { timeout: 2500 },
+      { timeout: 2000 },
     )
   })
 
@@ -63,7 +63,7 @@ describe("Navbar", () => {
         const link = screen.queryByText(Language.audit)
         expect(link).toBe(null)
       },
-      { timeout: 2500 },
+      { timeout: 2000 },
     )
   })
 })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -15,41 +15,55 @@ import { server } from "testHelpers/server"
  */
 describe("Navbar", () => {
   it("shows Audit Log link when permitted and entitled", async () => {
+    // set entitlements to allow audit log
     server.use(
       rest.get("/api/v2/entitlements", (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockEntitlementsWithAuditLog))
       }),
     )
     render(<App />)
-    await waitFor(() => {
-      const link = screen.getByText(Language.users) // TODO change after debugging
-      expect(link).toBeDefined()
-    }, { timeout: 10000 })
+    await waitFor(
+      () => {
+        const link = screen.getByText(Language.audit)
+        expect(link).toBeDefined()
+      },
+      { timeout: 5000 },
+    )
   })
 
   it("does not show Audit Log link when not entitled", async () => {
+    // by default, user is an Admin with permission to see the audit log,
+    // but is unlicensed so not entitled to see the audit log
     render(<App />)
-    await waitFor(() => {
-      const link = screen.queryByText(Language.audit)
-      expect(link).toBe(null)
-    })
+    await waitFor(
+      () => {
+        const link = screen.queryByText(Language.audit)
+        expect(link).toBe(null)
+      },
+      { timeout: 5000 },
+    )
   })
 
   it("does not show Audit Log link when not permitted via role", async () => {
+    // set permissions to Member (can't audit)
     server.use(
       rest.post(`/api/v2/users/${MockUser.id}/authorization`, async (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockMemberPermissions))
       }),
     )
+    // set entitlements to allow audit log
     server.use(
       rest.get("/api/v2/entitlements", (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockEntitlementsWithAuditLog))
       }),
     )
     render(<App />)
-    await waitFor(() => {
-      const link = screen.queryByText(Language.audit)
-      expect(link).toBe(null)
-    })
+    await waitFor(
+      () => {
+        const link = screen.queryByText(Language.audit)
+        expect(link).toBe(null)
+      },
+      { timeout: 5000 },
+    )
   })
 })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -17,13 +17,13 @@ describe("Navbar", () => {
       }),
     )
     render(<Navbar />)
-    const link = await screen.findByText("Audit Log")
+    const link = await screen.findByText("Audit")
     expect(link).toBeDefined()
   })
 
   it("does not show Audit Log link when not entitled", () => {
     render(<Navbar />)
-    const link = screen.getByText("Audit Log")
+    const link = screen.getByText("Audit")
     expect(link).not.toBeDefined()
   })
 
@@ -34,7 +34,7 @@ describe("Navbar", () => {
       }),
     )
     render(<Navbar />)
-    const link = screen.getByText("Audit Log")
+    const link = screen.getByText("Audit")
     expect(link).not.toBeDefined()
   })
 })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -27,7 +27,7 @@ describe("Navbar", () => {
         const link = screen.getByText(Language.audit)
         expect(link).toBeDefined()
       },
-      { timeout: 5000 },
+      { timeout: 2500 },
     )
   })
 
@@ -40,7 +40,7 @@ describe("Navbar", () => {
         const link = screen.queryByText(Language.audit)
         expect(link).toBe(null)
       },
-      { timeout: 5000 },
+      { timeout: 2500 },
     )
   })
 
@@ -63,7 +63,7 @@ describe("Navbar", () => {
         const link = screen.queryByText(Language.audit)
         expect(link).toBe(null)
       },
-      { timeout: 5000 },
+      { timeout: 2500 },
     )
   })
 })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -1,33 +1,40 @@
-import { render, MockEntitlementsWithAuditLog, MockMemberPermissions, MockUser } from "testHelpers/renderHelpers"
-import { server } from "testHelpers/server"
 import { screen } from "@testing-library/react"
-import { Navbar } from "./Navbar"
 import { rest } from "msw"
+import {
+  MockEntitlementsWithAuditLog,
+  MockMemberPermissions,
+  MockUser,
+  render,
+} from "testHelpers/renderHelpers"
+import { server } from "testHelpers/server"
+import { Navbar } from "./Navbar"
 
 describe("Navbar", () => {
-  it("shows Audit Log link when permitted and entitled", () => {
+  it("shows Audit Log link when permitted and entitled", async () => {
     server.use(
       rest.get("/api/entitlements", (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockEntitlementsWithAuditLog))
       }),
     )
     render(<Navbar />)
-    expect(screen.getByText("Audit Log"))
+    const link = await screen.findByText("Audit Log")
+    expect(link).toBeDefined()
   })
 
   it("does not show Audit Log link when not entitled", () => {
-    server.use()
     render(<Navbar />)
-    expect(screen.queryByText("Audit Log")).not.toBeDefined()
+    const link = screen.getByText("Audit Log")
+    expect(link).not.toBeDefined()
   })
 
   it("does not show Audit Log link when not permitted via role", () => {
-     server.use(
+    server.use(
       rest.post(`/api/v2/users/${MockUser.id}/authorization`, async (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockMemberPermissions))
       }),
     )
     render(<Navbar />)
-    expect(screen.queryByText("Audit Log")).not.toBeDefined()
+    const link = screen.getByText("Audit Log")
+    expect(link).not.toBeDefined()
   })
 })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -22,7 +22,7 @@ describe("Navbar", () => {
     )
     render(<App />)
     await waitFor(() => {
-      const link = screen.getByText(Language.audit)
+      const link = screen.getByText(Language.users) // TODO change after debugging
       expect(link).toBeDefined()
     })
   })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import { App } from "app"
+import { Language } from "components/NavbarView/NavbarView"
 import { rest } from "msw"
 import {
   MockEntitlementsWithAuditLog,
@@ -21,7 +22,7 @@ describe("Navbar", () => {
     )
     render(<App />)
     await waitFor(() => {
-      const link = screen.getByText("Audit")
+      const link = screen.getByText(Language.audit)
       expect(link).toBeDefined()
     })
   })
@@ -29,7 +30,7 @@ describe("Navbar", () => {
   it("does not show Audit Log link when not entitled", async () => {
     render(<App />)
     await waitFor(() => {
-      const link = screen.queryByText("Audit")
+      const link = screen.queryByText(Language.audit)
       expect(link).toBe(null)
     })
   })
@@ -47,7 +48,7 @@ describe("Navbar", () => {
     )
     render(<App />)
     await waitFor(() => {
-      const link = screen.queryByText("Audit")
+      const link = screen.queryByText(Language.audit)
       expect(link).toBe(null)
     })
   })

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -1,0 +1,33 @@
+import { render, MockEntitlementsWithAuditLog, MockMemberPermissions } from "testHelpers/renderHelpers"
+import { server } from "testHelpers/server"
+import { screen } from "@testing-library/react"
+import { Navbar } from "./Navbar"
+import { rest } from "msw"
+
+describe("Navbar", () => {
+  it("shows Audit Log link when permitted and entitled", () => {
+    server.use(
+      rest.get("/api/entitlements", (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(MockEntitlementsWithAuditLog))
+      }),
+    )
+    render(<Navbar />)
+    expect(screen.getByText("Audit Log"))
+  })
+
+  it("does not show Audit Log link when not entitled", () => {
+    server.use()
+    render(<Navbar />)
+    expect(screen.queryByText("Audit Log")).not.toBeDefined()
+  })
+
+  it("does not show Audit Log link when not permitted via role", () => {
+     server.use(
+      rest.post("/api/v2/users/:userId/authorization", async (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(MockMemberPermissions))
+      }),
+    )
+    render(<Navbar />)
+    expect(screen.queryByText("Audit Log")).not.toBeDefined()
+  })
+})

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, MockEntitlementsWithAuditLog, MockMemberPermissions } from "testHelpers/renderHelpers"
+import { render, MockEntitlementsWithAuditLog, MockMemberPermissions, MockUser } from "testHelpers/renderHelpers"
 import { server } from "testHelpers/server"
 import { screen } from "@testing-library/react"
 import { Navbar } from "./Navbar"
@@ -23,7 +23,7 @@ describe("Navbar", () => {
 
   it("does not show Audit Log link when not permitted via role", () => {
      server.use(
-      rest.post("/api/v2/users/:userId/authorization", async (req, res, ctx) => {
+      rest.post(`/api/v2/users/${MockUser.id}/authorization`, async (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(MockMemberPermissions))
       }),
     )

--- a/site/src/components/Navbar/Navbar.test.tsx
+++ b/site/src/components/Navbar/Navbar.test.tsx
@@ -24,7 +24,7 @@ describe("Navbar", () => {
     await waitFor(() => {
       const link = screen.getByText(Language.users) // TODO change after debugging
       expect(link).toBeDefined()
-    })
+    }, { timeout: 10000 })
   })
 
   it("does not show Audit Log link when not entitled", async () => {

--- a/site/src/components/Navbar/Navbar.tsx
+++ b/site/src/components/Navbar/Navbar.tsx
@@ -9,7 +9,11 @@ export const Navbar: React.FC = () => {
   const xServices = useContext(XServiceContext)
   const [authState, authSend] = useActor(xServices.authXService)
   const { me, permissions } = authState.context
-  const featureVisibility = useSelector(xServices.entitlementsXService, selectFeatureVisibility, shallowEqual)
+  const featureVisibility = useSelector(
+    xServices.entitlementsXService,
+    selectFeatureVisibility,
+    shallowEqual,
+  )
   const canViewAuditLog = featureVisibility[FeatureNames.AuditLog] && !!permissions?.viewAuditLog
   const onSignOut = () => authSend("SIGN_OUT")
 

--- a/site/src/components/Navbar/Navbar.tsx
+++ b/site/src/components/Navbar/Navbar.tsx
@@ -1,5 +1,7 @@
-import { useActor } from "@xstate/react"
+import { useActor, useSelector } from "@xstate/react"
+import { FeatureNames } from "api/types"
 import React, { useContext } from "react"
+import { selectFeatureVisibility } from "xServices/entitlements/entitlementsSelectors"
 import { XServiceContext } from "../../xServices/StateContext"
 import { NavbarView } from "../NavbarView/NavbarView"
 
@@ -7,13 +9,15 @@ export const Navbar: React.FC = () => {
   const xServices = useContext(XServiceContext)
   const [authState, authSend] = useActor(xServices.authXService)
   const { me, permissions } = authState.context
+  const featureVisibility = useSelector(xServices.entitlementsXService, selectFeatureVisibility)
+  const canViewAuditLog = featureVisibility[FeatureNames.AuditLog] && !!permissions?.viewAuditLog
   const onSignOut = () => authSend("SIGN_OUT")
 
   return (
     <NavbarView
       user={me}
       onSignOut={onSignOut}
-      canViewAuditLog={permissions?.viewAuditLog ?? false}
+      canViewAuditLog={canViewAuditLog}
     />
   )
 }

--- a/site/src/components/Navbar/Navbar.tsx
+++ b/site/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useActor, useSelector } from "@xstate/react"
+import { shallowEqual, useActor, useSelector } from "@xstate/react"
 import { FeatureNames } from "api/types"
 import React, { useContext } from "react"
 import { selectFeatureVisibility } from "xServices/entitlements/entitlementsSelectors"
@@ -9,7 +9,7 @@ export const Navbar: React.FC = () => {
   const xServices = useContext(XServiceContext)
   const [authState, authSend] = useActor(xServices.authXService)
   const { me, permissions } = authState.context
-  const featureVisibility = useSelector(xServices.entitlementsXService, selectFeatureVisibility)
+  const featureVisibility = useSelector(xServices.entitlementsXService, selectFeatureVisibility, shallowEqual)
   const canViewAuditLog = featureVisibility[FeatureNames.AuditLog] && !!permissions?.viewAuditLog
   const onSignOut = () => authSend("SIGN_OUT")
 

--- a/site/src/components/Navbar/Navbar.tsx
+++ b/site/src/components/Navbar/Navbar.tsx
@@ -13,11 +13,5 @@ export const Navbar: React.FC = () => {
   const canViewAuditLog = featureVisibility[FeatureNames.AuditLog] && !!permissions?.viewAuditLog
   const onSignOut = () => authSend("SIGN_OUT")
 
-  return (
-    <NavbarView
-      user={me}
-      onSignOut={onSignOut}
-      canViewAuditLog={canViewAuditLog}
-    />
-  )
+  return <NavbarView user={me} onSignOut={onSignOut} canViewAuditLog={canViewAuditLog} />
 }

--- a/site/src/components/RequirePermission/RequirePermission.tsx
+++ b/site/src/components/RequirePermission/RequirePermission.tsx
@@ -1,0 +1,18 @@
+import { FC } from "react"
+import { Navigate } from "react-router"
+
+export interface RequirePermissionProps {
+  children: JSX.Element
+  isFeatureVisible: boolean
+}
+
+/**
+ * Wraps routes that are available based on RBAC or licensing.
+ */
+export const RequirePermission: FC<RequirePermissionProps> = ({ children, isFeatureVisible }) => {
+  if (!isFeatureVisible) {
+    return <Navigate to="/workspaces" />
+  } else {
+    return children
+  }
+}

--- a/site/src/components/RequirePermission/RequirePermission.tsx
+++ b/site/src/components/RequirePermission/RequirePermission.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react"
 import { Navigate } from "react-router"
 
-export interface RequirePermissionProps  {
+export interface RequirePermissionProps {
   children: JSX.Element
   isFeatureVisible: boolean
 }

--- a/site/src/components/RequirePermission/RequirePermission.tsx
+++ b/site/src/components/RequirePermission/RequirePermission.tsx
@@ -1,10 +1,10 @@
-import { FC } from "react"
+import { FC, PropsWithChildren } from "react"
 import { Navigate } from "react-router"
 
-export interface RequirePermissionProps {
+export type RequirePermissionProps = PropsWithChildren<{
   children: JSX.Element
   isFeatureVisible: boolean
-}
+}>
 
 /**
  * Wraps routes that are available based on RBAC or licensing.

--- a/site/src/components/RequirePermission/RequirePermission.tsx
+++ b/site/src/components/RequirePermission/RequirePermission.tsx
@@ -1,10 +1,10 @@
-import { FC, PropsWithChildren } from "react"
+import { FC } from "react"
 import { Navigate } from "react-router"
 
-export type RequirePermissionProps = PropsWithChildren<{
+export interface RequirePermissionProps  {
   children: JSX.Element
   isFeatureVisible: boolean
-}>
+}
 
 /**
  * Wraps routes that are available based on RBAC or licensing.

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -647,11 +647,15 @@ export const MockEntitlementsWithWarnings: TypesGen.Entitlements = {
   warnings: ["You are over your active user limit.", "And another thing."],
   has_license: true,
   features: {
-    activeUsers: {
+    user_limit: {
       enabled: true,
-      entitlement: "entitled",
+      entitlement: "grace_period",
       limit: 100,
       actual: 102,
     },
+    audit_log: {
+      enabled: true,
+      entitlement: "entitled",
+    }
   },
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -51,6 +51,10 @@ export function assignableRole(role: TypesGen.Role, assignable: boolean): TypesG
   }
 }
 
+export const MockMemberPermissions = {
+  viewAuditLog: false
+}
+
 export const MockUser: TypesGen.User = {
   id: "test-user",
   username: "TestUser",
@@ -653,6 +657,17 @@ export const MockEntitlementsWithWarnings: TypesGen.Entitlements = {
       limit: 100,
       actual: 102,
     },
+    audit_log: {
+      enabled: true,
+      entitlement: "entitled",
+    },
+  },
+}
+
+export const MockEntitlementsWithAuditLog: TypesGen.Entitlements = {
+  warnings: [],
+  has_license: true,
+  features: {
     audit_log: {
       enabled: true,
       entitlement: "entitled",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -656,6 +656,6 @@ export const MockEntitlementsWithWarnings: TypesGen.Entitlements = {
     audit_log: {
       enabled: true,
       entitlement: "entitled",
-    }
+    },
   },
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -52,7 +52,7 @@ export function assignableRole(role: TypesGen.Role, assignable: boolean): TypesG
 }
 
 export const MockMemberPermissions = {
-  viewAuditLog: false
+  viewAuditLog: false,
 }
 
 export const MockUser: TypesGen.User = {

--- a/site/src/xServices/entitlements/entitlementsSelectors.test.ts
+++ b/site/src/xServices/entitlements/entitlementsSelectors.test.ts
@@ -1,24 +1,34 @@
 import { getFeatureVisibility } from "./entitlementsSelectors"
 
-describe('getFeatureVisibility', () => {
+describe("getFeatureVisibility", () => {
   it("returns empty object if there is no license", () => {
-    const result = getFeatureVisibility(false, { audit_log: { entitlement: "entitled", enabled: true } })
+    const result = getFeatureVisibility(false, {
+      audit_log: { entitlement: "entitled", enabled: true },
+    })
     expect(result).toEqual(expect.objectContaining({}))
   })
-  it('returns false for a feature that is not enabled', () => {
-    const result = getFeatureVisibility(true, { audit_log: { entitlement: "entitled", enabled: false } })
+  it("returns false for a feature that is not enabled", () => {
+    const result = getFeatureVisibility(true, {
+      audit_log: { entitlement: "entitled", enabled: false },
+    })
     expect(result).toEqual(expect.objectContaining({ audit_log: false }))
   })
   it("returns false for a feature that is not entitled", () => {
-    const result = getFeatureVisibility(true, { audit_log: { entitlement: "not_entitled", enabled: true } })
+    const result = getFeatureVisibility(true, {
+      audit_log: { entitlement: "not_entitled", enabled: true },
+    })
     expect(result).toEqual(expect.objectContaining({ audit_log: false }))
   })
   it("returns true for a feature that is in grace period", () => {
-    const result = getFeatureVisibility(true, { audit_log: { entitlement: "grace_period", enabled: true } })
+    const result = getFeatureVisibility(true, {
+      audit_log: { entitlement: "grace_period", enabled: true },
+    })
     expect(result).toEqual(expect.objectContaining({ audit_log: true }))
   })
   it("returns true for a feature that is in entitled", () => {
-    const result = getFeatureVisibility(true, { audit_log: { entitlement: "entitled", enabled: true } })
+    const result = getFeatureVisibility(true, {
+      audit_log: { entitlement: "entitled", enabled: true },
+    })
     expect(result).toEqual(expect.objectContaining({ audit_log: true }))
   })
 })

--- a/site/src/xServices/entitlements/entitlementsSelectors.test.ts
+++ b/site/src/xServices/entitlements/entitlementsSelectors.test.ts
@@ -1,0 +1,24 @@
+import { getFeatureVisibility } from "./entitlementsSelectors"
+
+describe('getFeatureVisibility', () => {
+  it("returns empty object if there is no license", () => {
+    const result = getFeatureVisibility(false, { audit_log: { entitlement: "entitled", enabled: true } })
+    expect(result).toEqual(expect.objectContaining({}))
+  })
+  it('returns false for a feature that is not enabled', () => {
+    const result = getFeatureVisibility(true, { audit_log: { entitlement: "entitled", enabled: false } })
+    expect(result).toEqual(expect.objectContaining({ audit_log: false }))
+  })
+  it("returns false for a feature that is not entitled", () => {
+    const result = getFeatureVisibility(true, { audit_log: { entitlement: "not_entitled", enabled: true } })
+    expect(result).toEqual(expect.objectContaining({ audit_log: false }))
+  })
+  it("returns true for a feature that is in grace period", () => {
+    const result = getFeatureVisibility(true, { audit_log: { entitlement: "grace_period", enabled: true } })
+    expect(result).toEqual(expect.objectContaining({ audit_log: true }))
+  })
+  it("returns true for a feature that is in entitled", () => {
+    const result = getFeatureVisibility(true, { audit_log: { entitlement: "entitled", enabled: true } })
+    expect(result).toEqual(expect.objectContaining({ audit_log: true }))
+  })
+})

--- a/site/src/xServices/entitlements/entitlementsSelectors.ts
+++ b/site/src/xServices/entitlements/entitlementsSelectors.ts
@@ -9,15 +9,17 @@ type EntitlementState = State<EntitlementsContext, EntitlementsEvent>
  * @param features record from feature name to feature object
  * @returns record from feature name whether to show the feature
  */
-export const getFeatureVisibility = (hasLicense: boolean, features: Record<string, Feature>): Record<string, boolean> => {
+export const getFeatureVisibility = (
+  hasLicense: boolean,
+  features: Record<string, Feature>,
+): Record<string, boolean> => {
   if (hasLicense) {
     const permissionPairs = Object.keys(features).map((feature) => {
-        const { entitlement, limit, actual, enabled } = features[feature]
-        const entitled = ["entitled", "grace_period"].includes(entitlement)
-        const limitCompliant = (limit && actual) ? limit >= actual : true
-        return [feature, entitled && limitCompliant && enabled]
+      const { entitlement, limit, actual, enabled } = features[feature]
+      const entitled = ["entitled", "grace_period"].includes(entitlement)
+      const limitCompliant = limit && actual ? limit >= actual : true
+      return [feature, entitled && limitCompliant && enabled]
     })
-    console.log(permissionPairs, Object.fromEntries(permissionPairs))
     return Object.fromEntries(permissionPairs)
   } else {
     return {}
@@ -25,5 +27,8 @@ export const getFeatureVisibility = (hasLicense: boolean, features: Record<strin
 }
 
 export const selectFeatureVisibility = (state: EntitlementState): Record<string, boolean> => {
-  return getFeatureVisibility(state.context.entitlements.has_license, state.context.entitlements.features)
+  return getFeatureVisibility(
+    state.context.entitlements.has_license,
+    state.context.entitlements.features,
+  )
 }

--- a/site/src/xServices/entitlements/entitlementsSelectors.ts
+++ b/site/src/xServices/entitlements/entitlementsSelectors.ts
@@ -1,0 +1,29 @@
+import { Feature } from "api/typesGenerated"
+import { State } from "xstate"
+import { EntitlementsContext, EntitlementsEvent } from "./entitlementsXService"
+
+type EntitlementState = State<EntitlementsContext, EntitlementsEvent>
+
+/**
+ * @param hasLicense true if Enterprise edition
+ * @param features record from feature name to feature object
+ * @returns record from feature name whether to show the feature
+ */
+export const getFeatureVisibility = (hasLicense: boolean, features: Record<string, Feature>): Record<string, boolean> => {
+  if (hasLicense) {
+    const permissionPairs = Object.keys(features).map((feature) => {
+        const { entitlement, limit, actual, enabled } = features[feature]
+        const entitled = ["entitled", "grace_period"].includes(entitlement)
+        const limitCompliant = (limit && actual) ? limit >= actual : true
+        return [feature, entitled && limitCompliant && enabled]
+    })
+    console.log(permissionPairs, Object.fromEntries(permissionPairs))
+    return Object.fromEntries(permissionPairs)
+  } else {
+    return {}
+  }
+}
+
+export const selectFeatureVisibility = (state: EntitlementState): Record<string, boolean> => {
+  return getFeatureVisibility(state.context.entitlements.has_license, state.context.entitlements.features)
+}

--- a/site/src/xServices/entitlements/entitlementsXService.ts
+++ b/site/src/xServices/entitlements/entitlementsXService.ts
@@ -47,7 +47,7 @@ export const entitlementsMachine = createMachine(
         on: {
           GET_ENTITLEMENTS: "gettingEntitlements",
           SHOW_MOCK_BANNER: { actions: "assignMockEntitlements" },
-          HIDE_MOCK_BANNER: "gettingEntitlements"
+          HIDE_MOCK_BANNER: "gettingEntitlements",
         },
       },
       gettingEntitlements: {

--- a/site/src/xServices/entitlements/entitlementsXService.ts
+++ b/site/src/xServices/entitlements/entitlementsXService.ts
@@ -47,7 +47,7 @@ export const entitlementsMachine = createMachine(
         on: {
           GET_ENTITLEMENTS: "gettingEntitlements",
           SHOW_MOCK_BANNER: { actions: "assignMockEntitlements" },
-          HIDE_MOCK_BANNER: { actions: "clearMockEntitlements" },
+          HIDE_MOCK_BANNER: "gettingEntitlements"
         },
       },
       gettingEntitlements: {
@@ -80,9 +80,6 @@ export const entitlementsMachine = createMachine(
       }),
       assignMockEntitlements: assign({
         entitlements: (_) => MockEntitlementsWithWarnings,
-      }),
-      clearMockEntitlements: assign({
-        entitlements: (_) => emptyEntitlements,
       }),
     },
     services: {

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -3896,10 +3896,10 @@
   resolved "https://registry.yarnpkg.com/@xstate/machine-extractor/-/machine-extractor-0.7.0.tgz#3f46a3686462f309ee208a97f6285e7d6a55cdb8"
   integrity sha512-dXHI/sWWWouN/yG687ZuRCP7Cm6XggFWSK1qWj3NohBTyhaYWSR7ojwP6OUK6e1cbiJqxmM9EDnE2Auf+Xlp+A==
 
-"@xstate/react@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-3.0.0.tgz#888d9a6f128c70b632c18ad55f1f851f6ab092ba"
-  integrity sha512-KHSCfwtb8gZ7QH2luihvmKYI+0lcdHQOmGNRUxUEs4zVgaJCyd8csCEmwPsudpliLdUmyxX2pzUBojFkINpotw==
+"@xstate/react@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-3.0.1.tgz#937eeb5d5d61734ab756ca40146f84a6fe977095"
+  integrity sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
     use-sync-external-store "^1.0.0"


### PR DESCRIPTION
Closes #3219 

- Add `RequirePermissions` wrapper component to make `AppRouter` more readable (currently doing the XState stuff in `AppRouter` instead of the wrapper, either way is workable though)
- Condition Audit Log link and page visibility on license in addition to RBAC and dev mode
- upgrade xstate-react because a recent patch fixes a testing issue

In the past, we've punted on some component tests thinking that e2e tests would work better for cases that need to include the whole component tree. But e2e tests are difficult - they require setup instead of mocks and can be flaky. So I tried doing a component test while rendering `App`. I think it's a good way forward for such cases.

Click SHOW_MOCK_BANNER and HIDE_MOCK_BANNER in the XState inspector to see/hide the Audit link in the navbar - they change the stored license data to trigger both the warning banner and enabling the Audit Log.

Remaining issue:
A test that passes in my workspace fails on CI, I'm investigating.
