### PR TITLE
ci: Improve gotestsum failure detection, prevent early exit

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -345,11 +345,14 @@ jobs:
             # Eternalize test timeout logs because "re-run failed" erases
             # artifacts and gotestsum doesn't always capture it:
             # https://github.com/gotestyourself/gotestsum/issues/292
-            testWithStack=$(grep 'panic: test timed out' gotestsum.json | grep -E -o '("Test":[^,}]*)')
-            if [ -n "$testWithStack" ] && grep -q "${testWithStack}.*PASS" gotestsum.json; then
-              echo "Conditions met for gotestsum stack trace missing bug, outputting panic trace:"
-              grep -A 999999 "${testWithStack}.*panic: test timed out" gotestsum.json
-            fi
+            # Multiple test packages could've failed, each one may or may
+            # not run into the edge case. PS. Don't summon ShellCheck here.
+            for testWithStack in $(grep 'panic: test timed out' gotestsum.json | grep -E -o '("Test":[^,}]*)'); do
+              if [ -n "$testWithStack" ] && grep -q "${testWithStack}.*PASS" gotestsum.json; then
+                echo "Conditions met for gotestsum stack trace missing bug, outputting panic trace:"
+                grep -A 999999 "${testWithStack}.*panic: test timed out" gotestsum.json
+              fi
+            done
           fi
           exit $ret
 
@@ -434,11 +437,14 @@ jobs:
             # Eternalize test timeout logs because "re-run failed" erases
             # artifacts and gotestsum doesn't always capture it:
             # https://github.com/gotestyourself/gotestsum/issues/292
-            testWithStack=$(grep 'panic: test timed out' gotestsum.json | grep -E -o '("Test":[^,}]*)')
-            if [ -n "$testWithStack" ] && grep -q "${testWithStack}.*PASS" gotestsum.json; then
-              echo "Conditions met for gotestsum stack trace missing bug, outputting panic trace:"
-              grep -A 999999 "${testWithStack}.*panic: test timed out" gotestsum.json
-            fi
+            # Multiple test packages could've failed, each one may or may
+            # not run into the edge case. PS. Don't summon ShellCheck here.
+            for testWithStack in $(grep 'panic: test timed out' gotestsum.json | grep -E -o '("Test":[^,}]*)'); do
+              if [ -n "$testWithStack" ] && grep -q "${testWithStack}.*PASS" gotestsum.json; then
+                echo "Conditions met for gotestsum stack trace missing bug, outputting panic trace:"
+                grep -A 999999 "${testWithStack}.*panic: test timed out" gotestsum.json
+              fi
+            done
           fi
           exit $ret
 

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -339,7 +339,7 @@ jobs:
             echo ::set-output name=cover::false
           fi
           set +e
-          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=5m -short -failfast $COVERAGE_FLAGS
+          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=30s -short -failfast $COVERAGE_FLAGS
           ret=$?
           if ((ret)); then
             # Eternalize test timeout logs because "re-run failed" erases

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -339,7 +339,7 @@ jobs:
             echo ::set-output name=cover::false
           fi
           set +e
-          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=30s -short -failfast $COVERAGE_FLAGS
+          gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=5m -short -failfast $COVERAGE_FLAGS
           ret=$?
           if ((ret)); then
             # Eternalize test timeout logs because "re-run failed" erases

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -345,8 +345,11 @@ jobs:
             # Eternalize test timeout logs because "re-run failed" erases
             # artifacts and gotestsum doesn't always capture it:
             # https://github.com/gotestyourself/gotestsum/issues/292
-            echo "Checking gotestsum.json for panic trace:"
-            grep -A 999999 'panic: test timed out' gotestsum.json
+            testWithStack=$(grep 'panic: test timed out' gotestsum.json | grep -E -o '("Test":[^,}]*)')
+            if [ -n "$testWithStack" ] && grep -q "${testWithStack}.*PASS" gotestsum.json; then
+              echo "Conditions met for gotestsum stack trace missing bug, outputting panic trace:"
+              grep -A 999999 "${testWithStack}.*panic: test timed out" gotestsum.json
+            fi
           fi
           exit $ret
 
@@ -431,8 +434,11 @@ jobs:
             # Eternalize test timeout logs because "re-run failed" erases
             # artifacts and gotestsum doesn't always capture it:
             # https://github.com/gotestyourself/gotestsum/issues/292
-            echo "Checking gotestsum.json for panic trace:"
-            grep -A 999999 'panic: test timed out' gotestsum.json
+            testWithStack=$(grep 'panic: test timed out' gotestsum.json | grep -E -o '("Test":[^,}]*)')
+            if [ -n "$testWithStack" ] && grep -q "${testWithStack}.*PASS" gotestsum.json; then
+              echo "Conditions met for gotestsum stack trace missing bug, outputting panic trace:"
+              grep -A 999999 "${testWithStack}.*panic: test timed out" gotestsum.json
+            fi
           fi
           exit $ret
 

--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -338,6 +338,7 @@ jobs:
           else
             echo ::set-output name=cover::false
           fi
+          set +e
           gotestsum --junitfile="gotests.xml" --jsonfile="gotestsum.json" --packages="./..." --debug -- -parallel=8 -timeout=5m -short -failfast $COVERAGE_FLAGS
           ret=$?
           if ((ret)); then
@@ -423,6 +424,7 @@ jobs:
 
       - name: Test with PostgreSQL Database
         run: |
+          set +e
           make test-postgres
           ret=$?
           if ((ret)); then


### PR DESCRIPTION
This PR fixes early exit (missing `set +e`) which prevented the `if` statement from being executed.

Since the log was too noisy, I applied filtering and edge case detection.

Example output after this PR: https://github.com/coder/coder/actions/runs/3697831254/jobs/6273476923

**PS.** I never realized, but it seems setting `-timeout=Xm` like we do applies on a per-package basis, not the entire run of `go test`. As a result, the entire run can be much longer it seems 🤔 (or am I misunderstanding something?)