### PR TITLE
docs: adding sharkymark example templates to community page

### DIFF
--- a/examples/templates/community-templates.md
+++ b/examples/templates/community-templates.md
@@ -14,3 +14,4 @@ maintained, please submit a pull request to improve this list. Thank you!
 - [m.lan/coder-templates](https://gitlab.com/m.lan/coder-templates) - Kubernetes template with DinD.
 - [jsjoeio/coder-templates](https://github.com/jsjoeio/coder-templates) - Docker templates that prompt for dotfiles and base Docker image.
 - [8Bitz0/coder-rust-template @ GitLab](https://gitlab.com/8Bitz0/coder-rust-template) - Coder templates with various Linux distros for out-of-the-box Rust development.
+- [sharkymark/v2-templates](https://github.com/sharkymark/v2-templates) - Kubernetes, Docker, AWS, Google Cloud, Azure templates, videos, emoji links, and API examples


### PR DESCRIPTION
This PR:

1. adds sharkymark's v2 example templates repo to the examples community page.

🦈
