### PR TITLE
chore: Rename agent statistics server to http api server

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-func (*agent) statisticsHandler() http.Handler {
+func (*agent) apiHandler() http.Handler {
 	r := chi.NewRouter()
 	r.Get("/", func(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.Response{

--- a/codersdk/workspaceagentconn.go
+++ b/codersdk/workspaceagentconn.go
@@ -23,20 +23,18 @@ import (
 	"github.com/coder/coder/tailnet"
 )
 
-var (
-	// WorkspaceAgentIP is a static IPv6 address with the Tailscale prefix that is used to route
-	// connections from clients to this node. A dynamic address is not required because a Tailnet
-	// client only dials a single agent at a time.
-	WorkspaceAgentIP = netip.MustParseAddr("fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4")
-)
+// WorkspaceAgentIP is a static IPv6 address with the Tailscale prefix that is used to route
+// connections from clients to this node. A dynamic address is not required because a Tailnet
+// client only dials a single agent at a time.
+var WorkspaceAgentIP = netip.MustParseAddr("fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4")
 
 const (
 	WorkspaceAgentSSHPort             = 1
 	WorkspaceAgentReconnectingPTYPort = 2
 	WorkspaceAgentSpeedtestPort       = 3
-	// WorkspaceAgentStatisticsPort serves a HTTP server with endpoints for gathering
-	// agent statistics.
-	WorkspaceAgentStatisticsPort = 4
+	// WorkspaceAgentHTTPAPIServerPort serves a HTTP server with endpoints for e.g.
+	// gathering agent statistics.
+	WorkspaceAgentHTTPAPIServerPort = 4
 
 	// WorkspaceAgentMinimumListeningPort is the minimum port that the listening-ports
 	// endpoint will return to the client, and the minimum port that is accepted
@@ -282,7 +280,7 @@ type WorkspaceAgentListeningPort struct {
 func (c *WorkspaceAgentConn) ListeningPorts(ctx context.Context) (WorkspaceAgentListeningPortsResponse, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	res, err := c.requestStatisticsServer(ctx, http.MethodGet, "/api/v0/listening-ports", nil)
+	res, err := c.apiRequest(ctx, http.MethodGet, "/api/v0/listening-ports", nil)
 	if err != nil {
 		return WorkspaceAgentListeningPortsResponse{}, xerrors.Errorf("do request: %w", err)
 	}
@@ -295,30 +293,30 @@ func (c *WorkspaceAgentConn) ListeningPorts(ctx context.Context) (WorkspaceAgent
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-// requestStatisticsServer makes a request to the workspace agent's statistics server.
-func (c *WorkspaceAgentConn) requestStatisticsServer(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+// apiRequest makes a request to the workspace agent's HTTP API server.
+func (c *WorkspaceAgentConn) apiRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	host := net.JoinHostPort(WorkspaceAgentIP.String(), strconv.Itoa(WorkspaceAgentStatisticsPort))
+	host := net.JoinHostPort(WorkspaceAgentIP.String(), strconv.Itoa(WorkspaceAgentHTTPAPIServerPort))
 	url := fmt.Sprintf("http://%s%s", host, path)
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return nil, xerrors.Errorf("new statistics server request to %q: %w", url, err)
+		return nil, xerrors.Errorf("new http api request to %q: %w", url, err)
 	}
 
-	return c.statisticsServerClient().Do(req)
+	return c.apiClient().Do(req)
 }
 
-// statisticsServerClient returns an HTTP client that can be used to make
-// requests to the workspace agent's statistics server.
-func (c *WorkspaceAgentConn) statisticsServerClient() *http.Client {
+// apiClient returns an HTTP client that can be used to make
+// requests to the workspace agent's HTTP API server.
+func (c *WorkspaceAgentConn) apiClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			// Disable keep alives as we're usually only making a single
 			// request, and this triggers goleak in tests
 			DisableKeepAlives: true,
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
 				if network != "tcp" {
 					return nil, xerrors.Errorf("network must be tcp")
 				}
@@ -328,13 +326,13 @@ func (c *WorkspaceAgentConn) statisticsServerClient() *http.Client {
 				}
 				// Verify that host is TailnetIP and port is
 				// TailnetStatisticsPort.
-				if host != WorkspaceAgentIP.String() || port != strconv.Itoa(WorkspaceAgentStatisticsPort) {
-					return nil, xerrors.Errorf("request %q does not appear to be for statistics server", addr)
+				if host != WorkspaceAgentIP.String() || port != strconv.Itoa(WorkspaceAgentHTTPAPIServerPort) {
+					return nil, xerrors.Errorf("request %q does not appear to be for http api", addr)
 				}
 
-				conn, err := c.DialContextTCP(context.Background(), netip.AddrPortFrom(WorkspaceAgentIP, WorkspaceAgentStatisticsPort))
+				conn, err := c.DialContextTCP(context.Background(), netip.AddrPortFrom(WorkspaceAgentIP, WorkspaceAgentHTTPAPIServerPort))
 				if err != nil {
-					return nil, xerrors.Errorf("dial statistics: %w", err)
+					return nil, xerrors.Errorf("dial http api: %w", err)
 				}
 
 				return conn, nil

--- a/scaletest/agentconn/run.go
+++ b/scaletest/agentconn/run.go
@@ -218,7 +218,7 @@ func verifyConnection(ctx context.Context, logs io.Writer, conn *codersdk.Worksp
 
 		u := &url.URL{
 			Scheme: "http",
-			Host:   net.JoinHostPort("localhost", strconv.Itoa(codersdk.WorkspaceAgentStatisticsPort)),
+			Host:   net.JoinHostPort("localhost", strconv.Itoa(codersdk.WorkspaceAgentHTTPAPIServerPort)),
 			Path:   "/",
 		}
 		req, err := http.NewRequestWithContext(verifyCtx, http.MethodGet, u.String(), nil)


### PR DESCRIPTION
As discussed in https://github.com/coder/coder/issues/2957#issuecomment-1412433331, the agent HTTP server will be extended with non-statistics endpoints, so this rename is in preparation for that.
