### PR TITLE
fix: Load template page chunks without blocking

### DIFF
--- a/site/src/pages/TemplatePage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
@@ -13,6 +13,7 @@ import { Helmet } from "react-helmet-async"
 import { pageTitle } from "util/page"
 import { templateACLMachine } from "xServices/template/templateACLXService"
 import { TemplatePermissionsPageView } from "./TemplatePermissionsPageView"
+import { Loader } from "components/Loader/Loader"
 
 export const TemplatePermissionsPage: FC<
   React.PropsWithChildren<unknown>
@@ -20,16 +21,14 @@ export const TemplatePermissionsPage: FC<
   const organizationId = useOrganizationId()
   const { context } = useTemplateLayoutContext()
   const { template, permissions } = context
-  if (!template || !permissions) {
-    throw new Error(
-      "This page should not be displayed until template or permissions being loaded.",
-    )
-  }
   const { template_rbac: isTemplateRBACEnabled } = useFeatureVisibility()
   const [state, send] = useMachine(templateACLMachine, {
-    context: { templateId: template.id },
+    context: { templateId: template?.id },
   })
   const { templateACL, userToBeUpdated, groupToBeUpdated } = state.context
+  if (!template || !permissions) {
+    return <Loader />
+  }
 
   return (
     <>

--- a/site/src/pages/TemplatePage/TemplateSummaryPage/TemplateSummaryPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateSummaryPage/TemplateSummaryPage.tsx
@@ -3,6 +3,7 @@ import { FC } from "react"
 import { Helmet } from "react-helmet-async"
 import { pageTitle } from "util/page"
 import { TemplateSummaryPageView } from "./TemplateSummaryPageView"
+import { Loader } from "components/Loader/Loader"
 
 export const TemplateSummaryPage: FC = () => {
   const { context } = useTemplateLayoutContext()
@@ -16,9 +17,7 @@ export const TemplateSummaryPage: FC = () => {
   } = context
 
   if (!template || !activeTemplateVersion || !templateResources) {
-    throw new Error(
-      "This page should not be displayed until template, activeTemplateVersion or templateResources being loaded.",
-    )
+    return <Loader />
   }
 
   return (


### PR DESCRIPTION
The page was blocking loading children of the template page because the summary waited for `isLoading`. The removal of this should make the template page load a lot faster!
