### PR TITLE
fix: don't log disconnect error when the database is shutting down

### DIFF
--- a/coderd/database/errors.go
+++ b/coderd/database/errors.go
@@ -27,3 +27,13 @@ func IsUniqueViolation(err error, uniqueConstraints ...UniqueConstraint) bool {
 
 	return false
 }
+
+// IsQueryCanceledError checks if the error is due to a query being canceled.
+func IsQueryCanceledError(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code.Name() == "query_canceled"
+	}
+
+	return false
+}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -644,7 +644,9 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 			// This is a bug with unit tests that cancel the app context and
 			// cause this error log to be generated. We should fix the unit tests
 			// as this is a valid log.
-			if !xerrors.Is(err, context.Canceled) {
+			//
+			// The pq error occurs when the server is shutting down.
+			if !xerrors.Is(err, context.Canceled) && err.Error() != "pq: canceling statement due to user request" {
 				api.Logger.Error(ctx, "failed to update agent disconnect time",
 					slog.Error(err),
 					slog.F("workspace", build.WorkspaceID),

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -646,7 +646,7 @@ func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request
 			// as this is a valid log.
 			//
 			// The pq error occurs when the server is shutting down.
-			if !xerrors.Is(err, context.Canceled) && err.Error() != "pq: canceling statement due to user request" {
+			if !xerrors.Is(err, context.Canceled) && !database.IsQueryCanceledError(err) {
 				api.Logger.Error(ctx, "failed to update agent disconnect time",
 					slog.Error(err),
 					slog.F("workspace", build.WorkspaceID),


### PR DESCRIPTION
Seen in: https://github.com/coder/coder/actions/runs/4244980490/jobs/7379867681
