### PR TITLE
chore: combine dogfood regions, use tailscale

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -13,10 +13,19 @@ terraform {
 
 # User parameters
 
+variable "region" {
+  type        = string
+  description = "Which region to deploy to."
+  default     = "us-pittsburgh"
+  validation {
+    condition     = contains(["us-pittsburgh", "eu-helsinki", "ap-sydney"], var.region)
+    error_message = "Region must be one of us-pittsburg, eu-helsinki, or ap-sydney."
+  }
+}
+
 variable "dotfiles_uri" {
   type        = string
   description = <<-EOF
-  default     = ""
   Dotfiles repo URI (optional)
 
   see https://dotfiles.github.io
@@ -30,17 +39,23 @@ variable "datocms_api_token" {
   default     = ""
 }
 
-# Admin parameters
+locals {
+  // These are Tailscale IP addresses. Ask Dean or Kyle for help.
+  docker_host = {
+    ""              = "tcp://100.94.74.63:2375"
+    "us-pittsburgh" = "tcp://100.94.74.63:2375"
+    "eu-helsinki"   = "tcp://100.117.102.81:2375"
+    "ap-sydney"     = "tcp://100.127.2.1:2375"
+  }
+}
 
 provider "docker" {
-  host = "unix:///var/run/dogfood-docker.sock"
+  host = lookup(local.docker_host, var.region)
 }
 
-provider "coder" {
-}
+provider "coder" {}
 
-data "coder_workspace" "me" {
-}
+data "coder_workspace" "me" {}
 
 resource "coder_agent" "dev" {
   arch           = "amd64"


### PR DESCRIPTION
Changes the docker socket that we were forwarding over SSH to be Tailscale (like we have been using for Sydney for months, and Helsinki since it was made a few days ago).

On each node there is a `tailscale/` and `socat/` dir with docker-compose files. The tailscale docker-compose is obvious, but the socat one forwards the docker daemon socket to a TCP port that only binds to the tailscale IP. I chose to use socat instead of making Docker listen on the tailscale IP directly because I still wanted `docker ps` on the node to work without having to set `DOCKER_HOST`.