### PR TITLE
fix: do not truncate system PATH in win installer

### DIFF
--- a/scripts/win-installer/path.nsh
+++ b/scripts/win-installer/path.nsh
@@ -42,7 +42,7 @@ Function AddToPath
   ; Native calls are used here to check actual length of PATH
 
   ; $4 = RegOpenKey(HKEY_CURRENT_USER, "Environment", &$3)
-	System::Call "advapi32::RegOpenKey(i 0x80000002, t'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', *i.r3) i.r4"
+  System::Call "advapi32::RegOpenKey(i 0x80000002, t'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', *i.r3) i.r4"
   IntCmp $4 0 0 done done
   ; $4 = RegQueryValueEx($3, "PATH", (DWORD*)0, (DWORD*)0, &$1, ($2=NSIS_MAX_STRLEN, &$2))
   ; RegCloseKey($3)

--- a/scripts/win-installer/path.nsh
+++ b/scripts/win-installer/path.nsh
@@ -20,14 +20,11 @@
 
 !include "WinMessages.nsh"
 
-; Registry Entry for environment (NT4,2000,XP)
-; All users:
+; Registry Entry for system environment (NT4,2000,XP)
 !define Environ 'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
-; Current user only:
-;!define Environ 'HKCU "Environment"'
 
 
-; AddToPath - Appends dir to PATH
+; AddToPath - Appends dir to system PATH
 ;   (does not work on Win9x/ME)
 ;
 ; Usage:
@@ -45,7 +42,7 @@ Function AddToPath
   ; Native calls are used here to check actual length of PATH
 
   ; $4 = RegOpenKey(HKEY_CURRENT_USER, "Environment", &$3)
-  System::Call "advapi32::RegOpenKey(i 0x80000001, t'Environment', *i.r3) i.r4"
+	System::Call "advapi32::RegOpenKey(i 0x80000002, t'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', *i.r3) i.r4"
   IntCmp $4 0 0 done done
   ; $4 = RegQueryValueEx($3, "PATH", (DWORD*)0, (DWORD*)0, &$1, ($2=NSIS_MAX_STRLEN, &$2))
   ; RegCloseKey($3)
@@ -110,7 +107,7 @@ done:
 FunctionEnd
 
 
-; RemoveFromPath - Removes dir from PATH
+; RemoveFromPath - Removes dir from system PATH
 ;
 ; Usage:
 ;   Push "dir"


### PR DESCRIPTION
The path.nsh script in the NSIS installer provided methods for adding paths to the PATH and removing them. It would do this by reading the current PATH value from the registry, adding the new value (if it doesn't exist) and then writing it to the registry.

Unfortunately, it would read from the user's PATH and write the updated result to the system PATH, which would remove important PATH entries like the following in the process:

- C:\Windows\System32
- C:\Windows
- C:\Windows\System32\wbem
- C:\Windows\System32\WindowsPowerShell\v1.0
- C:\Windows\System32\OpenSSH
- C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR
- C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common

and would copy all user environment variables in their place. The variables listed above were the ones missing from my machine when I compared with a friend's machine.

The existing installers for the last couple of versions of Coder have been yanked from GitHub releases and this message will be included in the release notes for the next patch.

This patch has been tested to ensure that it doesn't copy PATH from user to system.

Thanks to @cmor for finding and reporting this bug. Closes #5240 

## Recommended course of action for affected users:
1. Add the paths listed above to your system PATH if they aren't there already and exist on your system.
2. Remove any paths that are in your user's PATH from your system PATH.