### PR TITLE
chore: Add security section to release notes

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -45,6 +45,9 @@ main() {
 	breaking_label=release/breaking
 	breaking_category=breaking
 
+	# Security related changes are labeled `security`.
+	security_label=security
+
 	# Get abbreviated and full commit hashes and titles for each commit.
 	mapfile -t commits < <(git log --no-merges --pretty=format:"%h %H %s" "$range")
 
@@ -99,6 +102,9 @@ main() {
 		if [[ $commit_prefix =~ $breaking_title ]] || [[ ${labels[$commit_sha_long]} = *"label:$breaking_label"* ]]; then
 			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$breaking_category
 			COMMIT_METADATA_BREAKING=1
+			continue
+		elif [[ ${labels[$commit_sha_long]} = *"label:$security_label"* ]]; then
+			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$security_label
 			continue
 		fi
 

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -68,6 +68,7 @@ mapfile -t commits < <(git log --no-merges --pretty=format:"%ct %h %s" "${old_ve
 # NOTE(mafredri): These need to be supported in check_commit_metadata.sh as well.
 declare -a section_order=(
 	breaking
+	security
 	feat
 	fix
 	docs
@@ -83,6 +84,7 @@ declare -a section_order=(
 
 declare -A section_titles=(
 	[breaking]='BREAKING CHANGES'
+	[security]='SECURITY'
 	[feat]='Features'
 	[fix]='Bug Fixes'
 	[docs]='Documentation'


### PR DESCRIPTION
This PR adds a security section to the release notes by repurposing the `security` label that has been used previously.

Simply tag a PR with the `security` label to ensure it gets promoted in the release notes.

Example:

```
❯ ./scripts/release/generate_release_notes.sh --old-version v0.13.4 --new-version v0.13.5 --ref v0.13.5
```

```markdown
## Changelog

### SECURITY

- 1bc4eb53 fix: fix security vulnerabilities reported by CodeQL (#5467)

### Features

- e61234f2 feat: Add `vscodeipc` subcommand for VS Code Extension  (#5326)
- dc6d2712 feat: Build framework for generating API docs (#5383)
- a7e8f98e feat: Unhide workspace rename command (#5464)

...
```
