### PR TITLE
fix: prevent running helm chart without valid tag

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,6 +5,10 @@ home: https://github.com/coder/coder
 
 # version and appVersion are injected at release and will always be shown as
 # 0.1.0 in the repository.
+#
+# If you're installing the Helm chart directly from git it will have this
+# version, which means the auto-generated image URI will be invalid. You can set
+# "coder.image.tag" to the desired tag manually.
 type: application
 version: "0.1.0"
 appVersion: "0.1.0"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -33,6 +33,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Coder Docker image URI
+*/}}
+{{- define "coder.image" -}}
+{{- if and (eq .Values.coder.image.tag "") (eq .Chart.AppVersion "0.1.0") -}}
+{{ fail "You must specify coder.image.tag if you're installing the Helm chart directly from Git." }}
+{{- end -}}
+{{ .Values.coder.image.repo }}:{{ .Values.coder.image.tag | default (printf "v%v" .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
 Coder listen port (must be > 1024)
 */}}
 {{- define "coder.port" }}

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: coder
-          image: "{{ .Values.coder.image.repo }}:{{ .Values.coder.image.tag | default (printf "v%v" .Chart.AppVersion) }}"
+          image: {{ include "coder.image" . | quote }}
           imagePullPolicy: {{ .Values.coder.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,9 @@ coder:
     # coder.image.repo -- The repository of the image.
     repo: "ghcr.io/coder/coder"
     # coder.image.tag -- The tag of the image, defaults to {{.Chart.AppVersion}}
-    # if not set.
+    # if not set. If you're using the chart directly from git, the default
+    # app version will not work and you'll need to set this value. The helm
+    # chart helpfully fails quickly in this case.
     tag: ""
     # coder.image.pullPolicy -- The pull policy to use for the image. See:
     # https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy


### PR DESCRIPTION
blocks using helm chart from git unless they set `coder.image.tag`

Successor of #3764