### PR TITLE
chore: ignore traces from `(*API).workspaceAgentCoordinate` after accept

### DIFF
--- a/coderd/tracing/util.go
+++ b/coderd/tracing/util.go
@@ -1,9 +1,19 @@
 package tracing
 
 import (
+	"context"
 	"runtime"
 	"strings"
+
+	"go.opentelemetry.io/otel/trace"
 )
+
+var NoopSpan trace.Span
+
+func init() {
+	tracer := trace.NewNoopTracerProvider().Tracer("")
+	_, NoopSpan = tracer.Start(context.Background(), "")
+}
 
 const TracerName = "coderd"
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -351,8 +351,11 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// end span so we don't get long lived trace data
+	// End span so we don't get long lived trace data.
 	tracing.EndHTTPSpan(r, http.StatusOK, trace.SpanFromContext(ctx))
+	// Ignore all trace spans after this.
+	ctx = trace.ContextWithSpan(ctx, tracing.NoopSpan)
+
 	api.Logger.Info(ctx, "accepting agent", slog.F("resource", resource), slog.F("agent", workspaceAgent))
 
 	defer conn.Close(websocket.StatusNormalClosure, "")


### PR DESCRIPTION
The db calls are super spammy

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
