### PR TITLE
chore(cla): implement coder.com/cla

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,26 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CDRCOMMUNITY_GITHUB_TOKEN }}
+        with:
+          remote-organization-name: 'coder'
+          remote-repository-name: 'cla'
+          path-to-signatures: 'v2022-09-04/signatures.json'
+          path-to-document: 'https://github.com/coder/cla/blob/main/README.md'
+          # branch should not be protected
+          branch: 'main'
+          allowlist: dependabot*


### PR DESCRIPTION
This pull-request implements a GitHub actions based workflow that blocks contributions to `coder/coder` unless the contributor has signed our [Contributor License Agreement (CLA)](https://www.coder.com/cla). The end-to-end workflow looks similar to below.

![](https://github.com/cla-assistant/github-action/raw/master/images/signature-process.gif?raw=true)

Signatures are versioned and stored at https://github.com/coder/cla. 

<img width="512" alt="CleanShot 2022-10-04 at 12 19 15@2x" src="https://user-images.githubusercontent.com/127353/193720491-78115cf1-9ae6-4961-b87e-ec596de1e8ee.png">

When (or if) [Contributor License Agreement (CLA)](https://www.coder.com/cla) is updated then `path-to-signatures: 'v2022-09-04/signatures.json'` in `.github/workflows/cla.yml` should also be updated to ensure that future contributions are blocked unless people re-read/agree to the CLA.