### PR TITLE
fix: Remove TestWorkspaceBuildResources/ListRunning

### DIFF
--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -361,25 +361,6 @@ func TestPatchCancelWorkspaceBuild(t *testing.T) {
 
 func TestWorkspaceBuildResources(t *testing.T) {
 	t.Parallel()
-	t.Run("ListRunning", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerDaemon: true,
-		})
-		user := coderdtest.CreateFirstUser(t, client)
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.WorkspaceResourcesByBuild(ctx, workspace.LatestBuild.ID)
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
-	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})


### PR DESCRIPTION
Removing this test since I was unsure what is being tested and it has an inherent race condition.

If we wait for the workspace build to complete, the test will fail (i.e. add a sleep). Flakes more easily on Windows runners that are slow.

https://github.com/coder/coder/actions/runs/3066934171/jobs/4952674901
