### PR TITLE
Fix link to supported terraform versions

### DIFF
--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -27,7 +27,7 @@ RUN mkdir -p /opt/terraform
 # In order to run Coder airgapped or within private networks,
 # Terraform has to be bundled into the image in PATH or /opt.
 #
-# See https://github.com/coder/coder/blob/main/provisioner/terraform/serve.go#L24-L25
+# See https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24
 # for supported Terraform versions.
 ARG TERRAFORM_VERSION=1.3.0
 RUN curl -LOs https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \

--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -6,7 +6,7 @@ Coder can run in offline / air-gapped environments.
 
 First, build and push a container image extending our official image with the following:
 
-- Terraform [(supported versions)](https://github.com/coder/coder/blob/main/provisioner/terraform/serve.go#L24-L25)
+- Terraform [(supported versions)](https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24)
 - CLI config (.tfrc) for Terraform referring to [external mirror](https://www.terraform.io/cli/config/config-file#explicit-installation-method-configuration)
 - [Terraform Providers](https://registry.terraform.io) for templates
   - These could also be specified via a volume mount (Docker) or [network mirror](https://www.terraform.io/internals/provider-network-mirror-protocol). See below for details.


### PR DESCRIPTION
(Current link points to unrelated lines in `serve.go`)