### PR TITLE
DELETE license API endpoint

### DIFF
--- a/coderd/coderdtest/authtest.go
+++ b/coderd/coderdtest/authtest.go
@@ -2,6 +2,7 @@ package coderdtest
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -43,6 +44,7 @@ type AuthTester struct {
 	File                  codersdk.UploadResponse
 	TemplateVersionDryRun codersdk.ProvisionerJob
 	TemplateParam         codersdk.Parameter
+	URLParams             map[string]string
 }
 
 func NewAuthTester(ctx context.Context, t *testing.T, options *Options) *AuthTester {
@@ -86,7 +88,7 @@ func NewAuthTester(ctx context.Context, t *testing.T, options *Options) *AuthTes
 							Id:   "something",
 							Auth: &proto.Agent_Token{},
 							Apps: []*proto.App{{
-								Name: "app",
+								Name: "testapp",
 								Url:  "http://localhost:3000",
 							}},
 						}},
@@ -116,6 +118,28 @@ func NewAuthTester(ctx context.Context, t *testing.T, options *Options) *AuthTes
 	})
 	require.NoError(t, err, "create template param")
 
+	urlParameters := map[string]string{
+		"{organization}":       admin.OrganizationID.String(),
+		"{user}":               admin.UserID.String(),
+		"{organizationname}":   organization.Name,
+		"{workspace}":          workspace.ID.String(),
+		"{workspacebuild}":     workspace.LatestBuild.ID.String(),
+		"{workspacename}":      workspace.Name,
+		"{workspacebuildname}": workspace.LatestBuild.Name,
+		"{workspaceagent}":     workspaceResources[0].Agents[0].ID.String(),
+		"{buildnumber}":        strconv.FormatInt(int64(workspace.LatestBuild.BuildNumber), 10),
+		"{template}":           template.ID.String(),
+		"{hash}":               file.Hash,
+		"{workspaceresource}":  workspaceResources[0].ID.String(),
+		"{workspaceapp}":       workspaceResources[0].Agents[0].Apps[0].Name,
+		"{templateversion}":    version.ID.String(),
+		"{jobID}":              templateVersionDryRun.ID.String(),
+		"{templatename}":       template.Name,
+		// Only checking template scoped params here
+		"parameters/{scope}/{id}": fmt.Sprintf("parameters/%s/%s",
+			string(templateParam.Scope), templateParam.ScopeID.String()),
+	}
+
 	return &AuthTester{
 		t:                     t,
 		api:                   api,
@@ -130,6 +154,7 @@ func NewAuthTester(ctx context.Context, t *testing.T, options *Options) *AuthTes
 		File:                  file,
 		TemplateVersionDryRun: templateVersionDryRun,
 		TemplateParam:         templateParam,
+		URLParams:             urlParameters,
 	}
 }
 
@@ -153,13 +178,13 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 		"POST:/api/v2/csp/reports":      {NoAuthorize: true},
 		"GET:/api/v2/entitlements":      {NoAuthorize: true},
 
-		"GET:/%40{user}/{workspacename}/apps/{application}/*": {
-			AssertAction: rbac.ActionRead,
-			AssertObject: workspaceRBACObj,
+		"GET:/%40{user}/{workspacename}/apps/{workspaceapp}/*": {
+			AssertAction: rbac.ActionCreate,
+			AssertObject: workspaceExecObj,
 		},
-		"GET:/@{user}/{workspacename}/apps/{application}/*": {
-			AssertAction: rbac.ActionRead,
-			AssertObject: workspaceRBACObj,
+		"GET:/@{user}/{workspacename}/apps/{workspaceapp}/*": {
+			AssertAction: rbac.ActionCreate,
+			AssertObject: workspaceExecObj,
 		},
 
 		// Has it's own auth
@@ -188,7 +213,7 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertObject: rbac.ResourceWorkspace,
 			AssertAction: rbac.ActionRead,
 		},
-		"GET:/api/v2/users/me/workspace/{workspacename}/builds/{buildnumber}": {
+		"GET:/api/v2/users/{user}/workspace/{workspacename}/builds/{buildnumber}": {
 			AssertObject: rbac.ResourceWorkspace,
 			AssertAction: rbac.ActionRead,
 		},
@@ -216,7 +241,7 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertAction: rbac.ActionUpdate,
 			AssertObject: workspaceRBACObj,
 		},
-		"PUT:/api/v2/workspaces/{workspace}/autostop": {
+		"PUT:/api/v2/workspaces/{workspace}/ttl": {
 			AssertAction: rbac.ActionUpdate,
 			AssertObject: workspaceRBACObj,
 		},
@@ -275,7 +300,7 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Template.OrganizationID),
 		},
 		"POST:/api/v2/files": {AssertAction: rbac.ActionCreate, AssertObject: rbac.ResourceFile},
-		"GET:/api/v2/files/{fileHash}": {
+		"GET:/api/v2/files/{hash}": {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceFile.WithOwner(a.Admin.UserID.String()),
 		},
@@ -320,19 +345,19 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Version.OrganizationID),
 		},
-		"GET:/api/v2/templateversions/{templateversion}/dry-run/{templateversiondryrun}": {
+		"GET:/api/v2/templateversions/{templateversion}/dry-run/{jobID}": {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Version.OrganizationID),
 		},
-		"GET:/api/v2/templateversions/{templateversion}/dry-run/{templateversiondryrun}/resources": {
+		"GET:/api/v2/templateversions/{templateversion}/dry-run/{jobID}/resources": {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Version.OrganizationID),
 		},
-		"GET:/api/v2/templateversions/{templateversion}/dry-run/{templateversiondryrun}/logs": {
+		"GET:/api/v2/templateversions/{templateversion}/dry-run/{jobID}/logs": {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Version.OrganizationID),
 		},
-		"PATCH:/api/v2/templateversions/{templateversion}/dry-run/{templateversiondryrun}/cancel": {
+		"PATCH:/api/v2/templateversions/{templateversion}/dry-run/{jobID}/cancel": {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Version.OrganizationID),
 		},
@@ -366,10 +391,6 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertAction: rbac.ActionRead,
 			AssertObject: workspaceRBACObj,
 		},
-		"POST:/api/v2/users/{user}/organizations": {
-			AssertAction: rbac.ActionCreate,
-			AssertObject: rbac.ResourceOrganization,
-		},
 		"GET:/api/v2/users": {StatusCode: http.StatusOK, AssertObject: rbac.ResourceUser},
 
 		// These endpoints need payloads to get to the auth part. Payloads will be required
@@ -385,6 +406,7 @@ func (a *AuthTester) Test(ctx context.Context, assertRoute map[string]RouteCheck
 	// Always fail auth from this point forward
 	a.authorizer.AlwaysReturn = rbac.ForbiddenWithInternal(xerrors.New("fake implementation"), nil, nil)
 
+	routeMissing := make(map[string]bool)
 	for k, v := range assertRoute {
 		noTrailSlash := strings.TrimRight(k, "/")
 		if _, ok := assertRoute[noTrailSlash]; ok && noTrailSlash != k {
@@ -392,6 +414,7 @@ func (a *AuthTester) Test(ctx context.Context, assertRoute map[string]RouteCheck
 			a.t.FailNow()
 		}
 		assertRoute[noTrailSlash] = v
+		routeMissing[noTrailSlash] = true
 	}
 
 	for k, v := range skipRoutes {
@@ -422,32 +445,18 @@ func (a *AuthTester) Test(ctx context.Context, assertRoute map[string]RouteCheck
 			}
 			a.t.Run(name, func(t *testing.T) {
 				a.authorizer.reset()
-				routeAssertions, ok := assertRoute[strings.TrimRight(name, "/")]
+				routeKey := strings.TrimRight(name, "/")
+				routeAssertions, ok := assertRoute[routeKey]
 				if !ok {
 					// By default, all omitted routes check for just "authorize" called
 					routeAssertions = RouteCheck{}
 				}
+				delete(routeMissing, routeKey)
 
 				// Replace all url params with known values
-				route = strings.ReplaceAll(route, "{organization}", a.Admin.OrganizationID.String())
-				route = strings.ReplaceAll(route, "{user}", a.Admin.UserID.String())
-				route = strings.ReplaceAll(route, "{organizationname}", a.Organization.Name)
-				route = strings.ReplaceAll(route, "{workspace}", a.Workspace.ID.String())
-				route = strings.ReplaceAll(route, "{workspacebuild}", a.Workspace.LatestBuild.ID.String())
-				route = strings.ReplaceAll(route, "{workspacename}", a.Workspace.Name)
-				route = strings.ReplaceAll(route, "{workspacebuildname}", a.Workspace.LatestBuild.Name)
-				route = strings.ReplaceAll(route, "{workspaceagent}", a.WorkspaceResource.Agents[0].ID.String())
-				route = strings.ReplaceAll(route, "{buildnumber}", strconv.FormatInt(int64(a.Workspace.LatestBuild.BuildNumber), 10))
-				route = strings.ReplaceAll(route, "{template}", a.Template.ID.String())
-				route = strings.ReplaceAll(route, "{hash}", a.File.Hash)
-				route = strings.ReplaceAll(route, "{workspaceresource}", a.WorkspaceResource.ID.String())
-				route = strings.ReplaceAll(route, "{workspaceapp}", a.WorkspaceResource.Agents[0].Apps[0].Name)
-				route = strings.ReplaceAll(route, "{templateversion}", a.Version.ID.String())
-				route = strings.ReplaceAll(route, "{templateversiondryrun}", a.TemplateVersionDryRun.ID.String())
-				route = strings.ReplaceAll(route, "{templatename}", a.Template.Name)
-				// Only checking template scoped params here
-				route = strings.ReplaceAll(route, "{scope}", string(a.TemplateParam.Scope))
-				route = strings.ReplaceAll(route, "{id}", a.TemplateParam.ScopeID.String())
+				for k, v := range a.URLParams {
+					route = strings.ReplaceAll(route, k, v)
+				}
 
 				resp, err := a.Client.Request(ctx, method, route, nil)
 				require.NoError(t, err, "do req")
@@ -486,6 +495,7 @@ func (a *AuthTester) Test(ctx context.Context, assertRoute map[string]RouteCheck
 			return nil
 		})
 	require.NoError(a.t, err)
+	require.Len(a.t, routeMissing, 0, "didn't walk some asserted routes: %v", routeMissing)
 }
 
 type authCall struct {

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -2301,6 +2301,20 @@ func (q *fakeQuerier) GetLicenses(_ context.Context) ([]database.License, error)
 	return results, nil
 }
 
+func (q *fakeQuerier) DeleteLicense(_ context.Context, id int32) (int32, error) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for index, l := range q.licenses {
+		if l.ID == id {
+			q.licenses[index] = q.licenses[len(q.licenses)-1]
+			q.licenses = q.licenses[:len(q.licenses)-1]
+			return id, nil
+		}
+	}
+	return 0, sql.ErrNoRows
+}
+
 func (q *fakeQuerier) GetUserLinkByLinkedID(_ context.Context, id string) (database.UserLink, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -21,6 +21,7 @@ type querier interface {
 	AcquireProvisionerJob(ctx context.Context, arg AcquireProvisionerJobParams) (ProvisionerJob, error)
 	DeleteAPIKeyByID(ctx context.Context, id string) error
 	DeleteGitSSHKey(ctx context.Context, userID uuid.UUID) error
+	DeleteLicense(ctx context.Context, id int32) (int32, error)
 	DeleteParameterValueByID(ctx context.Context, id uuid.UUID) error
 	GetAPIKeyByID(ctx context.Context, id string) (APIKey, error)
 	GetAPIKeysLastUsedAfter(ctx context.Context, lastUsed time.Time) ([]APIKey, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -475,6 +475,19 @@ func (q *sqlQuerier) UpdateGitSSHKey(ctx context.Context, arg UpdateGitSSHKeyPar
 	return err
 }
 
+const deleteLicense = `-- name: DeleteLicense :one
+DELETE
+FROM licenses
+WHERE id = $1
+RETURNING id
+`
+
+func (q *sqlQuerier) DeleteLicense(ctx context.Context, id int32) (int32, error) {
+	row := q.db.QueryRowContext(ctx, deleteLicense, id)
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getLicenses = `-- name: GetLicenses :many
 SELECT id, uploaded_at, jwt, exp
 FROM licenses

--- a/coderd/database/queries/licenses.sql
+++ b/coderd/database/queries/licenses.sql
@@ -8,8 +8,13 @@ INSERT INTO
 VALUES
 	($1, $2, $3) RETURNING *;
 
-
 -- name: GetLicenses :many
 SELECT *
 FROM licenses
 ORDER BY (id);
+
+-- name: DeleteLicense :one
+DELETE
+FROM licenses
+WHERE id = $1
+RETURNING id;

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -3,6 +3,7 @@ package codersdk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -49,4 +50,16 @@ func (c *Client) Licenses(ctx context.Context) ([]License, error) {
 	d := json.NewDecoder(res.Body)
 	d.UseNumber()
 	return licenses, d.Decode(&licenses)
+}
+
+func (c *Client) DeleteLicense(ctx context.Context, id int32) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/licenses/%d", id), nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return readBodyAsError(res)
+	}
+	return nil
 }

--- a/enterprise/coderd/licenses.go
+++ b/enterprise/coderd/licenses.go
@@ -38,6 +38,7 @@ var ValidMethods = []string{"EdDSA"}
 
 // key20220812 is the Coder license public key with id 2022-08-12 used to validate licenses signed
 // by our signing infrastructure
+//
 //go:embed keys/2022-08-12
 var key20220812 []byte
 
@@ -136,12 +137,12 @@ func (a *licenseAPI) handler() http.Handler {
 // postLicense adds a new Enterprise license to the cluster.  We allow multiple different licenses
 // in the cluster at one time for several reasons:
 //
-// 1. Upgrades --- if the license format changes from one version of Coder to the next, during a
-//    rolling update you will have different Coder servers that need different licenses to function.
-// 2. Avoid abrupt feature breakage --- when an admin uploads a new license with different features
-//    we generally don't want the old features to immediately break without warning.  With a grace
-//    period on the license, features will continue to work from the old license until its grace
-//    period, then the users will get a warning allowing them to gracefully stop using the feature.
+//  1. Upgrades --- if the license format changes from one version of Coder to the next, during a
+//     rolling update you will have different Coder servers that need different licenses to function.
+//  2. Avoid abrupt feature breakage --- when an admin uploads a new license with different features
+//     we generally don't want the old features to immediately break without warning.  With a grace
+//     period on the license, features will continue to work from the old license until its grace
+//     period, then the users will get a warning allowing them to gracefully stop using the feature.
 func (a *licenseAPI) postLicense(rw http.ResponseWriter, r *http.Request) {
 	if !a.auth.Authorize(r, rbac.ActionCreate, rbac.ResourceLicense) {
 		httpapi.Forbidden(rw)

--- a/enterprise/coderd/licenses_internal_test.go
+++ b/enterprise/coderd/licenses_internal_test.go
@@ -250,6 +250,7 @@ func TestDeleteLicense(t *testing.T) {
 		resp, err := client.Request(ctx, http.MethodDelete, "/api/v2/licenses/drivers", nil)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
 	})
 
 	t.Run("DELETE", func(t *testing.T) {


### PR DESCRIPTION
First PR for #3281 

Follow on PR will include the CLI command.

@Emyrk In addition to the DELETE API, I've added a new check to the TestAuthorizeAllEndpoints test, which asserts that each route assertion actually gets checked during the API walk.  As it turns out, some of them were not getting hit, and we were silently thinking that certain RBAC assertions were being checked when they were not.  Most were simple errors in the parameter names in the paths (this could be due to drift in the API definition).  But, there were some where the RBAC check is actually different, so I would like you to take a look at the updates to the assertions.
