### PR TITLE
refactor: Update resources to look as a stack

### DIFF
--- a/site/src/components/Resources/ResourceCard.tsx
+++ b/site/src/components/Resources/ResourceCard.tsx
@@ -210,6 +210,17 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.background.paper,
     borderRadius: theme.shape.borderRadius,
     border: `1px solid ${theme.palette.divider}`,
+
+    "&:not(:first-child)": {
+      borderTop: 0,
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+    },
+
+    "&:not(:last-child)": {
+      borderBottomLeftRadius: 0,
+      borderBottomRightRadius: 0,
+    },
   },
 
   resourceCardProfile: {

--- a/site/src/components/Resources/Resources.tsx
+++ b/site/src/components/Resources/Resources.tsx
@@ -54,7 +54,7 @@ export const Resources: FC<React.PropsWithChildren<ResourcesProps>> = ({
   }
 
   return (
-    <Stack direction="column" spacing={1}>
+    <Stack direction="column" spacing={0}>
       {displayResources.map((resource) => {
         return (
           <ResourceCard


### PR DESCRIPTION
After seeing the resources in dev.coder.com I think it is better to group the resources together than add a space between them. 

Before:
<img width="1777" alt="Screen Shot 2022-10-18 at 16 00 18" src="https://user-images.githubusercontent.com/3165839/196520540-3575f06c-8669-44f5-af55-4d5673a4e4a9.png">

After:
<img width="1792" alt="Screen Shot 2022-10-18 at 16 00 31" src="https://user-images.githubusercontent.com/3165839/196520556-86ef33a4-ff85-4f59-983a-7044438e5d64.png">
