### PR TITLE
fix: removing unsupported resources from audit log documentation

### DIFF
--- a/docs/admin/audit-logs.md
+++ b/docs/admin/audit-logs.md
@@ -7,11 +7,9 @@ their deployment.
 
 We track **create, update and delete** events for the following resources:
 
-- GitSSHKey
 - Template
 - TemplateVersion
 - Workspace
-- APIKey
 - User
 
 ## Filtering logs


### PR DESCRIPTION
partially resolves #4316 

Our Audit Logging feature doesn't support GitSSHKeys or APIKeys right now.
I'm updating our documentation so we don't cause confusion while we build out support for these resources.

I've also created the following tickets as part of the discovery work here:
https://github.com/coder/coder/issues/4538
https://github.com/coder/coder/issues/4541


And a relevant ticket for long-lived token audit logging exists here:
https://github.com/coder/coder/issues/4519
