### PR TITLE
docs: fix persistent vs. ephemeral resources link

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -28,8 +28,8 @@ update](./templates.md#manage-templates) available.
 
 Resources are often destroyed and re-created when a workspace is restarted,
 though the exact behavior depends on the template's definitions. For more
-information, see [persistent and ephemeral
-resources](./templates.md#persistent-and-ephemeral-resources).
+information, see [persistent vs. ephemeral
+resources](./templates.md#persistent-vs-ephemeral-resources).
 
 > ⚠️ To avoid data loss, refer to your template documentation for information on
 > where to store files, install software, etc., so that they persist. Default

--- a/site/src/components/Tooltips/ResourcesHelpTooltip.tsx
+++ b/site/src/components/Tooltips/ResourcesHelpTooltip.tsx
@@ -10,7 +10,7 @@ export const Language = {
   resourceTooltipTitle: "What is a resource?",
   resourceTooltipText:
     "A resource is an infrastructure object that is created when the workspace is provisioned.",
-  resourceTooltipLink: "Persistent and ephemeral resources",
+  resourceTooltipLink: "Persistent vs. ephemeral resources",
 }
 
 export const ResourcesHelpTooltip: React.FC = () => {
@@ -19,7 +19,7 @@ export const ResourcesHelpTooltip: React.FC = () => {
       <HelpTooltipTitle>{Language.resourceTooltipTitle}</HelpTooltipTitle>
       <HelpTooltipText>{Language.resourceTooltipText}</HelpTooltipText>
       <HelpTooltipLinksGroup>
-        <HelpTooltipLink href="https://coder.com/docs/coder-oss/latest/templates#persistent-and-ephemeral-resources">
+        <HelpTooltipLink href="https://coder.com/docs/coder-oss/latest/templates#persistent-vs-ephemeral-resources">
           {Language.resourceTooltipLink}
         </HelpTooltipLink>
       </HelpTooltipLinksGroup>


### PR DESCRIPTION
Small one to fix a stale link in the docs.

[This link](https://coder.com/docs/coder-oss/latest/templates#persistent-and-ephemeral-resources) directs to the top of the Templates page, [this link](https://coder.com/docs/coder-oss/latest/templates#persistent-vs-ephemeral-resources) should be used instead.
