### PR TITLE
chore: add log_statement=all for test-postgres-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,8 @@ test-postgres-docker:
 		-c max_connections=1000 \
 		-c fsync=off \
 		-c synchronous_commit=off \
-		-c full_page_writes=off
+		-c full_page_writes=off \
+		-c log_statement=all
 	while ! pg_isready -h 127.0.0.1
 	do
 		echo "$(date) - waiting for database to start"


### PR DESCRIPTION
This PR changes the behaviour of the `test-postgres-docker` Makefile target to log all queries. 
This is incredibly useful when a random database-related unit tests fails and you wish it had been turned on originally. 