### PR TITLE
feat: Add agent logs in API, show startup_script tail on error (SSH)

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -1,7 +1,12 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -11,7 +16,7 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-func (*agent) apiHandler() http.Handler {
+func (a *agent) apiHandler() http.Handler {
 	r := chi.NewRouter()
 	r.Get("/", func(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.Response{
@@ -21,6 +26,26 @@ func (*agent) apiHandler() http.Handler {
 
 	lp := &listeningPortsHandler{}
 	r.Get("/api/v0/listening-ports", lp.handler)
+
+	logs := &logsHandler{
+		logFiles: []*logFile{
+			{
+				name: codersdk.WorkspaceAgentLogAgent,
+				path: filepath.Join(a.logDir, string(codersdk.WorkspaceAgentLogAgent)),
+			},
+			{
+				name: codersdk.WorkspaceAgentLogStartupScript,
+				path: filepath.Join(a.logDir, string(codersdk.WorkspaceAgentLogStartupScript)),
+			},
+		},
+	}
+	r.Route("/api/v0/logs", func(r chi.Router) {
+		r.Get("/", logs.list)
+		r.Route("/{log}", func(r chi.Router) {
+			r.Get("/", logs.info)
+			r.Get("/tail", logs.tail)
+		})
+	})
 
 	return r
 }
@@ -46,4 +71,217 @@ func (lp *listeningPortsHandler) handler(rw http.ResponseWriter, r *http.Request
 	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.WorkspaceAgentListeningPortsResponse{
 		Ports: ports,
 	})
+}
+
+type logFile struct {
+	name codersdk.WorkspaceAgentLog
+	path string
+
+	mu     sync.Mutex // Protects following.
+	lines  int
+	offset int64
+}
+
+type logsHandler struct {
+	logFiles []*logFile
+}
+
+func (lh *logsHandler) list(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logs, ok := logFileInfo(w, r, lh.logFiles...)
+	if !ok {
+		return
+	}
+
+	httpapi.Write(ctx, w, http.StatusOK, logs)
+}
+
+func (lh *logsHandler) info(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	logName := codersdk.WorkspaceAgentLog(chi.URLParam(r, "log"))
+	if logName == "" {
+		httpapi.Write(ctx, w, http.StatusBadRequest, codersdk.Response{
+			Message: "Missing log URL parameter.",
+		})
+		return
+	}
+
+	for _, f := range lh.logFiles {
+		if f.name == logName {
+			logs, ok := logFileInfo(w, r, f)
+			if !ok {
+				return
+			}
+
+			httpapi.Write(ctx, w, http.StatusOK, logs[0])
+			return
+		}
+	}
+
+	httpapi.Write(ctx, w, http.StatusNotFound, codersdk.Response{
+		Message: "Log file not found.",
+	})
+}
+
+func (lh *logsHandler) tail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	logName := codersdk.WorkspaceAgentLog(chi.URLParam(r, "log"))
+	if logName == "" {
+		httpapi.Write(ctx, w, http.StatusBadRequest, codersdk.Response{
+			Message: "Missing log URL parameter.",
+		})
+		return
+	}
+
+	qp := r.URL.Query()
+	parser := httpapi.NewQueryParamParser()
+	offset := parser.Int(qp, 0, "offset")
+	limit := parser.Int(qp, 0, "limit")
+	if len(parser.Errors) > 0 {
+		httpapi.Write(ctx, w, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: parser.Errors,
+		})
+		return
+	}
+
+	var lf *logFile
+	for _, f := range lh.logFiles {
+		if f.name == logName {
+			lf = f
+			break
+		}
+	}
+	if lf == nil {
+		httpapi.Write(ctx, w, http.StatusNotFound, codersdk.Response{
+			Message: "Log file not found.",
+		})
+		return
+	}
+
+	f, err := os.Open(lf.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			httpapi.Write(ctx, w, http.StatusNotFound, codersdk.Response{
+				Message: "Log file not found.",
+			})
+			return
+		}
+		httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
+			Message: "Could not open log file.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	defer f.Close()
+
+	var lines []string
+	fr := bufio.NewReader(f)
+	n := -1
+	for {
+		b, err := fr.ReadBytes('\n')
+		if err != nil {
+			// Note, we skip incomplete lines with no newline.
+			if err == io.EOF {
+				break
+			}
+			httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
+				Message: "Could not read log file.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		n++
+		if n < offset {
+			continue
+		}
+		b = bytes.TrimRight(b, "\r\n")
+		lines = append(lines, string(b))
+
+		if limit > 0 && len(lines) >= limit {
+			break
+		}
+	}
+
+	httpapi.Write(ctx, w, http.StatusOK, codersdk.WorkspaceAgentLogTailResponse{
+		Offset: offset,
+		Count:  len(lines),
+		Lines:  lines,
+	})
+}
+
+func logFileInfo(w http.ResponseWriter, r *http.Request, lf ...*logFile) ([]codersdk.WorkspaceAgentLogInfo, bool) {
+	ctx := r.Context()
+
+	var logs []codersdk.WorkspaceAgentLogInfo
+	for _, f := range lf {
+		size, lines, modified, exists, err := f.fileInfo()
+		if err != nil {
+			httpapi.Write(ctx, w, http.StatusInternalServerError, codersdk.Response{
+				Message: "Could not gather log file info.",
+				Detail:  err.Error(),
+			})
+			return nil, false
+		}
+
+		logs = append(logs, codersdk.WorkspaceAgentLogInfo{
+			Name:     f.name,
+			Path:     f.path,
+			Size:     size,
+			Lines:    lines,
+			Exists:   exists,
+			Modified: modified,
+		})
+	}
+
+	return logs, true
+}
+
+// fileInfo counts the number of lines in the log file and caches
+// the logFile's line count and offset.
+func (lf *logFile) fileInfo() (size int64, lines int, modified time.Time, exists bool, err error) {
+	lf.mu.Lock()
+	defer lf.mu.Unlock()
+
+	f, err := os.Open(lf.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, time.Time{}, false, nil
+		}
+		return 0, 0, time.Time{}, false, err
+	}
+	defer f.Close()
+
+	// Note, modified time will not be entirely accurate, but we rather
+	// give an old timestamp than one that is newer than when we counted
+	// the lines.
+	info, err := f.Stat()
+	if err != nil {
+		return 0, 0, time.Time{}, false, err
+	}
+
+	_, err = f.Seek(lf.offset, io.SeekStart)
+	if err != nil {
+		return 0, 0, time.Time{}, false, err
+	}
+
+	r := bufio.NewReader(f)
+	for {
+		b, err := r.ReadBytes('\n')
+		if err != nil {
+			// Note, we skip incomplete lines with no newline.
+			if err == io.EOF {
+				break
+			}
+			return 0, 0, time.Time{}, false, err
+		}
+		size += int64(len(b))
+		lines++
+	}
+	lf.offset += size
+	lf.lines += lines
+
+	return lf.offset, lf.lines, info.ModTime(), true, nil
 }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4277,6 +4277,148 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaceagents/{workspaceagent}/logs": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Agents"
+                ],
+                "summary": "Get workspace agent logs",
+                "operationId": "get-workspace-agent-logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace agent ID",
+                        "name": "workspaceagent",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.WorkspaceAgentLogInfo"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaceagents/{workspaceagent}/logs/{log}": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Agents"
+                ],
+                "summary": "Get workspace agent log file information.",
+                "operationId": "get-workspace-agent-log-file-information",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace agent ID",
+                        "name": "workspaceagent",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "coder-agent.log",
+                            "coder-startup-script.log"
+                        ],
+                        "type": "string",
+                        "description": "Workspace log file name",
+                        "name": "log",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceAgentLogInfo"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaceagents/{workspaceagent}/logs/{log}/tail": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Agents"
+                ],
+                "summary": "Get workspace agent log contents.",
+                "operationId": "get-workspace-agent-log-contents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace agent ID",
+                        "name": "workspaceagent",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "coder-agent.log",
+                            "coder-startup-script.log"
+                        ],
+                        "type": "string",
+                        "description": "Workspace log file name",
+                        "name": "log",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Line offset to start reading from",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of lines to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceAgentLogTailResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaceagents/{workspaceagent}/pty": {
             "get": {
                 "security": [
@@ -8065,6 +8207,63 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.WorkspaceAgentListeningPort"
                     }
+                }
+            }
+        },
+        "codersdk.WorkspaceAgentLog": {
+            "type": "string",
+            "enum": [
+                "coder-agent.log",
+                "coder-startup-script.log"
+            ],
+            "x-enum-varnames": [
+                "WorkspaceAgentLogAgent",
+                "WorkspaceAgentLogStartupScript"
+            ]
+        },
+        "codersdk.WorkspaceAgentLogInfo": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "lines": {
+                    "type": "integer",
+                    "example": 100
+                },
+                "modified": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "name": {
+                    "$ref": "#/definitions/codersdk.WorkspaceAgentLog"
+                },
+                "path": {
+                    "type": "string",
+                    "example": "/tmp/coder-agent.log"
+                },
+                "size": {
+                    "type": "integer",
+                    "example": 2048
+                }
+            }
+        },
+        "codersdk.WorkspaceAgentLogTailResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "count": {
+                    "description": "Number of lines returned.",
+                    "type": "integer"
+                },
+                "start": {
+                    "description": "Line offset, 0-based.",
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -3759,6 +3759,130 @@
         }
       }
     },
+    "/workspaceagents/{workspaceagent}/logs": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["Agents"],
+        "summary": "Get workspace agent logs",
+        "operationId": "get-workspace-agent-logs",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workspace agent ID",
+            "name": "workspaceagent",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/codersdk.WorkspaceAgentLogInfo"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workspaceagents/{workspaceagent}/logs/{log}": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["Agents"],
+        "summary": "Get workspace agent log file information.",
+        "operationId": "get-workspace-agent-log-file-information",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workspace agent ID",
+            "name": "workspaceagent",
+            "in": "path",
+            "required": true
+          },
+          {
+            "enum": ["coder-agent.log", "coder-startup-script.log"],
+            "type": "string",
+            "description": "Workspace log file name",
+            "name": "log",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/codersdk.WorkspaceAgentLogInfo"
+            }
+          }
+        }
+      }
+    },
+    "/workspaceagents/{workspaceagent}/logs/{log}/tail": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["Agents"],
+        "summary": "Get workspace agent log contents.",
+        "operationId": "get-workspace-agent-log-contents",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workspace agent ID",
+            "name": "workspaceagent",
+            "in": "path",
+            "required": true
+          },
+          {
+            "enum": ["coder-agent.log", "coder-startup-script.log"],
+            "type": "string",
+            "description": "Workspace log file name",
+            "name": "log",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "Line offset to start reading from",
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Maximum number of lines to return",
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/codersdk.WorkspaceAgentLogTailResponse"
+            }
+          }
+        }
+      }
+    },
     "/workspaceagents/{workspaceagent}/pty": {
       "get": {
         "security": [
@@ -7264,6 +7388,60 @@
           "items": {
             "$ref": "#/definitions/codersdk.WorkspaceAgentListeningPort"
           }
+        }
+      }
+    },
+    "codersdk.WorkspaceAgentLog": {
+      "type": "string",
+      "enum": ["coder-agent.log", "coder-startup-script.log"],
+      "x-enum-varnames": [
+        "WorkspaceAgentLogAgent",
+        "WorkspaceAgentLogStartupScript"
+      ]
+    },
+    "codersdk.WorkspaceAgentLogInfo": {
+      "type": "object",
+      "properties": {
+        "exists": {
+          "type": "boolean"
+        },
+        "lines": {
+          "type": "integer",
+          "example": 100
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "$ref": "#/definitions/codersdk.WorkspaceAgentLog"
+        },
+        "path": {
+          "type": "string",
+          "example": "/tmp/coder-agent.log"
+        },
+        "size": {
+          "type": "integer",
+          "example": 2048
+        }
+      }
+    },
+    "codersdk.WorkspaceAgentLogTailResponse": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "count": {
+          "description": "Number of lines returned.",
+          "type": "integer"
+        },
+        "start": {
+          "description": "Line offset, 0-based.",
+          "type": "integer"
         }
       }
     },

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -572,6 +572,13 @@ func New(options *Options) *API {
 				r.Get("/listening-ports", api.workspaceAgentListeningPorts)
 				r.Get("/connection", api.workspaceAgentConnection)
 				r.Get("/coordinate", api.workspaceAgentClientCoordinate)
+				r.Route("/logs", func(r chi.Router) {
+					r.Get("/", api.workspaceAgentLogs)
+					r.Route("/{log}", func(r chi.Router) {
+						r.Get("/", api.workspaceAgentLogInfo)
+						r.Get("/tail", api.workspaceAgentLogTail)
+					})
+				})
 			})
 		})
 		r.Route("/workspaces", func(r chi.Router) {

--- a/coderd/coderdtest/authorize.go
+++ b/coderd/coderdtest/authorize.go
@@ -146,6 +146,18 @@ func AGPLRoutes(a *AuthTester) (map[string]string, map[string]RouteCheck) {
 			AssertAction: rbac.ActionCreate,
 			AssertObject: workspaceExecObj,
 		},
+		"GET:/api/v2/workspaceagents/{workspaceagent}/logs": {
+			AssertAction: rbac.ActionRead,
+			AssertObject: workspaceRBACObj,
+		},
+		"GET:/api/v2/workspaceagents/{workspaceagent}/logs/{log}": {
+			AssertAction: rbac.ActionRead,
+			AssertObject: workspaceRBACObj,
+		},
+		"GET:/api/v2/workspaceagents/{workspaceagent}/logs/{log}/tail": {
+			AssertAction: rbac.ActionRead,
+			AssertObject: workspaceRBACObj,
+		},
 		"POST:/api/v2/organizations/{organization}/templates": {
 			AssertAction: rbac.ActionCreate,
 			AssertObject: rbac.ResourceTemplate.InOrg(a.Organization.ID),
@@ -695,6 +707,7 @@ func (s *PreparedRecorder) Authorize(ctx context.Context, object rbac.Object) er
 	}
 	return s.prepped.Authorize(ctx, object)
 }
+
 func (s *PreparedRecorder) CompileToSQL(ctx context.Context, cfg regosql.ConvertConfig) (string, error) {
 	s.rw.Lock()
 	defer s.rw.Unlock()

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -683,6 +683,170 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/lis
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get workspace agent logs
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/logs \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspaceagents/{workspaceagent}/logs`
+
+### Parameters
+
+| Name             | In   | Type         | Required | Description        |
+| ---------------- | ---- | ------------ | -------- | ------------------ |
+| `workspaceagent` | path | string(uuid) | true     | Workspace agent ID |
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "exists": true,
+    "lines": 100,
+    "modified": "2019-08-24T14:15:22Z",
+    "name": "coder-agent.log",
+    "path": "/tmp/coder-agent.log",
+    "size": 2048
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                              |
+| ------ | ------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.WorkspaceAgentLogInfo](schemas.md#codersdkworkspaceagentloginfo) |
+
+<h3 id="get-workspace-agent-logs-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type                                                               | Required | Restrictions | Description |
+| -------------- | ------------------------------------------------------------------ | -------- | ------------ | ----------- |
+| `[array item]` | array                                                              | false    |              |             |
+| `» exists`     | boolean                                                            | false    |              |             |
+| `» lines`      | integer                                                            | false    |              |             |
+| `» modified`   | string(date-time)                                                  | false    |              |             |
+| `» name`       | [codersdk.WorkspaceAgentLog](schemas.md#codersdkworkspaceagentlog) | false    |              |             |
+| `» path`       | string                                                             | false    |              |             |
+| `» size`       | integer                                                            | false    |              |             |
+
+#### Enumerated Values
+
+| Property | Value                      |
+| -------- | -------------------------- |
+| `name`   | `coder-agent.log`          |
+| `name`   | `coder-startup-script.log` |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get workspace agent log file information.
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/logs/{log} \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspaceagents/{workspaceagent}/logs/{log}`
+
+### Parameters
+
+| Name             | In   | Type         | Required | Description             |
+| ---------------- | ---- | ------------ | -------- | ----------------------- |
+| `workspaceagent` | path | string(uuid) | true     | Workspace agent ID      |
+| `log`            | path | string       | true     | Workspace log file name |
+
+#### Enumerated Values
+
+| Parameter | Value                      |
+| --------- | -------------------------- |
+| `log`     | `coder-agent.log`          |
+| `log`     | `coder-startup-script.log` |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "exists": true,
+  "lines": 100,
+  "modified": "2019-08-24T14:15:22Z",
+  "name": "coder-agent.log",
+  "path": "/tmp/coder-agent.log",
+  "size": 2048
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                     |
+| ------ | ------------------------------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.WorkspaceAgentLogInfo](schemas.md#codersdkworkspaceagentloginfo) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get workspace agent log contents.
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/logs/{log}/tail \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspaceagents/{workspaceagent}/logs/{log}/tail`
+
+### Parameters
+
+| Name             | In    | Type         | Required | Description                       |
+| ---------------- | ----- | ------------ | -------- | --------------------------------- |
+| `workspaceagent` | path  | string(uuid) | true     | Workspace agent ID                |
+| `log`            | path  | string       | true     | Workspace log file name           |
+| `offset`         | query | integer      | false    | Line offset to start reading from |
+| `limit`          | query | integer      | false    | Maximum number of lines to return |
+
+#### Enumerated Values
+
+| Parameter | Value                      |
+| --------- | -------------------------- |
+| `log`     | `coder-agent.log`          |
+| `log`     | `coder-startup-script.log` |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "content": ["string"],
+  "count": 0,
+  "start": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                     |
+| ------ | ------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.WorkspaceAgentLogTailResponse](schemas.md#codersdkworkspaceagentlogtailresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Open PTY to workspace agent
 
 ### Code samples

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -5249,6 +5249,63 @@ Parameter represents a set value for the scope.
 | ------- | ------------------------------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ports` | array of [codersdk.WorkspaceAgentListeningPort](#codersdkworkspaceagentlisteningport) | false    |              | If there are no ports in the list, nothing should be displayed in the UI. There must not be a "no ports available" message or anything similar, as there will always be no ports displayed on platforms where our port detection logic is unsupported. |
 
+## codersdk.WorkspaceAgentLog
+
+```json
+"coder-agent.log"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value                      |
+| -------------------------- |
+| `coder-agent.log`          |
+| `coder-startup-script.log` |
+
+## codersdk.WorkspaceAgentLogInfo
+
+```json
+{
+  "exists": true,
+  "lines": 100,
+  "modified": "2019-08-24T14:15:22Z",
+  "name": "coder-agent.log",
+  "path": "/tmp/coder-agent.log",
+  "size": 2048
+}
+```
+
+### Properties
+
+| Name       | Type                                                     | Required | Restrictions | Description |
+| ---------- | -------------------------------------------------------- | -------- | ------------ | ----------- |
+| `exists`   | boolean                                                  | false    |              |             |
+| `lines`    | integer                                                  | false    |              |             |
+| `modified` | string                                                   | false    |              |             |
+| `name`     | [codersdk.WorkspaceAgentLog](#codersdkworkspaceagentlog) | false    |              |             |
+| `path`     | string                                                   | false    |              |             |
+| `size`     | integer                                                  | false    |              |             |
+
+## codersdk.WorkspaceAgentLogTailResponse
+
+```json
+{
+  "content": ["string"],
+  "count": 0,
+  "start": 0
+}
+```
+
+### Properties
+
+| Name      | Type            | Required | Restrictions | Description               |
+| --------- | --------------- | -------- | ------------ | ------------------------- |
+| `content` | array of string | false    |              |                           |
+| `count`   | integer         | false    |              | Number of lines returned. |
+| `start`   | integer         | false    |              | Line offset, 0-based.     |
+
 ## codersdk.WorkspaceAgentStatus
 
 ```json

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -946,6 +946,23 @@ export interface WorkspaceAgentListeningPortsResponse {
   readonly ports: WorkspaceAgentListeningPort[]
 }
 
+// From codersdk/workspaceagentconn.go
+export interface WorkspaceAgentLogInfo {
+  readonly name: WorkspaceAgentLog
+  readonly path: string
+  readonly size: number
+  readonly lines: number
+  readonly exists: boolean
+  readonly modified: string
+}
+
+// From codersdk/workspaceagentconn.go
+export interface WorkspaceAgentLogTailResponse {
+  readonly start: number
+  readonly count: number
+  readonly content: string[]
+}
+
 // From codersdk/workspaceapps.go
 export interface WorkspaceApp {
   readonly id: string
@@ -1232,6 +1249,13 @@ export const WorkspaceAgentLifecycles: WorkspaceAgentLifecycle[] = [
   "start_error",
   "start_timeout",
   "starting",
+]
+
+// From codersdk/workspaceagents.go
+export type WorkspaceAgentLog = "coder-agent.log" | "coder-startup-script.log"
+export const WorkspaceAgentLogs: WorkspaceAgentLog[] = [
+  "coder-agent.log",
+  "coder-startup-script.log",
 ]
 
 // From codersdk/workspaceagents.go


### PR DESCRIPTION
This PR adds support for requesting logs (e.g. agent and startup script) from the agent. It also adds support for showing the tail of the startup logs when an error is encountered during startup.

Note that one API endpoint is named tail, although tailing functionality is kinda missing at the moment. The idea is for it to receive a `follow` option in the future, to stream new logs over e.g. long-polling, sse or websocket.

Not super happy with API duplication in both coder agent and coderd, but I didn't come up with a better solution since webUI can't establish connections to the agent.

Refs: #2957

---

Example of ssh into errored workspace:

```
❯ coder ssh test

 > The workspace ran into a problem while getting ready,
   the agent startup script exited with non-zero status.
   See troubleshooting instructions at:
   https://coder.com/docs/coder-oss/latest/templates#troubleshooting-templates

Showing up to the last 10 lines from startup_script:

[startup_script] +zsh:2> echo 'TEST_VAR: test'
[startup_script] TEST_VAR: test
[startup_script] +zsh:3> echo 'Sleeping 30 seconds...'
[startup_script] Sleeping 30 seconds...
[startup_script] +zsh:4> sleep 30
[startup_script] +zsh:5> echo 'This might fail...'
[startup_script] This might fail...
[startup_script] +zsh:6> false

Agent startup script exited with non-zero status, use --no-wait to login anyway.
Run 'coder ssh --help' for usage.
```
