### PR TITLE
fix!: enforce unique agent names per workspace

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -854,8 +854,16 @@ func InsertWorkspaceResource(ctx context.Context, db database.Store, jobID uuid.
 	}
 	snapshot.WorkspaceResources = append(snapshot.WorkspaceResources, telemetry.ConvertWorkspaceResource(resource))
 
-	appSlugs := make(map[string]struct{})
+	var (
+		agentNames = make(map[string]struct{})
+		appSlugs   = make(map[string]struct{})
+	)
 	for _, prAgent := range protoResource.Agents {
+		if _, ok := agentNames[prAgent.Name]; ok {
+			return xerrors.Errorf("duplicate agent name %q", prAgent.Name)
+		}
+		agentNames[prAgent.Name] = struct{}{}
+
 		var instanceID sql.NullString
 		if prAgent.GetInstanceId() != "" {
 			instanceID = sql.NullString{

--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -101,6 +101,7 @@ func ConvertResources(module *tfjson.StateModule, rawGraph string) ([]*proto.Res
 	findTerraformResources(module)
 
 	// Find all agents!
+	agentNames := map[string]struct{}{}
 	for _, tfResource := range tfResourceByLabel {
 		if tfResource.Type != "coder_agent" {
 			continue
@@ -110,6 +111,12 @@ func ConvertResources(module *tfjson.StateModule, rawGraph string) ([]*proto.Res
 		if err != nil {
 			return nil, xerrors.Errorf("decode agent attributes: %w", err)
 		}
+
+		if _, ok := agentNames[tfResource.Name]; ok {
+			return nil, xerrors.Errorf("duplicate agent name: %s", tfResource.Name)
+		}
+		agentNames[tfResource.Name] = struct{}{}
+
 		agent := &proto.Agent{
 			Name:                     tfResource.Name,
 			Id:                       attrs.ID,


### PR DESCRIPTION
This is only implemented in Go because writing a constraint would be difficult as the only way to check if an agent name is conflicting is by checking 3 different tables for information. Constraints don't support that, so we'd have to write a trigger. This is also how we do app name unique-per-workspace constraints because of the same problem.

I think this is good enough. Coder doesn't crash or have massively bad behavior if multiple agents share a name, it just will pick one instead of the other when doing operations by name.