### PR TITLE
fix: Setup redirect state

### DIFF
--- a/site/jest.setup.ts
+++ b/site/jest.setup.ts
@@ -3,6 +3,7 @@ import { cleanup } from "@testing-library/react"
 import crypto from "crypto"
 import * as util from "util"
 import { server } from "./src/testHelpers/server"
+import "jest-location-mock"
 
 // Polyfill the getRandomValues that is used on utils/random.ts
 Object.defineProperty(global.self, "crypto", {

--- a/site/package.json
+++ b/site/package.json
@@ -55,6 +55,7 @@
     "front-matter": "4.0.2",
     "history": "5.3.0",
     "i18next": "21.9.1",
+    "jest-location-mock": "1.0.9",
     "js-untar": "2.0.0",
     "just-debounce-it": "3.1.1",
     "playwright": "^1.29.2",

--- a/site/src/pages/SetupPage/SetupPage.test.tsx
+++ b/site/src/pages/SetupPage/SetupPage.test.tsx
@@ -94,8 +94,6 @@ describe("Setup Page", () => {
     )
 
     await fillForm()
-    await waitFor(() =>
-      expect(history.location.pathname).toEqual("/workspaces"),
-    )
+    await waitFor(() => expect(window.location).toBeAt("/workspaces"))
   })
 })

--- a/site/src/pages/SetupPage/SetupPage.tsx
+++ b/site/src/pages/SetupPage/SetupPage.tsx
@@ -15,6 +15,7 @@ export const SetupPage: FC = () => {
         if (!firstUser) {
           throw new Error("First user was not defined.")
         }
+        console.log("AUTH SEND")
         authSend({
           type: "SIGN_IN",
           email: firstUser.email,
@@ -26,6 +27,7 @@ export const SetupPage: FC = () => {
   const { createFirstUserFormErrors, createFirstUserErrorMessage } =
     setupState.context
 
+  console.log(setupState.value, setupState.context)
   useEffect(() => {
     if (authState.matches("signedIn")) {
       window.location.assign("/workspaces")

--- a/site/src/pages/SetupPage/SetupPage.tsx
+++ b/site/src/pages/SetupPage/SetupPage.tsx
@@ -15,7 +15,6 @@ export const SetupPage: FC = () => {
         if (!firstUser) {
           throw new Error("First user was not defined.")
         }
-        console.log("AUTH SEND")
         authSend({
           type: "SIGN_IN",
           email: firstUser.email,
@@ -27,7 +26,6 @@ export const SetupPage: FC = () => {
   const { createFirstUserFormErrors, createFirstUserErrorMessage } =
     setupState.context
 
-  console.log(setupState.value, setupState.context)
   useEffect(() => {
     if (authState.matches("signedIn")) {
       window.location.assign("/workspaces")

--- a/site/src/pages/SetupPage/SetupPage.tsx
+++ b/site/src/pages/SetupPage/SetupPage.tsx
@@ -1,14 +1,12 @@
 import { useActor, useMachine } from "@xstate/react"
 import { FC, useContext, useEffect } from "react"
 import { Helmet } from "react-helmet-async"
-import { useNavigate } from "react-router-dom"
 import { pageTitle } from "util/page"
 import { setupMachine } from "xServices/setup/setupXService"
 import { XServiceContext } from "xServices/StateContext"
 import { SetupPageView } from "./SetupPageView"
 
 export const SetupPage: FC = () => {
-  const navigate = useNavigate()
   const xServices = useContext(XServiceContext)
   const [authState, authSend] = useActor(xServices.authXService)
   const [setupState, setupSend] = useMachine(setupMachine, {
@@ -30,9 +28,9 @@ export const SetupPage: FC = () => {
 
   useEffect(() => {
     if (authState.matches("signedIn")) {
-      return navigate("/workspaces")
+      window.location.assign("/workspaces")
     }
-  }, [authState, navigate])
+  }, [authState])
 
   return (
     <>

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -1385,6 +1385,11 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@jedmao/location@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@jedmao/location/-/location-3.0.0.tgz#f2b24e937386f95252f3a1fefbf7ca2e0a4b87e9"
+  integrity sha512-p7mzNlgJbCioUYLUEKds3cQG4CHONVFJNYqMe6ocEtENCL/jYmMo1Q3ApwsMmU+L0ZkaDJEyv4HokaByLoPwlQ==
+
 "@jest/console@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.5.1.tgz#260fe7239602fe5130a94f1aa386eff54b014bba"
@@ -8793,7 +8798,7 @@ jest-config@^27.5.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.5.1:
+jest-diff@^27.0.1, jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -8960,6 +8965,14 @@ jest-leak-detector@^27.5.1:
   dependencies:
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
+
+jest-location-mock@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/jest-location-mock/-/jest-location-mock-1.0.9.tgz#f4466362423b273e12ca3716467a3d478ce78fa8"
+  integrity sha512-DN/v7Zsa3N4uGgWTCrMrPPxhZORr/4N5gi+u7Tk6sLdORYplrC0//wfFN5FOtx4ZdQzDVfY6rLa4d+wfTKzQHw==
+  dependencies:
+    "@jedmao/location" "^3.0.0"
+    jest-diff "^27.0.1"
 
 jest-matcher-utils@^27.0.0, jest-matcher-utils@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
After setup a new user we have to refresh a few pieces of info like permissions, entitlements, etc. We could refetch this info and update the state but it adds a complexity we don't need to have, at least for this screen since it will be used only once. So I just decided to do a "hard" redirect which is simple and does not add any logic complexity.