### PR TITLE
Compute template average build time

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1102,6 +1102,14 @@ func (q *fakeQuerier) GetTemplateVersionByJobID(_ context.Context, jobID uuid.UU
 	return database.TemplateVersion{}, sql.ErrNoRows
 }
 
+func (q *fakeQuerier) GetTemplatesAverageBuildTime(_ context.Context, _ database.GetTemplatesAverageBuildTimeParams) ([]database.GetTemplatesAverageBuildTimeRow, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	// TODO
+	return nil, nil
+}
+
 func (q *fakeQuerier) GetParameterSchemasByJobID(_ context.Context, jobID uuid.UUID) ([]database.ParameterSchema, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -66,6 +66,9 @@ type querier interface {
 	GetTemplateVersionsByTemplateID(ctx context.Context, arg GetTemplateVersionsByTemplateIDParams) ([]TemplateVersion, error)
 	GetTemplateVersionsCreatedAfter(ctx context.Context, createdAt time.Time) ([]TemplateVersion, error)
 	GetTemplates(ctx context.Context) ([]Template, error)
+	// Computes average build time for every template.
+	// Only considers last moving_average_size successful builds between start_ts and end_ts.
+	// If a template does not have at least min_completed_job_count such builds, it gets skipped.
 	GetTemplatesAverageBuildTime(ctx context.Context, arg GetTemplatesAverageBuildTimeParams) ([]GetTemplatesAverageBuildTimeRow, error)
 	GetTemplatesWithFilter(ctx context.Context, arg GetTemplatesWithFilterParams) ([]Template, error)
 	GetUnexpiredLicenses(ctx context.Context) ([]License, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -66,6 +66,7 @@ type querier interface {
 	GetTemplateVersionsByTemplateID(ctx context.Context, arg GetTemplateVersionsByTemplateIDParams) ([]TemplateVersion, error)
 	GetTemplateVersionsCreatedAfter(ctx context.Context, createdAt time.Time) ([]TemplateVersion, error)
 	GetTemplates(ctx context.Context) ([]Template, error)
+	GetTemplatesAverageBuildTime(ctx context.Context, arg GetTemplatesAverageBuildTimeParams) ([]GetTemplatesAverageBuildTimeRow, error)
 	GetTemplatesWithFilter(ctx context.Context, arg GetTemplatesWithFilterParams) ([]Template, error)
 	GetUnexpiredLicenses(ctx context.Context) ([]License, error)
 	GetUserByEmailOrUsername(ctx context.Context, arg GetUserByEmailOrUsernameParams) (User, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2174,9 +2174,12 @@ func (q *sqlQuerier) GetTemplates(ctx context.Context) ([]Template, error) {
 
 const getTemplatesAverageBuildTime = `-- name: GetTemplatesAverageBuildTime :many
 WITH query_with_all_job_count AS (SELECT
-    DISTINCT t.id,
+	DISTINCT t.id,
 	AVG(pj.exec_time_sec)
-	    OVER(PARTITION BY t.id ORDER BY pj.completed_at ROWS BETWEEN $2::integer PRECEDING AND CURRENT ROW)
+		OVER(
+			PARTITION BY t.id
+			ORDER BY pj.completed_at
+			ROWS BETWEEN $2::integer PRECEDING AND CURRENT ROW)
 		AS avg_build_time_sec,
 	COUNT(*) OVER(PARTITION BY t.id) as job_count
 FROM
@@ -2185,41 +2188,40 @@ FROM
 		active_version_id
 	FROM
 		templates) AS t
-LEFT JOIN
+INNER JOIN
 	(SELECT
-	    workspace_id,
-	    template_version_id,
-	    job_id
+		workspace_id,
+		template_version_id,
+		job_id
 	FROM
-	    workspace_builds)
+		workspace_builds)
 	AS
-	    wb
+		wb
 ON
-    t.id = wb.workspace_id AND t.active_version_id = wb.template_version_id
-LEFT JOIN
+	t.id = wb.workspace_id AND t.active_version_id = wb.template_version_id
+INNER JOIN
 	(SELECT
-	    id,
+		id,
 		completed_at,
 		EXTRACT(EPOCH FROM (completed_at - started_at)) AS exec_time_sec
 	FROM
-	    provisioner_jobs
+		provisioner_jobs
 	WHERE
-	    (completed_at IS NOT NULL) AND (started_at IS NOT NULL) AND
+		(completed_at IS NOT NULL) AND (started_at IS NOT NULL) AND
 		(completed_at >= $3 AND completed_at <= $4) AND
-	    (canceled_at IS NULL) AND
-	    ((error IS NULL) OR (error = '')))
+		(canceled_at IS NULL) AND
+		((error IS NULL) OR (error = '')))
 	AS
-	    pj
+		pj
 ON
 	wb.job_id = pj.id)
 SELECT
-    id,
+	id,
 	avg_build_time_sec
 FROM
 	query_with_all_job_count
 WHERE
-	avg_build_time_sec IS NOT NULL AND
-	job_count >= GREATEST($1::integer, 1)
+	job_count >= $1::integer
 `
 
 type GetTemplatesAverageBuildTimeParams struct {
@@ -2234,6 +2236,9 @@ type GetTemplatesAverageBuildTimeRow struct {
 	AvgBuildTimeSec string    `db:"avg_build_time_sec" json:"avg_build_time_sec"`
 }
 
+// Computes average build time for every template.
+// Only considers last moving_average_size successful builds between start_ts and end_ts.
+// If a template does not have at least min_completed_job_count such builds, it gets skipped.
 func (q *sqlQuerier) GetTemplatesAverageBuildTime(ctx context.Context, arg GetTemplatesAverageBuildTimeParams) ([]GetTemplatesAverageBuildTimeRow, error) {
 	rows, err := q.db.QueryContext(ctx, getTemplatesAverageBuildTime,
 		arg.MinCompletedJobCount,

--- a/coderd/database/queries/templates.sql
+++ b/coderd/database/queries/templates.sql
@@ -107,37 +107,51 @@ RETURNING
 	*;
 
 -- name: GetTemplatesAverageBuildTime :many
-SELECT
-    t.id,
-	AVG(pj.exec_time_sec) AS avg_build_time_sec,
-	COUNT(pj.id) AS job_count
+WITH query_with_all_job_count AS (SELECT
+    DISTINCT t.id,
+	AVG(pj.exec_time_sec)
+	    OVER(PARTITION BY t.id ORDER BY pj.completed_at ROWS BETWEEN @moving_average_size::integer PRECEDING AND CURRENT ROW)
+		AS avg_build_time_sec,
+	COUNT(*) OVER(PARTITION BY t.id) as job_count
 FROM
 	(SELECT
-		id
+		id,
+		active_version_id
 	FROM
 		templates) AS t
 LEFT JOIN
 	(SELECT
-	     workspace_id,
-	     template_version_id,
-	     job_id
-	 FROM
-	     workspace_builds) AS wb
+	    workspace_id,
+	    template_version_id,
+	    job_id
+	FROM
+	    workspace_builds)
+	AS
+	    wb
 ON
     t.id = wb.workspace_id AND t.active_version_id = wb.template_version_id
 LEFT JOIN
 	(SELECT
 	    id,
-		TIMESTAMPDIFF(second, started_at, completed_at) AS exec_time_sec
+		completed_at,
+		EXTRACT(EPOCH FROM (completed_at - started_at)) AS exec_time_sec
 	FROM
-	    provisioner_jobs pj
+	    provisioner_jobs
 	WHERE
-	    (pj.completed_at IS NOT NULL) AND
-		(pj.completed_at >= @start_ts AND pj.completed_at <= @end_ts) AND
-	    (pj.cancelled_at IS NULL) AND
-	    ((pj.error IS NULL) OR (pj.error = ''))) AS pj
+	    (completed_at IS NOT NULL) AND (started_at IS NOT NULL) AND
+		(completed_at >= @start_ts AND completed_at <= @end_ts) AND
+	    (canceled_at IS NULL) AND
+	    ((error IS NULL) OR (error = '')))
+	AS
+	    pj
 ON
-	wb.job_id = pj.id
-GROUP BY
-    t.id
+	wb.job_id = pj.id)
+SELECT
+    id,
+	avg_build_time_sec
+FROM
+	query_with_all_job_count
+WHERE
+	avg_build_time_sec IS NOT NULL AND
+	job_count >= GREATEST(@min_completed_job_count::integer, 1)
 ;

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -759,6 +759,7 @@ func (api *API) convertTemplate(
 	template database.Template, workspaceOwnerCount uint32, createdByName string,
 ) codersdk.Template {
 	activeCount, _ := api.metricsCache.TemplateUniqueUsers(template.ID)
+	averageBuildTimeSec, _ := api.metricsCache.TemplateAverageBuildTimeSec(template.ID)
 	return codersdk.Template{
 		ID:                         template.ID,
 		CreatedAt:                  template.CreatedAt,
@@ -769,6 +770,7 @@ func (api *API) convertTemplate(
 		ActiveVersionID:            template.ActiveVersionID,
 		WorkspaceOwnerCount:        workspaceOwnerCount,
 		ActiveUserCount:            activeCount,
+		AverageBuildTimeSec:        averageBuildTimeSec,
 		Description:                template.Description,
 		Icon:                       template.Icon,
 		MaxTTLMillis:               time.Duration(template.MaxTtl).Milliseconds(),

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -24,6 +24,8 @@ type Template struct {
 	WorkspaceOwnerCount uint32          `json:"workspace_owner_count"`
 	// ActiveUserCount is set to -1 when loading.
 	ActiveUserCount            int       `json:"active_user_count"`
+	// AverageBuildTimeSec is set to -1 when there aren't enough recent builds.
+	AverageBuildTimeSec        float64   `json:"average_build_time_sec"`
 	Description                string    `json:"description"`
 	Icon                       string    `json:"icon"`
 	MaxTTLMillis               int64     `json:"max_ttl_ms"`

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -379,6 +379,7 @@ export interface Template {
   readonly active_version_id: string
   readonly workspace_owner_count: number
   readonly active_user_count: number
+  readonly average_build_time_sec: number
   readonly description: string
   readonly icon: string
   readonly max_ttl_ms: number

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -10,6 +10,7 @@ import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import useTheme from "@material-ui/styles/useTheme"
 import { FC } from "react"
 import { useNavigate } from "react-router-dom"
+import dayjs from "dayjs"
 import { createDayString } from "util/createDayString"
 import { formatTemplateActiveDevelopers } from "util/templates"
 import * as TypesGen from "../../api/typesGenerated"
@@ -34,8 +35,8 @@ import {
 } from "../../components/Tooltips/HelpTooltip/HelpTooltip"
 
 export const Language = {
-  buildTime: (buildTime: number): string =>
-    buildTime === -1 ? "Unknown" : `${buildTime / 60}:${buildTime % 60}`,
+  buildTime: (buildTimeSec: number): string =>
+    buildTimeSec === -1 ? "Unknown" : dayjs.duration(buildTimeSec, "seconds").humanize(),
   developerCount: (activeCount: number): string => {
     return `${formatTemplateActiveDevelopers(activeCount)} developer${activeCount !== 1 ? "s" : ""}`
   },

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -34,10 +34,13 @@ import {
 } from "../../components/Tooltips/HelpTooltip/HelpTooltip"
 
 export const Language = {
+  buildTime: (buildTime: number): string =>
+    buildTime === -1 ? "Unknown" : `${buildTime / 60}:${buildTime % 60}`,
   developerCount: (activeCount: number): string => {
     return `${formatTemplateActiveDevelopers(activeCount)} developer${activeCount !== 1 ? "s" : ""}`
   },
   nameLabel: "Name",
+  buildTimeLabel: "Build time",
   usedByLabel: "Used by",
   lastUpdatedLabel: "Last updated",
   emptyViewNoPerms:
@@ -118,10 +121,11 @@ export const TemplatesPageView: FC<React.PropsWithChildren<TemplatesPageViewProp
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell width="50%">{Language.nameLabel}</TableCell>
-              <TableCell width="16%">{Language.usedByLabel}</TableCell>
-              <TableCell width="16%">{Language.lastUpdatedLabel}</TableCell>
-              <TableCell width="16%">{Language.createdByLabel}</TableCell>
+              <TableCell width="39%">{Language.nameLabel}</TableCell>
+              <TableCell width="15%">{Language.buildTimeLabel}</TableCell>
+              <TableCell width="15%">{Language.usedByLabel}</TableCell>
+              <TableCell width="15%">{Language.lastUpdatedLabel}</TableCell>
+              <TableCell width="15%">{Language.createdByLabel}</TableCell>
               <TableCell width="1%"></TableCell>
             </TableRow>
           </TableHead>
@@ -173,6 +177,12 @@ export const TemplatesPageView: FC<React.PropsWithChildren<TemplatesPageViewProp
                         ) : undefined
                       }
                     />
+                  </TableCellLink>
+
+                  <TableCellLink to={templatePageLink}>
+                    <span style={{ color: theme.palette.text.secondary }}>
+                      {Language.buildTime(template.average_build_time_sec)}
+                    </span>
                   </TableCellLink>
 
                   <TableCellLink to={templatePageLink}>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -177,6 +177,7 @@ export const MockTemplate: TypesGen.Template = {
   active_version_id: MockTemplateVersion.id,
   workspace_owner_count: 2,
   active_user_count: 1,
+  average_build_time_sec: 123,
   description: "This is a test description.",
   max_ttl_ms: 24 * 60 * 60 * 1000,
   min_autostart_interval_ms: 60 * 60 * 1000,


### PR DESCRIPTION
Metric for templates -- average build time, only builds within the last day are considered, if the number of builds is <10, the template doesn't get this metric.

Resolve #3784.
