### PR TITLE
fix(dogfood): Enable pipefail for startup_script

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -64,7 +64,7 @@ resource "coder_agent" "dev" {
   login_before_ready     = false
   startup_script_timeout = 60
   startup_script         = <<-EOT
-    set -ex
+    set -eux -o pipefail
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
     code-server --auth none --port 13337 &


### PR DESCRIPTION
Was trying to trigger workspace start_error state but that didn't work because personalize script ran behind a pipe.
