### PR TITLE
fix: prevent terraform init races and corrupted cache directories

### DIFF
--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -14,16 +14,28 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/xerrors"
-
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/provisionersdk/proto"
 )
 
+// initMut is a global mutex that protects the Terraform cache directory from
+// concurrent usage by path. Only `terraform init` commands are guarded by this
+// mutex.
+//
+// When cache path is set, we must protect against multiple calls to
+// `terraform init`.
+//
+// From the Terraform documentation:
+//
+//	Note: The plugin cache directory is not guaranteed to be concurrency
+//	safe. The provider installer's behavior in environments with multiple
+//	terraform init calls is undefined.
+var initMut = &sync.Mutex{}
+
 type executor struct {
-	initMu     sync.Locker
 	binaryPath string
 	cachePath  string
 	workdir    string
@@ -181,8 +193,8 @@ func (e executor) init(ctx, killCtx context.Context, logr logger) error {
 	//     concurrency safe. The provider installer's behavior in
 	//     environments with multiple terraform init calls is undefined.
 	if e.cachePath != "" {
-		e.initMu.Lock()
-		defer e.initMu.Unlock()
+		initMut.Lock()
+		defer initMut.Unlock()
 	}
 
 	return e.execWriteOutput(ctx, killCtx, args, e.basicEnv(), outWriter, errWriter)

--- a/provisioner/terraform/executor_internal_test.go
+++ b/provisioner/terraform/executor_internal_test.go
@@ -1,4 +1,3 @@
-// nolint:testpackage
 package terraform
 
 import (

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -113,7 +113,6 @@ type server struct {
 
 func (s *server) executor(workdir string) executor {
 	return executor{
-		initMu:     &s.initMu,
 		binaryPath: s.binaryPath,
 		cachePath:  s.cachePath,
 		workdir:    workdir,

--- a/provisioner/terraform/serve.go
+++ b/provisioner/terraform/serve.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"context"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/cli/safeexec"
@@ -100,14 +99,9 @@ func Serve(ctx context.Context, options *ServeOptions) error {
 }
 
 type server struct {
-	// initMu protects against executors running `terraform init`
-	// concurrently when cache path is set.
-	initMu sync.Mutex
-
-	binaryPath string
-	cachePath  string
-	logger     slog.Logger
-
+	binaryPath  string
+	cachePath   string
+	logger      slog.Logger
 	exitTimeout time.Duration
 }
 


### PR DESCRIPTION
Before we were creating a new `initMu` to guard `terraform init` calls for each `executor`, and a new `executor` for each job. This changes the `initMut` to be a global mutex to guard all `terraform init` calls.

In production we only use a single terraform cache directory shared for all provisioner daemons so there aren't any optimizations to this locking scheme that can be made that would help production deployments. I was going to have a global map from `e.cachePath` to a mutex but decided it wasn't worth it since we never use a different cache path between runs.