### PR TITLE
fix: Allow to stop or remove workspaces using rich and old parameters

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -518,7 +518,8 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(legacyParameters) > 0 && len(parameters) > 0 {
+	if (createBuild.Transition == codersdk.WorkspaceTransitionStart || createBuild.Transition == codersdk.WorkspaceTransitionCreate) &&
+		len(legacyParameters) > 0 && len(parameters) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Rich parameters can't be used together with legacy parameters.",
 		})

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -518,7 +518,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if (createBuild.Transition == codersdk.WorkspaceTransitionStart || createBuild.Transition == codersdk.WorkspaceTransitionCreate) &&
+	if createBuild.Transition == codersdk.WorkspaceTransitionStart &&
 		len(legacyParameters) > 0 && len(parameters) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Rich parameters can't be used together with legacy parameters.",

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -14,7 +14,6 @@ import (
 type WorkspaceTransition string
 
 const (
-	WorkspaceTransitionCreate WorkspaceTransition = "create"
 	WorkspaceTransitionStart  WorkspaceTransition = "start"
 	WorkspaceTransitionStop   WorkspaceTransition = "stop"
 	WorkspaceTransitionDelete WorkspaceTransition = "delete"

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -14,6 +14,7 @@ import (
 type WorkspaceTransition string
 
 const (
+	WorkspaceTransitionCreate WorkspaceTransition = "create"
 	WorkspaceTransitionStart  WorkspaceTransition = "start"
 	WorkspaceTransitionStop   WorkspaceTransition = "stop"
 	WorkspaceTransitionDelete WorkspaceTransition = "delete"


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6088

This PR brings back an option to stop or delete workspaces using rich parameters and legacy parameters.