### PR TITLE
Fix: Timeline Date Bug

### DIFF
--- a/site/src/components/Timeline/Timeline.test.tsx
+++ b/site/src/components/Timeline/Timeline.test.tsx
@@ -1,0 +1,8 @@
+import { createDisplayDate } from "./TimelineDateRow"
+
+describe("createDisplayDate", () => {
+  it("returns correctly for Saturdays", () => {
+    const date = new Date("Sat Dec 03 2022 00:00:00 GMT-0500")
+    expect(createDisplayDate(date)).toEqual("last Saturday")
+  })
+})

--- a/site/src/components/Timeline/TimelineDateRow.tsx
+++ b/site/src/components/Timeline/TimelineDateRow.tsx
@@ -8,16 +8,18 @@ export interface TimelineDateRow {
   date: Date
 }
 
+// We only want the message related to the date since the time is displayed
+// inside of the build row
+export const createDisplayDate = (date: Date): string =>
+  formatRelative(date, new Date()).split(" at ")[0]
+
 export const TimelineDateRow: FC<TimelineDateRow> = ({ date }) => {
   const styles = useStyles()
-  // We only want the message related to the date since the time is displayed
-  // inside of the build row
-  const displayDate = formatRelative(date, new Date()).split("at")[0]
 
   return (
     <TableRow className={styles.dateRow}>
       <TableCell className={styles.dateCell} title={date.toLocaleDateString()}>
-        {displayDate}
+        {createDisplayDate(date)}
       </TableCell>
     </TableRow>
   )


### PR DESCRIPTION
Before:
![Screen Shot 2022-12-06 at 1 35 42 PM](https://user-images.githubusercontent.com/19142439/205998745-0c1a622b-b686-432b-b79c-beaeee219895.png)

After:
![Screen Shot 2022-12-06 at 1 58 18 PM](https://user-images.githubusercontent.com/19142439/205998760-67123972-f07d-4b59-8c7e-f0bcdca1a68a.png)
