### PR TITLE
feat: amending audit string to show workspace owner 

### DIFF
--- a/coderd/audit.go
+++ b/coderd/audit.go
@@ -161,8 +161,9 @@ func (api *API) convertAuditLogs(ctx context.Context, dblogs []database.GetAudit
 }
 
 type AdditionalFields struct {
-	WorkspaceName string
-	BuildNumber   string
+	WorkspaceName  string
+	BuildNumber    string
+	WorkspaceOwner string
 }
 
 func (api *API) convertAuditLog(ctx context.Context, dblog database.GetAuditLogsOffsetRow) codersdk.AuditLog {
@@ -198,8 +199,9 @@ func (api *API) convertAuditLog(ctx context.Context, dblog database.GetAuditLogs
 	if err != nil {
 		api.Logger.Error(ctx, "unmarshal additional fields", slog.Error(err))
 		resourceInfo := map[string]string{
-			"workspaceName": "unknown",
-			"buildNumber":   "unknown",
+			"workspaceName":  "unknown",
+			"buildNumber":    "unknown",
+			"workspaceOwner": "unknown",
 		}
 		dblog.AdditionalFields, err = json.Marshal(resourceInfo)
 		api.Logger.Error(ctx, "marshal additional fields", slog.Error(err))

--- a/coderd/audit.go
+++ b/coderd/audit.go
@@ -333,8 +333,12 @@ func auditLogResourceLink(alog database.GetAuditLogsOffsetRow, additionalFields 
 		return fmt.Sprintf("/users?filter=%s",
 			alog.ResourceTarget)
 	case database.ResourceTypeWorkspace:
+		workspaceOwner := alog.UserUsername.String
+		if len(additionalFields.WorkspaceOwner) != 0 && additionalFields.WorkspaceOwner != "unknown" {
+			workspaceOwner = additionalFields.WorkspaceOwner
+		}
 		return fmt.Sprintf("/@%s/%s",
-			alog.UserUsername.String, alog.ResourceTarget)
+			workspaceOwner, alog.ResourceTarget)
 	case database.ResourceTypeWorkspaceBuild:
 		if len(additionalFields.WorkspaceName) == 0 || len(additionalFields.BuildNumber) == 0 {
 			return ""

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -236,6 +236,14 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 
 // Create a new workspace for the currently authenticated user.
 func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Request) {
+	workspaceResourceInfo := map[string]string{
+		"workspaceOwner": httpmw.UserParam(r).Username,
+	}
+	wriBytes, err := json.Marshal(workspaceResourceInfo)
+	if err != nil {
+		// log something
+	}
+
 	var (
 		ctx               = r.Context()
 		organization      = httpmw.OrganizationParam(r)
@@ -243,10 +251,11 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		auditor           = api.Auditor.Load()
 		user              = httpmw.UserParam(r)
 		aReq, commitAudit = audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionCreate,
+			Audit:            *auditor,
+			Log:              api.Logger,
+			Request:          r,
+			Action:           database.AuditActionCreate,
+			AdditionalFields: wriBytes,
 		})
 	)
 	defer commitAudit()

--- a/site/src/components/AuditLogRow/AuditLogDescription.test.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDescription.test.tsx
@@ -1,6 +1,7 @@
 import {
   MockAuditLog,
   MockAuditLogWithWorkspaceBuild,
+  MockWorkspaceCreateAuditLogForDifferentOwner,
 } from "testHelpers/entities"
 import { AuditLogDescription } from "./AuditLogDescription"
 import { render } from "../../testHelpers/renderHelpers"
@@ -44,6 +45,18 @@ describe("AuditLogDescription", () => {
 
     expect(
       getByTextContent("TestUser stopped build for workspace workspace"),
+    ).toBeDefined()
+  })
+  it("renders the correct string for a workspace created for a different owner", async () => {
+    render(
+      <AuditLogDescription
+        auditLog={MockWorkspaceCreateAuditLogForDifferentOwner}
+      />,
+    )
+    expect(
+      getByTextContent(
+        `TestUser created workspace bruno-dev on behalf of ${MockWorkspaceCreateAuditLogForDifferentOwner.additional_fields.workspaceOwner}`,
+      ),
     ).toBeDefined()
   })
 })

--- a/site/src/components/AuditLogRow/AuditLogDescription.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDescription.tsx
@@ -49,15 +49,16 @@ export const AuditLogDescription: FC<{ auditLog: AuditLog }> = ({
         </span>
       )}
       {/* logs for workspaces created on behalf of other users indicate ownership in the description */}
-      {auditLog.additional_fields.workspaceOwner && (
-        <span>
-          <>
-            {t("auditLog:table.logRow.onBehalfOf", {
-              owner: auditLog.additional_fields.workspaceOwner,
-            })}
-          </>
-        </span>
-      )}
+      {auditLog.additional_fields.workspaceOwner &&
+        auditLog.additional_fields.workspaceOwner !== "unknown" && (
+          <span>
+            <>
+              {t("auditLog:table.logRow.onBehalfOf", {
+                owner: auditLog.additional_fields.workspaceOwner,
+              })}
+            </>
+          </span>
+        )}
     </span>
   )
 }

--- a/site/src/components/AuditLogRow/AuditLogDescription.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDescription.tsx
@@ -45,7 +45,17 @@ export const AuditLogDescription: FC<{ auditLog: AuditLog }> = ({
       )}
       {auditLog.is_deleted && (
         <span className={classes.deletedLabel}>
-          <> {t("auditLog:table.logRow.deletedLabel")}</>
+          <>{t("auditLog:table.logRow.deletedLabel")}</>
+        </span>
+      )}
+      {/* logs for workspaces created on behalf of other users indicate ownership in the description */}
+      {auditLog.additional_fields.workspaceOwner && (
+        <span>
+          <>
+            {t("auditLog:table.logRow.onBehalfOf", {
+              owner: auditLog.additional_fields.workspaceOwner,
+            })}
+          </>
         </span>
       )}
     </span>

--- a/site/src/i18n/en/auditLog.json
+++ b/site/src/i18n/en/auditLog.json
@@ -8,11 +8,12 @@
     "emptyPage": "No audit logs available on this page",
     "noLogs": "No audit logs available",
     "logRow": {
-      "deletedLabel": "(deleted)",
+      "deletedLabel": " (deleted)",
       "ip": "IP: ",
       "os": "OS: ",
       "browser": "Browser: ",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "onBehalfOf": " on behalf of {{owner}}"
     }
   }
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1023,8 +1023,8 @@ export const MockAuditLog2: TypesGen.AuditLog = {
 export const MockWorkspaceCreateAuditLogForDifferentOwner = {
   ...MockAuditLog,
   additional_fields: {
-    workspaceOwner: "Member"
-  }
+    workspaceOwner: "Member",
+  },
 }
 
 export const MockAuditLogWithWorkspaceBuild: TypesGen.AuditLog = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1020,6 +1020,13 @@ export const MockAuditLog2: TypesGen.AuditLog = {
   },
 }
 
+export const MockWorkspaceCreateAuditLogForDifferentOwner = {
+  ...MockAuditLog,
+  additional_fields: {
+    workspaceOwner: "Member"
+  }
+}
+
 export const MockAuditLogWithWorkspaceBuild: TypesGen.AuditLog = {
   ...MockAuditLog,
   id: "f90995bf-4a2b-4089-b597-e66e025e523e",


### PR DESCRIPTION
resolves #5269

We now indicate the workspace owner in the audit log string if the owner differs from the initiator (if the workspace was created on behalf of a different user):
![Screen Shot 2022-12-09 at 11 26 09 AM](https://user-images.githubusercontent.com/19142439/206748213-7632af04-5904-411b-89ed-2641ec6d8a10.png)
