### PR TITLE
fix: use a waitgroup to ensure all connections are cleaned up in agent

### DIFF
--- a/scaletest/reconnectingpty/run_test.go
+++ b/scaletest/reconnectingpty/run_test.go
@@ -23,10 +23,6 @@ import (
 
 func Test_Runner(t *testing.T) {
 	t.Parallel()
-	// There's a race condition in agent/agent.go where connections
-	// aren't closed when the Tailnet connection is. This causes the
-	// goroutines to hang around and cause the test to fail.
-	t.Skip("TODO: fix this test")
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()

--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -2,7 +2,6 @@ package tailnet_test
 
 import (
 	"context"
-	"fmt"
 	"net/netip"
 	"testing"
 
@@ -84,60 +83,5 @@ func TestTailnet(t *testing.T) {
 
 		w1.Close()
 		w2.Close()
-	})
-	t.Run("CloseListeners", func(t *testing.T) {
-		t.Parallel()
-		w1IP := tailnet.IP()
-		w1, err := tailnet.NewConn(&tailnet.Options{
-			Addresses: []netip.Prefix{netip.PrefixFrom(w1IP, 128)},
-			Logger:    logger.Named("w1"),
-			DERPMap:   derpMap,
-		})
-		require.NoError(t, err)
-
-		w2, err := tailnet.NewConn(&tailnet.Options{
-			Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
-			Logger:    logger.Named("w2"),
-			DERPMap:   derpMap,
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_ = w1.Close()
-			_ = w2.Close()
-		})
-		w1.SetNodeCallback(func(node *tailnet.Node) {
-			err := w2.UpdateNodes([]*tailnet.Node{node})
-			require.NoError(t, err)
-		})
-		w2.SetNodeCallback(func(node *tailnet.Node) {
-			err := w1.UpdateNodes([]*tailnet.Node{node})
-			require.NoError(t, err)
-		})
-		require.True(t, w2.AwaitReachable(context.Background(), w1IP))
-		// conn := make(chan struct{})
-		accepted := make(chan struct{})
-		closed := make(chan struct{})
-		go func() {
-			listener, err := w1.Listen("tcp", ":35565")
-			assert.NoError(t, err)
-			defer listener.Close()
-			nc, err := listener.Accept()
-			if !assert.NoError(t, err) {
-				return
-			}
-			close(accepted)
-			_, err = nc.Read(make([]byte, 16))
-			fmt.Printf("Err: %s\n", err)
-			close(closed)
-			// _ = nc.Close()
-			// conn <- struct{}{}
-		}()
-
-		_, err = w2.DialContextTCP(context.Background(), netip.AddrPortFrom(w1IP, 35565))
-		require.NoError(t, err)
-		<-accepted
-		w1.Close()
-		w2.Close()
-		<-closed
 	})
 }


### PR DESCRIPTION
There was a race where connections would be created at the same time as close. The `net.Conn` produced by Tailscale doesn't close then the listener does.
