### PR TITLE
fix:  Switch primary font to Inter

### DIFF
--- a/site/src/theme/overrides.ts
+++ b/site/src/theme/overrides.ts
@@ -2,7 +2,7 @@ import { Theme } from "@material-ui/core/styles"
 import { SimplePaletteColorOptions } from "@material-ui/core/styles/createPalette"
 import { Overrides } from "@material-ui/core/styles/overrides"
 import { colors } from "./colors"
-import { borderRadius, MONOSPACE_FONT_FAMILY } from "./constants"
+import { borderRadius } from "./constants"
 
 export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
   return {
@@ -34,7 +34,6 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
         // Prevents a loading button from collapsing!
         minHeight: 42,
         fontWeight: "normal",
-        fontFamily: MONOSPACE_FONT_FAMILY,
         fontSize: 16,
         textTransform: "none",
         letterSpacing: "none",
@@ -78,7 +77,6 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
     MuiTableHead: {
       root: {
         display: "table-header-group",
-        fontFamily: MONOSPACE_FONT_FAMILY,
       },
     },
     MuiTableContainer: {
@@ -116,7 +114,6 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
         fontWeight: 600,
       },
       root: {
-        fontFamily: MONOSPACE_FONT_FAMILY,
         fontSize: 16,
         background: palette.background.paper,
         borderBottom: `1px solid ${palette.divider}`,


### PR DESCRIPTION
This stops using monospace for everything. I tried this
out to see what it looks like, and I think it's significantly
easier to parse visually.

Before:
![image](https://user-images.githubusercontent.com/7122116/188281479-e66be559-0f02-40c6-bd0b-0eca14761183.png)

After:
![image](https://user-images.githubusercontent.com/7122116/188281483-5975b0ce-9225-493d-9d7d-426644352a70.png)
