### PR TITLE
fix: Close tty first in `ptytest` cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -107,6 +107,7 @@
     "slogtest",
     "sourcemapped",
     "Srcs",
+    "stdbuf",
     "stretchr",
     "STTY",
     "stuntest",

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -14,7 +14,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
@@ -76,7 +75,9 @@ func create(t *testing.T, ptty pty.PTY, name string) *PTY {
 		// Close pty only so that the copy goroutine can consume the
 		// remainder of it's buffer and then exit.
 		err := ptty.Close()
-		assert.NoError(t, err, "close pty")
+		// Pty may already be closed, so don't fail the test, but log
+		// the error in case it's significant.
+		logf(t, name, "closed pty: %v", err)
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This is an attempt to make ptytest closure even more robust, due to https://github.com/coder/coder/issues/5247.
