### PR TITLE
fix: Line gets erased due to updateJob

### DIFF
--- a/cli/cliui/provisionerjob.go
+++ b/cli/cliui/provisionerjob.go
@@ -103,7 +103,6 @@ func ProvisionerJob(ctx context.Context, writer io.Writer, opts ProvisionerJobOp
 		}
 		updateStage("Running", *job.StartedAt)
 	}
-	updateJob()
 
 	if opts.Cancel != nil {
 		// Handles ctrl+c to cancel a job.
@@ -131,6 +130,7 @@ func ProvisionerJob(ctx context.Context, writer io.Writer, opts ProvisionerJobOp
 
 	// The initial stage needs to print after the signal handler has been registered.
 	printStage()
+	updateJob()
 
 	logs, closer, err := opts.Logs()
 	if err != nil {


### PR DESCRIPTION
The first updateJob should be called after the first printStage to guarantee that only stage prints can get erased and overwritten, otherwise there could be an unrelated line that gets erased.

fixes #3967
