### PR TITLE
fix: mount TLS secret in helm chart

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -31,3 +31,43 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Coder listen port (must be > 1024)
+*/}}
+{{- define "coder.port" }}
+{{- if .Values.coder.tls.secretName -}}
+8443
+{{- else -}}
+8080
+{{- end -}}
+{{- end }}
+
+{{/*
+Coder service port
+*/}}
+{{- define "coder.servicePort" }}
+{{- if .Values.coder.tls.secretName -}}
+443
+{{- else -}}
+80
+{{- end -}}
+{{- end }}
+
+{{/*
+Port name
+*/}}
+{{- define "coder.portName" }}
+{{- if .Values.coder.tls.secretName -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end }}
+
+{{/*
+Scheme
+*/}}
+{{- define "coder.scheme" }}
+{{- include "coder.portName" . | upper -}}
+{{- end }}

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -68,3 +68,16 @@ spec:
             httpGet:
               path: /api/v2/buildinfo
               port: http
+          {{- if .Values.coder.tls.secretName }}
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/ssl/certs/coder
+              readOnly: true
+          {{- end }}
+
+      {{- if .Values.coder.tls.secretName }}
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ .Values.coder.tls.secretName | quote }}
+      {{- end }}

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -34,40 +34,33 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            {{- if .Values.coder.tls.secretName }}
             - name: CODER_ADDRESS
-              value: "0.0.0.0:8443"
+              value: "0.0.0.0:{{ include "coder.port" . }}"
+            {{- if .Values.coder.tls.secretName }}
             - name: CODER_TLS_ENABLE
               value: "true"
             - name: CODER_TLS_CERT_FILE
               value: /etc/ssl/certs/coder/tls.crt
             - name: CODER_TLS_KEY_FILE
               value: /etc/ssl/certs/coder/tls.key
-            {{- else }}
-            - name: CODER_ADDRESS
-              value: "0.0.0.0:8080"
             {{- end }}
             {{- with .Values.coder.env -}}
             {{ toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            {{- if .Values.coder.tls.secretName }}
-            - name: https
-              containerPort: 8443
+            - name: {{ include "coder.portName" . | quote }}
+              containerPort: {{ include "coder.port" . }}
               protocol: TCP
-            {{- else }}
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-            {{- end }}
           readinessProbe:
             httpGet:
               path: /api/v2/buildinfo
-              port: http
+              port: {{ include "coder.portName" . | quote }}
+              scheme: {{ include "coder.scheme" . | quote }}
           livenessProbe:
             httpGet:
               path: /api/v2/buildinfo
-              port: http
+              port: {{ include "coder.portName" . | quote }}
+              scheme: {{ include "coder.scheme" . | quote }}
           {{- if .Values.coder.tls.secretName }}
           volumeMounts:
             - name: tls

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -9,17 +9,10 @@ metadata:
 spec:
   type: {{ .Values.coder.service.type }}
   ports:
-    {{- if .Values.coder.tls.secretName }}
-    - name: https
-      port: 443
-      targetPort: https
+    - name: {{ include "coder.portName" . | quote }}
+      port: {{ include "coder.servicePort" . }}
+      targetPort: {{ include "coder.portName" . | quote }}
       protocol: TCP
-    {{- else }}
-    - name: http
-      port: 80
-      targetPort: http
-      protocol: TCP
-    {{- end }}
   selector:
     {{- include "coder.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Fixes TLS via `coder.tls.secretName` not working in helm chart. The env vars were being set but the secret was never mounted.

Tested, works with and without `coder.tls.secretName` set