### PR TITLE
chore: Ignore expired at on chromatic

### DIFF
--- a/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
+++ b/site/src/pages/UserSettingsPage/TokensPage/TokensPageView.tsx
@@ -102,7 +102,10 @@ export const TokensPageView: FC<
                       <TableCell>{lastUsedOrNever(token.last_used)}</TableCell>
 
                       <TableCell>
-                        <span style={{ color: theme.palette.text.secondary }}>
+                        <span
+                          style={{ color: theme.palette.text.secondary }}
+                          data-chromatic="ignore"
+                        >
                           {dayjs(token.expires_at).fromNow()}
                         </span>
                       </TableCell>


### PR DESCRIPTION
Chromatic has been detecting changes because of the dynamic expired at a value so I just added an option to ignore it.