### PR TITLE
fix: Ensure coordinator is closed and freed in agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -272,6 +272,15 @@ func (a *agent) runTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) {
 
 // runCoordinator listens for nodes and updates the self-node as it changes.
 func (a *agent) runCoordinator(ctx context.Context) {
+	for {
+		reconnect := a.runCoordinatorWithRetry(ctx)
+		if !reconnect {
+			return
+		}
+	}
+}
+
+func (a *agent) runCoordinatorWithRetry(ctx context.Context) (reconnect bool) {
 	var coordinator net.Conn
 	var err error
 	// An exponential back-off occurs when the connection is failing to dial.
@@ -280,10 +289,10 @@ func (a *agent) runCoordinator(ctx context.Context) {
 		coordinator, err = a.coordinatorDialer(ctx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				return
+				return false
 			}
 			if a.isClosed() {
-				return
+				return false
 			}
 			a.logger.Warn(context.Background(), "failed to dial", slog.Error(err))
 			continue
@@ -295,24 +304,23 @@ func (a *agent) runCoordinator(ctx context.Context) {
 	}
 	select {
 	case <-ctx.Done():
-		return
+		return false
 	default:
 	}
 	sendNodes, errChan := tailnet.ServeCoordinator(coordinator, a.network.UpdateNodes)
 	a.network.SetNodeCallback(sendNodes)
 	select {
 	case <-ctx.Done():
-		return
+		return false
 	case err := <-errChan:
 		if a.isClosed() {
-			return
+			return false
 		}
 		if errors.Is(err, context.Canceled) {
-			return
+			return false
 		}
 		a.logger.Debug(ctx, "node broker accept exited; restarting connection", slog.Error(err))
-		a.runCoordinator(ctx)
-		return
+		return true
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -288,6 +288,8 @@ func (a *agent) runCoordinator(ctx context.Context) {
 			a.logger.Warn(context.Background(), "failed to dial", slog.Error(err))
 			continue
 		}
+		//nolint:revive // Defer is ok because we're exiting this loop.
+		defer coordinator.Close()
 		a.logger.Info(context.Background(), "connected to coordination server")
 		break
 	}
@@ -296,7 +298,6 @@ func (a *agent) runCoordinator(ctx context.Context) {
 		return
 	default:
 	}
-	defer coordinator.Close()
 	sendNodes, errChan := tailnet.ServeCoordinator(coordinator, a.network.UpdateNodes)
 	a.network.SetNodeCallback(sendNodes)
 	select {


### PR DESCRIPTION
This PR (likely) fixes a leak that was seen in CI. (Also managed to reproduce it locally running tests in a loop.)

```
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 2370 in state select, with nhooyr.io/websocket.(*Conn).timeoutLoop on top of the stack:
goroutine 2370 [select]:
nhooyr.io/websocket.(*Conn).timeoutLoop(0xc001216d00)
        /home/maf/go/pkg/mod/nhooyr.io/websocket@v1.8.7/conn_notjs.go:153 +0x23d
created by nhooyr.io/websocket.newConn
        /home/maf/go/pkg/mod/nhooyr.io/websocket@v1.8.7/conn_notjs.go:114 +0xc93
]
FAIL    github.com/coder/coder/coderd   5.528s
FAIL
```

- fix: Close coordinator on context cancellation
- fix: Refactor runCoordinator so that previous is closed/freed

