### PR TITLE
chore: Collect gotests.xml files

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -348,13 +348,12 @@ jobs:
           path: ./gotestsum.json
           retention-days: 7
 
-      - uses: datadog/junit-upload-github-action@v1
+      - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-            api-key: ${{ secrets.DD_API_KEY }}
-            service: "coder-gotests"
-            tags: "test_suite:${{ matrix.os }},github_ref:${{github.ref}}"
-            files: ./gotests.xml
+          name: gotests-${{ matrix.os }}.xml
+          path: ./gotests.xml
+          retention-days: 30
 
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has
@@ -424,13 +423,12 @@ jobs:
           path: ./gotestsum.json
           retention-days: 7
 
-      - uses: datadog/junit-upload-github-action@v1
+      - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-            api-key: ${{ secrets.DD_API_KEY }}
-            service: "coder-gotests"
-            tags: "test_suite:postgres,github_ref:${{github.ref}}"
-            files: ./gotests.xml
+          name: gotests-postgres.xml
+          path: ./gotests.xml
+          retention-days: 30
 
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -349,12 +349,12 @@ jobs:
           retention-days: 7
 
       - uses: datadog/junit-upload-github-action@v1
-        # TODO github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
-        if: success() || failure()
+        if: "!github.event.pull_request.head.repo.fork && (success() || failure())"
         with:
             api-key: ${{ secrets.DD_API_KEY }}
             service: "coder-gotests"
             tags: "test_suite:${{ matrix.os }}"
+            env: "{{ github.ref == 'refs/heads/main' && 'main' || 'pull_request' }}"
             files: ./gotests.xml
 
       - uses: codecov/codecov-action@v3
@@ -426,12 +426,12 @@ jobs:
           retention-days: 7
 
       - uses: datadog/junit-upload-github-action@v1
-        # TODO github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
-        if: success() || failure()
+        if: "!github.event.pull_request.head.repo.fork && (success() || failure())"
         with:
             api-key: ${{ secrets.DD_API_KEY }}
             service: "coder-gotests"
             tags: "test_suite:postgres"
+            env: "{{ github.ref == 'refs/heads/main' && 'main' || 'pull_request' }}"
             files: ./gotests.xml
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -429,7 +429,7 @@ jobs:
         with:
             api-key: ${{ secrets.DD_API_KEY }}
             service: "coder-gotests"
-            tags: "test_suite:${{ matrix.os }},github_ref:${{github.ref}}"
+            tags: "test_suite:postgres,github_ref:${{github.ref}}"
             files: ./gotests.xml
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -349,12 +349,11 @@ jobs:
           retention-days: 7
 
       - uses: datadog/junit-upload-github-action@v1
-        if: "!github.event.pull_request.head.repo.fork && (success() || failure())"
+        if: success() || failure()
         with:
             api-key: ${{ secrets.DD_API_KEY }}
             service: "coder-gotests"
-            tags: "test_suite:${{ matrix.os }}"
-            env: "{{ github.ref == 'refs/heads/main' && 'main' || 'pull_request' }}"
+            tags: "test_suite:${{ matrix.os }},github_ref:${{github.ref}}"
             files: ./gotests.xml
 
       - uses: codecov/codecov-action@v3
@@ -426,12 +425,11 @@ jobs:
           retention-days: 7
 
       - uses: datadog/junit-upload-github-action@v1
-        if: "!github.event.pull_request.head.repo.fork && (success() || failure())"
+        if: success() || failure()
         with:
             api-key: ${{ secrets.DD_API_KEY }}
             service: "coder-gotests"
-            tags: "test_suite:postgres"
-            env: "{{ github.ref == 'refs/heads/main' && 'main' || 'pull_request' }}"
+            tags: "test_suite:${{ matrix.os }},github_ref:${{github.ref}}"
             files: ./gotests.xml
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -348,6 +348,15 @@ jobs:
           path: ./gotestsum.json
           retention-days: 7
 
+      - uses: datadog/junit-upload-github-action@v1
+        # TODO github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+        if: success() || failure()
+        with:
+            api-key: ${{ secrets.DD_API_KEY }}
+            service: "coder-gotests"
+            tags: "test_suite:${{ matrix.os }}"
+            files: ./gotests.xml
+
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has
         # the `fail_ci_if_error` option that defaults to `false`, but
@@ -415,6 +424,15 @@ jobs:
           name: gotestsum-debug-postgres.json
           path: ./gotestsum.json
           retention-days: 7
+
+      - uses: datadog/junit-upload-github-action@v1
+        # TODO github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+        if: success() || failure()
+        with:
+            api-key: ${{ secrets.DD_API_KEY }}
+            service: "coder-gotests"
+            tags: "test_suite:postgres"
+            files: ./gotests.xml
 
       - uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has


### PR DESCRIPTION
~This PR enables the `datadog-ci` to collect JUnit test reports from go tests.~

We will not go with `datadog-ci` due to financial reasons. Let's just collect `gotests.xml` files, so we can process them on some machine once per week/month.