### PR TITLE
fix: typo

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -7,7 +7,7 @@ Docker is required. See the [official installation documentation](https://docs.d
 ## Run Coder with built-in database and tunnel (quick)
 
 For proof-of-concept deployments, you can run a complete Coder instance with
-with the following command:
+the following command:
 
 ```sh
 export CODER_DATA=$HOME/.config/coderv2-docker


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
Fix typo with double occurrence of the word `with` 
