### PR TITLE
Fix `kubectl get pods` command in k8s install docs

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -66,7 +66,7 @@ to log in and manage templates.
    # Uses Bitnami PostgreSQL example. If you have another database,
    # change to the proper URL.
    kubectl create secret generic coder-db-url -n coder \
-      --from-literal=url="postgres://coder:coder@postgres-postgresql.coder.svc.cluster.local:5432/coder?sslmode=disable"
+      --from-literal=url="postgres://coder:coder@coder-db-postgresql.coder.svc.cluster.local:5432/coder?sslmode=disable"
    ```
 
 1. Create a `values.yaml` with the configuration settings you'd like for your

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -119,7 +119,7 @@ to log in and manage templates.
        --values values.yaml
    ```
 
-   You can watch Coder start up by running `kubectl get pods`. Once Coder has
+   You can watch Coder start up by running `kubectl get pods -n coder`. Once Coder has
    started, the `coder-*` pods should enter the `Running` state.
 
 1. Log in to Coder


### PR DESCRIPTION
It was missing the namespace used in the rest of the tutorial.

Also fixes #4054.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
