### PR TITLE
refactor: Move deploy settings machine to the layout

### DIFF
--- a/site/src/components/DeploySettingsLayout/DeploySettingsLayout.tsx
+++ b/site/src/components/DeploySettingsLayout/DeploySettingsLayout.tsx
@@ -7,13 +7,12 @@ import {
   PropsWithChildren,
   Suspense,
   useContext,
-  useEffect,
   FC,
 } from "react"
-import { useActor } from "@xstate/react"
-import { XServiceContext } from "xServices/StateContext"
+import { useMachine } from "@xstate/react"
 import { Loader } from "components/Loader/Loader"
 import { DeploymentConfig } from "api/typesGenerated"
+import { deploymentConfigMachine } from "xServices/deploymentConfig/deploymentConfigMachine"
 
 type DeploySettingsContextValue = { deploymentConfig: DeploymentConfig }
 
@@ -32,16 +31,9 @@ export const useDeploySettings = (): DeploySettingsContextValue => {
 }
 
 export const DeploySettingsLayout: FC<PropsWithChildren> = ({ children }) => {
-  const xServices = useContext(XServiceContext)
-  const [state, send] = useActor(xServices.deploymentConfigXService)
+  const [state] = useMachine(deploymentConfigMachine)
   const styles = useStyles()
   const { deploymentConfig } = state.context
-
-  useEffect(() => {
-    if (state.matches("idle")) {
-      send("LOAD")
-    }
-  }, [send, state])
 
   return (
     <Margins>

--- a/site/src/xServices/StateContext.tsx
+++ b/site/src/xServices/StateContext.tsx
@@ -4,7 +4,6 @@ import { ActorRefFrom } from "xstate"
 import { authMachine } from "./auth/authXService"
 import { buildInfoMachine } from "./buildInfo/buildInfoXService"
 import { updateCheckMachine } from "./updateCheck/updateCheckXService"
-import { deploymentConfigMachine } from "./deploymentConfig/deploymentConfigMachine"
 import { entitlementsMachine } from "./entitlements/entitlementsXService"
 import { siteRolesMachine } from "./roles/siteRolesXService"
 import { appearanceMachine } from "./appearance/appearanceXService"
@@ -15,8 +14,6 @@ interface XServiceContextType {
   entitlementsXService: ActorRefFrom<typeof entitlementsMachine>
   appearanceXService: ActorRefFrom<typeof appearanceMachine>
   siteRolesXService: ActorRefFrom<typeof siteRolesMachine>
-  // Since the info here is used by multiple deployment settings page and we don't want to refetch them every time
-  deploymentConfigXService: ActorRefFrom<typeof deploymentConfigMachine>
   updateCheckXService: ActorRefFrom<typeof updateCheckMachine>
 }
 
@@ -39,7 +36,6 @@ export const XServiceProvider: FC<{ children: ReactNode }> = ({ children }) => {
         entitlementsXService: useInterpret(entitlementsMachine),
         appearanceXService: useInterpret(appearanceMachine),
         siteRolesXService: useInterpret(siteRolesMachine),
-        deploymentConfigXService: useInterpret(deploymentConfigMachine),
         updateCheckXService: useInterpret(updateCheckMachine),
       }}
     >

--- a/site/src/xServices/deploymentConfig/deploymentConfigMachine.ts
+++ b/site/src/xServices/deploymentConfig/deploymentConfigMachine.ts
@@ -6,7 +6,7 @@ export const deploymentConfigMachine = createMachine(
   {
     id: "deploymentConfigMachine",
     predictableActionArguments: true,
-    initial: "idle",
+
     schema: {
       context: {} as {
         deploymentConfig?: DeploymentConfig
@@ -20,28 +20,22 @@ export const deploymentConfigMachine = createMachine(
       },
     },
     tsTypes: {} as import("./deploymentConfigMachine.typegen").Typegen0,
+    initial: "loading",
     states: {
-      idle: {
-        on: {
-          LOAD: {
-            target: "loading",
-          },
-        },
-      },
       loading: {
         invoke: {
           src: "getDeploymentConfig",
           onDone: {
-            target: "loaded",
+            target: "done",
             actions: ["assignDeploymentConfig"],
           },
           onError: {
-            target: "idle",
+            target: "done",
             actions: ["assignGetDeploymentConfigError"],
           },
         },
       },
-      loaded: {
+      done: {
         type: "final",
       },
     },


### PR DESCRIPTION
The deploy settings machine is only used in the deploy settings layout so I moved it to there.