### PR TITLE
refactor: Fix list styles in markdown

### DIFF
--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -119,6 +119,15 @@ const useStyles = makeStyles((theme) => ({
       display: "flex",
       flexDirection: "column",
       gap: theme.spacing(1),
+      marginBottom: theme.spacing(2),
+    },
+
+    "& li > ul, & li > ol": {
+      marginTop: theme.spacing(2),
+    },
+
+    "& li > p": {
+      marginBottom: 0,
     },
 
     "& .prismjs": {


### PR DESCRIPTION
Before:
<img width="786" alt="Screen Shot 2022-10-28 at 17 28 59" src="https://user-images.githubusercontent.com/3165839/198726688-79601d75-c478-4d98-a959-8f963f7f4324.png">

After:
<img width="796" alt="Screen Shot 2022-10-28 at 17 29 05" src="https://user-images.githubusercontent.com/3165839/198726682-3057bcc1-95e5-45a0-8f60-03b0b7d3fd83.png">
