### PR TITLE
fix: Only update workspace LastUsed when the connection payload has changed

### DIFF
--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -159,6 +159,33 @@ func (q *fakeQuerier) InsertAgentStat(_ context.Context, p database.InsertAgentS
 	return stat, nil
 }
 
+func (q *fakeQuerier) GetLatestAgentStat(_ context.Context, agentID uuid.UUID) (database.AgentStat, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	found := false
+	latest := database.AgentStat{}
+	for _, agentStat := range q.agentStats {
+		if agentStat.AgentID != agentID {
+			continue
+		}
+		if !found {
+			latest = agentStat
+			found = true
+			continue
+		}
+		if agentStat.CreatedAt.After(latest.CreatedAt) {
+			latest = agentStat
+			found = true
+			continue
+		}
+	}
+	if !found {
+		return database.AgentStat{}, sql.ErrNoRows
+	}
+	return latest, nil
+}
+
 func (q *fakeQuerier) GetTemplateDAUs(_ context.Context, templateID uuid.UUID) ([]database.GetTemplateDAUsRow, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -37,6 +37,7 @@ type querier interface {
 	GetDeploymentID(ctx context.Context) (string, error)
 	GetFileByHash(ctx context.Context, hash string) (File, error)
 	GetGitSSHKey(ctx context.Context, userID uuid.UUID) (GitSSHKey, error)
+	GetLatestAgentStat(ctx context.Context, agentID uuid.UUID) (AgentStat, error)
 	GetLatestWorkspaceBuildByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (WorkspaceBuild, error)
 	GetLatestWorkspaceBuilds(ctx context.Context) ([]WorkspaceBuild, error)
 	GetLatestWorkspaceBuildsByWorkspaceIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceBuild, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -24,6 +24,25 @@ func (q *sqlQuerier) DeleteOldAgentStats(ctx context.Context) error {
 	return err
 }
 
+const getLatestAgentStat = `-- name: GetLatestAgentStat :one
+SELECT id, created_at, user_id, agent_id, workspace_id, template_id, payload FROM agent_stats WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1
+`
+
+func (q *sqlQuerier) GetLatestAgentStat(ctx context.Context, agentID uuid.UUID) (AgentStat, error) {
+	row := q.db.QueryRowContext(ctx, getLatestAgentStat, agentID)
+	var i AgentStat
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UserID,
+		&i.AgentID,
+		&i.WorkspaceID,
+		&i.TemplateID,
+		&i.Payload,
+	)
+	return i, err
+}
+
 const getTemplateDAUs = `-- name: GetTemplateDAUs :many
 select
 	(created_at at TIME ZONE 'UTC')::date as date,

--- a/coderd/database/queries/agentstats.sql
+++ b/coderd/database/queries/agentstats.sql
@@ -12,6 +12,9 @@ INSERT INTO
 VALUES
 	($1, $2, $3, $4, $5, $6, $7) RETURNING *;
 
+-- name: GetLatestAgentStat :one
+SELECT * FROM agent_stats WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1; 
+
 -- name: GetTemplateDAUs :many
 select
 	(created_at at TIME ZONE 'UTC')::date as date,


### PR DESCRIPTION
This was causing every workspace to update last used to time.Now() when coderd was restarted!
