### PR TITLE
chore: add resource reqs/limits on K8s template

### DIFF
--- a/examples/templates/kubernetes-with-podman/main.tf
+++ b/examples/templates/kubernetes-with-podman/main.tf
@@ -26,6 +26,34 @@ variable "os" {
   default = "ubuntu"
 }
 
+variable "cpu" {
+  description = "CPU (__ cores)"
+  default     = 2
+  validation {
+    condition = contains([
+      "2",
+      "4",
+      "6",
+      "8"
+    ], var.cpu)
+    error_message = "Invalid cpu!"
+  }
+}
+
+variable "memory" {
+  description = "Memory (__ GB)"
+  default     = 2
+  validation {
+    condition = contains([
+      "2",
+      "4",
+      "6",
+      "8"
+    ], var.memory)
+    error_message = "Invalid memory!"
+  }
+}
+
 resource "coder_agent" "dev" {
   os             = "linux"
   arch           = "amd64"
@@ -80,10 +108,17 @@ resource "kubernetes_pod" "main" {
         run_as_user = "1000"
       }
       resources {
+        requests = {
+          "cpu"    = "250m"
+          "memory" = "500Mi"
+        }
         limits = {
           # Acquire a FUSE device, powered by smarter-device-manager
           "github.com/fuse" : 1
+          cpu    = "${var.cpu}"
+          memory = "${var.memory}Gi"
         }
+
       }
       env {
         name  = "CODER_AGENT_TOKEN"

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -31,6 +31,34 @@ variable "namespace" {
   description = "The Kubernetes namespace to create workspaces in (must exist prior to creating workspaces)"
 }
 
+variable "cpu" {
+  description = "CPU (__ cores)"
+  default     = 2
+  validation {
+    condition = contains([
+      "2",
+      "4",
+      "6",
+      "8"
+    ], var.cpu)
+    error_message = "Invalid cpu!"
+  }
+}
+
+variable "memory" {
+  description = "Memory (__ GB)"
+  default     = 2
+  validation {
+    condition = contains([
+      "2",
+      "4",
+      "6",
+      "8"
+    ], var.memory)
+    error_message = "Invalid memory!"
+  }
+}
+
 variable "home_disk_size" {
   type        = number
   description = "How large would you like your home volume to be (in GB)?"
@@ -146,6 +174,16 @@ resource "kubernetes_pod" "main" {
       env {
         name  = "CODER_AGENT_TOKEN"
         value = coder_agent.main.token
+      }
+      resources {
+        requests = {
+          "cpu"    = "250m"
+          "memory" = "512Mi"
+        }
+        limits = {
+          "cpu"    = "${var.cpu}"
+          "memory" = "${var.memory}Gi"
+        }
       }
       volume_mount {
         mount_path = "/home/coder"


### PR DESCRIPTION
sets CPU/Mem requests & limits on the K8s pod examples. this ensures that the pod will run in OpenShift clusters, which usually require pods to set resource constraints.
