### PR TITLE
fix: Ignore deleted users when signing up with OAuth

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -518,7 +518,11 @@ func findLinkedUser(ctx context.Context, db database.Store, linkedID string, ema
 		if err != nil {
 			return database.User{}, database.UserLink{}, xerrors.Errorf("get user by id: %w", err)
 		}
-		return user, link, nil
+		if !user.Deleted {
+			return user, link, nil
+		}
+		// If the user was deleted, act as if no account link exists.
+		user = database.User{}
 	}
 
 	for _, email := range emails {


### PR DESCRIPTION
This prevented a deleted user from signing up again when they were already linked with a previous account.
