### PR TITLE
housekeeping(terraform): bump TerraformVersion

### DIFF
--- a/provisioner/terraform/install.go
+++ b/provisioner/terraform/install.go
@@ -18,10 +18,10 @@ import (
 var (
 	// TerraformVersion is the version of Terraform used internally
 	// when Terraform is not available on the system.
-	TerraformVersion = version.Must(version.NewVersion("1.3.0"))
+	TerraformVersion = version.Must(version.NewVersion("1.3.4"))
 
 	minTerraformVersion = version.Must(version.NewVersion("1.1.0"))
-	maxTerraformVersion = version.Must(version.NewVersion("1.3.0"))
+	maxTerraformVersion = version.Must(version.NewVersion("1.3.4"))
 
 	terraformMinorVersionMismatch = xerrors.New("Terraform binary minor version mismatch.")
 )


### PR DESCRIPTION
# context

In response to conversation over at https://discord.com/channels/747933592273027093/991429648200245358/1035977023035818065

> I just noticed that the Terraform version used by coder is outdated by 3 patch versions.

## notes

I have **not** tested this change.