### PR TITLE
housekeeping(branding): be consistent

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -105,7 +105,7 @@ func Root(subcommands []*cobra.Command) *cobra.Command {
 		Use:           "coder",
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		Long: `Coder — A tool for provisioning self-hosted development environments.
+		Long: `Coder — A tool for provisioning self-hosted development environments with Terraform.
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if cliflag.IsSetBool(cmd, varNoVersionCheck) &&


### PR DESCRIPTION
Opening as a draft pull-request as part of auditing ([internal link](https://github.com/coder/meta/issues/33)) how the Coder brand is used. 

See [internal discussion](https://codercom.slack.com/archives/C016Q9C710E/p1663244101886499).