### PR TITLE
fix: Generate trial in `scripts/develop.sh`

### DIFF
--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -135,7 +135,7 @@ fatal() {
 
 	if [ ! -f "${PROJECT_ROOT}/.coderv2/developsh-did-first-setup" ]; then
 		# Try to create the initial admin user.
-		if "${CODER_DEV_SHIM}" login http://127.0.0.1:3000 --first-user-username=admin --first-user-email=admin@coder.com --first-user-password="${password}"; then
+		if "${CODER_DEV_SHIM}" login http://127.0.0.1:3000 --first-user-username=admin --first-user-email=admin@coder.com --first-user-password="${password}" --first-user-trial=true; then
 			# Only create this file if an admin user was successfully
 			# created, otherwise we won't retry on a later attempt.
 			touch "${PROJECT_ROOT}/.coderv2/developsh-did-first-setup"


### PR DESCRIPTION
Script was prompting this and preventing `vite` from starting:

```
> Start a 30-day trial of Enterprise? (yes/no)
```
