### PR TITLE
patch: typo in dotfiles.md

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -32,7 +32,7 @@ resource "coder_agent" "main" {
 
 ## Persistent Home
 
-Sometimes you wants to support personalization without
+Sometimes you want to support personalization without
 requiring dotfiles.
 
 In such cases:


### PR DESCRIPTION
Fix for what looks like a minor subject-verb agreement typo in the dotfiles docs page.