### PR TITLE
docs: update port forwarding to state it works without a wildcard with tunnel

### DIFF
--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -46,10 +46,10 @@ For more examples, see `coder port-forward --help`.
 
 > To enable port forwarding via the dashboard, Coder must be configured with a
 > [wildcard access URL](../admin/configure.md#wildcard-access-url). If an access
-> URL is not specified, Coder will create [a publicly accessible
-> URL](../admin/configure#tunnel) to reverse proxy the deployment, and port
-> forwarding will work. There is a known limitation where if the port forwarding
-> URL length is greater than 63 characters, port forwarding will not work.
+> URL is not specified, Coder will create [a publicly accessible URL](../admin/configure#tunnel)
+> to reverse proxy the deployment, and port forwarding will work. There is a
+> known limitation where if the port forwarding URL length is greater than 63
+> characters, port forwarding will not work.
 
 ### From an arbitrary port
 

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -45,7 +45,7 @@ For more examples, see `coder port-forward --help`.
 ## Dashboard
 
 > To enable port forwarding via the dashboard, Coder must be configured with a
-> [wildcard access URL](../admin/configure.md#wildcard-access-url). If an access
+> [wildcard access URL](../admin/configure#wildcard-access-url). If an access
 > URL is not specified, Coder will create [a publicly accessible URL](../admin/configure#tunnel)
 > to reverse proxy the deployment, and port forwarding will work. There is a
 > known limitation where if the port forwarding URL length is greater than 63

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -45,8 +45,8 @@ For more examples, see `coder port-forward --help`.
 ## Dashboard
 
 > To enable port forwarding via the dashboard, Coder must be configured with a
-> [wildcard access URL](../admin/configure#wildcard-access-url). If an access
-> URL is not specified, Coder will create [a publicly accessible URL](../admin/configure#tunnel)
+> [wildcard access URL](../admin/configure.md#wildcard-access-url). If an access
+> URL is not specified, Coder will create [a publicly accessible URL](../admin/configure.md#tunnel)
 > to reverse proxy the deployment, and port forwarding will work. There is a
 > known limitation where if the port forwarding URL length is greater than 63
 > characters, port forwarding will not work.

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -49,7 +49,7 @@ For more examples, see `coder port-forward --help`.
 > URL is not specified, Coder will create [a publicly accessible
 > URL](../admin/configure#tunnel) to reverse proxy the deployment, and port
 > forwarding will work. There is a known limitation where if the port forwarding
-> URL length is greater than 63 characters, port fordwarding will not work.
+> URL length is greater than 63 characters, port forwarding will not work.
 
 ### From an arbitrary port
 

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -45,7 +45,11 @@ For more examples, see `coder port-forward --help`.
 ## Dashboard
 
 > To enable port forwarding via the dashboard, Coder must be configured with a
-> [wildcard access URL](../admin/configure.md#wildcard-access-url).
+> [wildcard access URL](../admin/configure.md#wildcard-access-url). If an access
+> URL is not specified, Coder will create [a publicly accessible
+> URL](../admin/configure#tunnel) to reverse proxy the deployment, and port
+> forwarding will work. There is a known limitation where if the port forwarding
+> URL length is greater than 63 characters, port fordwarding will not work.
 
 ### From an arbitrary port
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,7 +2,7 @@
 
 <blockquote class="info">
 This article explains how to use secrets in a workspace. To authenticate the
-workspace provisioner, see [this](./admin/auth).
+workspace provisioner, see [this](./admin/auth.md).
 </blockquote>
 
 Coder is open-minded about how you get your secrets into your workspaces.
@@ -20,7 +20,7 @@ Often, this workflow is simply:
 1. Your users write them to a persistent file after
    they've built their workspace
 
-[Template parameters](./templates#parameters)> are a dangerous way to accept secrets.
+[Template parameters](./templates.md#parameters)> are a dangerous way to accept secrets.
 We show parameters in cleartext around the product. Assume anyone with view
 access to a workspace can also see its parameters.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,7 +2,7 @@
 
 <blockquote class="info">
 This article explains how to use secrets in a workspace. To authenticate the
-workspace provisioner, see <a href="./templates/authentication">this</a>.
+workspace provisioner, see [this](./admin/auth).
 </blockquote>
 
 Coder is open-minded about how you get your secrets into your workspaces.
@@ -20,7 +20,7 @@ Often, this workflow is simply:
 1. Your users write them to a persistent file after
    they've built their workspace
 
-<a href="./templates#parameters">Template parameters</a> are a dangerous way to accept secrets.
+[Template parameters](./templates#parameters)> are a dangerous way to accept secrets.
 We show parameters in cleartext around the product. Assume anyone with view
 access to a workspace can also see its parameters.
 


### PR DESCRIPTION
This PR:

1. Clarifies the port forwarding dashboard docs to state that port forwarding works without a wildcard domain environment variable when tunnel (reverse proxy) is used.
