### PR TITLE
fix: apply loadBalancerIP and externalTrafficPolicy values in helm chart

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -15,6 +15,14 @@ spec:
       port: {{ include "coder.servicePort" . }}
       targetPort: {{ include "coder.portName" . | quote }}
       protocol: TCP
+  {{- if eq "LoadBalancer" .Values.coder.service.type }}
+  {{- with .Values.coder.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .Values.coder.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- end }}
   selector:
     {{- include "coder.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -17,10 +17,10 @@ spec:
       protocol: TCP
   {{- if eq "LoadBalancer" .Values.coder.service.type }}
   {{- with .Values.coder.service.loadBalancerIP }}
-  loadBalancerIP: {{ . }}
+  loadBalancerIP: {{ . | quote }}
   {{- end }}
   {{- with .Values.coder.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ . }}
+  externalTrafficPolicy: {{ . | quote }}
   {{- end }}
   {{- end }}
   selector:


### PR DESCRIPTION
we have loadBalancerIP and externalTrafficPolicy in values, and service must have them too

