### PR TITLE
docs(contributing): enable contribution via devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,83 @@
+FROM ubuntu
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV EDITOR=vim
+
+RUN apt-get update && apt-get upgrade
+
+RUN apt-get install --yes \
+        ca-certificates \
+        bash-completion \
+        build-essential \
+        curl \
+        cmake \
+        direnv \
+        emacs-nox \
+        gnupg \
+        htop \
+        jq \
+        less \
+        lsb-release \
+        lsof \
+        man-db \
+        nano \
+        neovim \
+        ssl-cert \
+        sudo \
+        unzip \
+        xz-utils \
+        zip
+
+# configure locales to UTF8
+RUN apt-get install locales && locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# configure direnv
+RUN direnv hook bash >> $HOME/.bashrc
+
+# install nix
+RUN sh <(curl -L https://nixos.org/nix/install) --daemon
+
+RUN mkdir -p $HOME/.config/nix $HOME/.config/nixpkgs \
+        && echo 'sandbox = false' >> $HOME/.config/nix/nix.conf \
+        && echo '{ allowUnfree = true; }' >> $HOME/.config/nixpkgs/config.nix \
+        && echo '. $HOME/.nix-profile/etc/profile.d/nix.sh' >> $HOME/.bashrc
+
+
+# install docker and configure daemon to use vfs as GitHub codespaces requires vfs
+# https://github.com/moby/moby/issues/13742#issuecomment-725197223
+RUN mkdir -p /etc/apt/keyrings \
+        && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+        && echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
+        && apt-get update \
+        && apt-get install --yes docker-ce docker-ce-cli containerd.io docker-compose-plugin \
+        && mkdir -p /etc/docker \
+        && echo '{"cgroup-parent":"/actions_job","storage-driver":"vfs"}' >> /etc/docker/daemon.json
+
+# install golang and language tooling
+ENV GO_VERSION=1.19
+ENV GOPATH=$HOME/go-packages
+ENV GOROOT=$HOME/go
+ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+RUN curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xzs
+RUN echo 'export PATH=$GOPATH/bin:$PATH' >> $HOME/.bashrc
+
+RUN bash -c ". $HOME/.bashrc \
+	go install -v golang.org/x/tools/gopls@latest \
+	&& go install -v mvdan.cc/sh/v3/cmd/shfmt@latest \
+	"
+
+# install nodejs
+RUN bash -c "$(curl -fsSL https://deb.nodesource.com/setup_14.x)" \
+	&& apt-get install -y nodejs
+
+# install zstd
+RUN bash -c "$(curl -fsSL https://raw.githubusercontent.com/horta/zstd.install/main/install)"
+
+# install nfpm
+RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list \
+	&& apt update \
+	&& apt install nfpm
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json
+{
+	"name": "Development environments on your infrastructure",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": ".",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "Dockerfile",
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	
+	"postStartCommand": "dockerd",
+
+	// privileged is required by GitHub codespaces - https://github.com/microsoft/vscode-dev-containers/issues/727
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--privileged", "--init" ]	
+}


### PR DESCRIPTION
Related https://github.com/coder/coder/issues/3972

nb:  I've installed nix in the devcontainer but nix is currently broken on GitHub Codespaces - https://github.com/NixOS/nix/issues/6680

```
error: suspicious ownership or permission on '/nix/store/lb9klrhgabn5k0mwhr31ml8cnsis3rmv-addintegrityfields.js' for output 'out'; rejecting this build output
error: 1 dependencies of derivation '/nix/store/l17qv1zk3zb9ynlvlcih3y8msj75nc6x-typescript-language-server-0.11.2.drv' failed to build
error: build of '/nix/store/l17qv1zk3zb9ynlvlcih3y8msj75nc6x-typescript-language-server-0.11.2.drv', '/nix/store/l6pfwkwx7ir2qf05p0f2kjqfjvf7a4wl-protoc-gen-go-drpc.drv' failed
```

Apart from that LGTM. Please check to see if I missed any dependencies 👍 