### PR TITLE
fix: prevent refreshing tokens that don't exist

### DIFF
--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -203,7 +203,7 @@ func ExtractAPIKey(cfg ExtractAPIKeyConfig) func(http.Handler) http.Handler {
 					return
 				}
 				// Check if the OAuth token is expired
-				if link.OAuthExpiry.Before(now) && !link.OAuthExpiry.IsZero() {
+				if link.OAuthExpiry.Before(now) && !link.OAuthExpiry.IsZero() && link.OAuthRefreshToken != "" {
 					var oauthConfig OAuth2Config
 					switch key.LoginType {
 					case database.LoginTypeGithub:

--- a/coderd/httpmw/apikey_test.go
+++ b/coderd/httpmw/apikey_test.go
@@ -468,9 +468,10 @@ func TestAPIKey(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = db.InsertUserLink(r.Context(), database.InsertUserLinkParams{
-			UserID:      user.ID,
-			LoginType:   database.LoginTypeGithub,
-			OAuthExpiry: database.Now().AddDate(0, 0, -1),
+			UserID:            user.ID,
+			LoginType:         database.LoginTypeGithub,
+			OAuthExpiry:       database.Now().AddDate(0, 0, -1),
+			OAuthRefreshToken: "hello",
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
- When logging in with Google OIDC refresh tokens are not provided unless explicitly asked for. This PR updates the logic to avoid attempting to refresh the token if a refresh token does not exist.

  A session should only be dependent on a valid Coder API key, the state of its OAuth token (beyond initial authentication) should be irrelevant.

fixes #4059