### PR TITLE
helm: add sa annotations

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: coder
+  annotations: {{ toYaml .Values.coder.serviceAccount.annotations | nindent 4 }}
+  labels:
+    {{- include "coder.labels" . | nindent 4 -}}
 
 ---
 apiVersion: apps/v1

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -6,7 +6,7 @@ metadata:
   name: coder
   annotations: {{ toYaml .Values.coder.serviceAccount.annotations | nindent 4 }}
   labels:
-    {{- include "coder.labels" . | nindent 4 -}}
+    {{- include "coder.labels" . | nindent 4 }}
 
 ---
 apiVersion: apps/v1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,8 +34,7 @@ coder:
     # within Coder.
     workspacePerms: true
     # coder.serviceAccount.annotations -- The Coder service account annotations.
-    annotations:
-      iam.gke.io/gke-metadata-server-enabled: "true"
+    annotations: {}
 
   # coder.env -- The environment variables to set for Coder. These can be used
   # to configure all aspects of `coder server`. Please see `coder server --help`

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -33,6 +33,9 @@ coder:
     # It is recommended to keep this on if you are using Kubernetes templates
     # within Coder.
     workspacePerms: true
+    # coder.serviceAccount.annotations -- The Coder service account annotations.
+    annotations:
+      iam.gke.io/gke-metadata-server-enabled: "true"
 
   # coder.env -- The environment variables to set for Coder. These can be used
   # to configure all aspects of `coder server`. Please see `coder server --help`


### PR DESCRIPTION
addresses #4620 by adding support for annotating the Coder-created service account in the `values.yaml` file. this allows for the service account to tie into cloud identities such as [Google Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) and [AWS IAM roles](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html).