### PR TITLE
test: Generate golden files for all (visible) CLI commands

### DIFF
--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -69,6 +70,9 @@ ExtractCommandPathsLoop:
 
 	wd, err := os.Getwd()
 	require.NoError(t, err)
+	if runtime.GOOS == "windows" {
+		wd = strings.ReplaceAll(wd, "\\", "\\\\")
+	}
 
 	for _, tt := range tests {
 		tt := tt

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,27 +31,44 @@ var updateGoldenFiles = flag.Bool("update", false, "update .golden files")
 func TestCommandHelp(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	commonEnv := map[string]string{
+		"CODER_CONFIG_DIR": "/tmp/coder-cli-test-config",
+	}
+
+	type testCase struct {
 		name string
 		cmd  []string
 		env  map[string]string
-	}{
+	}
+	tests := []testCase{
 		{
 			name: "coder --help",
 			cmd:  []string{"--help"},
-			env: map[string]string{
-				"CODER_CONFIG_DIR": "/tmp/coder-cli-test-config",
-			},
 		},
 		{
 			name: "coder server --help",
 			cmd:  []string{"server", "--help"},
 			env: map[string]string{
-				"CODER_CONFIG_DIR":      "/tmp/coder-cli-test-config",
 				"CODER_CACHE_DIRECTORY": "/tmp/coder-cli-test-cache",
 			},
 		},
 	}
+
+	root := cli.Root(cli.AGPL())
+ExtractCommandPathsLoop:
+	for _, cp := range extractVisibleCommandPaths(nil, root.Commands()) {
+		name := fmt.Sprintf("coder %s --help", strings.Join(cp, " "))
+		cmd := append(cp, "--help")
+		for _, tt := range tests {
+			if tt.name == name {
+				continue ExtractCommandPathsLoop
+			}
+		}
+		tests = append(tests, testCase{name: name, cmd: cmd})
+	}
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
 
 	for _, tt := range tests {
 		tt := tt
@@ -63,6 +81,14 @@ func TestCommandHelp(t *testing.T) {
 				}
 			}
 			// Override environment variables for a reproducible test.
+			for k, v := range commonEnv {
+				if tt.env != nil {
+					if _, ok := tt.env[k]; ok {
+						continue
+					}
+				}
+				t.Setenv(k, v)
+			}
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -79,6 +105,10 @@ func TestCommandHelp(t *testing.T) {
 			// Remove CRLF newlines (Windows).
 			got = bytes.ReplaceAll(got, []byte{'\r', '\n'}, []byte{'\n'})
 
+			// The `coder templates create --help` command prints the path
+			// to the working directory (--directory flag default value).
+			got = bytes.ReplaceAll(got, []byte(wd), []byte("/tmp/coder-cli-test-workdir"))
+
 			gf := filepath.Join("testdata", strings.Replace(tt.name, " ", "_", -1)+".golden")
 			if *updateGoldenFiles {
 				t.Logf("update golden file for: %q: %s", tt.name, gf)
@@ -93,6 +123,19 @@ func TestCommandHelp(t *testing.T) {
 			require.Equal(t, string(want), string(got), "golden file mismatch: %s, run \"make update-golden-files\", verify and commit the changes", gf)
 		})
 	}
+}
+
+func extractVisibleCommandPaths(cmdPath []string, cmds []*cobra.Command) [][]string {
+	var cmdPaths [][]string
+	for _, c := range cmds {
+		if c.Hidden {
+			continue
+		}
+		cmdPath := append(cmdPath, c.Name())
+		cmdPaths = append(cmdPaths, cmdPath)
+		cmdPaths = append(cmdPaths, extractVisibleCommandPaths(cmdPath, c.Commands())...)
+	}
+	return cmdPaths
 }
 
 func TestRoot(t *testing.T) {

--- a/cli/testdata/coder_config-ssh_--help.golden
+++ b/cli/testdata/coder_config-ssh_--help.golden
@@ -1,0 +1,43 @@
+Add an SSH Host entry for your workspaces "ssh coder.workspace"
+
+Usage:
+  coder config-ssh [flags]
+
+Get Started:
+  - You can use -o (or --ssh-option) so set SSH options to be used for all your 
+    workspaces:                                                                 
+
+      [;m$ coder config-ssh -o ForwardAgent=yes[0m 
+
+  - You can use --dry-run (or -n) to see the changes that would be made:        
+
+      [;m$ coder config-ssh --dry-run[0m 
+
+Flags:
+  -n, --dry-run                  Perform a trial run with no changes made, showing a diff at
+                                 the end.
+  -h, --help                     help for config-ssh
+      --ssh-config-file string   Specifies the path to an SSH config.
+                                 Consumes $CODER_SSH_CONFIG_FILE (default "~/.ssh/config")
+  -o, --ssh-option stringArray   Specifies additional SSH options to embed in each host stanza.
+      --use-previous-options     Specifies whether or not to keep options from previous run of
+                                 config-ssh.
+                                 Consumes $CODER_SSH_USE_PREVIOUS_OPTIONS
+  -y, --yes                      Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -1,0 +1,36 @@
+Create a workspace
+
+Usage:
+  coder create [name] [flags]
+
+Flags:
+  -h, --help                                   help for create
+      --parameter-file string                  Specify a file path with parameter values.
+                                               Consumes $CODER_PARAMETER_FILE
+      --start-at coder schedule start --help   Specify the workspace autostart schedule. Check
+                                               coder schedule start --help for the syntax.
+                                               Consumes $CODER_WORKSPACE_START_AT
+      --stop-after duration                    Specify a duration after which the workspace
+                                               should shut down (e.g. 8h).
+                                               Consumes $CODER_WORKSPACE_STOP_AFTER (default
+                                               8h0m0s)
+  -t, --template string                        Specify a template name.
+                                               Consumes $CODER_TEMPLATE_NAME
+  -y, --yes                                    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_delete_--help.golden
+++ b/cli/testdata/coder_delete_--help.golden
@@ -1,0 +1,30 @@
+Delete a workspace
+
+Usage:
+  coder delete <workspace> [flags]
+
+Aliases:
+  delete, rm
+
+Flags:
+  -h, --help     help for delete
+      --orphan   Delete a workspace without deleting its resources. This can delete a
+                 workspace in a broken state, but may also lead to unaccounted cloud resources.
+  -y, --yes      Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_dotfiles_--help.golden
+++ b/cli/testdata/coder_dotfiles_--help.golden
@@ -1,0 +1,33 @@
+Checkout and install a dotfiles repository from a Git URL
+
+Usage:
+  coder dotfiles [git_repo_url] [flags]
+
+Get Started:
+  - Check out and install a dotfiles repository without prompts:                
+
+      [;m$ coder dotfiles --yes git@github.com:example/dotfiles.git[0m 
+
+Flags:
+  -h, --help                 help for dotfiles
+      --symlink-dir string   Specifies the directory for the dotfiles symlink destinations. If
+                             empty will use $HOME.
+                             Consumes $CODER_SYMLINK_DIR
+  -y, --yes                  Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_list_--help.golden
+++ b/cli/testdata/coder_list_--help.golden
@@ -1,0 +1,32 @@
+List workspaces
+
+Usage:
+  coder list [flags]
+
+Aliases:
+  list, ls
+
+Flags:
+  -a, --all                  Specifies whether all workspaces will be listed or not.
+  -c, --column stringArray   Specify a column to filter in the table. Available columns are:
+                             workspace, template, status, last_built, outdated, starts_at,
+                             stops_after
+  -h, --help                 help for list
+      --search string        Search for a workspace with a query. (default "owner:me")
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_login_--help.golden
+++ b/cli/testdata/coder_login_--help.golden
@@ -1,0 +1,36 @@
+Authenticate with Coder deployment
+
+Usage:
+  coder login <url> [flags]
+
+Flags:
+      --first-user-email string      Specifies an email address to use if creating the first
+                                     user for the deployment.
+                                     Consumes $CODER_FIRST_USER_EMAIL
+      --first-user-password string   Specifies a password to use if creating the first user
+                                     for the deployment.
+                                     Consumes $CODER_FIRST_USER_PASSWORD
+      --first-user-trial             Specifies whether a trial license should be provisioned
+                                     for the Coder deployment or not.
+                                     Consumes $CODER_FIRST_USER_TRIAL
+      --first-user-username string   Specifies a username to use if creating the first user
+                                     for the deployment.
+                                     Consumes $CODER_FIRST_USER_USERNAME
+  -h, --help                         help for login
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_logout_--help.golden
+++ b/cli/testdata/coder_logout_--help.golden
@@ -1,0 +1,25 @@
+Unauthenticate your local session
+
+Usage:
+  coder logout [flags]
+
+Flags:
+  -h, --help   help for logout
+  -y, --yes    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_port-forward_--help.golden
+++ b/cli/testdata/coder_port-forward_--help.golden
@@ -1,0 +1,51 @@
+Forward ports from machine to a workspace
+
+Usage:
+  coder port-forward <workspace> [flags]
+
+Aliases:
+  port-forward, tunnel
+
+Get Started:
+  - Port forward a single TCP port from 1234 in the workspace to port 5678 on   
+    your local machine:                                                         
+
+      [;m$ coder port-forward <workspace> --tcp 5678:1234[0m 
+
+  - Port forward a single UDP port from port 9000 to port 9000 on your local    
+    machine:                                                                    
+
+      [;m$ coder port-forward <workspace> --udp 9000[0m 
+
+  - Port forward multiple TCP ports and a UDP port:                             
+
+      [;m$ coder port-forward <workspace> --tcp 8080:8080 --tcp 9000:3000 --udp 5353:53[0m 
+
+  - Port forward multiple ports (TCP or UDP) in condensed syntax:               
+
+      [;m$ coder port-forward <workspace> --tcp 8080,9000:3000,9090-9092,10000-10002:10010-10012[0m 
+
+Flags:
+  -h, --help              help for port-forward
+  -p, --tcp stringArray   Forward TCP port(s) from the workspace to the local machine.
+                          Consumes $CODER_PORT_FORWARD_TCP
+      --udp stringArray   Forward UDP port(s) from the workspace to the local machine. The UDP
+                          connection has TCP-like semantics to support stateful UDP protocols.
+                          Consumes $CODER_PORT_FORWARD_UDP
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_publickey_--help.golden
+++ b/cli/testdata/coder_publickey_--help.golden
@@ -1,0 +1,30 @@
+Output your Coder public key used for Git operations
+
+Usage:
+  coder publickey [flags]
+
+Aliases:
+  publickey, pubkey
+
+Flags:
+  -h, --help    help for publickey
+      --reset   Regenerate your public key. This will require updating the key on any services
+                it's registered with.
+  -y, --yes     Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_rename_--help.golden
+++ b/cli/testdata/coder_rename_--help.golden
@@ -1,0 +1,25 @@
+Rename a workspace
+
+Usage:
+  coder rename <workspace> <new name> [flags]
+
+Flags:
+  -h, --help   help for rename
+  -y, --yes    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_reset-password_--help.golden
+++ b/cli/testdata/coder_reset-password_--help.golden
@@ -1,0 +1,26 @@
+Directly connect to the database to reset a user's password
+
+Usage:
+  coder reset-password <username> [flags]
+
+Flags:
+  -h, --help                  help for reset-password
+      --postgres-url string   URL of a PostgreSQL database to connect to.
+                              Consumes $CODER_PG_CONNECTION_URL
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_scaletest_--help.golden
+++ b/cli/testdata/coder_scaletest_--help.golden
@@ -1,0 +1,32 @@
+Perform scale tests against the Coder server.
+
+Usage:
+  coder scaletest [flags]
+
+  coder scaletest [command]
+
+Commands:
+  cleanup           Cleanup any orphaned scaletest resources
+  create-workspaces Creates many workspaces and waits for them to be ready
+
+Flags:
+  -h, --help   help for scaletest
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder scaletest [command] --help" for more information about a command.

--- a/cli/testdata/coder_scaletest_cleanup_--help.golden
+++ b/cli/testdata/coder_scaletest_cleanup_--help.golden
@@ -1,0 +1,32 @@
+Cleanup scaletest workspaces, then cleanup scaletest users. The strategy flags will apply to each stage of the cleanup process.
+
+Usage:
+  coder scaletest cleanup [flags]
+
+Flags:
+      --cleanup-concurrency int        Number of concurrent cleanup jobs to run. 0 means
+                                       unlimited.
+                                       Consumes $CODER_LOADTEST_CLEANUP_CONCURRENCY (default 1)
+      --cleanup-job-timeout duration   Timeout per job. Jobs may take longer to complete under
+                                       higher concurrency limits.
+                                       Consumes $CODER_LOADTEST_CLEANUP_JOB_TIMEOUT (default 5m0s)
+      --cleanup-timeout duration       Timeout for the entire cleanup run. 0 means unlimited.
+                                       Consumes $CODER_LOADTEST_CLEANUP_TIMEOUT (default 30m0s)
+  -h, --help                           help for cleanup
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_scaletest_create-workspaces_--help.golden
+++ b/cli/testdata/coder_scaletest_create-workspaces_--help.golden
@@ -1,0 +1,129 @@
+Creates many users, then creates a workspace for each user and waits for them finish building and fully come online. Optionally runs a command inside each workspace, and connects to the workspace over WireGuard.
+
+Usage:
+  coder scaletest create-workspaces [flags]
+
+Flags:
+      --cleanup-concurrency int              Number of concurrent cleanup jobs to run. 0 means
+                                             unlimited.
+                                             Consumes $CODER_LOADTEST_CLEANUP_CONCURRENCY
+                                             (default 1)
+      --cleanup-job-timeout duration         Timeout per job. Jobs may take longer to complete
+                                             under higher concurrency limits.
+                                             Consumes $CODER_LOADTEST_CLEANUP_JOB_TIMEOUT
+                                             (default 5m0s)
+      --cleanup-timeout duration             Timeout for the entire cleanup run. 0 means
+                                             unlimited.
+                                             Consumes $CODER_LOADTEST_CLEANUP_TIMEOUT (default
+                                             30m0s)
+      --concurrency int                      Number of concurrent jobs to run. 0 means
+                                             unlimited.
+                                             Consumes $CODER_LOADTEST_CONCURRENCY (default 1)
+      --connect-hold duration                How long to hold the WireGuard connection open
+                                             for.
+                                             Consumes $CODER_LOADTEST_CONNECT_HOLD (default 30s)
+      --connect-interval duration            How long to wait between making requests to the
+                                             --connect-url once the connection is established.
+                                             Consumes $CODER_LOADTEST_CONNECT_INTERVAL (default 1s)
+      --connect-mode string                  Mode to use for connecting to the workspace. Can
+                                             be 'derp' or 'direct'.
+                                             Consumes $CODER_LOADTEST_CONNECT_MODE (default "derp")
+      --connect-timeout duration             Timeout for each request to the --connect-url.
+                                             Consumes $CODER_LOADTEST_CONNECT_TIMEOUT (default 5s)
+      --connect-url string                   URL to connect to inside the the workspace over
+                                             WireGuard. If not specified, no connections will
+                                             be made over WireGuard.
+                                             Consumes $CODER_LOADTEST_CONNECT_URL
+  -c, --count int                            Required: Number of workspaces to create.
+                                             Consumes $CODER_LOADTEST_COUNT (default 1)
+  -h, --help                                 help for create-workspaces
+      --job-timeout duration                 Timeout per job. Jobs may take longer to complete
+                                             under higher concurrency limits.
+                                             Consumes $CODER_LOADTEST_JOB_TIMEOUT (default 5m0s)
+      --no-cleanup coder scaletest cleanup   Do not clean up resources after the test
+                                             completes. You can cleanup manually using coder
+                                             scaletest cleanup.
+                                             Consumes $CODER_LOADTEST_NO_CLEANUP
+      --no-plan                              Skip the dry-run step to plan the workspace
+                                             creation. This step ensures that the given
+                                             parameters are valid for the given template.
+                                             Consumes $CODER_LOADTEST_NO_PLAN
+      --no-wait-for-agents                   Do not wait for agents to start before marking
+                                             the test as succeeded. This can be useful if you
+                                             are running the test against a template that does
+                                             not start the agent quickly.
+                                             Consumes $CODER_LOADTEST_NO_WAIT_FOR_AGENTS
+      --output stringArray                   Output format specs in the format
+                                             "<format>[:<path>]". Not specifying a path will
+                                             default to stdout. Available formats: text, json.
+                                             Consumes $CODER_SCALETEST_OUTPUTS (default [text])
+      --parameter stringArray                Parameters to use for each workspace. Can be
+                                             specified multiple times. Overrides any existing
+                                             parameters with the same name from
+                                             --parameters-file. Format: key=value.
+                                             Consumes $CODER_LOADTEST_PARAMETERS
+      --parameters-file string               Path to a YAML file containing the parameters to
+                                             use for each workspace.
+                                             Consumes $CODER_LOADTEST_PARAMETERS_FILE
+      --run-command string                   Command to run inside each workspace using
+                                             reconnecting-pty (i.e. web terminal protocol). If
+                                             not specified, no command will be run.
+                                             Consumes $CODER_LOADTEST_RUN_COMMAND
+      --run-expect-output string             Expect the command to output the given string (on
+                                             a single line). If the command does not output
+                                             the given string, it will be marked as failed.
+                                             Consumes $CODER_LOADTEST_RUN_EXPECT_OUTPUT
+      --run-expect-timeout                   Expect the command to timeout. If the command
+                                             does not finish within the given --run-timeout,
+                                             it will be marked as succeeded. If the command
+                                             finishes before the timeout, it will be marked as
+                                             failed.
+                                             Consumes $CODER_LOADTEST_RUN_EXPECT_TIMEOUT
+      --run-log-output                       Log the output of the command to the test logs.
+                                             This should be left off unless you expect small
+                                             amounts of output. Large amounts of output will
+                                             cause high memory usage.
+                                             Consumes $CODER_LOADTEST_RUN_LOG_OUTPUT
+      --run-timeout duration                 Timeout for the command to complete.
+                                             Consumes $CODER_LOADTEST_RUN_TIMEOUT (default 5s)
+  -t, --template string                      Required: Name or ID of the template to use for
+                                             workspaces.
+                                             Consumes $CODER_LOADTEST_TEMPLATE
+      --timeout duration                     Timeout for the entire test run. 0 means
+                                             unlimited.
+                                             Consumes $CODER_LOADTEST_TIMEOUT (default 30m0s)
+      --trace                                Whether application tracing data is collected. It
+                                             exports to a backend configured by environment
+                                             variables. See:
+                                             https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md.
+                                             Consumes $CODER_LOADTEST_TRACE
+      --trace-coder                          Whether opentelemetry traces are sent to Coder.
+                                             We recommend keeping this disabled unless we
+                                             advise you to enable it.
+                                             Consumes $CODER_LOADTEST_TRACE_CODER
+      --trace-honeycomb-api-key string       Enables trace exporting to Honeycomb.io using the
+                                             provided API key.
+                                             Consumes $CODER_LOADTEST_TRACE_HONEYCOMB_API_KEY
+      --trace-propagate                      Enables trace propagation to the Coder backend,
+                                             which will be used to correlate server-side spans
+                                             with client-side spans. Only enable this if the
+                                             server is configured with the exact same tracing
+                                             configuration as the client.
+                                             Consumes $CODER_LOADTEST_TRACE_PROPAGATE
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_schedule_--help.golden
+++ b/cli/testdata/coder_schedule_--help.golden
@@ -1,0 +1,34 @@
+Schedule automated start and stop times for workspaces
+
+Usage:
+  coder schedule { show | start | stop | override } <workspace> [flags]
+
+  coder schedule [command]
+
+Commands:
+  override-stop Edit stop time of active workspace
+  show          Show workspace schedule
+  start         Edit workspace start schedule
+  stop          Edit workspace stop schedule
+
+Flags:
+  -h, --help   help for schedule
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder schedule [command] --help" for more information about a command.

--- a/cli/testdata/coder_schedule_override-stop_--help.golden
+++ b/cli/testdata/coder_schedule_override-stop_--help.golden
@@ -1,0 +1,30 @@
+Override the stop time of a currently running workspace instance.
+  * The new stop time is calculated from *now*.
+  * The new stop time must be at least 30 minutes in the future.
+  * The workspace template may restrict the maximum workspace runtime.
+
+Usage:
+  coder schedule override-stop <workspace-name> <duration from now> [flags]
+
+Get Started:
+  [;m$ coder schedule override-stop my-workspace 90m[0m 
+
+Flags:
+  -h, --help   help for override-stop
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_schedule_show_--help.golden
+++ b/cli/testdata/coder_schedule_show_--help.golden
@@ -1,0 +1,28 @@
+Shows the following information for the given workspace:
+  * The automatic start schedule
+  * The next scheduled start time
+  * The duration after which it will stop
+  * The next scheduled stop time
+
+Usage:
+  coder schedule show <workspace-name> [flags]
+
+Flags:
+  -h, --help   help for show
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_schedule_start_--help.golden
+++ b/cli/testdata/coder_schedule_start_--help.golden
@@ -1,0 +1,37 @@
+Schedules a workspace to regularly start at a specific time.
+Schedule format: <start-time> [day-of-week] [location].
+  * Start-time (required) is accepted either in 12-hour (hh:mm{am|pm}) format, or 24-hour format hh:mm.
+  * Day-of-week (optional) allows specifying in the cron format, e.g. 1,3,5 or Mon-Fri.
+    Aliases such as @daily are not supported.
+    Default: * (every day)
+  * Location (optional) must be a valid location in the IANA timezone database.
+    If omitted, we will fall back to either the TZ environment variable or /etc/localtime.
+    You can check your corresponding location by visiting https://ipinfo.io - it shows in the demo widget on the right.
+
+Usage:
+  coder schedule start <workspace-name> { <start-time> [day-of-week] [location] | manual } [flags]
+
+Get Started:
+  - Set the workspace to start at 9:30am (in Dublin) from Monday to Friday:     
+
+      [;m$ coder schedule start my-workspace 9:30AM Mon-Fri Europe/Dublin[0m 
+
+Flags:
+  -h, --help   help for start
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_schedule_stop_--help.golden
+++ b/cli/testdata/coder_schedule_stop_--help.golden
@@ -1,0 +1,38 @@
+Schedules a workspace to stop after a given duration has elapsed.
+  * Workspace runtime is measured from the time that the workspace build completed.
+  * The minimum scheduled stop time is 1 minute.
+  * The workspace template may place restrictions on the maximum shutdown time.
+  * Changes to workspace schedules only take effect upon the next build of the workspace,
+    and do not affect a running instance of a workspace.
+
+When enabling scheduled stop, enter a duration in one of the following formats:
+  * 3h2m (3 hours and two minutes)
+  * 3h   (3 hours)
+  * 2m   (2 minutes)
+  * 2    (2 minutes)
+
+Usage:
+  coder schedule stop <workspace-name> { <duration> | manual } [flags]
+
+Get Started:
+  [;m$ coder schedule stop my-workspace 2h30m[0m 
+
+Flags:
+  -h, --help   help for stop
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_server_postgres-builtin-serve_--help.golden
+++ b/cli/testdata/coder_server_postgres-builtin-serve_--help.golden
@@ -1,0 +1,25 @@
+Run the built-in PostgreSQL deployment.
+
+Usage:
+  coder server postgres-builtin-serve [flags]
+
+Flags:
+  -h, --help      help for postgres-builtin-serve
+      --raw-url   Output the raw connection URL instead of a psql command.
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_server_postgres-builtin-url_--help.golden
+++ b/cli/testdata/coder_server_postgres-builtin-url_--help.golden
@@ -1,0 +1,25 @@
+Output the connection URL for the built-in PostgreSQL deployment.
+
+Usage:
+  coder server postgres-builtin-url [flags]
+
+Flags:
+  -h, --help      help for postgres-builtin-url
+      --raw-url   Output the raw connection URL instead of a psql command.
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_show_--help.golden
+++ b/cli/testdata/coder_show_--help.golden
@@ -1,0 +1,24 @@
+Display details of a workspace's resources and agents
+
+Usage:
+  coder show <workspace> [flags]
+
+Flags:
+  -h, --help   help for show
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_speedtest_--help.golden
+++ b/cli/testdata/coder_speedtest_--help.golden
@@ -1,0 +1,28 @@
+Run upload and download tests from your machine to a workspace
+
+Usage:
+  coder speedtest <workspace> [flags]
+
+Flags:
+  -d, --direct          Specifies whether to wait for a direct connection before testing speed.
+  -h, --help            help for speedtest
+  -r, --reverse         Specifies whether to run in reverse mode where the client receives and
+                        the server sends.
+  -t, --time duration   Specifies the duration to monitor traffic. (default 5s)
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -1,0 +1,37 @@
+Start a shell into a workspace
+
+Usage:
+  coder ssh <workspace> [flags]
+
+Flags:
+  -A, --forward-agent                      Specifies whether to forward the SSH agent
+                                           specified in $SSH_AUTH_SOCK.
+                                           Consumes $CODER_SSH_FORWARD_AGENT
+  -h, --help                               help for ssh
+      --identity-agent string              Specifies which identity agent to use (overrides
+                                           $SSH_AUTH_SOCK), forward agent must also be
+                                           enabled.
+                                           Consumes $CODER_SSH_IDENTITY_AGENT
+      --stdio                              Specifies whether to emit SSH output over
+                                           stdin/stdout.
+                                           Consumes $CODER_SSH_STDIO
+      --workspace-poll-interval duration   Specifies how often to poll for workspace automated
+                                           shutdown.
+                                           Consumes $CODER_WORKSPACE_POLL_INTERVAL (default 1m0s)
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_start_--help.golden
+++ b/cli/testdata/coder_start_--help.golden
@@ -1,0 +1,25 @@
+Start a workspace
+
+Usage:
+  coder start <workspace> [flags]
+
+Flags:
+  -h, --help   help for start
+  -y, --yes    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_state_--help.golden
+++ b/cli/testdata/coder_state_--help.golden
@@ -1,0 +1,32 @@
+Manually manage Terraform state to fix broken workspaces
+
+Usage:
+  coder state [flags]
+
+  coder state [command]
+
+Commands:
+  pull        
+  push        
+
+Flags:
+  -h, --help   help for state
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder state [command] --help" for more information about a command.

--- a/cli/testdata/coder_state_pull_--help.golden
+++ b/cli/testdata/coder_state_pull_--help.golden
@@ -1,0 +1,23 @@
+Usage:
+  coder state pull <workspace> [file] [flags]
+
+Flags:
+  -b, --build int   Specify a workspace build to target by name.
+  -h, --help        help for pull
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_state_push_--help.golden
+++ b/cli/testdata/coder_state_push_--help.golden
@@ -1,0 +1,23 @@
+Usage:
+  coder state push <workspace> <file> [flags]
+
+Flags:
+  -b, --build int   Specify a workspace build to target by name.
+  -h, --help        help for push
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_stop_--help.golden
+++ b/cli/testdata/coder_stop_--help.golden
@@ -1,0 +1,25 @@
+Stop a workspace
+
+Usage:
+  coder stop <workspace> [flags]
+
+Flags:
+  -h, --help   help for stop
+  -y, --yes    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_--help.golden
+++ b/cli/testdata/coder_templates_--help.golden
@@ -1,0 +1,55 @@
+Templates are written in standard Terraform and describe the infrastructure for workspaces
+
+Usage:
+  coder templates [flags]
+
+  coder templates [command]
+
+Aliases:
+  templates, template
+
+Get Started:
+  - Create a template for developers to create workspaces:                      
+
+      [;m$ coder templates create[0m 
+
+  - Make changes to your template, and plan the changes:                        
+
+      [;m$ coder templates plan my-template[0m 
+
+  - Push an update to the template. Your developers can update their workspaces:
+
+      [;m$ coder templates push my-template[0m 
+
+Commands:
+  create      Create a template from the current directory or as specified by flag
+  delete      Delete templates
+  edit        Edit the metadata of a template by name.
+  init        Get started with a templated template.
+  list        List all the templates available for the organization
+  plan        Plan a template push from the current directory
+  pull        Download the latest version of a template to a path.
+  push        Push a new template version from the current directory or as specified by flag
+  versions    Manage different versions of the specified template
+
+Flags:
+  -h, --help   help for templates
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder templates [command] --help" for more information about a command.

--- a/cli/testdata/coder_templates_create_--help.golden
+++ b/cli/testdata/coder_templates_create_--help.golden
@@ -1,0 +1,31 @@
+Create a template from the current directory or as specified by flag
+
+Usage:
+  coder templates create [name] [flags]
+
+Flags:
+      --default-ttl duration          Specify a default TTL for workspaces created from this
+                                      template. (default 24h0m0s)
+  -d, --directory string              Specify the directory to create from (default
+                                      "/tmp/coder-cli-test-workdir")
+  -h, --help                          help for create
+      --parameter-file string         Specify a file path with parameter values.
+      --provisioner-tag stringArray   Specify a set of tags to target provisioner daemons.
+  -y, --yes                           Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_delete_--help.golden
+++ b/cli/testdata/coder_templates_delete_--help.golden
@@ -1,0 +1,25 @@
+Delete templates
+
+Usage:
+  coder templates delete [name...] [flags]
+
+Flags:
+  -h, --help   help for delete
+  -y, --yes    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_edit_--help.golden
+++ b/cli/testdata/coder_templates_edit_--help.golden
@@ -1,0 +1,33 @@
+Edit the metadata of a template by name.
+
+Usage:
+  coder templates edit <template> [flags]
+
+Flags:
+      --allow-user-cancel-workspace-jobs   Allow users to cancel in-progress workspace jobs.
+                                           (default true)
+      --default-ttl duration               Edit the template default time before shutdown -
+                                           workspaces created from this template to this value.
+      --description string                 Edit the template description
+      --display-name string                Edit the template display name
+  -h, --help                               help for edit
+      --icon string                        Edit the template icon path
+      --name string                        Edit the template name
+  -y, --yes                                Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_init_--help.golden
+++ b/cli/testdata/coder_templates_init_--help.golden
@@ -1,0 +1,24 @@
+Get started with a templated template.
+
+Usage:
+  coder templates init [directory] [flags]
+
+Flags:
+  -h, --help   help for init
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_list_--help.golden
+++ b/cli/testdata/coder_templates_list_--help.golden
@@ -1,0 +1,29 @@
+List all the templates available for the organization
+
+Usage:
+  coder templates list [flags]
+
+Aliases:
+  list, ls
+
+Flags:
+  -c, --column stringArray   Specify a column to filter in the table. (default
+                             [name,last_updated,used_by])
+  -h, --help                 help for list
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_plan_--help.golden
+++ b/cli/testdata/coder_templates_plan_--help.golden
@@ -1,0 +1,24 @@
+Plan a template push from the current directory
+
+Usage:
+  coder templates plan <directory> [flags]
+
+Flags:
+  -h, --help   help for plan
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_pull_--help.golden
+++ b/cli/testdata/coder_templates_pull_--help.golden
@@ -1,0 +1,25 @@
+Download the latest version of a template to a path.
+
+Usage:
+  coder templates pull <name> [destination] [flags]
+
+Flags:
+  -h, --help   help for pull
+  -y, --yes    Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_push_--help.golden
+++ b/cli/testdata/coder_templates_push_--help.golden
@@ -1,0 +1,33 @@
+Push a new template version from the current directory or as specified by flag
+
+Usage:
+  coder templates push [template] [flags]
+
+Flags:
+      --always-prompt                 Always prompt all parameters. Does not pull parameter
+                                      values from active template version
+  -d, --directory string              Specify the directory to create from (default
+                                      "/tmp/coder-cli-test-workdir")
+  -h, --help                          help for push
+      --name string                   Specify a name for the new template version. It will be
+                                      automatically generated if not provided.
+      --parameter-file string         Specify a file path with parameter values.
+      --provisioner-tag stringArray   Specify a set of tags to target provisioner daemons.
+  -y, --yes                           Bypass prompts
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_templates_versions_--help.golden
+++ b/cli/testdata/coder_templates_versions_--help.golden
@@ -1,0 +1,39 @@
+Manage different versions of the specified template
+
+Usage:
+  coder templates versions [flags]
+
+  coder templates versions [command]
+
+Aliases:
+  versions, version
+
+Get Started:
+  - List versions of a specific template:                                       
+
+      [;m$ coder templates versions list my-template[0m 
+
+Commands:
+  list        List all the versions of the specified template
+
+Flags:
+  -h, --help   help for versions
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder templates versions [command] --help" for more information about a command.

--- a/cli/testdata/coder_templates_versions_list_--help.golden
+++ b/cli/testdata/coder_templates_versions_list_--help.golden
@@ -1,0 +1,24 @@
+List all the versions of the specified template
+
+Usage:
+  coder templates versions list <template> [flags]
+
+Flags:
+  -h, --help   help for list
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_tokens_--help.golden
+++ b/cli/testdata/coder_tokens_--help.golden
@@ -1,0 +1,49 @@
+Tokens are used to authenticate automated clients to Coder.
+
+Usage:
+  coder tokens [flags]
+
+  coder tokens [command]
+
+Aliases:
+  tokens, token
+
+Get Started:
+  - Create a token for automation:                                              
+
+      [;m$ coder tokens create[0m 
+
+  - List your tokens:                                                           
+
+      [;m$ coder tokens ls[0m 
+
+  - Remove a token by ID:                                                       
+
+      [;m$ coder tokens rm WuoWs4ZsMX[0m 
+
+Commands:
+  create      Create a tokens
+  list        List tokens
+  remove      Delete a token
+
+Flags:
+  -h, --help   help for tokens
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder tokens [command] --help" for more information about a command.

--- a/cli/testdata/coder_tokens_create_--help.golden
+++ b/cli/testdata/coder_tokens_create_--help.golden
@@ -1,0 +1,26 @@
+Create a tokens
+
+Usage:
+  coder tokens create [flags]
+
+Flags:
+  -h, --help                help for create
+      --lifetime duration   Specify a duration for the lifetime of the token.
+                            Consumes $CODER_TOKEN_LIFETIME (default 720h0m0s)
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_tokens_list_--help.golden
+++ b/cli/testdata/coder_tokens_list_--help.golden
@@ -1,0 +1,27 @@
+List tokens
+
+Usage:
+  coder tokens list [flags]
+
+Aliases:
+  list, ls
+
+Flags:
+  -h, --help   help for list
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_tokens_remove_--help.golden
+++ b/cli/testdata/coder_tokens_remove_--help.golden
@@ -1,0 +1,27 @@
+Delete a token
+
+Usage:
+  coder tokens remove [id] [flags]
+
+Aliases:
+  remove, rm
+
+Flags:
+  -h, --help   help for remove
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_update_--help.golden
+++ b/cli/testdata/coder_update_--help.golden
@@ -1,0 +1,28 @@
+Update a workspace
+
+Usage:
+  coder update <workspace> [flags]
+
+Flags:
+      --always-prompt           Always prompt all parameters. Does not pull parameter values
+                                from existing workspace
+  -h, --help                    help for update
+      --parameter-file string   Specify a file path with parameter values.
+                                Consumes $CODER_PARAMETER_FILE
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_users_--help.golden
+++ b/cli/testdata/coder_users_--help.golden
@@ -1,0 +1,38 @@
+Manage users
+
+Usage:
+  coder users [flags]
+
+  coder users [command]
+
+Aliases:
+  users, user
+
+Commands:
+  activate    Update a user's status to 'active'. Active users can fully interact with the platform
+  create      
+  list        
+  show        Show a single user. Use 'me' to indicate the currently authenticated user.
+  suspend     Update a user's status to 'suspended'. A suspended user cannot log into the platform
+
+Flags:
+  -h, --help   help for users
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE
+
+Use "coder users [command] --help" for more information about a command.

--- a/cli/testdata/coder_users_activate_--help.golden
+++ b/cli/testdata/coder_users_activate_--help.golden
@@ -1,0 +1,32 @@
+Update a user's status to 'active'. Active users can fully interact with the platform
+
+Usage:
+  coder users activate <username|user_id> [flags]
+
+Aliases:
+  activate, active
+
+Get Started:
+  [;m$ coder users activate example_user[0m 
+
+Flags:
+  -c, --column stringArray   Specify a column to filter in the table. (default
+                             [username,email,created_at,status])
+  -h, --help                 help for activate
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_users_create_--help.golden
+++ b/cli/testdata/coder_users_create_--help.golden
@@ -1,0 +1,25 @@
+Usage:
+  coder users create [flags]
+
+Flags:
+  -e, --email string      Specifies an email address for the new user.
+  -h, --help              help for create
+  -p, --password string   Specifies a password for the new user.
+  -u, --username string   Specifies a username for the new user.
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_users_list_--help.golden
+++ b/cli/testdata/coder_users_list_--help.golden
@@ -1,0 +1,29 @@
+Usage:
+  coder users list [flags]
+
+Aliases:
+  list, ls
+
+Flags:
+  -c, --column stringArray   Specify a column to filter in the table. Available columns are:
+                             id, username, email, created_at, status. (default
+                             [username,email,created_at,status])
+  -h, --help                 help for list
+  -o, --output string        Output format. Available formats are: table, json. (default "table")
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_users_show_--help.golden
+++ b/cli/testdata/coder_users_show_--help.golden
@@ -1,0 +1,28 @@
+Show a single user. Use 'me' to indicate the currently authenticated user.
+
+Usage:
+  coder users show <username|user_id|'me'> [flags]
+
+Get Started:
+  [;m$ coder users show me[0m 
+
+Flags:
+  -h, --help            help for show
+  -o, --output string   Output format. Available formats are: table, json. (default "table")
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_users_suspend_--help.golden
+++ b/cli/testdata/coder_users_suspend_--help.golden
@@ -1,0 +1,32 @@
+Update a user's status to 'suspended'. A suspended user cannot log into the platform
+
+Usage:
+  coder users suspend <username|user_id> [flags]
+
+Aliases:
+  suspend, rm, delete
+
+Get Started:
+  [;m$ coder users suspend example_user[0m 
+
+Flags:
+  -c, --column stringArray   Specify a column to filter in the table. (default
+                             [username,email,created_at,status])
+  -h, --help                 help for suspend
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE

--- a/cli/testdata/coder_version_--help.golden
+++ b/cli/testdata/coder_version_--help.golden
@@ -1,0 +1,24 @@
+Show coder version
+
+Usage:
+  coder version [flags]
+
+Flags:
+  -h, --help   help for version
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE


### PR DESCRIPTION
This PR expands the existing implementation and iterates over subcommands to find all (non-hidden) commands and creates golden files for their `--help` output.

This way we can protect against surprising UI/UX regressions in the CLI.