### PR TITLE
fix: Adjust description for cancel in-progress workspace jobs

### DIFF
--- a/site/src/i18n/en/templatePage.json
+++ b/site/src/i18n/en/templatePage.json
@@ -12,5 +12,5 @@
   },
   "displayNameLabel": "Display name",
   "allowUserCancelWorkspaceJobsLabel": "Allow users to cancel in-progress workspace jobs.",
-  "allowUserCancelWorkspaceJobsNotice": "Depending on your template, cancelling builds may leave workspaces in an unhealthy state. This option isn't recommended for most use cases."
+  "allowUserCancelWorkspaceJobsNotice": "Depending on your template, canceling builds may leave workspaces in an unhealthy state. This option isn't recommended for most use cases."
 }

--- a/site/src/i18n/en/templatePage.json
+++ b/site/src/i18n/en/templatePage.json
@@ -12,5 +12,5 @@
   },
   "displayNameLabel": "Display name",
   "allowUserCancelWorkspaceJobsLabel": "Allow users to cancel in-progress workspace jobs.",
-  "allowUserCancelWorkspaceJobsNotice": "It is advised to keep the option disabled when canceling a workspace job may leave the workspace in an unhealthy state, and extra permissions are required to manually repair its resources."
+  "allowUserCancelWorkspaceJobsNotice": "Depending on your template, cancelling builds may leave workspaces in an unhealthy state. This option isn't recommended for most use cases."
 }


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/5115

This PR improves the description for the checkbox "allow cancel workspace jobs". It's an outcome of the slack discussion.