### PR TITLE
chore: Remove extra typegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,6 @@ build/coder_helm_$(VERSION).tgz:
 site/out/index.html: $(shell find ./site -not -path './site/node_modules/*' -type f -name '*.tsx') $(shell find ./site -not -path './site/node_modules/*' -type f -name '*.ts') site/package.json
 	./scripts/yarn_install.sh
 	cd site
-	yarn typegen
 	yarn build
 
 install: build/coder_$(VERSION)_$(GOOS)_$(GOARCH)$(GOOS_BIN_EXT)


### PR DESCRIPTION
`typegen` is already called in the `postinstall` script on package.json so it was being called twice.

```
bash: shfmt: command not found
bash: shfmt: command not found
+ yarn install --frozen-lockfile --silent --non-interactive
yarn run v1.[22](https://github.com/coder/coder/actions/runs/3145143806/jobs/5112557431#step:13:23).19
$ xstate typegen 'src/**/*.ts'
It is highly recommended to set `predictableActionArguments` to `true` when using `createMachine`. https://xstate.js.org/docs/guides/actions.html
src/xServices/audit/auditXService.ts - success
src/xServices/auth/authXService.ts - success
src/xServices/buildInfo/buildInfoXService.ts - success
src/xServices/createWorkspace/createWorkspaceXService.ts - success
src/xServices/entitlements/entitlementsXService.ts - success
src/xServices/roles/siteRolesXService.ts - success
src/xServices/setup/setupXService.ts - success
src/xServices/template/templateXService.ts - success
src/xServices/templateSettings/templateSettingsXService.ts - success
src/xServices/templates/templatesXService.ts - success
src/xServices/terminal/terminalXService.ts - success
src/xServices/users/createUserXService.ts - success
src/xServices/users/searchUserXService.ts - success
src/xServices/users/usersXService.ts - success
src/xServices/workspace/workspaceXService.ts - success
src/xServices/workspaceBuild/workspaceBuildXService.ts - success
src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts - success
src/xServices/workspaceSchedule/workspaceScheduleXService.ts - success
src/xServices/workspaces/workspacesXService.ts - success
Done in 39.57s.
yarn run v1.22.19
$ xstate typegen 'src/**/*.ts'
It is highly recommended to set `predictableActionArguments` to `true` when using `createMachine`. https://xstate.js.org/docs/guides/actions.html
src/xServices/audit/auditXService.ts - success
src/xServices/auth/authXService.ts - success
src/xServices/buildInfo/buildInfoXService.ts - success
src/xServices/createWorkspace/createWorkspaceXService.ts - success
src/xServices/entitlements/entitlementsXService.ts - success
src/xServices/roles/siteRolesXService.ts - success
src/xServices/setup/setupXService.ts - success
src/xServices/template/templateXService.ts - success
src/xServices/templateSettings/templateSettingsXService.ts - success
src/xServices/templates/templatesXService.ts - success
src/xServices/terminal/terminalXService.ts - success
src/xServices/users/createUserXService.ts - success
src/xServices/users/searchUserXService.ts - success
src/xServices/users/usersXService.ts - success
src/xServices/workspace/workspaceXService.ts - success
src/xServices/workspaceBuild/workspaceBuildXService.ts - success
src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts - success
src/xServices/workspaceSchedule/workspaceScheduleXService.ts - success
src/xServices/workspaces/workspacesXService.ts - success
Done in [28](https://github.com/coder/coder/actions/runs/3145143806/jobs/5112557431#step:13:29).[64](https://github.com/coder/coder/actions/runs/3145143806/jobs/5112557431#step:13:65)s.
yarn run v1.22.19
```