### PR TITLE
fix: race conditions in replicasync

### DIFF
--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -276,6 +276,8 @@ func (m *Manager) syncReplicas(ctx context.Context) error {
 		return xerrors.Errorf("ping database: %w", err)
 	}
 
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	replica, err := m.db.UpdateReplica(ctx, database.UpdateReplicaParams{
 		ID:              m.self.ID,
 		UpdatedAt:       database.Now(),
@@ -291,8 +293,6 @@ func (m *Manager) syncReplicas(ctx context.Context) error {
 	if err != nil {
 		return xerrors.Errorf("update replica: %w", err)
 	}
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
 	if m.self.Error != replica.Error {
 		// Publish an update occurred!
 		err = m.pubsub.Publish(PubsubEvent, []byte(m.self.ID.String()))

--- a/enterprise/replicasync/replicasync_test.go
+++ b/enterprise/replicasync/replicasync_test.go
@@ -206,7 +206,12 @@ func TestReplica(t *testing.T) {
 				_ = server.Close()
 			})
 			done := false
+
+			var m sync.Mutex
 			server.SetCallback(func() {
+				m.Lock()
+				defer m.Unlock()
+
 				if len(server.All()) != count {
 					return
 				}


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/5286

While fighting with flakes I noticed possible race conditions in `enterprise` (logs in the issue). 