### PR TITLE
fix: typo in error message

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -492,7 +492,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		if buildParameter, found := findWorkspaceBuildParameter(createBuild.RichParameterValues, templateVersionParameter.Name); found {
 			if !templateVersionParameter.Mutable {
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: fmt.Sprintf("Parameter %q is not mutable, so it can't be updated after creating workspace.", templateVersionParameter.Name),
+					Message: fmt.Sprintf("Parameter %q is not mutable, so it can't be updated after creating a workspace.", templateVersionParameter.Name),
 				})
 				return
 			}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -492,7 +492,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		if buildParameter, found := findWorkspaceBuildParameter(createBuild.RichParameterValues, templateVersionParameter.Name); found {
 			if !templateVersionParameter.Mutable {
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: fmt.Sprintf("Parameter %q is mutable, so it can't be updated after creating workspace.", templateVersionParameter.Name),
+					Message: fmt.Sprintf("Parameter %q is not mutable, so it can't be updated after creating workspace.", templateVersionParameter.Name),
 				})
 				return
 			}


### PR DESCRIPTION
This PR fixes a typo in the error message.

> Parameter %q is not mutable, so it can't be updated after creating a workspace.