### PR TITLE
fix: Update workspace wasn't using the latest build

### DIFF
--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -92,6 +92,9 @@ export const workspaceMachine = createMachine(
         getTemplate: {
           data: TypesGen.Template
         }
+        startWorkspaceWithLatestTemplate: {
+          data: TypesGen.WorkspaceBuild
+        }
         startWorkspace: {
           data: TypesGen.WorkspaceBuild
         }
@@ -212,7 +215,7 @@ export const workspaceMachine = createMachine(
                   START: "requestingStart",
                   STOP: "requestingStop",
                   ASK_DELETE: "askingDelete",
-                  UPDATE: "refreshingTemplate",
+                  UPDATE: "requestingStartWithLatestTemplate",
                   CANCEL: "requestingCancel",
                 },
               },
@@ -220,6 +223,21 @@ export const workspaceMachine = createMachine(
                 on: {
                   DELETE: "requestingDelete",
                   CANCEL_DELETE: "idle",
+                },
+              },
+              requestingStartWithLatestTemplate: {
+                entry: "clearBuildError",
+                invoke: {
+                  id: "startWorkspaceWithLatestTemplate",
+                  src: "startWorkspaceWithLatestTemplate",
+                  onDone: {
+                    target: "idle",
+                    actions: ["assignBuild", "refreshTimeline"],
+                  },
+                  onError: {
+                    target: "idle",
+                    actions: ["assignBuildError"],
+                  },
                 },
               },
               requestingStart: {
@@ -522,6 +540,13 @@ export const workspaceMachine = createMachine(
           return await API.getTemplate(context.workspace.template_id)
         } else {
           throw Error("Cannot get template without workspace")
+        }
+      },
+      startWorkspaceWithLatestTemplate: async (context) => {
+        if (context.workspace && context.template) {
+          return await API.startWorkspace(context.workspace.id, context.template.active_version_id)
+        } else {
+          throw Error("Cannot start workspace without workspace id")
         }
       },
       startWorkspace: async (context) => {


### PR DESCRIPTION
This was an oversight in a prior contribution. It broke the update button but fixed the other cases.
