### PR TITLE
chore: added the Group resource in audit-logs.md

### DIFF
--- a/docs/admin/audit-logs.md
+++ b/docs/admin/audit-logs.md
@@ -12,6 +12,7 @@ We track **create, update and delete** events for the following resources:
 - TemplateVersion
 - Workspace
 - User
+- Group
 
 ## Filtering logs
 


### PR DESCRIPTION
We want to make sure [our documentation for Audit Logs](https://coder.com/docs/coder-oss/latest/admin/audit-logs) reflects that we audit Groups.
