### PR TITLE
fix: Add timeout to selecting a dev tunnel

### DIFF
--- a/coderd/devtunnel/servers.go
+++ b/coderd/devtunnel/servers.go
@@ -73,6 +73,7 @@ func FindClosestNode() (Node, error) {
 			}
 
 			pinger.Count = 5
+			pinger.Timeout = 5 * time.Second
 			err = pinger.Run()
 			if err != nil {
 				return err


### PR DESCRIPTION
For some reason this timed out for a prospect. Even if this doesn't fix it, the problem will be revealed.
