### PR TITLE
chore: update JS tests in CI

### DIFF
--- a/.github/workflows/coder.yaml
+++ b/.github/workflows/coder.yaml
@@ -556,7 +556,7 @@ jobs:
       - name: Install node_modules
         run: ./scripts/yarn_install.sh
 
-      - run: yarn test:coverage
+      - run: yarn test:ci
         working-directory: site
 
       - uses: codecov/codecov-action@v3

--- a/site/package.json
+++ b/site/package.json
@@ -21,6 +21,7 @@
     "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
     "test": "jest --selectProjects test",
+    "test:ci": "jest --selectProjects test --silent",
     "test:coverage": "jest --selectProjects test --collectCoverage",
     "test:watch": "jest --selectProjects test --watch",
     "typegen": "xstate typegen 'src/**/*.ts'",


### PR DESCRIPTION
Avoid printing too much info on CI. Printing a lot of stuff on CI makes it harder to find what is the issue.