### PR TITLE
feat: add `coder.volumes` parameter to Helm chart

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -95,6 +95,11 @@ Coder volume definitions.
   secret:
     secretName: {{ $secret.name | quote }}
 {{ end -}}
+{{ if .Values.coder.kubeConfig.secretName != null -}}
+- name: "kube-config"
+  secret:
+    secretName: {{ .Values.coder.kubeConfig.secretName }}
+{{ end -}}
 {{- end }}
 
 {{/*
@@ -122,6 +127,12 @@ Coder volume mounts.
 - name: "ca-cert-{{ $secret.name }}"
   mountPath: "/etc/ssl/certs/{{ $secret.name }}.crt"
   subPath: {{ $secret.key | quote }}
+  readOnly: true
+{{ end -}}
+{{ if .Values.coder.kubeConfig.secretName != null -}}
+- name: "kube-config"
+  mountPath: "/home/coder/.kube/config"
+  subPath: {{ .Values.coder.kubeConfig.keyName }}
   readOnly: true
 {{ end -}}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -95,10 +95,8 @@ Coder volume definitions.
   secret:
     secretName: {{ $secret.name | quote }}
 {{ end -}}
-{{ if .Values.coder.kubeConfig.secretName != null -}}
-- name: "kube-config"
-  secret:
-    secretName: {{ .Values.coder.kubeConfig.secretName }}
+{{ if gt (len .Values.coder.volumes) 0 -}}
+{{ toYaml .Values.coder.volumes }}
 {{ end -}}
 {{- end }}
 
@@ -129,11 +127,8 @@ Coder volume mounts.
   subPath: {{ $secret.key | quote }}
   readOnly: true
 {{ end -}}
-{{ if .Values.coder.kubeConfig.secretName != null -}}
-- name: "kube-config"
-  mountPath: "/home/coder/.kube/config"
-  subPath: {{ .Values.coder.kubeConfig.keyName }}
-  readOnly: true
+{{ if gt (len .Values.coder.volumeMounts) 0 -}}
+{{ toYaml .Values.coder.volumeMounts }}
 {{ end -}}
 {{- end }}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -52,7 +52,24 @@ coder:
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
   # - CODER_PROMETHEUS_ADDRESS: set to 0.0.0.0:6060 and cannot be changed.
   #   Prometheus must still be enabled by setting CODER_PROMETHEUS_ENABLE.
+  # - KUBE_POD_IP
+  # - CODER_DERP_SERVER_RELAY_URL
+  #
+  # We will additionally set CODER_ACCESS_URL if unset to the cluster service
+  # URL.
   env: []
+  # - name: "CODER_ACCESS_URL"
+  #   value: "https://coder.example.com"
+
+  # coder.volumes -- A list of extra volumes to add to the Coder pod.
+  volumes: []
+  # - name: "my-volume"
+  #   emptyDir: {}
+
+  # coder.volumeMounts -- A list of extra volume mounts to add to the Coder pod.
+  volumeMounts: []
+  # - name: "my-volume"
+  #   mountPath: "/mnt/my-volume"
 
   # coder.tls -- The TLS configuration for Coder.
   tls:
@@ -171,9 +188,3 @@ coder:
       # coder.ingress.tls.wildcardSecretName -- The name of the TLS secret to
       # use for the wildcard host.
       wildcardSecretName: ""
-
-  # A secret ref that contains a Kubernetes configuration file that will be mounted at
-  # ~/.kube/config on the Coder host.
-  kubeConfig:
-    secretName: null
-    keyName: config

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -171,3 +171,9 @@ coder:
       # coder.ingress.tls.wildcardSecretName -- The name of the TLS secret to
       # use for the wildcard host.
       wildcardSecretName: ""
+
+  # A secret ref that contains a Kubernetes configuration file that will be mounted at
+  # ~/.kube/config on the Coder host.
+  kubeConfig:
+    secretName: null
+    keyName: config


### PR DESCRIPTION
This PR adds a `coder.kubeConfig` parameter to the Helm chart so that we can mount a `~/.kube/config` file on the Coder host.

See https://github.com/coder/coder/issues/5548