### PR TITLE
fix: Remove unused scopes from parameter computation

### DIFF
--- a/coderd/parameter/compute.go
+++ b/coderd/parameter/compute.go
@@ -15,8 +15,6 @@ import (
 // ComputeScope targets identifiers to pull parameters from.
 type ComputeScope struct {
 	TemplateImportJobID       uuid.UUID
-	OrganizationID            uuid.UUID
-	UserID                    uuid.UUID
 	TemplateID                uuid.NullUUID
 	WorkspaceID               uuid.NullUUID
 	AdditionalParameterValues []database.ParameterValue

--- a/coderd/parameter/compute_test.go
+++ b/coderd/parameter/compute_test.go
@@ -18,7 +18,6 @@ func TestCompute(t *testing.T) {
 	generateScope := func() parameter.ComputeScope {
 		return parameter.ComputeScope{
 			TemplateImportJobID: uuid.New(),
-			OrganizationID:      uuid.New(),
 			TemplateID: uuid.NullUUID{
 				UUID:  uuid.New(),
 				Valid: true,
@@ -27,7 +26,6 @@ func TestCompute(t *testing.T) {
 				UUID:  uuid.New(),
 				Valid: true,
 			},
-			UserID: uuid.New(),
 		}
 	}
 	type parameterOptions struct {

--- a/coderd/provisionerdaemons.go
+++ b/coderd/provisionerdaemons.go
@@ -226,12 +226,10 @@ func (server *provisionerdServer) AcquireJob(ctx context.Context, _ *proto.Empty
 		// Compute parameters for the workspace to consume.
 		parameters, err := parameter.Compute(ctx, server.Database, parameter.ComputeScope{
 			TemplateImportJobID: templateVersion.JobID,
-			OrganizationID:      job.OrganizationID,
 			TemplateID: uuid.NullUUID{
 				UUID:  template.ID,
 				Valid: true,
 			},
-			UserID: user.ID,
 			WorkspaceID: uuid.NullUUID{
 				UUID:  workspace.ID,
 				Valid: true,
@@ -283,9 +281,7 @@ func (server *provisionerdServer) AcquireJob(ctx context.Context, _ *proto.Empty
 		// Compute parameters for the dry-run to consume.
 		parameters, err := parameter.Compute(ctx, server.Database, parameter.ComputeScope{
 			TemplateImportJobID:       templateVersion.JobID,
-			OrganizationID:            job.OrganizationID,
 			TemplateID:                templateVersion.TemplateID,
-			UserID:                    user.ID,
 			WorkspaceID:               uuid.NullUUID{},
 			AdditionalParameterValues: input.ParameterValues,
 		}, nil)
@@ -476,8 +472,6 @@ func (server *provisionerdServer) UpdateJob(ctx context.Context, request *proto.
 		parameters, err := parameter.Compute(ctx, server.Database, parameter.ComputeScope{
 			TemplateImportJobID: job.ID,
 			TemplateID:          templateID,
-			OrganizationID:      job.OrganizationID,
-			UserID:              job.InitiatorID,
 		}, nil)
 		if err != nil {
 			return nil, xerrors.Errorf("compute parameters: %w", err)

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -148,7 +148,6 @@ func (api *API) templateVersionSchema(rw http.ResponseWriter, r *http.Request) {
 
 func (api *API) templateVersionParameters(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	apiKey := httpmw.APIKey(r)
 	templateVersion := httpmw.TemplateVersionParam(r)
 	if !api.Authorize(r, rbac.ActionRead, templateVersion) {
 		httpapi.ResourceNotFound(rw)
@@ -171,8 +170,6 @@ func (api *API) templateVersionParameters(rw http.ResponseWriter, r *http.Reques
 	}
 	values, err := parameter.Compute(ctx, api.Database, parameter.ComputeScope{
 		TemplateImportJobID: job.ID,
-		OrganizationID:      job.OrganizationID,
-		UserID:              apiKey.UserID,
 	}, &parameter.ComputeOptions{
 		// We *never* want to send the client secret parameter values.
 		HideRedisplayValues: true,


### PR DESCRIPTION
These just weren't used!