### PR TITLE
fix: Add timeouts to every tailnet ping

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -499,7 +499,9 @@ func TestAgent(t *testing.T) {
 
 				conn, _ := setupAgent(t, codersdk.WorkspaceAgentMetadata{}, 0)
 				require.Eventually(t, func() bool {
-					_, err := conn.Ping(context.Background())
+					ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.IntervalFast)
+					defer cancelFunc()
+					_, err := conn.Ping(ctx)
 					return err == nil
 				}, testutil.WaitMedium, testutil.IntervalFast)
 				conn1, err := conn.DialContext(context.Background(), l.Addr().Network(), l.Addr().String())

--- a/agent/apphealth.go
+++ b/agent/apphealth.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/xerrors"
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/codersdk"

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -72,6 +72,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		require.NoError(t, err)
 		defer dialer.Close()
 		require.Eventually(t, func() bool {
+			ctx, cancelFunc := context.WithTimeout(ctx, testutil.IntervalFast)
+			defer cancelFunc()
 			_, err := dialer.Ping(ctx)
 			return err == nil
 		}, testutil.WaitMedium, testutil.IntervalFast)
@@ -133,6 +135,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		require.NoError(t, err)
 		defer dialer.Close()
 		require.Eventually(t, func() bool {
+			ctx, cancelFunc := context.WithTimeout(ctx, testutil.IntervalFast)
+			defer cancelFunc()
 			_, err := dialer.Ping(ctx)
 			return err == nil
 		}, testutil.WaitMedium, testutil.IntervalFast)
@@ -194,6 +198,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		require.NoError(t, err)
 		defer dialer.Close()
 		require.Eventually(t, func() bool {
+			ctx, cancelFunc := context.WithTimeout(ctx, testutil.IntervalFast)
+			defer cancelFunc()
 			_, err := dialer.Ping(ctx)
 			return err == nil
 		}, testutil.WaitMedium, testutil.IntervalFast)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -179,6 +179,8 @@ func TestWorkspaceAgentListen(t *testing.T) {
 			_ = conn.Close()
 		}()
 		require.Eventually(t, func() bool {
+			ctx, cancelFunc := context.WithTimeout(ctx, testutil.IntervalFast)
+			defer cancelFunc()
 			_, err := conn.Ping(ctx)
 			return err == nil
 		}, testutil.WaitLong, testutil.IntervalFast)


### PR DESCRIPTION
A ping isn't guaranteed to deliver, so these need to have a tight timeout for tests to not flake.
