### PR TITLE
chore: add ignoreRestSiblings to no-unused-vars ESLint rule

### DIFF
--- a/site/.eslintrc.yaml
+++ b/site/.eslintrc.yaml
@@ -54,6 +54,7 @@ rules:
     - error
     - argsIgnorePattern: "^_"
       varsIgnorePattern: "^_"
+      ignoreRestSiblings: true
   "@typescript-eslint/no-use-before-define": "off"
   "@typescript-eslint/object-curly-spacing": ["error", "always"]
   "@typescript-eslint/triple-slash-reference": "off"

--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -30,8 +30,6 @@ export const Markdown: FC<{ children: string }> = ({ children }) => {
           </Link>
         ),
 
-        // Adding node so the ...props don't have it
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         code: ({ node, inline, className, children, ...props }) => {
           const match = /language-(\w+)/.exec(className || "")
           return !inline && match ? (


### PR DESCRIPTION
This PR adds a new setting to one of our ESLint rules called [`ignoreRestSiblings`](https://eslint.org/docs/latest/rules/no-unused-vars#ignorerestsiblings) which will come in handy if we use the spread operator to pass an object and exclude specific properties.

- chore: add ignoreRestSiblings to eslint config
- fix(site): remove eslint warning in <Markdown />
