### PR TITLE
fix: Use `lower` function in default Kubernetes template

### DIFF
--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -86,7 +86,7 @@ resource "coder_app" "code-server" {
 
 resource "kubernetes_persistent_volume_claim" "home" {
   metadata {
-    name      = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-home"
+    name      = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-home"
     namespace = var.namespace
   }
   spec {
@@ -102,7 +102,7 @@ resource "kubernetes_persistent_volume_claim" "home" {
 resource "kubernetes_pod" "main" {
   count = data.coder_workspace.me.start_count
   metadata {
-    name      = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
+    name      = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
     namespace = var.namespace
   }
   spec {


### PR DESCRIPTION
Fixes #4467.
