### PR TITLE
chore: fix flake in create-admin-user test

### DIFF
--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -135,14 +136,20 @@ func TestServerCreateAdminUser(t *testing.T) {
 			errC <- err
 		}()
 
-		pty.ExpectMatch("Creating user...")
-		pty.ExpectMatch("Generating user SSH key...")
-		pty.ExpectMatch(fmt.Sprintf("Adding user to organization %q (%s) as admin...", org1Name, org1ID.String()))
-		pty.ExpectMatch(fmt.Sprintf("Adding user to organization %q (%s) as admin...", org2Name, org2ID.String()))
-		pty.ExpectMatch("User created successfully.")
-		pty.ExpectMatch(username)
-		pty.ExpectMatch(email)
-		pty.ExpectMatch("****")
+		// Sometimes generating SSH keys takes a really long time if there isn't
+		// enough entropy. We don't want the tests to fail in these cases.
+		//nolint:gocritic
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+
+		pty.ExpectMatchContext(ctx, "Creating user...")
+		pty.ExpectMatchContext(ctx, "Generating user SSH key...")
+		pty.ExpectMatchContext(ctx, fmt.Sprintf("Adding user to organization %q (%s) as admin...", org1Name, org1ID.String()))
+		pty.ExpectMatchContext(ctx, fmt.Sprintf("Adding user to organization %q (%s) as admin...", org2Name, org2ID.String()))
+		pty.ExpectMatchContext(ctx, "User created successfully.")
+		pty.ExpectMatchContext(ctx, username)
+		pty.ExpectMatchContext(ctx, email)
+		pty.ExpectMatchContext(ctx, "****")
 
 		require.NoError(t, <-errC)
 
@@ -178,10 +185,16 @@ func TestServerCreateAdminUser(t *testing.T) {
 			errC <- err
 		}()
 
-		pty.ExpectMatch("User created successfully.")
-		pty.ExpectMatch(username)
-		pty.ExpectMatch(email)
-		pty.ExpectMatch("****")
+		// Sometimes generating SSH keys takes a really long time if there isn't
+		// enough entropy. We don't want the tests to fail in these cases.
+		//nolint:gocritic
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+
+		pty.ExpectMatchContext(ctx, "User created successfully.")
+		pty.ExpectMatchContext(ctx, username)
+		pty.ExpectMatchContext(ctx, email)
+		pty.ExpectMatchContext(ctx, "****")
 
 		require.NoError(t, <-errC)
 
@@ -226,10 +239,16 @@ func TestServerCreateAdminUser(t *testing.T) {
 		pty.ExpectMatch("> Confirm password")
 		pty.WriteLine(password)
 
-		pty.ExpectMatch("User created successfully.")
-		pty.ExpectMatch(username)
-		pty.ExpectMatch(email)
-		pty.ExpectMatch("****")
+		// Sometimes generating SSH keys takes a really long time if there isn't
+		// enough entropy. We don't want the tests to fail in these cases.
+		//nolint:gocritic
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+
+		pty.ExpectMatchContext(ctx, "User created successfully.")
+		pty.ExpectMatchContext(ctx, username)
+		pty.ExpectMatchContext(ctx, email)
+		pty.ExpectMatchContext(ctx, "****")
 
 		require.NoError(t, <-errC)
 

--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -86,13 +86,16 @@ func TestServerCreateAdminUser(t *testing.T) {
 		connectionURL, closeFunc, err := postgres.Open()
 		require.NoError(t, err)
 		defer closeFunc()
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		defer cancelFunc()
 
 		sqlDB, err := sql.Open("postgres", connectionURL)
 		require.NoError(t, err)
 		defer sqlDB.Close()
 		db := database.New(sqlDB)
+
+		// Sometimes generating SSH keys takes a really long time if there isn't
+		// enough entropy. We don't want the tests to fail in these cases.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
+		defer cancel()
 
 		pingCtx, pingCancel := context.WithTimeout(ctx, testutil.WaitShort)
 		defer pingCancel()
@@ -135,11 +138,6 @@ func TestServerCreateAdminUser(t *testing.T) {
 			errC <- err
 		}()
 
-		// Sometimes generating SSH keys takes a really long time if there isn't
-		// enough entropy. We don't want the tests to fail in these cases.
-		ctx, cancel := context.WithTimeout(ctx, testutil.WaitSuperLong)
-		defer cancel()
-
 		pty.ExpectMatchContext(ctx, "Creating user...")
 		pty.ExpectMatchContext(ctx, "Generating user SSH key...")
 		pty.ExpectMatchContext(ctx, fmt.Sprintf("Adding user to organization %q (%s) as admin...", org1Name, org1ID.String()))
@@ -163,8 +161,11 @@ func TestServerCreateAdminUser(t *testing.T) {
 		connectionURL, closeFunc, err := postgres.Open()
 		require.NoError(t, err)
 		defer closeFunc()
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		defer cancelFunc()
+
+		// Sometimes generating SSH keys takes a really long time if there isn't
+		// enough entropy. We don't want the tests to fail in these cases.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
+		defer cancel()
 
 		t.Setenv("CODER_POSTGRES_URL", connectionURL)
 		t.Setenv("CODER_SSH_KEYGEN_ALGORITHM", "ed25519")
@@ -182,11 +183,6 @@ func TestServerCreateAdminUser(t *testing.T) {
 			t.Log("root.ExecuteContext() returned:", err)
 			errC <- err
 		}()
-
-		// Sometimes generating SSH keys takes a really long time if there isn't
-		// enough entropy. We don't want the tests to fail in these cases.
-		ctx, cancel := context.WithTimeout(ctx, testutil.WaitSuperLong)
-		defer cancel()
 
 		pty.ExpectMatchContext(ctx, "User created successfully.")
 		pty.ExpectMatchContext(ctx, username)
@@ -208,8 +204,11 @@ func TestServerCreateAdminUser(t *testing.T) {
 		connectionURL, closeFunc, err := postgres.Open()
 		require.NoError(t, err)
 		defer closeFunc()
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		defer cancelFunc()
+
+		// Sometimes generating SSH keys takes a really long time if there isn't
+		// enough entropy. We don't want the tests to fail in these cases.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
+		defer cancel()
 
 		root, _ := clitest.New(t,
 			"server", "create-admin-user",
@@ -227,19 +226,14 @@ func TestServerCreateAdminUser(t *testing.T) {
 			errC <- err
 		}()
 
-		pty.ExpectMatch("> Username")
+		pty.ExpectMatchContext(ctx, "> Username")
 		pty.WriteLine(username)
-		pty.ExpectMatch("> Email")
+		pty.ExpectMatchContext(ctx, "> Email")
 		pty.WriteLine(email)
-		pty.ExpectMatch("> Password")
+		pty.ExpectMatchContext(ctx, "> Password")
 		pty.WriteLine(password)
-		pty.ExpectMatch("> Confirm password")
+		pty.ExpectMatchContext(ctx, "> Confirm password")
 		pty.WriteLine(password)
-
-		// Sometimes generating SSH keys takes a really long time if there isn't
-		// enough entropy. We don't want the tests to fail in these cases.
-		ctx, cancel := context.WithTimeout(ctx, testutil.WaitSuperLong)
-		defer cancel()
 
 		pty.ExpectMatchContext(ctx, "User created successfully.")
 		pty.ExpectMatchContext(ctx, username)

--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -162,7 +162,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 		defer cancelFunc()
 
 		t.Setenv("CODER_POSTGRES_URL", connectionURL)
-		t.Setenv("CODER_SSH_KEYGEN_ALGORITHM", "ecdsa")
+		t.Setenv("CODER_SSH_KEYGEN_ALGORITHM", "ed25519")
 		t.Setenv("CODER_USERNAME", username)
 		t.Setenv("CODER_EMAIL", email)
 		t.Setenv("CODER_PASSWORD", password)
@@ -204,7 +204,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 		root, _ := clitest.New(t,
 			"server", "create-admin-user",
 			"--postgres-url", connectionURL,
-			"--ssh-keygen-algorithm", "rsa4096",
+			"--ssh-keygen-algorithm", "ed25519",
 		)
 		pty := ptytest.New(t)
 		root.SetIn(pty.Input())

--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -138,8 +137,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 
 		// Sometimes generating SSH keys takes a really long time if there isn't
 		// enough entropy. We don't want the tests to fail in these cases.
-		//nolint:gocritic
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, testutil.WaitSuperLong)
 		defer cancel()
 
 		pty.ExpectMatchContext(ctx, "Creating user...")
@@ -187,8 +185,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 
 		// Sometimes generating SSH keys takes a really long time if there isn't
 		// enough entropy. We don't want the tests to fail in these cases.
-		//nolint:gocritic
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, testutil.WaitSuperLong)
 		defer cancel()
 
 		pty.ExpectMatchContext(ctx, "User created successfully.")
@@ -241,8 +238,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 
 		// Sometimes generating SSH keys takes a really long time if there isn't
 		// enough entropy. We don't want the tests to fail in these cases.
-		//nolint:gocritic
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, testutil.WaitSuperLong)
 		defer cancel()
 
 		pty.ExpectMatchContext(ctx, "User created successfully.")


### PR DESCRIPTION
Switches all of the tests to use ed25519 instead of all available key types to avoid needing a lot of randomness from the system.