### PR TITLE
feat(cli): add error message for bad login URL

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -83,7 +83,7 @@ func login() *cobra.Command {
 
 			hasInitialUser, err := client.HasFirstUser(cmd.Context())
 			if err != nil {
-				return xerrors.Errorf("has initial user: %w", err)
+				return xerrors.Errorf("Failed to check server %q for first user, is the URL correct and is coder accessible from your browser? Error - has initial user: %w", serverURL.String(), err)
 			}
 			if !hasInitialUser {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), caret+"Your Coder deployment hasn't been set up!\n")

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,15 @@ func TestLogin(t *testing.T) {
 		root, _ := clitest.New(t, "login", client.URL.String())
 		err := root.Execute()
 		require.Error(t, err)
+	})
+
+	t.Run("InitialUserBadLoginURL", func(t *testing.T) {
+		t.Parallel()
+		badLoginURL := "https://fcca2077f06e68aaf9"
+		root, _ := clitest.New(t, "login", badLoginURL)
+		err := root.Execute()
+		errMsg := fmt.Sprintf("Failed to check server %q for first user, is the URL correct and is coder accessible from your browser?", badLoginURL)
+		require.ErrorContains(t, err, errMsg)
 	})
 
 	t.Run("InitialUserTTY", func(t *testing.T) {


### PR DESCRIPTION
This adds a more friendly error message when a user mistypes the user when running `coder login <url>`. Open to additional feedback/suggestions!

Fixes https://github.com/coder/coder/issues/3963

To test locally, run: 
```shell
cd cli && go test -v -count 1 -run TestLogin/InitialUserBadLoginURL
```