### PR TITLE
fix: Always use UTC time when inserting stats

### DIFF
--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -665,6 +665,6 @@ func TestTemplateDAUs(t *testing.T) {
 	workspaces, err = client.Workspaces(ctx, codersdk.WorkspaceFilter{})
 	require.NoError(t, err)
 	assert.WithinDuration(t,
-		time.Now(), workspaces[0].LastUsedAt, time.Minute,
+		database.Now(), workspaces[0].LastUsedAt, time.Minute,
 	)
 }

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -848,7 +848,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 
 			_, err = api.Database.InsertAgentStat(ctx, database.InsertAgentStatParams{
 				ID:          uuid.New(),
-				CreatedAt:   time.Now(),
+				CreatedAt:   database.Now(),
 				AgentID:     workspaceAgent.ID,
 				WorkspaceID: build.WorkspaceID,
 				UserID:      workspace.OwnerID,
@@ -865,7 +865,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 
 			err = api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
 				ID:         build.WorkspaceID,
-				LastUsedAt: time.Now(),
+				LastUsedAt: database.Now(),
 			})
 			if err != nil {
 				httpapi.Write(rw, http.StatusBadRequest, codersdk.Response{


### PR DESCRIPTION
Fixes a flake reported by @mafredri
