### PR TITLE
chore: mark API doc files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 # Generated files
+coderd/apidoc/docs.go linguist-generated=true
+coderd/apidoc/swagger.json linguist-generated=true
 coderd/database/dump.sql linguist-generated=true
 peerbroker/proto/*.go linguist-generated=true
 provisionerd/proto/*.go linguist-generated=true


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/5710#discussion_r1069670914

This PR marks API doc files as generated, so they are hidden by default in the Github PR preview.