### PR TITLE
feat: add open in coder docs, fix missing templates

### DIFF
--- a/docs/admin/open-in-coder.md
+++ b/docs/admin/open-in-coder.md
@@ -1,11 +1,13 @@
 # Open in Coder Button
 
+> WARNING: this feature in Alpha and the API is subject to change.
+
 Add a markdown button to your project's `README.md` to get your developers up and running with Coder with a few clicks.
 
 A basic example looks like this:
 
 ```text
-[![Open in Coder](https://cdn.coder.com/embed-button.svg)](https://dev.coder.com/?template=coder-ts)
+[![Open in Coder](https://cdn.coder.com/embed-button.svg)](https://<deployment-url>/templates/<template-name>)
 ```
 
 which renders like this:
@@ -18,12 +20,10 @@ You can customize this to take developers directly to your team's template. Read
 
 The underlying link for this button consists of the following pieces:
 - <deployment-url>: where your Coder deployment lives i.e. https://dev.coder.com
-- <query-params>: optional query parameters to customize the experience
+- <template-name>: name of template i.e. coder
 
-These are the following query parameters we support:
-
-### template
+### template name
 
 A template to redirect your developers to after they authenticate on your deployment.
 
-Example: https://dev.coder.com/?template=coder-ts
+Example: https://dev.coder.com/templates/coder

--- a/docs/admin/open-in-coder.md
+++ b/docs/admin/open-in-coder.md
@@ -1,7 +1,5 @@
 # Open in Coder Button
 
-> WARNING: this feature in Alpha and the API is subject to change.
-
 Add a Markdown button to your project's `README.md` to get your developers up and running with Coder with a few clicks.
 
 A basic example looks like this:

--- a/docs/admin/open-in-coder.md
+++ b/docs/admin/open-in-coder.md
@@ -6,7 +6,7 @@ Add a Markdown button to your project's `README.md` to get your developers up an
 
 A basic example looks like this:
 
-```text
+```markdown
 [![Open in Coder](https://cdn.coder.com/embed-button.svg)](https://<deployment-url>/templates/<template-name>)
 ```
 

--- a/docs/admin/open-in-coder.md
+++ b/docs/admin/open-in-coder.md
@@ -2,7 +2,7 @@
 
 > WARNING: this feature in Alpha and the API is subject to change.
 
-Add a markdown button to your project's `README.md` to get your developers up and running with Coder with a few clicks.
+Add a Markdown button to your project's `README.md` to get your developers up and running with Coder with a few clicks.
 
 A basic example looks like this:
 

--- a/docs/admin/open-in-coder.md
+++ b/docs/admin/open-in-coder.md
@@ -1,0 +1,29 @@
+# Open in Coder Button
+
+Add a markdown button to your project's `README.md` to get your developers up and running with Coder with a few clicks.
+
+A basic example looks like this:
+
+```text
+[![Open in Coder](https://cdn.coder.com/embed-button.svg)](https://dev.coder.com/?template=coder-ts)
+```
+
+which renders like this:
+
+![Open in Coder](https://cdn.coder.com/embed-button.svg)
+
+You can customize this to take developers directly to your team's template. Read on to learn more.
+
+### Customization
+
+The underlying link for this button consists of the following pieces:
+- <deployment-url>: where your Coder deployment lives i.e. https://dev.coder.com
+- <query-params>: optional query parameters to customize the experience
+
+These are the following query parameters we support:
+
+### template
+
+A template to redirect your developers to after they authenticate on your deployment.
+
+Example: https://dev.coder.com/?template=coder-ts

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -188,6 +188,11 @@
           "title": "Enterprise",
           "description": "Learn how to enable Enterprise features.",
           "path": "./admin/enterprise.md"
+        },
+        {
+          "title": "Open in Coder Button",
+          "description": "Learn how to create an 'Open in Coder' button.",
+          "path": "./admin/open-in-coder.md"
         }
       ]
     },

--- a/dogfood/README.md
+++ b/dogfood/README.md
@@ -1,5 +1,7 @@
 # dogfood template
 
+[![Open in Coder](https://cdn.coder.com/embed-button.svg)](https://dev.coder.com/templates/coder)
+
 Ammar is this template's admin.
 
 ## Personalization

--- a/site/src/pages/TemplatePage/TemplatePage.tsx
+++ b/site/src/pages/TemplatePage/TemplatePage.tsx
@@ -1,5 +1,8 @@
+import { makeStyles } from "@material-ui/core/styles"
 import { useMachine, useSelector } from "@xstate/react"
 import { DeleteDialog } from "components/Dialogs/DeleteDialog/DeleteDialog"
+import { ErrorSummary } from "components/ErrorSummary/ErrorSummary"
+import { Margins } from "components/Margins/Margins"
 import { FC, useContext } from "react"
 import { Helmet } from "react-helmet-async"
 import { useTranslation } from "react-i18next"
@@ -23,6 +26,7 @@ const useTemplateName = () => {
 }
 
 export const TemplatePage: FC<React.PropsWithChildren<unknown>> = () => {
+  const styles = useStyles()
   const organizationId = useOrganizationId()
   const { t } = useTranslation("templatePage")
   const templateName = useTemplateName()
@@ -40,6 +44,7 @@ export const TemplatePage: FC<React.PropsWithChildren<unknown>> = () => {
     templateVersions,
     deleteTemplateError,
     templateDAUs,
+    getTemplateError,
   } = templateState.context
   const xServices = useContext(XServiceContext)
   const permissions = useSelector(xServices.authXService, selectPermissions)
@@ -48,6 +53,16 @@ export const TemplatePage: FC<React.PropsWithChildren<unknown>> = () => {
 
   const handleDeleteTemplate = () => {
     templateSend("DELETE")
+  }
+
+  if (templateState.matches("error") && Boolean(getTemplateError)) {
+    return (
+      <Margins>
+        <div className={styles.errorBox}>
+          <ErrorSummary error={getTemplateError} />
+        </div>
+      </Margins>
+    )
   }
 
   if (isLoading) {
@@ -89,5 +104,11 @@ export const TemplatePage: FC<React.PropsWithChildren<unknown>> = () => {
     </>
   )
 }
+
+const useStyles = makeStyles((theme) => ({
+  errorBox: {
+    padding: theme.spacing(3),
+  },
+}))
 
 export default TemplatePage

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,6 +1,13 @@
 import { FC } from "react"
-import { Navigate } from "react-router-dom"
+import { Navigate, useSearchParams } from "react-router-dom"
 
 export const IndexPage: FC = () => {
+  const [searchParams, _] = useSearchParams()
+  const template = searchParams.get("template")
+
+  if (template) {
+    return <Navigate to={`/templates/${template}`} replace />
+  }
+
   return <Navigate to="/workspaces" replace />
 }

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,13 +1,6 @@
 import { FC } from "react"
-import { Navigate, useSearchParams } from "react-router-dom"
+import { Navigate } from "react-router-dom"
 
 export const IndexPage: FC = () => {
-  const [searchParams, _] = useSearchParams()
-  const template = searchParams.get("template")
-
-  if (template) {
-    return <Navigate to={`/templates/${template}`} replace />
-  }
-
   return <Navigate to="/workspaces" replace />
 }

--- a/site/src/xServices/template/templateXService.ts
+++ b/site/src/xServices/template/templateXService.ts
@@ -25,6 +25,7 @@ interface TemplateContext {
   templateVersions?: TemplateVersion[]
   templateDAUs: TemplateDAUsResponse
   deleteTemplateError?: Error | unknown
+  getTemplateError?: Error | unknown
 }
 
 type TemplateEvent = { type: "DELETE" } | { type: "CONFIRM_DELETE" } | { type: "CANCEL_DELETE" }
@@ -69,6 +70,12 @@ export const templateMachine =
               {
                 actions: "assignTemplate",
                 target: "initialInfo",
+              },
+            ],
+            onError: [
+              {
+                actions: "assignGetTemplateError",
+                target: "error",
               },
             ],
           },
@@ -211,6 +218,9 @@ export const templateMachine =
         deleted: {
           type: "final",
         },
+        error: {
+          type: "final",
+        },
       },
     },
     {
@@ -256,6 +266,9 @@ export const templateMachine =
         }),
         assignActiveTemplateVersion: assign({
           activeTemplateVersion: (_, event) => event.data,
+        }),
+        assignGetTemplateError: assign({
+          getTemplateError: (_, event) => event.data,
         }),
         assignTemplateResources: assign({
           templateResources: (_, event) => event.data,


### PR DESCRIPTION
## Changes

- adds docs for the first version of the Open in Coder button 
- fix template missing error
- add Open in Coder button to dogfood `README`

### Screenshots

This is what the new error looks like on the Template page
![erro-template](https://user-images.githubusercontent.com/3806031/191358531-67a88fe8-b2d2-4bc5-8daf-79dac80d3d55.jpg)


Part 1 of ? for https://github.com/coder/coder/issues/3981

## Changes to address

- [x] remove query param on index page
- [x] change docs
- [x] add example to the dogfood docs
- [x] update PR description
