### PR TITLE
fix: Refactor agent to consume API client

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -34,6 +34,7 @@ import (
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/agent/usershell"
+	"github.com/coder/coder/buildinfo"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/pty"
 	"github.com/coder/coder/tailnet"
@@ -52,22 +53,20 @@ const (
 )
 
 type Options struct {
-	CoordinatorDialer           CoordinatorDialer
-	FetchMetadata               FetchMetadata
-	StatsReporter               StatsReporter
-	WorkspaceAgentApps          WorkspaceAgentApps
-	PostWorkspaceAgentAppHealth PostWorkspaceAgentAppHealth
-	ReconnectingPTYTimeout      time.Duration
-	EnvironmentVariables        map[string]string
-	Logger                      slog.Logger
+	ExchangeToken          func(ctx context.Context) error
+	Client                 Client
+	ReconnectingPTYTimeout time.Duration
+	EnvironmentVariables   map[string]string
+	Logger                 slog.Logger
 }
 
-// CoordinatorDialer is a function that constructs a new broker.
-// A dialer must be passed in to allow for reconnects.
-type CoordinatorDialer func(context.Context) (net.Conn, error)
-
-// FetchMetadata is a function to obtain metadata for the agent.
-type FetchMetadata func(context.Context) (codersdk.WorkspaceAgentMetadata, error)
+type Client interface {
+	WorkspaceAgentMetadata(ctx context.Context) (codersdk.WorkspaceAgentMetadata, error)
+	ListenWorkspaceAgent(ctx context.Context) (net.Conn, error)
+	AgentReportStats(ctx context.Context, log slog.Logger, stats func() *codersdk.AgentStats) (io.Closer, error)
+	PostWorkspaceAgentAppHealth(ctx context.Context, req codersdk.PostWorkspaceAppHealthsRequest) error
+	PostWorkspaceAgentVersion(ctx context.Context, version string) error
+}
 
 func New(options Options) io.Closer {
 	if options.ReconnectingPTYTimeout == 0 {
@@ -75,24 +74,23 @@ func New(options Options) io.Closer {
 	}
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	server := &agent{
-		reconnectingPTYTimeout:      options.ReconnectingPTYTimeout,
-		logger:                      options.Logger,
-		closeCancel:                 cancelFunc,
-		closed:                      make(chan struct{}),
-		envVars:                     options.EnvironmentVariables,
-		coordinatorDialer:           options.CoordinatorDialer,
-		fetchMetadata:               options.FetchMetadata,
-		stats:                       &Stats{},
-		statsReporter:               options.StatsReporter,
-		workspaceAgentApps:          options.WorkspaceAgentApps,
-		postWorkspaceAgentAppHealth: options.PostWorkspaceAgentAppHealth,
+		reconnectingPTYTimeout: options.ReconnectingPTYTimeout,
+		logger:                 options.Logger,
+		closeCancel:            cancelFunc,
+		closed:                 make(chan struct{}),
+		envVars:                options.EnvironmentVariables,
+		client:                 options.Client,
+		exchangeToken:          options.ExchangeToken,
+		stats:                  &Stats{},
 	}
 	server.init(ctx)
 	return server
 }
 
 type agent struct {
-	logger slog.Logger
+	logger        slog.Logger
+	client        Client
+	exchangeToken func(ctx context.Context) error
 
 	reconnectingPTYs       sync.Map
 	reconnectingPTYTimeout time.Duration
@@ -104,26 +102,23 @@ type agent struct {
 
 	envVars map[string]string
 	// metadata is atomic because values can change after reconnection.
-	metadata      atomic.Value
-	fetchMetadata FetchMetadata
-	sshServer     *ssh.Server
+	metadata  atomic.Value
+	sshServer *ssh.Server
 
-	network                     *tailnet.Conn
-	coordinatorDialer           CoordinatorDialer
-	stats                       *Stats
-	statsReporter               StatsReporter
-	workspaceAgentApps          WorkspaceAgentApps
-	postWorkspaceAgentAppHealth PostWorkspaceAgentAppHealth
+	network *tailnet.Conn
+	stats   *Stats
 }
 
-func (a *agent) run(ctx context.Context) {
-	var metadata codersdk.WorkspaceAgentMetadata
-	var err error
-	// An exponential back-off occurs when the connection is failing to dial.
-	// This is to prevent server spam in case of a coderd outage.
-	for retrier := retry.New(50*time.Millisecond, 10*time.Second); retrier.Wait(ctx); {
-		a.logger.Info(ctx, "connecting")
-		metadata, err = a.fetchMetadata(ctx)
+// runLoop attempts to start the agent in a retry loop.
+// Coder may be offline temporarily, a connection issue
+// may be happening, but regardless after the intermittent
+// failure, you'll want the agent to reconnect.
+func (a *agent) runLoop(ctx context.Context) {
+	for retrier := retry.New(100*time.Millisecond, 10*time.Second); retrier.Wait(ctx); {
+		ctx, cancelFunc := context.WithCancel(ctx)
+		err := a.run(ctx)
+		// Cancel after the run is complete to clean up any leaked resources!
+		cancelFunc()
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return
@@ -131,73 +126,99 @@ func (a *agent) run(ctx context.Context) {
 			if a.isClosed() {
 				return
 			}
-			a.logger.Warn(context.Background(), "failed to dial", slog.Error(err))
+			a.logger.Warn(context.Background(), "failed to run loop", slog.Error(err))
 			continue
 		}
-		a.logger.Info(context.Background(), "fetched metadata")
-		break
-	}
-	select {
-	case <-ctx.Done():
-		return
-	default:
-	}
-	a.metadata.Store(metadata)
-
-	// The startup script has not ran yet!
-	go func() {
-		err := a.runStartupScript(ctx, metadata.StartupScript)
-		if errors.Is(err, context.Canceled) {
-			return
-		}
-		if err != nil {
-			a.logger.Warn(ctx, "agent script failed", slog.Error(err))
-		}
-	}()
-
-	if metadata.DERPMap != nil {
-		go a.runTailnet(ctx, metadata.DERPMap)
-	}
-
-	if a.workspaceAgentApps != nil && a.postWorkspaceAgentAppHealth != nil {
-		go NewWorkspaceAppHealthReporter(a.logger, a.workspaceAgentApps, a.postWorkspaceAgentAppHealth)(ctx)
+		a.logger.Info(ctx, "running loop")
 	}
 }
 
-func (a *agent) runTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) {
+func (a *agent) run(ctx context.Context) error {
+	// This allows the agent to refresh it's token if necessary.
+	// For instance identity this is required, since the instance
+	// may not have re-provisioned, but a new agent ID was created.
+	if a.exchangeToken != nil {
+		err := a.exchangeToken(ctx)
+		if err != nil {
+			return xerrors.Errorf("exchange token: %w", err)
+		}
+	}
+
+	err := a.client.PostWorkspaceAgentVersion(ctx, buildinfo.Version())
+	if err != nil {
+		return xerrors.Errorf("update workspace agent version: %w", err)
+	}
+
+	metadata, err := a.client.WorkspaceAgentMetadata(ctx)
+	if err != nil {
+		return xerrors.Errorf("fetch metadata: %w", err)
+	}
+	a.logger.Info(context.Background(), "fetched metadata")
+	oldMetadata := a.metadata.Swap(metadata)
+
+	// The startup script should only execute on the first run!
+	if oldMetadata == nil {
+		go func() {
+			err := a.runStartupScript(ctx, metadata.StartupScript)
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			if err != nil {
+				a.logger.Warn(ctx, "agent script failed", slog.Error(err))
+			}
+		}()
+	}
+
+	// This automatically closes when the context ends!
+	go NewWorkspaceAppHealthReporter(
+		a.logger, metadata.Apps, a.client.PostWorkspaceAgentAppHealth)(ctx)
+
+	a.logger.Debug(ctx, "running tailnet with derpmap", slog.F("derpmap", metadata.DERPMap))
+
 	a.closeMutex.Lock()
-	defer a.closeMutex.Unlock()
-	if a.isClosed() {
-		return
+	network := a.network
+	a.closeMutex.Unlock()
+	if a.network == nil {
+		network, err = a.createTailnet(ctx, metadata.DERPMap)
+		if err != nil {
+			return xerrors.Errorf("create tailnet: %w", err)
+		}
+		a.closeMutex.Lock()
+		a.network = network
+		a.closeMutex.Unlock()
+	} else {
+		// Update the DERP map!
+		network.SetDERPMap(metadata.DERPMap)
 	}
-	a.logger.Debug(ctx, "running tailnet with derpmap", slog.F("derpmap", derpMap))
-	if a.network != nil {
-		a.network.SetDERPMap(derpMap)
-		return
+
+	err = a.runCoordinator(ctx, network)
+	if err != nil {
+		return xerrors.Errorf("run coordinator: %w", err)
 	}
-	var err error
-	a.network, err = tailnet.NewConn(&tailnet.Options{
+	return nil
+}
+
+func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (*tailnet.Conn, error) {
+	network, err := tailnet.NewConn(&tailnet.Options{
 		Addresses: []netip.Prefix{netip.PrefixFrom(codersdk.TailnetIP, 128)},
 		DERPMap:   derpMap,
 		Logger:    a.logger.Named("tailnet"),
 	})
 	if err != nil {
-		a.logger.Critical(ctx, "create tailnet", slog.Error(err))
-		return
+		return nil, xerrors.Errorf("create tailnet: %w", err)
 	}
-	a.network.SetForwardTCPCallback(func(conn net.Conn, listenerExists bool) net.Conn {
+	a.network = network
+	network.SetForwardTCPCallback(func(conn net.Conn, listenerExists bool) net.Conn {
 		if listenerExists {
 			// If a listener already exists, we would double-wrap the conn.
 			return conn
 		}
 		return a.stats.wrapConn(conn)
 	})
-	go a.runCoordinator(ctx)
 
-	sshListener, err := a.network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetSSHPort))
+	sshListener, err := network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetSSHPort))
 	if err != nil {
-		a.logger.Critical(ctx, "listen for ssh", slog.Error(err))
-		return
+		return nil, xerrors.Errorf("listen on the ssh port: %w", err)
 	}
 	go func() {
 		for {
@@ -209,10 +230,9 @@ func (a *agent) runTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) {
 		}
 	}()
 
-	reconnectingPTYListener, err := a.network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetReconnectingPTYPort))
+	reconnectingPTYListener, err := network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetReconnectingPTYPort))
 	if err != nil {
-		a.logger.Critical(ctx, "listen for reconnecting pty", slog.Error(err))
-		return
+		return nil, xerrors.Errorf("listen for reconnecting pty: %w", err)
 	}
 	go func() {
 		for {
@@ -244,10 +264,9 @@ func (a *agent) runTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) {
 		}
 	}()
 
-	speedtestListener, err := a.network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetSpeedtestPort))
+	speedtestListener, err := network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetSpeedtestPort))
 	if err != nil {
-		a.logger.Critical(ctx, "listen for speedtest", slog.Error(err))
-		return
+		return nil, xerrors.Errorf("listen for speedtest: %w", err)
 	}
 	go func() {
 		for {
@@ -266,10 +285,9 @@ func (a *agent) runTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) {
 		}
 	}()
 
-	statisticsListener, err := a.network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetStatisticsPort))
+	statisticsListener, err := network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetStatisticsPort))
 	if err != nil {
-		a.logger.Critical(ctx, "listen for statistics", slog.Error(err))
-		return
+		return nil, xerrors.Errorf("listen for statistics: %w", err)
 	}
 	go func() {
 		defer statisticsListener.Close()
@@ -290,59 +308,30 @@ func (a *agent) runTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) {
 			a.logger.Critical(ctx, "serve statistics HTTP server", slog.Error(err))
 		}
 	}()
+
+	return network, nil
 }
 
-// runCoordinator listens for nodes and updates the self-node as it changes.
-func (a *agent) runCoordinator(ctx context.Context) {
-	for {
-		reconnect := a.runCoordinatorWithRetry(ctx)
-		if !reconnect {
-			return
-		}
-	}
-}
-
-func (a *agent) runCoordinatorWithRetry(ctx context.Context) (reconnect bool) {
+// runCoordinator runs a coordinator and returns whether a reconnect
+// should occur.
+func (a *agent) runCoordinator(ctx context.Context, network *tailnet.Conn) error {
 	var coordinator net.Conn
 	var err error
 	// An exponential back-off occurs when the connection is failing to dial.
 	// This is to prevent server spam in case of a coderd outage.
-	for retrier := retry.New(50*time.Millisecond, 10*time.Second); retrier.Wait(ctx); {
-		coordinator, err = a.coordinatorDialer(ctx)
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return false
-			}
-			if a.isClosed() {
-				return false
-			}
-			a.logger.Warn(context.Background(), "failed to dial", slog.Error(err))
-			continue
-		}
-		//nolint:revive // Defer is ok because we're exiting this loop.
-		defer coordinator.Close()
-		a.logger.Info(context.Background(), "connected to coordination server")
-		break
+	coordinator, err = a.client.ListenWorkspaceAgent(ctx)
+	if err != nil {
+		return err
 	}
+	defer coordinator.Close()
+	a.logger.Info(context.Background(), "connected to coordination server")
+	sendNodes, errChan := tailnet.ServeCoordinator(coordinator, network.UpdateNodes)
+	network.SetNodeCallback(sendNodes)
 	select {
 	case <-ctx.Done():
-		return false
-	default:
-	}
-	sendNodes, errChan := tailnet.ServeCoordinator(coordinator, a.network.UpdateNodes)
-	a.network.SetNodeCallback(sendNodes)
-	select {
-	case <-ctx.Done():
-		return false
+		return ctx.Err()
 	case err := <-errChan:
-		if a.isClosed() {
-			return false
-		}
-		if errors.Is(err, context.Canceled) {
-			return false
-		}
-		a.logger.Debug(ctx, "node broker accept exited; restarting connection", slog.Error(err))
-		return true
+		return err
 	}
 }
 
@@ -474,22 +463,20 @@ func (a *agent) init(ctx context.Context) {
 		},
 	}
 
-	go a.run(ctx)
-	if a.statsReporter != nil {
-		cl, err := a.statsReporter(ctx, a.logger, func() *codersdk.AgentStats {
-			return a.stats.Copy()
-		})
-		if err != nil {
-			a.logger.Error(ctx, "report stats", slog.Error(err))
-			return
-		}
-		a.connCloseWait.Add(1)
-		go func() {
-			defer a.connCloseWait.Done()
-			<-a.closed
-			cl.Close()
-		}()
+	go a.runLoop(ctx)
+	cl, err := a.client.AgentReportStats(ctx, a.logger, func() *codersdk.AgentStats {
+		return a.stats.Copy()
+	})
+	if err != nil {
+		a.logger.Error(ctx, "report stats", slog.Error(err))
+		return
 	}
+	a.connCloseWait.Add(1)
+	go func() {
+		defer a.connCloseWait.Done()
+		<-a.closed
+		cl.Close()
+	}()
 }
 
 // createCommand processes raw command input with OpenSSH-like behavior.

--- a/agent/apphealth.go
+++ b/agent/apphealth.go
@@ -23,16 +23,8 @@ type PostWorkspaceAgentAppHealth func(context.Context, codersdk.PostWorkspaceApp
 type WorkspaceAppHealthReporter func(ctx context.Context)
 
 // NewWorkspaceAppHealthReporter creates a WorkspaceAppHealthReporter that reports app health to coderd.
-func NewWorkspaceAppHealthReporter(logger slog.Logger, workspaceAgentApps WorkspaceAgentApps, postWorkspaceAgentAppHealth PostWorkspaceAgentAppHealth) WorkspaceAppHealthReporter {
+func NewWorkspaceAppHealthReporter(logger slog.Logger, apps []codersdk.WorkspaceApp, postWorkspaceAgentAppHealth PostWorkspaceAgentAppHealth) WorkspaceAppHealthReporter {
 	runHealthcheckLoop := func(ctx context.Context) error {
-		apps, err := workspaceAgentApps(ctx)
-		if err != nil {
-			if xerrors.Is(err, context.Canceled) {
-				return nil
-			}
-			return xerrors.Errorf("getting workspace apps: %w", err)
-		}
-
 		// no need to run this loop if no apps for this workspace.
 		if len(apps) == 0 {
 			return nil

--- a/agent/apphealth_test.go
+++ b/agent/apphealth_test.go
@@ -199,7 +199,7 @@ func setupAppReporter(ctx context.Context, t *testing.T, apps []codersdk.Workspa
 		return nil
 	}
 
-	go agent.NewWorkspaceAppHealthReporter(slogtest.Make(t, nil).Leveled(slog.LevelDebug), workspaceAgentApps, postWorkspaceAgentAppHealth)(ctx)
+	go agent.NewWorkspaceAppHealthReporter(slogtest.Make(t, nil).Leveled(slog.LevelDebug), apps, postWorkspaceAgentAppHealth)(ctx)
 
 	return workspaceAgentApps, func() {
 		for _, closeFn := range closers {

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -1,12 +1,9 @@
 package agent
 
 import (
-	"context"
-	"io"
 	"net"
 	"sync/atomic"
 
-	"cdr.dev/slog"
 	"github.com/coder/coder/codersdk"
 )
 
@@ -59,10 +56,3 @@ func (s *Stats) wrapConn(conn net.Conn) net.Conn {
 
 	return cs
 }
-
-// StatsReporter periodically accept and records agent stats.
-type StatsReporter func(
-	ctx context.Context,
-	log slog.Logger,
-	stats func() *codersdk.AgentStats,
-) (io.Closer, error)

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/spf13/cobra"
@@ -78,6 +79,8 @@ func workspaceAgent() *cobra.Command {
 				slog.F("version", version),
 			)
 			client := codersdk.New(coderURL)
+			// Set a reasonable timeout so requests can't hang forever!
+			client.HTTPClient.Timeout = 10 * time.Second
 
 			if pprofEnabled {
 				srvClose := serveHandler(cmd.Context(), logger, nil, pprofAddress, "pprof")

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -106,9 +106,8 @@ func TestConfigSSH(t *testing.T) {
 	agentClient := codersdk.New(client.URL)
 	agentClient.SessionToken = authToken
 	agentCloser := agent.New(agent.Options{
-		FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-		CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-		Logger:            slogtest.Make(t, nil).Named("agent"),
+		Client: agentClient,
+		Logger: slogtest.Make(t, nil).Named("agent"),
 	})
 	defer func() {
 		_ = agentCloser.Close()

--- a/cli/speedtest_test.go
+++ b/cli/speedtest_test.go
@@ -24,9 +24,8 @@ func TestSpeedtest(t *testing.T) {
 	agentClient := codersdk.New(client.URL)
 	agentClient.SessionToken = agentToken
 	agentCloser := agent.New(agent.Options{
-		FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-		CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-		Logger:            slogtest.Make(t, nil).Named("agent"),
+		Client: agentClient,
+		Logger: slogtest.Make(t, nil).Named("agent"),
 	})
 	defer agentCloser.Close()
 	coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -89,9 +89,8 @@ func TestSSH(t *testing.T) {
 		agentClient := codersdk.New(client.URL)
 		agentClient.SessionToken = agentToken
 		agentCloser := agent.New(agent.Options{
-			FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-			CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-			Logger:            slogtest.Make(t, nil).Named("agent"),
+			Client: agentClient,
+			Logger: slogtest.Make(t, nil).Named("agent"),
 		})
 		defer func() {
 			_ = agentCloser.Close()
@@ -110,9 +109,8 @@ func TestSSH(t *testing.T) {
 			agentClient := codersdk.New(client.URL)
 			agentClient.SessionToken = agentToken
 			agentCloser := agent.New(agent.Options{
-				FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-				CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-				Logger:            slogtest.Make(t, nil).Named("agent"),
+				Client: agentClient,
+				Logger: slogtest.Make(t, nil).Named("agent"),
 			})
 			<-ctx.Done()
 			_ = agentCloser.Close()
@@ -178,9 +176,8 @@ func TestSSH(t *testing.T) {
 		agentClient := codersdk.New(client.URL)
 		agentClient.SessionToken = agentToken
 		agentCloser := agent.New(agent.Options{
-			FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-			CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-			Logger:            slogtest.Make(t, nil).Named("agent"),
+			Client: agentClient,
+			Logger: slogtest.Make(t, nil).Named("agent"),
 		})
 		defer agentCloser.Close()
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -471,7 +471,6 @@ func New(options *Options) *API {
 			r.Post("/google-instance-identity", api.postWorkspaceAuthGoogleInstanceIdentity)
 			r.Route("/me", func(r chi.Router) {
 				r.Use(httpmw.ExtractWorkspaceAgent(options.Database))
-				r.Get("/apps", api.workspaceAgentApps)
 				r.Get("/metadata", api.workspaceAgentMetadata)
 				r.Post("/version", api.postWorkspaceAgentVersion)
 				r.Post("/app-health", api.postWorkspaceAppHealth)

--- a/coderd/coderdtest/authorize.go
+++ b/coderd/coderdtest/authorize.go
@@ -57,7 +57,6 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 		"POST:/api/v2/workspaceagents/aws-instance-identity":    {NoAuthorize: true},
 		"POST:/api/v2/workspaceagents/azure-instance-identity":  {NoAuthorize: true},
 		"POST:/api/v2/workspaceagents/google-instance-identity": {NoAuthorize: true},
-		"GET:/api/v2/workspaceagents/me/apps":                   {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/me/gitsshkey":              {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/me/metadata":               {NoAuthorize: true},
 		"GET:/api/v2/workspaceagents/me/coordinate":             {NoAuthorize: true},

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -603,10 +603,8 @@ func TestTemplateMetrics(t *testing.T) {
 	agentClient := codersdk.New(client.URL)
 	agentClient.SessionToken = authToken
 	agentCloser := agent.New(agent.Options{
-		Logger:            slogtest.Make(t, nil),
-		StatsReporter:     agentClient.AgentReportStats,
-		FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-		CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
+		Logger: slogtest.Make(t, nil),
+		Client: agentClient,
 	})
 	defer func() {
 		_ = agentCloser.Close()

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -195,10 +195,8 @@ func createWorkspaceWithApps(t *testing.T, client *codersdk.Client, orgID uuid.U
 	agentClient := codersdk.New(client.URL)
 	agentClient.SessionToken = authToken
 	agentCloser := agent.New(agent.Options{
-		FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-		CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-		Logger:            slogtest.Make(t, nil).Named("agent"),
-		StatsReporter:     agentClient.AgentReportStats,
+		Client: agentClient,
+		Logger: slogtest.Make(t, nil).Named("agent"),
 	})
 	t.Cleanup(func() {
 		_ = agentCloser.Close()

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -105,6 +105,9 @@ func (c *Client) Request(ctx context.Context, method, path string, body interfac
 // readBodyAsError reads the response as an .Message, and
 // wraps it in a codersdk.Error type for easy marshaling.
 func readBodyAsError(res *http.Response) error {
+	if res == nil {
+		return xerrors.Errorf("no body returned")
+	}
 	defer res.Body.Close()
 	contentType := res.Header.Get("Content-Type")
 

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -119,9 +119,8 @@ func setupWorkspaceAgent(t *testing.T, client *codersdk.Client, user codersdk.Cr
 	}
 	agentClient.SessionToken = authToken
 	agentCloser := agent.New(agent.Options{
-		FetchMetadata:     agentClient.WorkspaceAgentMetadata,
-		CoordinatorDialer: agentClient.ListenWorkspaceAgentTailnet,
-		Logger:            slogtest.Make(t, nil).Named("agent"),
+		Client: agentClient,
+		Logger: slogtest.Make(t, nil).Named("agent"),
 	})
 	t.Cleanup(func() {
 		_ = agentCloser.Close()


### PR DESCRIPTION
This simplifies a lot of code by creating an interface for the codersdk client into the agent. It also moves agent authentication code so instance identity will work between restarts.

Fixes #3485 and #4082.
