### PR TITLE
fix: Disable viper auto-env to avoid assigning to parent structs

### DIFF
--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -199,6 +199,16 @@ func TestConfig(t *testing.T) {
 				Regex:        "gitlab.com",
 			}}, config.GitAuth.Value)
 		},
+	}, {
+		Name: "Wrong env must not break default values",
+		Env: map[string]string{
+			"CODER_PROMETHEUS_ENABLE": "true",
+			"CODER_PROMETHEUS":        "true", // Wrong env name, must not break prom addr.
+		},
+		Valid: func(config *codersdk.DeploymentConfig) {
+			require.Equal(t, config.Prometheus.Enable.Value, true)
+			require.Equal(t, config.Prometheus.Address.Value, config.Prometheus.Address.Default)
+		},
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
The viper automatic env mapping and BindEnv were both creating mappings
like `vip.BindEnv("telemetry", "CODER_TELEMETRY")` which we don't want
since `DeploymentConfig.Telemetry` is a struct housing fields.

For some reason, this was causing `DeploymentConfig.Telemetry.URL` to
**not** be assigned its default value when `CODER_TELEMETRY=false` was
set as an environment variable.

Potentially we would want `"telemetry.enable"` to be mapped to
`"CODER_TELEMETRY"` for simplicity. But that behavior is not changed by
this commit.

Arguably, we could remove `vip.SetEnvPrefix` and `vip.SetEnvKeyReplacer`
as well since we're manually controlling all environment variable names
via `formatEnv`.

