### PR TITLE
fix: incorrect templates list test assert

### DIFF
--- a/cli/templatelist_test.go
+++ b/cli/templatelist_test.go
@@ -49,7 +49,7 @@ func TestTemplateList(t *testing.T) {
 	})
 	t.Run("NoTemplates", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		client := coderdtest.New(t, &coderdtest.Options{})
 		coderdtest.CreateFirstUser(t, client)
 
 		cmd, root := clitest.New(t, "templates", "list")
@@ -66,6 +66,8 @@ func TestTemplateList(t *testing.T) {
 
 		require.NoError(t, <-errC)
 
-		pty.ExpectMatch("No templates found in testuser! Create one:")
+		pty.ExpectMatch("No templates found in")
+		pty.ExpectMatch(coderdtest.FirstUserParams.Username)
+		pty.ExpectMatch("Create one:")
 	})
 }


### PR DESCRIPTION
```
        	Error Trace:	/home/colin/Projects/coder/coder/cli/ptytest.go:180
        	            				/home/colin/Projects/coder/coder/cli/ptytest.go:140
        	            				/home/colin/Projects/coder/coder/cli/templatelist_test.go:69
        	Error:      	match exceeded deadline
        	Test:       	TestTemplateList/NoTemplates
        	Messages:   	wanted "No templates found in testuser! Create one:"; got "\x1b[38;2;92;92;92m>\x1b[0m  No templates found in \x1b[97mtestuser\x1b[0m! Create one:\r\n\r\n\x1b[95m  $ coder templates create <directory>\r\n\x1b[0m\r\n"
```

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
