### PR TITLE
test(cli): Improve speedtest debugging

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -192,11 +192,8 @@ func ContextWithLogger(ctx context.Context, l slog.Logger) context.Context {
 }
 
 func LoggerFromContext(ctx context.Context) (slog.Logger, bool) {
-	l := ctx.Value(contextKeyLogger)
-	if l == nil {
-		return slog.Logger{}, false
-	}
-	return l.(slog.Logger), true
+	l, ok := ctx.Value(contextKeyLogger).(slog.Logger)
+	return l, ok
 }
 
 // fixUnknownSubcommandError modifies the provided commands so that the

--- a/cli/root.go
+++ b/cli/root.go
@@ -19,6 +19,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kirsle/configdir"
 	"github.com/mattn/go-isatty"
@@ -177,6 +179,24 @@ func Root(subcommands []*cobra.Command) *cobra.Command {
 	cliflag.Bool(cmd.PersistentFlags(), varVerbose, "v", "CODER_VERBOSE", false, "Enable verbose output.")
 
 	return cmd
+}
+
+type contextKey int
+
+const (
+	contextKeyLogger contextKey = iota
+)
+
+func ContextWithLogger(ctx context.Context, l slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKeyLogger, l)
+}
+
+func LoggerFromContext(ctx context.Context) (slog.Logger, bool) {
+	l := ctx.Value(contextKeyLogger)
+	if l == nil {
+		return slog.Logger{}, false
+	}
+	return l.(slog.Logger), true
 }
 
 // fixUnknownSubcommandError modifies the provided commands so that the

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -51,7 +51,10 @@ func speedtest() *cobra.Command {
 			if err != nil && !xerrors.Is(err, cliui.AgentStartError) {
 				return xerrors.Errorf("await agent: %w", err)
 			}
-			logger := slog.Make(sloghuman.Sink(cmd.ErrOrStderr()))
+			logger, ok := LoggerFromContext(ctx)
+			if !ok {
+				logger = slog.Make(sloghuman.Sink(cmd.ErrOrStderr()))
+			}
 			if cliflag.IsSetBool(cmd, varVerbose) {
 				logger = logger.Leveled(slog.LevelDebug)
 			}

--- a/cli/speedtest_test.go
+++ b/cli/speedtest_test.go
@@ -10,6 +10,7 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/agent"
+	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/codersdk"
@@ -51,10 +52,12 @@ func TestSpeedtest(t *testing.T) {
 	clitest.SetupConfig(t, client, root)
 	pty := ptytest.New(t)
 	cmd.SetOut(pty.Output())
+	cmd.SetErr(pty.Output())
 
 	ctx, cancel = context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
+	ctx = cli.ContextWithLogger(ctx, slogtest.Make(t, nil).Named("speedtest").Leveled(slog.LevelDebug))
 	cmdDone := tGo(t, func() {
 		err := cmd.ExecuteContext(ctx)
 		assert.NoError(t, err)


### PR DESCRIPTION
This change improves debuggability of `TestSpeedtest` in the `cli` package by logging `tailnet` messages for the cli command as well.

Related: #6321
