### PR TITLE
fix: auto-stop bumper works and refreshes

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -791,6 +791,7 @@ func (api *API) putExtendWorkspace(rw http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		api.Logger.Info(ctx, "extending workspace", slog.Error(err))
 	}
+	api.publishWorkspaceUpdate(ctx, workspace.ID)
 	httpapi.Write(ctx, rw, code, resp)
 }
 

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -1,7 +1,7 @@
 import { useActor, useSelector } from "@xstate/react"
 import { FeatureNames } from "api/types"
 import dayjs from "dayjs"
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { Helmet } from "react-helmet-async"
 import { useTranslation } from "react-i18next"
 import {
@@ -63,6 +63,11 @@ export const WorkspaceReadyPage = ({
   const canUpdateWorkspace = Boolean(permissions?.updateWorkspace)
   const { t } = useTranslation("workspacePage")
   const favicon = getFaviconByStatus(workspace.latest_build)
+
+  // keep banner machine in sync with workspace
+  useEffect(() => {
+    bannerSend({ type: "REFRESH_WORKSPACE", workspace })
+  }, [bannerSend, workspace])
 
   return (
     <>

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -473,9 +473,6 @@ export const workspaceMachine = createMachine(
                 template: (context: WorkspaceContext) => context.template,
               },
             },
-            on: {
-              REFRESH_WORKSPACE: { actions: "sendWorkspaceToSchedule" },
-            },
           },
         },
       },
@@ -594,13 +591,6 @@ export const workspaceMachine = createMachine(
         )
         displayError(message)
       },
-      sendWorkspaceToSchedule: send(
-        (context) => ({
-          type: "REFRESH_WORKSPACE",
-          workspace: context.workspace,
-        }),
-        { to: "scheduleBannerMachine" },
-      ),
       // Optimistically update. So when the user clicks on stop, we can show
       // the "pending" state right away without having to wait 0.5s ~ 2s to
       // display the visual feedback to the user.


### PR DESCRIPTION
Fixes #5037

The backend wasn't sending workspace updates when the auto-stop time was increased or decreased via the button on the workspace page, so I fixed that. There was a remaining issue with keeping the workspace and schedule banner in sync now that the workspace isn't getting updated all the time, so I changed the way we do that on the frontend. I looked into taking the schedule banner machine out of the workspace machine entirely, but it relies on the template so it was easier to leave it in.
