### PR TITLE
chore: collect gotestsum TestEvents as workflow artifacts

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -336,7 +336,14 @@ jobs:
             echo ::set-output name=cover::false
           fi
           set -x
-          gotestsum --junitfile="gotests.xml" --packages="./..." --debug -- -parallel=8 -timeout=3m -short -failfast $COVERAGE_FLAGS
+          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=3m -short -failfast $COVERAGE_FLAGS
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: gotestsum-debug-${{ matrix.os }}.json
+          path: ./gotestsum.json
+          retention-days: 7
 
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has
@@ -398,6 +405,13 @@ jobs:
 
       - name: Test with PostgreSQL Database
         run: make test-postgres
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: gotestsum-debug-postgres.json
+          path: ./gotestsum.json
+          retention-days: 7
 
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ vendor
 yarn-error.log
 gotests.coverage
 gotests.xml
+gotestsum.json
 .idea
 .gitpod.yml
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,10 @@ test: test-clean
 test-postgres: test-clean test-postgres-docker
 	# The postgres test is prone to failure, so we limit parallelism for
 	# more consistent execution.
-	DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum --junitfile="gotests.xml" --packages="./..." -- \
+	DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum \
+		--junitfile="gotests.xml" \
+		--jsonfile="gotestsum.json" \
+		--packages="./..." -- \
 		-covermode=atomic -coverprofile="gotests.coverage" -timeout=20m \
 		-parallel=4 \
 		-coverpkg=./... \


### PR DESCRIPTION
Fixes: #5247 

This PR modifies the GitHub workflow to store raw `TestEvents` as artifacts. If there is anything wrong with `gotestsum`, we will notice it.

<img width="772" alt="Screenshot 2022-12-07 at 14 59 32" src="https://user-images.githubusercontent.com/14044910/206198686-91db2f46-05a0-4c70-bb47-9d5326b50de2.png">

