### PR TITLE
fix: Use a select when parameter input has many options

### DIFF
--- a/site/src/components/ParameterInput/ParameterInput.tsx
+++ b/site/src/components/ParameterInput/ParameterInput.tsx
@@ -1,4 +1,5 @@
 import FormControlLabel from "@material-ui/core/FormControlLabel"
+import MenuItem from "@material-ui/core/MenuItem"
 import Radio from "@material-ui/core/Radio"
 import RadioGroup from "@material-ui/core/RadioGroup"
 import { makeStyles } from "@material-ui/core/styles"
@@ -53,23 +54,23 @@ const ParameterField: React.FC<React.PropsWithChildren<ParameterInputProps>> = (
 }) => {
   if (schema.validation_contains && schema.validation_contains.length > 0) {
     return (
-      <RadioGroup
+      <TextField
         id={schema.name}
+        size="small"
         defaultValue={schema.default_source_value}
+        disabled={disabled}
         onChange={(event) => {
           onChange(event.target.value)
         }}
+        select
+        fullWidth
       >
         {schema.validation_contains.map((item) => (
-          <FormControlLabel
-            disabled={disabled}
-            key={item}
-            value={item}
-            control={<Radio color="primary" size="small" disableRipple />}
-            label={item}
-          />
+          <MenuItem key={item} value={item}>
+            {item}
+          </MenuItem>
         ))}
-      </RadioGroup>
+      </TextField>
     )
   }
 


### PR DESCRIPTION
Before: 
<img width="1496" alt="Screen Shot 2022-08-30 at 15 53 31" src="https://user-images.githubusercontent.com/3165839/187519372-a7a92d35-8cb1-400d-839d-1fa4d37c8942.png">

After:
<img width="1495" alt="Screen Shot 2022-08-30 at 15 52 14" src="https://user-images.githubusercontent.com/3165839/187519420-53b61183-8fb9-43f3-b514-9a73434ff35c.png">

Why? 
Radio groups look nice but when it is about 10+ items, it starts to occupy too much vertical space. Fixes #3744 