### PR TITLE
remove filter in templateACL endpoint

### DIFF
--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -31,15 +31,6 @@ func (api *API) templateACL(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	users, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, rbac.ActionRead, users)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching users.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
 	dbGroups, err := api.Database.GetTemplateGroupRoles(ctx, template.ID)
 	if err != nil {
 		httpapi.InternalServerError(rw, err)


### PR DESCRIPTION
the double filter adds considerable latency to the request. The fetch queries are taking ~1ms, the rego filtering is coming out to roughly ~20ms and this is with <5 resources.

cc @Emyrk 

We can leave em in if you think they're necessary but I don't think this leaks anything sensitive.