### PR TITLE
[WIP] feat(examples): lint examples automatically

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,28 @@
+plugin "terraform" {
+    enabled = true
+    version = "0.2.1"
+    source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+}
+
+rule "terraform_standard_module_structure" {
+  enabled = false
+}
+
+plugin "aws" {
+    enabled = true
+    version = "0.18.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+plugin "google" {
+    enabled = true
+    version = "0.21.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+
+plugin "azurerm" {
+    enabled = true
+    version = "0.19.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+

--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ else
 endif
 .PHONY: fmt/shfmt
 
-lint: lint/shellcheck lint/go
+lint: lint/shellcheck lint/tflint lint/go
 .PHONY: lint
 
 lint/go:
@@ -387,6 +387,13 @@ lint/shellcheck: $(shell shfmt -f .)
 	echo "--- shellcheck"
 	shellcheck --external-sources $(shell shfmt -f .)
 .PHONY: lint/shellcheck
+
+lint/tflint: $(shell ls -d examples/templates/*/*.tf) $(shell ls -d dogfood/*.tf)
+	tflint --init
+	for i in $^ ; do \
+        tflint $$i ; \
+    done
+.PHONY: lint/tflint
 
 # all gen targets should be added here and to gen/mark-fresh
 gen: \

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -172,6 +172,9 @@ RUN apt-get update --quiet && apt-get install --yes \
 RUN curl -L https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb -o gh.deb && \
     dpkg -i gh.deb
 
+# Install tflint
+RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
 # Install frontend utilities
 RUN apt-get update && \
     # Node.js (from nodesource) and Yarn (from yarnpkg)

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
             shfmt
             sqlc
             terraform
+            tflint
             typos
             yarn
             zip


### PR DESCRIPTION
Opening this pull-request early for discussion about approach before resolving linting errors. The intention here would be to introduce automation that enforces from this point forward that coder never regresses on terraform linting...

# current errors

```
coder@coder:~/coder/lint$ make lint/tflint
Plugin `terraform` is already installed
Plugin `aws` is already installed
Plugin `google` is already installed
Plugin `azurerm` is already installed
7 issue(s) found:

Warning: `ecs-cluster` variable has no type (terraform_typed_variables)

  on examples/templates/aws-ecs-container/main.tf line 14:
  14: variable "ecs-cluster" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_typed_variables.md

Notice: variable name `ecs-cluster` must match the following format: snake_case (terraform_naming_convention)

  on examples/templates/aws-ecs-container/main.tf line 14:
  14: variable "ecs-cluster" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_naming_convention.md

Notice: `cpu` variable has no description (terraform_documented_variables)

  on examples/templates/aws-ecs-container/main.tf line 18:
  18: variable "cpu" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_documented_variables.md

Warning: `cpu` variable has no type (terraform_typed_variables)

  on examples/templates/aws-ecs-container/main.tf line 18:
  18: variable "cpu" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_typed_variables.md

Notice: `memory` variable has no description (terraform_documented_variables)

  on examples/templates/aws-ecs-container/main.tf line 22:
  22: variable "memory" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_documented_variables.md

Warning: `memory` variable has no type (terraform_typed_variables)

  on examples/templates/aws-ecs-container/main.tf line 22:
  22: variable "memory" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_typed_variables.md

Notice: resource name `code-server` must match the following format: snake_case (terraform_naming_convention)

  on examples/templates/aws-ecs-container/main.tf line 107:
 107: resource "coder_app" "code-server" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.1/docs/rules/terraform_naming_convention.md

make: *** [Makefile:392: lint/tflint] Error 2
```

Resolves https://github.com/coder/coder/issues/3889