### PR TITLE
fix: coderd/prometheusmetrics wait for all metrics in require.Eventually

### DIFF
--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -224,7 +224,9 @@ func TestWorkspaces(t *testing.T) {
 					if !ok {
 						t.Fail()
 					}
-					require.Equal(t, count, int(metric.Gauge.GetValue()), "invalid count for %s", metric.Label[0].GetValue())
+					if metric.Gauge.GetValue() != float64(count) {
+						return false
+					}
 					sum += int(metric.Gauge.GetValue())
 				}
 				t.Logf("sum %d == total %d", sum, tc.Total)


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/5323

There is a bug in the test causing some flakiness. The test should wait until all metrics have been reported and don't fail the `require` routine in the meantime.
