### PR TITLE
fix: do not build Packer images on dry run releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -289,6 +289,7 @@ jobs:
           retention-days: 7
 
       - name: Start Packer builds
+        if: ${{ !inputs.dry_run }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.CDRCI_GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
