### PR TITLE
chore: Stop building images on tag pushes

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
     paths:
       - "dogfood/**"
   pull_request:


### PR DESCRIPTION
This was causing a red X on releases!
