### PR TITLE
feat: Add ability to configure coder container lifecycle hooks in helm chart

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -55,6 +55,8 @@ spec:
           imagePullPolicy: {{ .Values.coder.image.pullPolicy }}
           resources:
             {{- toYaml .Values.coder.resources | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.coder.lifecycle | nindent 12 }}
           env:
             - name: CODER_HTTP_ADDRESS
               value: "0.0.0.0:8080"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -115,6 +115,18 @@ coder:
     # will be automatically mounted into the pod if specified, and the correct
     # "CODER_TLS_*" environment variables will be set for you.
     secretNames: []
+  
+  # coder.lifecycle -- container lifecycle handlers for the Coder container, allowing
+  # for lifecycle events such as postStart and preStop events
+  # See: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+  lifecycle:
+    {}
+    # postStart:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "echo postStart"]
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh","-c","echo preStart"]
 
   # coder.resources -- The resources to request for Coder. These are optional
   # and are not set by default.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -115,7 +115,7 @@ coder:
     # will be automatically mounted into the pod if specified, and the correct
     # "CODER_TLS_*" environment variables will be set for you.
     secretNames: []
-  
+
   # coder.lifecycle -- container lifecycle handlers for the Coder container, allowing
   # for lifecycle events such as postStart and preStop events
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/


### PR DESCRIPTION
<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->

Per #6417, adding ability to configure container lifecycle hooks through the Coder Helm chart. By default, none are configured.

This can be useful for bootstrapping the Coder deployment with an initial user, for example, or any other bootstrapping setup that can't be accomplished via an `initContainer`.