### PR TITLE
chore: support underscores in agent bin filenames

### DIFF
--- a/site/site_test.go
+++ b/site/site_test.go
@@ -315,7 +315,9 @@ func TestServingBin(t *testing.T) {
 				},
 			},
 			reqs: []req{
+				// We support both hyphens and underscores for compatibility.
 				{url: "/bin/coder-linux-amd64", wantStatus: http.StatusOK, wantBody: []byte("embed")},
+				{url: "/bin/coder_linux_amd64", wantStatus: http.StatusOK, wantBody: []byte("embed")},
 				{url: "/bin/GITKEEP", wantStatus: http.StatusOK, wantBody: []byte("")},
 			},
 		},


### PR DESCRIPTION
This is so we can eventually change the bin filenames to use underscores without any disruptions caused by mismatched agent scripts and coder server version.

Changing to underscores gives us uniformity with our Makefile scripts so we can improve builds. We will likely make this change next month.