### PR TITLE
feat: allow init script to be used as docker entrypoint

### DIFF
--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -46,3 +46,7 @@ fi
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
 exec ./$BINARY_NAME agent
+
+if [ "$@" ]; then
+        exec "$@"
+fi

--- a/provisionersdk/scripts/bootstrap_linux.sh
+++ b/provisionersdk/scripts/bootstrap_linux.sh
@@ -45,7 +45,7 @@ fi
 
 export CODER_AGENT_AUTH="${AUTH_TYPE}"
 export CODER_AGENT_URL="${ACCESS_URL}"
-exec ./$BINARY_NAME agent
+exec ./$BINARY_NAME agent &
 
 if [ "$@" ]; then
         exec "$@"


### PR DESCRIPTION
<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->

It would be cool to use the init script as a docker entrypoint so we can easily run other commands as well via command property. What do you think?
