### PR TITLE
fix: Improve docker example first user experience

### DIFF
--- a/examples/templates/docker/build/Dockerfile
+++ b/examples/templates/docker/build/Dockerfile
@@ -1,3 +1,17 @@
 FROM ubuntu
 
-RUN apt-get update && apt-get install -y curl wget git vim golang
+RUN apt-get update \
+	&& apt-get install -y \
+	curl \
+	git \
+	golang \
+	sudo \
+	vim \
+	wget
+
+ARG USER=coder
+RUN useradd --groups sudo --no-create-home ${USER} \
+	&& echo "${USER} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/${USER} \
+	&& chmod 0440 /etc/sudoers.d/${USER}
+USER ${USER}
+WORKDIR /home/${USER}

--- a/examples/templates/docker/build/Dockerfile
+++ b/examples/templates/docker/build/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update \
 	golang \
 	sudo \
 	vim \
-	wget
+	wget \
+	&& rm -rf /var/lib/apt/lists/*
 
 ARG USER=coder
 RUN useradd --groups sudo --no-create-home ${USER} \


### PR DESCRIPTION
Noticed we use an image build in the base docker image these days, however, it did not add any users accounts. This is my take on fixing it.

The base ubuntu image lands the user as root, but the terraform tempalte
expected /home/coder to be used. This change adds a user with the same
name as the Coder users username and allows them to sudo.

