### PR TITLE
fix: Change use of 1337 to 13337 in example templates

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -44,7 +44,7 @@ resource "coder_app" "code-server" {
   icon     = "/icon/code.svg"
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/aws-ecs-container/main.tf
+++ b/examples/templates/aws-ecs-container/main.tf
@@ -112,7 +112,7 @@ resource "coder_app" "code-server" {
   subdomain = false
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -92,7 +92,7 @@ resource "coder_app" "code-server" {
   icon     = "/icon/code.svg"
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/bare/main.tf
+++ b/examples/templates/bare/main.tf
@@ -49,7 +49,7 @@ resource "coder_app" "fake-app" {
   url      = "http://localhost:8080"
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:8080/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -40,7 +40,7 @@ resource "coder_app" "code-server" {
   icon     = "/icon/code.svg"
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -67,7 +67,7 @@ resource "coder_app" "code-server" {
   subdomain = false
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -57,7 +57,7 @@ resource "coder_app" "code-server" {
   subdomain = false
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -78,7 +78,7 @@ resource "coder_app" "code-server" {
   subdomain = false
 
   healthcheck {
-    url       = "http://localhost:1337/healthz"
+    url       = "http://localhost:13337/healthz"
     interval  = 3
     threshold = 10
   }


### PR DESCRIPTION
This seemed like a bug, changed all occurances I could find.
