### PR TITLE
fix: Don't check for existing replicas when starting up

### DIFF
--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -93,14 +93,6 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, pubsub data
 	if err != nil {
 		return nil, xerrors.Errorf("run replica: %w", err)
 	}
-	peers := manager.Regional()
-	if len(peers) > 0 {
-		self := manager.Self()
-		if self.RelayAddress == "" {
-			return nil, xerrors.Errorf("a relay address must be specified when running multiple replicas in the same region")
-		}
-	}
-
 	err = manager.subscribe(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("subscribe: %w", err)

--- a/enterprise/replicasync/replicasync_test.go
+++ b/enterprise/replicasync/replicasync_test.go
@@ -44,23 +44,6 @@ func TestReplica(t *testing.T) {
 		_ = server.Close()
 		require.NoError(t, err)
 	})
-	t.Run("ErrorsWithoutRelayAddress", func(t *testing.T) {
-		// Ensures that the replica reports a successful status for
-		// accessing all of its peers.
-		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
-		_, err := db.InsertReplica(context.Background(), database.InsertReplicaParams{
-			ID:        uuid.New(),
-			CreatedAt: database.Now(),
-			StartedAt: database.Now(),
-			UpdatedAt: database.Now(),
-			Hostname:  "something",
-		})
-		require.NoError(t, err)
-		_, err = replicasync.New(context.Background(), slogtest.Make(t, nil), db, pubsub, nil)
-		require.Error(t, err)
-		require.Equal(t, "a relay address must be specified when running multiple replicas in the same region", err.Error())
-	})
 	t.Run("ConnectsToPeerReplica", func(t *testing.T) {
 		// Ensures that the replica reports a successful status for
 		// accessing all of its peers.


### PR DESCRIPTION
This was blocking startup, creating a chicken and egg problem where if a replica died, a single one couldn't be bootstrapped again.
