### PR TITLE
feat(footer): apply appropriate GitHub labels

### DIFF
--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -11,7 +11,9 @@ export const Language = {
     return `Coder ${buildInfo.version}`
   },
   copyrightText: `Copyright \u00a9 ${new Date().getFullYear()} Coder Technologies, Inc.`,
-  reportBugLink: "Report an issue or share feedback",
+  reportBugLink: "Report a bug encountered while using Coder",
+  enhancementLink: "Request an enhancement to Coder",
+  shareFeedbackLink: "Share your experience with Coder",
   discordLink: "Join Coder on Discord",
 }
 
@@ -24,16 +26,22 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
 }) => {
   const styles = useFooterStyles()
 
-  const githubUrl = `https://github.com/coder/coder/issues/new?labels=needs+grooming&body=${encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})
 
-<!--- Ask a question or leave feedback! -->`)}`
-  const discordUrl = `https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer`
+  const githubUrl = 'https://github.com/coder/coder/issues/new'
+  const versionUrl = `Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`
+
+  const reportBugUrl = githubUrl + `labels=bug&body=${encodeURIComponent(`${versionUrl}`)}`
+  const enhancementUrl = githubUrl + `labels=enhancement&body=${encodeURIComponent(`${versionUrl}`)}`
+  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${encodeURIComponent(`${versionUrl}`)}`
+
+  const discordUrl = 'https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer'
 
   return (
     <div className={styles.root}>
       <div className={styles.copyRight}>{Language.copyrightText}</div>
       {buildInfo && (
         <div className={styles.buildInfo}>
+
           <Link
             className={styles.link}
             variant="caption"
@@ -44,15 +52,37 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
             {Language.buildInfoText(buildInfo)}
           </Link>
           &nbsp;|&nbsp;
+
           <Link
             className={styles.link}
             variant="caption"
             target="_blank"
-            href={githubUrl}
+            href={reportBugUrl}
           >
             <AssistantIcon className={styles.icon} /> {Language.reportBugLink}
           </Link>
           &nbsp;|&nbsp;
+
+          <Link
+            className={styles.link}
+            variant="caption"
+            target="_blank"
+            href={enhancementUrl}
+          >
+            <AssistantIcon className={styles.icon} /> {Language.enhancementLink}
+          </Link>
+          &nbsp;|&nbsp;
+
+          <Link
+            className={styles.link}
+            variant="caption"
+            target="_blank"
+            href={shareFeedbackUrl}
+          >
+            <AssistantIcon className={styles.icon} /> {Language.shareFeedbackLink}
+          </Link>
+          &nbsp;|&nbsp;
+
           <Link
             className={styles.link}
             variant="caption"

--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -28,11 +28,11 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
 
 
   const githubUrl = 'https://github.com/coder/coder/issues/new?'
-  const versionUrl = encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)
+  const body = encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)
 
-  const reportBugUrl = githubUrl + `labels=bug&body=${versionUrl}}`
-  const enhancementUrl = githubUrl + `labels=enhancement&body=${versionUrl}}`
-  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${versionUrl}}`
+  const reportBugUrl = githubUrl + `labels=bug&body=${body}}`
+  const enhancementUrl = githubUrl + `labels=enhancement&body=${body}}`
+  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${body}}`
 
   const discordUrl = 'https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer'
 

--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -30,9 +30,9 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
   const githubUrl = 'https://github.com/coder/coder/issues/new?'
   const body = encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)
 
-  const reportBugUrl = githubUrl + `labels=bug&body=${body}}`
-  const enhancementUrl = githubUrl + `labels=enhancement&body=${body}}`
-  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${body}}`
+  const reportBugUrl = githubUrl + `labels=bug&body=${body}`
+  const enhancementUrl = githubUrl + `labels=enhancement&body=${body}`
+  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${body}`
 
   const discordUrl = 'https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer'
 

--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -26,22 +26,28 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
 }) => {
   const styles = useFooterStyles()
 
+  const buildURL = (label: string): URL => {
+    const githubURL = new URL("https://github.com/coder/coder/issues/new")
+    githubURL.searchParams.append("labels", label)
+    githubURL.searchParams.append(
+      "body",
+      `Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`,
+    )
+    return githubURL
+  }
 
-  const githubUrl = 'https://github.com/coder/coder/issues/new?'
-  const body = encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)
+  const reportBugUrl = buildURL("bug")
+  const enhancementUrl = buildURL("enhancement")
+  const shareFeedbackUrl = buildURL("feedback")
 
-  const reportBugUrl = githubUrl + `labels=bug&body=${body}`
-  const enhancementUrl = githubUrl + `labels=enhancement&body=${body}`
-  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${body}`
-
-  const discordUrl = 'https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer'
+  const discordUrl =
+    "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer"
 
   return (
     <div className={styles.root}>
       <div className={styles.copyRight}>{Language.copyrightText}</div>
       {buildInfo && (
         <div className={styles.buildInfo}>
-
           <Link
             className={styles.link}
             variant="caption"
@@ -52,7 +58,6 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
             {Language.buildInfoText(buildInfo)}
           </Link>
           &nbsp;|&nbsp;
-
           <Link
             className={styles.link}
             variant="caption"
@@ -62,7 +67,6 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
             <AssistantIcon className={styles.icon} /> {Language.reportBugLink}
           </Link>
           &nbsp;|&nbsp;
-
           <Link
             className={styles.link}
             variant="caption"
@@ -72,17 +76,16 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
             <AssistantIcon className={styles.icon} /> {Language.enhancementLink}
           </Link>
           &nbsp;|&nbsp;
-
           <Link
             className={styles.link}
             variant="caption"
             target="_blank"
             href={shareFeedbackUrl}
           >
-            <AssistantIcon className={styles.icon} /> {Language.shareFeedbackLink}
+            <AssistantIcon className={styles.icon} />{" "}
+            {Language.shareFeedbackLink}
           </Link>
           &nbsp;|&nbsp;
-
           <Link
             className={styles.link}
             variant="caption"

--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -28,11 +28,11 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
 
 
   const githubUrl = 'https://github.com/coder/coder/issues/new?'
-  const versionUrl = `Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`
+  const versionUrl = encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)
 
-  const reportBugUrl = githubUrl + `labels=bug&body=${encodeURIComponent(`${versionUrl}`)}`
-  const enhancementUrl = githubUrl + `labels=enhancement&body=${encodeURIComponent(`${versionUrl}`)}`
-  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${encodeURIComponent(`${versionUrl}`)}`
+  const reportBugUrl = githubUrl + `labels=bug&body=${versionUrl}}`
+  const enhancementUrl = githubUrl + `labels=enhancement&body=${versionUrl}}`
+  const shareFeedbackUrl = githubUrl + `labels=feedback&body=${versionUrl}}`
 
   const discordUrl = 'https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer'
 

--- a/site/src/components/Footer/Footer.tsx
+++ b/site/src/components/Footer/Footer.tsx
@@ -27,7 +27,7 @@ export const Footer: React.FC<React.PropsWithChildren<FooterProps>> = ({
   const styles = useFooterStyles()
 
 
-  const githubUrl = 'https://github.com/coder/coder/issues/new'
+  const githubUrl = 'https://github.com/coder/coder/issues/new?'
   const versionUrl = `Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`
 
   const reportBugUrl = githubUrl + `labels=bug&body=${encodeURIComponent(`${versionUrl}`)}`


### PR DESCRIPTION
Complements this PR: https://github.com/coder/coder/pull/5025

<img width="1602" alt="CleanShot 2022-11-11 at 15 00 12@2x" src="https://user-images.githubusercontent.com/127353/201267191-d0ea4673-f526-47a8-826c-d127866fc555.png">
