### PR TITLE
feat: publish helm chart to helm.coder.com

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,14 +168,17 @@ jobs:
             ./build/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Setup GCloud SDK
         uses: 'google-github-actions/setup-gcloud@v0'
+
       - name: Publish Helm Chart
         run: |
           version="$(./scripts/version.sh)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ permissions:
   contents: write
   # Necessary to push docker images to ghcr.io.
   packages: write
+  # Necessary for GCP authentication (https://github.com/google-github-actions/setup-gcloud#usage)
+  id-token: write
 
 env:
   CODER_RELEASE: ${{ github.event.inputs.snapshot && 'false' || 'true' }}
@@ -166,6 +168,23 @@ jobs:
             ./build/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_ID_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Setup GCloud SDK
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - name: Publish Helm Chart
+        run: |
+          version="$(./scripts/version.sh)"
+          mkdir -p build/helm
+          cp "build/coder_helm_${version}.tgz" build/helm
+          gsutil cp gs://helm.coder.com/v2/index.yaml build/helm/index.yaml
+          helm repo index build/helm --url https://helm.coder.com/v2 --merge build/helm/index.yaml
+          gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/coder_helm_${version}.tgz gs://helm.coder.com/v2
+          gsutil -h "Cache-Control:no-cache,max-age=0" cp build/helm/index.yaml gs://helm.coder.com/v2
 
       - name: Upload artifacts to actions (if dry-run or snapshot)
         if: ${{ github.event.inputs.dry_run || github.event.inputs.snapshot }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,7 +170,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Authenticate to Google Cloud
-        id: auth
         uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_ID_PROVIDER }}
@@ -181,6 +180,7 @@ jobs:
 
       - name: Publish Helm Chart
         run: |
+          set -euo pipefail
           version="$(./scripts/version.sh)"
           mkdir -p build/helm
           cp "build/coder_helm_${version}.tgz" build/helm

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -60,7 +60,7 @@ to log in and manage templates.
 1. Add the Coder Helm repo:
 
    ```console
-   helm repo add coder https://helm.coder.com/v2
+   helm repo add coder-v2 https://helm.coder.com/v2
    ```
 
 1. Create a secret with the database URL:
@@ -118,7 +118,7 @@ to log in and manage templates.
 1. Run the following command to install the chart in your cluster.
 
    ```sh
-   helm install coder coder/coder \
+   helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml
    ```
@@ -142,7 +142,7 @@ you can run the following command:
 
 ```sh
 helm repo update
-helm upgrade coder coder/coder \
+helm upgrade coder coder-v2/coder \
   --namespace coder \
   -f values.yaml
 ```

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -57,11 +57,10 @@ to log in and manage templates.
    [Postgres operator](https://github.com/zalando/postgres-operator) to
    manage PostgreSQL deployments on your Kubernetes cluster.
 
-1. Download the latest `coder_helm` package from
-   [GitHub releases](https://github.com/coder/coder/releases).
+1. Add the Coder Helm repo:
 
    ```console
-   wget https://github.com/coder/coder/releases/download/<release>/coder_helm_<release>.tgz
+   helm repo add coder https://helm.coder.com/v2
    ```
 
 1. Create a secret with the database URL:
@@ -116,10 +115,10 @@ to log in and manage templates.
    > [values.yaml](https://github.com/coder/coder/blob/main/helm/values.yaml)
    > file directly.
 
-1. Run the following commands to install the chart in your cluster.
+1. Run the following command to install the chart in your cluster.
 
    ```sh
-   helm install coder ./coder_helm_x.y.z.tgz \
+   helm install coder coder/coder \
        --namespace coder \
        --values values.yaml
    ```
@@ -139,12 +138,13 @@ to log in and manage templates.
 ## Upgrading Coder via Helm
 
 To upgrade Coder in the future or change values,
-you can run the following command with a new `coder_helm_x.y.z.tgz` file from GitHub releases:
+you can run the following command:
 
-```console
-$ helm upgrade coder ./coder_helm_x.y.z.tgz \
-    --namespace coder \
-    -f values.yaml
+```sh
+helm repo update
+helm upgrade coder coder/coder \
+  --namespace coder \
+  -f values.yaml
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
fixes #3545

I opted to push it to our GCP bucket but if we want to host it in `ghcr` then I suppose we can. The only caveats to doing that:

1. To pull the helm chart you will have to `helm install oci://ghcr.io/coder/helm/coder` which looks weird imo.
2. `ghcr.io` has no concept of helm so the `helm` package is going to look like it points to a docker registry. Which kind of supports the point that `ghcr.io` is kind of a hack.
3. ~~I can't find a way to point the package to this repo since it's not a docker image, npm pkg, etc~~ nvm I think we could still do this one
