### PR TITLE
docs: change format from console to sh for psql URL and coder update repair sections

### DIFF
--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -40,7 +40,7 @@ downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the
 If you are using the built-in PostgreSQL deployment and need to use `psql` (aka
 the PostgreSQL interactive terminal), output the connection URL with the following command:
 
-```console
+```sh
 $ coder server postgres-builtin-url
 $ psql "postgres://coder@localhost:49627/coder?sslmode=disable&password=feU...yI1"
 ```

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -76,7 +76,7 @@ Use the following command to re-enter template input
 variables in an existing workspace. This command is useful when a workspace fails
 to build because its state is out of sync with the template.
 
-```console
+```sh
 coder update <your workspace name> --always-prompt
 ```
 


### PR DESCRIPTION
This PR:

Changes formatting to `sh` from `console` to be consistent.
