### PR TITLE
fix: rebase docker image from `alpine` to `alpine/git`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # cross-compiled, it cannot have ANY "RUN" commands. All binaries are built
 # using the go toolchain on the host and then copied into the build context by
 # scripts/build_docker.sh.
-FROM alpine:latest
+FROM alpine/git:latest
 
 # LABEL doesn't add any real layers so it's fine (and easier) to do it here than
 # in the build script.

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -101,9 +101,9 @@ log "--- Building Docker image for $arch ($image_tag)"
 # add the coder group and user. We have to do this in a separate step instead of
 # using the RUN directive in the Dockerfile because you can't use RUN if you're
 # building the image for a different architecture than the host.
-docker pull --platform "$arch" alpine:latest 1>&2
+docker pull --platform "$arch" alpine/git:latest 1>&2
 
-temp_container_id="$(docker create --platform "$arch" alpine:latest)"
+temp_container_id="$(docker create --platform "$arch" alpine/git:latest)"
 docker cp "$temp_container_id":/etc/group ./group 1>&2
 docker cp "$temp_container_id":/etc/passwd ./passwd 1>&2
 docker rm "$temp_container_id" 1>&2


### PR DESCRIPTION
This PR rebases the image from `alpine` to `alpine/git` to ensure the Docker Image can also build templates which require git such as the [`gcp-vm-container`](https://github.com/coder/coder/tree/main/examples/templates/gcp-vm-container) example.

## Subtasks

- [x] Replace `FROM alpine:latest` with `FROM alpine/git:latest`
- [x] Replace `docker pull alpine:latest` with `docker pull alpine/git:latest`

Fixes #3724
