### PR TITLE
chore: enable debug logging for gotestsum

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -336,7 +336,7 @@ jobs:
             echo ::set-output name=cover::false
           fi
           set -x
-          gotestsum --junitfile="gotests.xml" --packages="./..." -- -parallel=8 -timeout=3m -short -failfast $COVERAGE_FLAGS
+          gotestsum --junitfile="gotests.xml" --packages="./..." --debug -- -parallel=8 -timeout=3m -short -failfast $COVERAGE_FLAGS
 
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ cli/testdata/.gen-golden: $(wildcard cli/testdata/*.golden) $(GO_SRC_FILES)
 	touch "$@"
 
 test: test-clean
-	gotestsum -- -v -short ./...
+	gotestsum --debug -- -v -short ./...
 .PHONY: test
 
 # When updating -timeout for this test, keep in sync with


### PR DESCRIPTION
Issue: https://github.com/coder/coder/issues/5247

This PR enables debug logging for `gotestsum`. It seems that there is an interleave between some logger calls, so `gotestsum` can't find the line with the prefix `--- PASS:`. With the debug mode enabled we should the output from `go test`.