### PR TITLE
fix: match ubuntu tags on dogfood

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:slim AS rust-utils
 ENV CARGO_INSTALL_ROOT=/tmp/
 RUN cargo install exa bat ripgrep typos-cli watchexec-cli
 
-FROM ubuntu AS go
+FROM ubuntu:jammy AS go
 
 RUN apt-get update && apt-get install --yes curl gcc
 # Install Go manually, so that we can control the version
@@ -80,7 +80,7 @@ RUN apk add curl unzip
 RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip
 RUN unzip protoc.zip
 
-FROM ubuntu
+FROM ubuntu:jammy
 
 SHELL ["/bin/bash", "-c"]
 

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -80,8 +80,7 @@ RUN apk add curl unzip
 RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip
 RUN unzip protoc.zip
 
-# Ubuntu 20.04 LTS (Focal Fossa)
-FROM ubuntu:focal
+FROM ubuntu
 
 SHELL ["/bin/bash", "-c"]
 

--- a/dogfood/files/etc/apt/sources.list
+++ b/dogfood/files/etc/apt/sources.list
@@ -1,3 +1,3 @@
-deb http://mirror.pit.teraswitch.com/ubuntu/ focal main restricted universe
-deb http://mirror.pit.teraswitch.com/ubuntu/ focal-updates main restricted universe
-deb http://mirror.pit.teraswitch.com/ubuntu/ focal-backports main restricted universe
+deb http://mirror.pit.teraswitch.com/ubuntu/ jammy main restricted universe
+deb http://mirror.pit.teraswitch.com/ubuntu/ jammy-updates main restricted universe
+deb http://mirror.pit.teraswitch.com/ubuntu/ jammy-backports main restricted universe

--- a/dogfood/files/etc/apt/sources.list.d/docker.list
+++ b/dogfood/files/etc/apt/sources.list.d/docker.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu focal stable
+deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu jammy stable

--- a/dogfood/files/etc/apt/sources.list.d/hashicorp.list
+++ b/dogfood/files/etc/apt/sources.list.d/hashicorp.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com focal main
+deb [signed-by=/usr/share/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com jammy main

--- a/dogfood/files/etc/apt/sources.list.d/nodesource.list
+++ b/dogfood/files/etc/apt/sources.list.d/nodesource.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x focal main
+deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x jammy main

--- a/dogfood/files/etc/apt/sources.list.d/postgresql.list
+++ b/dogfood/files/etc/apt/sources.list.d/postgresql.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt focal-pgdg main
+deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt jammy-pgdg main

--- a/dogfood/files/etc/apt/sources.list.d/security.list
+++ b/dogfood/files/etc/apt/sources.list.d/security.list
@@ -1,1 +1,1 @@
-deb http://security.ubuntu.com/ubuntu/ focal-security main restricted universe
+deb http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe


### PR DESCRIPTION
golangci-lint needs GLIBC>=2.32 which made me notice that we're building binaries on a different Ubuntu version than we dev on.
