### PR TITLE
fix: add sessionAffinity to helm values

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml .Values.coder.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.coder.service.type }}
-  sessionAffinity: ClientIP
+  sessionAffinity: {{ .Values.coder.service.sessionAffinity }}
   ports:
     - name: "http"
       port: 80

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -121,6 +121,11 @@ coder:
     # coder.service.type -- The type of service to expose. See:
     # https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: LoadBalancer
+    # coder.service.sessionAffinity -- Must be set to ClientIP or None
+    # AWS ELB does not support session stickiness based on ClientIP, so you must set this to None.
+    # The error message you might see: "Unsupported load balancer affinity: ClientIP"
+    # https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity
+    sessionAffinity: ClientIP
     # coder.service.externalTrafficPolicy -- The external traffic policy to use.
     # You may need to change this to "Local" to preserve the source IP address
     # in some situations.


### PR DESCRIPTION
This PR allows the ability to override the sessionAffinity value. This is required if you try to deploy this helm chart in AWS, as it will error out unless it's set to 'None'. 