### PR TITLE
feat: add debug server for tailnet coordinators

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1193,7 +1193,7 @@ func (c *client) ListenWorkspaceAgent(_ context.Context) (net.Conn, error) {
 	}
 	c.t.Cleanup(c.lastWorkspaceAgent)
 	go func() {
-		_ = c.coordinator.ServeAgent(serverConn, c.agentID)
+		_ = c.coordinator.ServeAgent(serverConn, c.agentID, "")
 		close(closed)
 	}()
 	return clientConn, nil

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -370,7 +370,7 @@ const docTemplate = `{
                     }
                 ],
                 "produces": [
-                    "text/html; charset=utf-8"
+                    "text/html"
                 ],
                 "tags": [
                     "Debug"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -362,6 +362,28 @@ const docTemplate = `{
                 }
             }
         },
+        "/debug/coordinator": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "Debug"
+                ],
+                "summary": "Wireguard Coordinator Debug Info",
+                "operationId": "debuginfo-coordinator",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/entitlements": {
             "get": {
                 "security": [

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -370,13 +370,13 @@ const docTemplate = `{
                     }
                 ],
                 "produces": [
-                    "text/html"
+                    "text/html; charset=utf-8"
                 ],
                 "tags": [
                     "Debug"
                 ],
-                "summary": "Wireguard Coordinator Debug Info",
-                "operationId": "debuginfo-coordinator",
+                "summary": "Debug Info Wireguard Coordinator",
+                "operationId": "debug-info-wireguard-coordinator",
                 "responses": {
                     "200": {
                         "description": "OK"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -315,7 +315,7 @@
             "CoderSessionToken": []
           }
         ],
-        "produces": ["text/html; charset=utf-8"],
+        "produces": ["text/html"],
         "tags": ["Debug"],
         "summary": "Debug Info Wireguard Coordinator",
         "operationId": "debug-info-wireguard-coordinator",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -308,6 +308,24 @@
         }
       }
     },
+    "/debug/coordinator": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["text/html"],
+        "tags": ["Debug"],
+        "summary": "Wireguard Coordinator Debug Info",
+        "operationId": "debuginfo-coordinator",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/entitlements": {
       "get": {
         "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -315,10 +315,10 @@
             "CoderSessionToken": []
           }
         ],
-        "produces": ["text/html"],
+        "produces": ["text/html; charset=utf-8"],
         "tags": ["Debug"],
-        "summary": "Wireguard Coordinator Debug Info",
-        "operationId": "debuginfo-coordinator",
+        "summary": "Debug Info Wireguard Coordinator",
+        "operationId": "debug-info-wireguard-coordinator",
         "responses": {
           "200": {
             "description": "OK"

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -630,7 +630,7 @@ func New(options *Options) *API {
 				},
 			)
 
-			r.HandleFunc("/coordinator", api.debugCoordinator)
+			r.Get("/coordinator", api.debugCoordinator)
 		})
 	})
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -630,9 +630,7 @@ func New(options *Options) *API {
 				},
 			)
 
-			r.HandleFunc("/coordinator", func(w http.ResponseWriter, r *http.Request) {
-				(*api.TailnetCoordinator.Load()).ServeHTTPDebug(w, r)
-			})
+			r.HandleFunc("/coordinator", api.debugCoordinator)
 		})
 	})
 

--- a/coderd/coderdtest/authorize.go
+++ b/coderd/coderdtest/authorize.go
@@ -272,6 +272,11 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertAction: rbac.ActionRead,
 			AssertObject: rbac.ResourceTemplate,
 		},
+
+		"GET:/api/v2/debug/coordinator": {
+			AssertAction: rbac.ActionRead,
+			AssertObject: rbac.ResourceDebugInfo,
+		},
 	}
 
 	// Routes like proxy routes support all HTTP methods. A helper func to expand

--- a/coderd/coderdtest/swaggerparser.go
+++ b/coderd/coderdtest/swaggerparser.go
@@ -327,7 +327,7 @@ func assertAccept(t *testing.T, comment SwaggerComment) {
 	}
 }
 
-var allowedProduceTypes = []string{"json", "text/event-stream"}
+var allowedProduceTypes = []string{"json", "text/event-stream", "text/html"}
 
 func assertProduce(t *testing.T, comment SwaggerComment) {
 	var hasResponseModel bool
@@ -344,7 +344,8 @@ func assertProduce(t *testing.T, comment SwaggerComment) {
 	} else {
 		if (comment.router == "/workspaceagents/me/app-health" && comment.method == "post") ||
 			(comment.router == "/workspaceagents/me/version" && comment.method == "post") ||
-			(comment.router == "/licenses/{id}" && comment.method == "delete") {
+			(comment.router == "/licenses/{id}" && comment.method == "delete") ||
+			(comment.router == "/debug/coordinator" && comment.method == "get") {
 			return // Exception: HTTP 200 is returned without response entity
 		}
 

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -5,7 +5,7 @@ import "net/http"
 // @Summary Debug Info Wireguard Coordinator
 // @ID debug-info-wireguard-coordinator
 // @Security CoderSessionToken
-// @Produce text/html; charset=utf-8
+// @Produce text/html
 // @Tags Debug
 // @Success 200
 // @Router /debug/coordinator [get]

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -2,10 +2,10 @@ package coderd
 
 import "net/http"
 
-// @Summary Wireguard Coordinator Debug Info
-// @ID debuginfo-coordinator
+// @Summary Debug Info Wireguard Coordinator
+// @ID debug-info-wireguard-coordinator
 // @Security CoderSessionToken
-// @Produce html
+// @Produce text/html; charset=utf-8
 // @Tags Debug
 // @Success 200
 // @Router /debug/coordinator [get]

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -1,0 +1,14 @@
+package coderd
+
+import "net/http"
+
+// @Summary Wireguard Coordinator Debug Info
+// @ID debuginfo-coordinator
+// @Security CoderSessionToken
+// @Produce html
+// @Tags Debug
+// @Success 200
+// @Router /debug/coordinator [get]
+func (api *API) debugCoordinator(rw http.ResponseWriter, r *http.Request) {
+	(*api.TailnetCoordinator.Load()).ServeHTTPDebug(rw, r)
+}

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -150,6 +150,11 @@ var (
 	ResourceReplicas = Object{
 		Type: "replicas",
 	}
+
+	// ResourceDebugInfo controls access to the debug routes `/api/v2/debug/*`.
+	ResourceDebugInfo = Object{
+		Type: "debug_info",
+	}
 )
 
 // Object is used to create objects for authz checks when you have none in

--- a/coderd/wsconncache/wsconncache_test.go
+++ b/coderd/wsconncache/wsconncache_test.go
@@ -207,7 +207,7 @@ func (c *client) ListenWorkspaceAgent(_ context.Context) (net.Conn, error) {
 		<-closed
 	})
 	go func() {
-		_ = c.coordinator.ServeAgent(serverConn, c.agentID)
+		_ = c.coordinator.ServeAgent(serverConn, c.agentID, "")
 		close(closed)
 	}()
 	return clientConn, nil

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -1,0 +1,21 @@
+# Debug
+
+## Wireguard Coordinator Debug Info
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/debug/coordinator \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /debug/coordinator`
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema |
+| ------ | ------------------------------------------------------- | ----------- | ------ |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -1,6 +1,6 @@
 # Debug
 
-## Wireguard Coordinator Debug Info
+## Debug Info Wireguard Coordinator
 
 ### Code samples
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -365,6 +365,10 @@
           "path": "./api/builds.md"
         },
         {
+          "title": "Debug",
+          "path": "./api/debug.md"
+        },
+        {
           "title": "Enterprise",
           "path": "./api/enterprise.md"
         },

--- a/enterprise/tailnet/coordinator.go
+++ b/enterprise/tailnet/coordinator.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -174,7 +176,7 @@ func (c *haCoordinator) handleNextClientMessage(id, agent uuid.UUID, decoder *js
 
 // ServeAgent accepts a WebSocket connection to an agent that listens to
 // incoming connections and publishes node updates.
-func (c *haCoordinator) ServeAgent(conn net.Conn, id uuid.UUID) error {
+func (c *haCoordinator) ServeAgent(conn net.Conn, id uuid.UUID, _ string) error {
 	// Tell clients on other instances to send a callmemaybe to us.
 	err := c.publishAgentHello(id)
 	if err != nil {
@@ -572,4 +574,10 @@ func (c *haCoordinator) formatAgentUpdate(id uuid.UUID, node *agpl.Node) ([]byte
 	}
 
 	return buf.Bytes(), nil
+}
+
+func (*haCoordinator) ServeHTTPDebug(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, "<h1>coordinator</h1>")
+	fmt.Fprintf(w, "<h2>ha debug coming soon</h2>")
 }

--- a/enterprise/tailnet/coordinator_test.go
+++ b/enterprise/tailnet/coordinator_test.go
@@ -60,7 +60,7 @@ func TestCoordinatorSingle(t *testing.T) {
 		id := uuid.New()
 		closeChan := make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(server, id)
+			err := coordinator.ServeAgent(server, id, "")
 			assert.NoError(t, err)
 			close(closeChan)
 		}()
@@ -91,7 +91,7 @@ func TestCoordinatorSingle(t *testing.T) {
 		agentID := uuid.New()
 		closeAgentChan := make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(agentServerWS, agentID)
+			err := coordinator.ServeAgent(agentServerWS, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan)
 		}()
@@ -142,7 +142,7 @@ func TestCoordinatorSingle(t *testing.T) {
 		})
 		closeAgentChan = make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(agentServerWS, agentID)
+			err := coordinator.ServeAgent(agentServerWS, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan)
 		}()
@@ -184,7 +184,7 @@ func TestCoordinatorHA(t *testing.T) {
 		agentID := uuid.New()
 		closeAgentChan := make(chan struct{})
 		go func() {
-			err := coordinator1.ServeAgent(agentServerWS, agentID)
+			err := coordinator1.ServeAgent(agentServerWS, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan)
 		}()
@@ -240,7 +240,7 @@ func TestCoordinatorHA(t *testing.T) {
 		})
 		closeAgentChan = make(chan struct{})
 		go func() {
-			err := coordinator1.ServeAgent(agentServerWS, agentID)
+			err := coordinator1.ServeAgent(agentServerWS, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan)
 		}()

--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -25,7 +25,8 @@ import (
 // └──────────────────┘   └────────────────────┘   └───────────────────┘   └──────────────────┘
 // Coordinators have different guarantees for HA support.
 type Coordinator interface {
-	// ServeHTTPDebug
+	// ServeHTTPDebug serves a debug webpage that shows the internal state of
+	// the coordinator.
 	ServeHTTPDebug(w http.ResponseWriter, r *http.Request)
 	// Node returns an in-memory node by ID.
 	Node(id uuid.UUID) *Node

--- a/tailnet/coordinator_test.go
+++ b/tailnet/coordinator_test.go
@@ -48,7 +48,7 @@ func TestCoordinator(t *testing.T) {
 		id := uuid.New()
 		closeChan := make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(server, id)
+			err := coordinator.ServeAgent(server, id, "")
 			assert.NoError(t, err)
 			close(closeChan)
 		}()
@@ -76,7 +76,7 @@ func TestCoordinator(t *testing.T) {
 		agentID := uuid.New()
 		closeAgentChan := make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(agentServerWS, agentID)
+			err := coordinator.ServeAgent(agentServerWS, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan)
 		}()
@@ -127,7 +127,7 @@ func TestCoordinator(t *testing.T) {
 		})
 		closeAgentChan = make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(agentServerWS, agentID)
+			err := coordinator.ServeAgent(agentServerWS, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan)
 		}()
@@ -160,7 +160,7 @@ func TestCoordinator(t *testing.T) {
 		agentID := uuid.New()
 		closeAgentChan1 := make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(agentServerWS1, agentID)
+			err := coordinator.ServeAgent(agentServerWS1, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan1)
 		}()
@@ -205,7 +205,7 @@ func TestCoordinator(t *testing.T) {
 		})
 		closeAgentChan2 := make(chan struct{})
 		go func() {
-			err := coordinator.ServeAgent(agentServerWS2, agentID)
+			err := coordinator.ServeAgent(agentServerWS2, agentID, "")
 			assert.NoError(t, err)
 			close(closeAgentChan2)
 		}()


### PR DESCRIPTION
Implements a Tailscale-like debug server for our in-memory coordinator. This should provide some visibility into why connections could be failing.
Resolves: https://github.com/coder/coder/issues/5845

![image](https://user-images.githubusercontent.com/6332295/214680832-2724d633-2d54-44d6-a7ce-5841e5824ee5.png)
