### PR TITLE
fix: show help on wraper commands

### DIFF
--- a/cli/parameters.go
+++ b/cli/parameters.go
@@ -20,6 +20,9 @@ func parameters() *cobra.Command {
 		// constructing curl requests.
 		Hidden:  true,
 		Aliases: []string{"params"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		parameterList(),

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -58,6 +58,9 @@ func schedules() *cobra.Command {
 		Annotations: workspaceCommand,
 		Use:         "schedule { show | start | stop | override } <workspace>",
 		Short:       "Schedule automated start and stop times for workspaces",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	scheduleCmd.AddCommand(

--- a/cli/state.go
+++ b/cli/state.go
@@ -17,6 +17,9 @@ func state() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "state",
 		Short: "Manually manage Terraform state to fix broken workspaces",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(statePull(), statePush())
 	return cmd

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -30,6 +30,9 @@ func templates() *cobra.Command {
 				Command:     "coder templates push my-template",
 			},
 		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		templateCreate(),

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -24,6 +24,9 @@ func templateVersions() *cobra.Command {
 				Command:     "coder templates versions list my-template",
 			},
 		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		templateVersionsList(),

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -32,6 +32,9 @@ func tokens() *cobra.Command {
 				Command:     "coder tokens rm WuoWs4ZsMX",
 			},
 		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		createToken(),

--- a/cli/users.go
+++ b/cli/users.go
@@ -11,6 +11,9 @@ func users() *cobra.Command {
 		Short:   "Manage users",
 		Use:     "users",
 		Aliases: []string{"user"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		userCreate(),

--- a/enterprise/cli/features.go
+++ b/enterprise/cli/features.go
@@ -21,6 +21,9 @@ func features() *cobra.Command {
 		Short:   "List Enterprise features",
 		Use:     "features",
 		Aliases: []string{"feature"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		featuresList(),


### PR DESCRIPTION
Before if you ran these commands without subcommands it would just exit silently.