### PR TITLE
feat(agent): Allow specifying log directory via flag or env

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -89,6 +89,9 @@ func New(options Options) io.Closer {
 		options.TempDir = os.TempDir()
 	}
 	if options.LogDir == "" {
+		if options.TempDir != os.TempDir() {
+			options.Logger.Debug(context.Background(), "log dir not set, using temp dir", slog.F("temp_dir", options.TempDir))
+		}
 		options.LogDir = options.TempDir
 	}
 	if options.ExchangeToken == nil {

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -53,6 +53,13 @@ func TestCommandHelp(t *testing.T) {
 				"CODER_CACHE_DIRECTORY": "/tmp/coder-cli-test-cache",
 			},
 		},
+		{
+			name: "coder agent --help",
+			cmd:  []string{"agent", "--help"},
+			env: map[string]string{
+				"CODER_AGENT_LOG_DIR": "/tmp",
+			},
+		},
 	}
 
 	root := cli.Root(cli.AGPL())

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -1,0 +1,29 @@
+Usage:
+  coder agent [flags]
+
+Flags:
+      --auth string            Specify the authentication type to use for the agent.
+                               Consumes $CODER_AGENT_AUTH (default "token")
+  -h, --help                   help for agent
+      --log-dir string         Specify the location for the agent log files.
+                               Consumes $CODER_AGENT_LOG_DIR (default "/tmp")
+      --no-reap                Do not start a process reaper.
+      --pprof-address string   The address to serve pprof.
+                               Consumes $CODER_AGENT_PPROF_ADDRESS (default "127.0.0.1:6060")
+
+Global Flags:
+      --global-config coder   Path to the global coder config directory.
+                              Consumes $CODER_CONFIG_DIR (default "/tmp/coder-cli-test-config")
+      --header stringArray    HTTP headers added to all requests. Provide as "Key=Value".
+                              Consumes $CODER_HEADER
+      --no-feature-warning    Suppress warnings about unlicensed features.
+                              Consumes $CODER_NO_FEATURE_WARNING
+      --no-version-warning    Suppress warning when client and server versions do not match.
+                              Consumes $CODER_NO_VERSION_WARNING
+      --token string          Specify an authentication token. For security reasons setting
+                              CODER_SESSION_TOKEN is preferred.
+                              Consumes $CODER_SESSION_TOKEN
+      --url string            URL to a deployment.
+                              Consumes $CODER_URL
+  -v, --verbose               Enable verbose output.
+                              Consumes $CODER_VERBOSE


### PR DESCRIPTION
This PR adds support for `--log-dir` and `$CODER_AGENT_LOG_DIR`.

This is useful for storing the logs in persistent storage. For instance in Docker containers `/tmp` can often be mounted as tmpfs, and this may have RAM implications and does not persist. Similarly it's currently not possible to run multiple agents on the same machine because they write to the same log.

**NOTE:** That this PR targets another PR due to introduction of an additional log file.
