### PR TITLE
fix: replace fireEvent with userEvent

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -163,9 +163,7 @@ describe("WorkspacePage", () => {
       name: "cancel action",
     })
 
-    await userEvent
-      .setup()
-      .click(cancelButton)
+    await userEvent.setup().click(cancelButton)
 
     expect(cancelWorkspaceMock).toBeCalled()
   })
@@ -185,9 +183,7 @@ describe("WorkspacePage", () => {
     await renderWorkspacePage()
     const buttonText = t("actionButton.update", { ns: "workspacePage" })
     const button = await screen.findByText(buttonText, { exact: true })
-    await userEvent
-      .setup()
-      .click(button)
+    await userEvent.setup().click(button)
 
     // getTemplate is called twice: once when the machine starts, and once after the user requests to update
     expect(getTemplateMock).toBeCalledTimes(2)
@@ -209,9 +205,7 @@ describe("WorkspacePage", () => {
     await renderWorkspacePage()
     const buttonText = t("actionButton.update", { ns: "workspacePage" })
     const button = await screen.findByText(buttonText, { exact: true })
-    await userEvent
-      .setup()
-      .click(button)
+    await userEvent.setup().click(button)
 
     await waitFor(() =>
       expect(api.startWorkspace).toBeCalledWith(

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import EventSourceMock from "eventsourcemock"
 import i18next from "i18next"
@@ -48,9 +48,11 @@ const renderWorkspacePage = async () => {
  * workspaceStatus was calculated correctly.
  */
 const testButton = async (label: string, actionMock: jest.SpyInstance) => {
+  const user = userEvent.setup()
+
   await renderWorkspacePage()
   const button = await screen.findByRole("button", { name: label })
-  fireEvent.click(button)
+  await user.click(button)
   expect(actionMock).toBeCalled()
 }
 
@@ -65,7 +67,7 @@ const testStatus = async (ws: Workspace, label: string) => {
   )
   await renderWorkspacePage()
   const header = screen.getByTestId("header")
-  const status = await within(header).findByRole("status")
+  const status = within(header).getByRole("status")
   expect(status).toHaveTextContent(label)
 }
 
@@ -88,6 +90,7 @@ afterAll(() => {
 describe("WorkspacePage", () => {
   it("requests a delete job when the user presses Delete and confirms", async () => {
     const user = userEvent.setup()
+
     const deleteWorkspaceMock = jest
       .spyOn(api, "deleteWorkspace")
       .mockResolvedValueOnce(MockWorkspaceBuild)
@@ -160,7 +163,9 @@ describe("WorkspacePage", () => {
       name: "cancel action",
     })
 
-    fireEvent.click(cancelButton)
+    await userEvent
+      .setup()
+      .click(cancelButton)
 
     expect(cancelWorkspaceMock).toBeCalled()
   })
@@ -180,7 +185,9 @@ describe("WorkspacePage", () => {
     await renderWorkspacePage()
     const buttonText = t("actionButton.update", { ns: "workspacePage" })
     const button = await screen.findByText(buttonText, { exact: true })
-    fireEvent.click(button)
+    await userEvent
+      .setup()
+      .click(button)
 
     // getTemplate is called twice: once when the machine starts, and once after the user requests to update
     expect(getTemplateMock).toBeCalledTimes(2)
@@ -202,7 +209,9 @@ describe("WorkspacePage", () => {
     await renderWorkspacePage()
     const buttonText = t("actionButton.update", { ns: "workspacePage" })
     const button = await screen.findByText(buttonText, { exact: true })
-    fireEvent.click(button)
+    await userEvent
+      .setup()
+      .click(button)
 
     await waitFor(() =>
       expect(api.startWorkspace).toBeCalledWith(
@@ -211,6 +220,7 @@ describe("WorkspacePage", () => {
       ),
     )
   })
+
   it("shows the Stopping status when the workspace is stopping", async () => {
     await testStatus(
       MockStoppingWorkspace,


### PR DESCRIPTION
Possibly fix: https://github.com/coder/coder/issues/5309

I wasn't able to run WorkspacePage tests on M1 Macbook until I modified the test source. 

Changes:
1. Replace `fireEvent` with `userEvent`.
2. Remove `await` (_I'm not quite sure why it helps_): 

```diff
-  const status = await within(header).findByRole("status")
+  const status = within(header).getByRole("status")
```

<details>
<summary>Error trace</summary>

```
yarn jest ./src/pages/WorkspacePage/ --selectProjects test
yarn run v1.22.19
$ /Users/mtojek/code/coder/site/node_modules/.bin/jest ./src/pages/WorkspacePage/ --selectProjects test
Running one project: test

 RUNS   test  src/pages/WorkspacePage/WorkspacePage.test.tsx
/Users/mtojek/code/coder/site/jest.setup.ts:66
        throw new Error(`Failing due to console.${logType} while running test!\n\n${util.format(format, ...args)}`);
              ^

Error: Failing due to console.error while running test!

Missing onError handler and/or unhandled exception/promise rejection for invocation 'startWorkspace'. Original error: 'Error: Failing due to console.error while running test!

Warning: An update to WorkspacePage inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at WorkspacePage (/Users/mtojek/code/coder/site/src/pages/WorkspacePage/WorkspacePage.tsx:15:14)
    at RequireAuth (/Users/mtojek/code/coder/site/src/components/RequireAuth/RequireAuth.tsx:14:8)
    at RenderedRoute (/Users/mtojek/code/coder/site/node_modules/react-router/lib/hooks.tsx:579:26)
    at Routes (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:374:3)
    at ThemeProvider (/Users/mtojek/code/coder/site/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
    at I18nextProvider (/Users/mtojek/code/coder/site/node_modules/react-i18next/dist/commonjs/I18nextProvider.js:13:19)
    at XServiceProvider (/Users/mtojek/code/coder/site/src/xServices/StateContext.tsx:33:65)
    at Router (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:292:13)
    at MemoryRouter (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:125:3)
    at e (/Users/mtojek/code/coder/site/node_modules/react-helmet-async/src/Provider.js:36:22)'.  Stacktrace was 'Error: Failing due to console.error while running test!

Warning: An update to WorkspacePage inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at WorkspacePage (/Users/mtojek/code/coder/site/src/pages/WorkspacePage/WorkspacePage.tsx:15:14)
    at RequireAuth (/Users/mtojek/code/coder/site/src/components/RequireAuth/RequireAuth.tsx:14:8)
    at RenderedRoute (/Users/mtojek/code/coder/site/node_modules/react-router/lib/hooks.tsx:579:26)
    at Routes (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:374:3)
    at ThemeProvider (/Users/mtojek/code/coder/site/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
    at I18nextProvider (/Users/mtojek/code/coder/site/node_modules/react-i18next/dist/commonjs/I18nextProvider.js:13:19)
    at XServiceProvider (/Users/mtojek/code/coder/site/src/xServices/StateContext.tsx:33:65)
    at Router (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:292:13)
    at MemoryRouter (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:125:3)
    at e (/Users/mtojek/code/coder/site/node_modules/react-helmet-async/src/Provider.js:36:22)
    at console.global.console.<computed> [as error] (/Users/mtojek/code/coder/site/jest.setup.ts:47:11)
    at printWarning (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:86:30)
    at error (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:60:7)
    at warnIfUpdatesNotWrappedWithActDEV (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:27589:9)
    at scheduleUpdateOnFiber (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:25508:5)
    at forceStoreRerender (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:16977:5)
    at handleStoreChange (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:16953:7)
    at Interpreter.update (/Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:442:9)
    at /Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:110:15
    at Scheduler.process (/Users/mtojek/code/coder/site/node_modules/xstate/lib/scheduler.js:69:7)
    at Scheduler.schedule (/Users/mtojek/code/coder/site/node_modules/xstate/lib/scheduler.js:48:10)
    at Interpreter.send (/Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:104:23)
    at receive (/Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:1213:13)
    at /Users/mtojek/code/coder/site/src/xServices/workspace/workspaceXService.ts:651:11
    at runNextTicks (node:internal/process/task_queues:61:5)
    at listOnTimeout (node:internal/timers:528:9)
    at processTimers (node:internal/timers:502:7)' Current error is 'Error: Failing due to console.error while running test!

Warning: An update to WorkspacePage inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at WorkspacePage (/Users/mtojek/code/coder/site/src/pages/WorkspacePage/WorkspacePage.tsx:15:14)
    at RequireAuth (/Users/mtojek/code/coder/site/src/components/RequireAuth/RequireAuth.tsx:14:8)
    at RenderedRoute (/Users/mtojek/code/coder/site/node_modules/react-router/lib/hooks.tsx:579:26)
    at Routes (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:374:3)
    at ThemeProvider (/Users/mtojek/code/coder/site/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
    at I18nextProvider (/Users/mtojek/code/coder/site/node_modules/react-i18next/dist/commonjs/I18nextProvider.js:13:19)
    at XServiceProvider (/Users/mtojek/code/coder/site/src/xServices/StateContext.tsx:33:65)
    at Router (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:292:13)
    at MemoryRouter (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:125:3)
    at e (/Users/mtojek/code/coder/site/node_modules/react-helmet-async/src/Provider.js:36:22)'. Stacktrace was 'Error: Failing due to console.error while running test!

Warning: An update to WorkspacePage inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at WorkspacePage (/Users/mtojek/code/coder/site/src/pages/WorkspacePage/WorkspacePage.tsx:15:14)
    at RequireAuth (/Users/mtojek/code/coder/site/src/components/RequireAuth/RequireAuth.tsx:14:8)
    at RenderedRoute (/Users/mtojek/code/coder/site/node_modules/react-router/lib/hooks.tsx:579:26)
    at Routes (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:374:3)
    at ThemeProvider (/Users/mtojek/code/coder/site/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
    at I18nextProvider (/Users/mtojek/code/coder/site/node_modules/react-i18next/dist/commonjs/I18nextProvider.js:13:19)
    at XServiceProvider (/Users/mtojek/code/coder/site/src/xServices/StateContext.tsx:33:65)
    at Router (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:292:13)
    at MemoryRouter (/Users/mtojek/code/coder/site/node_modules/react-router/lib/components.tsx:125:3)
    at e (/Users/mtojek/code/coder/site/node_modules/react-helmet-async/src/Provider.js:36:22)
    at console.global.console.<computed> [as error] (/Users/mtojek/code/coder/site/jest.setup.ts:47:11)
    at printWarning (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:86:30)
    at error (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:60:7)
    at warnIfUpdatesNotWrappedWithActDEV (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:27589:9)
    at scheduleUpdateOnFiber (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:25508:5)
    at forceStoreRerender (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:16977:5)
    at handleStoreChange (/Users/mtojek/code/coder/site/node_modules/react-dom/cjs/react-dom.development.js:16953:7)
    at Interpreter.update (/Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:442:9)
    at /Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:110:15
    at Scheduler.process (/Users/mtojek/code/coder/site/node_modules/xstate/lib/scheduler.js:69:7)
    at Scheduler.schedule (/Users/mtojek/code/coder/site/node_modules/xstate/lib/scheduler.js:48:10)
    at Interpreter.send (/Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:104:23)
    at /Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:1122:17
    at runNextTicks (node:internal/process/task_queues:61:5)
    at listOnTimeout (node:internal/timers:528:9)
    at processTimers (node:internal/timers:502:7)'
    at console.global.console.<computed> [as error] (/Users/mtojek/code/coder/site/jest.setup.ts:47:11)
    at Object.reportUnhandledExceptionOnInvocation (/Users/mtojek/code/coder/site/node_modules/xstate/lib/utils.js:578:15)
    at /Users/mtojek/code/coder/site/node_modules/xstate/lib/interpreter.js:1126:17
    at runNextTicks (node:internal/process/task_queues:61:5)
    at listOnTimeout (node:internal/timers:528:9)
    at processTimers (node:internal/timers:502:7)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>