### PR TITLE
docs: add gitauth validate url var

### DIFF
--- a/docs/admin/git-providers.md
+++ b/docs/admin/git-providers.md
@@ -39,6 +39,7 @@ used for self-managed Git provider deployments.
 ```console
 CODER_GITAUTH_0_AUTH_URL="https://github.example.com/oauth/authorize"
 CODER_GITAUTH_0_TOKEN_URL="https://github.example.com/oauth/token"
+CODER_GITAUTH_0_VALIDATE_URL="https://your-domain.com/oauth/token/info"
 ```
 
 ### Custom scopes


### PR DESCRIPTION
documents the `CODER_GITAUTH_0_VALIDATE_URL` varaible for custom validation URLs.