### PR TITLE
chore(cli)!: change default max-token-duration to unlimited

### DIFF
--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -499,10 +499,11 @@ func newConfig() *codersdk.DeploymentConfig {
 			Default: flag.Lookup("test.v") == nil && !buildinfo.IsDev(),
 		},
 		MaxTokenLifetime: &codersdk.DeploymentConfigField[time.Duration]{
-			Name:    "Max Token Lifetime",
-			Usage:   "The maximum lifetime duration users can specify when creating an API token.",
-			Flag:    "max-token-lifetime",
-			Default: 24 * 30 * time.Hour,
+			Name:  "Max Token Lifetime",
+			Usage: "The maximum lifetime duration users can specify when creating an API token.",
+			Flag:  "max-token-lifetime",
+			// max time.Duration is 290 years
+			Default: 290 * 365 * 24 * time.Hour,
 		},
 		Swagger: &codersdk.SwaggerConfig{
 			Enable: &codersdk.DeploymentConfigField[bool]{

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -147,7 +147,7 @@ Flags:
                                                           can specify when creating an API
                                                           token.
                                                           Consumes $CODER_MAX_TOKEN_LIFETIME
-                                                          (default 720h0m0s)
+                                                          (default 2540400h0m0s)
       --oauth2-github-allow-everyone                      Allow all logins, setting this
                                                           option means allowed orgs and teams
                                                           must be empty.

--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -71,7 +71,7 @@ func TestTokenScoped(t *testing.T) {
 	require.Equal(t, keys[0].Scope, codersdk.APIKeyScopeApplicationConnect)
 }
 
-func TestTokenDuration(t *testing.T) {
+func TestUserSetTokenDuration(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -89,7 +89,23 @@ func TestTokenDuration(t *testing.T) {
 	require.Less(t, keys[0].ExpiresAt, time.Now().Add(time.Hour*8*24))
 }
 
-func TestTokenMaxLifetime(t *testing.T) {
+func TestDefaultTokenDuration(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	_, err := client.CreateToken(ctx, codersdk.Me, codersdk.CreateTokenRequest{})
+	require.NoError(t, err)
+	keys, err := client.Tokens(ctx, codersdk.Me, codersdk.TokensFilter{})
+	require.NoError(t, err)
+	require.Greater(t, keys[0].ExpiresAt, time.Now().Add(time.Hour*29*24))
+	require.Less(t, keys[0].ExpiresAt, time.Now().Add(time.Hour*31*24))
+}
+
+func TestTokenUserSetMaxLifetime(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -110,6 +126,31 @@ func TestTokenMaxLifetime(t *testing.T) {
 	// fail
 	_, err = client.CreateToken(ctx, codersdk.Me, codersdk.CreateTokenRequest{
 		Lifetime: time.Hour * 24 * 8,
+	})
+	require.ErrorContains(t, err, "lifetime must be less")
+}
+
+func TestTokenDefaultMaxLifetime(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+	dc := coderdtest.DeploymentConfig(t)
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentConfig: dc,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	// success
+	_, err := client.CreateToken(ctx, codersdk.Me, codersdk.CreateTokenRequest{
+		Lifetime: time.Hour * 24 * 365,
+	})
+	require.NoError(t, err)
+
+	// fail - default --max-token-lifetime is the maximum value of time.Duration
+	// which is 24 * 365 * 290.
+	_, err = client.CreateToken(ctx, codersdk.Me, codersdk.CreateTokenRequest{
+		Lifetime: time.Hour * 24 * 366 * 290,
 	})
 	require.ErrorContains(t, err, "lifetime must be less")
 }

--- a/docs/cli/coder_server.md
+++ b/docs/cli/coder_server.md
@@ -211,7 +211,7 @@ The maximum lifetime duration users can specify when creating an API token.
 | | |
 | --- | --- |
 | Consumes | <code>$CODER_MAX_TOKEN_LIFETIME</code> |
-| Default | <code>720h0m0s</code> |
+| Default | <code>2540400h0m0s</code> |
 
 ### --oauth2-github-allow-everyone
 

--- a/docs/templates/change-management.md
+++ b/docs/templates/change-management.md
@@ -8,6 +8,8 @@ curl -L https://coder.com/install.sh | sh
 # curl -L https://coder.com/install.sh | sh -s -- --version=0.x
 
 # To create API tokens, use `coder tokens create`.
+# If no `--lifetime` flag is passed during creation, the default token lifetime
+# will be 30 days.
 # These variables are consumed by Coder
 export CODER_URL=https://coder.example.com
 export CODER_SESSION_TOKEN=*****
@@ -26,4 +28,4 @@ coder templates push --yes $CODER_TEMPLATE_NAME \
 > Looking for an example? See how we push our development image
 > and template [via GitHub actions](https://github.com/coder/coder/blob/main/.github/workflows/dogfood.yaml).
 
-> To create tokens with over a 30 day lifetime, [configure Coder server to set a longer max token lifetime](../cli/coder_server#--max-token-lifetime)
+> To cap token lifetime on creation, [configure Coder server to set a shorter max token lifetime](../cli/coder_server#--max-token-lifetime)


### PR DESCRIPTION
Product has requested that token lifetimes follow the below rules:

- Make default of `--max-token-lifetime` unlimited.

- Make default lifetime of `coder tokens create` 30 days, but then another lifetime can be set with `--lifetime` up to the max (set by server).