### PR TITLE
fix: Prevent suspending owners

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -441,7 +441,7 @@ func (api *API) putUserStatus(status database.UserStatus) func(rw http.ResponseW
 			case slice.Contains(user.RBACRoles, rbac.RoleOwner()):
 				// You may not suspend an owner
 				httpapi.Write(rw, http.StatusBadRequest, codersdk.Response{
-					Message: fmt.Sprintf("You cannot suspend a user with the %q role.", rbac.RoleOwner()),
+					Message: fmt.Sprintf("You cannot suspend a user with the %q role. You must remove the role first.", rbac.RoleOwner()),
 				})
 				return
 			}

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coder/coder/coderd/util/slice"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"github.com/google/uuid"
@@ -23,7 +21,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
-
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/gitsshkey"
 	"github.com/coder/coder/coderd/httpapi"
@@ -31,6 +28,7 @@ import (
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/coderd/telemetry"
 	"github.com/coder/coder/coderd/userpassword"
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/cryptorand"
 	"github.com/coder/coder/examples"

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -737,21 +737,28 @@ func TestInitialRoles(t *testing.T) {
 func TestPutUserSuspend(t *testing.T) {
 	t.Parallel()
 
-	t.Run("SuspendAnotherUser", func(t *testing.T) {
+	t.Run("SuspendAnOwner", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		me := coderdtest.CreateFirstUser(t, client)
+		_, user := coderdtest.CreateAnotherUserWithUser(t, client, me.OrganizationID, rbac.RoleOwner())
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		client.User(ctx, codersdk.Me)
-		user, _ := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "bruno@coder.com",
-			Username:       "bruno",
-			Password:       "password",
-			OrganizationID: me.OrganizationID,
-		})
+		_, err := client.UpdateUserStatus(ctx, user.Username, codersdk.UserStatusSuspended)
+		require.Error(t, err, "cannot suspend owners")
+	})
+
+	t.Run("SuspendAnotherUser", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		me := coderdtest.CreateFirstUser(t, client)
+		_, user := coderdtest.CreateAnotherUserWithUser(t, client, me.OrganizationID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
 		user, err := client.UpdateUserStatus(ctx, user.Username, codersdk.UserStatusSuspended)
 		require.NoError(t, err)
 		require.Equal(t, user.Status, codersdk.UserStatusSuspended)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -848,7 +848,7 @@ func TestUsersFilter(t *testing.T) {
 	for i := 0; i < 15; i++ {
 		roles := []string{}
 		if i%2 == 0 {
-			roles = append(roles, rbac.RoleOwner())
+			roles = append(roles, rbac.RoleTemplateAdmin(), rbac.RoleUserAdmin())
 		}
 		if i%3 == 0 {
 			roles = append(roles, "auditor")


### PR DESCRIPTION
Fixes #3659


If you want to suspend an owner, you have to remove their "owner" role first. Seems fair
