### PR TITLE
refactor: Refactor site roles machine to be used in the page

### DIFF
--- a/site/src/xServices/StateContext.tsx
+++ b/site/src/xServices/StateContext.tsx
@@ -6,7 +6,6 @@ import { buildInfoMachine } from "./buildInfo/buildInfoXService"
 import { updateCheckMachine } from "./updateCheck/updateCheckXService"
 import { deploymentConfigMachine } from "./deploymentConfig/deploymentConfigMachine"
 import { entitlementsMachine } from "./entitlements/entitlementsXService"
-import { siteRolesMachine } from "./roles/siteRolesXService"
 import { appearanceMachine } from "./appearance/appearanceXService"
 
 interface XServiceContextType {
@@ -14,7 +13,6 @@ interface XServiceContextType {
   buildInfoXService: ActorRefFrom<typeof buildInfoMachine>
   entitlementsXService: ActorRefFrom<typeof entitlementsMachine>
   appearanceXService: ActorRefFrom<typeof appearanceMachine>
-  siteRolesXService: ActorRefFrom<typeof siteRolesMachine>
   // Since the info here is used by multiple deployment settings page and we don't want to refetch them every time
   deploymentConfigXService: ActorRefFrom<typeof deploymentConfigMachine>
   updateCheckXService: ActorRefFrom<typeof updateCheckMachine>
@@ -38,7 +36,6 @@ export const XServiceProvider: FC<{ children: ReactNode }> = ({ children }) => {
         buildInfoXService: useInterpret(buildInfoMachine),
         entitlementsXService: useInterpret(entitlementsMachine),
         appearanceXService: useInterpret(appearanceMachine),
-        siteRolesXService: useInterpret(siteRolesMachine),
         deploymentConfigXService: useInterpret(deploymentConfigMachine),
         updateCheckXService: useInterpret(updateCheckMachine),
       }}


### PR DESCRIPTION
Since the user roles are only used on the users page, I moved it to be used only there instead of passing it to the provider.