### PR TITLE
chore: Upgrade to sqlc version 2 yaml configuration

### DIFF
--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -48,10 +48,6 @@ sql:
   - schema: "./dump.sql"
     queries: "./queries"
     engine: "postgresql"
-    # codegen
-    # gen
-    # strict_function_checks: true
-    # strict_type_checks: true
     gen:
       go:
         package: "database"

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -1,56 +1,61 @@
 # sqlc is used to generate types from sql schema language.
 # It was chosen to ensure type-safety when interacting with
 # the database.
-version: "1"
-packages:
-  - name: "database"
-    path: "./queries"
-    queries: "./queries"
-    schema: "./dump.sql"
-    engine: "postgresql"
-    emit_interface: true
-    emit_json_tags: true
-    emit_db_tags: true
-    # We replace the generated db file with our own
-    # to add support for transactions. This file is
-    # deleted after generation.
-    output_db_file_name: db_tmp.go
-
+version: "2"
+# Ideally renames & overrides would go under the sql section, but there is a
+# bug in sqlc that only global renames & overrides are currently being applied.
 overrides:
-  - column: "provisioner_daemons.tags"
-    go_type: "github.com/coder/coder/coderd/database/dbtype.StringMap"
-  - column: "provisioner_jobs.tags"
-    go_type: "github.com/coder/coder/coderd/database/dbtype.StringMap"
-  - column: "users.rbac_roles"
-    go_type: "github.com/lib/pq.StringArray"
-  - column: "templates.user_acl"
-    go_type:
-      type: "TemplateACL"
-  - column: "templates.group_acl"
-    go_type:
-      type: "TemplateACL"
+  go:
+    overrides:
+      - column: "provisioner_daemons.tags"
+        go_type: "github.com/coder/coder/coderd/database/dbtype.StringMap"
+      - column: "provisioner_jobs.tags"
+        go_type: "github.com/coder/coder/coderd/database/dbtype.StringMap"
+      - column: "users.rbac_roles"
+        go_type: "github.com/lib/pq.StringArray"
+      - column: "templates.user_acl"
+        go_type:
+          type: "TemplateACL"
+      - column: "templates.group_acl"
+        go_type:
+          type: "TemplateACL"
+    rename:
+      api_key: APIKey
+      api_key_scope: APIKeyScope
+      api_key_scope_all: APIKeyScopeAll
+      api_key_scope_application_connect: APIKeyScopeApplicationConnect
+      avatar_url: AvatarURL
+      login_type_oidc: LoginTypeOIDC
+      oauth_access_token: OAuthAccessToken
+      oauth_expiry: OAuthExpiry
+      oauth_id_token: OAuthIDToken
+      oauth_refresh_token: OAuthRefreshToken
+      parameter_type_system_hcl: ParameterTypeSystemHCL
+      userstatus: UserStatus
+      gitsshkey: GitSSHKey
+      rbac_roles: RBACRoles
+      ip_address: IPAddress
+      ip_addresses: IPAddresses
+      ids: IDs
+      jwt: JWT
+      user_acl: UserACL
+      group_acl: GroupACL
+      troubleshooting_url: TroubleshootingURL
+      default_ttl: DefaultTTL
+      motd_file: MOTDFile
 
-rename:
-  api_key: APIKey
-  api_key_scope: APIKeyScope
-  api_key_scope_all: APIKeyScopeAll
-  api_key_scope_application_connect: APIKeyScopeApplicationConnect
-  avatar_url: AvatarURL
-  login_type_oidc: LoginTypeOIDC
-  oauth_access_token: OAuthAccessToken
-  oauth_expiry: OAuthExpiry
-  oauth_id_token: OAuthIDToken
-  oauth_refresh_token: OAuthRefreshToken
-  parameter_type_system_hcl: ParameterTypeSystemHCL
-  userstatus: UserStatus
-  gitsshkey: GitSSHKey
-  rbac_roles: RBACRoles
-  ip_address: IPAddress
-  ip_addresses: IPAddresses
-  ids: IDs
-  jwt: JWT
-  user_acl: UserACL
-  group_acl: GroupACL
-  troubleshooting_url: TroubleshootingURL
-  default_ttl: DefaultTTL
-  motd_file: MOTDFile
+sql:
+  - schema: "./dump.sql"
+    queries: "./queries"
+    engine: "postgresql"
+    # codegen
+    # gen
+    # strict_function_checks: true
+    # strict_type_checks: true
+    gen:
+      go:
+        package: "database"
+        out: "./queries"
+        emit_interface: true
+        emit_json_tags: true
+        emit_db_tags: true


### PR DESCRIPTION
Just upgrading to v2 sqlc config. We were using version 1. 

The generated code is **exactly** the same.