### PR TITLE
fix(tailnet): Skip nodes without DERP, avoid use of RemoveAllPeers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -601,7 +601,9 @@ func (a *agent) runCoordinator(ctx context.Context, network *tailnet.Conn) error
 	}
 	defer coordinator.Close()
 	a.logger.Info(ctx, "connected to coordination server")
-	sendNodes, errChan := tailnet.ServeCoordinator(coordinator, network.UpdateNodes)
+	sendNodes, errChan := tailnet.ServeCoordinator(coordinator, func(nodes []*tailnet.Node) error {
+		return network.UpdateNodes(nodes, false)
+	})
 	network.SetNodeCallback(sendNodes)
 	select {
 	case <-ctx.Done():

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1179,12 +1179,21 @@ func setupAgent(t *testing.T, metadata agentsdk.Metadata, ptyTimeout time.Durati
 		coordinator.ServeClient(serverConn, uuid.New(), agentID)
 	}()
 	sendNode, _ := tailnet.ServeCoordinator(clientConn, func(node []*tailnet.Node) error {
-		return conn.UpdateNodes(node)
+		return conn.UpdateNodes(node, false)
 	})
 	conn.SetNodeCallback(sendNode)
-	return &codersdk.WorkspaceAgentConn{
+	agentConn := &codersdk.WorkspaceAgentConn{
 		Conn: conn,
-	}, c, statsCh, fs
+	}
+	t.Cleanup(func() {
+		_ = agentConn.Close()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancel()
+	if !agentConn.AwaitReachable(ctx) {
+		t.Fatal("agent not reachable")
+	}
+	return agentConn, c, statsCh, fs
 }
 
 var dialTestPayload = []byte("dean-was-here123")

--- a/cli/speedtest_test.go
+++ b/cli/speedtest_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/agent"
 	"github.com/coder/coder/cli/clitest"
@@ -28,7 +29,7 @@ func TestSpeedtest(t *testing.T) {
 	agentClient.SetSessionToken(agentToken)
 	agentCloser := agent.New(agent.Options{
 		Client: agentClient,
-		Logger: slogtest.Make(t, nil).Named("agent"),
+		Logger: slogtest.Make(t, nil).Named("agent").Leveled(slog.LevelDebug),
 	})
 	defer agentCloser.Close()
 	coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	gosshagent "golang.org/x/crypto/ssh/agent"
 
+	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 
 	"github.com/coder/coder/agent"
@@ -47,6 +48,7 @@ func setupWorkspaceForAgent(t *testing.T, mutate func([]*proto.Agent) []*proto.A
 		}
 	}
 	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	client.Logger = slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug)
 	user := coderdtest.CreateFirstUser(t, client)
 	agentToken := uuid.NewString()
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -80,16 +80,16 @@ func TestDERP(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	w2Ready := make(chan struct{}, 1)
+	w2Ready := make(chan struct{})
 	w2ReadyOnce := sync.Once{}
 	w1.SetNodeCallback(func(node *tailnet.Node) {
-		w2.UpdateNodes([]*tailnet.Node{node})
+		w2.UpdateNodes([]*tailnet.Node{node}, false)
 		w2ReadyOnce.Do(func() {
 			close(w2Ready)
 		})
 	})
 	w2.SetNodeCallback(func(node *tailnet.Node) {
-		w1.UpdateNodes([]*tailnet.Node{node})
+		w1.UpdateNodes([]*tailnet.Node{node}, false)
 	})
 
 	conn := make(chan struct{})

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -404,6 +404,7 @@ func (api *API) workspaceAgentListeningPorts(rw http.ResponseWriter, r *http.Req
 }
 
 func (api *API) dialWorkspaceAgentTailnet(r *http.Request, agentID uuid.UUID) (*codersdk.WorkspaceAgentConn, error) {
+	ctx := r.Context()
 	clientConn, serverConn := net.Pipe()
 
 	derpMap := api.DERPMap.Clone()
@@ -474,7 +475,7 @@ func (api *API) dialWorkspaceAgentTailnet(r *http.Request, agentID uuid.UUID) (*
 			_ = agentConn.Close()
 		}
 	}()
-	if !agentConn.AwaitReachable(context.TODO()) {
+	if !agentConn.AwaitReachable(ctx) {
 		_ = agentConn.Close()
 		return nil, xerrors.Errorf("agent not reachable")
 	}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -453,32 +453,32 @@ func (api *API) dialWorkspaceAgentTailnet(r *http.Request, agentID uuid.UUID) (*
 	}
 
 	sendNodes, _ := tailnet.ServeCoordinator(clientConn, func(node []*tailnet.Node) error {
-		err := conn.RemoveAllPeers()
-		if err != nil {
-			return xerrors.Errorf("remove all peers: %w", err)
-		}
-
-		err = conn.UpdateNodes(node)
+		err = conn.UpdateNodes(node, true)
 		if err != nil {
 			return xerrors.Errorf("update nodes: %w", err)
 		}
 		return nil
 	})
 	conn.SetNodeCallback(sendNodes)
-	go func() {
-		err := (*api.TailnetCoordinator.Load()).ServeClient(serverConn, uuid.New(), agentID)
-		if err != nil {
-			api.Logger.Warn(r.Context(), "tailnet coordinator client error", slog.Error(err))
-			_ = conn.Close()
-		}
-	}()
-	return &codersdk.WorkspaceAgentConn{
+	agentConn := &codersdk.WorkspaceAgentConn{
 		Conn: conn,
 		CloseFunc: func() {
 			_ = clientConn.Close()
 			_ = serverConn.Close()
 		},
-	}, nil
+	}
+	go func() {
+		err := (*api.TailnetCoordinator.Load()).ServeClient(serverConn, uuid.New(), agentID)
+		if err != nil {
+			api.Logger.Warn(r.Context(), "tailnet coordinator client error", slog.Error(err))
+			_ = agentConn.Close()
+		}
+	}()
+	if !agentConn.AwaitReachable(context.TODO()) {
+		_ = agentConn.Close()
+		return nil, xerrors.Errorf("agent not reachable")
+	}
+	return agentConn, nil
 }
 
 // @Summary Get connection info for workspace agent

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -100,7 +100,7 @@ type DialWorkspaceAgentOptions struct {
 	BlockEndpoints bool
 }
 
-func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, options *DialWorkspaceAgentOptions) (*WorkspaceAgentConn, error) {
+func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, options *DialWorkspaceAgentOptions) (agentConn *WorkspaceAgentConn, err error) {
 	if options == nil {
 		options = &DialWorkspaceAgentOptions{}
 	}
@@ -128,6 +128,11 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 	if err != nil {
 		return nil, xerrors.Errorf("create tailnet: %w", err)
 	}
+	defer func() {
+		if err != nil {
+			_ = conn.Close()
+		}
+	}()
 
 	coordinateURL, err := c.URL.Parse(fmt.Sprintf("/api/v2/workspaceagents/%s/coordinate", agentID))
 	if err != nil {
@@ -145,7 +150,12 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 		Jar:       jar,
 		Transport: c.HTTPClient.Transport,
 	}
-	ctx, cancelFunc := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
 	closed := make(chan struct{})
 	first := make(chan error)
 	go func() {
@@ -175,7 +185,7 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 				continue
 			}
 			sendNode, errChan := tailnet.ServeCoordinator(websocket.NetConn(ctx, ws, websocket.MessageBinary), func(node []*tailnet.Node) error {
-				return conn.UpdateNodes(node)
+				return conn.UpdateNodes(node, false)
 			})
 			conn.SetNodeCallback(sendNode)
 			options.Logger.Debug(ctx, "serving coordinator")
@@ -194,15 +204,13 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 	}()
 	err = <-first
 	if err != nil {
-		cancelFunc()
-		_ = conn.Close()
 		return nil, err
 	}
 
-	agentConn := &WorkspaceAgentConn{
+	agentConn = &WorkspaceAgentConn{
 		Conn: conn,
 		CloseFunc: func() {
-			cancelFunc()
+			cancel()
 			<-closed
 		},
 	}

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -364,12 +364,15 @@ func (c *Conn) RemoveAllPeers() error {
 }
 
 // UpdateNodes connects with a set of peers. This can be constantly updated,
-// and peers will continually be reconnected as necessary.
-func (c *Conn) UpdateNodes(nodes []*Node, replace bool) error {
+// and peers will continually be reconnected as necessary. If replacePeers is
+// true, all peers will be removed before adding the new ones.
+//
+//nolint:revive // Complains about replacePeers.
+func (c *Conn) UpdateNodes(nodes []*Node, replacePeers bool) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	status := c.Status()
-	if replace {
+	if replacePeers {
 		c.netMap.Peers = []*tailcfg.Node{}
 		c.peerMap = map[tailcfg.NodeID]*tailcfg.Node{}
 	}

--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -55,12 +55,12 @@ func TestTailnet(t *testing.T) {
 			_ = w2.Close()
 		})
 		w1.SetNodeCallback(func(node *tailnet.Node) {
-			err := w2.UpdateNodes([]*tailnet.Node{node})
-			require.NoError(t, err)
+			err := w2.UpdateNodes([]*tailnet.Node{node}, false)
+			assert.NoError(t, err)
 		})
 		w2.SetNodeCallback(func(node *tailnet.Node) {
-			err := w1.UpdateNodes([]*tailnet.Node{node})
-			require.NoError(t, err)
+			err := w1.UpdateNodes([]*tailnet.Node{node}, false)
+			assert.NoError(t, err)
 		})
 		require.True(t, w2.AwaitReachable(context.Background(), w1IP))
 		conn := make(chan struct{})


### PR DESCRIPTION
This PR targets https://github.com/coder/coder/pull/6292 and has two main changes:

1. Skip nodes that have no preferred DERP server so that we don't try to contact them too early (this often leads to a 5+ seconds timeout due to WireGuard retries)
2. Avoid the use of `conn.RemoveAllPeers` (in favor of `conn.UpdateNodes(nodes, replace=true)`
3. (A few additional agentConn fixes where we `AwaitReacahble` first)

The reason for 2. is that on initial connections, there's a race between receiving a valid node, removing it, and then trying to add it back, this leads to 30+ seconds delays e.g. in scaletests and sometimes timeouts.

We might be able to replace many uses of AwaitReachable with something akin to "wait until first peer node with derp". This might speed up connections by not having to do a ping.

