### PR TITLE
ci: Add support for release/experimental label

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -236,3 +236,7 @@ Breaking changes can be triggered in two ways:
 ### Security
 
 The [`security`](https://github.com/coder/coder/issues?q=sort%3Aupdated-desc+label%3Asecurity) label can be added to PRs that have, or will be, merged into `main`. Doing so will make sure the change stands out in the release notes.
+
+### Experimental
+
+The [`release/experimental`](https://github.com/coder/coder/issues?q=sort%3Aupdated-desc+label%3Arelease%2Fexperimental) label can be used to move the note to the bottom of the release notes under a separate title.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,6 +25,7 @@ either contain a known prefix with an exclamation mark ("feat!:",
 GitHub labels that affect release notes:
 
 - release/breaking: Shown under BREAKING CHANGES, prevents patch release.
+- release/experimental: Shown at the bottom under Experimental.
 - security: Shown under SECURITY.
 
 Flags:

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -48,9 +48,12 @@ main() {
 	breaking_title="^[a-z]+(\([a-z]*\))?!:"
 	breaking_label=release/breaking
 	breaking_category=breaking
+	experimental_label=release/experimental
+	experimental_category=experimental
 
 	# Security related changes are labeled `security`.
 	security_label=security
+	security_category=security
 
 	# Get abbreviated and full commit hashes and titles for each commit.
 	git_log_out="$(git log --no-merges --pretty=format:"%h %H %s" "$range")"
@@ -120,7 +123,10 @@ main() {
 			COMMIT_METADATA_BREAKING=1
 			continue
 		elif [[ ${labels[$commit_sha_long]:-} = *"label:$security_label"* ]]; then
-			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$security_label
+			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$security_category
+			continue
+		elif [[ ${labels[$commit_sha_long]:-} = *"label:$experimental_label"* ]]; then
+			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$experimental_category
 			continue
 		fi
 

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -137,7 +137,7 @@ changelog="$(
 		if ((${#changes} > 0)); then
 			echo -e "\n### ${section_titles["$cat"]}\n"
 			if [[ $cat == experimental ]]; then
-				echo -e "These features or changes are experimental and may change or be removed in future releases.\n"
+				echo -e "These changes are feature-flagged and can be enabled with the `--experiments` server flag. They may change or be removed in future releases.\n"
 			fi
 			echo -e "$changes"
 		fi

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -137,7 +137,7 @@ changelog="$(
 		if ((${#changes} > 0)); then
 			echo -e "\n### ${section_titles["$cat"]}\n"
 			if [[ $cat == experimental ]]; then
-				echo -e "These changes are feature-flagged and can be enabled with the `--experiments` server flag. They may change or be removed in future releases.\n"
+				echo -e "These changes are feature-flagged and can be enabled with the \`--experiments\` server flag. They may change or be removed in future releases.\n"
 			fi
 			echo -e "$changes"
 		fi

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -81,6 +81,7 @@ declare -a section_order=(
 	chore
 	revert
 	other
+	experimental
 )
 
 declare -A section_titles=(
@@ -97,6 +98,7 @@ declare -A section_titles=(
 	[chore]='Chores'
 	[revert]='Reverts'
 	[other]='Other changes'
+	[experimental]='Experimental changes'
 )
 
 # Verify that all items in section_order exist as keys in section_titles and
@@ -134,6 +136,9 @@ changelog="$(
 		changes="$(eval "echo -e \"\${${cat}_changelog:-}\"")"
 		if ((${#changes} > 0)); then
 			echo -e "\n### ${section_titles["$cat"]}\n"
+			if [[ $cat == experimental ]]; then
+				echo -e "These features or changes are experimental and may change or be removed in future releases.\n"
+			fi
 			echo -e "$changes"
 		fi
 	done


### PR DESCRIPTION
Example after tagging one of my PRs that went in to v0.17.2.

```md
### Other changes

- 22f6400ea helm: add deployment securityContext values (#6136) (@ericpaulsen)

### Experimental changes

These features or changes are experimental and may change or be removed in future releases.

- 860e2829c fix: Prevent race between provisionerd connect and close (#6206) (@mafredri)

Compare: [`v0.17.1...v0.17.2`](https://github.com/coder/coder/compare/v0.17.1...v0.17.2)
```
