### PR TITLE
fix: fix builds on windows_arm64

### DIFF
--- a/agent/ports_supported.go
+++ b/agent/ports_supported.go
@@ -1,5 +1,4 @@
-//go:build linux || windows
-// +build linux windows
+//go:build linux || (windows && amd64)
 
 package agent
 

--- a/agent/ports_unsupported.go
+++ b/agent/ports_unsupported.go
@@ -1,13 +1,12 @@
-//go:build !linux && !windows
-// +build !linux,!windows
+//go:build !linux && !(windows && amd64)
 
 package agent
 
 import "github.com/coder/coder/codersdk"
 
 func (lp *listeningPortsHandler) getListeningPorts() ([]codersdk.ListeningPort, error) {
-	// Can't scan for ports on non-linux or non-windows systems at the moment.
-	// The UI will not show any "no ports found" message to the user, so the
-	// user won't suspect a thing.
+	// Can't scan for ports on non-linux or non-windows_amd64 systems at the
+	// moment. The UI will not show any "no ports found" message to the user, so
+	// the user won't suspect a thing.
 	return []codersdk.ListeningPort{}, nil
 }


### PR DESCRIPTION
go-netstat does not support windows_arm64, so add it to the build directive.

I had to remove the `+build` directive as it is not powerful enough to support this conditional, but it's fine because since 1.18 `go fix` has recommended removing it [source](https://stackoverflow.com/a/68361186).