### PR TITLE
docs: Rephrase Templates section

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -236,7 +236,7 @@ coder templates edit <template-name> --description "This is my template"
 
 Review editable template properties by running `coder templates edit -h`.
 
-Alternatively, you can pull down the template as a compressed file (`.tar.gz`) to your current directory:
+Alternatively, you can pull down the template as a tape archive (`.tar`) to your current directory:
 
 ```sh
 coder templates pull <template-name> file.tar

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -245,7 +245,7 @@ coder templates pull <template-name> file.tar
 Then, unzip it by running:
 
 ```sh
-tar -xf file.tar.gz
+tar -xf file.tar
 ```
 
 Make the changes to your template then run this command from the root of the template folder:

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -242,7 +242,7 @@ Alternatively, you can pull down the template as a tape archive (`.tar`) to your
 coder templates pull <template-name> file.tar
 ```
 
-Then, unzip it by running:
+Then, extract it by running:
 
 ```sh
 tar -xf file.tar

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -239,7 +239,7 @@ Review editable template properties by running `coder templates edit -h`.
 Alternatively, you can pull down the template as a compressed file (`.tar.gz`) to your current directory:
 
 ```sh
-coder templates pull <template-name> file.tar.gz
+coder templates pull <template-name> file.tar
 ```
 
 Then, unzip it by running:

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -225,17 +225,24 @@ resource "kubernetes_pod" "podName" {
 
 ### Edit templates
 
-You can delete a template using the coder CLI. Only
+You can edit a template using the coder CLI. Only
 [template admins and owners](./admin/users.md) can edit a template.
 
-Using the CLI, login to Coder and run the following command to delete a template:
+Using the CLI, login to Coder and run the following command to edit a single template:
+
+```sh
+coder templates edit <template-name> --description "This is my template"
+```
+
+Review editable template properties by running `coder templates edit -h`.
+
+Alternatively, you can pull down the template as a compressed file (`.tar.gz`) to your current directory:
 
 ```sh
 coder templates pull <template-name> file.tar.gz
 ```
 
-This will pull down the template as a gzipped file to your current directory. Then unzip
-it by running:
+Then, unzip it by running:
 
 ```sh
 tar -xf file.tar.gz


### PR DESCRIPTION
While working on https://github.com/coder/coder/issues/3321, I spotted some typos in the [Edit templates](https://coder.com/docs/coder-oss/latest/templates#edit-templates) section.

Preview: [link](https://github.com/mtojek/coder/blob/3321-template-docs/docs/templates.md#edit-templates)