### PR TITLE
chore: Update docs for `secretNames` TLS change

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -102,7 +102,8 @@ to log in and manage templates.
          value: "kubernetes"
 
      #tls:
-     #  secretName: my-tls-secret-name
+     #  secretNames: 
+     #    - my-tls-secret-name
    ```
 
    > You can view our

--- a/helm/README.md
+++ b/helm/README.md
@@ -51,5 +51,6 @@ coder:
       value: "kubernetes"
 
   tls:
-    secretName: my-tls-secret-name
+    secretNames: 
+      - my-tls-secret-name
 ```


### PR DESCRIPTION
This was changed but the docs didn't reflect it.

fixes #4464
