### PR TITLE
chore: improve markdown-link-check workflow

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -676,4 +676,6 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+          use-quiet-mode: yes
+          use-verbose-mode: yes
           config-file: .github/workflows/mlc_config.json

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -678,4 +678,6 @@ jobs:
       with:
           use-quiet-mode: yes
           use-verbose-mode: yes
+          check-modified-files-only: yes
+          base-branch: main
           config-file: .github/workflows/mlc_config.json


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5301

Changes:
1. Enable quite mode - just post errors.
2. Use verbose mode - when error happens, post more [details](https://github.com/coder/coder/issues/5301#issuecomment-1339111971).
3. `check-modified-files-only` and `base-branch` - just check modified files, don't fail tests due to unrelated link issues. Run all checks on the `main` branch.