### PR TITLE
chore: Disable docs.github.com for link checks

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -10,6 +10,12 @@
             "pattern": "developer.github.com"
         },
         {
+            "pattern": "docs.github.com"
+        },
+        {
+            "pattern": "support.google.com"
+        },
+        {
             "pattern": "tailscale.com"
         }
     ]


### PR DESCRIPTION
This was causing CI to fail... maybe they have bot detection?
