### PR TITLE
feat(cli): display help syntax on error

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -123,7 +123,7 @@ func Root(subcommands []*cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "coder",
 		SilenceErrors: true,
-		SilenceUsage:  true,
+		SilenceUsage:  false,
 		Long:          fmt.Sprintf(fmtLong, buildinfo.Version()),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if gitauth.CheckCommand(args, os.Environ()) {


### PR DESCRIPTION
[Internal discussion](https://codercom.slack.com/archives/CJURPL8DN/p1670121044915979).

Was:

```shell
ghuntley@GeoffreysMBP16 ~ % coder login
accepts 1 arg(s), received 0       
Run 'coder login --help' for usage.
```


Now:

```shell
coder@coder-sydney:~/coder$ /home/coder/coder/build/coder-slim_0.13.1-devel+b4603582_linux_amd64  login
Usage:
  coder login <url> [flags]

Flags:
      --first-user-email string      Specifies an email address to use if creating the first
                                     user for the deployment.
                                     Consumes $CODER_FIRST_USER_EMAIL
      --first-user-password string   Specifies a password to use if creating the first user
                                     for the deployment.
                                     Consumes $CODER_FIRST_USER_PASSWORD
      --first-user-trial             Specifies whether a trial license should be provisioned
                                     for the Coder deployment or not.
                                     Consumes $CODER_FIRST_USER_TRIAL
      --first-user-username string   Specifies a username to use if creating the first user
                                     for the deployment.
                                     Consumes $CODER_FIRST_USER_USERNAME
  -h, --help                         help for login

Global Flags:
      --global-config coder   Path to the global coder config directory.
                              Consumes $CODER_CONFIG_DIR (default
                              "/home/coder/.config/coderv2")
      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
                              Consumes $CODER_HEADER
      --no-feature-warning    Suppress warnings about unlicensed features.
                              Consumes $CODER_NO_FEATURE_WARNING
      --no-version-warning    Suppress warning when client and server versions do not match.
                              Consumes $CODER_NO_VERSION_WARNING
      --token string          Specify an authentication token. For security reasons setting
                              CODER_SESSION_TOKEN is preferred.
                              Consumes $CODER_SESSION_TOKEN
      --url string            URL to a deployment.
                              Consumes $CODER_URL
  -v, --verbose               Enable verbose output.
                              Consumes $CODER_VERBOSE

accepts 1 arg(s), received 0       
Run 'coder login --help' for usage.
```