### PR TITLE
fix: Remove `action` from build cancelation names

### DIFF
--- a/codersdk/workspacedisplaystatus.go
+++ b/codersdk/workspacedisplaystatus.go
@@ -37,9 +37,9 @@ func WorkspaceDisplayStatus(jobStatus ProvisionerJobStatus, transition Workspace
 	case ProvisionerJobPending:
 		return "Queued"
 	case ProvisionerJobCanceling:
-		return "Canceling action"
+		return "Canceling"
 	case ProvisionerJobCanceled:
-		return "Canceled action"
+		return "Canceled"
 	case ProvisionerJobFailed:
 		return "Failed"
 	default:

--- a/codersdk/workspacedisplaystatus_internal_test.go
+++ b/codersdk/workspacedisplaystatus_internal_test.go
@@ -56,13 +56,13 @@ func TestWorkspaceDisplayStatus(t *testing.T) {
 			name:       "CancelingStatusWithStartTransition",
 			jobStatus:  ProvisionerJobCanceling,
 			transition: WorkspaceTransitionStart,
-			want:       "Canceling action",
+			want:       "Canceling",
 		},
 		{
 			name:       "CanceledStatusWithStartTransition",
 			jobStatus:  ProvisionerJobCanceled,
 			transition: WorkspaceTransitionStart,
-			want:       "Canceled action",
+			want:       "Canceled",
 		},
 		{
 			name:       "FailedStatusWithDeleteTransition",


### PR DESCRIPTION
This looked weird in the UI and didn't conform to our other states.
