### PR TITLE
feat: Enable custom support links

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -570,6 +570,15 @@ func newConfig() *codersdk.DeploymentConfig {
 			Flag:    "disable-password-auth",
 			Default: false,
 		},
+		Support: &codersdk.SupportConfig{
+			Links: &codersdk.DeploymentConfigField[[]codersdk.LinkConfig]{
+				Name:       "Support links",
+				Usage:      "Use custom support links",
+				Flag:       "support-links",
+				Default:    []codersdk.LinkConfig{},
+				Enterprise: true,
+			},
+		},
 	}
 }
 
@@ -648,6 +657,10 @@ func setConfig(prefix string, vip *viper.Viper, target interface{}) {
 		case []codersdk.GitAuthConfig:
 			// Do not bind to CODER_GITAUTH, instead bind to CODER_GITAUTH_0_*, etc.
 			values := readSliceFromViper[codersdk.GitAuthConfig](vip, prefix, value)
+			val.FieldByName("Value").Set(reflect.ValueOf(values))
+		case []codersdk.LinkConfig:
+			// Do not bind to CODER_SUPPORT_LINKS, instead bind to CODER_SUPPORT_LINKS_0_*, etc.
+			values := readSliceFromViper[codersdk.LinkConfig](vip, prefix, value)
 			val.FieldByName("Value").Set(reflect.ValueOf(values))
 		default:
 			panic(fmt.Sprintf("unsupported type %T", value))
@@ -824,6 +837,8 @@ func setFlags(prefix string, flagset *pflag.FlagSet, vip *viper.Viper, target in
 			_ = flagset.DurationP(flg, shorthand, vip.GetDuration(prefix), usage)
 		case []string:
 			_ = flagset.StringSliceP(flg, shorthand, vip.GetStringSlice(prefix), usage)
+		case []codersdk.LinkConfig:
+			// Ignore this one!
 		case []codersdk.GitAuthConfig:
 			// Ignore this one!
 		default:

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -223,6 +223,29 @@ func TestConfig(t *testing.T) {
 			}}, config.GitAuth.Value)
 		},
 	}, {
+		Name: "Support links",
+		Env: map[string]string{
+			"CODER_SUPPORT_LINKS_0_NAME":   "First link",
+			"CODER_SUPPORT_LINKS_0_TARGET": "http://target-link-1",
+			"CODER_SUPPORT_LINKS_0_ICON":   "bug",
+
+			"CODER_SUPPORT_LINKS_1_NAME":   "Second link",
+			"CODER_SUPPORT_LINKS_1_TARGET": "http://target-link-2",
+			"CODER_SUPPORT_LINKS_1_ICON":   "chat",
+		},
+		Valid: func(config *codersdk.DeploymentConfig) {
+			require.Len(t, config.Support.Links.Value, 2)
+			require.Equal(t, []codersdk.LinkConfig{{
+				Name:   "First link",
+				Target: "http://target-link-1",
+				Icon:   "bug",
+			}, {
+				Name:   "Second link",
+				Target: "http://target-link-2",
+				Icon:   "chat",
+			}}, config.Support.Links.Value)
+		},
+	}, {
 		Name: "Wrong env must not break default values",
 		Env: map[string]string{
 			"CODER_PROMETHEUS_ENABLE": "true",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -93,7 +93,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/codersdk.AppearanceConfig"
+                            "$ref": "#/definitions/codersdk.UpdateAppearanceConfig"
                         }
                     }
                 ],
@@ -101,7 +101,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/codersdk.AppearanceConfig"
+                            "$ref": "#/definitions/codersdk.UpdateAppearanceConfig"
                         }
                     }
                 }
@@ -7861,6 +7861,17 @@ const docTemplate = `{
                 "id": {
                     "type": "string",
                     "format": "uuid"
+                }
+            }
+        },
+        "codersdk.UpdateAppearanceConfig": {
+            "type": "object",
+            "properties": {
+                "logo_url": {
+                    "type": "string"
+                },
+                "service_banner": {
+                    "$ref": "#/definitions/codersdk.ServiceBannerConfig"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5379,6 +5379,12 @@ const docTemplate = `{
                 },
                 "service_banner": {
                     "$ref": "#/definitions/codersdk.ServiceBannerConfig"
+                },
+                "support_links": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.LinkConfig"
+                    }
                 }
             }
         },
@@ -6196,6 +6202,9 @@ const docTemplate = `{
                 "strict_transport_security_options": {
                     "$ref": "#/definitions/codersdk.DeploymentConfigField-array_string"
                 },
+                "support": {
+                    "$ref": "#/definitions/codersdk.SupportConfig"
+                },
                 "swagger": {
                     "$ref": "#/definitions/codersdk.SwaggerConfig"
                 },
@@ -6250,6 +6259,44 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/codersdk.GitAuthConfig"
+                    }
+                }
+            }
+        },
+        "codersdk.DeploymentConfigField-array_codersdk_LinkConfig": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.LinkConfig"
+                    }
+                },
+                "enterprise": {
+                    "type": "boolean"
+                },
+                "flag": {
+                    "type": "string"
+                },
+                "hidden": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "secret": {
+                    "type": "boolean"
+                },
+                "shorthand": {
+                    "type": "string"
+                },
+                "usage": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.LinkConfig"
                     }
                 }
             }
@@ -6648,6 +6695,20 @@ const docTemplate = `{
                 "uuid": {
                     "type": "string",
                     "format": "uuid"
+                }
+            }
+        },
+        "codersdk.LinkConfig": {
+            "type": "object",
+            "properties": {
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "string"
                 }
             }
         },
@@ -7359,6 +7420,14 @@ const docTemplate = `{
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.SupportConfig": {
+            "type": "object",
+            "properties": {
+                "links": {
+                    "$ref": "#/definitions/codersdk.DeploymentConfigField-array_codersdk_LinkConfig"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4760,6 +4760,12 @@
         },
         "service_banner": {
           "$ref": "#/definitions/codersdk.ServiceBannerConfig"
+        },
+        "support_links": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.LinkConfig"
+          }
         }
       }
     },
@@ -5516,6 +5522,9 @@
         "strict_transport_security_options": {
           "$ref": "#/definitions/codersdk.DeploymentConfigField-array_string"
         },
+        "support": {
+          "$ref": "#/definitions/codersdk.SupportConfig"
+        },
         "swagger": {
           "$ref": "#/definitions/codersdk.SwaggerConfig"
         },
@@ -5570,6 +5579,44 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/codersdk.GitAuthConfig"
+          }
+        }
+      }
+    },
+    "codersdk.DeploymentConfigField-array_codersdk_LinkConfig": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.LinkConfig"
+          }
+        },
+        "enterprise": {
+          "type": "boolean"
+        },
+        "flag": {
+          "type": "string"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "boolean"
+        },
+        "shorthand": {
+          "type": "string"
+        },
+        "usage": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.LinkConfig"
           }
         }
       }
@@ -5958,6 +6005,20 @@
         "uuid": {
           "type": "string",
           "format": "uuid"
+        }
+      }
+    },
+    "codersdk.LinkConfig": {
+      "type": "object",
+      "properties": {
+        "icon": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
         }
       }
     },
@@ -6605,6 +6666,14 @@
         },
         "message": {
           "type": "string"
+        }
+      }
+    },
+    "codersdk.SupportConfig": {
+      "type": "object",
+      "properties": {
+        "links": {
+          "$ref": "#/definitions/codersdk.DeploymentConfigField-array_codersdk_LinkConfig"
         }
       }
     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -71,7 +71,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/codersdk.AppearanceConfig"
+              "$ref": "#/definitions/codersdk.UpdateAppearanceConfig"
             }
           }
         ],
@@ -79,7 +79,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/codersdk.AppearanceConfig"
+              "$ref": "#/definitions/codersdk.UpdateAppearanceConfig"
             }
           }
         }
@@ -7077,6 +7077,17 @@
         "id": {
           "type": "string",
           "format": "uuid"
+        }
+      }
+    },
+    "codersdk.UpdateAppearanceConfig": {
+      "type": "object",
+      "properties": {
+        "logo_url": {
+          "type": "string"
+        },
+        "service_banner": {
+          "$ref": "#/definitions/codersdk.ServiceBannerConfig"
         }
       }
     },

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -363,6 +363,11 @@ type AppearanceConfig struct {
 	SupportLinks  []LinkConfig        `json:"support_links,omitempty"`
 }
 
+type UpdateAppearanceConfig struct {
+	LogoURL       string              `json:"logo_url"`
+	ServiceBanner ServiceBannerConfig `json:"service_banner"`
+}
+
 type ServiceBannerConfig struct {
 	Enabled         bool   `json:"enabled"`
 	Message         string `json:"message,omitempty"`
@@ -384,7 +389,7 @@ func (c *Client) Appearance(ctx context.Context) (AppearanceConfig, error) {
 	return cfg, json.NewDecoder(res.Body).Decode(&cfg)
 }
 
-func (c *Client) UpdateAppearance(ctx context.Context, appearance AppearanceConfig) error {
+func (c *Client) UpdateAppearance(ctx context.Context, appearance UpdateAppearanceConfig) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/v2/appearance", appearance)
 	if err != nil {
 		return err

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -285,7 +285,7 @@ type SupportConfig struct {
 type LinkConfig struct {
 	Name   string `json:"name"`
 	Target string `json:"target"`
-	Icon   string `json:"icon,omitempty"`
+	Icon   string `json:"icon"`
 }
 
 type Flaggable interface {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -153,6 +153,8 @@ type DeploymentConfig struct {
 	Address *DeploymentConfigField[string] `json:"address" typescript:",notnull"`
 	// DEPRECATED: Use Experiments instead.
 	Experimental *DeploymentConfigField[bool] `json:"experimental" typescript:",notnull"`
+
+	Support *SupportConfig `json:"support" typescript:",notnull"`
 }
 
 type DERP struct {
@@ -276,8 +278,18 @@ type DangerousConfig struct {
 	AllowPathAppSiteOwnerAccess *DeploymentConfigField[bool] `json:"allow_path_app_site_owner_access" typescript:",notnull"`
 }
 
+type SupportConfig struct {
+	Links *DeploymentConfigField[[]LinkConfig] `json:"links" typescript:",notnull"`
+}
+
+type LinkConfig struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+	Icon   string `json:"icon,omitempty"`
+}
+
 type Flaggable interface {
-	string | time.Duration | bool | int | []string | []GitAuthConfig
+	string | time.Duration | bool | int | []string | []GitAuthConfig | []LinkConfig
 }
 
 type DeploymentConfigField[T Flaggable] struct {
@@ -348,6 +360,7 @@ func (c *Client) DeploymentConfig(ctx context.Context) (DeploymentConfig, error)
 type AppearanceConfig struct {
 	LogoURL       string              `json:"logo_url"`
 	ServiceBanner ServiceBannerConfig `json:"service_banner"`
+	SupportLinks  []LinkConfig        `json:"support_links,omitempty"`
 }
 
 type ServiceBannerConfig struct {

--- a/docs/api/enterprise.md
+++ b/docs/api/enterprise.md
@@ -24,7 +24,14 @@ curl -X GET http://coder-server:8080/api/v2/appearance \
     "background_color": "string",
     "enabled": true,
     "message": "string"
-  }
+  },
+  "support_links": [
+    {
+      "icon": "string",
+      "name": "string",
+      "target": "string"
+    }
+  ]
 }
 ```
 
@@ -59,7 +66,14 @@ curl -X PUT http://coder-server:8080/api/v2/appearance \
     "background_color": "string",
     "enabled": true,
     "message": "string"
-  }
+  },
+  "support_links": [
+    {
+      "icon": "string",
+      "name": "string",
+      "target": "string"
+    }
+  ]
 }
 ```
 
@@ -80,7 +94,14 @@ curl -X PUT http://coder-server:8080/api/v2/appearance \
     "background_color": "string",
     "enabled": true,
     "message": "string"
-  }
+  },
+  "support_links": [
+    {
+      "icon": "string",
+      "name": "string",
+      "target": "string"
+    }
+  ]
 }
 ```
 

--- a/docs/api/enterprise.md
+++ b/docs/api/enterprise.md
@@ -66,22 +66,15 @@ curl -X PUT http://coder-server:8080/api/v2/appearance \
     "background_color": "string",
     "enabled": true,
     "message": "string"
-  },
-  "support_links": [
-    {
-      "icon": "string",
-      "name": "string",
-      "target": "string"
-    }
-  ]
+  }
 }
 ```
 
 ### Parameters
 
-| Name   | In   | Type                                                             | Required | Description               |
-| ------ | ---- | ---------------------------------------------------------------- | -------- | ------------------------- |
-| `body` | body | [codersdk.AppearanceConfig](schemas.md#codersdkappearanceconfig) | true     | Update appearance request |
+| Name   | In   | Type                                                                         | Required | Description               |
+| ------ | ---- | ---------------------------------------------------------------------------- | -------- | ------------------------- |
+| `body` | body | [codersdk.UpdateAppearanceConfig](schemas.md#codersdkupdateappearanceconfig) | true     | Update appearance request |
 
 ### Example responses
 
@@ -94,22 +87,15 @@ curl -X PUT http://coder-server:8080/api/v2/appearance \
     "background_color": "string",
     "enabled": true,
     "message": "string"
-  },
-  "support_links": [
-    {
-      "icon": "string",
-      "name": "string",
-      "target": "string"
-    }
-  ]
+  }
 }
 ```
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                           |
-| ------ | ------------------------------------------------------- | ----------- | ---------------------------------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.AppearanceConfig](schemas.md#codersdkappearanceconfig) |
+| Status | Meaning                                                 | Description | Schema                                                                       |
+| ------ | ------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UpdateAppearanceConfig](schemas.md#codersdkupdateappearanceconfig) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -879,6 +879,31 @@ curl -X GET http://coder-server:8080/api/v2/config/deployment \
     "usage": "string",
     "value": ["string"]
   },
+  "support": {
+    "links": {
+      "default": [
+        {
+          "icon": "string",
+          "name": "string",
+          "target": "string"
+        }
+      ],
+      "enterprise": true,
+      "flag": "string",
+      "hidden": true,
+      "name": "string",
+      "secret": true,
+      "shorthand": "string",
+      "usage": "string",
+      "value": [
+        {
+          "icon": "string",
+          "name": "string",
+          "target": "string"
+        }
+      ]
+    }
+  },
   "swagger": {
     "enable": {
       "default": true,

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -440,7 +440,14 @@
     "background_color": "string",
     "enabled": true,
     "message": "string"
-  }
+  },
+  "support_links": [
+    {
+      "icon": "string",
+      "name": "string",
+      "target": "string"
+    }
+  ]
 }
 ```
 
@@ -450,6 +457,7 @@
 | ---------------- | ------------------------------------------------------------ | -------- | ------------ | ----------- |
 | `logo_url`       | string                                                       | false    |              |             |
 | `service_banner` | [codersdk.ServiceBannerConfig](#codersdkservicebannerconfig) | false    |              |             |
+| `support_links`  | array of [codersdk.LinkConfig](#codersdklinkconfig)          | false    |              |             |
 
 ## codersdk.AssignableRoles
 
@@ -2285,6 +2293,31 @@ CreateParameterRequest is a structure used to create a new parameter value for a
     "usage": "string",
     "value": ["string"]
   },
+  "support": {
+    "links": {
+      "default": [
+        {
+          "icon": "string",
+          "name": "string",
+          "target": "string"
+        }
+      ],
+      "enterprise": true,
+      "flag": "string",
+      "hidden": true,
+      "name": "string",
+      "secret": true,
+      "shorthand": "string",
+      "usage": "string",
+      "value": [
+        {
+          "icon": "string",
+          "name": "string",
+          "target": "string"
+        }
+      ]
+    }
+  },
   "swagger": {
     "enable": {
       "default": true,
@@ -2546,6 +2579,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `ssh_keygen_algorithm`               | [codersdk.DeploymentConfigField-string](#codersdkdeploymentconfigfield-string)                                             | false    |              |                                                 |
 | `strict_transport_security`          | [codersdk.DeploymentConfigField-int](#codersdkdeploymentconfigfield-int)                                                   | false    |              |                                                 |
 | `strict_transport_security_options`  | [codersdk.DeploymentConfigField-array_string](#codersdkdeploymentconfigfield-array_string)                                 | false    |              |                                                 |
+| `support`                            | [codersdk.SupportConfig](#codersdksupportconfig)                                                                           | false    |              |                                                 |
 | `swagger`                            | [codersdk.SwaggerConfig](#codersdkswaggerconfig)                                                                           | false    |              |                                                 |
 | `telemetry`                          | [codersdk.TelemetryConfig](#codersdktelemetryconfig)                                                                       | false    |              |                                                 |
 | `tls`                                | [codersdk.TLSConfig](#codersdktlsconfig)                                                                                   | false    |              |                                                 |
@@ -2606,6 +2640,48 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `shorthand`  | string                                                    | false    |              |             |
 | `usage`      | string                                                    | false    |              |             |
 | `value`      | array of [codersdk.GitAuthConfig](#codersdkgitauthconfig) | false    |              |             |
+
+## codersdk.DeploymentConfigField-array_codersdk_LinkConfig
+
+```json
+{
+  "default": [
+    {
+      "icon": "string",
+      "name": "string",
+      "target": "string"
+    }
+  ],
+  "enterprise": true,
+  "flag": "string",
+  "hidden": true,
+  "name": "string",
+  "secret": true,
+  "shorthand": "string",
+  "usage": "string",
+  "value": [
+    {
+      "icon": "string",
+      "name": "string",
+      "target": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name         | Type                                                | Required | Restrictions | Description |
+| ------------ | --------------------------------------------------- | -------- | ------------ | ----------- |
+| `default`    | array of [codersdk.LinkConfig](#codersdklinkconfig) | false    |              |             |
+| `enterprise` | boolean                                             | false    |              |             |
+| `flag`       | string                                              | false    |              |             |
+| `hidden`     | boolean                                             | false    |              |             |
+| `name`       | string                                              | false    |              |             |
+| `secret`     | boolean                                             | false    |              |             |
+| `shorthand`  | string                                              | false    |              |             |
+| `usage`      | string                                              | false    |              |             |
+| `value`      | array of [codersdk.LinkConfig](#codersdklinkconfig) | false    |              |             |
 
 ## codersdk.DeploymentConfigField-array_string
 
@@ -3042,6 +3118,24 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `id`          | integer | false    |              |                                                                                                                                                                                                        |
 | `uploaded_at` | string  | false    |              |                                                                                                                                                                                                        |
 | `uuid`        | string  | false    |              |                                                                                                                                                                                                        |
+
+## codersdk.LinkConfig
+
+```json
+{
+  "icon": "string",
+  "name": "string",
+  "target": "string"
+}
+```
+
+### Properties
+
+| Name     | Type   | Required | Restrictions | Description |
+| -------- | ------ | -------- | ------------ | ----------- |
+| `icon`   | string | false    |              |             |
+| `name`   | string | false    |              |             |
+| `target` | string | false    |              |             |
 
 ## codersdk.LogLevel
 
@@ -4119,6 +4213,42 @@ Parameter represents a set value for the scope.
 | `background_color` | string  | false    |              |             |
 | `enabled`          | boolean | false    |              |             |
 | `message`          | string  | false    |              |             |
+
+## codersdk.SupportConfig
+
+```json
+{
+  "links": {
+    "default": [
+      {
+        "icon": "string",
+        "name": "string",
+        "target": "string"
+      }
+    ],
+    "enterprise": true,
+    "flag": "string",
+    "hidden": true,
+    "name": "string",
+    "secret": true,
+    "shorthand": "string",
+    "usage": "string",
+    "value": [
+      {
+        "icon": "string",
+        "name": "string",
+        "target": "string"
+      }
+    ]
+  }
+}
+```
+
+### Properties
+
+| Name    | Type                                                                                                                 | Required | Restrictions | Description |
+| ------- | -------------------------------------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `links` | [codersdk.DeploymentConfigField-array_codersdk_LinkConfig](#codersdkdeploymentconfigfield-array_codersdk_linkconfig) | false    |              |             |
 
 ## codersdk.SwaggerConfig
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -4887,6 +4887,26 @@ Parameter represents a set value for the scope.
 | ---- | ------ | -------- | ------------ | ----------- |
 | `id` | string | true     |              |             |
 
+## codersdk.UpdateAppearanceConfig
+
+```json
+{
+  "logo_url": "string",
+  "service_banner": {
+    "background_color": "string",
+    "enabled": true,
+    "message": "string"
+  }
+}
+```
+
+### Properties
+
+| Name             | Type                                                         | Required | Restrictions | Description |
+| ---------------- | ------------------------------------------------------------ | -------- | ------------ | ----------- |
+| `logo_url`       | string                                                       | false    |              |             |
+| `service_banner` | [codersdk.ServiceBannerConfig](#codersdkservicebannerconfig) | false    |              |             |
+
 ## codersdk.UpdateCheckResponse
 
 ```json

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -15,25 +15,23 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-var (
-	defaultSupportLinks = []codersdk.LinkConfig{
-		{
-			Name:   "Documentation",
-			Target: "https://coder.com/docs/coder-oss",
-			Icon:   "docs",
-		},
-		{
-			Name:   "Report a bug",
-			Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=TODO",
-			Icon:   "bug",
-		},
-		{
-			Name:   "Join the Coder Discord",
-			Target: "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer",
-			Icon:   "chat",
-		},
-	}
-)
+var defaultSupportLinks = []codersdk.LinkConfig{
+	{
+		Name:   "Documentation",
+		Target: "https://coder.com/docs/coder-oss",
+		Icon:   "docs",
+	},
+	{
+		Name:   "Report a bug",
+		Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=TODO",
+		Icon:   "bug",
+	},
+	{
+		Name:   "Join the Coder Discord",
+		Target: "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer",
+		Icon:   "chat",
+	},
+}
 
 // @Summary Get appearance
 // @ID get-appearance

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -23,7 +23,7 @@ var defaultSupportLinks = []codersdk.LinkConfig{
 	},
 	{
 		Name:   "Report a bug",
-		Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=TODO",
+		Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body={CODER_BUILD_INFO}",
 		Icon:   "bug",
 	},
 	{

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -15,6 +15,26 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
+var (
+	defaultSupportLinks = []codersdk.LinkConfig{
+		{
+			Name:   "Documentation",
+			Target: "https://coder.com/docs/coder-oss",
+			Icon:   "docs",
+		},
+		{
+			Name:   "Report a bug",
+			Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=TODO",
+			Icon:   "bug",
+		},
+		{
+			Name:   "Join the Coder Discord",
+			Target: "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer",
+			Icon:   "chat",
+		},
+	}
+)
+
 // @Summary Get appearance
 // @ID get-appearance
 // @Security CoderSessionToken
@@ -65,6 +85,11 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+	}
+
+	cfg.SupportLinks = defaultSupportLinks
+	if len(api.DeploymentConfig.Support.Links.Value) > 0 {
+		cfg.SupportLinks = api.DeploymentConfig.Support.Links.Value
 	}
 
 	httpapi.Write(r.Context(), rw, http.StatusOK, cfg)

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -15,7 +15,7 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-var defaultSupportLinks = []codersdk.LinkConfig{
+var DefaultSupportLinks = []codersdk.LinkConfig{
 	{
 		Name:   "Documentation",
 		Target: "https://coder.com/docs/coder-oss",
@@ -49,7 +49,7 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 
 	if !isEntitled {
 		httpapi.Write(ctx, rw, http.StatusOK, codersdk.AppearanceConfig{
-			SupportLinks: defaultSupportLinks,
+			SupportLinks: DefaultSupportLinks,
 		})
 		return
 	}
@@ -88,7 +88,7 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(api.DeploymentConfig.Support.Links.Value) == 0 {
-		cfg.SupportLinks = defaultSupportLinks
+		cfg.SupportLinks = DefaultSupportLinks
 	} else {
 		cfg.SupportLinks = api.DeploymentConfig.Support.Links.Value
 	}

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -48,7 +48,9 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	if !isEntitled {
-		httpapi.Write(ctx, rw, http.StatusOK, codersdk.AppearanceConfig{})
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.AppearanceConfig{
+			SupportLinks: defaultSupportLinks,
+		})
 		return
 	}
 
@@ -85,8 +87,9 @@ func (api *API) appearance(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	cfg.SupportLinks = defaultSupportLinks
-	if len(api.DeploymentConfig.Support.Links.Value) > 0 {
+	if len(api.DeploymentConfig.Support.Links.Value) == 0 {
+		cfg.SupportLinks = defaultSupportLinks
+	} else {
 		cfg.SupportLinks = api.DeploymentConfig.Support.Links.Value
 	}
 
@@ -125,6 +128,13 @@ func (api *API) putAppearance(rw http.ResponseWriter, r *http.Request) {
 
 	var appearance codersdk.AppearanceConfig
 	if !httpapi.Read(ctx, rw, r, &appearance) {
+		return
+	}
+
+	if len(appearance.SupportLinks) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Support links cannot be dynamically updated, use the config file instead.",
+		})
 		return
 	}
 

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -113,8 +113,8 @@ func validateHexColor(color string) error {
 // @Accept json
 // @Produce json
 // @Tags Enterprise
-// @Param request body codersdk.AppearanceConfig true "Update appearance request"
-// @Success 200 {object} codersdk.AppearanceConfig
+// @Param request body codersdk.UpdateAppearanceConfig true "Update appearance request"
+// @Success 200 {object} codersdk.UpdateAppearanceConfig
 // @Router /appearance [put]
 func (api *API) putAppearance(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -126,15 +126,8 @@ func (api *API) putAppearance(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var appearance codersdk.AppearanceConfig
+	var appearance codersdk.UpdateAppearanceConfig
 	if !httpapi.Read(ctx, rw, r, &appearance) {
-		return
-	}
-
-	if len(appearance.SupportLinks) > 0 {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Support links cannot be dynamically updated, use the config file instead.",
-		})
 		return
 	}
 

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/enterprise/coderd"
 	"github.com/coder/coder/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/enterprise/coderd/license"
 	"github.com/coder/coder/testutil"
@@ -111,8 +112,6 @@ func TestCustomSupportLinks(t *testing.T) {
 
 	appearance, err := client.Appearance(ctx)
 	require.NoError(t, err)
-
-	require.Len(t, appearance.SupportLinks, 2)
 	require.Equal(t, supportLinks, appearance.SupportLinks)
 }
 
@@ -121,20 +120,12 @@ func TestDefaultSupportLinks(t *testing.T) {
 
 	client := coderdenttest.New(t, nil)
 	coderdtest.CreateFirstUser(t, client)
-	coderdenttest.AddLicense(t, client, coderdenttest.LicenseOptions{
-		Features: license.Features{
-			codersdk.FeatureAppearance: 1,
-		},
-	})
+	// Don't need to set the license, as default links are passed without it.
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
 
 	appearance, err := client.Appearance(ctx)
 	require.NoError(t, err)
-
-	require.Len(t, appearance.SupportLinks, 3) // Documentation, Report a bug, Join the Coder Discord
-	require.Equal(t, appearance.SupportLinks[0].Name, "Documentation")
-	require.Equal(t, appearance.SupportLinks[1].Name, "Report a bug")
-	require.Equal(t, appearance.SupportLinks[2].Name, "Join the Coder Discord")
+	require.Equal(t, coderd.DefaultSupportLinks, appearance.SupportLinks)
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -827,6 +827,12 @@ export interface UpdateActiveTemplateVersion {
   readonly id: string
 }
 
+// From codersdk/deployment.go
+export interface UpdateAppearanceConfig {
+  readonly logo_url: string
+  readonly service_banner: ServiceBannerConfig
+}
+
 // From codersdk/updatecheck.go
 export interface UpdateCheckResponse {
   readonly current: boolean

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -440,7 +440,7 @@ export interface License {
 export interface LinkConfig {
   readonly name: string
   readonly target: string
-  readonly icon?: string
+  readonly icon: string
 }
 
 // From codersdk/deployment.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -34,6 +34,7 @@ export interface AppHostResponse {
 export interface AppearanceConfig {
   readonly logo_url: string
   readonly service_banner: ServiceBannerConfig
+  readonly support_links?: LinkConfig[]
 }
 
 // From codersdk/roles.go
@@ -334,6 +335,7 @@ export interface DeploymentConfig {
   readonly disable_password_auth: DeploymentConfigField<boolean>
   readonly address: DeploymentConfigField<string>
   readonly experimental: DeploymentConfigField<boolean>
+  readonly support: SupportConfig
 }
 
 // From codersdk/deployment.go
@@ -432,6 +434,13 @@ export interface License {
   readonly uploaded_at: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO explain why this is needed
   readonly claims: Record<string, any>
+}
+
+// From codersdk/deployment.go
+export interface LinkConfig {
+  readonly name: string
+  readonly target: string
+  readonly icon?: string
 }
 
 // From codersdk/deployment.go
@@ -655,6 +664,11 @@ export interface ServiceBannerConfig {
   readonly enabled: boolean
   readonly message?: string
   readonly background_color?: string
+}
+
+// From codersdk/deployment.go
+export interface SupportConfig {
+  readonly links: DeploymentConfigField<LinkConfig[]>
 }
 
 // From codersdk/deployment.go
@@ -1326,4 +1340,10 @@ export const WorkspaceTransitions: WorkspaceTransition[] = [
 ]
 
 // From codersdk/deployment.go
-export type Flaggable = string | number | boolean | string[] | GitAuthConfig[]
+export type Flaggable =
+  | string
+  | number
+  | boolean
+  | string[]
+  | GitAuthConfig[]
+  | LinkConfig[]

--- a/site/src/components/Navbar/Navbar.tsx
+++ b/site/src/components/Navbar/Navbar.tsx
@@ -22,6 +22,7 @@ export const Navbar: FC = () => {
       user={me}
       logo_url={appearance.config.logo_url}
       buildInfo={buildInfo}
+      supportLinks={appearance.config.support_links}
       onSignOut={onSignOut}
       canViewAuditLog={canViewAuditLog}
       canViewDeployment={canViewDeployment}

--- a/site/src/components/NavbarView/NavbarView.tsx
+++ b/site/src/components/NavbarView/NavbarView.tsx
@@ -19,6 +19,7 @@ export interface NavbarViewProps {
   logo_url?: string
   user?: TypesGen.User
   buildInfo?: TypesGen.BuildInfoResponse
+  supportLinks?: TypesGen.LinkConfig[]
   onSignOut: () => void
   canViewAuditLog: boolean
   canViewDeployment: boolean
@@ -86,6 +87,7 @@ export const NavbarView: React.FC<React.PropsWithChildren<NavbarViewProps>> = ({
   user,
   logo_url,
   buildInfo,
+  supportLinks,
   onSignOut,
   canViewAuditLog,
   canViewDeployment,
@@ -147,6 +149,7 @@ export const NavbarView: React.FC<React.PropsWithChildren<NavbarViewProps>> = ({
             <UserDropdown
               user={user}
               buildInfo={buildInfo}
+              supportLinks={supportLinks}
               onSignOut={onSignOut}
             />
           )}

--- a/site/src/components/UserDropdown/UserDropdown.test.tsx
+++ b/site/src/components/UserDropdown/UserDropdown.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react"
-import { MockUser } from "../../testHelpers/entities"
+import { MockSupportLinks, MockUser } from "../../testHelpers/entities"
 import { render } from "../../testHelpers/renderHelpers"
 import { Language } from "../UserDropdownContent/UserDropdownContent"
 import { UserDropdown, UserDropdownProps } from "./UsersDropdown"
@@ -8,6 +8,7 @@ const renderAndClick = async (props: Partial<UserDropdownProps> = {}) => {
   render(
     <UserDropdown
       user={props.user ?? MockUser}
+      supportLinks={MockSupportLinks}
       onSignOut={props.onSignOut ?? jest.fn()}
     />,
   )
@@ -20,7 +21,9 @@ describe("UserDropdown", () => {
     it("opens the menu", async () => {
       await renderAndClick()
       expect(screen.getByText(Language.accountLabel)).toBeDefined()
-      expect(screen.getByText(Language.docsLabel)).toBeDefined()
+      expect(screen.getByText(MockSupportLinks[0].name)).toBeDefined()
+      expect(screen.getByText(MockSupportLinks[1].name)).toBeDefined()
+      expect(screen.getByText(MockSupportLinks[2].name)).toBeDefined()
       expect(screen.getByText(Language.signOutLabel)).toBeDefined()
     })
   })

--- a/site/src/components/UserDropdown/UsersDropdown.tsx
+++ b/site/src/components/UserDropdown/UsersDropdown.tsx
@@ -13,12 +13,14 @@ import { UserDropdownContent } from "../UserDropdownContent/UserDropdownContent"
 export interface UserDropdownProps {
   user: TypesGen.User
   buildInfo?: TypesGen.BuildInfoResponse
+  supportLinks?: TypesGen.LinkConfig[]
   onSignOut: () => void
 }
 
 export const UserDropdown: FC<PropsWithChildren<UserDropdownProps>> = ({
   buildInfo,
   user,
+  supportLinks,
   onSignOut,
 }: UserDropdownProps) => {
   const styles = useStyles()
@@ -69,6 +71,7 @@ export const UserDropdown: FC<PropsWithChildren<UserDropdownProps>> = ({
         <UserDropdownContent
           user={user}
           buildInfo={buildInfo}
+          supportLinks={supportLinks}
           onPopoverClose={onPopoverClose}
           onSignOut={onSignOut}
         />

--- a/site/src/components/UserDropdownContent/UserDropdownContent.test.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.test.tsx
@@ -1,5 +1,9 @@
 import { screen } from "@testing-library/react"
-import { MockBuildInfo, MockSupportLinks, MockUser } from "../../testHelpers/entities"
+import {
+  MockBuildInfo,
+  MockSupportLinks,
+  MockUser,
+} from "../../testHelpers/entities"
 import { render } from "../../testHelpers/renderHelpers"
 import { Language, UserDropdownContent } from "./UserDropdownContent"
 
@@ -32,8 +36,12 @@ describe("UserDropdownContent", () => {
     expect(screen.getByText(MockSupportLinks[0].name)).toBeDefined()
     expect(screen.getByText(MockSupportLinks[1].name)).toBeDefined()
     expect(screen.getByText(MockSupportLinks[2].name)).toBeDefined()
-    expect(screen.getByText(MockSupportLinks[2].name)
-      .closest("a")).toHaveAttribute("href", "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=Version%3A%20%5B%60v99.999.9999%2Bc9cdf14%60%5D(file%3A%2F%2F%2Fmock-url)")
+    expect(
+      screen.getByText(MockSupportLinks[2].name).closest("a"),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=Version%3A%20%5B%60v99.999.9999%2Bc9cdf14%60%5D(file%3A%2F%2F%2Fmock-url)",
+    )
     expect(screen.getByText(MockBuildInfo.version)).toBeDefined()
   })
 

--- a/site/src/components/UserDropdownContent/UserDropdownContent.test.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.test.tsx
@@ -32,6 +32,8 @@ describe("UserDropdownContent", () => {
     expect(screen.getByText(MockSupportLinks[0].name)).toBeDefined()
     expect(screen.getByText(MockSupportLinks[1].name)).toBeDefined()
     expect(screen.getByText(MockSupportLinks[2].name)).toBeDefined()
+    expect(screen.getByText(MockSupportLinks[2].name)
+      .closest("a")).toHaveAttribute("href", "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=Version%3A%20%5B%60v99.999.9999%2Bc9cdf14%60%5D(file%3A%2F%2F%2Fmock-url)")
     expect(screen.getByText(MockBuildInfo.version)).toBeDefined()
   })
 

--- a/site/src/components/UserDropdownContent/UserDropdownContent.test.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react"
-import { MockBuildInfo, MockUser } from "../../testHelpers/entities"
+import { MockBuildInfo, MockSupportLinks, MockUser } from "../../testHelpers/entities"
 import { render } from "../../testHelpers/renderHelpers"
 import { Language, UserDropdownContent } from "./UserDropdownContent"
 
@@ -21,16 +21,17 @@ describe("UserDropdownContent", () => {
       <UserDropdownContent
         user={MockUser}
         buildInfo={MockBuildInfo}
+        supportLinks={MockSupportLinks}
         onSignOut={jest.fn()}
         onPopoverClose={jest.fn()}
       />,
     )
     expect(screen.getByText(Language.accountLabel)).toBeDefined()
-    expect(screen.getByText(Language.docsLabel)).toBeDefined()
     expect(screen.getByText(Language.signOutLabel)).toBeDefined()
-    expect(screen.getByText(Language.bugLabel)).toBeDefined()
-    expect(screen.getByText(Language.discordLabel)).toBeDefined()
     expect(screen.getByText(Language.copyrightText)).toBeDefined()
+    expect(screen.getByText(MockSupportLinks[0].name)).toBeDefined()
+    expect(screen.getByText(MockSupportLinks[1].name)).toBeDefined()
+    expect(screen.getByText(MockSupportLinks[2].name)).toBeDefined()
     expect(screen.getByText(MockBuildInfo.version)).toBeDefined()
   })
 

--- a/site/src/components/UserDropdownContent/UserDropdownContent.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.tsx
@@ -63,7 +63,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
         {supportLinks &&
           supportLinks.map((link) => (
             <a
-              href={link.target}
+              href={includeBuildInfo(link.target, buildInfo)}
               key={link.name}
               target="_blank"
               rel="noreferrer"
@@ -166,3 +166,8 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.primary,
   },
 }))
+
+const includeBuildInfo = (href: string, buildInfo?: TypesGen.BuildInfoResponse): string => {
+  return href.replace("{CODER_BUILD_INFO}",
+    `${encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)}`)
+}

--- a/site/src/components/UserDropdownContent/UserDropdownContent.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.tsx
@@ -63,27 +63,32 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
       <Divider className={styles.divider} />
 
       <>
-        { supportLinks && supportLinks.map((link) => (
-          <a
-            href={link.target}
-            key={link.name}
-            target="_blank"
-            rel="noreferrer"
-            className={styles.link}
-          >
-            <MenuItem className={styles.menuItem} onClick={onPopoverClose}>
-            {link.icon === "bug" && ( <BugIcon className={styles.menuItemIcon}/> )}
-            {link.icon === "chat" && ( <ChatIcon className={styles.menuItemIcon}/> )}
-            {link.icon === "docs" && ( <DocsIcon className={styles.menuItemIcon}/> )}
-              <span className={styles.menuItemText}>{link.name}</span>
-            </MenuItem>
-          </a>
-        )) }
+        {supportLinks &&
+          supportLinks.map((link) => (
+            <a
+              href={link.target}
+              key={link.name}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.link}
+            >
+              <MenuItem className={styles.menuItem} onClick={onPopoverClose}>
+                {link.icon === "bug" && (
+                  <BugIcon className={styles.menuItemIcon} />
+                )}
+                {link.icon === "chat" && (
+                  <ChatIcon className={styles.menuItemIcon} />
+                )}
+                {link.icon === "docs" && (
+                  <DocsIcon className={styles.menuItemIcon} />
+                )}
+                <span className={styles.menuItemText}>{link.name}</span>
+              </MenuItem>
+            </a>
+          ))}
       </>
 
-      {supportLinks && (
-        <Divider className={styles.divider} />
-      )}
+      {supportLinks && <Divider className={styles.divider} />}
 
       <Stack className={styles.info} spacing={0}>
         <a

--- a/site/src/components/UserDropdownContent/UserDropdownContent.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.tsx
@@ -15,10 +15,7 @@ import { combineClasses } from "util/combineClasses"
 
 export const Language = {
   accountLabel: "Account",
-  docsLabel: "Documentation",
   signOutLabel: "Sign Out",
-  bugLabel: "Report a Bug",
-  discordLabel: "Join the Coder Discord",
   copyrightText: `\u00a9 ${new Date().getFullYear()} Coder Technologies, Inc.`,
 }
 

--- a/site/src/components/UserDropdownContent/UserDropdownContent.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.tsx
@@ -167,7 +167,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-const includeBuildInfo = (href: string, buildInfo?: TypesGen.BuildInfoResponse): string => {
-  return href.replace("{CODER_BUILD_INFO}",
-    `${encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`)}`)
+const includeBuildInfo = (
+  href: string,
+  buildInfo?: TypesGen.BuildInfoResponse,
+): string => {
+  return href.replace(
+    "{CODER_BUILD_INFO}",
+    `${encodeURIComponent(
+      `Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})`,
+    )}`,
+  )
 }

--- a/site/src/components/UserDropdownContent/UserDropdownContent.tsx
+++ b/site/src/components/UserDropdownContent/UserDropdownContent.tsx
@@ -25,6 +25,7 @@ export const Language = {
 export interface UserDropdownContentProps {
   user: TypesGen.User
   buildInfo?: TypesGen.BuildInfoResponse
+  supportLinks?: TypesGen.LinkConfig[]
   onPopoverClose: () => void
   onSignOut: () => void
 }
@@ -32,14 +33,11 @@ export interface UserDropdownContentProps {
 export const UserDropdownContent: FC<UserDropdownContentProps> = ({
   buildInfo,
   user,
+  supportLinks,
   onPopoverClose,
   onSignOut,
 }) => {
   const styles = useStyles()
-  const githubUrl = `https://github.com/coder/coder/issues/new?labels=needs+grooming&body=${encodeURIComponent(`Version: [\`${buildInfo?.version}\`](${buildInfo?.external_url})
-
-  <!--- Ask a question or leave feedback! -->`)}`
-  const discordUrl = `https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer`
 
   return (
     <div>
@@ -64,43 +62,28 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 
       <Divider className={styles.divider} />
 
-      <a
-        href="https://coder.com/docs/coder-oss"
-        target="_blank"
-        rel="noreferrer"
-        className={styles.link}
-      >
-        <MenuItem className={styles.menuItem} onClick={onPopoverClose}>
-          <DocsIcon className={styles.menuItemIcon} />
-          <span className={styles.menuItemText}>{Language.docsLabel}</span>
-        </MenuItem>
-      </a>
+      <>
+        { supportLinks && supportLinks.map((link) => (
+          <a
+            href={link.target}
+            key={link.name}
+            target="_blank"
+            rel="noreferrer"
+            className={styles.link}
+          >
+            <MenuItem className={styles.menuItem} onClick={onPopoverClose}>
+            {link.icon === "bug" && ( <BugIcon className={styles.menuItemIcon}/> )}
+            {link.icon === "chat" && ( <ChatIcon className={styles.menuItemIcon}/> )}
+            {link.icon === "docs" && ( <DocsIcon className={styles.menuItemIcon}/> )}
+              <span className={styles.menuItemText}>{link.name}</span>
+            </MenuItem>
+          </a>
+        )) }
+      </>
 
-      <a
-        href={githubUrl}
-        target="_blank"
-        rel="noreferrer"
-        className={styles.link}
-      >
-        <MenuItem className={styles.menuItem} onClick={onPopoverClose}>
-          <BugIcon className={styles.menuItemIcon} />
-          <span className={styles.menuItemText}>{Language.bugLabel}</span>
-        </MenuItem>
-      </a>
-
-      <a
-        href={discordUrl}
-        target="_blank"
-        rel="noreferrer"
-        className={styles.link}
-      >
-        <MenuItem className={styles.menuItem} onClick={onPopoverClose}>
-          <ChatIcon className={styles.menuItemIcon} />
-          <span className={styles.menuItemText}>{Language.discordLabel}</span>
-        </MenuItem>
-      </a>
-
-      <Divider className={styles.divider} />
+      {supportLinks && (
+        <Divider className={styles.divider} />
+      )}
 
       <Stack className={styles.info} spacing={0}>
         <a

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPage.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { AppearanceConfig } from "api/typesGenerated"
+import { UpdateAppearanceConfig } from "api/typesGenerated"
 import { useDashboard } from "components/Dashboard/DashboardProvider"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
@@ -15,7 +15,7 @@ const AppearanceSettingsPage: FC = () => {
     entitlements.features["appearance"].entitlement !== "not_entitled"
 
   const updateAppearance = (
-    newConfig: Partial<AppearanceConfig>,
+    newConfig: Partial<UpdateAppearanceConfig>,
     preview: boolean,
   ) => {
     const newAppearance = {

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -17,16 +17,16 @@ import { useTranslation } from "react-i18next"
 import makeStyles from "@material-ui/core/styles/makeStyles"
 import Switch from "@material-ui/core/Switch"
 import TextField from "@material-ui/core/TextField"
-import { AppearanceConfig } from "api/typesGenerated"
+import { UpdateAppearanceConfig } from "api/typesGenerated"
 import { Stack } from "components/Stack/Stack"
 import { useFormik } from "formik"
 import { useTheme } from "@material-ui/core/styles"
 
 export type AppearanceSettingsPageViewProps = {
-  appearance: AppearanceConfig
+  appearance: UpdateAppearanceConfig
   isEntitled: boolean
   updateAppearance: (
-    newConfig: Partial<AppearanceConfig>,
+    newConfig: Partial<UpdateAppearanceConfig>,
     preview: boolean,
   ) => void
 }
@@ -48,7 +48,7 @@ export const AppearanceSettingsPageView = ({
   })
   const logoFieldHelpers = getFormHelpers(logoForm)
 
-  const serviceBannerForm = useFormik<AppearanceConfig["service_banner"]>({
+  const serviceBannerForm = useFormik<UpdateAppearanceConfig["service_banner"]>({
     initialValues: {
       message: appearance.service_banner.message,
       enabled: appearance.service_banner.enabled,

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -48,20 +48,22 @@ export const AppearanceSettingsPageView = ({
   })
   const logoFieldHelpers = getFormHelpers(logoForm)
 
-  const serviceBannerForm = useFormik<UpdateAppearanceConfig["service_banner"]>({
-    initialValues: {
-      message: appearance.service_banner.message,
-      enabled: appearance.service_banner.enabled,
-      background_color: appearance.service_banner.background_color,
+  const serviceBannerForm = useFormik<UpdateAppearanceConfig["service_banner"]>(
+    {
+      initialValues: {
+        message: appearance.service_banner.message,
+        enabled: appearance.service_banner.enabled,
+        background_color: appearance.service_banner.background_color,
+      },
+      onSubmit: (values) =>
+        updateAppearance(
+          {
+            service_banner: values,
+          },
+          false,
+        ),
     },
-    onSubmit: (values) =>
-      updateAppearance(
-        {
-          service_banner: values,
-        },
-        false,
-      ),
-  })
+  )
   const serviceBannerFieldHelpers = getFormHelpers(serviceBannerForm)
   const [backgroundColor, setBackgroundColor] = useState(
     serviceBannerForm.values.background_color,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -73,7 +73,7 @@ export const MockSupportLinks: TypesGen.LinkConfig[] = [
   },
   {
     name: "Third link",
-    target: "http://third-link",
+    target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body={CODER_BUILD_INFO}",
     icon: ""
   }
 ];

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -60,6 +60,24 @@ export const MockBuildInfo: TypesGen.BuildInfoResponse = {
   version: "v99.999.9999+c9cdf14",
 }
 
+export const MockSupportLinks: TypesGen.LinkConfig[] = [
+  {
+    name: "First link",
+    target: "http://first-link",
+    icon: "chat"
+  },
+  {
+    name: "Second link",
+    target: "http://second-link",
+    icon: "docs"
+  },
+  {
+    name: "Third link",
+    target: "http://third-link",
+    icon: ""
+  }
+];
+
 export const MockUpdateCheck: TypesGen.UpdateCheckResponse = {
   current: true,
   url: "file:///mock-url",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -64,19 +64,20 @@ export const MockSupportLinks: TypesGen.LinkConfig[] = [
   {
     name: "First link",
     target: "http://first-link",
-    icon: "chat"
+    icon: "chat",
   },
   {
     name: "Second link",
     target: "http://second-link",
-    icon: "docs"
+    icon: "docs",
   },
   {
     name: "Third link",
-    target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body={CODER_BUILD_INFO}",
-    icon: ""
-  }
-];
+    target:
+      "https://github.com/coder/coder/issues/new?labels=needs+grooming&body={CODER_BUILD_INFO}",
+    icon: "",
+  },
+]
 
 export const MockUpdateCheck: TypesGen.UpdateCheckResponse = {
   current: true,


### PR DESCRIPTION
_part of the Hackathon challenge_

The goal of this PR is to enable use of custom support links in the user dropdown menu. 

<img width="340" alt="Screenshot 2023-02-22 at 17 34 31" src="https://user-images.githubusercontent.com/14044910/220795616-567874ba-ec38-42ef-b202-5ce942767707.png">

--- 
TODOs:
- [x] site unit tests
- [x] include build version in the bug report link
- [ ] document the feature (will do in the follow-up)