### PR TITLE
fix: update workspace button should properly update the workspace

### DIFF
--- a/site/src/components/DropdownButton/ActionCtas.tsx
+++ b/site/src/components/DropdownButton/ActionCtas.tsx
@@ -17,6 +17,7 @@ export const Language = {
   delete: "Delete",
   cancel: "Cancel",
   update: "Update",
+  updating: "Updating",
   // these labels are used in WorkspaceActions.tsx
   starting: "Starting...",
   stopping: "Stopping...",

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -39,6 +39,7 @@ export interface WorkspaceProps {
   handleDelete: () => void
   handleUpdate: () => void
   handleCancel: () => void
+  isUpdating: boolean
   workspace: TypesGen.Workspace
   resources?: TypesGen.WorkspaceResource[]
   builds?: TypesGen.WorkspaceBuild[]
@@ -61,6 +62,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
   handleUpdate,
   handleCancel,
   workspace,
+  isUpdating,
   resources,
   builds,
   canUpdateWorkspace,
@@ -104,6 +106,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
               handleDelete={handleDelete}
               handleUpdate={handleUpdate}
               handleCancel={handleCancel}
+              isUpdating={isUpdating}
             />
           </Stack>
         }

--- a/site/src/components/WorkspaceActions/WorkspaceActions.stories.tsx
+++ b/site/src/components/WorkspaceActions/WorkspaceActions.stories.tsx
@@ -16,6 +16,7 @@ const defaultArgs = {
   handleDelete: action("delete"),
   handleUpdate: action("update"),
   handleCancel: action("cancel"),
+  isUpdating: false,
 }
 
 export const Starting = Template.bind({})
@@ -76,4 +77,11 @@ export const Errored = Template.bind({})
 Errored.args = {
   ...defaultArgs,
   workspace: Mocks.MockFailedWorkspace,
+}
+
+export const Updating = Template.bind({})
+Updating.args = {
+  ...defaultArgs,
+  isUpdating: true,
+  workspace: Mocks.MockOutdatedWorkspace,
 }

--- a/site/src/components/WorkspaceActions/WorkspaceActions.test.tsx
+++ b/site/src/components/WorkspaceActions/WorkspaceActions.test.tsx
@@ -14,6 +14,7 @@ const renderComponent = async (props: Partial<WorkspaceActionsProps> = {}) => {
       handleDelete={jest.fn()}
       handleUpdate={jest.fn()}
       handleCancel={jest.fn()}
+      isUpdating={false}
     />,
   )
 }
@@ -27,6 +28,7 @@ const renderAndClick = async (props: Partial<WorkspaceActionsProps> = {}) => {
       handleDelete={jest.fn()}
       handleUpdate={jest.fn()}
       handleCancel={jest.fn()}
+      isUpdating={false}
     />,
   )
   const trigger = await screen.findByTestId("workspace-actions-button")

--- a/site/src/components/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/components/WorkspaceActions/WorkspaceActions.tsx
@@ -27,6 +27,7 @@ export interface WorkspaceActionsProps {
   handleDelete: () => void
   handleUpdate: () => void
   handleCancel: () => void
+  isUpdating: boolean
   children?: ReactNode
 }
 
@@ -37,6 +38,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   handleDelete,
   handleUpdate,
   handleCancel,
+  isUpdating,
 }) => {
   const workspaceStatus: keyof typeof WorkspaceStateEnum = getWorkspaceStatus(
     workspace.latest_build,
@@ -63,6 +65,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   // A mapping of button type to the corresponding React component
   const buttonMapping: ButtonMapping = {
     [ButtonTypesEnum.update]: <UpdateButton handleAction={handleUpdate} />,
+    [ButtonTypesEnum.updating]: <ActionLoadingButton label={Language.updating} />,
     [ButtonTypesEnum.start]: <StartButton handleAction={handleStart} />,
     [ButtonTypesEnum.starting]: <ActionLoadingButton label={Language.starting} />,
     [ButtonTypesEnum.stop]: <StopButton handleAction={handleStop} />,
@@ -77,7 +80,9 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
 
   return (
     <DropdownButton
-      primaryAction={buttonMapping[actions.primary]}
+      primaryAction={
+        isUpdating ? buttonMapping[ButtonTypesEnum.updating] : buttonMapping[actions.primary]
+      }
       canCancel={actions.canCancel}
       handleCancel={handleCancel}
       secondaryActions={actions.secondary.map((action) => ({

--- a/site/src/components/WorkspaceActions/constants.ts
+++ b/site/src/components/WorkspaceActions/constants.ts
@@ -10,6 +10,7 @@ export enum ButtonTypesEnum {
   delete = "delete",
   deleting = "deleting",
   update = "update",
+  updating = "updating",
   // disabled buttons
   canceling = "canceling",
   disabled = "disabled",

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -113,6 +113,7 @@ export const WorkspacePage: FC = () => {
               return canExtendDeadline(deadline, workspace, template)
             },
           }}
+          isUpdating={workspaceState.hasTag("updating")}
           workspace={workspace}
           handleStart={() => workspaceSend("START")}
           handleStop={() => workspaceSend("STOP")}

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -257,7 +257,7 @@ export const workspaceMachine = createMachine(
                   START: "requestingStart",
                   STOP: "requestingStop",
                   ASK_DELETE: "askingDelete",
-                  UPDATE: "requestingStartWithLatestTemplate",
+                  UPDATE: "refreshTemplate",
                   CANCEL: "requestingCancel",
                 },
               },
@@ -268,6 +268,20 @@ export const workspaceMachine = createMachine(
                   },
                   CANCEL_DELETE: {
                     target: "idle",
+                  },
+                },
+              },
+              refreshTemplate: {
+                invoke: {
+                  id: "refreshTemplate",
+                  src: "getTemplate",
+                  onDone: {
+                    target: "requestingStartWithLatestTemplate",
+                    actions: ["assignTemplate"],
+                  },
+                  onError: {
+                    target: "idle",
+                    actions: ["assignGetTemplateWarning"],
                   },
                 },
               },

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -257,7 +257,7 @@ export const workspaceMachine = createMachine(
                   START: "requestingStart",
                   STOP: "requestingStop",
                   ASK_DELETE: "askingDelete",
-                  UPDATE: "refreshTemplate",
+                  UPDATE: "updatingWorkspace",
                   CANCEL: "requestingCancel",
                 },
               },
@@ -271,32 +271,37 @@ export const workspaceMachine = createMachine(
                   },
                 },
               },
-              refreshTemplate: {
-                invoke: {
-                  id: "refreshTemplate",
-                  src: "getTemplate",
-                  onDone: {
-                    target: "requestingStartWithLatestTemplate",
-                    actions: ["assignTemplate"],
+              updatingWorkspace: {
+                tags: "updating",
+                initial: "refreshingTemplate",
+                states: {
+                  refreshingTemplate: {
+                    invoke: {
+                      id: "refreshTemplate",
+                      src: "getTemplate",
+                      onDone: {
+                        target: "startingWithLatestTemplate",
+                        actions: ["assignTemplate"],
+                      },
+                      onError: {
+                        target: "#workspaceState.ready.build.idle",
+                        actions: ["assignGetTemplateWarning"],
+                      },
+                    },
                   },
-                  onError: {
-                    target: "idle",
-                    actions: ["assignGetTemplateWarning"],
-                  },
-                },
-              },
-              requestingStartWithLatestTemplate: {
-                entry: "clearBuildError",
-                invoke: {
-                  id: "startWorkspaceWithLatestTemplate",
-                  src: "startWorkspaceWithLatestTemplate",
-                  onDone: {
-                    target: "idle",
-                    actions: ["assignBuild"],
-                  },
-                  onError: {
-                    target: "idle",
-                    actions: ["assignBuildError"],
+                  startingWithLatestTemplate: {
+                    invoke: {
+                      id: "startWorkspaceWithLatestTemplate",
+                      src: "startWorkspaceWithLatestTemplate",
+                      onDone: {
+                        target: "#workspaceState.ready.build.idle",
+                        actions: ["assignBuild"],
+                      },
+                      onError: {
+                        target: "#workspaceState.ready.build.idle",
+                        actions: ["assignBuildError"],
+                      },
+                    },
                   },
                 },
               },


### PR DESCRIPTION
Resolves #4098

We didn't have the latest template on our machine context so we weren't sending down the correct `template.active_version_id` when posting a new build.