### PR TITLE
chore: Deprecate old cookie value

### DIFF
--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -380,14 +380,6 @@ func apiTokenFromRequest(r *http.Request) string {
 		return cookie.Value
 	}
 
-	// TODO: @emyrk in October 2022, remove this oldCookie check.
-	//	This is just to support the old cli for 1 release. Then everyone
-	//	must update.
-	oldCookie, err := r.Cookie("session_token")
-	if err == nil && oldCookie.Value != "" {
-		return oldCookie.Value
-	}
-
 	urlValue := r.URL.Query().Get(codersdk.SessionTokenKey)
 	if urlValue != "" {
 		return urlValue

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -83,13 +83,6 @@ func (c *Client) Request(ctx context.Context, method, path string, body interfac
 	}
 	req.Header.Set(SessionCustomHeader, c.SessionToken)
 
-	// Delete this custom cookie set in November 2022. This is just to remain
-	// backwards compatible with older versions of Coder.
-	req.AddCookie(&http.Cookie{
-		Name:  "session_token",
-		Value: c.SessionToken,
-	})
-
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}


### PR DESCRIPTION
Older clis will need to be updated.
Modern clis cannot communicate with <8.15 coderd

# Future work

Remove logout legacy cookies:

https://github.com/coder/coder/blob/0d1ab74e0d83134c76b2dc579344b4bc29c36f28/coderd/users.go#L1021-L1037


Enable CSRF:

https://github.com/coder/coder/blob/0d1ab74e0d83134c76b2dc579344b4bc29c36f28/coderd/httpmw/csrf.go#L35-L39

# Note

I began writing code to return nice errors `Coder cli version out of date to communicate with...`, but the error code was messy.

I think an easier way to do this is somehow write some generic code that says what version of `coderd` a cli can communicate with and vis-versa. 

It would be nice as a dev to say "Coder cli version 8.15+" is required for a coderd, so the cli can lookup the supported list. We can do this generically rather than a bunch of 1 off code in random spots accumulating debt.