### PR TITLE
fix(audit): properly set old workspace in putWorkspaceTTL

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -636,6 +636,7 @@ func (api *API) putWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 		})
 	)
 	defer commitAudit()
+	aReq.Old = workspace
 
 	if !api.Authorize(r, rbac.ActionUpdate, workspace) {
 		httpapi.ResourceNotFound(rw)


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
