### PR TITLE
feat(usermgmt): allow usernames with "_", "."

### DIFF
--- a/coderd/httpapi/name.go
+++ b/coderd/httpapi/name.go
@@ -47,7 +47,7 @@ func NameValid(str string) error {
 	}
 	matched := UsernameValidRegex.MatchString(str)
 	if !matched {
-		return xerrors.New("must be alphanumeric with hyphens")
+		return xerrors.New("must be alphanumeric with hyphens, underscores or periods")
 	}
 	return nil
 }

--- a/coderd/httpapi/name.go
+++ b/coderd/httpapi/name.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	UsernameValidRegex = regexp.MustCompile("^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$")
+	UsernameValidRegex = regexp.MustCompile("^[a-zA-Z0-9._]+(?:-[a-zA-Z0-9._]+)*$")
 	usernameReplace    = regexp.MustCompile("[^a-zA-Z0-9-]*")
 
 	templateDisplayName = regexp.MustCompile(`^[^\s](.*[^\s])?$`)

--- a/coderd/httpapi/name_test.go
+++ b/coderd/httpapi/name_test.go
@@ -30,6 +30,10 @@ func TestUsernameValid(t *testing.T) {
 		{"abcdefghijklmnopqrst", true},
 		{"abcdefghijklmnopqrstu", true},
 		{"wow-test", true},
+		{"_domain-user-convention", true},
+		{"bananas_wow", true},
+		{"firstname.surname", true},
+		{"firstname.surname1", true},
 
 		{"", false},
 		{" ", false},
@@ -48,7 +52,6 @@ func TestUsernameValid(t *testing.T) {
 		{" 123456789012345678901", false},
 		{" a1b2c3d4e5f6g7h8i9j0k", false},
 		{"a1b2c3d4e5f6g7h8i9j0k ", false},
-		{"bananas_wow", false},
 		{"test--now", false},
 
 		{"123456789012345678901234567890123", false},

--- a/site/src/util/formUtils.ts
+++ b/site/src/util/formUtils.ts
@@ -17,7 +17,7 @@ export const Language = {
     return name ? `Please enter a ${name.toLowerCase()}.` : "Required"
   },
   nameInvalidChars: (name: string): string => {
-    return `${name} must start with a-Z or 0-9 and can contain a-Z, 0-9 or -`
+    return `${name} must start with a-Z or 0-9 and can contain a-Z, 0-9, . or -`
   },
   nameTooLong: (name: string, len: number): string => {
     return `${name} cannot be longer than ${len} characters`
@@ -80,7 +80,7 @@ export const onChangeTrimmed =
 // REMARK: Keep these consts in sync with coderd/httpapi/httpapi.go
 const maxLenName = 32
 const templateDisplayNameMaxLength = 64
-const usernameRE = /^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/
+const usernameRE = /^[a-zA-Z0-9._]+(?:-[a-zA-Z0-9._]+)*$/
 const templateDisplayNameRE = /^[^\s](.*[^\s])?$/
 
 // REMARK: see #1756 for name/username semantics

--- a/site/src/util/formUtils.ts
+++ b/site/src/util/formUtils.ts
@@ -17,7 +17,7 @@ export const Language = {
     return name ? `Please enter a ${name.toLowerCase()}.` : "Required"
   },
   nameInvalidChars: (name: string): string => {
-    return `${name} must start with a-Z or 0-9 and can contain a-Z, 0-9, . or -`
+    return `${name} must start with 'a-Z' or '0-9' and can contain 'a-Z' '0-9' '_' '.' or '-'`
   },
   nameTooLong: (name: string, len: number): string => {
     return `${name} cannot be longer than ${len} characters`


### PR DESCRIPTION
> This is my actual username at my current role, and I think “.”s are fairly common in usernames.

Resolves this item of feedback https://github.com/coder/coder/issues/4307

My RegEx is rusty, so would appreciate a second set of eyes validating..

<img width="508" alt="CleanShot 2022-12-08 at 21 29 49@2x" src="https://user-images.githubusercontent.com/127353/206438711-7e9275d9-e79a-4478-bb3a-1303b5766331.png">

Related items:
- https://github.com/coder/coder/issues/1756
- https://github.com/coder/coder/issues/3321
- https://github.com/coder/coder/pull/5082