### PR TITLE
fix(site): always use 95th percentile in progress bar

### DIFF
--- a/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.tsx
+++ b/site/src/components/WorkspaceBuildProgress/WorkspaceBuildProgress.tsx
@@ -42,7 +42,7 @@ const estimateFinish = (
     return isNaN(max) ? 0 : max
   }
 
-  const lowGuess = secondsLeft(p50)
+  // Under-promise, over-deliver with the 95th percentile estimate.
   const highGuess = secondsLeft(p95)
 
   const anyMomentNow: [number | undefined, string] = [
@@ -54,11 +54,7 @@ const estimateFinish = (
   if (highGuess <= 0) {
     return anyMomentNow
   }
-  const diff = highGuess - lowGuess
-  if (diff < 3) {
-    // If there is sufficient consistency, keep display simple.
-    return [p50percent, `${highGuess} seconds remaining...`]
-  }
+
   return [p50percent, `Up to ${highGuess} seconds remaining...`]
 }
 


### PR DESCRIPTION
This fixes the issue where the bar flickers from "Up to X seconds
remaining" to "X seconds remaining".

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
