### PR TITLE
feat: Support for comma-separation and ranges in port-forward

### DIFF
--- a/cli/portforward_internal_test.go
+++ b/cli/portforward_internal_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parsePortForwards(t *testing.T) {
+	portForwardSpecToString := func(v []portForwardSpec) (out []string) {
+		for _, p := range v {
+			require.Equal(t, p.listenNetwork, p.dialNetwork)
+			out = append(out, fmt.Sprintf("%s:%s", strings.Replace(p.listenAddress, "127.0.0.1:", "", 1), strings.Replace(p.dialAddress, "127.0.0.1:", "", 1)))
+		}
+		return out
+	}
+	type args struct {
+		tcpSpecs []string
+		udpSpecs []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "TCP mixed ports and ranges",
+			args: args{
+				tcpSpecs: []string{
+					"8000,8080:8081,9000-9002,9003-9004:9005-9006",
+					"10000",
+				},
+			},
+			want: []string{
+				"8000:8000",
+				"8080:8081",
+				"9000:9000",
+				"9001:9001",
+				"9002:9002",
+				"9003:9005",
+				"9004:9006",
+				"10000:10000",
+			},
+		},
+		{
+			name: "UDP with port range",
+			args: args{
+				udpSpecs: []string{"8000,8080-8081"},
+			},
+			want: []string{
+				"8000:8000",
+				"8080:8080",
+				"8081:8081",
+			},
+		},
+		{
+			name: "Bad port range",
+			args: args{
+				tcpSpecs: []string{"8000-7000"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Bad dest port range",
+			args: args{
+				tcpSpecs: []string{"8080-8081:9080-9082"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePortForwards(tt.args.tcpSpecs, tt.args.udpSpecs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parsePortForwards() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotStrings := portForwardSpecToString(got)
+			require.Equal(t, tt.want, gotStrings)
+		})
+	}
+}

--- a/cli/portforward_internal_test.go
+++ b/cli/portforward_internal_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func Test_parsePortForwards(t *testing.T) {
+	t.Parallel()
+
 	portForwardSpecToString := func(v []portForwardSpec) (out []string) {
 		for _, p := range v {
 			require.Equal(t, p.listenNetwork, p.dialNetwork)

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -11,12 +11,32 @@ There are two ways to forward ports in Coder:
 
 The `coder port-forward` command is generally more performant.
 
-## coder port-forward
+## The `coder port-forward` command
 
-Forward the remote TCP port `8080` to local port `8000` like so:
+This command can be used to forward TCP or UDP ports from the remote
+workspace so they can be accessed locally. Both the TCP and UDP command
+line flags (`--tcp` and `--udp`) can be given once or multiple times.
+
+The supported syntax variations for the `--tcp` and `--udp` flag are:
+
+- Single port with optional remote port: `local_port[:remote_port]`
+- Comma separation `local_port1,local_port2`
+- Port ranges `start_port-end_port`
+- Any combination of the above
+
+### Examples
+
+Forward the remote TCP port `8080` to local port `8000`:
 
 ```console
 coder port-forward myworkspace --tcp 8000:8080
+```
+
+Forward the remote TCP port `3000` and all ports from `9990` to `9999`
+to their respective local ports.
+
+```console
+coder port-forward myworkspace --tcp 3000,9990-9999
 ```
 
 For more examples, see `coder port-forward --help`.


### PR DESCRIPTION
This PR adds support for a more condensed port-forwarding syntax (e.g. `--tcp 8080,9000-9010,9990-9999:10990-10999`).

Tests implemented as an internal test since testing the effect (multiple port ranges) isn't feasible externally.

Fixes #3766

