### PR TITLE
helm: add deployment securityContext values

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         {{- include "coder.labels" . | nindent 8 }}
     spec:
+      securityContext: {{ toYaml .Values.coder.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ .Values.coder.serviceAccount.name | quote }}
       restartPolicy: Always
       {{- with .Values.coder.image.pullSecrets }}
@@ -48,6 +49,7 @@ spec:
       {{- with .Values.coder.initContainers }}
       initContainers:
       {{ toYaml . | nindent 8 }}
+          securityContext: {{ toYaml .Values.coder.securityContext | nindent 12 }}
       {{- end }}
       containers:
         - name: coder
@@ -107,6 +109,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+          securityContext: {{ toYaml .Values.coder.securityContext | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /api/v2/buildinfo

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -26,7 +26,6 @@ spec:
       labels:
         {{- include "coder.labels" . | nindent 8 }}
     spec:
-      securityContext: {{ toYaml .Values.coder.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ .Values.coder.serviceAccount.name | quote }}
       restartPolicy: Always
       {{- with .Values.coder.image.pullSecrets }}
@@ -49,7 +48,6 @@ spec:
       {{- with .Values.coder.initContainers }}
       initContainers:
       {{ toYaml . | nindent 8 }}
-          securityContext: {{ toYaml .Values.coder.securityContext | nindent 12 }}
       {{- end }}
       containers:
         - name: coder

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,6 +50,53 @@ coder:
     # coder.serviceAccount.name -- The service account name
     name: coder
 
+  # coder.podSecurityContext -- Fields related to the pod's security context
+  # (as opposed to the container). Some fields are also present in the
+  # container security context, which will take precedence over these values.
+  podSecurityContext:
+    # coder.podSecurityContext.runAsNonRoot -- Requires that containers in
+    # the pod run as an unprivileged user. If setting runAsUser to 0 (root),
+    # this will need to be set to false.
+    runAsNonRoot: true
+    # coder.podSecurityContext.runAsUser -- Sets the user id of the pod.
+    # For security reasons, we recommend using a non-root user.
+    runAsUser: 1000
+    # coder.podSecurityContext.runAsGroup -- Sets the group id of the pod.
+    # For security reasons, we recommend using a non-root group.
+    runAsGroup: 1000
+    # coder.podSecurityContext.seccompProfile -- Sets the seccomp profile
+    # for the pod. If set, the container security context setting will take
+    # precedence over this value.
+    seccompProfile:
+      type: RuntimeDefault
+
+  # coder.securityContext -- Fields related to the container's security
+  # context (as opposed to the pod). Some fields are also present in the pod
+  # security context, in which case these values will take precedence.
+  securityContext:
+    # coder.securityContext.runAsNonRoot -- Requires that the coder container
+    # runs as an unprivileged user. If setting runAsUser to 0 (root), this
+    # will need to be set to false.
+    runAsNonRoot: true
+    # coder.securityContext.runAsUser -- Sets the user id of the pod.
+    # For security reasons, we recommend using a non-root user.
+    runAsUser: 1000
+    # coder.securityContext.runAsGroup -- Sets the group id of the pod.
+    # For security reasons, we recommend using a non-root group.
+    runAsGroup: 1000
+    # coder.securityContext.readOnlyRootFilesystem -- Mounts the container's
+    # root filesystem as read-only. It is recommended to leave this setting
+    # enabled in production. This will override the same setting in the pod
+    readOnlyRootFilesystem: true
+    # coder.securityContext.seccompProfile -- Sets the seccomp profile for
+    # the coder container.
+    seccompProfile:
+      type: RuntimeDefault
+    # coder.securityContext.allowPrivilegeEscalation -- Controls whether
+    # the container can gain additional privileges, such as escalating to
+    # root. It is recommended to leave this setting disabled in production.
+    allowPrivilegeEscalation: false
+
   # coder.env -- The environment variables to set for Coder. These can be used
   # to configure all aspects of `coder server`. Please see `coder server --help`
   # for information about what environment variables can be set.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,26 +50,6 @@ coder:
     # coder.serviceAccount.name -- The service account name
     name: coder
 
-  # coder.podSecurityContext -- Fields related to the pod's security context
-  # (as opposed to the container). Some fields are also present in the
-  # container security context, which will take precedence over these values.
-  podSecurityContext:
-    # coder.podSecurityContext.runAsNonRoot -- Requires that containers in
-    # the pod run as an unprivileged user. If setting runAsUser to 0 (root),
-    # this will need to be set to false.
-    runAsNonRoot: true
-    # coder.podSecurityContext.runAsUser -- Sets the user id of the pod.
-    # For security reasons, we recommend using a non-root user.
-    runAsUser: 1000
-    # coder.podSecurityContext.runAsGroup -- Sets the group id of the pod.
-    # For security reasons, we recommend using a non-root group.
-    runAsGroup: 1000
-    # coder.podSecurityContext.seccompProfile -- Sets the seccomp profile
-    # for the pod. If set, the container security context setting will take
-    # precedence over this value.
-    seccompProfile:
-      type: RuntimeDefault
-
   # coder.securityContext -- Fields related to the container's security
   # context (as opposed to the pod). Some fields are also present in the pod
   # security context, in which case these values will take precedence.


### PR DESCRIPTION
this PR adds support for configuring the Coder deployment's `securityContext` (for both pod & container) in the values file. this comes in handy when deploying Coder on OpenShift, which applies `SecurityContextConstraints` to deployments.

one question i have - since the Coder deployment consists of a single container, is it necessary for us to have a pod-level `securityContext`? the `securityContext` set at the container-level takes precedence over the pod-level context.

keeping the `podSecurityContext` values is beneficial if there is any possibility of us adding containers to the deployment. otherwise, I don't see much a reason to keep it.