### PR TITLE
fix: set Coder read-only fs to null

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -67,7 +67,7 @@ coder:
     # coder.securityContext.readOnlyRootFilesystem -- Mounts the container's
     # root filesystem as read-only. It is recommended to leave this setting
     # enabled in production. This will override the same setting in the pod
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: null
     # coder.securityContext.seccompProfile -- Sets the seccomp profile for
     # the coder container.
     seccompProfile:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -58,10 +58,10 @@ coder:
     # runs as an unprivileged user. If setting runAsUser to 0 (root), this
     # will need to be set to false.
     runAsNonRoot: true
-    # coder.securityContext.runAsUser -- Sets the user id of the pod.
+    # coder.securityContext.runAsUser -- Sets the user id of the container.
     # For security reasons, we recommend using a non-root user.
     runAsUser: 1000
-    # coder.securityContext.runAsGroup -- Sets the group id of the pod.
+    # coder.securityContext.runAsGroup -- Sets the group id of the container.
     # For security reasons, we recommend using a non-root group.
     runAsGroup: 1000
     # coder.securityContext.readOnlyRootFilesystem -- Mounts the container's

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,8 +65,7 @@ coder:
     # For security reasons, we recommend using a non-root group.
     runAsGroup: 1000
     # coder.securityContext.readOnlyRootFilesystem -- Mounts the container's
-    # root filesystem as read-only. It is recommended to leave this setting
-    # enabled in production. This will override the same setting in the pod
+    # root filesystem as read-only.
     readOnlyRootFilesystem: null
     # coder.securityContext.seccompProfile -- Sets the seccomp profile for
     # the coder container.


### PR DESCRIPTION
the prior default of `readOnlyRootFilesystem: true` is a regression, and causes installs to fail with:

```
create cache directory: mkdir /home/coder/.cache: read-only file system
Run 'coder server --help' for usage.    
```
