### PR TITLE
fix: use correct interval for healthcheck loop

### DIFF
--- a/agent/apphealth.go
+++ b/agent/apphealth.go
@@ -109,7 +109,7 @@ func NewWorkspaceAppHealthReporter(logger slog.Logger, workspaceAgentApps Worksp
 						mu.Unlock()
 					}
 
-					t.Reset(time.Duration(app.Healthcheck.Interval))
+					t.Reset(time.Duration(app.Healthcheck.Interval) * time.Second)
 				}
 			}()
 		}


### PR DESCRIPTION
@bpmct noticed that his http server was being spammed by healthcheck and this issue was this bug where I missed multiplying the interval by `time.Second`. 