### PR TITLE
fix: Use immutable links for docker with intellij/pycharm

### DIFF
--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -200,9 +200,9 @@ resource "coder_app" "intellij" {
 
 You can also reference/use to these pre-built templates with JetBrains projector:
 
-- IntelliJ ([Docker](https://github.com/mark-theshark/v2-templates/tree/main/docker-with-intellij), [Kubernetes](https://github.com/sharkymark/v2-templates/tree/main/multi-projector-intellij))
+- IntelliJ ([Docker](https://github.com/sharkymark/v2-templates/tree/e815748bf5d029da15dac29fb25a6fd4ef8e73bf/the-archives/docker-with-intellij), [Kubernetes](https://github.com/sharkymark/v2-templates/tree/main/multi-projector-intellij))
 
-- PyCharm ([Docker](https://github.com/mark-theshark/v2-templates/tree/main/docker-with-pycharm), [Kubernetes](https://github.com/sharkymark/v2-templates/tree/main/multi-projector-pycharm)
+- PyCharm ([Docker](https://github.com/sharkymark/v2-templates/tree/e815748bf5d029da15dac29fb25a6fd4ef8e73bf/the-archives/docker-with-pycharm), [Kubernetes](https://github.com/sharkymark/v2-templates/tree/main/multi-projector-pycharm)
 
 > You need to have a valid `~/.kube/config` on your Coder host and a namespace on a Kubernetes cluster to use the Kubernetes pod template examples.
 


### PR DESCRIPTION
The original links broke and made [markdown link checker cry](https://github.com/coder/coder/actions/runs/3368834328/jobs/5588011866)