### PR TITLE
fix: Use UTC in cli/cliui table test to match expected output

### DIFF
--- a/cli/cliui/table_test.go
+++ b/cli/cliui/table_test.go
@@ -52,7 +52,7 @@ type tableTest3 struct {
 func Test_DisplayTable(t *testing.T) {
 	t.Parallel()
 
-	someTime := time.Date(2022, 8, 2, 15, 49, 10, 0, time.Local)
+	someTime := time.Date(2022, 8, 2, 15, 49, 10, 0, time.UTC)
 	in := []tableTest1{
 		{
 			Name:  "foo",


### PR DESCRIPTION
Noticed this while trying to reproduce a test issue on Windows.
