### PR TITLE
fix: hide IP on workspace build logs

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.tsx
@@ -117,14 +117,12 @@ export const AuditLogRow: React.FC<AuditLogRowProps> = ({
 
                 <Stack direction="row" alignItems="center">
                   <Stack direction="row" spacing={1} alignItems="baseline">
-                    <span className={styles.auditLogInfo}>
-                      <>{t("auditLog:table.logRow.ip")}</>
-                      <strong>
-                        {auditLog.ip
-                          ? auditLog.ip
-                          : t("auditLog:table.logRow.notAvailable")}
-                      </strong>
-                    </span>
+                    {auditLog.ip && (
+                      <span className={styles.auditLogInfo}>
+                        <>{t("auditLog:table.logRow.ip")}</>
+                        <strong>{auditLog.ip}</strong>
+                      </span>
+                    )}
 
                     <span className={styles.auditLogInfo}>
                       <>{t("auditLog:table.logRow.os")}</>

--- a/site/src/i18n/en/auditLog.json
+++ b/site/src/i18n/en/auditLog.json
@@ -12,7 +12,6 @@
       "ip": "IP: ",
       "os": "OS: ",
       "browser": "Browser: ",
-      "notAvailable": "Not available",
       "onBehalfOf": " on behalf of {{owner}}",
       "buildReason": "Coder automatically"
     }


### PR DESCRIPTION
Resolves #5268 
We no longer show IP address for workspace build logs because it doesn't really exist.

![Screen Shot 2023-02-02 at 2 56 57 PM](https://user-images.githubusercontent.com/19142439/216436548-570960c5-5927-402d-9314-a3e05b77b876.png)
