### PR TITLE
ci: Allow missing commit metadata to be ignored in releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,45 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email ""
 
+      - name: Create release tag and release notes
+        run: |
+          set -euo pipefail
+          ref=HEAD
+          old_version="$(git describe --abbrev=0 "$ref^1")"
+
+          # Warn if CODER_IGNORE_MISSING_COMMIT_METADATA is set any other way
+          # than via dry-run.
+          if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} != 0 ]]; then
+            echo "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata." 1>&2
+          fi
+
+          if [[ $DRY_RUN == true ]]; then
+            # Allow dry-run of branches to pass.
+            export CODER_IGNORE_MISSING_COMMIT_METADATA=1
+          fi
+
+          # Cache commit metadata.
+          . ./scripts/release/check_commit_metadata.sh "$old_version" "$ref"
+
+          # Create new release tag (note that this tag is not pushed before
+          # release.sh is run).
+          version="$(
+            ./scripts/release/tag_version.sh \
+              ${{ (github.event.inputs.dry_run || github.event.inputs.snapshot) && '--dry-run' }} \
+              --ref "$ref" \
+              --${{ github.event.inputs.increment }}
+          )"
+
+          # Generate notes.
+          release_notes_file="$(mktemp -t release_notes.XXXXXX)"
+          ./scripts/release/generate_release_notes.sh --old-version "$old_version" --new-version "$version" --ref "$ref" >> "$release_notes_file"
+          echo CODER_RELEASE_NOTES_FILE="$release_notes_file" >> $GITHUB_ENV
+
+      - name: Echo release notes
+        run: |
+          set -euo pipefail
+          cat "$CODER_RELEASE_NOTES_FILE"
+
       - name: Docker Login
         uses: docker/login-action@v2
         with:
@@ -124,44 +163,6 @@ jobs:
           AC_CERTIFICATE_P12_BASE64: ${{ secrets.AC_CERTIFICATE_P12_BASE64 }}
           AC_CERTIFICATE_PASSWORD: ${{ secrets.AC_CERTIFICATE_PASSWORD }}
           AC_APIKEY_P8_BASE64: ${{ secrets.AC_APIKEY_P8_BASE64 }}
-
-      - name: Create release tag and release notes
-        run: |
-          set -euo pipefail
-          ref=HEAD
-          old_version="$(git describe --abbrev=0 "$ref^1")"
-
-          # Warn if CODER_IGNORE_MISSING_COMMIT_METADATA is set any other way
-          # than via dry-run.
-          if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} != 0 ]]; then
-            echo "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata." 1>&2
-          fi
-
-          if [[ $DRY_RUN == true ]]; then
-            # Allow dry-run of branches to pass.
-            export CODER_IGNORE_MISSING_COMMIT_METADATA=1
-          fi
-
-          # Cache commit metadata.
-          . ./scripts/release/check_commit_metadata.sh "$old_version" "$ref"
-
-          # Create new release tag.
-          version="$(
-            ./scripts/release/tag_version.sh \
-              ${{ (github.event.inputs.dry_run || github.event.inputs.snapshot) && '--dry-run' }} \
-              --ref "$ref" \
-              --${{ github.event.inputs.increment }}
-          )"
-
-          # Generate notes.
-          release_notes_file="$(mktemp -t release_notes.XXXXXX)"
-          ./scripts/release/generate_release_notes.sh --old-version "$old_version" --new-version "$version" --ref "$ref" >> "$release_notes_file"
-          echo CODER_RELEASE_NOTES_FILE="$release_notes_file" >> $GITHUB_ENV
-
-      - name: Echo release notes
-        run: |
-          set -euo pipefail
-          cat "$CODER_RELEASE_NOTES_FILE"
 
       - name: Build binaries
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ on:
         type: boolean
         required: true
       ignore_missing_commit_metadata:
-        description: Warning! This option disables the requirement that all commits have a PR. Not needed for dry_run.
+        description: WARNING! This option disables the requirement that all commits have a PR. Not needed for dry_run.
         type: boolean
         default: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,6 +130,12 @@ jobs:
           ref=HEAD
           old_version="$(git describe --abbrev=0 "$ref^1")"
 
+          # Warn if CODER_IGNORE_MISSING_COMMIT_METADATA is set any other way
+          # than via dry-run.
+          if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} != 0 ]]; then
+            log "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata."
+          fi
+
           if [[ $DRY_RUN == true ]]; then
             # Allow dry-run of branches to pass.
             export CODER_IGNORE_MISSING_COMMIT_METADATA=1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,7 +133,7 @@ jobs:
           # Warn if CODER_IGNORE_MISSING_COMMIT_METADATA is set any other way
           # than via dry-run.
           if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} != 0 ]]; then
-            log "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata."
+            echo "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata." 1>&2
           fi
 
           if [[ $DRY_RUN == true ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,10 @@ on:
         description: Perform a dry-run release.
         type: boolean
         required: true
+      ignore_missing_commit_metadata:
+        description: Warning! This option disables the requirement that all commits have a PR. Not needed for dry_run.
+        type: boolean
+        default: false
 
 permissions:
   # Required to publish a release
@@ -36,10 +40,7 @@ permissions:
 env:
   CODER_RELEASE: ${{ github.event.inputs.snapshot && 'false' || 'true' }}
   DRY_RUN: ${{ (github.event.inputs.dry_run || github.event.inputs.snapshot) && 'true' || 'false' }}
-  # Temporary workaround for commits on `main` without a PR, we can remove this
-  # once we ensure all commits for a release will have a PR.
-  # Also see scripts/release.sh.
-  CODER_IGNORE_MISSING_COMMIT_METADATA: "1"
+  CODER_IGNORE_MISSING_COMMIT_METADATA: ${{ github.event.inputs.ignore_missing_commit_metadata && '1' || '0' }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,10 @@ permissions:
 env:
   CODER_RELEASE: ${{ github.event.inputs.snapshot && 'false' || 'true' }}
   DRY_RUN: ${{ (github.event.inputs.dry_run || github.event.inputs.snapshot) && 'true' || 'false' }}
+  # Temporary workaround for commits on `main` without a PR, we can remove this
+  # once we ensure all commits for a release will have a PR.
+  # Also see scripts/release.sh.
+  CODER_IGNORE_MISSING_COMMIT_METADATA: "1"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -149,12 +149,19 @@ fi
 args=()
 if ((draft)); then
 	args+=(-F draft=true)
+else
+	args+=(-F draft=false)
 fi
 if ((dry_run)); then
 	args+=(-F dry_run=true)
-fi
-if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} == 1 ]]; then
-	args+=(-F ignore_missing_commit_metadata=true)
+else
+	args+=(-F dry_run=false)
+
+	# We only set this on non-dry-run releases because it will show a
+	# warning in CI.
+	if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} == 1 ]]; then
+		args+=(-F ignore_missing_commit_metadata=true)
+	fi
 fi
 
 log

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -118,8 +118,8 @@ fi
 mapfile -t versions < <(gh api -H "Accept: application/vnd.github+json" /repos/coder/coder/git/refs/tags -q '.[].ref | split("/") | .[2]' | grep '^v' | sort -r -V)
 old_version=${versions[0]}
 
-# shellcheck source=scripts/release/check_commit_metadata.sh
 trap 'log "Check commit metadata failed, you can try to set \"export CODER_IGNORE_MISSING_COMMIT_METADATA=1\" and try again, if you know what you are doing."' EXIT
+# shellcheck source=scripts/release/check_commit_metadata.sh
 source "$SCRIPT_DIR/release/check_commit_metadata.sh" "$old_version" "$ref"
 trap - EXIT
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,6 +37,17 @@ specified branch as the release commit. This will also set --dry-run.
 EOH
 }
 
+# Temporary workaround for commits on `main` without a PR, we can remove this
+# once we ensure all commits for a release will have a PR.
+# Also see .github/workflow/release.yml.
+export CODER_IGNORE_MISSING_COMMIT_METADATA=1
+
+# Warn if CODER_IGNORE_MISSING_COMMIT_METADATA is set any other way than via
+# --branch.
+if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} != 0 ]]; then
+	log "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata."
+fi
+
 branch=main
 draft=0
 dry_run=0


### PR DESCRIPTION
The release script is currently failing, this fixes that:

```
./scripts/release.sh --patch
Fetching main and tags from origin...
ERROR: Metadata missing for commit 41cefef9
```