### PR TITLE
feat(windows): default to PowerShell v7 over v6 and fallback to cmd.exe

### DIFF
--- a/agent/usershell/usershell_windows.go
+++ b/agent/usershell/usershell_windows.go
@@ -4,7 +4,11 @@ import "os/exec"
 
 // Get returns the command prompt binary name.
 func Get(username string) (string, error) {
-	_, err := exec.LookPath("powershell.exe")
+	_, err := exec.LookPath("pwsh.exe")
+	if err == nil {
+		return "pwsh.exe", nil
+	}
+	_, err = exec.LookPath("powershell.exe")
 	if err == nil {
 		return "powershell.exe", nil
 	}


### PR DESCRIPTION
When invoking the usershell default to Version 7 of PowerShell (if installed) otherwise choose V6 or fallback to `cmd.exe`. For more information about PowerShell v7 see https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-70

A general user experience improvement related to #5051 