### PR TITLE
fix: use consistent tracer name

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -198,8 +198,8 @@ func New(options *Options) *API {
 
 	apps := func(r chi.Router) {
 		r.Use(
+			tracing.Middleware(api.TracerProvider),
 			httpmw.RateLimitPerMinute(options.APIRateLimit),
-			tracing.HTTPMW(api.TracerProvider),
 			httpmw.ExtractAPIKey(options.Database, oauthConfigs, true),
 			httpmw.ExtractUserParam(api.Database),
 			// Extracts the <workspace.agent> from the url
@@ -227,9 +227,9 @@ func New(options *Options) *API {
 			})
 		})
 		r.Use(
+			tracing.Middleware(api.TracerProvider),
 			// Specific routes can specify smaller limits.
 			httpmw.RateLimitPerMinute(options.APIRateLimit),
-			tracing.HTTPMW(api.TracerProvider),
 		)
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			httpapi.Write(w, http.StatusOK, codersdk.Response{

--- a/coderd/tracing/util.go
+++ b/coderd/tracing/util.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const TracerName = "coderd"
+
 func FuncName() string {
 	fnpc, _, _, ok := runtime.Caller(1)
 	if !ok {


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
