### PR TITLE
fix: styles for <AlertBanner />

### DIFF
--- a/site/src/components/AlertBanner/AlertBanner.tsx
+++ b/site/src/components/AlertBanner/AlertBanner.tsx
@@ -96,6 +96,11 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     borderRadius: theme.shape.borderRadius,
     padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
     backgroundColor: `${colors.gray[16]}`,
+    textAlign: "left",
+
+    "& span": {
+      paddingTop: `${theme.spacing(0.25)}px`
+    },
 
     // targeting the alert icon rather than the expander icon
     "& svg:nth-child(2)": {

--- a/site/src/components/AlertBanner/AlertBanner.tsx
+++ b/site/src/components/AlertBanner/AlertBanner.tsx
@@ -99,7 +99,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     textAlign: "left",
 
     "& span": {
-      paddingTop: `${theme.spacing(0.25)}px`
+      paddingTop: `${theme.spacing(0.25)}px`,
     },
 
     // targeting the alert icon rather than the expander icon

--- a/site/src/pages/LoginPage/LoginPageView.stories.tsx
+++ b/site/src/pages/LoginPage/LoginPageView.stories.tsx
@@ -17,3 +17,15 @@ Example.args = {
   onSignIn: action("onSignIn"),
   context: {},
 }
+
+const err = new Error("You are signed out or your session has expired. Please sign in again to continue.")
+
+export const AuthError = Template.bind({})
+AuthError.args = {
+  isLoading: false,
+  onSignIn: action("onSignIn"),
+  context: {
+    authError: err
+  },
+}
+

--- a/site/src/pages/LoginPage/LoginPageView.stories.tsx
+++ b/site/src/pages/LoginPage/LoginPageView.stories.tsx
@@ -18,14 +18,15 @@ Example.args = {
   context: {},
 }
 
-const err = new Error("You are signed out or your session has expired. Please sign in again to continue.")
+const err = new Error(
+  "You are signed out or your session has expired. Please sign in again to continue.",
+)
 
 export const AuthError = Template.bind({})
 AuthError.args = {
   isLoading: false,
   onSignIn: action("onSignIn"),
   context: {
-    authError: err
+    authError: err,
   },
 }
-


### PR DESCRIPTION
This fixes a minor styling issue on the login page with the `<AlertBanner />`. The text alignment was centered-aligned when it should be left-aligned.

I also added some top padding to the "Click here to learn more".

I added a Storybook story to reproduce and then fixed it.

## Before
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/3806031/210642421-c4fbfcda-7aaa-431d-b5e6-1a1ffa89584d.png">


## After

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/3806031/210642288-91bddf3d-540b-4b9f-a7a4-db9e2cb094ee.png">

