### PR TITLE
feat: upgrade prettier and add --cache

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,7 @@
     "check:all": "yarn format:check && yarn lint && yarn test",
     "chromatic": "chromatic",
     "dev": "vite",
-    "format:check": "prettier --check '**/*.{css,html,js,json,jsx,md,ts,tsx,yaml,yml}'",
+    "format:check": "prettier --cache --check '**/*.{css,html,js,json,jsx,md,ts,tsx,yaml,yml}'",
     "format:types": "prettier --write 'src/api/typesGenerated.ts'",
     "format:write": "prettier --write '**/*.{css,html,js,json,jsx,md,ts,tsx,yaml,yml}'",
     "lint": "jest --selectProjects lint",


### PR DESCRIPTION
This uses the `--cache` flag with `prettier --check` to cache the
results and speed up subsequent runs.

Without flag (i.e. no cache):
```shell
yarn run v1.22.19
$ prettier --cache --check '**/*.{css,html,js,json,jsx,md,ts,tsx,yaml,yml}'
Checking formatting...
All matched files use Prettier code style!
Done in 6.01s.
```

With flag after cache:
```shell
yarn run v1.22.19
$ prettier --cache --check '**/*.{css,html,js,json,jsx,md,ts,tsx,yaml,yml}'
Checking formatting...
All matched files use Prettier code style!
Done in 1.33s.
```

For more info, read here: https://prettier.io/docs/en/cli.html#--cache
