### PR TITLE
feat: make scrollbars match color scheme

### DIFF
--- a/site/src/theme/overrides.ts
+++ b/site/src/theme/overrides.ts
@@ -14,6 +14,9 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
           backgroundAttachment: "fixed",
           letterSpacing: "-0.015em",
         },
+        ":root": {
+          colorScheme: palette.type,
+        },
       },
     },
     MuiAvatar: {


### PR DESCRIPTION
Closes #3595 

Before:
<img width="266" alt="Screen Shot 2022-09-01 at 1 09 40 PM" src="https://user-images.githubusercontent.com/1290996/187973648-9e57c249-6afa-4322-af2c-7ca266444fe1.png">

After:
<img width="338" alt="Screen Shot 2022-09-01 at 1 10 03 PM" src="https://user-images.githubusercontent.com/1290996/187973682-b5a1c791-04c3-47bd-a6b7-7254345e1c95.png">

