### PR TITLE
fix(tailnet): data race in `coordinator.Close()`

### DIFF
--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -338,10 +338,10 @@ func (c *coordinator) handleNextAgentMessage(id uuid.UUID, decoder *json.Decoder
 func (c *coordinator) Close() error {
 	c.mutex.Lock()
 	if c.closed {
+		c.mutex.Unlock()
 		return nil
 	}
 	c.closed = true
-	c.mutex.Unlock()
 
 	wg := sync.WaitGroup{}
 
@@ -364,6 +364,8 @@ func (c *coordinator) Close() error {
 			}()
 		}
 	}
+
+	c.mutex.Unlock()
 
 	wg.Wait()
 	return nil


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c0047998f0 by goroutine 94756:
  runtime.mapdelete()
      /opt/hostedtoolcache/go/1.19.1/x64/src/runtime/map.go:695 +0x0
  github.com/coder/coder/tailnet.(*coordinator).ServeAgent.func1()
      /home/runner/work/coder/coder/tailnet/coordinator.go:284 +0x104
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.1/x64/src/runtime/panic.go:476 +0x32
  github.com/coder/coder/coderd.(*API).workspaceAgentCoordinate.func4()
      /home/runner/work/coder/coder/coderd/workspaceagents.go:518 +0x191
Previous read at 0x00c0047998f0 by goroutine 12585:
  runtime.mapiternext()
      /opt/hostedtoolcache/go/1.19.1/x64/src/runtime/map.go:866 +0x0
  github.com/coder/coder/tailnet.(*coordinator).Close()
      /home/runner/work/coder/coder/tailnet/coordinator.go:349 +0x1d1
  github.com/coder/coder/coderd.(*API).Close()
      /home/runner/work/coder/coder/coderd/coderd.go:584 +0xe1
  github.com/coder/coder/coderd/coderdtest.NewWithAPI.func1()
      /home/runner/work/coder/coder/coderd/coderdtest/coderdtest.go:289 +0x7b
  testing.(*common).Cleanup.func1()
      /opt/hostedtoolcache/go/1.19.1/x64/src/testing/testing.go:1041 +0x193
  testing.(*common).runCleanup()
      /opt/hostedtoolcache/go/1.19.1/x64/src/testing/testing.go:1210 +0x143
  testing.tRunner.func2()
      /opt/hostedtoolcache/go/1.19.1/x64/src/testing/testing.go:1440 +0x52
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.1/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.1/x64/src/testing/testing.go:1493 +0x47
```