### PR TITLE
test: Disable error on agent log in `scaletest/reconnectingpty`

### DIFF
--- a/scaletest/reconnectingpty/run_test.go
+++ b/scaletest/reconnectingpty/run_test.go
@@ -281,7 +281,7 @@ func setupRunnerTest(t *testing.T) (client *codersdk.Client, agentID uuid.UUID) 
 	agentClient.SetSessionToken(authToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
-		Logger: slogtest.Make(t, nil).Named("agent"),
+		Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named("agent"),
 	})
 	t.Cleanup(func() {
 		_ = agentCloser.Close()


### PR DESCRIPTION
They way the reconnectingpty tests behave inherently will cause the
agent to occasionally log an error (e.g. due to test disconnecting at a
certain time), allowing these error logs to fail the test will cause
these tests to be flakey.

It's best for these tests to only rely on the observed behavior.

Example: https://github.com/coder/coder/actions/runs/3707568640/jobs/6284142189
