### PR TITLE
feat: add init containers to the helm chart

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -45,6 +45,10 @@ spec:
       nodeSelector:
       {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.coder.initContainers }}
+      initContainers:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: coder
           image: {{ include "coder.image" . | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,6 +21,13 @@ coder:
     # a private registry.
     pullSecrets: []
     #  - name: "pull-secret"
+  
+  # coder.initContainers -- Init containers for the deployment. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  initContainers: []
+    # - name: init-container
+    #   image: busybox:1.28
+    #   command: ['sh', '-c', "sleep 2"]
 
   # coder.annotations -- The Deployment annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,10 +21,11 @@ coder:
     # a private registry.
     pullSecrets: []
     #  - name: "pull-secret"
-  
+
   # coder.initContainers -- Init containers for the deployment. See:
   # https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-  initContainers: []
+  initContainers:
+    []
     # - name: init-container
     #   image: busybox:1.28
     #   command: ['sh', '-c', "sleep 2"]


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->

I'd like to be able to bootstrap my coder deployment with templates. One way to do this is via init containers & volume mounts. There are already volumes & volume mounts in the helm chart, so init containers provides a nice way to tie them together and pre-load templates.