### PR TITLE
fix: update docs link for configuration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ To run a Coder server:
   $ coder server
 
   Default URL: http://127.0.0.1:3000
-  Configuring Coder: https://coder.com/docs/coder-oss/admin/configure
+  Configuring Coder: https://coder.com/docs/v2/latest/admin/configure
 
 To connect to a Coder deployment:
 


### PR DESCRIPTION
This was set to the old URL pre docs move!
