### PR TITLE
fix: Allow dumping db with pg_dump, utilize make cache

### DIFF
--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -8,10 +8,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/coder/coder/coderd/database/migrations"
 	"github.com/coder/coder/coderd/database/postgres"
 )
+
+const minimumPostgreSQLVersion = 13
 
 func main() {
 	connection, closeFn, err := postgres.Open()
@@ -30,12 +34,24 @@ func main() {
 		panic(err)
 	}
 
-	cmd := exec.Command(
-		"docker",
-		"run",
-		"--rm",
-		"--network=host",
-		"postgres:13",
+	hasPGDump := false
+	if _, err = exec.LookPath("pg_dump"); err == nil {
+		fmt.Fprintln(os.Stderr, "yahhoo")
+		out, err := exec.Command("pg_dump", "--version").Output()
+		if err == nil {
+			// Parse output:
+			// pg_dump (PostgreSQL) 14.5 (Ubuntu 14.5-0ubuntu0.22.04.1)
+			parts := strings.Split(string(out), " ")
+			if len(parts) > 2 {
+				version, err := strconv.Atoi(strings.Split(parts[2], ".")[0])
+				if err == nil && version >= minimumPostgreSQLVersion {
+					hasPGDump = true
+				}
+			}
+		}
+	}
+
+	cmdArgs := []string{
 		"pg_dump",
 		"--schema-only",
 		connection,
@@ -45,8 +61,18 @@ func main() {
 		// We never want to manually generate
 		// queries executing against this table.
 		"--exclude-table=schema_migrations",
-	)
+	}
 
+	if !hasPGDump {
+		cmdArgs = append([]string{
+			"docker",
+			"run",
+			"--rm",
+			"--network=host",
+			fmt.Sprintf("postgres:%d", minimumPostgreSQLVersion),
+		}, cmdArgs...)
+	}
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //#nosec
 	cmd.Env = append(os.Environ(), []string{
 		"PGTZ=UTC",
 		"PGCLIENTENCODING=UTF8",

--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	hasPGDump := false
 	if _, err = exec.LookPath("pg_dump"); err == nil {
-		fmt.Fprintln(os.Stderr, "yahhoo")
 		out, err := exec.Command("pg_dump", "--version").Output()
 		if err == nil {
 			// Parse output:

--- a/coderd/database/generate.sh
+++ b/coderd/database/generate.sh
@@ -13,8 +13,10 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 (
 	cd "$SCRIPT_DIR"
 
-	# Dump the updated schema.
-	go run gen/dump/main.go
+	echo generate 1>&2
+
+	# Dump the updated schema (use make to utilize caching).
+	make -C ../.. --no-print-directory coderd/database/dump.sql
 	# The logic below depends on the exact version being correct :(
 	go run github.com/kyleconroy/sqlc/cmd/sqlc@v1.13.0 generate
 


### PR DESCRIPTION
Occasionally I'm running `make gen` without Docker available, seems like we can save precious seconds by not launching a Docker container for dumping the database.

Since `generate.sh` also launches the dump (in addition to `Makefile`), I decided to invoke make within it.

- fix: Allow dumping database without docker using pg_dump binary
- fix: Utilize make cache for dumping database

