### PR TITLE
fix: Use immutable names for volumes in example templates

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -184,7 +184,7 @@ data "coder_workspace" "me" {
 resource "docker_volume" "home_volume" {
   # persistent resource (remains a workspace is stopped)
   count = 1
-  name  = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name  = "coder-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_container" "workspace" {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -185,6 +185,9 @@ resource "docker_volume" "home_volume" {
   # persistent resource (remains a workspace is stopped)
   count = 1
   name  = "coder-${data.coder_workspace.me.id}-home"
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "docker_container" "workspace" {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -184,7 +184,7 @@ data "coder_workspace" "me" {
 resource "docker_volume" "home_volume" {
   # persistent resource (remains a workspace is stopped)
   count = 1
-  name  = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  name  = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_container" "workspace" {

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -55,8 +55,28 @@ resource "coder_app" "code-server" {
 
 resource "docker_volume" "home_volume" {
   name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
   lifecycle {
     ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
   }
 }
 
@@ -115,6 +135,23 @@ resource "docker_container" "workspace" {
     container_path = "/home/coder/"
     volume_name    = docker_volume.home_volume.name
     read_only      = false
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
   }
 }
 

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -54,7 +54,7 @@ resource "coder_app" "code-server" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name = "coder-${data.coder_workspace.me.id}-home"
   lifecycle {
     ignore_changes = all
   }

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -54,7 +54,7 @@ resource "coder_app" "code-server" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-home"
+  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
   lifecycle {
     ignore_changes = all
   }

--- a/examples/templates/do-linux/main.tf
+++ b/examples/templates/do-linux/main.tf
@@ -100,7 +100,7 @@ resource "coder_agent" "main" {
 
 resource "digitalocean_volume" "home_volume" {
   region                   = var.region
-  name                     = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name                     = "coder-${data.coder_workspace.me.id}-home"
   size                     = var.home_volume_size
   initial_filesystem_type  = "ext4"
   initial_filesystem_label = "coder-home"

--- a/examples/templates/do-linux/main.tf
+++ b/examples/templates/do-linux/main.tf
@@ -100,7 +100,7 @@ resource "coder_agent" "main" {
 
 resource "digitalocean_volume" "home_volume" {
   region                   = var.region
-  name                     = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-home"
+  name                     = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
   size                     = var.home_volume_size
   initial_filesystem_type  = "ext4"
   initial_filesystem_label = "coder-home"

--- a/examples/templates/do-linux/main.tf
+++ b/examples/templates/do-linux/main.tf
@@ -104,6 +104,10 @@ resource "digitalocean_volume" "home_volume" {
   size                     = var.home_volume_size
   initial_filesystem_type  = "ext4"
   initial_filesystem_label = "coder-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "digitalocean_droplet" "workspace" {

--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -54,7 +54,7 @@ resource "coder_app" "code-server" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-root"
+  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_container" "workspace" {

--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -55,6 +55,29 @@ resource "coder_app" "code-server" {
 
 resource "docker_volume" "home_volume" {
   name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
 }
 
 resource "docker_container" "workspace" {
@@ -75,5 +98,22 @@ resource "docker_container" "workspace" {
     container_path = "/home/coder/"
     volume_name    = docker_volume.home_volume.name
     read_only      = false
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
   }
 }

--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -54,7 +54,7 @@ resource "coder_app" "code-server" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name = "coder-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_container" "workspace" {

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -70,6 +70,29 @@ variable "docker_image" {
 
 resource "docker_volume" "home_volume" {
   name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
 }
 
 resource "docker_image" "coder_image" {
@@ -103,6 +126,23 @@ resource "docker_container" "workspace" {
     container_path = "/home/coder/"
     volume_name    = docker_volume.home_volume.name
     read_only      = false
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
   }
 }
 

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -69,7 +69,7 @@ variable "docker_image" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}-root"
+  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_image" "coder_image" {

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -69,7 +69,7 @@ variable "docker_image" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name = "coder-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_image" "coder_image" {

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -47,7 +47,7 @@ resource "coder_agent" "main" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}-root"
+  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_container" "workspace" {

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -48,6 +48,29 @@ resource "coder_agent" "main" {
 
 resource "docker_volume" "home_volume" {
   name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
 }
 
 resource "docker_container" "workspace" {
@@ -67,6 +90,23 @@ resource "docker_container" "workspace" {
     container_path = "/home/coder/"
     volume_name    = docker_volume.home_volume.name
     read_only      = false
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
   }
 }
 

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -47,7 +47,7 @@ resource "coder_agent" "main" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name = "coder-${data.coder_workspace.me.id}-home"
 }
 
 resource "docker_container" "workspace" {

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -60,7 +60,7 @@ resource "coder_app" "code-server" {
 
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}-home"
+  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
 }
 
 

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -61,6 +61,29 @@ resource "coder_app" "code-server" {
 
 resource "docker_volume" "home_volume" {
   name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
 }
 
 
@@ -99,5 +122,22 @@ resource "docker_container" "workspace" {
     container_path = "/home/coder/"
     volume_name    = docker_volume.home_volume.name
     read_only      = false
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace.me.owner
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace.me.owner_id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
   }
 }

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -60,7 +60,7 @@ resource "coder_app" "code-server" {
 
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-home"
+  name = "coder-${data.coder_workspace.me.id}-home"
 }
 
 

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -36,7 +36,7 @@ data "coder_workspace" "me" {
 }
 
 resource "google_compute_disk" "root" {
-  name  = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-root"
+  name  = "coder-${data.coder_workspace.me.id}-root"
   type  = "pd-ssd"
   zone  = var.zone
   image = "debian-cloud/debian-11"

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -41,7 +41,7 @@ resource "google_compute_disk" "root" {
   zone  = var.zone
   image = "debian-cloud/debian-11"
   lifecycle {
-    ignore_changes = [image]
+    ignore_changes = [name, image]
   }
 }
 

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -36,7 +36,7 @@ data "coder_workspace" "me" {
 }
 
 resource "google_compute_disk" "root" {
-  name  = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
+  name  = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-root"
   type  = "pd-ssd"
   zone  = var.zone
   image = "debian-cloud/debian-11"

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -36,7 +36,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 resource "google_compute_disk" "root" {
-  name  = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-root"
+  name  = "coder-${data.coder_workspace.me.id}-root"
   type  = "pd-ssd"
   zone  = var.zone
   image = "projects/windows-cloud/global/images/windows-server-2022-dc-core-v20220215"

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -36,7 +36,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 resource "google_compute_disk" "root" {
-  name  = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
+  name  = "coder-${data.coder_workspace.me.owner_id}-${data.coder_workspace.me.id}-root"
   type  = "pd-ssd"
   zone  = var.zone
   image = "projects/windows-cloud/global/images/windows-server-2022-dc-core-v20220215"

--- a/examples/templates/gcp-windows/main.tf
+++ b/examples/templates/gcp-windows/main.tf
@@ -41,7 +41,7 @@ resource "google_compute_disk" "root" {
   zone  = var.zone
   image = "projects/windows-cloud/global/images/windows-server-2022-dc-core-v20220215"
   lifecycle {
-    ignore_changes = [image]
+    ignore_changes = [name, image]
   }
 }
 


### PR DESCRIPTION
This contributes towards #3000, #3386

Related #3409

Revives #3663 (with changes)

I've added a bunch of labels to the docker templates that are nice when needed, but look a bit verbose. Thoughts? Keep them all? Reduce their numbers? Or only keep them in one template?

These changes also mean that it _should_ be safe for anyone to update their templates to the latest version as long as they keep the `lifecycle` blocks (thanks @ammario for that tip).