### PR TITLE
refactor: Improve long rows in audit log

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogDiff.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDiff.tsx
@@ -83,14 +83,12 @@ const useStyles = makeStyles((theme) => ({
   },
 
   diffColumn: {
-    width: "50%",
+    flex: 1,
     paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(2.5),
     paddingRight: theme.spacing(2),
     lineHeight: "160%",
     alignSelf: "stretch",
-    maxWidth: "50%",
-    overflowX: "auto",
   },
 
   diffOld: {

--- a/site/src/components/AuditLogRow/AuditLogDiff.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDiff.tsx
@@ -83,10 +83,14 @@ const useStyles = makeStyles((theme) => ({
   },
 
   diffColumn: {
-    flex: 1,
+    width: "50%",
     paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(2.5),
+    paddingRight: theme.spacing(2),
     lineHeight: "160%",
+    alignSelf: "stretch",
+    maxWidth: "50%",
+    overflowX: "auto",
   },
 
   diffOld: {
@@ -101,7 +105,7 @@ const useStyles = makeStyles((theme) => ({
 
   diffLine: {
     opacity: 0.5,
-    width: theme.spacing(8),
+    width: theme.spacing(6),
     textAlign: "right",
     flexShrink: 0,
   },
@@ -110,6 +114,7 @@ const useStyles = makeStyles((theme) => ({
     width: theme.spacing(4),
     textAlign: "center",
     fontSize: theme.typography.body1.fontSize,
+    flexShrink: 0,
   },
 
   diffNew: {

--- a/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
@@ -34,12 +34,31 @@ const Template: Story<AuditLogRowProps> = (args) => (
 
 export const NoDiff = Template.bind({})
 NoDiff.args = {
-  auditLog: MockAuditLog,
+  auditLog: {
+    ...MockAuditLog,
+    diff: {},
+  },
 }
 
 export const WithDiff = Template.bind({})
 WithDiff.args = {
   auditLog: MockAuditLog2,
+  defaultIsDiffOpen: true,
+}
+
+export const WithLongDiffRow = Template.bind({})
+WithLongDiffRow.args = {
+  auditLog: {
+    ...MockAuditLog2,
+    diff: {
+      ...MockAuditLog2.diff,
+      icon: {
+        old: "https://www.docker.com/wp-content/uploads/2022/03/Moby-logo.png",
+        new: "https://www.docker.com/wp-content/uploads/2022/03/vertical-logo-monochromatic.png",
+        secret: false,
+      },
+    },
+  },
   defaultIsDiffOpen: true,
 }
 


### PR DESCRIPTION
Before:
<img width="1505" alt="Screen Shot 2022-11-04 at 14 09 59" src="https://user-images.githubusercontent.com/3165839/200035194-5e6565e6-0ab5-4145-ae34-d99a71a582da.png">

Now:
<img width="1509" alt="Screen Shot 2022-11-04 at 14 10 55" src="https://user-images.githubusercontent.com/3165839/200035250-e121df23-e8e2-4a26-bf0a-909eb8860247.png">
