### PR TITLE
chore: ensure pubsub messages are delivered in order for in-memory variant

### DIFF
--- a/coderd/database/pubsub_memory.go
+++ b/coderd/database/pubsub_memory.go
@@ -46,9 +46,16 @@ func (m *memoryPubsub) Publish(event string, message []byte) error {
 	if !ok {
 		return nil
 	}
+	var wg sync.WaitGroup
 	for _, listener := range listeners {
-		go listener(context.Background(), message)
+		wg.Add(1)
+		listener := listener
+		go func() {
+			defer wg.Done()
+			listener(context.Background(), message)
+		}()
 	}
+	wg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
PostgreSQL provides this guarantee, which led to some flakes in tests. See: https://github.com/coder/coder/actions/runs/4350034299/jobs/7600478096
