### PR TITLE
feat: tweak timeline design

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.tsx
@@ -184,9 +184,8 @@ const useStyles = makeStyles((theme) => ({
       outlineColor: theme.palette.secondary.dark,
     },
 
-    "&:not(:last-child) td:before": {
+    "& td:before": {
       position: "absolute",
-      top: 20,
       left: 50,
       display: "block",
       content: "''",

--- a/site/src/components/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.tsx
@@ -1,7 +1,6 @@
 import Collapse from "@material-ui/core/Collapse"
 import { makeStyles } from "@material-ui/core/styles"
 import TableCell from "@material-ui/core/TableCell"
-import TableRow from "@material-ui/core/TableRow"
 import { AuditLog } from "api/typesGenerated"
 import {
   CloseDropdown,
@@ -9,11 +8,11 @@ import {
 } from "components/DropdownArrows/DropdownArrows"
 import { Pill } from "components/Pill/Pill"
 import { Stack } from "components/Stack/Stack"
+import { TimelineEntry } from "components/Timeline/TimelineEntry"
 import { UserAvatar } from "components/UserAvatar/UserAvatar"
 import { useState } from "react"
 import { PaletteIndex } from "theme/palettes"
 import userAgentParser from "ua-parser-js"
-import { combineClasses } from "util/combineClasses"
 import { AuditLogDiff } from "./AuditLogDiff"
 
 export const readableActionMessage = (auditLog: AuditLog): string => {
@@ -68,19 +67,16 @@ export const AuditLogRow: React.FC<AuditLogRowProps> = ({
   }
 
   return (
-    <TableRow
+    <TimelineEntry
       key={auditLog.id}
       data-testid={`audit-log-row-${auditLog.id}`}
-      className={styles.auditLogRow}
+      clickable={shouldDisplayDiff}
     >
       <TableCell className={styles.auditLogCell}>
         <Stack
           direction="row"
           alignItems="center"
-          className={combineClasses({
-            [styles.auditLogHeader]: true,
-            [styles.clickable]: shouldDisplayDiff,
-          })}
+          className={styles.auditLogHeader}
           tabIndex={0}
           onClick={toggle}
           onKeyDown={(event) => {
@@ -164,7 +160,7 @@ export const AuditLogRow: React.FC<AuditLogRowProps> = ({
           </Collapse>
         )}
       </TableCell>
-    </TableRow>
+    </TimelineEntry>
   )
 }
 
@@ -174,37 +170,8 @@ const useStyles = makeStyles((theme) => ({
     border: 0,
   },
 
-  auditLogRow: {
-    position: "relative",
-
-    "&:focus": {
-      outlineStyle: "solid",
-      outlineOffset: -1,
-      outlineWidth: 2,
-      outlineColor: theme.palette.secondary.dark,
-    },
-
-    "& td:before": {
-      position: "absolute",
-      left: 50,
-      display: "block",
-      content: "''",
-      height: "100%",
-      width: 2,
-      background: theme.palette.divider,
-    },
-  },
-
   auditLogHeader: {
     padding: theme.spacing(2, 4),
-  },
-
-  clickable: {
-    cursor: "pointer",
-
-    "&:hover": {
-      backgroundColor: theme.palette.action.hover,
-    },
   },
 
   auditLogHeaderInfo: {

--- a/site/src/components/BuildsTable/BuildRow.tsx
+++ b/site/src/components/BuildsTable/BuildRow.tsx
@@ -1,8 +1,8 @@
 import { makeStyles } from "@material-ui/core/styles"
 import TableCell from "@material-ui/core/TableCell"
-import TableRow from "@material-ui/core/TableRow"
 import { WorkspaceBuild } from "api/typesGenerated"
 import { Stack } from "components/Stack/Stack"
+import { TimelineEntry } from "components/Timeline/TimelineEntry"
 import { useClickable } from "hooks/useClickable"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -27,12 +27,7 @@ export const BuildRow: React.FC<BuildRowProps> = ({ build }) => {
   )
 
   return (
-    <TableRow
-      hover
-      data-testid={`build-${build.id}`}
-      className={styles.buildRow}
-      {...clickableProps}
-    >
+    <TimelineEntry hover data-testid={`build-${build.id}`} {...clickableProps}>
       <TableCell className={styles.buildCell}>
         <Stack
           direction="row"
@@ -76,32 +71,11 @@ export const BuildRow: React.FC<BuildRowProps> = ({ build }) => {
           </Stack>
         </Stack>
       </TableCell>
-    </TableRow>
+    </TimelineEntry>
   )
 }
 
 const useStyles = makeStyles((theme) => ({
-  buildRow: {
-    cursor: "pointer",
-
-    "&:focus": {
-      outlineStyle: "solid",
-      outlineOffset: -1,
-      outlineWidth: 2,
-      outlineColor: theme.palette.secondary.dark,
-    },
-
-    "& td:before": {
-      position: "absolute",
-      left: 50,
-      display: "block",
-      content: "''",
-      height: "100%",
-      width: 2,
-      background: theme.palette.divider,
-    },
-  },
-
   buildWrapper: {
     padding: theme.spacing(2, 4),
   },

--- a/site/src/components/BuildsTable/BuildRow.tsx
+++ b/site/src/components/BuildsTable/BuildRow.tsx
@@ -91,9 +91,8 @@ const useStyles = makeStyles((theme) => ({
       outlineColor: theme.palette.secondary.dark,
     },
 
-    "&:not(:last-child) td:before": {
+    "& td:before": {
       position: "absolute",
-      top: 20,
       left: 50,
       display: "block",
       content: "''",

--- a/site/src/components/Timeline/TimelineEntry.tsx
+++ b/site/src/components/Timeline/TimelineEntry.tsx
@@ -1,0 +1,56 @@
+import { makeStyles } from "@material-ui/core/styles"
+import TableRow, { TableRowProps } from "@material-ui/core/TableRow"
+import { PropsWithChildren } from "react"
+import { combineClasses } from "util/combineClasses"
+
+interface TimelineEntryProps {
+  clickable?: boolean
+}
+
+export const TimelineEntry = ({
+  children,
+  clickable = true,
+  ...props
+}: PropsWithChildren<TimelineEntryProps & TableRowProps>): JSX.Element => {
+  const styles = useStyles()
+  return (
+    <TableRow
+      className={combineClasses({
+        [styles.timelineEntry]: true,
+        [styles.clickable]: clickable,
+      })}
+      {...props}
+    >
+      {children}
+    </TableRow>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  clickable: {
+    cursor: "pointer",
+
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+
+  timelineEntry: {
+    position: "relative",
+    "&:focus": {
+      outlineStyle: "solid",
+      outlineOffset: -1,
+      outlineWidth: 2,
+      outlineColor: theme.palette.secondary.dark,
+    },
+    "& td:before": {
+      position: "absolute",
+      left: 50,
+      display: "block",
+      content: "''",
+      height: "100%",
+      width: 2,
+      background: theme.palette.divider,
+    },
+  },
+}))

--- a/site/src/components/VersionsTable/VersionRow.tsx
+++ b/site/src/components/VersionsTable/VersionRow.tsx
@@ -1,8 +1,8 @@
 import { makeStyles } from "@material-ui/core/styles"
 import TableCell from "@material-ui/core/TableCell"
-import TableRow from "@material-ui/core/TableRow"
 import { TemplateVersion } from "api/typesGenerated"
 import { Stack } from "components/Stack/Stack"
+import { TimelineEntry } from "components/Timeline/TimelineEntry"
 import { UserAvatar } from "components/UserAvatar/UserAvatar"
 import { useClickable } from "hooks/useClickable"
 import { useTranslation } from "react-i18next"
@@ -21,11 +21,7 @@ export const VersionRow: React.FC<VersionRowProps> = ({ version }) => {
   })
 
   return (
-    <TableRow
-      className={styles.versionRow}
-      data-testid={`version-${version.id}`}
-      {...clickableProps}
-    >
+    <TimelineEntry data-testid={`version-${version.id}`} {...clickableProps}>
       <TableCell className={styles.versionCell}>
         <Stack
           direction="row"
@@ -55,29 +51,11 @@ export const VersionRow: React.FC<VersionRowProps> = ({ version }) => {
           </Stack>
         </Stack>
       </TableCell>
-    </TableRow>
+    </TimelineEntry>
   )
 }
 
 const useStyles = makeStyles((theme) => ({
-  versionRow: {
-    cursor: "pointer",
-
-    "&:hover": {
-      backgroundColor: theme.palette.action.hover,
-    },
-
-    "& td:before": {
-      position: "absolute",
-      left: 50,
-      display: "block",
-      content: "''",
-      height: "100%",
-      width: 2,
-      background: theme.palette.divider,
-    },
-  },
-
   versionWrapper: {
     padding: theme.spacing(2, 4),
   },

--- a/site/src/components/VersionsTable/VersionRow.tsx
+++ b/site/src/components/VersionsTable/VersionRow.tsx
@@ -67,9 +67,8 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.action.hover,
     },
 
-    "&:not(:last-child) td:before": {
+    "& td:before": {
       position: "absolute",
-      top: 20,
       left: 50,
       display: "block",
       content: "''",


### PR DESCRIPTION
The vertical line in our timelines was a little bit inconsistent as shown here:
<img width="398" alt="Screen Shot 2022-11-21 at 10 59 36 AM" src="https://user-images.githubusercontent.com/1290996/203156167-83cb8ad0-5fff-495d-a687-f721aa2f5f2e.png">

So I made it extend the full length so there won't be weird edge cases like that:
<img width="532" alt="Screen Shot 2022-11-21 at 1 42 17 PM" src="https://user-images.githubusercontent.com/1290996/203156316-a69bc16a-088c-4c4f-89ed-cf2206cda56c.png">

This affects the audit log, template versions timeline, and workspace build timeline. I pulled out the styles into a reusable component, `TimelineEntry`, that wraps `TableRow`.

