### PR TITLE
chore: Reduce test times

### DIFF
--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -20,8 +20,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		instanceID := "instanceidentifier"
 		certificates, metadataClient := coderdtest.NewAzureInstanceIdentity(t, instanceID)
 		client := coderdtest.New(t, &coderdtest.Options{
-			AzureCertificates:   certificates,
-			IncludeProvisionerD: true,
+			AzureCertificates:        certificates,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -78,8 +78,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		instanceID := "instanceidentifier"
 		certificates, metadataClient := coderdtest.NewAWSInstanceIdentity(t, instanceID)
 		client := coderdtest.New(t, &coderdtest.Options{
-			AWSCertificates:     certificates,
-			IncludeProvisionerD: true,
+			AWSCertificates:          certificates,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -136,8 +136,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		instanceID := "instanceidentifier"
 		validator, metadata := coderdtest.NewGoogleInstanceIdentity(t, instanceID, false)
 		client := coderdtest.New(t, &coderdtest.Options{
-			GoogleTokenValidator: validator,
-			IncludeProvisionerD:  true,
+			GoogleTokenValidator:     validator,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -61,7 +61,7 @@ func sshConfigFileRead(t *testing.T, name string) string {
 func TestConfigSSH(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -520,7 +520,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			t.Parallel()
 
 			var (
-				client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+				client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 				user      = coderdtest.CreateFirstUser(t, client)
 				version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 				_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -642,7 +642,7 @@ func TestConfigSSH_Hostnames(t *testing.T) {
 				},
 			}}
 
-			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user := coderdtest.CreateFirstUser(t, client)
 			// authToken := uuid.NewString()
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -23,7 +23,7 @@ func TestCreate(t *testing.T) {
 	t.Parallel()
 	t.Run("Create", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse:           echo.ParseComplete,
@@ -80,7 +80,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("CreateFromListWithSkip", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -102,7 +102,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("FromNothing", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -139,7 +139,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("WithParameter", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		defaultValue := "something"
@@ -180,7 +180,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("WithParameterFileContainingTheValue", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		defaultValue := "something"
@@ -223,7 +223,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("WithParameterFileNotContainingTheValue", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		defaultValue := "something"
@@ -254,7 +254,7 @@ func TestCreate(t *testing.T) {
 
 	t.Run("FailedDryRun", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: []*proto.Parse_Response{{

--- a/cli/delete_test.go
+++ b/cli/delete_test.go
@@ -18,7 +18,7 @@ func TestDelete(t *testing.T) {
 	t.Parallel()
 	t.Run("WithParameter", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -45,7 +45,7 @@ func TestDelete(t *testing.T) {
 
 	t.Run("DifferentUser", func(t *testing.T) {
 		t.Parallel()
-		adminClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		adminClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		adminUser := coderdtest.CreateFirstUser(t, adminClient)
 		orgID := adminUser.OrganizationID
 		client := coderdtest.CreateAnotherUser(t, adminClient, orgID)

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -23,7 +23,7 @@ func TestGitSSH(t *testing.T) {
 	t.Parallel()
 	t.Run("Dial", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		// get user public key

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -16,7 +16,7 @@ func TestList(t *testing.T) {
 	t.Parallel()
 	t.Run("Single", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -135,7 +135,7 @@ func TestPortForward(t *testing.T) {
 	// Setup agent once to be shared between test-cases (avoid expensive
 	// non-parallel setup).
 	var (
-		client       = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client       = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user         = coderdtest.CreateFirstUser(t, client)
 		_, workspace = runAgent(t, client, user.UserID)
 	)

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -16,7 +16,7 @@ import (
 func TestRename(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -28,7 +28,7 @@ func TestScheduleShow(t *testing.T) {
 			sched     = "30 7 * * 1-5"
 			schedCron = fmt.Sprintf("CRON_TZ=%s %s", tz, sched)
 			ttl       = 8 * time.Hour
-			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user      = coderdtest.CreateFirstUser(t, client)
 			version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -62,7 +62,7 @@ func TestScheduleShow(t *testing.T) {
 
 		var (
 			ctx       = context.Background()
-			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user      = coderdtest.CreateFirstUser(t, client)
 			version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -96,7 +96,7 @@ func TestScheduleShow(t *testing.T) {
 		t.Parallel()
 
 		var (
-			client  = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client  = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user    = coderdtest.CreateFirstUser(t, client)
 			version = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_       = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -115,7 +115,7 @@ func TestScheduleStart(t *testing.T) {
 
 	var (
 		ctx       = context.Background()
-		client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user      = coderdtest.CreateFirstUser(t, client)
 		version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -168,7 +168,7 @@ func TestScheduleStop(t *testing.T) {
 	t.Parallel()
 
 	var (
-		client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user      = coderdtest.CreateFirstUser(t, client)
 		version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -221,7 +221,7 @@ func TestScheduleOverride(t *testing.T) {
 		var (
 			err       error
 			ctx       = context.Background()
-			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user      = coderdtest.CreateFirstUser(t, client)
 			version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -262,7 +262,7 @@ func TestScheduleOverride(t *testing.T) {
 		var (
 			err       error
 			ctx       = context.Background()
-			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user      = coderdtest.CreateFirstUser(t, client)
 			version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -298,7 +298,7 @@ func TestScheduleOverride(t *testing.T) {
 		var (
 			err       error
 			ctx       = context.Background()
-			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user      = coderdtest.CreateFirstUser(t, client)
 			version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -349,7 +349,7 @@ func TestScheduleOverride(t *testing.T) {
 func TestScheduleStartDefaults(t *testing.T) {
 	t.Setenv("TZ", "Pacific/Tongatapu")
 	var (
-		client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user      = coderdtest.CreateFirstUser(t, client)
 		version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/show_test.go
+++ b/cli/show_test.go
@@ -15,7 +15,7 @@ func TestShow(t *testing.T) {
 	t.Parallel()
 	t.Run("Exists", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse:           echo.ParseComplete,

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -33,7 +33,7 @@ import (
 
 func setupWorkspaceForSSH(t *testing.T) (*codersdk.Client, codersdk.Workspace, string) {
 	t.Helper()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	agentToken := uuid.NewString()
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/cli/state_test.go
+++ b/cli/state_test.go
@@ -19,7 +19,7 @@ func TestStatePull(t *testing.T) {
 	t.Parallel()
 	t.Run("File", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		wantState := []byte("some state")
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -47,7 +47,7 @@ func TestStatePull(t *testing.T) {
 	})
 	t.Run("Stdout", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		wantState := []byte("some state")
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -78,7 +78,7 @@ func TestStatePush(t *testing.T) {
 	t.Parallel()
 	t.Run("File", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse:     echo.ParseComplete,
@@ -103,7 +103,7 @@ func TestStatePush(t *testing.T) {
 
 	t.Run("Stdin", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse:     echo.ParseComplete,

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -40,7 +40,7 @@ func TestTemplateCreate(t *testing.T) {
 	t.Parallel()
 	t.Run("Create", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		coderdtest.CreateFirstUser(t, client)
 		source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
 			Parse:     echo.ParseComplete,
@@ -87,7 +87,7 @@ func TestTemplateCreate(t *testing.T) {
 
 	t.Run("WithParameter", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		coderdtest.CreateFirstUser(t, client)
 		source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
 			Parse:           createTestParseResponse(),
@@ -123,7 +123,7 @@ func TestTemplateCreate(t *testing.T) {
 
 	t.Run("WithParameterFileContainingTheValue", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		coderdtest.CreateFirstUser(t, client)
 		source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
 			Parse:           createTestParseResponse(),
@@ -162,7 +162,7 @@ func TestTemplateCreate(t *testing.T) {
 
 	t.Run("WithParameterFileNotContainingTheValue", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		coderdtest.CreateFirstUser(t, client)
 		source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
 			Parse:           createTestParseResponse(),
@@ -200,7 +200,7 @@ func TestTemplateCreate(t *testing.T) {
 
 	t.Run("Recreate template with same name (create, delete, create)", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		coderdtest.CreateFirstUser(t, client)
 
 		create := func() error {

--- a/cli/templatedelete_test.go
+++ b/cli/templatedelete_test.go
@@ -21,7 +21,7 @@ func TestTemplateDelete(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -51,7 +51,7 @@ func TestTemplateDelete(t *testing.T) {
 	t.Run("Multiple --yes", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -78,7 +78,7 @@ func TestTemplateDelete(t *testing.T) {
 	t.Run("Multiple prompted", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -117,7 +117,7 @@ func TestTemplateDelete(t *testing.T) {
 	t.Run("Selector", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/templateedit_test.go
+++ b/cli/templateedit_test.go
@@ -19,7 +19,7 @@ func TestTemplateEdit(t *testing.T) {
 
 	t.Run("Modified", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -65,7 +65,7 @@ func TestTemplateEdit(t *testing.T) {
 
 	t.Run("NotModified", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/templatelist_test.go
+++ b/cli/templatelist_test.go
@@ -15,7 +15,7 @@ func TestTemplateList(t *testing.T) {
 	t.Parallel()
 	t.Run("ListTemplates", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		firstVersion := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, firstVersion.ID)
@@ -49,7 +49,7 @@ func TestTemplateList(t *testing.T) {
 	})
 	t.Run("NoTemplates", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		coderdtest.CreateFirstUser(t, client)
 
 		cmd, root := clitest.New(t, "templates", "list")

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -32,7 +32,7 @@ func TestTemplatePull(t *testing.T) {
 	t.Run("Stdout", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		// Create an initial template bundle.
@@ -70,7 +70,7 @@ func TestTemplatePull(t *testing.T) {
 	t.Run("ToFile", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		// Create an initial template bundle.

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -31,7 +31,7 @@ func TestTemplatePush(t *testing.T) {
 	//	7. Asset 0 params in new version
 	t.Run("NewParameter", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		// Create initial template version to update
 		lastActiveVersion := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -110,7 +110,7 @@ func TestTemplatePush(t *testing.T) {
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -157,7 +157,7 @@ func TestTemplatePush(t *testing.T) {
 
 	t.Run("UseWorkingDir", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/templateversions_test.go
+++ b/cli/templateversions_test.go
@@ -14,7 +14,7 @@ func TestTemplateVersions(t *testing.T) {
 	t.Parallel()
 	t.Run("ListVersions", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -30,7 +30,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 
@@ -77,7 +77,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("WithParameter", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 

--- a/coderd/autobuild/executor/lifecycle_executor_test.go
+++ b/coderd/autobuild/executor/lifecycle_executor_test.go
@@ -27,9 +27,9 @@ func TestExecutorAutostartOK(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace that has autostart enabled
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -66,9 +66,9 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace that has autostart enabled
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -113,9 +113,9 @@ func TestExecutorAutostartAlreadyRunning(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace that has autostart enabled
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -145,9 +145,9 @@ func TestExecutorAutostartNotEnabled(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace that does not have autostart enabled
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -180,9 +180,9 @@ func TestExecutorAutostopOK(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -216,9 +216,9 @@ func TestExecutorAutostopExtend(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace        = mustProvisionWorkspace(t, client)
@@ -266,9 +266,9 @@ func TestExecutorAutostopAlreadyStopped(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace (disabling autostart)
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -299,9 +299,9 @@ func TestExecutorAutostopNotEnabled(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -341,9 +341,9 @@ func TestExecutorWorkspaceDeleted(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace that has autostart enabled
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
@@ -374,9 +374,9 @@ func TestExecutorWorkspaceAutostartTooEarly(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// futureTime     = time.Now().Add(time.Hour)
 		// futureTimeCron = fmt.Sprintf("%d %d * * *", futureTime.Minute(), futureTime.Hour())
@@ -405,9 +405,9 @@ func TestExecutorWorkspaceAutostopBeforeDeadline(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -433,9 +433,9 @@ func TestExecutorWorkspaceAutostopNoWaitChangedMyMind(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan executor.Stats)
 		client  = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
 		})
 		// Given: we have a user with a workspace
 		workspace = mustProvisionWorkspace(t, client)
@@ -502,14 +502,14 @@ func TestExecutorAutostartMultipleOK(t *testing.T) {
 		statsCh1 = make(chan executor.Stats)
 		statsCh2 = make(chan executor.Stats)
 		client   = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh1,
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh1,
 		})
 		_ = coderdtest.New(t, &coderdtest.Options{
-			AutobuildTicker:     tickCh2,
-			IncludeProvisionerD: true,
-			AutobuildStats:      statsCh2,
+			AutobuildTicker:          tickCh2,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh2,
 		})
 		// Given: we have a user with a workspace that has autostart enabled (default)
 		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {

--- a/coderd/coderdtest/authtest.go
+++ b/coderd/coderdtest/authtest.go
@@ -56,7 +56,7 @@ func NewAuthTester(ctx context.Context, t *testing.T, options *Options) *AuthTes
 		t.Error("NewAuthTester cannot be called with custom Authorizer")
 	}
 	options.Authorizer = authorizer
-	options.IncludeProvisionerD = true
+	options.IncludeProvisionerDaemon = true
 
 	client, _, api := newWithAPI(t, options)
 	admin := CreateFirstUser(t, client)

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -455,11 +455,11 @@ func AwaitTemplateVersionJob(t *testing.T, client *codersdk.Client, version uuid
 
 	t.Logf("waiting for template version job %s", version)
 	var templateVersion codersdk.TemplateVersion
-	require.True(t, testutil.EventuallyShort(t, func(ctx context.Context) bool {
+	require.Eventually(t, func() bool {
 		var err error
-		templateVersion, err = client.TemplateVersion(ctx, version)
+		templateVersion, err = client.TemplateVersion(context.Background(), version)
 		return assert.NoError(t, err) && templateVersion.Job.CompletedAt != nil
-	}))
+	}, testutil.WaitShort, testutil.IntervalFast)
 	return templateVersion
 }
 
@@ -469,10 +469,10 @@ func AwaitWorkspaceBuildJob(t *testing.T, client *codersdk.Client, build uuid.UU
 
 	t.Logf("waiting for workspace build job %s", build)
 	var workspaceBuild codersdk.WorkspaceBuild
-	require.True(t, testutil.EventuallyShort(t, func(ctx context.Context) bool {
-		workspaceBuild, err := client.WorkspaceBuild(ctx, build)
+	require.Eventually(t, func() bool {
+		workspaceBuild, err := client.WorkspaceBuild(context.Background(), build)
 		return assert.NoError(t, err) && workspaceBuild.Job.CompletedAt != nil
-	}))
+	}, testutil.WaitShort, testutil.IntervalFast)
 	return workspaceBuild
 }
 
@@ -482,9 +482,9 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 
 	t.Logf("waiting for workspace agents (build %s)", build)
 	var resources []codersdk.WorkspaceResource
-	require.True(t, testutil.EventuallyLong(t, func(ctx context.Context) bool {
+	require.Eventually(t, func() bool {
 		var err error
-		resources, err = client.WorkspaceResourcesByBuild(ctx, build)
+		resources, err = client.WorkspaceResourcesByBuild(context.Background(), build)
 		if !assert.NoError(t, err) {
 			return false
 		}
@@ -497,7 +497,7 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, build uuid.UUID
 			}
 		}
 		return true
-	}))
+	}, testutil.WaitLong, testutil.IntervalFast)
 	return resources
 }
 

--- a/coderd/coderdtest/coderdtest_test.go
+++ b/coderd/coderdtest/coderdtest_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 func TestNew(t *testing.T) {
 	t.Parallel()
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerD: true,
+		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)

--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -96,7 +96,7 @@ func TestAgentGitSSHKey(t *testing.T) {
 	t.Parallel()
 
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerD: true,
+		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()

--- a/coderd/provisionerdaemons_test.go
+++ b/coderd/provisionerdaemons_test.go
@@ -23,7 +23,7 @@ func TestProvisionerDaemons(t *testing.T) {
 			// Takes too long to allocate memory on Windows!
 			t.Skip()
 		}
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		data := make([]byte, provisionersdk.MaxMessageSize)
 		rand.Read(data)

--- a/coderd/provisionerjobs_test.go
+++ b/coderd/provisionerjobs_test.go
@@ -18,7 +18,7 @@ func TestProvisionerJobLogs(t *testing.T) {
 	t.Parallel()
 	t.Run("StreamAfterComplete", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -57,7 +57,7 @@ func TestProvisionerJobLogs(t *testing.T) {
 
 	t.Run("StreamWhileRunning", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -94,7 +94,7 @@ func TestProvisionerJobLogs(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -42,7 +42,7 @@ func TestTemplate(t *testing.T) {
 
 	t.Run("WorkspaceCount", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		member := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleOwner())
 		memberWithDeleted := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleOwner())
@@ -529,7 +529,7 @@ func TestDeleteTemplate(t *testing.T) {
 
 	t.Run("Workspaces", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -550,7 +550,7 @@ func TestTemplateDAUs(t *testing.T) {
 	t.Parallel()
 
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerD: true,
+		IncludeProvisionerDaemon: true,
 	})
 
 	user := coderdtest.CreateFirstUser(t, client)
@@ -620,12 +620,7 @@ func TestTemplateDAUs(t *testing.T) {
 
 	sshConn, err := conn.SSHClient()
 	require.NoError(t, err)
-
-	session, err := sshConn.NewSession()
-	require.NoError(t, err)
-
-	_, err = session.Output("echo hello")
-	require.NoError(t, err)
+	_ = sshConn.Close()
 
 	want := &codersdk.TemplateDAUsResponse{
 		Entries: []codersdk.DAUEntry{

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/coderd/util/ptr"
 	"github.com/coder/coder/codersdk"
-	"github.com/coder/coder/peer"
 	"github.com/coder/coder/provisioner/echo"
 	"github.com/coder/coder/provisionersdk/proto"
 	"github.com/coder/coder/testutil"
@@ -597,10 +596,6 @@ func TestTemplateDAUs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	opts := &peer.ConnOptions{
-		Logger: slogtest.Make(t, nil).Named("client"),
-	}
-
 	daus, err := client.TemplateDAUs(context.Background(), template.ID)
 	require.NoError(t, err)
 
@@ -612,7 +607,7 @@ func TestTemplateDAUs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, workspaces[0].LastUsedAt)
 
-	conn, err := client.DialWorkspaceAgent(ctx, resources[0].Agents[0].ID, opts)
+	conn, err := client.DialWorkspaceAgentTailnet(ctx, slogtest.Make(t, nil).Named("tailnet"), resources[0].Agents[0].ID)
 	require.NoError(t, err)
 	defer func() {
 		_ = conn.Close()

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -109,7 +109,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 	t.Parallel()
 	t.Run("AlreadyCompleted", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -124,7 +124,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 	})
 	t.Run("AlreadyCanceled", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -163,7 +163,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 	// Running -> Canceling is the best we can do for now.
 	t.Run("Canceling", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -218,7 +218,7 @@ func TestTemplateVersionSchema(t *testing.T) {
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: []*proto.Parse_Response{{
@@ -247,7 +247,7 @@ func TestTemplateVersionSchema(t *testing.T) {
 	})
 	t.Run("ListContains", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: []*proto.Parse_Response{{
@@ -298,7 +298,7 @@ func TestTemplateVersionParameters(t *testing.T) {
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: []*proto.Parse_Response{{
@@ -365,7 +365,7 @@ func TestTemplateVersionResources(t *testing.T) {
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -404,7 +404,7 @@ func TestTemplateVersionResources(t *testing.T) {
 
 func TestTemplateVersionLogs(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	before := time.Now()
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -571,7 +571,7 @@ func TestTemplateVersionDryRun(t *testing.T) {
 			Type: "cool_resource_type",
 		}
 
-		client := coderdtest.New(t, &coderdtest.Options{APIRateLimit: -1, IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{APIRateLimit: -1, IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -639,7 +639,7 @@ func TestTemplateVersionDryRun(t *testing.T) {
 
 	t.Run("ImportNotFinished", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		// This import job will never finish
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -728,7 +728,7 @@ func TestTemplateVersionDryRun(t *testing.T) {
 
 		t.Run("AlreadyCompleted", func(t *testing.T) {
 			t.Parallel()
-			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user := coderdtest.CreateFirstUser(t, client)
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -834,7 +834,7 @@ func TestGetUser(t *testing.T) {
 func TestUsersFilter(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	first := coderdtest.CreateFirstUser(t, client)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -1133,7 +1133,7 @@ func TestWorkspacesByUser(t *testing.T) {
 	})
 	t.Run("Access", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -29,7 +29,7 @@ func TestWorkspaceAgent(t *testing.T) {
 	t.Run("Connect", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		authToken := uuid.NewString()
@@ -78,7 +78,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 		t.Parallel()
 
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		authToken := uuid.NewString()
@@ -136,7 +136,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 		t.Parallel()
 
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 
 		user := coderdtest.CreateFirstUser(t, client)
@@ -211,7 +211,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 func TestWorkspaceAgentTURN(t *testing.T) {
 	t.Parallel()
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerD: true,
+		IncludeProvisionerDaemon: true,
 	})
 
 	user := coderdtest.CreateFirstUser(t, client)
@@ -339,7 +339,7 @@ func TestWorkspaceAgentPTY(t *testing.T) {
 		t.Skip("ConPTY appears to be inconsistent on Windows.")
 	}
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerD: true,
+		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -43,7 +43,7 @@ func TestWorkspaceAppsProxyPath(t *testing.T) {
 	tcpAddr, _ := ln.Addr().(*net.TCPAddr)
 
 	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerD: true,
+		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestWorkspaceBuild(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -40,7 +40,7 @@ func TestWorkspaceBuildByBuildNumber(t *testing.T) {
 	t.Parallel()
 	t.Run("Successful", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -63,7 +63,7 @@ func TestWorkspaceBuildByBuildNumber(t *testing.T) {
 
 	t.Run("BuildNumberNotInt", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -89,7 +89,7 @@ func TestWorkspaceBuildByBuildNumber(t *testing.T) {
 
 	t.Run("WorkspaceNotFound", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -115,7 +115,7 @@ func TestWorkspaceBuildByBuildNumber(t *testing.T) {
 
 	t.Run("WorkspaceBuildNotFound", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -144,7 +144,7 @@ func TestWorkspaceBuilds(t *testing.T) {
 	t.Parallel()
 	t.Run("Single", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -166,7 +166,7 @@ func TestWorkspaceBuilds(t *testing.T) {
 
 	t.Run("PaginateNonExistentRow", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -191,7 +191,7 @@ func TestWorkspaceBuilds(t *testing.T) {
 
 	t.Run("PaginateLimitOffset", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -232,7 +232,7 @@ func TestWorkspaceBuilds(t *testing.T) {
 
 func TestPatchCancelWorkspaceBuild(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 		Parse: echo.ParseComplete,
@@ -274,7 +274,7 @@ func TestWorkspaceBuildResources(t *testing.T) {
 	t.Run("ListRunning", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -292,7 +292,7 @@ func TestWorkspaceBuildResources(t *testing.T) {
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -334,7 +334,7 @@ func TestWorkspaceBuildResources(t *testing.T) {
 
 func TestWorkspaceBuildLogs(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	before := time.Now()
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -387,7 +387,7 @@ func TestWorkspaceBuildLogs(t *testing.T) {
 
 func TestWorkspaceBuildState(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	wantState := []byte("some kinda state")
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/coderd/workspaceresourceauth_test.go
+++ b/coderd/workspaceresourceauth_test.go
@@ -19,8 +19,8 @@ func TestPostWorkspaceAuthAzureInstanceIdentity(t *testing.T) {
 	instanceID := "instanceidentifier"
 	certificates, metadataClient := coderdtest.NewAzureInstanceIdentity(t, instanceID)
 	client := coderdtest.New(t, &coderdtest.Options{
-		AzureCertificates:   certificates,
-		IncludeProvisionerD: true,
+		AzureCertificates:        certificates,
+		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -61,8 +61,8 @@ func TestPostWorkspaceAuthAWSInstanceIdentity(t *testing.T) {
 		instanceID := "instanceidentifier"
 		certificates, metadataClient := coderdtest.NewAWSInstanceIdentity(t, instanceID)
 		client := coderdtest.New(t, &coderdtest.Options{
-			AWSCertificates:     certificates,
-			IncludeProvisionerD: true,
+			AWSCertificates:          certificates,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -138,8 +138,8 @@ func TestPostWorkspaceAuthGoogleInstanceIdentity(t *testing.T) {
 		instanceID := "instanceidentifier"
 		validator, metadata := coderdtest.NewGoogleInstanceIdentity(t, instanceID, false)
 		client := coderdtest.New(t, &coderdtest.Options{
-			GoogleTokenValidator: validator,
-			IncludeProvisionerD:  true,
+			GoogleTokenValidator:     validator,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/coderd/workspaceresources_test.go
+++ b/coderd/workspaceresources_test.go
@@ -17,7 +17,7 @@ func TestWorkspaceResource(t *testing.T) {
 	t.Parallel()
 	t.Run("Get", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Parse: echo.ParseComplete,
@@ -62,7 +62,7 @@ func TestWorkspaceResource(t *testing.T) {
 	t.Run("Apps", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		app := &proto.App{
@@ -113,7 +113,7 @@ func TestWorkspaceResource(t *testing.T) {
 	t.Run("Metadata", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -27,7 +27,7 @@ func TestWorkspace(t *testing.T) {
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -45,7 +45,7 @@ func TestWorkspace(t *testing.T) {
 
 	t.Run("Deleted", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -80,7 +80,7 @@ func TestWorkspace(t *testing.T) {
 
 	t.Run("Rename", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -112,7 +112,7 @@ func TestWorkspace(t *testing.T) {
 
 func TestAdminViewAllWorkspaces(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -192,7 +192,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("AlreadyExists", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -214,7 +214,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -224,7 +224,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("TemplateNoTTL", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
@@ -244,7 +244,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("TemplateCustomTTL", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		templateTTL := 24 * time.Hour.Milliseconds()
@@ -264,7 +264,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 		t.Parallel()
 		t.Run("BelowMin", func(t *testing.T) {
 			t.Parallel()
-			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user := coderdtest.CreateFirstUser(t, client)
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -290,7 +290,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 		t.Run("AboveMax", func(t *testing.T) {
 			t.Parallel()
-			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 			user := coderdtest.CreateFirstUser(t, client)
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -317,7 +317,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 
 	t.Run("InvalidAutostart", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -358,7 +358,7 @@ func TestWorkspaceByOwnerAndName(t *testing.T) {
 	})
 	t.Run("Get", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -373,7 +373,7 @@ func TestWorkspaceByOwnerAndName(t *testing.T) {
 	})
 	t.Run("Deleted", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -449,7 +449,7 @@ func TestWorkspaceFilter(t *testing.T) {
 		Org  codersdk.Organization
 	}
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	first := coderdtest.CreateFirstUser(t, client)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -644,7 +644,7 @@ func TestWorkspaceFilterManual(t *testing.T) {
 
 	t.Run("Name", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -679,7 +679,7 @@ func TestWorkspaceFilterManual(t *testing.T) {
 	})
 	t.Run("Template", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -706,7 +706,7 @@ func TestWorkspaceFilterManual(t *testing.T) {
 	})
 	t.Run("FilterQuery", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -732,7 +732,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 	t.Parallel()
 	t.Run("NoTemplateVersion", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -754,7 +754,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 
 	t.Run("TemplateVersionFailedImport", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 			Provision: []*proto.Provision_Response{{}},
@@ -802,7 +802,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 
 	t.Run("IncrementBuildNumber", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -824,7 +824,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 	t.Run("WithState", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerD: true,
+			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
@@ -850,7 +850,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 
 	t.Run("Delete", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -880,7 +880,7 @@ func TestWorkspaceBuildByName(t *testing.T) {
 	t.Parallel()
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
@@ -898,7 +898,7 @@ func TestWorkspaceBuildByName(t *testing.T) {
 
 	t.Run("Found", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -988,7 +988,7 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			var (
-				client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+				client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 				user      = coderdtest.CreateFirstUser(t, client)
 				version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 				_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -1125,7 +1125,7 @@ func TestWorkspaceUpdateTTL(t *testing.T) {
 				mutators = append(mutators, testCase.modifyTemplate)
 			}
 			var (
-				client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+				client    = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 				user      = coderdtest.CreateFirstUser(t, client)
 				version   = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 				_         = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -1184,7 +1184,7 @@ func TestWorkspaceExtend(t *testing.T) {
 	var (
 		ttl         = 8 * time.Hour
 		newDeadline = time.Now().Add(ttl + time.Hour).UTC()
-		client      = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+		client      = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user        = coderdtest.CreateFirstUser(t, client)
 		version     = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		_           = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
@@ -1256,7 +1256,7 @@ func TestWorkspaceExtend(t *testing.T) {
 
 func TestWorkspaceWatcher(t *testing.T) {
 	t.Parallel()
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerD: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	user := coderdtest.CreateFirstUser(t, client)
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)

--- a/testutil/eventually.go
+++ b/testutil/eventually.go
@@ -44,27 +44,3 @@ func Eventually(ctx context.Context, t testing.TB, condition func(context.Contex
 		}
 	}
 }
-
-// EventuallyShort is a convenience function that runs Eventually with
-// IntervalFast and times out after WaitShort.
-func EventuallyShort(t testing.TB, condition func(context.Context) bool) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), WaitShort)
-	defer cancel()
-	return Eventually(ctx, t, condition, IntervalFast)
-}
-
-// EventuallyMedium is a convenience function that runs Eventually with
-// IntervalMedium and times out after WaitMedium.
-func EventuallyMedium(t testing.TB, condition func(context.Context) bool) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), WaitMedium)
-	defer cancel()
-	return Eventually(ctx, t, condition, IntervalMedium)
-}
-
-// EventuallyLong is a convenience function that runs Eventually with
-// IntervalSlow and times out after WaitLong.
-func EventuallyLong(t testing.TB, condition func(context.Context) bool) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), WaitLong)
-	defer cancel()
-	return Eventually(ctx, t, condition, IntervalSlow)
-}

--- a/testutil/eventually_test.go
+++ b/testutil/eventually_test.go
@@ -30,18 +30,6 @@ func TestEventually(t *testing.T) {
 		testutil.Eventually(ctx, t, condition, testutil.IntervalFast)
 	})
 
-	t.Run("Timeout", func(t *testing.T) {
-		t.Parallel()
-		condition := func(_ context.Context) bool {
-			return false
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
-		defer cancel()
-		mockT := new(testing.T)
-		testutil.Eventually(ctx, mockT, condition, testutil.IntervalFast)
-		assert.True(t, mockT.Failed())
-	})
-
 	t.Run("Panic", func(t *testing.T) {
 		t.Parallel()
 
@@ -51,20 +39,5 @@ func TestEventually(t *testing.T) {
 			testutil.Eventually(context.Background(), mockT, condition, testutil.IntervalFast)
 		}
 		assert.Panics(t, panicky)
-	})
-
-	t.Run("Short", func(t *testing.T) {
-		t.Parallel()
-		testutil.EventuallyShort(t, func(_ context.Context) bool { return true })
-	})
-
-	t.Run("Medium", func(t *testing.T) {
-		t.Parallel()
-		testutil.EventuallyMedium(t, func(_ context.Context) bool { return true })
-	})
-
-	t.Run("Long", func(t *testing.T) {
-		t.Parallel()
-		testutil.EventuallyLong(t, func(_ context.Context) bool { return true })
 	})
 }


### PR DESCRIPTION
Discovered with: `go test -json -short ./... | gotestsum tool slowest`

- Testing the timeout for `testutil.Eventually` is not required since other tests that consume it would error.
- `TestPaginatedTemplateVersions` doesn't need fully built templates!
- Renames `IncludeProvisionerD` to `IncludeProvisionerDaemon`. It just looks a bit nicer IMO
- Increased test provisioner daemon refresh intervals. They were refreshing *really* quickly, which actually slowed things down.