### PR TITLE
Add support for `coder tunnel` in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,11 +8,14 @@ services:
       - "7080:7080"
     environment:
       CODER_PG_CONNECTION_URL: "postgresql://${POSTGRES_USER:-username}:${POSTGRES_PASSWORD:-password}@database/${POSTGRES_DB:-coder}?sslmode=disable"
+      CODER_ADDRESS: "0.0.0.0:7080"
       # You'll need to set CODER_ACCESS_URL to an IP or domain
       # that workspaces can reach. This cannot be localhost
       # or 127.0.0.1 for non-Docker templates!
-      CODER_ADDRESS: "0.0.0.0:7080"
       CODER_ACCESS_URL: "${CODER_ACCESS_URL}"
+      # Alternatively, you can enable CODER_TUNNEL for
+      # proof-of-concept deployments.
+      CODER_TUNNEL: "${CODER_TUNNEL:-false}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -12,6 +12,8 @@ This is a quick way to allow users and workspaces outside your LAN to connect to
 that users and workspaces use to connect to Coder (e.g. https://coder.example.com). This
 should not be localhost.
 
+> Access URL should be a external IP address or domain with DNS records pointing to Coder.
+
 ## PostgreSQL Database
 
 Coder uses a PostgreSQL database to store users, workspace metadata, and other deployment information.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -54,16 +54,27 @@ an PostgreSQL container and volume.
 
 3. Start Coder with `docker-compose up`:
 
-   In order to use cloud-based templates (e.g. Kubernetes, AWS), you must set `CODER_ACCESS_URL` to the external URL that users and workspaces will use to connect to Coder.
+   In order to use cloud-based templates (e.g. Kubernetes, AWS), you must have an external URL that users and workspaces will use to connect to Coder.
+   
+   For proof-of-concept deployments, you can use [Coder's tunnel](../admin/configure.md#tunnel):
 
-   ```console
+   ```sh
    cd coder
 
-   CODER_ACCESS_URL=https://coder.example.com
+   CODER_TUNNEL=true
    docker-compose up
    ```
 
-   > Without `CODER_ACCESS_URL` set, Coder will bind to `localhost:7080`. This will only work for Docker-based templates.
+   For production deployments, we recommend setting an [access URL](../admin/configure.md#access-url):
+
+   ```sh
+   cd coder
+
+   CODER_ACCESS_URL=https://coder.example.com # URL that 
+   docker-compose up
+   ```
+
+   > Without `CODER_ACCESS_URL` or `CODER_TUNNEL` set, Coder will bind to `localhost:7080`. This will only work for Docker-based templates.
 
 4. Follow the on-screen instructions log in and create your first template and workspace
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -69,8 +69,7 @@ an PostgreSQL container and volume.
    ```sh
    cd coder
 
-   CODER_ACCESS_URL=https://coder.example.com # URL that 
-   docker-compose up
+   CODER_ACCESS_URL=https://coder.example.com docker-compose up
    ```
 
    > Without `CODER_ACCESS_URL` or `CODER_TUNNEL` set, Coder will bind to `localhost:7080`. This will only work for Docker-based templates.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -61,8 +61,7 @@ an PostgreSQL container and volume.
    ```sh
    cd coder
 
-   CODER_TUNNEL=true
-   docker-compose up
+   CODER_TUNNEL=true docker-compose up
    ```
 
    For production deployments, we recommend setting an [access URL](../admin/configure.md#access-url):


### PR DESCRIPTION
```sh
# if you have a domain/IP
CODER_ACCESS_URL=https://coder.mywebsite.com docker-compose up

# if you want to use Coder's tunnel
CODER_TUNNEL=true docker-compose up
```
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
