### PR TITLE
Add periods to end of license warning text.

### DIFF
--- a/enterprise/coderd/features.go
+++ b/enterprise/coderd/features.go
@@ -112,7 +112,7 @@ func (s *featuresService) EntitlementsAPI(rw http.ResponseWriter, r *http.Reques
 		if n > e.activeUsers.limit {
 			resp.Warnings = append(resp.Warnings,
 				fmt.Sprintf(
-					"Your deployment has %d active users but is only licensed for %d",
+					"Your deployment has %d active users but is only licensed for %d.",
 					n, e.activeUsers.limit))
 		}
 	}
@@ -125,7 +125,7 @@ func (s *featuresService) EntitlementsAPI(rw http.ResponseWriter, r *http.Reques
 	}
 	if e.auditLogs.state == gracePeriod && s.enablements.AuditLogs {
 		resp.Warnings = append(resp.Warnings,
-			"Audit logging is enabled but your license for this feature is expired")
+			"Audit logging is enabled but your license for this feature is expired.")
 	}
 
 	httpapi.Write(rw, http.StatusOK, resp)

--- a/enterprise/coderd/features_internal_test.go
+++ b/enterprise/coderd/features_internal_test.go
@@ -165,9 +165,9 @@ func TestFeaturesService_EntitlementsAPI(t *testing.T) {
 		assert.Nil(t, al.Actual)
 		assert.Len(t, result.Warnings, 2)
 		assert.Contains(t, result.Warnings,
-			"Your deployment has 5 active users but is only licensed for 4")
+			"Your deployment has 5 active users but is only licensed for 4.")
 		assert.Contains(t, result.Warnings,
-			"Audit logging is enabled but your license for this feature is expired")
+			"Audit logging is enabled but your license for this feature is expired.")
 	})
 }
 


### PR DESCRIPTION
Full sentences with periods will make things look better on front end.
