### PR TITLE
chore: derive workspace status on backend

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -996,7 +996,42 @@ func convertWorkspace(
 		AutostartSchedule: autostartSchedule,
 		TTLMillis:         ttlMillis,
 		LastUsedAt:        workspace.LastUsedAt,
+		Status:            convertStatus(workspaceBuild),
 	}
+}
+
+func convertStatus(build codersdk.WorkspaceBuild) codersdk.WorkspaceStatus {
+	switch build.Job.Status {
+	case codersdk.ProvisionerJobPending:
+		return codersdk.WorkspaceStatusPending
+	case codersdk.ProvisionerJobRunning:
+		switch build.Transition {
+		case codersdk.WorkspaceTransitionStart:
+			return codersdk.WorkspaceStatusStarting
+		case codersdk.WorkspaceTransitionStop:
+			return codersdk.WorkspaceStatusStopping
+		case codersdk.WorkspaceTransitionDelete:
+			return codersdk.WorkspaceStatusDeleting
+		}
+	case codersdk.ProvisionerJobSucceeded:
+		switch build.Transition {
+		case codersdk.WorkspaceTransitionStart:
+			return codersdk.WorkspaceStatusRunning
+		case codersdk.WorkspaceTransitionStop:
+			return codersdk.WorkspaceStatusStopped
+		case codersdk.WorkspaceTransitionDelete:
+			return codersdk.WorkspaceStatusDeleted
+		}
+	case codersdk.ProvisionerJobCanceling:
+		return codersdk.WorkspaceStatusCanceling
+	case codersdk.ProvisionerJobCanceled:
+		return codersdk.WorkspaceStatusCanceled
+	case codersdk.ProvisionerJobFailed:
+		return codersdk.WorkspaceStatusFailed
+	}
+
+	// return error status since we should never get here
+	return codersdk.WorkspaceStatusFailed
 }
 
 func convertWorkspaceTTLMillis(i sql.NullInt64) *int64 {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -15,21 +15,37 @@ import (
 // Workspace is a deployment of a template. It references a specific
 // version and can be updated.
 type Workspace struct {
-	ID                uuid.UUID      `json:"id"`
-	CreatedAt         time.Time      `json:"created_at"`
-	UpdatedAt         time.Time      `json:"updated_at"`
-	OwnerID           uuid.UUID      `json:"owner_id"`
-	OwnerName         string         `json:"owner_name"`
-	TemplateID        uuid.UUID      `json:"template_id"`
-	TemplateName      string         `json:"template_name"`
-	TemplateIcon      string         `json:"template_icon"`
-	LatestBuild       WorkspaceBuild `json:"latest_build"`
-	Outdated          bool           `json:"outdated"`
-	Name              string         `json:"name"`
-	AutostartSchedule *string        `json:"autostart_schedule,omitempty"`
-	TTLMillis         *int64         `json:"ttl_ms,omitempty"`
-	LastUsedAt        time.Time      `json:"last_used_at"`
+	ID                uuid.UUID       `json:"id"`
+	CreatedAt         time.Time       `json:"created_at"`
+	UpdatedAt         time.Time       `json:"updated_at"`
+	OwnerID           uuid.UUID       `json:"owner_id"`
+	OwnerName         string          `json:"owner_name"`
+	TemplateID        uuid.UUID       `json:"template_id"`
+	TemplateName      string          `json:"template_name"`
+	TemplateIcon      string          `json:"template_icon"`
+	LatestBuild       WorkspaceBuild  `json:"latest_build"`
+	Outdated          bool            `json:"outdated"`
+	Name              string          `json:"name"`
+	AutostartSchedule *string         `json:"autostart_schedule,omitempty"`
+	TTLMillis         *int64          `json:"ttl_ms,omitempty"`
+	LastUsedAt        time.Time       `json:"last_used_at"`
+	Status            WorkspaceStatus `json:"status"`
 }
+
+type WorkspaceStatus string
+
+const (
+	WorkspaceStatusPending   WorkspaceStatus = "pending"
+	WorkspaceStatusStarting  WorkspaceStatus = "starting"
+	WorkspaceStatusRunning   WorkspaceStatus = "running"
+	WorkspaceStatusStopping  WorkspaceStatus = "stopping"
+	WorkspaceStatusStopped   WorkspaceStatus = "stopped"
+	WorkspaceStatusFailed    WorkspaceStatus = "failed"
+	WorkspaceStatusCanceling WorkspaceStatus = "canceling"
+	WorkspaceStatusCanceled  WorkspaceStatus = "canceled"
+	WorkspaceStatusDeleting  WorkspaceStatus = "deleting"
+	WorkspaceStatusDeleted   WorkspaceStatus = "deleted"
+)
 
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.
 type CreateWorkspaceBuildRequest struct {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -550,6 +550,7 @@ export interface Workspace {
   readonly autostart_schedule?: string
   readonly ttl_ms?: number
   readonly last_used_at: string
+  readonly status: WorkspaceStatus
 }
 
 // From codersdk/workspaceresources.go
@@ -734,6 +735,19 @@ export type WorkspaceAgentStatus = "connected" | "connecting" | "disconnected"
 
 // From codersdk/workspaceapps.go
 export type WorkspaceAppHealth = "disabled" | "healthy" | "initializing" | "unhealthy"
+
+// From codersdk/workspaces.go
+export type WorkspaceStatus =
+  | "canceled"
+  | "canceling"
+  | "deleted"
+  | "deleting"
+  | "failed"
+  | "pending"
+  | "running"
+  | "starting"
+  | "stopped"
+  | "stopping"
 
 // From codersdk/workspacebuilds.go
 export type WorkspaceTransition = "delete" | "start" | "stop"

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -268,6 +268,7 @@ export const MockWorkspace: TypesGen.Workspace = {
   ttl_ms: 2 * 60 * 60 * 1000, // 2 hours as milliseconds
   latest_build: MockWorkspaceBuild,
   last_used_at: "",
+  status: "running",
 }
 
 export const MockStoppedWorkspace: TypesGen.Workspace = {


### PR DESCRIPTION
I wanted to just knock this out while I had the time so I went ahead but would like to explain my work here for learning purposes. Going through each commit should tell the story of my process. 

1. [a71547e](https://github.com/coder/coder/pull/4284/commits/a71547e4e60a516ebb23719f0d3ab1eb1401de7b) - I added the new types to the `codersdk` package, added the `status` field to the `workspace` type, and ran `make gen` to generate the ts client as well. 
2. [de9623d](https://github.com/coder/coder/pull/4284/commits/de9623d76e2406c5e82c901bc481b67b74d5fdd9) - I knew we had a `convertWorkspace` function that took a few different DB objects and made a `codersdk.Workspace` for api responses. I also knew that the status was completely derived from the workspace build, which is already passed into this conversion function. I added the logic there and some tests for it that at least cover the states at rest. 

Note I changed the state `started` to `running` in this case since it matched what we display and made more sense to me. I also did the same with changing `error` to `failed`. These changes made more sense to me as a consumer. 

I'm going to leave the frontend changes for another PR to keep this simple and easy to read. 