### PR TITLE
chore: Skip authz on various functions used for api data building

### DIFF
--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -251,8 +251,6 @@ func (q *querier) GetProvisionerJobByID(ctx context.Context, id uuid.UUID) (data
 	return job, nil
 }
 
-
-
 func (q *querier) GetProvisionerLogsByIDBetween(ctx context.Context, arg database.GetProvisionerLogsByIDBetweenParams) ([]database.ProvisionerJobLog, error) {
 	// Authorized read on job lets the actor also read the logs.
 	_, err := q.GetProvisionerJobByID(ctx, arg.JobID)
@@ -721,7 +719,6 @@ func (q *querier) GetTemplateVersionVariables(ctx context.Context, templateVersi
 	return q.db.GetTemplateVersionVariables(ctx, templateVersionID)
 }
 
-
 func (q *querier) GetTemplateVersionsByTemplateID(ctx context.Context, arg database.GetTemplateVersionsByTemplateIDParams) ([]database.TemplateVersion, error) {
 	// An actor can read template versions if they can read the related template.
 	template, err := q.db.GetTemplateByID(ctx, arg.TemplateID)
@@ -1185,8 +1182,6 @@ func (q *querier) GetWorkspaceAgentByInstanceID(ctx context.Context, authInstanc
 	return agent, nil
 }
 
-
-
 func (q *querier) UpdateWorkspaceAgentLifecycleStateByID(ctx context.Context, arg database.UpdateWorkspaceAgentLifecycleStateByIDParams) error {
 	agent, err := q.db.GetWorkspaceAgentByID(ctx, arg.ID)
 	if err != nil {
@@ -1238,8 +1233,6 @@ func (q *querier) GetWorkspaceAppsByAgentID(ctx context.Context, agentID uuid.UU
 	}
 	return q.db.GetWorkspaceAppsByAgentID(ctx, agentID)
 }
-
-
 
 func (q *querier) GetWorkspaceBuildByID(ctx context.Context, buildID uuid.UUID) (database.WorkspaceBuild, error) {
 	build, err := q.db.GetWorkspaceBuildByID(ctx, buildID)
@@ -1317,7 +1310,6 @@ func (q *querier) GetWorkspaceResourceByID(ctx context.Context, id uuid.UUID) (d
 	return resource, nil
 }
 
-
 func (q *querier) GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.UUID) ([]database.WorkspaceResource, error) {
 	job, err := q.db.GetProvisionerJobByID(ctx, jobID)
 	if err != nil {
@@ -1362,8 +1354,6 @@ func (q *querier) GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.U
 	}
 	return q.db.GetWorkspaceResourcesByJobID(ctx, jobID)
 }
-
-
 
 func (q *querier) InsertWorkspace(ctx context.Context, arg database.InsertWorkspaceParams) (database.Workspace, error) {
 	obj := rbac.ResourceWorkspace.WithOwner(arg.OwnerID.String()).InOrg(arg.OrganizationID)

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -622,7 +622,7 @@ func (s *MethodTestSuite) TestTemplate() {
 			TemplateID: uuid.NullUUID{UUID: t2.ID, Valid: true},
 		})
 		check.Args([]uuid.UUID{tv1.ID, tv2.ID, tv3.ID}).
-			Asserts(t1, rbac.ActionRead, t2, rbac.ActionRead).
+			Asserts( /*t1, rbac.ActionRead, t2, rbac.ActionRead*/ ).
 			Returns(slice.New(tv1, tv2, tv3))
 	}))
 	s.Run("GetTemplateVersionsByTemplateID", s.Subtest(func(db database.Store, check *expects) {
@@ -797,7 +797,7 @@ func (s *MethodTestSuite) TestUser() {
 		a := dbgen.User(s.T(), db, database.User{CreatedAt: database.Now().Add(-time.Hour)})
 		b := dbgen.User(s.T(), db, database.User{CreatedAt: database.Now()})
 		check.Args([]uuid.UUID{a.ID, b.ID}).
-			Asserts(a, rbac.ActionRead, b, rbac.ActionRead).
+			Asserts( /*a, rbac.ActionRead, b, rbac.ActionRead*/ ).
 			Returns(slice.New(a, b))
 	}))
 	s.Run("InsertUser", s.Subtest(func(db database.Store, check *expects) {
@@ -972,7 +972,7 @@ func (s *MethodTestSuite) TestWorkspace() {
 		build := dbgen.WorkspaceBuild(s.T(), db, database.WorkspaceBuild{WorkspaceID: ws.ID, JobID: uuid.New()})
 		res := dbgen.WorkspaceResource(s.T(), db, database.WorkspaceResource{JobID: build.JobID})
 		agt := dbgen.WorkspaceAgent(s.T(), db, database.WorkspaceAgent{ResourceID: res.ID})
-		check.Args([]uuid.UUID{res.ID}).Asserts(ws, rbac.ActionRead).
+		check.Args([]uuid.UUID{res.ID}).Asserts( /*ws, rbac.ActionRead*/ ).
 			Returns([]database.WorkspaceAgent{agt})
 	}))
 	s.Run("UpdateWorkspaceAgentLifecycleStateByID", s.Subtest(func(db database.Store, check *expects) {
@@ -1030,7 +1030,7 @@ func (s *MethodTestSuite) TestWorkspace() {
 		b := dbgen.WorkspaceApp(s.T(), db, database.WorkspaceApp{AgentID: bAgt.ID})
 
 		check.Args([]uuid.UUID{a.AgentID, b.AgentID}).
-			Asserts(aWs, rbac.ActionRead, bWs, rbac.ActionRead).
+			Asserts( /*aWs, rbac.ActionRead, bWs, rbac.ActionRead*/ ).
 			Returns([]database.WorkspaceApp{a, b})
 	}))
 	s.Run("GetWorkspaceBuildByID", s.Subtest(func(db database.Store, check *expects) {
@@ -1093,7 +1093,7 @@ func (s *MethodTestSuite) TestWorkspace() {
 		a := dbgen.WorkspaceResource(s.T(), db, database.WorkspaceResource{JobID: build.JobID})
 		b := dbgen.WorkspaceResource(s.T(), db, database.WorkspaceResource{JobID: build.JobID})
 		check.Args([]uuid.UUID{a.ID, b.ID}).
-			Asserts(ws, []rbac.Action{rbac.ActionRead, rbac.ActionRead})
+			Asserts( /*ws, []rbac.Action{rbac.ActionRead, rbac.ActionRead}*/ )
 	}))
 	s.Run("Build/GetWorkspaceResourcesByJobID", s.Subtest(func(db database.Store, check *expects) {
 		ws := dbgen.Workspace(s.T(), db, database.Workspace{})
@@ -1115,7 +1115,9 @@ func (s *MethodTestSuite) TestWorkspace() {
 		ws := dbgen.Workspace(s.T(), db, database.Workspace{})
 		build := dbgen.WorkspaceBuild(s.T(), db, database.WorkspaceBuild{WorkspaceID: ws.ID, JobID: uuid.New()})
 		wJob := dbgen.ProvisionerJob(s.T(), db, database.ProvisionerJob{ID: build.JobID, Type: database.ProvisionerJobTypeWorkspaceBuild})
-		check.Args([]uuid.UUID{tJob.ID, wJob.ID}).Asserts(v.RBACObject(tpl), rbac.ActionRead, ws, rbac.ActionRead).Returns([]database.WorkspaceResource{})
+		check.Args([]uuid.UUID{tJob.ID, wJob.ID}).
+			Asserts( /*v.RBACObject(tpl), rbac.ActionRead, ws, rbac.ActionRead*/ ).
+			Returns([]database.WorkspaceResource{})
 	}))
 	s.Run("InsertWorkspace", s.Subtest(func(db database.Store, check *expects) {
 		u := dbgen.User(s.T(), db, database.User{})

--- a/coderd/database/dbauthz/system.go
+++ b/coderd/database/dbauthz/system.go
@@ -14,6 +14,56 @@ import (
 // to these objects. Might need a negative permission on the `Owner` role to
 // prevent owners.
 
+// GetWorkspaceAppsByAgentIDs
+// The workspace/job is already fetched.
+// TODO: This function should be removed/replaced with something with proper auth.
+func (q *querier) GetWorkspaceAppsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceApp, error) {
+	return q.db.GetWorkspaceAppsByAgentIDs(ctx, ids)
+}
+
+// GetWorkspaceAgentsByResourceIDs
+// The workspace/job is already fetched.
+// TODO: This function should be removed/replaced with something with proper auth.
+func (q *querier) GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceAgent, error) {
+	return q.db.GetWorkspaceAgentsByResourceIDs(ctx, ids)
+}
+
+// GetWorkspaceResourceMetadataByResourceIDs is only used for build data.
+// The workspace/job is already fetched.
+// TODO: This function should be removed/replaced with something with proper auth.
+func (q *querier) GetWorkspaceResourceMetadataByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceResourceMetadatum, error) {
+	return q.db.GetWorkspaceResourceMetadataByResourceIDs(ctx, ids)
+}
+
+// GetUsersByIDs is only used for usernames on workspace return data.
+// This function should be replaced by joining this data to the workspace query
+// itself.
+// TODO: This function should be removed/replaced with something with proper auth.
+// A SQL compiled filter is an option.
+func (q *querier) GetUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]database.User, error) {
+	return q.db.GetUsersByIDs(ctx, ids)
+}
+
+func (q *querier) GetProvisionerJobsByIDs(ctx context.Context, ids []uuid.UUID) ([]database.ProvisionerJob, error) {
+	// TODO: This is missing authorization and is incorrect. This call is used by telemetry, and by 1 http route.
+	// That http handler should find a better way to fetch these jobs with easier rbac authz.
+	return q.db.GetProvisionerJobsByIDs(ctx, ids)
+}
+
+// GetTemplateVersionsByIDs is only used for workspace build data.
+// The workspace is already fetched.
+// TODO: Find a way to replace this with proper authz.
+func (q *querier) GetTemplateVersionsByIDs(ctx context.Context, ids []uuid.UUID) ([]database.TemplateVersion, error) {
+	return q.GetTemplateVersionsByIDs(ctx, ids)
+}
+
+// GetWorkspaceResourcesByJobIDs is only used for workspace build data.
+// The workspace is already fetched.
+// TODO: Find a way to replace this with proper authz.
+func (q *querier) GetWorkspaceResourcesByJobIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceResource, error) {
+	return q.db.GetWorkspaceResourcesByJobIDs(ctx, ids)
+}
+
 func (q *querier) UpdateUserLinkedID(ctx context.Context, arg database.UpdateUserLinkedIDParams) (database.UserLink, error) {
 	return q.db.UpdateUserLinkedID(ctx, arg)
 }

--- a/coderd/database/dbauthz/system.go
+++ b/coderd/database/dbauthz/system.go
@@ -54,7 +54,7 @@ func (q *querier) GetProvisionerJobsByIDs(ctx context.Context, ids []uuid.UUID) 
 // The workspace is already fetched.
 // TODO: Find a way to replace this with proper authz.
 func (q *querier) GetTemplateVersionsByIDs(ctx context.Context, ids []uuid.UUID) ([]database.TemplateVersion, error) {
-	return q.GetTemplateVersionsByIDs(ctx, ids)
+	return q.db.GetTemplateVersionsByIDs(ctx, ids)
 }
 
 // GetWorkspaceResourcesByJobIDs is only used for workspace build data.

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -9,14 +9,13 @@ import (
 	"sort"
 	"time"
 
-	"github.com/coder/coder/coderd/database/dbauthz"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/coderd/audit"
 	"github.com/coder/coder/coderd/database"
+	"github.com/coder/coder/coderd/database/dbauthz"
 	"github.com/coder/coder/coderd/httpapi"
 	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/coderd/rbac"

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/coder/coder/coderd/database/dbauthz"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -82,11 +84,10 @@ func (api *API) deleteTemplate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: This just returns the workspaces a user can view. We should use
-	// a system function to get all workspaces that use this template.
-	// This data should never be exposed to the user aside from a non-zero count.
-	// Or we move this into a postgres constraint.
-	workspaces, err := api.Database.GetWorkspaces(ctx, database.GetWorkspacesParams{
+	// This is just to get the workspace count, so we use a system context to
+	// return ALL workspaces. Not just workspaces the user can view.
+	// nolint:gocritic
+	workspaces, err := api.Database.GetWorkspaces(dbauthz.AsSystemRestricted(ctx), database.GetWorkspacesParams{
 		TemplateIds: []uuid.UUID{template.ID},
 	})
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -570,7 +570,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 	}
 	aReq.New = workspace
 
-	users, err := api.Database.GetUsersByIDs(ctx, []uuid.UUID{user.ID, workspaceBuild.InitiatorID})
+	initiator, err := api.Database.GetUserByID(ctx, workspaceBuild.InitiatorID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching user.",
@@ -584,6 +584,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		WorkspaceBuilds: []telemetry.WorkspaceBuild{telemetry.ConvertWorkspaceBuild(workspaceBuild)},
 	})
 
+	users := []database.User{user, initiator}
 	apiBuild, err := api.convertWorkspaceBuild(
 		workspaceBuild,
 		workspace,


### PR DESCRIPTION
API already fetches the parent object and does the rbac check. Until these functions are optimized, skipping authz is better. It leaves us no worse off than the status quo.

This is easier to fix once dbauthz leaves experimental. Without this change, a lot of db round trips are unnecessarily added. So this is a temporary solution.

