### PR TITLE
ci: Fix $version being empty in packages.yaml

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "Installer URL: $installer_url"
 
           # The package version is the same as the tag minus the leading "v".
-          $version = $env:CODER_VERSION -replace "^v", ""
+          $version = $env:CODER_VERSION.Trim('v')
 
           echo "Package version: $version"
 


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
Apparently, Winget submission is still failing due to the `$version` being empty. I tested the last approach on local `pwsh` prompt and it was working. I am not sure why it is not working as expected in ci.
