### PR TITLE
fix(examples): use correct build args for Docker template

### DIFF
--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -95,7 +95,7 @@ resource "docker_image" "main" {
   name = "coder-${data.coder_workspace.me.id}"
   build {
     path = "./build"
-    build_arg = {
+    build_args = {
       USER = local.username
     }
   }


### PR DESCRIPTION
**TL;DR:** The `docker` sample template does not properly pass the `USER` build variable to the image build process, because the wrong argument (`build_arg` ) is being used instead of `build_args`.

The thing kinda works only because the `Dockerfile` itself sets a default `USER` value to `coder`. However, if your actual Coder username is different (e.g. mine is `olance`), then you’ll end up with an Ubuntu install with two homes: `/home/coder` and `/home/olance` in my case.

The problem is, the `code-server` app will then run as the `coder` user, but open the `/home/olance` directory as the default workspace… which it has no write permission to! That’s because most paths & username expansion are made in Terraform using the correct owner name, whereas the Unix user being used depends on the `USER` arg being correctly set.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
