### PR TITLE
docs: fix docker-compose up command

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -59,8 +59,7 @@ an PostgreSQL container and volume.
    ```console
    cd coder
 
-   CODER_ACCESS_URL=https://coder.example.com
-   docker-compose up
+   CODER_ACCESS_URL=https://coder.example.com docker-compose up
    ```
 
    > Without `CODER_ACCESS_URL` set, Coder will bind to `localhost:7080`. This will only work for Docker-based templates.


### PR DESCRIPTION
I copy/pasted the instructions from the docs and noticed this warning.

<img width="917" alt="image" src="https://user-images.githubusercontent.com/3806031/189712814-1e2682ea-f877-4985-9ee8-8163f1c18401.png">

I think putting the environment variable on the same line as `docker-compose up` should fix this.