### PR TITLE
fix: routinely ping agent websocket to ensure liveness

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -430,6 +430,9 @@ func (a *agent) createTailnet(ctx context.Context, derpMap *tailcfg.DERPMap) (_ 
 // runCoordinator runs a coordinator and returns whether a reconnect
 // should occur.
 func (a *agent) runCoordinator(ctx context.Context, network *tailnet.Conn) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	coordinator, err := a.client.ListenWorkspaceAgent(ctx)
 	if err != nil {
 		return err

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -83,6 +83,7 @@ func workspaceAgent() *cobra.Command {
 				slog.F("version", version),
 			)
 			client := codersdk.New(coderURL)
+			client.Logger = logger
 			// Set a reasonable timeout so requests can't hang forever!
 			client.HTTPClient.Timeout = 10 * time.Second
 

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -342,6 +342,7 @@ func (c *Client) ListenWorkspaceAgent(ctx context.Context) (net.Conn, error) {
 
 	// Ping once every 30 seconds to ensure that the websocket is alive. If we
 	// don't get a response within 30s we kill the websocket and reconnect.
+	// See: https://github.com/coder/coder/pull/5824
 	go func() {
 		tick := 30 * time.Second
 		ticker := time.NewTicker(tick)

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -361,7 +361,7 @@ func (c *Client) ListenWorkspaceAgent(ctx context.Context) (net.Conn, error) {
 				if err != nil {
 					c.Logger.Error(ctx, "workspace agent coordinate ping", slog.Error(err))
 
-					err := conn.Close(websocket.StatusAbnormalClosure, "Ping failed")
+					err := conn.Close(websocket.StatusGoingAway, "Ping failed")
 					if err != nil {
 						c.Logger.Error(ctx, "close workspace agent coordinate websocket", slog.Error(err))
 					}

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -340,6 +340,8 @@ func (c *Client) ListenWorkspaceAgent(ctx context.Context) (net.Conn, error) {
 		return nil, readBodyAsError(res)
 	}
 
+	// Ping once every 30 seconds to ensure that the websocket is alive. If we
+	// don't get a response within 30s we kill the websocket and reconnect.
 	go func() {
 		tick := 30 * time.Second
 		ticker := time.NewTicker(tick)

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -12,9 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coder/coder/provisionerd/runner"
-	"github.com/coder/coder/testutil"
-
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,11 +23,12 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
-
 	"github.com/coder/coder/provisionerd"
 	"github.com/coder/coder/provisionerd/proto"
+	"github.com/coder/coder/provisionerd/runner"
 	"github.com/coder/coder/provisionersdk"
 	sdkproto "github.com/coder/coder/provisionersdk/proto"
+	"github.com/coder/coder/testutil"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
There seems to be a sneaky websocket bug when behind GCP load balancers. I've noticed that sometimes when cycling a `coder server` VM behind a GCP load balancer the websocket can hang trying to read, which prevents it from reconnecting to the new `coder server`.