### PR TITLE
Allow changing db schema from public

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -133,7 +133,7 @@ CREATE TABLE api_keys (
     login_type login_type NOT NULL,
     lifetime_seconds bigint DEFAULT 86400 NOT NULL,
     ip_address inet DEFAULT '0.0.0.0'::inet NOT NULL,
-    scope api_key_scope DEFAULT 'all'::public.api_key_scope NOT NULL
+    scope api_key_scope DEFAULT 'all'::api_key_scope NOT NULL
 );
 
 COMMENT ON COLUMN api_keys.hashed_secret IS 'hashed_secret contains a SHA256 hash of the key secret. This is considered a secret and MUST NOT be returned from the API as it is used for API key encryption in app proxying code.';
@@ -364,9 +364,9 @@ CREATE TABLE users (
     hashed_password bytea NOT NULL,
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
-    status user_status DEFAULT 'active'::public.user_status NOT NULL,
+    status user_status DEFAULT 'active'::user_status NOT NULL,
     rbac_roles text[] DEFAULT '{}'::text[] NOT NULL,
-    login_type login_type DEFAULT 'password'::public.login_type NOT NULL,
+    login_type login_type DEFAULT 'password'::login_type NOT NULL,
     avatar_url text,
     deleted boolean DEFAULT false NOT NULL,
     last_seen_at timestamp without time zone DEFAULT '0001-01-01 00:00:00'::timestamp without time zone NOT NULL
@@ -406,9 +406,9 @@ CREATE TABLE workspace_apps (
     healthcheck_url text DEFAULT ''::text NOT NULL,
     healthcheck_interval integer DEFAULT 0 NOT NULL,
     healthcheck_threshold integer DEFAULT 0 NOT NULL,
-    health workspace_app_health DEFAULT 'disabled'::public.workspace_app_health NOT NULL,
+    health workspace_app_health DEFAULT 'disabled'::workspace_app_health NOT NULL,
     subdomain boolean DEFAULT false NOT NULL,
-    sharing_level app_sharing_level DEFAULT 'owner'::public.app_sharing_level NOT NULL,
+    sharing_level app_sharing_level DEFAULT 'owner'::app_sharing_level NOT NULL,
     slug text NOT NULL
 );
 
@@ -424,7 +424,7 @@ CREATE TABLE workspace_builds (
     provisioner_state bytea,
     job_id uuid NOT NULL,
     deadline timestamp with time zone DEFAULT '0001-01-01 00:00:00+00'::timestamp with time zone NOT NULL,
-    reason build_reason DEFAULT 'initiator'::public.build_reason NOT NULL
+    reason build_reason DEFAULT 'initiator'::build_reason NOT NULL
 );
 
 CREATE TABLE workspace_resource_metadata (

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -212,7 +212,7 @@ CREATE SEQUENCE licenses_id_seq
     NO MAXVALUE
     CACHE 1;
 
-ALTER SEQUENCE licenses_id_seq OWNED BY public.licenses.id;
+ALTER SEQUENCE licenses_id_seq OWNED BY licenses.id;
 
 CREATE TABLE organization_members (
     user_id uuid NOT NULL,
@@ -460,7 +460,7 @@ CREATE TABLE workspaces (
     last_used_at timestamp without time zone DEFAULT '0001-01-01 00:00:00'::timestamp without time zone NOT NULL
 );
 
-ALTER TABLE ONLY licenses ALTER COLUMN id SET DEFAULT nextval('public.licenses_id_seq'::regclass);
+ALTER TABLE ONLY licenses ALTER COLUMN id SET DEFAULT nextval('licenses_id_seq'::regclass);
 
 ALTER TABLE ONLY agent_stats
     ADD CONSTRAINT agent_stats_pkey PRIMARY KEY (id);

--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -63,8 +63,9 @@ func main() {
 		// Remove all comments.
 		"/^--/d",
 		// Public is implicit in the schema.
-		"s/ public\\./ /",
-		"s/::public\\./::/",
+		"s/ public\\./ /g",
+		"s/::public\\./::/g",
+		"s/'public\\./'/g",
 		// Remove database settings.
 		"s/SET .* = .*;//g",
 		// Remove select statements. These aren't useful

--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -64,6 +64,7 @@ func main() {
 		"/^--/d",
 		// Public is implicit in the schema.
 		"s/ public\\./ /",
+		"s/::public\\./::/",
 		// Remove database settings.
 		"s/SET .* = .*;//g",
 		// Remove select statements. These aren't useful

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3875,7 +3875,7 @@ SELECT
 FROM
 	users
 WHERE
-    status = 'active'::public.user_status AND deleted = false
+    status = 'active'::user_status AND deleted = false
 `
 
 func (q *sqlQuerier) GetActiveUserCount(ctx context.Context) (int64, error) {

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -37,7 +37,7 @@ SELECT
 FROM
 	users
 WHERE
-    status = 'active'::public.user_status AND deleted = false;
+    status = 'active'::user_status AND deleted = false;
 
 -- name: InsertUser :one
 INSERT INTO


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->

Fixes: https://github.com/coder/coder/issues/4747

This PR removes hard-coded references to the `public` schema, which prevents users from predefining their own schemas. As the application depends on the connection string, I suppose that it doesn't need an extra ENV var (like `DB_SEARCH_STRING` in https://github.com/coder/v1/pull/13216) to provide the `search_path`.