### PR TITLE
feat: Let port-forwarding support custom http(s) port

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -123,6 +123,9 @@ func (api *API) workspaceAgentMetadata(rw http.ResponseWriter, r *http.Request) 
 			workspace.Name,
 			owner.Username,
 		))
+	if api.AccessURL.Port() != "" {
+		vscodeProxyURI += fmt.Sprintf(":%s", api.AccessURL.Port())
+	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.WorkspaceAgentMetadata{
 		Apps:                 convertApps(dbApps),

--- a/coderd/workspaceapps.go
+++ b/coderd/workspaceapps.go
@@ -40,8 +40,13 @@ const (
 )
 
 func (api *API) appHost(rw http.ResponseWriter, r *http.Request) {
+	host := api.AppHostname
+	if api.AccessURL.Port() != "" {
+		host += fmt.Sprintf(":%s", api.AccessURL.Port())
+	}
+
 	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.GetAppHostResponse{
-		Host: api.AppHostname,
+		Host: host,
 	})
 }
 


### PR DESCRIPTION
Set

- `CODER_ACCESS_URL=https://coder.example.com:8443`
- `CODER_WILDCARD_ACCESS_URL=*.coder.example.com`

Then the  port-forwarding url will be

`https://3000--xxx--xxxx--xxx.coder.example.com`

It should be:

`https://3000--xxx--xxxx--xxx.coder.example.com:8443`
