### PR TITLE
feat: Add a cli flag to specify a required OIDC group

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -777,6 +777,7 @@ flags, and YAML configuration. The precedence is as follows:
 					SignInText:          cfg.OIDC.SignInText.String(),
 					IconURL:             cfg.OIDC.IconURL.String(),
 					IgnoreEmailVerified: cfg.OIDC.IgnoreEmailVerified.Value(),
+					Group:               cfg.OIDC.Group.String(),
 				}
 			}
 

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7078,6 +7078,9 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "group": {
+                    "type": "string"
+                },
                 "icon_url": {
                     "$ref": "#/definitions/clibase.URL"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6338,6 +6338,9 @@
             "type": "string"
           }
         },
+        "group": {
+          "type": "string"
+        },
         "icon_url": {
           "$ref": "#/definitions/clibase.URL"
         },

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -481,6 +481,7 @@ type OIDCConfig struct {
 	SignInText string
 	// IconURL points to the URL of an icon to display on the OIDC login button
 	IconURL string
+	Group   string
 }
 
 // @Summary OpenID Connect Callback
@@ -653,6 +654,21 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		if !ok {
 			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 				Message: fmt.Sprintf("Your email %q is not in domains %q !", email, api.OIDCConfig.EmailDomain),
+			})
+			return
+		}
+	}
+
+	if len(api.OIDCConfig.Group) > 0 {
+		ok = false
+		for _, group := range groups {
+			if group == api.OIDCConfig.Group {
+				ok = true
+			}
+		}
+		if !ok {
+			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+				Message: fmt.Sprintf("You do not belong to the required group %q !", api.OIDCConfig.Group),
 			})
 			return
 		}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -222,6 +222,7 @@ type OIDCConfig struct {
 	UsernameField       clibase.String  `json:"username_field" typescript:",notnull"`
 	SignInText          clibase.String  `json:"sign_in_text" typescript:",notnull"`
 	IconURL             clibase.URL     `json:"icon_url" typescript:",notnull"`
+	Group               clibase.String  `json:"group" typescript:",notnull"`
 }
 
 type TelemetryConfig struct {
@@ -836,6 +837,16 @@ when required by your organization's security policy.`,
 			Value:       &c.OIDC.IconURL,
 			Group:       &deploymentGroupOIDC,
 			YAML:        "iconURL",
+		},
+		{
+			Name:        "OIDC Required Group",
+			Description: "Group that clients logging in with OIDC must match.",
+			Flag:        "oidc-group",
+			Env:         "OIDC_GROUP",
+			Default:     "",
+			Value:       &c.OIDC.Group,
+			Group:       &deploymentGroupOIDC,
+			YAML:        "group",
 		},
 		// Telemetry settings
 		{

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -230,6 +230,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "client_id": "string",
       "client_secret": "string",
       "email_domain": ["string"],
+      "group": "string",
       "icon_url": {
         "forceQuery": true,
         "fragment": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1762,6 +1762,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
       "client_id": "string",
       "client_secret": "string",
       "email_domain": ["string"],
+      "group": "string",
       "icon_url": {
         "forceQuery": true,
         "fragment": "string",
@@ -2101,6 +2102,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
     "client_id": "string",
     "client_secret": "string",
     "email_domain": ["string"],
+    "group": "string",
     "icon_url": {
       "forceQuery": true,
       "fragment": "string",
@@ -2761,6 +2763,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
   "client_id": "string",
   "client_secret": "string",
   "email_domain": ["string"],
+  "group": "string",
   "icon_url": {
     "forceQuery": true,
     "fragment": "string",
@@ -2790,6 +2793,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 | `client_id`             | string                     | false    |              |             |
 | `client_secret`         | string                     | false    |              |             |
 | `email_domain`          | array of string            | false    |              |             |
+| `group`                 | string                     | false    |              |             |
 | `icon_url`              | [clibase.URL](#clibaseurl) | false    |              |             |
 | `ignore_email_verified` | boolean                    | false    |              |             |
 | `issuer_url`            | string                     | false    |              |             |

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -559,6 +559,8 @@ export interface OIDCConfig {
   // This is likely an enum in an external package ("github.com/coder/coder/cli/clibase.String")
   readonly sign_in_text: string
   readonly icon_url: string
+  // This is likely an enum in an external package ("github.com/coder/coder/cli/clibase.String")
+  readonly group: string
 }
 
 // From codersdk/organizations.go


### PR DESCRIPTION
My Use-Case:

My organization is running GitLab and I am using it to handle my Coder instance's authentication

My Issue:

*Everyone* at my organization has the same email *domain*, so I can't use the built-in `EmailDomain` flag to limit access to my Coder instance. Therefore *everyone* at my organization has access to my Coder instance when I'd like to limit access to just my team

My Solution:

Coder is already pulling in the `groups` claim in the OAuth flow, so we may as well allow Coder instances to deny access based on group membership?

Interested in others thoughts (or perhaps this should be plural `groups`? 🤷‍♂️ )

Thanks!