### PR TITLE
fix: Update flake.lock to fix Go build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1659803779,
-        "narHash": "sha256-+5zkHlbcbFyN5f3buO1RAZ9pH1wXLxCesUJ0vFmLr9Y=",
+        "lastModified": 1676110339,
+        "narHash": "sha256-kOS/L8OOL2odpCOM11IevfHxcUeE0vnZUQ74EOiwXcs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f44884060cb94240efbe55620f38a8ec8d9af601",
+        "rev": "e5530aba13caff5a4f41713f1265b754dc2abfd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/5968

This PR fixes build problems with Go 1.20. I can see this error when I enter the `coder` directory.

```
       … while calling anonymous lambda
       at /nix/store/vgx3678yb41cb8g2g66nlj1alf3ksh92-source/pkgs/stdenv/generic/make-derivation.nix:192:81:
          191|   checkDependencyList = checkDependencyList' [];
          192|   checkDependencyList' = positions: name: deps: lib.flip lib.imap1 deps (index: dep:
             |                                                                                 ^
          193|     if lib.isDerivation dep || isNull dep || builtins.typeOf dep == "string" || builtins.typeOf dep == "path" then dep
       … while evaluating call site
       at /nix/store/vgx3678yb41cb8g2g66nlj1alf3ksh92-source/pkgs/stdenv/generic/make-derivation.nix:193:8:
          192|   checkDependencyList' = positions: name: deps: lib.flip lib.imap1 deps (index: dep:
          193|     if lib.isDerivation dep || isNull dep || builtins.typeOf dep == "string" || builtins.typeOf dep == "path" then dep
             |        ^
          194|     else if lib.isList dep then checkDependencyList' ([index] ++ positions) name dep
       … while calling 'isDerivation'
       at /nix/store/vgx3678yb41cb8g2g66nlj1alf3ksh92-source/lib/attrsets.nix:427:18:
          426|   */
          427|   isDerivation = x: x.type or null == "derivation";
             |                  ^
          428|
       error: undefined variable 'go_1_20'
       at /nix/store/xm53r3d6cc8vn9vw1pmcm331xpv72aqa-source/flake.nix:27:13:
           26|             go-migrate
           27|             go_1_20
             |             ^
           28|             golangci-lint
```