### PR TITLE
chore: manually specify templates to embed

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -18,7 +18,20 @@ import (
 )
 
 var (
-	//go:embed templates
+	// Only some templates are embedded that we want to display inside the UI.
+	//go:embed templates/aws-ecs-container
+	//go:embed templates/aws-linux
+	//go:embed templates/aws-windows
+	//go:embed templates/azure-linux
+	//go:embed templates/do-linux
+	//go:embed templates/docker
+	//go:embed templates/docker-code-server
+	//go:embed templates/docker-image-builds
+	//go:embed templates/docker-with-dotfiles
+	//go:embed templates/gcp-linux
+	//go:embed templates/gcp-vm-container
+	//go:embed templates/gcp-windows
+	//go:embed templates/kubernetes
 	files embed.FS
 
 	exampleBasePath = "https://github.com/coder/coder/tree/main/examples/templates/"


### PR DESCRIPTION
This is part of a multi-step cleanup for the example templates. The goal is to have a lot of templates here, and only embed specific ones we feel are impactful during setup.
