### PR TITLE
fix: Users page filter resets page

### DIFF
--- a/site/src/xServices/users/usersXService.ts
+++ b/site/src/xServices/users/usersXService.ts
@@ -137,8 +137,11 @@ export const usersMachine =
       id: "usersState",
       on: {
         UPDATE_FILTER: {
-          target: ".gettingUsers",
           actions: ["assignFilter", "sendResetPage"],
+        },
+        UPDATE_PAGE: {
+          target: "gettingUsers",
+          actions: "updateURL",
         },
       },
       initial: "startingPagination",
@@ -198,14 +201,6 @@ export const usersMachine =
             UPDATE_USER_ROLES: {
               target: "updatingUserRoles",
               actions: "assignUserIdToUpdateRoles",
-            },
-            UPDATE_PAGE: {
-              target: "gettingUsers",
-              actions: "updateURL",
-            },
-            UPDATE_FILTER: {
-              target: "gettingUsers",
-              actions: ["assignFilter", "sendResetPage"],
             },
           },
         },


### PR DESCRIPTION
Changing the filter on a page should reset the page to page 1, but that wasn't happening on the Users page. The fix is to avoid going to the `gettingUsers` state in response to the `UPDATE_FILTER` event, and instead to wait until the `UPDATE_PAGE` event to fetch users. 
