### PR TITLE
fix: open terminal and coder_app in a new tab, not window

### DIFF
--- a/site/src/components/AppLink/AppLink.tsx
+++ b/site/src/components/AppLink/AppLink.tsx
@@ -6,14 +6,8 @@ import Tooltip from "@material-ui/core/Tooltip"
 import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline"
 import { FC } from "react"
 import * as TypesGen from "../../api/typesGenerated"
-import { generateRandomString } from "../../util/random"
 import { BaseIcon } from "./BaseIcon"
 import { ShareIcon } from "./ShareIcon"
-
-const Language = {
-  appTitle: (appName: string, identifier: string): string =>
-    `${appName} - ${identifier}`,
-}
 
 export interface AppLinkProps {
   appsHost?: string
@@ -98,18 +92,6 @@ export const AppLink: FC<AppLinkProps> = ({
           href={href}
           target="_blank"
           className={canClick ? styles.link : styles.disabledLink}
-          onClick={
-            canClick
-              ? (event) => {
-                  event.preventDefault()
-                  window.open(
-                    href,
-                    Language.appTitle(appDisplayName, generateRandomString(12)),
-                    "width=900,height=600",
-                  )
-                }
-              : undefined
-          }
         >
           {button}
         </Link>

--- a/site/src/components/TerminalLink/TerminalLink.tsx
+++ b/site/src/components/TerminalLink/TerminalLink.tsx
@@ -5,11 +5,9 @@ import ComputerIcon from "@material-ui/icons/Computer"
 import { FC } from "react"
 import * as TypesGen from "../../api/typesGenerated"
 import { combineClasses } from "../../util/combineClasses"
-import { generateRandomString } from "../../util/random"
 
 export const Language = {
   linkText: "Terminal",
-  terminalTitle: (identifier: string): string => `Terminal - ${identifier}`,
 }
 
 export interface TerminalLinkProps {
@@ -42,14 +40,6 @@ export const TerminalLink: FC<React.PropsWithChildren<TerminalLinkProps>> = ({
       href={href}
       className={combineClasses([styles.link, className])}
       target="_blank"
-      onClick={(event) => {
-        event.preventDefault()
-        window.open(
-          href,
-          Language.terminalTitle(generateRandomString(12)),
-          "width=900,height=600",
-        )
-      }}
     >
       <Button startIcon={<ComputerIcon />} size="small">
         {Language.linkText}


### PR DESCRIPTION
This is will change the current behavior change, but I think it improves the UX a bit. Personally, I always cntrl+click to open it as a tab.

Open to thoughts though. Fixes #4950