### PR TITLE
docs: add contact us form for sales; improve enterprise page

### DIFF
--- a/docs/admin/upgrade.md
+++ b/docs/admin/upgrade.md
@@ -22,10 +22,11 @@ curl -L https://coder.com/install.sh | sh
 ```
 
 The script will unpack the new `coder` binary version over the one currently installed.
-Next, you can restart Coder with the following command (if running it as a system
+Next, you can restart Coder with the following commands (if running it as a system
 service):
 
 ```console
+systemctl daemon-reload
 systemctl restart coder
 ```
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -4,24 +4,22 @@ Coder is free to use and includes some features that are only accessible with a 
 [Contact Sales](https://coder.com/contact) for pricing or [get a free
 trial](https://coder.com/trial).
 
+| Category        | Feature                                                                     |  Open Source   | Enterprise |
+| --------------- | --------------------------------------------------------------------------- | :------------: | :--------: |
+| User Management | [Groups](./admin/groups.md)                                                 |                |     X      |
+| User Management | [OIDC](./admin/auth.md)                                                     | X<sup>\*</sup> |     X      |
+| User Management | [SCIM](./admin/auth.md#scim)                                                |                |     X      |
+| Governance      | [Audit Logging](./admin/audit-logs.md)                                      |                |     X      |
+| Governance      | [Browser Only Connections](./networking.md#browser-only-connections)        |                |     X      |
+| Governance      | [Template Access Control](./admin/rbac.md)                                  |                |     X      |
+| Cost Control    | [Quotas](./admin/quotas.md)                                                 |                |     X      |
+| Cost Control    | [Max Workspace Auto-Stop](./templates.md#configure-max-workspace-auto-stop) |                |     X      |
+| Deployment      | [High Availability](./admin/high-availability.md)                           |                |     X      |
+| Deployment      | [Service Banners](./admin/service-banners.md)                               |                |     X      |
+| Deployment      | [Git Provider Integration](./admin/git-providers.md)                        | X<sup>\*</sup> |     X      |
+| Deployment      | Isolated Terraform Runners                                                  |                |     X      |
 
-| Category | Feature | Open Source | Enterprise |
-| -------- | ------- | :-----------: | :----------: |
-| User Management | [Groups](./admin/groups.md) |  | X |
-| User Management | [OIDC](./admin/auth.md) | X<sup>*</sup>  | X |
-| User Management | [SCIM](./admin/auth.md#scim) |  | X |
-| Governance | [Audit Logging](./admin/audit-logs.md) |  | X |
-| Governance | [Browser Only Connections](./networking.md#browser-only-connections) |  | X |
-| Governance | [Template Access Control](./admin/rbac.md) |  | X |
-| Cost Control | [Quotas](./admin/quotas.md) |  | X |
-| Cost Control | [Max Workspace Auto-Stop](./templates.md#configure-max-workspace-auto-stop) |  | X |
-| Deployment | [High Availability](./admin/high-availability.md) |  | X |
-| Deployment | [Service Banners](./admin/service-banners.md) |  | X |
-| Deployment | [Git Provider Integration](./admin/git-providers.md) | X<sup>*</sup> | X |
-| Deployment | Isolated Terraform Runners |  | X |
-
-<sup>*</sup> Free for up to 20 users
-
+<sup>\*</sup> Free for up to 20 users
 
 ## Adding your license key
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -1,35 +1,33 @@
 # Enterprise Features
 
 Coder is free to use and includes some features that are only accessible with a paid license.
-Contact sales@coder.com to obtain a license.
+[Contact Sales](https://coder.com/contact) for pricing or [get a free
+trial](https://coder.com/trial).
 
-### User Management
 
-- [Groups](./admin/groups.md)
-- [Template RBAC](./admin/rbac.md)
-- [SCIM](./admin/auth.md#scim)
+| Category | Feature | Open Source | Enterprise |
+| -------- | ------- | :-----------: | :----------: |
+| User Management | [Groups](./admin/groups.md) |  | X |
+| User Management | [OIDC](./admin/auth.md) | X<sup>*</sup>  | X |
+| User Management | [SCIM](./admin/auth.md#scim) |  | X |
+| Governance | [Audit Logging](./admin/audit-logs.md) |  | X |
+| Governance | [Browser Only Connections](./networking.md#browser-only-connections) |  | X |
+| Governance | [Template Access Control](./admin/rbac.md) |  | X |
+| Cost Control | [Quotas](./admin/quotas.md) |  | X |
+| Cost Control | [Max Workspace Auto-Stop](./templates.md#configure-max-workspace-auto-stop) |  | X |
+| Deployment | [High Availability](./admin/high-availability.md) |  | X |
+| Deployment | [Service Banners](./admin/service-banners.md) |  | X |
+| Deployment | [Git Provider Integration](./admin/git-providers.md) | X<sup>*</sup> | X |
+| Deployment | Isolated Terraform Runners |  | X |
 
-### Networking & Deployment
+<sup>*</sup> Free for up to 20 users
 
-- [High Availability](./admin/high-availability.md)
-- [Browser Only Connections](./networking.md#browser-only-connections)
-- [Service Banners](./admin/service-banners.md)
-
-### Other
-
-- [Audit Logging](./admin/audit-logs.md)
-- [Quotas](./admin/quotas.md)
-
-### Coming soon
-
-- Multiple Git Provider Authentication
-- Max Workspace Auto-Stop
 
 ## Adding your license key
 
 ### Requirements
 
-- Your license key (contact sales@coder.com if you don't have yours)
+- Your license key
 - Coder CLI installed
 
 ### Instructions

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -86,7 +86,8 @@ $ coder server --derp-config-path derpmap.json
 
 The dashboard (and web apps opened through the dashboard) are served from the
 coder server, so they can only be geo-distributed with High Availability mode in
-our Enterprise Edition. [Reach out to sales](mailto:sales@coder.com) to learn more.
+our Enterprise Edition. [Reach out to Sales](https://coder.com/contact) to learn
+more.
 
 ## Browser-only connections (enterprise)
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -70,6 +70,15 @@ coder templates create <template-name>
 > [examples/](https://github.com/coder/coder/tree/main/examples/templates)
 > directory in the repo.
 
+## Configure Max Workspace Auto-Stop
+
+To control cost, specify a maximum time to live flag for a template in hours or
+minutes.
+
+```sh
+coder templates create my-template --ttl 4h
+```
+
 ## Customize templates
 
 Example templates are not designed to support every use (e.g


### PR DESCRIPTION
This PR:

1. Replaces the mailto:sales@coder.com with the coder.com contact form
2. Improves the Enterprise page with a table and categories; designate OIDC, Git Auth as also limited in OSS
3. Adds TTL flag to templates page
