### PR TITLE
refactor: pin code-server to 4.8.3

### DIFF
--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -51,7 +51,8 @@ resource "coder_agent" "main" {
     startup_script = <<EOF
     #!/bin/sh
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh
+    # remove '-s -- --version 4.8.3' to install the latest version
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
     code-server --auth none --port 13337
     EOF
 }
@@ -63,7 +64,7 @@ For advanced use, we recommend installing code-server in your VM snapshot or con
 FROM codercom/enterprise-base:ubuntu
 
 # install a specific code-server version
-RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version=4.3.0
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version=4.8.3
 
 # pre-install versions
 RUN code-server --install-extension eamodio.gitlens

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -153,8 +153,8 @@ resource "coder_agent" "coder" {
   startup_script = <<EOT
 #!/bin/bash
 
-# install code-server
-curl -fsSL https://code-server.dev/install.sh | sh
+# install code-server 4.8.3
+curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
 
 # The & prevents the startup_script from blocking so the
 # next commands can run.

--- a/examples/templates/aws-ecs-container/main.tf
+++ b/examples/templates/aws-ecs-container/main.tf
@@ -99,7 +99,7 @@ resource "coder_agent" "coder" {
   startup_script = <<EOT
     #!/bin/bash
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -80,7 +80,7 @@ resource "coder_agent" "main" {
     #!/bin/bash
 
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -28,7 +28,7 @@ resource "coder_agent" "main" {
     #!/bin/bash
 
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -30,7 +30,7 @@ resource "coder_agent" "main" {
   startup_script = <<EOF
     #!/bin/sh
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
     code-server --auth none --port 13337
     EOF
 

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -53,7 +53,7 @@ resource "coder_agent" "main" {
     #!/bin/bash
 
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -43,7 +43,7 @@ resource "coder_agent" "main" {
     #!/bin/bash
 
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -63,7 +63,7 @@ resource "coder_agent" "main" {
     fi
 
     # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }


### PR DESCRIPTION
# Description

Pin code-server to 4.8.3 in all examples and docs.

## Rationale

The most important things for users is to have working software. While we test code-server heavily, bugs do happen in releases. By pinning to a specific version, we achieve the following:
- we educate users on the `--version` flag which they can use to upgrade or downgrade as needed
- we allow them to _opt-in_ to upgrading rather than forcing them to use the latest version

## Changes
- chore(templates): pin code-server to 4.8.3
- docs: use code-server 4.8.3 in install snippets
