### PR TITLE
fix: Revert develop.sh timeout -> curl change

### DIFF
--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -96,7 +96,7 @@ fatal() {
 	start_cmd "${CODER_DEV_SHIM}" server --address 0.0.0.0:3000
 
 	echo '== Waiting for Coder to become ready'
-	curl --silent --fail --connect-timeout 1 --max-time 1 --retry 60 --retry-delay 1 --retry-max-time 60 --retry-all-errors 'http://localhost:3000/healthz' ||
+	timeout 60s bash -c 'until curl -s --fail http://localhost:3000/healthz > /dev/null 2>&1; do sleep 0.5; done' ||
 		fatal 'Coder did not become ready in time'
 
 	# Check if credentials are already set up to avoid setting up again.


### PR DESCRIPTION
It seems `--retry-all-errors` is not available on e.g. curl 7.68.0.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
