### PR TITLE
dogfood: remove github apt source

### DIFF
--- a/dogfood/files/etc/apt/sources.list.d/github-cli.list
+++ b/dogfood/files/etc/apt/sources.list.d/github-cli.list
@@ -1,1 +1,0 @@
-deb [signed-by=/usr/share/keyrings/github-cli.gpg] https://cli.github.com/packages stable main


### PR DESCRIPTION
The source was causing our dogfood CI to fail.

See https://github.com/cli/cli/issues/6175#issuecomment-1235984381.
