### PR TITLE
fix: Avoid deadlock in AgentReportStats Close during agent Close

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -241,7 +241,7 @@ func (a *agent) run(ctx context.Context) error {
 				<-a.closed
 				_ = cl.Close()
 			}); err != nil {
-				a.logger.Error(ctx, "report stats goroutine", slog.Error(err))
+				a.logger.Debug(ctx, "report stats goroutine", slog.Error(err))
 				_ = cl.Close()
 			}
 		}


### PR DESCRIPTION
Since AgentReportStats takes a stats function which was doing mutex
locking on agent shutdown, it was possible for there to be a deadlock
depending on how the AgentReportsStats Close function is implemented.

This mostly seems to happen on Windows test runners as it's pretty hard
to hit this edge case. The bug currently only exists in the test
implementation of AgentReportStats, however, this was refactored to be
more robust in case of future changes.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
