### PR TITLE
chore: Fix make gen for docs/manifest.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,10 +490,9 @@ docs/admin/prometheus.md: scripts/metricsdocgen/main.go scripts/metricsdocgen/me
 	cd site
 	yarn run format:write:only ../docs/admin/prometheus.md
 
-coderd/apidoc/swagger.json: $(shell find ./scripts/apidocgen -not \( -path './scripts/apidocgen/node_modules' -prune \) -type f) $(wildcard coderd/*.go) $(wildcard enterprise/coderd/*.go) $(wildcard codersdk/*.go) .swaggo
+coderd/apidoc/swagger.json: $(shell find ./scripts/apidocgen $(FIND_EXCLUSIONS) -type f) $(wildcard coderd/*.go) $(wildcard enterprise/coderd/*.go) $(wildcard codersdk/*.go) .swaggo docs/manifest.json
 	./scripts/apidocgen/generate.sh
-	cd site
-	yarn run format:write:only ../docs/api ../docs/manifest.json ../coderd/apidoc/swagger.json
+	yarn run --cwd=site format:write:only ../docs/api ../docs/manifest.json ../coderd/apidoc/swagger.json
 
 update-golden-files: cli/testdata/.gen-golden
 .PHONY: update-golden-files

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -251,8 +251,8 @@
         {
           "title": "Scaling Coder",
           "description": "Reference architecture and load testing tools",
-          "icon_path": "./images/icons/scale.svg",
-          "path": "./admin/scale.md"
+          "path": "./admin/scale.md",
+          "icon_path": "./images/icons/scale.svg"
         },
         {
           "title": "Audit Logs",


### PR DESCRIPTION
Since apidocs modify docs/manifest.json, if there are changes to this file we need to re-gen.
