### PR TITLE
fix: Display service banner after login

### DIFF
--- a/site/src/components/ServiceBanner/ServiceBanner.tsx
+++ b/site/src/components/ServiceBanner/ServiceBanner.tsx
@@ -1,14 +1,22 @@
 import { useActor } from "@xstate/react"
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { XServiceContext } from "xServices/StateContext"
 import { ServiceBannerView } from "./ServiceBannerView"
 
 export const ServiceBanner: React.FC = () => {
   const xServices = useContext(XServiceContext)
-  const [appearanceState] = useActor(xServices.appearanceXService)
-
+  const [appearanceState, appearanceSend] = useActor(
+    xServices.appearanceXService,
+  )
+  const [authState] = useActor(xServices.authXService)
   const { message, background_color, enabled } =
     appearanceState.context.appearance.service_banner
+
+  useEffect(() => {
+    if (authState.matches("signedIn")) {
+      appearanceSend("GET_APPEARANCE")
+    }
+  }, [appearanceSend, authState])
 
   if (!enabled) {
     return null

--- a/site/src/xServices/appearance/appearanceXService.ts
+++ b/site/src/xServices/appearance/appearanceXService.ts
@@ -50,7 +50,7 @@ export const appearanceMachine = createMachine(
       appearance: emptyAppearance,
       preview: false,
     },
-    initial: "gettingAppearance",
+    initial: "idle",
     states: {
       idle: {
         on: {


### PR DESCRIPTION
When the user was not signed in, the service banner request was made on the login screen, so the API was returning a 401 error. I updated the state to start idle and only fetch the appearance info when the user is signed in.