### PR TITLE
fix: Fix template create with sub-folders on Windows

### DIFF
--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -87,7 +87,8 @@ func Tar(directory string, limit int64) ([]byte, error) {
 			// Don't store tfstate!
 			return err
 		}
-		header.Name = rel
+		// Use unix paths in the tar archive.
+		header.Name = filepath.ToSlash(rel)
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}
@@ -131,7 +132,7 @@ func Untar(directory string, archive []byte) error {
 			return err
 		}
 		// #nosec
-		target := filepath.Join(directory, header.Name)
+		target := filepath.Join(directory, filepath.FromSlash(header.Name))
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if _, err := os.Stat(target); err != nil {

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -1,7 +1,6 @@
 package provisionersdk_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,6 +58,7 @@ func TestTar(t *testing.T) {
 		}}
 		for _, file := range files {
 			newDir := dir
+			file.Name = filepath.FromSlash(file.Name)
 			if filepath.Base(file.Name) != file.Name {
 				newDir = filepath.Join(newDir, filepath.Dir(file.Name))
 				err := os.MkdirAll(newDir, 0755)
@@ -70,7 +70,6 @@ func TestTar(t *testing.T) {
 			_ = tmpFile.Close()
 			file.Name, err = filepath.Rel(dir, tmpFile.Name())
 			require.NoError(t, err)
-			fmt.Printf("rel")
 		}
 		content, err := provisionersdk.Tar(dir, 1024)
 		require.NoError(t, err)


### PR DESCRIPTION
On Windows, files in tar archives were stored with Windows
path-separators resulting in them being individual files as opposed to
contained in a folder.

This commit ensures Unix-based paths (slash) are being used inside tar
archives.

Exmple of previous output:

```
/tmp/provisionerd673501182/images:
/tmp/provisionerd673501182/:
README.md
images
images\base.Dockerfile
images\java.Dockerfile
images\node.Dockerfile
main.tf
```

Fixes #2815

