### PR TITLE
feat: add http proxy override

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -211,7 +211,7 @@ func Root(subcommands []*cobra.Command) *cobra.Command {
 	_ = cmd.PersistentFlags().MarkHidden(varAgentURL)
 	cliflag.String(cmd.PersistentFlags(), config.FlagName, "", "CODER_CONFIG_DIR", configdir.LocalConfig("coderv2"), "Path to the global `coder` config directory.")
 	cliflag.StringArray(cmd.PersistentFlags(), varHeader, "", "CODER_HEADER", []string{}, "HTTP headers added to all requests. Provide as \"Key=Value\"")
-	cliflag.String(cmd.PersistentFlags(), varHttpProxy, "", "CODER_HTTP_PROXY", "", "HTTP proxy used used for client requests. Not inherited by children.")
+	cliflag.String(cmd.PersistentFlags(), varHttpProxy, "", "CODER_HTTP_PROXY", "", "HTTP proxy used for client requests. Not inherited by children.")
 	cmd.PersistentFlags().Bool(varForceTty, false, "Force the `coder` command to run as if connected to a TTY.")
 	_ = cmd.PersistentFlags().MarkHidden(varForceTty)
 	cmd.PersistentFlags().Bool(varNoOpen, false, "Block automatically opening URLs in the browser.")

--- a/cli/root.go
+++ b/cli/root.go
@@ -46,7 +46,6 @@ const (
 	varAgentURL         = "agent-url"
 	varHeader           = "header"
 	varHttpProxy        = "http-proxy"
-	varHttpsProxy       = "https-proxy"
 	varNoOpen           = "no-open"
 	varNoVersionCheck   = "no-version-warning"
 	varNoFeatureWarning = "no-feature-warning"


### PR DESCRIPTION
As per https://github.com/coder/coder/issues/5029 this is becoming a pain for us so I thought I'd just raise it as a PR to see thoughts around this initially before doing more work on it.

We want the ability to tunnel coder traffic via a Tailscale proxy without impacting the workspace http_proxy environment. I.e. traffic to the coder server.

We have some strict requirements so Coder must route via this proxy that is locked down to specific endpoints. At the moment we're using http_proxy environment variable which works fine but it's passing it through to children sessions which we don't want.

We're thinking we could do a CODER_HTTP_PROXY variable in the environment and only Coder would honour this.

Not sure how this would go with the agent code that is using Tailscale... Open to any ideas.
