### PR TITLE
refactor: Refactor page header spacing and stats

### DIFF
--- a/site/src/components/PageHeader/PageHeader.tsx
+++ b/site/src/components/PageHeader/PageHeader.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
     paddingTop: theme.spacing(6),
-    paddingBottom: theme.spacing(5),
+    paddingBottom: theme.spacing(6),
 
     [theme.breakpoints.down("sm")]: {
       flexDirection: "column",

--- a/site/src/components/Pill/Pill.tsx
+++ b/site/src/components/Pill/Pill.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, Theme } from "@material-ui/core/styles"
 import { FC } from "react"
-import { MONOSPACE_FONT_FAMILY } from "theme/constants"
 import { PaletteIndex } from "theme/palettes"
 import { combineClasses } from "util/combineClasses"
 
@@ -28,14 +27,12 @@ export const Pill: FC<PillProps> = (props) => {
 
 const useStyles = makeStyles<Theme, PillProps>((theme) => ({
   wrapper: {
-    fontFamily: MONOSPACE_FONT_FAMILY,
     display: "inline-flex",
     alignItems: "center",
     borderWidth: 1,
     borderStyle: "solid",
     borderRadius: 99999,
-    fontSize: 14,
-    fontWeight: 500,
+    fontSize: 12,
     color: "#FFF",
     height: theme.spacing(3),
     paddingLeft: ({ icon }) =>

--- a/site/src/components/TemplateStats/TemplateStats.tsx
+++ b/site/src/components/TemplateStats/TemplateStats.tsx
@@ -6,7 +6,6 @@ import {
   formatTemplateActiveDevelopers,
 } from "util/templates"
 import { Template, TemplateVersion } from "../../api/typesGenerated"
-import { MONOSPACE_FONT_FAMILY } from "../../theme/constants"
 
 const Language = {
   usedByLabel: "Used by",
@@ -32,7 +31,7 @@ export const TemplateStats: FC<TemplateStatsProps> = ({
   return (
     <div className={styles.stats}>
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.usedByLabel}</span>
+        <span className={styles.statsLabel}>{Language.usedByLabel}:</span>
 
         <span className={styles.statsValue}>
           {formatTemplateActiveDevelopers(template.active_user_count)}{" "}
@@ -41,29 +40,27 @@ export const TemplateStats: FC<TemplateStatsProps> = ({
             : Language.developerPlural}
         </span>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.buildTimeLabel}</span>
+        <span className={styles.statsLabel}>{Language.buildTimeLabel}:</span>
 
         <span className={styles.statsValue}>
           {formatTemplateBuildTime(template.build_time_stats.start_ms)}{" "}
         </span>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.activeVersionLabel}</span>
+        <span className={styles.statsLabel}>
+          {Language.activeVersionLabel}:
+        </span>
         <span className={styles.statsValue}>{activeVersion.name}</span>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.lastUpdateLabel}</span>
+        <span className={styles.statsLabel}>{Language.lastUpdateLabel}:</span>
         <span className={styles.statsValue} data-chromatic="ignore">
           {createDayString(template.updated_at)}
         </span>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.createdByLabel}</span>
+        <span className={styles.statsLabel}>{Language.createdByLabel}:</span>
         <span className={styles.statsValue}>{template.created_by_name}</span>
       </div>
     </div>
@@ -74,12 +71,10 @@ const useStyles = makeStyles((theme) => ({
   stats: {
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
-    backgroundColor: theme.palette.background.paper,
     borderRadius: theme.shape.borderRadius,
     display: "flex",
     alignItems: "center",
     color: theme.palette.text.secondary,
-    fontFamily: MONOSPACE_FONT_FAMILY,
     border: `1px solid ${theme.palette.divider}`,
     [theme.breakpoints.down("sm")]: {
       display: "block",
@@ -87,33 +82,21 @@ const useStyles = makeStyles((theme) => ({
   },
 
   statItem: {
-    minWidth: "15%",
     padding: theme.spacing(2),
     paddingTop: theme.spacing(1.75),
+    display: "flex",
+    alignItems: "baseline",
+    gap: theme.spacing(1),
   },
 
   statsLabel: {
-    fontSize: 12,
-    textTransform: "uppercase",
     display: "block",
-    fontWeight: 600,
     wordWrap: "break-word",
   },
 
   statsValue: {
-    fontSize: 16,
-    marginTop: theme.spacing(0.25),
     display: "block",
     wordWrap: "break-word",
-  },
-
-  statsDivider: {
-    width: 1,
-    height: theme.spacing(5),
-    backgroundColor: theme.palette.divider,
-    marginRight: theme.spacing(2),
-    [theme.breakpoints.down("sm")]: {
-      display: "none",
-    },
+    color: theme.palette.text.primary,
   },
 }))

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -179,7 +179,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
       <Stack
         direction="column"
         className={styles.firstColumnSpacer}
-        spacing={6}
+        spacing={4}
       >
         {buildError}
         {cancellationError}

--- a/site/src/components/WorkspaceStats/WorkspaceStats.tsx
+++ b/site/src/components/WorkspaceStats/WorkspaceStats.tsx
@@ -7,7 +7,6 @@ import { combineClasses } from "util/combineClasses"
 import { createDayString } from "util/createDayString"
 import { getDisplayWorkspaceBuildInitiatedBy } from "util/workspace"
 import { Workspace } from "../../api/typesGenerated"
-import { MONOSPACE_FONT_FAMILY } from "../../theme/constants"
 
 const Language = {
   workspaceDetails: "Workspace Details",
@@ -17,7 +16,7 @@ const Language = {
   lastBuiltLabel: "Last Built",
   outdated: "Outdated",
   upToDate: "Up to date",
-  byLabel: "Last Built by",
+  byLabel: "Last built by",
 }
 
 export interface WorkspaceStatsProps {
@@ -38,7 +37,7 @@ export const WorkspaceStats: FC<WorkspaceStatsProps> = ({
   return (
     <div className={styles.stats} aria-label={Language.workspaceDetails}>
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.templateLabel}</span>
+        <span className={styles.statsLabel}>{Language.templateLabel}:</span>
         <Link
           component={RouterLink}
           to={`/templates/${workspace.template_name}`}
@@ -47,9 +46,8 @@ export const WorkspaceStats: FC<WorkspaceStatsProps> = ({
           {workspace.template_name}
         </Link>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.versionLabel}</span>
+        <span className={styles.statsLabel}>{Language.versionLabel}:</span>
         <span className={styles.statsValue}>
           {workspace.outdated ? (
             <span className={styles.outdatedLabel}>
@@ -66,16 +64,14 @@ export const WorkspaceStats: FC<WorkspaceStatsProps> = ({
           )}
         </span>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.lastBuiltLabel}</span>
+        <span className={styles.statsLabel}>{Language.lastBuiltLabel}:</span>
         <span className={styles.statsValue} data-chromatic="ignore">
           {createDayString(workspace.latest_build.created_at)}
         </span>
       </div>
-      <div className={styles.statsDivider} />
       <div className={styles.statItem}>
-        <span className={styles.statsLabel}>{Language.byLabel}</span>
+        <span className={styles.statsLabel}>{Language.byLabel}:</span>
         <span className={styles.statsValue}>{initiatedBy}</span>
       </div>
     </div>
@@ -86,13 +82,11 @@ const useStyles = makeStyles((theme) => ({
   stats: {
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
-    backgroundColor: theme.palette.background.paper,
     borderRadius: theme.shape.borderRadius,
     border: `1px solid ${theme.palette.divider}`,
     display: "flex",
     alignItems: "center",
     color: theme.palette.text.secondary,
-    fontFamily: MONOSPACE_FONT_FAMILY,
     margin: "0px",
     [theme.breakpoints.down("sm")]: {
       display: "block",
@@ -100,34 +94,23 @@ const useStyles = makeStyles((theme) => ({
   },
 
   statItem: {
-    minWidth: "16%",
     padding: theme.spacing(2),
     paddingTop: theme.spacing(1.75),
+    display: "flex",
+    alignItems: "baseline",
+    gap: theme.spacing(1),
   },
 
   statsLabel: {
-    fontSize: 12,
-    textTransform: "uppercase",
     display: "block",
-    fontWeight: 600,
     wordWrap: "break-word",
   },
 
   statsValue: {
-    fontSize: 16,
     marginTop: theme.spacing(0.25),
     display: "block",
     wordWrap: "break-word",
-  },
-
-  statsDivider: {
-    width: 1,
-    height: theme.spacing(5),
-    backgroundColor: theme.palette.divider,
-    marginRight: theme.spacing(2),
-    [theme.breakpoints.down("sm")]: {
-      display: "none",
-    },
+    color: theme.palette.text.primary,
   },
 
   capitalize: {

--- a/site/src/pages/TemplatePage/TemplateSummaryPage/TemplateSummaryPageView.tsx
+++ b/site/src/pages/TemplatePage/TemplateSummaryPage/TemplateSummaryPageView.tsx
@@ -54,13 +54,13 @@ export const TemplateSummaryPageView: FC<
   }
 
   return (
-    <Stack spacing={2.5}>
+    <Stack spacing={4}>
       {deleteError}
-      {templateDAUs && <DAUChart templateDAUs={templateDAUs} />}
       <TemplateStats
         template={template}
         activeVersion={activeTemplateVersion}
       />
+      {templateDAUs && <DAUChart templateDAUs={templateDAUs} />}
       <TemplateResourcesTable
         resources={getStartedResources(templateResources)}
       />


### PR DESCRIPTION
Before:
<img width="1790" alt="Screen Shot 2022-10-25 at 14 08 56" src="https://user-images.githubusercontent.com/3165839/197838427-64eedfa3-46f4-4348-900f-f784fe2dcd92.png">
<img width="1792" alt="Screen Shot 2022-10-25 at 14 02 31" src="https://user-images.githubusercontent.com/3165839/197838431-d9e17f1d-609f-40ea-aa6b-5db54ae77286.png">

After:
<img width="1792" alt="Screen Shot 2022-10-25 at 14 09 09" src="https://user-images.githubusercontent.com/3165839/197838419-86ec5fa9-5b4e-47b0-b0a4-cd3f509331ab.png">
<img width="1792" alt="Screen Shot 2022-10-25 at 14 02 21" src="https://user-images.githubusercontent.com/3165839/197838434-8819f85a-1095-45ad-b4d5-ce016f7bf46b.png">
