### PR TITLE
fix: Parse boolean in slice for gitauth

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -529,9 +529,11 @@ func readSliceFromViper[T any](vip *viper.Viper, key string, value any) []T {
 				newType := reflect.Indirect(reflect.New(elementType))
 				instance = &newType
 			}
-			switch instance.Field(i).Type().String() {
+			switch v := instance.Field(i).Type().String(); v {
 			case "[]string":
 				value = vip.GetStringSlice(configKey)
+			case "bool":
+				value = vip.GetBool(configKey)
 			default:
 			}
 			instance.Field(i).Set(reflect.ValueOf(value))

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -167,6 +167,7 @@ func TestConfig(t *testing.T) {
 			"CODER_GITAUTH_0_TOKEN_URL":     "https://token.com",
 			"CODER_GITAUTH_0_REGEX":         "github.com",
 			"CODER_GITAUTH_0_SCOPES":        "read write",
+			"CODER_GITAUTH_0_NO_REFRESH":    "true",
 
 			"CODER_GITAUTH_1_ID":            "another",
 			"CODER_GITAUTH_1_TYPE":          "gitlab",
@@ -187,6 +188,7 @@ func TestConfig(t *testing.T) {
 				TokenURL:     "https://token.com",
 				Regex:        "github.com",
 				Scopes:       []string{"read", "write"},
+				NoRefresh:    true,
 			}, {
 				ID:           "another",
 				Type:         "gitlab",


### PR DESCRIPTION
This was causing a panic for the new `no_refesh` option!
