### PR TITLE
chore: TemplatesPage tests failing on M1

### DIFF
--- a/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -24,7 +24,7 @@ describe("TemplatesPage", () => {
           return res(ctx.status(200), ctx.json([]))
         },
       ),
-      rest.post("/api/v2/authcheck", async (req, res, ctx) => {
+      rest.post("/api/v2/authcheck", (req, res, ctx) => {
         return res(
           ctx.status(200),
           ctx.json({
@@ -57,7 +57,7 @@ describe("TemplatesPage", () => {
           return res(ctx.status(200), ctx.json([]))
         },
       ),
-      rest.post("/api/v2/authcheck", async (req, res, ctx) => {
+      rest.post("/api/v2/authcheck", (req, res, ctx) => {
         return res(
           ctx.status(200),
           ctx.json({


### PR DESCRIPTION
Jest tests running on the local development environment (Macbook M1) are failing for `TemplatesPage` and `WorkspacePage`.

It seems that this PR fixes the problem for the `TemplatesPage` tests.