### PR TITLE
chore(dogfood): Avoid calling ~/personalize unless executable

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -68,11 +68,14 @@ resource "coder_agent" "dev" {
     code-server --auth none --port 13337 &
     sudo service docker start
     DOTFILES_URI=${var.dotfiles_uri}
+    rm -f ~/.personalize.log
     if [ -n "$DOTFILES_URI" ]; then
-      coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee  ~/.personalize.log
+      coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee -a ~/.personalize.log
     fi
-    if [ -f ./personalize ]; then
-      ./personalize
+    if [ -x ~/personalize ]; then
+      ~/personalize | tee -a ~/.personalize.log
+    elif [ -f ~/personalize ]; then
+      echo "~/personalize is not executable, skipping..." | tee -a ~/.personalize.log
     fi
     EOF
 }


### PR DESCRIPTION
This PR changes the dogfood startup script to only execute personalize if it has the executable bit. It won't fallback to running via `sh` so that users can `chmod -x` to disable it.

While we're atting, make logging to `personalize.log` consistent so that we start with an empty log and only append (not truncate between use).
