### PR TITLE
fix: Extend migration fixture test with down and fix 000045

### DIFF
--- a/coderd/database/migrations/000045_workspacebuildname.down.sql
+++ b/coderd/database/migrations/000045_workspacebuildname.down.sql
@@ -1,2 +1,2 @@
 ALTER TABLE workspace_builds
-    ADD COLUMN name character varying(64) NOT NULL;
+    ADD COLUMN name character varying(64) NOT NULL DEFAULT '';

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -331,6 +331,10 @@ func TestMigrateUpWithFixtures(t *testing.T) {
 					s.Add(table, count)
 				}
 			}
+
+			// Test that migration down is successful after up.
+			err = migrations.Down(db)
+			require.NoError(t, err, "final migration down should be successful")
 		})
 	}
 }


### PR DESCRIPTION
While writing fixtures and a test for a future feature, I noticed we didn't check down after migration up. This change ensures that even non-empty databases can be migrated down.
