### PR TITLE
add: deployment annotations

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -11,6 +11,7 @@ metadata:
   name: coder
   labels:
     {{- include "coder.labels" . | nindent 4 }}
+  annotations: {{ toYaml .Values.coder.annotations | nindent 4}}
 spec:
   # NOTE: this is currently not used as coder v2 does not support high
   #       availability yet.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,6 +18,10 @@ coder:
     # https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: IfNotPresent
 
+  # coder.annotations -- The Deployment annotations. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  annotations: {}
+
   # coder.serviceAccount -- Configuration for the automatically created service
   # account. Creation of the service account cannot be disabled.
   serviceAccount:


### PR DESCRIPTION
this PR adds support for annotating the Coder K8s Deployment resource via the Helm chart. closes #4340.
