### PR TITLE
chore: removing unaudited resources

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "afero",
     "apps",
     "ASKPASS",
+    "autostop",
     "awsidentity",
     "bodyclose",
     "buildinfo",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5648,15 +5648,13 @@ const docTemplate = `{
                 },
                 "resource_type": {
                     "enum": [
-                        "organization",
                         "template",
                         "template_version",
                         "user",
                         "workspace",
                         "workspace_build",
                         "git_ssh_key",
-                        "api_key",
-                        "group"
+                        "auditable_group"
                     ],
                     "allOf": [
                         {
@@ -7114,7 +7112,6 @@ const docTemplate = `{
         "codersdk.ResourceType": {
             "type": "string",
             "enum": [
-                "organization",
                 "template",
                 "template_version",
                 "user",
@@ -7125,7 +7122,6 @@ const docTemplate = `{
                 "group"
             ],
             "x-enum-varnames": [
-                "ResourceTypeOrganization",
                 "ResourceTypeTemplate",
                 "ResourceTypeTemplateVersion",
                 "ResourceTypeUser",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4996,15 +4996,13 @@
         },
         "resource_type": {
           "enum": [
-            "organization",
             "template",
             "template_version",
             "user",
             "workspace",
             "workspace_build",
             "git_ssh_key",
-            "api_key",
-            "group"
+            "auditable_group"
           ],
           "allOf": [
             {
@@ -6369,7 +6367,6 @@
     "codersdk.ResourceType": {
       "type": "string",
       "enum": [
-        "organization",
         "template",
         "template_version",
         "user",
@@ -6380,7 +6377,6 @@
         "group"
       ],
       "x-enum-varnames": [
-        "ResourceTypeOrganization",
         "ResourceTypeTemplate",
         "ResourceTypeTemplateVersion",
         "ResourceTypeUser",

--- a/coderd/audit.go
+++ b/coderd/audit.go
@@ -452,8 +452,6 @@ func auditSearchQuery(query string) (database.GetAuditLogsOffsetParams, []coders
 
 func resourceTypeFromString(resourceTypeString string) string {
 	switch codersdk.ResourceType(resourceTypeString) {
-	case codersdk.ResourceTypeOrganization:
-		return resourceTypeString
 	case codersdk.ResourceTypeTemplate:
 		return resourceTypeString
 	case codersdk.ResourceTypeTemplateVersion:

--- a/coderd/audit/diff.go
+++ b/coderd/audit/diff.go
@@ -9,8 +9,6 @@ import (
 // AuditableResources, then add it to this interface.
 type Auditable interface {
 	database.APIKey |
-		database.Organization |
-		database.OrganizationMember |
 		database.Template |
 		database.TemplateVersion |
 		database.User |

--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -49,8 +49,6 @@ type BuildAuditParams[T Auditable] struct {
 
 func ResourceTarget[T Auditable](tgt T) string {
 	switch typed := any(tgt).(type) {
-	case database.Organization:
-		return typed.Name
 	case database.Template:
 		return typed.Name
 	case database.TemplateVersion:
@@ -73,8 +71,6 @@ func ResourceTarget[T Auditable](tgt T) string {
 
 func ResourceID[T Auditable](tgt T) uuid.UUID {
 	switch typed := any(tgt).(type) {
-	case database.Organization:
-		return typed.ID
 	case database.Template:
 		return typed.ID
 	case database.TemplateVersion:
@@ -96,8 +92,6 @@ func ResourceID[T Auditable](tgt T) uuid.UUID {
 
 func ResourceType[T Auditable](tgt T) database.ResourceType {
 	switch any(tgt).(type) {
-	case database.Organization:
-		return database.ResourceTypeOrganization
 	case database.Template:
 		return database.ResourceTypeTemplate
 	case database.TemplateVersion:

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -14,7 +14,6 @@ import (
 type ResourceType string
 
 const (
-	ResourceTypeOrganization    ResourceType = "organization"
 	ResourceTypeTemplate        ResourceType = "template"
 	ResourceTypeTemplateVersion ResourceType = "template_version"
 	ResourceTypeUser            ResourceType = "user"
@@ -27,8 +26,6 @@ const (
 
 func (r ResourceType) FriendlyString() string {
 	switch r {
-	case ResourceTypeOrganization:
-		return "organization"
 	case ResourceTypeTemplate:
 		return "template"
 	case ResourceTypeTemplateVersion:
@@ -122,7 +119,7 @@ type AuditLogResponse struct {
 
 type CreateTestAuditLogRequest struct {
 	Action       AuditAction  `json:"action,omitempty" enums:"create,write,delete,start,stop"`
-	ResourceType ResourceType `json:"resource_type,omitempty" enums:"organization,template,template_version,user,workspace,workspace_build,git_ssh_key,api_key,group"`
+	ResourceType ResourceType `json:"resource_type,omitempty" enums:"template,template_version,user,workspace,workspace_build,git_ssh_key,auditable_group"`
 	ResourceID   uuid.UUID    `json:"resource_id,omitempty" format:"uuid"`
 	Time         time.Time    `json:"time,omitempty" format:"date-time"`
 	BuildReason  BuildReason  `json:"build_reason,omitempty" enums:"autostart,autostop,initiator"`

--- a/docs/api/audit.md
+++ b/docs/api/audit.md
@@ -54,7 +54,7 @@ curl -X GET http://coder-server:8080/api/v2/audit?q=string \
       "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
       "resource_link": "string",
       "resource_target": "string",
-      "resource_type": "organization",
+      "resource_type": "template",
       "status_code": 0,
       "time": "2019-08-24T14:15:22Z",
       "user": {
@@ -108,7 +108,7 @@ curl -X POST http://coder-server:8080/api/v2/audit/testgenerate \
   "action": "create",
   "build_reason": "autostart",
   "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
-  "resource_type": "organization",
+  "resource_type": "template",
   "time": "2019-08-24T14:15:22Z"
 }
 ```

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -330,7 +330,7 @@
   "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
   "resource_link": "string",
   "resource_target": "string",
-  "resource_type": "organization",
+  "resource_type": "template",
   "status_code": 0,
   "time": "2019-08-24T14:15:22Z",
   "user": {
@@ -406,7 +406,7 @@
       "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
       "resource_link": "string",
       "resource_target": "string",
-      "resource_type": "organization",
+      "resource_type": "template",
       "status_code": 0,
       "time": "2019-08-24T14:15:22Z",
       "user": {
@@ -785,7 +785,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
   "action": "create",
   "build_reason": "autostart",
   "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
-  "resource_type": "organization",
+  "resource_type": "template",
   "time": "2019-08-24T14:15:22Z"
 }
 ```
@@ -812,15 +812,13 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `build_reason`  | `autostart`        |
 | `build_reason`  | `autostop`         |
 | `build_reason`  | `initiator`        |
-| `resource_type` | `organization`     |
 | `resource_type` | `template`         |
 | `resource_type` | `template_version` |
 | `resource_type` | `user`             |
 | `resource_type` | `workspace`        |
 | `resource_type` | `workspace_build`  |
 | `resource_type` | `git_ssh_key`      |
-| `resource_type` | `api_key`          |
-| `resource_type` | `group`            |
+| `resource_type` | `auditable_group`  |
 
 ## codersdk.CreateTokenRequest
 
@@ -3739,7 +3737,7 @@ Parameter represents a set value for the scope.
 ## codersdk.ResourceType
 
 ```json
-"organization"
+"template"
 ```
 
 ### Properties
@@ -3748,7 +3746,6 @@ Parameter represents a set value for the scope.
 
 | Value              |
 | ------------------ |
-| `organization`     |
 | `template`         |
 | `template_version` |
 | `user`             |

--- a/enterprise/audit/diff_internal_test.go
+++ b/enterprise/audit/diff_internal_test.go
@@ -278,44 +278,6 @@ func Test_diff(t *testing.T) {
 	runDiffTests(t, []diffTest{
 		{
 			name: "Create",
-			left: audit.Empty[database.OrganizationMember](),
-			right: database.OrganizationMember{
-				UserID:         uuid.UUID{1},
-				OrganizationID: uuid.UUID{2},
-				CreatedAt:      time.Now(),
-				UpdatedAt:      time.Now(),
-				Roles:          []string{"auditor"},
-			},
-			exp: audit.Map{
-				"user_id":         audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
-				"organization_id": audit.OldNew{Old: "", New: uuid.UUID{2}.String()},
-				"roles":           audit.OldNew{Old: ([]string)(nil), New: []string{"auditor"}},
-			},
-		},
-	})
-
-	runDiffTests(t, []diffTest{
-		{
-			name: "Create",
-			left: audit.Empty[database.Organization](),
-			right: database.Organization{
-				ID:          uuid.UUID{1},
-				Name:        "rust developers",
-				Description: "an organization for rust developers",
-				CreatedAt:   time.Now(),
-				UpdatedAt:   time.Now(),
-			},
-			exp: audit.Map{
-				"id":          audit.OldNew{Old: "", New: uuid.UUID{1}.String()},
-				"name":        audit.OldNew{Old: "", New: "rust developers"},
-				"description": audit.OldNew{Old: "", New: "an organization for rust developers"},
-			},
-		},
-	})
-
-	runDiffTests(t, []diffTest{
-		{
-			name: "Create",
 			left: audit.Empty[database.Template](),
 			right: database.Template{
 				ID:              uuid.UUID{1},

--- a/enterprise/audit/table.go
+++ b/enterprise/audit/table.go
@@ -33,20 +33,6 @@ var AuditableResources = auditMap(map[any]map[string]Action{
 		"private_key": ActionSecret, // We don't want to expose private keys in diffs.
 		"public_key":  ActionTrack,  // Public keys are ok to expose in a diff.
 	},
-	&database.OrganizationMember{}: {
-		"user_id":         ActionTrack,
-		"organization_id": ActionTrack,
-		"created_at":      ActionIgnore, // Never changes, but is implicit and not helpful in a diff.
-		"updated_at":      ActionIgnore, // Changes, but is implicit and not helpful in a diff.
-		"roles":           ActionTrack,
-	},
-	&database.Organization{}: {
-		"id":          ActionTrack,
-		"name":        ActionTrack,
-		"description": ActionTrack,
-		"created_at":  ActionIgnore, // Never changes, but is implicit and not helpful in a diff.
-		"updated_at":  ActionIgnore, // Changes, but is implicit and not helpful in a diff.
-	},
 	&database.Template{}: {
 		"id":                               ActionTrack,
 		"created_at":                       ActionIgnore, // Never changes, but is implicit and not helpful in a diff.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1201,7 +1201,6 @@ export type ResourceType =
   | "api_key"
   | "git_ssh_key"
   | "group"
-  | "organization"
   | "template"
   | "template_version"
   | "user"
@@ -1211,7 +1210,6 @@ export const ResourceTypes: ResourceType[] = [
   "api_key",
   "git_ssh_key",
   "group",
-  "organization",
   "template",
   "template_version",
   "user",


### PR DESCRIPTION
We don't support creating an org in the product right now, so we should remove the `Organization` resource. We also already audit `user`, so there's no need for the `OrganizationMember` resource. It's important to clean these up because our [docs will be autogenerated](https://github.com/coder/coder/pull/5862) going forward, and we need `audit.AuditableResources` to be accurate.

Neither of these resources were actively being audited, so the only cleanup is the scaffolding.