### PR TITLE
feat: build Packer images every release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -337,7 +337,7 @@ jobs:
       - name: Start Packer builds
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CDRCI_GITHUB_TOKEN }}
           repository: coder/packages
           event-type: coder-release
           client-payload: '{"coder_version": "${{ needs.release.outputs.version }}"}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -333,3 +333,11 @@ jobs:
           # For gh CLI. We need a real token since we're commenting on a PR in a
           # different repo.
           GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
+
+      - name: Start Packer builds
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: coder/packages
+          event-type: coder-release
+          client-payload: '{"coder_version": "${{ needs.release.outputs.version }}"}'


### PR DESCRIPTION
Right now, we're only building AMIs. Doing it in a separate repo for now [coder/packages](https://github.com/coder/packages), but we may add it into coder/coder after its published & stable.