### PR TITLE
fix(site): Use relative date in Timeline test

### DIFF
--- a/site/src/components/Timeline/Timeline.test.tsx
+++ b/site/src/components/Timeline/Timeline.test.tsx
@@ -2,7 +2,13 @@ import { createDisplayDate } from "./TimelineDateRow"
 
 describe("createDisplayDate", () => {
   it("returns correctly for Saturdays", () => {
-    const date = new Date("Sat Dec 03 2022 00:00:00 GMT-0500")
+    const now = new Date()
+    const date = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      // Previous Saturday, from now.
+      now.getDate() - now.getDay() - 1,
+    )
     expect(createDisplayDate(date)).toEqual("last Saturday")
   })
 })


### PR DESCRIPTION
CI is currently failing because the test uses a static date, this fixes that.
