### PR TITLE
chore: 🦈 😎 👀 1. add psql URL for the built-in db 2. repair workspace with coder update CLI command 

### DIFF
--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -42,8 +42,7 @@ the PostgreSQL interactive terminal), output the connection URL with the followi
 
 ```console
 $ coder server postgres-builtin-url
-
-psql "postgres://coder@localhost:49627/coder?sslmode=disable&password=feU...yI1"
+$ psql "postgres://coder@localhost:49627/coder?sslmode=disable&password=feU...yI1"
 ```
 
 ## System packages

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -37,6 +37,15 @@ downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the
 
 > Postgres 13 is the minimum supported version.
 
+If you are using the built-in PostgreSQL deployment and need to use `psql` (aka
+the PostgreSQL interactive terminal), output the connection URL with the following command:
+
+```console
+$ coder server postgres-builtin-url
+
+psql "postgres://coder@localhost:49627/coder?sslmode=disable&password=feU...yI1"
+```
+
 ## System packages
 
 If you've installed Coder via a [system package](../install/packages.md) Coder, you can

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -70,6 +70,16 @@ The workspace will be stopped and started:
 coder update <workspace-name>
 ```
 
+## Repairing workspaces
+
+Use the following command to prompt the user to re-enter template input
+variables in an existing workspace. e.g., a workspace fails to build when the
+workspace state is out of sync with updates to the workspace's template.
+
+```console
+coder update <your workspace name> --always-prompt
+```
+
 ## Logging
 
 Coder stores macOS and Linux logs at the following locations:

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -72,9 +72,9 @@ coder update <workspace-name>
 
 ## Repairing workspaces
 
-Use the following command to prompt the user to re-enter template input
-variables in an existing workspace. e.g., a workspace fails to build when the
-workspace state is out of sync with updates to the workspace's template.
+Use the following command to re-enter template input
+variables in an existing workspace. This command is useful when a workspace fails
+to build because its state is out of sync with the template.
 
 ```console
 coder update <your workspace name> --always-prompt


### PR DESCRIPTION
This PR by Mark and Eric to the docs addresses:

1. how to repair a workspace with `coder update <workspace name> --always-prompt
2. how to get the `psql` connection URL for the built-in Postgres database

<img width="589" alt="image" src="https://user-images.githubusercontent.com/2022166/199615029-1b87a746-8023-4292-a91e-2a00f00ac67e.png">

<img width="622" alt="Screen Shot 2022-11-02 at 5 34 31 PM" src="https://user-images.githubusercontent.com/2022166/199615738-342a8158-cb6c-4a52-85dc-054974ef4edd.png">

