### PR TITLE
fix(provisionerd): log workspace build transition in lower case

### DIFF
--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -124,7 +124,7 @@ func New(
 			slog.F("workspace_id", build.Metadata.WorkspaceId),
 			slog.F("workspace_name", build.Metadata.WorkspaceName),
 			slog.F("workspace_owner", build.Metadata.WorkspaceOwner),
-			slog.F("workspace_transition", build.Metadata.WorkspaceTransition.String()),
+			slog.F("workspace_transition", strings.ToLower(build.Metadata.WorkspaceTransition.String())),
 		)
 	}
 


### PR DESCRIPTION
Some services (such as DataDog) will automagically transform log fields to lower case from upper case, but then will perform case-sensitive matching on those log fields.