### PR TITLE
docs: add postgres version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Once installed, you can start a production deployment<sup>1</sup> with a single 
 # Automatically sets up an external access URL on *.try.coder.app
 coder server
 
-# Requires a PostgreSQL instance and external access URL
+# Requires a PostgreSQL instance (version 13 or higher) and external access URL
 coder server --postgres-url <url> --access-url <url>
 ```
 
@@ -95,7 +95,7 @@ Join our community on [Discord](https://coder.com/chat?utm_source=github.com/cod
 
 ## Contributing
 
-If you're using Coder in your organization, please try to add your company name to the [ADOPTERS.md](./ADOPTERS.md). It really helps the project to gain momentum and credibility. It's a small contribution back to the project with a big impact. 
+If you're using Coder in your organization, please try to add your company name to the [ADOPTERS.md](./ADOPTERS.md). It really helps the project to gain momentum and credibility. It's a small contribution back to the project with a big impact.
 
 Read the [contributing docs](https://coder.com/docs/coder-oss/latest/CONTRIBUTING).
 

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -29,6 +29,8 @@ Coder uses a PostgreSQL database to store users, workspace metadata, and other d
 Use `CODER_PG_CONNECTION_URL` to set the database that Coder connects to. If unset, PostgreSQL binaries will be
 downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the config root.
 
+> Postgres 13 is the minimum supported version.
+
 ## System packages
 
 If you've installed Coder via a [system package](../install/packages.md) Coder, you can

--- a/docs/install/binary.md
+++ b/docs/install/binary.md
@@ -17,7 +17,7 @@ Coder publishes self-contained .zip and .tar.gz archives in [GitHub releases](ht
    # Automatically sets up an external access URL on *.try.coder.app
    coder server
 
-   # Requires a PostgreSQL instance and external access URL
+   # Requires a PostgreSQL instance (version 13 or higher) and external access URL
    coder server --postgres-url <url> --access-url <url>
    ```
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -30,9 +30,9 @@ Learn more about Coder's [configuration options](../admin/configure.md).
 
 ## Run Coder with access URL and external PostgreSQL (recommended)
 
-For production deployments, we recommend using an external PostgreSQL database.
-Set `ACCESS_URL` to the external URL that users and workspaces will use to
-connect to Coder.
+For production deployments, we recommend using an external PostgreSQL database
+(version 13 or higher). Set `ACCESS_URL` to the external URL that users and
+workspaces will use to connect to Coder.
 
 ```sh
 docker run --rm -it \


### PR DESCRIPTION
our minimum supported Postgres version is 13. closes #4608 