### PR TITLE
fix: pin code-server to 4.8.3

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -36,7 +36,7 @@ resource "coder_agent" "dev" {
     #!/bin/sh
     set -x
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh
+    curl -fsSL https://code-server.dev/install.sh | sh -- --version 4.8.3
     code-server --auth none --port 13337 &
     sudo service docker start
     coder dotfiles -y 2>&1 | tee  ~/.personalize.log

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -36,7 +36,7 @@ resource "coder_agent" "dev" {
     #!/bin/sh
     set -x
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -- --version 4.8.3
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
     code-server --auth none --port 13337 &
     sudo service docker start
     coder dotfiles -y 2>&1 | tee  ~/.personalize.log


### PR DESCRIPTION
We're having some terminal issues on macOS clients (i.e. iPad) with 4.9.0 so downgrading to 4.8.3 in the meantime.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->

(NOTE: I will do this with all the templates next week and I think we should encourage this in the docs).