### PR TITLE
feat: support partial parameter files

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -232,13 +232,16 @@ func TestCreate(t *testing.T) {
 			ProvisionApply: echo.ProvisionComplete,
 			ProvisionPlan:  echo.ProvisionComplete,
 		})
+
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		_ = coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+
 		tempDir := t.TempDir()
 		removeTmpDirUntilSuccessAfterTest(t, tempDir)
 		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
-		_, _ = parameterFile.WriteString("zone: \"bananas\"")
-		cmd, root := clitest.New(t, "create", "my-workspace", "--template", template.Name, "--parameter-file", parameterFile.Name())
+		_, _ = parameterFile.WriteString("username: \"boingo\"")
+
+		cmd, root := clitest.New(t, "create", "", "--parameter-file", parameterFile.Name())
 		clitest.SetupConfig(t, client, root)
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t)
@@ -247,11 +250,22 @@ func TestCreate(t *testing.T) {
 		go func() {
 			defer close(doneChan)
 			err := cmd.Execute()
-			assert.EqualError(t, err, "Parameter value absent in parameter file for \"region\"!")
+			assert.NoError(t, err)
 		}()
+
+		matches := []string{
+			"Specify a name", "my-workspace",
+			fmt.Sprintf("Enter a value (default: %q):", defaultValue), "bingo",
+			"Confirm create?", "yes",
+		}
+		for i := 0; i < len(matches); i += 2 {
+			match := matches[i]
+			value := matches[i+1]
+			pty.ExpectMatch(match)
+			pty.WriteLine(value)
+		}
 		<-doneChan
 	})
-
 	t.Run("FailedDryRun", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -252,17 +252,27 @@ func TestCreate(t *testing.T) {
 			err := cmd.Execute()
 			assert.NoError(t, err)
 		}()
-
-		matches := []string{
-			"Specify a name", "my-workspace",
-			fmt.Sprintf("Enter a value (default: %q):", defaultValue), "bingo",
-			"Confirm create?", "yes",
+		matches := []struct {
+			match string
+			write string
+		}{
+			{
+				match: "Specify a name",
+				write: "my-workspace",
+			},
+			{
+				match: fmt.Sprintf("Enter a value (default: %q):", defaultValue),
+				write: "bingo",
+			},
+			{
+				match: "Confirm create?",
+				write: "yes",
+			},
 		}
-		for i := 0; i < len(matches); i += 2 {
-			match := matches[i]
-			value := matches[i+1]
-			pty.ExpectMatch(match)
-			pty.WriteLine(value)
+
+		for _, m := range matches {
+			pty.ExpectMatch(m.match)
+			pty.WriteLine(m.write)
 		}
 		<-doneChan
 	})

--- a/cli/parameter.go
+++ b/cli/parameter.go
@@ -36,18 +36,21 @@ func createParameterMapFromFile(parameterFile string) (map[string]string, error)
 	return nil, xerrors.Errorf("Parameter file name is not specified")
 }
 
-// Returns a parameter value from a given map, if the map exists, else takes input from the user.
-// Throws an error if the map exists but does not include a value for the parameter.
+// Returns a parameter value from a given map, if the map does not exist or does not contain the item, it takes input from the user.
+// Throws an error if there are any errors with the users input.
 func getParameterValueFromMapOrInput(cmd *cobra.Command, parameterMap map[string]string, parameterSchema codersdk.ParameterSchema) (string, error) {
 	var parameterValue string
+	var err error
 	if parameterMap != nil {
 		var ok bool
 		parameterValue, ok = parameterMap[parameterSchema.Name]
 		if !ok {
-			return "", xerrors.Errorf("Parameter value absent in parameter file for %q!", parameterSchema.Name)
+			parameterValue, err = cliui.ParameterSchema(cmd, parameterSchema)
+			if err != nil {
+				return "", err
+			}
 		}
 	} else {
-		var err error
 		parameterValue, err = cliui.ParameterSchema(cmd, parameterSchema)
 		if err != nil {
 			return "", err

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -187,14 +187,25 @@ func TestTemplateCreate(t *testing.T) {
 			match string
 			write string
 		}{
-			{match: "Create and upload", write: "yes"},
+			{
+				match: "Create and upload",
+				write: "yes",
+			},
+			{
+				match: "Enter a value:",
+				write: "bingo",
+			},
+			{
+				match: "Confirm create?",
+				write: "yes",
+			},
 		}
 		for _, m := range matches {
 			pty.ExpectMatch(m.match)
 			pty.WriteLine(m.write)
 		}
 
-		require.EqualError(t, <-execDone, "Parameter value absent in parameter file for \"region\"!")
+		require.NoError(t, <-execDone)
 	})
 
 	t.Run("Recreate template with same name (create, delete, create)", func(t *testing.T) {


### PR DESCRIPTION
Facilitate consuming partial parameter files and prompt users for any parameters that were expected but not found in the parameter file.

Fixes #5390 