### PR TITLE
fix: don't override 0 ttl with template default

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -670,15 +670,8 @@ func (api *API) putWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 	var dbTTL sql.NullInt64
 
 	err := api.Database.InTx(func(s database.Store) error {
-		template, err := s.GetTemplateByID(ctx, workspace.TemplateID)
-		if err != nil {
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-				Message: "Error fetching workspace template!",
-			})
-			return xerrors.Errorf("fetch workspace template: %w", err)
-		}
-
-		dbTTL, err = validWorkspaceTTLMillis(req.TTLMillis, template.DefaultTTL)
+		// don't override 0 ttl with template default here because it indicates disabled auto-stop
+		dbTTL, err := validWorkspaceTTLMillis(req.TTLMillis, 0)
 		if err != nil {
 			return codersdk.ValidationError{Field: "ttl_ms", Detail: err.Error()}
 		}

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -302,7 +302,7 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
 			ctr.DefaultTTLMillis = ptr.Ref(int64(0))
 		})
-		// Given: the template has no max TTL set
+		// Given: the template has no default TTL set
 		require.Zero(t, template.DefaultTTLMillis)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
 
@@ -1175,11 +1175,17 @@ func TestWorkspaceUpdateTTL(t *testing.T) {
 			name:          "disable ttl",
 			ttlMillis:     nil,
 			expectedError: "",
+			modifyTemplate: func(ctr *codersdk.CreateTemplateRequest) {
+				ctr.DefaultTTLMillis = ptr.Ref((8 * time.Hour).Milliseconds())
+			},
 		},
 		{
 			name:          "update ttl",
 			ttlMillis:     ptr.Ref(12 * time.Hour.Milliseconds()),
 			expectedError: "",
+			modifyTemplate: func(ctr *codersdk.CreateTemplateRequest) {
+				ctr.DefaultTTLMillis = ptr.Ref((8 * time.Hour).Milliseconds())
+			},
 		},
 		{
 			name:          "below minimum ttl",


### PR DESCRIPTION
Fixes #5146 

We were overriding 0 or null ttl (auto-stop duration) with the template default both on workspace creation (as desired) and on workspace update (not desired as that's how we disable auto-stop).