### PR TITLE
fix: use proper validate url for gitauth

### DIFF
--- a/coderd/gitauth/config.go
+++ b/coderd/gitauth/config.go
@@ -121,7 +121,7 @@ func ConvertConfig(entries []codersdk.GitAuthConfig, accessURL *url.URL) ([]*Con
 			Regex:        regex,
 			Type:         typ,
 			NoRefresh:    entry.NoRefresh,
-			ValidateURL:  validateURL[typ],
+			ValidateURL:  entry.ValidateURL,
 		})
 	}
 	return configs, nil


### PR DESCRIPTION
This was preventing custom validation URLs from being used to verify git tokens.

Credit to @ntimo for helping me discover this!