### PR TITLE
fix: change TLS client auth default to "none"

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -303,7 +303,7 @@ func newConfig() *codersdk.DeploymentConfig {
 				Name:    "TLS Client Auth",
 				Usage:   "Policy the server will follow for TLS Client Authentication. Accepted values are \"none\", \"request\", \"require-any\", \"verify-if-given\", or \"require-and-verify\".",
 				Flag:    "tls-client-auth",
-				Default: "request",
+				Default: "none",
 			},
 			KeyFiles: &codersdk.DeploymentConfigField[[]string]{
 				Name:  "TLS Key Files",

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -198,7 +198,7 @@ Flags:
                                                      "verify-if-given", or
                                                      "require-and-verify".
                                                      Consumes $CODER_TLS_CLIENT_AUTH (default
-                                                     "request")
+                                                     "none")
       --tls-client-ca-file string                    PEM-encoded Certificate Authority file
                                                      used for checking the authenticity of
                                                      client


### PR DESCRIPTION
"request" causes usability issues when it's not necessary:

- Browsers may prompt the user to select a client certificate
- iOS returns an error page instead of sending no certificate and loading properly (not sure why or what the conditions are)