### PR TITLE
feat: add insecure flag to the workspace agent

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -651,7 +651,7 @@ func AwaitWorkspaceAgents(t *testing.T, client *codersdk.Client, workspaceID uui
 		for _, resource := range workspace.LatestBuild.Resources {
 			for _, agent := range resource.Agents {
 				if agent.Status != codersdk.WorkspaceAgentConnected {
-					// t.Logf("agent %s not connected yet", agent.Name)
+					t.Logf("agent %s not connected yet", agent.Name)
 					return false
 				}
 			}

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -2,6 +2,7 @@ package codersdk
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -369,6 +370,12 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 		return nil, xerrors.Errorf("decode conn info: %w", err)
 	}
 
+	var tlsConfig *tls.Config
+	httpTransport, ok := c.HTTPClient.Transport.(*http.Transport)
+	if ok {
+		tlsConfig = httpTransport.TLSClientConfig
+	}
+
 	ip := tailnet.IP()
 	conn, err := tailnet.NewConn(&tailnet.Options{
 		Addresses:          []netip.Prefix{netip.PrefixFrom(ip, 128)},
@@ -376,6 +383,7 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 		Logger:             options.Logger,
 		BlockEndpoints:     options.BlockEndpoints,
 		EnableTrafficStats: options.EnableTrafficStats,
+		TLSConfig:          tlsConfig,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("create tailnet: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ replace github.com/tcnksm/go-httpstat => github.com/kylecarbs/go-httpstat v0.0.0
 
 // There are a few minor changes we make to Tailscale that we're slowly upstreaming. Compare here:
 // https://github.com/tailscale/tailscale/compare/main...coder:tailscale:main
-replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20221117204504-2d6503f027c3
+replace tailscale.com => github.com/coder/tailscale v1.1.1-0.20230119204348-9073c302b0b9
 
 // Switch to our fork that imports fixes from http://github.com/tailscale/ssh.
 // See: https://github.com/coder/coder/issues/3371
@@ -67,6 +67,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.6.0
 	github.com/cli/safeexec v1.0.0
 	github.com/coder/retry v1.3.0
+	github.com/coder/terraform-provider-coder v0.6.6
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/creack/pty v1.1.18
@@ -169,7 +170,6 @@ require (
 
 require (
 	cloud.google.com/go/longrunning v0.1.1 // indirect
-	github.com/coder/terraform-provider-coder v0.6.6 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/coder/ssh v0.0.0-20220811105153-fcea99919338 h1:tN5GKFT68YLVzJoA8AHui
 github.com/coder/ssh v0.0.0-20220811105153-fcea99919338/go.mod h1:ZSS+CUoKHDrqVakTfTWUlKSr9MtMFkC4UvtQKD7O914=
 github.com/coder/tailscale v1.1.1-0.20221117204504-2d6503f027c3 h1:lq8GmpE5bn8A36uxq1h+TWnaQKPugtRkxKrYZA78O9c=
 github.com/coder/tailscale v1.1.1-0.20221117204504-2d6503f027c3/go.mod h1:lkCb74eSJwxeNq8YwyILoHD5vtHktiZnTOxBxo3tbNc=
+github.com/coder/tailscale v1.1.1-0.20230119204348-9073c302b0b9 h1:WBaRLw+/SddwmYH7igAj0Q34daeEoAQhM+A4M9iaBRs=
+github.com/coder/tailscale v1.1.1-0.20230119204348-9073c302b0b9/go.mod h1:lkCb74eSJwxeNq8YwyILoHD5vtHktiZnTOxBxo3tbNc=
 github.com/coder/terraform-provider-coder v0.6.6 h1:ZAYvERlgjQPHyDdemXEuVcwdCFGfk9v5zQARegWL6nQ=
 github.com/coder/terraform-provider-coder v0.6.6/go.mod h1:UIfU3bYNeSzJJvHyJ30tEKjD6Z9utloI+HUM/7n94CY=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -153,7 +153,9 @@ func NewConn(options *Options) (*Conn, error) {
 	if !ok {
 		return nil, xerrors.New("get wireguard internals")
 	}
-	magicConn.SetTLSConfig(options.TLSConfig)
+	if options.TLSConfig != nil {
+		magicConn.SetTLSConfig(options.TLSConfig)
+	}
 	tunDevice.SetStatisticsEnabled(options.EnableTrafficStats)
 
 	// Update the keys for the magic connection!

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -2,6 +2,7 @@ package tailnet
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -50,6 +51,7 @@ func init() {
 type Options struct {
 	Addresses []netip.Prefix
 	DERPMap   *tailcfg.DERPMap
+	TLSConfig *tls.Config
 
 	// BlockEndpoints specifies whether P2P endpoints are blocked.
 	// If so, only DERPs can establish connections.
@@ -151,6 +153,7 @@ func NewConn(options *Options) (*Conn, error) {
 	if !ok {
 		return nil, xerrors.New("get wireguard internals")
 	}
+	magicConn.SetTLSConfig(options.TLSConfig)
 	tunDevice.SetStatisticsEnabled(options.EnableTrafficStats)
 
 	// Update the keys for the magic connection!


### PR DESCRIPTION
This should help POCs where certificates are tricky to get inside the environment. As noted, it's never intended for production scenarios.

