### PR TITLE
fix: default coder image tag

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,8 +6,8 @@ home: https://github.com/coder/coder
 # version and appVersion are injected at release and will always be shown as
 # 0.1.0 in the repository.
 type: application
-version: "0.1.0"
-appVersion: "0.1.0"
+version: "0.8.9"
+appVersion: "0.8.9"
 
 # Coder has a hard requirement on Kubernetes 1.19, as this version introduced
 # the networking.k8s.io/v1 API.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,7 +11,7 @@ coder:
     repo: "ghcr.io/coder/coder"
     # coder.image.tag -- The tag of the image, defaults to {{.Chart.AppVersion}}
     # if not set.
-    tag: "latest"
+    tag: ""
     # coder.image.pullPolicy -- The pull policy to use for the image. See:
     # https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: IfNotPresent

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,7 +11,7 @@ coder:
     repo: "ghcr.io/coder/coder"
     # coder.image.tag -- The tag of the image, defaults to {{.Chart.AppVersion}}
     # if not set.
-    tag: ""
+    tag: "latest"
     # coder.image.pullPolicy -- The pull policy to use for the image. See:
     # https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: IfNotPresent


### PR DESCRIPTION
this PR fixes the default Coder image tag in the Helm chart. it is currently set to `0.1.0`, [which does not exist](https://github.com/coder/coder/pkgs/container/coder).

below is the current behavior, using the default `values.yaml` file:

```
Failed to pull image "ghcr.io/coder/coder:v0.1.0": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/coder/coder:v0.1.0": failed to resolve reference "ghcr.io/coder/coder:v0.1.0": ghcr.io/coder/coder:v0.1.0: not found
```

I've set `coder.image.tag` to default to `latest`, and updated the `{{.Chart.AppVersion}}` to be `0.8.9`, our latest release.


