### PR TITLE
docs: add offical kubernetes provider runtime_class_name

### DIFF
--- a/docs/templates/docker-in-docker.md
+++ b/docs/templates/docker-in-docker.md
@@ -37,7 +37,7 @@ resource "coder_agent" "main" {
 
 ### Use Sysbox in Kubernetes-based templates
 
-After [installing Sysbox on Kubernetes](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md), modify your template to use the sysbox-runc RuntimeClass. This requires the Kuberentes Terrafom provider version 2.16.0 or greater.
+After [installing Sysbox on Kubernetes](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md), modify your template to use the sysbox-runc RuntimeClass. This requires the Kubernetes Terraform provider version 2.16.0 or greater.
 
 ```hcl
 terraform {
@@ -243,7 +243,7 @@ resource "coder_agent" "main" {
 ### Use systemd in Kubernetes-based templates
 
 After [installing Sysbox on Kubernetes](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md),
-modify your template to use the sysbox-runc RuntimeClass. This requires the Kuberentes Terrafom provider version 2.16.0 or greater.
+modify your template to use the sysbox-runc RuntimeClass. This requires the Kubernetes Terraform provider version 2.16.0 or greater.
 
 ```hcl
 terraform {

--- a/docs/templates/docker-in-docker.md
+++ b/docs/templates/docker-in-docker.md
@@ -52,6 +52,12 @@ terraform {
   }
 }
 
+variable "workspaces_namespace" {
+  default = "coder-namespace"
+}
+
+data "coder_workspace" "me" {}
+
 resource "coder_agent" "main" {
   os   = "linux"
   arch = "amd64"
@@ -153,6 +159,12 @@ terraform {
     }
   }
 }
+
+variable "workspaces_namespace" {
+  default = "coder-namespace"
+}
+
+data "coder_workspace" "me" {}
 
 resource "coder_agent" "main" {
   os             = "linux"
@@ -257,6 +269,12 @@ terraform {
     }
   }
 }
+
+variable "workspaces_namespace" {
+  default = "coder-namespace"
+}
+
+data "coder_workspace" "me" {}
 
 resource "coder_agent" "main" {
   os   = "linux"


### PR DESCRIPTION
as a result of @kylecarbs's [merged PR](https://github.com/hashicorp/terraform-provider-kubernetes/pull/1895), we can now use the official K8s provider to set the RuntimeClass on the pod spec.

this PR updates our Docker-in-Kubernetes documentation to reflect this update, and removes the third-party K8s provider that was previously referenced. 
