### PR TITLE
fix(site): Hide agent lifecycle unless opted in via `delay_login_until_ready`

### DIFF
--- a/site/src/components/Resources/AgentStatus.tsx
+++ b/site/src/components/Resources/AgentStatus.tsx
@@ -138,6 +138,10 @@ const ConnectedStatus: React.FC<{
   // NOTE(mafredri): Keep this behind feature flag for the time-being,
   // if delay_login_until_ready is true, the user has updated to
   // terraform-provider-coder v0.6.7 and opted in to the functionality.
+  //
+  // Remove check once documentation is in place and we we do a breaking
+  // release indicating startup script behavior has changed.
+  // https://github.com/coder/coder/issues/5749
   if (agent.delay_login_until_ready) {
     return (
       <ChooseOne>

--- a/site/src/components/Resources/AgentStatus.tsx
+++ b/site/src/components/Resources/AgentStatus.tsx
@@ -139,7 +139,7 @@ const ConnectedStatus: React.FC<{
   // if delay_login_until_ready is true, the user has updated to
   // terraform-provider-coder v0.6.7 and opted in to the functionality.
   //
-  // Remove check once documentation is in place and we we do a breaking
+  // Remove check once documentation is in place and we do a breaking
   // release indicating startup script behavior has changed.
   // https://github.com/coder/coder/issues/5749
   if (agent.delay_login_until_ready) {

--- a/site/src/components/Resources/AgentStatus.tsx
+++ b/site/src/components/Resources/AgentStatus.tsx
@@ -135,22 +135,28 @@ const StartErrorLifecycle: React.FC<{
 const ConnectedStatus: React.FC<{
   agent: WorkspaceAgent
 }> = ({ agent }) => {
-  return (
-    <ChooseOne>
-      <Cond condition={agent.lifecycle_state === "ready"}>
-        <ReadyLifeCycle />
-      </Cond>
-      <Cond condition={agent.lifecycle_state === "start_timeout"}>
-        <StartTimeoutLifecycle agent={agent} />
-      </Cond>
-      <Cond condition={agent.lifecycle_state === "start_error"}>
-        <StartErrorLifecycle agent={agent} />
-      </Cond>
-      <Cond>
-        <StartingLifecycle />
-      </Cond>
-    </ChooseOne>
-  )
+  // NOTE(mafredri): Keep this behind feature flag for the time-being,
+  // if delay_login_until_ready is true, the user has updated to
+  // terraform-provider-coder v0.6.7 and opted in to the functionality.
+  if (agent.delay_login_until_ready) {
+    return (
+      <ChooseOne>
+        <Cond condition={agent.lifecycle_state === "ready"}>
+          <ReadyLifeCycle />
+        </Cond>
+        <Cond condition={agent.lifecycle_state === "start_timeout"}>
+          <StartTimeoutLifecycle agent={agent} />
+        </Cond>
+        <Cond condition={agent.lifecycle_state === "start_error"}>
+          <StartErrorLifecycle agent={agent} />
+        </Cond>
+        <Cond>
+          <StartingLifecycle />
+        </Cond>
+      </ChooseOne>
+    )
+  }
+  return <ReadyLifeCycle />
 }
 
 const DisconnectedStatus: React.FC = () => {


### PR DESCRIPTION
Refs: #5835, #5749
