### PR TITLE
fix: loop variable captured by func literal in parameters test

### DIFF
--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -900,7 +900,7 @@ func TestWorkspaceBuildValidateRichParameters(t *testing.T) {
 			{numberParameterName, "10", true, numberRichParameters},
 			{numberParameterName, "11", false, numberRichParameters},
 
-			{stringParameterName, "", false, stringRichParameters},
+			{stringParameterName, "", true, stringRichParameters},
 			{stringParameterName, "foobar", true, stringRichParameters},
 
 			{stringParameterName, "abcd", true, regexRichParameters},
@@ -912,6 +912,7 @@ func TestWorkspaceBuildValidateRichParameters(t *testing.T) {
 		}
 
 		for _, tc := range tests {
+			tc := tc
 			t.Run(tc.parameterName+"-"+tc.value, func(t *testing.T) {
 				t.Parallel()
 


### PR DESCRIPTION
I noticed this when adding a new parameter type. There's a test case for an empty string that returned false for validation, but appears like it could be true.

If there is no value for a string, then the default is used. In this case there is no default, but that's technically fine I believe.
