### PR TITLE
fix: add back missing postAPIKey route

### DIFF
--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -39,3 +39,15 @@ func TestTokens(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, keys)
 }
+
+func TestAPIKey(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	res, err := client.CreateAPIKey(ctx, codersdk.Me)
+	require.NoError(t, err)
+	require.Greater(t, len(res.Key), 2)
+}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -399,6 +399,7 @@ func New(options *Options) *API {
 					r.Get("/roles", api.userRoles)
 
 					r.Route("/keys", func(r chi.Router) {
+						r.Post("/", api.postAPIKey)
 						r.Route("/tokens", func(r chi.Router) {
 							r.Post("/", api.postToken)
 							r.Get("/", api.tokens)

--- a/codersdk/apikey.go
+++ b/codersdk/apikey.go
@@ -45,6 +45,20 @@ func (c *Client) CreateToken(ctx context.Context, userID string) (*GenerateAPIKe
 	return apiKey, json.NewDecoder(res.Body).Decode(apiKey)
 }
 
+// CreateAPIKey generates an API key for the user ID provided.
+func (c *Client) CreateAPIKey(ctx context.Context, user string) (*GenerateAPIKeyResponse, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/users/%s/keys", user), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode > http.StatusCreated {
+		return nil, readBodyAsError(res)
+	}
+	apiKey := &GenerateAPIKeyResponse{}
+	return apiKey, json.NewDecoder(res.Body).Decode(apiKey)
+}
+
 // GetTokens list machine API keys.
 func (c *Client) GetTokens(ctx context.Context, userID string) ([]APIKey, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/keys/tokens", userID), nil)


### PR DESCRIPTION
This was making the `cli-auth` route on the frontend hang - this is a partial revert of changes from https://github.com/coder/coder/pull/4380