### PR TITLE
fix: fix apps being unavailable until rebuild

### DIFF
--- a/coderd/database/migrations/000056_app_subdomain_fix.down.sql
+++ b/coderd/database/migrations/000056_app_subdomain_fix.down.sql
@@ -1,0 +1,1 @@
+-- nothing

--- a/coderd/database/migrations/000056_app_subdomain_fix.up.sql
+++ b/coderd/database/migrations/000056_app_subdomain_fix.up.sql
@@ -1,0 +1,12 @@
+-- There was a mistake in the last migration which set "subdomain" to be the
+-- opposite of the deprecated value "relative_path", however the "relative_path"
+-- value may not have been correct as it was not consumed anywhere prior to this
+-- point.
+--
+-- Force all workspace apps to use path based routing until rebuild. This should
+-- not impact any existing workspaces as the only supported routing method has
+-- been path based routing prior to this point.
+--
+-- On rebuild the value from the Terraform template will be used instead
+-- (defaulting to false if unspecified).
+UPDATE "workspace_apps" SET "subdomain" = false;

--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -235,7 +235,6 @@ func ConvertResources(module *tfjson.StateModule, rawGraph string) ([]*proto.Res
 			}
 		}
 
-		subdomain := attrs.Subdomain
 		for _, agents := range resourceAgents {
 			for _, agent := range agents {
 				// Find agents with the matching ID and associate them!
@@ -247,7 +246,7 @@ func ConvertResources(module *tfjson.StateModule, rawGraph string) ([]*proto.Res
 					Command:     attrs.Command,
 					Url:         attrs.URL,
 					Icon:        attrs.Icon,
-					Subdomain:   subdomain,
+					Subdomain:   attrs.Subdomain,
 					Healthcheck: healthcheck,
 				})
 			}


### PR DESCRIPTION
Fixes apps that do not set `relative_path` to `true` explicitly being blocked from access until a workspace rebuild.