### PR TITLE
docs: add comment to ResourceAvatar

### DIFF
--- a/site/src/components/Resources/ResourceAvatar.tsx
+++ b/site/src/components/Resources/ResourceAvatar.tsx
@@ -13,6 +13,10 @@ const AdjustedMemoryIcon: typeof MemoryIcon = ({ style, ...props }) => {
   return <MemoryIcon style={{ ...style, fontSize: 24 }} {...props} />
 }
 
+// NOTE@jsjoeio, @BrunoQuaresma
+// These resources (i.e. docker_image, kubernetes_deployment) map to Terraform
+// resource types. These are the most used ones and are based on user usage.
+// We may want to update from time-to-time.
 const iconByResource: Record<WorkspaceResource["type"], typeof MemoryIcon | undefined> = {
   docker_volume: FolderIcon,
   docker_container: AdjustedMemoryIcon,


### PR DESCRIPTION
I originally asked @BrunoQuaresma on Slack why we weren't using these same strings for workspace resource types on the backend. Turns out it's based on Terraform and these are only the most used ones. We agreed this context should live next to the code so this adds that.