### PR TITLE
fix: Allow overriding env variable names, restore CODER_TELEMETRY

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -295,6 +295,7 @@ func newConfig() *codersdk.DeploymentConfig {
 				Name:  "Trace Enable",
 				Usage: "Whether application tracing data is collected. It exports to a backend configured by environment variables. See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md",
 				Flag:  "trace",
+				Env:   "CODER_TRACE", // Override default environment.
 			},
 			HoneycombAPIKey: &codersdk.DeploymentConfigField[string]{
 				Name:   "Trace Honeycomb API Key",

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -199,6 +199,16 @@ func TestConfig(t *testing.T) {
 				Regex:        "gitlab.com",
 			}}, config.GitAuth.Value)
 		},
+	}, {
+		Name: "Wrong env must not break default values",
+		Env: map[string]string{
+			"CODER_PROMETHEUS_ENABLE": "true",
+			"CODER_PROMETHEUS":        "true", // Wrong env name, must not break prom addr.
+		},
+		Valid: func(config *codersdk.DeploymentConfig) {
+			require.Equal(t, config.Prometheus.Enable.Value, true)
+			require.Equal(t, config.Prometheus.Address.Value, config.Prometheus.Address.Default)
+		},
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -212,8 +212,8 @@ func TestConfig(t *testing.T) {
 	}, {
 		Name: "Env fields are populated with manual or automatic name",
 		Valid: func(config *codersdk.DeploymentConfig) {
-			require.Equal(t, config.Telemetry.Enable.Env, "CODER_TELEMETRY")
-			require.Equal(t, config.Prometheus.Address.Env, "CODER_PROMETHEUS_ADDRESS")
+			require.Equal(t, config.Telemetry.Enable.Env, "CODER_TELEMETRY")            // Manual
+			require.Equal(t, config.Prometheus.Address.Env, "CODER_PROMETHEUS_ADDRESS") // Automatic
 		},
 	}} {
 		tc := tc

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -35,7 +35,7 @@ func TestConfig(t *testing.T) {
 			"CODER_PROVISIONER_DAEMONS":  "5",
 			"CODER_SECURE_AUTH_COOKIE":   "true",
 			"CODER_SSH_KEYGEN_ALGORITHM": "potato",
-			"CODER_TELEMETRY":            "false",
+			"CODER_TELEMETRY":            "true",
 			"CODER_TELEMETRY_TRACE":      "false",
 			"CODER_WILDCARD_ACCESS_URL":  "something-wildcard.com",
 		},
@@ -50,7 +50,7 @@ func TestConfig(t *testing.T) {
 			require.Equal(t, config.ProvisionerDaemons.Value, 5)
 			require.Equal(t, config.SecureAuthCookie.Value, true)
 			require.Equal(t, config.SSHKeygenAlgorithm.Value, "potato")
-			require.Equal(t, config.Telemetry.Enable.Value, false)
+			require.Equal(t, config.Telemetry.Enable.Value, true)
 			require.Equal(t, config.Telemetry.Trace.Value, false)
 			require.Equal(t, config.WildcardAccessURL.Value, "something-wildcard.com")
 		},

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -209,6 +209,12 @@ func TestConfig(t *testing.T) {
 			require.Equal(t, config.Prometheus.Enable.Value, true)
 			require.Equal(t, config.Prometheus.Address.Value, config.Prometheus.Address.Default)
 		},
+	}, {
+		Name: "Env fields are populated with manual or automatic name",
+		Valid: func(config *codersdk.DeploymentConfig) {
+			require.Equal(t, config.Telemetry.Enable.Env, "CODER_TELEMETRY")
+			require.Equal(t, config.Prometheus.Address.Env, "CODER_PROMETHEUS_ADDRESS")
+		},
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -117,7 +117,7 @@ func TestConfig(t *testing.T) {
 	}, {
 		Name: "Trace",
 		Env: map[string]string{
-			"CODER_TRACE_ENABLE":            "true",
+			"CODER_TRACE":                   "true",
 			"CODER_TRACE_HONEYCOMB_API_KEY": "my-honeycomb-key",
 		},
 		Valid: func(config *codersdk.DeploymentConfig) {
@@ -212,6 +212,7 @@ func TestConfig(t *testing.T) {
 	}, {
 		Name: "Env fields are populated with manual or automatic name",
 		Valid: func(config *codersdk.DeploymentConfig) {
+			require.Equal(t, config.Trace.Enable.Env, "CODER_TRACE")                    // Manual
 			require.Equal(t, config.Telemetry.Enable.Env, "CODER_TELEMETRY")            // Manual
 			require.Equal(t, config.Prometheus.Address.Env, "CODER_PROMETHEUS_ADDRESS") // Automatic
 		},

--- a/codersdk/deploymentconfig.go
+++ b/codersdk/deploymentconfig.go
@@ -131,6 +131,7 @@ type DeploymentConfigField[T Flaggable] struct {
 	Name       string `json:"name"`
 	Usage      string `json:"usage"`
 	Flag       string `json:"flag"`
+	Env        string `json:"env"`
 	Shorthand  string `json:"shorthand"`
 	Enterprise bool   `json:"enterprise"`
 	Hidden     bool   `json:"hidden"`
@@ -146,6 +147,7 @@ func (f *DeploymentConfigField[T]) MarshalJSON() ([]byte, error) {
 		Name       string `json:"name"`
 		Usage      string `json:"usage"`
 		Flag       string `json:"flag"`
+		Env        string `json:"env"`
 		Shorthand  string `json:"shorthand"`
 		Enterprise bool   `json:"enterprise"`
 		Hidden     bool   `json:"hidden"`
@@ -156,6 +158,7 @@ func (f *DeploymentConfigField[T]) MarshalJSON() ([]byte, error) {
 		Name:       f.Name,
 		Usage:      f.Usage,
 		Flag:       f.Flag,
+		Env:        f.Env,
 		Shorthand:  f.Shorthand,
 		Enterprise: f.Enterprise,
 		Hidden:     f.Hidden,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -310,6 +310,7 @@ export interface DeploymentConfigField<T extends Flaggable> {
   readonly name: string
   readonly usage: string
   readonly flag: string
+  readonly env: string
   readonly shorthand: string
   readonly enterprise: boolean
   readonly hidden: boolean


### PR DESCRIPTION
This change allows us to set a custom env for certain flags. Useful when it does not match the deployment config struct 1-to-1.

This also restores the `CODER_TELEMETRY` name (was changed to `CODER_TELEMETRY_ENABLE` for the last release or two).

**NOTE:** This PR is targets #4893 as it builds upon the change there.
