### PR TITLE
Revert "refactor(ci): conditionally run jobs based on file changes (#4242)"

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -64,12 +64,10 @@ jobs:
               - '**'
             docs:
               - 'docs/**'
+              # For testing:
+              # - '.github/**'
             sh:
               - "**.sh"
-            go:
-              - "**.go"
-            tf:
-              - "**.tf"
             ts:
               - 'site/**'
             k8s:
@@ -94,8 +92,6 @@ jobs:
     name: style/lint/golangci
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.go == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -119,8 +115,6 @@ jobs:
     name: style/lint/shellcheck
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.sh == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
@@ -134,8 +128,6 @@ jobs:
     name: "style/lint/typescript"
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.ts == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -255,8 +247,6 @@ jobs:
     name: "style/fmt"
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: changes
-    if: needs.changes.outputs.sh == 'true' || needs.changes.outputs.ts == 'true' || needs.changes.outputs.tf == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -290,7 +280,6 @@ jobs:
     name: "test/go"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    needs: changes
     strategy:
       matrix:
         os:
@@ -299,36 +288,30 @@ jobs:
           - windows-2022
     steps:
       - uses: actions/checkout@v3
-        if: needs.changes.outputs.go == 'true'
 
       - uses: actions/setup-go@v3
-        if: needs.changes.outputs.go == 'true'
         with:
           go-version: "~1.19"
 
       - name: Echo Go Cache Paths
-        if: needs.changes.outputs.go == 'true'
         id: go-cache-paths
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
 
       - name: Go Build Cache
-        if: needs.changes.outputs.go == 'true'
         uses: actions/cache@v3
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.**', '**.go') }}
 
       - name: Go Mod Cache
-        if: needs.changes.outputs.go == 'true'
         uses: actions/cache@v3
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Install gotestsum
-        if: needs.changes.outputs.go == 'true'
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -337,13 +320,11 @@ jobs:
           tag: v1.7.0
 
       - uses: hashicorp/setup-terraform@v2
-        if: needs.changes.outputs.go == 'true'
         with:
           terraform_version: 1.1.9
           terraform_wrapper: false
 
       - name: Test with Mock Database
-        if: needs.changes.outputs.go == 'true'
         id: test
         shell: bash
         run: |
@@ -369,7 +350,7 @@ jobs:
         # that is no guarantee, see:
         # https://github.com/codecov/codecov-action/issues/788
         continue-on-error: true
-        if: steps.test.outputs.cover && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork && needs.changes.outputs.go == 'true'
+        if: steps.test.outputs.cover && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./gotests.coverage
@@ -383,8 +364,6 @@ jobs:
     # goroutines. Setting this to the timeout +5m should work quite well
     # even if some of the preceding steps are slow.
     timeout-minutes: 25
-    needs: changes
-    if: needs.changes.outputs.go == 'true'
     steps:
       - uses: actions/checkout@v3
 
@@ -539,8 +518,6 @@ jobs:
     name: "test/js"
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: changes
-    if: needs.changes.outputs.ts == 'true'
     steps:
       - uses: actions/checkout@v3
 
@@ -579,8 +556,9 @@ jobs:
 
   test-e2e:
     name: "test/e2e/${{ matrix.os }}"
-    needs: changes
-    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ts == 'true' || needs.changes.outputs.tf == 'true'
+    needs:
+      - changes
+    if: needs.changes.outputs.docs-only == 'false'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
This reverts commit f9b758896390667b9c9f418067b08672cf392013.

Tests and golangci-lint were being skipped for some reason, reverting to see if that fixes it.
