### PR TITLE
chore: fix workspace audit log flake

### DIFF
--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -269,9 +269,10 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
-		_ = coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
-		require.Len(t, auditor.AuditLogs, 5)
+		require.Len(t, auditor.AuditLogs, 6)
 		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs[4].Action)
 	})
 


### PR DESCRIPTION
This happened because sometimes a build would be queued and completed intermittently in CI.

See https://github.com/coder/coder/actions/runs/4358121985/jobs/7618290591
