### PR TITLE
fix: Fix flakeyness of TestProvisionerd/ReconnectAndComplete

### DIFF
--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -918,6 +918,7 @@ func TestProvisionerd(t *testing.T) {
 					<-failChan
 					_ = client.DRPCConn().Close()
 					second.Store(true)
+					time.Sleep(50 * time.Millisecond)
 					failedOnce.Do(func() { close(failedChan) })
 				}()
 			}


### PR DESCRIPTION
I noticed this sleep was added to another test in https://github.com/coder/coder/pull/5136 as well. Since `TestProvisionerd/ReconnectAndComplete` was constantly flaking, I added it there as well. It seems to have alleviated the issue but I don't really even understand this test.

Why is this issue triggered via memDRPC and not yamux? Maybe because memDRPC is faster? Or perhaps isn't handling some edge case in the same way causing "reconnect" to fail.

Logs on fail:

```
    t.go:81: 2022-11-24 11:37:34.016 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/runner/runner.go:333>	(*Runner).doCleanFinish.func2	cleaned up work directory	{"job_id": "test"}
    t.go:81: 2022-11-24 11:37:34.377 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/runner/runner.go:194>	(*Runner).Run	sending CompletedJob	{"job_id": "test"}
    t.go:81: 2022-11-24 11:37:34.429 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:200>	(*Server).connect.func1	client stream ended
    t.go:86: 2022-11-24 11:37:34.429 [ERROR]	(provisionerd)	<github.com/coder/coder/provisionerd/runner/runner.go:197>	(*Runner).Run	send CompletedJob	{"job_id": "test"} ...
        "error": connection closed
                 	storj.io/drpc/drpcstream.(*Stream).sendPacket:268
                 	storj.io/drpc/drpcstream.(*Stream).Close:478
                 	storj.io/drpc/drpcconn.(*Conn).Invoke.func1:80
                 	storj.io/drpc/drpcconn.(*Conn).Invoke:96
                 	github.com/coder/coder/provisionersdk.(*memDRPC).Invoke:103
                 	github.com/coder/coder/provisionerd/proto.(*drpcProvisionerDaemonClient).CompleteJob:96
                 	github.com/coder/coder/provisionerd.(*Server).CompleteJob.func1:406
                 	github.com/coder/coder/provisionerd.(*Server).clientDoWithRetries:366
                 	github.com/coder/coder/provisionerd.(*Server).CompleteJob:405
                 	github.com/coder/coder/provisionerd/runner.(*Runner).Run:195
    t.go:81: 2022-11-24 11:37:34.530 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:176>	(*Server).connect	connected
    t.go:81: 2022-11-24 11:37:34.584 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:489>	(*Server).closeWithError	closing server with error	{"error": null}
```

Logs on success:

```
    t.go:81: 2022-11-24 11:37:36.934 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/runner/runner.go:333>	(*Runner).doCleanFinish.func2	cleaned up work directory	{"job_id": "test"}
    t.go:81: 2022-11-24 11:37:37.091 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/runner/runner.go:194>	(*Runner).Run	sending CompletedJob	{"job_id": "test"}
    t.go:81: 2022-11-24 11:37:37.144 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:200>	(*Server).connect.func1	client stream ended
    t.go:81: 2022-11-24 11:37:37.245 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:176>	(*Server).connect	connected
    t.go:81: 2022-11-24 11:37:37.446 [INFO]	(provisionerd)	<github.com/coder/coder/provisionerd/runner/runner.go:199>	(*Runner).Run	sent CompletedJob	{"job_id": "test"}
    t.go:81: 2022-11-24 11:37:37.496 [DEBUG]	(provisionerd)	<github.com/coder/coder/provisionerd/provisionerd.go:489>	(*Server).closeWithError	closing server with error	{"error": null}
```

We can see that the error pops up before `connected` when it does, i.e. we tried to do something whilst waiting for the connection to be (re)established.