### PR TITLE
chore: remove address from deployment page

### DIFF
--- a/site/src/pages/DeploySettingsPage/GeneralSettingsPage.tsx
+++ b/site/src/pages/DeploySettingsPage/GeneralSettingsPage.tsx
@@ -23,7 +23,6 @@ const GeneralSettingsPage: React.FC = () => {
       <OptionsTable
         options={{
           access_url: deploymentConfig.access_url,
-          address: deploymentConfig.address,
           wildcard_access_url: deploymentConfig.wildcard_access_url,
         }}
       />


### PR DESCRIPTION
The `address` deployment config field is deprecated in favor of `http_address` and `tls.address`.

I considered adding replacing this value with both of the above values, but it doesn't make sense as the `tls.address` may have a value even if TLS is disabled (`tls.enabled`). We'd have to have the TLS enabled value here too for this to make sense, but it's already in the security page.

At the end of the day this doesn't really matter and is easy to discern from the logs (or the page URL) so I removed it.