### PR TITLE
fix: print correct listen adress in `coder server`

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -674,6 +674,58 @@ func TestServer(t *testing.T) {
 		}
 	})
 
+	t.Run("CanListenUnspecifiedv4", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		defer cancelFunc()
+
+		root, _ := clitest.New(t,
+			"server",
+			"--in-memory",
+			"--http-address", "0.0.0.0:0",
+			"--access-url", "http://example.com",
+		)
+
+		pty := ptytest.New(t)
+		root.SetOutput(pty.Output())
+		root.SetErr(pty.Output())
+		errC := make(chan error, 1)
+		go func() {
+			errC <- root.ExecuteContext(ctx)
+		}()
+
+		pty.ExpectMatch("Started HTTP listener at http://0.0.0.0:")
+
+		cancelFunc()
+		require.NoError(t, <-errC)
+	})
+
+	t.Run("CanListenUnspecifiedv6", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		defer cancelFunc()
+
+		root, _ := clitest.New(t,
+			"server",
+			"--in-memory",
+			"--http-address", "[::]:0",
+			"--access-url", "http://example.com",
+		)
+
+		pty := ptytest.New(t)
+		root.SetOutput(pty.Output())
+		root.SetErr(pty.Output())
+		errC := make(chan error, 1)
+		go func() {
+			errC <- root.ExecuteContext(ctx)
+		}()
+
+		pty.ExpectMatch("Started HTTP listener at http://[::]:")
+
+		cancelFunc()
+		require.NoError(t, <-errC)
+	})
+
 	t.Run("NoAddress", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancelFunc := context.WithCancel(context.Background())


### PR DESCRIPTION
It is a bit confusing when the server always prints that it's listening on localhost when the provided address is unspecified. This fixes `coder server` to properly print the address it's listening on.