### PR TITLE
fix: Output help on license subcommand

### DIFF
--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -24,6 +24,9 @@ func licenses() *cobra.Command {
 		Short:   "Add, delete, and list licenses",
 		Use:     "licenses",
 		Aliases: []string{"license"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		licenseAdd(),


### PR DESCRIPTION
Fixes #4314.
