### PR TITLE
feat: add SIGQUIT/SIGTRAP handler for the CLI

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -39,6 +39,8 @@ func workspaceAgent() *cobra.Command {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
+			go dumpHandler(ctx)
+
 			rawURL, err := cmd.Flags().GetString(varAgentURL)
 			if err != nil {
 				return xerrors.Errorf("CODER_AGENT_URL must be set: %w", err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -713,7 +713,7 @@ func dumpHandler(ctx context.Context) {
 		_, err = f.Write(buf[:stacklen])
 		_ = f.Close()
 		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
+			_, _ = fmt.Fprintf(os.Stderr, "failed to write dump file: %v\n", err.Error())
 			goto done
 		}
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -8,8 +8,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -630,4 +633,92 @@ func (h *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Add(k, v)
 	}
 	return h.transport.RoundTrip(req)
+}
+
+// dumpHandler provides a custom SIGQUIT and SIGTRAP handler that dumps the
+// stacktrace of all goroutines to stderr and a well-known file in the home
+// directory. This is useful for debugging deadlock issues that may occur in
+// production in workspaces, since the default Go runtime will only dump to
+// stderr (which is often difficult/impossible to read in a workspace).
+//
+// SIGQUITs will still cause the program to exit (similarly to the default Go
+// runtime behavior).
+//
+// A SIGQUIT handler will not be registered if GOTRACEBACK=crash.
+//
+// On Windows this immediately returns.
+func dumpHandler(ctx context.Context) {
+	if runtime.GOOS == "windows" {
+		// free up the goroutine since it'll be permanently blocked anyways
+		return
+	}
+
+	listenSignals := []os.Signal{syscall.SIGTRAP}
+	if os.Getenv("GOTRACEBACK") != "crash" {
+		listenSignals = append(listenSignals, syscall.SIGQUIT)
+	}
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, listenSignals...)
+	for {
+		sigStr := ""
+		select {
+		case <-ctx.Done():
+			return
+		case sig := <-sigs:
+			switch sig {
+			case syscall.SIGQUIT:
+				sigStr = "SIGQUIT"
+			case syscall.SIGTRAP:
+				sigStr = "SIGTRAP"
+			}
+		}
+
+		// Start with a 1MB buffer and keep doubling it until we can fit the
+		// entire stacktrace, stopping early once we reach 64MB.
+		buf := make([]byte, 1_000_000)
+		stacklen := 0
+		for {
+			stacklen = runtime.Stack(buf, true)
+			if stacklen < len(buf) {
+				break
+			}
+			if 2*len(buf) > 64_000_000 {
+				// Write a message to the end of the buffer saying that it was
+				// truncated.
+				const truncatedMsg = "\n\n\nstack trace truncated due to size\n"
+				copy(buf[len(buf)-len(truncatedMsg):], truncatedMsg)
+				break
+			}
+			buf = make([]byte, 2*len(buf))
+		}
+
+		_, _ = fmt.Fprintf(os.Stderr, "%s:\n%s\n", sigStr, buf[:stacklen])
+
+		// Write to a well-known file.
+		dir, err := os.UserHomeDir()
+		if err != nil {
+			dir = os.TempDir()
+		}
+		fpath := filepath.Join(dir, fmt.Sprintf("coder-agent-%s.dump", time.Now().Format("2006-01-02T15:04:05.000Z")))
+		_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)
+
+		f, err := os.Create(fpath)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
+			goto done
+		}
+		_, err = f.Write(buf[:stacklen])
+		_ = f.Close()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
+			goto done
+		}
+
+	done:
+		if sigStr == "SIGQUIT" {
+			//nolint:revive
+			os.Exit(1)
+		}
+	}
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -660,6 +660,8 @@ func dumpHandler(ctx context.Context) {
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, listenSignals...)
+	defer signal.Stop(sigs)
+
 	for {
 		sigStr := ""
 		select {

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -1,15 +1,10 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math/rand"
 	"os"
-	"os/signal"
-	"path/filepath"
-	"runtime"
-	"syscall"
 	"time"
 	_ "time/tzdata"
 
@@ -19,48 +14,6 @@ import (
 
 func main() {
 	rand.Seed(time.Now().UnixMicro())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Add a custom SIGQUIT handler that outputs to stderr and a well-known file
-	// in the home directory. This also prevents SIGQUITs from killing the CLI.
-	go func() {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGQUIT)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-sigs:
-			}
-
-			buf := make([]byte, 10_000_000)
-			stacklen := runtime.Stack(buf, true)
-
-			_, _ = fmt.Fprintf(os.Stderr, "SIGQUIT:\n%s\n", buf[:stacklen])
-
-			// Write to a well-known file.
-			dir, err := os.UserHomeDir()
-			if err != nil {
-				dir = os.TempDir()
-			}
-			fpath := filepath.Join(dir, fmt.Sprintf("coder-agent-%s.dump", time.Now().Format("2006-01-02T15:04:05.000Z")))
-			_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)
-
-			f, err := os.Create(fpath)
-			if err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
-				continue
-			}
-			_, err = f.Write(buf[:stacklen])
-			_ = f.Close()
-			if err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
-				continue
-			}
-		}
-	}()
 
 	cmd, err := cli.Root(cli.AGPL()).ExecuteC()
 	if err != nil {

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
 	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
 	"time"
 	_ "time/tzdata"
 
@@ -14,6 +19,48 @@ import (
 
 func main() {
 	rand.Seed(time.Now().UnixMicro())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Add a custom SIGQUIT handler that outputs to stderr and a well-known file
+	// in the home directory. This also prevents SIGQUITs from killing the CLI.
+	go func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGQUIT)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sigs:
+			}
+
+			buf := make([]byte, 10_000_000)
+			stacklen := runtime.Stack(buf, true)
+
+			_, _ = fmt.Fprintf(os.Stderr, "SIGQUIT:\n%s\n", buf[:stacklen])
+
+			// Write to a well-known file.
+			dir, err := os.UserHomeDir()
+			if err != nil {
+				dir = os.TempDir()
+			}
+			fpath := filepath.Join(dir, fmt.Sprintf("coder-agent-%s.dump", time.Now().Format("2006-01-02T15:04:05.000Z")))
+			_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)
+
+			f, err := os.Create(fpath)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
+				continue
+			}
+			_, err = f.Write(buf[:stacklen])
+			_ = f.Close()
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "failed to open dump file: %v\n", err.Error())
+				continue
+			}
+		}
+	}()
 
 	cmd, err := cli.Root(cli.AGPL()).ExecuteC()
 	if err != nil {


### PR DESCRIPTION
The default SIGQUIT handler in Golang dumps all goroutine stacktraces to stderr and then exits the program.

This changes the behavior so it dumps all goroutine stacktraces to stderr and a file (with the date) to $HOME, then exits. For the SIGTRAP handler, it does the same thing but doesn't exit.