### PR TITLE
fix: Print postgres-builtin-url to stdout without formatting

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -659,13 +659,13 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 	root.AddCommand(&cobra.Command{
 		Use:   "postgres-builtin-url",
 		Short: "Output the connection URL for the built-in PostgreSQL deployment.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := createConfig(cmd)
 			url, err := embeddedPostgresURL(cfg)
 			if err != nil {
 				return err
 			}
-			cmd.Println(cliui.Styles.Code.Render("psql \"" + url + "\""))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "psql %q", url)
 			return nil
 		},
 	})

--- a/cli/server.go
+++ b/cli/server.go
@@ -665,7 +665,7 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "psql %q", url)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "psql %q\n", url)
 			return nil
 		},
 	})


### PR DESCRIPTION
This allows use-cases like `eval $(coder server postgres-builtin-url)`.

(Previously went to stderr with formatting, resulting in use-case looking like this: `eval $(coder server postgres-builtin-url 2>&1 | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")`.)

