### PR TITLE
update: google provider to latest

### DIFF
--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.15"
+      version = "~> 4.34.0"
     }
   }
 }
@@ -39,16 +39,30 @@ resource "google_compute_disk" "root" {
   name  = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
   type  = "pd-ssd"
   zone  = var.zone
-  image = "debian-cloud/debian-10"
+  image = "debian-cloud/debian-11"
   lifecycle {
     ignore_changes = [image]
   }
 }
 
 resource "coder_agent" "main" {
-  auth = "google-instance-identity"
-  arch = "amd64"
-  os   = "linux"
+  auth  = "google-instance-identity"
+  arch  = "amd64"
+  os    = "linux"
+  startup_script = <<EOT
+    #!/bin/bash
+
+    # install and start code-server
+    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    code-server --auth none --port 13337 | tee code-server-install.log &
+  EOT
+}
+
+resource "coder_app" "code-server" {
+  agent_id = coder_agent.main.id
+  name     = "code-server"
+  url      = "http://localhost:13337/?folder=/home/coder"
+  icon     = "/icon/code.svg"
 }
 
 resource "google_compute_instance" "dev" {

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -49,20 +49,6 @@ resource "coder_agent" "main" {
   auth  = "google-instance-identity"
   arch  = "amd64"
   os    = "linux"
-  startup_script = <<EOT
-    #!/bin/bash
-
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
-    code-server --auth none --port 13337 | tee code-server-install.log &
-  EOT
-}
-
-resource "coder_app" "code-server" {
-  agent_id = coder_agent.main.id
-  name     = "code-server"
-  url      = "http://localhost:13337/?folder=/home/coder"
-  icon     = "/icon/code.svg"
 }
 
 resource "google_compute_instance" "dev" {

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.15"
+      version = "~> 4.34.0"
     }
   }
 }
@@ -46,7 +46,7 @@ module "gce-container" {
   version = "3.0.0"
 
   container = {
-    image   = "mcr.microsoft.com/vscode/devcontainers/go:1"
+    image   = "codercom/enterprise-base:ubuntu"
     command = ["sh"]
     args    = ["-c", coder_agent.main.init_script]
     securityContext = {

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.15"
+      version = "~> 4.34.0"
     }
   }
 }


### PR DESCRIPTION
this PR updates the GCP example templates to use the latest version of the google terraform provider, `4.34.0`. it also updates the `gcp-linux` template's boot disk image version to `debian-cloud/debian-11`.

fixes #3738 and #3621.