### PR TITLE
fix: Fix audit log collapse

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogDiff.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDiff.tsx
@@ -78,6 +78,8 @@ const useStyles = makeStyles((theme) => ({
     fontSize: theme.typography.body2.fontSize,
     borderTop: `1px solid ${theme.palette.divider}`,
     fontFamily: MONOSPACE_FONT_FAMILY,
+    position: "relative",
+    zIndex: 2,
   },
 
   diffColumn: {


### PR DESCRIPTION
Before:
<img width="1386" alt="Screen Shot 2022-10-26 at 21 46 44" src="https://user-images.githubusercontent.com/3165839/198165573-cbf70cda-b3eb-4aba-8ab4-5b2c16eabe50.png">

After:
<img width="1369" alt="Screen Shot 2022-10-26 at 21 50 12" src="https://user-images.githubusercontent.com/3165839/198165583-cf2df743-d90a-457e-a747-0b83e65933fd.png">
