### PR TITLE
chore: Minor rego optimization by removing excessive queries

### DIFF
--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -241,21 +241,21 @@ func TestAuthorizeDomain(t *testing.T) {
 
 	testAuthorize(t, "GroupACLList", user, []authTestCase{
 		{
-			resource: ResourceWorkspace.WithOwner(unuseID.String()).InOrg(unuseID).WithGroupACL(map[string][]Action{
+			resource: ResourceWorkspace.WithOwner(unuseID.String()).InOrg(defOrg).WithGroupACL(map[string][]Action{
 				allUsersGroup: allActions(),
 			}),
 			actions: allActions(),
 			allow:   true,
 		},
 		{
-			resource: ResourceWorkspace.WithOwner(unuseID.String()).InOrg(unuseID).WithGroupACL(map[string][]Action{
+			resource: ResourceWorkspace.WithOwner(unuseID.String()).InOrg(defOrg).WithGroupACL(map[string][]Action{
 				allUsersGroup: {WildcardSymbol},
 			}),
 			actions: allActions(),
 			allow:   true,
 		},
 		{
-			resource: ResourceWorkspace.WithOwner(unuseID.String()).InOrg(unuseID).WithGroupACL(map[string][]Action{
+			resource: ResourceWorkspace.WithOwner(unuseID.String()).InOrg(defOrg).WithGroupACL(map[string][]Action{
 				allUsersGroup: {ActionRead, ActionUpdate},
 			}),
 			actions: []Action{ActionCreate, ActionDelete},

--- a/coderd/rbac/builtin_test.go
+++ b/coderd/rbac/builtin_test.go
@@ -97,11 +97,17 @@ func BenchmarkRBACFilter(b *testing.B) {
 
 func benchmarkSetup(orgs []uuid.UUID, users []uuid.UUID, size int) []rbac.Object {
 	// Create a "random" but deterministic set of objects.
+	aclList := map[string][]rbac.Action{
+		uuid.NewString(): {rbac.ActionRead, rbac.ActionUpdate},
+		uuid.NewString(): {rbac.ActionCreate},
+	}
 	objectList := make([]rbac.Object, size)
 	for i := range objectList {
 		objectList[i] = rbac.ResourceWorkspace.
 			InOrg(orgs[i%len(orgs)]).
-			WithOwner(users[i%len(users)].String())
+			WithOwner(users[i%len(users)].String()).
+			WithACLUserList(aclList).
+			WithGroupACL(aclList)
 	}
 
 	return objectList

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -119,9 +119,13 @@ org_mem := true {
 	input.object.org_owner in org_members
 }
 
+org_ok {
+	org_mem
+}
+
 # If the object has no organization, then the user is also considered part of
 # the non-existent org.
-org_mem := true {
+org_ok {
 	input.object.org_owner == ""
 }
 
@@ -170,7 +174,7 @@ role_allow {
 	not org = -1
 	# If we are not a member of an org, and the object has an org, then we are
 	# not authorized. This is an "implied -1" for not being in the org.
-	org_mem
+	org_ok
 	user = 1
 }
 
@@ -188,7 +192,7 @@ scope_allow {
 	not scope_org = -1
 	# If we are not a member of an org, and the object has an org, then we are
 	# not authorized. This is an "implied -1" for not being in the org.
-	org_mem
+	org_ok
 	scope_user = 1
 }
 
@@ -204,13 +208,7 @@ acl_allow {
 acl_allow {
 	# If there is no organization owner, the object cannot be owned by an
 	# org_scoped team.
-	# TODO: This line and 'org_mem' are similar and should be combined.
-	# 	Currently the simplfied queries return extra queries that are always
-	# 	false. If these 2 lines are combined, we reduce the number of queries
-	# 	returned by partial execution.
-#	input.object.org_owner != ""
-	# Only people in the org can use the team access.
-#	org_mem
+	org_mem
 	group := input.subject.groups[_]
 	perms := input.object.acl_group_list[group]
 	# Either the input action or wildcard
@@ -220,7 +218,6 @@ acl_allow {
 # ACL for 'all_users' special group
 acl_allow {
 	org_mem
-	input.object.org_owner != ""
 	perms := input.object.acl_group_list[input.object.org_owner]
 	[input.action, "*"][_] in perms
 }

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -228,7 +228,6 @@ func TestTemplateACL(t *testing.T) {
 			Role:  codersdk.TemplateRoleView,
 		})
 	})
-
 }
 
 func TestUpdateTemplateACL(t *testing.T) {


### PR DESCRIPTION
# What this does

Removes this "always false" query in the list. Also enforces you must also be an org member for group acl to work.

```
input.object.org_owner = ""
input.object.org_owner != ""
```

# Before

```
cpu: Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
BenchmarkRBACFilter/NoRoles-8              11394            108734 ns/op           27871 B/op        565 allocs/op
BenchmarkRBACFilter/Admin-8              3897625               898.6 ns/op           385 B/op          0 allocs/op
BenchmarkRBACFilter/OrgAdmin-8             12157             90951 ns/op           28912 B/op        586 allocs/op
BenchmarkRBACFilter/OrgMember-8            10772            106122 ns/op           31898 B/op        641 allocs/op
BenchmarkRBACFilter/ManyRoles-8            26516             40330 ns/op           13193 B/op        292 allocs/op
BenchmarkRBACFilter/AdminWithScope-8      749647              1510 ns/op             139 B/op          3 allocs/op
```

```
+---------+--------------------------------------------------------------------+
| Query 1 | input.object.org_owner != ""                                       |
|         | input.object.org_owner in {"19a3d781-9e53-4608-948e-ac084470cd99"} |
|         | input.object.owner != ""                                           |
|         | "me" = input.object.owner                                          |
+---------+--------------------------------------------------------------------+
| Query 2 | input.object.org_owner = ""                                        |
|         | input.object.owner != ""                                           |
|         | "me" = input.object.owner                                          |
+---------+--------------------------------------------------------------------+
| Query 3 | input.object.org_owner != ""                                       |
|         | input.object.org_owner in {"19a3d781-9e53-4608-948e-ac084470cd99"} |
|         | input.object.org_owner != ""                                       |
|         | "read" in input.object.acl_group_list[input.object.org_owner]      |
+---------+--------------------------------------------------------------------+
| Query 4 | input.object.org_owner != ""                                       |
|         | input.object.org_owner in {"19a3d781-9e53-4608-948e-ac084470cd99"} |
|         | input.object.org_owner != ""                                       |
|         | "*" in input.object.acl_group_list[input.object.org_owner]         |
+---------+--------------------------------------------------------------------+
| Query 5 | input.object.org_owner = ""                                        |
|         | input.object.org_owner != ""                                       |
|         | "read" in input.object.acl_group_list[input.object.org_owner]      |
+---------+--------------------------------------------------------------------+
| Query 6 | input.object.org_owner = ""                                        |
|         | input.object.org_owner != ""                                       |
|         | "*" in input.object.acl_group_list[input.object.org_owner]         |
+---------+--------------------------------------------------------------------+
| Query 7 | "read" in input.object.acl_user_list.me                            |
+---------+--------------------------------------------------------------------+
| Query 8 | "*" in input.object.acl_user_list.me                               |
+---------+--------------------------------------------------------------------+
```

# After

```
cpu: Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
BenchmarkRBACFilter/NoRoles-8              16071            101915 ns/op           21373 B/op        442 allocs/op
BenchmarkRBACFilter/Admin-8              3791935               749.4 ns/op           396 B/op          0 allocs/op
BenchmarkRBACFilter/OrgAdmin-8             14983             81771 ns/op           24588 B/op        503 allocs/op
BenchmarkRBACFilter/OrgMember-8            12266             90102 ns/op           26505 B/op        539 allocs/op
BenchmarkRBACFilter/ManyRoles-8            27688             38889 ns/op           13237 B/op        291 allocs/op
BenchmarkRBACFilter/AdminWithScope-8      761229              1480 ns/op             139 B/op          3 allocs/op
```

```
+---------+--------------------------------------------------------------------+
| Query 1 | input.object.org_owner != ""                                       |
|         | input.object.org_owner in {"19a3d781-9e53-4608-948e-ac084470cd99"} |
|         | input.object.owner != ""                                           |
|         | "me" = input.object.owner                                          |
+---------+--------------------------------------------------------------------+
| Query 2 | input.object.org_owner = ""                                        |
|         | input.object.owner != ""                                           |
|         | "me" = input.object.owner                                          |
+---------+--------------------------------------------------------------------+
| Query 3 | input.object.org_owner != ""                                       |
|         | input.object.org_owner in {"19a3d781-9e53-4608-948e-ac084470cd99"} |
|         | "read" in input.object.acl_group_list[input.object.org_owner]      |
+---------+--------------------------------------------------------------------+
| Query 4 | input.object.org_owner != ""                                       |
|         | input.object.org_owner in {"19a3d781-9e53-4608-948e-ac084470cd99"} |
|         | "*" in input.object.acl_group_list[input.object.org_owner]         |
+---------+--------------------------------------------------------------------+
| Query 5 | "read" in input.object.acl_user_list.me                            |
+---------+--------------------------------------------------------------------+
| Query 6 | "*" in input.object.acl_user_list.me                               |
+---------+--------------------------------------------------------------------+
```