### PR TITLE
feat: better display secret audit values

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogDiff.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDiff.tsx
@@ -41,7 +41,7 @@ export const AuditLogDiff: FC<{ diff: AuditLog["diff"] }> = ({ diff }) => {
                   styles.diffValueOld,
                 ])}
               >
-                {getDiffValue(valueDiff.old)}
+                {valueDiff.secret ? "••••••••" : getDiffValue(valueDiff.old)}
               </span>
             </div>
           </div>
@@ -60,7 +60,7 @@ export const AuditLogDiff: FC<{ diff: AuditLog["diff"] }> = ({ diff }) => {
                   styles.diffValueNew,
                 ])}
               >
-                {getDiffValue(valueDiff.new)}
+                {valueDiff.secret ? "••••••••" : getDiffValue(valueDiff.new)}
               </span>
             </div>
           </div>

--- a/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
@@ -10,6 +10,7 @@ import {
   MockAuditLog2,
   MockAuditLogWithWorkspaceBuild,
   MockAuditLogWithDeletedResource,
+  MockAuditLogGitSSH,
 } from "testHelpers/entities"
 import { AuditLogRow, AuditLogRowProps } from "./AuditLogRow"
 
@@ -71,4 +72,9 @@ WithWorkspaceBuild.args = {
 export const DeletedResource = Template.bind({})
 DeletedResource.args = {
   auditLog: MockAuditLogWithDeletedResource,
+}
+
+export const SecretDiffValue = Template.bind({})
+SecretDiffValue.args = {
+  auditLog: MockAuditLogGitSSH,
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1066,6 +1066,22 @@ export const MockAuditLogWithDeletedResource: TypesGen.AuditLog = {
   is_deleted: true,
 }
 
+export const MockAuditLogGitSSH: TypesGen.AuditLog = {
+  ...MockAuditLog,
+  diff: {
+    private_key: {
+      old: "",
+      new: "",
+      secret: true,
+    },
+    public_key: {
+      old: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINRUPjBSNtOAnL22+r07OSu9t3Lnm8/5OX8bRHECKS9g\n",
+      new: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEwoUPJPMekuSzMZyV0rA82TGGNzw/Uj/dhLbwiczTpV\n",
+      secret: false,
+    },
+  },
+}
+
 export const MockWorkspaceQuota: TypesGen.WorkspaceQuota = {
   credits_consumed: 0,
   budget: 100,


### PR DESCRIPTION
Resolves #4561 

We decided to go really simple here and just match the sensitive value treatment on the workspace resource cards:
![Screen Shot 2023-01-19 at 4 41 37 PM](https://user-images.githubusercontent.com/19142439/213569672-83d1c9f4-c3c3-4193-b375-a02335640856.png)
