### PR TITLE
fix(provisionerd): add more detailed workspace build logging

### DIFF
--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -353,12 +353,13 @@ func (p *Server) acquireJob(ctx context.Context) {
 
 	if build := job.GetWorkspaceBuild(); build != nil {
 		fields = append(fields,
+			slog.F("action", build.Metadata.WorkspaceTransition.String()),
+			slog.F("owner_email", build.Metadata.WorkspaceOwnerEmail),
+			slog.F("template_name", build.Metadata.TemplateName),
+			slog.F("template_version", build.Metadata.TemplateVersion),
 			slog.F("workspace_build_id", build.WorkspaceBuildId),
 			slog.F("workspace_id", build.Metadata.WorkspaceId),
 			slog.F("workspace_name", build.WorkspaceName),
-			slog.F("workspace_owner_id", build.Metadata.WorkspaceOwnerId),
-			slog.F("workspace_owner", build.Metadata.WorkspaceOwner),
-			slog.F("action", build.Metadata.WorkspaceTransition.String()),
 		)
 
 		span.SetAttributes(

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -123,7 +123,7 @@ func New(
 			slog.F("workspace_name", build.Metadata.WorkspaceName),
 			slog.F("template_name", build.Metadata.TemplateName),
 			slog.F("template_version", build.Metadata.TemplateVersion),
-			slog.F("transition", build.Metadata.WorkspaceTransition.String()),
+			slog.F("action", build.Metadata.WorkspaceTransition.String()),
 		)
 	}
 

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -118,12 +118,13 @@ func New(
 	logger := opts.Logger.With(slog.F("job_id", job.JobId))
 	if build := job.GetWorkspaceBuild(); build != nil {
 		logger = logger.With(
+			slog.F("action", build.Metadata.WorkspaceTransition.String()),
 			slog.F("owner_email", build.Metadata.WorkspaceOwnerEmail),
-			slog.F("workspace_id", build.Metadata.WorkspaceId),
-			slog.F("workspace_name", build.Metadata.WorkspaceName),
 			slog.F("template_name", build.Metadata.TemplateName),
 			slog.F("template_version", build.Metadata.TemplateVersion),
-			slog.F("action", build.Metadata.WorkspaceTransition.String()),
+			slog.F("workspace_build_id", build.WorkspaceBuildId),
+			slog.F("workspace_id", build.Metadata.WorkspaceId),
+			slog.F("workspace_name", build.Metadata.WorkspaceName),
 		)
 	}
 


### PR DESCRIPTION
Adding some fields to provisionerd logs to make it more easily to correlate failed workspace builds