### PR TITLE
chore: remove unused sql-formatter

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -118,7 +118,6 @@
     "react-hot-loader": "4.13.0",
     "resize-observer": "^1.0.4",
     "semver": "^7.3.7",
-    "sql-formatter": "8.2.0",
     "style-loader": "3.3.1",
     "ts-jest": "27.1.4",
     "ts-loader": "9.3.1",

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -13258,13 +13258,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sql-formatter@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-8.2.0.tgz#2b664f02bb6b7bb6fcad1346e850b8f583303469"
-  integrity sha512-5hQOSOk8jfhPkNgUmpm+9Fn2aaLWcf4vKL/dIvUN5q9rsamKHSyN/gL79xpkETNOyL+Zv5BMQfA7z9Rmz/DJJg==
-  dependencies:
-    argparse "^2.0.1"
-
 ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"


### PR DESCRIPTION
We stopped linting SQL in https://github.com/coder/coder/pull/1062 so we don't need this package anymore.
