### PR TITLE
fix: workspacesapps: use doWithRetries when making HTTP calls

### DIFF
--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -414,7 +414,7 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 		t.Log("navigating to: ", gotLocation.String())
 		req, err = http.NewRequestWithContext(ctx, "GET", gotLocation.String(), nil)
 		require.NoError(t, err)
-		resp, err = client.HTTPClient.Do(req)
+		resp, err = doWithRetries(t, client, req)
 		require.NoError(t, err)
 		resp.Body.Close()
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
@@ -471,7 +471,7 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 		req, err = http.NewRequestWithContext(ctx, "GET", gotLocation.String(), nil)
 		require.NoError(t, err)
 		req.Header.Set(codersdk.SessionCustomHeader, apiKey)
-		resp, err = client.HTTPClient.Do(req)
+		resp, err = doWithRetries(t, client, req)
 		require.NoError(t, err)
 		resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1153,7 +1153,7 @@ func TestWorkspaceAppsNonCanonicalHeaders(t *testing.T) {
 		req.Header["Sec-WebSocket-Key"] = []string{secWebSocketKey}
 
 		req.Header.Set(codersdk.SessionCustomHeader, client.SessionToken())
-		resp, err := client.HTTPClient.Do(req)
+		resp, err := doWithRetries(t, client, req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -1205,7 +1205,7 @@ func TestWorkspaceAppsNonCanonicalHeaders(t *testing.T) {
 		req.Header["Sec-WebSocket-Key"] = []string{secWebSocketKey}
 
 		req.Header.Set(codersdk.SessionCustomHeader, client.SessionToken())
-		resp, err := client.HTTPClient.Do(req)
+		resp, err := doWithRetries(t, client, req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/5343
Similar: https://github.com/coder/coder/pull/5255

This PR modifies the test code to use `doWithRetries`, so that it can recover when HTTP 502 occurs. 