### PR TITLE
fix: do not skip properties on creating templates

### DIFF
--- a/cli/templateedit_test.go
+++ b/cli/templateedit_test.go
@@ -17,7 +17,7 @@ import (
 func TestTemplateEdit(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Modified", func(t *testing.T) {
+	t.Run("FirstEmptyThenModified", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
@@ -58,7 +58,7 @@ func TestTemplateEdit(t *testing.T) {
 		assert.Equal(t, icon, updated.Icon)
 		assert.Equal(t, defaultTTL.Milliseconds(), updated.DefaultTTLMillis)
 	})
-	t.Run("NotModified", func(t *testing.T) {
+	t.Run("FirstEmptyThenNotModified", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
@@ -123,5 +123,55 @@ func TestTemplateEdit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, template.Name, updated.Name)
 		assert.Equal(t, "", template.DisplayName)
+	})
+	t.Run("WithPropertiesThenModified", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		_ = coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+
+		initialDisplayName := "This is a template"
+		initialDescription := "This is description"
+		initialIcon := "/img/icon.png"
+
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+			ctr.DisplayName = initialDisplayName
+			ctr.Description = initialDescription
+			ctr.Icon = initialIcon
+		})
+
+		// Test created template
+		created, err := client.Template(context.Background(), template.ID)
+		require.NoError(t, err)
+		assert.Equal(t, initialDisplayName, created.DisplayName)
+		assert.Equal(t, initialDescription, created.Description)
+		assert.Equal(t, initialIcon, created.Icon)
+
+		// Test the cli command.
+		displayName := "New Display Name 789"
+		icon := "/icons/new-icon.png"
+		cmdArgs := []string{
+			"templates",
+			"edit",
+			template.Name,
+			"--display-name", displayName,
+			"--icon", icon,
+		}
+		cmd, root := clitest.New(t, cmdArgs...)
+		clitest.SetupConfig(t, client, root)
+
+		ctx, _ := testutil.Context(t)
+		err = cmd.ExecuteContext(ctx)
+
+		require.NoError(t, err)
+
+		// Assert that the template metadata changed.
+		updated, err := client.Template(context.Background(), template.ID)
+		require.NoError(t, err)
+		assert.Equal(t, template.Name, updated.Name)             // doesn't change
+		assert.Equal(t, initialDescription, updated.Description) // doesn't change
+		assert.Equal(t, displayName, updated.DisplayName)
+		assert.Equal(t, icon, updated.Icon)
 	})
 }

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -2091,6 +2091,8 @@ func (q *fakeQuerier) InsertTemplate(_ context.Context, arg database.InsertTempl
 		CreatedBy:       arg.CreatedBy,
 		UserACL:         arg.UserACL,
 		GroupACL:        arg.GroupACL,
+		DisplayName:     arg.DisplayName,
+		Icon:            arg.Icon,
 	}
 	q.templates = append(q.templates, template)
 	return template, nil

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -239,6 +239,8 @@ func (api *API) postTemplateByOrganization(rw http.ResponseWriter, r *http.Reque
 			GroupACL: database.TemplateACL{
 				organization.ID.String(): []rbac.Action{rbac.ActionRead},
 			},
+			DisplayName: createTemplate.DisplayName,
+			Icon:        createTemplate.Icon,
 		})
 		if err != nil {
 			return xerrors.Errorf("insert template: %s", err)


### PR DESCRIPTION
While working on https://github.com/coder/coder/issues/3321 I found that `POST /templates` rejects properties, even though the [API contract](https://github.com/coder/coder/blob/main/codersdk/organizations.go#L50) expects it. This PR fixes the behavior.