### PR TITLE
fix: Misc improvements to `scripts/develop.sh`

### DIFF
--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -118,15 +118,17 @@ CODER_DEV_SHIM="${PROJECT_ROOT}/scripts/coder-dev.sh"
 		interfaces+=($(ifconfig | awk '/inet / {print $2}'))
 	fi
 
+	# Space padding used after the URLs to align "==".
+	space_padding=26
 	log
 	log "===================================================================="
 	log "==                                                                =="
 	log "==            Coder is now running in development mode.           =="
 	for iface in "${interfaces[@]}"; do
-		log "$(printf "==                  API:    http://%s:3000%$((26 - ${#iface}))s==" "$iface" "")"
+		log "$(printf "==                  API:    http://%s:3000%$((space_padding - ${#iface}))s==" "$iface" "")"
 	done
 	for iface in "${interfaces[@]}"; do
-		log "$(printf "==                  Web UI: http://%s:8080%$((26 - ${#iface}))s==" "$iface" "")"
+		log "$(printf "==                  Web UI: http://%s:8080%$((space_padding - ${#iface}))s==" "$iface" "")"
 	done
 	log "==                                                                =="
 	log "==      Use ./scripts/coder-dev.sh to talk to this instance!      =="


### PR DESCRIPTION
* Use new `/healthz` endpoint for checking API liveness
* Improved credential handling/retrying in failure scenarios
* Separate site (`vite`) logs with prefix and date, additionally this
  method also disables the `vite` clearing of the screen
* Show all interfaces coder API is listening on (due to `0.0.0.0`)

Edit:

* Improved shutdown procedure / interrupt handling ([ac5d221](https://github.com/coder/coder/pull/4995/commits/ac5d2213d312137ba666c0638cdc4104e9ae07a0))

<img width="600" alt="image" src="https://user-images.githubusercontent.com/147409/201082690-28254792-f18d-48e1-98a7-c58db42e8c40.png">
