### PR TITLE
chore: remove empty case for metricscache

### DIFF
--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -173,10 +173,6 @@ func TestCache_TemplateUsers(t *testing.T) {
 				Provisioner: database.ProvisionerTypeEcho,
 			})
 
-			gotUniqueUsers, ok := cache.TemplateUniqueUsers(template.ID)
-			require.False(t, ok, "template shouldn't have loaded yet")
-			require.EqualValues(t, -1, gotUniqueUsers)
-
 			for _, row := range tt.args.rows {
 				row.TemplateID = template.ID
 				db.InsertWorkspaceAgentStat(context.Background(), row)
@@ -189,7 +185,7 @@ func TestCache_TemplateUsers(t *testing.T) {
 				"TemplateDAUs never populated",
 			)
 
-			gotUniqueUsers, ok = cache.TemplateUniqueUsers(template.ID)
+			gotUniqueUsers, ok := cache.TemplateUniqueUsers(template.ID)
 			require.True(t, ok)
 
 			gotEntries, ok := cache.TemplateDAUs(template.ID)


### PR DESCRIPTION
This wasn't necessary to test and just caused flakes. See: https://github.com/coder/coder/actions/runs/4350034299/jobs/7600340648
