### PR TITLE
chore(.github): relax stale bot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,23 +11,22 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      # v5.1.0 has a weird bug that makes stalebot add then remove its own label
-      # https://github.com/actions/stale/pull/775
       - uses: actions/stale@v7.0.0
         with:
           stale-issue-label: "stale"
           stale-pr-label: "stale"
+          days-before-stale: 90
           # Pull Requests become stale more quickly due to merge conflicts.
           # Also, we promote minimizing WIP.
           days-before-pr-stale: 7
           days-before-pr-close: 3
           stale-pr-message: >
-            This Pull Request is becoming stale. In order to minimize WIP, 
+            This Pull Request is becoming stale. In order to minimize WIP,
             prevent merge conflicts and keep the tracker readable, I'm going
             close to this PR in 3 days if there isn't more activity.
           stale-issue-message: >
             This issue is becoming stale. In order to keep the tracker readable
-            and actionable, I'm going close to this issue in 7 days if there 
+            and actionable, I'm going close to this issue in 7 days if there
             isn't more activity.
           # Upped from 30 since we have a big tracker and was hitting the limit.
           operations-per-run: 60


### PR DESCRIPTION
At 60 days it was more spammy than helpful.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
