### PR TITLE
docs: feature stages

### DIFF
--- a/docs/contributing/feature-stages.md
+++ b/docs/contributing/feature-stages.md
@@ -1,0 +1,25 @@
+# Feature stages
+
+Some Coder features are released as Alpha or Experimental.
+
+## Alpha features
+
+Alpha features are enabled in all Coder deployments but the feature is subject to change, or even be removed. Breaking changes may not be documented in the changelog. In most cases, features will only stay in alpha for 1 month.
+
+We recommend using [GitHub issues](https://github.com/coder/coder/issues) to leave feedback and get support for alpha features.
+
+## Experimental features
+
+These features are disabled by default, and not recommended for use in production as they may cause performance or stability issues. In most cases, features will only stay in experimental for 1-2 weeks of internal testing.
+
+```yaml
+# Enable all experimental features
+coder server --experiments=*
+
+# Enable multiple experimental features
+coder server --experiments=feature1,feature2
+
+# Alternatively, use the `CODER_EXPERIMENTS` environment variable.
+```
+
+Visit `https://<your-coder-url>/api/v2/experiments` to see which experimental features are available for your deployment.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -319,6 +319,11 @@
           "path": "./contributing/CODE_OF_CONDUCT.md"
         },
         {
+          "title": "Feature stages",
+          "description": "Policies for Alpha and Experimental features.",
+          "path": "./contributing/feature-stages.md"
+        },
+        {
           "title": "Documentation",
           "description": "Our style guide for use when authoring documentation",
           "path": "./contributing/documentation.md"


### PR DESCRIPTION
With #6114 being our first alpha feature, I'd like to document what mandates an alpha vs. an experimental feature and what our general timeframe is for each. The main problem I'd like to avoid is a feature staying in alpha forever with no clear criteria for GA/deletion. 

I describe my workflow for experiments [here](https://github.com/coder/coder/pull/5767#pullrequestreview-1254045715). TLDR: I have a weekly calendar event to review features. I'll start doing the same for alpha features.