### PR TITLE
refactor: clean up types in jest.setup.ts

### DIFF
--- a/site/jest.setup.ts
+++ b/site/jest.setup.ts
@@ -38,16 +38,12 @@ afterAll(() => server.close())
 // For now, I limited this to just 'error' - but failing on warnings
 // would be a nice next step! We may need to filter out some noise
 // from material-ui though.
-const CONSOLE_FAIL_TYPES = ["error" /* 'warn' */]
+const CONSOLE_FAIL_TYPES = ["error" /* 'warn' */] as const
 
 // Throw errors when a `console.error` or `console.warn` happens
 // by overriding the functions
-CONSOLE_FAIL_TYPES.forEach((logType: string) => {
-  // Suppressing the no-explicit-any to override certain console functions for testing
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const consoleAsAny = global.console as any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  consoleAsAny[logType] = (format: string, ...args: any[]): void => {
+CONSOLE_FAIL_TYPES.forEach((logType: typeof CONSOLE_FAIL_TYPES[number]) => {
+  global.console[logType] = <Type>(format: string, ...args: Type[]): void => {
     throw new Error(
       `Failing due to console.${logType} while running test!\n\n${util.format(format, ...args)}`,
     )


### PR DESCRIPTION
This PR cleans up some of the types in `jest.setup.ts`.