### PR TITLE
helm: fix coder resource ref

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -34,7 +34,7 @@ spec:
           image: {{ include "coder.image" . | quote }}
           imagePullPolicy: {{ .Values.coder.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.coder.resources | nindent 12 }}
           env:
             - name: CODER_ADDRESS
               value: "0.0.0.0:{{ include "coder.port" . }}"


### PR DESCRIPTION
fixes an incorrect reference to the `coder.resource` values in the `coder.yaml` template. this resulted in resource values not getting applied to the pod spec.

tested with `helm template`
