### PR TITLE
chore: remove org_id from audit diffs

### DIFF
--- a/enterprise/audit/diff_internal_test.go
+++ b/enterprise/audit/diff_internal_test.go
@@ -256,7 +256,6 @@ func Test_diff(t *testing.T) {
 			},
 			exp: audit.Map{
 				"id":                     audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
-				"organization_id":        audit.OldNew{Old: "", New: uuid.UUID{2}.String()},
 				"name":                   audit.OldNew{Old: "", New: "rust"},
 				"provisioner":            audit.OldNew{Old: database.ProvisionerType(""), New: database.ProvisionerTypeTerraform},
 				"active_version_id":      audit.OldNew{Old: "", New: uuid.UUID{3}.String()},
@@ -281,11 +280,10 @@ func Test_diff(t *testing.T) {
 				CreatedBy:      uuid.NullUUID{UUID: uuid.UUID{4}, Valid: true},
 			},
 			exp: audit.Map{
-				"id":              audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
-				"template_id":     audit.OldNew{Old: "", New: uuid.UUID{2}.String()},
-				"organization_id": audit.OldNew{Old: "", New: uuid.UUID{3}.String()},
-				"created_by":      audit.OldNew{Old: "", New: uuid.UUID{4}.String()},
-				"name":            audit.OldNew{Old: "", New: "rust"},
+				"id":          audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
+				"template_id": audit.OldNew{Old: "", New: uuid.UUID{2}.String()},
+				"created_by":  audit.OldNew{Old: "", New: uuid.UUID{4}.String()},
+				"name":        audit.OldNew{Old: "", New: "rust"},
 			},
 		},
 		{
@@ -301,10 +299,9 @@ func Test_diff(t *testing.T) {
 				CreatedBy:      uuid.NullUUID{UUID: uuid.UUID{4}, Valid: true},
 			},
 			exp: audit.Map{
-				"id":              audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
-				"organization_id": audit.OldNew{Old: "", New: uuid.UUID{3}.String()},
-				"created_by":      audit.OldNew{Old: "null", New: uuid.UUID{4}.String()},
-				"name":            audit.OldNew{Old: "", New: "rust"},
+				"id":         audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
+				"created_by": audit.OldNew{Old: "null", New: uuid.UUID{4}.String()},
+				"name":       audit.OldNew{Old: "", New: "rust"},
 			},
 		},
 	})

--- a/enterprise/audit/table.go
+++ b/enterprise/audit/table.go
@@ -51,7 +51,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 		"id":                     ActionTrack,
 		"created_at":             ActionIgnore, // Never changes, but is implicit and not helpful in a diff.
 		"updated_at":             ActionIgnore, // Changes, but is implicit and not helpful in a diff.
-		"organization_id":        ActionTrack,
+		"organization_id":        ActionIgnore, // Rarely changes and not useful to the user
 		"deleted":                ActionIgnore, // Changes, but is implicit when a delete event is fired.
 		"name":                   ActionTrack,
 		"provisioner":            ActionTrack,
@@ -68,7 +68,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 	&database.TemplateVersion{}: {
 		"id":              ActionTrack,
 		"template_id":     ActionTrack,
-		"organization_id": ActionTrack,
+		"organization_id": ActionIgnore, // Rarely changes and not useful to the user
 		"created_at":      ActionIgnore, // Never changes, but is implicit and not helpful in a diff.
 		"updated_at":      ActionIgnore, // Changes, but is implicit and not helpful in a diff.
 		"name":            ActionTrack,
@@ -95,7 +95,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 		"created_at":         ActionIgnore, // Never changes.
 		"updated_at":         ActionIgnore, // Changes, but is implicit and not helpful in a diff.
 		"owner_id":           ActionTrack,
-		"organization_id":    ActionTrack,
+		"organization_id":    ActionIgnore, // Rarely changes and not useful to the user
 		"template_id":        ActionTrack,
 		"deleted":            ActionIgnore, // Changes, but is implicit when a delete event is fired.
 		"name":               ActionTrack,
@@ -106,7 +106,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 	&database.Group{}: {
 		"id":              ActionTrack,
 		"name":            ActionTrack,
-		"organization_id": ActionTrack,
+		"organization_id": ActionIgnore, // Rarely changes and not useful to the user
 		"avatar_url":      ActionTrack,
 	},
 })

--- a/enterprise/audit/table.go
+++ b/enterprise/audit/table.go
@@ -51,7 +51,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 		"id":                     ActionTrack,
 		"created_at":             ActionIgnore, // Never changes, but is implicit and not helpful in a diff.
 		"updated_at":             ActionIgnore, // Changes, but is implicit and not helpful in a diff.
-		"organization_id":        ActionIgnore, // Rarely changes and not useful to the user
+		"organization_id":        ActionIgnore, /// Never changes.
 		"deleted":                ActionIgnore, // Changes, but is implicit when a delete event is fired.
 		"name":                   ActionTrack,
 		"provisioner":            ActionTrack,
@@ -68,7 +68,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 	&database.TemplateVersion{}: {
 		"id":              ActionTrack,
 		"template_id":     ActionTrack,
-		"organization_id": ActionIgnore, // Rarely changes and not useful to the user
+		"organization_id": ActionIgnore, // Never changes.
 		"created_at":      ActionIgnore, // Never changes, but is implicit and not helpful in a diff.
 		"updated_at":      ActionIgnore, // Changes, but is implicit and not helpful in a diff.
 		"name":            ActionTrack,
@@ -95,7 +95,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 		"created_at":         ActionIgnore, // Never changes.
 		"updated_at":         ActionIgnore, // Changes, but is implicit and not helpful in a diff.
 		"owner_id":           ActionTrack,
-		"organization_id":    ActionIgnore, // Rarely changes and not useful to the user
+		"organization_id":    ActionIgnore, // Never changes.
 		"template_id":        ActionTrack,
 		"deleted":            ActionIgnore, // Changes, but is implicit when a delete event is fired.
 		"name":               ActionTrack,
@@ -106,7 +106,7 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 	&database.Group{}: {
 		"id":              ActionTrack,
 		"name":            ActionTrack,
-		"organization_id": ActionIgnore, // Rarely changes and not useful to the user
+		"organization_id": ActionIgnore, // Never changes.
 		"avatar_url":      ActionTrack,
 	},
 })


### PR DESCRIPTION
We decided during demo yesterday that `organization_id` is not a useful property to have in most diffs. I've removed it for now.