### PR TITLE
fix: remove "something went wrong" text for watching a workspace

### DIFF
--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -113,16 +113,6 @@ GetBuildsError.args = {
   },
 }
 
-export const GetResourcesError = Template.bind({})
-GetResourcesError.args = {
-  ...Running.args,
-  workspaceErrors: {
-    [WorkspaceErrors.GET_RESOURCES_ERROR]: Mocks.makeMockApiError({
-      message: "There is a problem fetching workspace resources.",
-    }),
-  },
-}
-
 export const CancellationError = Template.bind({})
 CancellationError.args = {
   ...Failed.args,

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -17,7 +17,6 @@ import { WorkspaceDeletedBanner } from "../WorkspaceDeletedBanner/WorkspaceDelet
 import { WorkspaceScheduleButton } from "../WorkspaceScheduleButton/WorkspaceScheduleButton"
 import { WorkspaceStats } from "../WorkspaceStats/WorkspaceStats"
 import { AlertBanner } from "../AlertBanner/AlertBanner"
-import { useTranslation } from "react-i18next"
 import {
   ActiveTransition,
   WorkspaceBuildProgress,
@@ -26,11 +25,9 @@ import { AgentRow } from "components/Resources/AgentRow"
 import { Avatar } from "components/Avatar/Avatar"
 
 export enum WorkspaceErrors {
-  GET_RESOURCES_ERROR = "getResourcesError",
   GET_BUILDS_ERROR = "getBuildsError",
   BUILD_ERROR = "buildError",
   CANCELLATION_ERROR = "cancellationError",
-  WORKSPACE_REFRESH_WARNING = "refreshWorkspaceWarning",
 }
 
 export interface WorkspaceProps {
@@ -88,7 +85,6 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
   templateParameters,
   quota_budget,
 }) => {
-  const { t } = useTranslation("workspacePage")
   const styles = useStyles()
   const navigate = useNavigate()
   const serverVersion = buildInfo?.version || ""
@@ -107,16 +103,6 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
     <AlertBanner
       severity="error"
       error={workspaceErrors[WorkspaceErrors.CANCELLATION_ERROR]}
-      dismissible
-    />
-  )
-
-  const workspaceRefreshWarning = Boolean(
-    workspaceErrors[WorkspaceErrors.WORKSPACE_REFRESH_WARNING],
-  ) && (
-    <AlertBanner
-      severity="warning"
-      text={t("warningsAndErrors.workspaceRefreshWarning")}
       dismissible
     />
   )
@@ -187,7 +173,6 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
       >
         {buildError}
         {cancellationError}
-        {workspaceRefreshWarning}
 
         <WorkspaceDeletedBanner
           workspace={workspace}
@@ -204,13 +189,6 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
           <WorkspaceBuildProgress
             workspace={workspace}
             transitionStats={transitionStats}
-          />
-        )}
-
-        {Boolean(workspaceErrors[WorkspaceErrors.GET_RESOURCES_ERROR]) && (
-          <AlertBanner
-            severity="error"
-            error={workspaceErrors[WorkspaceErrors.GET_RESOURCES_ERROR]}
           />
         )}
 

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -46,7 +46,6 @@ export const WorkspaceReadyPage = ({
     workspace,
     template,
     templateParameters,
-    refreshWorkspaceWarning,
     builds,
     getBuildsError,
     buildError,
@@ -119,7 +118,6 @@ export const WorkspaceReadyPage = ({
         hideSSHButton={featureVisibility["browser_only"]}
         hideVSCodeDesktopButton={featureVisibility["browser_only"]}
         workspaceErrors={{
-          [WorkspaceErrors.GET_RESOURCES_ERROR]: refreshWorkspaceWarning,
           [WorkspaceErrors.GET_BUILDS_ERROR]: getBuildsError,
           [WorkspaceErrors.BUILD_ERROR]: buildError,
           [WorkspaceErrors.CANCELLATION_ERROR]: cancellationError,

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -58,8 +58,6 @@ export interface WorkspaceContext {
   templateParameters?: TypesGen.TemplateVersionParameter[]
   build?: TypesGen.WorkspaceBuild
   getWorkspaceError?: Error | unknown
-  // these are labeled as warnings because they don't make the page unusable
-  refreshWorkspaceWarning?: Error | unknown
   getTemplateWarning: Error | unknown
   getTemplateParametersWarning: Error | unknown
   // Builds
@@ -278,10 +276,7 @@ export const workspaceMachine = createMachine(
                 },
                 on: {
                   REFRESH_WORKSPACE: {
-                    actions: [
-                      "refreshWorkspace",
-                      "clearRefreshWorkspaceWarning",
-                    ],
+                    actions: ["refreshWorkspace"],
                   },
                   EVENT_SOURCE_ERROR: {
                     target: "error",
@@ -289,7 +284,7 @@ export const workspaceMachine = createMachine(
                 },
               },
               error: {
-                entry: "assignRefreshWorkspaceWarning",
+                entry: "logWatchWorkspaceWarning",
                 after: {
                   "2000": {
                     target: "gettingEvents",
@@ -586,12 +581,9 @@ export const workspaceMachine = createMachine(
       refreshWorkspace: assign({
         workspace: (_, event) => event.data,
       }),
-      assignRefreshWorkspaceWarning: assign({
-        refreshWorkspaceWarning: (_, event) => event,
-      }),
-      clearRefreshWorkspaceWarning: assign({
-        refreshWorkspaceWarning: (_) => undefined,
-      }),
+      logWatchWorkspaceWarning: (_, event) => {
+        console.error("Watch workspace error:", event)
+      },
       assignGetTemplateWarning: assign({
         getTemplateWarning: (_, event) => event.data,
       }),


### PR DESCRIPTION
This text wasn't useful to a customer anyways, because we don't get an error from EventSource. This can happen if you close your laptop and open it again, so it's better if we don't display it.

Fixes #6423 
Fixes #6274 