### PR TITLE
fix: Improve ptytest closure on expect match timeout

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -72,7 +72,7 @@ func create(t *testing.T, ptty pty.PTY, name string) *PTY {
 	}
 	// Set the actual close function for the tpty.
 	tpty.close = func(reason string) error {
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()
 
 		tpty.logf("closing tpty: %s", reason)


### PR DESCRIPTION
To ensure ptytest closure always happens the same way, we now define a
new `Close` function on `PTY` and always call the close function instead
of manually closing read/writers.

A few additional log messages have been added as well, to better
understand the shutdown process in case of errors.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
