### PR TITLE
feat: Add control for max workspaces per user

### DIFF
--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -90,6 +90,23 @@ func Uint8VarP(flagset *pflag.FlagSet, ptr *uint8, name string, shorthand string
 	flagset.Uint8VarP(ptr, name, shorthand, uint8(vi64), fmtUsage(usage, env))
 }
 
+// UintVarP sets a uint flag on the given flag set.
+func UintVarP(flagset *pflag.FlagSet, ptr *uint, name string, shorthand string, env string, def uint, usage string) {
+	val, ok := os.LookupEnv(env)
+	if !ok || val == "" {
+		flagset.UintVarP(ptr, name, shorthand, def, fmtUsage(usage, env))
+		return
+	}
+
+	vi64, err := strconv.ParseUint(val, 10, 8)
+	if err != nil {
+		flagset.UintVarP(ptr, name, shorthand, def, fmtUsage(usage, env))
+		return
+	}
+
+	flagset.UintVarP(ptr, name, shorthand, uint(vi64), fmtUsage(usage, env))
+}
+
 func Bool(flagset *pflag.FlagSet, name, shorthand, env string, def bool, usage string) {
 	val, ok := os.LookupEnv(env)
 	if !ok || val == "" {

--- a/cli/server.go
+++ b/cli/server.go
@@ -111,8 +111,8 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 		autoImportTemplates              []string
 		spooky                           bool
 		verbose                          bool
-		// maxWorkspacesPerUser is a uint8 to ensure a number > 0.
-		maxWorkspacesPerUser uint8
+		// maxWorkspacesPerUser is a uint to ensure a number > 0.
+		maxWorkspacesPerUser uint
 	)
 
 	root := &cobra.Command{
@@ -778,7 +778,7 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 	cliflag.StringArrayVarP(root.Flags(), &autoImportTemplates, "auto-import-template", "", "CODER_TEMPLATE_AUTOIMPORT", []string{}, "Which templates to auto-import. Available auto-importable templates are: kubernetes")
 	cliflag.BoolVarP(root.Flags(), &spooky, "spooky", "", "", false, "Specifies spookiness level")
 	cliflag.BoolVarP(root.Flags(), &verbose, "verbose", "v", "CODER_VERBOSE", false, "Enables verbose logging.")
-	cliflag.Uint8VarP(root.Flags(), &maxWorkspacesPerUser, "max-workspaces-per-user", "", "CODER_MAX_WORKSPACES_PER_USER", 50, "Specifies the max number of workspaces that can be created by a user.")
+	cliflag.UintVarP(root.Flags(), &maxWorkspacesPerUser, "max-workspaces-per-user", "", "CODER_MAX_WORKSPACES_PER_USER", 50, "Specifies the max number of workspaces that can be created by a user.")
 	_ = root.Flags().MarkHidden("spooky")
 
 	return root

--- a/cli/server.go
+++ b/cli/server.go
@@ -111,6 +111,8 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 		autoImportTemplates              []string
 		spooky                           bool
 		verbose                          bool
+		// maxWorkspacesPerUser is a uint8 to ensure a number > 0.
+		maxWorkspacesPerUser uint8
 	)
 
 	root := &cobra.Command{
@@ -307,6 +309,10 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 				validatedAutoImportTemplates[i] = v
 			}
 
+			if maxWorkspacesPerUser < 1 {
+				return xerrors.New("max workspaces per user must be greater than 0")
+			}
+
 			options := &coderd.Options{
 				AccessURL:            accessURLParsed,
 				ICEServers:           iceServers,
@@ -321,6 +327,7 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 				TracerProvider:       tracerProvider,
 				Telemetry:            telemetry.NewNoop(),
 				AutoImportTemplates:  validatedAutoImportTemplates,
+				MaxWorkspacesPerUser: maxWorkspacesPerUser,
 			}
 
 			if oauth2GithubClientSecret != "" {
@@ -771,6 +778,7 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 	cliflag.StringArrayVarP(root.Flags(), &autoImportTemplates, "auto-import-template", "", "CODER_TEMPLATE_AUTOIMPORT", []string{}, "Which templates to auto-import. Available auto-importable templates are: kubernetes")
 	cliflag.BoolVarP(root.Flags(), &spooky, "spooky", "", "", false, "Specifies spookiness level")
 	cliflag.BoolVarP(root.Flags(), &verbose, "verbose", "v", "CODER_VERBOSE", false, "Enables verbose logging.")
+	cliflag.Uint8VarP(root.Flags(), &maxWorkspacesPerUser, "max-workspaces-per-user", "", "CODER_MAX_WORKSPACES_PER_USER", 50, "Specifies the max number of workspaces that can be created by a user.")
 	_ = root.Flags().MarkHidden("spooky")
 
 	return root

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -68,7 +68,7 @@ type Options struct {
 	TracerProvider       *sdktrace.TracerProvider
 	AutoImportTemplates  []AutoImportTemplate
 	LicenseHandler       http.Handler
-	MaxWorkspacesPerUser uint8
+	MaxWorkspacesPerUser uint
 }
 
 // New constructs a Coder API handler.

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -68,6 +68,7 @@ type Options struct {
 	TracerProvider       *sdktrace.TracerProvider
 	AutoImportTemplates  []AutoImportTemplate
 	LicenseHandler       http.Handler
+	MaxWorkspacesPerUser uint8
 }
 
 // New constructs a Coder API handler.

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -73,8 +73,9 @@ type Options struct {
 	AutobuildStats       chan<- executor.Stats
 
 	// IncludeProvisionerD when true means to start an in-memory provisionerD
-	IncludeProvisionerD bool
-	APIBuilder          func(*coderd.Options) *coderd.API
+	IncludeProvisionerD  bool
+	APIBuilder           func(*coderd.Options) *coderd.API
+	MaxWorkspacesPerUser uint8
 }
 
 // New constructs a codersdk client connected to an in-memory API instance.
@@ -134,6 +135,10 @@ func newWithAPI(t *testing.T, options *Options) (*codersdk.Client, io.Closer, *c
 	}
 	if options.APIBuilder == nil {
 		options.APIBuilder = coderd.New
+	}
+
+	if options.MaxWorkspacesPerUser == 0 {
+		options.MaxWorkspacesPerUser = 50
 	}
 
 	// This can be hotswapped for a live database instance.
@@ -212,6 +217,7 @@ func newWithAPI(t *testing.T, options *Options) (*codersdk.Client, io.Closer, *c
 		Authorizer:           options.Authorizer,
 		Telemetry:            telemetry.NewNoop(),
 		AutoImportTemplates:  options.AutoImportTemplates,
+		MaxWorkspacesPerUser: options.MaxWorkspacesPerUser,
 	})
 	t.Cleanup(func() {
 		_ = coderAPI.Close()

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -75,7 +75,7 @@ type Options struct {
 	// IncludeProvisionerD when true means to start an in-memory provisionerD
 	IncludeProvisionerD  bool
 	APIBuilder           func(*coderd.Options) *coderd.API
-	MaxWorkspacesPerUser uint8
+	MaxWorkspacesPerUser uint
 }
 
 // New constructs a codersdk client connected to an in-memory API instance.

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -312,7 +312,8 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 	dbAutostartSchedule, err := validWorkspaceSchedule(createWorkspace.AutostartSchedule, time.Duration(template.MinAutostartInterval))
 	if err != nil {
 		httpapi.Write(rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf("Template is not in organization %q.", organization.Name),
+			Message:     "Invalid Autostart Schedule.",
+			Validations: []codersdk.ValidationError{{Field: "schedule", Detail: err.Error()}},
 		})
 		return
 	}


### PR DESCRIPTION
This adds a flag for controlling the max number of workspaces a user can create. 

Implements part of the work referenced in https://github.com/coder/coder/issues/2988