### PR TITLE
fix: handle NaN in build time estimate

### DIFF
--- a/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.stories.tsx
+++ b/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.stories.tsx
@@ -67,3 +67,9 @@ StartingHighVariaton.args = {
   ...Starting.args,
   transitionStats: { P50: 10000, P95: 20000 },
 }
+
+export const StartingZeroEstimate = Template.bind({})
+StartingZeroEstimate.args = {
+  ...Starting.args,
+  transitionStats: { P50: 0, P95: 0 },
+}

--- a/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.tsx
+++ b/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.tsx
@@ -34,11 +34,13 @@ const estimateFinish = (
   p95: number,
 ): [number | undefined, string] => {
   const sinceStart = dayjs().diff(startedAt)
-  const secondsLeft = (est: number) =>
-    Math.max(
+  const secondsLeft = (est: number) => {
+    const max = Math.max(
       Math.ceil(dayjs.duration((1 - sinceStart / est) * est).asSeconds()),
       0,
     )
+    return isNaN(max) ? 0 : max
+  }
 
   const lowGuess = secondsLeft(p50)
   const highGuess = secondsLeft(p95)


### PR DESCRIPTION
Fixes #5437 

If the estimated time left is 0, we divide by 0 and get NaN, and the max of 0 and NaN is NaN, so it takes an extra step to avoid passing NaN on. 
