### PR TITLE
fix(helm): revert use correct antiaffinity label

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -113,10 +113,10 @@ coder:
         - podAffinityTerm:
             labelSelector:
               matchExpressions:
-                - key: app.kubernetes.io/instance
+                - key: app.coder.com
                   operator: In
                   values:
-                    - "coder"
+                    - "true"
             topologyKey: kubernetes.io/hostname
           weight: 1
 


### PR DESCRIPTION
Reverts coder/coder#5649

This caused some pain when upgrading for our Kubernetes users. See:
![image](https://user-images.githubusercontent.com/7122116/213616733-770488da-435f-4bcd-8b7b-4a48d04bd7f3.png)
