### PR TITLE
feat: add cleanup strategy to loadtest

### DIFF
--- a/cli/loadtest.go
+++ b/cli/loadtest.go
@@ -135,8 +135,9 @@ func loadtest() *cobra.Command {
 			client.PropagateTracing = tracePropagate
 
 			// Prepare the test.
-			strategy := config.Strategy.ExecutionStrategy()
-			th := harness.NewTestHarness(strategy)
+			runStrategy := config.Strategy.ExecutionStrategy()
+			cleanupStrategy := config.CleanupStrategy.ExecutionStrategy()
+			th := harness.NewTestHarness(runStrategy, cleanupStrategy)
 
 			for i, t := range config.Tests {
 				name := fmt.Sprintf("%s-%d", t.Type, i)

--- a/cli/loadtest_test.go
+++ b/cli/loadtest_test.go
@@ -38,6 +38,9 @@ func TestLoadTest(t *testing.T) {
 			Strategy: cli.LoadTestStrategy{
 				Type: cli.LoadTestStrategyTypeLinear,
 			},
+			CleanupStrategy: cli.LoadTestStrategy{
+				Type: cli.LoadTestStrategyTypeLinear,
+			},
 			Tests: []cli.LoadTest{
 				{
 					Type:  cli.LoadTestTypePlacebo,
@@ -86,6 +89,10 @@ func TestLoadTest(t *testing.T) {
 
 		config := cli.LoadTestConfig{
 			Strategy: cli.LoadTestStrategy{
+				Type:             cli.LoadTestStrategyTypeConcurrent,
+				ConcurrencyLimit: 2,
+			},
+			CleanupStrategy: cli.LoadTestStrategy{
 				Type:             cli.LoadTestStrategyTypeConcurrent,
 				ConcurrencyLimit: 2,
 			},
@@ -208,6 +215,9 @@ func TestLoadTest(t *testing.T) {
 
 				config := cli.LoadTestConfig{
 					Strategy: cli.LoadTestStrategy{
+						Type: cli.LoadTestStrategyTypeLinear,
+					},
+					CleanupStrategy: cli.LoadTestStrategy{
 						Type: cli.LoadTestStrategyTypeLinear,
 					},
 					Tests: []cli.LoadTest{

--- a/cli/loadtestconfig.go
+++ b/cli/loadtestconfig.go
@@ -15,8 +15,9 @@ import (
 
 // LoadTestConfig is the overall configuration for a call to `coder loadtest`.
 type LoadTestConfig struct {
-	Strategy LoadTestStrategy `json:"strategy"`
-	Tests    []LoadTest       `json:"tests"`
+	Strategy        LoadTestStrategy `json:"strategy"`
+	CleanupStrategy LoadTestStrategy `json:"cleanup_strategy"`
+	Tests           []LoadTest       `json:"tests"`
 	// Timeout sets a timeout for the entire test run, to control the timeout
 	// for each individual run use strategy.timeout.
 	Timeout httpapi.Duration `json:"timeout"`
@@ -133,6 +134,10 @@ func (c *LoadTestConfig) Validate() error {
 	err := c.Strategy.Validate()
 	if err != nil {
 		return xerrors.Errorf("validate strategy: %w", err)
+	}
+	err = c.CleanupStrategy.Validate()
+	if err != nil {
+		return xerrors.Errorf("validate cleanup_strategy: %w", err)
 	}
 
 	for i, test := range c.Tests {

--- a/loadtest/harness/harness.go
+++ b/loadtest/harness/harness.go
@@ -11,19 +11,11 @@ import (
 	"github.com/coder/coder/coderd/tracing"
 )
 
-// ExecutionStrategy defines how a TestHarness should execute a set of runs. It
-// essentially defines the concurrency model for a given testing session.
-type ExecutionStrategy interface {
-	// Execute runs the given runs in whatever way the strategy wants. An error
-	// may only be returned if the strategy has a failure itself, not if any of
-	// the runs fail.
-	Execute(ctx context.Context, runs []*TestRun) error
-}
-
-// TestHarness runs a bunch of registered test runs using the given
-// ExecutionStrategy.
+// TestHarness runs a bunch of registered test runs using the given execution
+// strategies.
 type TestHarness struct {
-	strategy ExecutionStrategy
+	runStrategy     ExecutionStrategy
+	cleanupStrategy ExecutionStrategy
 
 	mut     *sync.Mutex
 	runIDs  map[string]struct{}
@@ -33,14 +25,15 @@ type TestHarness struct {
 	elapsed time.Duration
 }
 
-// NewTestHarness creates a new TestHarness with the given ExecutionStrategy.
-func NewTestHarness(strategy ExecutionStrategy) *TestHarness {
+// NewTestHarness creates a new TestHarness with the given execution strategies.
+func NewTestHarness(runStrategy, cleanupStrategy ExecutionStrategy) *TestHarness {
 	return &TestHarness{
-		strategy: strategy,
-		mut:      new(sync.Mutex),
-		runIDs:   map[string]struct{}{},
-		runs:     []*TestRun{},
-		done:     make(chan struct{}),
+		runStrategy:     runStrategy,
+		cleanupStrategy: cleanupStrategy,
+		mut:             new(sync.Mutex),
+		runIDs:          map[string]struct{}{},
+		runs:            []*TestRun{},
+		done:            make(chan struct{}),
 	}
 }
 
@@ -62,11 +55,16 @@ func (h *TestHarness) Run(ctx context.Context) (err error) {
 	h.started = true
 	h.mut.Unlock()
 
+	runFns := make([]TestFn, len(h.runs))
+	for i, run := range h.runs {
+		runFns[i] = run.Run
+	}
+
 	defer close(h.done)
 	defer func() {
 		e := recover()
 		if e != nil {
-			err = xerrors.Errorf("execution strategy panicked: %w", e)
+			err = xerrors.Errorf("panic in harness.Run: %+v", e)
 		}
 	}()
 
@@ -77,7 +75,9 @@ func (h *TestHarness) Run(ctx context.Context) (err error) {
 		h.elapsed = time.Since(start)
 	}()
 
-	err = h.strategy.Execute(ctx, h.runs)
+	// We don't care about test failures here since they already get recorded
+	// by the *TestRun.
+	_, err = h.runStrategy.Run(ctx, runFns)
 	//nolint:revive // we use named returns because we mutate it in a defer
 	return
 }
@@ -96,20 +96,34 @@ func (h *TestHarness) Cleanup(ctx context.Context) (err error) {
 		panic("harness has not finished")
 	}
 
+	cleanupFns := make([]TestFn, len(h.runs))
+	for i, run := range h.runs {
+		cleanupFns[i] = run.Cleanup
+	}
+
 	defer func() {
 		e := recover()
 		if e != nil {
-			err = multierror.Append(err, xerrors.Errorf("panic in cleanup: %w", e))
+			err = xerrors.Errorf("panic in harness.Cleanup: %+v", e)
 		}
 	}()
 
-	for _, run := range h.runs {
-		e := run.Cleanup(ctx)
-		if e != nil {
-			err = multierror.Append(err, xerrors.Errorf("cleanup for %s failed: %w", run.FullID(), e))
+	var cleanupErrs []error
+	cleanupErrs, err = h.cleanupStrategy.Run(ctx, cleanupFns)
+	if err != nil {
+		err = xerrors.Errorf("cleanup strategy error: %w", err)
+		//nolint:revive // we use named returns because we mutate it in a defer
+		return
+	}
+
+	var merr error
+	for _, cleanupErr := range cleanupErrs {
+		if cleanupErr != nil {
+			merr = multierror.Append(merr, cleanupErr)
 		}
 	}
 
+	err = merr
 	//nolint:revive // we use named returns because we mutate it in a defer
 	return
 }

--- a/loadtest/harness/results_test.go
+++ b/loadtest/harness/results_test.go
@@ -1,0 +1,70 @@
+package harness_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/coderd/httpapi"
+	"github.com/coder/coder/loadtest/harness"
+)
+
+func Test_Results(t *testing.T) {
+	t.Parallel()
+
+	results := harness.Results{
+		TotalRuns: 10,
+		TotalPass: 8,
+		TotalFail: 2,
+		Runs: map[string]harness.RunResult{
+			"test-0/0": {
+				FullID:     "test-0/0",
+				TestName:   "test-0",
+				ID:         "0",
+				Logs:       "test-0/0 log line 1\ntest-0/0 log line 2",
+				Error:      xerrors.New("test-0/0 error"),
+				StartedAt:  time.Now(),
+				Duration:   httpapi.Duration(time.Second),
+				DurationMS: 1000,
+			},
+			"test-0/1": {
+				FullID:     "test-0/1",
+				TestName:   "test-0",
+				ID:         "1",
+				Logs:       "test-0/1 log line 1\ntest-0/1 log line 2",
+				Error:      nil,
+				StartedAt:  time.Now(),
+				Duration:   httpapi.Duration(time.Second),
+				DurationMS: 1000,
+			},
+		},
+		Elapsed:   httpapi.Duration(time.Second),
+		ElapsedMS: 1000,
+	}
+
+	expected := `
+== FAIL: test-0/0
+
+	Error: test-0/0 error
+
+	Log:
+		test-0/0 log line 1
+
+
+Test results:
+	Pass:  8
+	Fail:  2
+	Total: 10
+
+	Total duration: 1s
+	Avg. duration:  200ms
+`
+
+	out := bytes.NewBuffer(nil)
+	results.PrintText(out)
+
+	require.Equal(t, expected, out.String())
+}

--- a/loadtest/harness/run.go
+++ b/loadtest/harness/run.go
@@ -108,7 +108,7 @@ func (r *TestRun) Run(ctx context.Context) (err error) {
 	return
 }
 
-func (r *TestRun) Cleanup(ctx context.Context) error {
+func (r *TestRun) Cleanup(ctx context.Context) (err error) {
 	c, ok := r.runner.(Cleanable)
 	if !ok {
 		return nil
@@ -121,5 +121,14 @@ func (r *TestRun) Cleanup(ctx context.Context) error {
 		return nil
 	}
 
-	return c.Cleanup(ctx, r.id)
+	defer func() {
+		e := recover()
+		if e != nil {
+			err = xerrors.Errorf("panic: %v", e)
+		}
+	}()
+
+	err = c.Cleanup(ctx, r.id)
+	//nolint:revive // we use named returns because we mutate it in a defer
+	return
 }

--- a/loadtest/harness/strategies.go
+++ b/loadtest/harness/strategies.go
@@ -4,11 +4,24 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/binary"
-	"io"
 	"math/rand"
 	"sync"
 	"time"
+
+	"golang.org/x/xerrors"
 )
+
+// TestFn is a function that can be run by an ExecutionStrategy.
+type TestFn func(ctx context.Context) error
+
+// ExecutionStrategy defines how a TestHarness should execute a set of runs. It
+// essentially defines the concurrency model for a given testing session.
+type ExecutionStrategy interface {
+	// Execute calls each function in whatever way the strategy wants. All
+	// errors returned from the function should be wrapped and returned, but all
+	// given functions must be executed.
+	Run(ctx context.Context, fns []TestFn) ([]error, error)
+}
 
 // LinearExecutionStrategy executes all test runs in a linear fashion, one after
 // the other.
@@ -16,13 +29,17 @@ type LinearExecutionStrategy struct{}
 
 var _ ExecutionStrategy = LinearExecutionStrategy{}
 
-// Execute implements ExecutionStrategy.
-func (LinearExecutionStrategy) Execute(ctx context.Context, runs []*TestRun) error {
-	for _, run := range runs {
-		_ = run.Run(ctx)
+// Run implements ExecutionStrategy.
+func (LinearExecutionStrategy) Run(ctx context.Context, fns []TestFn) ([]error, error) {
+	var errs []error
+	for i, fn := range fns {
+		err := fn(ctx)
+		if err != nil {
+			errs = append(errs, xerrors.Errorf("run %d: %w", i, err))
+		}
 	}
 
-	return nil
+	return errs, nil
 }
 
 // ConcurrentExecutionStrategy executes all test runs concurrently without any
@@ -31,21 +48,27 @@ type ConcurrentExecutionStrategy struct{}
 
 var _ ExecutionStrategy = ConcurrentExecutionStrategy{}
 
-// Execute implements ExecutionStrategy.
-func (ConcurrentExecutionStrategy) Execute(ctx context.Context, runs []*TestRun) error {
-	var wg sync.WaitGroup
-	for _, run := range runs {
-		run := run
+// Run implements ExecutionStrategy.
+func (ConcurrentExecutionStrategy) Run(ctx context.Context, fns []TestFn) ([]error, error) {
+	var (
+		wg   sync.WaitGroup
+		errs = newErrorsList()
+	)
+	for i, fn := range fns {
+		i, fn := i, fn
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = run.Run(ctx)
+			err := fn(ctx)
+			if err != nil {
+				errs.add(xerrors.Errorf("run %d: %w", i, err))
+			}
 		}()
 	}
 
 	wg.Wait()
-	return nil
+	return errs.errs, nil
 }
 
 // ParallelExecutionStrategy executes all test runs concurrently, but limits the
@@ -56,14 +79,17 @@ type ParallelExecutionStrategy struct {
 
 var _ ExecutionStrategy = ParallelExecutionStrategy{}
 
-// Execute implements ExecutionStrategy.
-func (p ParallelExecutionStrategy) Execute(ctx context.Context, runs []*TestRun) error {
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, p.Limit)
+// Run implements ExecutionStrategy.
+func (p ParallelExecutionStrategy) Run(ctx context.Context, fns []TestFn) ([]error, error) {
+	var (
+		wg   sync.WaitGroup
+		errs = newErrorsList()
+		sem  = make(chan struct{}, p.Limit)
+	)
 	defer close(sem)
 
-	for _, run := range runs {
-		run := run
+	for i, fn := range fns {
+		i, fn := i, fn
 
 		wg.Add(1)
 		go func() {
@@ -72,12 +98,15 @@ func (p ParallelExecutionStrategy) Execute(ctx context.Context, runs []*TestRun)
 				wg.Done()
 			}()
 			sem <- struct{}{}
-			_ = run.Run(ctx)
+			err := fn(ctx)
+			if err != nil {
+				errs.add(xerrors.Errorf("run %d: %w", i, err))
+			}
 		}()
 	}
 
 	wg.Wait()
-	return nil
+	return errs.errs, nil
 }
 
 // TimeoutExecutionStrategyWrapper is an ExecutionStrategy that wraps another
@@ -89,41 +118,19 @@ type TimeoutExecutionStrategyWrapper struct {
 
 var _ ExecutionStrategy = TimeoutExecutionStrategyWrapper{}
 
-type timeoutRunnerWrapper struct {
-	timeout time.Duration
-	inner   Runnable
-}
-
-var _ Runnable = timeoutRunnerWrapper{}
-var _ Cleanable = timeoutRunnerWrapper{}
-
-func (t timeoutRunnerWrapper) Run(ctx context.Context, id string, logs io.Writer) error {
-	ctx, cancel := context.WithTimeout(ctx, t.timeout)
-	defer cancel()
-
-	return t.inner.Run(ctx, id, logs)
-}
-
-func (t timeoutRunnerWrapper) Cleanup(ctx context.Context, id string) error {
-	c, ok := t.inner.(Cleanable)
-	if !ok {
-		return nil
-	}
-
-	return c.Cleanup(ctx, id)
-}
-
-// Execute implements ExecutionStrategy.
-func (t TimeoutExecutionStrategyWrapper) Execute(ctx context.Context, runs []*TestRun) error {
-	for _, run := range runs {
-		oldRunner := run.runner
-		run.runner = timeoutRunnerWrapper{
-			timeout: t.Timeout,
-			inner:   oldRunner,
+// Run implements ExecutionStrategy.
+func (t TimeoutExecutionStrategyWrapper) Run(ctx context.Context, fns []TestFn) ([]error, error) {
+	newFns := make([]TestFn, len(fns))
+	for i, fn := range fns {
+		fn := fn
+		newFns[i] = func(ctx context.Context) error {
+			ctx, cancel := context.WithTimeout(ctx, t.Timeout)
+			defer cancel()
+			return fn(ctx)
 		}
 	}
 
-	return t.Inner.Execute(ctx, runs)
+	return t.Inner.Run(ctx, newFns)
 }
 
 // ShuffleExecutionStrategyWrapper is an ExecutionStrategy that wraps another
@@ -151,17 +158,35 @@ func (cryptoRandSource) Int63() int64 {
 
 func (cryptoRandSource) Seed(_ int64) {}
 
-// Execute implements ExecutionStrategy.
-func (s ShuffleExecutionStrategyWrapper) Execute(ctx context.Context, runs []*TestRun) error {
-	shuffledRuns := make([]*TestRun, len(runs))
-	copy(shuffledRuns, runs)
+// Run implements ExecutionStrategy.
+func (s ShuffleExecutionStrategyWrapper) Run(ctx context.Context, fns []TestFn) ([]error, error) {
+	shuffledFns := make([]TestFn, len(fns))
+	copy(shuffledFns, fns)
 
 	//nolint:gosec // gosec thinks we're using an insecure RNG, but we're not.
 	src := rand.New(cryptoRandSource{})
-	for i := range shuffledRuns {
+	for i := range shuffledFns {
 		j := src.Intn(i + 1)
-		shuffledRuns[i], shuffledRuns[j] = shuffledRuns[j], shuffledRuns[i]
+		shuffledFns[i], shuffledFns[j] = shuffledFns[j], shuffledFns[i]
 	}
 
-	return s.Inner.Execute(ctx, shuffledRuns)
+	return s.Inner.Run(ctx, shuffledFns)
+}
+
+type errorsList struct {
+	mut  *sync.Mutex
+	errs []error
+}
+
+func newErrorsList() *errorsList {
+	return &errorsList{
+		mut:  &sync.Mutex{},
+		errs: []error{},
+	}
+}
+
+func (l *errorsList) add(err error) {
+	l.mut.Lock()
+	defer l.mut.Unlock()
+	l.errs = append(l.errs, err)
 }


### PR DESCRIPTION
Running cleanup is taking a very long time so this makes the cleanup strategy configurable in the same way the run strategy is.