### PR TITLE
fix: Remove `@main` tag from pkg.go.dev in docs links

### DIFF
--- a/docs/admin/audit-logs.md
+++ b/docs/admin/audit-logs.md
@@ -24,10 +24,10 @@ In the Coder UI you can filter your audit logs using the pre-defined filter or b
 
 The supported filters are:
 
-- `resource_type` - The type of the resource. It can be a workspace, template, user, etc. You can [find here](https://pkg.go.dev/github.com/coder/coder@main/codersdk#ResourceType) all the resource types that are supported.
+- `resource_type` - The type of the resource. It can be a workspace, template, user, etc. You can [find here](https://pkg.go.dev/github.com/coder/coder/codersdk#ResourceType) all the resource types that are supported.
 - `resource_id` - The ID of the resource.
 - `resource_target` - The name of the resource. Can be used instead of `resource_id`.
-- `action`- The action applied to a resource. You can [find here](https://pkg.go.dev/github.com/coder/coder@main/codersdk#AuditAction) all the actions that are supported.
+- `action`- The action applied to a resource. You can [find here](https://pkg.go.dev/github.com/coder/coder/codersdk#AuditAction) all the actions that are supported.
 - `username` - The username of the user who triggered the action.
 - `email` - The email of the user who triggered the action.
 - `date_from` - The inclusive start date with format `YYYY-MM-DD`.

--- a/docs/admin/automation.md
+++ b/docs/admin/automation.md
@@ -34,4 +34,4 @@ curl 'https://dev.coder.com/api/v2/workspaces' \
 
 ## Golang SDK
 
-Coder publishes a public [Golang SDK](https://pkg.go.dev/github.com/coder/coder@main/codersdk) for Coder. This is consumed by the [CLI package](https://github.com/coder/coder/tree/main/cli).
+Coder publishes a public [Golang SDK](https://pkg.go.dev/github.com/coder/coder/codersdk) for Coder. This is consumed by the [CLI package](https://github.com/coder/coder/tree/main/cli).


### PR DESCRIPTION
This seems to have broken, but removing the `main` tag makes it resolve to the latest version.

See: https://github.com/coder/coder/actions/runs/3675316304/jobs/6215503383
