### PR TITLE
ci: allow writing security events for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+permissions:
+  security-events: write
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
