### PR TITLE
ci: Revert to local tag creation and push for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       increment:
-        description: Preferred version increment (release script may promote e.g. patch to minor depending on changes).
+        description: Version increment.
         type: choice
         required: true
         default: patch
@@ -37,7 +37,6 @@ env:
   # https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/
   CODER_RELEASE: ${{ !inputs.dry_run }}
   CODER_RELEASE_INCREMENT: ${{ inputs.increment }}
-  CODER_RELEASE_DRAFT: ${{ inputs.draft }}
   CODER_DRY_RUN: ${{ inputs.dry_run }}
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,9 @@
 # GitHub release workflow.
 name: Release
-run-name: Release ${{ github.ref_name }}${{ inputs.dry_run && ' (DRYRUN)' || '' }}
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       increment:
@@ -13,19 +15,10 @@ on:
           - patch
           - minor
           - major
-      draft:
-        description: Create a draft release (for manually editing release notes before publishing).
-        type: boolean
-        required: true
-        default: false
       dry_run:
         description: Perform a dry-run release.
         type: boolean
         required: true
-        default: false
-      ignore_missing_commit_metadata:
-        description: WARNING! This option disables the requirement that all commits have a PR. Not needed for dry_run.
-        type: boolean
         default: false
 
 permissions:
@@ -55,17 +48,9 @@ jobs:
       # Necessary for Docker manifest
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Check release on main (or dry-run)
-        if: ${{ github.ref_name != 'main' && !inputs.dry_run }}
-        run: |
-          echo "Release not allowed on ${{ github.ref_name }}, use dry-run."
-          exit 1
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          # Set token for pushing protected tag (vX.X.X).
-          token: ${{ secrets.RELEASE_GITHUB_PAT }}
 
       # If the event that triggered the build was an annotated tag (which our
       # tags are supposed to be), actions/checkout has a bug where the tag in
@@ -75,55 +60,39 @@ jobs:
       - name: Fetch git tags
         run: git fetch --tags --force
 
-      # Configure git user name/email for creating annotated version tag.
-      - name: Setup git config
-        run: |
-          git config user.name "Coder CI"
-          git config user.email "dean+cdrci@coder.com"
-
-      - name: Create release tag and release notes
+      - name: Create release notes
+        if: ${{ inputs.dry_run }}
+        env:
+          # We always have to set this since there might be commits on
+          # main that didn't have a PR.
+          CODER_IGNORE_MISSING_COMMIT_METADATA: "1"
         run: |
           set -euo pipefail
           ref=HEAD
           old_version="$(git describe --abbrev=0 "$ref^1")"
 
-          if [[ "${{ inputs.ignore_missing_commit_metadata }}" == *t* ]]; then
-            export CODER_IGNORE_MISSING_COMMIT_METADATA=1
-          fi
-
-          # Warn if CODER_IGNORE_MISSING_COMMIT_METADATA is set any other way
-          # than via dry-run.
-          if [[ ${CODER_IGNORE_MISSING_COMMIT_METADATA:-0} != 0 ]]; then
-            echo "WARNING: CODER_IGNORE_MISSING_COMMIT_METADATA is enabled and we will ignore missing commit metadata." 1>&2
-          fi
-
-          version_args=()
-          if [[ $CODER_DRY_RUN == *t* ]]; then
-            # Allow dry-run of branches to pass.
-            export CODER_IGNORE_MISSING_COMMIT_METADATA=1
-            version_args+=(--dry-run)
-          fi
-
           # Cache commit metadata.
           . ./scripts/release/check_commit_metadata.sh "$old_version" "$ref"
 
-          declare -p version_args
-
-          # Create new release tag (note that this tag is not pushed before
-          # release.sh is run).
-          version="$(
-            ./scripts/release/tag_version.sh \
-              "${version_args[@]}" \
-              --ref "$ref" \
-              --"$CODER_RELEASE_INCREMENT"
-          )"
+          if [[ $CODER_DRY_RUN != *t* ]]; then
+            # This will fail if we're doing a non-dry-run without tag
+            # being present.
+            version="$(./scripts/version.sh)"
+          else
+            # Create a tag for this dry-run (local only, can't be uploaded).
+            version="$(
+              ./scripts/release/tag_version.sh \
+                --ref "$ref" \
+                --"$CODER_RELEASE_INCREMENT"
+            )"
+          fi
 
           # Generate notes.
           release_notes_file="$(mktemp -t release_notes.XXXXXX)"
           ./scripts/release/generate_release_notes.sh --old-version "$old_version" --new-version "$version" --ref "$ref" >> "$release_notes_file"
           echo CODER_RELEASE_NOTES_FILE="$release_notes_file" >> $GITHUB_ENV
 
-      - name: Echo release notes
+      - name: Show release notes
         run: |
           set -euo pipefail
           cat "$CODER_RELEASE_NOTES_FILE"
@@ -243,9 +212,6 @@ jobs:
           set -euo pipefail
 
           publish_args=()
-          if [[ $CODER_RELEASE_DRAFT == *t* ]]; then
-            publish_args+=(--draft)
-          fi
           if [[ $CODER_DRY_RUN == *t* ]]; then
             publish_args+=(--dry-run)
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: Perform a dry-run release (devel).
+        description: Perform a dry-run release (devel). Note that ref must be an annotated tag when run without dry-run.
         type: boolean
         required: true
         default: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,17 +6,8 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
-      increment:
-        description: Version increment.
-        type: choice
-        required: true
-        default: patch
-        options:
-          - patch
-          - minor
-          - major
       dry_run:
-        description: Perform a dry-run release.
+        description: Perform a dry-run release (devel).
         type: boolean
         required: true
         default: false
@@ -36,7 +27,6 @@ env:
   # booleans, not strings.
   # https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/
   CODER_RELEASE: ${{ !inputs.dry_run }}
-  CODER_RELEASE_INCREMENT: ${{ inputs.increment }}
   CODER_DRY_RUN: ${{ inputs.dry_run }}
 
 jobs:
@@ -69,18 +59,6 @@ jobs:
           ref=HEAD
           old_version="$(git describe --abbrev=0 "$ref^1")"
           version="$(./scripts/version.sh)"
-
-          # Cache commit metadata.
-          . ./scripts/release/check_commit_metadata.sh "$old_version" "$ref"
-
-          if [[ $CODER_DRY_RUN == *t* ]]; then
-            # Create a tag for this dry-run (local only, can't be uploaded).
-            version="$(
-              ./scripts/release/tag_version.sh \
-                --ref "$ref" \
-                --"$CODER_RELEASE_INCREMENT"
-            )"
-          fi
 
           # Generate notes.
           release_notes_file="$(mktemp -t release_notes.XXXXXX)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   release:
-    name: Create and publish
+    name: Build and publish
     runs-on: ${{ github.repository_owner == 'coder' && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
     env:
       # Necessary for Docker manifest
@@ -60,7 +60,6 @@ jobs:
         run: git fetch --tags --force
 
       - name: Create release notes
-        if: ${{ inputs.dry_run }}
         env:
           # We always have to set this since there might be commits on
           # main that didn't have a PR.
@@ -69,15 +68,12 @@ jobs:
           set -euo pipefail
           ref=HEAD
           old_version="$(git describe --abbrev=0 "$ref^1")"
+          version="$(./scripts/version.sh)"
 
           # Cache commit metadata.
           . ./scripts/release/check_commit_metadata.sh "$old_version" "$ref"
 
-          if [[ $CODER_DRY_RUN != *t* ]]; then
-            # This will fail if we're doing a non-dry-run without tag
-            # being present.
-            version="$(./scripts/version.sh)"
-          else
+          if [[ $CODER_DRY_RUN == *t* ]]; then
             # Create a tag for this dry-run (local only, can't be uploaded).
             version="$(
               ./scripts/release/tag_version.sh \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -133,6 +133,11 @@ log
 maybedryrun "$dry_run" execrelative ./release/tag_version.sh --old-version "$old_version" --ref "$ref" --"$increment" >/dev/null
 maybedryrun "$dry_run" git push --tags -u origin "$new_version"
 
+if ((dry_run)); then
+	# We can't watch the release.yaml workflow if we're in dry-run mode.
+	exit 0
+fi
+
 log
 read -p "Watch release? (y/n) " -n 1 -r watch
 log

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -106,11 +106,14 @@ trap - EXIT
 log "Executing DRYRUN of release tagging..."
 new_version="$(execrelative ./release/tag_version.sh --old-version "$old_version" --ref "$ref" --"$increment" --dry-run)"
 log
-read -p "Continue? (y/n) " -n 1 -r show_reply
+read -p "Continue? (y/n) " -n 1 -r continue_release
+log
+if ! [[ $continue_release =~ ^[Yy]$ ]]; then
+	exit 0
+fi
 
 release_notes="$(execrelative ./release/generate_release_notes.sh --old-version "$old_version" --new-version "$new_version" --ref "$ref")"
 
-log
 read -p "Preview release notes? (y/n) " -n 1 -r show_reply
 log
 if [[ $show_reply =~ ^[Yy]$ ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -86,9 +86,9 @@ git fetch --quiet --tags origin "$branch"
 ref=$(git rev-parse --short "${ref:-origin/$branch}")
 
 # Make sure that we're running the latest release script.
-# if [[ -n $(git diff --name-status origin/"$branch" -- ./scripts/release.sh) ]]; then
-# 	error "Release script is out-of-date. Please check out the latest version and try again."
-# fi
+if [[ -n $(git diff --name-status origin/"$branch" -- ./scripts/release.sh) ]]; then
+	error "Release script is out-of-date. Please check out the latest version and try again."
+fi
 
 # Check the current version tag from GitHub (by number) using the API to
 # ensure no local tags are considered.

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -96,7 +96,7 @@ main() {
 			if [[ $ignore_missing_metadata != 1 ]]; then
 				error "Metadata missing for commit $commit_sha_short"
 			else
-				log "WARING: Metadata missing for commit $commit_sha_short"
+				log "WARNING: Metadata missing for commit $commit_sha_short"
 			fi
 		fi
 

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -91,10 +91,12 @@ main() {
 		commit_sha_long=${parts[1]}
 		commit_prefix=${parts[2]}
 
-		if [[ $ignore_missing_metadata != 1 ]]; then
-			# Safety-check, guarantee all commits had their metadata fetched.
-			if [[ ! -v labels[$commit_sha_long] ]]; then
+		# Safety-check, guarantee all commits had their metadata fetched.
+		if [[ ! -v labels[$commit_sha_long] ]]; then
+			if [[ $ignore_missing_metadata != 1 ]]; then
 				error "Metadata missing for commit $commit_sha_short"
+			else
+				log "WARING: Metadata missing for commit $commit_sha_short"
 			fi
 		fi
 

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -35,10 +35,9 @@ fi
 
 version=""
 release_notes_file=""
-draft=0
 dry_run=0
 
-args="$(getopt -o "" -l version:,release-notes-file:,draft,dry-run -- "$@")"
+args="$(getopt -o "" -l version:,release-notes-file:,dry-run -- "$@")"
 eval set -- "$args"
 while true; do
 	case "$1" in
@@ -49,10 +48,6 @@ while true; do
 	--release-notes-file)
 		release_notes_file="$2"
 		shift 2
-		;;
-	--draft)
-		draft=1
-		shift
 		;;
 	--dry-run)
 		dry_run=1

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -134,20 +134,11 @@ popd
 log
 log
 
-log "Pushing git tag"
-maybedryrun "$dry_run" git push --quiet origin "$new_tag"
-
-args=()
-if ((draft)); then
-	args+=(--draft)
-fi
-
 # We pipe `true` into `gh` so that it never tries to be interactive.
 true |
 	maybedryrun "$dry_run" gh release create \
 		--title "$new_tag" \
 		--notes-file "$release_notes_file" \
-		"${args[@]}" \
 		"$new_tag" \
 		"$temp_dir"/*
 


### PR DESCRIPTION
This PR reverts to pre-refactor behavior of requiring manual tag creation/push (via `release.sh`) to create a release.

The manual workflow dispatch now only has one option, dry-run. To run it without dry-run requires the ref to be set to an annotated tag.

We also drop support for `--draft` since there's no way to tell the action to create a draft release when triggered by `on.push`.