### PR TITLE
fix: Close coordinator in wsconncache test

### DIFF
--- a/coderd/wsconncache/wsconncache_test.go
+++ b/coderd/wsconncache/wsconncache_test.go
@@ -148,6 +148,9 @@ func setupAgent(t *testing.T, metadata codersdk.WorkspaceAgentMetadata, ptyTimeo
 	metadata.DERPMap = tailnettest.RunDERPAndSTUN(t)
 
 	coordinator := tailnet.NewCoordinator()
+	t.Cleanup(func() {
+		_ = coordinator.Close()
+	})
 	agentID := uuid.New()
 	closer := agent.New(agent.Options{
 		Client: &client{


### PR DESCRIPTION
Possibly related to #5302

