### PR TITLE
fix: ignore context canceled error on server

### DIFF
--- a/cli/resetpassword_test.go
+++ b/cli/resetpassword_test.go
@@ -47,7 +47,7 @@ func TestResetPassword(t *testing.T) {
 	go func() {
 		defer close(serverDone)
 		err = serverCmd.ExecuteContext(ctx)
-		assert.ErrorIs(t, err, context.Canceled)
+		assert.NoError(t, err)
 	}()
 	var rawURL string
 	require.Eventually(t, func() bool {

--- a/cli/server.go
+++ b/cli/server.go
@@ -687,6 +687,9 @@ func Server(newAPI func(*coderd.Options) *coderd.API) *cobra.Command {
 			// Trigger context cancellation for any remaining services.
 			cancel()
 
+			if xerrors.Is(exitErr, context.Canceled) {
+				return nil
+			}
 			return exitErr
 		},
 	}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -73,7 +73,7 @@ func TestServer(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 	})
 	t.Run("BuiltinPostgres", func(t *testing.T) {
 		t.Parallel()
@@ -144,7 +144,7 @@ func TestServer(t *testing.T) {
 		pty.ExpectMatch("View the Web UI: http://localhost:3000/")
 
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 	})
 
 	// Validate that an https scheme is prepended to a remote access URL
@@ -176,7 +176,7 @@ func TestServer(t *testing.T) {
 		pty.ExpectMatch("View the Web UI: https://foobarbaz.mydomain")
 
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 	})
 
 	t.Run("NoWarningWithRemoteAccessURL", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestServer(t *testing.T) {
 		pty.ExpectMatch("View the Web UI: https://google.com")
 
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 	})
 
 	t.Run("TLSBadVersion", func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 	})
 	// This cannot be ran in parallel because it uses a signal.
 	//nolint:paralleltest
@@ -322,7 +322,7 @@ func TestServer(t *testing.T) {
 		// We cannot send more signals here, because it's possible Coder
 		// has already exited, which could cause the test to fail due to interrupt.
 		err = <-serverErr
-		require.ErrorIs(t, err, context.Canceled)
+		require.NoError(t, err)
 	})
 	t.Run("TracerNoLeak", func(t *testing.T) {
 		t.Parallel()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -101,7 +101,7 @@ func TestServer(t *testing.T) {
 			return err == nil && rawURL != ""
 		}, 3*time.Minute, testutil.IntervalFast, "failed to get access URL")
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 	})
 	t.Run("BuiltinPostgresURL", func(t *testing.T) {
 		t.Parallel()
@@ -341,7 +341,7 @@ func TestServer(t *testing.T) {
 			errC <- root.ExecuteContext(ctx)
 		}()
 		cancelFunc()
-		require.ErrorIs(t, <-errC, context.Canceled)
+		require.NoError(t, <-errC)
 		require.Error(t, goleak.Find())
 	})
 	t.Run("Telemetry", func(t *testing.T) {


### PR DESCRIPTION
Doesn't really make sense to show an error when gracefully shutting down the server.

![image](https://user-images.githubusercontent.com/6332295/191162696-228591bd-689c-47d8-8f52-5ac88c07e3b1.png)
