### PR TITLE
ci: Fix silent missing metadata for release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Create release notes
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # We always have to set this since there might be commits on
           # main that didn't have a PR.
           CODER_IGNORE_MISSING_COMMIT_METADATA: "1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -100,7 +100,8 @@ fi
 # Check the current version tag from GitHub (by number) using the API to
 # ensure no local tags are considered.
 log "Checking GitHub for latest release..."
-mapfile -t versions < <(gh api -H "Accept: application/vnd.github+json" /repos/coder/coder/git/refs/tags -q '.[].ref | split("/") | .[2]' | grep '^v' | sort -r -V)
+versions_out="$(gh api -H "Accept: application/vnd.github+json" /repos/coder/coder/git/refs/tags -q '.[].ref | split("/") | .[2]' | grep '^v' | sort -r -V)"
+mapfile -t versions <<<"$versions_out"
 old_version=${versions[0]}
 log "Latest release: $old_version"
 log
@@ -156,7 +157,7 @@ log 'Waiting for job to become "in_progress"...'
 
 # Wait at most 3 minutes (3*60)/3 = 60 for the job to start.
 for _ in $(seq 1 60); do
-	mapfile -t run < <(
+	output="$(
 		# Output:
 		# 3886828508
 		# in_progress
@@ -164,7 +165,8 @@ for _ in $(seq 1 60); do
 			--limit 1 \
 			--json status,databaseId \
 			--jq '.[] | (.databaseId | tostring), .status'
-	)
+	)"
+	mapfile -t run <<<"$output"
 	if [[ ${run[1]} != "in_progress" ]]; then
 		sleep 3
 		continue

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -70,7 +70,7 @@ main() {
 	#   d9f2aaf3b430d8b6f3d5f24032ed6357adaab1f1 author:world
 	#   fd54512858c906e66f04b0744d8715c2e0de97e6 author:bye labels:label:stale label:enhancement
 	from_commit_date=2023-01-18
-	mapfile -t pr_labels_raw < <(
+	pr_list="$(
 		gh pr list \
 			--base main \
 			--state merged \
@@ -78,7 +78,8 @@ main() {
 			--search "merged:>=$from_commit_date" \
 			--json mergeCommit,labels,author \
 			--jq '.[] | "\( .mergeCommit.oid ) author:\( .author.login ) labels:\(["label:\( .labels[].name )"] | join(" "))"'
-	)
+	)"
+	mapfile -t pr_labels_raw <<<"$pr_list"
 	declare -A authors labels
 	for entry in "${pr_labels_raw[@]}"; do
 		commit_sha_long=${entry%% *}

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -53,7 +53,8 @@ main() {
 	security_label=security
 
 	# Get abbreviated and full commit hashes and titles for each commit.
-	mapfile -t commits < <(git log --no-merges --pretty=format:"%h %H %s" "$range")
+	git_log_out="$(git log --no-merges --pretty=format:"%h %H %s" "$range")"
+	mapfile -t commits <<<"$git_log_out"
 
 	# If this is a tag, use rev-list to find the commit it points to.
 	from_commit=$(git rev-list -n 1 "$from_ref")
@@ -70,7 +71,7 @@ main() {
 	#   d9f2aaf3b430d8b6f3d5f24032ed6357adaab1f1 author:world
 	#   fd54512858c906e66f04b0744d8715c2e0de97e6 author:bye labels:label:stale label:enhancement
 	from_commit_date=2023-01-18
-	pr_list="$(
+	pr_list_out="$(
 		gh pr list \
 			--base main \
 			--state merged \
@@ -79,9 +80,9 @@ main() {
 			--json mergeCommit,labels,author \
 			--jq '.[] | "\( .mergeCommit.oid ) author:\( .author.login ) labels:\(["label:\( .labels[].name )"] | join(" "))"'
 	)"
-	mapfile -t pr_labels_raw <<<"$pr_list"
+	mapfile -t pr_metadata_raw <<<"$pr_list_out"
 	declare -A authors labels
-	for entry in "${pr_labels_raw[@]}"; do
+	for entry in "${pr_metadata_raw[@]}"; do
 		commit_sha_long=${entry%% *}
 		commit_author=${entry#* author:}
 		commit_author=${commit_author%% *}

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -70,7 +70,6 @@ main() {
 	#   27386d49d08455b6f8fbf2c18f38244d03fda892 author:hello labels:label:security
 	#   d9f2aaf3b430d8b6f3d5f24032ed6357adaab1f1 author:world
 	#   fd54512858c906e66f04b0744d8715c2e0de97e6 author:bye labels:label:stale label:enhancement
-	from_commit_date=2023-01-18
 	pr_list_out="$(
 		gh pr list \
 			--base main \

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -62,7 +62,8 @@ fi
 source "$SCRIPT_DIR/release/check_commit_metadata.sh" "$old_version" "$ref"
 
 # Sort commits by title prefix, then by date, only return sha at the end.
-mapfile -t commits < <(git log --no-merges --pretty=format:"%ct %h %s" "$old_version..$ref" | sort -k3,3 -k1,1n | cut -d' ' -f2)
+git_log_out="$(git log --no-merges --pretty=format:"%ct %h %s" "$old_version..$ref" | sort -k3,3 -k1,1n | cut -d' ' -f2)"
+mapfile -t commits <<<"$git_log_out"
 
 # From: https://github.com/commitizen/conventional-commit-types
 # NOTE(mafredri): These need to be supported in check_commit_metadata.sh as well.

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -151,7 +151,5 @@ Compare: [\`$old_version...$new_version\`](https://github.com/coder/coder/compar
 
 ## Install/upgrade
 
-Refer to our docs to [install](https://coder.com/docs/v2/latest/install)
-or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use
-a release asset below.
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
 "

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -59,7 +59,7 @@ if [[ -z $ref ]]; then
 fi
 
 # shellcheck source=scripts/release/check_commit_metadata.sh
-source "$SCRIPT_DIR/release/check_commit_metadata.sh" "$old_version" "$ref"
+source "$SCRIPT_DIR/check_commit_metadata.sh" "$old_version" "$ref"
 
 # Sort commits by title prefix, then by date, only return sha at the end.
 git_log_out="$(git log --no-merges --pretty=format:"%ct %h %s" "$old_version..$ref" | sort -k3,3 -k1,1n | cut -d' ' -f2)"
@@ -139,7 +139,7 @@ changelog="$(
 	done
 )"
 
-image_tag="$(execrelative ./image_tag.sh --version "$new_version")"
+image_tag="$(execrelative ../image_tag.sh --version "$new_version")"
 
 echo -e "## Changelog
 $changelog

--- a/scripts/release/tag_version.sh
+++ b/scripts/release/tag_version.sh
@@ -82,7 +82,7 @@ ref=$(git rev-parse --short "$ref")
 
 log "Checking commit metadata for changes since $old_version..."
 # shellcheck source=scripts/release/check_commit_metadata.sh
-source "$SCRIPT_DIR/release/check_commit_metadata.sh" "$old_version" "$ref"
+source "$SCRIPT_DIR/check_commit_metadata.sh" "$old_version" "$ref"
 
 if ((COMMIT_METADATA_BREAKING == 1)); then
 	prev_increment=$increment


### PR DESCRIPTION
I'm not exactly sure what happened in: https://github.com/coder/coder/actions/runs/4116713821/jobs/7107102185

But it looks like all commits were missing metadata. And the form: `mapfile < <(cmd)` can allow for silent failure of the command (`gh pr list`), so perhaps that was the issue.

It's weird that we didn't see any stderr output, though.
