### PR TITLE
refactor(site): Add more info on agent outdated tooltip and update action

### DIFF
--- a/site/src/components/Resources/AgentRow.stories.tsx
+++ b/site/src/components/Resources/AgentRow.stories.tsx
@@ -3,6 +3,7 @@ import {
   MockWorkspace,
   MockWorkspaceAgent,
   MockWorkspaceAgentConnecting,
+  MockWorkspaceAgentOutdated,
   MockWorkspaceAgentStartError,
   MockWorkspaceAgentStarting,
   MockWorkspaceAgentStartTimeout,
@@ -119,4 +120,13 @@ ShowingPortForward.args = {
   workspace: MockWorkspace,
   applicationsHost: "https://coder.com",
   showApps: true,
+}
+
+export const Outdated = Template.bind({})
+Outdated.args = {
+  agent: MockWorkspaceAgentOutdated,
+  workspace: MockWorkspace,
+  applicationsHost: "",
+  showApps: true,
+  serverVersion: "v99.999.9999+c1cdf14",
 }

--- a/site/src/components/Resources/AgentRow.tsx
+++ b/site/src/components/Resources/AgentRow.tsx
@@ -23,6 +23,7 @@ export interface AgentRowProps {
   hideSSHButton?: boolean
   hideVSCodeDesktopButton?: boolean
   serverVersion: string
+  onUpdateAgent: () => void
 }
 
 export const AgentRow: FC<AgentRowProps> = ({
@@ -33,6 +34,7 @@ export const AgentRow: FC<AgentRowProps> = ({
   hideSSHButton,
   hideVSCodeDesktopButton,
   serverVersion,
+  onUpdateAgent,
 }) => {
   const styles = useStyles()
   const { t } = useTranslation("agent")
@@ -61,7 +63,11 @@ export const AgentRow: FC<AgentRowProps> = ({
             <span className={styles.agentOS}>{agent.operating_system}</span>
 
             <Maybe condition={agent.status === "connected"}>
-              <AgentVersion agent={agent} serverVersion={serverVersion} />
+              <AgentVersion
+                agent={agent}
+                serverVersion={serverVersion}
+                onUpdate={onUpdateAgent}
+              />
             </Maybe>
 
             <AgentLatency agent={agent} />

--- a/site/src/components/Resources/AgentVersion.tsx
+++ b/site/src/components/Resources/AgentVersion.tsx
@@ -1,17 +1,23 @@
 import { useRef, useState, FC } from "react"
 import { makeStyles } from "@material-ui/core/styles"
+import RefreshIcon from "@material-ui/icons/RefreshOutlined"
 import {
   HelpTooltipText,
   HelpPopover,
   HelpTooltipTitle,
+  HelpTooltipAction,
+  HelpTooltipLinksGroup,
+  HelpTooltipContext,
 } from "components/Tooltips/HelpTooltip"
 import { WorkspaceAgent } from "api/typesGenerated"
 import { getDisplayVersionStatus } from "util/workspace"
+import { Stack } from "components/Stack/Stack"
 
 export const AgentVersion: FC<{
   agent: WorkspaceAgent
   serverVersion: string
-}> = ({ agent, serverVersion }) => {
+  onUpdate: () => void
+}> = ({ agent, serverVersion, onUpdate }) => {
   const styles = useStyles()
   const anchorRef = useRef<HTMLButtonElement>(null)
   const [isOpen, setIsOpen] = useState(false)
@@ -44,19 +50,52 @@ export const AgentVersion: FC<{
         onOpen={() => setIsOpen(true)}
         onClose={() => setIsOpen(false)}
       >
-        <HelpTooltipTitle>Agent Outdated</HelpTooltipTitle>
-        <HelpTooltipText>
-          This agent is an older version than the Coder server. This can happen
-          after you update Coder with running workspaces. To fix this, you can
-          stop and start the workspace.
-        </HelpTooltipText>
+        <HelpTooltipContext.Provider
+          value={{ open: isOpen, onClose: () => setIsOpen(false) }}
+        >
+          <Stack spacing={1}>
+            <div>
+              <HelpTooltipTitle>Agent Outdated</HelpTooltipTitle>
+              <HelpTooltipText>
+                This agent is an older version than the Coder server. This can
+                happen after you update Coder with running workspaces. To fix
+                this, you can stop and start the workspace.
+              </HelpTooltipText>
+            </div>
+
+            <Stack spacing={0.5}>
+              <span className={styles.versionLabel}>Agent version</span>
+              <span>{agent.version}</span>
+            </Stack>
+
+            <Stack spacing={0.5}>
+              <span className={styles.versionLabel}>Server version</span>
+              <span>{serverVersion}</span>
+            </Stack>
+
+            <HelpTooltipLinksGroup>
+              <HelpTooltipAction
+                icon={RefreshIcon}
+                onClick={onUpdate}
+                ariaLabel="Update workspace"
+              >
+                Update workspace
+              </HelpTooltipAction>
+            </HelpTooltipLinksGroup>
+          </Stack>
+        </HelpTooltipContext.Provider>
       </HelpPopover>
     </>
   )
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   trigger: {
     cursor: "pointer",
+  },
+
+  versionLabel: {
+    fontWeight: 600,
+    color: theme.palette.text.primary,
   },
 }))

--- a/site/src/components/Resources/AgentVersion.tsx
+++ b/site/src/components/Resources/AgentVersion.tsx
@@ -1,17 +1,8 @@
 import { useRef, useState, FC } from "react"
 import { makeStyles } from "@material-ui/core/styles"
-import RefreshIcon from "@material-ui/icons/RefreshOutlined"
-import {
-  HelpTooltipText,
-  HelpPopover,
-  HelpTooltipTitle,
-  HelpTooltipAction,
-  HelpTooltipLinksGroup,
-  HelpTooltipContext,
-} from "components/Tooltips/HelpTooltip"
 import { WorkspaceAgent } from "api/typesGenerated"
 import { getDisplayVersionStatus } from "util/workspace"
-import { Stack } from "components/Stack/Stack"
+import { AgentOutdatedTooltip } from "components/Tooltips/AgentOutdatedTooltip"
 
 export const AgentVersion: FC<{
   agent: WorkspaceAgent
@@ -43,59 +34,22 @@ export const AgentVersion: FC<{
       >
         Agent Outdated
       </span>
-      <HelpPopover
+      <AgentOutdatedTooltip
         id={id}
         open={isOpen}
         anchorEl={anchorRef.current}
         onOpen={() => setIsOpen(true)}
         onClose={() => setIsOpen(false)}
-      >
-        <HelpTooltipContext.Provider
-          value={{ open: isOpen, onClose: () => setIsOpen(false) }}
-        >
-          <Stack spacing={1}>
-            <div>
-              <HelpTooltipTitle>Agent Outdated</HelpTooltipTitle>
-              <HelpTooltipText>
-                This agent is an older version than the Coder server. This can
-                happen after you update Coder with running workspaces. To fix
-                this, you can stop and start the workspace.
-              </HelpTooltipText>
-            </div>
-
-            <Stack spacing={0.5}>
-              <span className={styles.versionLabel}>Agent version</span>
-              <span>{agent.version}</span>
-            </Stack>
-
-            <Stack spacing={0.5}>
-              <span className={styles.versionLabel}>Server version</span>
-              <span>{serverVersion}</span>
-            </Stack>
-
-            <HelpTooltipLinksGroup>
-              <HelpTooltipAction
-                icon={RefreshIcon}
-                onClick={onUpdate}
-                ariaLabel="Update workspace"
-              >
-                Update workspace
-              </HelpTooltipAction>
-            </HelpTooltipLinksGroup>
-          </Stack>
-        </HelpTooltipContext.Provider>
-      </HelpPopover>
+        agent={agent}
+        serverVersion={serverVersion}
+        onUpdate={onUpdate}
+      />
     </>
   )
 }
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   trigger: {
     cursor: "pointer",
-  },
-
-  versionLabel: {
-    fontWeight: 600,
-    color: theme.palette.text.primary,
   },
 }))

--- a/site/src/components/Resources/ResourceCard.stories.tsx
+++ b/site/src/components/Resources/ResourceCard.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions"
 import { Story } from "@storybook/react"
 import { MockWorkspace, MockWorkspaceResource } from "testHelpers/entities"
 import { AgentRow } from "./AgentRow"
@@ -21,6 +22,7 @@ Example.args = {
       workspace={MockWorkspace}
       applicationsHost=""
       serverVersion=""
+      onUpdateAgent={action("updateAgent")}
     />
   ),
 }
@@ -75,6 +77,7 @@ BunchOfMetadata.args = {
       workspace={MockWorkspace}
       applicationsHost=""
       serverVersion=""
+      onUpdateAgent={action("updateAgent")}
     />
   ),
 }

--- a/site/src/components/Tooltips/AgentOutdatedTooltip.tsx
+++ b/site/src/components/Tooltips/AgentOutdatedTooltip.tsx
@@ -11,6 +11,7 @@ import {
 } from "components/Tooltips/HelpTooltip"
 import { WorkspaceAgent } from "api/typesGenerated"
 import { Stack } from "components/Stack/Stack"
+import { useTranslation } from "react-i18next"
 
 type AgentOutdatedTooltipProps = ComponentProps<typeof HelpPopover> & {
   agent: WorkspaceAgent
@@ -29,6 +30,7 @@ export const AgentOutdatedTooltip: FC<AgentOutdatedTooltipProps> = ({
   anchorEl,
 }) => {
   const styles = useStyles()
+  const { t } = useTranslation("workspacePage")
 
   return (
     <HelpPopover
@@ -41,21 +43,25 @@ export const AgentOutdatedTooltip: FC<AgentOutdatedTooltipProps> = ({
       <HelpTooltipContext.Provider value={{ open, onClose }}>
         <Stack spacing={1}>
           <div>
-            <HelpTooltipTitle>Agent Outdated</HelpTooltipTitle>
+            <HelpTooltipTitle>
+              {t("agentOutdatedTooltip.title")}
+            </HelpTooltipTitle>
             <HelpTooltipText>
-              This agent is an older version than the Coder server. This can
-              happen after you update Coder with running workspaces. To fix
-              this, you can stop and start the workspace.
+              {t("agentOutdatedTooltip.description")}
             </HelpTooltipText>
           </div>
 
           <Stack spacing={0.5}>
-            <span className={styles.versionLabel}>Agent version</span>
+            <span className={styles.versionLabel}>
+              {t("agentOutdatedTooltip.agentVersionLabel")}
+            </span>
             <span>{agent.version}</span>
           </Stack>
 
           <Stack spacing={0.5}>
-            <span className={styles.versionLabel}>Server version</span>
+            <span className={styles.versionLabel}>
+              {t("agentOutdatedTooltip.serverVersionLabel")}
+            </span>
             <span>{serverVersion}</span>
           </Stack>
 
@@ -65,7 +71,7 @@ export const AgentOutdatedTooltip: FC<AgentOutdatedTooltipProps> = ({
               onClick={onUpdate}
               ariaLabel="Update workspace"
             >
-              Update workspace
+              {t("agentOutdatedTooltip.updateWorkspaceLabel")}
             </HelpTooltipAction>
           </HelpTooltipLinksGroup>
         </Stack>

--- a/site/src/components/Tooltips/AgentOutdatedTooltip.tsx
+++ b/site/src/components/Tooltips/AgentOutdatedTooltip.tsx
@@ -1,0 +1,82 @@
+import { ComponentProps, FC } from "react"
+import { makeStyles } from "@material-ui/core/styles"
+import RefreshIcon from "@material-ui/icons/RefreshOutlined"
+import {
+  HelpTooltipText,
+  HelpPopover,
+  HelpTooltipTitle,
+  HelpTooltipAction,
+  HelpTooltipLinksGroup,
+  HelpTooltipContext,
+} from "components/Tooltips/HelpTooltip"
+import { WorkspaceAgent } from "api/typesGenerated"
+import { Stack } from "components/Stack/Stack"
+
+type AgentOutdatedTooltipProps = ComponentProps<typeof HelpPopover> & {
+  agent: WorkspaceAgent
+  serverVersion: string
+  onUpdate: () => void
+}
+
+export const AgentOutdatedTooltip: FC<AgentOutdatedTooltipProps> = ({
+  agent,
+  serverVersion,
+  onUpdate,
+  onOpen,
+  id,
+  open,
+  onClose,
+  anchorEl,
+}) => {
+  const styles = useStyles()
+
+  return (
+    <HelpPopover
+      id={id}
+      open={open}
+      anchorEl={anchorEl}
+      onOpen={onOpen}
+      onClose={onClose}
+    >
+      <HelpTooltipContext.Provider value={{ open, onClose }}>
+        <Stack spacing={1}>
+          <div>
+            <HelpTooltipTitle>Agent Outdated</HelpTooltipTitle>
+            <HelpTooltipText>
+              This agent is an older version than the Coder server. This can
+              happen after you update Coder with running workspaces. To fix
+              this, you can stop and start the workspace.
+            </HelpTooltipText>
+          </div>
+
+          <Stack spacing={0.5}>
+            <span className={styles.versionLabel}>Agent version</span>
+            <span>{agent.version}</span>
+          </Stack>
+
+          <Stack spacing={0.5}>
+            <span className={styles.versionLabel}>Server version</span>
+            <span>{serverVersion}</span>
+          </Stack>
+
+          <HelpTooltipLinksGroup>
+            <HelpTooltipAction
+              icon={RefreshIcon}
+              onClick={onUpdate}
+              ariaLabel="Update workspace"
+            >
+              Update workspace
+            </HelpTooltipAction>
+          </HelpTooltipLinksGroup>
+        </Stack>
+      </HelpTooltipContext.Provider>
+    </HelpPopover>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  versionLabel: {
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+}))

--- a/site/src/components/Tooltips/HelpTooltip/HelpTooltip.tsx
+++ b/site/src/components/Tooltips/HelpTooltip/HelpTooltip.tsx
@@ -30,7 +30,7 @@ export const Language = {
   ariaLabel: "tooltip",
 }
 
-const HelpTooltipContext = createContext<
+export const HelpTooltipContext = createContext<
   { open: boolean; onClose: () => void } | undefined
 >(undefined)
 

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -228,6 +228,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
                 hideSSHButton={hideSSHButton}
                 hideVSCodeDesktopButton={hideVSCodeDesktopButton}
                 serverVersion={serverVersion}
+                onUpdateAgent={handleUpdate} // On updating the workspace the agent version is also updated
               />
             )}
           />

--- a/site/src/i18n/en/workspacePage.json
+++ b/site/src/i18n/en/workspacePage.json
@@ -56,5 +56,12 @@
     "reason": "Reason",
     "duration": "Duration",
     "version": "Version"
+  },
+  "agentOutdatedTooltip": {
+    "title": "Agent Outdated",
+    "description": "This agent is an older version than the Coder server. This can happen after you update Coder with running workspaces. To fix this, you can stop and start the workspace.",
+    "agentVersionLabel": "Agent version",
+    "serverVersionLabel": "Server version",
+    "updateWorkspaceLabel": "Update workspace"
   }
 }


### PR DESCRIPTION
Now: 
<img width="565" alt="Screen Shot 2023-02-01 at 18 10 28" src="https://user-images.githubusercontent.com/3165839/216164152-3ef5cea5-cf9a-4879-b445-fa39afed617f.png">

Before:
![image](https://user-images.githubusercontent.com/3165839/216164364-23086fd0-9d7a-4b43-a54a-751557d838ff.png)

Fix https://github.com/coder/coder/issues/5393 and https://github.com/coder/coder/issues/5432
