### PR TITLE
fix: skip windows udp dial flake

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -467,6 +467,7 @@ func TestAgent(t *testing.T) {
 			{
 				name: "UDP",
 				setup: func(t *testing.T) net.Listener {
+					testutil.SkipIfWindows(t, "UDP flakes on Windows")
 					addr := net.UDPAddr{
 						IP:   net.ParseIP("127.0.0.1"),
 						Port: 0,

--- a/testutil/skip.go
+++ b/testutil/skip.go
@@ -1,0 +1,14 @@
+package testutil
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func SkipIfWindows(t *testing.T, msg string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip(fmt.Sprintf("skipping test on windows - %s", msg))
+	}
+}


### PR DESCRIPTION
This is happening a lot on main