### PR TITLE
ci: Fix release publish script

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -6,6 +6,15 @@
 
 set -euo pipefail
 
+# Avoid sourcing this script multiple times to guard against when lib.sh
+# is used by another sourced script, it can lead to confusing results.
+if [[ ${SCRIPTS_LIB_IS_SOURCED:-0} == 1 ]]; then
+	return
+fi
+# Do not export to avoid this value being inherited by non-sourced
+# scripts.
+SCRIPTS_LIB_IS_SOURCED=1
+
 # realpath returns an absolute path to the given relative path. It will fail if
 # the parent directory of the path does not exist. Make sure you are in the
 # expected directory before running this to avoid errors.

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 # shellcheck source=scripts/lib.sh
-source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+source "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib.sh"
 
 from_ref=${1:-}
 to_ref=${2:-}

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 # shellcheck source=scripts/lib.sh
-source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+source "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib.sh"
 
 old_version=
 new_version=

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -27,7 +27,7 @@
 
 set -euo pipefail
 # shellcheck source=scripts/lib.sh
-source "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+source "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib.sh"
 
 if [[ "${CI:-}" == "" ]]; then
 	error "This script must be run in CI"
@@ -110,7 +110,7 @@ fi
 source "$SCRIPT_DIR/release/check_commit_metadata.sh" "$old_tag" "$new_ref"
 
 # Craft the release notes.
-release_notes="$(execrelative ./generate_release_notes.sh --old-version "$old_tag" --new-version "$new_tag" --ref "$new_ref")"
+release_notes="$(execrelative ./release/generate_release_notes.sh --old-version "$old_tag" --new-version "$new_tag" --ref "$new_ref")"
 
 release_notes_file="$(mktemp)"
 echo "$release_notes" >"$release_notes_file"


### PR DESCRIPTION
Moving the release scripts to the `release` subfolder surfaced an issue with double sourcing of `lib.sh`, this PR improves upon this case.

```
The provided version does not match the current git tag, but --dry-run was supplied so continuing...
17
/home/runner/work/coder/coder/scripts/release/../release/../lib.sh: line 64: ./generate_release_notes.sh: No such file or directory
18
```
