### PR TITLE
Revert "fix: Avoid double escaping of ProxyCommand on Windows (#3664)"

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -280,16 +280,10 @@ func configSSH() *cobra.Command {
 						"\tLogLevel ERROR",
 					)
 					if !skipProxyCommand {
-						// In SSH configs, strings inside "" are interpreted literally and there
-						// is no need to e.g. escape backslashes (common on Windows platforms).
-						// We will escape the quotes, though.
-						escapedBinaryFile := strings.ReplaceAll(binaryFile, "\"", "\\\"")
 						if !wireguard {
-							//nolint:gocritic // We don't want to use %q here, see above.
-							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand \"%s\" --global-config \"%s\" ssh --stdio %s", escapedBinaryFile, root, hostname))
+							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand %q --global-config %q ssh --stdio %s", binaryFile, root, hostname))
 						} else {
-							//nolint:gocritic // We don't want to use %q here, see above.
-							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand \"%s\" --global-config \"%s\" ssh --wireguard --stdio %s", escapedBinaryFile, root, hostname))
+							configOptions = append(configOptions, fmt.Sprintf("\tProxyCommand %q --global-config %q ssh --wireguard --stdio %s", binaryFile, root, hostname))
 						}
 					}
 


### PR DESCRIPTION
This reverts commit 123fe0131eacef645c64c60226a64c097abc5906.

As discussed in #2853, the change did not fix the Windows 10 case (quotes are the problem). However, it's not a problem on all Windows 10 setups, this is why I'm reverting the change. We only did this change to fix Windows 10 and it didn't help, so we'll need to understand better what causes the problem before we attempt to fix it (again).
