### PR TITLE
fix: Avoid parsing telemetry URL when telemetry is disabled

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -236,7 +236,7 @@ func newConfig() *codersdk.DeploymentConfig {
 
 		Telemetry: &codersdk.TelemetryConfig{
 			Enable: &codersdk.DeploymentConfigField[bool]{
-				Name:    "Telemetry Enable",
+				Name:    "Telemetry",
 				Usage:   "Whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.",
 				Flag:    "telemetry",
 				Default: flag.Lookup("test.v") == nil,

--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -236,7 +236,7 @@ func newConfig() *codersdk.DeploymentConfig {
 
 		Telemetry: &codersdk.TelemetryConfig{
 			Enable: &codersdk.DeploymentConfigField[bool]{
-				Name:    "Telemetry",
+				Name:    "Telemetry Enable",
 				Usage:   "Whether telemetry is enabled or not. Coder collects anonymized usage data to help improve our product.",
 				Flag:    "telemetry",
 				Default: flag.Lookup("test.v") == nil,

--- a/cli/server.go
+++ b/cli/server.go
@@ -468,16 +468,17 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 				}
 			}
 
-			// Parse the raw telemetry URL!
-			telemetryURL, err := parseURL(cfg.Telemetry.URL.Value)
-			if err != nil {
-				return xerrors.Errorf("parse telemetry url: %w", err)
-			}
 			// Disable telemetry if the in-memory database is used unless explicitly defined!
 			if cfg.InMemoryDatabase.Value && !cmd.Flags().Changed(cfg.Telemetry.Enable.Flag) {
 				cfg.Telemetry.Enable.Value = false
 			}
 			if cfg.Telemetry.Enable.Value {
+				// Parse the raw telemetry URL!
+				telemetryURL, err := parseURL(cfg.Telemetry.URL.Value)
+				if err != nil {
+					return xerrors.Errorf("parse telemetry url: %w", err)
+				}
+
 				options.Telemetry, err = telemetry.New(telemetry.Options{
 					BuiltinPostgres: builtinPostgres,
 					DeploymentID:    deploymentID,


### PR DESCRIPTION
~~CODER_TRACE=false was renamed to CODER_TRACE_ENABLE=false (probably not intentional?). This changes it back~~ 

This PR moves telemetry URL parsing to avoid:

```
parse telemetry url: URL "" must have a scheme of either http or https
Run 'coder server --help' for usage.
```