### PR TITLE
feat: Compile the codersdk for wasm

### DIFF
--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -71,7 +71,7 @@ func speedtest() *cobra.Command {
 						return ctx.Err()
 					case <-ticker.C:
 					}
-					dur, err := conn.Ping(ctx)
+					dur, p2p, err := conn.Ping(ctx)
 					if err != nil {
 						continue
 					}
@@ -80,7 +80,7 @@ func speedtest() *cobra.Command {
 						continue
 					}
 					peer := status.Peer[status.Peers()[0]]
-					if peer.CurAddr == "" && direct {
+					if !p2p && direct {
 						cmd.Printf("Waiting for a direct connection... (%dms via %s)\n", dur.Milliseconds(), peer.Relay)
 						continue
 					}

--- a/codersdk/agentconn.go
+++ b/codersdk/agentconn.go
@@ -139,7 +139,7 @@ func (c *AgentConn) AwaitReachable(ctx context.Context) bool {
 	return c.Conn.AwaitReachable(ctx, TailnetIP)
 }
 
-func (c *AgentConn) Ping(ctx context.Context) (time.Duration, error) {
+func (c *AgentConn) Ping(ctx context.Context) (time.Duration, bool, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -130,10 +130,7 @@ func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after
 	httpClient := &http.Client{
 		Jar: jar,
 	}
-	conn, res, err := websocket.Dial(ctx, followURL.String(), &websocket.DialOptions{
-		HTTPClient:      httpClient,
-		CompressionMode: websocket.CompressionDisabled,
-	})
+	conn, res, err := websocket.Dial(ctx, followURL.String(), websocketOptions(httpClient, 0))
 	if err != nil {
 		if res == nil {
 			return nil, nil, err
@@ -192,11 +189,7 @@ func (c *Client) ServeProvisionerDaemon(ctx context.Context, organization uuid.U
 	httpClient := &http.Client{
 		Jar: jar,
 	}
-	conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
-		HTTPClient: httpClient,
-		// Need to disable compression to avoid a data-race.
-		CompressionMode: websocket.CompressionDisabled,
-	})
+	conn, res, err := websocket.Dial(ctx, serverURL.String(), websocketOptions(httpClient, 0))
 	if err != nil {
 		if res == nil {
 			return nil, err

--- a/codersdk/websocket_js.go
+++ b/codersdk/websocket_js.go
@@ -1,0 +1,13 @@
+//go:build js
+
+package codersdk
+
+import (
+	"net/http"
+
+	"nhooyr.io/websocket"
+)
+
+func websocketOptions(_ *http.Client, _ websocket.CompressionMode) *websocket.DialOptions {
+	return &websocket.DialOptions{}
+}

--- a/codersdk/websocket_notjs.go
+++ b/codersdk/websocket_notjs.go
@@ -1,0 +1,16 @@
+//go:build !js
+
+package codersdk
+
+import (
+	"net/http"
+
+	"nhooyr.io/websocket"
+)
+
+func websocketOptions(httpClient *http.Client, compression websocket.CompressionMode) *websocket.DialOptions {
+	return &websocket.DialOptions{
+		HTTPClient:      httpClient,
+		CompressionMode: compression,
+	}
+}

--- a/enterprise/coderd/replicas_test.go
+++ b/enterprise/coderd/replicas_test.go
@@ -81,7 +81,7 @@ func TestReplicas(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitShort)
 			defer cancelFunc()
-			_, err = conn.Ping(ctx)
+			_, _, err = conn.Ping(ctx)
 			return err == nil
 		}, testutil.WaitLong, testutil.IntervalFast)
 		_ = conn.Close()
@@ -124,7 +124,7 @@ func TestReplicas(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.IntervalSlow)
 			defer cancelFunc()
-			_, err = conn.Ping(ctx)
+			_, _, err = conn.Ping(ctx)
 			return err == nil
 		}, testutil.WaitLong, testutil.IntervalFast)
 		_ = conn.Close()

--- a/loadtest/agentconn/run.go
+++ b/loadtest/agentconn/run.go
@@ -141,7 +141,7 @@ func waitForDisco(ctx context.Context, logs io.Writer, conn *codersdk.AgentConn)
 	for i := 0; i < pingAttempts; i++ {
 		_, _ = fmt.Fprintf(logs, "\tDisco ping attempt %d/%d...\n", i+1, pingAttempts)
 		pingCtx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
-		_, err := conn.Ping(pingCtx)
+		_, _, err := conn.Ping(pingCtx)
 		cancel()
 		if err == nil {
 			break

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -77,6 +77,7 @@ func NewConn(options *Options) (*Conn, error) {
 	nodePublicKey := nodePrivateKey.Public()
 
 	netMap := &netmap.NetworkMap{
+		DERPMap:    options.DERPMap,
 		NodeKey:    nodePublicKey,
 		PrivateKey: nodePrivateKey,
 		Addresses:  options.Addresses,
@@ -172,7 +173,6 @@ func NewConn(options *Options) (*Conn, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("start netstack: %w", err)
 	}
-	wireguardEngine = wgengine.NewWatchdog(wireguardEngine)
 	wireguardEngine.SetDERPMap(options.DERPMap)
 	netMapCopy := *netMap
 	wireguardEngine.SetNetworkMap(&netMapCopy)
@@ -244,6 +244,13 @@ func NewConn(options *Options) (*Conn, error) {
 	})
 	netStack.ForwardTCPIn = server.forwardTCP
 	return server, nil
+}
+
+// DERPMap returns the currently set DERP mapping.
+func (c *Conn) DERPMap() *tailcfg.DERPMap {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.netMap.DERPMap
 }
 
 // IP generates a new IP with a static service prefix.
@@ -407,23 +414,24 @@ func (c *Conn) Status() *ipnstate.Status {
 }
 
 // Ping sends a Disco ping to the Wireguard engine.
-func (c *Conn) Ping(ctx context.Context, ip netip.Addr) (time.Duration, error) {
+// The bool returns true if the ping was made P2P.
+func (c *Conn) Ping(ctx context.Context, ip netip.Addr) (time.Duration, bool, error) {
 	errCh := make(chan error, 1)
-	durCh := make(chan time.Duration, 1)
+	prChan := make(chan *ipnstate.PingResult, 1)
 	go c.wireguardEngine.Ping(ip, tailcfg.PingDisco, func(pr *ipnstate.PingResult) {
 		if pr.Err != "" {
 			errCh <- xerrors.New(pr.Err)
 			return
 		}
-		durCh <- time.Duration(pr.LatencySeconds * float64(time.Second))
+		prChan <- pr
 	})
 	select {
 	case err := <-errCh:
-		return 0, err
+		return 0, false, err
 	case <-ctx.Done():
-		return 0, ctx.Err()
-	case dur := <-durCh:
-		return dur, nil
+		return 0, false, ctx.Err()
+	case pr := <-prChan:
+		return time.Duration(pr.LatencySeconds * float64(time.Second)), pr.Endpoint != "", nil
 	}
 }
 
@@ -445,7 +453,7 @@ func (c *Conn) AwaitReachable(ctx context.Context, ip netip.Addr) bool {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
 
-		_, err := c.Ping(ctx, ip)
+		_, _, err := c.Ping(ctx, ip)
 		if err == nil {
 			completed()
 		}
@@ -523,17 +531,7 @@ func (c *Conn) sendNode() {
 		c.nodeChanged = true
 		return
 	}
-	node := &Node{
-		ID:            c.netMap.SelfNode.ID,
-		AsOf:          database.Now(),
-		Key:           c.netMap.SelfNode.Key,
-		Addresses:     c.netMap.SelfNode.Addresses,
-		AllowedIPs:    c.netMap.SelfNode.AllowedIPs,
-		DiscoKey:      c.magicConn.DiscoPublicKey(),
-		Endpoints:     c.lastEndpoints,
-		PreferredDERP: c.lastPreferredDERP,
-		DERPLatency:   c.lastDERPLatency,
-	}
+	node := c.selfNode()
 	if c.blockEndpoints {
 		node.Endpoints = nil
 	}
@@ -555,6 +553,31 @@ func (c *Conn) sendNode() {
 		}
 		c.lastMutex.Unlock()
 	}()
+}
+
+// Node returns the last node that was sent to the node callback.
+func (c *Conn) Node() *Node {
+	c.lastMutex.Lock()
+	defer c.lastMutex.Unlock()
+	return c.selfNode()
+}
+
+func (c *Conn) selfNode() *Node {
+	node := &Node{
+		ID:            c.netMap.SelfNode.ID,
+		AsOf:          database.Now(),
+		Key:           c.netMap.SelfNode.Key,
+		Addresses:     c.netMap.SelfNode.Addresses,
+		AllowedIPs:    c.netMap.SelfNode.AllowedIPs,
+		DiscoKey:      c.magicConn.DiscoPublicKey(),
+		Endpoints:     c.lastEndpoints,
+		PreferredDERP: c.lastPreferredDERP,
+		DERPLatency:   c.lastDERPLatency,
+	}
+	if c.blockEndpoints {
+		node.Endpoints = nil
+	}
+	return node
 }
 
 // This and below is taken _mostly_ verbatim from Tailscale:


### PR DESCRIPTION
```
GOOS=js GOARCH=wasm go build -o main.wasm ./codersdk
```
This enables the sdk to be built for WebAssembly. It also adds a few functions to the tailnet conn that will be used for integration into a VS Code extension.