### PR TITLE
refactor: Extract security logic from auth service

### DIFF
--- a/site/src/i18n/en/index.ts
+++ b/site/src/i18n/en/index.ts
@@ -17,6 +17,7 @@ import appearanceSettings from "./appearanceSettings.json"
 import starterTemplatesPage from "./starterTemplatesPage.json"
 import starterTemplatePage from "./starterTemplatePage.json"
 import createTemplatePage from "./createTemplatePage.json"
+import userSettingsPage from "./userSettingsPage.json"
 
 export const en = {
   common,
@@ -38,4 +39,5 @@ export const en = {
   starterTemplatesPage,
   starterTemplatePage,
   createTemplatePage,
+  userSettingsPage,
 }

--- a/site/src/i18n/en/userSettingsPage.json
+++ b/site/src/i18n/en/userSettingsPage.json
@@ -1,0 +1,3 @@
+{
+  "securityUpdateSuccessMessage": "Updated password."
+}

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
@@ -3,7 +3,6 @@ import * as API from "../../../api/api"
 import { GlobalSnackbar } from "../../../components/GlobalSnackbar/GlobalSnackbar"
 import * as SecurityForm from "../../../components/SettingsSecurityForm/SettingsSecurityForm"
 import { renderWithAuth } from "../../../testHelpers/renderHelpers"
-import * as AuthXService from "../../../xServices/auth/authXService"
 import { SecurityPage } from "./SecurityPage"
 import i18next from "i18next"
 
@@ -47,9 +46,10 @@ describe("SecurityPage", () => {
       const { user } = renderPage()
       await fillAndSubmitForm()
 
-      const successMessage = await screen.findByText(
-        AuthXService.Language.successSecurityUpdate,
-      )
+      const expectedMessage = t("securityUpdateSuccessMessage", {
+        ns: "userSettingsPage",
+      })
+      const successMessage = await screen.findByText(expectedMessage)
       expect(successMessage).toBeDefined()
       expect(API.updateUserPassword).toBeCalledTimes(1)
       expect(API.updateUserPassword).toBeCalledWith(user.id, newData)

--- a/site/src/xServices/userSecuritySettings/userSecuritySettingsXService.ts
+++ b/site/src/xServices/userSecuritySettings/userSecuritySettingsXService.ts
@@ -1,0 +1,71 @@
+import { assign, createMachine } from "xstate"
+import * as API from "api/api"
+import { UpdateUserPasswordRequest } from "api/typesGenerated"
+import { displaySuccess } from "components/GlobalSnackbar/utils"
+import { t } from "i18next"
+
+interface Context {
+  userId: string
+  error?: unknown
+}
+
+type Events = { type: "UPDATE_SECURITY"; data: UpdateUserPasswordRequest }
+
+export const userSecuritySettingsMachine = createMachine(
+  {
+    id: "userSecuritySettings",
+    predictableActionArguments: true,
+    schema: {
+      context: {} as Context,
+      events: {} as Events,
+    },
+    tsTypes: {} as import("./userSecuritySettingsXService.typegen").Typegen0,
+    initial: "idle",
+    states: {
+      idle: {
+        on: {
+          UPDATE_SECURITY: {
+            target: "updatingSecurity",
+          },
+        },
+      },
+      updatingSecurity: {
+        entry: "clearError",
+        invoke: {
+          src: "updateSecurity",
+          onDone: [
+            {
+              actions: "notifyUpdate",
+              target: "idle",
+            },
+          ],
+          onError: [
+            {
+              actions: "assignError",
+              target: "idle",
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    services: {
+      updateSecurity: async ({ userId }, { data }) =>
+        API.updateUserPassword(userId, data),
+    },
+    actions: {
+      clearError: assign({
+        error: (_) => undefined,
+      }),
+      notifyUpdate: () => {
+        displaySuccess(
+          t("securityUpdateSuccessMessage", { ns: "userSettingsPage" }),
+        )
+      },
+      assignError: assign({
+        error: (_, event) => event.data,
+      }),
+    },
+  },
+)


### PR DESCRIPTION
In order to simplify the auth service, I'm extract the security logic since it can be a different machine and it is not attached to the auth service at all.