### PR TITLE
fix: Fix ssh message/spinner in VSCode integrated terminal

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -58,6 +58,7 @@ func Agent(ctx context.Context, writer io.Writer, opts AgentOptions) error {
 			return
 		case <-stopSpin:
 		}
+		cancelFunc()
 		signal.Stop(stopSpin)
 		spin.Stop()
 		// nolint:revive
@@ -87,8 +88,12 @@ func Agent(ctx context.Context, writer io.Writer, opts AgentOptions) error {
 		spin.Stop()
 		// Clear the line and (if necessary) move up a line to write our message.
 		_, _ = fmt.Fprintf(writer, "\033[2K%s%s\n\n", moveUp, Styles.Paragraph.Render(Styles.Prompt.String()+waitMessage))
-		// Safe to resume operation.
-		spin.Start()
+		select {
+		case <-ctx.Done():
+		default:
+			// Safe to resume operation.
+			spin.Start()
+		}
 	}
 	go func() {
 		select {

--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -83,10 +83,12 @@ func Agent(ctx context.Context, writer io.Writer, opts AgentOptions) error {
 		}
 		waitMessage = m
 
-		// This saves the cursor position, then defers clearing from the cursor
-		// position to the end of the screen.
-		_, _ = fmt.Fprintf(writer, "\033[s\r\033[2K%s%s\n\n", moveUp, Styles.Paragraph.Render(Styles.Prompt.String()+waitMessage))
-		defer fmt.Fprintf(writer, "\033[u\033[J")
+		// Stop the spinner while we write our message.
+		spin.Stop()
+		// Clear the line and (if necessary) move up a line to write our message.
+		_, _ = fmt.Fprintf(writer, "\033[2K%s%s\n\n", moveUp, Styles.Paragraph.Render(Styles.Prompt.String()+waitMessage))
+		// Safe to resume operation.
+		spin.Start()
 	}
 	go func() {
 		select {


### PR DESCRIPTION
The messages never show up in VSCode integrated terminal due to the
defer `fmt.Fprintf`. There could be a race in VSCode in handling the
terminal codes but ultimately, we can simplify our logic by just
stopping the spinner for the duration of the update.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
