### PR TITLE
fix: agent panics on closed network

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -245,12 +245,13 @@ func (a *agent) trackConnGoroutine(fn func()) error {
 	return nil
 }
 
-func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (network *tailnet.Conn, err error) {
+func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (_ *tailnet.Conn, err error) {
 	a.closeMutex.Lock()
 	if a.isClosed() {
 		a.closeMutex.Unlock()
 		return nil, xerrors.New("closed")
 	}
+	var network *tailnet.Conn
 	network, err = tailnet.NewConn(&tailnet.Options{
 		Addresses:          []netip.Prefix{netip.PrefixFrom(codersdk.TailnetIP, 128)},
 		DERPMap:            derpMap,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -262,13 +262,10 @@ func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (ne
 		return nil, xerrors.Errorf("create tailnet: %w", err)
 	}
 	defer func() {
-		// Apparently, it's possible to shut down network via agent.Close().
-		// The condition `network != nil` prevents panic in tests.
 		if err != nil {
 			network.Close()
 		}
 	}()
-	// a.network = network
 	a.closeMutex.Unlock()
 
 	sshListener, err := network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetSSHPort))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -251,8 +251,7 @@ func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (_ 
 		a.closeMutex.Unlock()
 		return nil, xerrors.New("closed")
 	}
-	var network *tailnet.Conn
-	network, err = tailnet.NewConn(&tailnet.Options{
+	network, err := tailnet.NewConn(&tailnet.Options{
 		Addresses:          []netip.Prefix{netip.PrefixFrom(codersdk.TailnetIP, 128)},
 		DERPMap:            derpMap,
 		Logger:             a.logger.Named("tailnet"),

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -264,11 +264,11 @@ func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (ne
 	defer func() {
 		// Apparently, it's possible to shut down network via agent.Close().
 		// The condition `network != nil` prevents panic in tests.
-		if err != nil && network != nil {
+		if err != nil {
 			network.Close()
 		}
 	}()
-	a.network = network
+	// a.network = network
 	a.closeMutex.Unlock()
 
 	sshListener, err := network.Listen("tcp", ":"+strconv.Itoa(codersdk.TailnetSSHPort))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -262,7 +262,9 @@ func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (ne
 		return nil, xerrors.Errorf("create tailnet: %w", err)
 	}
 	defer func() {
-		if err != nil {
+		// Apparently, it's possible to shut down network via agent.Close().
+		// The condition `network != nil` prevents panic in tests.
+		if err != nil && network != nil {
 			network.Close()
 		}
 	}()


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/5293

This PR adds a simple condition, `network != nil`, to prevent the agent from panicking.