### PR TITLE
test: Fix `scaletest/reconnectingpty` commands for use in powershell

### DIFF
--- a/scaletest/reconnectingpty/run_test.go
+++ b/scaletest/reconnectingpty/run_test.go
@@ -31,7 +31,8 @@ func Test_Runner(t *testing.T) {
 		runner := reconnectingpty.NewRunner(client, reconnectingpty.Config{
 			AgentID: agentID,
 			Init: codersdk.ReconnectingPTYInit{
-				Command: "echo 'hello world' && sleep 1",
+				// Use ; here because it's powershell compatible (vs &&).
+				Command: "echo 'hello world'; sleep 1",
 			},
 			LogOutput: true,
 		})
@@ -195,7 +196,7 @@ func Test_Runner(t *testing.T) {
 			runner := reconnectingpty.NewRunner(client, reconnectingpty.Config{
 				AgentID: agentID,
 				Init: codersdk.ReconnectingPTYInit{
-					Command: "echo 'hello world' && sleep 1",
+					Command: "echo 'hello world'; sleep 1",
 				},
 				ExpectOutput: "hello world",
 				LogOutput:    false,
@@ -219,7 +220,7 @@ func Test_Runner(t *testing.T) {
 			runner := reconnectingpty.NewRunner(client, reconnectingpty.Config{
 				AgentID: agentID,
 				Init: codersdk.ReconnectingPTYInit{
-					Command: "echo 'hello world' && sleep 1",
+					Command: "echo 'hello world'; sleep 1",
 				},
 				ExpectOutput: "bello borld",
 				LogOutput:    false,


### PR DESCRIPTION
I'm confused as to why this works in CI, the default shell must be bash. In my Windows VM, I'm unable to successfully run the tests because powershell is spawned.

This fix only fixes powershell, `cmd.exe` won't sleep it'll just echo the line including `; sleep 1`. For `cmd.exe` the `&&` works, but needs to use `timeout 1` instead.

Perhaps we should explicitly invoke a shell, depending on platform, to control the parsing/execution?

```
PS C:\Users\ZeroCool> echo 'hello world' && sleep 1
At line:1 char:19
+ echo 'hello world' && sleep 1
+                   ~~
The token '&&' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```
