### PR TITLE
ci: Fix `scripts/release/publish.sh` execrelative path

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -69,7 +69,7 @@ dependencies gh
 # Remove the "v" prefix.
 version="${version#v}"
 if [[ "$version" == "" ]]; then
-	version="$(execrelative ./version.sh)"
+	version="$(execrelative ../version.sh)"
 fi
 
 if [[ -z $release_notes_file ]]; then


### PR DESCRIPTION
Behavior of `lib.sh` changed in: #5934

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
