### PR TITLE
docs: add note around offline docs provider versions

### DIFF
--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -55,11 +55,11 @@ ADD filesystem-mirror-example.tfrc /opt/terraform/config.tfrc
 # volume or network mirror:
 RUN mkdir -p /opt/terraform/plugins/registry.terraform.io
 WORKDIR /opt/terraform/plugins/registry.terraform.io
-ARG CODER_PROVIDER_VERSION=0.5.3
+ARG CODER_PROVIDER_VERSION=0.6.10
 RUN echo "Adding coder/coder v${CODER_PROVIDER_VERSION}" \
     && mkdir -p coder/coder && cd coder/coder \
     && curl -LOs https://github.com/coder/terraform-provider-coder/releases/download/v${CODER_PROVIDER_VERSION}/terraform-provider-coder_${CODER_PROVIDER_VERSION}_linux_amd64.zip
-ARG DOCKER_PROVIDER_VERSION=2.22.0
+ARG DOCKER_PROVIDER_VERSION=3.0.1
 RUN echo "Adding kreuzwerker/docker v${DOCKER_PROVIDER_VERSION}" \
     && mkdir -p kreuzwerker/docker && cd kreuzwerker/docker \
     && curl -LOs https://github.com/kreuzwerker/terraform-provider-docker/releases/download/v${DOCKER_PROVIDER_VERSION}/terraform-provider-docker_${DOCKER_PROVIDER_VERSION}_linux_amd64.zip
@@ -80,6 +80,9 @@ USER coder
 # Use the tfrc file to inform
 ENV TF_CLI_CONFIG_FILE=/opt/terraform/config.tfrc
 ```
+
+> If you are bundling Terraform providers into your Coder image, be sure the
+> provider version matches any templates or [example templates](https://github.com/coder/coder/tree/main/examples/templates) you intend to use.
 
 ```hcl
 # filesystem-mirror-example.tfrc


### PR DESCRIPTION
Since we update our provider a lot, this will quickly get out of date from our examples. 

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
