### PR TITLE
fix: Set a default `CODER_ACCESS_URL` in Helm

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -87,8 +87,6 @@ to log in and manage templates.
      # `CODER_TLS_ENABLE`, `CODER_TLS_CERT_FILE` or `CODER_TLS_KEY_FILE` as
      # they are already set by the Helm chart and will cause conflicts.
      env:
-       - name: CODER_ACCESS_URL
-         value: "https://coder.example.com"
        - name: CODER_PG_CONNECTION_URL
          valueFrom:
            secretKeyRef:
@@ -97,6 +95,11 @@ to log in and manage templates.
              # postgres://coder:password@postgres:5432/coder?sslmode=disable
              name: coder-db-url
              key: url
+
+       # (Optional) For production deployments the access URL should be set.
+       # If you're just trying Coder, access the dashboard via the service IP.
+       - name: CODER_ACCESS_URL
+         value: "https://coder.example.com"
 
        # This env variable controls whether or not to auto-import the
        # "kubernetes" template on first startup. This will not work unless

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -54,6 +54,18 @@ spec:
           env:
             - name: CODER_ADDRESS
               value: "0.0.0.0:{{ include "coder.port" . }}"
+            # Set the default access URL so a `helm apply` works by default.
+            # See: https://github.com/coder/coder/issues/5024
+            {{- $hasAccessURL := false }}
+            {{- range .Values.coder.env }}
+              {{- if eq .name "CODER_ACCESS_URL" }}
+                {{- $hasAccessURL = true }}
+              {{- end }}
+            {{- end }}
+            {{- if not $hasAccessURL }}
+            - name: CODER_ACCESS_URL
+              value: "{{ include "coder.portName" . }}://coder.{{.Release.Namespace}}.svc.cluster.local"
+            {{- end }}
             # Used for inter-pod communication with high-availability.
             - name: KUBE_POD_IP
               valueFrom:


### PR DESCRIPTION
This allows for a simple `helm apply` to create a full Coder deployment that works for creating workspaces.
