### PR TITLE
docs: AWS EKS `sessionAffinity` Helm config required for LB external IP to be issued

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -112,6 +112,15 @@ to log in and manage templates.
    > [values.yaml](https://github.com/coder/coder/blob/main/helm/values.yaml)
    > file directly.
 
+   If you are deploying Coder on AWS EKS and service is set to LoadBalancer, the load balancer external IP will be stuck in a pending status unless sessionAffinity is set to None.
+
+   ```yaml
+   coder:
+     service:
+       type: LoadBalancer
+       sessionAffinity: None
+   ```
+
 1. Run the following command to install the chart in your cluster.
 
    ```console


### PR DESCRIPTION
The PR for updating the Coder installation docs - addresses an issue where if Coder is deployed in AWS EKS, that the load balancer external IP will not be issued without a sessionAffinity set to None.

Since one or more prospects have hit this, it is important to put in the docs and not assume people read our notes buried in the Helm chart.