### PR TITLE
fix: stop time incrementer on workspace page

### DIFF
--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -1,7 +1,5 @@
 import { action } from "@storybook/addon-actions"
 import { Story } from "@storybook/react"
-import dayjs from "dayjs"
-import { canExtendDeadline, canReduceDeadline } from "util/schedule"
 import * as Mocks from "../../testHelpers/entities"
 import { Workspace, WorkspaceErrors, WorkspaceProps } from "./Workspace"
 
@@ -21,15 +19,6 @@ Running.args = {
     },
     onDeadlinePlus: () => {
       // do nothing, this is just for storybook
-    },
-    deadlineMinusEnabled: () => {
-      return canReduceDeadline(dayjs(Mocks.MockWorkspace.latest_build.deadline))
-    },
-    deadlinePlusEnabled: () => {
-      return canExtendDeadline(
-        dayjs(Mocks.MockWorkspace.latest_build.deadline),
-        Mocks.MockWorkspace,
-      )
     },
     maxDeadlineDecrease: 1000,
     maxDeadlineIncrease: 1000,

--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -20,8 +20,8 @@ Running.args = {
     onDeadlinePlus: () => {
       // do nothing, this is just for storybook
     },
-    maxDeadlineDecrease: 1000,
-    maxDeadlineIncrease: 1000,
+    maxDeadlineDecrease: 0,
+    maxDeadlineIncrease: 24,
   },
   workspace: Mocks.MockWorkspace,
   handleStart: action("start"),

--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -29,7 +29,6 @@ Running.args = {
       return canExtendDeadline(
         dayjs(Mocks.MockWorkspace.latest_build.deadline),
         Mocks.MockWorkspace,
-        Mocks.MockTemplate,
       )
     },
     maxDeadlineDecrease: 1000,

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -35,8 +35,6 @@ export interface WorkspaceProps {
   scheduleProps: {
     onDeadlinePlus: (hours: number) => void
     onDeadlineMinus: (hours: number) => void
-    deadlinePlusEnabled: () => boolean
-    deadlineMinusEnabled: () => boolean
     maxDeadlineIncrease: number
     maxDeadlineDecrease: number
   }
@@ -131,8 +129,6 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
               workspace={workspace}
               onDeadlineMinus={scheduleProps.onDeadlineMinus}
               onDeadlinePlus={scheduleProps.onDeadlinePlus}
-              deadlineMinusEnabled={scheduleProps.deadlineMinusEnabled}
-              deadlinePlusEnabled={scheduleProps.deadlinePlusEnabled}
               maxDeadlineDecrease={scheduleProps.maxDeadlineDecrease}
               maxDeadlineIncrease={scheduleProps.maxDeadlineIncrease}
               canUpdateWorkspace={canUpdateWorkspace}

--- a/site/src/components/WorkspaceScheduleButton/EditHours.tsx
+++ b/site/src/components/WorkspaceScheduleButton/EditHours.tsx
@@ -19,6 +19,7 @@ export const EditHours = ({
   const styles = useStyles()
 
   return (
+    // hours is NaN when user deletes the value, so treat it as 0
     <form onSubmit={() => handleSubmit(Number.isNaN(hours) ? 0 : hours)}>
       <Stack direction="row" alignItems="baseline" spacing={1}>
         <TextField

--- a/site/src/components/WorkspaceScheduleButton/EditHours.tsx
+++ b/site/src/components/WorkspaceScheduleButton/EditHours.tsx
@@ -19,13 +19,13 @@ export const EditHours = ({
   const styles = useStyles()
 
   return (
-    <form onSubmit={() => handleSubmit(hours)}>
+    <form onSubmit={() => handleSubmit(Number.isNaN(hours) ? 0 : hours)}>
       <Stack direction="row" alignItems="baseline" spacing={1}>
         <TextField
           className={styles.inputField}
           inputProps={{ min: 0, max, step: 1 }}
           label={t("workspaceScheduleButton.hours")}
-          value={hours}
+          value={hours.toString()}
           onChange={(e) => setHours(parseInt(e.target.value))}
           type="number"
         />

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
@@ -105,6 +105,7 @@ export const WorkspaceScheduleButton: React.FC<
               <span className={styles.actions}>
                 <IconButton
                   className={styles.subtractButton}
+                  aria-label="Subtract hours from deadline"
                   size="small"
                   disabled={!deadlineMinusEnabled}
                   onClick={() => {
@@ -119,6 +120,7 @@ export const WorkspaceScheduleButton: React.FC<
                 </IconButton>
                 <IconButton
                   className={styles.addButton}
+                  aria-label="Add hours to deadline"
                   size="small"
                   disabled={!deadlinePlusEnabled}
                   onClick={() => {

--- a/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
+++ b/site/src/components/WorkspaceScheduleButton/WorkspaceScheduleButton.tsx
@@ -48,8 +48,6 @@ export interface WorkspaceScheduleButtonProps {
   workspace: Workspace
   onDeadlinePlus: (hours: number) => void
   onDeadlineMinus: (hours: number) => void
-  deadlineMinusEnabled: () => boolean
-  deadlinePlusEnabled: () => boolean
   maxDeadlineIncrease: number
   maxDeadlineDecrease: number
   canUpdateWorkspace: boolean
@@ -63,8 +61,6 @@ export const WorkspaceScheduleButton: React.FC<
   workspace,
   onDeadlinePlus,
   onDeadlineMinus,
-  deadlinePlusEnabled,
-  deadlineMinusEnabled,
   maxDeadlineDecrease,
   maxDeadlineIncrease,
   canUpdateWorkspace,
@@ -75,6 +71,8 @@ export const WorkspaceScheduleButton: React.FC<
   const [editMode, setEditMode] = useState<EditMode>("off")
   const id = isOpen ? "schedule-popover" : undefined
   const styles = useStyles({ editMode })
+  const deadlinePlusEnabled = maxDeadlineIncrease >= 1
+  const deadlineMinusEnabled = maxDeadlineDecrease >= 1
 
   const onClose = () => {
     setIsOpen(false)
@@ -108,7 +106,7 @@ export const WorkspaceScheduleButton: React.FC<
                 <IconButton
                   className={styles.subtractButton}
                   size="small"
-                  disabled={!deadlineMinusEnabled()}
+                  disabled={!deadlineMinusEnabled}
                   onClick={() => {
                     setEditMode("subtract")
                   }}
@@ -122,7 +120,7 @@ export const WorkspaceScheduleButton: React.FC<
                 <IconButton
                   className={styles.addButton}
                   size="small"
-                  disabled={!deadlinePlusEnabled()}
+                  disabled={!deadlinePlusEnabled}
                   onClick={() => {
                     setEditMode("add")
                   }}

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -6,6 +6,7 @@ import { Helmet } from "react-helmet-async"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import {
+  getDeadline,
   getMaxDeadline,
   getMaxDeadlineChange,
   getMinDeadline,
@@ -37,10 +38,9 @@ export const WorkspaceReadyPage = ({
   quotaState,
   workspaceSend,
 }: WorkspaceReadyPageProps): JSX.Element => {
-  const [bannerState, bannerSend] = useActor(
+  const [_, bannerSend] = useActor(
     workspaceState.children["scheduleBannerMachine"],
   )
-  const deadline = bannerState.context.deadline
   const xServices = useContext(XServiceContext)
   const featureVisibility = useSelector(
     xServices.entitlementsXService,
@@ -61,6 +61,7 @@ export const WorkspaceReadyPage = ({
   if (workspace === undefined) {
     throw Error("Workspace is undefined")
   }
+  const deadline = getDeadline(workspace)
   const canUpdateWorkspace = Boolean(permissions?.updateWorkspace)
   const { t } = useTranslation("workspacePage")
   const favicon = getFaviconByStatus(workspace.latest_build)
@@ -101,17 +102,11 @@ export const WorkspaceReadyPage = ({
               hours,
             })
           },
-          deadlineMinusEnabled: () => !bannerState.matches("atMinDeadline"),
-          deadlinePlusEnabled: () => !bannerState.matches("atMaxDeadline"),
-          maxDeadlineDecrease: deadline
-            ? getMaxDeadlineChange(deadline, getMinDeadline())
-            : 0,
-          maxDeadlineIncrease: deadline
-              ? getMaxDeadlineChange(
-                  getMaxDeadline(workspace),
-                  deadline,
-                )
-              : 0,
+          maxDeadlineDecrease: getMaxDeadlineChange(deadline, getMinDeadline()),
+          maxDeadlineIncrease: getMaxDeadlineChange(
+              getMaxDeadline(workspace),
+              deadline,
+            )
         }}
         isUpdating={workspaceState.hasTag("updating")}
         workspace={workspace}

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -104,9 +104,9 @@ export const WorkspaceReadyPage = ({
           },
           maxDeadlineDecrease: getMaxDeadlineChange(deadline, getMinDeadline()),
           maxDeadlineIncrease: getMaxDeadlineChange(
-              getMaxDeadline(workspace),
-              deadline,
-            )
+            getMaxDeadline(workspace),
+            deadline,
+          ),
         }}
         isUpdating={workspaceState.hasTag("updating")}
         workspace={workspace}

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -106,10 +106,9 @@ export const WorkspaceReadyPage = ({
           maxDeadlineDecrease: deadline
             ? getMaxDeadlineChange(deadline, getMinDeadline())
             : 0,
-          maxDeadlineIncrease:
-            deadline && template
+          maxDeadlineIncrease: deadline
               ? getMaxDeadlineChange(
-                  getMaxDeadline(workspace, template),
+                  getMaxDeadline(workspace),
                   deadline,
                 )
               : 0,

--- a/site/src/util/schedule.test.ts
+++ b/site/src/util/schedule.test.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs"
 import duration from "dayjs/plugin/duration"
 import { emptySchedule } from "pages/WorkspaceSchedulePage/schedule"
 import { emptyTTL } from "pages/WorkspaceSchedulePage/ttl"
-import { Template, Workspace } from "../api/typesGenerated"
+import { Workspace } from "../api/typesGenerated"
 import * as Mocks from "../testHelpers/entities"
 import {
   canExtendDeadline,
@@ -53,29 +53,20 @@ describe("maxDeadline", () => {
   }
   describe("given a template with 25 hour max ttl", () => {
     it("should be never be greater than global max deadline", () => {
-      const template: Template = {
-        ...Mocks.MockTemplate,
-        default_ttl_ms: 25 * 60 * 60 * 1000,
-      }
-
       // Then: deadlineMinusDisabled should be falsy
-      const delta = getMaxDeadline(workspace, template).diff(now)
+      const delta = getMaxDeadline(workspace).diff(now)
       expect(delta).toBeLessThanOrEqual(deadlineExtensionMax.asMilliseconds())
     })
   })
 
   describe("given a template with 4 hour max ttl", () => {
     it("should be never be greater than global max deadline", () => {
-      const template: Template = {
-        ...Mocks.MockTemplate,
-        default_ttl_ms: 4 * 60 * 60 * 1000,
-      }
-
       // Then: deadlineMinusDisabled should be falsy
-      const delta = getMaxDeadline(workspace, template).diff(now)
+      const delta = getMaxDeadline(workspace).diff(now)
       expect(delta).toBeLessThanOrEqual(deadlineExtensionMax.asMilliseconds())
     })
   })
+
 })
 
 describe("minDeadline", () => {
@@ -91,7 +82,6 @@ describe("canExtendDeadline", () => {
       canExtendDeadline(
         dayjs().add(25, "hours"),
         Mocks.MockWorkspace,
-        Mocks.MockTemplate,
       ),
     ).toBeFalsy()
   })
@@ -101,7 +91,7 @@ describe("canExtendDeadline", () => {
       dayjs.duration(Mocks.MockTemplate.default_ttl_ms, "milliseconds"),
     )
     expect(
-      canExtendDeadline(tooFarAhead, Mocks.MockWorkspace, Mocks.MockTemplate),
+      canExtendDeadline(tooFarAhead, Mocks.MockWorkspace),
     ).toBeFalsy()
   })
 
@@ -110,7 +100,7 @@ describe("canExtendDeadline", () => {
       dayjs.duration(Mocks.MockTemplate.default_ttl_ms / 2, "milliseconds"),
     )
     expect(
-      canExtendDeadline(okDeadline, Mocks.MockWorkspace, Mocks.MockTemplate),
+      canExtendDeadline(okDeadline, Mocks.MockWorkspace),
     ).toBeFalsy()
   })
 })

--- a/site/src/util/schedule.test.ts
+++ b/site/src/util/schedule.test.ts
@@ -65,7 +65,7 @@ describe("minDeadline", () => {
 })
 
 describe("canExtendDeadline", () => {
-  it("should be falsy if the deadline is more than 24 hours in the future", () => {
+  it("should be falsy if the deadline is more than 24 hours from the start time", () => {
     expect(
       canExtendDeadline(
         startTime.add(25, "hours"),
@@ -73,18 +73,37 @@ describe("canExtendDeadline", () => {
       ),
     ).toBeFalsy()
   })
+  it("should be falsy if the deadline is less than an hour below the max deadline", () => {
+    expect(
+      canExtendDeadline(
+        startTime.add(23.5, "hours"),
+        Mocks.MockWorkspace
+      )
+    ).toBeFalsy()
+  })
+  it("should be true if the deadline is one hour below the max deadline", () => {
+    expect(
+      canExtendDeadline(
+        startTime.add(23, "hours"),
+        Mocks.MockWorkspace
+      )
+    ).toBeTruthy()
+  })
 })
 
 describe("canReduceDeadline", () => {
-  it("should be falsy if the deadline is 30 minutes or less in the future", () => {
+  // the minimum ttl is 30 minutes from the current time
+  // ttl can be reduced by one hour at a time
+  // so current deadline must be >=90 minutes from current time to be reducible
+  it("should be falsy if the deadline is 90 minutes or less in the future", () => {
     expect(canReduceDeadline(dayjs())).toBeFalsy()
     expect(canReduceDeadline(dayjs().add(1, "minutes"))).toBeFalsy()
-    expect(canReduceDeadline(dayjs().add(29, "minutes"))).toBeFalsy()
-    expect(canReduceDeadline(dayjs().add(30, "minutes"))).toBeFalsy()
+    expect(canReduceDeadline(dayjs().add(89, "minutes"))).toBeFalsy()
+    expect(canReduceDeadline(dayjs().add(90, "minutes"))).toBeTruthy()
   })
 
-  it("should be truthy if the deadline is 30 minutes or more in the future", () => {
-    expect(canReduceDeadline(dayjs().add(31, "minutes"))).toBeTruthy()
+  it("should be truthy if the deadline is 90 minutes or more in the future", () => {
+    expect(canReduceDeadline(dayjs().add(91, "minutes"))).toBeTruthy()
     expect(canReduceDeadline(dayjs().add(100, "years"))).toBeTruthy()
   })
 })

--- a/site/src/util/schedule.test.ts
+++ b/site/src/util/schedule.test.ts
@@ -19,6 +19,7 @@ import {
 
 dayjs.extend(duration)
 const now = dayjs()
+const startTime = dayjs(Mocks.MockWorkspaceBuild.updated_at)
 
 describe("util/schedule", () => {
   describe("stripTimezone", () => {
@@ -43,30 +44,17 @@ describe("util/schedule", () => {
 })
 
 describe("maxDeadline", () => {
-  // Given: a workspace built from a template with a max deadline equal to 25 hours which isn't really possible
   const workspace: Workspace = {
     ...Mocks.MockWorkspace,
     latest_build: {
       ...Mocks.MockWorkspaceBuild,
-      deadline: now.add(8, "hours").utc().format(),
+      deadline: startTime.add(8, "hours").utc().format(),
     },
   }
-  describe("given a template with 25 hour max ttl", () => {
-    it("should be never be greater than global max deadline", () => {
-      // Then: deadlineMinusDisabled should be falsy
-      const delta = getMaxDeadline(workspace).diff(now)
-      expect(delta).toBeLessThanOrEqual(deadlineExtensionMax.asMilliseconds())
-    })
+  it("should be 24 hours from the workspace start time", () => {
+    const delta = getMaxDeadline(workspace).diff(startTime)
+    expect(delta).toEqual(deadlineExtensionMax.asMilliseconds())
   })
-
-  describe("given a template with 4 hour max ttl", () => {
-    it("should be never be greater than global max deadline", () => {
-      // Then: deadlineMinusDisabled should be falsy
-      const delta = getMaxDeadline(workspace).diff(now)
-      expect(delta).toBeLessThanOrEqual(deadlineExtensionMax.asMilliseconds())
-    })
-  })
-
 })
 
 describe("minDeadline", () => {
@@ -80,27 +68,9 @@ describe("canExtendDeadline", () => {
   it("should be falsy if the deadline is more than 24 hours in the future", () => {
     expect(
       canExtendDeadline(
-        dayjs().add(25, "hours"),
+        startTime.add(25, "hours"),
         Mocks.MockWorkspace,
       ),
-    ).toBeFalsy()
-  })
-
-  it("should be falsy if the deadline is more than the template max_ttl", () => {
-    const tooFarAhead = dayjs().add(
-      dayjs.duration(Mocks.MockTemplate.default_ttl_ms, "milliseconds"),
-    )
-    expect(
-      canExtendDeadline(tooFarAhead, Mocks.MockWorkspace),
-    ).toBeFalsy()
-  })
-
-  it("should be truth if the deadline is within the template max_ttl", () => {
-    const okDeadline = dayjs().add(
-      dayjs.duration(Mocks.MockTemplate.default_ttl_ms / 2, "milliseconds"),
-    )
-    expect(
-      canExtendDeadline(okDeadline, Mocks.MockWorkspace),
     ).toBeFalsy()
   })
 })

--- a/site/src/util/schedule.test.ts
+++ b/site/src/util/schedule.test.ts
@@ -5,8 +5,6 @@ import { emptyTTL } from "pages/WorkspaceSchedulePage/ttl"
 import { Workspace } from "../api/typesGenerated"
 import * as Mocks from "../testHelpers/entities"
 import {
-  canExtendDeadline,
-  canReduceDeadline,
   deadlineExtensionMax,
   deadlineExtensionMin,
   extractTimezone,
@@ -61,50 +59,6 @@ describe("minDeadline", () => {
   it("should never be less than 30 minutes", () => {
     const delta = getMinDeadline().diff(now)
     expect(delta).toBeGreaterThanOrEqual(deadlineExtensionMin.asMilliseconds())
-  })
-})
-
-describe("canExtendDeadline", () => {
-  it("should be falsy if the deadline is more than 24 hours from the start time", () => {
-    expect(
-      canExtendDeadline(
-        startTime.add(25, "hours"),
-        Mocks.MockWorkspace,
-      ),
-    ).toBeFalsy()
-  })
-  it("should be falsy if the deadline is less than an hour below the max deadline", () => {
-    expect(
-      canExtendDeadline(
-        startTime.add(23.5, "hours"),
-        Mocks.MockWorkspace
-      )
-    ).toBeFalsy()
-  })
-  it("should be true if the deadline is one hour below the max deadline", () => {
-    expect(
-      canExtendDeadline(
-        startTime.add(23, "hours"),
-        Mocks.MockWorkspace
-      )
-    ).toBeTruthy()
-  })
-})
-
-describe("canReduceDeadline", () => {
-  // the minimum ttl is 30 minutes from the current time
-  // ttl can be reduced by one hour at a time
-  // so current deadline must be >=90 minutes from current time to be reducible
-  it("should be falsy if the deadline is 90 minutes or less in the future", () => {
-    expect(canReduceDeadline(dayjs())).toBeFalsy()
-    expect(canReduceDeadline(dayjs().add(1, "minutes"))).toBeFalsy()
-    expect(canReduceDeadline(dayjs().add(89, "minutes"))).toBeFalsy()
-    expect(canReduceDeadline(dayjs().add(90, "minutes"))).toBeTruthy()
-  })
-
-  it("should be truthy if the deadline is 90 minutes or more in the future", () => {
-    expect(canReduceDeadline(dayjs().add(91, "minutes"))).toBeTruthy()
-    expect(canReduceDeadline(dayjs().add(100, "years"))).toBeTruthy()
   })
 })
 

--- a/site/src/util/schedule.ts
+++ b/site/src/util/schedule.ts
@@ -131,9 +131,7 @@ export const deadlineExtensionMax = dayjs.duration(24, "hours")
  * @param ws workspace
  * @returns the latest datetime at which the workspace can be automatically shut down.
  */
-export function getMaxDeadline(
-  ws: Workspace | undefined,
-): dayjs.Dayjs {
+export function getMaxDeadline(ws: Workspace | undefined): dayjs.Dayjs {
   // note: we count runtime from updated_at as started_at counts from the start of
   // the workspace build process, which can take a while.
   if (ws === undefined) {

--- a/site/src/util/schedule.ts
+++ b/site/src/util/schedule.ts
@@ -151,31 +151,6 @@ export function getMinDeadline(): dayjs.Dayjs {
   return dayjs().add(deadlineExtensionMin)
 }
 
-/**
- * Determines if ScheduleBanner can increase ttl by one or more hours
- * without hitting the global max deadline.
- * @param deadline
- * @param workspace
- */
-export function canExtendDeadline(
-  deadline: dayjs.Dayjs,
-  workspace: Workspace,
-): boolean {
-  const diff = (getMaxDeadline(workspace)).diff(deadline, 'hours')
-  return diff >= 1
-}
-
-/**
- * Determines if ScheduleBanner can reduce ttl by one or more hours
- * without hitting the global min remaining time to live.
- * Depends on workspace deadline, current time, and a global constant.
- * @param deadline current workspace deadline
- */
-export function canReduceDeadline(deadline: dayjs.Dayjs): boolean {
-  const diff = deadline.diff(getMinDeadline(), 'hours')
-  return diff >= 1
-}
-
 export const getDeadline = (workspace: Workspace): dayjs.Dayjs =>
   dayjs(workspace.latest_build.deadline).utc()
 

--- a/site/src/util/schedule.ts
+++ b/site/src/util/schedule.ts
@@ -143,11 +143,17 @@ export function getMaxDeadline(
     throw Error("Cannot calculate max deadline because workspace is undefined")
   }
   const startedAt = dayjs(ws.latest_build.updated_at)
-  const maxTemplateDeadline = startedAt.add(
-    dayjs.duration(tpl.default_ttl_ms, "milliseconds"),
-  )
   const maxGlobalDeadline = startedAt.add(deadlineExtensionMax)
-  return dayjs.min(maxTemplateDeadline, maxGlobalDeadline)
+  // only consider template default if it is defined and > 0, because undefined or 0
+  // means stop never, not stop immediately
+  if (tpl.default_ttl_ms) {
+    const maxTemplateDeadline = startedAt.add(
+      dayjs.duration(tpl.default_ttl_ms, "milliseconds"),
+    )
+    return dayjs.min(maxTemplateDeadline, maxGlobalDeadline)
+  } else {
+    return maxGlobalDeadline
+  }
 }
 
 /**

--- a/site/src/util/schedule.ts
+++ b/site/src/util/schedule.ts
@@ -151,15 +151,29 @@ export function getMinDeadline(): dayjs.Dayjs {
   return dayjs().add(deadlineExtensionMin)
 }
 
+/**
+ * Determines if ScheduleBanner can increase ttl by one or more hours
+ * without hitting the global max deadline.
+ * @param deadline
+ * @param workspace
+ */
 export function canExtendDeadline(
   deadline: dayjs.Dayjs,
   workspace: Workspace,
 ): boolean {
-  return deadline < getMaxDeadline(workspace)
+  const diff = (getMaxDeadline(workspace)).diff(deadline, 'hours')
+  return diff >= 1
 }
 
+/**
+ * Determines if ScheduleBanner can reduce ttl by one or more hours
+ * without hitting the global min remaining time to live.
+ * Depends on workspace deadline, current time, and a global constant.
+ * @param deadline current workspace deadline
+ */
 export function canReduceDeadline(deadline: dayjs.Dayjs): boolean {
-  return deadline > getMinDeadline()
+  const diff = deadline.diff(getMinDeadline(), 'hours')
+  return diff >= 1
 }
 
 export const getDeadline = (workspace: Workspace): dayjs.Dayjs =>

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -470,7 +470,6 @@ export const workspaceMachine = createMachine(
               src: workspaceScheduleBannerMachine,
               data: {
                 workspace: (context: WorkspaceContext) => context.workspace,
-                template: (context: WorkspaceContext) => context.template,
               },
             },
           },

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -6,11 +6,7 @@ import { getErrorMessage } from "api/errors"
 import { Workspace } from "api/typesGenerated"
 import dayjs from "dayjs"
 import minMax from "dayjs/plugin/minMax"
-import {
-  getDeadline,
-  getMaxDeadline,
-  getMinDeadline,
-} from "util/schedule"
+import { getDeadline, getMaxDeadline, getMinDeadline } from "util/schedule"
 import { ActorRefFrom, assign, createMachine } from "xstate"
 import * as API from "../../api/api"
 import {
@@ -118,7 +114,10 @@ export const workspaceScheduleBannerMachine = createMachine(
         if (!context.workspace.latest_build.deadline) {
           throw Error("Deadline is undefined.")
         }
-        const proposedDeadline = getDeadline(context.workspace).add(event.hours, "hours")
+        const proposedDeadline = getDeadline(context.workspace).add(
+          event.hours,
+          "hours",
+        )
         const newDeadline = dayjs.min(
           proposedDeadline,
           getMaxDeadline(context.workspace),
@@ -129,7 +128,10 @@ export const workspaceScheduleBannerMachine = createMachine(
         if (!context.workspace.latest_build.deadline) {
           throw Error("Deadline is undefined.")
         }
-        const proposedDeadline = getDeadline(context.workspace).subtract(event.hours, "hours")
+        const proposedDeadline = getDeadline(context.workspace).subtract(
+          event.hours,
+          "hours",
+        )
         const newDeadline = dayjs.max(proposedDeadline, getMinDeadline())
         await API.putWorkspaceExtension(context.workspace.id, newDeadline)
       },

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -3,7 +3,7 @@
  * presented as an Alert/banner, for reactively updating a workspace schedule.
  */
 import { getErrorMessage } from "api/errors"
-import { Template, Workspace } from "api/typesGenerated"
+import { Workspace } from "api/typesGenerated"
 import dayjs from "dayjs"
 import minMax from "dayjs/plugin/minMax"
 import {
@@ -29,7 +29,6 @@ export const Language = {
 
 export interface WorkspaceScheduleBannerContext {
   workspace: Workspace
-  template: Template
   deadline?: dayjs.Dayjs
 }
 
@@ -141,7 +140,6 @@ export const workspaceScheduleBannerMachine = createMachine(
           ? !canExtendDeadline(
               context.deadline,
               context.workspace,
-              context.template,
             )
           : false,
       isAtMinDeadline: (context) =>
@@ -169,7 +167,7 @@ export const workspaceScheduleBannerMachine = createMachine(
         const proposedDeadline = context.deadline.add(event.hours, "hours")
         const newDeadline = dayjs.min(
           proposedDeadline,
-          getMaxDeadline(context.workspace, context.template),
+          getMaxDeadline(context.workspace),
         )
         await API.putWorkspaceExtension(context.workspace.id, newDeadline)
       },

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -171,7 +171,6 @@ export const workspaceScheduleBannerMachine = createMachine(
           proposedDeadline,
           getMaxDeadline(context.workspace, context.template),
         )
-        console.log(getMaxDeadline(context.workspace, context.template), proposedDeadline, newDeadline)
         await API.putWorkspaceExtension(context.workspace.id, newDeadline)
       },
       decreaseDeadline: async (context, event) => {

--- a/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
+++ b/site/src/xServices/workspaceSchedule/workspaceScheduleBannerXService.ts
@@ -171,6 +171,7 @@ export const workspaceScheduleBannerMachine = createMachine(
           proposedDeadline,
           getMaxDeadline(context.workspace, context.template),
         )
+        console.log(getMaxDeadline(context.workspace, context.template), proposedDeadline, newDeadline)
         await API.putWorkspaceExtension(context.workspace.id, newDeadline)
       },
       decreaseDeadline: async (context, event) => {


### PR DESCRIPTION
Fixes #5354 

The incrementer wasn't working when the template default ttl was 0, because the max deadline was being calculated as start time + 0. 