### PR TITLE
fix: Test race for TestPostWorkspaceBuild

### DIFF
--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -830,7 +830,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 
 	t.Run("WithState", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{
+		client, closeDaemon := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
@@ -840,6 +840,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 		wantState := []byte("something")
+		_ = closeDaemon.Close()
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()


### PR DESCRIPTION
The job could run before the state was fetched, which resulted in an empty state being returned.
