### PR TITLE
chore: enable react/no-array-index-key eslint

### DIFF
--- a/site/.eslintrc.yaml
+++ b/site/.eslintrc.yaml
@@ -115,6 +115,7 @@ rules:
     - error
     - children: ignore
   # https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
+  react/jsx-key: error
   react/jsx-uses-react: "off"
   react/react-in-jsx-scope: "off"
 settings:

--- a/site/src/components/TemplateResourcesTable/TemplateResourcesTable.tsx
+++ b/site/src/components/TemplateResourcesTable/TemplateResourcesTable.tsx
@@ -55,7 +55,7 @@ export const TemplateResourcesTable: FC<React.PropsWithChildren<TemplateResource
               //  If there is no agent, just display the resource name
               if (!agent) {
                 return (
-                  <TableRow>
+                  <TableRow key={resource.id}>
                     <TableCell className={styles.resourceNameCell}>
                       <AvatarData
                         title={resource.name}


### PR DESCRIPTION
## Description

This PR enables a new ESLint rule: [react/jsx-key](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)

### Example 

It catches missing `key` props like this one:

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/3806031/186731856-fcdeac3c-abef-4d99-bab7-bc775bc80e58.png">

### Motivation

This helps us keep the console free of warnings/errors for our end users and encourages us to follow best practices. A lint rule will help us catch these when we forget. 

Fixes https://github.com/coder/coder/issues/3599