### PR TITLE
refactor(site): update agent status to include the lifecycle

### DIFF
--- a/site/src/components/Resources/AgentRow.stories.tsx
+++ b/site/src/components/Resources/AgentRow.stories.tsx
@@ -3,6 +3,9 @@ import {
   MockWorkspace,
   MockWorkspaceAgent,
   MockWorkspaceAgentConnecting,
+  MockWorkspaceAgentStartError,
+  MockWorkspaceAgentStarting,
+  MockWorkspaceAgentStartTimeout,
   MockWorkspaceAgentTimeout,
   MockWorkspaceApp,
 } from "testHelpers/entities"
@@ -81,6 +84,30 @@ Connecting.args = {
 export const Timeout = Template.bind({})
 Timeout.args = {
   agent: MockWorkspaceAgentTimeout,
+  workspace: MockWorkspace,
+  applicationsHost: "",
+  showApps: true,
+}
+
+export const Starting = Template.bind({})
+Starting.args = {
+  agent: MockWorkspaceAgentStarting,
+  workspace: MockWorkspace,
+  applicationsHost: "",
+  showApps: true,
+}
+
+export const StartTimeout = Template.bind({})
+StartTimeout.args = {
+  agent: MockWorkspaceAgentStartTimeout,
+  workspace: MockWorkspace,
+  applicationsHost: "",
+  showApps: true,
+}
+
+export const StartError = Template.bind({})
+StartError.args = {
+  agent: MockWorkspaceAgentStartError,
   workspace: MockWorkspace,
   applicationsHost: "",
   showApps: true,

--- a/site/src/i18n/en/agent.json
+++ b/site/src/i18n/en/agent.json
@@ -12,11 +12,23 @@
     "noApps": "None"
   },
   "status": {
-    "timeout": "Timeout"
+    "timeout": "Timeout",
+    "startTimeout": "Start Timeout",
+    "startError": "Error"
   },
   "timeoutTooltip": {
     "title": "Agent is taking too long to connect",
     "message": "We noticed this agent is taking longer than expected to connect.",
+    "link": "Troubleshoot"
+  },
+  "startTimeoutTooltip": {
+    "title": "Agent is taking too long to start",
+    "message": "We noticed this agent is taking longer than expected to start.",
+    "link": "Troubleshoot"
+  },
+  "startErrorTooltip": {
+    "title": "Error starting agent",
+    "message": "Something wrong happening during the agent start.",
     "link": "Troubleshoot"
   },
   "unableToConnect": "Unable to connect"

--- a/site/src/i18n/en/agent.json
+++ b/site/src/i18n/en/agent.json
@@ -28,7 +28,7 @@
   },
   "startErrorTooltip": {
     "title": "Error starting agent",
-    "message": "Something wrong happening during the agent start.",
+    "message": "Something went wrong during the agent start.",
     "link": "Troubleshoot"
   },
   "unableToConnect": "Unable to connect"

--- a/site/src/i18n/en/workspacePage.json
+++ b/site/src/i18n/en/workspacePage.json
@@ -36,7 +36,10 @@
     "pending": "Pending"
   },
   "agentStatus": {
-    "connected": "Connected",
+    "connected": {
+      "ready": "Ready",
+      "starting": "Starting..."
+    },
     "connecting": "Connecting...",
     "disconnected": "Disconnected",
     "timeout": "Timeout"

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -18,11 +18,7 @@ import {
   MockStoppingWorkspace,
   MockTemplate,
   MockWorkspace,
-  MockWorkspaceAgent,
-  MockWorkspaceAgentConnecting,
-  MockWorkspaceAgentDisconnected,
   MockWorkspaceBuild,
-  MockWorkspaceResource2,
   renderWithAuth,
   waitForLoaderToBeRemoved,
 } from "../../testHelpers/renderHelpers"
@@ -282,67 +278,6 @@ describe("WorkspacePage", () => {
         // Added +1 because of the date row
         expect(rows).toHaveLength(MockBuilds.length + 1)
       })
-    })
-  })
-
-  describe("Resources", () => {
-    it("shows the status of each agent in each resource", async () => {
-      const getTemplateMock = jest
-        .spyOn(api, "getTemplate")
-        .mockResolvedValueOnce(MockTemplate)
-
-      const workspaceWithResources = {
-        ...MockWorkspace,
-        latest_build: {
-          ...MockWorkspaceBuild,
-          resources: [
-            {
-              ...MockWorkspaceResource2,
-              agents: [
-                MockWorkspaceAgent,
-                MockWorkspaceAgentDisconnected,
-                MockWorkspaceAgentConnecting,
-              ],
-            },
-          ],
-        },
-      }
-
-      server.use(
-        rest.get(
-          `/api/v2/users/:username/workspace/:workspaceName`,
-          (req, res, ctx) => {
-            return res(ctx.status(200), ctx.json(workspaceWithResources))
-          },
-        ),
-      )
-
-      await renderWorkspacePage()
-      const agent1Names = await screen.findAllByText(MockWorkspaceAgent.name)
-      expect(agent1Names.length).toEqual(1)
-      const agent2Names = await screen.findAllByText(
-        MockWorkspaceAgentDisconnected.name,
-      )
-      expect(agent2Names.length).toEqual(2)
-      const agent1Status = await screen.findAllByLabelText(
-        t<string>(`agentStatus.${MockWorkspaceAgent.status}`, {
-          ns: "workspacePage",
-        }),
-      )
-      expect(agent1Status.length).toEqual(1)
-      const agentDisconnected = await screen.findAllByLabelText(
-        t<string>(`agentStatus.${MockWorkspaceAgentDisconnected.status}`, {
-          ns: "workspacePage",
-        }),
-      )
-      expect(agentDisconnected.length).toEqual(1)
-      const agentConnecting = await screen.findAllByLabelText(
-        t<string>(`agentStatus.${MockWorkspaceAgentConnecting.status}`, {
-          ns: "workspacePage",
-        }),
-      )
-      expect(agentConnecting.length).toEqual(1)
-      expect(getTemplateMock).toBeCalled()
     })
   })
 })


### PR DESCRIPTION
Updating the FE, specifically the <AgentStatus> component to handle the new agent's lifecycles.

Refs: #5749