### PR TITLE
fix: No org admins until organizations are in the UI

### DIFF
--- a/coderd/database/migrations/000086_no_org_admins.up.sql
+++ b/coderd/database/migrations/000086_no_org_admins.up.sql
@@ -1,1 +1,6 @@
-UPDATE organization_members SET roles = ARRAY ['organization-member:'||organization_id];
+UPDATE 
+  organization_members
+SET 
+  roles = ARRAY [] :: text[]
+WHERE 
+  'organization-admin:'||organization_id = ANY(roles);

--- a/coderd/database/migrations/000086_no_org_admins.up.sql
+++ b/coderd/database/migrations/000086_no_org_admins.up.sql
@@ -1,0 +1,1 @@
+UPDATE organization_members SET roles = ARRAY ['organization-member:'||organization_id];

--- a/coderd/organizations.go
+++ b/coderd/organizations.go
@@ -76,7 +76,11 @@ func (api *API) postOrganizations(rw http.ResponseWriter, r *http.Request) {
 			CreatedAt:      database.Now(),
 			UpdatedAt:      database.Now(),
 			Roles: []string{
-				rbac.RoleOrgAdmin(organization.ID),
+				// TODO: When organizations are allowed to be created, we should
+				// come back to determining the default role of the person who
+				// creates the org. Until that happens, all users in an organization
+				// should be just regular members.
+				rbac.RoleOrgMember(organization.ID),
 			},
 		})
 		if err != nil {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1071,7 +1071,11 @@ func (api *API) CreateUser(ctx context.Context, store database.Store, req Create
 				return xerrors.Errorf("create organization: %w", err)
 			}
 			req.OrganizationID = organization.ID
-			orgRoles = append(orgRoles, rbac.RoleOrgAdmin(req.OrganizationID))
+			// TODO: When organizations are allowed to be created, we should
+			// come back to determining the default role of the person who
+			// creates the org. Until that happens, all users in an organization
+			// should be just regular members.
+			orgRoles = append(orgRoles, rbac.RoleOrgMember(req.OrganizationID))
 
 			_, err = tx.InsertAllUsersGroup(ctx, organization.ID)
 			if err != nil {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -921,7 +921,7 @@ func TestInitialRoles(t *testing.T) {
 	}, "should be a member and admin")
 
 	require.ElementsMatch(t, roles.OrganizationRoles[first.OrganizationID], []string{
-		rbac.RoleOrgAdmin(first.OrganizationID),
+		rbac.RoleOrgMember(first.OrganizationID),
 	}, "should be a member and admin")
 }
 

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -818,15 +818,6 @@ func TestGrantSiteRoles(t *testing.T) {
 			StatusCode:   http.StatusForbidden,
 		},
 		{
-			Name:         "MemberAssignMember",
-			Client:       member,
-			OrgID:        first.OrganizationID,
-			AssignToUser: first.UserID.String(),
-			Roles:        []string{},
-			Error:        true,
-			StatusCode:   http.StatusForbidden,
-		},
-		{
 			Name:         "AdminUpdateOrgSelf",
 			Client:       admin,
 			OrgID:        first.OrganizationID,


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/5379

Until organizations have management UI, we should not set any org admins. This goes around the site wide perms transparently and is confusing to users.

# Migration

I made the migration put all org members to only members. Removing all admins.