### PR TITLE
fix: remove default namespace in k8s example

### DIFF
--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -29,7 +29,6 @@ variable "namespace" {
   type        = string
   sensitive   = true
   description = "The namespace to create workspaces in (must exist prior to creating workspaces)"
-  default     = "coder-workspaces"
 }
 
 variable "home_disk_size" {


### PR DESCRIPTION
Since there was a default value, a template author was never prompted. This leads to a confusing behavior if the namespace doesn't exist or the ServiceAccount does not have permissions on `coder-workspaces`