### PR TITLE
docs: fix base path for JupyterLab

### DIFF
--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -219,7 +219,7 @@ data "coder_workspace" "me" {}
 ## string in the base_url. This caveat is unique to Jupyter.
 
 locals {
-  jupyter_base_path = "/@${data.coder_workspace.me.owner}/${data.coder_workspace.me.name}/apps/jupyter/"
+  jupyter_base_path = "/@${data.coder_workspace.me.owner}/${data.coder_workspace.me.name}/apps/JupyterLab/"
 }
 
 resource "coder_agent" "coder" {


### PR DESCRIPTION
It seems the base path uses the app name (for now anyway).

https://github.com/coder/coder/discussions/4785

In the linked discussion the application would load at `/apps/JupyterLab` then Jupyter would redirect itself to base URL + `/lab` resulting in `/apps/jupyter/lab` which is a 404.