### PR TITLE
fix: Don't run CI for releases

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
 
   pull_request:
 


### PR DESCRIPTION
This was unnecessary and causing weird issues like double deploys and runs.
