### PR TITLE
feat: Expose workspace build parameters via API

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4309,6 +4309,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspacebuilds/{workspacebuild}/parameters": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Builds"
+                ],
+                "summary": "Get build parameters for workspace build",
+                "operationId": "get-build-parameters-for-workspace-build",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace build ID",
+                        "name": "workspacebuild",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.WorkspaceBuildParameter"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/workspacebuilds/{workspacebuild}/resources": {
             "get": {
                 "security": [
@@ -5566,6 +5603,12 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.CreateParameterRequest"
+                    }
+                },
+                "rich_parameter_values": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.WorkspaceBuildParameter"
                     }
                 },
                 "state": {
@@ -7892,6 +7935,17 @@ const docTemplate = `{
                     "format": "uuid"
                 },
                 "workspace_owner_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.WorkspaceBuildParameter": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
                     "type": "string"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3793,6 +3793,39 @@
         }
       }
     },
+    "/workspacebuilds/{workspacebuild}/parameters": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["Builds"],
+        "summary": "Get build parameters for workspace build",
+        "operationId": "get-build-parameters-for-workspace-build",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Workspace build ID",
+            "name": "workspacebuild",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/codersdk.WorkspaceBuildParameter"
+              }
+            }
+          }
+        }
+      }
+    },
     "/workspacebuilds/{workspacebuild}/resources": {
       "get": {
         "security": [
@@ -4928,6 +4961,12 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/codersdk.CreateParameterRequest"
+          }
+        },
+        "rich_parameter_values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.WorkspaceBuildParameter"
           }
         },
         "state": {
@@ -7104,6 +7143,17 @@
           "format": "uuid"
         },
         "workspace_owner_name": {
+          "type": "string"
+        }
+      }
+    },
+    "codersdk.WorkspaceBuildParameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
           "type": "string"
         }
       }

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -582,6 +582,7 @@ func New(options *Options) *API {
 			r.Get("/", api.workspaceBuild)
 			r.Patch("/cancel", api.patchCancelWorkspaceBuild)
 			r.Get("/logs", api.workspaceBuildLogs)
+			r.Get("/parameters", api.workspaceBuildParameters)
 			r.Get("/resources", api.workspaceBuildResources)
 			r.Get("/state", api.workspaceBuildState)
 		})

--- a/coderd/database/databasefake/databasefake.go
+++ b/coderd/database/databasefake/databasefake.go
@@ -1372,7 +1372,7 @@ func (q *fakeQuerier) GetWorkspaceBuildParameters(_ context.Context, workspaceBu
 	defer q.mutex.RUnlock()
 
 	params := make([]database.WorkspaceBuildParameter, 0)
-	for _, param := range params {
+	for _, param := range q.workspaceBuildParameters {
 		if param.WorkspaceBuildID != workspaceBuildID {
 			continue
 		}

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -636,52 +636,106 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 func TestWorkspaceBuildWithRichParameters(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
-	user := coderdtest.CreateFirstUser(t, client)
-	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+	const (
+		firstParameterName        = "first_parameter"
+		firstParameterDescription = "This is first parameter"
+		firstParameterValue       = "1"
+
+		secondParameterName        = "second_parameter"
+		secondParameterDescription = "This is second parameter"
+		secondParameterValue       = "2"
+	)
+
+	initialBuildParameters := []codersdk.WorkspaceBuildParameter{
+		{Name: firstParameterName, Value: firstParameterValue},
+		{Name: secondParameterName, Value: secondParameterValue},
+	}
+
+	echoResponses := &echo.Responses{
 		Parse: echo.ParseComplete,
 		ProvisionPlan: []*proto.Provision_Response{
 			{
 				Type: &proto.Provision_Response_Complete{
 					Complete: &proto.Provision_Complete{
 						Parameters: []*proto.RichParameter{
-							{
-								Name:        "first_parameter",
-								Description: "This is first parameter",
-							},
-							{
-								Name:        "second_parameter",
-								Description: "This is second parameter",
-							},
+							{Name: firstParameterName, Description: firstParameterDescription},
+							{Name: secondParameterName, Description: secondParameterDescription},
 						},
 					},
 				},
 			}},
-	})
-	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
-
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-	defer cancel()
-
-	richParameters, err := client.TemplateVersionRichParameters(ctx, version.ID)
-	require.NoError(t, err)
-	require.Len(t, richParameters, 2)
-	require.Equal(t, richParameters[0].Name, "first_parameter")
-	require.Equal(t, richParameters[1].Name, "second_parameter")
-
-	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
-		cwr.RichParameterValues = []codersdk.WorkspaceBuildParameter{
-			{
-				Name:  "first_parameter",
-				Value: "1",
+		ProvisionApply: []*proto.Provision_Response{{
+			Type: &proto.Provision_Response_Complete{
+				Complete: &proto.Provision_Complete{},
 			},
-			{
-				Name:  "second_parameter",
-				Value: "2",
-			},
+		}},
+	}
+
+	t.Run("UpdateParameterValues", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, echoResponses)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.RichParameterValues = initialBuildParameters
+		})
+
+		workspaceBuild := coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+		require.Equal(t, codersdk.WorkspaceStatusRunning, workspaceBuild.Status)
+
+		// Update build parameters
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		const updatedParameterValue = "3"
+		nextBuildParameters := []codersdk.WorkspaceBuildParameter{
+			{Name: firstParameterName, Value: firstParameterValue},
+			{Name: secondParameterName, Value: updatedParameterValue},
 		}
+		nextWorkspaceBuild, err := client.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+			Transition:          codersdk.WorkspaceTransitionStart,
+			RichParameterValues: nextBuildParameters,
+		})
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, nextWorkspaceBuild.ID)
+
+		workspaceBuildParameters, err := client.WorkspaceBuildParameters(ctx, nextWorkspaceBuild.ID)
+		require.NoError(t, err)
+		require.ElementsMatch(t, nextBuildParameters, workspaceBuildParameters)
 	})
-	_, err = client.WorkspaceBuild(ctx, workspace.LatestBuild.ID)
-	require.NoError(t, err)
+	t.Run("UsePreviousParameterValues", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, echoResponses)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.RichParameterValues = initialBuildParameters
+		})
+
+		firstWorkspaceBuild := coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+		require.Equal(t, codersdk.WorkspaceStatusRunning, firstWorkspaceBuild.Status)
+
+		// Start new workspace build
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		nextWorkspaceBuild, err := client.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+			Transition: codersdk.WorkspaceTransitionStart,
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, firstWorkspaceBuild, nextWorkspaceBuild)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, nextWorkspaceBuild.ID)
+
+		workspaceBuildParameters, err := client.WorkspaceBuildParameters(ctx, nextWorkspaceBuild.ID)
+		require.NoError(t, err)
+		require.ElementsMatch(t, initialBuildParameters, workspaceBuildParameters)
+	})
 }

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -502,6 +502,21 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		if err != nil {
 			return xerrors.Errorf("insert workspace build: %w", err)
 		}
+
+		names := make([]string, 0, len(createWorkspace.RichParameterValues))
+		values := make([]string, 0, len(createWorkspace.RichParameterValues))
+		for _, param := range createWorkspace.RichParameterValues {
+			names = append(names, param.Name)
+			values = append(values, param.Value)
+		}
+		err = db.InsertWorkspaceBuildParameters(ctx, database.InsertWorkspaceBuildParametersParams{
+			WorkspaceBuildID: workspaceBuildID,
+			Name:             names,
+			Value:            values,
+		})
+		if err != nil {
+			return xerrors.Errorf("insert workspace build parameters: %w", err)
+		}
 		return nil
 	}, nil)
 	if err != nil {

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -164,3 +164,16 @@ func (c *Client) WorkspaceBuildByUsernameAndWorkspaceNameAndBuildNumber(ctx cont
 	var workspaceBuild WorkspaceBuild
 	return workspaceBuild, json.NewDecoder(res.Body).Decode(&workspaceBuild)
 }
+
+func (c *Client) WorkspaceBuildParameters(ctx context.Context, build uuid.UUID) ([]WorkspaceBuildParameter, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/workspacebuilds/%s/parameters", build), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, readBodyAsError(res)
+	}
+	var params []WorkspaceBuildParameter
+	return params, json.NewDecoder(res.Body).Decode(&params)
+}

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -56,7 +56,8 @@ type CreateWorkspaceBuildRequest struct {
 	// ParameterValues are optional. It will write params to the 'workspace' scope.
 	// This will overwrite any existing parameters with the same name.
 	// This will not delete old params not included in this list.
-	ParameterValues []CreateParameterRequest `json:"parameter_values,omitempty"`
+	ParameterValues     []CreateParameterRequest  `json:"parameter_values,omitempty"`
+	RichParameterValues []WorkspaceBuildParameter `json:"rich_parameter_values,omitempty"`
 }
 
 type WorkspaceOptions struct {

--- a/docs/api/builds.md
+++ b/docs/api/builds.md
@@ -405,6 +405,56 @@ Status Code **200**
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get build parameters for workspace build
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/parameters \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspacebuilds/{workspacebuild}/parameters`
+
+### Parameters
+
+| Name             | In   | Type   | Required | Description        |
+| ---------------- | ---- | ------ | -------- | ------------------ |
+| `workspacebuild` | path | string | true     | Workspace build ID |
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "name": "string",
+    "value": "string"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                  |
+| ------ | ------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.WorkspaceBuildParameter](schemas.md#codersdkworkspacebuildparameter) |
+
+<h3 id="get-build-parameters-for-workspace-build-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type   | Required | Restrictions | Description |
+| -------------- | ------ | -------- | ------------ | ----------- |
+| `[array item]` | array  | false    |              |             |
+| `» name`       | string | false    |              |             |
+| `» value`      | string | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get workspace resources for workspace build
 
 ### Code samples
@@ -1040,6 +1090,12 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
       "name": "string",
       "source_scheme": "none",
       "source_value": "string"
+    }
+  ],
+  "rich_parameter_values": [
+    {
+      "name": "string",
+      "value": "string"
     }
   ],
   "state": [0],

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -870,6 +870,12 @@ CreateParameterRequest is a structure used to create a new parameter value for a
       "source_value": "string"
     }
   ],
+  "rich_parameter_values": [
+    {
+      "name": "string",
+      "value": "string"
+    }
+  ],
   "state": [0],
   "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
   "transition": "create"
@@ -878,14 +884,15 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 
 ### Properties
 
-| Name                  | Type                                                                        | Required | Restrictions | Description                                                                                                                                                                                              |
-| --------------------- | --------------------------------------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dry_run`             | boolean                                                                     | false    |              |                                                                                                                                                                                                          |
-| `orphan`              | boolean                                                                     | false    |              | Orphan may be set for the Destroy transition.                                                                                                                                                            |
-| `parameter_values`    | array of [codersdk.CreateParameterRequest](#codersdkcreateparameterrequest) | false    |              | Parameter values are optional. It will write params to the 'workspace' scope. This will overwrite any existing parameters with the same name. This will not delete old params not included in this list. |
-| `state`               | array of integer                                                            | false    |              |                                                                                                                                                                                                          |
-| `template_version_id` | string                                                                      | false    |              |                                                                                                                                                                                                          |
-| `transition`          | [codersdk.WorkspaceTransition](#codersdkworkspacetransition)                | true     |              |                                                                                                                                                                                                          |
+| Name                    | Type                                                                          | Required | Restrictions | Description                                                                                                                                                                                              |
+| ----------------------- | ----------------------------------------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dry_run`               | boolean                                                                       | false    |              |                                                                                                                                                                                                          |
+| `orphan`                | boolean                                                                       | false    |              | Orphan may be set for the Destroy transition.                                                                                                                                                            |
+| `parameter_values`      | array of [codersdk.CreateParameterRequest](#codersdkcreateparameterrequest)   | false    |              | Parameter values are optional. It will write params to the 'workspace' scope. This will overwrite any existing parameters with the same name. This will not delete old params not included in this list. |
+| `rich_parameter_values` | array of [codersdk.WorkspaceBuildParameter](#codersdkworkspacebuildparameter) | false    |              |                                                                                                                                                                                                          |
+| `state`                 | array of integer                                                              | false    |              |                                                                                                                                                                                                          |
+| `template_version_id`   | string                                                                        | false    |              |                                                                                                                                                                                                          |
+| `transition`            | [codersdk.WorkspaceTransition](#codersdkworkspacetransition)                  | true     |              |                                                                                                                                                                                                          |
 
 #### Enumerated Values
 
@@ -5104,6 +5111,22 @@ Parameter represents a set value for the scope.
 | `transition` | `start`     |
 | `transition` | `stop`      |
 | `transition` | `delete`    |
+
+## codersdk.WorkspaceBuildParameter
+
+```json
+{
+  "name": "string",
+  "value": "string"
+}
+```
+
+### Properties
+
+| Name    | Type   | Required | Restrictions | Description |
+| ------- | ------ | -------- | ------------ | ----------- |
+| `name`  | string | false    |              |             |
+| `value` | string | false    |              |             |
 
 ## codersdk.WorkspaceQuota
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -233,6 +233,7 @@ export interface CreateWorkspaceBuildRequest {
   readonly state?: string
   readonly orphan?: boolean
   readonly parameter_values?: CreateParameterRequest[]
+  readonly rich_parameter_values?: WorkspaceBuildParameter[]
 }
 
 // From codersdk/organizations.go


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5574

Changes:
- expose workspace build parameters via API (+ unit tests)
- fix: workspace build parameters are set for `workspace` and `workspacebuild` flows