### PR TITLE
fix: use more descriptive login flags

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -248,9 +248,9 @@ func login() *cobra.Command {
 			return nil
 		},
 	}
-	cliflag.StringVarP(cmd.Flags(), &email, "email", "e", "CODER_EMAIL", "", "Specifies an email address to authenticate with.")
-	cliflag.StringVarP(cmd.Flags(), &username, "username", "u", "CODER_USERNAME", "", "Specifies a username to authenticate with.")
-	cliflag.StringVarP(cmd.Flags(), &password, "password", "p", "CODER_PASSWORD", "", "Specifies a password to authenticate with.")
+	cliflag.StringVarP(cmd.Flags(), &email, "first-user-email", "", "CODER_FIRST_USER_EMAIL", "", "Specifies an email address to use if creating the first user for the deployment.")
+	cliflag.StringVarP(cmd.Flags(), &username, "first-user-username", "", "CODER_FIRST_USER_USERNAME", "", "Specifies a username to use if creating the first user for the deployment.")
+	cliflag.StringVarP(cmd.Flags(), &password, "first-user-password", "", "CODER_FIRST_USER_PASSWORD", "", "Specifies a password to use if creating the first user for the deployment.")
 	return cmd
 }
 

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -74,7 +74,7 @@ func TestLogin(t *testing.T) {
 		// accurately detect Windows ptys when they are not attached to a process:
 		// https://github.com/mattn/go-isatty/issues/59
 		doneChan := make(chan struct{})
-		root, _ := clitest.New(t, "login", client.URL.String(), "--username", "testuser", "--email", "user@coder.com", "--password", "password")
+		root, _ := clitest.New(t, "login", client.URL.String(), "--first-user-username", "testuser", "--first-user-email", "user@coder.com", "--first-user-password", "password")
 		pty := ptytest.New(t)
 		root.SetIn(pty.Input())
 		root.SetOut(pty.Output())

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -95,7 +95,7 @@ provision:
     # If we are already logged in, nothing to do
     coder templates list >/dev/null 2>&1 && exit 0
     # Set up initial user
-    [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --username admin --email admin@coder.com --password $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8 | tee ${HOME}/.config/coderv2/password)
+    [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --first-user-username admin --first-user-email admin@coder.com --first-user-password $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8 | tee ${HOME}/.config/coderv2/password)
     # Create an initial template
     temp_template_dir=$(mktemp -d)
     echo code-server | coder templates init "${temp_template_dir}"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -66,7 +66,7 @@ CODER_DEV_SHIM="${PROJECT_ROOT}/scripts/coder-dev.sh"
 
 	if [ ! -f "${PROJECT_ROOT}/.coderv2/developsh-did-first-setup" ]; then
 		# Try to create the initial admin user.
-		"${CODER_DEV_SHIM}" login http://127.0.0.1:3000 --username=admin --email=admin@coder.com --password="${password}" ||
+		"${CODER_DEV_SHIM}" login http://127.0.0.1:3000 --first-user-username=admin --first-user-email=admin@coder.com --first-user-password="${password}" ||
 			echo 'Failed to create admin user. To troubleshoot, try running this command manually.'
 
 		# Try to create a regular user.


### PR DESCRIPTION
Currently these flags just apply to the command if you are logging into a fresh deployment of coder and not if you are a longtime user just logging in. This PR clarifies that behavior. 

Closes https://github.com/coder/coder/issues/4485