### PR TITLE
chore: Update PR template to mention checking for docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,3 @@
-<!-- Help reviewers by listing the subtasks in this PR
-
-Here's an example:
-
-This PR adds a new feature to the CLI.
-
-## Subtasks
-
-- [x] added a test for feature
-
-Fixes #345
-
+<!--
+Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
 -->


### PR DESCRIPTION
This arose from a conversation Presley and I had about developers
maintaining docs, and that this little reminder could be useful!
