### PR TITLE
fix: Protect codersdk.Client SessionToken so it can be updated

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -97,7 +97,7 @@ func workspaceAgent() *cobra.Command {
 				if err != nil {
 					return xerrors.Errorf("CODER_AGENT_TOKEN must be set for token auth: %w", err)
 				}
-				client.SessionToken = token
+				client.SetSessionToken(token)
 			case "google-instance-identity":
 				// This is *only* done for testing to mock client authentication.
 				// This will never be set in a production scenario.
@@ -153,13 +153,13 @@ func workspaceAgent() *cobra.Command {
 				Logger: logger,
 				ExchangeToken: func(ctx context.Context) (string, error) {
 					if exchangeToken == nil {
-						return client.SessionToken, nil
+						return client.SessionToken(), nil
 					}
 					resp, err := exchangeToken(ctx)
 					if err != nil {
 						return "", err
 					}
-					client.SessionToken = resp.SessionToken
+					client.SetSessionToken(resp.SessionToken)
 					return resp.SessionToken, nil
 				},
 				EnvironmentVariables: map[string]string{

--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -43,7 +43,7 @@ func NewWithSubcommands(
 
 // SetupConfig applies the URL and SessionToken of the client to the config.
 func SetupConfig(t *testing.T, client *codersdk.Client, root config.Root) {
-	err := root.Session().Write(client.SessionToken)
+	err := root.Session().Write(client.SessionToken())
 	require.NoError(t, err)
 	err = root.URL().Write(client.URL.String())
 	require.NoError(t, err)

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -105,7 +105,7 @@ func TestConfigSSH(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent"),

--- a/cli/login.go
+++ b/cli/login.go
@@ -214,7 +214,7 @@ func login() *cobra.Command {
 					Text:   "Paste your token here:",
 					Secret: true,
 					Validate: func(token string) error {
-						client.SessionToken = token
+						client.SetSessionToken(token)
 						_, err := client.User(cmd.Context(), codersdk.Me)
 						if err != nil {
 							return xerrors.New("That's not a valid token!")
@@ -228,7 +228,7 @@ func login() *cobra.Command {
 			}
 
 			// Login to get user data - verify it is OK before persisting
-			client.SessionToken = sessionToken
+			client.SetSessionToken(sessionToken)
 			resp, err := client.User(cmd.Context(), codersdk.Me)
 			if err != nil {
 				return xerrors.Errorf("get user: %w", err)

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -148,7 +148,7 @@ func TestLogin(t *testing.T) {
 		}()
 
 		pty.ExpectMatch("Paste your token here:")
-		pty.WriteLine(client.SessionToken)
+		pty.WriteLine(client.SessionToken())
 		pty.ExpectMatch("Welcome to Coder")
 		<-doneChan
 	})
@@ -183,11 +183,11 @@ func TestLogin(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		coderdtest.CreateFirstUser(t, client)
-		root, cfg := clitest.New(t, "login", client.URL.String(), "--token", client.SessionToken)
+		root, cfg := clitest.New(t, "login", client.URL.String(), "--token", client.SessionToken())
 		err := root.Execute()
 		require.NoError(t, err)
 		sessionFile, err := cfg.Session().Read()
 		require.NoError(t, err)
-		require.Equal(t, client.SessionToken, sessionFile)
+		require.Equal(t, client.SessionToken(), sessionFile)
 	})
 }

--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -209,7 +209,7 @@ func login(t *testing.T, pty *ptytest.PTY) config.Root {
 	}()
 
 	pty.ExpectMatch("Paste your token here:")
-	pty.WriteLine(client.SessionToken)
+	pty.WriteLine(client.SessionToken())
 	pty.ExpectMatch("Welcome to Coder")
 	<-doneChan
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -306,7 +306,7 @@ func CreateClient(cmd *cobra.Command) (*codersdk.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	client.SessionToken = token
+	client.SetSessionToken(token)
 	return client, nil
 }
 
@@ -347,7 +347,7 @@ func createAgentClient(cmd *cobra.Command) (*codersdk.Client, error) {
 		return nil, err
 	}
 	client := codersdk.New(serverURL)
-	client.SessionToken = token
+	client.SetSessionToken(token)
 	return client, nil
 }
 

--- a/cli/speedtest_test.go
+++ b/cli/speedtest_test.go
@@ -22,7 +22,7 @@ func TestSpeedtest(t *testing.T) {
 	}
 	client, workspace, agentToken := setupWorkspaceForAgent(t)
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = agentToken
+	agentClient.SetSessionToken(agentToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent"),

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -87,7 +87,7 @@ func TestSSH(t *testing.T) {
 		pty.ExpectMatch("Waiting")
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = agentToken
+		agentClient.SetSessionToken(agentToken)
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
 			Logger: slogtest.Make(t, nil).Named("agent"),
@@ -107,7 +107,7 @@ func TestSSH(t *testing.T) {
 			// Run this async so the SSH command has to wait for
 			// the build and agent to connect!
 			agentClient := codersdk.New(client.URL)
-			agentClient.SessionToken = agentToken
+			agentClient.SetSessionToken(agentToken)
 			agentCloser := agent.New(agent.Options{
 				Client: agentClient,
 				Logger: slogtest.Make(t, nil).Named("agent"),
@@ -174,7 +174,7 @@ func TestSSH(t *testing.T) {
 		client, workspace, agentToken := setupWorkspaceForAgent(t)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = agentToken
+		agentClient.SetSessionToken(agentToken)
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
 			Logger: slogtest.Make(t, nil).Named("agent"),

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -360,7 +360,7 @@ func CreateFirstUser(t *testing.T, client *codersdk.Client) codersdk.CreateFirst
 		Password: FirstUserParams.Password,
 	})
 	require.NoError(t, err)
-	client.SessionToken = login.SessionToken
+	client.SetSessionToken(login.SessionToken)
 	return resp
 }
 
@@ -400,7 +400,7 @@ func createAnotherUserRetry(t *testing.T, client *codersdk.Client, organizationI
 	require.NoError(t, err)
 
 	other := codersdk.New(client.URL)
-	other.SessionToken = login.SessionToken
+	other.SetSessionToken(login.SessionToken)
 
 	if len(roles) > 0 {
 		// Find the roles for the org vs the site wide roles

--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -134,7 +134,7 @@ func TestAgentGitSSHKey(t *testing.T) {
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -601,7 +601,7 @@ func TestTemplateMetrics(t *testing.T) {
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Logger: slogtest.Make(t, nil),
 		Client: agentClient,

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -275,7 +275,7 @@ func TestUserOAuth2Github(t *testing.T) {
 		resp := oauth2Callback(t, client)
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 
-		client.SessionToken = authCookieValue(resp.Cookies())
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
 		user, err := client.User(context.Background(), "me")
 		require.NoError(t, err)
 		require.Equal(t, "kyle@coder.com", user.Email)
@@ -485,14 +485,14 @@ func TestUserOIDC(t *testing.T) {
 			ctx, _ := testutil.Context(t)
 
 			if tc.Username != "" {
-				client.SessionToken = authCookieValue(resp.Cookies())
+				client.SetSessionToken(authCookieValue(resp.Cookies()))
 				user, err := client.User(ctx, "me")
 				require.NoError(t, err)
 				require.Equal(t, tc.Username, user.Username)
 			}
 
 			if tc.AvatarURL != "" {
-				client.SessionToken = authCookieValue(resp.Cookies())
+				client.SetSessionToken(authCookieValue(resp.Cookies()))
 				user, err := client.User(ctx, "me")
 				require.NoError(t, err)
 				require.Equal(t, tc.AvatarURL, user.AvatarURL)
@@ -520,7 +520,7 @@ func TestUserOIDC(t *testing.T) {
 
 		ctx, _ := testutil.Context(t)
 
-		client.SessionToken = authCookieValue(resp.Cookies())
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
 		user, err := client.User(ctx, "me")
 		require.NoError(t, err)
 		require.Equal(t, "jon", user.Username)
@@ -534,7 +534,7 @@ func TestUserOIDC(t *testing.T) {
 		resp = oidcCallback(t, client, code)
 		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 
-		client.SessionToken = authCookieValue(resp.Cookies())
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
 		user, err = client.User(ctx, "me")
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(user.Username, "jon-"), "username %q should have prefix %q", user.Username, "jon-")

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -280,7 +280,7 @@ func TestPostLogin(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		split := strings.Split(client.SessionToken, "-")
+		split := strings.Split(client.SessionToken(), "-")
 		key, err := client.GetAPIKey(ctx, admin.UserID.String(), split[0])
 		require.NoError(t, err, "fetch login key")
 		require.Equal(t, int64(86400), key.LifetimeSeconds, "default should be 86400")
@@ -356,7 +356,7 @@ func TestPostLogout(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		keyID := strings.Split(client.SessionToken, "-")[0]
+		keyID := strings.Split(client.SessionToken(), "-")[0]
 		apiKey, err := client.GetAPIKey(ctx, admin.UserID.String(), keyID)
 		require.NoError(t, err)
 		require.Equal(t, keyID, apiKey.ID, "API key should exist in the database")
@@ -676,7 +676,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		client.SessionToken = resp.SessionToken
+		client.SetSessionToken(resp.SessionToken)
 
 		// Trying to get an API key should fail since all keys are deleted
 		// on password change.
@@ -1359,7 +1359,7 @@ func TestWorkspacesByUser(t *testing.T) {
 		require.NoError(t, err)
 
 		newUserClient := codersdk.New(client.URL)
-		newUserClient.SessionToken = auth.SessionToken
+		newUserClient.SetSessionToken(auth.SessionToken)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -113,7 +113,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = authToken
+		agentClient.SetSessionToken(authToken)
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
 			Logger: slogtest.Make(t, nil).Named("agent").Leveled(slog.LevelDebug),
@@ -205,7 +205,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, stopBuild.ID)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = authToken
+		agentClient.SetSessionToken(authToken)
 
 		_, err = agentClient.ListenWorkspaceAgent(ctx)
 		require.Error(t, err)
@@ -245,7 +245,7 @@ func TestWorkspaceAgentTailnet(t *testing.T) {
 	daemonCloser.Close()
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent").Leveled(slog.LevelDebug),
@@ -311,7 +311,7 @@ func TestWorkspaceAgentPTY(t *testing.T) {
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent").Leveled(slog.LevelDebug),
@@ -408,7 +408,7 @@ func TestWorkspaceAgentListeningPorts(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = authToken
+		agentClient.SetSessionToken(authToken)
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
 			Logger: slogtest.Make(t, nil).Named("agent").Leveled(slog.LevelDebug),
@@ -670,7 +670,7 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 	defer cancel()
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 
 	metadata, err := agentClient.WorkspaceAgentMetadata(ctx)
 	require.NoError(t, err)
@@ -754,7 +754,7 @@ func TestWorkspaceAgentsGitAuth(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = authToken
+		agentClient.SetSessionToken(authToken)
 		_, err := agentClient.WorkspaceAgentGitAuth(context.Background(), "github.com", false)
 		var apiError *codersdk.Error
 		require.ErrorAs(t, err, &apiError)
@@ -799,7 +799,7 @@ func TestWorkspaceAgentsGitAuth(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = authToken
+		agentClient.SetSessionToken(authToken)
 		token, err := agentClient.WorkspaceAgentGitAuth(context.Background(), "github.com/asd/asd", false)
 		require.NoError(t, err)
 		require.True(t, strings.HasSuffix(token.URL, fmt.Sprintf("/gitauth/%s", "github")))
@@ -879,7 +879,7 @@ func TestWorkspaceAgentsGitAuth(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 		agentClient := codersdk.New(client.URL)
-		agentClient.SessionToken = authToken
+		agentClient.SetSessionToken(authToken)
 
 		token, err := agentClient.WorkspaceAgentGitAuth(context.Background(), "github.com/asd/asd", false)
 		require.NoError(t, err)
@@ -920,7 +920,7 @@ func gitAuthCallback(t *testing.T, id string, client *codersdk.Client) *http.Res
 	})
 	req.AddCookie(&http.Cookie{
 		Name:  codersdk.SessionTokenKey,
-		Value: client.SessionToken,
+		Value: client.SessionToken(),
 	})
 	res, err := client.HTTPClient.Do(req)
 	require.NoError(t, err)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1400,7 +1400,7 @@ func TestWorkspaceWatcher(t *testing.T) {
 	wait()
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent").Leveled(slog.LevelDebug),

--- a/codersdk/client_internal_test.go
+++ b/codersdk/client_internal_test.go
@@ -58,7 +58,7 @@ func Test_Client(t *testing.T) {
 	u, err := url.Parse(s.URL)
 	require.NoError(t, err)
 	client := New(u)
-	client.SessionToken = token
+	client.SetSessionToken(token)
 	client.BypassRatelimits = true
 
 	logBuf := bytes.NewBuffer(nil)

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -121,7 +121,7 @@ func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after
 	}
 	jar.SetCookies(followURL, []*http.Cookie{{
 		Name:  SessionTokenKey,
-		Value: c.SessionToken,
+		Value: c.SessionToken(),
 	}})
 	httpClient := &http.Client{
 		Jar: jar,

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -319,7 +319,7 @@ func (c *Client) ListenWorkspaceAgent(ctx context.Context) (net.Conn, error) {
 	}
 	jar.SetCookies(coordinateURL, []*http.Cookie{{
 		Name:  SessionTokenKey,
-		Value: c.SessionToken,
+		Value: c.SessionToken(),
 	}})
 	httpClient := &http.Client{
 		Jar:       jar,
@@ -385,7 +385,7 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 	}
 	jar.SetCookies(coordinateURL, []*http.Cookie{{
 		Name:  SessionTokenKey,
-		Value: c.SessionToken,
+		Value: c.SessionToken(),
 	}})
 	httpClient := &http.Client{
 		Jar:       jar,
@@ -508,7 +508,7 @@ func (c *Client) WorkspaceAgentReconnectingPTY(ctx context.Context, agentID, rec
 	}
 	jar.SetCookies(serverURL, []*http.Cookie{{
 		Name:  SessionTokenKey,
-		Value: c.SessionToken,
+		Value: c.SessionToken(),
 	}})
 	httpClient := &http.Client{
 		Jar: jar,
@@ -569,7 +569,7 @@ func (c *Client) AgentReportStats(
 
 	jar.SetCookies(serverURL, []*http.Cookie{{
 		Name:  SessionTokenKey,
-		Value: c.SessionToken,
+		Value: c.SessionToken(),
 	}})
 
 	httpClient := &http.Client{

--- a/enterprise/coderd/replicas_test.go
+++ b/enterprise/coderd/replicas_test.go
@@ -36,7 +36,7 @@ func TestReplicas(t *testing.T) {
 				Pubsub:   pubsub,
 			},
 		})
-		secondClient.SessionToken = firstClient.SessionToken
+		secondClient.SetSessionToken(firstClient.SessionToken())
 		ents, err := secondClient.Entitlements(context.Background())
 		require.NoError(t, err)
 		require.Len(t, ents.Errors, 1)
@@ -67,7 +67,7 @@ func TestReplicas(t *testing.T) {
 				Pubsub:   pubsub,
 			},
 		})
-		secondClient.SessionToken = firstClient.SessionToken
+		secondClient.SetSessionToken(firstClient.SessionToken())
 		replicas, err := secondClient.Replicas(context.Background())
 		require.NoError(t, err)
 		require.Len(t, replicas, 2)
@@ -110,7 +110,7 @@ func TestReplicas(t *testing.T) {
 				TLSCertificates: certificates,
 			},
 		})
-		secondClient.SessionToken = firstClient.SessionToken
+		secondClient.SetSessionToken(firstClient.SessionToken())
 		replicas, err := secondClient.Replicas(context.Background())
 		require.NoError(t, err)
 		require.Len(t, replicas, 2)

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -120,7 +120,7 @@ func setupWorkspaceAgent(t *testing.T, client *codersdk.Client, user codersdk.Cr
 			},
 		},
 	}
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent"),

--- a/loadtest/agentconn/run_test.go
+++ b/loadtest/agentconn/run_test.go
@@ -254,7 +254,7 @@ func setupRunnerTest(t *testing.T) (client *codersdk.Client, agentID uuid.UUID) 
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 	agentClient := codersdk.New(client.URL)
-	agentClient.SessionToken = authToken
+	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
 		Logger: slogtest.Make(t, nil).Named("agent"),

--- a/loadtest/workspacebuild/run_test.go
+++ b/loadtest/workspacebuild/run_test.go
@@ -129,7 +129,7 @@ func Test_Runner(t *testing.T) {
 				i := i + 1
 
 				agentClient := codersdk.New(client.URL)
-				agentClient.SessionToken = authToken
+				agentClient.SetSessionToken(authToken)
 				agentCloser := agent.New(agent.Options{
 					Client: agentClient,
 					Logger: slogtest.Make(t, nil).


### PR DESCRIPTION
This feature is used by the coder agent to exchange a new token. By
protecting the SessionToken via mutex we ensure there are no data races
when accessing it.

This race can be seen here: https://github.com/coder/coder/actions/runs/3427027452/jobs/5709526632
