### PR TITLE
fix: Long audit log string overflowing table

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogDiff.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDiff.tsx
@@ -89,6 +89,7 @@ const useStyles = makeStyles((theme) => ({
     paddingRight: theme.spacing(2),
     lineHeight: "160%",
     alignSelf: "stretch",
+    overflowWrap: "anywhere",
   },
 
   diffOld: {

--- a/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
@@ -53,8 +53,8 @@ WithLongDiffRow.args = {
     diff: {
       ...MockAuditLog2.diff,
       icon: {
-        old: "https://www.docker.com/wp-content/uploads/2022/03/Moby-logo.png",
-        new: "https://www.docker.com/wp-content/uploads/2022/03/vertical-logo-monochromatic.png",
+        old: "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.docker.com%2Fcompany%2Fnewsroom%2Fmedia-resources%2F&psig=AOvVaw3hLg_lm0tzXPBt74XZD2GC&ust=1666892413988000&source=images&cd=vfe&ved=0CAwQjRxqFwoTCPDsiKa4_voCFQAAAAAdAAAAABAD",
+        new: "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.kindpng.com%2Fimgv%2FhRowRxi_docker-icon-png-transparent-png%2F&psig=AOvVaw3hLg_lm0tzXPBt74XZD2GC&ust=1666892413988000&source=images&cd=vfe&ved=0CAwQjRxqFwoTCPDsiKa4_voCFQAAAAAdAAAAABAI",
         secret: false,
       },
     },


### PR DESCRIPTION
fix #4773

Before (overflowing X and creating a scroll for all the entire table)
![image](https://user-images.githubusercontent.com/3165839/200365299-3d228c01-6940-40cb-80d3-e08d9e9bc3da.png)

After (force break word - not the best but I think it is a better solution for now)
<img width="1508" alt="Screen Shot 2022-11-07 at 13 38 59" src="https://user-images.githubusercontent.com/3165839/200365447-3c9fddca-e7c8-4095-8329-3ccbba25d2e3.png">
