### PR TITLE
fix: improve error messages when the agent token is invalid

### DIFF
--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -218,8 +218,15 @@ func ConvertResources(module *tfjson.StateModule, rawGraph string) ([]*proto.Res
 				if agent.Id != agentID {
 					continue
 				}
-				agent.Auth = &proto.Agent_InstanceId{
-					InstanceId: instanceID,
+				// Only apply the instance ID if the agent authentication
+				// type is set to do so. A user ran into a bug where they
+				// had the instance ID block, but auth was set to "token". See:
+				// https://github.com/coder/coder/issues/4551#issuecomment-1336293468
+				switch t := agent.Auth.(type) {
+				case *proto.Agent_Token:
+					continue
+				case *proto.Agent_InstanceId:
+					t.InstanceId = instanceID
 				}
 				break
 			}


### PR DESCRIPTION
I'm not sure why this issue is common, but it seems to be based on: https://github.com/coder/coder/issues/4551.

This improves the error messages to be unique,
and also fixes a small edge-case bug a user ran into.
