### PR TITLE
fix: ensure deleting workspace creates audit log

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -255,7 +255,6 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 	workspace := httpmw.WorkspaceParam(r)
-
 	var createBuild codersdk.CreateWorkspaceBuildRequest
 	if !httpapi.Read(ctx, rw, r, &createBuild) {
 		return
@@ -263,7 +262,6 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 
 	// Rbac action depends on the transition
 	var action rbac.Action
-
 	switch createBuild.Transition {
 	case codersdk.WorkspaceTransitionDelete:
 		action = rbac.ActionDelete

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -251,8 +251,6 @@ func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Requ
 	httpapi.Write(ctx, rw, http.StatusOK, apiBuild)
 }
 
-// STARTS HERE
-
 func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -545,8 +543,6 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 
 	httpapi.Write(ctx, rw, http.StatusCreated, apiBuild)
 }
-
-// ENDS HERE !!!!!
 
 func (api *API) patchCancelWorkspaceBuild(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()


### PR DESCRIPTION
partially fixes #4316 

We weren't create Audit Log entries when deleting a workspace.

Now we are:
![Screen Shot 2022-10-13 at 1 56 19 PM](https://user-images.githubusercontent.com/19142439/195678167-3b9cda70-1393-4561-9516-6fa211e73cd3.png)
