### PR TITLE
feat: Associate connected workspace agents with replicas

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/andybalholm/brotli"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
@@ -165,6 +166,7 @@ func New(options *Options) *API {
 
 	r := chi.NewRouter()
 	api := &API{
+		ID:          uuid.New(),
 		Options:     options,
 		RootHandler: r,
 		siteHandler: site.Handler(site.FS(), binFS),
@@ -579,6 +581,11 @@ func New(options *Options) *API {
 
 type API struct {
 	*Options
+	// ID is a uniquely generated ID on initialization.
+	// This is used to associate objects with a specific
+	// Coder API instance, like workspace agents to a
+	// specific replica.
+	ID                                uuid.UUID
 	Auditor                           atomic.Pointer[audit.Auditor]
 	WorkspaceClientCoordinateOverride atomic.Pointer[func(rw http.ResponseWriter) bool]
 	WorkspaceQuotaEnforcer            atomic.Pointer[workspacequota.Enforcer]

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -390,7 +390,8 @@ CREATE TABLE workspace_agents (
     instance_metadata jsonb,
     resource_metadata jsonb,
     directory character varying(4096) DEFAULT ''::character varying NOT NULL,
-    version text DEFAULT ''::text NOT NULL
+    version text DEFAULT ''::text NOT NULL,
+    last_connected_replica_id uuid
 );
 
 COMMENT ON COLUMN workspace_agents.version IS 'Version tracks the version of the currently running workspace agent. Workspace agents register their version upon start.';

--- a/coderd/database/migrations/000070_deployment_graph.down.sql
+++ b/coderd/database/migrations/000070_deployment_graph.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_agents
+    DROP COLUMN last_connected_replica_id;

--- a/coderd/database/migrations/000070_deployment_graph.up.sql
+++ b/coderd/database/migrations/000070_deployment_graph.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_agents
+    ADD COLUMN last_connected_replica_id uuid;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -660,7 +660,8 @@ type WorkspaceAgent struct {
 	ResourceMetadata     pqtype.NullRawMessage `db:"resource_metadata" json:"resource_metadata"`
 	Directory            string                `db:"directory" json:"directory"`
 	// Version tracks the version of the currently running workspace agent. Workspace agents register their version upon start.
-	Version string `db:"version" json:"version"`
+	Version                string        `db:"version" json:"version"`
+	LastConnectedReplicaID uuid.NullUUID `db:"last_connected_replica_id" json:"last_connected_replica_id"`
 }
 
 type WorkspaceApp struct {

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -64,8 +64,9 @@ UPDATE
 SET
 	first_connected_at = $2,
 	last_connected_at = $3,
-	disconnected_at = $4,
-	updated_at = $5
+	last_connected_replica_id = $4,
+	disconnected_at = $5,
+	updated_at = $6
 WHERE
 	id = $1;
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -522,6 +522,10 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 			LastConnectedAt:  lastConnectedAt,
 			DisconnectedAt:   disconnectedAt,
 			UpdatedAt:        database.Now(),
+			LastConnectedReplicaID: uuid.NullUUID{
+				UUID:  api.ID,
+				Valid: true,
+			},
 		})
 		if err != nil {
 			return err

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -158,6 +158,7 @@ func New(ctx context.Context, options *Options) (*API, error) {
 	}
 	var err error
 	api.replicaManager, err = replicasync.New(ctx, options.Logger, options.Database, options.Pubsub, &replicasync.Options{
+		ID:           api.AGPL.ID,
 		RelayAddress: options.DERPServerRelayAddress,
 		RegionID:     int32(options.DERPServerRegionID),
 		TLSConfig:    meshTLSConfig,


### PR DESCRIPTION
This will enable displaying a graph that associates agents to running replicas.
