### PR TITLE
fix: use static base date for timeline tests

### DIFF
--- a/site/src/components/Timeline/Timeline.test.tsx
+++ b/site/src/components/Timeline/Timeline.test.tsx
@@ -2,13 +2,13 @@ import { createDisplayDate } from "./TimelineDateRow"
 
 describe("createDisplayDate", () => {
   it("returns correctly for Saturdays", () => {
-    const now = new Date()
+    const now = new Date(2020, 1, 7)
     const date = new Date(
       now.getFullYear(),
       now.getMonth(),
       // Previous Saturday, from now.
       now.getDate() - now.getDay() - 1,
     )
-    expect(createDisplayDate(date)).toEqual("last Saturday")
+    expect(createDisplayDate(date, now)).toEqual("last Saturday")
   })
 })

--- a/site/src/components/Timeline/TimelineDateRow.tsx
+++ b/site/src/components/Timeline/TimelineDateRow.tsx
@@ -10,8 +10,8 @@ export interface TimelineDateRow {
 
 // We only want the message related to the date since the time is displayed
 // inside of the build row
-export const createDisplayDate = (date: Date): string =>
-  formatRelative(date, new Date()).split(" at ")[0]
+export const createDisplayDate = (date: Date, base = new Date()): string =>
+  formatRelative(date, base).split(" at ")[0]
 
 export const TimelineDateRow: FC<TimelineDateRow> = ({ date }) => {
   const styles = useStyles()


### PR DESCRIPTION
It was returning "yesterday" since today is Sunday ;p
