### PR TITLE
feat: loadtest output formats

### DIFF
--- a/cli/loadtest_test.go
+++ b/cli/loadtest_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/httpapi"
 	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/loadtest/harness"
 	"github.com/coder/coder/loadtest/placebo"
 	"github.com/coder/coder/loadtest/workspacebuild"
 	"github.com/coder/coder/pty/ptytest"
@@ -132,5 +134,162 @@ func TestLoadTest(t *testing.T) {
 		pty.ExpectMatch("Pass:  2")
 		<-done
 		cancelFunc()
+	})
+
+	t.Run("OutputFormats", func(t *testing.T) {
+		t.Parallel()
+
+		type outputFlag struct {
+			format string
+			path   string
+		}
+
+		dir := t.TempDir()
+
+		cases := []struct {
+			name        string
+			outputs     []outputFlag
+			errContains string
+		}{
+			{
+				name:    "Default",
+				outputs: []outputFlag{},
+			},
+			{
+				name:    "ExplicitText",
+				outputs: []outputFlag{{format: "text"}},
+			},
+			{
+				name: "JSON",
+				outputs: []outputFlag{
+					{
+						format: "json",
+						path:   filepath.Join(dir, "results.json"),
+					},
+				},
+			},
+			{
+				name: "TextAndJSON",
+				outputs: []outputFlag{
+					{
+						format: "text",
+					},
+					{
+						format: "json",
+						path:   filepath.Join(dir, "results.json"),
+					},
+				},
+			},
+			{
+				name: "TextAndJSON2",
+				outputs: []outputFlag{
+					{
+						format: "text",
+					},
+					{
+						format: "text",
+						path:   filepath.Join(dir, "results.txt"),
+					},
+					{
+						format: "json",
+						path:   filepath.Join(dir, "results.json"),
+					},
+				},
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				t.Parallel()
+
+				client := coderdtest.New(t, nil)
+				_ = coderdtest.CreateFirstUser(t, client)
+
+				config := cli.LoadTestConfig{
+					Strategy: cli.LoadTestStrategy{
+						Type: cli.LoadTestStrategyTypeLinear,
+					},
+					Tests: []cli.LoadTest{
+						{
+							Type:  cli.LoadTestTypePlacebo,
+							Count: 10,
+							Placebo: &placebo.Config{
+								Sleep: httpapi.Duration(10 * time.Millisecond),
+							},
+						},
+					},
+					Timeout: httpapi.Duration(testutil.WaitShort),
+				}
+
+				configBytes, err := json.Marshal(config)
+				require.NoError(t, err)
+
+				args := []string{"loadtest", "--config", "-"}
+				for _, output := range c.outputs {
+					flag := output.format
+					if output.path != "" {
+						flag += ":" + output.path
+					}
+					args = append(args, "--output", flag)
+				}
+
+				cmd, root := clitest.New(t, args...)
+				clitest.SetupConfig(t, client, root)
+				cmd.SetIn(bytes.NewReader(configBytes))
+				out := bytes.NewBuffer(nil)
+				cmd.SetOut(out)
+				pty := ptytest.New(t)
+				cmd.SetErr(pty.Output())
+
+				ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitLong)
+				defer cancelFunc()
+
+				done := make(chan any)
+				go func() {
+					errC := cmd.ExecuteContext(ctx)
+					if c.errContains != "" {
+						assert.Error(t, errC)
+						assert.Contains(t, errC.Error(), c.errContains)
+					} else {
+						assert.NoError(t, errC)
+					}
+					close(done)
+				}()
+
+				<-done
+
+				if c.errContains != "" {
+					return
+				}
+				if len(c.outputs) == 0 {
+					// This is the default output format when no flags are
+					// specified.
+					c.outputs = []outputFlag{{format: "text"}}
+				}
+				for i, output := range c.outputs {
+					msg := fmt.Sprintf("flag %d", i)
+					var b []byte
+					if output.path == "" {
+						b = out.Bytes()
+					} else {
+						b, err = os.ReadFile(output.path)
+						require.NoError(t, err, msg)
+					}
+
+					switch output.format {
+					case "text":
+						require.Contains(t, string(b), "Test results:", msg)
+						require.Contains(t, string(b), "Pass:  10", msg)
+					case "json":
+						var res harness.Results
+						err = json.Unmarshal(b, &res)
+						require.NoError(t, err, msg)
+						require.Equal(t, 10, res.TotalRuns, msg)
+						require.Equal(t, 10, res.TotalPass, msg)
+						require.Len(t, res.Runs, 10, msg)
+					}
+				}
+			})
+		}
 	})
 }

--- a/loadtest/harness/results.go
+++ b/loadtest/harness/results.go
@@ -1,25 +1,36 @@
 package harness
 
-import "time"
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/coder/coder/coderd/httpapi"
+)
 
 // Results is the full compiled results for a set of test runs.
 type Results struct {
-	TotalRuns int
-	TotalPass int
-	TotalFail int
+	TotalRuns int              `json:"total_runs"`
+	TotalPass int              `json:"total_pass"`
+	TotalFail int              `json:"total_fail"`
+	Elapsed   httpapi.Duration `json:"elapsed"`
+	ElapsedMS int64            `json:"elapsed_ms"`
 
-	Runs map[string]RunResult
+	Runs map[string]RunResult `json:"runs"`
 }
 
 // RunResult is the result of a single test run.
 type RunResult struct {
-	FullID    string
-	TestName  string
-	ID        string
-	Logs      []byte
-	Error     error
-	StartedAt time.Time
-	Duration  time.Duration
+	FullID     string           `json:"full_id"`
+	TestName   string           `json:"test_name"`
+	ID         string           `json:"id"`
+	Logs       string           `json:"logs"`
+	Error      error            `json:"error"`
+	StartedAt  time.Time        `json:"started_at"`
+	Duration   httpapi.Duration `json:"duration"`
+	DurationMS int64            `json:"duration_ms"`
 }
 
 // Results returns the results of the test run. Panics if the test run is not
@@ -32,13 +43,14 @@ func (r *TestRun) Result() RunResult {
 	}
 
 	return RunResult{
-		FullID:    r.FullID(),
-		TestName:  r.testName,
-		ID:        r.id,
-		Logs:      r.logs.Bytes(),
-		Error:     r.err,
-		StartedAt: r.started,
-		Duration:  r.duration,
+		FullID:     r.FullID(),
+		TestName:   r.testName,
+		ID:         r.id,
+		Logs:       r.logs.String(),
+		Error:      r.err,
+		StartedAt:  r.started,
+		Duration:   httpapi.Duration(r.duration),
+		DurationMS: r.duration.Milliseconds(),
 	}
 }
 
@@ -56,6 +68,8 @@ func (h *TestHarness) Results() Results {
 	results := Results{
 		TotalRuns: len(h.runs),
 		Runs:      make(map[string]RunResult, len(h.runs)),
+		Elapsed:   httpapi.Duration(h.elapsed),
+		ElapsedMS: h.elapsed.Milliseconds(),
 	}
 	for _, run := range h.runs {
 		runRes := run.Result()
@@ -69,4 +83,41 @@ func (h *TestHarness) Results() Results {
 	}
 
 	return results
+}
+
+// PrintText prints the results as human-readable text to the given writer.
+func (r *Results) PrintText(w io.Writer) {
+	var totalDuration time.Duration
+	for _, run := range r.Runs {
+		totalDuration += time.Duration(run.Duration)
+		if run.Error == nil {
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "\n== FAIL: %s\n\n", run.FullID)
+		_, _ = fmt.Fprintf(w, "\tError: %s\n\n", run.Error)
+
+		// Print log lines indented.
+		_, _ = fmt.Fprintf(w, "\tLog:\n")
+		rd := bufio.NewReader(strings.NewReader(run.Logs))
+		for {
+			line, err := rd.ReadBytes('\n')
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				_, _ = fmt.Fprintf(w, "\n\tLOG PRINT ERROR: %+v\n", err)
+			}
+
+			_, _ = fmt.Fprintf(w, "\t\t%s", line)
+		}
+	}
+
+	_, _ = fmt.Fprintln(w, "\n\nTest results:")
+	_, _ = fmt.Fprintf(w, "\tPass:  %d\n", r.TotalPass)
+	_, _ = fmt.Fprintf(w, "\tFail:  %d\n", r.TotalFail)
+	_, _ = fmt.Fprintf(w, "\tTotal: %d\n", r.TotalRuns)
+	_, _ = fmt.Fprintln(w, "")
+	_, _ = fmt.Fprintf(w, "\tTotal duration: %s\n", time.Duration(r.Elapsed))
+	_, _ = fmt.Fprintf(w, "\tAvg. duration:  %s\n", totalDuration/time.Duration(r.TotalRuns))
 }


### PR DESCRIPTION
Adds `--output format[:path]` flag to `coder loadtest` which may be specified multiple times.