### PR TITLE
fix: Off-by-one created after notification for provisioner logs

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -287,7 +287,7 @@ func (server *Server) UpdateJob(ctx context.Context, request *proto.UpdateJobReq
 		lowestID := logs[0].ID
 		server.Logger.Debug(ctx, "inserted job logs", slog.F("job_id", parsedID))
 		data, err := json.Marshal(ProvisionerJobLogsNotifyMessage{
-			CreatedAfter: lowestID,
+			CreatedAfter: lowestID - 1,
 		})
 		if err != nil {
 			return nil, xerrors.Errorf("marshal: %w", err)


### PR DESCRIPTION
This seemed like the obvious case, but I have yet to verify if it actually fixes the bug.

Maybe fixes #4948

