### PR TITLE
docs: Update WebIDE Section Headers

### DIFF
--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -169,7 +169,7 @@ resource "coder_app" "jupyter" {
 
 ![JupyterLab in Coder](../images/jupyter-on-docker.png)
 
-### RStudio
+## RStudio
 
 Configure your agent and `coder_app` like so to use RStudio. Notice the
 `subdomain=true` configuration:
@@ -206,7 +206,7 @@ resource "coder_app" "rstudio" {
 
 ![RStudio in Coder](../images/rstudio-port-forward.png)
 
-### Airflow
+## Airflow
 
 Configure your agent and `coder_app` like so to use Airflow. Notice the
 `subdomain=true` configuration:


### PR DESCRIPTION
Minor documentation update to headers in the [Web IDE section of the doc](https://coder.com/docs/coder-oss/latest/ides/web-ides) to allow RStudio and Airflow to show in the "Contents" section on the right of the rendered page.