### PR TITLE
chore: Use Vite as build tool

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "yarn typegen",
-    "build": "NODE_ENV=production webpack build --config=webpack.prod.ts",
+    "build": "NODE_ENV=production yarn vite build",
     "build:analyze": "NODE_ENV=production webpack --profile --progress --json --config=webpack.prod.ts > out/stats.json && webpack-bundle-analyzer out/stats.json out",
     "check:all": "yarn format:check && yarn lint && yarn test",
     "chromatic": "chromatic",

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
     outDir: path.resolve(__dirname, "./out"),
   },
   define: {
-    "process.env": process.env,
+    "process.env": {
+      NODE_ENV: process.env.NODE_ENV,
+    },
   },
   server: {
     port: process.env.PORT ? Number(process.env.PORT) : 8080,

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   publicDir: path.resolve(__dirname, "./static"),
   build: {
     outDir: path.resolve(__dirname, "./out"),
+    // We need to keep the /bin folder and GITKEEP files
+    emptyOutDir: false,
   },
   define: {
     "process.env": {


### PR DESCRIPTION
Running some build comparisons with Vite and Webpack for prod.

- Webpack - 20M -  `yarn build  13.41s user 1.14s system 220% cpu 6.598 total`
- Vite -  20M - `yarn vite build  32.33s user 1.84s system 158% cpu 21.545 total`

Vite, surprisingly, does not perform well as webpack on build BUT it is WAY easier to set up. No need for extra files or a lot of plugins.

For now, I'm keeping Webpack + related config to make it easier to roll back if we need it.