### PR TITLE
docs: resolve release link from binary.md

### DIFF
--- a/docs/install/binary.md
+++ b/docs/install/binary.md
@@ -1,4 +1,4 @@
-Coder publishes self-contained .zip and .tar.gz archives in [GitHub releases](https://github.com/coder//latest). The archives bundle `coder` binary.
+Coder publishes self-contained .zip and .tar.gz archives in [GitHub releases](https://github.com/coder/coder/releases/latest). The archives bundle `coder` binary.
 
 1. Download the [release archive](https://github.com/coder/coder/releases/latest) appropriate for your operating system
 


### PR DESCRIPTION
Fixed broken Link to Github release archive

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
