### PR TITLE
chore: increase activitybump deadline duration to fix flake

### DIFF
--- a/coderd/activitybump_test.go
+++ b/coderd/activitybump_test.go
@@ -42,7 +42,7 @@ func TestWorkspaceActivityBump(t *testing.T) {
 		require.NoError(t, err)
 		require.WithinDuration(t,
 			time.Now().Add(time.Duration(ttlMillis)*time.Millisecond),
-			workspace.LatestBuild.Deadline.Time, testutil.WaitShort,
+			workspace.LatestBuild.Deadline.Time, testutil.WaitMedium,
 		)
 		firstDeadline := workspace.LatestBuild.Deadline.Time
 


### PR DESCRIPTION
This is a bad fix because the test is still dependant on time, but it's still an improvement.
