### PR TITLE
refactor: Minor build bar UI improvement

### DIFF
--- a/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.tsx
+++ b/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.tsx
@@ -3,7 +3,6 @@ import makeStyles from "@material-ui/core/styles/makeStyles"
 import { TransitionStats, Template, Workspace } from "api/typesGenerated"
 import dayjs, { Dayjs } from "dayjs"
 import { FC, useEffect, useState } from "react"
-import { MONOSPACE_FONT_FAMILY } from "theme/constants"
 
 import duration from "dayjs/plugin/duration"
 
@@ -140,11 +139,10 @@ const useStyles = makeStyles((theme) => ({
   barHelpers: {
     display: "flex",
     justifyContent: "space-between",
+    marginTop: theme.spacing(0.5),
   },
   label: {
-    fontFamily: MONOSPACE_FONT_FAMILY,
     fontSize: 12,
-    textTransform: "uppercase",
     display: "block",
     fontWeight: 600,
     color: theme.palette.text.secondary,


### PR DESCRIPTION
Before:
<img width="1503" alt="Screen Shot 2022-11-18 at 15 04 18" src="https://user-images.githubusercontent.com/3165839/202772952-90b91d8f-98df-43b8-a0c2-81595477766f.png">

After:
<img width="1503" alt="Screen Shot 2022-11-18 at 15 03 55" src="https://user-images.githubusercontent.com/3165839/202772959-52f4dd0a-2bd5-4e63-930b-0402fb6b3926.png">
