### PR TITLE
fix: only sum connection latencies when they are set

### DIFF
--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -340,6 +340,9 @@ func (q *fakeQuerier) GetDeploymentWorkspaceAgentStats(_ context.Context, create
 
 	latencies := make([]float64, 0)
 	for _, agentStat := range agentStatsCreatedAfter {
+		if agentStat.ConnectionMedianLatencyMS <= 0 {
+			continue
+		}
 		stat.WorkspaceRxBytes += agentStat.RxBytes
 		stat.WorkspaceTxBytes += agentStat.TxBytes
 		latencies = append(latencies, agentStat.ConnectionMedianLatencyMS)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5552,7 +5552,8 @@ WITH agent_stats AS (
 		coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_50,
 		coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_95
 	 FROM workspace_agent_stats
-		WHERE workspace_agent_stats.created_at > $1
+	 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
+		WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 ), latest_agent_stats AS (
 	SELECT
 		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -60,7 +60,8 @@ WITH agent_stats AS (
 		coalesce((PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_50,
 		coalesce((PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY connection_median_latency_ms)), -1)::FLOAT AS workspace_connection_latency_95
 	 FROM workspace_agent_stats
-		WHERE workspace_agent_stats.created_at > $1
+	 	-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
+		WHERE workspace_agent_stats.created_at > $1 AND connection_median_latency_ms > 0
 ), latest_agent_stats AS (
 	SELECT
 		coalesce(SUM(session_count_vscode), 0)::bigint AS session_count_vscode,


### PR DESCRIPTION
This was producing a median that didn't make sense.
