### PR TITLE
fix: call testing lib cleanup afterEach test

### DIFF
--- a/site/jest.setup.ts
+++ b/site/jest.setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom"
+import { cleanup } from "@testing-library/react"
 import crypto from "crypto"
 import * as util from "util"
 import { server } from "./src/testHelpers/server"
@@ -22,6 +23,7 @@ beforeAll(() =>
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.
 afterEach(() => {
+  cleanup()
   server.resetHandlers()
   jest.clearAllMocks()
 })


### PR DESCRIPTION
I was reading the docs for using the `render` function and noticed this:

> Render into a container which is appended to document.body. It should be used with cleanup.

Since we're using a custom `render` I think it's expected we call `cleanup` after each test. After adding it, I noticed a significant number of `act` warnings disappear. It doesn't reduce all of them, but it's progress.

The remaining ones are mostly warnings related to `submitForm` and then an `act` warning in `TemplatePage.test.tsx`.

Related to #3626 