### PR TITLE
ci: Add authors to release notes

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -109,7 +109,7 @@ main() {
 		title=${title%$'\n'}
 		COMMIT_METADATA_TITLE[$commit_sha_short]=$title
 		if [[ -v authors[$commit_sha_long] ]]; then
-			COMMIT_METADATA_AUTHORS[$commit_sha_short]="[${authors[$commit_sha_long]}](https://github.com/${authors[$commit_sha_long]})"
+			COMMIT_METADATA_AUTHORS[$commit_sha_short]="@${authors[$commit_sha_long]}"
 		fi
 
 		# First, check the title for breaking changes. This avoids doing a

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -32,7 +32,7 @@ range="$from_ref..$to_ref"
 dependencies gh
 
 COMMIT_METADATA_BREAKING=0
-declare -A COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY
+declare -A COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
 
 # This environment variable can be set to 1 to ignore missing commit metadata,
 # useful for dry-runs.
@@ -66,22 +66,26 @@ main() {
 	#
 	# Example output:
 	#
-	#   27386d49d08455b6f8fbf2c18f38244d03fda892 label:security
-	#   d9f2aaf3b430d8b6f3d5f24032ed6357adaab1f1
-	#   fd54512858c906e66f04b0744d8715c2e0de97e6 label:stale label:enhancement
+	#   27386d49d08455b6f8fbf2c18f38244d03fda892 author:hello labels:label:security
+	#   d9f2aaf3b430d8b6f3d5f24032ed6357adaab1f1 author:world
+	#   fd54512858c906e66f04b0744d8715c2e0de97e6 author:bye labels:label:stale label:enhancement
+	from_commit_date=2023-01-18
 	mapfile -t pr_labels_raw < <(
 		gh pr list \
 			--base main \
 			--state merged \
 			--limit 10000 \
 			--search "merged:>=$from_commit_date" \
-			--json mergeCommit,labels \
-			--jq '.[] | .mergeCommit.oid + " " + (["label:" + .labels[].name] | join(" "))'
+			--json mergeCommit,labels,author \
+			--jq '.[] | "\( .mergeCommit.oid ) author:\( .author.login ) labels:\(["label:\( .labels[].name )"] | join(" "))"'
 	)
-	declare -A labels
+	declare -A authors labels
 	for entry in "${pr_labels_raw[@]}"; do
 		commit_sha_long=${entry%% *}
-		all_labels=${entry#* }
+		commit_author=${entry#* author:}
+		commit_author=${commit_author%% *}
+		authors[$commit_sha_long]=$commit_author
+		all_labels=${entry#* labels:}
 		labels[$commit_sha_long]=$all_labels
 	done
 
@@ -92,7 +96,7 @@ main() {
 		commit_prefix=${parts[2]}
 
 		# Safety-check, guarantee all commits had their metadata fetched.
-		if [[ ! -v labels[$commit_sha_long] ]]; then
+		if [[ ! -v authors[$commit_sha_long] ]] || [[ ! -v labels[$commit_sha_long] ]]; then
 			if [[ $ignore_missing_metadata != 1 ]]; then
 				error "Metadata missing for commit $commit_sha_short"
 			else
@@ -104,6 +108,7 @@ main() {
 		title=${parts[*]:2}
 		title=${title%$'\n'}
 		COMMIT_METADATA_TITLE[$commit_sha_short]=$title
+		COMMIT_METADATA_AUTHORS[$commit_sha_short]="@${authors[$commit_sha_long]}"
 
 		# First, check the title for breaking changes. This avoids doing a
 		# GH API request if there's a match.
@@ -132,12 +137,12 @@ main() {
 }
 
 declare_print_commit_metadata() {
-	declare -p COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY
+	declare -p COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
 }
 
 export_commit_metadata() {
 	_COMMIT_METADATA_CACHE="${range}:$(declare_print_commit_metadata)"
-	export _COMMIT_METADATA_CACHE COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY
+	export _COMMIT_METADATA_CACHE COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
 }
 
 # _COMMIT_METADATA_CACHE is used to cache the results of this script in

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -108,7 +108,9 @@ main() {
 		title=${parts[*]:2}
 		title=${title%$'\n'}
 		COMMIT_METADATA_TITLE[$commit_sha_short]=$title
-		COMMIT_METADATA_AUTHORS[$commit_sha_short]="@${authors[$commit_sha_long]}"
+		if [[ -v authors[$commit_sha_long] ]]; then
+			COMMIT_METADATA_AUTHORS[$commit_sha_short]="[${authors[$commit_sha_long]}](https://github.com/${authors[$commit_sha_long]})"
+		fi
 
 		# First, check the title for breaking changes. This avoids doing a
 		# GH API request if there's a match.

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -112,7 +112,10 @@ for cat in "${!section_titles[@]}"; do
 done
 
 for commit in "${commits[@]}"; do
-	line="- $commit ${COMMIT_METADATA_TITLE[$commit]}\n"
+	line="- $commit ${COMMIT_METADATA_TITLE[$commit]}"
+	if [[ -v COMMIT_METADATA_AUTHORS[$commit] ]]; then
+		line+=" (${COMMIT_METADATA_AUTHORS[$commit]})"
+	fi
 
 	# Default to "other" category.
 	cat=other
@@ -122,7 +125,7 @@ for commit in "${commits[@]}"; do
 			break
 		fi
 	done
-	declare "$cat"_changelog+="$line"
+	declare "$cat"_changelog+="$line"$'\n'
 done
 
 changelog="$(


### PR DESCRIPTION
This PR adds PR authors to release notes.

Currently co-authors are not supported, perhaps in a future enchancement.

```markdown
## Changelog

### Features

- b045734b6 feat: Add use template button to template row (#5811) ([BrunoQuaresma](https://github.com/BrunoQuaresma))
- bbb208e29 feat: Add CLI support for workspace build parameters (#5768) ([mtojek](https://github.com/mtojek))
- 443e2180f feat: indicate when workspace builds are stopped/started by Coder (#5813) ([Kira-Pilot](https://github.com/Kira-Pilot))

### Bug fixes

- 0e58772f5 fix: filter workspace_build resource on start/stop action (#5809) ([Kira-Pilot](https://github.com/Kira-Pilot))
- 37628c8b5 fix: comment on winget PR correctly (#5789) ([deansheather](https://github.com/deansheather))
- d2ae16dd2 fix: routinely ping agent websocket to ensure liveness (#5824) ([coadler](https://github.com/coadler))
- c3731a1be fix: ensure agent websocket only removes its own conn (#5828) ([coadler](https://github.com/coadler))
- dbfeb5630 fix: update docs link for configuration (#5827) ([kylecarbs](https://github.com/kylecarbs))

### Documentation

- f67acac2b docs: updated diagram with git provider logos (#5816) ([sharkymark](https://github.com/sharkymark))

### Tests

- 6a245ab1c test: Fix GPG test so it does not inherit parent parallelism (#5820) ([mafredri](https://github.com/mafredri))

### Continuous integration

- 8a9661e3c ci: Add authors to release notes

### Chores

- 918c37c35 chore: Ignore expired at on chromatic (#5808) ([BrunoQuaresma](https://github.com/BrunoQuaresma))
- 8afdf24d1 chore: Update sqlc to v1.16.0 (#5788) ([mafredri](https://github.com/mafredri))
- 73afdd7c0 chore: agent_test.go: use ptty.Peek() instead of expecting caret in TestAgent_SessionTTYShell (#5821) ([johnstcn](https://github.com/johnstcn))
- ba8dd496c chore: manually specify templates to embed (#5823) ([kylecarbs](https://github.com/kylecarbs))
- 882832cc5 chore: removed FE code owners (#5826) ([Kira-Pilot](https://github.com/Kira-Pilot))

Compare: [`v0.15.1...v0.15.2`](https://github.com/coder/coder/compare/v0.15.1...v0.15.2)

## Container image

- `docker pull ghcr.io/coder/coder:v0.15.2`
```

