### PR TITLE
chore: Optimize parial rego execution byte allocations 

### DIFF
--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -977,9 +977,14 @@ func testAuthorize(t *testing.T, name string, subject Subject, sets ...[]authTes
 
 					d, _ := json.Marshal(map[string]interface{}{
 						// This is not perfect marshal, but it is good enough for debugging this test.
-						"subject": subject,
-						"object":  c.resource,
-						"action":  a,
+						"subject": authSubject{
+							ID:     subject.ID,
+							Roles:  must(subject.Roles.Expand()),
+							Groups: subject.Groups,
+							Scope:  must(subject.Scope.Expand()),
+						},
+						"object": c.resource,
+						"action": a,
 					})
 
 					// Logging only

--- a/coderd/rbac/authz_test.go
+++ b/coderd/rbac/authz_test.go
@@ -189,6 +189,17 @@ func BenchmarkRBACFilter(b *testing.B) {
 	)
 
 	authorizer := rbac.NewAuthorizer(prometheus.NewRegistry())
+
+	for _, c := range benchCases {
+		b.Run("PrepareOnly-"+c.Name, func(b *testing.B) {
+			obType := rbac.ResourceWorkspace.Type
+			for i := 0; i < b.N; i++ {
+				_, err := authorizer.Prepare(context.Background(), c.Actor, rbac.ActionRead, obType)
+				require.NoError(b, err)
+			}
+		})
+	}
+
 	for _, c := range benchCases {
 		b.Run(c.Name, func(b *testing.B) {
 			objects := benchmarkSetup(orgs, users, b.N)

--- a/coderd/rbac/builtin_internal_test.go
+++ b/coderd/rbac/builtin_internal_test.go
@@ -51,7 +51,11 @@ func BenchmarkRBACValueAllocation(b *testing.B) {
 	})
 	b.Run("JSONRegoValue", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := ast.InterfaceToValue(jsonSubject)
+			_, err := ast.InterfaceToValue(map[string]interface{}{
+				"subject": jsonSubject,
+				"action":  ActionRead,
+				"object":  obj,
+			})
 			require.NoError(b, err)
 		}
 	})

--- a/coderd/rbac/partial.go
+++ b/coderd/rbac/partial.go
@@ -127,24 +127,7 @@ EachQueryLoop:
 		pa.subjectInput, pa.subjectAction, pa.subjectResourceType, nil)
 }
 
-// Precompiled values to be reused for each Prepare call.
-// These values are static and do not change.
-var (
-	// unknownTerms are the unknown values in the rego input.
-	// These values are pre-parsed to prevent reparsing on every Prepare call.
-	unknownTerms = []*ast.Term{
-		ast.MustParseTerm("input.object.id"),
-		ast.MustParseTerm("input.object.owner"),
-		ast.MustParseTerm("input.object.org_owner"),
-		ast.MustParseTerm("input.object.acl_user_list"),
-		ast.MustParseTerm("input.object.acl_group_list"),
-	}
-
-	partialQuery = ast.MustParseBody("data.authz.allow = true")
-	policyModule = ast.MustParseModule(policy)
-)
-
-func newPartialAuthorizer(ctx context.Context, subject Subject, action Action, objectType string) (*PartialAuthorizer, error) {
+func (a RegoAuthorizer) newPartialAuthorizer(ctx context.Context, subject Subject, action Action, objectType string) (*PartialAuthorizer, error) {
 	if subject.Roles == nil {
 		return nil, xerrors.Errorf("subject must have roles")
 	}
@@ -157,14 +140,8 @@ func newPartialAuthorizer(ctx context.Context, subject Subject, action Action, o
 		return nil, xerrors.Errorf("prepare input: %w", err)
 	}
 
-	// Run the rego policy with a few unknown fields. This should simplify our
-	// policy to a set of queries.
-	partialQueries, err := rego.New(
-		rego.ParsedQuery(partialQuery),
-		rego.ParsedModule(policyModule),
-		rego.ParsedUnknowns(unknownTerms),
-		rego.ParsedInput(input),
-	).Partial(ctx)
+	partialQueries, err := a.partialQuery.Partial(ctx, rego.EvalParsedInput(input))
+
 	if err != nil {
 		return nil, xerrors.Errorf("prepare: %w", err)
 	}

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -93,6 +93,8 @@ default scope_org := 0
 scope_org := org_allow([input.scope])
 
 org_allow(roles) := num {
+	# Rule index on org_owner being set.
+	input.object.org_owner != ""
 	allow := { id: num |
 		id := org_members[_]
 		set := { x |

--- a/coderd/rbac/policy.rego
+++ b/coderd/rbac/policy.rego
@@ -93,8 +93,6 @@ default scope_org := 0
 scope_org := org_allow([input.scope])
 
 org_allow(roles) := num {
-	# Rule index on org_owner being set.
-	input.object.org_owner != ""
 	allow := { id: num |
 		id := org_members[_]
 		set := { x |


### PR DESCRIPTION
Preventing some allocations by reusing the same prepared partial query. Unfortunately the bulk of the work happens when the inputs are passed in, which cannot be done in advance.

The unit tests that are most affected by this change are `Owner` role users. Since the partial execution results in a single empty query. Meaning most of the memory allocations happens before the input is passed in.

# Before

```
cpu: Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
BenchmarkRBACFilter/PrepareOnly-NoRoles-8                     91          15761998 ns/op         2693954 B/op      76514 allocs/op
BenchmarkRBACFilter/PrepareOnly-Admin-8                       76          15272378 ns/op         3154366 B/op      93904 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgAdmin-8                    61          23254933 ns/op         4741804 B/op     133793 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgMember-8                   51          21488792 ns/op         4609187 B/op     130032 allocs/op
BenchmarkRBACFilter/PrepareOnly-ManyRoles-8                   46          25034282 ns/op         5267128 B/op     147494 allocs/op
BenchmarkRBACFilter/PrepareOnly-AdminWithScope-8              78          13232737 ns/op         2932466 B/op      85865 allocs/op
```

# After

```
cpu: Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
BenchmarkRBACFilter/PrepareOnly-NoRoles-8                    205           6279153 ns/op         1048482 B/op      29024 allocs/op
BenchmarkRBACFilter/PrepareOnly-Admin-8                      130           8191177 ns/op         1495304 B/op      46161 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgAdmin-8                    82          13969795 ns/op         3081619 B/op      86025 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgMember-8                   86          14498713 ns/op         2944946 B/op      82249 allocs/op
BenchmarkRBACFilter/PrepareOnly-ManyRoles-8                   72          25139446 ns/op         3588279 B/op      99513 allocs/op
BenchmarkRBACFilter/PrepareOnly-AdminWithScope-8             150           7135444 ns/op         1276023 B/op      38142 allocs/op
```

# EMPTY POLICY

**This is an illustration if `input` has 0 impact on the output prepared queries. I did this to illustrate the speedup of the `Partial()` call on the rego policy.**

You can see the difference if you use an empty `policy.rego` so that the `inputs` do not really affect the output. This shows that the impact of `inputs` is a magnitude larger than the compilation of the original policy.


## Before

```
cpu: Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
BenchmarkRBACFilter/PrepareOnly-NoRoles-8                   1681            667725 ns/op          172588 B/op       3580 allocs/op
BenchmarkRBACFilter/PrepareOnly-Admin-8                     1701            754506 ns/op          186134 B/op       3998 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgAdmin-8                  1872            672738 ns/op          184188 B/op       3924 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgMember-8                 1552            673768 ns/op          186339 B/op       3993 allocs/op
BenchmarkRBACFilter/PrepareOnly-ManyRoles-8                 1669            695561 ns/op          198783 B/op       4318 allocs/op
BenchmarkRBACFilter/PrepareOnly-AdminWithScope-8            1740            686103 ns/op          186142 B/op       3998 allocs/op
```

## After

```
cpu: Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
BenchmarkRBACFilter/PrepareOnly-NoRoles-8                   4116            247152 ns/op           47435 B/op        665 allocs/op
BenchmarkRBACFilter/PrepareOnly-Admin-8                     3962            271590 ns/op           61014 B/op       1083 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgAdmin-8                  5521            255080 ns/op           59069 B/op       1009 allocs/op
BenchmarkRBACFilter/PrepareOnly-OrgMember-8                 3532            290196 ns/op           61221 B/op       1078 allocs/op
BenchmarkRBACFilter/PrepareOnly-ManyRoles-8                 3758            305439 ns/op           73677 B/op       1403 allocs/op
BenchmarkRBACFilter/PrepareOnly-AdminWithScope-8            3994            286214 ns/op           61014 B/op       1083 allocs/op
```