### PR TITLE
test: Make cli speedtest more reliable

### DIFF
--- a/cli/speedtest_test.go
+++ b/cli/speedtest_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/agent"
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/codersdk/agentsdk"
 	"github.com/coder/coder/pty/ptytest"
 	"github.com/coder/coder/testutil"
@@ -30,13 +32,27 @@ func TestSpeedtest(t *testing.T) {
 	defer agentCloser.Close()
 	coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	require.Eventually(t, func() bool {
+		ws, err := client.Workspace(ctx, workspace.ID)
+		if !assert.NoError(t, err) {
+			return false
+		}
+		a := ws.LatestBuild.Resources[0].Agents[0]
+		return a.Status == codersdk.WorkspaceAgentConnected &&
+			a.LifecycleState == codersdk.WorkspaceAgentLifecycleReady
+	}, testutil.WaitLong, testutil.IntervalFast, "agent is not ready")
+
 	cmd, root := clitest.New(t, "speedtest", workspace.Name)
 	clitest.SetupConfig(t, client, root)
 	pty := ptytest.New(t)
 	cmd.SetOut(pty.Output())
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	ctx, cancel = context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
+
 	cmdDone := tGo(t, func() {
 		err := cmd.ExecuteContext(ctx)
 		assert.NoError(t, err)


### PR DESCRIPTION
We now wait for the agent to be connected/ready before start.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
