### PR TITLE
ci: Fix release tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # Set token for pushing protected tag (vX.X.X).
+          token: ${{ secrets.RELEASE_GITHUB_PAT }}
 
       # If the event that triggered the build was an annotated tag (which our
       # tags are supposed to be), actions/checkout has a bug where the tag in
@@ -76,8 +78,8 @@ jobs:
       # Configure git user name/email for creating annotated version tag.
       - name: Setup git config
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email ""
+          git config user.name "Coder CI"
+          git config user.email "dean+cdrci@coder.com"
 
       - name: Create release tag and release notes
         run: |


### PR DESCRIPTION
With tag protection rules, GitHub actions isn't able to push tags with the default token.

```
GH006: Protected tag update failed ...
```
