### PR TITLE
fix: Remove license on Coder Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ LABEL \
 	org.opencontainers.image.description="A tool for provisioning self-hosted development environments with Terraform." \
 	org.opencontainers.image.url="https://github.com/coder/coder" \
 	org.opencontainers.image.source="https://github.com/coder/coder" \
-	org.opencontainers.image.version="$CODER_VERSION" \
-	org.opencontainers.image.licenses="AGPL-3.0"
+	org.opencontainers.image.version="$CODER_VERSION"
 
 # The coder binary is injected by scripts/build_docker.sh.
 COPY --chown=coder:coder --chmod=755 coder /opt/coder


### PR DESCRIPTION
I didn't know what do change it to, but figured removing it made the most sense. Fixes #3723.
