### PR TITLE
fix(site): Fix long template descriptions on template header

### DIFF
--- a/site/src/components/PageHeader/PageHeader.tsx
+++ b/site/src/components/PageHeader/PageHeader.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     paddingTop: theme.spacing(6),
     paddingBottom: theme.spacing(6),
+    gap: theme.spacing(4),
 
     [theme.breakpoints.down("sm")]: {
       flexDirection: "column",
@@ -83,6 +84,7 @@ const useStyles = makeStyles((theme) => ({
     margin: 0,
     marginTop: ({ condensed }: { condensed?: boolean }) =>
       condensed ? theme.spacing(0.5) : theme.spacing(1),
+    lineHeight: "140%",
   },
 
   actions: {

--- a/site/src/theme/overrides.ts
+++ b/site/src/theme/overrides.ts
@@ -49,6 +49,7 @@ export const getOverrides = ({
         textTransform: "none",
         letterSpacing: "none",
         border: `1px solid ${palette.divider}`,
+        whiteSpace: "nowrap",
 
         "&:focus-visible": {
           outline: `2px solid ${palette.primary.dark}`,


### PR DESCRIPTION
Before:
<img width="1025" alt="Screen Shot 2023-03-01 at 14 42 41" src="https://user-images.githubusercontent.com/3165839/222219619-4e759e2d-9bdb-46b8-9ec8-8fdd7d30cc0e.png">

After:
<img width="1028" alt="Screen Shot 2023-03-01 at 14 41 55" src="https://user-images.githubusercontent.com/3165839/222219624-e116edd2-05e2-4e1f-aeac-01a11609a975.png">

Fix #6153 
