### PR TITLE
docs: deprecate name arg

### DIFF
--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -191,7 +191,7 @@ resource "coder_app" "rstudio" {
   agent_id      = coder_agent.coder.id
   slug          = "rstudio"
   display_name  = "R Studio"
-  icon          = "/icon/rstudio.svg"
+  icon          = "https://upload.wikimedia.org/wikipedia/commons/d/d0/RStudio_logo_flat.svg"
   url           = "http://localhost:8787"
   subdomain     = true
   share         = "owner"

--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -46,8 +46,8 @@ vim main.tf
 
 ```hcl
 resource "coder_agent" "main" {
-    arch          = "amd64"
-    os            = "linux"
+    arch           = "amd64"
+    os             = "linux"
     startup_script = <<EOF
     #!/bin/sh
     # install and start code-server
@@ -140,9 +140,9 @@ Configure your agent and `coder_app` like so to use Jupyter:
 data "coder_workspace" "me" {}
 
 resource "coder_agent" "coder" {
-  os   = "linux"
-  arch = "amd64"
-  dir  = "/home/coder"
+  os             = "linux"
+  arch           = "amd64"
+  dir            = "/home/coder"
   startup_script = <<-EOF
 pip3 install jupyterlab
 $HOME/.local/bin/jupyter lab --ServerApp.token='' --ip='*'
@@ -176,9 +176,9 @@ Configure your agent and `coder_app` like so to use RStudio. Notice the
 
 ```hcl
 resource "coder_agent" "coder" {
-  os   = "linux"
-  arch = "amd64"
-  dir = "/home/coder"
+  os             = "linux"
+  arch           = "amd64"
+  dir            = "/home/coder"
   startup_script = <<EOT
 #!/bin/bash
 # start rstudio
@@ -189,11 +189,12 @@ EOT
 # rstudio
 resource "coder_app" "rstudio" {
   agent_id      = coder_agent.coder.id
-  name          = "rstudio"
+  slug          = "rstudio"
+  display_name  = "R Studio"
   icon          = "/icon/rstudio.svg"
   url           = "http://localhost:8787"
-  subdomain = true
-  share     = "owner"
+  subdomain     = true
+  share         = "owner"
 
   healthcheck {
     url       = "http://localhost:8787/healthz"
@@ -214,7 +215,7 @@ Configure your agent and `coder_app` like so to use Airflow. Notice the
 resource "coder_agent" "coder" {
   os   = "linux"
   arch = "amd64"
-  dir = "/home/coder"
+  dir  = "/home/coder"
   startup_script = <<EOT
 #!/bin/bash
 # install and start airflow
@@ -225,11 +226,12 @@ EOT
 
 resource "coder_app" "airflow" {
   agent_id      = coder_agent.coder.id
-  name          = "airflow"
+  slug          = "airflow"
+  display_name  = "Airflow"
   icon          = "https://upload.wikimedia.org/wikipedia/commons/d/de/AirflowLogo.png"
   url           = "http://localhost:8080"
-  subdomain = true
-  share     = "owner"
+  subdomain     = true
+  share         = "owner"
 
   healthcheck {
     url       = "http://localhost:8080/healthz"

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -66,7 +66,7 @@ Another way to port forward is to configure a `coder_app` resource in the worksp
 resource "coder_app" "node-react-app" {
   agent_id  = coder_agent.dev.id
   slug      = "node-react-app"
-  icon      = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/2300px-React-icon.svg.png"
+  icon      = "https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg"
   url       = "http://localhost:3000"
   subdomain = true
   share     = "authenticated"

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -61,13 +61,13 @@ One way to port forward in the dashboard is to use the "Port forward" button to 
 
 Another way to port forward is to configure a `coder_app` resource in the workspace's template. This approach shows a visual application icon in the dashboard. See the following `coder_app` example for a Node React app and note the `subdomain` and `share` settings:
 
-```sh
+```hcl
 # node app
 resource "coder_app" "node-react-app" {
-  agent_id = coder_agent.dev.id
-  name     = "node-react-app"
-  icon     = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/2300px-React-icon.svg.png"
-  url      = "http://localhost:3000"
+  agent_id  = coder_agent.dev.id
+  slug      = "node-react-app"
+  icon      = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/2300px-React-icon.svg.png"
+  url       = "http://localhost:3000"
   subdomain = true
   share     = "authenticated"
 
@@ -75,7 +75,7 @@ resource "coder_app" "node-react-app" {
     url       = "http://localhost:3000/healthz"
     interval  = 10
     threshold = 30
-  }  
+  }
 
 }
 ```


### PR DESCRIPTION
this PR removes the deprecated `name` argument in a few of our `coder_app` examples in favor of `slug`. it also cleans up some terraform formatting.
