### PR TITLE
bug: fixed prompt in `.devcontainer/Dockerfile`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV EDITOR=vim
 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get upgrade --yes
 
 RUN apt-get install --yes \
         ca-certificates \


### PR DESCRIPTION
The user prompt was causing the GitHub codespaces build to fail.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
