### PR TITLE
fix: actually test `httpapi.WebsocketCloseSprintf`

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -182,7 +182,7 @@ func WebsocketCloseSprintf(format string, vars ...any) string {
 	if len(msg) > websocketCloseMaxLen {
 		// Trim the string to 123 bytes. If we accidentally cut in the middle of
 		// a UTF-8 character, remove it from the string.
-		return strings.ToValidUTF8(string(msg[123]), "")
+		return strings.ToValidUTF8(msg[:websocketCloseMaxLen], "")
 	}
 
 	return msg

--- a/coderd/httpapi/httpapi_test.go
+++ b/coderd/httpapi/httpapi_test.go
@@ -122,7 +122,7 @@ func TestRead(t *testing.T) {
 	})
 }
 
-func WebsocketCloseMsg(t *testing.T) {
+func TestWebsocketCloseMsg(t *testing.T) {
 	t.Parallel()
 
 	t.Run("TruncateSingleByteCharacters", func(t *testing.T) {
@@ -130,7 +130,7 @@ func WebsocketCloseMsg(t *testing.T) {
 
 		msg := strings.Repeat("d", 255)
 		trunc := httpapi.WebsocketCloseSprintf(msg)
-		assert.LessOrEqual(t, len(trunc), 123)
+		assert.Equal(t, len(trunc), 123)
 	})
 
 	t.Run("TruncateMultiByteCharacters", func(t *testing.T) {
@@ -138,6 +138,6 @@ func WebsocketCloseMsg(t *testing.T) {
 
 		msg := strings.Repeat("こんにちは", 10)
 		trunc := httpapi.WebsocketCloseSprintf(msg)
-		assert.LessOrEqual(t, len(trunc), 123)
+		assert.Equal(t, len(trunc), 123)
 	})
 }

--- a/coderd/httpapi/httpapi_test.go
+++ b/coderd/httpapi/httpapi_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -124,6 +125,19 @@ func TestRead(t *testing.T) {
 
 func TestWebsocketCloseMsg(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Sprintf", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			msg  = "this is my message %q %q"
+			opts = []any{"colin", "kyle"}
+		)
+
+		expected := fmt.Sprintf(msg, opts...)
+		got := httpapi.WebsocketCloseSprintf(msg, opts...)
+		assert.Equal(t, expected, got)
+	})
 
 	t.Run("TruncateSingleByteCharacters", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Tests didn't run because it wasn't prefixed with `Test`.

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
