### PR TITLE
ci: Increase Go mock db test timeout to 5m

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -338,7 +338,7 @@ jobs:
           else
             echo ::set-output name=cover::false
           fi
-          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=3m -short -failfast $COVERAGE_FLAGS
+          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=5m -short -failfast $COVERAGE_FLAGS
           ret=$?
           if ((ret)); then
             # Eternalize test timeout logs because "re-run failed" erases


### PR DESCRIPTION
Our Windows test-runner often takes close to 3m to complete the test,
this was producing a few false failures due to us adding tests over time
and test times increasing.

Refs: #5411