### PR TITLE
fix(scaletest): increase time range check causing flake on MacOS

### DIFF
--- a/scaletest/agentconn/run_test.go
+++ b/scaletest/agentconn/run_test.go
@@ -186,7 +186,7 @@ func Test_Runner(t *testing.T) {
 		require.WithinRange(t,
 			time.Now(),
 			start.Add(testutil.WaitShort-time.Second),
-			start.Add(testutil.WaitShort+5*time.Second),
+			start.Add(testutil.WaitShort+10*time.Second),
 		)
 
 		require.Contains(t, logStr, "Opening connection to workspace agent")


### PR DESCRIPTION
See flake here: https://github.com/coder/coder/actions/runs/3953218870/jobs/6769242819#step:9:452