### PR TITLE
fix(ci): fix winget package submission

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -15,13 +15,6 @@ jobs:
         run: |
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      # The package version is the same as the tag minus the leading "v".
-      - name: Calculate package version
-        id: version
-        run: |
-          $version = $env:CODER_VERSION -replace "^v", ""
-          echo "::set-output name=version::$version"
-
       - name: Submit updated manifest to winget-pkgs
         run: |
           $release_assets = gh release view --repo coder/coder "$env:CODER_VERSION" --json assets | `
@@ -32,6 +25,11 @@ jobs:
             Select -ExpandProperty url
 
           echo "Installer URL: $installer_url"
+
+          # The package version is the same as the tag minus the leading "v".
+          $version = $env:CODER_VERSION -replace "^v", ""
+          
+          echo "Package vesion: $version"
 
           # The URL "|X64" suffix forces the architecture as it cannot be
           # sniffed properly from the URL. wingetcreate checks both the URL and
@@ -44,7 +42,7 @@ jobs:
           # submission.
           .\wingetcreate.exe update Coder.Coder `
             --submit `
-            --version "${{ steps.version.outputs.version }}" `
+            --version "${version}" `
             --urls "${installer_url}|X64" `
             --token "${{ secrets.CDRCI_GITHUB_TOKEN }}"
 

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           $release_assets = gh release view --repo coder/coder "$env:CODER_VERSION" --json assets | `
             ConvertFrom-Json
-
+          # Get the installer URL from the release assets.
           $installer_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_amd64_installer.exe$" | `
             Select -ExpandProperty url
@@ -28,8 +28,8 @@ jobs:
 
           # The package version is the same as the tag minus the leading "v".
           $version = $env:CODER_VERSION -replace "^v", ""
-          
-          echo "Package vesion: $version"
+
+          echo "Package version: $version"
 
           # The URL "|X64" suffix forces the architecture as it cannot be
           # sniffed properly from the URL. wingetcreate checks both the URL and


### PR DESCRIPTION
I removed the step to calculate the version, as somehow the `$version` was not populated with the version. Also, GitHub actions suggest removing `:set-output:` as it is deprecated. 

This commit should probably fix the winget package submission using `wingetcreate` cli.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
@bpmct Thanks for pinging me, though. 
I have tested all commands locally and they seem to work.