### PR TITLE
fix: Make entire row clickable in responsive navbar

### DIFF
--- a/site/src/components/NavbarView/NavbarView.tsx
+++ b/site/src/components/NavbarView/NavbarView.tsx
@@ -178,6 +178,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     color: colors.gray[6],
     display: "flex",
+    flex: 1,
     fontSize: 16,
     padding: `${theme.spacing(1.5)}px ${theme.spacing(2)}px`,
     textDecoration: "none",


### PR DESCRIPTION
Fixes #3235.
