### PR TITLE
chore: Drop unused Experimental flag from api options

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -476,6 +476,7 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 				LoginRateLimit:              loginRateLimit,
 				FilesRateLimit:              filesRateLimit,
 				HTTPClient:                  httpClient,
+				Experimental:                cfg.Experimental.Value,
 			}
 			if tlsConfig != nil {
 				options.TLSCertificates = tlsConfig.Certificates

--- a/cli/server.go
+++ b/cli/server.go
@@ -476,7 +476,6 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 				LoginRateLimit:              loginRateLimit,
 				FilesRateLimit:              filesRateLimit,
 				HTTPClient:                  httpClient,
-				Experimental:                cfg.Experimental.Value,
 			}
 			if tlsConfig != nil {
 				options.TLSCertificates = tlsConfig.Certificates

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -123,7 +123,6 @@ type Options struct {
 
 	MetricsCacheRefreshInterval time.Duration
 	AgentStatsRefreshInterval   time.Duration
-	Experimental                bool
 	DeploymentConfig            *codersdk.DeploymentConfig
 	UpdateCheckOptions          *updatecheck.Options // Set non-nil to enable update checking.
 


### PR DESCRIPTION
Currently the `experimental` flag is only set on Enterprise routes via `updateEntitlements`.

In the free version, `Experimental` is on the api config and never set.

Dropping the unused boolean.
