### PR TITLE
fix: fix nested dirs in example tars

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -51,6 +51,6 @@ func TestSubdirs(t *testing.T) {
 		entryPaths[header.Typeflag] = append(entryPaths[header.Typeflag], header.Name)
 	}
 
-	require.Subset(t, entryPaths[tar.TypeDir], []string{"./", "images/"})
+	require.Subset(t, entryPaths[tar.TypeDir], []string{"images"})
 	require.Subset(t, entryPaths[tar.TypeReg], []string{"README.md", "main.tf", "images/base.Dockerfile"})
 }

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -81,11 +81,11 @@ func Tar(directory string, limit int64) ([]byte, error) {
 				return filepath.SkipDir
 			}
 			// Don't archive hidden files!
-			return err
+			return nil
 		}
 		if strings.Contains(rel, ".tfstate") {
 			// Don't store tfstate!
-			return err
+			return nil
 		}
 		// Use unix paths in the tar archive.
 		header.Name = filepath.ToSlash(rel)


### PR DESCRIPTION
The example tar generation code had some problems compared to the regular directory -> tar code we use for provisioners:
1. it included `./` prefix on every file
2. it included the root entry `./` when it's not supposed to
3. directories had the mode `0644` when it should've been `0755`
4. subdirectory contents weren't added properly

This caused the docker template to not work using the `example_id` field on template version creation.