### PR TITLE
chore: add resources to workspace watch endpoint

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -138,9 +138,14 @@ func Event(rw http.ResponseWriter, event interface{}) error {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(true)
-	err := enc.Encode(struct {
-		Data interface{} `json:"data"`
-	}{Data: event})
+
+	_, err := buf.Write([]byte("data: "))
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return err
+	}
+
+	err = enc.Encode(event)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return err

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -50,8 +50,9 @@ type WorkspaceBuild struct {
 	InitiatorID        uuid.UUID           `json:"initiator_id"`
 	InitiatorUsername  string              `json:"initiator_name"`
 	Job                ProvisionerJob      `json:"job"`
-	Deadline           NullTime            `json:"deadline,omitempty"`
 	Reason             BuildReason         `db:"reason" json:"reason"`
+	Deadline           NullTime            `json:"deadline,omitempty"`
+	Resources          []WorkspaceResource `json:"resources,omitempty"`
 }
 
 // WorkspaceBuild returns a single workspace build for a workspace.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -527,8 +527,9 @@ export interface WorkspaceBuild {
   readonly initiator_id: string
   readonly initiator_name: string
   readonly job: ProvisionerJob
-  readonly deadline?: string
   readonly reason: BuildReason
+  readonly deadline?: string
+  readonly resources?: WorkspaceResource[]
 }
 
 // From codersdk/workspaces.go

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -12,6 +12,7 @@ import "xterm/css/xterm.css"
 import { MONOSPACE_FONT_FAMILY } from "../../theme/constants"
 import { pageTitle } from "../../util/page"
 import { terminalMachine } from "../../xServices/terminal/terminalXService"
+import { colors } from "theme/colors"
 
 export const Language = {
   workspaceErrorMessagePrefix: "Unable to fetch workspace: ",

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -12,7 +12,6 @@ import "xterm/css/xterm.css"
 import { MONOSPACE_FONT_FAMILY } from "../../theme/constants"
 import { pageTitle } from "../../util/page"
 import { terminalMachine } from "../../xServices/terminal/terminalXService"
-import { colors } from "theme/colors"
 
 export const Language = {
   workspaceErrorMessagePrefix: "Unable to fetch workspace: ",


### PR DESCRIPTION
The goal here is to have a single endpoint for the dashboard to get pushed updates. Right now the dashboard polls for both the workspace and the resources, so this combines them into one.