### PR TITLE
docs: consolidate docker quickstarts

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -76,19 +76,19 @@
         },
         {
           "title": "Google Cloud Platform",
-          "description": "Setup Coder with Google Cloud Platform",
+          "description": "Setup Coder on a GCP Compute Engine VM",
           "icon_path": "./images/google-cloud.svg",
           "path": "./quickstart/google-cloud-platform.md"
         },
         {
           "title": "AWS",
-          "description": "Setup Coder with AWS",
+          "description": "Setup Coder on an AWS EC2 VM",
           "icon_path": "./images/aws.svg",
           "path": "./quickstart/aws.md"
         },
         {
           "title": "Azure",
-          "description": "Setup Coder with Azure",
+          "description": "Setup Coder on an Azure VM",
           "icon_path": "./images/azure.svg",
           "path": "./quickstart/azure.md"
         }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,68 +1,9 @@
 # Quickstart
 
-See our [Docker quickstart](./quickstart/docker.md) for the easiest
-possible way to use Coder.
+Quickstarts are the fastest way to try Coder. We'll walk you through installation and adding your first template and workspace.
 
-## Generic Quickstart
+First, pick a platform:
 
-Please [install Coder](./install/index.md) before proceeding with the steps below.
-
-## First time owner user setup
-
-1. Run `coder login <your Access URL>` in a new terminal and follow the
-   interactive instructions to create your owner user and password.
-
-## Templates
-
-To get started using templates, run the following command to generate a sample template:
-
-```bash
-coder templates init
-```
-
-Follow the CLI instructions to select an example that you can modify for your
-specific usage (e.g., a template to **Develop code-server in Docker**):
-
-1. Navigate into your new templates folder and create your first template using
-   the provided command (e.g., `cd ./docker-code-server && coder templates create`)
-
-1. Answer the CLI prompts; when done, confirm that you want to create your template.
-
-## Create a workspace
-
-Now, create a workspace using your template:
-
-```bash
-coder create --template="yourTemplate" <workspaceName>
-```
-
-Connect to your workspace via SSH:
-
-```bash
-coder ssh <workspaceName>
-```
-
-To access your workspace in the Coder dashboard, navigate to the [configured access URL](./admin/configure.md#access-url),
-and log in with the owner credentials provided to you by Coder.
-
-![Coder Web UI with code-server](./images/code-server.png)
-
-You can also create workspaces using the access URL and the Templates UI.
-
-![Templates UI to create a
-workspace](./images/create-workspace-from-templates-ui.png)
-
-## Modifying templates
-
-You can edit the Terraform template as follows:
-
-```sh
-coder templates init
-cd gcp-linux # modify this line as needed to access the template
-vim main.tf
-coder templates push gcp-linux # updates the template
-```
-
-## Up Next
-
-Learn about [templates](./templates.md).
+<children>
+  This page is rendered on https://coder.com/docs/coder-oss/latest/quickstart. Refer to the other documents in the `install/` directory for per-platform instructions.
+</children>

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -40,7 +40,7 @@ Coder with Docker has the following advantages:
 
 1.  Pull the "Docker" example template using the interactive `coder templates init`:
 
-    ```sh
+    ```shell
     coder templates init
     cd docker
     ```

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -31,7 +31,7 @@ Coder with Docker has the following advantages:
 
 1.  In new terminal, [install Coder](../install/) in order to connect to your deployment through the CLI.
 
-    ```sh
+    ```shell
     curl -L https://coder.com/install.sh | sh
     ```
 

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -13,34 +13,41 @@ Coder with Docker has the following advantages:
 
 ## Instructions
 
-1.  [Install and launch Coder](../install)
+1. Run Coder with Docker.
 
-    The Coder server binds to port 3000 by default. Use `--address :<port>` to customize it!
+    ```sh
+    export CODER_DATA=$HOME/.config/coderv2-docker
+    export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
+    mkdir -p $CODER_DATA
+    docker run --rm -it \
+        -v $CODER_DATA:/home/coder/.config \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --group-add $DOCKER_GROUP \
+        ghcr.io/coder/coder:latest
+    ```
+    
+    > This will use Coder's tunnel and built-in database. See our [Docker documentation](../install/docker.md) for other configuration options such as running on localhost, using docker-compose, and external PostgreSQL.
 
-    Use the [Coder tunnel](../admin/configure.md#tunnel) for a public URL:
 
-    ```bash
-    coder server
+1.  In new terminal, [install Coder](../install/) in order to connect to your deployment through the CLI.
+
+    ```sh
+    curl -L https://coder.com/install.sh | sh
     ```
 
-    Or set an [access URL](../admin/configure.md#access-url) to run entirely locally:
-
-    ```bash
-    coder server --access-url=http://localhost:3000 --address=:3000
-    ```
-
-1.  Run `coder login <access url>` in a new terminal and follow the
+1.  Run `coder login <access url>` and follow the
     interactive instructions to create your user.
 
 1.  Pull the "Docker" example template using the interactive `coder templates init`:
 
-    ```bash
+    ```sh
     coder templates init
     cd docker
     ```
 
 1.  Push up the template with `coder templates create`
-1.  Open the dashboard in your browser (http://localhost:3000) to create your
+
+1.  Open the dashboard in your browser to create your
     first workspace:
 
     <img src="../images/quickstart/docker/login.png">

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -15,7 +15,7 @@ Coder with Docker has the following advantages:
 
 1. Run Coder with Docker.
 
-    ```sh
+    ```shell
     export CODER_DATA=$HOME/.config/coderv2-docker
     export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
     mkdir -p $CODER_DATA


### PR DESCRIPTION
I changed the Docker quickstart to do the same thing as the others

- Install Coder on that platform (using the tunnel, built-in DB)
- Add a template using that platform

I also removed the "generic quickstart" since it was essentially a duplicate of the Docker one.