### PR TITLE
feat: Add support for update checks and notifications

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -68,6 +68,11 @@ func VersionsMatch(v1, v2 string) bool {
 	return semver.MajorMinor(v1) == semver.MajorMinor(v2)
 }
 
+// IsDev returns true if this is a development build.
+func IsDev() bool {
+	return strings.HasPrefix(Version(), develPrefix)
+}
+
 // ExternalURL returns a URL referencing the current Coder version.
 // For production builds, this will link directly to a release.
 // For development builds, this will link to a commit.

--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -408,7 +408,7 @@ func newConfig() *codersdk.DeploymentConfig {
 		},
 		UpdateCheck: &codersdk.DeploymentConfigField[bool]{
 			Name:    "Update Check",
-			Usage:   "Periodically check for new releases of Coder and inform the owner.",
+			Usage:   "Periodically check for new releases of Coder and inform the owner. The check is performed once per day.",
 			Flag:    "update-check",
 			Default: flag.Lookup("test.v") == nil && !buildinfo.IsDev(),
 		},

--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/buildinfo"
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/cli/config"
 	"github.com/coder/coder/codersdk"
@@ -404,6 +405,12 @@ func newConfig() *codersdk.DeploymentConfig {
 			Name:  "Experimental",
 			Usage: "Enable experimental features. Experimental features are not ready for production.",
 			Flag:  "experimental",
+		},
+		UpdateCheck: &codersdk.DeploymentConfigField[bool]{
+			Name:    "Update Check",
+			Usage:   "Periodically check for new releases of Coder and inform the owner.",
+			Flag:    "update-check",
+			Default: flag.Lookup("test.v") == nil && !buildinfo.IsDev(),
 		},
 	}
 }

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -38,6 +38,7 @@ func TestConfig(t *testing.T) {
 			"CODER_TELEMETRY":            "false",
 			"CODER_TELEMETRY_TRACE":      "false",
 			"CODER_WILDCARD_ACCESS_URL":  "something-wildcard.com",
+			"CODER_UPDATE_CHECK":         "false",
 		},
 		Valid: func(config *codersdk.DeploymentConfig) {
 			require.Equal(t, config.Address.Value, "0.0.0.0:8443")
@@ -53,6 +54,7 @@ func TestConfig(t *testing.T) {
 			require.Equal(t, config.Telemetry.Enable.Value, false)
 			require.Equal(t, config.Telemetry.Trace.Value, false)
 			require.Equal(t, config.WildcardAccessURL.Value, "something-wildcard.com")
+			require.Equal(t, config.UpdateCheck.Value, false)
 		},
 	}, {
 		Name: "DERP",

--- a/cli/server.go
+++ b/cli/server.go
@@ -63,6 +63,7 @@ import (
 	"github.com/coder/coder/coderd/prometheusmetrics"
 	"github.com/coder/coder/coderd/telemetry"
 	"github.com/coder/coder/coderd/tracing"
+	"github.com/coder/coder/coderd/updatecheck"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/cryptorand"
 	"github.com/coder/coder/provisioner/echo"
@@ -371,6 +372,25 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 			}
 			if tlsConfig != nil {
 				options.TLSCertificates = tlsConfig.Certificates
+			}
+
+			if cfg.UpdateCheck.Value {
+				options.UpdateCheckOptions = &updatecheck.Options{
+					// Avoid spamming GitHub API checking for updates.
+					Interval: 24 * time.Hour,
+					// Inform server admins of new versions.
+					Notify: func(r updatecheck.Result) {
+						if semver.Compare(r.Version, buildinfo.Version()) > 0 {
+							options.Logger.Info(
+								context.Background(),
+								"new version of coder available",
+								slog.F("new_version", r.Version),
+								slog.F("url", r.URL),
+								slog.F("upgrade_instructions", "https://coder.com/docs/coder-oss/latest/admin/upgrade"),
+							)
+						}
+					},
+				}
 			}
 
 			if cfg.OAuth2.Github.ClientSecret.Value != "" {

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -219,6 +219,9 @@ Flags:
                                                      verbose flag was supplied, debug-level
                                                      logs will be included.
                                                      Consumes $CODER_TRACE_CAPTURE_LOGS
+      --update-check                                 Periodically check for new releases of
+                                                     Coder and inform the owner.
+                                                     Consumes $CODER_UPDATE_CHECK
       --wildcard-access-url string                   Specifies the wildcard hostname to use
                                                      for workspace applications in the form
                                                      "*.example.com".

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -220,7 +220,8 @@ Flags:
                                                      logs will be included.
                                                      Consumes $CODER_TRACE_CAPTURE_LOGS
       --update-check                                 Periodically check for new releases of
-                                                     Coder and inform the owner.
+                                                     Coder and inform the owner. The check is
+                                                     performed once per day.
                                                      Consumes $CODER_UPDATE_CHECK
       --wildcard-access-url string                   Specifies the wildcard hostname to use
                                                      for workspace applications in the form

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -47,6 +47,7 @@ import (
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/coderd/telemetry"
 	"github.com/coder/coder/coderd/tracing"
+	"github.com/coder/coder/coderd/updatecheck"
 	"github.com/coder/coder/coderd/wsconncache"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/provisionerd/proto"
@@ -105,6 +106,7 @@ type Options struct {
 	AgentStatsRefreshInterval   time.Duration
 	Experimental                bool
 	DeploymentConfig            *codersdk.DeploymentConfig
+	UpdateCheckOptions          *updatecheck.Options // Set non-nil to enable update checking.
 }
 
 // New constructs a Coder API handler.
@@ -123,19 +125,13 @@ func New(options *Options) *API {
 		options.AgentInactiveDisconnectTimeout = options.AgentConnectionUpdateFrequency * 2
 	}
 	if options.AgentStatsRefreshInterval == 0 {
-		options.AgentStatsRefreshInterval = 10 * time.Minute
+		options.AgentStatsRefreshInterval = 5 * time.Minute
 	}
 	if options.MetricsCacheRefreshInterval == 0 {
 		options.MetricsCacheRefreshInterval = time.Hour
 	}
 	if options.APIRateLimit == 0 {
 		options.APIRateLimit = 512
-	}
-	if options.AgentStatsRefreshInterval == 0 {
-		options.AgentStatsRefreshInterval = 5 * time.Minute
-	}
-	if options.MetricsCacheRefreshInterval == 0 {
-		options.MetricsCacheRefreshInterval = time.Hour
 	}
 	if options.Authorizer == nil {
 		options.Authorizer = rbac.NewAuthorizer()
@@ -180,6 +176,13 @@ func New(options *Options) *API {
 		},
 		metricsCache: metricsCache,
 		Auditor:      atomic.Pointer[audit.Auditor]{},
+	}
+	if options.UpdateCheckOptions != nil {
+		api.updateChecker = updatecheck.New(
+			options.Database,
+			options.Logger.Named("update_checker"),
+			*options.UpdateCheckOptions,
+		)
 	}
 	api.Auditor.Store(&options.Auditor)
 	api.workspaceAgentCache = wsconncache.New(api.dialWorkspaceAgentTailnet, 0)
@@ -307,6 +310,9 @@ func New(options *Options) *API {
 					Version:     buildinfo.Version(),
 				})
 			})
+		})
+		r.Route("/updatecheck", func(r chi.Router) {
+			r.Get("/", api.updateCheck)
 		})
 		r.Route("/config", func(r chi.Router) {
 			r.Use(apiKeyMiddleware)
@@ -590,13 +596,14 @@ type API struct {
 	// RootHandler serves "/"
 	RootHandler chi.Router
 
-	metricsCache *metricscache.Cache
-	siteHandler  http.Handler
+	siteHandler http.Handler
 
 	WebsocketWaitMutex sync.Mutex
 	WebsocketWaitGroup sync.WaitGroup
 
+	metricsCache        *metricscache.Cache
 	workspaceAgentCache *wsconncache.Cache
+	updateChecker       *updatecheck.Checker
 }
 
 // Close waits for all WebSocket connections to drain before returning.
@@ -606,6 +613,9 @@ func (api *API) Close() error {
 	api.WebsocketWaitMutex.Unlock()
 
 	api.metricsCache.Close()
+	if api.updateChecker != nil {
+		api.updateChecker.Close()
+	}
 	coordinator := api.TailnetCoordinator.Load()
 	if coordinator != nil {
 		_ = (*coordinator).Close()

--- a/coderd/coderdtest/authorize.go
+++ b/coderd/coderdtest/authorize.go
@@ -48,6 +48,7 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 		"GET:/healthz":                  {NoAuthorize: true},
 		"GET:/api/v2":                   {NoAuthorize: true},
 		"GET:/api/v2/buildinfo":         {NoAuthorize: true},
+		"GET:/api/v2/updatecheck":       {NoAuthorize: true},
 		"GET:/api/v2/users/first":       {NoAuthorize: true},
 		"POST:/api/v2/users/first":      {NoAuthorize: true},
 		"POST:/api/v2/users/login":      {NoAuthorize: true},

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -64,6 +64,7 @@ import (
 	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/coderd/telemetry"
+	"github.com/coder/coder/coderd/updatecheck"
 	"github.com/coder/coder/coderd/util/ptr"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/cryptorand"
@@ -101,6 +102,9 @@ type Options struct {
 	MetricsCacheRefreshInterval time.Duration
 	AgentStatsRefreshInterval   time.Duration
 	DeploymentConfig            *codersdk.DeploymentConfig
+
+	// Set update check options to enable update check.
+	UpdateCheckOptions *updatecheck.Options
 
 	// Overriding the database is heavily discouraged.
 	// It should only be used in cases where multiple Coder
@@ -283,6 +287,7 @@ func NewOptions(t *testing.T, options *Options) (func(http.Handler), context.Can
 			MetricsCacheRefreshInterval: options.MetricsCacheRefreshInterval,
 			AgentStatsRefreshInterval:   options.AgentStatsRefreshInterval,
 			DeploymentConfig:            options.DeploymentConfig,
+			UpdateCheckOptions:          options.UpdateCheckOptions,
 		}
 }
 

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -119,9 +119,10 @@ type data struct {
 	workspaceResources        []database.WorkspaceResource
 	workspaces                []database.Workspace
 
-	deploymentID  string
-	derpMeshKey   string
-	lastLicenseID int32
+	deploymentID    string
+	derpMeshKey     string
+	lastUpdateCheck []byte
+	lastLicenseID   int32
 }
 
 func (fakeQuerier) IsFakeDB() {}
@@ -3270,6 +3271,24 @@ func (q *fakeQuerier) GetDERPMeshKey(_ context.Context) (string, error) {
 	defer q.mutex.RUnlock()
 
 	return q.derpMeshKey, nil
+}
+
+func (q *fakeQuerier) InsertOrUpdateLastUpdateCheck(_ context.Context, data string) error {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	q.lastUpdateCheck = []byte(data)
+	return nil
+}
+
+func (q *fakeQuerier) GetLastUpdateCheck(_ context.Context) (string, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	if q.lastUpdateCheck == nil {
+		return "", sql.ErrNoRows
+	}
+	return string(q.lastUpdateCheck), nil
 }
 
 func (q *fakeQuerier) InsertLicense(

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -50,6 +50,7 @@ type sqlcQuerier interface {
 	GetGroupByOrgAndName(ctx context.Context, arg GetGroupByOrgAndNameParams) (Group, error)
 	GetGroupMembers(ctx context.Context, groupID uuid.UUID) ([]User, error)
 	GetGroupsByOrganizationID(ctx context.Context, organizationID uuid.UUID) ([]Group, error)
+	GetLastUpdateCheck(ctx context.Context) (string, error)
 	GetLatestAgentStat(ctx context.Context, agentID uuid.UUID) (AgentStat, error)
 	GetLatestWorkspaceBuildByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (WorkspaceBuild, error)
 	GetLatestWorkspaceBuilds(ctx context.Context) ([]WorkspaceBuild, error)
@@ -141,6 +142,7 @@ type sqlcQuerier interface {
 	InsertGroup(ctx context.Context, arg InsertGroupParams) (Group, error)
 	InsertGroupMember(ctx context.Context, arg InsertGroupMemberParams) error
 	InsertLicense(ctx context.Context, arg InsertLicenseParams) (License, error)
+	InsertOrUpdateLastUpdateCheck(ctx context.Context, value string) error
 	InsertOrganization(ctx context.Context, arg InsertOrganizationParams) (Organization, error)
 	InsertOrganizationMember(ctx context.Context, arg InsertOrganizationMemberParams) (OrganizationMember, error)
 	InsertParameterSchema(ctx context.Context, arg InsertParameterSchemaParams) (ParameterSchema, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2970,6 +2970,17 @@ func (q *sqlQuerier) GetDeploymentID(ctx context.Context) (string, error) {
 	return value, err
 }
 
+const getLastUpdateCheck = `-- name: GetLastUpdateCheck :one
+SELECT value FROM site_configs WHERE key = 'last_update_check'
+`
+
+func (q *sqlQuerier) GetLastUpdateCheck(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getLastUpdateCheck)
+	var value string
+	err := row.Scan(&value)
+	return value, err
+}
+
 const insertDERPMeshKey = `-- name: InsertDERPMeshKey :exec
 INSERT INTO site_configs (key, value) VALUES ('derp_mesh_key', $1)
 `
@@ -2985,6 +2996,16 @@ INSERT INTO site_configs (key, value) VALUES ('deployment_id', $1)
 
 func (q *sqlQuerier) InsertDeploymentID(ctx context.Context, value string) error {
 	_, err := q.db.ExecContext(ctx, insertDeploymentID, value)
+	return err
+}
+
+const insertOrUpdateLastUpdateCheck = `-- name: InsertOrUpdateLastUpdateCheck :exec
+INSERT INTO site_configs (key, value) VALUES ('last_update_check', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'last_update_check'
+`
+
+func (q *sqlQuerier) InsertOrUpdateLastUpdateCheck(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, insertOrUpdateLastUpdateCheck, value)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -9,3 +9,10 @@ INSERT INTO site_configs (key, value) VALUES ('derp_mesh_key', $1);
 
 -- name: GetDERPMeshKey :one
 SELECT value FROM site_configs WHERE key = 'derp_mesh_key';
+
+-- name: InsertOrUpdateLastUpdateCheck :exec
+INSERT INTO site_configs (key, value) VALUES ('last_update_check', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'last_update_check';
+
+-- name: GetLastUpdateCheck :one
+SELECT value FROM site_configs WHERE key = 'last_update_check';

--- a/coderd/updatecheck.go
+++ b/coderd/updatecheck.go
@@ -1,9 +1,11 @@
 package coderd
 
 import (
+	"database/sql"
 	"net/http"
 
 	"golang.org/x/mod/semver"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/buildinfo"
 	"github.com/coder/coder/coderd/httpapi"
@@ -13,19 +15,28 @@ import (
 func (api *API) updateCheck(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	currentVersion := codersdk.UpdateCheckResponse{
+		Current: true,
+		Version: buildinfo.Version(),
+		URL:     buildinfo.ExternalURL(),
+	}
+
 	if api.updateChecker == nil {
 		// If update checking is disabled, echo the current
 		// version.
-		httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateCheckResponse{
-			Current: true,
-			Version: buildinfo.Version(),
-			URL:     buildinfo.ExternalURL(),
-		})
+		httpapi.Write(ctx, rw, http.StatusOK, currentVersion)
 		return
 	}
 
 	uc, err := api.updateChecker.Latest(ctx)
 	if err != nil {
+		if xerrors.Is(err, sql.ErrNoRows) {
+			// Update checking is enabled, but has never
+			// succeeded, reproduce behavior as if disabled.
+			httpapi.Write(ctx, rw, http.StatusOK, currentVersion)
+			return
+		}
+
 		httpapi.InternalServerError(rw, err)
 		return
 	}

--- a/coderd/updatecheck.go
+++ b/coderd/updatecheck.go
@@ -1,0 +1,38 @@
+package coderd
+
+import (
+	"net/http"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/coder/coder/buildinfo"
+	"github.com/coder/coder/coderd/httpapi"
+	"github.com/coder/coder/codersdk"
+)
+
+func (api *API) updateCheck(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if api.updateChecker == nil {
+		// If update checking is disabled, echo the current
+		// version.
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateCheckResponse{
+			Current: true,
+			Version: buildinfo.Version(),
+			URL:     buildinfo.ExternalURL(),
+		})
+		return
+	}
+
+	uc, err := api.updateChecker.Latest(ctx)
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateCheckResponse{
+		Current: semver.Compare(buildinfo.Version(), uc.Version) >= 0,
+		Version: uc.Version,
+		URL:     uc.URL,
+	})
+}

--- a/coderd/updatecheck.go
+++ b/coderd/updatecheck.go
@@ -3,6 +3,7 @@ package coderd
 import (
 	"database/sql"
 	"net/http"
+	"strings"
 
 	"golang.org/x/mod/semver"
 	"golang.org/x/xerrors"
@@ -41,8 +42,12 @@ func (api *API) updateCheck(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Since our dev version (v0.12.9-devel+f7246386) is not semver compatible,
+	// ignore everything after "-"."
+	versionWithoutDevel := strings.SplitN(buildinfo.Version(), "-", 2)[0]
+
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UpdateCheckResponse{
-		Current: semver.Compare(buildinfo.Version(), uc.Version) >= 0,
+		Current: semver.Compare(versionWithoutDevel, uc.Version) >= 0,
 		Version: uc.Version,
 		URL:     uc.URL,
 	})

--- a/coderd/updatecheck/updatecheck.go
+++ b/coderd/updatecheck/updatecheck.go
@@ -1,0 +1,233 @@
+// Package updatecheck provides a mechanism for periodically checking
+// for updates to Coder.
+//
+// The update check is performed by querying the GitHub API for the
+// latest release of Coder.
+package updatecheck
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/go-github/v43/github"
+	"golang.org/x/mod/semver"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+
+	"github.com/coder/coder/coderd/database"
+)
+
+const (
+	// defaultURL defines the URL to check for the latest version of Coder.
+	defaultURL = "https://api.github.com/repos/coder/coder/releases/latest"
+)
+
+// Checker is responsible for periodically checking for updates.
+type Checker struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
+	db         database.Store
+	log        slog.Logger
+	opts       Options
+	firstCheck chan struct{}
+	closed     chan struct{}
+}
+
+// Options set optional parameters for the update check.
+type Options struct {
+	// Client is the HTTP client to use for the update check,
+	// if omitted, http.DefaultClient will be used.
+	Client *http.Client
+	// URL is the URL to check for the latest version of Coder,
+	// if omitted, the default URL will be used.
+	URL string
+	// Interval is the interval at which to check for updates,
+	// default 24h.
+	Interval time.Duration
+	// Notify is called when a newer version of Coder (than the
+	// last update check) is available.
+	Notify func(r Result)
+}
+
+// New returns a new Checker that periodically checks for Coder updates.
+func New(db database.Store, log slog.Logger, opts Options) *Checker {
+	if opts.Client == nil {
+		opts.Client = http.DefaultClient
+	}
+	if opts.URL == "" {
+		opts.URL = defaultURL
+	}
+	if opts.Interval == 0 {
+		opts.Interval = 24 * time.Hour
+	}
+	if opts.Notify == nil {
+		opts.Notify = func(r Result) {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Checker{
+		ctx:        ctx,
+		cancel:     cancel,
+		db:         db,
+		log:        log,
+		opts:       opts,
+		firstCheck: make(chan struct{}),
+		closed:     make(chan struct{}),
+	}
+	go c.start()
+	return c
+}
+
+// Result is the result from the last update check.
+type Result struct {
+	Checked time.Time `json:"checked,omitempty"`
+	Version string    `json:"version,omitempty"`
+	URL     string    `json:"url,omitempty"`
+}
+
+// Latest returns the latest version of Coder.
+func (c *Checker) Latest(ctx context.Context) (r Result, err error) {
+	select {
+	case <-c.ctx.Done():
+		return r, c.ctx.Err()
+	case <-ctx.Done():
+		return r, ctx.Err()
+	case <-c.firstCheck:
+	}
+
+	return c.lastUpdateCheck(ctx)
+}
+
+func (c *Checker) init() (Result, error) {
+	defer close(c.firstCheck)
+
+	r, err := c.lastUpdateCheck(c.ctx)
+	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+		return Result{}, xerrors.Errorf("last update check: %w", err)
+	}
+	if r.Checked.IsZero() || time.Since(r.Checked) > c.opts.Interval {
+		r, err = c.update()
+		if err != nil {
+			return Result{}, xerrors.Errorf("update check failed: %w", err)
+		}
+	}
+
+	return r, nil
+}
+
+func (c *Checker) start() {
+	defer close(c.closed)
+
+	r, err := c.init()
+	if err != nil {
+		if xerrors.Is(err, context.Canceled) {
+			return
+		}
+		c.log.Error(c.ctx, "init failed", slog.Error(err))
+	} else {
+		c.opts.Notify(r)
+	}
+
+	t := time.NewTicker(c.opts.Interval)
+	defer t.Stop()
+
+	doCheck := func() {
+		rr, err := c.update()
+		if err != nil {
+			if xerrors.Is(err, context.Canceled) {
+				return
+			}
+			c.log.Error(c.ctx, "update check failed", slog.Error(err))
+		} else {
+			c.notifyIfNewer(r, rr)
+			r = rr
+		}
+		c.log.Info(c.ctx, "time until next update check", slog.F("duration", c.opts.Interval))
+		t.Reset(c.opts.Interval)
+	}
+
+	if !r.Checked.IsZero() {
+		diff := time.Until(r.Checked.Add(c.opts.Interval))
+		if diff > 0 {
+			c.log.Info(c.ctx, "time until next update check", slog.F("duration", diff))
+			t.Reset(diff)
+		}
+	}
+
+	for {
+		select {
+		case <-t.C:
+			doCheck()
+		case <-c.ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *Checker) update() (r Result, err error) {
+	c.log.Info(c.ctx, "checking for update")
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodGet, c.opts.URL, nil)
+	if err != nil {
+		return r, xerrors.Errorf("new request: %w", err)
+	}
+	resp, err := c.opts.Client.Do(req)
+	if err != nil {
+		return r, xerrors.Errorf("client do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return r, xerrors.Errorf("unexpected status code %d: %s", resp.StatusCode, b)
+	}
+
+	var rr github.RepositoryRelease
+	err = json.NewDecoder(resp.Body).Decode(&rr)
+	if err != nil {
+		return r, xerrors.Errorf("json decode: %w", err)
+	}
+
+	r = Result{
+		Checked: time.Now(),
+		Version: rr.GetTagName(),
+		URL:     rr.GetHTMLURL(),
+	}
+	c.log.Info(c.ctx, "update check result", slog.F("latest_version", r.Version))
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		return r, xerrors.Errorf("json marshal result: %w", err)
+	}
+
+	err = c.db.InsertOrUpdateLastUpdateCheck(c.ctx, string(b))
+	if err != nil {
+		return r, err
+	}
+
+	return r, nil
+}
+
+func (c *Checker) notifyIfNewer(prev, next Result) {
+	if (prev.Version == "" && next.Version != "") || semver.Compare(next.Version, prev.Version) > 0 {
+		c.opts.Notify(next)
+	}
+}
+
+func (c *Checker) lastUpdateCheck(ctx context.Context) (r Result, err error) {
+	s, err := c.db.GetLastUpdateCheck(ctx)
+	if err != nil {
+		return r, err
+	}
+	return r, json.Unmarshal([]byte(s), &r)
+}
+
+func (c *Checker) Close() error {
+	c.cancel()
+	<-c.closed
+	return nil
+}

--- a/coderd/updatecheck/updatecheck_test.go
+++ b/coderd/updatecheck/updatecheck_test.go
@@ -1,0 +1,158 @@
+package updatecheck_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v43/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"cdr.dev/slog/sloggers/slogtest"
+
+	"github.com/coder/coder/coderd/database/databasefake"
+	"github.com/coder/coder/coderd/updatecheck"
+	"github.com/coder/coder/testutil"
+)
+
+func TestChecker_Notify(t *testing.T) {
+	t.Parallel()
+
+	responses := []github.RepositoryRelease{
+		{TagName: github.String("v1.2.3"), HTMLURL: github.String("https://someurl.com")},
+		{TagName: github.String("v1.2.4"), HTMLURL: github.String("https://someurl.com")},
+		{TagName: github.String("v1.2.4"), HTMLURL: github.String("https://someurl.com")},
+		{TagName: github.String("v1.2.5"), HTMLURL: github.String("https://someurl.com")},
+	}
+	responseC := make(chan github.RepositoryRelease, len(responses))
+	for _, r := range responses {
+		responseC <- r
+	}
+
+	wantVersion := []string{"v1.2.3", "v1.2.4", "v1.2.5"}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case resp := <-responseC:
+			b, err := json.Marshal(resp)
+			assert.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+		}
+	}))
+	defer srv.Close()
+
+	db := databasefake.New()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named(t.Name())
+	notify := make(chan updatecheck.Result, len(wantVersion))
+	c := updatecheck.New(db, logger, updatecheck.Options{
+		Interval: 1 * time.Nanosecond, // Zero means unset.
+		URL:      srv.URL,
+		Notify: func(r updatecheck.Result) {
+			select {
+			case notify <- r:
+			default:
+				t.Error("unexpected notification")
+			}
+		},
+	})
+	defer c.Close()
+
+	ctx, _ := testutil.Context(t)
+
+	for i := 0; i < len(wantVersion); i++ {
+		select {
+		case <-ctx.Done():
+			t.Error("timed out waiting for notification")
+		case r := <-notify:
+			assert.Equal(t, wantVersion[i], r.Version)
+		}
+	}
+}
+
+func TestChecker_Latest(t *testing.T) {
+	t.Parallel()
+
+	rr := github.RepositoryRelease{
+		TagName: github.String("v1.2.3"),
+		HTMLURL: github.String("https://someurl.com"),
+	}
+
+	tests := []struct {
+		name    string
+		release github.RepositoryRelease
+		wantR   updatecheck.Result
+		wantErr bool
+	}{
+		{
+			name:    "check latest",
+			release: rr,
+			wantR: updatecheck.Result{
+				Version: "v1.2.3",
+				URL:     "https://someurl.com",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing release data",
+			release: github.RepositoryRelease{},
+			wantErr: true,
+		},
+		{
+			name:    "error",
+			release: rr,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.wantErr {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+
+				rrJSON, err := json.Marshal(rr)
+				assert.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(rrJSON)
+			}))
+			defer srv.Close()
+
+			db := databasefake.New()
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named(t.Name())
+			c := updatecheck.New(db, logger, updatecheck.Options{
+				URL: srv.URL,
+			})
+			defer c.Close()
+
+			ctx, _ := testutil.Context(t)
+			_ = ctx
+
+			gotR, err := c.Latest(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			// Zero out the time so we can compare the rest of the struct.
+			gotR.Checked = time.Time{}
+			require.Equal(t, tt.wantR, gotR, "wrong version")
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/coderd/updatecheck_test.go
+++ b/coderd/updatecheck_test.go
@@ -1,0 +1,79 @@
+package coderd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-github/v43/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/buildinfo"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/coderd/updatecheck"
+	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/testutil"
+)
+
+func TestUpdateCheck_NewVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		resp github.RepositoryRelease
+		want codersdk.UpdateCheckResponse
+	}{
+		{
+			name: "New version",
+			resp: github.RepositoryRelease{
+				TagName: github.String("v99.999.999"),
+				HTMLURL: github.String("https://someurl.com"),
+			},
+			want: codersdk.UpdateCheckResponse{
+				Current: false,
+				Version: "v99.999.999",
+				URL:     "https://someurl.com",
+			},
+		},
+		{
+			name: "Same version",
+			resp: github.RepositoryRelease{
+				TagName: github.String(buildinfo.Version()),
+				HTMLURL: github.String("https://someurl.com"),
+			},
+			want: codersdk.UpdateCheckResponse{
+				Current: true,
+				Version: buildinfo.Version(),
+				URL:     "https://someurl.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				b, err := json.Marshal(tt.resp)
+				assert.NoError(t, err)
+				w.Write(b)
+			}))
+			defer srv.Close()
+
+			client := coderdtest.New(t, &coderdtest.Options{
+				UpdateCheckOptions: &updatecheck.Options{
+					URL: srv.URL,
+				},
+			})
+
+			ctx, _ := testutil.Context(t)
+
+			got, err := client.UpdateCheck(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/codersdk/deploymentconfig.go
+++ b/codersdk/deploymentconfig.go
@@ -41,6 +41,7 @@ type DeploymentConfig struct {
 	Provisioner                     *ProvisionerConfig                      `json:"provisioner" typescript:",notnull"`
 	APIRateLimit                    *DeploymentConfigField[int]             `json:"api_rate_limit" typescript:",notnull"`
 	Experimental                    *DeploymentConfigField[bool]            `json:"experimental" typescript:",notnull"`
+	UpdateCheck                     *DeploymentConfigField[bool]            `json:"update_check" typescript:",notnull"`
 }
 
 type DERP struct {

--- a/codersdk/updatecheck.go
+++ b/codersdk/updatecheck.go
@@ -1,0 +1,37 @@
+package codersdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// UpdateCheckResponse contains information
+// on the latest release of Coder.
+type UpdateCheckResponse struct {
+	// Current is a boolean indicating whether the
+	// server version is the same as the latest.
+	Current bool `json:"current"`
+	// Version is the semantic version for the latest
+	// release of Coder.
+	Version string `json:"version"`
+	// URL to download the latest release of Coder.
+	URL string `json:"url"`
+}
+
+// UpdateCheck returns information about the latest release version of
+// Coder and whether or not the server is running the latest release.
+func (c *Client) UpdateCheck(ctx context.Context) (UpdateCheckResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/updatecheck", nil)
+	if err != nil {
+		return UpdateCheckResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return UpdateCheckResponse{}, readBodyAsError(res)
+	}
+
+	var buildInfo UpdateCheckResponse
+	return buildInfo, json.NewDecoder(res.Body).Decode(&buildInfo)
+}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -376,6 +376,12 @@ export const getBuildInfo = async (): Promise<TypesGen.BuildInfoResponse> => {
   return response.data
 }
 
+export const getUpdateCheck =
+  async (): Promise<TypesGen.UpdateCheckResponse> => {
+    const response = await axios.get("/api/v2/updatecheck")
+    return response.data
+  }
+
 export const putWorkspaceAutostart = async (
   workspaceID: string,
   autostart: TypesGen.UpdateWorkspaceAutostartRequest,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -299,6 +299,7 @@ export interface DeploymentConfig {
   readonly provisioner: ProvisionerConfig
   readonly api_rate_limit: DeploymentConfigField<number>
   readonly experimental: DeploymentConfigField<boolean>
+  readonly update_check: DeploymentConfigField<boolean>
 }
 
 // From codersdk/deploymentconfig.go
@@ -699,6 +700,13 @@ export interface TransitionStats {
 // From codersdk/templates.go
 export interface UpdateActiveTemplateVersion {
   readonly id: string
+}
+
+// From codersdk/updatecheck.go
+export interface UpdateCheckResponse {
+  readonly current: boolean
+  readonly version: string
+  readonly url: string
 }
 
 // From codersdk/users.go

--- a/site/src/components/AlertBanner/AlertBanner.stories.tsx
+++ b/site/src/components/AlertBanner/AlertBanner.stories.tsx
@@ -3,6 +3,7 @@ import { AlertBanner } from "./AlertBanner"
 import Button from "@material-ui/core/Button"
 import { makeMockApiError } from "testHelpers/entities"
 import { AlertBannerProps } from "./alertTypes"
+import Link from "@material-ui/core/Link"
 
 export default {
   title: "components/AlertBanner",
@@ -105,4 +106,17 @@ export const ErrorAsWarning = Template.bind({})
 ErrorAsWarning.args = {
   error: mockError,
   severity: "warning",
+}
+
+const WithChildren: Story<AlertBannerProps> = (args) => (
+  <AlertBanner {...args}>
+    <div>
+      This is a message with a <Link href="#">link</Link>
+    </div>
+  </AlertBanner>
+)
+
+export const InfoWithChildContent = WithChildren.bind({})
+InfoWithChildContent.args = {
+  severity: "info",
 }

--- a/site/src/components/AlertBanner/AlertBanner.tsx
+++ b/site/src/components/AlertBanner/AlertBanner.tsx
@@ -18,7 +18,8 @@ import { AlertBannerCtas } from "./AlertBannerCtas"
  * @param dismissible: determines whether or not the banner should have a `Dismiss` CTA
  * @param retry: a handler to retry the action that spawned the error
  */
-export const AlertBanner: FC<AlertBannerProps> = ({
+export const AlertBanner: FC<React.PropsWithChildren<AlertBannerProps>> = ({
+  children,
   severity,
   text,
   error,
@@ -55,6 +56,7 @@ export const AlertBanner: FC<AlertBannerProps> = ({
         <Stack direction="row" alignItems="center" spacing={1}>
           {severityConstants[severity].icon}
           <Stack spacing={0}>
+            {children}
             {alertMessage}
             {detail && (
               <Expander expanded={showDetails} setExpanded={setShowDetails}>

--- a/site/src/components/AlertBanner/AlertBanner.tsx
+++ b/site/src/components/AlertBanner/AlertBanner.tsx
@@ -16,8 +16,9 @@ import { AlertBannerCtas } from "./AlertBannerCtas"
  * @param text: default text to be displayed to the user; useful for warnings or as a fallback error message
  * @param error: should be passed in if the severity is 'Error'; warnings can use 'text' instead
  * @param actions: an array of CTAs passed in by the consumer
- * @param dismissible: determines whether or not the banner should have a `Dismiss` CTA
  * @param retry: a handler to retry the action that spawned the error
+ * @param dismissible: determines whether or not the banner should have a `Dismiss` CTA
+ * @param onDismiss: a handler that is called when the `Dismiss` CTA is clicked, after the animation has finished
  */
 export const AlertBanner: FC<React.PropsWithChildren<AlertBannerProps>> = ({
   children,
@@ -27,6 +28,7 @@ export const AlertBanner: FC<React.PropsWithChildren<AlertBannerProps>> = ({
   actions = [],
   retry,
   dismissible = false,
+  onDismiss,
 }) => {
   const { t } = useTranslation("common")
 
@@ -50,7 +52,7 @@ export const AlertBanner: FC<React.PropsWithChildren<AlertBannerProps>> = ({
   const [showDetails, setShowDetails] = useState(false)
 
   return (
-    <Collapse in={open}>
+    <Collapse in={open} onExited={() => onDismiss && onDismiss()}>
       <Stack
         className={classes.alertContainer}
         direction="row"

--- a/site/src/components/AlertBanner/AlertBanner.tsx
+++ b/site/src/components/AlertBanner/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import { useState, FC } from "react"
+import { useState, FC, Children } from "react"
 import Collapse from "@material-ui/core/Collapse"
 import { Stack } from "components/Stack/Stack"
 import { makeStyles, Theme } from "@material-ui/core/styles"
@@ -11,6 +11,7 @@ import { severityConstants } from "./severityConstants"
 import { AlertBannerCtas } from "./AlertBannerCtas"
 
 /**
+ * @param children: the children to be displayed in the alert
  * @param severity: the level of alert severity (see ./severityTypes.ts)
  * @param text: default text to be displayed to the user; useful for warnings or as a fallback error message
  * @param error: should be passed in if the severity is 'Error'; warnings can use 'text' instead
@@ -31,12 +32,16 @@ export const AlertBanner: FC<React.PropsWithChildren<AlertBannerProps>> = ({
 
   const [open, setOpen] = useState(true)
 
+  // Set a fallback message if no text or children are provided.
+  const defaultMessage =
+    text ??
+    (Children.count(children) === 0
+      ? t("warningsAndErrors.somethingWentWrong")
+      : "")
+
   // if an error is passed in, display that error, otherwise
   // display the text passed in, e.g. warning text
-  const alertMessage = getErrorMessage(
-    error,
-    text ?? t("warningsAndErrors.somethingWentWrong"),
-  )
+  const alertMessage = getErrorMessage(error, defaultMessage)
 
   // if we have an error, check if there's detail to display
   const detail = error ? getErrorDetail(error) : undefined

--- a/site/src/components/AlertBanner/alertTypes.ts
+++ b/site/src/components/AlertBanner/alertTypes.ts
@@ -9,5 +9,6 @@ export interface AlertBannerProps {
   error?: ApiError | Error | unknown
   actions?: ReactElement[]
   dismissible?: boolean
+  onDismiss?: () => void
   retry?: () => void
 }

--- a/site/src/components/AuthAndFrame/AuthAndFrame.tsx
+++ b/site/src/components/AuthAndFrame/AuthAndFrame.tsx
@@ -6,6 +6,7 @@ import { XServiceContext } from "../../xServices/StateContext"
 import { Footer } from "../Footer/Footer"
 import { Navbar } from "../Navbar/Navbar"
 import { RequireAuth } from "../RequireAuth/RequireAuth"
+import { UpdateCheckBanner } from "components/UpdateCheckBanner/UpdateCheckBanner"
 
 interface AuthAndFrameProps {
   children: JSX.Element
@@ -18,11 +19,13 @@ export const AuthAndFrame: FC<AuthAndFrameProps> = ({ children }) => {
   const styles = useStyles()
   const xServices = useContext(XServiceContext)
   const [buildInfoState] = useActor(xServices.buildInfoXService)
+  const [updateCheckState] = useActor(xServices.updateCheckXService)
 
   return (
     <RequireAuth>
       <div className={styles.site}>
         <Navbar />
+        <UpdateCheckBanner updateCheck={updateCheckState.context.updateCheck} />
         <div className={styles.siteContent}>
           <Suspense fallback={<Loader />}>{children}</Suspense>
         </div>

--- a/site/src/components/AuthAndFrame/AuthAndFrame.tsx
+++ b/site/src/components/AuthAndFrame/AuthAndFrame.tsx
@@ -17,7 +17,7 @@ interface AuthAndFrameProps {
  * Wraps page in RequireAuth and renders it between Navbar and Footer
  */
 export const AuthAndFrame: FC<AuthAndFrameProps> = ({ children }) => {
-  const styles = useStyles({})
+  const styles = useStyles()
   const xServices = useContext(XServiceContext)
   const [authState] = useActor(xServices.authXService)
   const [buildInfoState] = useActor(xServices.buildInfoXService)

--- a/site/src/components/AuthAndFrame/AuthAndFrame.tsx
+++ b/site/src/components/AuthAndFrame/AuthAndFrame.tsx
@@ -7,6 +7,7 @@ import { Footer } from "../Footer/Footer"
 import { Navbar } from "../Navbar/Navbar"
 import { RequireAuth } from "../RequireAuth/RequireAuth"
 import { UpdateCheckBanner } from "components/UpdateCheckBanner/UpdateCheckBanner"
+import { Margins } from "components/Margins/Margins"
 
 interface AuthAndFrameProps {
   children: JSX.Element
@@ -16,7 +17,7 @@ interface AuthAndFrameProps {
  * Wraps page in RequireAuth and renders it between Navbar and Footer
  */
 export const AuthAndFrame: FC<AuthAndFrameProps> = ({ children }) => {
-  const styles = useStyles()
+  const styles = useStyles({})
   const xServices = useContext(XServiceContext)
   const [buildInfoState] = useActor(xServices.buildInfoXService)
   const [updateCheckState] = useActor(xServices.updateCheckXService)
@@ -25,7 +26,13 @@ export const AuthAndFrame: FC<AuthAndFrameProps> = ({ children }) => {
     <RequireAuth>
       <div className={styles.site}>
         <Navbar />
-        <UpdateCheckBanner updateCheck={updateCheckState.context.updateCheck} />
+        <div className={styles.siteBanner}>
+          <Margins>
+            <UpdateCheckBanner
+              updateCheck={updateCheckState.context.updateCheck}
+            />
+          </Margins>
+        </div>
         <div className={styles.siteContent}>
           <Suspense fallback={<Loader />}>{children}</Suspense>
         </div>
@@ -35,13 +42,18 @@ export const AuthAndFrame: FC<AuthAndFrameProps> = ({ children }) => {
   )
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   site: {
     display: "flex",
     minHeight: "100vh",
     flexDirection: "column",
   },
+  siteBanner: {
+    marginTop: theme.spacing(2),
+  },
   siteContent: {
     flex: 1,
+    // Accommodate for banner margin since it is dismissible.
+    marginTop: -theme.spacing(2),
   },
 }))

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.stories.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.stories.tsx
@@ -30,5 +30,5 @@ NoUpdateAvailable.args = {
 
 export const UpdateCheckError = Template.bind({})
 UpdateCheckError.args = {
-  error: new Error("Coder update check failed."),
+  error: new Error("Something went wrong."),
 }

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.stories.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.stories.tsx
@@ -19,15 +19,6 @@ UpdateAvailable.args = {
   },
 }
 
-export const NoUpdateAvailable = Template.bind({})
-NoUpdateAvailable.args = {
-  updateCheck: {
-    current: true,
-    version: "v0.12.9",
-    url: "https://github.com/coder/coder/releases/tag/v0.12.9",
-  },
-}
-
 export const UpdateCheckError = Template.bind({})
 UpdateCheckError.args = {
   error: new Error("Something went wrong."),

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.stories.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.stories.tsx
@@ -1,0 +1,34 @@
+import { ComponentMeta, Story } from "@storybook/react"
+import { UpdateCheckBanner, UpdateCheckBannerProps } from "./UpdateCheckBanner"
+
+export default {
+  title: "components/UpdateCheckBanner",
+  component: UpdateCheckBanner,
+} as ComponentMeta<typeof UpdateCheckBanner>
+
+const Template: Story<UpdateCheckBannerProps> = (args) => (
+  <UpdateCheckBanner {...args} />
+)
+
+export const UpdateAvailable = Template.bind({})
+UpdateAvailable.args = {
+  updateCheck: {
+    current: false,
+    version: "v0.12.9",
+    url: "https://github.com/coder/coder/releases/tag/v0.12.9",
+  },
+}
+
+export const NoUpdateAvailable = Template.bind({})
+NoUpdateAvailable.args = {
+  updateCheck: {
+    current: true,
+    version: "v0.12.9",
+    url: "https://github.com/coder/coder/releases/tag/v0.12.9",
+  },
+}
+
+export const UpdateCheckError = Template.bind({})
+UpdateCheckError.args = {
+  error: new Error("Coder update check failed."),
+}

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.test.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import i18next from "i18next"
+import { MockUpdateCheck, render } from "testHelpers/renderHelpers"
+import { UpdateCheckBanner } from "./UpdateCheckBanner"
+
+describe("UpdateCheckBanner", () => {
+  it("shows an update notification when one is available", () => {
+    const { t } = i18next
+    render(
+      <UpdateCheckBanner
+        updateCheck={{ ...MockUpdateCheck, current: false }}
+      />,
+    )
+
+    const updateText = t("updateCheck.message", {
+      ns: "common",
+      version: MockUpdateCheck.version,
+    })
+    // Message contatins HTML elements so we check it in parts.
+    for (const text of updateText.split(/<\/?[0-9]+>/)) {
+      expect(screen.getByText(text, { exact: false })).toBeInTheDocument()
+    }
+
+    expect(screen.getAllByRole("link")[0]).toHaveAttribute(
+      "href",
+      MockUpdateCheck.url,
+    )
+  })
+
+  it("is hidden when dismissed", async () => {
+    const dismiss = jest.fn()
+    const { container } = render(
+      <UpdateCheckBanner
+        onDismiss={dismiss}
+        updateCheck={{ ...MockUpdateCheck, current: false }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button"))
+    await waitFor(() => expect(dismiss).toBeCalledTimes(1), { timeout: 2000 })
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("does not show when up-to-date", async () => {
+    const { container } = render(
+      <UpdateCheckBanner updateCheck={{ ...MockUpdateCheck, current: true }} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
@@ -1,0 +1,45 @@
+import Link from "@material-ui/core/Link"
+import { makeStyles } from "@material-ui/core/styles"
+import { AlertBanner } from "components/AlertBanner/AlertBanner"
+import { Margins } from "components/Margins/Margins"
+import { Trans, useTranslation } from "react-i18next"
+import * as TypesGen from "api/typesGenerated"
+
+export interface UpdateCheckBannerProps {
+  updateCheck?: TypesGen.UpdateCheckResponse
+}
+
+export const UpdateCheckBanner: React.FC<
+  React.PropsWithChildren<UpdateCheckBannerProps>
+> = ({ updateCheck }) => {
+  const styles = useStyles({})
+  const { t } = useTranslation("common")
+
+  return (
+    <div className={styles.root}>
+      {updateCheck && !updateCheck.current && (
+        <Margins>
+          <AlertBanner severity="info" text="" dismissible>
+            <div>
+              <Trans t={t} i18nKey="updateCheck.message">
+                Coder {updateCheck.version} is now available. View the{" "}
+                <Link href={updateCheck.url}>release notes</Link> and{" "}
+                <Link href="https://coder.com/docs/coder-oss/latest/admin/upgrade">
+                  upgrade instructions
+                </Link>{" "}
+                for more information.
+              </Trans>
+            </div>
+          </AlertBanner>
+        </Margins>
+      )}
+    </div>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    // Common spacing between elements, adds separation from Navbar.
+    paddingTop: theme.spacing(2),
+  },
+}))

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
@@ -1,7 +1,5 @@
 import Link from "@material-ui/core/Link"
-import { makeStyles } from "@material-ui/core/styles"
 import { AlertBanner } from "components/AlertBanner/AlertBanner"
-import { Margins } from "components/Margins/Margins"
 import { Trans, useTranslation } from "react-i18next"
 import * as TypesGen from "api/typesGenerated"
 
@@ -12,34 +10,28 @@ export interface UpdateCheckBannerProps {
 export const UpdateCheckBanner: React.FC<
   React.PropsWithChildren<UpdateCheckBannerProps>
 > = ({ updateCheck }) => {
-  const styles = useStyles({})
   const { t } = useTranslation("common")
 
   return (
-    <div className={styles.root}>
+    <>
       {updateCheck && !updateCheck.current && (
-        <Margins>
-          <AlertBanner severity="info" text="" dismissible>
-            <div>
-              <Trans t={t} i18nKey="updateCheck.message">
-                Coder {updateCheck.version} is now available. View the{" "}
-                <Link href={updateCheck.url}>release notes</Link> and{" "}
-                <Link href="https://coder.com/docs/coder-oss/latest/admin/upgrade">
-                  upgrade instructions
-                </Link>{" "}
-                for more information.
-              </Trans>
-            </div>
-          </AlertBanner>
-        </Margins>
+        <AlertBanner severity="info" dismissible>
+          <div>
+            <Trans
+              t={t}
+              i18nKey="updateCheck.message"
+              values={{ version: updateCheck.version }}
+            >
+              Coder {"{{version}}"} is now available. View the{" "}
+              <Link href={updateCheck.url}>release notes</Link> and{" "}
+              <Link href="https://coder.com/docs/coder-oss/latest/admin/upgrade">
+                upgrade instructions
+              </Link>{" "}
+              for more information.
+            </Trans>
+          </div>
+        </AlertBanner>
       )}
-    </div>
+    </>
   )
 }
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    // Common spacing between elements, adds separation from Navbar.
-    paddingTop: theme.spacing(2),
-  },
-}))

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
@@ -5,17 +5,19 @@ import * as TypesGen from "api/typesGenerated"
 
 export interface UpdateCheckBannerProps {
   updateCheck?: TypesGen.UpdateCheckResponse
+  error?: Error | unknown
+  onDismiss?: () => void
 }
 
 export const UpdateCheckBanner: React.FC<
   React.PropsWithChildren<UpdateCheckBannerProps>
-> = ({ updateCheck }) => {
+> = ({ updateCheck, error, onDismiss }) => {
   const { t } = useTranslation("common")
 
   return (
     <>
-      {updateCheck && !updateCheck.current && (
-        <AlertBanner severity="info" dismissible>
+      {!error && updateCheck && !updateCheck.current && (
+        <AlertBanner severity="info" onDismiss={onDismiss} dismissible>
           <div>
             <Trans
               t={t}
@@ -31,6 +33,15 @@ export const UpdateCheckBanner: React.FC<
             </Trans>
           </div>
         </AlertBanner>
+      )}
+      {error && (
+        <AlertBanner
+          severity="error"
+          error={error}
+          text={t("updateCheck.error")}
+          onDismiss={onDismiss}
+          dismissible
+        />
       )}
     </>
   )

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
@@ -2,7 +2,7 @@ import Link from "@material-ui/core/Link"
 import { AlertBanner } from "components/AlertBanner/AlertBanner"
 import { Trans, useTranslation } from "react-i18next"
 import * as TypesGen from "api/typesGenerated"
-import { FC } from "react"
+import { FC, useState } from "react"
 
 export interface UpdateCheckBannerProps {
   updateCheck?: TypesGen.UpdateCheckResponse
@@ -15,34 +15,44 @@ export const UpdateCheckBanner: FC<
 > = ({ updateCheck, error, onDismiss }) => {
   const { t } = useTranslation("common")
 
+  const isOutdated = updateCheck && !updateCheck.current
+
+  const [show, setShow] = useState(error || isOutdated)
+
+  const dismiss = () => {
+    onDismiss && onDismiss()
+    setShow(false)
+  }
+
   return (
     <>
-      {!error && updateCheck && !updateCheck.current && (
-        <AlertBanner severity="info" onDismiss={onDismiss} dismissible>
-          <div>
-            <Trans
-              t={t}
-              i18nKey="updateCheck.message"
-              values={{ version: updateCheck.version }}
-            >
-              Coder {"{{version}}"} is now available. View the{" "}
-              <Link href={updateCheck.url}>release notes</Link> and{" "}
-              <Link href="https://coder.com/docs/coder-oss/latest/admin/upgrade">
-                upgrade instructions
-              </Link>{" "}
-              for more information.
-            </Trans>
-          </div>
-        </AlertBanner>
-      )}
-      {error && (
+      {show && (
         <AlertBanner
-          severity="error"
+          severity={error ? "error" : "info"}
           error={error}
-          text={t("updateCheck.error")}
-          onDismiss={onDismiss}
+          onDismiss={dismiss}
           dismissible
-        />
+        >
+          <>
+            {error && <>{t("updateCheck.error")} </>}
+            {isOutdated && (
+              <div>
+                <Trans
+                  t={t}
+                  i18nKey="updateCheck.message"
+                  values={{ version: updateCheck.version }}
+                >
+                  Coder {"{{version}}"} is now available. View the{" "}
+                  <Link href={updateCheck.url}>release notes</Link> and{" "}
+                  <Link href="https://coder.com/docs/coder-oss/latest/admin/upgrade">
+                    upgrade instructions
+                  </Link>{" "}
+                  for more information.
+                </Trans>
+              </div>
+            )}
+          </>
+        </AlertBanner>
       )}
     </>
   )

--- a/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
+++ b/site/src/components/UpdateCheckBanner/UpdateCheckBanner.tsx
@@ -2,6 +2,7 @@ import Link from "@material-ui/core/Link"
 import { AlertBanner } from "components/AlertBanner/AlertBanner"
 import { Trans, useTranslation } from "react-i18next"
 import * as TypesGen from "api/typesGenerated"
+import { FC } from "react"
 
 export interface UpdateCheckBannerProps {
   updateCheck?: TypesGen.UpdateCheckResponse
@@ -9,7 +10,7 @@ export interface UpdateCheckBannerProps {
   onDismiss?: () => void
 }
 
-export const UpdateCheckBanner: React.FC<
+export const UpdateCheckBanner: FC<
   React.PropsWithChildren<UpdateCheckBannerProps>
 > = ({ updateCheck, error, onDismiss }) => {
   const { t } = useTranslation("common")

--- a/site/src/i18n/en/common.json
+++ b/site/src/i18n/en/common.json
@@ -35,5 +35,8 @@
   },
   "emojiPicker": {
     "select": "Select emoji"
+  },
+  "updateCheck": {
+    "message": "Coder {updateCheck.version} is now available. View the <4>release notes</4> and <7>upgrade instructions</7> for more information."
   }
 }

--- a/site/src/i18n/en/common.json
+++ b/site/src/i18n/en/common.json
@@ -37,6 +37,7 @@
     "select": "Select emoji"
   },
   "updateCheck": {
-    "message": "Coder {{version}} is now available. View the <4>release notes</4> and <7>upgrade instructions</7> for more information."
+    "message": "Coder {{version}} is now available. View the <4>release notes</4> and <7>upgrade instructions</7> for more information.",
+    "error": "Coder update check failed."
   }
 }

--- a/site/src/i18n/en/common.json
+++ b/site/src/i18n/en/common.json
@@ -37,6 +37,6 @@
     "select": "Select emoji"
   },
   "updateCheck": {
-    "message": "Coder {updateCheck.version} is now available. View the <4>release notes</4> and <7>upgrade instructions</7> for more information."
+    "message": "Coder {{version}} is now available. View the <4>release notes</4> and <7>upgrade instructions</7> for more information."
   }
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -24,6 +24,12 @@ export const MockBuildInfo: TypesGen.BuildInfoResponse = {
   version: "v99.999.9999+c9cdf14",
 }
 
+export const MockUpdateCheck: TypesGen.UpdateCheckResponse = {
+  current: true,
+  url: "file:///mock-url",
+  version: "v99.999.9999+c9cdf14",
+}
+
 export const MockOwnerRole: TypesGen.Role = {
   name: "owner",
   display_name: "Owner",

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -15,6 +15,11 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(M.MockBuildInfo))
   }),
 
+  // update check
+  rest.get("/api/v2/updatecheck", async (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(M.MockUpdateCheck))
+  }),
+
   // organizations
   rest.get("/api/v2/organizations/:organizationId", async (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(M.MockOrganization))

--- a/site/src/xServices/StateContext.tsx
+++ b/site/src/xServices/StateContext.tsx
@@ -3,6 +3,7 @@ import { createContext, FC, ReactNode } from "react"
 import { ActorRefFrom } from "xstate"
 import { authMachine } from "./auth/authXService"
 import { buildInfoMachine } from "./buildInfo/buildInfoXService"
+import { updateCheckMachine } from "./updateCheck/updateCheckXService"
 import { deploymentConfigMachine } from "./deploymentConfig/deploymentConfigMachine"
 import { entitlementsMachine } from "./entitlements/entitlementsXService"
 import { siteRolesMachine } from "./roles/siteRolesXService"
@@ -14,6 +15,7 @@ interface XServiceContextType {
   siteRolesXService: ActorRefFrom<typeof siteRolesMachine>
   // Since the info here is used by multiple deployment settings page and we don't want to refetch them every time
   deploymentConfigXService: ActorRefFrom<typeof deploymentConfigMachine>
+  updateCheckXService: ActorRefFrom<typeof updateCheckMachine>
 }
 
 /**
@@ -35,6 +37,7 @@ export const XServiceProvider: FC<{ children: ReactNode }> = ({ children }) => {
         entitlementsXService: useInterpret(entitlementsMachine),
         siteRolesXService: useInterpret(siteRolesMachine),
         deploymentConfigXService: useInterpret(deploymentConfigMachine),
+        updateCheckXService: useInterpret(updateCheckMachine),
       }}
     >
       {children}

--- a/site/src/xServices/updateCheck/updateCheckXService.ts
+++ b/site/src/xServices/updateCheck/updateCheckXService.ts
@@ -1,0 +1,103 @@
+import { assign, createMachine } from "xstate"
+import * as API from "../../api/api"
+import * as TypesGen from "../../api/typesGenerated"
+import { displayMsg } from "../../components/GlobalSnackbar/utils"
+
+export const Language = {
+  updateAvailable: "New version available",
+  updateAvailableMessage: (
+    version: string,
+    url: string,
+    upgrade_instructions_url: string,
+  ): string =>
+    `Coder ${version} is now available at ${url}. See ${upgrade_instructions_url} for information on how to upgrade.`,
+}
+
+export interface UpdateCheckContext {
+  getUpdateCheckError?: Error | unknown
+  updateCheck?: TypesGen.UpdateCheckResponse
+}
+
+export const updateCheckMachine = createMachine(
+  {
+    id: "updateCheckState",
+    predictableActionArguments: true,
+    tsTypes: {} as import("./updateCheckXService.typegen").Typegen0,
+    schema: {
+      context: {} as UpdateCheckContext,
+      services: {} as {
+        getUpdateCheck: {
+          data: TypesGen.UpdateCheckResponse
+        }
+      },
+    },
+    context: {
+      updateCheck: undefined,
+    },
+    initial: "gettingUpdateCheck",
+    states: {
+      gettingUpdateCheck: {
+        invoke: {
+          src: "getUpdateCheck",
+          id: "getUpdateCheck",
+          onDone: [
+            {
+              actions: [
+                "assignUpdateCheck",
+                "clearGetUpdateCheckError",
+                "notifyUpdateAvailable",
+              ],
+              target: "#updateCheckState.success",
+            },
+          ],
+          onError: [
+            {
+              actions: ["assignGetUpdateCheckError", "clearUpdateCheck"],
+              target: "#updateCheckState.failure",
+            },
+          ],
+        },
+      },
+      success: {
+        type: "final",
+      },
+      failure: {
+        type: "final",
+      },
+    },
+  },
+  {
+    services: {
+      getUpdateCheck: API.getUpdateCheck,
+    },
+    actions: {
+      assignUpdateCheck: assign({
+        updateCheck: (_, event) => event.data,
+      }),
+      clearUpdateCheck: assign((context: UpdateCheckContext) => ({
+        ...context,
+        updateCheck: undefined,
+      })),
+      assignGetUpdateCheckError: assign({
+        getUpdateCheckError: (_, event) => event.data,
+      }),
+      clearGetUpdateCheckError: assign((context: UpdateCheckContext) => ({
+        ...context,
+        getUpdateCheckError: undefined,
+      })),
+      notifyUpdateAvailable: (context: UpdateCheckContext) => {
+        if (context.updateCheck && !context.updateCheck.current) {
+          // TODO(mafredri): HTML formatting, persistance?
+          displayMsg(
+            Language.updateAvailable,
+            Language.updateAvailableMessage(
+              context.updateCheck.version,
+              context.updateCheck.url,
+              "https://coder.com/docs/coder-oss/latest/admin/upgrade",
+            ),
+          )
+        }
+      },
+    },
+  },
+)

--- a/site/src/xServices/updateCheck/updateCheckXService.ts
+++ b/site/src/xServices/updateCheck/updateCheckXService.ts
@@ -4,7 +4,7 @@ import { AuthorizationResponse, UpdateCheckResponse } from "api/typesGenerated"
 
 export const checks = {
   viewUpdateCheck: "viewUpdateCheck",
-} as const
+}
 
 export const permissionsToCheck = {
   [checks.viewUpdateCheck]: {
@@ -13,7 +13,7 @@ export const permissionsToCheck = {
     },
     action: "read",
   },
-} as const
+}
 
 export type Permissions = Record<keyof typeof permissionsToCheck, boolean>
 

--- a/site/src/xServices/updateCheck/updateCheckXService.ts
+++ b/site/src/xServices/updateCheck/updateCheckXService.ts
@@ -1,7 +1,6 @@
 import { assign, createMachine } from "xstate"
-import * as API from "../../api/api"
-import * as TypesGen from "../../api/typesGenerated"
-import { displayMsg } from "../../components/GlobalSnackbar/utils"
+import * as API from "api/api"
+import * as TypesGen from "api/typesGenerated"
 
 export const Language = {
   updateAvailable: "New version available",
@@ -42,11 +41,7 @@ export const updateCheckMachine = createMachine(
           id: "getUpdateCheck",
           onDone: [
             {
-              actions: [
-                "assignUpdateCheck",
-                "clearGetUpdateCheckError",
-                "notifyUpdateAvailable",
-              ],
+              actions: ["assignUpdateCheck", "clearGetUpdateCheckError"],
               target: "#updateCheckState.success",
             },
           ],
@@ -85,19 +80,6 @@ export const updateCheckMachine = createMachine(
         ...context,
         getUpdateCheckError: undefined,
       })),
-      notifyUpdateAvailable: (context: UpdateCheckContext) => {
-        if (context.updateCheck && !context.updateCheck.current) {
-          // TODO(mafredri): HTML formatting, persistance?
-          displayMsg(
-            Language.updateAvailable,
-            Language.updateAvailableMessage(
-              context.updateCheck.version,
-              context.updateCheck.url,
-              "https://coder.com/docs/coder-oss/latest/admin/upgrade",
-            ),
-          )
-        }
-      },
     },
   },
 )


### PR DESCRIPTION
This PR adds support for update checking to coder server.

Fixes #2701

## TODO for site:
- [x] Only show message to owners
- [ ] ~~Refresh update check status at X interval?~~
- [x] Links / HTML styling in ~~GlobalSnackbar~~ AlertBanner or redirect on click
    - [ ] ~~Or alternative display method?~~
- [x] Require manual dismissal of notification
- [x] Add tests

## Description

The server implementation:

- Periodically checks GitHub API for new release (24h)
- Data is stored in DB (`site_config`) so that we don't spam GitHub API on every startup (this could otherwise cause our customers IP to be rate-limited in a crash-loop scenario)
- This data is available via `/api/v2/updatecheck`
- Logs a message when a new version is available, or on startup on outdated installations

Server log example:

```console
2022-10-31 15:35:09.015 [INFO]	(coderd)	<./cli/server.go:374>	Server.func1.3	new version of coder available	{"new_version": "v0.11.0", "url": "https://github.com/coder/coder/releases/tag/v0.11.0", "upgrade_instructions": "https://coder.com/docs/coder-oss/latest/admin/upgrade"}
2022-10-31 15:35:09.018 [INFO]	(coderd.update_checker)	<./coderd/updatecheck/updatecheck.go:157>	(*Checker).start	time until next update check	{"duration": "22h24m56.543305984s"}
```

The notification in the Web UI looks like this:

<img width="1017" src="https://user-images.githubusercontent.com/147409/204900660-133573ab-256a-4fbb-921a-2fef4a8ca4ee.png">

~~An alternative display method may be required, or extending GlobalSnackbar features (no timeout, HTML content, etc).~~
