### PR TITLE
clean up

### DIFF
--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -148,7 +148,7 @@ func InitRequest[T Auditable](w http.ResponseWriter, p *RequestParams) (*Request
 		if sw.Status < 400 {
 			diff := Diff(p.Audit, req.Old, req.New)
 
-			// Group resource types maybe have group member changes.
+			// Group resource types may have group member changes.
 			// We track diffs of this nature differently as GroupMember is a distinct table.
 			if p.HasGroupMemberChange {
 				diff = addGroupMemberDiff(logCtx, diff, p.GroupMemberLists, p.Log)


### PR DESCRIPTION
resolves #4736 

Previously, we were logging audit entries for updates to the user table, but not to the user members table. This meant that if someone updated a group by adding or removing members, these changes weren't logged.

This PR adds member logging. We keep the diff for members under the Group resource as this is most intuitive for the auditor.

![Screen Shot 2022-12-08 at 11 07 47 AM](https://user-images.githubusercontent.com/19142439/206522246-a9642893-0050-4394-ace7-b9f93858c90b.png)

NOTE: unsure why the `TestAuthorizeAllEndpoints` test is failing - any ideas?
