### PR TITLE
chore: convert agent stats to use a table

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -767,12 +767,12 @@ func (a *agent) init(ctx context.Context) {
 
 func convertAgentStats(counts map[netlogtype.Connection]netlogtype.Counts) *agentsdk.Stats {
 	stats := &agentsdk.Stats{
-		ConnsByProto: map[string]int64{},
-		NumConns:     int64(len(counts)),
+		ConnectionsByProto: map[string]int64{},
+		ConnectionCount:    int64(len(counts)),
 	}
 
 	for conn, count := range counts {
-		stats.ConnsByProto[conn.Proto.String()]++
+		stats.ConnectionsByProto[conn.Proto.String()]++
 		stats.RxPackets += int64(count.RxPackets)
 		stats.RxBytes += int64(count.RxBytes)
 		stats.TxPackets += int64(count.TxPackets)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -73,7 +73,7 @@ func TestAgent_Stats_SSH(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		var ok bool
 		s, ok = <-stats
-		return ok && s.NumConns > 0 && s.RxBytes > 0 && s.TxBytes > 0
+		return ok && s.ConnectionCount > 0 && s.RxBytes > 0 && s.TxBytes > 0
 	}, testutil.WaitLong, testutil.IntervalFast,
 		"never saw stats: %+v", s,
 	)
@@ -102,7 +102,7 @@ func TestAgent_Stats_ReconnectingPTY(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		var ok bool
 		s, ok = <-stats
-		return ok && s.NumConns > 0 && s.RxBytes > 0 && s.TxBytes > 0
+		return ok && s.ConnectionCount > 0 && s.RxBytes > 0 && s.TxBytes > 0
 	}, testutil.WaitLong, testutil.IntervalFast,
 		"never saw stats: %+v", s,
 	)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5202,14 +5202,14 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "conns_by_proto": {
-                    "description": "ConnsByProto is a count of connections by protocol.",
+                    "description": "ConnectionsByProto is a count of connections by protocol.",
                     "type": "object",
                     "additionalProperties": {
                         "type": "integer"
                     }
                 },
                 "num_comms": {
-                    "description": "NumConns is the number of connections received by an agent.",
+                    "description": "ConnectionCount is the number of connections received by an agent.",
                     "type": "integer"
                 },
                 "rx_bytes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4595,14 +4595,14 @@
       "type": "object",
       "properties": {
         "conns_by_proto": {
-          "description": "ConnsByProto is a count of connections by protocol.",
+          "description": "ConnectionsByProto is a count of connections by protocol.",
           "type": "object",
           "additionalProperties": {
             "type": "integer"
           }
         },
         "num_comms": {
-          "description": "NumConns is the number of connections received by an agent.",
+          "description": "ConnectionCount is the number of connections received by an agent.",
           "type": "integer"
         },
         "rx_bytes": {

--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -1528,18 +1528,18 @@ func (q *querier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg da
 	return update(q.log, q.auth, fetch, q.db.UpdateWorkspaceAgentConnectionByID)(ctx, arg)
 }
 
-func (q *querier) InsertAgentStat(ctx context.Context, arg database.InsertAgentStatParams) (database.AgentStat, error) {
+func (q *querier) InsertWorkspaceAgentStat(ctx context.Context, arg database.InsertWorkspaceAgentStatParams) (database.WorkspaceAgentStat, error) {
 	// TODO: This is a workspace agent operation. Should users be able to query this?
 	// Not really sure what this is for.
 	workspace, err := q.db.GetWorkspaceByID(ctx, arg.WorkspaceID)
 	if err != nil {
-		return database.AgentStat{}, err
+		return database.WorkspaceAgentStat{}, err
 	}
 	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace)
 	if err != nil {
-		return database.AgentStat{}, err
+		return database.WorkspaceAgentStat{}, err
 	}
-	return q.db.InsertAgentStat(ctx, arg)
+	return q.db.InsertWorkspaceAgentStat(ctx, arg)
 }
 
 func (q *querier) UpdateWorkspaceAppHealthByID(ctx context.Context, arg database.UpdateWorkspaceAppHealthByIDParams) error {

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -1168,9 +1168,9 @@ func (s *MethodTestSuite) TestWorkspace() {
 			ID: agt.ID,
 		}).Asserts(ws, rbac.ActionUpdate).Returns()
 	}))
-	s.Run("InsertAgentStat", s.Subtest(func(db database.Store, check *expects) {
+	s.Run("InsertWorkspaceAgentStat", s.Subtest(func(db database.Store, check *expects) {
 		ws := dbgen.Workspace(s.T(), db, database.Workspace{})
-		check.Args(database.InsertAgentStatParams{
+		check.Args(database.InsertWorkspaceAgentStatParams{
 			WorkspaceID: ws.ID,
 		}).Asserts(ws, rbac.ActionUpdate)
 	}))

--- a/coderd/database/dbauthz/system.go
+++ b/coderd/database/dbauthz/system.go
@@ -147,8 +147,8 @@ func (q *querier) GetWorkspaceResourceMetadataCreatedAfter(ctx context.Context, 
 	return q.db.GetWorkspaceResourceMetadataCreatedAfter(ctx, createdAt)
 }
 
-func (q *querier) DeleteOldAgentStats(ctx context.Context) error {
-	return q.db.DeleteOldAgentStats(ctx)
+func (q *querier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {
+	return q.db.DeleteOldWorkspaceAgentStats(ctx)
 }
 
 func (q *querier) GetParameterSchemasCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.ParameterSchema, error) {

--- a/coderd/database/dbauthz/system_test.go
+++ b/coderd/database/dbauthz/system_test.go
@@ -128,7 +128,7 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		_ = dbgen.WorkspaceResourceMetadatums(s.T(), db, database.WorkspaceResourceMetadatum{})
 		check.Args(time.Now()).Asserts()
 	}))
-	s.Run("DeleteOldAgentStats", s.Subtest(func(db database.Store, check *expects) {
+	s.Run("DeleteOldWorkspaceAgentStats", s.Subtest(func(db database.Store, check *expects) {
 		check.Args().Asserts()
 	}))
 	s.Run("GetParameterSchemasCreatedAfter", s.Subtest(func(db database.Store, check *expects) {

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -272,13 +272,18 @@ func (q *fakeQuerier) InsertWorkspaceAgentStat(_ context.Context, p database.Ins
 	defer q.mutex.Unlock()
 
 	stat := database.WorkspaceAgentStat{
-		ID:          p.ID,
-		CreatedAt:   p.CreatedAt,
-		WorkspaceID: p.WorkspaceID,
-		AgentID:     p.AgentID,
-		UserID:      p.UserID,
-		Payload:     p.Payload,
-		TemplateID:  p.TemplateID,
+		ID:                 p.ID,
+		CreatedAt:          p.CreatedAt,
+		WorkspaceID:        p.WorkspaceID,
+		AgentID:            p.AgentID,
+		UserID:             p.UserID,
+		ConnectionsByProto: p.ConnectionsByProto,
+		ConnectionCount:    p.ConnectionCount,
+		RxPackets:          p.RxPackets,
+		RxBytes:            p.RxBytes,
+		TxPackets:          p.TxPackets,
+		TxBytes:            p.TxBytes,
+		TemplateID:         p.TemplateID,
 	}
 	q.workspaceAgentStats = append(q.workspaceAgentStats, stat)
 	return stat, nil

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -123,16 +123,6 @@ CREATE TYPE workspace_transition AS ENUM (
     'delete'
 );
 
-CREATE TABLE agent_stats (
-    id uuid NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    user_id uuid NOT NULL,
-    agent_id uuid NOT NULL,
-    workspace_id uuid NOT NULL,
-    template_id uuid NOT NULL,
-    payload jsonb NOT NULL
-);
-
 CREATE TABLE api_keys (
     id text NOT NULL,
     hashed_secret bytea NOT NULL,
@@ -472,6 +462,16 @@ CREATE TABLE users (
     last_seen_at timestamp without time zone DEFAULT '0001-01-01 00:00:00'::timestamp without time zone NOT NULL
 );
 
+CREATE TABLE workspace_agent_stats (
+    id uuid NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    user_id uuid NOT NULL,
+    agent_id uuid NOT NULL,
+    workspace_id uuid NOT NULL,
+    template_id uuid NOT NULL,
+    payload jsonb NOT NULL
+);
+
 CREATE TABLE workspace_agents (
     id uuid NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -611,7 +611,7 @@ ALTER TABLE ONLY provisioner_job_logs ALTER COLUMN id SET DEFAULT nextval('provi
 
 ALTER TABLE ONLY workspace_resource_metadata ALTER COLUMN id SET DEFAULT nextval('workspace_resource_metadata_id_seq'::regclass);
 
-ALTER TABLE ONLY agent_stats
+ALTER TABLE ONLY workspace_agent_stats
     ADD CONSTRAINT agent_stats_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY api_keys
@@ -734,9 +734,9 @@ ALTER TABLE ONLY workspace_resources
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_pkey PRIMARY KEY (id);
 
-CREATE INDEX idx_agent_stats_created_at ON agent_stats USING btree (created_at);
+CREATE INDEX idx_agent_stats_created_at ON workspace_agent_stats USING btree (created_at);
 
-CREATE INDEX idx_agent_stats_user_id ON agent_stats USING btree (user_id);
+CREATE INDEX idx_agent_stats_user_id ON workspace_agent_stats USING btree (user_id);
 
 CREATE INDEX idx_api_keys_user ON api_keys USING btree (user_id);
 

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -469,7 +469,12 @@ CREATE TABLE workspace_agent_stats (
     agent_id uuid NOT NULL,
     workspace_id uuid NOT NULL,
     template_id uuid NOT NULL,
-    payload jsonb NOT NULL
+    connections_by_proto jsonb DEFAULT '{}'::jsonb NOT NULL,
+    connection_count integer DEFAULT 0 NOT NULL,
+    rx_packets integer DEFAULT 0 NOT NULL,
+    rx_bytes integer DEFAULT 0 NOT NULL,
+    tx_packets integer DEFAULT 0 NOT NULL,
+    tx_bytes integer DEFAULT 0 NOT NULL
 );
 
 CREATE TABLE workspace_agents (

--- a/coderd/database/migrations/000101_workspace_agent_stats_tableify.down.sql
+++ b/coderd/database/migrations/000101_workspace_agent_stats_tableify.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE workspace_agent_stats RENAME TO agent_stats;
+
+ALTER TABLE agent_stats ADD COLUMN payload jsonb NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE agent_stats DROP COLUMN connections_by_proto,
+	DROP COLUMN connection_count,
+	DROP COLUMN rx_packets,
+	DROP COLUMN rx_bytes,
+	DROP COLUMN tx_packets,
+	DROP COLUMN tx_bytes;

--- a/coderd/database/migrations/000101_workspace_agent_stats_tableify.up.sql
+++ b/coderd/database/migrations/000101_workspace_agent_stats_tableify.up.sql
@@ -1,5 +1,4 @@
-ALTER TABLE agent_stats
-	RENAME TO workspace_agent_stats;
+ALTER TABLE agent_stats	RENAME TO workspace_agent_stats;
 
 ALTER TABLE	workspace_agent_stats ADD COLUMN connections_by_proto jsonb NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE	workspace_agent_stats ADD COLUMN connection_count integer DEFAULT 0 NOT NULL;
@@ -9,11 +8,11 @@ ALTER TABLE workspace_agent_stats ADD COLUMN tx_packets integer DEFAULT 0 NOT NU
 ALTER TABLE workspace_agent_stats ADD COLUMN tx_bytes integer DEFAULT 0 NOT NULL;
 
 UPDATE workspace_agent_stats SET
-	connections_by_proto = (payload ->> 'conns_by_proto')::jsonb,
-	connection_count = (payload ->> 'num_conns')::integer,
-	rx_packets = (payload ->> 'rx_packets')::integer,
-	rx_bytes = (payload ->> 'rx_bytes')::integer,
-	tx_packets = (payload ->> 'tx_packets')::integer,
-	tx_bytes = (payload ->> 'tx_bytes')::integer;
+	connections_by_proto = coalesce((payload ->> 'conns_by_proto')::jsonb, '{}'::jsonb),
+	connection_count = coalesce((payload ->> 'num_conns')::integer, 0),
+	rx_packets = coalesce((payload ->> 'rx_packets')::integer, 0),
+	rx_bytes = coalesce((payload ->> 'rx_bytes')::integer, 0),
+	tx_packets = coalesce((payload ->> 'tx_packets')::integer, 0),
+	tx_bytes = coalesce((payload ->> 'tx_bytes')::integer, 0);
 
 ALTER TABLE workspace_agent_stats DROP COLUMN payload;

--- a/coderd/database/migrations/000101_workspace_agent_stats_tableify.up.sql
+++ b/coderd/database/migrations/000101_workspace_agent_stats_tableify.up.sql
@@ -1,3 +1,19 @@
 ALTER TABLE agent_stats
 	RENAME TO workspace_agent_stats;
 
+ALTER TABLE	workspace_agent_stats ADD COLUMN connections_by_proto jsonb NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE	workspace_agent_stats ADD COLUMN connection_count integer DEFAULT 0 NOT NULL;
+ALTER TABLE	workspace_agent_stats ADD COLUMN rx_packets integer DEFAULT 0 NOT NULL;
+ALTER TABLE workspace_agent_stats ADD COLUMN rx_bytes integer DEFAULT 0 NOT NULL;
+ALTER TABLE workspace_agent_stats ADD COLUMN tx_packets integer DEFAULT 0 NOT NULL;
+ALTER TABLE workspace_agent_stats ADD COLUMN tx_bytes integer DEFAULT 0 NOT NULL;
+
+UPDATE workspace_agent_stats SET
+	connections_by_proto = (payload ->> 'conns_by_proto')::jsonb,
+	connection_count = (payload ->> 'num_conns')::integer,
+	rx_packets = (payload ->> 'rx_packets')::integer,
+	rx_bytes = (payload ->> 'rx_bytes')::integer,
+	tx_packets = (payload ->> 'tx_packets')::integer,
+	tx_bytes = (payload ->> 'tx_bytes')::integer;
+
+ALTER TABLE workspace_agent_stats DROP COLUMN payload;

--- a/coderd/database/migrations/000101_workspace_agent_stats_tableify.up.sql
+++ b/coderd/database/migrations/000101_workspace_agent_stats_tableify.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_stats
+	RENAME TO workspace_agent_stats;
+

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1549,13 +1549,18 @@ type WorkspaceAgent struct {
 }
 
 type WorkspaceAgentStat struct {
-	ID          uuid.UUID       `db:"id" json:"id"`
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	UserID      uuid.UUID       `db:"user_id" json:"user_id"`
-	AgentID     uuid.UUID       `db:"agent_id" json:"agent_id"`
-	WorkspaceID uuid.UUID       `db:"workspace_id" json:"workspace_id"`
-	TemplateID  uuid.UUID       `db:"template_id" json:"template_id"`
-	Payload     json.RawMessage `db:"payload" json:"payload"`
+	ID                 uuid.UUID       `db:"id" json:"id"`
+	CreatedAt          time.Time       `db:"created_at" json:"created_at"`
+	UserID             uuid.UUID       `db:"user_id" json:"user_id"`
+	AgentID            uuid.UUID       `db:"agent_id" json:"agent_id"`
+	WorkspaceID        uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID         uuid.UUID       `db:"template_id" json:"template_id"`
+	ConnectionsByProto json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount    int32           `db:"connection_count" json:"connection_count"`
+	RxPackets          int32           `db:"rx_packets" json:"rx_packets"`
+	RxBytes            int32           `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets          int32           `db:"tx_packets" json:"tx_packets"`
+	TxBytes            int32           `db:"tx_bytes" json:"tx_bytes"`
 }
 
 type WorkspaceApp struct {

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1218,16 +1218,6 @@ type APIKey struct {
 	Scope           APIKeyScope `db:"scope" json:"scope"`
 }
 
-type AgentStat struct {
-	ID          uuid.UUID       `db:"id" json:"id"`
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	UserID      uuid.UUID       `db:"user_id" json:"user_id"`
-	AgentID     uuid.UUID       `db:"agent_id" json:"agent_id"`
-	WorkspaceID uuid.UUID       `db:"workspace_id" json:"workspace_id"`
-	TemplateID  uuid.UUID       `db:"template_id" json:"template_id"`
-	Payload     json.RawMessage `db:"payload" json:"payload"`
-}
-
 type AuditLog struct {
 	ID               uuid.UUID       `db:"id" json:"id"`
 	Time             time.Time       `db:"time" json:"time"`
@@ -1556,6 +1546,16 @@ type WorkspaceAgent struct {
 	StartupScriptTimeoutSeconds int32 `db:"startup_script_timeout_seconds" json:"startup_script_timeout_seconds"`
 	// The resolved path of a user-specified directory. e.g. ~/coder -> /home/coder/coder
 	ExpandedDirectory string `db:"expanded_directory" json:"expanded_directory"`
+}
+
+type WorkspaceAgentStat struct {
+	ID          uuid.UUID       `db:"id" json:"id"`
+	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
+	UserID      uuid.UUID       `db:"user_id" json:"user_id"`
+	AgentID     uuid.UUID       `db:"agent_id" json:"agent_id"`
+	WorkspaceID uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID  uuid.UUID       `db:"template_id" json:"template_id"`
+	Payload     json.RawMessage `db:"payload" json:"payload"`
 }
 
 type WorkspaceApp struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -26,7 +26,7 @@ type sqlcQuerier interface {
 	DeleteGroupMemberFromGroup(ctx context.Context, arg DeleteGroupMemberFromGroupParams) error
 	DeleteGroupMembersByOrgAndUser(ctx context.Context, arg DeleteGroupMembersByOrgAndUserParams) error
 	DeleteLicense(ctx context.Context, id int32) (int32, error)
-	DeleteOldAgentStats(ctx context.Context) error
+	DeleteOldWorkspaceAgentStats(ctx context.Context) error
 	DeleteParameterValueByID(ctx context.Context, id uuid.UUID) error
 	DeleteReplicasUpdatedBefore(ctx context.Context, updatedAt time.Time) error
 	GetAPIKeyByID(ctx context.Context, id string) (APIKey, error)
@@ -133,7 +133,6 @@ type sqlcQuerier interface {
 	GetWorkspaceResourcesCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceResource, error)
 	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]GetWorkspacesRow, error)
 	InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (APIKey, error)
-	InsertAgentStat(ctx context.Context, arg InsertAgentStatParams) (AgentStat, error)
 	// We use the organization_id as the id
 	// for simplicity since all users is
 	// every member of the org.
@@ -168,6 +167,7 @@ type sqlcQuerier interface {
 	InsertUserLink(ctx context.Context, arg InsertUserLinkParams) (UserLink, error)
 	InsertWorkspace(ctx context.Context, arg InsertWorkspaceParams) (Workspace, error)
 	InsertWorkspaceAgent(ctx context.Context, arg InsertWorkspaceAgentParams) (WorkspaceAgent, error)
+	InsertWorkspaceAgentStat(ctx context.Context, arg InsertWorkspaceAgentStatParams) (WorkspaceAgentStat, error)
 	InsertWorkspaceApp(ctx context.Context, arg InsertWorkspaceAppParams) (WorkspaceApp, error)
 	InsertWorkspaceBuild(ctx context.Context, arg InsertWorkspaceBuildParams) (WorkspaceBuild, error)
 	InsertWorkspaceBuildParameters(ctx context.Context, arg InsertWorkspaceBuildParametersParams) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5411,20 +5411,30 @@ INSERT INTO
 		workspace_id,
 		template_id,
 		agent_id,
-		payload
+		connections_by_proto,
+		connection_count,
+		rx_packets,
+		rx_bytes,
+		tx_packets,
+		tx_bytes
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7) RETURNING id, created_at, user_id, agent_id, workspace_id, template_id, payload
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes
 `
 
 type InsertWorkspaceAgentStatParams struct {
-	ID          uuid.UUID       `db:"id" json:"id"`
-	CreatedAt   time.Time       `db:"created_at" json:"created_at"`
-	UserID      uuid.UUID       `db:"user_id" json:"user_id"`
-	WorkspaceID uuid.UUID       `db:"workspace_id" json:"workspace_id"`
-	TemplateID  uuid.UUID       `db:"template_id" json:"template_id"`
-	AgentID     uuid.UUID       `db:"agent_id" json:"agent_id"`
-	Payload     json.RawMessage `db:"payload" json:"payload"`
+	ID                 uuid.UUID       `db:"id" json:"id"`
+	CreatedAt          time.Time       `db:"created_at" json:"created_at"`
+	UserID             uuid.UUID       `db:"user_id" json:"user_id"`
+	WorkspaceID        uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID         uuid.UUID       `db:"template_id" json:"template_id"`
+	AgentID            uuid.UUID       `db:"agent_id" json:"agent_id"`
+	ConnectionsByProto json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount    int32           `db:"connection_count" json:"connection_count"`
+	RxPackets          int32           `db:"rx_packets" json:"rx_packets"`
+	RxBytes            int32           `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets          int32           `db:"tx_packets" json:"tx_packets"`
+	TxBytes            int32           `db:"tx_bytes" json:"tx_bytes"`
 }
 
 func (q *sqlQuerier) InsertWorkspaceAgentStat(ctx context.Context, arg InsertWorkspaceAgentStatParams) (WorkspaceAgentStat, error) {
@@ -5435,7 +5445,12 @@ func (q *sqlQuerier) InsertWorkspaceAgentStat(ctx context.Context, arg InsertWor
 		arg.WorkspaceID,
 		arg.TemplateID,
 		arg.AgentID,
-		arg.Payload,
+		arg.ConnectionsByProto,
+		arg.ConnectionCount,
+		arg.RxPackets,
+		arg.RxBytes,
+		arg.TxPackets,
+		arg.TxBytes,
 	)
 	var i WorkspaceAgentStat
 	err := row.Scan(
@@ -5445,7 +5460,12 @@ func (q *sqlQuerier) InsertWorkspaceAgentStat(ctx context.Context, arg InsertWor
 		&i.AgentID,
 		&i.WorkspaceID,
 		&i.TemplateID,
-		&i.Payload,
+		&i.ConnectionsByProto,
+		&i.ConnectionCount,
+		&i.RxPackets,
+		&i.RxBytes,
+		&i.TxPackets,
+		&i.TxBytes,
 	)
 	return i, err
 }

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -7,10 +7,15 @@ INSERT INTO
 		workspace_id,
 		template_id,
 		agent_id,
-		payload
+		connections_by_proto,
+		connection_count,
+		rx_packets,
+		rx_bytes,
+		tx_packets,
+		tx_bytes
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7) RETURNING *;
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *;
 
 -- name: GetTemplateDAUs :many
 SELECT

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -1,6 +1,6 @@
--- name: InsertAgentStat :one
+-- name: InsertWorkspaceAgentStat :one
 INSERT INTO
-	agent_stats (
+	workspace_agent_stats (
 		id,
 		created_at,
 		user_id,
@@ -17,7 +17,7 @@ SELECT
 	(created_at at TIME ZONE 'UTC')::date as date,
 	user_id
 FROM
-	agent_stats
+	workspace_agent_stats
 WHERE
 	template_id = $1
 GROUP BY
@@ -30,11 +30,11 @@ SELECT
 	(created_at at TIME ZONE 'UTC')::date as date,
 	user_id
 FROM
-	agent_stats
+	workspace_agent_stats
 GROUP BY
 	date, user_id
 ORDER BY
 	date ASC;
 
--- name: DeleteOldAgentStats :exec
-DELETE FROM agent_stats WHERE created_at < NOW() - INTERVAL '30 days';
+-- name: DeleteOldWorkspaceAgentStats :exec
+DELETE FROM workspace_agent_stats WHERE created_at < NOW() - INTERVAL '30 days';

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -145,7 +145,7 @@ func countUniqueUsers(rows []database.GetTemplateDAUsRow) int {
 func (c *Cache) refresh(ctx context.Context) error {
 	//nolint:gocritic // This is a system service.
 	ctx = dbauthz.AsSystemRestricted(ctx)
-	err := c.database.DeleteOldAgentStats(ctx)
+	err := c.database.DeleteOldWorkspaceAgentStats(ctx)
 	if err != nil {
 		return xerrors.Errorf("delete old stats: %w", err)
 	}

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -31,7 +31,7 @@ func TestCache_TemplateUsers(t *testing.T) {
 	)
 
 	type args struct {
-		rows []database.InsertAgentStatParams
+		rows []database.InsertWorkspaceAgentStatParams
 	}
 	type want struct {
 		entries     []codersdk.DAUEntry
@@ -45,7 +45,7 @@ func TestCache_TemplateUsers(t *testing.T) {
 		{"empty", args{}, want{nil, 0}},
 		{
 			"one hole", args{
-				rows: []database.InsertAgentStatParams{
+				rows: []database.InsertWorkspaceAgentStatParams{
 					{
 						CreatedAt: date(2022, 8, 27),
 						UserID:    zebra,
@@ -75,7 +75,7 @@ func TestCache_TemplateUsers(t *testing.T) {
 			}, 1},
 		},
 		{"no holes", args{
-			rows: []database.InsertAgentStatParams{
+			rows: []database.InsertWorkspaceAgentStatParams{
 				{
 					CreatedAt: date(2022, 8, 27),
 					UserID:    zebra,
@@ -104,7 +104,7 @@ func TestCache_TemplateUsers(t *testing.T) {
 			},
 		}, 1}},
 		{"holes", args{
-			rows: []database.InsertAgentStatParams{
+			rows: []database.InsertWorkspaceAgentStatParams{
 				{
 					CreatedAt: date(2022, 1, 1),
 					UserID:    zebra,
@@ -179,7 +179,7 @@ func TestCache_TemplateUsers(t *testing.T) {
 
 			for _, row := range tt.args.rows {
 				row.TemplateID = template.ID
-				db.InsertAgentStat(context.Background(), row)
+				db.InsertWorkspaceAgentStat(context.Background(), row)
 			}
 
 			require.Eventuallyf(t, func() bool {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -933,21 +933,26 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 
 	activityBumpWorkspace(ctx, api.Logger.Named("activity_bump"), api.Database, workspace.ID)
 
-	payload, err := json.Marshal(req)
+	payload, err := json.Marshal(req.ConnectionsByProto)
 	if err != nil {
-		api.Logger.Error(ctx, "marshal agent stats report", slog.Error(err))
+		api.Logger.Error(ctx, "marshal agent connections by proto", slog.F("workspace_agent", workspaceAgent.ID), slog.Error(err))
 		payload = json.RawMessage("{}")
 	}
 
 	now := database.Now()
 	_, err = api.Database.InsertWorkspaceAgentStat(ctx, database.InsertWorkspaceAgentStatParams{
-		ID:          uuid.New(),
-		CreatedAt:   now,
-		AgentID:     workspaceAgent.ID,
-		WorkspaceID: workspace.ID,
-		UserID:      workspace.OwnerID,
-		TemplateID:  workspace.TemplateID,
-		Payload:     payload,
+		ID:                 uuid.New(),
+		CreatedAt:          now,
+		AgentID:            workspaceAgent.ID,
+		WorkspaceID:        workspace.ID,
+		UserID:             workspace.OwnerID,
+		TemplateID:         workspace.TemplateID,
+		ConnectionsByProto: payload,
+		ConnectionCount:    int32(req.ConnectionCount),
+		RxPackets:          int32(req.RxPackets),
+		RxBytes:            int32(req.RxBytes),
+		TxPackets:          int32(req.TxPackets),
+		TxBytes:            int32(req.TxBytes),
 	})
 	if err != nil {
 		httpapi.InternalServerError(rw, err)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -940,7 +940,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 	}
 
 	now := database.Now()
-	_, err = api.Database.InsertAgentStat(ctx, database.InsertAgentStatParams{
+	_, err = api.Database.InsertWorkspaceAgentStat(ctx, database.InsertWorkspaceAgentStatParams{
 		ID:          uuid.New(),
 		CreatedAt:   now,
 		AgentID:     workspaceAgent.ID,

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1178,12 +1178,12 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 		agentClient.SetSessionToken(authToken)
 
 		_, err := agentClient.PostStats(context.Background(), &agentsdk.Stats{
-			ConnsByProto: map[string]int64{"TCP": 1},
-			NumConns:     1,
-			RxPackets:    1,
-			RxBytes:      1,
-			TxPackets:    1,
-			TxBytes:      1,
+			ConnectionsByProto: map[string]int64{"TCP": 1},
+			ConnectionCount:    1,
+			RxPackets:          1,
+			RxBytes:            1,
+			TxPackets:          1,
+			TxBytes:            1,
 		})
 		require.NoError(t, err)
 

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -397,7 +397,7 @@ func (c *Client) ReportStats(ctx context.Context, log slog.Logger, statsChan <-c
 	}
 
 	// Send an empty stat to get the interval.
-	postStat(&Stats{ConnsByProto: map[string]int64{}})
+	postStat(&Stats{ConnectionsByProto: map[string]int64{}})
 
 	go func() {
 		defer close(exited)
@@ -426,10 +426,10 @@ func (c *Client) ReportStats(ctx context.Context, log slog.Logger, statsChan <-c
 // Stats records the Agent's network connection statistics for use in
 // user-facing metrics and debugging.
 type Stats struct {
-	// ConnsByProto is a count of connections by protocol.
-	ConnsByProto map[string]int64 `json:"conns_by_proto"`
-	// NumConns is the number of connections received by an agent.
-	NumConns int64 `json:"num_comms"`
+	// ConnectionsByProto is a count of connections by protocol.
+	ConnectionsByProto map[string]int64 `json:"conns_by_proto"`
+	// ConnectionCount is the number of connections received by an agent.
+	ConnectionCount int64 `json:"num_comms"`
 	// RxPackets is the number of received packets.
 	RxPackets int64 `json:"rx_packets"`
 	// RxBytes is the number of received bytes.

--- a/codersdk/workspaceagents_test.go
+++ b/codersdk/workspaceagents_test.go
@@ -79,7 +79,7 @@ func TestAgentReportStats(t *testing.T) {
 	chanLen := 3
 	statCh := make(chan *agentsdk.Stats, chanLen)
 	for i := 0; i < chanLen; i++ {
-		statCh <- &agentsdk.Stats{ConnsByProto: map[string]int64{}}
+		statCh <- &agentsdk.Stats{ConnectionsByProto: map[string]int64{}}
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Backwards compatibility becomes hard when all agent stats are in a JSON blob.
We also want to query this table for new agents that are failing health checks
so we can display it in the UI.