### PR TITLE
fix: fix app hostname returning port number

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -61,6 +61,7 @@ type Options struct {
 	AccessURL *url.URL
 	// AppHostname should be the wildcard hostname to use for workspace
 	// applications INCLUDING the asterisk, (optional) suffix and leading dot.
+	// It will use the same scheme and port number as the access URL.
 	// E.g. "*.apps.coder.com" or "*-apps.coder.com".
 	AppHostname string
 	// AppHostnameRegex contains the regex version of options.AppHostname as

--- a/coderd/workspaceapps.go
+++ b/coderd/workspaceapps.go
@@ -58,7 +58,7 @@ var nonCanonicalHeaders = map[string]string{
 
 func (api *API) appHost(rw http.ResponseWriter, r *http.Request) {
 	host := api.AppHostname
-	if api.AccessURL.Port() != "" {
+	if host != "" && api.AccessURL.Port() != "" {
 		host += fmt.Sprintf(":%s", api.AccessURL.Port())
 	}
 

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -62,7 +62,7 @@ func NewWithAPI(t *testing.T, options *Options) (*codersdk.Client, io.Closer, *c
 	if options.Options == nil {
 		options.Options = &coderdtest.Options{}
 	}
-	setHandler, cancelFunc, oop := coderdtest.NewOptions(t, options.Options)
+	setHandler, cancelFunc, serverURL, oop := coderdtest.NewOptions(t, options.Options)
 	coderAPI, err := coderd.New(context.Background(), &coderd.Options{
 		RBAC:                       true,
 		AuditLogging:               options.AuditLogging,
@@ -86,7 +86,7 @@ func NewWithAPI(t *testing.T, options *Options) (*codersdk.Client, io.Closer, *c
 		_ = provisionerCloser.Close()
 		_ = coderAPI.Close()
 	})
-	client := codersdk.New(coderAPI.AccessURL)
+	client := codersdk.New(serverURL)
 	client.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{


### PR DESCRIPTION
If wildcard access URL was not set, and the access URL contained a port it would result in the app hostname endpoint incorrectly returning `:8080` (or whatever the port was) instead of an empty string.

This would result in the frontend rendering the port forwarding button which wouldn't work.

Reported by a customer in Slack