### PR TITLE
fix: Panic when loading coordination override

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -405,8 +405,11 @@ func (api *API) workspaceAgentClientCoordinate(rw http.ResponseWriter, r *http.R
 	}
 	// This is used by Enterprise code to control the functionality of this route.
 	override := api.WorkspaceClientCoordinateOverride.Load()
-	if override != nil && (*override)(rw) {
-		return
+	if override != nil {
+		overrideFunc := *override
+		if overrideFunc != nil && overrideFunc(rw) {
+			return
+		}
 	}
 
 	api.websocketWaitMutex.Lock()

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -43,7 +43,9 @@ func New(ctx context.Context, options *Options) (*API, error) {
 				Entitlement: codersdk.EntitlementNotEntitled,
 				Enabled:     false,
 			},
-			auditLogs: codersdk.EntitlementNotEntitled,
+			auditLogs:   codersdk.EntitlementNotEntitled,
+			browserOnly: codersdk.EntitlementNotEntitled,
+			scim:        codersdk.EntitlementNotEntitled,
 		},
 		cancelEntitlementsLoop: cancelFunc,
 	}


### PR DESCRIPTION
This was broken because of browser-only. This should fix it!
