### PR TITLE
feat: add ingress to helm chart

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,33 @@
+
+{{- if .Values.coder.ingress.enable }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coder
+  labels:
+    {{- include "coder.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.coder.ingress.className }}
+  {{/* If this is set to an empty string it fails validation on K8s */}}
+  ingressClassName: {{ .Values.coder.ingress.className | quote }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.coder.ingress.host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: coder
+            port:
+              name: {{ include "coder.portName" . | quote }}
+
+  {{- if .Values.coder.ingress.tls.enable }}
+  tls:
+    - hosts:
+      - {{ .Values.coder.ingress.host | quote }}
+      secretName: {{ .Values.coder.ingress.tls.secretName | quote}}
+  {{- end }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -7,27 +7,47 @@ metadata:
   name: coder
   labels:
     {{- include "coder.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.coder.ingress.annotations | nindent 4 }}
 spec:
   {{- if .Values.coder.ingress.className }}
   {{/* If this is set to an empty string it fails validation on K8s */}}
   ingressClassName: {{ .Values.coder.ingress.className | quote }}
   {{- end }}
+
   rules:
-  - host: {{ .Values.coder.ingress.host | quote }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: coder
-            port:
-              name: {{ include "coder.portName" . | quote }}
+    - host: {{ .Values.coder.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: coder
+                port:
+                  name: {{ include "coder.portName" . | quote }}
+    {{- if .Values.coder.ingress.wildcardHost }}
+    - host: {{ .Values.coder.ingress.wildcardHost | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: coder
+                port:
+                  name: {{ include "coder.portName" . | quote }}
+    {{- end }}
 
   {{- if .Values.coder.ingress.tls.enable }}
   tls:
     - hosts:
-      - {{ .Values.coder.ingress.host | quote }}
+        - {{ .Values.coder.ingress.host | quote }}
       secretName: {{ .Values.coder.ingress.tls.secretName | quote}}
+    {{- if .Values.coder.ingress.tls.wildcardSecretName }}
+    - hosts:
+        - {{ .Values.coder.ingress.wildcardHost | quote }}
+      secretName: {{ .Values.coder.ingress.tls.wildcardSecretName | quote}}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,9 +98,18 @@ coder:
     className: ""
     # coder.ingress.host -- The hostname to match on.
     host: ""
+    # coder.ingress.wildcardHost -- The wildcard hostname to match on. Should be
+    # in the form "*.example.com". Optional if not using applications over
+    # subdomains.
+    wildcardHost: ""
+    # coder.ingress.annotations -- The ingress annotations.
+    annotations: {}
     # coder.ingress.tls -- The TLS configuration to use for the Ingress.
     tls:
       # coder.ingress.tls.enable -- Whether to enable TLS on the Ingress.
       enable: false
       # coder.ingress.tls.secretName -- The name of the TLS secret to use.
       secretName: ""
+      # coder.ingress.tls.wildcardSecretName -- The name of the TLS secret to
+      # use for the wildcard host.
+      wildcardSecretName: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -92,7 +92,9 @@ coder:
 
   # coder.ingress -- The Ingress object to expose for Coder.
   ingress:
-    # coder.ingress.enable -- Whether to create the Ingress object.
+    # coder.ingress.enable -- Whether to create the Ingress object. If using an
+    # Ingress, we recommend not specifying coder.tls.secretNames as the Ingress
+    # will handle TLS termination.
     enable: false
     # coder.ingress.className -- The name of the Ingress class to use.
     className: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -59,7 +59,8 @@ coder:
 
   # coder.resources -- The resources to request for Coder. These are optional
   # and are not set by default.
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -88,3 +89,18 @@ coder:
     # coder.service.annotations -- The service annotations. See:
     # https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
     annotations: {}
+
+  # coder.ingress -- The Ingress object to expose for Coder.
+  ingress:
+    # coder.ingress.enable -- Whether to create the Ingress object.
+    enable: false
+    # coder.ingress.className -- The name of the Ingress class to use.
+    className: ""
+    # coder.ingress.host -- The hostname to match on.
+    host: ""
+    # coder.ingress.tls -- The TLS configuration to use for the Ingress.
+    tls:
+      # coder.ingress.tls.enable -- Whether to enable TLS on the Ingress.
+      enable: false
+      # coder.ingress.tls.secretName -- The name of the TLS secret to use.
+      secretName: ""


### PR DESCRIPTION
Fixes #3959. Reverted from 761e12473567616289c54e1668135c678250e46c

- [x] Test it
- [x] Support [multiple certifcates](https://github.com/coder/coder/blob/5e594adfba52c0875ed066031ac36defff158b65/helm/values.yaml#L55)
- [x] Consider warning the user or automatically changing ServiceType to CluserIP if ingress is enabled (however v1 does not do this)