### PR TITLE
Remove alpha warning from about

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,6 @@ on your preferred clouds and servers.
 
 By building on top of common development interfaces (SSH) and infrastructure tools (Terraform), Coder aims to make the process of **provisioning** and **accessing** remote workspaces approachable for organizations of various sizes and stages of cloud-native maturity.
 
-> ⚠️ Coder OSS is in **alpha** state and is not ready for production use. For
-> production environments, please consider [Coder v1](https://coder.com/docs) or
-> [code-server](https://github.com/cdr/code-server).
-
 ## How it works
 
 Coder workspaces are represented with Terraform, but no Terraform knowledge is


### PR DESCRIPTION
The doc was outdated; I don't think the software is alpha anymore.
