### PR TITLE
fix: Templates table columns width

### DIFF
--- a/site/src/components/TableCellData/TableCellData.tsx
+++ b/site/src/components/TableCellData/TableCellData.tsx
@@ -37,5 +37,8 @@ const useStyles = makeStyles((theme) => ({
   secondary: {
     fontSize: 12,
     color: theme.palette.text.secondary,
+    lineHeight: "140%",
+    marginTop: 2,
+    maxWidth: 540,
   },
 }))

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -25,6 +25,11 @@ AllStates.args = {
       description: "😮 Wow, this one has a bunch of usage!",
       icon: "",
     },
+    {
+      ...MockTemplate,
+      description:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ",
+    },
   ],
 }
 

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -115,10 +115,10 @@ export const TemplatesPageView: FC<React.PropsWithChildren<TemplatesPageViewProp
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>{Language.nameLabel}</TableCell>
-              <TableCell>{Language.usedByLabel}</TableCell>
-              <TableCell>{Language.lastUpdatedLabel}</TableCell>
-              <TableCell>{Language.createdByLabel}</TableCell>
+              <TableCell width="50%">{Language.nameLabel}</TableCell>
+              <TableCell width="16%">{Language.usedByLabel}</TableCell>
+              <TableCell width="16%">{Language.lastUpdatedLabel}</TableCell>
+              <TableCell width="16%">{Language.createdByLabel}</TableCell>
               <TableCell width="1%"></TableCell>
             </TableRow>
           </TableHead>


### PR DESCRIPTION
Fixes #3639 

Before fix:
![image](https://user-images.githubusercontent.com/3165839/187245817-88218002-8720-40c4-8655-815b3d032519.png)

After fix:
<img width="1492" alt="Screen Shot 2022-08-29 at 13 08 13" src="https://user-images.githubusercontent.com/3165839/187245738-0fba3388-3283-479d-a293-6227e154ecee.png">
