### PR TITLE
refactor: User settings page

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -420,10 +420,37 @@ export const AppRouter: FC = () => {
           />
         </Route>
 
-        <Route path="settings" element={<SettingsLayout />}>
-          <Route path="account" element={<AccountPage />} />
-          <Route path="security" element={<SecurityPage />} />
-          <Route path="ssh-keys" element={<SSHKeysPage />} />
+        <Route path="settings">
+          <Route
+            path="account"
+            element={
+              <AuthAndFrame>
+                <SettingsLayout>
+                  <AccountPage />
+                </SettingsLayout>
+              </AuthAndFrame>
+            }
+          />
+          <Route
+            path="security"
+            element={
+              <AuthAndFrame>
+                <SettingsLayout>
+                  <SecurityPage />
+                </SettingsLayout>
+              </AuthAndFrame>
+            }
+          />
+          <Route
+            path="ssh-keys"
+            element={
+              <AuthAndFrame>
+                <SettingsLayout>
+                  <SSHKeysPage />
+                </SettingsLayout>
+              </AuthAndFrame>
+            }
+          />
         </Route>
 
         <Route path="/@:username">

--- a/site/src/components/DeploySettingsLayout/DeploySettingsLayout.tsx
+++ b/site/src/components/DeploySettingsLayout/DeploySettingsLayout.tsx
@@ -46,7 +46,7 @@ export const DeploySettingsLayout: React.FC<PropsWithChildren> = ({
 
   return (
     <Margins>
-      <Stack className={styles.wrapper} direction="row" spacing={5}>
+      <Stack className={styles.wrapper} direction="row" spacing={6}>
         <Sidebar />
         <main className={styles.content}>
           {deploymentConfig ? (

--- a/site/src/components/Section/Section.tsx
+++ b/site/src/components/Section/Section.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from "@material-ui/core/styles"
 import Typography from "@material-ui/core/Typography"
 import { FC } from "react"
-import { combineClasses } from "../../util/combineClasses"
 import { SectionAction } from "../SectionAction/SectionAction"
 
 type SectionLayout = "fixed" | "fluid"
@@ -31,7 +30,7 @@ export const Section: SectionFC = ({
 }) => {
   const styles = useStyles({ layout })
   return (
-    <section className={combineClasses([styles.root, className])}>
+    <section className={className}>
       <div className={styles.inner}>
         {(title || description) && (
           <div className={styles.header}>
@@ -60,18 +59,6 @@ export const Section: SectionFC = ({
 Section.Action = SectionAction
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.paper,
-    boxShadow: theme.shadows[6],
-    marginBottom: theme.spacing(1),
-    padding: theme.spacing(6),
-    borderRadius: theme.shape.borderRadius,
-    border: `1px solid ${theme.palette.divider}`,
-
-    [theme.breakpoints.down("sm")]: {
-      padding: theme.spacing(4, 3, 4, 3),
-    },
-  },
   inner: ({ layout }: { layout: SectionLayout }) => ({
     maxWidth: layout === "fluid" ? "100%" : 500,
   }),
@@ -79,7 +66,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(1),
   },
   header: {
-    marginBottom: theme.spacing(4),
+    marginBottom: theme.spacing(3),
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
@@ -87,6 +74,6 @@ const useStyles = makeStyles((theme) => ({
   description: {
     color: theme.palette.text.secondary,
     fontSize: 16,
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacing(0.5),
   },
 }))

--- a/site/src/components/SettingsLayout/Section.tsx
+++ b/site/src/components/SettingsLayout/Section.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from "@material-ui/core/styles"
 import Typography from "@material-ui/core/Typography"
 import { FC } from "react"
-import { combineClasses } from "../../util/combineClasses"
 import { SectionAction } from "../SectionAction/SectionAction"
 
 type SectionLayout = "fixed" | "fluid"
@@ -31,7 +30,7 @@ export const Section: SectionFC = ({
 }) => {
   const styles = useStyles({ layout })
   return (
-    <section className={combineClasses([styles.root, className])}>
+    <section className={className}>
       <div className={styles.inner}>
         {(title || description) && (
           <div className={styles.header}>
@@ -60,18 +59,6 @@ export const Section: SectionFC = ({
 Section.Action = SectionAction
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.paper,
-    boxShadow: theme.shadows[6],
-    marginBottom: theme.spacing(1),
-    padding: theme.spacing(6),
-    borderRadius: theme.shape.borderRadius,
-    border: `1px solid ${theme.palette.divider}`,
-
-    [theme.breakpoints.down("sm")]: {
-      padding: theme.spacing(4, 3, 4, 3),
-    },
-  },
   inner: ({ layout }: { layout: SectionLayout }) => ({
     maxWidth: layout === "fluid" ? "100%" : 500,
   }),
@@ -79,7 +66,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(1),
   },
   header: {
-    marginBottom: theme.spacing(4),
+    marginBottom: theme.spacing(3),
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
@@ -87,6 +74,6 @@ const useStyles = makeStyles((theme) => ({
   description: {
     color: theme.palette.text.secondary,
     fontSize: 16,
-    marginTop: theme.spacing(2),
+    marginTop: theme.spacing(0.5),
   },
 }))

--- a/site/src/components/SettingsLayout/SettingsLayout.tsx
+++ b/site/src/components/SettingsLayout/SettingsLayout.tsx
@@ -1,38 +1,42 @@
-import Box from "@material-ui/core/Box"
-import { FC } from "react"
+import { makeStyles } from "@material-ui/core/styles"
+import { Sidebar } from "./Sidebar"
+import { Stack } from "components/Stack/Stack"
+import { FC, PropsWithChildren, Suspense } from "react"
 import { Helmet } from "react-helmet-async"
-import { Outlet } from "react-router-dom"
 import { pageTitle } from "../../util/page"
-import { AuthAndFrame } from "../AuthAndFrame/AuthAndFrame"
 import { Margins } from "../Margins/Margins"
-import { TabPanel } from "../TabPanel/TabPanel"
+import { useMe } from "hooks/useMe"
+import { Loader } from "components/Loader/Loader"
 
-export const Language = {
-  accountLabel: "Account",
-  securityLabel: "Security",
-  sshKeysLabel: "SSH keys",
-  settingsLabel: "Settings",
-}
+export const SettingsLayout: FC<PropsWithChildren> = ({ children }) => {
+  const styles = useStyles()
+  const me = useMe()
 
-const menuItems = [
-  { label: Language.accountLabel, path: "/settings/account" },
-  { label: Language.securityLabel, path: "/settings/security" },
-  { label: Language.sshKeysLabel, path: "/settings/ssh-keys" },
-]
-
-export const SettingsLayout: FC = () => {
   return (
-    <AuthAndFrame>
-      <Box display="flex" flexDirection="column">
-        <Helmet>
-          <title>{pageTitle("Settings")}</title>
-        </Helmet>
-        <Margins>
-          <TabPanel title={Language.settingsLabel} menuItems={menuItems}>
-            <Outlet />
-          </TabPanel>
-        </Margins>
-      </Box>
-    </AuthAndFrame>
+    <>
+      <Helmet>
+        <title>{pageTitle("Settings")}</title>
+      </Helmet>
+
+      <Margins>
+        <Stack className={styles.wrapper} direction="row" spacing={6}>
+          <Sidebar user={me} />
+          <Suspense fallback={<Loader />}>
+            <main className={styles.content}>{children}</main>
+          </Suspense>
+        </Stack>
+      </Margins>
+    </>
   )
 }
+
+const useStyles = makeStyles((theme) => ({
+  wrapper: {
+    padding: theme.spacing(6, 0),
+  },
+
+  content: {
+    maxWidth: 800,
+    width: "100%",
+  },
+}))

--- a/site/src/components/SettingsLayout/Sidebar.tsx
+++ b/site/src/components/SettingsLayout/Sidebar.tsx
@@ -1,14 +1,13 @@
 import { makeStyles } from "@material-ui/core/styles"
-import Brush from "@material-ui/icons/Brush"
-import LaunchOutlined from "@material-ui/icons/LaunchOutlined"
-import LockRounded from "@material-ui/icons/LockOutlined"
-import Globe from "@material-ui/icons/PublicOutlined"
 import VpnKeyOutlined from "@material-ui/icons/VpnKeyOutlined"
-import { GitIcon } from "components/Icons/GitIcon"
+import { User } from "api/typesGenerated"
 import { Stack } from "components/Stack/Stack"
+import { UserAvatar } from "components/UserAvatar/UserAvatar"
 import React, { ElementType, PropsWithChildren, ReactNode } from "react"
 import { NavLink } from "react-router-dom"
 import { combineClasses } from "util/combineClasses"
+import AccountIcon from "@material-ui/icons/Person"
+import SecurityIcon from "@material-ui/icons/LockOutlined"
 
 const SidebarNavItem: React.FC<
   PropsWithChildren<{ href: string; icon: ReactNode }>
@@ -39,46 +38,36 @@ const SidebarNavItemIcon: React.FC<{ icon: ElementType }> = ({
   return <Icon className={styles.sidebarNavItemIcon} />
 }
 
-export const Sidebar: React.FC = () => {
+export const Sidebar: React.FC<{ user: User }> = ({ user }) => {
   const styles = useStyles()
 
   return (
     <nav className={styles.sidebar}>
+      <Stack direction="row" alignItems="center" className={styles.userInfo}>
+        <UserAvatar username={user.username} avatarURL={user.avatar_url} />
+        <Stack spacing={0} className={styles.userData}>
+          <span className={styles.username}>{user.username}</span>
+          <span className={styles.email}>{user.email}</span>
+        </Stack>
+      </Stack>
+
       <SidebarNavItem
-        href="../general"
-        icon={<SidebarNavItemIcon icon={LaunchOutlined} />}
+        href="../account"
+        icon={<SidebarNavItemIcon icon={AccountIcon} />}
       >
-        General
-      </SidebarNavItem>
-      <SidebarNavItem
-        href="../appearance"
-        icon={<SidebarNavItemIcon icon={Brush} />}
-      >
-        Appearance
-      </SidebarNavItem>
-      <SidebarNavItem
-        href="../userauth"
-        icon={<SidebarNavItemIcon icon={VpnKeyOutlined} />}
-      >
-        User Authentication
-      </SidebarNavItem>
-      <SidebarNavItem
-        href="../gitauth"
-        icon={<SidebarNavItemIcon icon={GitIcon} />}
-      >
-        Git Authentication
-      </SidebarNavItem>
-      <SidebarNavItem
-        href="../network"
-        icon={<SidebarNavItemIcon icon={Globe} />}
-      >
-        Network
+        Account
       </SidebarNavItem>
       <SidebarNavItem
         href="../security"
-        icon={<SidebarNavItemIcon icon={LockRounded} />}
+        icon={<SidebarNavItemIcon icon={SecurityIcon} />}
       >
         Security
+      </SidebarNavItem>
+      <SidebarNavItem
+        href="../ssh-keys"
+        icon={<SidebarNavItemIcon icon={VpnKeyOutlined} />}
+      >
+        SSH Keys
       </SidebarNavItem>
     </nav>
   )
@@ -87,8 +76,8 @@ export const Sidebar: React.FC = () => {
 const useStyles = makeStyles((theme) => ({
   sidebar: {
     width: 245,
+    flexShrink: 0,
   },
-
   sidebarNavItem: {
     color: "inherit",
     display: "block",
@@ -104,7 +93,6 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.action.hover,
     },
   },
-
   sidebarNavItemActive: {
     backgroundColor: theme.palette.action.hover,
 
@@ -121,9 +109,25 @@ const useStyles = makeStyles((theme) => ({
       borderBottomLeftRadius: theme.shape.borderRadius,
     },
   },
-
   sidebarNavItemIcon: {
     width: theme.spacing(2),
     height: theme.spacing(2),
+  },
+  userInfo: {
+    marginBottom: theme.spacing(2),
+  },
+  userData: {
+    overflow: "hidden",
+  },
+  username: {
+    fontWeight: 600,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+  email: {
+    color: theme.palette.text.secondary,
+    fontSize: 12,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
   },
 }))

--- a/site/src/components/SettingsLayout/Sidebar.tsx
+++ b/site/src/components/SettingsLayout/Sidebar.tsx
@@ -3,13 +3,13 @@ import VpnKeyOutlined from "@material-ui/icons/VpnKeyOutlined"
 import { User } from "api/typesGenerated"
 import { Stack } from "components/Stack/Stack"
 import { UserAvatar } from "components/UserAvatar/UserAvatar"
-import React, { ElementType, PropsWithChildren, ReactNode } from "react"
+import { FC, ElementType, PropsWithChildren, ReactNode } from "react"
 import { NavLink } from "react-router-dom"
 import { combineClasses } from "util/combineClasses"
 import AccountIcon from "@material-ui/icons/Person"
 import SecurityIcon from "@material-ui/icons/LockOutlined"
 
-const SidebarNavItem: React.FC<
+const SidebarNavItem: FC<
   PropsWithChildren<{ href: string; icon: ReactNode }>
 > = ({ children, href, icon }) => {
   const styles = useStyles()

--- a/site/src/components/SettingsSecurityForm/SettingsSecurityForm.tsx
+++ b/site/src/components/SettingsSecurityForm/SettingsSecurityForm.tsx
@@ -77,6 +77,9 @@ export const SecurityForm: React.FC<SecurityFormProps> = ({
           )}
           <TextField
             {...getFieldHelpers("old_password")}
+            InputLabelProps={{
+              shrink: true,
+            }}
             autoComplete="old_password"
             fullWidth
             label={Language.oldPasswordLabel}
@@ -85,6 +88,9 @@ export const SecurityForm: React.FC<SecurityFormProps> = ({
           />
           <TextField
             {...getFieldHelpers("password")}
+            InputLabelProps={{
+              shrink: true,
+            }}
             autoComplete="password"
             fullWidth
             label={Language.newPasswordLabel}
@@ -93,6 +99,9 @@ export const SecurityForm: React.FC<SecurityFormProps> = ({
           />
           <TextField
             {...getFieldHelpers("confirm_password")}
+            InputLabelProps={{
+              shrink: true,
+            }}
             autoComplete="confirm_password"
             fullWidth
             label={Language.confirmPasswordLabel}

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -19,7 +19,7 @@ export const AccountPage: React.FC = () => {
   }
 
   return (
-    <Section title={Language.title}>
+    <Section title={Language.title} description="Update your account info">
       <AccountForm
         editable={Boolean(canEditUsers)}
         email={me.email}

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -1,6 +1,6 @@
 import { useActor } from "@xstate/react"
 import React, { useContext } from "react"
-import { Section } from "../../../components/Section/Section"
+import { Section } from "../../../components/SettingsLayout/Section"
 import { AccountForm } from "../../../components/SettingsAccountForm/SettingsAccountForm"
 import { XServiceContext } from "../../../xServices/StateContext"
 

--- a/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPage.tsx
+++ b/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPage.tsx
@@ -1,7 +1,7 @@
 import { useActor } from "@xstate/react"
 import React, { useContext, useEffect } from "react"
 import { ConfirmDialog } from "../../../components/Dialogs/ConfirmDialog/ConfirmDialog"
-import { Section } from "../../../components/Section/Section"
+import { Section } from "../../../components/SettingsLayout/Section"
 import { XServiceContext } from "../../../xServices/StateContext"
 import { SSHKeysPageView } from "./SSHKeysPageView"
 

--- a/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPage.tsx
+++ b/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPage.tsx
@@ -7,15 +7,6 @@ import { SSHKeysPageView } from "./SSHKeysPageView"
 
 export const Language = {
   title: "SSH keys",
-  description: (
-    <p>
-      The following public key is used to authenticate Git in workspaces. You
-      may add it to Git services (such as GitHub) that you need to access from
-      your workspace. <br />
-      <br />
-      Coder configures authentication via <code>$GIT_SSH_COMMAND</code>.
-    </p>
-  ),
   regenerateDialogTitle: "Regenerate SSH key?",
   regenerateDialogMessage:
     "You will need to replace the public SSH key on services you use it with, and you'll need to rebuild existing workspaces.",
@@ -41,7 +32,7 @@ export const SSHKeysPage: React.FC<React.PropsWithChildren<unknown>> = () => {
 
   return (
     <>
-      <Section title={Language.title} description={Language.description}>
+      <Section title={Language.title}>
         <SSHKeysPageView
           isLoading={isLoading}
           hasLoaded={hasLoaded}

--- a/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPageView.tsx
+++ b/site/src/pages/UserSettingsPage/SSHKeysPage/SSHKeysPageView.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from "@material-ui/core/styles"
 import Box from "@material-ui/core/Box"
 import Button from "@material-ui/core/Button"
 import CircularProgress from "@material-ui/core/CircularProgress"
@@ -31,6 +32,8 @@ export const SSHKeysPageView: FC<
   sshKey,
   onRegenerateClick,
 }) => {
+  const styles = useStyles()
+
   if (isLoading) {
     return (
       <Box p={4}>
@@ -43,7 +46,6 @@ export const SSHKeysPageView: FC<
     <Stack>
       {/* Regenerating the key is not an option if getSSHKey fails.
         Only one of the error messages will exist at a single time */}
-
       {Boolean(getSSHKeyError) && (
         <AlertBanner severity="error" error={getSSHKeyError} />
       )}
@@ -57,6 +59,12 @@ export const SSHKeysPageView: FC<
       )}
       {hasLoaded && sshKey && (
         <>
+          <p className={styles.description}>
+            The following public key is used to authenticate Git in workspaces.
+            You may add it to Git services (such as GitHub) that you need to
+            access from your workspace. Coder configures authentication via{" "}
+            <code className={styles.code}>$GIT_SSH_COMMAND</code>.
+          </p>
           <CodeExample code={sshKey.public_key.trim()} />
           <div>
             <Button onClick={onRegenerateClick}>
@@ -68,3 +76,18 @@ export const SSHKeysPageView: FC<
     </Stack>
   )
 }
+
+const useStyles = makeStyles((theme) => ({
+  description: {
+    fontSize: 14,
+    color: theme.palette.text.secondary,
+    margin: 0,
+  },
+  code: {
+    background: theme.palette.divider,
+    fontSize: 12,
+    padding: "2px 4px",
+    color: theme.palette.text.primary,
+    borderRadius: 2,
+  },
+}))

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.tsx
@@ -22,7 +22,7 @@ export const SecurityPage: React.FC = () => {
   const { error } = securityState.context
 
   return (
-    <Section title={Language.title}>
+    <Section title={Language.title} description="Update your account password">
       <SecurityForm
         updateSecurityError={error}
         isLoading={securityState.matches("updatingSecurity")}

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.tsx
@@ -2,7 +2,7 @@ import { useMachine } from "@xstate/react"
 import { useMe } from "hooks/useMe"
 import React from "react"
 import { userSecuritySettingsMachine } from "xServices/userSecuritySettings/userSecuritySettingsXService"
-import { Section } from "../../../components/Section/Section"
+import { Section } from "../../../components/SettingsLayout/Section"
 import { SecurityForm } from "../../../components/SettingsSecurityForm/SettingsSecurityForm"
 
 export const Language = {


### PR DESCRIPTION
Update the user settings page to use the same layout as Deployment Settings. 

Things to consider:
- The components are not abstracted yet. I would wait a bit before creating common components. I'm not sure this is the design we want to keep/follow.

Before:
<img width="1792" alt="Screen Shot 2023-01-10 at 16 13 29" src="https://user-images.githubusercontent.com/3165839/211642163-f6451358-b1a5-4878-a904-1629d0de2b92.png">
<img width="1792" alt="Screen Shot 2023-01-10 at 16 13 37" src="https://user-images.githubusercontent.com/3165839/211642178-fe7ba8de-18bd-47ce-9a62-5859d989fc4b.png">
<img width="1792" alt="Screen Shot 2023-01-10 at 16 13 45" src="https://user-images.githubusercontent.com/3165839/211642185-e7e4959f-8f90-48b2-b1f3-9b2c4262df8c.png">

After:
<img width="1792" alt="Screen Shot 2023-01-10 at 16 13 56" src="https://user-images.githubusercontent.com/3165839/211642228-4b931987-be44-4338-b21a-007f310ca902.png">
<img width="1792" alt="Screen Shot 2023-01-10 at 16 14 16" src="https://user-images.githubusercontent.com/3165839/211642232-6ee1b3a5-e707-4c55-a959-218670d8e086.png">
<img width="1792" alt="Screen Shot 2023-01-10 at 16 14 05" src="https://user-images.githubusercontent.com/3165839/211642234-c722b264-c696-4c17-97ee-a172fc764845.png">
