### PR TITLE
chore: migrate security checks to run on a cron

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -6,17 +6,11 @@ permissions:
   security-events: write
 
 on:
-  push:
-    branches: ["main"]
-
-  pull_request:
-    branches: ["main"]
-
   workflow_dispatch:
 
   schedule:
-    # Run every week at 10:24 on Thursday.
-    - cron: "24 10 * * 4"
+    # Run every 6 hours Monday-Friday!
+    - cron: "0 0,6,12,18 * * 1-5"
 
 # Cancel in-progress runs for pull requests when developers push
 # additional changes
@@ -58,6 +52,17 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+
+      - name: Send Slack notification on failure
+        if: ${{ failure() }}
+        run: |
+          msg="❌ CodeQL Failed\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl \
+            -qfsSL \
+            -X POST \
+            -H "Content-Type: application/json" \
+            --data "{\"content\": \"$msg\"}" \
+            "${{ secrets.SLACK_SECURITY_FAILURE_WEBHOOK_URL }}"
 
   trivy:
     runs-on: ${{ github.repository_owner == 'coder' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
@@ -135,3 +140,14 @@ jobs:
           name: trivy
           path: trivy-results.sarif
           retention-days: 7
+
+      - name: Send Slack notification on failure
+        if: ${{ failure() }}
+        run: |
+          msg="❌ CodeQL Failed\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl \
+            -qfsSL \
+            -X POST \
+            -H "Content-Type: application/json" \
+            --data "{\"content\": \"$msg\"}" \
+            "${{ secrets.SLACK_SECURITY_FAILURE_WEBHOOK_URL }}"


### PR DESCRIPTION
They were taking a long time and seemed to be reducing concurrency for our other CI actions.
