### PR TITLE
fix: Use the maximum number of users for a license warning

### DIFF
--- a/cli/cliui/table.go
+++ b/cli/cliui/table.go
@@ -158,6 +158,10 @@ func DisplayTable(out any, sort string, filterColumns []string) (string, error) 
 				if val != nil {
 					v = val.Format(time.RFC3339)
 				}
+			case *int64:
+				if val != nil {
+					v = *val
+				}
 			case fmt.Stringer:
 				if val != nil {
 					v = val.String()


### PR DESCRIPTION
This was causing a banner on dev.coder.com. But now we have a test!
