### PR TITLE
feat!: generate a self-signed certificate if no certificates are specified

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -32,6 +32,11 @@ func newConfig() *codersdk.DeploymentConfig {
 			Usage: "Specifies the wildcard hostname to use for workspace applications in the form \"*.example.com\".",
 			Flag:  "wildcard-access-url",
 		},
+		RedirectToAccessURL: &codersdk.DeploymentConfigField[bool]{
+			Name:  "Redirect to Access URL",
+			Usage: "Specifies whether to redirect requests that do not match the access URL host.",
+			Flag:  "redirect-to-access-url",
+		},
 		// DEPRECATED: Use HTTPAddress or TLS.Address instead.
 		Address: &codersdk.DeploymentConfigField[string]{
 			Name:      "Address",
@@ -300,11 +305,13 @@ func newConfig() *codersdk.DeploymentConfig {
 				Flag:    "tls-address",
 				Default: "127.0.0.1:3443",
 			},
+			// DEPRECATED: Use RedirectToAccessURL instead.
 			RedirectHTTP: &codersdk.DeploymentConfigField[bool]{
 				Name:    "Redirect HTTP to HTTPS",
 				Usage:   "Whether HTTP requests will be redirected to the access URL (if it's a https URL and TLS is enabled). Requests to local IP addresses are never redirected regardless of this setting.",
 				Flag:    "tls-redirect-http-to-https",
 				Default: true,
+				Hidden:  true,
 			},
 			CertFiles: &codersdk.DeploymentConfigField[[]string]{
 				Name:  "TLS Certificate Files",

--- a/cli/server.go
+++ b/cli/server.go
@@ -271,6 +271,13 @@ func Server(vip *viper.Viper, newAPI func(context.Context, *coderd.Options) (*co
 					return xerrors.New("tls address must be set if tls is enabled")
 				}
 
+				// DEPRECATED: This redirect used to default to true.
+				// It made more sense to have the redirect be opt-in.
+				if os.Getenv("CODER_TLS_REDIRECT_HTTP") == "true" || cmd.Flags().Changed("tls-redirect-http-to-https") {
+					cmd.PrintErr(cliui.Styles.Warn.Render("WARN:") + " --tls-redirect-http-to-https is deprecated, please use --redirect-to-access-url instead\n")
+					cfg.RedirectToAccessURL.Value = cfg.TLS.RedirectHTTP.Value
+				}
+
 				tlsConfig, err = configureTLS(
 					cfg.TLS.MinVersion.Value,
 					cfg.TLS.ClientAuth.Value,

--- a/cli/server.go
+++ b/cli/server.go
@@ -1245,19 +1245,16 @@ func configureTLS(tlsMinVersion, tlsClientAuth string, tlsCertFiles, tlsKeyFiles
 	if err != nil {
 		return nil, xerrors.Errorf("load certificates: %w", err)
 	}
-	var selfSignedCertificate *tls.Certificate
 	if len(certs) == 0 {
-		selfSignedCertificate, err = generateSelfSignedCertificate()
+		selfSignedCertificate, err := generateSelfSignedCertificate()
 		if err != nil {
 			return nil, xerrors.Errorf("generate self signed certificate: %w", err)
 		}
+		certs = append(certs, *selfSignedCertificate)
 	}
 
 	tlsConfig.Certificates = certs
 	tlsConfig.GetCertificate = func(hi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-		if selfSignedCertificate != nil {
-			return selfSignedCertificate, nil
-		}
 		// If there's only one certificate, return it.
 		if len(certs) == 1 {
 			return &certs[0], nil

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -291,11 +291,6 @@ func TestServer(t *testing.T) {
 			errContains string
 		}{
 			{
-				name:        "NoCertAndKey",
-				args:        []string{"--tls-enable"},
-				errContains: "--tls-cert-file is required when tls is enabled",
-			},
-			{
 				name:        "NoCert",
 				args:        []string{"--tls-enable", "--tls-key-file", key1Path},
 				errContains: "--tls-cert-file and --tls-key-file must be used the same amount of times",
@@ -373,6 +368,7 @@ func TestServer(t *testing.T) {
 				},
 			},
 		}
+		defer client.HTTPClient.CloseIdleConnections()
 		_, err := client.HasFirstUser(ctx)
 		require.NoError(t, err)
 
@@ -527,6 +523,7 @@ func TestServer(t *testing.T) {
 				},
 			},
 		}
+		defer client.HTTPClient.CloseIdleConnections()
 		_, err = client.HasFirstUser(ctx)
 		require.NoError(t, err)
 
@@ -680,6 +677,7 @@ func TestServer(t *testing.T) {
 							},
 						},
 					}
+					defer client.HTTPClient.CloseIdleConnections()
 					_, err = client.HasFirstUser(ctx)
 					require.NoError(t, err)
 
@@ -851,6 +849,7 @@ func TestServer(t *testing.T) {
 					},
 				},
 			}
+			defer client.HTTPClient.CloseIdleConnections()
 			_, err := client.HasFirstUser(ctx)
 			require.NoError(t, err)
 

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -216,6 +216,9 @@ Flags:
                                                      "proxy-trusted-headers". e.g.
                                                      192.168.1.0/24
                                                      Consumes $CODER_PROXY_TRUSTED_ORIGINS
+      --redirect-to-access-url                       Specifies whether to redirect requests
+                                                     that do not match the access URL host.
+                                                     Consumes $CODER_REDIRECT_TO_ACCESS_URL
       --secure-auth-cookie                           Controls if the 'Secure' property is set
                                                      on browser session cookies.
                                                      Consumes $CODER_SECURE_AUTH_COOKIE
@@ -277,13 +280,6 @@ Flags:
                                                      "tls12" or "tls13"
                                                      Consumes $CODER_TLS_MIN_VERSION (default
                                                      "tls12")
-      --tls-redirect-http-to-https                   Whether HTTP requests will be redirected
-                                                     to the access URL (if it's a https URL
-                                                     and TLS is enabled). Requests to local IP
-                                                     addresses are never redirected regardless
-                                                     of this setting.
-                                                     Consumes $CODER_TLS_REDIRECT_HTTP
-                                                     (default true)
       --trace                                        Whether application tracing data is
                                                      collected. It exports to a backend
                                                      configured by environment variables. See:

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6057,6 +6057,9 @@ const docTemplate = `{
                 "rate_limit": {
                     "$ref": "#/definitions/codersdk.RateLimitConfig"
                 },
+                "redirect_to_access_url": {
+                    "$ref": "#/definitions/codersdk.DeploymentConfigField-bool"
+                },
                 "scim_api_key": {
                     "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5388,6 +5388,9 @@
         "rate_limit": {
           "$ref": "#/definitions/codersdk.RateLimitConfig"
         },
+        "redirect_to_access_url": {
+          "$ref": "#/definitions/codersdk.DeploymentConfigField-bool"
+        },
         "scim_api_key": {
           "$ref": "#/definitions/codersdk.DeploymentConfigField-string"
         },

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -108,6 +108,7 @@ func (c *Client) Entitlements(ctx context.Context) (Entitlements, error) {
 type DeploymentConfig struct {
 	AccessURL                       *DeploymentConfigField[string]          `json:"access_url" typescript:",notnull"`
 	WildcardAccessURL               *DeploymentConfigField[string]          `json:"wildcard_access_url" typescript:",notnull"`
+	RedirectToAccessURL             *DeploymentConfigField[bool]            `json:"redirect_to_access_url" typescript:",notnull"`
 	HTTPAddress                     *DeploymentConfigField[string]          `json:"http_address" typescript:",notnull"`
 	AutobuildPollInterval           *DeploymentConfigField[time.Duration]   `json:"autobuild_poll_interval" typescript:",notnull"`
 	DERP                            *DERP                                   `json:"derp" typescript:",notnull"`

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -780,6 +780,17 @@ curl -X GET http://coder-server:8080/api/v2/config/deployment \
       "value": true
     }
   },
+  "redirect_to_access_url": {
+    "default": true,
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": true
+  },
   "scim_api_key": {
     "default": "string",
     "enterprise": true,

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2138,6 +2138,17 @@ CreateParameterRequest is a structure used to create a new parameter value for a
       "value": true
     }
   },
+  "redirect_to_access_url": {
+    "default": true,
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": true
+  },
   "scim_api_key": {
     "default": "string",
     "enterprise": true,
@@ -2423,6 +2434,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `proxy_trusted_headers`              | [codersdk.DeploymentConfigField-array_string](#codersdkdeploymentconfigfield-array_string)                                 | false    |              |                                                 |
 | `proxy_trusted_origins`              | [codersdk.DeploymentConfigField-array_string](#codersdkdeploymentconfigfield-array_string)                                 | false    |              |                                                 |
 | `rate_limit`                         | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                                                       | false    |              |                                                 |
+| `redirect_to_access_url`             | [codersdk.DeploymentConfigField-bool](#codersdkdeploymentconfigfield-bool)                                                 | false    |              |                                                 |
 | `scim_api_key`                       | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |                                                 |
 | `secure_auth_cookie`                 | [codersdk.DeploymentConfigField-bool](#codersdkdeploymentconfigfield-bool)                                                 | false    |              |                                                 |
 | `ssh_keygen_algorithm`               | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |                                                 |

--- a/docs/cli/coder_server.md
+++ b/docs/cli/coder_server.md
@@ -106,6 +106,8 @@ coder server [flags]
                                                      Consumes $CODER_PROXY_TRUSTED_HEADERS
       --proxy-trusted-origins strings                Origin addresses to respect "proxy-trusted-headers". e.g. 192.168.1.0/24
                                                      Consumes $CODER_PROXY_TRUSTED_ORIGINS
+      --redirect-to-access-url                       Specifies whether to redirect requests that do not match the access URL host.
+                                                     Consumes $CODER_REDIRECT_TO_ACCESS_URL
       --secure-auth-cookie                           Controls if the 'Secure' property is set on browser session cookies.
                                                      Consumes $CODER_SECURE_AUTH_COOKIE
       --ssh-keygen-algorithm string                  The algorithm to use for generating ssh keys. Accepted values are "ed25519", "ecdsa", or "rsa4096".
@@ -134,8 +136,6 @@ coder server [flags]
                                                      Consumes $CODER_TLS_KEY_FILE
       --tls-min-version string                       Minimum supported version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13"
                                                      Consumes $CODER_TLS_MIN_VERSION (default "tls12")
-      --tls-redirect-http-to-https                   Whether HTTP requests will be redirected to the access URL (if it's a https URL and TLS is enabled). Requests to local IP addresses are never redirected regardless of this setting.
-                                                     Consumes $CODER_TLS_REDIRECT_HTTP (default true)
       --trace                                        Whether application tracing data is collected. It exports to a backend configured by environment variables. See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
                                                      Consumes $CODER_TRACE_ENABLE
       --trace-honeycomb-api-key string               Enables trace exporting to Honeycomb.io using the provided API Key.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -291,6 +291,7 @@ export interface DangerousConfig {
 export interface DeploymentConfig {
   readonly access_url: DeploymentConfigField<string>
   readonly wildcard_access_url: DeploymentConfigField<string>
+  readonly redirect_to_access_url: DeploymentConfigField<boolean>
   readonly http_address: DeploymentConfigField<string>
   readonly autobuild_poll_interval: DeploymentConfigField<number>
   readonly derp: DERP


### PR DESCRIPTION
Clouds like AWS automatically navigate to https://<ip-here>. This allows us to bind to that immediately, serve a self-signed certificate, then reroute to the access URL.

@deansheather I'm going to change the `tls-redirect-http-to-https` flag to `redirect-to-access-url` instead.

Edit: to automatically listen on 443 then redirect to the access URL:
```
coder server --tls-enable --tls-address 0.0.0.0:443 --redirect-to-access-url
```
This will still open the tunnel (because `access-url` is not set), prompt for a self-signed certificate, then redirect the user to our external tunnel.