### PR TITLE
feat: Add `no_refresh` option to Git auth configs

### DIFF
--- a/coderd/gitauth/config.go
+++ b/coderd/gitauth/config.go
@@ -22,6 +22,12 @@ type Config struct {
 	Regex *regexp.Regexp
 	// Type is the type of provider.
 	Type codersdk.GitProvider
+	// NoRefresh stops Coder from using the refresh token
+	// to renew the access token.
+	//
+	// Some organizations have security policies that require
+	// re-authentication for every token.
+	NoRefresh bool
 }
 
 // ConvertConfig converts the YAML configuration entry to the
@@ -107,6 +113,7 @@ func ConvertConfig(entries []codersdk.GitAuthConfig, accessURL *url.URL) ([]*Con
 			ID:           entry.ID,
 			Regex:        regex,
 			Type:         typ,
+			NoRefresh:    entry.NoRefresh,
 		})
 	}
 	return configs, nil

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1154,6 +1154,15 @@ func (api *API) workspaceAgentsGitAuth(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// If the token is expired and refresh is disabled, we prompt
+	// the user to authenticate again.
+	if gitAuthConfig.NoRefresh && gitAuthLink.OAuthExpiry.Before(database.Now()) {
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.WorkspaceAgentGitAuthResponse{
+			URL: redirectURL.String(),
+		})
+		return
+	}
+
 	token, err := gitAuthConfig.TokenSource(ctx, &oauth2.Token{
 		AccessToken:  gitAuthLink.OAuthAccessToken,
 		RefreshToken: gitAuthLink.OAuthRefreshToken,

--- a/codersdk/deploymentconfig.go
+++ b/codersdk/deploymentconfig.go
@@ -124,6 +124,7 @@ type GitAuthConfig struct {
 	AuthURL      string   `json:"auth_url"`
 	TokenURL     string   `json:"token_url"`
 	Regex        string   `json:"regex"`
+	NoRefresh    bool     `json:"no_refresh"`
 	Scopes       []string `json:"scopes"`
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -362,6 +362,7 @@ export interface GitAuthConfig {
   readonly auth_url: string
   readonly token_url: string
   readonly regex: string
+  readonly no_refresh: boolean
   readonly scopes: string[]
 }
 


### PR DESCRIPTION
This allows organizations to disable refreshing Git tokens and instead prompt for authentication again.

