### PR TITLE
refactor: Add group badge to diff groups from users

### DIFF
--- a/site/src/components/GroupAvatar/GroupAvatar.stories.tsx
+++ b/site/src/components/GroupAvatar/GroupAvatar.stories.tsx
@@ -1,0 +1,14 @@
+import { Story } from "@storybook/react"
+import { GroupAvatar, GroupAvatarProps } from "./GroupAvatar"
+
+export default {
+  title: "components/GroupAvatar",
+  component: GroupAvatar,
+}
+
+const Template: Story<GroupAvatarProps> = (args) => <GroupAvatar {...args} />
+
+export const Example = Template.bind({})
+Example.args = {
+  name: "My Group",
+}

--- a/site/src/components/GroupAvatar/GroupAvatar.tsx
+++ b/site/src/components/GroupAvatar/GroupAvatar.tsx
@@ -1,0 +1,43 @@
+import Avatar from "@material-ui/core/Avatar"
+import Badge from "@material-ui/core/Badge"
+import { withStyles } from "@material-ui/core/styles"
+import Group from "@material-ui/icons/Group"
+import React from "react"
+import { firstLetter } from "util/firstLetter"
+
+const StyledBadge = withStyles((theme) => ({
+  badge: {
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: "100%",
+    width: 24,
+    height: 24,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+
+    "& svg": {
+      width: 14,
+      height: 14,
+    },
+  },
+}))(Badge)
+
+export type GroupAvatarProps = {
+  name: string
+}
+
+export const GroupAvatar: React.FC<GroupAvatarProps> = ({ name }) => {
+  return (
+    <StyledBadge
+      overlap="circular"
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "right",
+      }}
+      badgeContent={<Group />}
+    >
+      <Avatar>{firstLetter(name)}</Avatar>
+    </StyledBadge>
+  )
+}

--- a/site/src/components/GroupAvatar/GroupAvatar.tsx
+++ b/site/src/components/GroupAvatar/GroupAvatar.tsx
@@ -2,7 +2,7 @@ import Avatar from "@material-ui/core/Avatar"
 import Badge from "@material-ui/core/Badge"
 import { withStyles } from "@material-ui/core/styles"
 import Group from "@material-ui/icons/Group"
-import React from "react"
+import { FC } from "react"
 import { firstLetter } from "util/firstLetter"
 
 const StyledBadge = withStyles((theme) => ({
@@ -27,7 +27,7 @@ export type GroupAvatarProps = {
   name: string
 }
 
-export const GroupAvatar: React.FC<GroupAvatarProps> = ({ name }) => {
+export const GroupAvatar: FC<GroupAvatarProps> = ({ name }) => {
   return (
     <StyledBadge
       overlap="circular"

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -21,6 +21,7 @@ import React from "react"
 import { Link as RouterLink, useNavigate } from "react-router-dom"
 import { Paywall } from "components/Paywall/Paywall"
 import { Group } from "api/typesGenerated"
+import { GroupAvatar } from "components/GroupAvatar/GroupAvatar"
 
 export type GroupsPageViewProps = {
   groups: Group[] | undefined
@@ -135,6 +136,7 @@ export const GroupsPageView: React.FC<GroupsPageViewProps> = ({
                         >
                           <TableCell>
                             <AvatarData
+                              avatar={<GroupAvatar name={group.name} />}
                               title={group.name}
                               subtitle={`${group.members.length} members`}
                               highlightTitle

--- a/site/src/pages/TemplatePage/TemplatePermissionsPage/TemplatePermissionsPageView.tsx
+++ b/site/src/pages/TemplatePage/TemplatePermissionsPage/TemplatePermissionsPageView.tsx
@@ -28,6 +28,7 @@ import {
 } from "components/UserOrGroupAutocomplete/UserOrGroupAutocomplete"
 import { FC, useState } from "react"
 import { Maybe } from "components/Conditionals/Maybe"
+import { GroupAvatar } from "components/GroupAvatar/GroupAvatar"
 
 type AddTemplateUserOrGroupProps = {
   organizationId: string
@@ -208,6 +209,7 @@ export const TemplatePermissionsPageView: FC<
                   <TableRow key={group.id}>
                     <TableCell>
                       <AvatarData
+                        avatar={<GroupAvatar name={group.name} />}
                         title={group.name}
                         subtitle={`${group.members.length} members`}
                         highlightTitle

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -73,7 +73,7 @@ export const MockUser: TypesGen.User = {
   status: "active",
   organization_ids: ["fc0774ce-cc9e-48d4-80ae-88f7a4d4a8b0"],
   roles: [MockOwnerRole],
-  avatar_url: "https://github.com/coder.png",
+  avatar_url: "https://avatars.githubusercontent.com/u/95932066?s=200&v=4",
   last_seen_at: "",
 }
 


### PR DESCRIPTION
Closes #4459 

Before:
<img width="1504" alt="Screen Shot 2022-10-11 at 10 25 28" src="https://user-images.githubusercontent.com/3165839/195103515-d56c753d-9061-4c96-bb99-aa2dfb2c3aa3.png">

After:
<img width="1503" alt="Screen Shot 2022-10-11 at 10 25 18" src="https://user-images.githubusercontent.com/3165839/195103552-306deac2-edb7-46e3-853a-d6bf7655cdc1.png">
