### PR TITLE
chore: ignore trend line in storybook

### DIFF
--- a/site/src/components/DAUChart/DAUChart.tsx
+++ b/site/src/components/DAUChart/DAUChart.tsx
@@ -111,6 +111,7 @@ export const DAUChart: FC<DAUChartProps> = ({ daus }) => {
         }
       >
         <Line
+          data-chromatic="ignore"
           data={{
             labels: labels,
             datasets: [


### PR DESCRIPTION
This story kept changing so lets ignore the trendline.

**Note** Idk why all the stories have regenerated, but I don't believe its related to this PR. 1) this doesn't happen locally and 2) i see another storybook blip [here](https://github.com/coder/coder/pull/6001)
![Screen Shot 2023-02-02 at 3 19 49 PM](https://user-images.githubusercontent.com/19142439/216456338-f39722d4-0bf4-4a36-8874-cfcd414cfed0.png)
