### PR TITLE
feat: Allow Docker container to run as root with builtin pg as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ COPY --chown=1000:1000 --chmod=700 empty-dir /home/coder
 # The coder binary is injected by scripts/build_docker.sh.
 COPY --chown=1000:1000 --chmod=755 coder /opt/coder
 
+# For cases where the container is run as root, allow embedded postgres,
+# if enabled, to be de-elevated.
+ENV CODER_CONFIG_DIR=/home/coder/.config/coderv2 CODER_BUILTIN_POSTGRES_UID=1000 CODER_BUILTIN_POSTGRES_GID=1000
+
 USER 1000:1000
 ENV HOME=/home/coder
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ COPY --chown=1000:1000 --chmod=700 empty-dir /home/coder
 # The coder binary is injected by scripts/build_docker.sh.
 COPY --chown=1000:1000 --chmod=755 coder /opt/coder
 
+# We prefer to store the configuration in /home/coder/.config/coderv2,
+# even if the container is run as root.
+ENV CODER_CONFIG_DIR=/home/coder/.config/coderv2
 # For cases where the container is run as root, allow embedded postgres,
 # if enabled, to be de-elevated.
-ENV CODER_CONFIG_DIR=/home/coder/.config/coderv2
 ENV CODER_BUILTIN_POSTGRES_USER=1000:1000
 
 USER 1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ COPY --chown=1000:1000 --chmod=755 coder /opt/coder
 
 # For cases where the container is run as root, allow embedded postgres,
 # if enabled, to be de-elevated.
-ENV CODER_CONFIG_DIR=/home/coder/.config/coderv2 CODER_BUILTIN_POSTGRES_UID=1000 CODER_BUILTIN_POSTGRES_GID=1000
+ENV CODER_CONFIG_DIR=/home/coder/.config/coderv2
+ENV CODER_BUILTIN_POSTGRES_USER=1000:1000
 
 USER 1000:1000
 ENV HOME=/home/coder

--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -168,6 +168,12 @@ func newConfig() *codersdk.DeploymentConfig {
 			Flag:   "postgres-url",
 			Secret: true,
 		},
+		PostgresBuiltinUser: &codersdk.DeploymentConfigField[string]{
+			Name:   "Postgres Built-in User",
+			Usage:  "The built-in PostgreSQL database will be run as this user (uid:gid) if the server is started as root. This allows the server to be run as root using the built-in PostgreSQL database.",
+			Flag:   "postgres-builtin-user",
+			Hidden: true,
+		},
 		OAuth2: &codersdk.OAuth2Config{
 			Github: &codersdk.OAuth2GithubConfig{
 				ClientID: &codersdk.DeploymentConfigField[string]{

--- a/cli/server.go
+++ b/cli/server.go
@@ -14,6 +14,7 @@ import (
 	"net/http/pprof"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"os/user"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -187,17 +189,106 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 			builtinPostgres := false
 			// Only use built-in if PostgreSQL URL isn't specified!
 			if !cfg.InMemoryDatabase.Value && cfg.PostgresURL.Value == "" {
-				var closeFunc func() error
-				cmd.Printf("Using built-in PostgreSQL (%s)\n", config.PostgresPath())
-				cfg.PostgresURL.Value, closeFunc, err = startBuiltinPostgres(ctx, config, logger)
+				u, err := user.Current()
 				if err != nil {
-					return err
+					return xerrors.Errorf("current user: %w", err)
+				}
+				var closePostgres func() error
+				switch {
+				// This is a special case for the Docker image where the
+				// user is set to root to conveniently allow operations on
+				// e.g. the Docker socket.
+				case u.Uid == "0":
+					parseUint32 := func(s string) uint32 {
+						v, err := strconv.ParseUint(s, 10, 32)
+						if err != nil {
+							return 0
+						}
+						return uint32(v)
+					}
+					uid := parseUint32(os.Getenv("CODER_BUILTIN_POSTGRES_UID"))
+					gid := parseUint32(os.Getenv("CODER_BUILTIN_POSTGRES_GID"))
+					if uid == 0 || gid == 0 {
+						return xerrors.Errorf("CODER_BUILTIN_POSTGRES_UID and CODER_BUILTIN_POSTGRES_GID must be set when using built-in PostgreSQL and running as root")
+					}
+
+					cmd.Printf("Using built-in PostgreSQL (%s) as %d:%d\n", config.PostgresPath(), uid, gid)
+					cfg.PostgresURL.Value, err = embeddedPostgresURL(config)
+					if err != nil {
+						return err
+					}
+
+					// TODO(mafredri): Ensure all relevant configs / envs are
+					// propagated to serve.
+					pgCmd := exec.Command(os.Args[0], "server", "postgres-builtin-serve") //nolint:gosec
+					pgCmd.Stdout = cmd.OutOrStdout()
+					pgCmd.Stderr = cmd.ErrOrStderr()
+					pgCmd.Env = append([]string{}, os.Environ()...)
+
+					// TODO(mafredri): Embedded postgres will do os.MkdirAll,
+					// but that will fail if $HOME/.config doesn't have the
+					// right permissions, fix this.
+					os.MkdirAll(config.PostgresPath(), 0o750)
+					os.Chown(config.PostgresPath(), int(uid), int(gid))
+
+					pgCmd.Env = append(pgCmd.Env, "CODER_CONFIG_DIR="+string(config))
+					pgCmd.SysProcAttr = &syscall.SysProcAttr{
+						// Prevent Ctrl+C propagation via process group (handle manually).
+						Setpgid: true,
+						Pgid:    0,
+					}
+					pgCmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
+					err = pgCmd.Start()
+					if err != nil {
+						return xerrors.Errorf("start built-in PostgreSQL: %w", err)
+					}
+					defer func() {
+						err := pgCmd.Wait()
+						if err != nil {
+							cmd.Printf("Built-in PostgreSQL exited: %v", err)
+						}
+					}()
+					closePostgres = func() error {
+						return pgCmd.Process.Signal(os.Interrupt)
+					}
+					defer closePostgres() // Ensure this is called in case of error below.
+
+					// Wait for PostgreSQL to be ready.
+					for i := 0; ; i++ {
+						ok, err := func() (bool, error) {
+							sqlDB, err := sql.Open(sqlDriver, cfg.PostgresURL.Value)
+							if err != nil {
+								return false, err
+							}
+							defer sqlDB.Close()
+							err = sqlDB.PingContext(ctx)
+							if err != nil {
+								return false, err
+							}
+							return true, nil
+						}()
+						if xerrors.Is(err, context.Canceled) {
+							return err
+						}
+						if ok {
+							break
+						}
+						if i == 100 { // 50 * 100ms = 5s.
+							return xerrors.New("wait for built-in PostgreSQL timeout")
+						}
+						time.Sleep(50 * time.Millisecond)
+					}
+				default:
+					cmd.Printf("Using built-in PostgreSQL (%s)\n", config.PostgresPath())
+					cfg.PostgresURL.Value, closePostgres, err = startBuiltinPostgres(ctx, config, logger)
+					if err != nil {
+						return err
+					}
 				}
 				builtinPostgres = true
 				defer func() {
 					cmd.Printf("Stopping built-in PostgreSQL...\n")
-					// Gracefully shut PostgreSQL down!
-					if err := closeFunc(); err != nil {
+					if err := closePostgres(); err != nil {
 						cmd.Printf("Failed to stop built-in PostgreSQL: %v\n", err)
 					} else {
 						cmd.Printf("Stopped built-in PostgreSQL\n")
@@ -561,7 +652,7 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 				}
 				logger.Debug(ctx, "connected to postgresql", slog.F("version", versionStr))
 
-				err = sqlDB.Ping()
+				err = sqlDB.PingContext(ctx)
 				if err != nil {
 					return xerrors.Errorf("ping postgres: %w", err)
 				}

--- a/cli/server_linux.go
+++ b/cli/server_linux.go
@@ -39,9 +39,8 @@ func startBuiltinPostgresAs(ctx context.Context, uid, gid uint32, stdout, stderr
 	}
 
 	// Fix privileges for the postgres directory, note that this will
-	// won't help if the coder config is located inside e.g. /root
-	// because the unprivileged user won't be able to access anything
-	// inside.
+	// not help if the coder config is located inside e.g. /root because
+	// the unprivileged user won't be able to access anything inside.
 	err = filepath.WalkDir(cfg.PostgresPath(), func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/cli/server_linux.go
+++ b/cli/server_linux.go
@@ -1,0 +1,121 @@
+//go:build linux
+
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/cli/config"
+)
+
+func startBuiltinPostgresAs(ctx context.Context, uid, gid uint32, stdout, stderr io.Writer, cfg config.Root, connectionURL string) (closer func() error, err error) {
+	cmd := exec.Command(os.Args[0], "server", "postgres-builtin-serve") //nolint:gosec
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	// The postgres-builtin-serve command only uses the global config dir.
+	cmd.Env = append(cmd.Env, "CODER_CONFIG_DIR="+string(cfg))
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// Drop privileges.
+		Credential: &syscall.Credential{
+			Uid: uid,
+			Gid: gid,
+		},
+		// Prevent signal propagation via
+		// process group (handle manually).
+		Setpgid: true,
+		Pgid:    0,
+	}
+
+	// Fix privileges for the postgres directory, note that this will
+	// won't help if the coder config is located inside e.g. /root
+	// because the unprivileged user won't be able to access anything
+	// inside.
+	err = filepath.WalkDir(cfg.PostgresPath(), func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		err = os.Chown(path, int(uid), int(gid))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, xerrors.Errorf("start built-in PostgreSQL: %w", err)
+	}
+	errC := make(chan error, 1)
+	go func() {
+		errC <- cmd.Wait()
+		close(errC)
+	}()
+
+	closePg := func() error {
+		err := cmd.Process.Signal(os.Interrupt)
+		if err != nil {
+			return err
+		}
+		err = <-errC
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	defer func() {
+		if err != nil {
+			_ = closePg()
+		}
+	}()
+
+	// Wait for PostgreSQL to be ready.
+	for i := 0; ; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case err = <-errC:
+			return nil, xerrors.Errorf("built-in PostgreSQL exited: %w", err)
+		default:
+		}
+
+		ok, err := func() (bool, error) {
+			sqlDB, err := sql.Open("postgres", connectionURL)
+			if err != nil {
+				return false, err
+			}
+			defer sqlDB.Close()
+			err = sqlDB.PingContext(ctx)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}()
+		if xerrors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		if ok {
+			break
+		}
+		if i >= 100 { // 50 * 100ms = 5s.
+			return nil, xerrors.Errorf("wait for built-in PostgreSQL timeout: %w", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return closePg, nil
+}

--- a/cli/server_other.go
+++ b/cli/server_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package cli
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+)
+
+func startBuiltinPostgresAs(ctx context.Context, uid, gid uint32, stdout, stderr io.Writer, cfg config.Root, connectionURL string) (closer func() error, err error) {
+	return nil, xerrors.New("not implemented")
+}

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1615,6 +1615,9 @@ const docTemplate = `{
                 "pg_connection_url": {
                     "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
                 },
+                "postgres_builtin_user": {
+                    "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
+                },
                 "pprof": {
                     "$ref": "#/definitions/codersdk.PprofConfig"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1435,6 +1435,9 @@
         "pg_connection_url": {
           "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
         },
+        "postgres_builtin_user": {
+          "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
+        },
         "pprof": {
           "$ref": "#/definitions/codersdk.PprofConfig"
         },

--- a/codersdk/deploymentconfig.go
+++ b/codersdk/deploymentconfig.go
@@ -26,6 +26,7 @@ type DeploymentConfig struct {
 	CacheDirectory                  *DeploymentConfigField[string]          `json:"cache_directory" typescript:",notnull"`
 	InMemoryDatabase                *DeploymentConfigField[bool]            `json:"in_memory_database" typescript:",notnull"`
 	PostgresURL                     *DeploymentConfigField[string]          `json:"pg_connection_url" typescript:",notnull"`
+	PostgresBuiltinUser             *DeploymentConfigField[string]          `json:"postgres_builtin_user" typescript:",notnull"`
 	OAuth2                          *OAuth2Config                           `json:"oauth2" typescript:",notnull"`
 	OIDC                            *OIDCConfig                             `json:"oidc" typescript:",notnull"`
 	Telemetry                       *TelemetryConfig                        `json:"telemetry" typescript:",notnull"`

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -548,6 +548,17 @@ curl -X GET http://coder-server:8080/api/v2/config/deployment \
     "usage": "string",
     "value": "string"
   },
+  "postgres_builtin_user": {
+    "default": "string",
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": "string"
+  },
   "pprof": {
     "address": {
       "default": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1132,6 +1132,17 @@ CreateParameterRequest is a structure used to create a new parameter value for a
     "usage": "string",
     "value": "string"
   },
+  "postgres_builtin_user": {
+    "default": "string",
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": "string"
+  },
   "pprof": {
     "address": {
       "default": "string",
@@ -1525,6 +1536,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `oauth2`                             | [codersdk.OAuth2Config](#codersdkoauth2config)                                                                             | false    |              |             |
 | `oidc`                               | [codersdk.OIDCConfig](#codersdkoidcconfig)                                                                                 | false    |              |             |
 | `pg_connection_url`                  | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |             |
+| `postgres_builtin_user`              | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |             |
 | `pprof`                              | [codersdk.PprofConfig](#codersdkpprofconfig)                                                                               | false    |              |             |
 | `prometheus`                         | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                                                     | false    |              |             |
 | `provisioner`                        | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                                                   | false    |              |             |

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -288,6 +288,7 @@ export interface DeploymentConfig {
   readonly cache_directory: DeploymentConfigField<string>
   readonly in_memory_database: DeploymentConfigField<boolean>
   readonly pg_connection_url: DeploymentConfigField<string>
+  readonly postgres_builtin_user: DeploymentConfigField<string>
   readonly oauth2: OAuth2Config
   readonly oidc: OIDCConfig
   readonly telemetry: TelemetryConfig


### PR DESCRIPTION
This is a prototype implementation for allowing to run embedded postgres with lower credentials inside Docker if started as root.

If we go forward, this needs to be cleaned up.

**Purpose:** Allow Docker Desktop users on macOS to quick-start via:

```
docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock --name coder --user root ghcr.io/coder/coder:latest
```

This would allow us to improve documentation and fix https://github.com/coder/coder/issues/5263.