### PR TITLE
fix: disable pointer events on app icons

### DIFF
--- a/site/src/components/AppLink/BaseIcon.tsx
+++ b/site/src/components/AppLink/BaseIcon.tsx
@@ -4,7 +4,13 @@ import ComputerIcon from "@material-ui/icons/Computer"
 
 export const BaseIcon: FC<{ app: WorkspaceApp }> = ({ app }) => {
   return app.icon ? (
-    <img alt={`${app.display_name} Icon`} src={app.icon} />
+    <img
+      alt={`${app.display_name} Icon`}
+      src={app.icon}
+      style={{
+        pointerEvents: "none",
+      }}
+    />
   ) : (
     <ComputerIcon />
   )


### PR DESCRIPTION
Ben accidentally clicked to open this in a new tab which seemed kinda janky UX-wise on our part.
