### PR TITLE
feat: add "on this page" to empty table message when you're past page 1

### DIFF
--- a/site/src/components/Conditionals/ChooseOne.tsx
+++ b/site/src/components/Conditionals/ChooseOne.tsx
@@ -40,7 +40,7 @@ export const ChooseOne = ({
   }
   if (conditionedOptions.some((cond) => cond.props.condition === undefined)) {
     throw new Error(
-      "A non-final Cond in a ChooseOne does not have a condition prop.",
+      "A non-final Cond in a ChooseOne does not have a condition prop or the prop is undefined.",
     )
   }
   const chosen = conditionedOptions.find((child) => child.props.condition)

--- a/site/src/components/PaginationWidget/utils.ts
+++ b/site/src/components/PaginationWidget/utils.ts
@@ -103,7 +103,7 @@ export const createPaginationRef = (
   return spawn(paginationMachine.withContext(context))
 }
 
-export const isNonInitialPage = (searchParams: URLSearchParams): boolean => {
+export const nonInitialPage = (searchParams: URLSearchParams): boolean => {
   const page = searchParams.get("page")
   const numberPage = page ? Number(page) : 1
   return numberPage > 1

--- a/site/src/components/PaginationWidget/utils.ts
+++ b/site/src/components/PaginationWidget/utils.ts
@@ -102,3 +102,9 @@ export const createPaginationRef = (
 ): PaginationMachineRef => {
   return spawn(paginationMachine.withContext(context))
 }
+
+export const isNonInitialPage = (searchParams: URLSearchParams): boolean => {
+  const page = searchParams.get("page")
+  const numberPage = page ? Number(page) : 1
+  return numberPage > 1
+}

--- a/site/src/components/UsersTable/UsersTable.stories.tsx
+++ b/site/src/components/UsersTable/UsersTable.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, Story } from "@storybook/react"
 import {
-  MockSiteRoles,
+  MockAssignableSiteRoles,
   MockUser,
   MockUser2,
 } from "../../testHelpers/renderHelpers"
@@ -9,6 +9,11 @@ import { UsersTable, UsersTableProps } from "./UsersTable"
 export default {
   title: "components/UsersTable",
   component: UsersTable,
+  argTypes: {
+    isNonInitialPage: {
+      defaultValue: false,
+    },
+  },
 } as ComponentMeta<typeof UsersTable>
 
 const Template: Story<UsersTableProps> = (args) => <UsersTable {...args} />
@@ -16,27 +21,27 @@ const Template: Story<UsersTableProps> = (args) => <UsersTable {...args} />
 export const Example = Template.bind({})
 Example.args = {
   users: [MockUser, MockUser2],
-  roles: MockSiteRoles,
+  roles: MockAssignableSiteRoles,
   canEditUsers: false,
 }
 
 export const Editable = Template.bind({})
 Editable.args = {
   users: [MockUser, MockUser2],
-  roles: MockSiteRoles,
+  roles: MockAssignableSiteRoles,
   canEditUsers: true,
 }
 
 export const Empty = Template.bind({})
 Empty.args = {
   users: [],
-  roles: MockSiteRoles,
+  roles: MockAssignableSiteRoles,
 }
 
 export const Loading = Template.bind({})
 Loading.args = {
   users: [],
-  roles: MockSiteRoles,
+  roles: MockAssignableSiteRoles,
   isLoading: true,
 }
 Loading.parameters = {

--- a/site/src/components/UsersTable/UsersTable.test.tsx
+++ b/site/src/components/UsersTable/UsersTable.test.tsx
@@ -15,6 +15,7 @@ describe("AuditPage", () => {
         onActivateUser={() => jest.fn()}
         onResetUserPassword={() => jest.fn()}
         onUpdateUserRoles={() => jest.fn()}
+        isNonInitialPage={false}
       />,
     )
 

--- a/site/src/components/UsersTable/UsersTable.tsx
+++ b/site/src/components/UsersTable/UsersTable.tsx
@@ -32,6 +32,7 @@ export interface UsersTableProps {
     user: TypesGen.User,
     roles: TypesGen.Role["name"][],
   ) => void
+  isNonInitialPage: boolean
 }
 
 export const UsersTable: FC<React.PropsWithChildren<UsersTableProps>> = ({
@@ -46,6 +47,7 @@ export const UsersTable: FC<React.PropsWithChildren<UsersTableProps>> = ({
   isUpdatingUserRoles,
   canEditUsers,
   isLoading,
+  isNonInitialPage,
 }) => {
   return (
     <TableContainer>
@@ -78,6 +80,7 @@ export const UsersTable: FC<React.PropsWithChildren<UsersTableProps>> = ({
             onResetUserPassword={onResetUserPassword}
             onSuspendUser={onSuspendUser}
             onUpdateUserRoles={onUpdateUserRoles}
+            isNonInitialPage={isNonInitialPage}
           />
         </TableBody>
       </Table>

--- a/site/src/components/UsersTable/UsersTableBody.tsx
+++ b/site/src/components/UsersTable/UsersTableBody.tsx
@@ -2,8 +2,10 @@ import Box from "@material-ui/core/Box"
 import { makeStyles } from "@material-ui/core/styles"
 import TableCell from "@material-ui/core/TableCell"
 import TableRow from "@material-ui/core/TableRow"
+import { ChooseOne, Cond } from "components/Conditionals/ChooseOne"
 import { LastUsed } from "components/LastUsed/LastUsed"
 import { FC } from "react"
+import { useTranslation } from "react-i18next"
 import * as TypesGen from "../../api/typesGenerated"
 import { combineClasses } from "../../util/combineClasses"
 import { AvatarData } from "../AvatarData/AvatarData"
@@ -11,15 +13,6 @@ import { EmptyState } from "../EmptyState/EmptyState"
 import { RoleSelect } from "../RoleSelect/RoleSelect"
 import { TableLoader } from "../TableLoader/TableLoader"
 import { TableRowMenu } from "../TableRowMenu/TableRowMenu"
-
-export const Language = {
-  emptyMessage: "No users found",
-  suspendMenuItem: "Suspend",
-  deleteMenuItem: "Delete",
-  listWorkspacesMenuItem: "View workspaces",
-  activateMenuItem: "Activate",
-  resetPasswordMenuItem: "Reset password",
-}
 
 interface UsersTableBodyProps {
   users?: TypesGen.User[]
@@ -36,6 +29,7 @@ interface UsersTableBodyProps {
     user: TypesGen.User,
     roles: TypesGen.Role["name"][],
   ) => void
+  isNonInitialPage: boolean
 }
 
 export const UsersTableBody: FC<
@@ -52,121 +46,144 @@ export const UsersTableBody: FC<
   isUpdatingUserRoles,
   canEditUsers,
   isLoading,
+  isNonInitialPage,
 }) => {
   const styles = useStyles()
-
-  if (isLoading) {
-    return <TableLoader />
-  }
-
-  if (!users || users.length === 0) {
-    return (
-      <TableRow>
-        <TableCell colSpan={999}>
-          <Box p={4}>
-            <EmptyState message={Language.emptyMessage} />
-          </Box>
-        </TableCell>
-      </TableRow>
-    )
-  }
+  const { t } = useTranslation("usersPage")
 
   return (
-    <>
-      {users.map((user) => {
-        // When the user has no role we want to show they are a Member
-        const fallbackRole: TypesGen.Role = {
-          name: "member",
-          display_name: "Member",
-        }
-        const userRoles = user.roles.length === 0 ? [fallbackRole] : user.roles
-
-        return (
-          <TableRow key={user.id}>
-            <TableCell>
-              <AvatarData
-                title={user.username}
-                subtitle={user.email}
-                highlightTitle
-                avatar={
-                  user.avatar_url ? (
-                    <img
-                      className={styles.avatar}
-                      alt={`${user.username}'s Avatar`}
-                      src={user.avatar_url}
-                    />
-                  ) : null
-                }
-              />
-            </TableCell>
-            <TableCell
-              className={combineClasses([
-                styles.status,
-                user.status === "suspended" ? styles.suspended : undefined,
-              ])}
-            >
-              {user.status}
-            </TableCell>
-            <TableCell>
-              <LastUsed lastUsedAt={user.last_seen_at} />
-            </TableCell>
-            <TableCell>
-              {canEditUsers ? (
-                <RoleSelect
-                  roles={roles ?? []}
-                  selectedRoles={userRoles}
-                  loading={isUpdatingUserRoles}
-                  onChange={(roles) => {
-                    // Remove the fallback role because it is only for the UI
-                    roles = roles.filter((role) => role !== fallbackRole.name)
-                    onUpdateUserRoles(user, roles)
-                  }}
-                />
-              ) : (
-                <>{userRoles.map((role) => role.display_name).join(", ")}</>
-              )}
-            </TableCell>
-            {canEditUsers && (
-              <TableCell>
-                <TableRowMenu
-                  data={user}
-                  menuItems={
-                    // Return either suspend or activate depending on status
-                    (user.status === "active"
-                      ? [
-                          {
-                            label: Language.suspendMenuItem,
-                            onClick: onSuspendUser,
-                          },
-                        ]
-                      : [
-                          {
-                            label: Language.activateMenuItem,
-                            onClick: onActivateUser,
-                          },
-                        ]
-                    ).concat(
-                      {
-                        label: Language.deleteMenuItem,
-                        onClick: onDeleteUser,
-                      },
-                      {
-                        label: Language.listWorkspacesMenuItem,
-                        onClick: onListWorkspaces,
-                      },
-                      {
-                        label: Language.resetPasswordMenuItem,
-                        onClick: onResetUserPassword,
-                      },
-                    )
-                  }
-                />
+    <ChooseOne>
+      <Cond condition={Boolean(isLoading)}>
+        <TableLoader />
+      </Cond>
+      <Cond condition={!users || users.length === 0}>
+        <ChooseOne>
+          <Cond condition={isNonInitialPage}>
+            <TableRow>
+              <TableCell colSpan={999}>
+                <Box p={4}>
+                  <EmptyState message={t("emptyPageMessage")} />
+                </Box>
               </TableCell>
-            )}
-          </TableRow>
-        )
-      })}
-    </>
+            </TableRow>
+          </Cond>
+          <Cond>
+            <TableRow>
+              <TableCell colSpan={999}>
+                <Box p={4}>
+                  <EmptyState message={t("emptyMessage")} />
+                </Box>
+              </TableCell>
+            </TableRow>
+          </Cond>
+        </ChooseOne>
+      </Cond>
+      <Cond>
+        <>
+          {users &&
+            users.map((user) => {
+              // When the user has no role we want to show they are a Member
+              const fallbackRole: TypesGen.Role = {
+                name: "member",
+                display_name: "Member",
+              }
+              const userRoles =
+                user.roles.length === 0 ? [fallbackRole] : user.roles
+
+              return (
+                <TableRow key={user.id}>
+                  <TableCell>
+                    <AvatarData
+                      title={user.username}
+                      subtitle={user.email}
+                      highlightTitle
+                      avatar={
+                        user.avatar_url ? (
+                          <img
+                            className={styles.avatar}
+                            alt={`${user.username}'s Avatar`}
+                            src={user.avatar_url}
+                          />
+                        ) : null
+                      }
+                    />
+                  </TableCell>
+                  <TableCell
+                    className={combineClasses([
+                      styles.status,
+                      user.status === "suspended"
+                        ? styles.suspended
+                        : undefined,
+                    ])}
+                  >
+                    {user.status}
+                  </TableCell>
+                  <TableCell>
+                    <LastUsed lastUsedAt={user.last_seen_at} />
+                  </TableCell>
+                  <TableCell>
+                    {canEditUsers ? (
+                      <RoleSelect
+                        roles={roles ?? []}
+                        selectedRoles={userRoles}
+                        loading={isUpdatingUserRoles}
+                        onChange={(roles) => {
+                          // Remove the fallback role because it is only for the UI
+                          roles = roles.filter(
+                            (role) => role !== fallbackRole.name,
+                          )
+                          onUpdateUserRoles(user, roles)
+                        }}
+                      />
+                    ) : (
+                      <>
+                        {userRoles.map((role) => role.display_name).join(", ")}
+                      </>
+                    )}
+                  </TableCell>
+                  {canEditUsers && (
+                    <TableCell>
+                      <TableRowMenu
+                        data={user}
+                        menuItems={
+                          // Return either suspend or activate depending on status
+                          (user.status === "active"
+                            ? [
+                                {
+                                  label: t("suspendMenuItem"),
+                                  onClick: onSuspendUser,
+                                },
+                              ]
+                            : [
+                                {
+                                  label: t("activateMenuItem"),
+                                  onClick: onActivateUser,
+                                },
+                              ]
+                          ).concat(
+                            {
+                              label: t("deleteMenuItem"),
+                              onClick: onDeleteUser,
+                            },
+                            {
+                              label: t("listWorkspacesMenuItem"),
+                              onClick: onListWorkspaces,
+                            },
+                            {
+                              label: t("resetPasswordMenuItem"),
+                              onClick: onResetUserPassword,
+                            },
+                          )
+                        }
+                      />
+                    </TableCell>
+                  )}
+                </TableRow>
+              )
+            })}
+        </>
+      </Cond>
+    </ChooseOne>
   )
 }
 

--- a/site/src/components/UsersTable/UsersTableBody.tsx
+++ b/site/src/components/UsersTable/UsersTableBody.tsx
@@ -50,6 +50,7 @@ export const UsersTableBody: FC<
 }) => {
   const styles = useStyles()
   const { t } = useTranslation("usersPage")
+  console.log(isNonInitialPage)
 
   return (
     <ChooseOne>

--- a/site/src/components/UsersTable/UsersTableBody.tsx
+++ b/site/src/components/UsersTable/UsersTableBody.tsx
@@ -50,7 +50,6 @@ export const UsersTableBody: FC<
 }) => {
   const styles = useStyles()
   const { t } = useTranslation("usersPage")
-  console.log(isNonInitialPage)
 
   return (
     <ChooseOne>

--- a/site/src/components/WorkspacesTable/WorkspacesTable.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesTable.tsx
@@ -21,11 +21,12 @@ export interface WorkspacesTableProps {
   isLoading?: boolean
   workspaceRefs?: WorkspaceItemMachineRef[]
   filter?: string
+  isNonInitialPage: boolean
 }
 
 export const WorkspacesTable: FC<
   React.PropsWithChildren<WorkspacesTableProps>
-> = ({ isLoading, workspaceRefs, filter }) => {
+> = ({ isLoading, workspaceRefs, filter, isNonInitialPage }) => {
   return (
     <TableContainer>
       <Table>
@@ -44,6 +45,7 @@ export const WorkspacesTable: FC<
             isLoading={isLoading}
             workspaceRefs={workspaceRefs}
             filter={filter}
+            isNonInitialPage={isNonInitialPage}
           />
         </TableBody>
       </Table>

--- a/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
@@ -38,7 +38,12 @@ export const WorkspacesTableBody: FC<
               <Cond condition={isNonInitialPage}>
                 <EmptyState message={t("emptyPageMessage")} />
               </Cond>
-              <Cond condition={filter === workspaceFilterQuery.me || filter === workspaceFilterQuery.all}>
+              <Cond
+                condition={
+                  filter === workspaceFilterQuery.me ||
+                  filter === workspaceFilterQuery.all
+                }
+              >
                 <EmptyState
                   message={t("emptyCreateWorkspaceMessage")}
                   description={t("emptyCreateWorkspaceDescription")}

--- a/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
@@ -3,21 +3,15 @@ import Link from "@material-ui/core/Link"
 import TableCell from "@material-ui/core/TableCell"
 import TableRow from "@material-ui/core/TableRow"
 import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
+import { ChooseOne, Cond } from "components/Conditionals/ChooseOne"
 import { FC } from "react"
-import { Link as RouterLink } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { Link as RouterLink, useSearchParams } from "react-router-dom"
 import { workspaceFilterQuery } from "../../util/filters"
 import { WorkspaceItemMachineRef } from "../../xServices/workspaces/workspacesXService"
 import { EmptyState } from "../EmptyState/EmptyState"
 import { TableLoader } from "../TableLoader/TableLoader"
 import { WorkspacesRow } from "./WorkspacesRow"
-
-export const Language = {
-  emptyCreateWorkspaceMessage: "Create your first workspace",
-  emptyCreateWorkspaceDescription:
-    "Start editing your source code and building your software.",
-  createFromTemplateButton: "Create from template",
-  emptyResultsMessage: "No results matched your search",
-}
 
 interface TableBodyProps {
   isLoading?: boolean
@@ -28,46 +22,53 @@ interface TableBodyProps {
 export const WorkspacesTableBody: FC<
   React.PropsWithChildren<TableBodyProps>
 > = ({ isLoading, workspaceRefs, filter }) => {
-  if (isLoading) {
-    return <TableLoader />
-  }
-
-  if (!workspaceRefs || workspaceRefs.length === 0) {
-    return (
-      <>
-        {filter === workspaceFilterQuery.me ||
-        filter === workspaceFilterQuery.all ? (
-          <TableRow>
-            <TableCell colSpan={999}>
-              <EmptyState
-                message={Language.emptyCreateWorkspaceMessage}
-                description={Language.emptyCreateWorkspaceDescription}
-                cta={
-                  <Link underline="none" component={RouterLink} to="/templates">
-                    <Button startIcon={<AddCircleOutline />}>
-                      {Language.createFromTemplateButton}
-                    </Button>
-                  </Link>
-                }
-              />
-            </TableCell>
-          </TableRow>
-        ) : (
-          <TableRow>
-            <TableCell colSpan={999}>
-              <EmptyState message={Language.emptyResultsMessage} />
-            </TableCell>
-          </TableRow>
-        )}
-      </>
-    )
-  }
+  const [searchParams, _] = useSearchParams()
+  const page = parseInt(searchParams.get("page") ?? "1")
+  const { t } = useTranslation("workspacesPage")
+  console.log(searchParams.get("page"), page)
 
   return (
-    <>
-      {workspaceRefs.map((workspaceRef) => (
-        <WorkspacesRow workspaceRef={workspaceRef} key={workspaceRef.id} />
-      ))}
-    </>
+    <ChooseOne>
+      <Cond condition={Boolean(isLoading)}>
+        <TableLoader />
+      </Cond>
+      <Cond condition={!workspaceRefs || workspaceRefs.length === 0}>
+        <TableRow>
+          <TableCell colSpan={999}>
+            <ChooseOne>
+              <Cond condition={page > 1}>
+                <EmptyState message={t("emptyPageMessage")} />
+              </Cond>
+              <Cond condition={filter === workspaceFilterQuery.me || filter === workspaceFilterQuery.all}>
+                <EmptyState
+                  message={t("emptyCreateWorkspaceMessage")}
+                  description={t("emptyCreateWorkspaceDescription")}
+                  cta={
+                    <Link
+                      underline="none"
+                      component={RouterLink}
+                      to="/templates"
+                    >
+                      <Button startIcon={<AddCircleOutline />}>
+                        {t("createFromTemplateButton")}
+                      </Button>
+                    </Link>
+                  }
+                />
+              </Cond>
+              <Cond>
+                <EmptyState message={t("emptyResultsMessage")} />
+              </Cond>
+            </ChooseOne>
+          </TableCell>
+        </TableRow>
+      </Cond>
+      <Cond>
+        {workspaceRefs &&
+          workspaceRefs.map((workspaceRef) => (
+            <WorkspacesRow workspaceRef={workspaceRef} key={workspaceRef.id} />
+          ))}
+      </Cond>
+    </ChooseOne>
   )
 }

--- a/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
@@ -24,7 +24,6 @@ export const WorkspacesTableBody: FC<
   React.PropsWithChildren<TableBodyProps>
 > = ({ isLoading, workspaceRefs, filter, isNonInitialPage }) => {
   const { t } = useTranslation("workspacesPage")
-  console.log(isNonInitialPage)
 
   return (
     <ChooseOne>

--- a/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesTableBody.tsx
@@ -6,7 +6,7 @@ import AddCircleOutline from "@material-ui/icons/AddCircleOutline"
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne"
 import { FC } from "react"
 import { useTranslation } from "react-i18next"
-import { Link as RouterLink, useSearchParams } from "react-router-dom"
+import { Link as RouterLink } from "react-router-dom"
 import { workspaceFilterQuery } from "../../util/filters"
 import { WorkspaceItemMachineRef } from "../../xServices/workspaces/workspacesXService"
 import { EmptyState } from "../EmptyState/EmptyState"
@@ -17,15 +17,14 @@ interface TableBodyProps {
   isLoading?: boolean
   workspaceRefs?: WorkspaceItemMachineRef[]
   filter?: string
+  isNonInitialPage: boolean
 }
 
 export const WorkspacesTableBody: FC<
   React.PropsWithChildren<TableBodyProps>
-> = ({ isLoading, workspaceRefs, filter }) => {
-  const [searchParams, _] = useSearchParams()
-  const page = parseInt(searchParams.get("page") ?? "1")
+> = ({ isLoading, workspaceRefs, filter, isNonInitialPage }) => {
   const { t } = useTranslation("workspacesPage")
-  console.log(searchParams.get("page"), page)
+  console.log(isNonInitialPage)
 
   return (
     <ChooseOne>
@@ -36,7 +35,7 @@ export const WorkspacesTableBody: FC<
         <TableRow>
           <TableCell colSpan={999}>
             <ChooseOne>
-              <Cond condition={page > 1}>
+              <Cond condition={isNonInitialPage}>
                 <EmptyState message={t("emptyPageMessage")} />
               </Cond>
               <Cond condition={filter === workspaceFilterQuery.me || filter === workspaceFilterQuery.all}>

--- a/site/src/i18n/en/auditLog.json
+++ b/site/src/i18n/en/auditLog.json
@@ -3,5 +3,9 @@
     "create": "created a new",
     "write": "updated",
     "delete": "deleted"
+  },
+  "table": {
+    "emptyPage": "No audit logs available on this page",
+    "noLogs": "No audit logs available"
   }
 }

--- a/site/src/i18n/en/index.ts
+++ b/site/src/i18n/en/index.ts
@@ -17,5 +17,5 @@ export const en = {
   createWorkspacePage,
   agent,
   buildPage,
-  workspacesPage
+  workspacesPage,
 }

--- a/site/src/i18n/en/index.ts
+++ b/site/src/i18n/en/index.ts
@@ -6,6 +6,7 @@ import templatesPage from "./templatesPage.json"
 import workspacePage from "./workspacePage.json"
 import agent from "./agent.json"
 import buildPage from "./buildPage.json"
+import workspacesPage from "./workspacesPage.json"
 
 export const en = {
   common,
@@ -16,4 +17,5 @@ export const en = {
   createWorkspacePage,
   agent,
   buildPage,
+  workspacesPage
 }

--- a/site/src/i18n/en/index.ts
+++ b/site/src/i18n/en/index.ts
@@ -7,6 +7,7 @@ import workspacePage from "./workspacePage.json"
 import agent from "./agent.json"
 import buildPage from "./buildPage.json"
 import workspacesPage from "./workspacesPage.json"
+import usersPage from "./usersPage.json"
 
 export const en = {
   common,
@@ -18,4 +19,5 @@ export const en = {
   agent,
   buildPage,
   workspacesPage,
+  usersPage,
 }

--- a/site/src/i18n/en/usersPage.json
+++ b/site/src/i18n/en/usersPage.json
@@ -1,0 +1,9 @@
+{
+  "emptyMessage": "No users found",
+  "emptyPageMessage": "No users found on this page",
+  "suspendMenuItem": "Suspend",
+  "deleteMenuItem": "Delete",
+  "listWorkspacesMenuItem": "View workspaces",
+  "activateMenuItem": "Activate",
+  "resetPasswordMenuItem": "Reset password"
+}

--- a/site/src/i18n/en/workspacesPage.json
+++ b/site/src/i18n/en/workspacesPage.json
@@ -1,0 +1,7 @@
+{
+  "emptyCreateWorkspaceMessage": "Create your first workspace",
+  "emptyCreateWorkspaceDescription": "Start editing your source code and building your software.",
+  "createFromTemplateButton": "Create from template",
+  "emptyResultsMessage": "No results matched your search",
+  "emptyPageMessage": "No results on this page"
+}

--- a/site/src/pages/AuditPage/AuditPage.tsx
+++ b/site/src/pages/AuditPage/AuditPage.tsx
@@ -1,7 +1,7 @@
 import { useMachine } from "@xstate/react"
 import {
   getPaginationContext,
-  isNonInitialPage,
+  nonInitialPage,
 } from "components/PaginationWidget/utils"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
@@ -41,7 +41,7 @@ const AuditPage: FC = () => {
           auditSend("FILTER", { filter })
         }}
         paginationRef={paginationRef}
-        isNonInitialPage={isNonInitialPage(searchParams)}
+        isNonInitialPage={nonInitialPage(searchParams)}
       />
     </>
   )

--- a/site/src/pages/AuditPage/AuditPage.tsx
+++ b/site/src/pages/AuditPage/AuditPage.tsx
@@ -1,5 +1,8 @@
 import { useMachine } from "@xstate/react"
-import { getPaginationContext } from "components/PaginationWidget/utils"
+import {
+  getPaginationContext,
+  isNonInitialPage,
+} from "components/PaginationWidget/utils"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
 import { useSearchParams } from "react-router-dom"
@@ -38,6 +41,7 @@ const AuditPage: FC = () => {
           auditSend("FILTER", { filter })
         }}
         paginationRef={paginationRef}
+        isNonInitialPage={isNonInitialPage(searchParams)}
       />
     </>
   )

--- a/site/src/pages/AuditPage/AuditPageView.stories.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.stories.tsx
@@ -25,6 +25,26 @@ const Template: Story<AuditPageViewProps> = (args) => (
 
 export const AuditPage = Template.bind({})
 
+export const Loading = Template.bind({})
+Loading.args = {
+  auditLogs: undefined,
+  count: undefined,
+  isNonInitialPage: false,
+}
+
+export const EmptyPage = Template.bind({})
+EmptyPage.args = {
+  auditLogs: [],
+  isNonInitialPage: true,
+}
+
+export const NoLogs = Template.bind({})
+NoLogs.args = {
+  auditLogs: [],
+  count: 0,
+  isNonInitialPage: false,
+}
+
 export const AuditPageSmallViewport = Template.bind({})
 AuditPageSmallViewport.parameters = {
   chromatic: { viewports: [600] },

--- a/site/src/pages/AuditPage/AuditPageView.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.tsx
@@ -5,6 +5,7 @@ import TableContainer from "@material-ui/core/TableContainer"
 import TableRow from "@material-ui/core/TableRow"
 import { AuditLog } from "api/typesGenerated"
 import { AuditLogRow } from "components/AuditLogRow/AuditLogRow"
+import { ChooseOne, Cond } from "components/Conditionals/ChooseOne"
 import { EmptyState } from "components/EmptyState/EmptyState"
 import { Margins } from "components/Margins/Margins"
 import {
@@ -19,6 +20,7 @@ import { TableLoader } from "components/TableLoader/TableLoader"
 import { Timeline } from "components/Timeline/Timeline"
 import { AuditHelpTooltip } from "components/Tooltips"
 import { FC } from "react"
+import { useTranslation } from "react-i18next"
 import { PaginationMachineRef } from "xServices/pagination/paginationXService"
 
 export const Language = {
@@ -43,6 +45,7 @@ export interface AuditPageViewProps {
   filter: string
   onFilter: (filter: string) => void
   paginationRef: PaginationMachineRef
+  isNonInitialPage: boolean
 }
 
 export const AuditPageView: FC<AuditPageViewProps> = ({
@@ -51,7 +54,9 @@ export const AuditPageView: FC<AuditPageViewProps> = ({
   filter,
   onFilter,
   paginationRef,
+  isNonInitialPage,
 }) => {
+  const { t } = useTranslation("auditLog")
   const isLoading = auditLogs === undefined || count === undefined
   const isEmpty = !isLoading && auditLogs.length === 0
 
@@ -77,23 +82,38 @@ export const AuditPageView: FC<AuditPageViewProps> = ({
       <TableContainer>
         <Table>
           <TableBody>
-            {isLoading && <TableLoader />}
-
-            {auditLogs && (
-              <Timeline
-                items={auditLogs}
-                getDate={(log) => new Date(log.time)}
-                row={(log) => <AuditLogRow key={log.id} auditLog={log} />}
-              />
-            )}
-
-            {isEmpty && (
-              <TableRow>
-                <TableCell colSpan={999}>
-                  <EmptyState message="No audit logs available" />
-                </TableCell>
-              </TableRow>
-            )}
+            <ChooseOne>
+              <Cond condition={isLoading}>
+                <TableLoader />
+              </Cond>
+              <Cond condition={isEmpty}>
+                <ChooseOne>
+                  <Cond condition={isNonInitialPage}>
+                    <TableRow>
+                      <TableCell colSpan={999}>
+                        <EmptyState message={t("table.emptyPage")} />
+                      </TableCell>
+                    </TableRow>
+                  </Cond>
+                  <Cond>
+                    <TableRow>
+                      <TableCell colSpan={999}>
+                        <EmptyState message={t("table.noLogs")} />
+                      </TableCell>
+                    </TableRow>
+                  </Cond>
+                </ChooseOne>
+              </Cond>
+              <Cond>
+                {auditLogs && (
+                  <Timeline
+                    items={auditLogs}
+                    getDate={(log) => new Date(log.time)}
+                    row={(log) => <AuditLogRow key={log.id} auditLog={log} />}
+                  />
+                )}
+              </Cond>
+            </ChooseOne>
           </TableBody>
         </Table>
       </TableContainer>

--- a/site/src/pages/UsersPage/UsersPage.test.tsx
+++ b/site/src/pages/UsersPage/UsersPage.test.tsx
@@ -8,7 +8,6 @@ import { Role } from "../../api/typesGenerated"
 import { Language as ResetPasswordDialogLanguage } from "../../components/Dialogs/ResetPasswordDialog/ResetPasswordDialog"
 import { GlobalSnackbar } from "../../components/GlobalSnackbar/GlobalSnackbar"
 import { Language as RoleSelectLanguage } from "../../components/RoleSelect/RoleSelect"
-import { Language as UsersTableBodyLanguage } from "../../components/UsersTable/UsersTableBody"
 import {
   MockAuditorRole,
   MockUser,
@@ -39,9 +38,8 @@ const suspendUser = async (setupActionSpies: () => void) => {
   await user.click(firstMoreButton)
 
   const menu = await screen.findByRole("menu")
-  const suspendButton = within(menu).getByText(
-    UsersTableBodyLanguage.suspendMenuItem,
-  )
+  const text = t("suspendMenuItem", { ns: "usersPage" })
+  const suspendButton = within(menu).getByText(text)
 
   await user.click(suspendButton)
 
@@ -72,9 +70,8 @@ const deleteUser = async (setupActionSpies: () => void) => {
   await user.click(selectedMoreButton)
 
   const menu = await screen.findByRole("menu")
-  const deleteButton = within(menu).getByText(
-    UsersTableBodyLanguage.deleteMenuItem,
-  )
+  const text = t("deleteMenuItem", { ns: "usersPage" })
+  const deleteButton = within(menu).getByText(text)
 
   await user.click(deleteButton)
 
@@ -107,9 +104,8 @@ const activateUser = async (setupActionSpies: () => void) => {
   fireEvent.click(suspendedMoreButton)
 
   const menu = screen.getByRole("menu")
-  const activateButton = within(menu).getByText(
-    UsersTableBodyLanguage.activateMenuItem,
-  )
+  const text = t("activateMenuItem", { ns: "usersPage" })
+  const activateButton = within(menu).getByText(text)
   fireEvent.click(activateButton)
 
   // Check if the confirm message is displayed
@@ -135,9 +131,8 @@ const resetUserPassword = async (setupActionSpies: () => void) => {
   fireEvent.click(firstMoreButton)
 
   const menu = screen.getByRole("menu")
-  const resetPasswordButton = within(menu).getByText(
-    UsersTableBodyLanguage.resetPasswordMenuItem,
-  )
+  const text = t("resetPasswordMenuItem", { ns: "usersPage" })
+  const resetPasswordButton = within(menu).getByText(text)
 
   fireEvent.click(resetPasswordButton)
 

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -1,7 +1,10 @@
 import { useActor, useMachine } from "@xstate/react"
 import { User } from "api/typesGenerated"
 import { DeleteDialog } from "components/Dialogs/DeleteDialog/DeleteDialog"
-import { getPaginationContext } from "components/PaginationWidget/utils"
+import {
+  getPaginationContext,
+  nonInitialPage,
+} from "components/PaginationWidget/utils"
 import { usePermissions } from "hooks/usePermissions"
 import { FC, ReactNode, useContext, useEffect } from "react"
 import { Helmet } from "react-helmet-async"
@@ -127,6 +130,7 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
           usersSend({ type: "UPDATE_FILTER", query })
         }}
         paginationRef={paginationRef}
+        isNonInitialPage={nonInitialPage(searchParams)}
       />
 
       <DeleteDialog

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -15,17 +15,17 @@ export default {
       defaultValue: createPaginationRef({ page: 1, limit: 25 }),
     },
     isNonInitialPage: {
-      defaultValue: false
+      defaultValue: false,
     },
     users: {
-      defaultValue: [MockUser, MockUser2]
+      defaultValue: [MockUser, MockUser2],
     },
     roles: {
-      defaultValue: MockAssignableSiteRoles
+      defaultValue: MockAssignableSiteRoles,
     },
     canEditUsers: {
-      defaultValue: true
-    }
+      defaultValue: true,
+    },
   },
 } as ComponentMeta<typeof UsersPageView>
 

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -44,7 +44,7 @@ export const Member = Template.bind({})
 Member.args = { canEditUsers: false }
 
 export const Empty = Template.bind({})
-Empty.args = { users: [], isNonInitialPage: false }
+Empty.args = { users: [] }
 
 export const EmptyPage = Template.bind({})
 EmptyPage.args = { users: [], isNonInitialPage: true }

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -44,7 +44,7 @@ export const Member = Template.bind({})
 Member.args = { canEditUsers: false }
 
 export const Empty = Template.bind({})
-Empty.args = { users: [] }
+Empty.args = { users: [], isNonInitialPage: false }
 
 export const EmptyPage = Template.bind({})
 EmptyPage.args = { users: [], isNonInitialPage: true }

--- a/site/src/pages/UsersPage/UsersPageView.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.stories.tsx
@@ -14,6 +14,18 @@ export default {
     paginationRef: {
       defaultValue: createPaginationRef({ page: 1, limit: 25 }),
     },
+    isNonInitialPage: {
+      defaultValue: false
+    },
+    users: {
+      defaultValue: [MockUser, MockUser2]
+    },
+    roles: {
+      defaultValue: MockAssignableSiteRoles
+    },
+    canEditUsers: {
+      defaultValue: true
+    }
   },
 } as ComponentMeta<typeof UsersPageView>
 
@@ -22,29 +34,23 @@ const Template: Story<UsersPageViewProps> = (args) => (
 )
 
 export const Admin = Template.bind({})
-Admin.args = {
-  users: [MockUser, MockUser2],
-  roles: MockAssignableSiteRoles,
-  canEditUsers: true,
-}
 
 export const SmallViewport = Template.bind({})
-SmallViewport.args = {
-  ...Admin.args,
-}
 SmallViewport.parameters = {
   chromatic: { viewports: [600] },
 }
 
 export const Member = Template.bind({})
-Member.args = { ...Admin.args, canEditUsers: false }
+Member.args = { canEditUsers: false }
 
 export const Empty = Template.bind({})
-Empty.args = { ...Admin.args, users: [] }
+Empty.args = { users: [] }
+
+export const EmptyPage = Template.bind({})
+EmptyPage.args = { users: [], isNonInitialPage: true }
 
 export const Error = Template.bind({})
 Error.args = {
-  ...Admin.args,
   users: undefined,
   error: {
     response: {

--- a/site/src/pages/UsersPage/UsersPageView.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.tsx
@@ -29,6 +29,7 @@ export interface UsersPageViewProps {
   ) => void
   onFilter: (query: string) => void
   paginationRef: PaginationMachineRef
+  isNonInitialPage: boolean
 }
 
 export const UsersPageView: FC<React.PropsWithChildren<UsersPageViewProps>> = ({
@@ -47,6 +48,7 @@ export const UsersPageView: FC<React.PropsWithChildren<UsersPageViewProps>> = ({
   filter,
   onFilter,
   paginationRef,
+  isNonInitialPage,
 }) => {
   const presetFilters = [
     { query: userFilterQuery.active, name: Language.activeUsersFilterName },
@@ -74,6 +76,7 @@ export const UsersPageView: FC<React.PropsWithChildren<UsersPageViewProps>> = ({
         isUpdatingUserRoles={isUpdatingUserRoles}
         canEditUsers={canEditUsers}
         isLoading={isLoading}
+        isNonInitialPage={isNonInitialPage}
       />
 
       <PaginationWidget paginationRef={paginationRef} />

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -1,11 +1,13 @@
 import { screen, waitFor } from "@testing-library/react"
 import { rest } from "msw"
 import * as CreateDayString from "util/createDayString"
-import { Language as WorkspacesTableBodyLanguage } from "../../components/WorkspacesTable/WorkspacesTableBody"
 import { MockWorkspace } from "../../testHelpers/entities"
 import { history, render } from "../../testHelpers/renderHelpers"
 import { server } from "../../testHelpers/server"
 import WorkspacesPage from "./WorkspacesPage"
+import { i18n } from "i18n"
+
+const { t } = i18n
 
 describe("WorkspacesPage", () => {
   beforeEach(() => {
@@ -27,9 +29,8 @@ describe("WorkspacesPage", () => {
     render(<WorkspacesPage />)
 
     // Then
-    await screen.findByText(
-      WorkspacesTableBodyLanguage.emptyCreateWorkspaceMessage,
-    )
+    const text = t("emptyCreateWorkspaceMessage", { ns: "workspacesPage" })
+    await screen.findByText(text)
   })
 
   it("renders a filled workspaces page", async () => {

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -1,5 +1,8 @@
 import { useMachine } from "@xstate/react"
-import { getPaginationContext, isNonInitialPage } from "components/PaginationWidget/utils"
+import {
+  getPaginationContext,
+  isNonInitialPage,
+} from "components/PaginationWidget/utils"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
 import { useSearchParams } from "react-router-dom"

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -1,7 +1,7 @@
 import { useMachine } from "@xstate/react"
 import {
   getPaginationContext,
-  isNonInitialPage,
+  nonInitialPage,
 } from "components/PaginationWidget/utils"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
@@ -52,7 +52,7 @@ const WorkspacesPage: FC = () => {
           })
         }}
         paginationRef={paginationRef}
-        isNonInitialPage={isNonInitialPage(searchParams)}
+        isNonInitialPage={nonInitialPage(searchParams)}
       />
     </>
   )

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -1,5 +1,5 @@
 import { useMachine } from "@xstate/react"
-import { getPaginationContext } from "components/PaginationWidget/utils"
+import { getPaginationContext, isNonInitialPage } from "components/PaginationWidget/utils"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
 import { useSearchParams } from "react-router-dom"
@@ -49,6 +49,7 @@ const WorkspacesPage: FC = () => {
           })
         }}
         paginationRef={paginationRef}
+        isNonInitialPage={isNonInitialPage(searchParams)}
       />
     </>
   )

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -112,6 +112,7 @@ AllStates.args = {
     ...Object.values(additionalWorkspaces),
   ],
   count: 14,
+  isNonInitialPage: false
 }
 
 export const OwnerHasNoWorkspaces = Template.bind({})
@@ -119,6 +120,7 @@ OwnerHasNoWorkspaces.args = {
   workspaceRefs: [],
   filter: workspaceFilterQuery.me,
   count: 0,
+  isNonInitialPage: false
 }
 
 export const NoResults = Template.bind({})
@@ -126,4 +128,13 @@ NoResults.args = {
   workspaceRefs: [],
   filter: "searchtearmwithnoresults",
   count: 0,
+  isNonInitialPage: false
+}
+
+export const EmptyPage = Template.bind({})
+EmptyPage.args = {
+  workspaceRefs: [],
+  filter: workspaceFilterQuery.me,
+  count: 0,
+  isNonInitialPage: true
 }

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -112,7 +112,7 @@ AllStates.args = {
     ...Object.values(additionalWorkspaces),
   ],
   count: 14,
-  isNonInitialPage: false
+  isNonInitialPage: false,
 }
 
 export const OwnerHasNoWorkspaces = Template.bind({})
@@ -120,7 +120,7 @@ OwnerHasNoWorkspaces.args = {
   workspaceRefs: [],
   filter: workspaceFilterQuery.me,
   count: 0,
-  isNonInitialPage: false
+  isNonInitialPage: false,
 }
 
 export const NoResults = Template.bind({})
@@ -128,7 +128,7 @@ NoResults.args = {
   workspaceRefs: [],
   filter: "searchtearmwithnoresults",
   count: 0,
-  isNonInitialPage: false
+  isNonInitialPage: false,
 }
 
 export const EmptyPage = Template.bind({})
@@ -136,5 +136,5 @@ EmptyPage.args = {
   workspaceRefs: [],
   filter: workspaceFilterQuery.me,
   count: 0,
-  isNonInitialPage: true
+  isNonInitialPage: true,
 }

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -50,7 +50,7 @@ export const WorkspacesPageView: FC<
   filter,
   onFilter,
   paginationRef,
-  isNonInitialPage
+  isNonInitialPage,
 }) => {
   const presetFilters = [
     { query: workspaceFilterQuery.me, name: Language.yourWorkspacesButton },

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -36,6 +36,7 @@ export interface WorkspacesPageViewProps {
   filter?: string
   onFilter: (query: string) => void
   paginationRef: PaginationMachineRef
+  isNonInitialPage: boolean
 }
 
 export const WorkspacesPageView: FC<
@@ -49,6 +50,7 @@ export const WorkspacesPageView: FC<
   filter,
   onFilter,
   paginationRef,
+  isNonInitialPage
 }) => {
   const presetFilters = [
     { query: workspaceFilterQuery.me, name: Language.yourWorkspacesButton },
@@ -105,6 +107,7 @@ export const WorkspacesPageView: FC<
         isLoading={isLoading}
         workspaceRefs={workspaceRefs}
         filter={filter}
+        isNonInitialPage={isNonInitialPage}
       />
 
       <PaginationWidget numRecords={count} paginationRef={paginationRef} />


### PR DESCRIPTION
If a saved url takes a user to a page beyond the number of records they have, they see an empty table. The message in the empty table should point out that they might not have no records at all; they just don't have any on this page. So I added an empty-page treatment to the currently paginated pages: workspaces, users, and audit log. I ended up going with this solution over a redirect because I don't think a redirect is always the best behavior, and it was hard to single out just the on-mount cases (since I don't know we have no results until after the fetch).

I added stories for each as well, and in order to do that I needed to prop-drill because the query-params storybook add-on doesn't work for some reason.

While I was in there I switched to `ChooseOne`, making it a little clearer that each page has a 3-way choice, and switched from `Language` to i18n.
