### PR TITLE
fix: `packages.yaml` action is not running on `release` trigger

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -1,8 +1,9 @@
 name: Submit Packages
 on:
-  release:
-    types: [published]
-
+  workflow_run:
+    workflows: [release]
+    types:
+      - completed
 env:
   CODER_VERSION: "${{ github.event.release.tag_name }}"
 


### PR DESCRIPTION
This commit is a workaround to run the `packages.yaml` action after the release action Fixes #5137.
Check #5137 for context.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
@deansheather 