### PR TITLE
fix: fmt should check for unstaged files

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -274,6 +274,9 @@ jobs:
           export PATH=${PATH}:$(go env GOPATH)/bin
           make --output-sync -j -B fmt
 
+      - name: Check for unstaged files
+        run: ./scripts/check_unstaged.sh
+
   test-go:
     name: "test/go"
     runs-on: ${{ matrix.os == 'ubuntu-latest' && github.repository_owner == 'coder' && 'ubuntu-latest-16-cores' ||  matrix.os == 'windows-2022' && github.repository_owner == 'coder' && 'windows-latest-8-cores'|| matrix.os }}

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -12,9 +12,9 @@ terraform {
 }
 
 variable "datocms_api_token" {
-  type = string
+  type        = string
   description = "An API token from DATOCMS for usage with building our website."
-  default = ""
+  default     = ""
 }
 
 # Admin parameters
@@ -124,7 +124,7 @@ resource "docker_container" "workspace" {
   # CPU limits are unnecessary since Docker will load balance automatically
   memory  = 32768
   runtime = "sysbox-runc"
-  env     = [
+  env = [
     "CODER_AGENT_TOKEN=${coder_agent.dev.token}",
     "DATOCMS_API_TOKEN=${var.datocms_api_token}",
   ]


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/actions/runs/3643167089/jobs/6151099869

```
--- shfmt
dogfood/main.tf
--- prettier
yarn run v1.22.19
$ prettier --cache --check '**/*.{css,html,js,json,jsx,md,ts,tsx,yaml,yml}' . ../ADOPTERS.md ../README.md ../docs
Checking formatting...
All matched files use Prettier code style!
Done in 2.8[6](https://github.com/coder/coder/actions/runs/3643167089/jobs/6151099869#step:6:7)s.
```

File `dogfood/main.tf` hasn't been formatted before, but `fmt` doesn't complain about it.