### PR TITLE
feat: log requests at info level by default

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -520,6 +520,12 @@ func newConfig() *codersdk.DeploymentConfig {
 			Flag:    "disable-path-apps",
 			Default: false,
 		},
+		RequestLogLevel: &codersdk.DeploymentConfigField[string]{
+			Name:    "Request Log Level",
+			Usage:   `Set the log level for successful (1xx, 2xx, 3xx, 4xx) request logs. Requests that fail due to a server error (5xx) are always logged at the "warn" level. Valid values are: "info" and "debug".`,
+			Flag:    "request-log-level",
+			Default: "info",
+		},
 	}
 }
 

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -209,6 +209,12 @@ Flags:
                                                      "proxy-trusted-headers". e.g.
                                                      192.168.1.0/24
                                                      Consumes $CODER_PROXY_TRUSTED_ORIGINS
+      --request-log-level string                     Set the log level for successful (1xx,
+                                                     2xx, 3xx, 4xx) request logs. Requests
+                                                     that fail due to a server error (5xx) are
+                                                     always logged at the "warn" level. Valid
+                                                     values are: "info" and "debug".
+                                                     Consumes $CODER_ (default "info")
       --secure-auth-cookie                           Controls if the 'Secure' property is set
                                                      on browser session cookies.
                                                      Consumes $CODER_SECURE_AUTH_COOKIE

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5846,6 +5846,9 @@ const docTemplate = `{
                 "rate_limit": {
                     "$ref": "#/definitions/codersdk.RateLimitConfig"
                 },
+                "requestLogLevel": {
+                    "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
+                },
                 "scim_api_key": {
                     "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5195,6 +5195,9 @@
         "rate_limit": {
           "$ref": "#/definitions/codersdk.RateLimitConfig"
         },
+        "requestLogLevel": {
+          "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
+        },
         "scim_api_key": {
           "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
         },

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -263,7 +263,7 @@ func New(options *Options) *API {
 		tracing.Middleware(api.TracerProvider),
 		httpmw.AttachRequestID,
 		httpmw.ExtractRealIP(api.RealIPConfig),
-		httpmw.Logger(api.Logger),
+		httpmw.Logger(api.Logger, api.DeploymentConfig.RequestLogLevel.Value),
 		httpmw.Prometheus(options.PrometheusRegistry),
 		// handleSubdomainApplications checks if the first subdomain is a valid
 		// app URL. If it is, it will serve that application.

--- a/coderd/httpmw/logger.go
+++ b/coderd/httpmw/logger.go
@@ -11,7 +11,10 @@ import (
 	"github.com/coder/coder/coderd/tracing"
 )
 
-func Logger(log slog.Logger) func(next http.Handler) http.Handler {
+// Logger middleware logs details about the request and response to the provided
+// slog.Logger. The "level" parameter can either be "debug" or "info", and falls
+// back to "info" if an invalid value is provided.
+func Logger(log slog.Logger, level string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -52,7 +55,10 @@ func Logger(log slog.Logger) func(next http.Handler) http.Handler {
 			// We should not log at level ERROR for 5xx status codes because 5xx
 			// includes proxy errors etc. It also causes slogtest to fail
 			// instantly without an error message by default.
-			logLevelFn := httplog.Debug
+			logLevelFn := httplog.Info
+			if level == "debug" {
+				logLevelFn = httplog.Debug
+			}
 			if sw.Status >= http.StatusInternalServerError {
 				logLevelFn = httplog.Warn
 			}

--- a/coderd/httpmw/logger.go
+++ b/coderd/httpmw/logger.go
@@ -8,6 +8,7 @@ import (
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/coderd/httpapi"
+	"github.com/coder/coder/coderd/httpmw/patternmatcher"
 	"github.com/coder/coder/coderd/tracing"
 )
 
@@ -55,8 +56,10 @@ func Logger(log slog.Logger, level string) func(next http.Handler) http.Handler 
 			// We should not log at level ERROR for 5xx status codes because 5xx
 			// includes proxy errors etc. It also causes slogtest to fail
 			// instantly without an error message by default.
+			//
+			// Frontend routes should always be logged at debug level.
 			logLevelFn := httplog.Info
-			if level == "debug" {
+			if level == "debug" || !patternmatcher.APIRoutes.MatchString(r.URL.Path) {
 				logLevelFn = httplog.Debug
 			}
 			if sw.Status >= http.StatusInternalServerError {

--- a/coderd/httpmw/patternmatcher/routepatterns.go
+++ b/coderd/httpmw/patternmatcher/routepatterns.go
@@ -8,6 +8,16 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// APIRoutes is a RoutePatterns which matches all API routes (including apps)
+// and not frontend routes.
+var APIRoutes = RoutePatterns{
+	"/api",
+	"/api/**",
+	"/@*/*/apps/**",
+	"/%40*/*/apps/**",
+	"/gitauth/*/callback",
+}.MustCompile()
+
 // RoutePatterns provides a method to generate a regex which will match a URL
 // path against a collection of patterns. If any of the patterns match the path,
 // the regex will return a successful match.

--- a/coderd/tracing/httpmw.go
+++ b/coderd/tracing/httpmw.go
@@ -16,17 +16,6 @@ import (
 
 // Middleware adds tracing to http routes.
 func Middleware(tracerProvider trace.TracerProvider) func(http.Handler) http.Handler {
-	// We only want to create spans on the following route patterns, however
-	// we want the middleware to be very high in the middleware stack so it can
-	// capture the entire request.
-	re := patternmatcher.RoutePatterns{
-		"/api",
-		"/api/**",
-		"/@*/*/apps/**",
-		"/%40*/*/apps/**",
-		"/gitauth/*/callback",
-	}.MustCompile()
-
 	var tracer trace.Tracer
 	if tracerProvider != nil {
 		tracer = tracerProvider.Tracer(TracerName)
@@ -34,7 +23,7 @@ func Middleware(tracerProvider trace.TracerProvider) func(http.Handler) http.Han
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			if tracer == nil || !re.MatchString(r.URL.Path) {
+			if tracer == nil || !patternmatcher.APIRoutes.MatchString(r.URL.Path) {
 				next.ServeHTTP(rw, r)
 				return
 			}

--- a/codersdk/deploymentconfig.go
+++ b/codersdk/deploymentconfig.go
@@ -46,6 +46,7 @@ type DeploymentConfig struct {
 	Logging                         *LoggingConfig                          `json:"logging" typescript:",notnull"`
 	Dangerous                       *DangerousConfig                        `json:"dangerous" typescript:",notnull"`
 	DisablePathApps                 *DeploymentConfigField[bool]            `json:"disable_path_apps" typescript:",notnull"`
+	RequestLogLevel                 *DeploymentConfigField[string]
 
 	// DEPRECATED: Use HTTPAddress or TLS.Address instead.
 	Address *DeploymentConfigField[string] `json:"address" typescript:",notnull"`

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -758,6 +758,17 @@ curl -X GET http://coder-server:8080/api/v2/config/deployment \
       "value": true
     }
   },
+  "requestLogLevel": {
+    "default": "string",
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": "string"
+  },
   "scim_api_key": {
     "default": "string",
     "enterprise": true,

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1881,6 +1881,17 @@ CreateParameterRequest is a structure used to create a new parameter value for a
       "value": true
     }
   },
+  "requestLogLevel": {
+    "default": "string",
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": "string"
+  },
   "scim_api_key": {
     "default": "string",
     "enterprise": true,
@@ -2166,6 +2177,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `proxy_trusted_headers`              | [codersdk.DeploymentConfigField-array_string](#codersdkdeploymentconfigfield-array_string)                                 | false    |              |                                                 |
 | `proxy_trusted_origins`              | [codersdk.DeploymentConfigField-array_string](#codersdkdeploymentconfigfield-array_string)                                 | false    |              |                                                 |
 | `rate_limit`                         | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                                       | false    |              |                                                 |
+| `requestLogLevel`                    | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |                                                 |
 | `scim_api_key`                       | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |                                                 |
 | `secure_auth_cookie`                 | [codersdk.DeploymentConfigField-bool](#codersdkdeploymentconfigfield-bool)                                                 | false    |              |                                                 |
 | `ssh_keygen_algorithm`               | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |                                                 |

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -324,6 +324,7 @@ export interface DeploymentConfig {
   readonly logging: LoggingConfig
   readonly dangerous: DangerousConfig
   readonly disable_path_apps: DeploymentConfigField<boolean>
+  readonly RequestLogLevel?: DeploymentConfigField<string>
   readonly address: DeploymentConfigField<string>
   readonly experimental: DeploymentConfigField<boolean>
 }


### PR DESCRIPTION
This recently bit us on the backside when we needed request logs but they aren't logged by default. This changes request logs so they are logged at info by default, and can be disabled via a flag.

cc @ElliotG 