### PR TITLE
chore: Unify Docker terraform templates

### DIFF
--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -61,9 +61,9 @@ resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
   image = "codercom/code-server:latest"
   # Uses lower() to avoid Docker restriction on container names.
-  name     = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
-  hostname = lower(data.coder_workspace.me.name)
-  dns      = ["1.1.1.1"]
+  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  # Hostname makes the shell more user friendly: coder@my-workspace:~$
+  hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1
   entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
   env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -90,11 +90,10 @@ resource "docker_container" "workspace" {
   # Uses lower() to avoid Docker restriction on container names.
   name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
-  hostname = lower(data.coder_workspace.me.name)
-  dns      = ["1.1.1.1"]
+  hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1
-  command = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
-  env     = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
   host {
     host = "host.docker.internal"
     ip   = "host-gateway"

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -55,10 +55,11 @@ resource "docker_container" "workspace" {
   image = var.docker_image
   # Uses lower() to avoid Docker restriction on container names.
   name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
-  dns  = ["1.1.1.1"]
-  # Refer to Docker host when Coder is on localhost
-  command = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
-  env     = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  # Hostname makes the shell more user friendly: coder@my-workspace:~$
+  hostname = data.coder_workspace.me.name
+  # Use the docker gateway if the access URL is 127.0.0.1
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
   host {
     host = "host.docker.internal"
     ip   = "host-gateway"

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -80,17 +80,10 @@ resource "docker_container" "workspace" {
   # Uses lower() to avoid Docker restriction on container names.
   name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
-  hostname = lower(data.coder_workspace.me.name)
-  dns      = ["1.1.1.1"]
+  hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1
-  command = [
-    "sh", "-c",
-    <<EOT
-    trap '[ $? -ne 0 ] && echo === Agent script exited with non-zero code. Sleeping infinitely to preserve logs... && sleep infinity' EXIT
-    ${replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")}
-    EOT
-  ]
-  env = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  entrypoint = ["sh", "-c", replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
   host {
     host = "host.docker.internal"
     ip   = "host-gateway"


### PR DESCRIPTION
Changes to terraform templates:

* Remove DNS (this can interfere with users running their own DNS
  servers)
* Remove `lower()` restriction from hostnames so that it will show the
  name set by the user, as-is (there is no restriction on upper case
  letters in hostnames)
* Remove superfluous `trap` in entrypoints, this is already handled by
  the init script
* Switch from `command` to `entrypoint` as the latter can support more
  Docker images out-of-the-box

