### PR TITLE
add: helm binary download cmd

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -47,7 +47,7 @@ to log in and manage templates.
 
    The cluster-internal DB URL for the above database is:
 
-   ```
+   ```console
    postgres://coder:coder@postgres-postgresql.coder.svc.cluster.local:5432/coder?sslmode=disable
    ```
 
@@ -59,6 +59,10 @@ to log in and manage templates.
 
 1. Download the latest `coder_helm` package from
    [GitHub releases](https://github.com/coder/coder/releases).
+
+   ```console
+   wget https://github.com/coder/coder/releases/download/<release>/coder_helm_<release>.tgz
+   ```
 
 1. Create a secret with the database URL:
 
@@ -102,7 +106,7 @@ to log in and manage templates.
          value: "kubernetes"
 
      #tls:
-     #  secretNames: 
+     #  secretNames:
      #    - my-tls-secret-name
    ```
 


### PR DESCRIPTION
adds a command for downloading the helm binary.

customers are typically installing the helm chart via a VM or other remote client, and it isn't entirely intuitive as to how to do this from the GitHub releases page.