### PR TITLE
refactor: use WidgetsIcon for null resources

### DIFF
--- a/site/src/components/Resources/ResourceAvatar.tsx
+++ b/site/src/components/Resources/ResourceAvatar.tsx
@@ -5,6 +5,7 @@ import ImageIcon from "@material-ui/icons/ImageOutlined"
 import MemoryIcon from "@material-ui/icons/MemoryOutlined"
 import WidgetsIcon from "@material-ui/icons/WidgetsOutlined"
 import React from "react"
+import { WorkspaceResource } from "../../api/typesGenerated"
 
 // For this special case, we need to apply a different style because how this
 // particular icon has been designed
@@ -12,7 +13,7 @@ const AdjustedMemoryIcon: typeof MemoryIcon = ({ style, ...props }) => {
   return <MemoryIcon style={{ ...style, fontSize: 24 }} {...props} />
 }
 
-const iconByResource: Record<string, typeof MemoryIcon> = {
+const iconByResource: Record<WorkspaceResource["type"], typeof MemoryIcon | undefined> = {
   docker_volume: FolderIcon,
   docker_container: AdjustedMemoryIcon,
   docker_image: ImageIcon,
@@ -25,7 +26,7 @@ const iconByResource: Record<string, typeof MemoryIcon> = {
   null_resource: WidgetsIcon,
 }
 
-export type ResourceAvatarProps = { type: string }
+export type ResourceAvatarProps = { type: WorkspaceResource["type"] }
 
 export const ResourceAvatar: React.FC<ResourceAvatarProps> = ({ type }) => {
   const IconComponent = iconByResource[type] ?? WidgetsIcon

--- a/site/src/components/Resources/ResourceAvatar.tsx
+++ b/site/src/components/Resources/ResourceAvatar.tsx
@@ -1,9 +1,9 @@
 import Avatar from "@material-ui/core/Avatar"
 import { makeStyles } from "@material-ui/core/styles"
 import FolderIcon from "@material-ui/icons/FolderOutlined"
-import WidgetsIcon from "@material-ui/icons/WidgetsOutlined"
 import ImageIcon from "@material-ui/icons/ImageOutlined"
 import MemoryIcon from "@material-ui/icons/MemoryOutlined"
+import WidgetsIcon from "@material-ui/icons/WidgetsOutlined"
 import React from "react"
 
 // For this special case, we need to apply a different style because how this

--- a/site/src/components/Resources/ResourceAvatar.tsx
+++ b/site/src/components/Resources/ResourceAvatar.tsx
@@ -1,7 +1,7 @@
 import Avatar from "@material-ui/core/Avatar"
 import { makeStyles } from "@material-ui/core/styles"
 import FolderIcon from "@material-ui/icons/FolderOutlined"
-import HelpIcon from "@material-ui/icons/HelpOutlined"
+import WidgetsIcon from "@material-ui/icons/WidgetsOutlined"
 import ImageIcon from "@material-ui/icons/ImageOutlined"
 import MemoryIcon from "@material-ui/icons/MemoryOutlined"
 import React from "react"
@@ -22,15 +22,13 @@ const iconByResource: Record<string, typeof MemoryIcon> = {
   google_compute_instance: AdjustedMemoryIcon,
   aws_instance: AdjustedMemoryIcon,
   kubernetes_deployment: AdjustedMemoryIcon,
-  null_resource: HelpIcon,
+  null_resource: WidgetsIcon,
 }
 
 export type ResourceAvatarProps = { type: string }
 
 export const ResourceAvatar: React.FC<ResourceAvatarProps> = ({ type }) => {
-  // this resource can return undefined
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const IconComponent = iconByResource[type] ?? HelpIcon
+  const IconComponent = iconByResource[type] ?? WidgetsIcon
   const styles = useStyles()
 
   return (


### PR DESCRIPTION
This PR updates the icon used for null resources 

<img width="59" alt="image" src="https://user-images.githubusercontent.com/3806031/187471925-7c3d73a9-2876-4fca-a770-89b5c2241581.png">

Previous icon used:

<img width="49" alt="image" src="https://user-images.githubusercontent.com/3806031/187471858-ee56ce89-8848-404e-b23e-4b9719931b9f.png">


h/t to @kconley-sq for the suggestion! 🎉

Also found another issue which I will tackle after this: https://github.com/coder/coder/issues/3767
