### PR TITLE
docs: Update Docker docs and docker-compose, mention `group-add`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,12 @@ services:
       # Alternatively, you can enable CODER_TUNNEL for
       # proof-of-concept deployments.
       CODER_TUNNEL: "${CODER_TUNNEL:-false}"
+    # If the coder user does not have write permissions on
+    # the docker socket, you can uncomment the following
+    # lines and set the group ID to one that has write
+    # permissions on the docker socket.
+    #group_add:
+    #  - "998" # docker group on host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -11,13 +11,20 @@ the following command:
 
 ```sh
 export CODER_DATA=$HOME/.config/coderv2-docker
+export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
 mkdir -p $CODER_DATA
 docker run --rm -it \
   -e CODER_TUNNEL=true \
   -v $CODER_DATA:/home/coder/.config \
   -v /var/run/docker.sock:/var/run/docker.sock \
+  --group-add $DOCKER_GROUP \
   ghcr.io/coder/coder:latest
 ```
+
+**<sup>Note:</sup>** <sup>Coder runs as a non-root user, we use `--group-add` to
+ensure Coder has permissions to manage Docker via `docker.sock`. If the host
+systems `/var/run/docker.sock` is not group writeable or does not belong to the
+`docker` group, this method may not work.</sup>
 
 Coder configuration is defined via environment variables.
 Learn more about Coder's [configuration options](../admin/configure.md).
@@ -55,7 +62,7 @@ an PostgreSQL container and volume.
 3. Start Coder with `docker-compose up`:
 
    In order to use cloud-based templates (e.g. Kubernetes, AWS), you must have an external URL that users and workspaces will use to connect to Coder.
-   
+
    For proof-of-concept deployments, you can use [Coder's tunnel](../admin/configure.md#tunnel):
 
    ```sh
@@ -74,7 +81,7 @@ an PostgreSQL container and volume.
 
    > Without `CODER_ACCESS_URL` or `CODER_TUNNEL` set, Coder will bind to `localhost:7080`. This will only work for Docker-based templates.
 
-4. Visit the web ui via the configured url. You can add `/login` to the base url to create the first user via the ui. 
+4. Visit the web ui via the configured url. You can add `/login` to the base url to create the first user via the ui.
 
 5. Follow the on-screen instructions log in and create your first template and workspace
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -24,7 +24,7 @@ docker run --rm -it \
 **<sup>Note:</sup>** <sup>Coder runs as a non-root user, we use `--group-add` to
 ensure Coder has permissions to manage Docker via `docker.sock`. If the host
 systems `/var/run/docker.sock` is not group writeable or does not belong to the
-`docker` group, this method may not work.</sup>
+`docker` group, the above may not work as-is.</sup>
 
 Coder configuration is defined via environment variables.
 Learn more about Coder's [configuration options](../admin/configure.md).


### PR DESCRIPTION
This PR was prompted by a discussion on Discord.

It's most likely never the case that our Docker images `coder` user (`1000:1000`) will have write permissions on the Docker socket. For this reason we mention `--group-add` in the CLI commands and add a commented `group_add:` to our `docker-compose.yaml`.

Hopefully this will help users resolve permission errors on their docker sockets and avoid cases where they have to manually `chown` it.

An alternative/additional step we could take is to run our image as `root` with an entrypoint that 1) ensures socket permissions and 2) drops privileges via `gosu`/`su-exec`.
