### PR TITLE
test: Fix data race in loadtest/reconnectingpty

### DIFF
--- a/loadtest/reconnectingpty/run.go
+++ b/loadtest/reconnectingpty/run.go
@@ -83,8 +83,8 @@ func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) error {
 	}
 
 	copyCtx, copyCancel := context.WithTimeout(ctx, time.Duration(copyTimeout))
+	defer copyCancel()
 	matched, err := copyContext(copyCtx, copyOutput, conn, r.cfg.ExpectOutput)
-	copyCancel()
 	if r.cfg.ExpectTimeout {
 		if err == nil {
 			return xerrors.Errorf("expected timeout, but the command exited successfully")
@@ -107,11 +107,27 @@ func copyContext(ctx context.Context, dst io.Writer, src io.Reader, expectOutput
 		copyErr = make(chan error)
 		matched = expectOutput == ""
 	)
+
+	// Guard goroutine for loop body to ensure reading `matched` is safe on
+	// context cancellation and that `dst` won't be written to after we
+	// return from this function.
+	processing := make(chan struct{}, 1)
+	processing <- struct{}{}
+
 	go func() {
+		defer close(processing)
 		defer close(copyErr)
 
 		scanner := bufio.NewScanner(src)
 		for scanner.Scan() {
+			select {
+			case <-processing:
+			default:
+			}
+			if ctx.Err() != nil {
+				return
+			}
+
 			if expectOutput != "" && strings.Contains(scanner.Text(), expectOutput) {
 				matched = true
 			}
@@ -121,6 +137,7 @@ func copyContext(ctx context.Context, dst io.Writer, src io.Reader, expectOutput
 				copyErr <- xerrors.Errorf("write to logs: %w", err)
 				return
 			}
+			processing <- struct{}{}
 		}
 		if scanner.Err() != nil {
 			copyErr <- xerrors.Errorf("read from reconnecting PTY: %w", scanner.Err())
@@ -130,6 +147,10 @@ func copyContext(ctx context.Context, dst io.Writer, src io.Reader, expectOutput
 
 	select {
 	case <-ctx.Done():
+		select {
+		case <-processing:
+		case <-copyErr:
+		}
 		return matched, ctx.Err()
 	case err := <-copyErr:
 		return matched, err


### PR DESCRIPTION
There is a data race in loadtest/reconnectingpty where the goroutine created by copyContext is left behind and producing writes after Run has exited. Tests use simple `bytes.Buffer` and reading it is unsafe.

This PR fixes the data race:

```
==================
WARNING: DATA RACE
Write at 0x00c001b2c990 by goroutine 358:
  bytes.(*Buffer).tryGrowByReslice()
      C:/Program Files/Go/src/bytes/buffer.go:108 +0xb3
  bytes.(*Buffer).Write()
      C:/Program Files/Go/src/bytes/buffer.go:168 +0x18
  github.com/coder/coder/loadtest/loadtestutil.(*SyncWriter).Write()
      C:/Users/ZeroCool/Downloads/coder/loadtest/loadtestutil/syncwriter.go:25 +0x121
  github.com/coder/coder/loadtest/reconnectingpty.copyContext.func1()
      C:/Users/ZeroCool/Downloads/coder/loadtest/reconnectingpty/run.go:119 +0x24a

Previous read at 0x00c001b2c990 by goroutine 27:
  bytes.(*Buffer).String()
      C:/Program Files/Go/src/bytes/buffer.go:65 +0x294
  github.com/coder/coder/loadtest/reconnectingpty_test.Test_Runner.func3.2()
      C:/Users/ZeroCool/Downloads/coder/loadtest/reconnectingpty/run_test.go:125 +0x274
  testing.tRunner()
      C:/Program Files/Go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      C:/Program Files/Go/src/testing/testing.go:1493 +0x47
```
