### PR TITLE
fix: enterprise link for groups

### DIFF
--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -50,7 +50,7 @@ export const GroupsPageView: React.FC<GroupsPageViewProps> = ({
               <Stack direction="row" alignItems="center">
                 <Link
                   underline="none"
-                  href="https://coder.com/docs/coder-oss/latest/admin/upgrade"
+                  href="https://coder.com/docs/coder-oss/latest/admin/enterprise"
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -60,7 +60,7 @@ export const GroupsPageView: React.FC<GroupsPageViewProps> = ({
                 </Link>
                 <Link
                   underline="none"
-                  href="https://coder.com/docs/coder-oss/latest/admin/upgrade"
+                  href="https://coder.com/docs/coder-oss/latest/admin/groups"
                   target="_blank"
                   rel="noreferrer"
                 >


### PR DESCRIPTION
closes #4490