### PR TITLE
chore: ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ site/out/
 **/*.swp
 .coderv2/*
 **/__debug_bin
+
+# direnv
+.envrc


### PR DESCRIPTION
Our [CONTRIBUTING](https://coder.com/docs/coder-oss/latest/CONTRIBUTING#requirements) page recommends setting the .envrc file to automatically enable the nix-shell.

This PR adds the `.envrc` to the `.gitignore`. I assume that not every developer uses `nix-shell`, but can use `direnv`, and in this case, the `.envrc` will be problematic.