### PR TITLE
refactor(docs): Change console to shell and remove unused elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can run the install script with `--dry-run` to see the commands that will be
 
 Once installed, you can start a production deployment<sup>1</sup> with a single command:
 
-```console
+```shell
 # Automatically sets up an external access URL on *.try.coder.app
 coder server
 

--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -21,7 +21,7 @@ values in the next step.
 Navigate to your Coder host and run the following command to start up the Coder
 server:
 
-```console
+```shell
 coder server --oauth2-github-allow-signups=true --oauth2-github-allowed-orgs="your-org" --oauth2-github-client-id="8d1...e05" --oauth2-github-client-secret="57ebc9...02c24c"
 ```
 
@@ -31,7 +31,7 @@ Alternatively, if you are running Coder as a system service, you can achieve the
 same result as the command above by adding the following environment variables
 to the `/etc/coder.d/coder.env` file:
 
-```console
+```shell
 CODER_OAUTH2_GITHUB_ALLOW_SIGNUPS=true
 CODER_OAUTH2_GITHUB_ALLOWED_ORGS="your-org"
 CODER_OAUTH2_GITHUB_CLIENT_ID="8d1...e05"
@@ -40,7 +40,7 @@ CODER_OAUTH2_GITHUB_CLIENT_SECRET="57ebc9...02c24c"
 
 **Note:** To allow everyone to signup using GitHub, set:
 
-```console
+```shell
 CODER_OAUTH2_GITHUB_ALLOW_EVERYONE=true
 ```
 
@@ -59,7 +59,7 @@ First, [register a GitLab OAuth application](https://docs.gitlab.com/ee/integrat
 Navigate to your Coder host and run the following command to start up the Coder
 server:
 
-```console
+```shell
 coder server --oidc-issuer-url="https://gitlab.com" --oidc-email-domain="your-domain-1,your-domain-2" --oidc-client-id="533...des" --oidc-client-secret="G0CSP...7qSM"
 ```
 
@@ -67,7 +67,7 @@ Alternatively, if you are running Coder as a system service, you can achieve the
 same result as the command above by adding the following environment variables
 to the `/etc/coder.d/coder.env` file:
 
-```console
+```shell
 CODER_OIDC_ISSUER_URL="https://gitlab.com"
 CODER_OIDC_EMAIL_DOMAIN="your-domain-1,your-domain-2"
 CODER_OIDC_CLIENT_ID="533...des"
@@ -80,7 +80,7 @@ Once complete, run `sudo service coder restart` to reboot Coder.
 
 GitLab maintains configuration settings for OIDC applications at the following URL:
 
-```console
+```shell
 https://gitlab.com/.well-known/openid-configuration
 ```
 
@@ -101,7 +101,7 @@ First, [register a Google OAuth application](https://support.google.com/cloud/an
 Navigate to your Coder host and run the following command to start up the Coder
 server:
 
-```console
+```shell
 coder server --oidc-issuer-url="https://accounts.google.com" --oidc-email-domain="your-domain-1,your-domain-2" --oidc-client-id="533...ent.com" --oidc-client-secret="G0CSP...7qSM"
 ```
 
@@ -109,7 +109,7 @@ Alternatively, if you are running Coder as a system service, you can achieve the
 same result as the command above by adding the following environment variables
 to the `/etc/coder.d/coder.env` file:
 
-```console
+```shell
 CODER_OIDC_ISSUER_URL="https://accounts.google.com"
 CODER_OIDC_EMAIL_DOMAIN="your-domain-1,your-domain-2"
 CODER_OIDC_CLIENT_ID="533...ent.com"
@@ -123,7 +123,7 @@ Once complete, run `sudo service coder restart` to reboot Coder.
 Coder requires all OIDC email addresses to be verified by default. If the `email_verified` claim is present in the token response from the identity provider, Coder will validate that its value is `true`.
 If needed, you can disable this behavior with the following setting:
 
-```console
+```shell
 CODER_OIDC_IGNORE_EMAIL_VERIFIED=true
 ```
 
@@ -133,7 +133,7 @@ When a new user is created, the `preferred_username` claim becomes the username.
 
 If you'd like to change the OpenID Connect button text and/or icon, you can configure them like so:
 
-```console
+```shell
 CODER_OIDC_SIGN_IN_TEXT="Sign in with Gitea"
 CODER_OIDC_ICON_URL=https://gitea.io/images/gitea.png
 ```
@@ -145,7 +145,7 @@ authentication. Upon deactivation, users are [suspended](./users.md#suspend-a-us
 and are not deleted. [Configure](./configure.md) your SCIM application with an
 auth key and supply it the Coder server.
 
-```console
+```shell
 CODER_SCIM_API_KEY="your-api-key"
 ```
 
@@ -153,7 +153,7 @@ CODER_SCIM_API_KEY="your-api-key"
 
 If your OpenID Connect provider requires client TLS certificates for authentication, you can configure them like so:
 
-```console
+```shell
 CODER_TLS_CLIENT_CERT_FILE=/path/to/cert.pem
 CODER_TLS_CLIENT_KEY_FILE=/path/to/key.pem
 ```

--- a/docs/admin/automation.md
+++ b/docs/admin/automation.md
@@ -11,7 +11,7 @@ Coder uses authentication tokens to grant machine users access to the REST API. 
 You can use tokens with the CLI by setting the `--token` CLI flag or the `CODER_SESSION_TOKEN`
 environment variable.
 
-```console
+```shell
 export CODER_URL=https://coder.example.com
 export CODER_SESSION_TOKEN=*****
 coder workspaces ls
@@ -21,7 +21,7 @@ coder workspaces ls
 
 You can review the [API reference](../api/index.md) to find the necessary routes and payload. Alternatively, you can enable the [Swagger](https://swagger.io/) endpoint to read the documentation and do requests against the API:
 
-```console
+```shell
 coder server --swagger-enable
 ```
 

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -59,7 +59,7 @@ downloaded from Maven (https://repo1.maven.org/maven2) and store all data in the
 If you are using the built-in PostgreSQL deployment and need to use `psql` (aka
 the PostgreSQL interactive terminal), output the connection URL with the following command:
 
-```console
+```shell
 $ coder server postgres-builtin-url
 $ psql "postgres://coder@localhost:49627/coder?sslmode=disable&password=feU...yI1"
 ```
@@ -69,7 +69,7 @@ $ psql "postgres://coder@localhost:49627/coder?sslmode=disable&password=feU...yI
 If you've installed Coder via a [system package](../install/packages.md) Coder, you can
 configure the server by setting the following variables in `/etc/coder.d/coder.env`:
 
-```console
+```shell
 # String. Specifies the external URL (HTTP/S) to access Coder.
 CODER_ACCESS_URL=https://coder.example.com
 
@@ -97,7 +97,7 @@ CODER_TLS_KEY_FILE=
 
 To run Coder as a system service on the host:
 
-```console
+```shell
 # Use systemd to start Coder now and on reboot
 sudo systemctl enable --now coder
 
@@ -107,7 +107,7 @@ journalctl -u coder.service -b
 
 To restart Coder after applying system changes:
 
-```console
+```shell
 sudo systemctl restart coder
 ```
 

--- a/docs/admin/git-providers.md
+++ b/docs/admin/git-providers.md
@@ -24,7 +24,7 @@ Example callback URL: `https://coder.example.com/gitauth/primary-github/callback
 
 Set the following environment variables to [configure the Coder server](./configure.md):
 
-```console
+```shell
 CODER_GITAUTH_0_ID="primary-github"
 CODER_GITAUTH_0_TYPE=github|gitlab|azure-devops|bitbucket
 CODER_GITAUTH_0_CLIENT_ID=xxxxxx
@@ -36,7 +36,7 @@ CODER_GITAUTH_0_CLIENT_SECRET=xxxxxxx
 Custom authentication and token URLs should be
 used for self-managed Git provider deployments.
 
-```console
+```shell
 CODER_GITAUTH_0_AUTH_URL="https://github.example.com/oauth/authorize"
 CODER_GITAUTH_0_TOKEN_URL="https://github.example.com/oauth/token"
 CODER_GITAUTH_0_VALIDATE_URL="https://your-domain.com/oauth/token/info"
@@ -46,7 +46,7 @@ CODER_GITAUTH_0_VALIDATE_URL="https://your-domain.com/oauth/token/info"
 
 Optionally, you can request custom scopes:
 
-```console
+```shell
 CODER_GITAUTH_0_SCOPES="repo:read repo:write write:gpg_key"
 ```
 
@@ -56,7 +56,7 @@ Multiple providers are an Enterprise feature. [Learn more](../enterprise.md).
 
 A custom regex can be used to match a specific repository or organization to limit auth scope. Here's a sample config:
 
-```console
+```shell
 # Provider 1) github.com
 CODER_GITAUTH_0_ID=primary-github
 CODER_GITAUTH_0_TYPE=github
@@ -76,6 +76,6 @@ CODER_GITAUTH_1_TOKEN_URL="https://github.example.com/oauth/token"
 
 To support regex matching for paths (e.g. github.com/orgname), youll need to add this to the [Coder agent startup script](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#startup_script):
 
-```console
+```shell
 git config --global credential.useHttpPath true
 ```

--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -12,7 +12,7 @@ The Prometheus endpoint address is `http://localhost:2112/` by default. You can 
 
 If `coder server --prometheus-enable` is started locally, you can preview the metrics endpoint in your browser or by using curl: <!-- markdown-link-check-disable -->http://localhost:2112/<!-- markdown-link-check-enable -->.
 
-```console
+```shell
 $ curl http://localhost:2112/
 # HELP coderd_api_active_users_duration_hour The number of users that have been active within the last hour.
 # TYPE coderd_api_active_users_duration_hour gauge

--- a/docs/admin/upgrade.md
+++ b/docs/admin/upgrade.md
@@ -17,7 +17,7 @@ of [install](../install).
 If you installed Coder using the `install.sh` script, re-run the below
 command on the host:
 
-```console
+```shell
 curl -L https://coder.com/install.sh | sh
 ```
 
@@ -25,7 +25,7 @@ The script will unpack the new `coder` binary version over the one currently ins
 Next, you can restart Coder with the following commands (if running it as a system
 service):
 
-```console
+```shell
 systemctl daemon-reload
 systemctl restart coder
 ```
@@ -35,7 +35,7 @@ systemctl restart coder
 If you installed using `docker-compose`, run the below command to upgrade the
 Coder container:
 
-```console
+```shell
 docker-compose pull coder && docker-compose up coder -d
 ```
 

--- a/docs/admin/users.md
+++ b/docs/admin/users.md
@@ -35,7 +35,7 @@ The new user will appear in the **Users** list. Use the toggle to change their
 
 To create a user via the Coder CLI, run:
 
-```console
+```shell
 coder users create
 ```
 
@@ -44,7 +44,7 @@ When prompted, provide the **username** and **email** for the new user.
 You'll receive a response that includes the following; share the instructions
 with the user so that they can log into Coder:
 
-```console
+```shell
 Download the Coder command line for your operating system:
 https://github.com/coder/coder/releases
 
@@ -69,7 +69,7 @@ To suspend a user via the web UI:
 
 To suspend a user via the CLI, run:
 
-```console
+```shell
 coder users suspend <username|user_id>
 ```
 
@@ -88,7 +88,7 @@ To activate a user via the web UI:
 
 To activate a user via the CLI, run:
 
-```console
+```shell
 coder users activate <username|user_id>
 ```
 
@@ -108,7 +108,7 @@ Coder will prompt the user to change their temporary password immediately after 
 
 You can also reset a password via the CLI:
 
-```console
+```shell
 # run `coder reset-password <username> --help` for usage instructions
 coder reset-password <username>
 ```

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -2,13 +2,13 @@
 
 Long-lived tokens can be generated to perform actions on behalf of your user account:
 
-```console
+```shell
 coder tokens create
 ```
 
 You can use tokens with the Coder's REST API using the `Coder-Session-Token` HTTP header.
 
-```console
+```shell
 curl 'http://coder-server:8080/api/v2/workspaces' \
   -H 'Coder-Session-Token: *****'
 ```

--- a/docs/ides.md
+++ b/docs/ides.md
@@ -41,7 +41,7 @@ Alternatively, manually install the VSIX from the [latest release](https://githu
 
 To access Coder via SSH, run the following in the terminal:
 
-```console
+```shell
 coder config-ssh
 ```
 
@@ -51,7 +51,7 @@ coder config-ssh
 Confirm that you want to continue by typing **yes** and pressing enter. If
 successful, you'll see the following message:
 
-```console
+```shell
 You should now be able to ssh into your workspace.
 For example, try running:
 

--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -38,7 +38,7 @@ resource "coder_app" "portainer" {
 
 [code-server](https://github.com/coder/coder) is our supported method of running VS Code in the web browser. A simple way to install code-server in Linux/macOS workspaces is via the Coder agent in your template:
 
-```console
+```shell
 # edit your template
 cd your-template/
 vim main.tf

--- a/docs/install/binary.md
+++ b/docs/install/binary.md
@@ -4,7 +4,7 @@ Coder publishes self-contained .zip and .tar.gz archives in [GitHub releases](ht
 
 1. Unzip the folder you just downloaded, and move the `coder` executable to a location that's on your `PATH`
 
-   ```console
+   ```shell
    # ex. macOS and Linux
    mv coder /usr/local/bin
    ```
@@ -13,7 +13,7 @@ Coder publishes self-contained .zip and .tar.gz archives in [GitHub releases](ht
 
 1. Start a Coder server
 
-   ```console
+   ```shell
    # Automatically sets up an external access URL on *.try.coder.app
    coder server
 

--- a/docs/install/database.md
+++ b/docs/install/database.md
@@ -22,7 +22,7 @@ CREATE DATABASE coder;
 Coder configuration is defined via [environment variables](../admin/configure.md).
 The database client requires the connection string provided via the `CODER_PG_CONNECTION_URL` variable.
 
-```console
+```shell
 export CODER_PG_CONNECTION_URL="postgres://coder:secret42@localhost/coder?sslmode=disable"
 ```
 
@@ -49,7 +49,7 @@ Once the schema is created, you can list all schemas with `\dn`:
 
 In this case the database client requires the modified connection string:
 
-```console
+```shell
 export CODER_PG_CONNECTION_URL="postgres://coder:secret42@localhost/coder?sslmode=disable&search_path=myschema"
 ```
 
@@ -77,7 +77,7 @@ ALTER ROLE coder SET search_path = myschema;
 Please make sure that the schema selected in the connection string `...&search_path=myschema` exists
 and the role has granted permissions to access it. The schema should be present on this listing:
 
-```console
+```shell
 psql -U coder -c '\dn'
 ```
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -9,7 +9,7 @@ Docker is required. See the [official installation documentation](https://docs.d
 For proof-of-concept deployments, you can run a complete Coder instance with
 the following command:
 
-```console
+```shell
 export CODER_DATA=$HOME/.config/coderv2-docker
 export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
 mkdir -p $CODER_DATA
@@ -34,7 +34,7 @@ For production deployments, we recommend using an external PostgreSQL database
 (version 13 or higher). Set `ACCESS_URL` to the external URL that users and
 workspaces will use to connect to Coder.
 
-```console
+```shell
 docker run --rm -it \
   -e CODER_ACCESS_URL="https://coder.example.com" \
   -e CODER_PG_CONNECTION_URL="postgresql://username:password@database/coder" \
@@ -54,7 +54,7 @@ an PostgreSQL container and volume.
 
 2. Clone the `coder` repository:
 
-   ```console
+   ```shell
    git clone https://github.com/coder/coder.git
    ```
 
@@ -64,7 +64,7 @@ an PostgreSQL container and volume.
 
    For proof-of-concept deployments, you can use [Coder's tunnel](../admin/configure.md#tunnel):
 
-   ```console
+   ```shell
    cd coder
 
    docker-compose up
@@ -72,7 +72,7 @@ an PostgreSQL container and volume.
 
    For production deployments, we recommend setting an [access URL](../admin/configure.md#access-url):
 
-   ```console
+   ```shell
    cd coder
 
    CODER_ACCESS_URL=https://coder.example.com docker-compose up

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -13,7 +13,7 @@ to log in and manage templates.
 
 1. Create a namespace for Coder, such as `coder`:
 
-   ```console
+   ```shell
    $ kubectl create namespace coder
    ```
 
@@ -34,7 +34,7 @@ to log in and manage templates.
    [helpful guides](https://phoenixnap.com/kb/postgresql-kubernetes) on the
    internet that explain sensible configurations for this chart. Example:
 
-   ```console
+   ```shell
    # Install PostgreSQL
    helm repo add bitnami https://charts.bitnami.com/bitnami
    helm install coder-db bitnami/postgresql \
@@ -47,7 +47,7 @@ to log in and manage templates.
 
    The cluster-internal DB URL for the above database is:
 
-   ```console
+   ```shell
    postgres://coder:coder@coder-db-postgresql.coder.svc.cluster.local:5432/coder?sslmode=disable
    ```
 
@@ -59,13 +59,13 @@ to log in and manage templates.
 
 1. Add the Coder Helm repo:
 
-   ```console
+   ```shell
    helm repo add coder-v2 https://helm.coder.com/v2
    ```
 
 1. Create a secret with the database URL:
 
-   ```console
+   ```shell
    # Uses Bitnami PostgreSQL example. If you have another database,
    # change to the proper URL.
    kubectl create secret generic coder-db-url -n coder \
@@ -114,7 +114,7 @@ to log in and manage templates.
 
 1. Run the following command to install the chart in your cluster.
 
-   ```console
+   ```shell
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml
@@ -137,7 +137,7 @@ to log in and manage templates.
 To upgrade Coder in the future or change values,
 you can run the following command:
 
-```console
+```shell
 helm repo update
 helm upgrade coder coder-v2/coder \
   --namespace coder \

--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -105,13 +105,13 @@ Follow our [docker-compose](./docker.md#run-coder-with-docker-compose) documenta
 
 First, make a create an empty plugins directory:
 
-```console
+```shell
 mkdir $HOME/plugins
 ```
 
 Next, add a volume mount to docker-compose.yaml:
 
-```console
+```shell
 vim docker-compose.yaml
 ```
 

--- a/docs/install/packages.md
+++ b/docs/install/packages.md
@@ -6,7 +6,7 @@
 
 1. Run Coder as a system service.
 
-   ```console
+   ```shell
    # Optional) Set up an access URL
    sudo vim /etc/coder.d/coder.env
 
@@ -23,7 +23,7 @@
 
 1. Visit the Coder URL in the logs to set up your first account, or use the CLI:
 
-   ```console
+   ```shell
    coder login <access-url>
    ```
 
@@ -31,7 +31,7 @@
 
 After updating Coder or applying configuration changes, restart the server:
 
-```console
+```shell
 sudo systemctl restart coder
 ```
 

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -6,7 +6,7 @@ To uninstall your Coder server, delete the following directories.
 
 ## Cached Coder releases
 
-```console
+```shell
 rm -rf ~/.cache/coder
 ```
 
@@ -14,31 +14,31 @@ rm -rf ~/.cache/coder
 
 Debian, Ubuntu:
 
-```console
+```shell
 sudo apt remove coder
 ```
 
 Fedora, CentOS, RHEL, SUSE:
 
-```console
+```shell
 sudo yum remove coder
 ```
 
 Alpine:
 
-```console
+```shell
 sudo apk del coder
 ```
 
 If you installed Coder manually or used the install script on an unsupported operating system, you can remove the binary directly:
 
-```console
+```shell
 sudo rm /usr/local/bin/coder
 ```
 
 ## Coder as a system service configuration
 
-```console
+```shell
 sudo rm /etc/coder.d/coder.env
 ```
 
@@ -51,18 +51,18 @@ sudo rm /etc/coder.d/coder.env
 
 ### macOS
 
-```console
+```shell
 rm -rf ~/Library/Application\ Support/coderv2
 ```
 
 ### Linux
 
-```console
+```shell
 rm -rf ~/.config/coderv2
 ```
 
 ### Windows
 
-```console
+```shell
 C:\Users\USER\AppData\Roaming\coderv2
 ```

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -14,7 +14,7 @@ Use the Windows installer to download the CLI and add Coder to `PATH`. Alternati
 
 3. Start a Coder server
 
-   ```console
+   ```shell
    # Automatically sets up an external access URL on *.try.coder.app
    coder server
 

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -29,14 +29,14 @@ The supported syntax variations for the `--tcp` and `--udp` flag are:
 
 Forward the remote TCP port `8080` to local port `8000`:
 
-```console
+```shell
 coder port-forward myworkspace --tcp 8000:8080
 ```
 
 Forward the remote TCP port `3000` and all ports from `9990` to `9999`
 to their respective local ports.
 
-```console
+```shell
 coder port-forward myworkspace --tcp 3000,9990-9999
 ```
 
@@ -89,7 +89,7 @@ Valid `share` values include `owner` - private to the user, `authenticated` - ac
 First, [configure SSH](../ides.md#ssh-configuration) on your
 local machine. Then, use `ssh` to forward like so:
 
-```console
+```shell
 ssh -L 8080:localhost:8000 coder.myworkspace
 ```
 

--- a/docs/quickstart/aws.md
+++ b/docs/quickstart/aws.md
@@ -52,7 +52,7 @@ You will also need the IP address of the server. Click on the server in the `Ins
 
 Now that we’ve gathered all the information you will need to SSH into your EC2 instance, on a terminal on your local system, navigate to the `.pem` file downloaded when you created the EC2 instance. Run the following command:
 
-```console
+```shell
 chmod 400 [mykey].pem
 ```
 
@@ -60,7 +60,7 @@ This adds the required permissions for SSH-ing into an EC2 instance.
 
 Run the following command in terminal, where `mykey` is the security key file, `username` is the username found above for the relevant EC2 operating system image, and the `ip-address` is the IPv4 address for the server:
 
-```console
+```shell
 ssh -i [mykey].pem username@ip-address
 ```
 
@@ -72,7 +72,7 @@ For this instance, we will run Coder as a system service, however you can run Co
 
 In the EC2 instance, run the following command to install Coder
 
-```console
+```shell
 curl -fsSL https://coder.com/install.sh | sh
 ```
 
@@ -80,13 +80,13 @@ curl -fsSL https://coder.com/install.sh | sh
 
 Run the following command to start Coder as a system level service:
 
-```console
+```shell
 sudo systemctl enable --now coder
 ```
 
 The following command will get you information about the Coder launch service
 
-```console
+```shell
 journalctl -u coder.service -b
 ```
 
@@ -98,7 +98,7 @@ In this instance, Coder can be accessed at the url `https://fccad1b6c901511b30cf
 
 Copy the URL and run the following command to create the first user, either on your local machine or in the AWS EC2 instance terminal.
 
-```console
+```shell
 coder login <url***.try.coder.app>
 ```
 
@@ -122,20 +122,20 @@ Coder runs as a system service under a system user `coder`. The `coder` user wil
 
 Run the following command to create a folder for the AWS credentials to live in:
 
-```console
+```shell
 sudo mkdir /home/coder/.aws
 ```
 
 Run the following commands to copy the AWS credentials and give the `coder` user access to them:
 
-```console
+```shell
 sudo cp ~/.aws/credentials /home/coder/.aws/credentials
 sudo chown coder:coder /home/coder/.aws/credentials
 ```
 
 Navigate to the `./aws-linux` folder where you created your template and run the following command to put the template on your Coder instance.
 
-```console
+```shell
 coder templates create
 ```
 

--- a/docs/quickstart/azure.md
+++ b/docs/quickstart/azure.md
@@ -43,7 +43,7 @@ For this instance, we will run Coder as a system service, however you can run Co
 
 In the Azure VM instance, run the following command to install Coder
 
-```console
+```shell
 curl -fsSL <https://coder.com/install.sh> | sh
 ```
 
@@ -51,13 +51,13 @@ curl -fsSL <https://coder.com/install.sh> | sh
 
 Run the following command to start Coder as a system level service:
 
-```console
+```shell
  sudo systemctl enable --now coder
 ```
 
 The following command will get you information about the Coder launch service
 
-```console
+```shell
  journalctl -u coder.service -b
 ```
 
@@ -65,7 +65,7 @@ This will return a series of logs related to running Coder as a system service. 
 
 Copy the URL and run the following command to create the first user, either on your local machine or in the instance terminal.
 
-```console
+```shell
 coder login <url***.try.coder.app>
 ```
 
@@ -89,14 +89,14 @@ Coder is running as a system service, which creates the system user `coder` for 
 
 Run the following commands to copy the Azure credentials and give the `coder` user access to them:
 
-```console
+```shell
 sudo cp -r ~/.azure /home/coder/.azure
 sudo chown -R coder:coder /home/coder/.azure/
 ```
 
 Navigate to the `./azure-linux` folder where you created your template and run the following command to put the template on your Coder instance.
 
-```console
+```shell
 coder templates create
 ```
 

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -15,7 +15,7 @@ Coder with Docker has the following advantages:
 
 1. Run Coder with Docker.
 
-   ```console
+   ```shell
    export CODER_DATA=$HOME/.config/coderv2-docker
    export DOCKER_GROUP=$(getent group docker | cut -d: -f3)
    mkdir -p $CODER_DATA
@@ -30,7 +30,7 @@ Coder with Docker has the following advantages:
 
 1. In new terminal, [install Coder](../install/) in order to connect to your deployment through the CLI.
 
-   ```console
+   ```shell
    curl -L https://coder.com/install.sh | sh
    ```
 
@@ -39,7 +39,7 @@ Coder with Docker has the following advantages:
 
 1. Pull the "Docker" example template using the interactive `coder templates init`:
 
-   ```console
+   ```shell
    coder templates init
    cd docker
    ```

--- a/docs/quickstart/google-cloud-platform.md
+++ b/docs/quickstart/google-cloud-platform.md
@@ -36,7 +36,7 @@ This will give you a terminal into the VM that we will use to install Coder.
 
 In the terminal, run the following command
 
-```console
+```shell
 curl -fsSL https://coder.com/install.sh | sh
 ```
 
@@ -46,7 +46,7 @@ For this tutorial, we will run Coder as a `systemd` service. You can run Coder i
 
 First, edit the `coder.env` file to enable `CODER_TUNNEL` by setting the value to true with the following command:
 
-```console
+```shell
 sudo vim /etc/coder.d/coder.env
 ```
 
@@ -54,13 +54,13 @@ sudo vim /etc/coder.d/coder.env
 
 Exit vim and run the following command to start Coder as a system service:
 
-```console
+```shell
 sudo systemctl enable --now coder
 ```
 
 The following command shows the Coder service's logs, including the Access URL. The Access URL will be used to access the Coder control plane.
 
-```console
+```shell
 journalctl -u coder.service -b
 ```
 
@@ -70,7 +70,7 @@ In this instance, Coder can be accessed at the URL `https://fcca2f3bfc9d2e3bf1b9
 
 Copy the URL and run the following command to create the workspace admin:
 
-```console
+```shell
 coder login <url***.try.coder.app>
 ```
 
@@ -86,7 +86,7 @@ Select the `Develop in Linux on Google Cloud`, then `cd ./gcp-linux`.
 
 Run the following command:
 
-```console
+```shell
 coder templates create
 ```
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -17,13 +17,13 @@ individuals can start their own Coder deployments.
 From your local machine, download the CLI for your operating system from the
 [releases](https://github.com/coder/coder/releases) or run:
 
-```console
+```shell
 curl -fsSL https://coder.com/install.sh | sh
 ```
 
 To see the sub-commands for managing templates, run:
 
-```console
+```shell
 coder templates --help
 ```
 
@@ -32,7 +32,7 @@ coder templates --help
 Before you can create templates, you must first login to your Coder deployment
 with the CLI.
 
-```console
+```shell
 coder login https://coder.example.com # aka the URL to your coder instance
 ```
 
@@ -42,7 +42,7 @@ returning an API Key.
 > Make a note of the API Key. You can re-use the API Key in future CLI logins or
 > sessions.
 
-```console
+```shell
 coder --token <your-api-key> login https://coder.example.com/ # aka the URL to your coder instance
 ```
 
@@ -282,7 +282,7 @@ owners](./admin/users.md) can edit a template.
 Using the CLI, login to Coder and run the following command to edit a single
 template:
 
-```console
+```shell
 coder templates edit <template-name> --description "This is my template"
 ```
 
@@ -291,7 +291,7 @@ Review editable template properties by running `coder templates edit -h`.
 Alternatively, you can pull down the template as a tape archive (`.tar`) to your
 current directory:
 
-```console
+```shell
 coder templates pull <template-name> file.tar
 ```
 
@@ -304,7 +304,7 @@ tar -xf file.tar
 Make the changes to your template then run this command from the root of the
 template folder:
 
-```console
+```shell
 coder templates push <template-name>
 ```
 
@@ -320,7 +320,7 @@ have any running workspaces associated to it.
 Using the CLI, login to Coder and run the following command to delete a
 template:
 
-```console
+```shell
 coder templates delete <template-name>
 ```
 
@@ -383,7 +383,7 @@ has failed or timed out.
 If the agent is not connected, it means the agent or [init script](https://github.com/coder/coder/tree/main/provisionersdk/scripts)
 has failed on the resource.
 
-```console
+```shell
 $ coder ssh myworkspace
 ⢄⡱ Waiting for connection from [agent]...
 ```
@@ -403,14 +403,14 @@ practices:
 
 If the agent does not become ready, it means the [startup script](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#startup_script) is still running or has exited with a non-zero status. This also means the [login before ready](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#login_before_ready) option hasn't been set to true.
 
-```console
+```shell
 $ coder ssh myworkspace
 ⢄⡱ Waiting for [agent] to become ready...
 ```
 
 To troubleshoot readiness issues, check the agent logs as suggested above. You can connect to the workspace using `coder ssh` with the `--no-wait` flag. Please note that while this makes login possible, the workspace may be in an incomplete state.
 
-```console
+```shell
 $ coder ssh myworkspace --no-wait
 
  > The workspace is taking longer than expected to get

--- a/docs/templates/change-management.md
+++ b/docs/templates/change-management.md
@@ -2,7 +2,7 @@
 
 We recommend source controlling your templates as you would other code. [Install Coder](../install/) in CI/CD pipelines to push new template versions.
 
-```console
+```shell
 # Install the Coder CLI
 curl -L https://coder.com/install.sh | sh
 # curl -L https://coder.com/install.sh | sh -s -- --version=0.x

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -8,7 +8,7 @@ for software development.
 Each Coder user has their own workspaces created from [shared
 templates](./templates.md):
 
-```console
+```shell
 # create a workspace from the template; specify any variables
 coder create --template="<templateName>" <workspaceName>
 
@@ -66,7 +66,7 @@ one hour. IDE, SSH, Port Forwarding, and coder_app activity trigger this bump.
 Use the following command to update a workspace to the latest template version.
 The workspace will be stopped and started:
 
-```console
+```shell
 coder update <workspace-name>
 ```
 
@@ -76,7 +76,7 @@ Use the following command to re-enter template input
 variables in an existing workspace. This command is useful when a workspace fails
 to build because its state is out of sync with the template.
 
-```console
+```shell
 coder update <your workspace name> --always-prompt
 ```
 
@@ -88,8 +88,6 @@ Coder stores macOS and Linux logs at the following locations:
 | ---------------- | ------------------------------- |
 | `startup_script` | `/tmp/coder-startup-script.log` |
 | Agent            | `/tmp/coder-agent.log`          |
-
----
 
 ## Up next
 

--- a/dogfood/guide.md
+++ b/dogfood/guide.md
@@ -61,7 +61,7 @@ The following explains how to do certain things related to dogfooding.
 
 ### My Docker containers keep failing and I have no idea what's going on!
 
-```console
+```shell
 ✔ Queued [236ms]
 ✔ Setting up [5ms]
 ⧗  Starting workspace
@@ -89,7 +89,7 @@ Check the output of `docker ps -a`
 
 Enable verbose container logging for Docker:
 
-```console
+```shell
 sudo cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
 sudo cat > /etc/docker/daemon.json << EOF
 {

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -8,7 +8,7 @@ List template examples in our CLI with `coder templates init`.
 
 Clone this repository to create a project from any example listed here:
 
-```console
+```shell
 git clone https://github.com/coder/coder
 cd examples/templates/aws-macos
 coder templates create

--- a/examples/templates/docker-image-builds/README.md
+++ b/examples/templates/docker-image-builds/README.md
@@ -20,7 +20,7 @@ on-screen instructions to proceed.
 
 Create a Dockerfile (e.g `images/golang.Dockerfile`):
 
-```console
+```shell
 vim images/golang.Dockerfile
 ```
 
@@ -48,7 +48,7 @@ USER coder
 
 Edit the Terraform template (`main.tf`):
 
-```console
+```shell
 vim main.tf
 ```
 
@@ -88,7 +88,7 @@ resource "docker_image" "coder_image" {
 
 Update the template:
 
-```console
+```shell
 coder template push docker-image-builds
 ```
 
@@ -99,7 +99,7 @@ the removed image until you update the workspace to the latest version.
 
 Edit the Dockerfile (or related assets):
 
-```console
+```shell
 vim images/node.Dockerfile
 ```
 
@@ -113,7 +113,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y && \
 
 1. Edit the Terraform template (`main.tf`)
 
-```console
+```shell
 vim main.tf
 ```
 
@@ -136,13 +136,13 @@ resource "docker_image" "coder_image" {
 
 Update the template:
 
-```console
+```shell
 coder template push docker-image-builds
 ```
 
 Optional: Update workspaces to the latest template version
 
-```console
+```shell
 coder ls
 coder update [workspace name]
 ```

--- a/examples/web-server/caddy/README.md
+++ b/examples/web-server/caddy/README.md
@@ -10,7 +10,7 @@ This is an example configuration of how to use Coder with [caddy](https://caddys
 
 1. Start with our example configuration
 
-   ```console
+   ```shell
    # Create a project folder
    cd $HOME
    mkdir coder-with-caddy
@@ -30,7 +30,7 @@ This is an example configuration of how to use Coder with [caddy](https://caddys
 
 1. Start Coder. Set `CODER_ACCESS_URL` and `CODER_WILDCARD_ACCESS_URL` to the domain you're using in your Caddyfile.
 
-   ```console
+   ```shell
    export CODER_ACCESS_URL=https://coder.example.com
    export CODER_WILDCARD_ACCESS_URL=*.coder.example.com
    docker compose up -d # Run on startup
@@ -60,19 +60,19 @@ This is an example configuration of how to use Coder with [caddy](https://caddys
 
    If you're [keeping Caddy running](https://caddyserver.com/docs/running) via a system service:
 
-   ```console
+   ```shell
    sudo systemctl restart caddy
    ```
 
    Or run a standalone server:
 
-   ```console
+   ```shell
    caddy run
    ```
 
 1. Optionally, use [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall) or another firewall to disable external traffic outside of Caddy.
 
-   ```console
+   ```shell
    # Check status of UncomplicatedFirewall
    sudo ufw status
 

--- a/scripts/apidocgen/markdown-template/security.def
+++ b/scripts/apidocgen/markdown-template/security.def
@@ -3,13 +3,13 @@
 
 Long-lived tokens can be generated to perform actions on behalf of your user account:
 
-```console
+```shell
 coder tokens create
 ```
 
 You can use tokens with the Coder's REST API using the `Coder-Session-Token` HTTP header.
 
-```console
+```shell
 curl 'http://coder-server:8080/api/v2/workspaces' \
   -H 'Coder-Session-Token: *****'
 ```


### PR DESCRIPTION
- Replace `console` by `shell` because it is supported by highlight.js and github
- Remove `--` element. For some reason, our markdown parser is parsing some commands as images