### PR TITLE
dogfood: remove gitconfig to allow cloning with HTTPS

### DIFF
--- a/dogfood/files/etc/gitconfig
+++ b/dogfood/files/etc/gitconfig
@@ -1,4 +1,0 @@
-# This is required to force SSH authentication for go mod.
-# See: https://golang.org/ref/mod#private-module-repo-auth
-[url "git@github.com:"]
-    insteadOf = https://github.com/


### PR DESCRIPTION
This reflects a more natural environment that our customers might have, and enables us to use the new git authentication!
