### PR TITLE
fix: remove deprecation warnings when option unset

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -257,6 +257,10 @@ flags, and YAML configuration. The precedence is as follows:
 					continue
 				}
 
+				if opt.Value.String() == opt.Default {
+					continue
+				}
+
 				warnStr := opt.Name + " is deprecated, please use "
 				for i, use := range opt.UseInstead {
 					warnStr += use.Name + " "


### PR DESCRIPTION
Resolves #6531

<!--
Check if your change requires documentation edits before merging: https://coder.com/docs/coder. Make edits in `docs/`.
-->
