### PR TITLE
Update `username` in connecting to a workspace documenation (using JetBrains Gateway)

### DIFF
--- a/docs/ides/gateway.md
+++ b/docs/ides/gateway.md
@@ -17,7 +17,7 @@ Coder.
 
 1. For the Host, enter `coder.<workspace name>`
 1. For the Port, enter `22` (this is ignored by Coder)
-1. For the Username, enter `coder`
+1. For the Username, enter your workspace username (default 'coder')
 1. For the Authentication Type, select "OpenSSH config and authentication
    agent"
 1. Make sure the checkbox for "Parse config file ~/.ssh/config" is checked.

--- a/docs/ides/gateway.md
+++ b/docs/ides/gateway.md
@@ -17,7 +17,7 @@ Coder.
 
 1. For the Host, enter `coder.<workspace name>`
 1. For the Port, enter `22` (this is ignored by Coder)
-1. For the Username, enter your workspace username (default 'coder')
+1. For the Username, enter your workspace username
 1. For the Authentication Type, select "OpenSSH config and authentication
    agent"
 1. Make sure the checkbox for "Parse config file ~/.ssh/config" is checked.


### PR DESCRIPTION
The workspace username is not always `coder`.

Update `username` in connecting to a workspace using JetBrains Gateway.
If someone is not using the coder-provided default templates and using their custom templates or a pre-built docker image e.g.`matlab`, where username is `matlab`.
