### PR TITLE
fix: remove `(http.Server).ReadHeaderTimeout`

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -499,9 +499,8 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 			server := &http.Server{
 				// These errors are typically noise like "TLS: EOF". Vault does similar:
 				// https://github.com/hashicorp/vault/blob/e2490059d0711635e529a4efcbaa1b26998d6e1c/command/server.go#L2714
-				ErrorLog:          log.New(io.Discard, "", 0),
-				Handler:           coderAPI.Handler,
-				ReadHeaderTimeout: time.Minute,
+				ErrorLog: log.New(io.Discard, "", 0),
+				Handler:  coderAPI.Handler,
 				BaseContext: func(_ net.Listener) context.Context {
 					return shutdownConnsCtx
 				},
@@ -1107,9 +1106,8 @@ func serveHandler(ctx context.Context, logger slog.Logger, handler http.Handler,
 	logger.Debug(ctx, "http server listening", slog.F("addr", addr), slog.F("name", name))
 
 	srv := &http.Server{
-		Addr:              addr,
-		Handler:           handler,
-		ReadHeaderTimeout: time.Minute,
+		Addr:    addr,
+		Handler: handler,
 	}
 	go func() {
 		err := srv.ListenAndServe()

--- a/cli/server.go
+++ b/cli/server.go
@@ -496,6 +496,11 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 
 			shutdownConnsCtx, shutdownConns := context.WithCancel(ctx)
 			defer shutdownConns()
+
+			// ReadHeaderTimeout is purposefully not enabled. It caused some issues with
+			// websockets over the dev tunnel.
+			// See: https://github.com/coder/coder/pull/3730
+			//nolint:gosec
 			server := &http.Server{
 				// These errors are typically noise like "TLS: EOF". Vault does similar:
 				// https://github.com/hashicorp/vault/blob/e2490059d0711635e529a4efcbaa1b26998d6e1c/command/server.go#L2714
@@ -1105,6 +1110,10 @@ func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, al
 func serveHandler(ctx context.Context, logger slog.Logger, handler http.Handler, addr, name string) (closeFunc func()) {
 	logger.Debug(ctx, "http server listening", slog.F("addr", addr), slog.F("name", name))
 
+	// ReadHeaderTimeout is purposefully not enabled. It caused some issues with
+	// websockets over the dev tunnel.
+	// See: https://github.com/coder/coder/pull/3730
+	//nolint:gosec
 	srv := &http.Server{
 		Addr:    addr,
 		Handler: handler,

--- a/coderd/httpmw/workspaceparam.go
+++ b/coderd/httpmw/workspaceparam.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/httpapi"
 	"github.com/coder/coder/codersdk"
-	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 type workspaceParamContextKey struct{}
@@ -57,8 +58,8 @@ func ExtractWorkspaceParam(db database.Store) func(http.Handler) http.Handler {
 // "workspace_and_agent" URL parameter. `ExtractUserParam` must be called
 // before this.
 // This can be in the form of:
-//	- "<workspace-name>.[workspace-agent]"	: If multiple agents exist
-//	- "<workspace-name>"					: If one agent exists
+//   - "<workspace-name>.[workspace-agent]"	: If multiple agents exist
+//   - "<workspace-name>"					: If one agent exists
 func ExtractWorkspaceAndAgentParam(db database.Store) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/3710. It caused some race
condition for websockets where the server sent the first message.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->
