### PR TITLE
feat: Improve experience with local SSH keys

### DIFF
--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -147,6 +147,7 @@ func praseIdentityFilesForHost(ctx context.Context, args, env []string) (identit
 	cmd := exec.CommandContext(ctx, "ssh", args...)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stdout = &outBuf
+	cmd.Stderr = io.Discard
 	err = cmd.Run()
 	if err != nil {
 		// If ssh -G failed, the SSH version is likely too old, fallback

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -154,6 +154,9 @@ func praseIdentityFilesForHost(ctx context.Context, args, env []string) (identit
 		// to using the default identity files.
 		r = strings.NewReader(fallbackIdentityFiles)
 	}
+	if errBuf.Len() > 0 {
+		return nil, xerrors.Errorf("ssh -G encountered an error: %s", errBuf.String())
+	}
 
 	s := bufio.NewScanner(r)
 	for s.Scan() {

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -140,22 +140,18 @@ func praseIdentityFilesForHost(ctx context.Context, args, env []string) (identit
 		return nil, xerrors.Errorf("get user home dir failed: %w", err)
 	}
 
-	var outBuf, errBuf bytes.Buffer
+	var outBuf bytes.Buffer
 	var r io.Reader = &outBuf
 
 	args = append([]string{"-G"}, args...)
 	cmd := exec.CommandContext(ctx, "ssh", args...)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
 	err = cmd.Run()
 	if err != nil {
 		// If ssh -G failed, the SSH version is likely too old, fallback
 		// to using the default identity files.
 		r = strings.NewReader(fallbackIdentityFiles)
-	}
-	if errBuf.Len() > 0 {
-		return nil, xerrors.Errorf("ssh -G encountered an error: %s", errBuf.String())
 	}
 
 	s := bufio.NewScanner(r)

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -33,7 +33,7 @@ func gitssh() *cobra.Command {
 			defer stop()
 
 			// Early check so errors are reported immediately.
-			identityFiles, err := praseIdentityFilesForHost(ctx, args, env)
+			identityFiles, err := parseIdentityFilesForHost(ctx, args, env)
 			if err != nil {
 				return err
 			}
@@ -120,7 +120,7 @@ var fallbackIdentityFiles = strings.Join([]string{
 	"identityfile ~/.ssh/id_xmss",
 }, "\n")
 
-// praseIdentityFilesForHost uses ssh -G to discern what SSH keys have
+// parseIdentityFilesForHost uses ssh -G to discern what SSH keys have
 // been enabled for the host (via the users SSH config) and returns a
 // list of existing identity files.
 //
@@ -128,13 +128,13 @@ var fallbackIdentityFiles = strings.Join([]string{
 // fallback keys (see above). However, by passing `-i` to attach our
 // private key, we're effectively disabling the fallback keys.
 //
-// Example invokation:
+// Example invocation:
 //
 //	ssh -G -o SendEnv=GIT_PROTOCOL git@github.com git-upload-pack 'coder/coder'
 //
 // The extra arguments work without issue and lets us run the command
 // as-is without stripping out the excess (git-upload-pack 'coder/coder').
-func praseIdentityFilesForHost(ctx context.Context, args, env []string) (identityFiles []string, error error) {
+func parseIdentityFilesForHost(ctx context.Context, args, env []string) (identityFiles []string, error error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, xerrors.Errorf("get user home dir failed: %w", err)

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -41,6 +41,7 @@ func prepareTestGitSSH(ctx context.Context, t *testing.T) (*codersdk.Client, str
 	// get user public key
 	keypair, err := client.GitSSHKey(ctx, codersdk.Me)
 	require.NoError(t, err)
+	//nolint:dogsled
 	pubkey, _, _, _, err := gossh.ParseAuthorizedKey([]byte(keypair.PublicKey))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This change means that users can place SSH keys in the default locations for OpenSSH, like `~/.ssh/id_rsa` and it will be automatically picked up (as per a default OpenSSH experience).

Fixes #3126

**Notes:**

- I wanted to implement a `-test.homedir` flag to test the SSH fallback key locations, however, setting `HOME=/tmp/` seems to have no effect on where OpenSSH looks for the config :(
- Although this fixes #3126, we'll want to break out some Windows related discussions from there to:
  1. Fix SSH agent forwarding on Windows
  2. Potentially refactor this into using our own proxy agent, once our Windows SSH agent story is fixed
