### PR TITLE
fix: panic on deleted template

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -256,6 +256,11 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if len(data.builds) == 0 || len(data.templates) == 0 {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+
 	httpapi.Write(ctx, rw, http.StatusOK, convertWorkspace(
 		workspace,
 		data.builds[0],


### PR DESCRIPTION
This PR fixes the following panic:

```
[API] 2023-03-10 10:49:15.895 [WARN]	(coderd)	<./coderd/httpmw/recover.go:19>	Recover.func1.1.1	panic serving http request (recovered)	{"panic": "runtime error: index out of range [0] with length 0"} ...
[API] "stack": goroutine 8141 [running]:
[API]          runtime/debug.Stack()
[API]          	/nix/store/79z3m4iw5y7sj5mk4w7rs37vzlian9dj-go-1.20/share/go/src/runtime/debug/stack.go:24 +0x64
[API]          github.com/coder/coder/coderd/httpmw.Recover.func1.1.1()
[API]          	/Users/mtojek/code/coder/coderd/httpmw/recover.go:22 +0x5c
[API]          panic({0x116b9ffe0, 0x1400162e090})
[API]          	/nix/store/79z3m4iw5y7sj5mk4w7rs37vzlian9dj-go-1.20/share/go/src/runtime/panic.go:884 +0x1f4
[API]          go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
[API]          	/Users/mtojek/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.11.1/trace/span.go:383 +0x2c
[API]          go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0x1400160d080, {0x0, 0x0, 0x1?})
[API]          	/Users/mtojek/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.11.1/trace/span.go:421 +0x7e4
[API]          panic({0x116b9ffe0, 0x1400162e090})
[API]          	/nix/store/79z3m4iw5y7sj5mk4w7rs37vzlian9dj-go-1.20/share/go/src/runtime/panic.go:884 +0x1f4
[API]          github.com/coder/coder/coderd.(*API).workspaceByOwnerAndName(0x140011ae000, {0x116cf4470, 0x1400123c480}, 0x140019e7d00)
[API]          	/Users/mtojek/code/coder/coderd/workspaces.go:262 +0xa70
[API]          net/http.HandlerFunc.ServeHTTP(0x11697c400?, {0x116cf4470?, 0x1400123c480?}, 0x11670b048?)
[API]          	/nix/store/79z3m4iw5y7sj5mk4w7rs37vzlian9dj-go-1.20/share/go/src/net/http/server.go:2122 +0x38
[API]          github.com/go-chi/chi/v5.(*Mux).routeHTTP(0x140003719e0, {0x116cf4470, 0x1400123c480}, 0x140019e7d00)
[API]          	/Users/mtojek/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.7/mux.go:442 +0x21c
[API]          net/http.HandlerFunc.ServeHTTP(0x14001b8ca80?, {0x116cf4470?, 0x1400123c480?}, 0x100f557c8?)
```

It happens when you leave a browser tab open with an old workspace that used a template that is deleted now.

