### PR TITLE
fix(api): Allow workspace agent coordinate to report disconnect

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -674,7 +674,7 @@ func New(options *Options) *API {
 
 type API struct {
 	// ctx is canceled immediately on shutdown, it can be used to abort
-	// interruptable tasks.
+	// interruptible tasks.
 	ctx    context.Context
 	cancel context.CancelFunc
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -633,7 +633,7 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 			Valid: true,
 		}
 		_ = updateConnectionTimes(ctx)
-		_ = api.Pubsub.Publish(watchWorkspaceChannel(build.WorkspaceID), []byte{})
+		api.publishWorkspaceUpdate(ctx, build.WorkspaceID)
 	}()
 
 	err = updateConnectionTimes(ctx)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -601,7 +601,7 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 		Valid: true,
 	}
 	disconnectedAt := workspaceAgent.DisconnectedAt
-	updateConnectionTimes := func() error {
+	updateConnectionTimes := func(ctx context.Context) error {
 		err = api.Database.UpdateWorkspaceAgentConnectionByID(ctx, database.UpdateWorkspaceAgentConnectionByIDParams{
 			ID:               workspaceAgent.ID,
 			FirstConnectedAt: firstConnectedAt,
@@ -620,15 +620,23 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 	}
 
 	defer func() {
+		// If connection closed then context will be canceled, try to
+		// ensure our final update is sent. By waiting at most the agent
+		// inactive disconnect timeout we ensure that we don't block but
+		// also guarantee that the agent will be considered disconnected
+		// by normal status check.
+		ctx, cancel := context.WithTimeout(api.ctx, api.AgentInactiveDisconnectTimeout)
+		defer cancel()
+
 		disconnectedAt = sql.NullTime{
 			Time:  database.Now(),
 			Valid: true,
 		}
-		_ = updateConnectionTimes()
+		_ = updateConnectionTimes(ctx)
 		_ = api.Pubsub.Publish(watchWorkspaceChannel(build.WorkspaceID), []byte{})
 	}()
 
-	err = updateConnectionTimes()
+	err = updateConnectionTimes(ctx)
 	if err != nil {
 		_ = conn.Close(websocket.StatusGoingAway, err.Error())
 		return
@@ -668,7 +676,7 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 			Time:  database.Now(),
 			Valid: true,
 		}
-		err = updateConnectionTimes()
+		err = updateConnectionTimes(ctx)
 		if err != nil {
 			_ = conn.Close(websocket.StatusGoingAway, err.Error())
 			return


### PR DESCRIPTION
Coordinate was unable to report agent disconnect because of context cancellation. This fixes the issue in a way that does not block if the coder server is shut down.

This is relevant for both #5901 and #6139.
