### PR TITLE
ci: Output tail of `gotestsum.json` if test timed out

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -415,7 +415,17 @@ jobs:
           terraform_wrapper: false
 
       - name: Test with PostgreSQL Database
-        run: make test-postgres
+        run: |
+          make test-postgres
+          ret=$?
+          if ((ret)); then
+            # Eternalize test timeout logs because "re-run failed" erases
+            # artifacts and gotestsum doesn't always capture it:
+            # https://github.com/gotestyourself/gotestsum/issues/292
+            echo "Checking gotestsum.json for panic trace:"
+            grep -A 999999 'panic: test timed out' gotestsum.json
+          fi
+          exit $ret
 
       - uses: actions/upload-artifact@v3
         if: success() || failure()

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -338,8 +338,16 @@ jobs:
           else
             echo ::set-output name=cover::false
           fi
-          set -x
           gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=3m -short -failfast $COVERAGE_FLAGS
+          ret=$?
+          if ((ret)); then
+            # Eternalize test timeout logs because "re-run failed" erases
+            # artifacts and gotestsum doesn't always capture it:
+            # https://github.com/gotestyourself/gotestsum/issues/292
+            echo "Checking gotestsum.json for panic trace:"
+            grep -A 999999 'panic: test timed out' gotestsum.json
+          fi
+          exit $ret
 
       - uses: actions/upload-artifact@v3
         if: success() || failure()


### PR DESCRIPTION
This is to eternalize the log in case "re-run failed" is used, which
erases artifacts from previous run.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
