### PR TITLE
fix!: Updated PreconditionFailed responses

### DIFF
--- a/coderd/httpmw/oauth2.go
+++ b/coderd/httpmw/oauth2.go
@@ -50,7 +50,7 @@ func ExtractOAuth2(config OAuth2Config, client *http.Client) func(http.Handler) 
 
 			// Interfaces can hold a nil value
 			if config == nil || reflect.ValueOf(config).IsNil() {
-				httpapi.Write(ctx, rw, http.StatusPreconditionRequired, codersdk.Response{
+				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 					Message: "The oauth2 method requested is not configured!",
 				})
 				return

--- a/coderd/httpmw/oauth2_test.go
+++ b/coderd/httpmw/oauth2_test.go
@@ -40,7 +40,7 @@ func TestOAuth2(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		res := httptest.NewRecorder()
 		httpmw.ExtractOAuth2(nil, nil)(nil).ServeHTTP(res, req)
-		require.Equal(t, http.StatusPreconditionRequired, res.Result().StatusCode)
+		require.Equal(t, http.StatusBadRequest, res.Result().StatusCode)
 	})
 	t.Run("RedirectWithoutCode", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -193,7 +193,7 @@ func (api *API) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 func (api *API) provisionerJobResources(rw http.ResponseWriter, r *http.Request, job database.ProvisionerJob) {
 	ctx := r.Context()
 	if !job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job hasn't completed!",
 		})
 		return

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -120,7 +120,7 @@ func (api *API) deleteTemplate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(workspaces) > 0 {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "All workspaces must be deleted before a template can be removed.",
 		})
 		return

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -501,7 +501,7 @@ func TestDeleteTemplate(t *testing.T) {
 		err := client.DeleteTemplate(ctx, template.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 }
 

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -81,13 +81,13 @@ func (api *API) patchCancelTemplateVersion(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 	if job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job has already completed!",
 		})
 		return
 	}
 	if job.CanceledAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job has already been marked as canceled!",
 		})
 		return
@@ -137,7 +137,7 @@ func (api *API) templateVersionSchema(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Template version job hasn't completed!",
 		})
 		return
@@ -188,7 +188,7 @@ func (api *API) templateVersionParameters(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 	if !job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job hasn't completed!",
 		})
 		return
@@ -246,7 +246,7 @@ func (api *API) postTemplateVersionDryRun(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 	if !job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Template version import job hasn't completed!",
 		})
 		return
@@ -351,13 +351,13 @@ func (api *API) patchTemplateVersionDryRunCancel(rw http.ResponseWriter, r *http
 	}
 
 	if job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job has already completed.",
 		})
 		return
 	}
 	if job.CanceledAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job has already been marked as canceled.",
 		})
 		return

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -206,7 +206,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		err := client.CancelTemplateVersion(ctx, version.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 	t.Run("AlreadyCanceled", func(t *testing.T) {
 		t.Parallel()
@@ -238,7 +238,7 @@ func TestPatchCancelTemplateVersion(t *testing.T) {
 		err = client.CancelTemplateVersion(ctx, version.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 		require.Eventually(t, func() bool {
 			var err error
 			version, err = client.TemplateVersion(ctx, version.ID)
@@ -300,7 +300,7 @@ func TestTemplateVersionSchema(t *testing.T) {
 		_, err := client.TemplateVersionSchema(ctx, version.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
@@ -380,7 +380,7 @@ func TestTemplateVersionParameters(t *testing.T) {
 		_, err := client.TemplateVersionParameters(ctx, version.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
@@ -447,7 +447,7 @@ func TestTemplateVersionResources(t *testing.T) {
 		_, err := client.TemplateVersionResources(ctx, version.ID)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
@@ -749,7 +749,7 @@ func TestTemplateVersionDryRun(t *testing.T) {
 		})
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 
 	t.Run("Cancel", func(t *testing.T) {
@@ -828,7 +828,7 @@ func TestTemplateVersionDryRun(t *testing.T) {
 			err = client.CancelTemplateVersionDryRun(ctx, version.ID, job.ID)
 			var apiErr *codersdk.Error
 			require.ErrorAs(t, err, &apiErr)
-			require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+			require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 		})
 
 		t.Run("AlreadyCanceled", func(t *testing.T) {
@@ -873,7 +873,7 @@ func TestTemplateVersionDryRun(t *testing.T) {
 			err = client.CancelTemplateVersionDryRun(ctx, version.ID, job.ID)
 			var apiErr *codersdk.Error
 			require.ErrorAs(t, err, &apiErr)
-			require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+			require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 		})
 	})
 }

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -148,7 +148,7 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if verifiedEmail == nil {
-		httpapi.Write(ctx, rw, http.StatusPreconditionRequired, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Your primary email must be verified on GitHub!",
 		})
 		return

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -177,7 +177,7 @@ func TestUserOAuth2Github(t *testing.T) {
 		})
 		_ = coderdtest.CreateFirstUser(t, client)
 		resp := oauth2Callback(t, client)
-		require.Equal(t, http.StatusPreconditionRequired, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 	t.Run("BlockSignups", func(t *testing.T) {
 		t.Parallel()
@@ -686,7 +686,7 @@ func TestUserOIDC(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		resp := oidcCallback(t, client, "asdf")
-		require.Equal(t, http.StatusPreconditionRequired, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("NoIDToken", func(t *testing.T) {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -206,7 +206,7 @@ func (api *API) workspaceAgentPTY(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if apiAgent.Status != codersdk.WorkspaceAgentConnected {
-		httpapi.Write(ctx, rw, http.StatusPreconditionRequired, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: fmt.Sprintf("Agent state is %q, it must be in the %q state.", apiAgent.Status, codersdk.WorkspaceAgentConnected),
 		})
 		return
@@ -279,7 +279,7 @@ func (api *API) workspaceAgentListeningPorts(rw http.ResponseWriter, r *http.Req
 		return
 	}
 	if apiAgent.Status != codersdk.WorkspaceAgentConnected {
-		httpapi.Write(ctx, rw, http.StatusPreconditionRequired, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: fmt.Sprintf("Agent state is %q, it must be in the %q state.", apiAgent.Status, codersdk.WorkspaceAgentConnected),
 		})
 		return

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -368,12 +368,12 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	case codersdk.ProvisionerJobFailed:
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: fmt.Sprintf("The provided template version %q has failed to import: %q. You cannot build workspaces with it!", templateVersion.Name, templateVersionJob.Error.String),
 		})
 		return
 	case codersdk.ProvisionerJobCanceled:
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "The provided template version was canceled during import. You cannot builds workspaces with it!",
 		})
 		return
@@ -575,13 +575,13 @@ func (api *API) patchCancelWorkspaceBuild(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 	if job.CompletedAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job has already completed!",
 		})
 		return
 	}
 	if job.CanceledAt.Valid {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Job has already been marked as canceled!",
 		})
 		return

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -413,12 +413,12 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		})
 		return
 	case codersdk.ProvisionerJobFailed:
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: fmt.Sprintf("The provided template version %q has failed to import. You cannot create workspaces using it!", templateVersion.Name),
 		})
 		return
 	case codersdk.ProvisionerJobCanceled:
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "The provided template version was canceled during import. You cannot create workspaces using it!",
 		})
 		return

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1053,7 +1053,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 		})
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
 	})
 
 	t.Run("AlreadyActive", func(t *testing.T) {

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -126,7 +126,7 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 			UserID:         uuid.MustParse(id),
 		})
 		if xerrors.Is(err, sql.ErrNoRows) {
-			httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: fmt.Sprintf("User %q must be a member of organization %q", id, group.ID),
 			})
 			return
@@ -197,14 +197,14 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 		return nil
 	}, nil)
 	if database.IsUniqueViolation(err) {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Cannot add the same user to a group twice!",
 			Detail:  err.Error(),
 		})
 		return
 	}
 	if xerrors.Is(err, sql.ErrNoRows) {
-		httpapi.Write(ctx, rw, http.StatusPreconditionFailed, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to add or remove non-existent group member",
 			Detail:  err.Error(),
 		})

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -322,7 +322,7 @@ func TestPatchGroup(t *testing.T) {
 		require.Error(t, err)
 		cerr, ok := codersdk.AsError(err)
 		require.True(t, ok)
-		require.Equal(t, http.StatusPreconditionFailed, cerr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, cerr.StatusCode())
 	})
 
 	t.Run("MalformedUUID", func(t *testing.T) {
@@ -372,7 +372,7 @@ func TestPatchGroup(t *testing.T) {
 		cerr, ok := codersdk.AsError(err)
 		require.True(t, ok)
 
-		require.Equal(t, http.StatusPreconditionFailed, cerr.StatusCode())
+		require.Equal(t, http.StatusBadRequest, cerr.StatusCode())
 	})
 
 	t.Run("allUsers", func(t *testing.T) {


### PR DESCRIPTION
* Fixes #5422

### Summary

In all cases where a **412 Precondition Failed** is used, it is actually a **400 Bad Request** response (often with a descriptor for the particular reason).

It's easy to see why status 412 was used, because on a surface level it makes sense. You're waiting on a condition for a successful request, like a job completing, workspaces to be deleted before removing a template, configuring a particular oauth method etc..

However, these requests aren't conditional, and should be represented as bad requests. Think of it like being told the ice cream machine at McDonalds is broken, but you keep re-ordering the ice cream in the exact same way; technically there _is_ a precondition failure that the ice cream machine is working, but that's not factored into your request. If you were to validate the state of the ice cream machine beforehand, maybe it would be different, but you're making a request against an ice cream machine that happens to be broken, so in that way you're making a bad/unreasonable request. 