### PR TITLE
fix: fix helm prometheus block causing failures

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -89,10 +89,18 @@ spec:
               protocol: TCP
             {{- end }}
             {{- range .Values.coder.env }}
-            {{- if and (eq .name "CODER_PROMETHEUS_ENABLE") (eq .value "true") }}
+            {{- if eq .name "CODER_PROMETHEUS_ENABLE" }}
+            {{/*
+            This sadly has to be nested to avoid evaluating the second part
+            of the condition too early and potentially getting type errors if
+            the value is not a string (like a `valueFrom`). We do not support
+            `valueFrom` for this env var specifically.
+            */}}
+            {{- if eq .value "true" }}
             - name: "prometheus-http"
               containerPort: 6060
               protocol: TCP
+            {{- end }}
             {{- end }}
             {{- end }}
           readinessProbe:


### PR DESCRIPTION
If helm chart users had `valueFrom` environment variables (like what we recommend for the DB URL) then it would cause the prometheus port block to hard fail, even if the `valueFrom` wasn't on `CODER_PROMETHEUS_ENABLE`.

This is because go templates would evaluate the parameters to the `and` function early since they are implemented as functions and not optimized programming conditionals.

cc @denbeigh2000 