### PR TITLE
chore: ignore query cancel error in activitybump

### DIFF
--- a/coderd/activitybump.go
+++ b/coderd/activitybump.go
@@ -82,7 +82,7 @@ func activityBumpWorkspace(ctx context.Context, log slog.Logger, db database.Sto
 		return nil
 	}, nil)
 	if err != nil {
-		if !xerrors.Is(err, context.Canceled) {
+		if !xerrors.Is(err, context.Canceled) && !database.IsQueryCanceledError(err) {
 			// Bump will fail if the context is canceled, but this is ok.
 			log.Error(ctx, "bump failed", slog.Error(err),
 				slog.F("workspace_id", workspaceID),


### PR DESCRIPTION
See https://github.com/coder/coder/actions/runs/4350254306/jobs/7600782432

It's fine to ignore this, because workspace agent stats happen async and might occur when shutting down.
