### PR TITLE
chore: Add more categories and titles for release notes

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -106,7 +106,8 @@ main() {
 			commit_prefix=${BASH_REMATCH[1]}
 		fi
 		case $commit_prefix in
-		feat | fix)
+		# From: https://github.com/commitizen/conventional-commit-types
+		feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert)
 			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$commit_prefix
 			;;
 		*)

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -64,53 +64,78 @@ source "$SCRIPT_DIR/release/check_commit_metadata.sh" "${old_version}" "${ref}"
 # Sort commits by title prefix, then by date, only return sha at the end.
 mapfile -t commits < <(git log --no-merges --pretty=format:"%ct %h %s" "${old_version}..${ref}" | sort -k3,3 -k1,1n | cut -d' ' -f2)
 
-breaking_changelog=
-feat_changelog=
-fix_changelog=
-other_changelog=
+# From: https://github.com/commitizen/conventional-commit-types
+# NOTE(mafredri): These need to be supported in check_commit_metadata.sh as well.
+declare -a section_order=(
+	breaking
+	feat
+	fix
+	docs
+	refactor
+	perf
+	test
+	build
+	ci
+	chore
+	revert
+	other
+)
+
+declare -A section_titles=(
+	[breaking]='BREAKING CHANGES'
+	[feat]='Features'
+	[fix]='Bug Fixes'
+	[docs]='Documentation'
+	[refactor]='Code Refactoring'
+	[perf]='Performance Improvements'
+	[test]='Tests'
+	[build]='Builds'
+	[ci]='Continuous Integration'
+	[chore]='Chores'
+	[revert]='Reverts'
+	[other]='Other Changes'
+)
+
+# Verify that all items in section_order exist as keys in section_titles and
+# vice-versa.
+for cat in "${section_order[@]}"; do
+	if [[ " ${!section_titles[*]} " != *" $cat "* ]]; then
+		error "BUG: ategory $cat does not exist in section_titles"
+	fi
+done
+for cat in "${!section_titles[@]}"; do
+	if [[ " ${section_order[*]} " != *" $cat "* ]]; then
+		error "BUG: Category $cat does not exist in section_order"
+	fi
+done
 
 for commit in "${commits[@]}"; do
 	line="- $commit ${COMMIT_METADATA_TITLE[$commit]}\n"
 
-	case "${COMMIT_METADATA_CATEGORY[$commit]}" in
-	breaking)
-		breaking_changelog+="$line"
-		;;
-	feat)
-		feat_changelog+="$line"
-		;;
-	fix)
-		fix_changelog+="$line"
-		;;
-	*)
-		other_changelog+="$line"
-		;;
-	esac
+	# Default to "other" category.
+	cat=other
+	for c in "${!section_titles[@]}"; do
+		if [[ $c == "${COMMIT_METADATA_CATEGORY[$commit]}" ]]; then
+			cat=$c
+			break
+		fi
+	done
+	declare "$cat"_changelog+="$line"
 done
 
 changelog="$(
-	if ((${#breaking_changelog} > 0)); then
-		echo -e "### BREAKING CHANGES\n"
-		echo -e "$breaking_changelog"
-	fi
-	if ((${#feat_changelog} > 0)); then
-		echo -e "### Features\n"
-		echo -e "$feat_changelog"
-	fi
-	if ((${#fix_changelog} > 0)); then
-		echo -e "### Bug fixes\n"
-		echo -e "$fix_changelog"
-	fi
-	if ((${#other_changelog} > 0)); then
-		echo -e "### Other changes\n"
-		echo -e "$other_changelog"
-	fi
+	for cat in "${section_order[@]}"; do
+		changes="$(eval "echo -e \"\${${cat}_changelog:-}\"")"
+		if ((${#changes} > 0)); then
+			echo -e "\n### ${section_titles["$cat"]}\n"
+			echo -e "$changes"
+		fi
+	done
 )"
 
 image_tag="$(execrelative ./image_tag.sh --version "$new_version")"
 
 echo -e "## Changelog
-
 $changelog
 
 Compare: [\`${old_version}...${new_version}\`](https://github.com/coder/coder/compare/${old_version}...${new_version})

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -100,7 +100,7 @@ declare -A section_titles=(
 # vice-versa.
 for cat in "${section_order[@]}"; do
 	if [[ " ${!section_titles[*]} " != *" $cat "* ]]; then
-		error "BUG: ategory $cat does not exist in section_titles"
+		error "BUG: category $cat does not exist in section_titles"
 	fi
 done
 for cat in "${!section_titles[@]}"; do

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -140,7 +140,7 @@ $changelog
 
 Compare: [\`${old_version}...${new_version}\`](https://github.com/coder/coder/compare/${old_version}...${new_version})
 
-## Container image
+## Container Image
 
 - \`docker pull $image_tag\`
 "


### PR DESCRIPTION
This PR adds more sections/titles to the autogenerated release notes.

Compare old: https://github.com/coder/coder/releases/tag/v0.14.0

VS new:

```markdown
## Changelog

### BREAKING CHANGES

- 8bb7e17b chore!: remove GET workspaceagents/me/report-stats (#5530)
- 04d45f3c fix!: remove AUTO_IMPORT_TEMPLATE for Kubernetes installs (#5401)
- 3e2e2ac4 fix: enforce unique agent names per workspace (#5497)

### Features

- de0601d6 feat: allow configurable username claim field in OIDC (#5507)
- 0dba2def feat: enable enterprise users to specify a custom logo (#5566)
- dcf6c201 feat: add `coder.volumes` parameter to Helm chart (#5551)
- 5a968e2f feat: add flag to disaable all rate limits (#5570)
- bb03df81 feat: add storybook for /deployment/appearance page (#5582)
- 59e919ab feat: add storybook for /deployments/general (#5595)
- f1fe2b5c feat: add GPG forwarding to coder ssh (#5482)
- 242676ba feat: add storybook for /deployment/gitauth (#5596)
- 763147e5 feat: add storybook for /deployment/network (#5603)
- 9b602f55 feat: Added --with-terraform argument to install coder and terraform together (#5586)
- 6807ad0d feat: add storybook for /deployment/userauth (#5609)

### Bug Fixes

- 0124289f fix(ci): fix winget installer workflow (#5569)
- 41802294 fix: use template default ttl when enabling auto-stop (#5494)
- 8968a000 fix: add spacing between the copyright and login box (#5578)
- c51b5a05 fix: add case for non-entitled logo url (#5580)
- a231c1a3 fix: styles for <AlertBanner /> (#5579)
- 0d30a1eb fix: Display service banner after login (#5594)
- aa68e0f8 fix: Too many requests  during watching template version (#5602)
- 888766c1 fix: respect global `--url` flag in `coder login` (#5613)
- a4ca8ffa fix: don't hang forever getting pg version (#5614)

### Documentation

- 461c0d0d docs: v1 docs redirect (#5509)
- 05dc83e5 docs: add hero image to About (#5539)
- e67d1315 docs: audit, deploymentconfig, files, parameters (#5506)
- c5128db4 docs: Add auditor role to roles table (#5557)
- 925b2983 docs: improve authentication page (#5567)
- 66fa2a1a docs: API workspace agents and builds (#5538)

### Code Refactoring

- 829cfee2 refactor: Improve users table view for non admins (#5547)
- 4e14cc52 refactor: Remove template UI from experimental (#5555)
- a36cd0bd refactor: move footer items into the user dropdown (#5562)
- 175be621 refactor: Improve roles UI (#5576)
- ab7e676b refactor: Refactor user menu (#5591)
- 70d71bc7 refactor: Do not display port forward button if it is disabled (#5604)

### Continuous Integration

- 341c4329 ci: enable CodeQL code scanning (#5279)

### Chores

- 26b54cd1 chore(autofix): upgrade-examples-terraform-provider-coder (#5498)
- 86c1753e chore: bump react-i18next from 12.0.0 to 12.1.1 in /site (#5525)
- f711abb2 chore: bump github.com/elastic/go-sysinfo from 1.8.1 to 1.9.0 (#5524)
- 8d254bd9 chore: bump github.com/prometheus/client_model from 0.2.0 to 0.3.0 (#5523)
- 54eb6a5b chore: bump github.com/valyala/fasthttp from 1.41.0 to 1.43.0 (#5522)
- b6dab5fb chore: bump golang.org/x/text from 0.4.0 to 0.5.0 (#5521)
- 4b093115 chore: bump google-github-actions/setup-gcloud from 0 to 1 (#5517)
- d124fab6 chore: bump jaxxstorm/action-install-gh-release from 1.7.1 to 1.9.0 (#5516)
- 5435bcea chore: bump tj-actions/branch-names from 6.3 to 6.4 (#5518)
- 856f0ab6 chore: Improve project-wide prettier formatting and ignored files (#5505)
- 3969a8b5 chore: bump prettier from 2.7.1 to 2.8.1 in /site (#5526)
- 5e36fd52 chore: bump cronstrue from 2.14.0 to 2.21.0 in /site (#5545)
- f1419bbc chore: bump golang.org/x/term from 0.2.0 to 0.3.0 (#5543)
- ed114ec3 chore: bump golang.org/x/tools from 0.3.0 to 0.4.0 (#5542)
- 3e2477f2 chore: bump actions/stale from 6.0.0 to 7.0.0 (#5515)
- 5e540e34 chore: Log out the failed audit log on failures (#5561)
- 91a4c2dc chore: remove address from deployment page (#5565)
- ebe1b56c chore: Switch from npm to yarn in `scripts/apidocgen` (#5575)
- c0dfbdf1 chore: bump emoji-mart from 5.3.3 to 5.4.0 in /site (#5527)
- 2db9df44 chore: bump github.com/prometheus/common from 0.37.0 to 0.39.0 (#5544)
- 24592332 chore: bump github.com/gohugoio/hugo from 0.107.0 to 0.109.0 (#5541)
- e6b17b6e chore: update Lima example (#5588)
- 8ee3e2c5 chore: bump chartjs-adapter-date-fns from 2.0.0 to 3.0.0 in /site (#5528)
- 421e5297 chore: bump json5 from 1.0.1 to 1.0.2 in /site (#5553)
- 34225b03 chore: bump luxon from 3.1.1 to 3.2.1 in /site (#5624)

### Other Changes

- c8f34bba Test enabling deadline change buttons (#5508)
- 0b63825a site: fix copy in users roles view (#5583)

Compare: [`v0.13.6...v0.14.0`](https://github.com/coder/coder/compare/v0.13.6...v0.14.0)

## Container Image

- `docker pull ghcr.io/coder/coder:v0.14.0`
```
