### PR TITLE
feat(cli): validate name length on template create

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -49,6 +49,10 @@ func templateCreate() *cobra.Command {
 				templateName = args[0]
 			}
 
+			if len(templateName) > 31 {
+				return xerrors.Errorf("Template name must be less than 32 characters")
+			}
+
 			_, err = client.TemplateByName(cmd.Context(), organization.ID, templateName)
 			if err == nil {
 				return xerrors.Errorf("A template already exists named %q!", templateName)

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
@@ -49,7 +50,7 @@ func templateCreate() *cobra.Command {
 				templateName = args[0]
 			}
 
-			if len(templateName) > 31 {
+			if utf8.RuneCountInString(templateName) > 31 {
 				return xerrors.Errorf("Template name must be less than 32 characters")
 			}
 

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -246,16 +246,7 @@ func TestTemplateCreate(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
 		coderdtest.CreateFirstUser(t, client)
-		source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
-			Parse:           createTestParseResponse(),
-			Provision:       echo.ProvisionComplete,
-			ProvisionDryRun: echo.ProvisionComplete,
-		})
-		tempDir := t.TempDir()
-		removeTmpDirUntilSuccessAfterTest(t, tempDir)
-		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
-		_, _ = parameterFile.WriteString("zone: \"bananas\"")
-		cmd, root := clitest.New(t, "templates", "create", "1234567890123456789012345678901234567890", "--directory", source, "--test.provisioner", string(database.ProvisionerTypeEcho), "--parameter-file", parameterFile.Name())
+		cmd, root := clitest.New(t, "templates", "create", "1234567890123456789012345678901234567891", "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t)
 		cmd.SetIn(pty.Input())
@@ -266,18 +257,7 @@ func TestTemplateCreate(t *testing.T) {
 			execDone <- cmd.Execute()
 		}()
 
-		matches := []struct {
-			match string
-			write string
-		}{
-			{match: "Create and upload", write: "yes"},
-		}
-		for _, m := range matches {
-			pty.ExpectMatch(m.match)
-			pty.WriteLine(m.write)
-		}
-
-		require.EqualError(t, <-execDone, "template name must be less than 32 characters")
+		require.EqualError(t, <-execDone, "Template name must be less than 32 characters")
 	})
 }
 

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -248,9 +248,6 @@ func TestTemplateCreate(t *testing.T) {
 		coderdtest.CreateFirstUser(t, client)
 		cmd, root := clitest.New(t, "templates", "create", "1234567890123456789012345678901234567891", "--test.provisioner", string(database.ProvisionerTypeEcho))
 		clitest.SetupConfig(t, client, root)
-		pty := ptytest.New(t)
-		cmd.SetIn(pty.Input())
-		cmd.SetOut(pty.Output())
 
 		execDone := make(chan error)
 		go func() {


### PR DESCRIPTION
This adds a test to validate that `template create` prints an error
message if called with a template name exceeding the 32-char limit.

<!-- Help reviewers by listing the subtasks in this PR

Here's an example:

This PR adds a new feature to the CLI.

## Subtasks

- [x] added a test for feature

Fixes #345

-->

### Notes to self

To run this test locally:
```shell
cd cli && go test -v -count 1 -run TestTemplateCreate/WithParameterExceedingCharLimit
```

It doesn't look like my attempt at TDD with this is working. The test should fail so I'll need to fix that first.