### PR TITLE
fix: use UIDs in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,15 @@ LABEL \
 	org.opencontainers.image.source="https://github.com/coder/coder" \
 	org.opencontainers.image.version="$CODER_VERSION"
 
-# The coder binary is injected by scripts/build_docker.sh.
-COPY --chown=coder:coder --chmod=755 coder /opt/coder
-
 # Create coder group and user. We cannot use `addgroup` and `adduser` because
 # they won't work if we're building the image for a different architecture.
-COPY --chown=root:root --chmod=644 group passwd /etc/
-COPY --chown=coder:coder --chmod=700 empty-dir /home/coder
+COPY --chown=0:0 --chmod=644 group passwd /etc/
+COPY --chown=1000:1000 --chmod=700 empty-dir /home/coder
 
-USER coder:coder
+# The coder binary is injected by scripts/build_docker.sh.
+COPY --chown=1000:1000 --chmod=755 coder /opt/coder
+
+USER 1000:1000
 ENV HOME=/home/coder
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt
 WORKDIR /home/coder


### PR DESCRIPTION
Tested that the default user has the expected ID and group, that the username resolves via `whoami`, and that the permissions of all files look right.

cc @ericpaulsen 