### PR TITLE
chore: Allow RecordingAuthorizer to record multiple rbac authz calls 

### DIFF
--- a/coderd/coderdtest/authorize_test.go
+++ b/coderd/coderdtest/authorize_test.go
@@ -16,7 +16,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 		// Required for any subdomain-based proxy tests to pass.
 		AppHostname:              "*.test.coder.com",
-		Authorizer:               &coderdtest.RecordingAuthorizer{},
+		Authorizer:               &coderdtest.RecordingAuthorizer{Wrapped: &coderdtest.FakeAuthorizer{}},
 		IncludeProvisionerDaemon: true,
 	})
 	admin := coderdtest.CreateFirstUser(t, client)

--- a/coderd/coderdtest/authorize_test.go
+++ b/coderd/coderdtest/authorize_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/moby/moby/pkg/namesgenerator"
+	"github.com/stretchr/testify/require"
+
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/coderd/rbac"
 )
 
 func TestAuthorizeAllEndpoints(t *testing.T) {
@@ -19,4 +23,106 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 	a := coderdtest.NewAuthTester(context.Background(), t, client, api, admin)
 	skipRoute, assertRoute := coderdtest.AGPLRoutes(a)
 	a.Test(context.Background(), assertRoute, skipRoute)
+}
+
+func TestAuthzRecorder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Authorize", func(t *testing.T) {
+		rec := &coderdtest.RecordingAuthorizer{
+			Wrapped: &coderdtest.FakeAuthorizer{},
+		}
+		sub := randomSubject()
+		pairs := fuzzAuthz(t, sub, rec, 10)
+		rec.AssertActor(t, sub, pairs...)
+		require.NoError(t, rec.AllAsserted(), "all assertions should have been made")
+	})
+
+	t.Run("Authorize2Subjects", func(t *testing.T) {
+		rec := &coderdtest.RecordingAuthorizer{
+			Wrapped: &coderdtest.FakeAuthorizer{},
+		}
+		a := randomSubject()
+		aPairs := fuzzAuthz(t, a, rec, 10)
+
+		b := randomSubject()
+		bPairs := fuzzAuthz(t, b, rec, 10)
+
+		rec.AssertActor(t, b, bPairs...)
+		rec.AssertActor(t, a, aPairs...)
+		require.NoError(t, rec.AllAsserted(), "all assertions should have been made")
+	})
+
+	t.Run("Authorize&Prepared", func(t *testing.T) {
+		rec := &coderdtest.RecordingAuthorizer{
+			Wrapped: &coderdtest.FakeAuthorizer{},
+		}
+		a := randomSubject()
+		aPairs := fuzzAuthz(t, a, rec, 10)
+
+		b := randomSubject()
+
+		act, ot := randomAction(), randomObject().Type
+		prep, _ := rec.Prepare(context.Background(), b, act, ot)
+		bPairs := fuzzAuthzPrep(t, prep, 10, act, ot)
+
+		rec.AssertActor(t, b, bPairs...)
+		rec.AssertActor(t, a, aPairs...)
+		require.NoError(t, rec.AllAsserted(), "all assertions should have been made")
+	})
+}
+
+// fuzzAuthzPrep has same action and object types for all calls.
+func fuzzAuthzPrep(t *testing.T, prep rbac.PreparedAuthorized, n int, action rbac.Action, objectType string) []coderdtest.ActionObjectPair {
+	t.Helper()
+	pairs := make([]coderdtest.ActionObjectPair, 0, n)
+
+	for i := 0; i < n; i++ {
+		obj := randomObject()
+		obj.Type = objectType
+		p := coderdtest.ActionObjectPair{Action: action, Object: obj}
+		_ = prep.Authorize(context.Background(), p.Object)
+		pairs = append(pairs, p)
+	}
+	return pairs
+}
+
+func fuzzAuthz(t *testing.T, sub rbac.Subject, rec rbac.Authorizer, n int) []coderdtest.ActionObjectPair {
+	t.Helper()
+	pairs := make([]coderdtest.ActionObjectPair, 0, n)
+
+	for i := 0; i < n; i++ {
+		p := coderdtest.ActionObjectPair{Action: randomAction(), Object: randomObject()}
+		_ = rec.Authorize(context.Background(), sub, p.Action, p.Object)
+		pairs = append(pairs, p)
+	}
+	return pairs
+}
+
+func randomAction() rbac.Action {
+	return rbac.Action(namesgenerator.GetRandomName(1))
+}
+
+func randomObject() rbac.Object {
+	return rbac.Object{
+		ID:    namesgenerator.GetRandomName(1),
+		Owner: namesgenerator.GetRandomName(1),
+		OrgID: namesgenerator.GetRandomName(1),
+		Type:  namesgenerator.GetRandomName(1),
+		ACLUserList: map[string][]rbac.Action{
+			namesgenerator.GetRandomName(1): {rbac.ActionRead},
+		},
+		ACLGroupList: map[string][]rbac.Action{
+			namesgenerator.GetRandomName(1): {rbac.ActionRead},
+		},
+	}
+}
+
+func randomSubject() rbac.Subject {
+	return rbac.Subject{
+		ID:     namesgenerator.GetRandomName(1),
+		Roles:  rbac.RoleNames{rbac.RoleMember()},
+		Groups: []string{namesgenerator.GetRandomName(1)},
+		Scope:  rbac.ScopeAll,
+	}
 }

--- a/coderd/coderdtest/authorize_test.go
+++ b/coderd/coderdtest/authorize_test.go
@@ -29,6 +29,8 @@ func TestAuthzRecorder(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Authorize", func(t *testing.T) {
+		t.Parallel()
+
 		rec := &coderdtest.RecordingAuthorizer{
 			Wrapped: &coderdtest.FakeAuthorizer{},
 		}
@@ -39,6 +41,8 @@ func TestAuthzRecorder(t *testing.T) {
 	})
 
 	t.Run("Authorize2Subjects", func(t *testing.T) {
+		t.Parallel()
+
 		rec := &coderdtest.RecordingAuthorizer{
 			Wrapped: &coderdtest.FakeAuthorizer{},
 		}
@@ -54,6 +58,8 @@ func TestAuthzRecorder(t *testing.T) {
 	})
 
 	t.Run("Authorize&Prepared", func(t *testing.T) {
+		t.Parallel()
+
 		rec := &coderdtest.RecordingAuthorizer{
 			Wrapped: &coderdtest.FakeAuthorizer{},
 		}

--- a/coderd/coderdtest/authorize_test.go
+++ b/coderd/coderdtest/authorize_test.go
@@ -62,9 +62,9 @@ func TestAuthzRecorder(t *testing.T) {
 
 		b := randomSubject()
 
-		act, ot := randomAction(), randomObject().Type
-		prep, _ := rec.Prepare(context.Background(), b, act, ot)
-		bPairs := fuzzAuthzPrep(t, prep, 10, act, ot)
+		act, objTy := randomAction(), randomObject().Type
+		prep, _ := rec.Prepare(context.Background(), b, act, objTy)
+		bPairs := fuzzAuthzPrep(t, prep, 10, act, objTy)
 
 		rec.AssertActor(t, b, bPairs...)
 		rec.AssertActor(t, a, aPairs...)

--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/coder/coder/coderd/rbac/regosql"
 	"github.com/coder/coder/coderd/tracing"
+	"github.com/coder/coder/coderd/util/slice"
 )
 
 // Subject is a struct that contains all the elements of a subject in an rbac
@@ -24,6 +25,25 @@ type Subject struct {
 	Roles  ExpandableRoles
 	Groups []string
 	Scope  ExpandableScope
+}
+
+func (s Subject) Equal(b Subject) bool {
+	if s.ID != b.ID {
+		return false
+	}
+
+	if !slice.SameElements(s.Groups, b.Groups) {
+		return false
+	}
+
+	if !slice.SameElements(s.SafeRoleNames(), b.SafeRoleNames()) {
+		return false
+	}
+
+	if s.SafeScopeName() != b.SafeScopeName() {
+		return false
+	}
+	return true
 }
 
 // SafeScopeName prevent nil pointer dereference.

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -176,6 +176,49 @@ type Object struct {
 	ACLGroupList map[string][]Action ` json:"acl_group_list"`
 }
 
+func (z Object) Equal(b Object) bool {
+	if z.ID != b.ID {
+		return false
+	}
+	if z.Owner != b.Owner {
+		return false
+	}
+	if z.OrgID != b.OrgID {
+		return false
+	}
+	if z.Type != b.Type {
+		return false
+	}
+
+	if !equalACLLists(z.ACLUserList, b.ACLUserList) {
+		return false
+	}
+
+	if !equalACLLists(z.ACLGroupList, b.ACLGroupList) {
+		return false
+	}
+
+	return true
+}
+
+func equalACLLists(a, b map[string][]Action) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, actions := range a {
+		if len(actions) != len(b[k]) {
+			return false
+		}
+		for i, a := range actions {
+			if a != b[k][i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func (z Object) RBACObject() Object {
 	return z
 }

--- a/coderd/rbac/object_test.go
+++ b/coderd/rbac/object_test.go
@@ -1,0 +1,176 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/coder/coder/coderd/rbac"
+)
+
+func TestObjectEqual(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name     string
+		A        rbac.Object
+		B        rbac.Object
+		Expected bool
+	}{
+		{
+			Name:     "Empty",
+			A:        rbac.Object{},
+			B:        rbac.Object{},
+			Expected: true,
+		},
+		{
+			Name: "NilVs0",
+			A: rbac.Object{
+				ACLGroupList: map[string][]rbac.Action{},
+				ACLUserList:  map[string][]rbac.Action{},
+			},
+			B:        rbac.Object{},
+			Expected: true,
+		},
+		{
+			Name: "Same",
+			A: rbac.Object{
+				ID:           "id",
+				Owner:        "owner",
+				OrgID:        "orgID",
+				Type:         "type",
+				ACLUserList:  map[string][]rbac.Action{},
+				ACLGroupList: map[string][]rbac.Action{},
+			},
+			B: rbac.Object{
+				ID:           "id",
+				Owner:        "owner",
+				OrgID:        "orgID",
+				Type:         "type",
+				ACLUserList:  map[string][]rbac.Action{},
+				ACLGroupList: map[string][]rbac.Action{},
+			},
+			Expected: true,
+		},
+		{
+			Name: "DifferentID",
+			A: rbac.Object{
+				ID: "id",
+			},
+			B: rbac.Object{
+				ID: "id2",
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentOwner",
+			A: rbac.Object{
+				Owner: "owner",
+			},
+			B: rbac.Object{
+				Owner: "owner2",
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentOrgID",
+			A: rbac.Object{
+				OrgID: "orgID",
+			},
+			B: rbac.Object{
+				OrgID: "orgID2",
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentType",
+			A: rbac.Object{
+				Type: "type",
+			},
+			B: rbac.Object{
+				Type: "type2",
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentACLUserList",
+			A: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionRead},
+				},
+			},
+			B: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user2": {rbac.ActionRead},
+				},
+			},
+			Expected: false,
+		},
+		{
+			Name: "ACLUserDiff#Actions",
+			A: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionRead},
+				},
+			},
+			B: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionRead, rbac.ActionUpdate},
+				},
+			},
+			Expected: false,
+		},
+		{
+			Name: "ACLUserDiffAction",
+			A: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionRead},
+				},
+			},
+			B: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionUpdate},
+				},
+			},
+			Expected: false,
+		},
+		{
+			Name: "ACLUserDiff#Users",
+			A: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionRead},
+				},
+			},
+			B: rbac.Object{
+				ACLUserList: map[string][]rbac.Action{
+					"user1": {rbac.ActionRead},
+					"user2": {rbac.ActionRead},
+				},
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentACLGroupList",
+			A: rbac.Object{
+				ACLGroupList: map[string][]rbac.Action{
+					"group1": {rbac.ActionRead},
+				},
+			},
+			B: rbac.Object{
+				ACLGroupList: map[string][]rbac.Action{
+					"group2": {rbac.ActionRead},
+				},
+			},
+			Expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := tc.A.Equal(tc.B)
+			if actual != tc.Expected {
+				t.Errorf("expected %v, got %v", tc.Expected, actual)
+			}
+		})
+	}
+}

--- a/coderd/rbac/subject_test.go
+++ b/coderd/rbac/subject_test.go
@@ -1,0 +1,132 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/coder/coder/coderd/rbac"
+)
+
+func TestSubjectEqual(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name     string
+		A        rbac.Subject
+		B        rbac.Subject
+		Expected bool
+	}{
+		{
+			Name:     "Empty",
+			A:        rbac.Subject{},
+			B:        rbac.Subject{},
+			Expected: true,
+		},
+		{
+			Name: "Same",
+			A: rbac.Subject{
+				ID:     "id",
+				Roles:  rbac.RoleNames{rbac.RoleMember()},
+				Groups: []string{"group"},
+				Scope:  rbac.ScopeAll,
+			},
+			B: rbac.Subject{
+				ID:     "id",
+				Roles:  rbac.RoleNames{rbac.RoleMember()},
+				Groups: []string{"group"},
+				Scope:  rbac.ScopeAll,
+			},
+			Expected: true,
+		},
+		{
+			Name: "DifferentID",
+			A: rbac.Subject{
+				ID: "id",
+			},
+			B: rbac.Subject{
+				ID: "id2",
+			},
+			Expected: false,
+		},
+		{
+			Name: "RolesNilVs0",
+			A: rbac.Subject{
+				Roles: rbac.RoleNames{},
+			},
+			B: rbac.Subject{
+				Roles: nil,
+			},
+			Expected: true,
+		},
+		{
+			Name: "GroupsNilVs0",
+			A: rbac.Subject{
+				Groups: []string{},
+			},
+			B: rbac.Subject{
+				Groups: nil,
+			},
+			Expected: true,
+		},
+		{
+			Name: "DifferentRoles",
+			A: rbac.Subject{
+				Roles: rbac.RoleNames{rbac.RoleMember()},
+			},
+			B: rbac.Subject{
+				Roles: rbac.RoleNames{rbac.RoleOwner()},
+			},
+			Expected: false,
+		},
+		{
+			Name: "Different#Roles",
+			A: rbac.Subject{
+				Roles: rbac.RoleNames{rbac.RoleMember()},
+			},
+			B: rbac.Subject{
+				Roles: rbac.RoleNames{rbac.RoleMember(), rbac.RoleOwner()},
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentGroups",
+			A: rbac.Subject{
+				Groups: []string{"group1"},
+			},
+			B: rbac.Subject{
+				Groups: []string{"group2"},
+			},
+			Expected: false,
+		},
+		{
+			Name: "Different#Groups",
+			A: rbac.Subject{
+				Groups: []string{"group1"},
+			},
+			B: rbac.Subject{
+				Groups: []string{"group1", "group2"},
+			},
+			Expected: false,
+		},
+		{
+			Name: "DifferentScope",
+			A: rbac.Subject{
+				Scope: rbac.ScopeAll,
+			},
+			B: rbac.Subject{
+				Scope: rbac.ScopeApplicationConnect,
+			},
+			Expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := tc.A.Equal(tc.B)
+			if actual != tc.Expected {
+				t.Errorf("expected %v, got %v", tc.Expected, actual)
+			}
+		})
+	}
+}

--- a/coderd/util/slice/slice.go
+++ b/coderd/util/slice/slice.go
@@ -1,5 +1,25 @@
 package slice
 
+// New is a convenience method for creating []T.
+func New[T any](items ...T) []T {
+	return items
+}
+
+// SameElements returns true if the 2 lists have the same elements in any
+// order.
+func SameElements[T comparable](a []T, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, element := range a {
+		if !Contains(b, element) {
+			return false
+		}
+	}
+	return true
+}
+
 func ContainsCompare[T any](haystack []T, needle T, equal func(a, b T) bool) bool {
 	for _, hay := range haystack {
 		if equal(needle, hay) {

--- a/coderd/util/slice/slice_test.go
+++ b/coderd/util/slice/slice_test.go
@@ -15,10 +15,10 @@ func TestSameElements(t *testing.T) {
 	t.Parallel()
 
 	// True
-	testSameElements(t, []int{})
-	testSameElements(t, []int{1, 2, 3})
-	testSameElements(t, slice.New("a", "b", "c"))
-	testSameElements(t, slice.New(uuid.New(), uuid.New(), uuid.New()))
+	assertSameElements(t, []int{})
+	assertSameElements(t, []int{1, 2, 3})
+	assertSameElements(t, slice.New("a", "b", "c"))
+	assertSameElements(t, slice.New(uuid.New(), uuid.New(), uuid.New()))
 
 	// False
 	assert.False(t, slice.SameElements([]int{1, 2, 3}, []int{1, 2, 3, 4}))
@@ -29,7 +29,7 @@ func TestSameElements(t *testing.T) {
 	assert.False(t, slice.SameElements([]int{1}, []int{2}))
 }
 
-func testSameElements[T comparable](t *testing.T, elements []T) {
+func assertSameElements[T comparable](t *testing.T, elements []T) {
 	cpy := make([]T, len(elements))
 	copy(cpy, elements)
 	rand.Shuffle(len(cpy), func(i, j int) {

--- a/coderd/util/slice/slice_test.go
+++ b/coderd/util/slice/slice_test.go
@@ -4,9 +4,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/util/slice"

--- a/coderd/util/slice/slice_test.go
+++ b/coderd/util/slice/slice_test.go
@@ -1,13 +1,43 @@
 package slice_test
 
 import (
+	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/util/slice"
 )
+
+func TestSameElements(t *testing.T) {
+	t.Parallel()
+
+	// True
+	testSameElements(t, []int{})
+	testSameElements(t, []int{1, 2, 3})
+	testSameElements(t, slice.New("a", "b", "c"))
+	testSameElements(t, slice.New(uuid.New(), uuid.New(), uuid.New()))
+
+	// False
+	assert.False(t, slice.SameElements([]int{1, 2, 3}, []int{1, 2, 3, 4}))
+	assert.False(t, slice.SameElements([]int{1, 2, 3}, []int{1, 2}))
+	assert.False(t, slice.SameElements([]int{1, 2, 3}, []int{}))
+	assert.False(t, slice.SameElements([]int{}, []int{1, 2, 3}))
+	assert.False(t, slice.SameElements([]int{1, 2, 3}, []int{1, 2, 4}))
+	assert.False(t, slice.SameElements([]int{1}, []int{2}))
+}
+
+func testSameElements[T comparable](t *testing.T, elements []T) {
+	cpy := make([]T, len(elements))
+	copy(cpy, elements)
+	rand.Shuffle(len(cpy), func(i, j int) {
+		cpy[i], cpy[j] = cpy[j], cpy[i]
+	})
+	assert.True(t, slice.SameElements(elements, cpy))
+}
 
 func TestUnique(t *testing.T) {
 	t.Parallel()

--- a/enterprise/coderd/coderdenttest/coderdenttest_test.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest_test.go
@@ -27,7 +27,7 @@ func TestAuthorizeAllEndpoints(t *testing.T) {
 		Options: &coderdtest.Options{
 			// Required for any subdomain-based proxy tests to pass.
 			AppHostname:              "*.test.coder.com",
-			Authorizer:               &coderdtest.RecordingAuthorizer{},
+			Authorizer:               &coderdtest.RecordingAuthorizer{Wrapped: &coderdtest.FakeAuthorizer{}},
 			IncludeProvisionerDaemon: true,
 		},
 	})


### PR DESCRIPTION
Prior iteration only recorded the last call. This is required for
more comprehensive testing