### PR TITLE
revert: "feat(dogfood): install nix package manager"

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -316,24 +316,7 @@ COPY --from=go /tmp/bin /usr/local/bin
 COPY --from=rust-utils /tmp/bin /usr/local/bin
 COPY --from=proto /tmp/bin /usr/local/bin
 
-# Configure Nix without sandboxing
-# - https://github.com/NixOS/nix/issues/2636#issuecomment-455302745
-# - https://nixos.org/manual/nix/stable/installation/multi-user.html#setting-up-the-build-users
-RUN addgroup --system nixbld \
-	&& adduser coder nixbld \
-	&& for i in $(seq 1 30); do useradd -ms /bin/bash nixbld$i &&  adduser nixbld$i nixbld; done \
-	&& mkdir -m 0755 /nix && chown coder:coder /nix \
-	&& mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
-
-# Install Nix
-ARG NIX_VERSION=2.3.15
-RUN cd /opt \
-	&& curl --silent --show-error --location \
-	"https://releases.nixos.org/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x86_64-linux.tar.xz" \
-	-o "nix-${NIX_VERSION}-x86_64-linux.tar.xz" \
-	&& tar -xf "nix-${NIX_VERSION}-x86_64-linux.tar.xz" \
-	&& ln -s "nix-${NIX_VERSION}-x86_64-linux" nix \
-	&& rm -rf "nix-${NIX_VERSION}-x86_64-linux.tar.xz"
+USER coder
 
 # Ensure go bins are in the 'coder' user's path. Note that no go bins are
 # installed in this docker file, as they'd be mounted over by the persistent
@@ -349,5 +332,3 @@ ENV GOPRIVATE="coder.com,cdr.dev,go.coder.com,github.com/cdr,github.com/coder"
 
 # Increase memory allocation to NodeJS
 ENV NODE_OPTIONS="--max-old-space-size=8192"
-
-USER coder

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -63,19 +63,10 @@ resource "coder_agent" "dev" {
   startup_script = <<EOF
     #!/bin/sh
     set -x
-
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
     code-server --auth none --port 13337 &
-
     sudo service docker start
-
-    # Install Nix into our bash profile so `nix-shell`, `nix-build, and `nix` are available
-    bash /opt/nix/install --no-daemon
-    if ! grep -q '. ~/.nix-profile/etc/profile.d/nix.sh' ~/.bashrc; then
-      echo '. ~/.nix-profile/etc/profile.d/nix.sh' >> ~/.bashrc
-    fi
-
     DOTFILES_URI=${var.dotfiles_uri}
     rm -f ~/.personalize.log
     if [ -n "$DOTFILES_URI" ]; then
@@ -107,33 +98,6 @@ resource "coder_app" "code-server" {
 
 resource "docker_volume" "home_volume" {
   name = "coder-${data.coder_workspace.me.id}-home"
-  # Protect the volume from being deleted due to changes in attributes.
-  lifecycle {
-    ignore_changes = all
-  }
-  # Add labels in Docker to keep track of orphan resources.
-  labels {
-    label = "coder.owner"
-    value = data.coder_workspace.me.owner
-  }
-  labels {
-    label = "coder.owner_id"
-    value = data.coder_workspace.me.owner_id
-  }
-  labels {
-    label = "coder.workspace_id"
-    value = data.coder_workspace.me.id
-  }
-  # This field becomes outdated if the workspace is renamed but can
-  # be useful for debugging or cleaning out dangling volumes.
-  labels {
-    label = "coder.workspace_name_at_creation"
-    value = data.coder_workspace.me.name
-  }
-}
-
-resource "docker_volume" "nix_volume" {
-  name = "coder-${data.coder_workspace.me.id}-nix"
   # Protect the volume from being deleted due to changes in attributes.
   lifecycle {
     ignore_changes = all
@@ -208,11 +172,6 @@ resource "docker_container" "workspace" {
   volumes {
     container_path = "/home/coder/"
     volume_name    = docker_volume.home_volume.name
-    read_only      = false
-  }
-  volumes {
-    container_path = "/nix"
-    volume_name    = docker_volume.nix_volume.name
     read_only      = false
   }
   # Add labels in Docker to keep track of orphan resources.


### PR DESCRIPTION
Reverts #5308.

After merging #5308, I noticed `bash /opt/nix/install --no-daemon` never completes. It gets stuck here:

```
performing a single-user installation of Nix...
copying Nix to /nix/store............................................
replacing old 'nix-2.3.15'
installing 'nix-2.3.15'
unpacking channels...
```

I've tried waiting for a good while. I tried upgrading nix to 2.13.2. I tried running the install as `sudo`. Same result every time.

Since I don't know the fix or cause, I'm reverting (to avoid breakage) until we can figure it out.