### PR TITLE
chore: Add missing metrics description

### DIFF
--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -36,7 +36,7 @@ coderd_api_active_users_duration_hour 0
 | `coderd_api_websocket_durations_ms` | histogram | Websocket duration distribution of requests in milliseconds | `path` |
 | `coderd_api_workspace_latest_build_total` | gauge | The latest workspace builds with a status. | `status` |
 | `coderd_provisionerd_job_timings_ms` | histogram | The provisioner job time duration. | `provisioner` `status` |
-| `coderd_provisionerd_jobs_current` | gauge | The number of concurrently running provisioner jobs. | `provisioner` |
+| `coderd_provisionerd_jobs_current` | gauge | The number of currently running provisioner jobs. | `provisioner` |
 | `go_gc_duration_seconds` | summary | A summary of the pause duration of garbage collection cycles. |  |
 | `go_goroutines` | gauge | Number of goroutines that currently exist. |  |
 | `go_info` | gauge | Information about the Go environment. | `version` |

--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -35,8 +35,8 @@ coderd_api_active_users_duration_hour 0
 | `coderd_api_requests_processed_total` | counter | The total number of processed API requests | `code` `method` `path` |
 | `coderd_api_websocket_durations_ms` | histogram | Websocket duration distribution of requests in milliseconds | `path` |
 | `coderd_api_workspace_latest_build_total` | gauge | The latest workspace builds with a status. | `status` |
-| `coderd_provisionerd_job_timings_ms` | histogram |  | `provisioner` `status` |
-| `coderd_provisionerd_jobs_current` | gauge |  | `provisioner` |
+| `coderd_provisionerd_job_timings_ms` | histogram | The provisioner job time duration. | `provisioner` `status` |
+| `coderd_provisionerd_jobs_current` | gauge | The number of concurrently running provisioner jobs. | `provisioner` |
 | `go_gc_duration_seconds` | summary | A summary of the pause duration of garbage collection cycles. |  |
 | `go_goroutines` | gauge | Number of goroutines that currently exist. |  |
 | `go_info` | gauge | Information about the Go environment. | `version` |

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -135,7 +135,7 @@ func NewMetrics(reg prometheus.Registerer) Metrics {
 				Namespace: "coderd",
 				Subsystem: "provisionerd",
 				Name:      "jobs_current",
-				Help:      "The number of concurrently running provisioner jobs.",
+				Help:      "The number of currently running provisioner jobs.",
 			}, []string{"provisioner"}),
 			JobTimings: auto.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "coderd",

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -135,11 +135,13 @@ func NewMetrics(reg prometheus.Registerer) Metrics {
 				Namespace: "coderd",
 				Subsystem: "provisionerd",
 				Name:      "jobs_current",
+				Help:      "The number of concurrently running provisioner jobs.",
 			}, []string{"provisioner"}),
 			JobTimings: auto.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "coderd",
 				Subsystem: "provisionerd",
 				Name:      "job_timings_ms",
+				Help:      "The provisioner job time duration.",
 				Buckets: []float64{
 					durationToFloatMs(1 * time.Second),
 					durationToFloatMs(10 * time.Second),

--- a/scripts/metricsdocgen/metrics
+++ b/scripts/metricsdocgen/metrics
@@ -463,7 +463,7 @@ coderd_api_websocket_durations_ms_count{path="/api/v2/workspaceagents/me/coordin
 # TYPE coderd_api_workspace_latest_build_total gauge
 coderd_api_workspace_latest_build_total{status="failed"} 1
 coderd_api_workspace_latest_build_total{status="succeeded"} 5
-# HELP coderd_provisionerd_job_timings_ms
+# HELP coderd_provisionerd_job_timings_ms The provisioner job time duration.
 # TYPE coderd_provisionerd_job_timings_ms histogram
 coderd_provisionerd_job_timings_ms_bucket{provisioner="terraform",status="success",le="1000"} 0
 coderd_provisionerd_job_timings_ms_bucket{provisioner="terraform",status="success",le="10000"} 1
@@ -476,7 +476,7 @@ coderd_provisionerd_job_timings_ms_bucket{provisioner="terraform",status="succes
 coderd_provisionerd_job_timings_ms_bucket{provisioner="terraform",status="success",le="+Inf"} 2
 coderd_provisionerd_job_timings_ms_sum{provisioner="terraform",status="success"} 21600
 coderd_provisionerd_job_timings_ms_count{provisioner="terraform",status="success"} 2
-# HELP coderd_provisionerd_jobs_current
+# HELP coderd_provisionerd_jobs_current The number of concurrently running provisioner jobs.
 # TYPE coderd_provisionerd_jobs_current gauge
 coderd_provisionerd_jobs_current{provisioner="terraform"} 0
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.

--- a/scripts/metricsdocgen/metrics
+++ b/scripts/metricsdocgen/metrics
@@ -476,7 +476,7 @@ coderd_provisionerd_job_timings_ms_bucket{provisioner="terraform",status="succes
 coderd_provisionerd_job_timings_ms_bucket{provisioner="terraform",status="success",le="+Inf"} 2
 coderd_provisionerd_job_timings_ms_sum{provisioner="terraform",status="success"} 21600
 coderd_provisionerd_job_timings_ms_count{provisioner="terraform",status="success"} 2
-# HELP coderd_provisionerd_jobs_current The number of concurrently running provisioner jobs.
+# HELP coderd_provisionerd_jobs_current The number of currently running provisioner jobs.
 # TYPE coderd_provisionerd_jobs_current gauge
 coderd_provisionerd_jobs_current{provisioner="terraform"} 0
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.


### PR DESCRIPTION
Minor improvement.

This PR fills in missing descriptions on the Prometheus metrics page.