### PR TITLE
fix: markdown-link-check base-branch should not be set on main branch

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -674,7 +674,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    # For the main branch:
+    - if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+          use-quiet-mode: yes
+          use-verbose-mode: yes
+          config-file: .github/workflows/mlc_config.json
+    # For pull requests:
+    - if: github.ref != 'refs/heads/main' || github.event.pull_request.head.repo.fork
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
           use-quiet-mode: yes
           use-verbose-mode: yes


### PR DESCRIPTION
Follow-up on: https://github.com/coder/coder/commit/133b2de1ca7ae34e8ca6e6a990aa8e7b417d9dbb

It looks like `markdown-link-check` can't determine that it's running on the `main` branch and [doesn't scan all files](https://github.com/coder/coder/actions/runs/3630060378/jobs/6122972651) (PR behavior).