### PR TITLE
fix: Check if the response body is nil before panicing

### DIFF
--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -130,6 +130,9 @@ func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after
 		CompressionMode: websocket.CompressionDisabled,
 	})
 	if err != nil {
+		if res == nil {
+			return nil, nil, err
+		}
 		return nil, nil, readBodyAsError(res)
 	}
 	logs := make(chan ProvisionerJobLog)


### PR DESCRIPTION
If a WebSocket connection couldn't be established, a panic would occur.
