### PR TITLE
feat: add storybook for /deployments/general

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -71,7 +71,10 @@ const SettingsGroupPage = lazy(
   () => import("./pages/GroupsPage/SettingsGroupPage"),
 )
 const GeneralSettingsPage = lazy(
-  () => import("./pages/DeploySettingsPage/GeneralSettingsPage"),
+  () =>
+    import(
+      "./pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPage"
+    ),
 )
 const SecuritySettingsPage = lazy(
   () => import("./pages/DeploySettingsPage/SecuritySettingsPage"),

--- a/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPage.tsx
+++ b/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPage.tsx
@@ -1,0 +1,20 @@
+import { useDeploySettings } from "components/DeploySettingsLayout/DeploySettingsLayout"
+import React from "react"
+import { Helmet } from "react-helmet-async"
+import { pageTitle } from "util/page"
+import { GeneralSettingsPageView } from "./GeneralSettingsPageView"
+
+const GeneralSettingsPage: React.FC = () => {
+  const { deploymentConfig: deploymentConfig } = useDeploySettings()
+
+  return (
+    <>
+      <Helmet>
+        <title>{pageTitle("General Settings")}</title>
+      </Helmet>
+      <GeneralSettingsPageView deploymentConfig={deploymentConfig} />
+    </>
+  )
+}
+
+export default GeneralSettingsPage

--- a/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.stories.tsx
+++ b/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.stories.tsx
@@ -1,0 +1,33 @@
+import { ComponentMeta, Story } from "@storybook/react"
+import {
+  GeneralSettingsPageView,
+  GeneralSettingsPageViewProps,
+} from "./GeneralSettingsPageView"
+
+export default {
+  title: "pages/GeneralSettingsPageView",
+  component: GeneralSettingsPageView,
+  argTypes: {
+    deploymentConfig: {
+      defaultValue: {
+        access_url: {
+          name: "Access URL",
+          usage:
+            "External URL to access your deployment. This must be accessible by all provisioned workspaces.",
+          value: "https://dev.coder.com",
+        },
+        wildcard_access_url: {
+          name: "Wildcard Access URL",
+          usage:
+            'Specifies the wildcard hostname to use for workspace applications in the form "*.example.com".',
+          value: "*--apps.dev.coder.com",
+        },
+      },
+    },
+  },
+} as ComponentMeta<typeof GeneralSettingsPageView>
+
+const Template: Story<GeneralSettingsPageViewProps> = (args) => (
+  <GeneralSettingsPageView {...args} />
+)
+export const Page = Template.bind({})

--- a/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -8,7 +8,6 @@ export type GeneralSettingsPageViewProps = {
 export const GeneralSettingsPageView = ({
   deploymentConfig,
 }: GeneralSettingsPageViewProps): JSX.Element => {
-  console.log(deploymentConfig, " is this")
   return (
     <>
       <Header

--- a/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -1,18 +1,16 @@
-import { useDeploySettings } from "components/DeploySettingsLayout/DeploySettingsLayout"
+import { DeploymentConfig } from "api/typesGenerated"
 import { Header } from "components/DeploySettingsLayout/Header"
 import OptionsTable from "components/DeploySettingsLayout/OptionsTable"
-import React from "react"
-import { Helmet } from "react-helmet-async"
-import { pageTitle } from "util/page"
 
-const GeneralSettingsPage: React.FC = () => {
-  const { deploymentConfig: deploymentConfig } = useDeploySettings()
-
+export type GeneralSettingsPageViewProps = {
+  deploymentConfig: Pick<DeploymentConfig, "access_url" | "wildcard_access_url">
+}
+export const GeneralSettingsPageView = ({
+  deploymentConfig,
+}: GeneralSettingsPageViewProps): JSX.Element => {
+  console.log(deploymentConfig, " is this")
   return (
     <>
-      <Helmet>
-        <title>{pageTitle("General Settings")}</title>
-      </Helmet>
       <Header
         title="General"
         description="Information about your Coder deployment."
@@ -27,5 +25,3 @@ const GeneralSettingsPage: React.FC = () => {
     </>
   )
 }
-
-export default GeneralSettingsPage


### PR DESCRIPTION
- refactor: split GeneralSettings page <> View
- feat: add story for generalsettingspageview

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/3806031/210865035-85bcdd93-154b-480c-b19a-8bc4a6d28f98.png">
