### PR TITLE
fix: install terraform in base Docker image

### DIFF
--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -6,10 +6,12 @@ Coder can run in offline / air-gapped environments.
 
 First, build and push a container image extending our official image with the following:
 
-- Terraform [(supported versions)](https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24)
 - CLI config (.tfrc) for Terraform referring to [external mirror](https://www.terraform.io/cli/config/config-file#explicit-installation-method-configuration)
 - [Terraform Providers](https://registry.terraform.io) for templates
   - These could also be specified via a volume mount (Docker) or [network mirror](https://www.terraform.io/internals/provider-network-mirror-protocol). See below for details.
+
+> Note: Coder includes the latest [supported version](https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24) of Terraform in the official Docker images.
+> If you need to bundle a different version of terraform, you can do so by customizing the image.
 
 Here's an example:
 
@@ -24,13 +26,16 @@ RUN apk add curl unzip
 # Create directory for the Terraform CLI (and assets)
 RUN mkdir -p /opt/terraform
 
-# In order to run Coder airgapped or within private networks,
-# Terraform has to be bundled into the image in PATH or /opt.
-#
+# Terraform is already included in the official Coder image.
+# See https://github.com/coder/coder/blob/main/scripts/Dockerfile.base#L15
+# If you need to install a different version of Terraform, you can do so here.
+# The below step is optional if you wish to keep the existing version.
 # See https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24
 # for supported Terraform versions.
 ARG TERRAFORM_VERSION=1.3.0
-RUN curl -LOs https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+RUN apk update && \
+    apk del terraform && \
+    curl -LOs https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
     && unzip -o terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
     && mv terraform /opt/terraform \
     && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip

--- a/provisioner/terraform/install.go
+++ b/provisioner/terraform/install.go
@@ -18,6 +18,7 @@ import (
 var (
 	// TerraformVersion is the version of Terraform used internally
 	// when Terraform is not available on the system.
+	// NOTE: Keep this in sync with the version in scripts/Dockerfile.base.
 	TerraformVersion = version.Must(version.NewVersion("1.3.4"))
 
 	minTerraformVersion = version.Must(version.NewVersion("1.1.0"))

--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
 		wget \
 		bash \
 		git \
-		openssh-client && \
+		openssh-client \
+		terraform && \
 	addgroup \
 		-g 1000 \
 		coder && \

--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -4,6 +4,8 @@
 FROM alpine:latest
 
 # We use a single RUN command to reduce the number of layers in the image.
+# NOTE: Keep the Terraform version in sync with minTerraformVersion and
+# maxTerraformVersion in provisioner/terraform/install.go.
 RUN apk add --no-cache \
 		curl \
 		wget \
@@ -21,25 +23,6 @@ RUN apk add --no-cache \
 		-u 1000 \
 		-G coder \
 		coder
-
-# Install Terraform plugins
-RUN mkdir -p /opt/terraform/plugins/registry.terraform.io
-# Add config for local terraform
-ADD files/terraform-config.tfrc /opt/terraform/config.tfrc
-ARG CODER_PROVIDER_VERSION=0.6.12
-RUN mkdir -p /opt/terraform/plugins/registry.terraform.io/coder/coder
-WORKDIR /opt/terraform/plugins/registry.terraform.io/coder/coder
-RUN curl -LOs https://github.com/coder/terraform-provider-coder/releases/download/v${CODER_PROVIDER_VERSION}/terraform-provider-coder_${CODER_PROVIDER_VERSION}_linux_amd64.zip
-ARG DOCKER_PROVIDER_VERSION=3.0.1
-RUN mkdir -p /opt/terraform/plugins/registry.terraform.io/kreuzwerker/docker
-WORKDIR /opt/terraform/plugins/registry.terraform.io/kreuzwerker/docker
-RUN curl -LOs https://github.com/kreuzwerker/terraform-provider-docker/releases/download/v${DOCKER_PROVIDER_VERSION}/terraform-provider-docker_${DOCKER_PROVIDER_VERSION}_linux_amd64.zip
-RUN chown -R coder:coder /opt/terraform/plugins
-ARG KUBERNETES_PROVIDER_VERSION=2.18.0
-RUN mkdir -p /opt/terraform/plugins/registry.terraform.io/hashicorp/kubernetes
-WORKDIR /opt/terraform/plugins/registry.terraform.io/hashicorp/kubernetes
-# TODO: What is the URL?
-RUN curl -LOs $KUBERNETES_URL_GOES_HERE
 
 USER 1000:1000
 ENV HOME=/home/coder

--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
 		bash \
 		git \
 		openssh-client \
-		terraform && \
+		terraform=1.3.4-r2 && \
 	addgroup \
 		-g 1000 \
 		coder && \
@@ -21,6 +21,25 @@ RUN apk add --no-cache \
 		-u 1000 \
 		-G coder \
 		coder
+
+# Install Terraform plugins
+RUN mkdir -p /opt/terraform/plugins/registry.terraform.io
+# Add config for local terraform
+ADD files/terraform-config.tfrc /opt/terraform/config.tfrc
+ARG CODER_PROVIDER_VERSION=0.6.12
+RUN mkdir -p /opt/terraform/plugins/registry.terraform.io/coder/coder
+WORKDIR /opt/terraform/plugins/registry.terraform.io/coder/coder
+RUN curl -LOs https://github.com/coder/terraform-provider-coder/releases/download/v${CODER_PROVIDER_VERSION}/terraform-provider-coder_${CODER_PROVIDER_VERSION}_linux_amd64.zip
+ARG DOCKER_PROVIDER_VERSION=3.0.1
+RUN mkdir -p /opt/terraform/plugins/registry.terraform.io/kreuzwerker/docker
+WORKDIR /opt/terraform/plugins/registry.terraform.io/kreuzwerker/docker
+RUN curl -LOs https://github.com/kreuzwerker/terraform-provider-docker/releases/download/v${DOCKER_PROVIDER_VERSION}/terraform-provider-docker_${DOCKER_PROVIDER_VERSION}_linux_amd64.zip
+RUN chown -R coder:coder /opt/terraform/plugins
+ARG KUBERNETES_PROVIDER_VERSION=2.18.0
+RUN mkdir -p /opt/terraform/plugins/registry.terraform.io/hashicorp/kubernetes
+WORKDIR /opt/terraform/plugins/registry.terraform.io/hashicorp/kubernetes
+# TODO: What is the URL?
+RUN curl -LOs $KUBERNETES_URL_GOES_HERE
 
 USER 1000:1000
 ENV HOME=/home/coder

--- a/scripts/files/terraform-config.tfrc
+++ b/scripts/files/terraform-config.tfrc
@@ -1,0 +1,5 @@
+provider_installation {
+  filesystem_mirror {
+    path = "/opt/terraform/plugins"
+  }
+}

--- a/scripts/files/terraform-config.tfrc
+++ b/scripts/files/terraform-config.tfrc
@@ -1,5 +1,0 @@
-provider_installation {
-  filesystem_mirror {
-    path = "/opt/terraform/plugins"
-  }
-}


### PR DESCRIPTION
This PR adds terraform to all Coder base images. It's a required dependency so it makes sense to bundle it with the image. 

~Still TODO: providers and plugins~
Not bundling providers at this time.

Fixes https://github.com/coder/coder/issues/6258