### PR TITLE
feat: Define Prometheus port in the pod spec

### DIFF
--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -10,8 +10,6 @@ Coder server exports metrics via the HTTP endpoint, which can be enabled using e
 
 The Prometheus endpoint address is `http://localhost:2112/` by default. You can use either the environment variable `CODER_PROMETHEUS_ADDRESS` or the flag ` --prometheus-address <network-interface>:<port>` to select a different listen address.
 
-__Notice__: Prometheus endpoint is not supported by the official Coder Helm chart yet.
-
 If `coder server --prometheus-enable` is started locally, you can preview the metrics endpoint in your browser or by using curl: <!-- markdown-link-check-disable -->http://localhost:2112/<!-- markdown-link-check-enable -->.
 
 ```shell
@@ -21,6 +19,11 @@ $ curl http://localhost:2112/
 coderd_api_active_users_duration_hour 0
 ...
 ```
+
+### Kubernetes deployment
+
+The Prometheus endpoint can be enabled in the [Helm chart's](https://github.com/coder/coder/tree/main/helm) `values.yml` by setting the environment variable `CODER_PROMETHEUS_ADDRESS` to `0.0.0.0:2112`.
+The environment variable `CODER_PROMETHEUS_ENABLE` will be enabled automatically.
 
 ## Available metrics
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -50,6 +50,9 @@ coder:
     - name: CODER_AUTO_IMPORT_TEMPLATES
       value: "kubernetes"
 
+    # This env enables the Prometheus metrics endpoint.
+    - name: CODER_PROMETHEUS_ADDRESS
+      value: "0.0.0.0:2112"
   tls:
     secretNames:
       - my-tls-secret-name

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -54,6 +54,15 @@ Coder listen port (must be > 1024)
 {{- end }}
 
 {{/*
+Coder Prometheus port (must be > 1024)
+*/}}
+{{- define "coder.prometheusPort" -}}
+{{- range .Values.coder.env }}
+6666
+{{- end }}
+{{- end }}
+
+{{/*
 Coder service port
 */}}
 {{- define "coder.servicePort" }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -54,15 +54,6 @@ Coder listen port (must be > 1024)
 {{- end }}
 
 {{/*
-Coder Prometheus port (must be > 1024)
-*/}}
-{{- define "coder.prometheusPort" -}}
-{{- range .Values.coder.env }}
-6666
-{{- end }}
-{{- end }}
-
-{{/*
 Coder service port
 */}}
 {{- define "coder.servicePort" }}

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -81,6 +81,13 @@ spec:
             - name: {{ include "coder.portName" . | quote }}
               containerPort: {{ include "coder.port" . }}
               protocol: TCP
+            {{- range .Values.coder.env }}
+            {{- if eq .name "CODER_PROMETHEUS_ENABLE" }}
+            - name: "prometheus"
+              containerPort: {{ include "coder.prometheusPort" . }}
+              protocol: TCP
+            {{- end }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /api/v2/buildinfo

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -77,14 +77,20 @@ spec:
             {{- with .Values.coder.env -}}
             {{ toYaml . | nindent 12 }}
             {{- end }}
+            {{- range .Values.coder.env }}
+            {{- if eq .name "CODER_PROMETHEUS_ADDRESS" }}
+            - name: CODER_PROMETHEUS_ENABLE
+              value: "true"
+            {{- end }}
+            {{- end }}
           ports:
             - name: {{ include "coder.portName" . | quote }}
               containerPort: {{ include "coder.port" . }}
               protocol: TCP
             {{- range .Values.coder.env }}
-            {{- if eq .name "CODER_PROMETHEUS_ENABLE" }}
-            - name: "prometheus"
-              containerPort: {{ include "coder.prometheusPort" . }}
+            {{- if eq .name "CODER_PROMETHEUS_ADDRESS" }}
+            - name: "prometheus-http"
+              containerPort: {{ (splitList ":" .value) | last }}
               protocol: TCP
             {{- end }}
             {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,14 +49,13 @@ coder:
   # - CODER_TLS_ENABLE: set if tls.secretName is not empty.
   # - CODER_TLS_CERT_FILE: set if tls.secretName is not empty.
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
+  # - CODER_PROMETHEUS_ENABLE: set if CODER_PROMETHEUS_ADDRESS is not empty.
   env:
     - name: CODER_PG_CONNECTION_URL
       valueFrom:
         secretKeyRef:
           name: coder-db-url
           key: url
-    - name: CODER_PROMETHEUS_ENABLE
-      value: "true"
     - name: CODER_PROMETHEUS_ADDRESS # Override the network interface targeting localhost
       value: "0.0.0.0:2112"
   # coder.tls -- The TLS configuration for Coder.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,12 +50,8 @@ coder:
   # - CODER_TLS_CERT_FILE: set if tls.secretName is not empty.
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
   # - CODER_PROMETHEUS_ENABLE: set if CODER_PROMETHEUS_ADDRESS is not empty.
-  env:
-    - name: CODER_PG_CONNECTION_URL
-      valueFrom:
-        secretKeyRef:
-          name: coder-db-url
-          key: url
+  env: []
+
   # coder.tls -- The TLS configuration for Coder.
   tls:
     # coder.tls.secretNames -- A list of TLS server certificate secrets to mount

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -56,8 +56,6 @@ coder:
         secretKeyRef:
           name: coder-db-url
           key: url
-    - name: CODER_PROMETHEUS_ADDRESS # Override the network interface targeting localhost
-      value: "0.0.0.0:2112"
   # coder.tls -- The TLS configuration for Coder.
   tls:
     # coder.tls.secretNames -- A list of TLS server certificate secrets to mount

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,8 +49,16 @@ coder:
   # - CODER_TLS_ENABLE: set if tls.secretName is not empty.
   # - CODER_TLS_CERT_FILE: set if tls.secretName is not empty.
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
-  env: []
-
+  env:
+    - name: CODER_PG_CONNECTION_URL
+      valueFrom:
+        secretKeyRef:
+          name: coder-db-url
+          key: url
+    - name: CODER_PROMETHEUS_ENABLE
+      value: "true"
+    - name: CODER_PROMETHEUS_ADDRESS # Override the network interface targeting localhost
+      value: "0.0.0.0:2112"
   # coder.tls -- The TLS configuration for Coder.
   tls:
     # coder.tls.secretNames -- A list of TLS server certificate secrets to mount


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/4666

This PR adds a port entry to the container spec.

Testing:

```yaml
helm template coder helm --namespace coder --set coder.image.tag=v0.12.9 --values helm/values.yaml --debug
...
      containers:
        - name: coder
          image: "ghcr.io/coder/coder:v0.12.9"
          imagePullPolicy: IfNotPresent
          resources:
            {}
          env:
            - name: CODER_ADDRESS
              value: "0.0.0.0:8080"
            # Set the default access URL so a `helm apply` works by default.
            # See: https://github.com/coder/coder/issues/5024
            - name: CODER_ACCESS_URL
              value: "http://coder.coder.svc.cluster.local"
            # Used for inter-pod communication with high-availability.
            - name: KUBE_POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            - name: CODER_DERP_SERVER_RELAY_URL
              value: "http://$(KUBE_POD_IP):8080"

            - name: CODER_PG_CONNECTION_URL
              valueFrom:
                secretKeyRef:
                  key: url
                  name: coder-db-url
            - name: CODER_PROMETHEUS_ADDRESS
              value: 0.0.0.0:2112
            - name: CODER_PROMETHEUS_ENABLE
              value: "true"
          ports:
            - name: "http"
              containerPort: 8080
              protocol: TCP
            - name: "prometheus-http"
              containerPort: 2112
              protocol: TCP
          readinessProbe:
            httpGet:
              path: /api/v2/buildinfo
              port: "http"
              scheme: "HTTP"
          livenessProbe:
            httpGet:
              path: /api/v2/buildinfo
              port: "http"
              scheme: "HTTP"

          volumeMounts: []
...
```

and

```yaml
  Containers:
   coder:
    Image:       ghcr.io/coder/coder:v0.12.9
    Ports:       8080/TCP, 2112/TCP
    Host Ports:  0/TCP, 0/TCP
    Liveness:    http-get http://:http/api/v2/buildinfo delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:   http-get http://:http/api/v2/buildinfo delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      CODER_ADDRESS:                0.0.0.0:8080
      CODER_ACCESS_URL:             http://coder.coder.svc.cluster.local
      KUBE_POD_IP:                   (v1:status.podIP)
      CODER_DERP_SERVER_RELAY_URL:  http://$(KUBE_POD_IP):8080
      CODER_PG_CONNECTION_URL:      <set to the key 'url' in secret 'coder-db-url'>  Optional: false
      CODER_PROMETHEUS_ADDRESS:     0.0.0.0:2112
      CODER_PROMETHEUS_ENABLE:      true
    Mounts:                         <none>
  Volumes:                          <none>
```