### PR TITLE
feat: Add --raw-url to coder server postgres-builtin-* commands

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -118,6 +118,19 @@ func TestServer(t *testing.T) {
 
 		pty.ExpectMatch("psql")
 	})
+	t.Run("BuiltinPostgresURLRaw", func(t *testing.T) {
+		t.Parallel()
+		root, _ := clitest.New(t, "server", "postgres-builtin-url", "--raw-url")
+		pty := ptytest.New(t)
+		root.SetOutput(pty.Output())
+		err := root.Execute()
+		require.NoError(t, err)
+
+		got := pty.ReadLine()
+		if !strings.HasPrefix(got, "postgres://") {
+			t.Fatalf("expected postgres URL to start with \"postgres://\", got %q", got)
+		}
+	})
 
 	// Validate that a warning is printed that it may not be externally
 	// reachable.


### PR DESCRIPTION
I have wanted this a couple of times and will come in handy if we decide to implement a way to run `coder server postgres-builtin-serve` inside the Docker container as a lower privilege user.
