### PR TITLE
feat: Add allow everyone option to GitHub OAuth2 logins

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -187,7 +187,7 @@ func newConfig() *codersdk.DeploymentConfig {
 				},
 				AllowEveryone: &codersdk.DeploymentConfigField[bool]{
 					Name:  "OAuth2 GitHub Allow Everyone",
-					Usage: "Allow all logins, setting this option means allowed orgs must be empty and no org limits will be imposed.",
+					Usage: "Allow all logins, setting this option means allowed orgs and teams must be empty.",
 					Flag:  "oauth2-github-allow-everyone",
 				},
 				EnterpriseBaseURL: &codersdk.DeploymentConfigField[string]{

--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -185,6 +185,11 @@ func newConfig() *codersdk.DeploymentConfig {
 					Usage: "Whether new users can sign up with GitHub.",
 					Flag:  "oauth2-github-allow-signups",
 				},
+				AllowEveryone: &codersdk.DeploymentConfigField[bool]{
+					Name:  "OAuth2 GitHub Allow Everyone",
+					Usage: "Allow all logins, setting this option means allowed orgs must be empty and no org limits will be imposed.",
+					Flag:  "oauth2-github-allow-everyone",
+				},
 				EnterpriseBaseURL: &codersdk.DeploymentConfigField[string]{
 					Name:  "OAuth2 GitHub Enterprise Base URL",
 					Usage: "Base URL of a GitHub Enterprise deployment to use for Login with GitHub.",

--- a/cli/server.go
+++ b/cli/server.go
@@ -1063,6 +1063,7 @@ func configureTLS(tlsMinVersion, tlsClientAuth string, tlsCertFiles, tlsKeyFiles
 	return tlsConfig, nil
 }
 
+//nolint:revive // Ignore flag-parameter: parameter 'allowEveryone' seems to be a control flag, avoid control coupling (revive)
 func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, allowSignups, allowEveryone bool, allowOrgs []string, rawTeams []string, enterpriseBaseURL string) (*coderd.GithubOAuth2Config, error) {
 	redirectURL, err := accessURL.Parse("/api/v2/users/oauth2/github/callback")
 	if err != nil {

--- a/cli/server.go
+++ b/cli/server.go
@@ -375,6 +375,7 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 					cfg.OAuth2.Github.ClientID.Value,
 					cfg.OAuth2.Github.ClientSecret.Value,
 					cfg.OAuth2.Github.AllowSignups.Value,
+					cfg.OAuth2.Github.AllowEveryone.Value,
 					cfg.OAuth2.Github.AllowedOrgs.Value,
 					cfg.OAuth2.Github.AllowedTeams.Value,
 					cfg.OAuth2.Github.EnterpriseBaseURL.Value,
@@ -1062,10 +1063,19 @@ func configureTLS(tlsMinVersion, tlsClientAuth string, tlsCertFiles, tlsKeyFiles
 	return tlsConfig, nil
 }
 
-func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, allowSignups bool, allowOrgs []string, rawTeams []string, enterpriseBaseURL string) (*coderd.GithubOAuth2Config, error) {
+func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, allowSignups, allowEveryone bool, allowOrgs []string, rawTeams []string, enterpriseBaseURL string) (*coderd.GithubOAuth2Config, error) {
 	redirectURL, err := accessURL.Parse("/api/v2/users/oauth2/github/callback")
 	if err != nil {
 		return nil, xerrors.Errorf("parse github oauth callback url: %w", err)
+	}
+	if allowEveryone && len(allowOrgs) > 0 {
+		return nil, xerrors.New("allow everyone and allowed orgs cannot be used together")
+	}
+	if allowEveryone && len(rawTeams) > 0 {
+		return nil, xerrors.New("allow everyone and allowed teams cannot be used together")
+	}
+	if !allowEveryone && len(allowOrgs) == 0 {
+		return nil, xerrors.New("allowed orgs is empty: must specify at least one org or allow everyone")
 	}
 	allowTeams := make([]coderd.GithubOAuth2Team, 0, len(rawTeams))
 	for _, rawTeam := range rawTeams {
@@ -1118,6 +1128,7 @@ func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, al
 			},
 		},
 		AllowSignups:       allowSignups,
+		AllowEveryone:      allowEveryone,
 		AllowOrganizations: allowOrgs,
 		AllowTeams:         allowTeams,
 		AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -608,6 +608,7 @@ func TestServer(t *testing.T) {
 			"--in-memory",
 			"--address", ":0",
 			"--access-url", "http://example.com",
+			"--oauth2-github-allow-everyone",
 			"--oauth2-github-client-id", "fake",
 			"--oauth2-github-client-secret", "fake",
 			"--oauth2-github-enterprise-base-url", fakeRedirect,

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -65,6 +65,10 @@ Flags:
                                                      production.
                                                      Consumes $CODER_EXPERIMENTAL
   -h, --help                                         help for server
+      --oauth2-github-allow-everyone                 Allow all logins, setting this option
+                                                     means allowed orgs must be empty and no
+                                                     org limits will be imposed.
+                                                     Consumes $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
       --oauth2-github-allow-signups                  Whether new users can sign up with
                                                      GitHub.
                                                      Consumes $CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -66,8 +66,8 @@ Flags:
                                                      Consumes $CODER_EXPERIMENTAL
   -h, --help                                         help for server
       --oauth2-github-allow-everyone                 Allow all logins, setting this option
-                                                     means allowed orgs must be empty and no
-                                                     org limits will be imposed.
+                                                     means allowed orgs and teams must be
+                                                     empty.
                                                      Consumes $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
       --oauth2-github-allow-signups                  Whether new users can sign up with
                                                      GitHub.

--- a/codersdk/deploymentconfig.go
+++ b/codersdk/deploymentconfig.go
@@ -81,6 +81,7 @@ type OAuth2GithubConfig struct {
 	AllowedOrgs       *DeploymentConfigField[[]string] `json:"allowed_orgs" typescript:",notnull"`
 	AllowedTeams      *DeploymentConfigField[[]string] `json:"allowed_teams" typescript:",notnull"`
 	AllowSignups      *DeploymentConfigField[bool]     `json:"allow_signups" typescript:",notnull"`
+	AllowEveryone     *DeploymentConfigField[bool]     `json:"allow_everyone" typescript:",notnull"`
 	EnterpriseBaseURL *DeploymentConfigField[string]   `json:"enterprise_base_url" typescript:",notnull"`
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -433,6 +433,7 @@ export interface OAuth2GithubConfig {
   readonly allowed_orgs: DeploymentConfigField<string[]>
   readonly allowed_teams: DeploymentConfigField<string[]>
   readonly allow_signups: DeploymentConfigField<boolean>
+  readonly allow_everyone: DeploymentConfigField<boolean>
   readonly enterprise_base_url: DeploymentConfigField<string>
 }
 


### PR DESCRIPTION
This PR adds support for GitHub logins without organization/team by introducing a new option, allow everyone.

This PR also fixes an issue where if you are a member of multiple organizations, and have permission to one of the required teams via org X, login might still fail because only the last matched organization was considered.

Thanks to @starcatmeow for the original PR (#4837) and bringing this to our attention!

Closes #4837
