### PR TITLE
chore: remove exa -> ls and bat -> cat replacements from dogfood img

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -299,10 +299,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 RUN update-alternatives --install /usr/local/bin/gofmt gofmt /usr/local/go/bin/gofmt 100
 
 COPY --from=go /tmp/bin /usr/local/bin
-
 COPY --from=rust-utils /tmp/bin /usr/local/bin
-RUN mv /usr/local/bin/exa /usr/local/bin/ls
-RUN mv /usr/local/bin/bat /usr/local/bin/cat
 
 USER coder
 


### PR DESCRIPTION
People can symlink these or add aliases in their own `.bashrc` or `.zshrc` files. The `bat` replacement was breaking my dotfiles because it's not posix compliant. Our build scripts are also only written with posix and coreutils in mind too so to avoid any problems we should stick to posix by default. Aliases in the rc files do not affect scripts (unless they're sourced into the shell, which we don't do)

```shell
alias ls=exa
alias cat=bat
```