### PR TITLE
feat: Unhide workspace rename command

### DIFF
--- a/cli/rename.go
+++ b/cli/rename.go
@@ -16,10 +16,6 @@ func rename() *cobra.Command {
 		Use:         "rename <workspace> <new name>",
 		Short:       "Rename a workspace",
 		Args:        cobra.ExactArgs(2),
-		// Keep hidden until renaming is safe, see:
-		// * https://github.com/coder/coder/issues/3000
-		// * https://github.com/coder/coder/issues/3386
-		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := CreateClient(cmd)
 			if err != nil {
@@ -31,8 +27,9 @@ func rename() *cobra.Command {
 			}
 
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n",
-				cliui.Styles.Wrap.Render("WARNING: A rename can result in data loss if a resource references the workspace name in the template (e.g volumes)."),
+				cliui.Styles.Wrap.Render("WARNING: A rename can result in data loss if a resource references the workspace name in the template (e.g volumes). Please backup any data before proceeding."),
 			)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "See: %s\n\n", "https://coder.com/docs/coder-oss/latest/templates/resource-persistence#%EF%B8%8F-persistence-pitfalls")
 			_, err = cliui.Prompt(cmd, cliui.PromptOptions{
 				Text: fmt.Sprintf("Type %q to confirm rename:", workspace.Name),
 				Validate: func(s string) error {

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -36,6 +36,7 @@ Workspace Commands:
   create         Create a workspace
   delete         Delete a workspace
   list           List workspaces
+  rename         Rename a workspace
   schedule       Schedule automated start and stop times for workspaces
   show           Display details of a workspace's resources and agents
   speedtest      Run upload and download tests from your machine to a workspace


### PR DESCRIPTION
I think we've made a best-effort to protect user volumes so that we can finally unhide this command. (See https://github.com/coder/coder/issues/3386 for context.)

For instance, `examples/templates/docker` now uses workspace ID in the home volume name and additionally ignores all lifecycle changes, so there should be no situation where a user volume based on it (using todays template) is lost.

I've expanded the warning a bit:

```
WARNING: A rename can result in data loss if a resource references the workspace
name in the template (e.g volumes). Please backup any data before proceeding.

See: https://coder.com/docs/coder-oss/latest/templates/resource-persistence#%EF%B8%8F-persistence-pitfalls

> Type "test" to confirm rename:
```

Thoughts?
