### PR TITLE
fix: Improve consistency on CLI help

### DIFF
--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/coder/coder/cli/cliui"
 )
 
 // IsSetBool returns the value of the boolean flag if it is set.
@@ -176,7 +178,7 @@ func fmtUsage(u string, env string) string {
 		if strings.HasSuffix(u, ".") {
 			dot = ""
 		}
-		u = fmt.Sprintf("%s%s\nConsumes $%s", u, dot, env)
+		u = fmt.Sprintf("%s%s\n"+cliui.Styles.Placeholder.Render("Consumes $%s"), u, dot, env)
 	}
 
 	return u

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -48,7 +48,7 @@ var Styles = struct {
 	Field:         defaultStyles.Code.Copy().Foreground(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"}),
 	Keyword:       defaultStyles.Keyword,
 	Paragraph:     defaultStyles.Paragraph,
-	Placeholder:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#585858", Dark: "#005fff"}),
+	Placeholder:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#585858", Dark: "#4d46b3"}),
 	Prompt:        defaultStyles.Prompt.Foreground(lipgloss.AdaptiveColor{Light: "#9B9B9B", Dark: "#5C5C5C"}),
 	FocusedPrompt: defaultStyles.FocusedPrompt.Foreground(lipgloss.Color("#651fff")),
 	Fuchsia:       defaultStyles.SelectedMenuItem.Copy(),

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -144,7 +144,7 @@ func configSSH() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "config-ssh",
-		Short:       "Populate your SSH config with Host entries for all of your workspaces",
+		Short:       "Add an SSH Host entry for your workspaces \"ssh coder.workspace\"",
 		Example: formatExamples(
 			example{
 				Description: "You can use -o (or --ssh-option) so set SSH options to be used for all your workspaces",

--- a/cli/create.go
+++ b/cli/create.go
@@ -25,7 +25,7 @@ func create() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "create [name]",
-		Short:       "Create a workspace from a template",
+		Short:       "Create a workspace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)
 			if err != nil {

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -22,7 +22,7 @@ func dotfiles() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dotfiles [git_repo_url]",
 		Args:  cobra.ExactArgs(1),
-		Short: "Check out and install a dotfiles repository.",
+		Short: "Checkout and install a dotfiles repository from a Git URL",
 		Example: formatExamples(
 			example{
 				Description: "Check out and install a dotfiles repository without prompts",

--- a/cli/features.go
+++ b/cli/features.go
@@ -15,7 +15,7 @@ import (
 
 func features() *cobra.Command {
 	cmd := &cobra.Command{
-		Short:   "List features",
+		Short:   "List Enterprise features",
 		Use:     "features",
 		Aliases: []string{"feature"},
 	}

--- a/cli/list.go
+++ b/cli/list.go
@@ -66,7 +66,7 @@ func list() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "list",
-		Short:       "List all workspaces",
+		Short:       "List workspaces",
 		Aliases:     []string{"ls"},
 		Args:        cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/login.go
+++ b/cli/login.go
@@ -45,7 +45,7 @@ func login() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "login <url>",
-		Short: "Authenticate with a Coder deployment",
+		Short: "Authenticate with Coder deployment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rawURL := args[0]

--- a/cli/logout.go
+++ b/cli/logout.go
@@ -14,7 +14,7 @@ import (
 func logout() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Remove the local authenticated session",
+		Short: "Unauthenticate your local session",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)
 			if err != nil {

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -32,7 +32,7 @@ func portForward() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:     "port-forward <workspace>",
-		Short:   "Forward one or more ports from the local machine to the remote workspace",
+		Short:   "Forward ports from machine to a workspace",
 		Aliases: []string{"tunnel"},
 		Args:    cobra.ExactArgs(1),
 		Example: formatExamples(

--- a/cli/publickey.go
+++ b/cli/publickey.go
@@ -18,7 +18,7 @@ func publickey() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "publickey",
 		Aliases: []string{"pubkey"},
-		Short:   "Output your public key for Git operations",
+		Short:   "Output your Coder public key used for Git operations",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)
 			if err != nil {

--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -20,7 +20,7 @@ func resetPassword() *cobra.Command {
 
 	root := &cobra.Command{
 		Use:   "reset-password <username>",
-		Short: "Reset a user's password by directly updating the database",
+		Short: "Directly connect to the database to reset a user's password",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			username := args[0]

--- a/cli/root.go
+++ b/cli/root.go
@@ -167,21 +167,21 @@ func Root(subcommands []*cobra.Command) *cobra.Command {
 
 	cmd.SetUsageTemplate(usageTemplate())
 
-	cmd.PersistentFlags().String(varURL, "", "Specify the URL to your deployment.")
+	cmd.PersistentFlags().String(varURL, "", "URL to a deployment.")
 	cliflag.Bool(cmd.PersistentFlags(), varNoVersionCheck, "", envNoVersionCheck, false, "Suppress warning when client and server versions do not match.")
 	cliflag.Bool(cmd.PersistentFlags(), varNoFeatureWarning, "", envNoFeatureWarning, false, "Suppress warnings about unlicensed features.")
 	cliflag.String(cmd.PersistentFlags(), varToken, "", envSessionToken, "", fmt.Sprintf("Specify an authentication token. For security reasons setting %s is preferred.", envSessionToken))
-	cliflag.String(cmd.PersistentFlags(), varAgentToken, "", "CODER_AGENT_TOKEN", "", "Specify an agent authentication token.")
+	cliflag.String(cmd.PersistentFlags(), varAgentToken, "", "CODER_AGENT_TOKEN", "", "An agent authentication token.")
 	_ = cmd.PersistentFlags().MarkHidden(varAgentToken)
-	cliflag.String(cmd.PersistentFlags(), varAgentURL, "", "CODER_AGENT_URL", "", "Specify the URL for an agent to access your deployment.")
+	cliflag.String(cmd.PersistentFlags(), varAgentURL, "", "CODER_AGENT_URL", "", "URL for an agent to access your deployment.")
 	_ = cmd.PersistentFlags().MarkHidden(varAgentURL)
-	cliflag.String(cmd.PersistentFlags(), varGlobalConfig, "", "CODER_CONFIG_DIR", configdir.LocalConfig("coderv2"), "Specify the path to the global `coder` config directory.")
+	cliflag.String(cmd.PersistentFlags(), varGlobalConfig, "", "CODER_CONFIG_DIR", configdir.LocalConfig("coderv2"), "Path to the global `coder` config directory.")
 	cliflag.StringArray(cmd.PersistentFlags(), varHeader, "", "CODER_HEADER", []string{}, "HTTP headers added to all requests. Provide as \"Key=Value\"")
 	cmd.PersistentFlags().Bool(varForceTty, false, "Force the `coder` command to run as if connected to a TTY.")
 	_ = cmd.PersistentFlags().MarkHidden(varForceTty)
 	cmd.PersistentFlags().Bool(varNoOpen, false, "Block automatically opening URLs in the browser.")
 	_ = cmd.PersistentFlags().MarkHidden(varNoOpen)
-	cliflag.Bool(cmd.PersistentFlags(), varVerbose, "v", "CODER_VERBOSE", false, "Enable verbose output")
+	cliflag.Bool(cmd.PersistentFlags(), varVerbose, "v", "CODER_VERBOSE", false, "Enable verbose output.")
 
 	return cmd
 }

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -57,7 +57,7 @@ func schedules() *cobra.Command {
 	scheduleCmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "schedule { show | start | stop | override } <workspace>",
-		Short:       "Modify scheduled stop and start times for your workspace",
+		Short:       "Schedule automated start and stop times for workspaces",
 	}
 
 	scheduleCmd.AddCommand(

--- a/cli/server.go
+++ b/cli/server.go
@@ -755,95 +755,119 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 		},
 	})
 
-	cliflag.DurationVarP(root.Flags(), &autobuildPollInterval, "autobuild-poll-interval", "", "CODER_AUTOBUILD_POLL_INTERVAL", time.Minute, "Specifies the interval at which to poll for and execute automated workspace build operations.")
-	cliflag.StringVarP(root.Flags(), &accessURL, "access-url", "", "CODER_ACCESS_URL", "", "Specifies the external URL to access Coder.")
-	cliflag.StringVarP(root.Flags(), &address, "address", "a", "CODER_ADDRESS", "127.0.0.1:3000", "The address to serve the API and dashboard.")
+	cliflag.DurationVarP(root.Flags(), &autobuildPollInterval, "autobuild-poll-interval", "", "CODER_AUTOBUILD_POLL_INTERVAL", time.Minute,
+		"Interval to poll for scheduled workspace builds.")
+	_ = root.Flags().MarkHidden("autobuild-poll-interval")
+	cliflag.StringVarP(root.Flags(), &accessURL, "access-url", "", "CODER_ACCESS_URL", "",
+		"External URL to access your deployment. This must be accessible by all provisioned workspaces.")
+	cliflag.StringVarP(root.Flags(), &address, "address", "a", "CODER_ADDRESS", "127.0.0.1:3000",
+		"Bind address of the server.")
 	cliflag.StringVarP(root.Flags(), &derpConfigURL, "derp-config-url", "", "CODER_DERP_CONFIG_URL", "",
-		"Specifies a URL to periodically fetch a DERP map. See: https://tailscale.com/kb/1118/custom-derp-servers/")
+		"URL to fetch a DERP mapping on startup. See: https://tailscale.com/kb/1118/custom-derp-servers/")
 	cliflag.StringVarP(root.Flags(), &derpConfigPath, "derp-config-path", "", "CODER_DERP_CONFIG_PATH", "",
-		"Specifies a path to read a DERP map from. See: https://tailscale.com/kb/1118/custom-derp-servers/")
-	cliflag.BoolVarP(root.Flags(), &derpServerEnabled, "derp-server-enable", "", "CODER_DERP_SERVER_ENABLE", true, "Specifies whether to enable or disable the embedded DERP server.")
-	cliflag.IntVarP(root.Flags(), &derpServerRegionID, "derp-server-region-id", "", "CODER_DERP_SERVER_REGION_ID", 999, "Specifies the region ID to use for the embedded DERP server.")
-	cliflag.StringVarP(root.Flags(), &derpServerRegionCode, "derp-server-region-code", "", "CODER_DERP_SERVER_REGION_CODE", "coder", "Specifies the region code that is displayed in the Coder UI for the embedded DERP server.")
-	cliflag.StringVarP(root.Flags(), &derpServerRegionName, "derp-server-region-name", "", "CODER_DERP_SERVER_REGION_NAME", "Coder Embedded Relay", "Specifies the region name that is displayed in the Coder UI for the embedded DERP server.")
+		"Path to read a DERP mapping from. See: https://tailscale.com/kb/1118/custom-derp-servers/")
+	cliflag.BoolVarP(root.Flags(), &derpServerEnabled, "derp-server-enable", "", "CODER_DERP_SERVER_ENABLE", true,
+		"Whether to enable or disable the embedded DERP relay server.")
+	cliflag.IntVarP(root.Flags(), &derpServerRegionID, "derp-server-region-id", "", "CODER_DERP_SERVER_REGION_ID", 999,
+		"Region ID to use for the embedded DERP server.")
+	cliflag.StringVarP(root.Flags(), &derpServerRegionCode, "derp-server-region-code", "", "CODER_DERP_SERVER_REGION_CODE", "coder",
+		"Region code that for the embedded DERP server.")
+	cliflag.StringVarP(root.Flags(), &derpServerRegionName, "derp-server-region-name", "", "CODER_DERP_SERVER_REGION_NAME", "Coder Embedded Relay",
+		"Region name that for the embedded DERP server.")
 	cliflag.StringArrayVarP(root.Flags(), &derpServerSTUNAddrs, "derp-server-stun-addresses", "", "CODER_DERP_SERVER_STUN_ADDRESSES", []string{
 		"stun.l.google.com:19302",
-	}, "Specify addresses for STUN servers to establish P2P connections. Set empty to disable P2P connections entirely.")
-	cliflag.BoolVarP(root.Flags(), &promEnabled, "prometheus-enable", "", "CODER_PROMETHEUS_ENABLE", false, "Enable serving prometheus metrics on the addressdefined by --prometheus-address.")
-	cliflag.StringVarP(root.Flags(), &promAddress, "prometheus-address", "", "CODER_PROMETHEUS_ADDRESS", "127.0.0.1:2112", "The address to serve prometheus metrics.")
-	cliflag.BoolVarP(root.Flags(), &pprofEnabled, "pprof-enable", "", "CODER_PPROF_ENABLE", false, "Enable serving pprof metrics on the address defined by --pprof-address.")
-	cliflag.StringVarP(root.Flags(), &pprofAddress, "pprof-address", "", "CODER_PPROF_ADDRESS", "127.0.0.1:6060", "The address to serve pprof.")
+	}, "Addresses for STUN servers to establish P2P connections. Set empty to disable P2P connections.")
+	cliflag.BoolVarP(root.Flags(), &promEnabled, "prometheus-enable", "", "CODER_PROMETHEUS_ENABLE", false,
+		"Serve prometheus metrics on the address defined by `prometheus-address`.")
+	cliflag.StringVarP(root.Flags(), &promAddress, "prometheus-address", "", "CODER_PROMETHEUS_ADDRESS", "127.0.0.1:2112",
+		"The bind address to serve prometheus metrics.")
+	cliflag.BoolVarP(root.Flags(), &pprofEnabled, "pprof-enable", "", "CODER_PPROF_ENABLE", false,
+		"Serve pprof metrics on the address defined by `pprof-address`.")
+	cliflag.StringVarP(root.Flags(), &pprofAddress, "pprof-address", "", "CODER_PPROF_ADDRESS", "127.0.0.1:6060",
+		"The bind address to serve pprof.")
 	defaultCacheDir := filepath.Join(os.TempDir(), "coder-cache")
 	if dir := os.Getenv("CACHE_DIRECTORY"); dir != "" {
 		// For compatibility with systemd.
 		defaultCacheDir = dir
 	}
-	cliflag.StringVarP(root.Flags(), &cacheDir, "cache-dir", "", "CODER_CACHE_DIRECTORY", defaultCacheDir, "Specifies a directory to cache binaries for provision operations. If unspecified and $CACHE_DIRECTORY is set, it will be used for compatibility with systemd.")
+	cliflag.StringVarP(root.Flags(), &cacheDir, "cache-dir", "", "CODER_CACHE_DIRECTORY", defaultCacheDir,
+		"The directory to cache temporary files. If unspecified and $CACHE_DIRECTORY is set, it will be used for compatibility with systemd.")
 	cliflag.BoolVarP(root.Flags(), &inMemoryDatabase, "in-memory", "", "CODER_INMEMORY", false,
-		"Specifies whether data will be stored in an in-memory database.")
+		"Controls whether data will be stored in an in-memory database.")
 	_ = root.Flags().MarkHidden("in-memory")
-	cliflag.StringVarP(root.Flags(), &postgresURL, "postgres-url", "", "CODER_PG_CONNECTION_URL", "", "The URL of a PostgreSQL database to connect to. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with \"coder server postgres-builtin-url\"")
-	cliflag.Uint8VarP(root.Flags(), &provisionerDaemonCount, "provisioner-daemons", "", "CODER_PROVISIONER_DAEMONS", 3, "The amount of provisioner daemons to create on start.")
+	cliflag.StringVarP(root.Flags(), &postgresURL, "postgres-url", "", "CODER_PG_CONNECTION_URL", "",
+		"URL of a PostgreSQL database. If empty, PostgreSQL binaries will be downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root. Access the built-in database with \"coder server postgres-builtin-url\"")
+	cliflag.Uint8VarP(root.Flags(), &provisionerDaemonCount, "provisioner-daemons", "", "CODER_PROVISIONER_DAEMONS", 3,
+		"Number of provisioner daemons to create on start. If builds are stuck in queued state for a long time, consider increasing this.")
 	cliflag.StringVarP(root.Flags(), &oauth2GithubClientID, "oauth2-github-client-id", "", "CODER_OAUTH2_GITHUB_CLIENT_ID", "",
-		"Specifies a client ID to use for oauth2 with GitHub.")
+		"Client ID for Login with GitHub.")
 	cliflag.StringVarP(root.Flags(), &oauth2GithubClientSecret, "oauth2-github-client-secret", "", "CODER_OAUTH2_GITHUB_CLIENT_SECRET", "",
-		"Specifies a client secret to use for oauth2 with GitHub.")
+		"Client secret for Login with GitHub.")
 	cliflag.StringArrayVarP(root.Flags(), &oauth2GithubAllowedOrganizations, "oauth2-github-allowed-orgs", "", "CODER_OAUTH2_GITHUB_ALLOWED_ORGS", nil,
-		"Specifies organizations the user must be a member of to authenticate with GitHub.")
+		"Organizations the user must be a member of to Login with GitHub.")
 	cliflag.StringArrayVarP(root.Flags(), &oauth2GithubAllowedTeams, "oauth2-github-allowed-teams", "", "CODER_OAUTH2_GITHUB_ALLOWED_TEAMS", nil,
-		"Specifies teams inside organizations the user must be a member of to authenticate with GitHub. Formatted as: <organization-name>/<team-slug>.")
+		"Teams inside organizations the user must be a member of to Login with GitHub. Structured as: <organization-name>/<team-slug>.")
 	cliflag.BoolVarP(root.Flags(), &oauth2GithubAllowSignups, "oauth2-github-allow-signups", "", "CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS", false,
-		"Specifies whether new users can sign up with GitHub.")
+		"Whether new users can sign up with GitHub.")
 	cliflag.StringVarP(root.Flags(), &oauth2GithubEnterpriseBaseURL, "oauth2-github-enterprise-base-url", "", "CODER_OAUTH2_GITHUB_ENTERPRISE_BASE_URL", "",
-		"Specifies the base URL of a GitHub Enterprise instance to use for oauth2.")
+		"Base URL of a GitHub Enterprise deployment to use for Login with GitHub.")
 	cliflag.BoolVarP(root.Flags(), &oidcAllowSignups, "oidc-allow-signups", "", "CODER_OIDC_ALLOW_SIGNUPS", true,
-		"Specifies whether new users can sign up with OIDC.")
+		"Whether new users can sign up with OIDC.")
 	cliflag.StringVarP(root.Flags(), &oidcClientID, "oidc-client-id", "", "CODER_OIDC_CLIENT_ID", "",
-		"Specifies a client ID to use for OIDC.")
+		"Client ID to use for Login with OIDC.")
 	cliflag.StringVarP(root.Flags(), &oidcClientSecret, "oidc-client-secret", "", "CODER_OIDC_CLIENT_SECRET", "",
-		"Specifies a client secret to use for OIDC.")
+		"Client secret to use for Login with OIDC.")
 	cliflag.StringVarP(root.Flags(), &oidcEmailDomain, "oidc-email-domain", "", "CODER_OIDC_EMAIL_DOMAIN", "",
-		"Specifies an email domain that clients authenticating with OIDC must match.")
+		"Email domain that clients logging in with OIDC must match.")
 	cliflag.StringVarP(root.Flags(), &oidcIssuerURL, "oidc-issuer-url", "", "CODER_OIDC_ISSUER_URL", "",
-		"Specifies an issuer URL to use for OIDC.")
+		"Issuer URL to use for Login with OIDC.")
 	cliflag.StringArrayVarP(root.Flags(), &oidcScopes, "oidc-scopes", "", "CODER_OIDC_SCOPES", []string{oidc.ScopeOpenID, "profile", "email"},
-		"Specifies scopes to grant when authenticating with OIDC.")
+		"Scopes to grant when authenticating with OIDC.")
 	cliflag.BoolVarP(root.Flags(), &tailscaleEnable, "tailscale", "", "CODER_TAILSCALE", true,
 		"Specifies whether Tailscale networking is used for web applications and terminals.")
 	_ = root.Flags().MarkHidden("tailscale")
 	enableTelemetryByDefault := !isTest()
-	cliflag.BoolVarP(root.Flags(), &telemetryEnable, "telemetry", "", "CODER_TELEMETRY", enableTelemetryByDefault, "Specifies whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.")
-	cliflag.StringVarP(root.Flags(), &telemetryURL, "telemetry-url", "", "CODER_TELEMETRY_URL", "https://telemetry.coder.com", "Specifies a URL to send telemetry to.")
+	cliflag.BoolVarP(root.Flags(), &telemetryEnable, "telemetry", "", "CODER_TELEMETRY", enableTelemetryByDefault,
+		"Whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.")
+	cliflag.StringVarP(root.Flags(), &telemetryURL, "telemetry-url", "", "CODER_TELEMETRY_URL", "https://telemetry.coder.com",
+		"URL to send telemetry.")
 	_ = root.Flags().MarkHidden("telemetry-url")
-	cliflag.BoolVarP(root.Flags(), &tlsEnable, "tls-enable", "", "CODER_TLS_ENABLE", false, "Specifies if TLS will be enabled")
+	cliflag.BoolVarP(root.Flags(), &tlsEnable, "tls-enable", "", "CODER_TLS_ENABLE", false,
+		"Whether TLS will be enabled.")
 	cliflag.StringVarP(root.Flags(), &tlsCertFile, "tls-cert-file", "", "CODER_TLS_CERT_FILE", "",
-		"Specifies the path to the certificate for TLS. It requires a PEM-encoded file. "+
+		"Path to the certificate for TLS. It requires a PEM-encoded file. "+
 			"To configure the listener to use a CA certificate, concatenate the primary certificate "+
-			"and the CA certificate together. The primary certificate should appear first in the combined file")
+			"and the CA certificate together. The primary certificate should appear first in the combined file.")
 	cliflag.StringVarP(root.Flags(), &tlsClientCAFile, "tls-client-ca-file", "", "CODER_TLS_CLIENT_CA_FILE", "",
 		"PEM-encoded Certificate Authority file used for checking the authenticity of client")
 	cliflag.StringVarP(root.Flags(), &tlsClientAuth, "tls-client-auth", "", "CODER_TLS_CLIENT_AUTH", "request",
-		`Specifies the policy the server will follow for TLS Client Authentication. `+
+		`Policy the server will follow for TLS Client Authentication. `+
 			`Accepted values are "none", "request", "require-any", "verify-if-given", or "require-and-verify"`)
 	cliflag.StringVarP(root.Flags(), &tlsKeyFile, "tls-key-file", "", "CODER_TLS_KEY_FILE", "",
-		"Specifies the path to the private key for the certificate. It requires a PEM-encoded file")
+		"Path to the private key for the certificate. It requires a PEM-encoded file")
 	cliflag.StringVarP(root.Flags(), &tlsMinVersion, "tls-min-version", "", "CODER_TLS_MIN_VERSION", "tls12",
-		`Specifies the minimum supported version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13"`)
+		`Minimum supported version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13"`)
 	cliflag.BoolVarP(root.Flags(), &tunnel, "tunnel", "", "CODER_TUNNEL", false,
 		"Workspaces must be able to reach the `access-url`. This overrides your access URL with a public access URL that tunnels your Coder deployment.")
 	cliflag.StringArrayVarP(root.Flags(), &stunServers, "stun-server", "", "CODER_STUN_SERVERS", []string{
 		"stun:stun.l.google.com:19302",
-	}, "Specify URLs for STUN servers to enable P2P connections.")
-	cliflag.BoolVarP(root.Flags(), &traceEnable, "trace", "", "CODER_TRACE", false, "Specifies if application tracing data is collected")
+	}, "URLs for STUN servers to enable P2P connections.")
+	cliflag.BoolVarP(root.Flags(), &traceEnable, "trace", "", "CODER_TRACE", false,
+		"Whether application tracing data is collected.")
 	cliflag.StringVarP(root.Flags(), &turnRelayAddress, "turn-relay-address", "", "CODER_TURN_RELAY_ADDRESS", "127.0.0.1",
-		"Specifies the address to bind TURN connections.")
-	cliflag.BoolVarP(root.Flags(), &secureAuthCookie, "secure-auth-cookie", "", "CODER_SECURE_AUTH_COOKIE", false, "Specifies if the 'Secure' property is set on browser session cookies")
-	cliflag.StringVarP(root.Flags(), &sshKeygenAlgorithmRaw, "ssh-keygen-algorithm", "", "CODER_SSH_KEYGEN_ALGORITHM", "ed25519", "Specifies the algorithm to use for generating ssh keys. "+
-		`Accepted values are "ed25519", "ecdsa", or "rsa4096"`)
-	cliflag.StringArrayVarP(root.Flags(), &autoImportTemplates, "auto-import-template", "", "CODER_TEMPLATE_AUTOIMPORT", []string{}, "Which templates to auto-import. Available auto-importable templates are: kubernetes")
-	cliflag.BoolVarP(root.Flags(), &spooky, "spooky", "", "", false, "Specifies spookiness level")
+		"The address to bind TURN connections.")
+	cliflag.BoolVarP(root.Flags(), &secureAuthCookie, "secure-auth-cookie", "", "CODER_SECURE_AUTH_COOKIE", false,
+		"Controls if the 'Secure' property is set on browser session cookies")
+	cliflag.StringVarP(root.Flags(), &sshKeygenAlgorithmRaw, "ssh-keygen-algorithm", "", "CODER_SSH_KEYGEN_ALGORITHM", "ed25519",
+		"The algorithm to use for generating ssh keys. "+
+			`Accepted values are "ed25519", "ecdsa", or "rsa4096"`)
+	cliflag.StringArrayVarP(root.Flags(), &autoImportTemplates, "auto-import-template", "", "CODER_TEMPLATE_AUTOIMPORT", []string{},
+		"Templates to auto-import. Available auto-importable templates are: kubernetes")
+	_ = root.Flags().MarkHidden("auto-import-template")
+	cliflag.BoolVarP(root.Flags(), &spooky, "spooky", "", "", false, "Specifies spookiness level...")
 	_ = root.Flags().MarkHidden("spooky")
-	cliflag.BoolVarP(root.Flags(), &verbose, "verbose", "v", "CODER_VERBOSE", false, "Enables verbose logging.")
+	cliflag.BoolVarP(root.Flags(), &verbose, "verbose", "v", "CODER_VERBOSE", false,
+		"Enables verbose logging.")
 
 	// These metrics flags are for manually testing the metric system.
 	// The defaults should be acceptable for any Coder deployment of any
@@ -851,7 +875,7 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 	cliflag.DurationVarP(root.Flags(), &metricsCacheRefreshInterval, "metrics-cache-refresh-interval", "", "CODER_METRICS_CACHE_REFRESH_INTERVAL", time.Hour, "How frequently metrics are refreshed")
 	_ = root.Flags().MarkHidden("metrics-cache-refresh-interval")
 	cliflag.DurationVarP(root.Flags(), &agentStatRefreshInterval, "agent-stats-refresh-interval", "", "CODER_AGENT_STATS_REFRESH_INTERVAL", time.Minute*10, "How frequently agent stats are recorded")
-	_ = root.Flags().MarkHidden("agent-stats-report-interval")
+	_ = root.Flags().MarkHidden("agent-stats-refresh-interval")
 
 	return root
 }

--- a/cli/show.go
+++ b/cli/show.go
@@ -11,7 +11,7 @@ func show() *cobra.Command {
 	return &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "show <workspace>",
-		Short:       "Show details of a workspace's resources and agents",
+		Short:       "Display details of a workspace's resources and agents",
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -28,7 +28,7 @@ func speedtest() *cobra.Command {
 		Annotations: workspaceCommand,
 		Use:         "speedtest <workspace>",
 		Args:        cobra.ExactArgs(1),
-		Short:       "Run a speed test from your machine to the workspace.",
+		Short:       "Run upload and download tests from your machine to a workspace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -48,7 +48,7 @@ func ssh() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "ssh <workspace>",
-		Short:       "SSH into a workspace",
+		Short:       "Start a shell into a workspace",
 		Args:        cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())

--- a/cli/start.go
+++ b/cli/start.go
@@ -14,7 +14,7 @@ func start() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "start <workspace>",
-		Short:       "Build a workspace with the start state",
+		Short:       "Start a workspace",
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -14,7 +14,7 @@ func stop() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations: workspaceCommand,
 		Use:         "stop <workspace>",
-		Short:       "Build a workspace with the stop state",
+		Short:       "Stop a workspace",
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := cliui.Prompt(cmd, cliui.PromptOptions{

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -13,7 +13,8 @@ import (
 func templates() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "templates",
-		Short:   "Create, manage, and deploy templates",
+		Short:   "Manage templates",
+		Long:    "Templates are written in standard Terraform and describe the infrastructure for workspaces",
 		Aliases: []string{"template"},
 		Example: formatExamples(
 			example{

--- a/cli/update.go
+++ b/cli/update.go
@@ -20,7 +20,7 @@ func update() *cobra.Command {
 		Annotations: workspaceCommand,
 		Use:         "update <workspace>",
 		Args:        cobra.ExactArgs(1),
-		Short:       "Update a workspace to the latest template version",
+		Short:       "Update a workspace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)
 			if err != nil {

--- a/cli/users.go
+++ b/cli/users.go
@@ -8,7 +8,7 @@ import (
 
 func users() *cobra.Command {
 	cmd := &cobra.Command{
-		Short:   "Create, remove, and list users",
+		Short:   "Manage users",
 		Use:     "users",
 		Aliases: []string{"user"},
 	}


### PR DESCRIPTION
This makes the english consistent on flags, and improves the contrast for the placeholder color on dark themes.

Before:
![image](https://user-images.githubusercontent.com/7122116/191062087-20336338-a1f9-417b-9296-73b477e80396.png)

After:
![image](https://user-images.githubusercontent.com/7122116/191062042-a3f2b916-538d-448b-992e-761343f8e0be.png)
