### PR TITLE
refactor: Typography, action hover and table head colors

### DIFF
--- a/site/src/components/NavbarView/NavbarView.tsx
+++ b/site/src/components/NavbarView/NavbarView.tsx
@@ -187,7 +187,7 @@ const useStyles = makeStyles((theme) => ({
     // NavLink adds this class when the current route matches.
     "&.active": {
       position: "relative",
-      color: theme.palette.primary.contrastText,
+      color: theme.palette.text.primary,
       fontWeight: "bold",
 
       "&::before": {

--- a/site/src/theme/overrides.ts
+++ b/site/src/theme/overrides.ts
@@ -11,7 +11,6 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
           backgroundImage: `linear-gradient(to right bottom, ${palette.background.default}, ${colors.gray[17]})`,
           backgroundRepeat: "no-repeat",
           backgroundAttachment: "fixed",
-          letterSpacing: "-0.015em",
         },
         ":root": {
           colorScheme: palette.type,

--- a/site/src/theme/overrides.ts
+++ b/site/src/theme/overrides.ts
@@ -80,11 +80,6 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
         },
       },
     },
-    MuiTableHead: {
-      root: {
-        display: "table-header-group",
-      },
-    },
     MuiTableContainer: {
       root: {
         borderRadius,
@@ -118,6 +113,7 @@ export const getOverrides = ({ palette, breakpoints }: Theme): Overrides => {
         fontSize: 14,
         color: palette.text.secondary,
         fontWeight: 600,
+        background: palette.background.paperLight,
       },
       root: {
         fontSize: 16,

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -4,6 +4,12 @@ import { colors } from "./colors"
 // Couldn't find a type for this so I made one. We can extend the palette if needed with module augmentation.
 export type PaletteIndex = "primary" | "secondary" | "info" | "success" | "error" | "warning"
 
+declare module "@material-ui/core/styles/createPalette" {
+  interface TypeBackground {
+    paperLight: string
+  }
+}
+
 export const darkPalette: PaletteOptions = {
   type: "dark",
   primary: {
@@ -20,6 +26,7 @@ export const darkPalette: PaletteOptions = {
   background: {
     default: colors.gray[17],
     paper: colors.gray[16],
+    paperLight: colors.gray[15],
   },
   text: {
     primary: colors.gray[1],
@@ -46,6 +53,6 @@ export const darkPalette: PaletteOptions = {
     contrastText: colors.gray[4],
   },
   action: {
-    hover: colors.gray[13],
+    hover: colors.gray[14],
   },
 }

--- a/site/src/theme/palettes.ts
+++ b/site/src/theme/palettes.ts
@@ -22,7 +22,7 @@ export const darkPalette: PaletteOptions = {
     paper: colors.gray[16],
   },
   text: {
-    primary: colors.gray[4],
+    primary: colors.gray[1],
     secondary: colors.gray[5],
   },
   divider: colors.gray[13],


### PR DESCRIPTION
Now:
<img width="1789" alt="Screen Shot 2022-09-13 at 16 49 27" src="https://user-images.githubusercontent.com/3165839/189995974-68d4319d-43b6-4376-8453-1bdf521cac7e.png">

Before:
<img width="1792" alt="Screen Shot 2022-09-13 at 16 49 16" src="https://user-images.githubusercontent.com/3165839/189995978-d6af08c0-6a8d-45cb-94ee-b907423a6fa9.png">
