### PR TITLE
feat: add count to get users endpoint

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -102,12 +102,12 @@ func list() *cobra.Command {
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 				return nil
 			}
-			users, err := client.Users(cmd.Context(), codersdk.UsersRequest{})
+			userRes, err := client.Users(cmd.Context(), codersdk.UsersRequest{})
 			if err != nil {
 				return err
 			}
 			usersByID := map[uuid.UUID]codersdk.User{}
-			for _, user := range users {
+			for _, user := range userRes.Users {
 				usersByID[user.ID] = user
 			}
 

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -30,7 +30,7 @@ func userList() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			users, err := client.Users(cmd.Context(), codersdk.UsersRequest{})
+			res, err := client.Users(cmd.Context(), codersdk.UsersRequest{})
 			if err != nil {
 				return err
 			}
@@ -38,12 +38,12 @@ func userList() *cobra.Command {
 			out := ""
 			switch outputFormat {
 			case "table", "":
-				out, err = cliui.DisplayTable(users, "Username", columns)
+				out, err = cliui.DisplayTable(res.Users, "Username", columns)
 				if err != nil {
 					return xerrors.Errorf("render table: %w", err)
 				}
 			case "json":
-				outBytes, err := json.Marshal(users)
+				outBytes, err := json.Marshal(res.Users)
 				if err != nil {
 					return xerrors.Errorf("marshal users to JSON: %w", err)
 				}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -437,7 +437,6 @@ func New(options *Options) *API {
 				)
 				r.Post("/", api.postUser)
 				r.Get("/", api.users)
-				r.Get("/count", api.userCount)
 				r.Post("/logout", api.postLogout)
 				// These routes query information about site wide roles.
 				r.Route("/roles", func(r chi.Router) {

--- a/coderd/coderdtest/authorize.go
+++ b/coderd/coderdtest/authorize.go
@@ -245,7 +245,6 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 
 		// Endpoints that use the SQLQuery filter.
 		"GET:/api/v2/workspaces/": {StatusCode: http.StatusOK, NoAuthorize: true},
-		"GET:/api/v2/users/count": {StatusCode: http.StatusOK, NoAuthorize: true},
 	}
 
 	// Routes like proxy routes support all HTTP methods. A helper func to expand

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -71,3 +71,25 @@ func (User) RBACObject() rbac.Object {
 func (License) RBACObject() rbac.Object {
 	return rbac.ResourceLicense
 }
+
+func ConvertUserRows(rows []GetUsersRow) []User {
+	users := make([]User, len(rows))
+	for i, r := range rows {
+		users[i] = User{
+			ID:             r.ID,
+			Email:          r.Email,
+			Username:       r.Username,
+			HashedPassword: r.HashedPassword,
+			CreatedAt:      r.CreatedAt,
+			UpdatedAt:      r.UpdatedAt,
+			Status:         r.Status,
+			RBACRoles:      r.RBACRoles,
+			LoginType:      r.LoginType,
+			AvatarURL:      r.AvatarURL,
+			Deleted:        r.Deleted,
+			LastSeenAt:     r.LastSeenAt,
+		}
+	}
+
+	return users
+}

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -121,7 +121,7 @@ type sqlcQuerier interface {
 	GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesByJobIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceResource, error)
-	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]GetWorkspacesRow, error)
+	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]Workspace, error)
 	InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (APIKey, error)
 	InsertAgentStat(ctx context.Context, arg InsertAgentStatParams) (AgentStat, error)
 	// We use the organization_id as the id

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -91,7 +91,7 @@ type sqlcQuerier interface {
 	GetUserGroups(ctx context.Context, userID uuid.UUID) ([]Group, error)
 	GetUserLinkByLinkedID(ctx context.Context, linkedID string) (UserLink, error)
 	GetUserLinkByUserIDLoginType(ctx context.Context, arg GetUserLinkByUserIDLoginTypeParams) (UserLink, error)
-	GetUsers(ctx context.Context, arg GetUsersParams) ([]User, error)
+	GetUsers(ctx context.Context, arg GetUsersParams) ([]GetUsersRow, error)
 	// This shouldn't check for deleted, because it's frequently used
 	// to look up references to actions. eg. a user could build a workspace
 	// for another user, then be deleted... we still want them to appear!
@@ -121,7 +121,7 @@ type sqlcQuerier interface {
 	GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesByJobIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceResource, error)
-	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]Workspace, error)
+	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]GetWorkspacesRow, error)
 	InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (APIKey, error)
 	InsertAgentStat(ctx context.Context, arg InsertAgentStatParams) (AgentStat, error)
 	// We use the organization_id as the id

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6080,7 +6080,7 @@ func (q *sqlQuerier) GetWorkspaceOwnerCountsByTemplateIDs(ctx context.Context, i
 
 const getWorkspaces = `-- name: GetWorkspaces :many
 SELECT
-	workspaces.id, workspaces.created_at, workspaces.updated_at, workspaces.owner_id, workspaces.organization_id, workspaces.template_id, workspaces.deleted, workspaces.name, workspaces.autostart_schedule, workspaces.ttl, workspaces.last_used_at, COUNT(workspaces.*) OVER() AS count
+	workspaces.id, workspaces.created_at, workspaces.updated_at, workspaces.owner_id, workspaces.organization_id, workspaces.template_id, workspaces.deleted, workspaces.name, workspaces.autostart_schedule, workspaces.ttl, workspaces.last_used_at
 FROM
 	workspaces
 LEFT JOIN LATERAL (
@@ -6227,22 +6227,7 @@ type GetWorkspacesParams struct {
 	Limit         int32       `db:"limit_" json:"limit_"`
 }
 
-type GetWorkspacesRow struct {
-	ID                uuid.UUID      `db:"id" json:"id"`
-	CreatedAt         time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt         time.Time      `db:"updated_at" json:"updated_at"`
-	OwnerID           uuid.UUID      `db:"owner_id" json:"owner_id"`
-	OrganizationID    uuid.UUID      `db:"organization_id" json:"organization_id"`
-	TemplateID        uuid.UUID      `db:"template_id" json:"template_id"`
-	Deleted           bool           `db:"deleted" json:"deleted"`
-	Name              string         `db:"name" json:"name"`
-	AutostartSchedule sql.NullString `db:"autostart_schedule" json:"autostart_schedule"`
-	Ttl               sql.NullInt64  `db:"ttl" json:"ttl"`
-	LastUsedAt        time.Time      `db:"last_used_at" json:"last_used_at"`
-	Count             int64          `db:"count" json:"count"`
-}
-
-func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]GetWorkspacesRow, error) {
+func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]Workspace, error) {
 	rows, err := q.db.QueryContext(ctx, getWorkspaces,
 		arg.Deleted,
 		arg.Status,
@@ -6258,9 +6243,9 @@ func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams)
 		return nil, err
 	}
 	defer rows.Close()
-	var items []GetWorkspacesRow
+	var items []Workspace
 	for rows.Next() {
-		var i GetWorkspacesRow
+		var i Workspace
 		if err := rows.Scan(
 			&i.ID,
 			&i.CreatedAt,
@@ -6273,7 +6258,6 @@ func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams)
 			&i.AutostartSchedule,
 			&i.Ttl,
 			&i.LastUsedAt,
-			&i.Count,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -128,7 +128,7 @@ WHERE
 
 -- name: GetUsers :many
 SELECT
-	*
+	*, COUNT(*) OVER() AS count
 FROM
 	users
 WHERE

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -10,7 +10,7 @@ LIMIT
 
 -- name: GetWorkspaces :many
 SELECT
-	workspaces.*, COUNT(workspaces.*) OVER() AS count
+	workspaces.*
 FROM
 	workspaces
 LEFT JOIN LATERAL (

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -10,7 +10,7 @@ LIMIT
 
 -- name: GetWorkspaces :many
 SELECT
-	workspaces.*
+	workspaces.*, COUNT(workspaces.*) OVER() AS count
 FROM
 	workspaces
 LEFT JOIN LATERAL (

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -344,10 +344,11 @@ func (r *remoteReporter) createSnapshot() (*Snapshot, error) {
 		return nil
 	})
 	eg.Go(func() error {
-		users, err := r.options.Database.GetUsers(ctx, database.GetUsersParams{})
+		userRows, err := r.options.Database.GetUsers(ctx, database.GetUsersParams{})
 		if err != nil {
 			return xerrors.Errorf("get users: %w", err)
 		}
+		users := database.ConvertUserRows(userRows)
 		var firstUser database.User
 		for _, dbUser := range users {
 			if dbUser.Status != database.UserStatusActive {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -198,7 +198,7 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	users, err := api.Database.GetUsers(ctx, database.GetUsersParams{
+	userRows, err := api.Database.GetUsers(ctx, database.GetUsersParams{
 		AfterID:   paginationParams.AfterID,
 		OffsetOpt: int32(paginationParams.Offset),
 		LimitOpt:  int32(paginationParams.Limit),
@@ -206,10 +206,6 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 		Status:    params.Status,
 		RbacRole:  params.RbacRole,
 	})
-	if errors.Is(err, sql.ErrNoRows) {
-		httpapi.Write(ctx, rw, http.StatusOK, []codersdk.User{})
-		return
-	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching users.",
@@ -217,8 +213,17 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// GetUsers does not return ErrNoRows because it uses a window function to get the count.
+	// So we need to check if the userRows is empty and return an empty array if so.
+	if len(userRows) == 0 {
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.GetUsersResponse{
+			Users: []codersdk.User{},
+			Count: 0,
+		})
+		return
+	}
 
-	users, err = AuthorizeFilter(api.HTTPAuth, r, rbac.ActionRead, users)
+	users, err := AuthorizeFilter(api.HTTPAuth, r, rbac.ActionRead, database.ConvertUserRows(userRows))
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching users.",
@@ -248,7 +253,10 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Status(r, http.StatusOK)
-	render.JSON(rw, r, convertUsers(users, organizationIDsByUserID))
+	render.JSON(rw, r, codersdk.GetUsersResponse{
+		Users: convertUsers(users, organizationIDsByUserID),
+		Count: int(userRows[0].Count),
+	})
 }
 
 func (api *API) userCount(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -259,42 +259,6 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (api *API) userCount(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	query := r.URL.Query().Get("q")
-	params, errs := userSearchQuery(query)
-	if len(errs) > 0 {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message:     "Invalid user search query.",
-			Validations: errs,
-		})
-		return
-	}
-
-	sqlFilter, err := api.HTTPAuth.AuthorizeSQLFilter(r, rbac.ActionRead, rbac.ResourceUser.Type)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error preparing sql filter.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	count, err := api.Database.GetAuthorizedUserCount(ctx, database.GetFilteredUserCountParams{
-		Search:   params.Search,
-		Status:   params.Status,
-		RbacRole: params.RbacRole,
-	}, sqlFilter)
-	if err != nil {
-		httpapi.InternalServerError(rw, err)
-		return
-	}
-
-	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UserCountResponse{
-		Count: count,
-	})
-}
-
 // Creates a new user.
 func (api *API) postUser(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1307,61 +1307,58 @@ func TestGetFilteredUserCount(t *testing.T) {
 	})
 }
 
-func TestNewGetUsers(t *testing.T) {
+func TestGetUsersPagination(t *testing.T) {
 	t.Parallel()
-	t.Run("Pagination", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+	client := coderdtest.New(t, nil)
+	first := coderdtest.CreateFirstUser(t, client)
 
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
 
-		_, err := client.User(ctx, first.UserID.String())
-		require.NoError(t, err, "")
+	_, err := client.User(ctx, first.UserID.String())
+	require.NoError(t, err, "")
 
-		_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "alice@email.com",
-			Username:       "alice",
-			Password:       "password",
-			OrganizationID: first.OrganizationID,
-		})
-		require.NoError(t, err)
-
-		res, err := client.Users(ctx, codersdk.UsersRequest{})
-		require.NoError(t, err)
-		require.Len(t, res.Users, 2)
-		require.Equal(t, res.Count, 2)
-
-		res, err = client.Users(ctx, codersdk.UsersRequest{
-			Pagination: codersdk.Pagination{
-				Limit: 1,
-			},
-		})
-		require.NoError(t, err)
-		require.Len(t, res.Users, 1)
-		require.Equal(t, res.Count, 2)
-
-		res, err = client.Users(ctx, codersdk.UsersRequest{
-			Pagination: codersdk.Pagination{
-				Offset: 1,
-			},
-		})
-		require.NoError(t, err)
-		require.Len(t, res.Users, 1)
-		require.Equal(t, res.Count, 2)
-
-		// if offset is higher than the count postgres returns an empty array
-		// and not an ErrNoRows error. This also means the count must be 0.
-		res, err = client.Users(ctx, codersdk.UsersRequest{
-			Pagination: codersdk.Pagination{
-				Offset: 3,
-			},
-		})
-		require.NoError(t, err)
-		require.Len(t, res.Users, 0)
-		require.Equal(t, res.Count, 0)
+	_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
+		Email:          "alice@email.com",
+		Username:       "alice",
+		Password:       "password",
+		OrganizationID: first.OrganizationID,
 	})
+	require.NoError(t, err)
+
+	res, err := client.Users(ctx, codersdk.UsersRequest{})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 2)
+	require.Equal(t, res.Count, 2)
+
+	res, err = client.Users(ctx, codersdk.UsersRequest{
+		Pagination: codersdk.Pagination{
+			Limit: 1,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 1)
+	require.Equal(t, res.Count, 2)
+
+	res, err = client.Users(ctx, codersdk.UsersRequest{
+		Pagination: codersdk.Pagination{
+			Offset: 1,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 1)
+	require.Equal(t, res.Count, 2)
+
+	// if offset is higher than the count postgres returns an empty array
+	// and not an ErrNoRows error. This also means the count must be 0.
+	res, err = client.Users(ctx, codersdk.UsersRequest{
+		Pagination: codersdk.Pagination{
+			Offset: 3,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 0)
+	require.Equal(t, res.Count, 0)
 }
 
 func TestPostTokens(t *testing.T) {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -81,11 +81,11 @@ func TestFirstUser(t *testing.T) {
 		allUsers, err := client.Users(ctx, codersdk.UsersRequest{})
 		require.NoError(t, err)
 
-		require.Len(t, allUsers, 2)
+		require.Len(t, allUsers.Users, 2)
 
 		// We sent the "GET Users" request with the first user, but the second user
 		// should be Never since they haven't performed a request.
-		for _, user := range allUsers {
+		for _, user := range allUsers.Users {
 			if user.ID == firstUser.ID {
 				require.WithinDuration(t, firstUser.LastSeenAt, database.Now(), testutil.WaitShort)
 			} else {
@@ -1211,7 +1211,7 @@ func TestGetUsers(t *testing.T) {
 		users, err := client.Users(ctx, codersdk.UsersRequest{})
 		require.NoError(t, err)
 		require.Len(t, users, 2)
-		require.Len(t, users[0].OrganizationIDs, 1)
+		require.Len(t, users.Users[0].OrganizationIDs, 1)
 	})
 	t.Run("ActiveUsers", func(t *testing.T) {
 		t.Parallel()
@@ -1304,6 +1304,63 @@ func TestGetFilteredUserCount(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, 1, int(response.Count))
+	})
+}
+
+func TestNewGetUsers(t *testing.T) {
+	t.Parallel()
+	t.Run("Pagination", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.User(ctx, first.UserID.String())
+		require.NoError(t, err, "")
+
+		_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
+			Email:          "alice@email.com",
+			Username:       "alice",
+			Password:       "password",
+			OrganizationID: first.OrganizationID,
+		})
+		require.NoError(t, err)
+
+		res, err := client.Users(ctx, codersdk.UsersRequest{})
+		require.NoError(t, err)
+		require.Len(t, res.Users, 2)
+		require.Equal(t, res.Count, 2)
+
+		res, err = client.Users(ctx, codersdk.UsersRequest{
+			Pagination: codersdk.Pagination{
+				Limit: 1,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Users, 1)
+		require.Equal(t, res.Count, 2)
+
+		res, err = client.Users(ctx, codersdk.UsersRequest{
+			Pagination: codersdk.Pagination{
+				Offset: 1,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Users, 1)
+		require.Equal(t, res.Count, 2)
+
+		// if offset is higher than the count postgres returns an empty array
+		// and not an ErrNoRows error. This also means the count must be 0.
+		res, err = client.Users(ctx, codersdk.UsersRequest{
+			Pagination: codersdk.Pagination{
+				Offset: 3,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Users, 0)
+		require.Equal(t, res.Count, 0)
 	})
 }
 
@@ -1546,15 +1603,15 @@ func assertPagination(ctx context.Context, t *testing.T, client *codersdk.Client
 		},
 	}))
 	require.NoError(t, err, "first page")
-	require.Equalf(t, page, allUsers[:limit], "first page, limit=%d", limit)
-	count += len(page)
+	require.Equalf(t, page.Users, allUsers[:limit], "first page, limit=%d", limit)
+	count += len(page.Users)
 
 	for {
-		if len(page) == 0 {
+		if len(page.Users) == 0 {
 			break
 		}
 
-		afterCursor := page[len(page)-1].ID
+		afterCursor := page.Users[len(page.Users)-1].ID
 		// Assert each page is the next expected page
 		// This is using a cursor, and only works if all users created_at
 		// is unique.
@@ -1593,7 +1650,7 @@ func assertPagination(ctx context.Context, t *testing.T, client *codersdk.Client
 		}))
 		require.NoError(t, err, "prev page")
 		require.Equal(t, allUsers[count-limit:count], prevPage, "prev users")
-		count += len(page)
+		count += len(page.Users)
 	}
 }
 

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1255,58 +1255,6 @@ func TestGetUsers(t *testing.T) {
 	})
 }
 
-func TestGetFilteredUserCount(t *testing.T) {
-	t.Parallel()
-	t.Run("AllUsers", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		user := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "alice@email.com",
-			Username:       "alice",
-			Password:       "password",
-			OrganizationID: user.OrganizationID,
-		})
-		// No params is all users
-		response, err := client.UserCount(ctx, codersdk.UserCountRequest{})
-		require.NoError(t, err)
-		require.Equal(t, 2, int(response.Count))
-	})
-	t.Run("ActiveUsers", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.User(ctx, first.UserID.String())
-		require.NoError(t, err, "")
-
-		// Alice will be suspended
-		alice, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "alice@email.com",
-			Username:       "alice",
-			Password:       "password",
-			OrganizationID: first.OrganizationID,
-		})
-		require.NoError(t, err)
-
-		_, err = client.UpdateUserStatus(ctx, alice.Username, codersdk.UserStatusSuspended)
-		require.NoError(t, err)
-
-		response, err := client.UserCount(ctx, codersdk.UserCountRequest{
-			Status: codersdk.UserStatusActive,
-		})
-		require.NoError(t, err)
-		require.Equal(t, 1, int(response.Count))
-	})
-}
-
 func TestGetUsersPagination(t *testing.T) {
 	t.Parallel()
 	client := coderdtest.New(t, nil)

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -52,20 +52,6 @@ type GetUsersResponse struct {
 	Count int    `json:"count"`
 }
 
-type UserCountRequest struct {
-	Search string `json:"search,omitempty" typescript:"-"`
-	// Filter users by status.
-	Status UserStatus `json:"status,omitempty" typescript:"-"`
-	// Filter users that have the given role.
-	Role string `json:"role,omitempty" typescript:"-"`
-
-	SearchQuery string `json:"q,omitempty"`
-}
-
-type UserCountResponse struct {
-	Count int64 `json:"count"`
-}
-
 type CreateFirstUserRequest struct {
 	Email            string `json:"email" validate:"required,email"`
 	Username         string `json:"username" validate:"required,username"`
@@ -362,40 +348,6 @@ func (c *Client) Users(ctx context.Context, req UsersRequest) (GetUsersResponse,
 
 	var usersRes GetUsersResponse
 	return usersRes, json.NewDecoder(res.Body).Decode(&usersRes)
-}
-
-func (c *Client) UserCount(ctx context.Context, req UserCountRequest) (UserCountResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/v2/users/count", nil,
-		func(r *http.Request) {
-			q := r.URL.Query()
-			var params []string
-			if req.Search != "" {
-				params = append(params, req.Search)
-			}
-			if req.Status != "" {
-				params = append(params, "status:"+string(req.Status))
-			}
-			if req.Role != "" {
-				params = append(params, "role:"+req.Role)
-			}
-			if req.SearchQuery != "" {
-				params = append(params, req.SearchQuery)
-			}
-			q.Set("q", strings.Join(params, " "))
-			r.URL.RawQuery = q.Encode()
-		},
-	)
-	if err != nil {
-		return UserCountResponse{}, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return UserCountResponse{}, readBodyAsError(res)
-	}
-
-	var count UserCountResponse
-	return count, json.NewDecoder(res.Body).Decode(&count)
 }
 
 // OrganizationsByUser returns all organizations the user is a member of.

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -47,6 +47,11 @@ type User struct {
 	AvatarURL       string      `json:"avatar_url"`
 }
 
+type GetUsersResponse struct {
+	Users []User `json:"users"`
+	Count int    `json:"count"`
+}
+
 type UserCountRequest struct {
 	Search string `json:"search,omitempty" typescript:"-"`
 	// Filter users by status.
@@ -324,7 +329,7 @@ func (c *Client) User(ctx context.Context, userIdent string) (User, error) {
 
 // Users returns all users according to the request parameters. If no parameters are set,
 // the default behavior is to return all users in a single page.
-func (c *Client) Users(ctx context.Context, req UsersRequest) ([]User, error) {
+func (c *Client) Users(ctx context.Context, req UsersRequest) (GetUsersResponse, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/v2/users", nil,
 		req.Pagination.asRequestOption(),
 		func(r *http.Request) {
@@ -347,16 +352,16 @@ func (c *Client) Users(ctx context.Context, req UsersRequest) ([]User, error) {
 		},
 	)
 	if err != nil {
-		return []User{}, err
+		return GetUsersResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return []User{}, readBodyAsError(res)
+		return GetUsersResponse{}, readBodyAsError(res)
 	}
 
-	var users []User
-	return users, json.NewDecoder(res.Body).Decode(&users)
+	var usersRes GetUsersResponse
+	return usersRes, json.NewDecoder(res.Body).Decode(&usersRes)
 }
 
 func (c *Client) UserCount(ctx context.Context, req UserCountRequest) (UserCountResponse, error) {

--- a/enterprise/cli/groupedit.go
+++ b/enterprise/cli/groupedit.go
@@ -54,17 +54,17 @@ func groupEdit() *cobra.Command {
 				req.AvatarURL = &avatarURL
 			}
 
-			users, err := client.Users(ctx, codersdk.UsersRequest{})
+			userRes, err := client.Users(ctx, codersdk.UsersRequest{})
 			if err != nil {
 				return xerrors.Errorf("get users: %w", err)
 			}
 
-			req.AddUsers, err = convertToUserIDs(addUsers, users)
+			req.AddUsers, err = convertToUserIDs(addUsers, userRes.Users)
 			if err != nil {
 				return xerrors.Errorf("parse add-users: %w", err)
 			}
 
-			req.RemoveUsers, err = convertToUserIDs(rmUsers, users)
+			req.RemoveUsers, err = convertToUserIDs(rmUsers, userRes.Users)
 			if err != nil {
 				return xerrors.Errorf("parse rm-users: %w", err)
 			}

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -114,12 +114,12 @@ func TestScim(t *testing.T) {
 			defer res.Body.Close()
 			assert.Equal(t, http.StatusOK, res.StatusCode)
 
-			users, err := client.Users(ctx, codersdk.UsersRequest{Search: sUser.Emails[0].Value})
+			userRes, err := client.Users(ctx, codersdk.UsersRequest{Search: sUser.Emails[0].Value})
 			require.NoError(t, err)
-			require.Len(t, users, 1)
+			require.Len(t, userRes.Users, 1)
 
-			assert.Equal(t, sUser.Emails[0].Value, users[0].Email)
-			assert.Equal(t, sUser.UserName, users[0].Username)
+			assert.Equal(t, sUser.Emails[0].Value, userRes.Users[0].Email)
+			assert.Equal(t, sUser.UserName, userRes.Users[0].Username)
 		})
 	})
 
@@ -194,10 +194,10 @@ func TestScim(t *testing.T) {
 			defer res.Body.Close()
 			assert.Equal(t, http.StatusOK, res.StatusCode)
 
-			users, err := client.Users(ctx, codersdk.UsersRequest{Search: sUser.Emails[0].Value})
+			userRes, err := client.Users(ctx, codersdk.UsersRequest{Search: sUser.Emails[0].Value})
 			require.NoError(t, err)
-			require.Len(t, users, 1)
-			assert.Equal(t, codersdk.UserStatusSuspended, users[0].Status)
+			require.Len(t, userRes.Users, 1)
+			assert.Equal(t, codersdk.UserStatusSuspended, userRes.Users[0].Status)
 		})
 	})
 }

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -139,14 +139,6 @@ export const getUsers = async (
   return response.data
 }
 
-export const getUserCount = async (
-  options: TypesGen.UserCountRequest,
-): Promise<TypesGen.UserCountResponse> => {
-  const url = getURLWithSearchParams("/api/v2/users/count", options)
-  const response = await axios.get(url.toString())
-  return response.data
-}
-
 export const getOrganization = async (
   organizationId: string,
 ): Promise<TypesGen.Organization> => {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -133,9 +133,9 @@ export const getApiKey = async (): Promise<TypesGen.GenerateAPIKeyResponse> => {
 
 export const getUsers = async (
   options: TypesGen.UsersRequest,
-): Promise<TypesGen.User[]> => {
+): Promise<TypesGen.GetUsersResponse> => {
   const url = getURLWithSearchParams("/api/v2/users", options)
-  const response = await axios.get<TypesGen.User[]>(url.toString())
+  const response = await axios.get<TypesGen.GetUsersResponse>(url.toString())
   return response.data
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -755,16 +755,6 @@ export interface User {
 }
 
 // From codersdk/users.go
-export interface UserCountRequest {
-  readonly q?: string
-}
-
-// From codersdk/users.go
-export interface UserCountResponse {
-  readonly count: number
-}
-
-// From codersdk/users.go
 export interface UserRoles {
   readonly roles: string[]
   readonly organization_roles: Record<string, string[]>

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -347,6 +347,12 @@ export interface GetAppHostResponse {
   readonly host: string
 }
 
+// From codersdk/users.go
+export interface GetUsersResponse {
+  readonly users: User[]
+  readonly count: number
+}
+
 // From codersdk/deploymentconfig.go
 export interface GitAuthConfig {
   readonly id: string

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -32,7 +32,9 @@ describe("CreateWorkspacePage", () => {
   })
 
   it("succeeds with default owner", async () => {
-    jest.spyOn(API, "getUsers").mockResolvedValueOnce({ users: [MockUser], count: 1 })
+    jest
+      .spyOn(API, "getUsers")
+      .mockResolvedValueOnce({ users: [MockUser], count: 1 })
     jest
       .spyOn(API, "getWorkspaceQuota")
       .mockResolvedValueOnce(MockWorkspaceQuota)

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -32,7 +32,7 @@ describe("CreateWorkspacePage", () => {
   })
 
   it("succeeds with default owner", async () => {
-    jest.spyOn(API, "getUsers").mockResolvedValueOnce([MockUser])
+    jest.spyOn(API, "getUsers").mockResolvedValueOnce({ users: [MockUser], count: 1 })
     jest
       .spyOn(API, "getWorkspaceQuota")
       .mockResolvedValueOnce(MockWorkspaceQuota)

--- a/site/src/pages/UsersPage/UsersPage.test.tsx
+++ b/site/src/pages/UsersPage/UsersPage.test.tsx
@@ -199,12 +199,10 @@ describe("UsersPage", () => {
 
         await suspendUser(() => {
           jest.spyOn(API, "suspendUser").mockResolvedValueOnce(MockUser)
-          jest
-            .spyOn(API, "getUsers")
-            .mockResolvedValueOnce({
-              users: [SuspendedMockUser, MockUser2],
-              count: 2,
-            })
+          jest.spyOn(API, "getUsers").mockResolvedValueOnce({
+            users: [SuspendedMockUser, MockUser2],
+            count: 2,
+          })
         })
 
         // Check if the success message is displayed
@@ -277,12 +275,10 @@ describe("UsersPage", () => {
 
         await deleteUser(() => {
           jest.spyOn(API, "deleteUser").mockResolvedValueOnce(undefined)
-          jest
-            .spyOn(API, "getUsers")
-            .mockResolvedValueOnce({
-              users: [MockUser, SuspendedMockUser],
-              count: 2,
-            })
+          jest.spyOn(API, "getUsers").mockResolvedValueOnce({
+            users: [MockUser, SuspendedMockUser],
+            count: 2,
+          })
         })
 
         // Check if the success message is displayed
@@ -326,14 +322,12 @@ describe("UsersPage", () => {
           jest
             .spyOn(API, "activateUser")
             .mockResolvedValueOnce(SuspendedMockUser)
-          jest
-            .spyOn(API, "getUsers")
-            .mockImplementationOnce(() =>
-              Promise.resolve({
-                users: [MockUser, MockUser2, SuspendedMockUser],
-                count: 3,
-              }),
-            )
+          jest.spyOn(API, "getUsers").mockImplementationOnce(() =>
+            Promise.resolve({
+              users: [MockUser, MockUser2, SuspendedMockUser],
+              count: 3,
+            }),
+          )
         })
 
         // Check if the success message is displayed

--- a/site/src/pages/UsersPage/UsersPage.test.tsx
+++ b/site/src/pages/UsersPage/UsersPage.test.tsx
@@ -201,7 +201,10 @@ describe("UsersPage", () => {
           jest.spyOn(API, "suspendUser").mockResolvedValueOnce(MockUser)
           jest
             .spyOn(API, "getUsers")
-            .mockResolvedValueOnce({ users: [SuspendedMockUser, MockUser2], count: 2 })
+            .mockResolvedValueOnce({
+              users: [SuspendedMockUser, MockUser2],
+              count: 2,
+            })
         })
 
         // Check if the success message is displayed
@@ -276,7 +279,10 @@ describe("UsersPage", () => {
           jest.spyOn(API, "deleteUser").mockResolvedValueOnce(undefined)
           jest
             .spyOn(API, "getUsers")
-            .mockResolvedValueOnce({ users: [MockUser, SuspendedMockUser], count: 2 })
+            .mockResolvedValueOnce({
+              users: [MockUser, SuspendedMockUser],
+              count: 2,
+            })
         })
 
         // Check if the success message is displayed
@@ -323,7 +329,10 @@ describe("UsersPage", () => {
           jest
             .spyOn(API, "getUsers")
             .mockImplementationOnce(() =>
-              Promise.resolve({ users: [MockUser, MockUser2, SuspendedMockUser], count: 3 }),
+              Promise.resolve({
+                users: [MockUser, MockUser2, SuspendedMockUser],
+                count: 3,
+              }),
             )
         })
 

--- a/site/src/pages/UsersPage/UsersPage.test.tsx
+++ b/site/src/pages/UsersPage/UsersPage.test.tsx
@@ -201,7 +201,7 @@ describe("UsersPage", () => {
           jest.spyOn(API, "suspendUser").mockResolvedValueOnce(MockUser)
           jest
             .spyOn(API, "getUsers")
-            .mockResolvedValueOnce([SuspendedMockUser, MockUser2])
+            .mockResolvedValueOnce({ users: [SuspendedMockUser, MockUser2], count: 2 })
         })
 
         // Check if the success message is displayed
@@ -240,7 +240,7 @@ describe("UsersPage", () => {
 
       const mock = jest
         .spyOn(API, "getUsers")
-        .mockResolvedValueOnce([MockUser, MockUser2])
+        .mockResolvedValueOnce({ users: [MockUser, MockUser2], count: 2 })
 
       const nextButton = await screen.findByLabelText("Next page")
       expect(nextButton).toBeEnabled()
@@ -276,7 +276,7 @@ describe("UsersPage", () => {
           jest.spyOn(API, "deleteUser").mockResolvedValueOnce(undefined)
           jest
             .spyOn(API, "getUsers")
-            .mockResolvedValueOnce([MockUser, SuspendedMockUser])
+            .mockResolvedValueOnce({ users: [MockUser, SuspendedMockUser], count: 2 })
         })
 
         // Check if the success message is displayed
@@ -323,7 +323,7 @@ describe("UsersPage", () => {
           jest
             .spyOn(API, "getUsers")
             .mockImplementationOnce(() =>
-              Promise.resolve([MockUser, MockUser2, SuspendedMockUser]),
+              Promise.resolve({ users: [MockUser, MockUser2, SuspendedMockUser], count: 3 }),
             )
         })
 

--- a/site/src/pages/UsersPage/UsersPage.test.tsx
+++ b/site/src/pages/UsersPage/UsersPage.test.tsx
@@ -241,7 +241,7 @@ describe("UsersPage", () => {
 
       const mock = jest
         .spyOn(API, "getUsers")
-        .mockResolvedValueOnce({ users: [MockUser, MockUser2], count: 2 })
+        .mockResolvedValueOnce({ users: [MockUser, MockUser2], count: 26 })
 
       const nextButton = await screen.findByLabelText("Next page")
       expect(nextButton).toBeEnabled()

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -66,7 +66,7 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
   // - users are loading or
   // - the user can edit the users but the roles are loading
   const isLoading =
-    usersState.matches("users.gettingUsers") ||
+    usersState.matches("gettingUsers") ||
     (canEditUsers && rolesState.matches("gettingRoles"))
 
   // Fetch roles on component mount
@@ -130,7 +130,7 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
           })
         }}
         error={getUsersError}
-        isUpdatingUserRoles={usersState.matches("users.updatingUserRoles")}
+        isUpdatingUserRoles={usersState.matches("updatingUserRoles")}
         isLoading={isLoading}
         canEditUsers={canEditUsers}
         filter={usersState.context.filter}
@@ -143,10 +143,10 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
 
       <DeleteDialog
         isOpen={
-          usersState.matches("users.confirmUserDeletion") ||
-          usersState.matches("users.deletingUser")
+          usersState.matches("confirmUserDeletion") ||
+          usersState.matches("deletingUser")
         }
-        confirmLoading={usersState.matches("users.deletingUser")}
+        confirmLoading={usersState.matches("deletingUser")}
         name={usernameToDelete ?? ""}
         entity="user"
         onConfirm={() => {
@@ -161,10 +161,10 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
         type="delete"
         hideCancel={false}
         open={
-          usersState.matches("users.confirmUserSuspension") ||
-          usersState.matches("users.suspendingUser")
+          usersState.matches("confirmUserSuspension") ||
+          usersState.matches("suspendingUser")
         }
-        confirmLoading={usersState.matches("users.suspendingUser")}
+        confirmLoading={usersState.matches("suspendingUser")}
         title={Language.suspendDialogTitle}
         confirmText={Language.suspendDialogAction}
         onConfirm={() => {
@@ -186,10 +186,10 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
         type="success"
         hideCancel={false}
         open={
-          usersState.matches("users.confirmUserActivation") ||
-          usersState.matches("users.activatingUser")
+          usersState.matches("confirmUserActivation") ||
+          usersState.matches("activatingUser")
         }
-        confirmLoading={usersState.matches("users.activatingUser")}
+        confirmLoading={usersState.matches("activatingUser")}
         title={Language.activateDialogTitle}
         confirmText={Language.activateDialogAction}
         onConfirm={() => {
@@ -210,10 +210,10 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
       {userIdToResetPassword && (
         <ResetPasswordDialog
           open={
-            usersState.matches("users.confirmUserPasswordReset") ||
-            usersState.matches("users.resettingUserPassword")
+            usersState.matches("confirmUserPasswordReset") ||
+            usersState.matches("resettingUserPassword")
           }
-          loading={usersState.matches("users.resettingUserPassword")}
+          loading={usersState.matches("resettingUserPassword")}
           user={getSelectedUser(userIdToResetPassword, users)}
           newPassword={newUserPassword}
           onClose={() => {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -83,10 +83,6 @@ export const MockUser: TypesGen.User = {
   last_seen_at: "",
 }
 
-export const MockUserCountResponse: TypesGen.UserCountResponse = {
-  count: 26,
-}
-
 export const MockUserAdmin: TypesGen.User = {
   id: "test-user",
   username: "TestUser",

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -71,7 +71,10 @@ export const handlers = [
   rest.get("/api/v2/users", async (req, res, ctx) => {
     return res(
       ctx.status(200),
-      ctx.json({ users: [M.MockUser, M.MockUser2, M.SuspendedMockUser], count: 26 }),
+      ctx.json({
+        users: [M.MockUser, M.MockUser2, M.SuspendedMockUser],
+        count: 26,
+      }),
     )
   }),
   rest.get("/api/v2/users/me/organizations", (req, res, ctx) => {

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -74,9 +74,6 @@ export const handlers = [
       ctx.json([M.MockUser, M.MockUser2, M.SuspendedMockUser]),
     )
   }),
-  rest.get("/api/v2/users/count", async (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(M.MockUserCountResponse))
-  }),
   rest.get("/api/v2/users/me/organizations", (req, res, ctx) => {
     return res(ctx.status(200), ctx.json([M.MockOrganization]))
   }),

--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -71,7 +71,7 @@ export const handlers = [
   rest.get("/api/v2/users", async (req, res, ctx) => {
     return res(
       ctx.status(200),
-      ctx.json([M.MockUser, M.MockUser2, M.SuspendedMockUser]),
+      ctx.json({ users: [M.MockUser, M.MockUser2, M.SuspendedMockUser], count: 26 }),
     )
   }),
   rest.get("/api/v2/users/me/organizations", (req, res, ctx) => {

--- a/site/src/xServices/template/searchUsersAndGroupsXService.ts
+++ b/site/src/xServices/template/searchUsersAndGroupsXService.ts
@@ -64,7 +64,10 @@ export const searchUsersAndGroupsMachine = createMachine(
 
         // The Everyone groups is not returned by the API so we have to add it
         // manually
-        return { users: userRes.users, groups: [everyOneGroup(organizationId), ...groups] }
+        return {
+          users: userRes.users,
+          groups: [everyOneGroup(organizationId), ...groups],
+        }
       },
     },
     actions: {

--- a/site/src/xServices/template/searchUsersAndGroupsXService.ts
+++ b/site/src/xServices/template/searchUsersAndGroupsXService.ts
@@ -57,14 +57,14 @@ export const searchUsersAndGroupsMachine = createMachine(
   {
     services: {
       search: async ({ organizationId }, { query }) => {
-        const [users, groups] = await Promise.all([
-          (await getUsers(queryToFilter(query))).users,
+        const [userRes, groups] = await Promise.all([
+          getUsers(queryToFilter(query)),
           getGroups(organizationId),
         ])
 
         // The Everyone groups is not returned by the API so we have to add it
         // manually
-        return { users, groups: [everyOneGroup(organizationId), ...groups] }
+        return { users: userRes.users, groups: [everyOneGroup(organizationId), ...groups] }
       },
     },
     actions: {

--- a/site/src/xServices/template/searchUsersAndGroupsXService.ts
+++ b/site/src/xServices/template/searchUsersAndGroupsXService.ts
@@ -58,7 +58,7 @@ export const searchUsersAndGroupsMachine = createMachine(
     services: {
       search: async ({ organizationId }, { query }) => {
         const [users, groups] = await Promise.all([
-          getUsers(queryToFilter(query)),
+          (await getUsers(queryToFilter(query))).users,
           getGroups(organizationId),
         ])
 

--- a/site/src/xServices/users/searchUserXService.ts
+++ b/site/src/xServices/users/searchUserXService.ts
@@ -50,7 +50,7 @@ export const searchUserMachine = createMachine(
   },
   {
     services: {
-      searchUsers: (_, { query }) => getUsers(queryToFilter(query)),
+      searchUsers: async (_, { query }) => await (await getUsers(queryToFilter(query))).users,
     },
     actions: {
       assignSearchResults: assign({

--- a/site/src/xServices/users/searchUserXService.ts
+++ b/site/src/xServices/users/searchUserXService.ts
@@ -50,7 +50,10 @@ export const searchUserMachine = createMachine(
   },
   {
     services: {
-      searchUsers: async (_, { query }) => await (await getUsers(queryToFilter(query))).users,
+      searchUsers: async (_, { query }) =>
+        await (
+          await getUsers(queryToFilter(query))
+        ).users,
     },
     actions: {
       assignSearchResults: assign({

--- a/site/src/xServices/users/usersXService.ts
+++ b/site/src/xServices/users/usersXService.ts
@@ -103,263 +103,257 @@ export type UsersEvent =
   | { type: "UPDATE_PAGE"; page: string }
 
 export const usersMachine =
-  /** @xstate-layout N4IgpgJg5mDOIC5QFdZgE6wMoBcCGOYAdAMYD2yAdjkTDjgJaVQDCF1AxBGZcUwG5kA1sToBVNOjZUcAbQAMAXUSgADmVgNGPFSAAeiAIwBWQ-KIBmABwAWCwHYrAJhcA2YwE4ANCACeiZ0Miew8LBxsrCw8Pe1MAXzifVAxsfEJSdho6RmZpTgx0MnQiVQAbAgAzIoBbWjAcCQw8uSVddU1tSl0DBEMneSDXC0MrQ2G3KysffwRo4yJjYxtlh1c1m2NXBKTJVIJichkOMQAFABEAQQAVAFEAfQAxAEkAGVuAJQVlJBB2rQYdD8en1DB4iE5NvYbCMokNvH5EK4NkRbI5XIYbE5DGNDPZtiBkphcPsiITYERYPh0DkoCc8FAmAQAZQOF82hp-oDQD0ALRQ8zyEIWYz2dwhJw2VzTRGOIiGdyjJwWSXyZV4xIE3bE9Jkur0JhQRqYLg8PiUQQiPVG2Bsn5-TrdRA84wuYLyVxWexRDy2Vz2ezShCRGwLRZ+0VOWzGT34sna4i67IG60cApFErlHBVdC1cS7W1qDkOoFOxxOSxK7HySKReSmQNWd0LEJ9L1OWLGeQeWNatIJ3ZEBgQUpgDhYMRYE43AByZzuE5un1adqLzMdCB5SNcKOhNdcddiHsDGJCKOjHjGStsZicPZS8dJA6HI44ZxuLxut3nWEXBd+q65fQnSReZrEcKwfSsJZNgsY9hkGNUIklRZBQsO8iT7R8UkHYdRwuFgrieAA1a57gXJdvkLDo1xLDcQKId1llcGIoUiJx4RmbEbDBP1QXFGIIVFdC9h1J9cI4d4bh-K5v0XO4TguLAsAAdQAeXeM4-3tGjuWAmx7Dlex2MlCEPCGGxjyGbcbEFDxBRskx7FxYSH11Z9R1OS4v3Iu53lUj8sC0gCulonkfW3eUsRiDEfWMaxjxGAy4rDD1wwxLYNTjTC3PEzzSPki4AHEbiC6jAN5DxJTlDEIOhD15TsQMPE7Bi1n9Vs7MbdUdnvbKB3ISgKgYHMjSwVBVDAShNB4DgWFU6dnneABZWT3jucdJxnLAnnm0rORC3SNzMCxgghCw1ja7ioUMY9uKsBiJU2aElVFDEXL67CBqGkbJDG2AJqm5lZouacWHfVb1onKdp223blyo-b1x5Gz7rsMZ3XkeQbLA49NnmDwJXdF1qz9DKeowkldS+4bqiNM4wBHTpZvmxaVp8t8P1uPbi0OnkuIWJEoQ2DY4vsQU4OFOUlXkFw4osLtIneyn+p4b7ackenGaBlgQbBl4IY5z8Svh-8yoOoCNwcAyYjssJG0lFiLIRXobPLaIImDOFFiV0TPtVmmjQuEhGH4JkZrmhanmWiH8MIkjCLhyjTcR0KQSIAmhlFRsBkjetnexIYiFcdsBn9OEZbJzVeuVv3BoDyQg5DsOWR10HwZ82PiOuHbp25nSLZ5ax7sbSYsRcUZroDfOlW3CVIzM1UK5dH3+2w2BxsmiBk0kE1eEHc1hGIdf-s3o0+-KxAy4WAnVUjEY62hW7C-YjHOyWUYYhXrDMApDfKC35gRpUzoEKMUMolQai-xPv-M+JttIXwQKYAyZYGqhCGC4G6+dzrzFMJEHE1ZpaVyyjXH+EAGb1G3hgXeZoLTEDIYzMAsCk7wPNj0RwJ1oyqkSo4aITg4LYiLohX0KFYhf11PQihgCd5pjAZmbMtQJGECYeyM2644puxGJMJYJkHAcSMFiEM1ZMaRCHpiSUYiBx4GDgwUONIgHcD3gIQ+RArFNyUZIc+rDL6ynOpVAYSIIJlmPF2csY8RieGatCMYFjsKuJsUyKRVCZEZggTmFx1jbGMI8XA4KailQLHlJ2L0LYInBPlBWVU3ExjCkqTEn+1MfoYDpLAWAAB3IoEB3hwHqMzSO0cfIKSUmpDSvkpKfk8UjSqRB9K1X8ZKdwMRLJehRFGOsfirDMTqeSBp6sml4Bae09AnTuk4GBm3fWAzFIqXUnOSS0kJmhUxAZQIWjJhmBdHo3osQTomNMJjGIEE1hbKIOgE5djJDNLaR06h+9aEgpOUaSFhyIAPMOi6E6VYx7u2LljY8IQQwXiMshYu78bDAtBWgfUiT0BIuhck8BWZIEUvqIi-ZUKjmootm-HcUYqx1kjBsSyfQUSxDFtozO1hgXIFUBABJhpJDvDICOWAMKnGWmlbK9xGBFXKs5byPo8si4j0KcsMVx4JSDGvPpSCfQzJSplXKo0Oq4DANASkxlaSNX7CdUquAeqnRjFCNMuyr02JO04r44IJ5+jy09C6dUGpKBkDIfAH4xD0iHGoDhEcKiU6HRMNESwywuwDEqh6eKztmpBFxFBFY8tzpDC-pmrI9QaTNFzTzC22J8lz2hO-Wy2JAw8LlOiT0VazK+ibZkDt-dgSCnmL2kwEQB2YJmGGHcaJkqRj9GhTKvYSHkkpHgakBo6QMkoM3GdCC+aYyCHWasFgXD9BcCEQMSIQzywhMXZw+lVREP3b7H+SZqWpoRp23kxdQkQQhJ6dsEYp4zDWPdAmEFGwE2hLw4F7kr1eLohecEazoxREFGLWC+csYhickhFD3p3TAp2aNP+01zYsKRudcs2dGINrhGEXGqoi1OU9PLfcOd6P+0aegTWFDAKsdCuxhifEnJ+icCBVdRgwjzANTLM68tYpibrhJxu8TO2yd5uda2HpYp+gcjLcNRh5QnWLmLDYlUoSxDJXu6ugHD1-wAfKjAOH1wjDBOh8z0Z0r+mMLdJyCwNhOS7EMdR3ZPMU280QRRlD0CBdosF8E98ohl0bH0KY08YhF2lpU5YUFJjAribYzL2X82nigg+5dthmrFwSpLNYMtlTth6xefTatWUHI6V0yljWB7YKLi6Eu8ozIuhK5xHdKzljcRFA4JUxhyVgsy7So5k22EhnYt+3ORlFgYjxcXQynCRZmGOvazVmXnWgeTuBgNjE5Sobiu6R6dnejCjvS2GW0QLxvRSyJVemBDsBuWEEbigpR2Pv+4sUCMtNj8o2VjZL5NIcw6OhEMECPQ3I8DPMyw6PPQLKhPubbCQ4hAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QFdZgE6wMoBcCGOYAdLPujgJYB2UACnlNQRQPZUDEA2gAwC6ioAA4tYFSmwEgAnogCM3AJzciAZm4AmAKwAOAOwA2TQt0AWfQBoQAD0QBaWbIWyimzepPqtCpd1n6Avv6WqBjY+IREMDiUNACqaJjsEGzE1ABuLADWxFHxoTz8SCDCouJUkjIIsuoq+kRmmrreJtqertqWNgj2stoKRLq13upOspq+AUEgIZi4BDlg0dRQeYkY6CzoRIIANgQAZpsAtpGLq7AFkiVirOVFXT19A0MKIw7jfpaVDtra9YZNBQtNo6QLBBJheZECgQHZgdhYWJYWgAUQAcgARAD6SJRACVLkVrmVJA8HMYBkCFCptH4Rvp9CYvnI1P1qbJTL1DNx9NoVGDphC5hEYXD2BiUQAZFEAFRROKw+MJQhENwk9zs5N0lJM1Np+npjOZVRpKlUxl5HhMul+3G0ApmkJFsPhAEEAMIygCSADVXXKFUq+FdVSSNd0tTq9XSFAymdI5CZNHVtPpauoGWp9NT+VNHcLUi72HiUYqZYG8VjaK6sFgAOoAeTxGOVxVDt1Jmsc2qauppMbjxrGalUI2TSlkKnGoLzQvChbFsVoGP98txlbxDelWFbxI74Z6FN70YNsaNCaq+kcRDTThUfjPDnUDrnUNF8KXK4D1YA4ijd+26qgGS3ZRv2p6DheD5mvI4ymNwvY1LoL6hAW0JFp+q5YgAYl6kpygSwZEoBdzAV2R5UuBhrxt8Bh1I08h+GYnjpihszzkQADGbD7BQ6BHKsWCoIIYBUKIbDsO6DZorheIALIVliiLIuiWBetJAGlPuZERuo3AmEQfiaCoCipoMnj6UO2iuEQtqNE4SYqCYHJsU6xDcVQvH8YJwmieJHDuq6aLulKinKaiaJqRpREqlpQHWJqekGUZJlmSoFk0XISjqDeuieK81nNJOrloR5XkCQkGJgHCZSSdJskKeuWIStKcqaWqpEJbpHJEIoV5+LIznAkOVL-CY3A8o0SbOSVHFlXxFUYFVNW3JJQUhZKiktbK-4xW2cWdWS6g9X1DhXkNrQjbGRBaI0enqH0g3cJos1QvN3kJK6nGUGkzASVJMlevJiket6fretFhSxR1nbdcoagtBoxgTQomiZVUo1mONk2mGjsivRE72LegX0-X9AXraFTWg76-rqWi7Vhjp9jHfD+naEjugo2jV11LdeUaI940vbOqEcbAvlUBAyyrEkKTQlQGTZCQksQKsjPaVBPguKmg3UgyD0KJ0Xb6MovhDPZNRXgTxAS7AIlSzLCTsOsmzbHsOCHPxKv26JasJBr8UgabvWTtmlu1LIVluDr536wafQ20QEDVYsTsYHLVCpIrWTECnNVgOre17kHXa6JoN2xn4jKoy0Fha6YvVuIoHK6oxIvgmLUL52ncTO67Wy7AcxzJ6nhBF1D+0wweDjl5XV5xrXqbGkl2qaL03BOZOjiDUneDfRQv0xCszvJFnCtK8Q+9k+PAfFyRsM9IyN6DQ4NJ8r0k4jY3z16U4phOF8B3QUXcIjX0PswPuGcB7u2Ht7cBR9C530niXQ6JsDLnTfr8e8tIVAr30mvDeW97wOSTkTVY9BYCwAAO6bAgHiOAiw6qA2Bk1astZGzNixCWMsgc0ERl6P0deKNrSfw8OoFeYdbLqHLrGWkHwFBkJ4gtCheAqG0PQPQxhOA1rBSpoqSs7D6xNmxDw2UfDH4-CEfIRQojaTiMkXyF+7Jf5V0UaLdiUJ0DaOPqo9RdDM7Z0vkQbxaAcB+JoXQixRRKhaH0k3QYNonCowcPGECvQbz6AMA4bsaYTAmCTqExYviEiUMiZol26ANiDw9l7E4RTwmlLUeUiA0TmY5L+AybJWo8no3cMmBJKgkmOHXrvDxbkiDIEEBASBJ8MB4hYHCWAgSL650mdM+YqwFlLLaV1Ho94BhNF+MZLJrg0wr0aGvGo6VJwaHSgU8ZaEpkzJKfMxZcBKnVNgZ7EezzNkJG2XAXZIEDm6COdZWo5dkx4IvBmcYRBTKvDTLydetQHmd08YQdgmEAy4XwkGFBD8Yl2F0M4IYTkHqb1RuMDoXUzBmyaPpPJpyVCssCFMKgLAU7wCKPmcWZBj70EYFQcmIYDqWPyc4XUCErx8ncEORQbMtB6EMMYMwScoivMwGK6e7TJX1CUNkuV6Nqi1H+PZIErRbr2keRxd8OqmZ7MGs5A1Mrej3KHKlXq+UHrv2nDajFEzyEJCEr7MSmtUESpddKo1HqoJo2Srrcax127AL5W9ZRH0lpjwjUSvV0bDWyrjd8A2CLdbPXeBzBCSjPIqM+gfI+ubxUz31TGot8qoI2mcDaK8Mj3DyHyQGkBmLbaq3TugB1msyStsLe6jt3xtY6DjrUBO7jA1oR7lqydpcIwzrdca-BBpDImBuXlIZNItB7wbbM1Y27+H2D3bG+diBPA1AGBNB6wjtDWgNDW8qESNFaLCXeqNUrZ0HthTSCuWhOTjUGnlX9tqvE+PHWUwDIGW0Fv3cWl94wDLPUSY9FJYz10cT+VqwFPLoaOunVhp9fSGQV3OnBVojRzo2ww3qp4ba53o3sCHLeRhUWm0GKmdl-ggA */
   createMachine(
     {
-      tsTypes: {} as import("./usersXService.typegen").Typegen0,
-      schema: {
-        context: {} as UsersContext,
-        events: {} as UsersEvent,
-        services: {} as {
-          getUsers: {
-            data: TypesGen.GetUsersResponse
-          }
-          createUser: {
-            data: TypesGen.User
-          }
-          suspendUser: {
-            data: TypesGen.User
-          }
-          deleteUser: {
-            data: undefined
-          }
-          activateUser: {
-            data: TypesGen.User
-          }
-          updateUserPassword: {
-            data: undefined
-          }
-          updateUserRoles: {
-            data: TypesGen.User
-          }
-        },
+  tsTypes: {} as import("./usersXService.typegen").Typegen0,
+  schema: {
+    context: {} as UsersContext,
+    events: {} as UsersEvent,
+    services: {} as {
+      getUsers: {
+        data: TypesGen.GetUsersResponse
+      }
+      createUser: {
+        data: TypesGen.User
+      }
+      suspendUser: {
+        data: TypesGen.User
+      }
+      deleteUser: {
+        data: undefined
+      }
+      activateUser: {
+        data: TypesGen.User
+      }
+      updateUserPassword: {
+        data: undefined
+      }
+      updateUserRoles: {
+        data: TypesGen.User
+      }
+    },
+  },
+  predictableActionArguments: true,
+  id: "usersState",
+  on: {
+    UPDATE_FILTER: {
+      target: ".gettingUsers",
+      actions: ["assignFilter", "sendResetPage"],
+      internal: false,
+    },
+  },
+  initial: "startingPagination",
+  states: {
+    startingPagination: {
+      entry: "assignPaginationRef",
+      always: {
+        target: "gettingUsers",
       },
-      predictableActionArguments: true,
-      id: "usersState",
-      states: {
-        users: {
-          initial: "startingPagination",
-          states: {
-            startingPagination: {
-              entry: "assignPaginationRef",
-              always: {
-                target: "gettingUsers",
-              },
-            },
-            gettingUsers: {
-              entry: "clearGetUsersError",
-              invoke: {
-                src: "getUsers",
-                id: "getUsers",
-                onDone: [
-                  {
-                    target: "idle",
-                    actions: "assignUsers",
-                  },
-                ],
-                onError: [
-                  {
-                    target: "idle",
-                    actions: [
-                      "clearUsers",
-                      "assignGetUsersError",
-                      "displayGetUsersErrorMessage",
-                    ],
-                  },
-                ],
-              },
-              tags: "loading",
-            },
-            idle: {
-              entry: "clearSelectedUser",
-              on: {
-                SUSPEND_USER: {
-                  target: "confirmUserSuspension",
-                  actions: "assignUserToSuspend",
-                },
-                DELETE_USER: {
-                  target: "confirmUserDeletion",
-                  actions: "assignUserToDelete",
-                },
-                ACTIVATE_USER: {
-                  target: "confirmUserActivation",
-                  actions: "assignUserToActivate",
-                },
-                RESET_USER_PASSWORD: {
-                  target: "confirmUserPasswordReset",
-                  actions: [
-                    "assignUserIdToResetPassword",
-                    "generateRandomPassword",
-                  ],
-                },
-                UPDATE_USER_ROLES: {
-                  target: "updatingUserRoles",
-                  actions: "assignUserIdToUpdateRoles",
-                },
-                UPDATE_PAGE: {
-                  target: "gettingUsers",
-                  actions: "updateURL",
-                },
-                UPDATE_FILTER: {
-                  target: "gettingUsers",
-                  actions: ["assignFilter", "sendResetPage"],
-                },
-              },
-            },
-            confirmUserSuspension: {
-              on: {
-                CONFIRM_USER_SUSPENSION: {
-                  target: "suspendingUser",
-                },
-                CANCEL_USER_SUSPENSION: {
-                  target: "idle",
-                },
-              },
-            },
-            confirmUserDeletion: {
-              on: {
-                CONFIRM_USER_DELETE: {
-                  target: "deletingUser",
-                },
-                CANCEL_USER_DELETE: {
-                  target: "idle",
-                },
-              },
-            },
-            confirmUserActivation: {
-              on: {
-                CONFIRM_USER_ACTIVATION: {
-                  target: "activatingUser",
-                },
-                CANCEL_USER_ACTIVATION: {
-                  target: "idle",
-                },
-              },
-            },
-            suspendingUser: {
-              entry: "clearSuspendUserError",
-              invoke: {
-                src: "suspendUser",
-                id: "suspendUser",
-                onDone: [
-                  {
-                    target: "gettingUsers",
-                    actions: "displaySuspendSuccess",
-                  },
-                ],
-                onError: [
-                  {
-                    target: "idle",
-                    actions: [
-                      "assignSuspendUserError",
-                      "displaySuspendedErrorMessage",
-                    ],
-                  },
-                ],
-              },
-            },
-            deletingUser: {
-              entry: "clearDeleteUserError",
-              invoke: {
-                src: "deleteUser",
-                id: "deleteUser",
-                onDone: [
-                  {
-                    target: "gettingUsers",
-                    actions: "displayDeleteSuccess",
-                  },
-                ],
-                onError: [
-                  {
-                    target: "idle",
-                    actions: [
-                      "assignDeleteUserError",
-                      "displayDeleteErrorMessage",
-                    ],
-                  },
-                ],
-              },
-            },
-            activatingUser: {
-              entry: "clearActivateUserError",
-              invoke: {
-                src: "activateUser",
-                id: "activateUser",
-                onDone: [
-                  {
-                    target: "gettingUsers",
-                    actions: "displayActivateSuccess",
-                  },
-                ],
-                onError: [
-                  {
-                    target: "idle",
-                    actions: [
-                      "assignActivateUserError",
-                      "displayActivatedErrorMessage",
-                    ],
-                  },
-                ],
-              },
-            },
-            confirmUserPasswordReset: {
-              on: {
-                CONFIRM_USER_PASSWORD_RESET: {
-                  target: "resettingUserPassword",
-                },
-                CANCEL_USER_PASSWORD_RESET: {
-                  target: "idle",
-                },
-              },
-            },
-            resettingUserPassword: {
-              entry: "clearResetUserPasswordError",
-              invoke: {
-                src: "resetUserPassword",
-                id: "resetUserPassword",
-                onDone: [
-                  {
-                    target: "idle",
-                    actions: "displayResetPasswordSuccess",
-                  },
-                ],
-                onError: [
-                  {
-                    target: "idle",
-                    actions: [
-                      "assignResetUserPasswordError",
-                      "displayResetPasswordErrorMessage",
-                    ],
-                  },
-                ],
-              },
-            },
-            updatingUserRoles: {
-              entry: "clearUpdateUserRolesError",
-              invoke: {
-                src: "updateUserRoles",
-                id: "updateUserRoles",
-                onDone: [
-                  {
-                    target: "idle",
-                    actions: "updateUserRolesInTheList",
-                  },
-                ],
-                onError: [
-                  {
-                    target: "idle",
-                    actions: [
-                      "assignUpdateRolesError",
-                      "displayUpdateRolesErrorMessage",
-                    ],
-                  },
-                ],
-              },
-            },
+    },
+    gettingUsers: {
+      entry: "clearGetUsersError",
+      invoke: {
+        src: "getUsers",
+        id: "getUsers",
+        onDone: [
+          {
+            target: "idle",
+            actions: "assignUsers",
           },
+        ],
+        onError: [
+          {
+            target: "idle",
+            actions: [
+              "clearUsers",
+              "assignGetUsersError",
+              "displayGetUsersErrorMessage",
+            ],
+          },
+        ],
+      },
+      tags: "loading",
+    },
+    idle: {
+      entry: "clearSelectedUser",
+      on: {
+        SUSPEND_USER: {
+          target: "confirmUserSuspension",
+          actions: "assignUserToSuspend",
+        },
+        DELETE_USER: {
+          target: "confirmUserDeletion",
+          actions: "assignUserToDelete",
+        },
+        ACTIVATE_USER: {
+          target: "confirmUserActivation",
+          actions: "assignUserToActivate",
+        },
+        RESET_USER_PASSWORD: {
+          target: "confirmUserPasswordReset",
+          actions: ["assignUserIdToResetPassword", "generateRandomPassword"],
+        },
+        UPDATE_USER_ROLES: {
+          target: "updatingUserRoles",
+          actions: "assignUserIdToUpdateRoles",
+        },
+        UPDATE_PAGE: {
+          target: "gettingUsers",
+          actions: "updateURL",
+        },
+        UPDATE_FILTER: {
+          target: "gettingUsers",
+          actions: ["assignFilter", "sendResetPage"],
         },
       },
     },
+    confirmUserSuspension: {
+      on: {
+        CONFIRM_USER_SUSPENSION: {
+          target: "suspendingUser",
+        },
+        CANCEL_USER_SUSPENSION: {
+          target: "idle",
+        },
+      },
+    },
+    confirmUserDeletion: {
+      on: {
+        CONFIRM_USER_DELETE: {
+          target: "deletingUser",
+        },
+        CANCEL_USER_DELETE: {
+          target: "idle",
+        },
+      },
+    },
+    confirmUserActivation: {
+      on: {
+        CONFIRM_USER_ACTIVATION: {
+          target: "activatingUser",
+        },
+        CANCEL_USER_ACTIVATION: {
+          target: "idle",
+        },
+      },
+    },
+    suspendingUser: {
+      entry: "clearSuspendUserError",
+      invoke: {
+        src: "suspendUser",
+        id: "suspendUser",
+        onDone: [
+          {
+            target: "gettingUsers",
+            actions: "displaySuspendSuccess",
+          },
+        ],
+        onError: [
+          {
+            target: "idle",
+            actions: ["assignSuspendUserError", "displaySuspendedErrorMessage"],
+          },
+        ],
+      },
+    },
+    deletingUser: {
+      entry: "clearDeleteUserError",
+      invoke: {
+        src: "deleteUser",
+        id: "deleteUser",
+        onDone: [
+          {
+            target: "gettingUsers",
+            actions: "displayDeleteSuccess",
+          },
+        ],
+        onError: [
+          {
+            target: "idle",
+            actions: ["assignDeleteUserError", "displayDeleteErrorMessage"],
+          },
+        ],
+      },
+    },
+    activatingUser: {
+      entry: "clearActivateUserError",
+      invoke: {
+        src: "activateUser",
+        id: "activateUser",
+        onDone: [
+          {
+            target: "gettingUsers",
+            actions: "displayActivateSuccess",
+          },
+        ],
+        onError: [
+          {
+            target: "idle",
+            actions: [
+              "assignActivateUserError",
+              "displayActivatedErrorMessage",
+            ],
+          },
+        ],
+      },
+    },
+    confirmUserPasswordReset: {
+      on: {
+        CONFIRM_USER_PASSWORD_RESET: {
+          target: "resettingUserPassword",
+        },
+        CANCEL_USER_PASSWORD_RESET: {
+          target: "idle",
+        },
+      },
+    },
+    resettingUserPassword: {
+      entry: "clearResetUserPasswordError",
+      invoke: {
+        src: "resetUserPassword",
+        id: "resetUserPassword",
+        onDone: [
+          {
+            target: "idle",
+            actions: "displayResetPasswordSuccess",
+          },
+        ],
+        onError: [
+          {
+            target: "idle",
+            actions: [
+              "assignResetUserPasswordError",
+              "displayResetPasswordErrorMessage",
+            ],
+          },
+        ],
+      },
+    },
+    updatingUserRoles: {
+      entry: "clearUpdateUserRolesError",
+      invoke: {
+        src: "updateUserRoles",
+        id: "updateUserRoles",
+        onDone: [
+          {
+            target: "idle",
+            actions: "updateUserRolesInTheList",
+          },
+        ],
+        onError: [
+          {
+            target: "idle",
+            actions: [
+              "assignUpdateRolesError",
+              "displayUpdateRolesErrorMessage",
+            ],
+          },
+        ],
+      },
+    },
+  },
+},
     {
       services: {
         // Passing API.getUsers directly does not invoke the function properly

--- a/site/src/xServices/users/usersXService.ts
+++ b/site/src/xServices/users/usersXService.ts
@@ -106,254 +106,260 @@ export const usersMachine =
   /** @xstate-layout N4IgpgJg5mDOIC5QFdZgE6wMoBcCGOYAdLPujgJYB2UACnlNQRQPZUDEA2gAwC6ioAA4tYFSmwEgAnogCM3AJzciAZm4AmAKwAOAOwA2TQt0AWfQBoQAD0QBaWbIWyimzepPqtCpd1n6Avv6WqBjY+IREMDiUNACqaJjsEGzE1ABuLADWxFHxoTz8SCDCouJUkjIIsuoq+kRmmrreJtqertqWNgj2stoKRLq13upOspq+AUEgIZi4BDlg0dRQeYkY6CzoRIIANgQAZpsAtpGLq7AFkiVirOVFXT19A0MKIw7jfpaVDtra9YZNBQtNo6QLBBJheZECgQHZgdhYWJYWgAUQAcgARAD6SJRACVLkVrmVJA8HMYBkCFCptH4Rvp9CYvnI1P1qbJTL1DNx9NoVGDphC5hEYXD2BiUQAZFEAFRROKw+MJQhENwk9zs5N0lJM1Np+npjOZVRpKlUxl5HhMul+3G0ApmkJFsPhAEEAMIygCSADVXXKFUq+FdVSSNd0tTq9XSFAymdI5CZNHVtPpauoGWp9NT+VNHcLUi72HiUYqZYG8VjaK6sFgAOoAeTxGOVxVDt1Jmsc2qauppMbjxrGalUI2TSlkKnGoLzQvChbFsVoGP98txlbxDelWFbxI74Z6FN70YNsaNCaq+kcRDTThUfjPDnUDrnUNF8KXK4D1YA4ijd+26qgGS3ZRv2p6DheD5mvI4ymNwvY1LoL6hAW0JFp+q5YgAYl6kpygSwZEoBdzAV2R5UuBhrxt8Bh1I08h+GYnjpihszzkQADGbD7BQ6BHKsWCoIIYBUKIbDsO6DZorheIALIVliiLIuiWBetJAGlPuZERuo3AmEQfiaCoCipoMnj6UO2iuEQtqNE4SYqCYHJsU6xDcVQvH8YJwmieJHDuq6aLulKinKaiaJqRpREqlpQHWJqekGUZJlmSoFk0XISjqDeuieK81nNJOrloR5XkCQkGJgHCZSSdJskKeuWIStKcqaWqpEJbpHJEIoV5+LIznAkOVL-CY3A8o0SbOSVHFlXxFUYFVNW3JJQUhZKiktbK-4xW2cWdWS6g9X1DhXkNrQjbGRBaI0enqH0g3cJos1QvN3kJK6nGUGkzASVJMlevJiket6fretFhSxR1nbdcoagtBoxgTQomiZVUo1mONk2mGjsivRE72LegX0-X9AXraFTWg76-rqWi7Vhjp9jHfD+naEjugo2jV11LdeUaI940vbOqEcbAvlUBAyyrEkKTQlQGTZCQksQKsjPaVBPguKmg3UgyD0KJ0Xb6MovhDPZNRXgTxAS7AIlSzLCTsOsmzbHsOCHPxKv26JasJBr8UgabvWTtmlu1LIVluDr536wafQ20QEDVYsTsYHLVCpIrWTECnNVgOre17kHXa6JoN2xn4jKoy0Fha6YvVuIoHK6oxIvgmLUL52ncTO67Wy7AcxzJ6nhBF1D+0wweDjl5XV5xrXqbGkl2qaL03BOZOjiDUneDfRQv0xCszvJFnCtK8Q+9k+PAfFyRsM9IyN6DQ4NJ8r0k4jY3z16U4phOF8B3QUXcIjX0PswPuGcB7u2Ht7cBR9C530niXQ6JsDLnTfr8e8tIVAr30mvDeW97wOSTkTVY9BYCwAAO6bAgHiOAiw6qA2Bk1astZGzNixCWMsgc0ERl6P0deKNrSfw8OoFeYdbLqHLrGWkHwFBkJ4gtCheAqG0PQPQxhOA1rBSpoqSs7D6xNmxDw2UfDH4-CEfIRQojaTiMkXyF+7Jf5V0UaLdiUJ0DaOPqo9RdDM7Z0vkQbxaAcB+JoXQixRRKhaH0k3QYNonCowcPGECvQbz6AMA4bsaYTAmCTqExYviEiUMiZol26ANiDw9l7E4RTwmlLUeUiA0TmY5L+AybJWo8no3cMmBJKgkmOHXrvDxbkiDIEEBASBJ8MB4hYHCWAgSL650mdM+YqwFlLLaV1Ho94BhNF+MZLJrg0wr0aGvGo6VJwaHSgU8ZaEpkzJKfMxZcBKnVNgZ7EezzNkJG2XAXZIEDm6COdZWo5dkx4IvBmcYRBTKvDTLydetQHmd08YQdgmEAy4XwkGFBD8Yl2F0M4IYTkHqb1RuMDoXUzBmyaPpPJpyVCssCFMKgLAU7wCKPmcWZBj70EYFQcmIYDqWPyc4XUCErx8ncEORQbMtB6EMMYMwScoivMwGK6e7TJX1CUNkuV6Nqi1H+PZIErRbr2keRxd8OqmZ7MGs5A1Mrej3KHKlXq+UHrv2nDajFEzyEJCEr7MSmtUESpddKo1HqoJo2Srrcax127AL5W9ZRH0lpjwjUSvV0bDWyrjd8A2CLdbPXeBzBCSjPIqM+gfI+ubxUz31TGot8qoI2mcDaK8Mj3DyHyQGkBmLbaq3TugB1msyStsLe6jt3xtY6DjrUBO7jA1oR7lqydpcIwzrdca-BBpDImBuXlIZNItB7wbbM1Y27+H2D3bG+diBPA1AGBNB6wjtDWgNDW8qESNFaLCXeqNUrZ0HthTSCuWhOTjUGnlX9tqvE+PHWUwDIGW0Fv3cWl94wDLPUSY9FJYz10cT+VqwFPLoaOunVhp9fSGQV3OnBVojRzo2ww3qp4ba53o3sCHLeRhUWm0GKmdl-ggA */
   createMachine(
     {
-  tsTypes: {} as import("./usersXService.typegen").Typegen0,
-  schema: {
-    context: {} as UsersContext,
-    events: {} as UsersEvent,
-    services: {} as {
-      getUsers: {
-        data: TypesGen.GetUsersResponse
-      }
-      createUser: {
-        data: TypesGen.User
-      }
-      suspendUser: {
-        data: TypesGen.User
-      }
-      deleteUser: {
-        data: undefined
-      }
-      activateUser: {
-        data: TypesGen.User
-      }
-      updateUserPassword: {
-        data: undefined
-      }
-      updateUserRoles: {
-        data: TypesGen.User
-      }
-    },
-  },
-  predictableActionArguments: true,
-  id: "usersState",
-  on: {
-    UPDATE_FILTER: {
-      target: ".gettingUsers",
-      actions: ["assignFilter", "sendResetPage"],
-      internal: false,
-    },
-  },
-  initial: "startingPagination",
-  states: {
-    startingPagination: {
-      entry: "assignPaginationRef",
-      always: {
-        target: "gettingUsers",
+      tsTypes: {} as import("./usersXService.typegen").Typegen0,
+      schema: {
+        context: {} as UsersContext,
+        events: {} as UsersEvent,
+        services: {} as {
+          getUsers: {
+            data: TypesGen.GetUsersResponse
+          }
+          createUser: {
+            data: TypesGen.User
+          }
+          suspendUser: {
+            data: TypesGen.User
+          }
+          deleteUser: {
+            data: undefined
+          }
+          activateUser: {
+            data: TypesGen.User
+          }
+          updateUserPassword: {
+            data: undefined
+          }
+          updateUserRoles: {
+            data: TypesGen.User
+          }
+        },
       },
-    },
-    gettingUsers: {
-      entry: "clearGetUsersError",
-      invoke: {
-        src: "getUsers",
-        id: "getUsers",
-        onDone: [
-          {
-            target: "idle",
-            actions: "assignUsers",
-          },
-        ],
-        onError: [
-          {
-            target: "idle",
-            actions: [
-              "clearUsers",
-              "assignGetUsersError",
-              "displayGetUsersErrorMessage",
-            ],
-          },
-        ],
-      },
-      tags: "loading",
-    },
-    idle: {
-      entry: "clearSelectedUser",
+      predictableActionArguments: true,
+      id: "usersState",
       on: {
-        SUSPEND_USER: {
-          target: "confirmUserSuspension",
-          actions: "assignUserToSuspend",
-        },
-        DELETE_USER: {
-          target: "confirmUserDeletion",
-          actions: "assignUserToDelete",
-        },
-        ACTIVATE_USER: {
-          target: "confirmUserActivation",
-          actions: "assignUserToActivate",
-        },
-        RESET_USER_PASSWORD: {
-          target: "confirmUserPasswordReset",
-          actions: ["assignUserIdToResetPassword", "generateRandomPassword"],
-        },
-        UPDATE_USER_ROLES: {
-          target: "updatingUserRoles",
-          actions: "assignUserIdToUpdateRoles",
-        },
-        UPDATE_PAGE: {
-          target: "gettingUsers",
-          actions: "updateURL",
-        },
         UPDATE_FILTER: {
-          target: "gettingUsers",
+          target: ".gettingUsers",
           actions: ["assignFilter", "sendResetPage"],
+          internal: false,
         },
       },
-    },
-    confirmUserSuspension: {
-      on: {
-        CONFIRM_USER_SUSPENSION: {
-          target: "suspendingUser",
-        },
-        CANCEL_USER_SUSPENSION: {
-          target: "idle",
-        },
-      },
-    },
-    confirmUserDeletion: {
-      on: {
-        CONFIRM_USER_DELETE: {
-          target: "deletingUser",
-        },
-        CANCEL_USER_DELETE: {
-          target: "idle",
-        },
-      },
-    },
-    confirmUserActivation: {
-      on: {
-        CONFIRM_USER_ACTIVATION: {
-          target: "activatingUser",
-        },
-        CANCEL_USER_ACTIVATION: {
-          target: "idle",
-        },
-      },
-    },
-    suspendingUser: {
-      entry: "clearSuspendUserError",
-      invoke: {
-        src: "suspendUser",
-        id: "suspendUser",
-        onDone: [
-          {
+      initial: "startingPagination",
+      states: {
+        startingPagination: {
+          entry: "assignPaginationRef",
+          always: {
             target: "gettingUsers",
-            actions: "displaySuspendSuccess",
           },
-        ],
-        onError: [
-          {
-            target: "idle",
-            actions: ["assignSuspendUserError", "displaySuspendedErrorMessage"],
-          },
-        ],
-      },
-    },
-    deletingUser: {
-      entry: "clearDeleteUserError",
-      invoke: {
-        src: "deleteUser",
-        id: "deleteUser",
-        onDone: [
-          {
-            target: "gettingUsers",
-            actions: "displayDeleteSuccess",
-          },
-        ],
-        onError: [
-          {
-            target: "idle",
-            actions: ["assignDeleteUserError", "displayDeleteErrorMessage"],
-          },
-        ],
-      },
-    },
-    activatingUser: {
-      entry: "clearActivateUserError",
-      invoke: {
-        src: "activateUser",
-        id: "activateUser",
-        onDone: [
-          {
-            target: "gettingUsers",
-            actions: "displayActivateSuccess",
-          },
-        ],
-        onError: [
-          {
-            target: "idle",
-            actions: [
-              "assignActivateUserError",
-              "displayActivatedErrorMessage",
+        },
+        gettingUsers: {
+          entry: "clearGetUsersError",
+          invoke: {
+            src: "getUsers",
+            id: "getUsers",
+            onDone: [
+              {
+                target: "idle",
+                actions: "assignUsers",
+              },
+            ],
+            onError: [
+              {
+                target: "idle",
+                actions: [
+                  "clearUsers",
+                  "assignGetUsersError",
+                  "displayGetUsersErrorMessage",
+                ],
+              },
             ],
           },
-        ],
-      },
-    },
-    confirmUserPasswordReset: {
-      on: {
-        CONFIRM_USER_PASSWORD_RESET: {
-          target: "resettingUserPassword",
+          tags: "loading",
         },
-        CANCEL_USER_PASSWORD_RESET: {
-          target: "idle",
-        },
-      },
-    },
-    resettingUserPassword: {
-      entry: "clearResetUserPasswordError",
-      invoke: {
-        src: "resetUserPassword",
-        id: "resetUserPassword",
-        onDone: [
-          {
-            target: "idle",
-            actions: "displayResetPasswordSuccess",
+        idle: {
+          entry: "clearSelectedUser",
+          on: {
+            SUSPEND_USER: {
+              target: "confirmUserSuspension",
+              actions: "assignUserToSuspend",
+            },
+            DELETE_USER: {
+              target: "confirmUserDeletion",
+              actions: "assignUserToDelete",
+            },
+            ACTIVATE_USER: {
+              target: "confirmUserActivation",
+              actions: "assignUserToActivate",
+            },
+            RESET_USER_PASSWORD: {
+              target: "confirmUserPasswordReset",
+              actions: [
+                "assignUserIdToResetPassword",
+                "generateRandomPassword",
+              ],
+            },
+            UPDATE_USER_ROLES: {
+              target: "updatingUserRoles",
+              actions: "assignUserIdToUpdateRoles",
+            },
+            UPDATE_PAGE: {
+              target: "gettingUsers",
+              actions: "updateURL",
+            },
+            UPDATE_FILTER: {
+              target: "gettingUsers",
+              actions: ["assignFilter", "sendResetPage"],
+            },
           },
-        ],
-        onError: [
-          {
-            target: "idle",
-            actions: [
-              "assignResetUserPasswordError",
-              "displayResetPasswordErrorMessage",
+        },
+        confirmUserSuspension: {
+          on: {
+            CONFIRM_USER_SUSPENSION: {
+              target: "suspendingUser",
+            },
+            CANCEL_USER_SUSPENSION: {
+              target: "idle",
+            },
+          },
+        },
+        confirmUserDeletion: {
+          on: {
+            CONFIRM_USER_DELETE: {
+              target: "deletingUser",
+            },
+            CANCEL_USER_DELETE: {
+              target: "idle",
+            },
+          },
+        },
+        confirmUserActivation: {
+          on: {
+            CONFIRM_USER_ACTIVATION: {
+              target: "activatingUser",
+            },
+            CANCEL_USER_ACTIVATION: {
+              target: "idle",
+            },
+          },
+        },
+        suspendingUser: {
+          entry: "clearSuspendUserError",
+          invoke: {
+            src: "suspendUser",
+            id: "suspendUser",
+            onDone: [
+              {
+                target: "gettingUsers",
+                actions: "displaySuspendSuccess",
+              },
+            ],
+            onError: [
+              {
+                target: "idle",
+                actions: [
+                  "assignSuspendUserError",
+                  "displaySuspendedErrorMessage",
+                ],
+              },
             ],
           },
-        ],
-      },
-    },
-    updatingUserRoles: {
-      entry: "clearUpdateUserRolesError",
-      invoke: {
-        src: "updateUserRoles",
-        id: "updateUserRoles",
-        onDone: [
-          {
-            target: "idle",
-            actions: "updateUserRolesInTheList",
-          },
-        ],
-        onError: [
-          {
-            target: "idle",
-            actions: [
-              "assignUpdateRolesError",
-              "displayUpdateRolesErrorMessage",
+        },
+        deletingUser: {
+          entry: "clearDeleteUserError",
+          invoke: {
+            src: "deleteUser",
+            id: "deleteUser",
+            onDone: [
+              {
+                target: "gettingUsers",
+                actions: "displayDeleteSuccess",
+              },
+            ],
+            onError: [
+              {
+                target: "idle",
+                actions: ["assignDeleteUserError", "displayDeleteErrorMessage"],
+              },
             ],
           },
-        ],
+        },
+        activatingUser: {
+          entry: "clearActivateUserError",
+          invoke: {
+            src: "activateUser",
+            id: "activateUser",
+            onDone: [
+              {
+                target: "gettingUsers",
+                actions: "displayActivateSuccess",
+              },
+            ],
+            onError: [
+              {
+                target: "idle",
+                actions: [
+                  "assignActivateUserError",
+                  "displayActivatedErrorMessage",
+                ],
+              },
+            ],
+          },
+        },
+        confirmUserPasswordReset: {
+          on: {
+            CONFIRM_USER_PASSWORD_RESET: {
+              target: "resettingUserPassword",
+            },
+            CANCEL_USER_PASSWORD_RESET: {
+              target: "idle",
+            },
+          },
+        },
+        resettingUserPassword: {
+          entry: "clearResetUserPasswordError",
+          invoke: {
+            src: "resetUserPassword",
+            id: "resetUserPassword",
+            onDone: [
+              {
+                target: "idle",
+                actions: "displayResetPasswordSuccess",
+              },
+            ],
+            onError: [
+              {
+                target: "idle",
+                actions: [
+                  "assignResetUserPasswordError",
+                  "displayResetPasswordErrorMessage",
+                ],
+              },
+            ],
+          },
+        },
+        updatingUserRoles: {
+          entry: "clearUpdateUserRolesError",
+          invoke: {
+            src: "updateUserRoles",
+            id: "updateUserRoles",
+            onDone: [
+              {
+                target: "idle",
+                actions: "updateUserRolesInTheList",
+              },
+            ],
+            onError: [
+              {
+                target: "idle",
+                actions: [
+                  "assignUpdateRolesError",
+                  "displayUpdateRolesErrorMessage",
+                ],
+              },
+            ],
+          },
+        },
       },
     },
-  },
-},
     {
       services: {
         // Passing API.getUsers directly does not invoke the function properly

--- a/site/src/xServices/users/usersXService.ts
+++ b/site/src/xServices/users/usersXService.ts
@@ -138,9 +138,12 @@ export const usersMachine =
       id: "usersState",
       on: {
         UPDATE_FILTER: {
-          target: ".gettingUsers",
           actions: ["assignFilter", "sendResetPage"],
           internal: false,
+        },
+        UPDATE_PAGE: {
+          target: "gettingUsers",
+          actions: "updateURL",
         },
       },
       initial: "startingPagination",
@@ -200,14 +203,6 @@ export const usersMachine =
             UPDATE_USER_ROLES: {
               target: "updatingUserRoles",
               actions: "assignUserIdToUpdateRoles",
-            },
-            UPDATE_PAGE: {
-              target: "gettingUsers",
-              actions: "updateURL",
-            },
-            UPDATE_FILTER: {
-              target: "gettingUsers",
-              actions: ["assignFilter", "sendResetPage"],
             },
           },
         },


### PR DESCRIPTION
What this changes:
- Removes the `GET /api/v2/users/count` endpoint and removes usage from the dashboard
- Adds `count` field to the `GET /api/v2/users` response
- Uses a window function to get count in single query from postgres

This will ideally be the template for paginated queries moving forward. 