### PR TITLE
feat: Sort templates by workspaces count

### DIFF
--- a/coderd/httpmw/workspaceparam.go
+++ b/coderd/httpmw/workspaceparam.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/httpapi"
 	"github.com/coder/coder/codersdk"
-	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 type workspaceParamContextKey struct{}
@@ -57,8 +58,8 @@ func ExtractWorkspaceParam(db database.Store) func(http.Handler) http.Handler {
 // "workspace_and_agent" URL parameter. `ExtractUserParam` must be called
 // before this.
 // This can be in the form of:
-//	- "<workspace-name>.[workspace-agent]"	: If multiple agents exist
-//	- "<workspace-name>"					: If one agent exists
+//   - "<workspace-name>.[workspace-agent]"	: If multiple agents exist
+//   - "<workspace-name>"					: If one agent exists
 func ExtractWorkspaceAndAgentParam(db database.Store) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/httpmw/workspaceparam.go
+++ b/coderd/httpmw/workspaceparam.go
@@ -8,12 +8,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
-
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/httpapi"
 	"github.com/coder/coder/codersdk"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 )
 
 type workspaceParamContextKey struct{}
@@ -58,8 +57,8 @@ func ExtractWorkspaceParam(db database.Store) func(http.Handler) http.Handler {
 // "workspace_and_agent" URL parameter. `ExtractUserParam` must be called
 // before this.
 // This can be in the form of:
-//   - "<workspace-name>.[workspace-agent]"	: If multiple agents exist
-//   - "<workspace-name>"					: If one agent exists
+//	- "<workspace-name>.[workspace-agent]"	: If multiple agents exist
+//	- "<workspace-name>"					: If one agent exists
 func ExtractWorkspaceAndAgentParam(db database.Store) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -339,13 +339,7 @@ func (api *API) templatesByOrganization(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Sort templates by WorkspaceOwnerCount DESC
-	templateList := convertTemplates(templates, workspaceCounts, createdByNameMap)
-	sort.SliceStable(templateList, func(i, j int) bool {
-		return templateList[i].WorkspaceOwnerCount > templateList[j].WorkspaceOwnerCount
-	})
-
-	httpapi.Write(rw, http.StatusOK, templateList)
+	httpapi.Write(rw, http.StatusOK, convertTemplates(templates, workspaceCounts, createdByNameMap))
 }
 
 func (api *API) templateByOrganizationAndName(rw http.ResponseWriter, r *http.Request) {
@@ -680,6 +674,7 @@ func getCreatedByNamesByTemplateIDs(ctx context.Context, db database.Store, temp
 
 func convertTemplates(templates []database.Template, workspaceCounts []database.GetWorkspaceOwnerCountsByTemplateIDsRow, createdByNameMap map[string]string) []codersdk.Template {
 	apiTemplates := make([]codersdk.Template, 0, len(templates))
+
 	for _, template := range templates {
 		found := false
 		for _, workspaceCount := range workspaceCounts {
@@ -694,6 +689,12 @@ func convertTemplates(templates []database.Template, workspaceCounts []database.
 			apiTemplates = append(apiTemplates, convertTemplate(template, uint32(0), createdByNameMap[template.ID.String()]))
 		}
 	}
+
+	// Sort templates by WorkspaceOwnerCount DESC
+	sort.SliceStable(apiTemplates, func(i, j int) bool {
+		return apiTemplates[i].WorkspaceOwnerCount > apiTemplates[j].WorkspaceOwnerCount
+	})
+
 	return apiTemplates
 }
 

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -338,7 +339,13 @@ func (api *API) templatesByOrganization(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	httpapi.Write(rw, http.StatusOK, convertTemplates(templates, workspaceCounts, createdByNameMap))
+	// Sort templates by WorkspaceOwnerCount DESC
+	templateList := convertTemplates(templates, workspaceCounts, createdByNameMap)
+	sort.SliceStable(templateList, func(i, j int) bool {
+		return templateList[i].WorkspaceOwnerCount > templateList[j].WorkspaceOwnerCount
+	})
+
+	httpapi.Write(rw, http.StatusOK, templateList)
 }
 
 func (api *API) templateByOrganizationAndName(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Since we are not using a DB for paginated results, and the workspace count is being calculated outside of the regular templates query, I think a simple sort works well without adding tech debt.

Closes #3713 

