### PR TITLE
feat: CLI use multiselect for list(string)

### DIFF
--- a/cli/cliui/parameter.go
+++ b/cli/cliui/parameter.go
@@ -1,6 +1,7 @@
 package cliui
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -69,7 +70,28 @@ func RichParameter(cmd *cobra.Command, templateVersionParameter codersdk.Templat
 
 	var err error
 	var value string
-	if len(templateVersionParameter.Options) > 0 {
+	if templateVersionParameter.Type == "list(string)" {
+		// Move the cursor up a single line for nicer display!
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[1A")
+
+		var options []string
+		err = json.Unmarshal([]byte(templateVersionParameter.DefaultValue), &options)
+		if err != nil {
+			return "", err
+		}
+
+		values, err := MultiSelect(cmd, options)
+		if err == nil {
+			v, err := json.Marshal(&values)
+			if err != nil {
+				return "", err
+			}
+
+			_, _ = fmt.Fprintln(cmd.OutOrStdout())
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+Styles.Prompt.String()+Styles.Field.Render(strings.Join(values, ", ")))
+			value = string(v)
+		}
+	} else if len(templateVersionParameter.Options) > 0 {
 		// Move the cursor up a single line for nicer display!
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), "\033[1A")
 		var richParameterOption *codersdk.TemplateVersionParameterOption

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -35,6 +35,21 @@ func init() {
   {{- template "option" $.IterateOption $ix $option}}
 {{- end}}
 {{- end }}`
+
+	survey.MultiSelectQuestionTemplate = `
+{{- define "option"}}
+    {{- if eq .SelectedIndex .CurrentIndex }}{{color .Config.Icons.SelectFocus.Format }}{{ .Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}
+    {{- if index .Checked .CurrentOpt.Index }}{{color .Config.Icons.MarkedOption.Format }} {{ .Config.Icons.MarkedOption.Text }} {{else}}{{color .Config.Icons.UnmarkedOption.Format }} {{ .Config.Icons.UnmarkedOption.Text }} {{end}}
+    {{- color "reset"}}
+    {{- " "}}{{- .CurrentOpt.Value}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- if not .ShowAnswer }}
+  {{- "\n"}}
+  {{- range $ix, $option := .PageEntries}}
+    {{- template "option" $.IterateOption $ix $option}}
+  {{- end}}
+{{- end}}`
 }
 
 type SelectOptions struct {
@@ -116,6 +131,30 @@ func Select(cmd *cobra.Command, opts SelectOptions) (string, error) {
 		return value, Canceled
 	}
 	return value, err
+}
+
+func MultiSelect(cmd *cobra.Command, items []string) ([]string, error) {
+	// Similar hack is applied to Select()
+	if flag.Lookup("test.v") != nil {
+		return items, nil
+	}
+
+	prompt := &survey.MultiSelect{
+		Message: "Options:",
+		Options: items,
+		Default: items,
+	}
+
+	var values []string
+	err := survey.AskOne(prompt, &values, survey.WithStdio(fileReadWriter{
+		Reader: cmd.InOrStdin(),
+	}, fileReadWriter{
+		Writer: cmd.OutOrStdout(),
+	}, cmd.OutOrStdout()))
+	if errors.Is(err, terminal.InterruptErr) {
+		return nil, Canceled
+	}
+	return values, err
 }
 
 type fileReadWriter struct {

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -140,7 +140,6 @@ func MultiSelect(cmd *cobra.Command, items []string) ([]string, error) {
 	}
 
 	prompt := &survey.MultiSelect{
-		Message: "Options:",
 		Options: items,
 		Default: items,
 	}

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -650,6 +650,48 @@ func TestCreateValidateRichParameters(t *testing.T) {
 		}
 		<-doneChan
 	})
+
+	t.Run("ValidateListOfStrings_YAMLFile", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, prepareEchoResponses(listOfStringsRichParameters))
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+
+		tempDir := t.TempDir()
+		removeTmpDirUntilSuccessAfterTest(t, tempDir)
+		parameterFile, _ := os.CreateTemp(tempDir, "testParameterFile*.yaml")
+		_, _ = parameterFile.WriteString(listOfStringsParameterName + `:
+  - ddd
+  - eee
+  - fff`)
+		cmd, root := clitest.New(t, "create", "my-workspace", "--template", template.Name, "--rich-parameter-file", parameterFile.Name())
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		}()
+
+		matches := []string{
+			"Confirm create?", "yes",
+		}
+		for i := 0; i < len(matches); i += 2 {
+			match := matches[i]
+			value := matches[i+1]
+			pty.ExpectMatch(match)
+			if value != "" {
+				pty.WriteLine(value)
+			}
+		}
+		<-doneChan
+	})
 }
 
 func TestCreateWithGitAuth(t *testing.T) {

--- a/cli/parameter.go
+++ b/cli/parameter.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,8 +31,8 @@ func createParameterMapFromFile(parameterFile string) (map[string]string, error)
 		parameterMap := map[string]string{}
 		for k, v := range mapStringInterface {
 			switch val := v.(type) {
-			case string:
-				parameterMap[k] = val
+			case string, bool, int:
+				parameterMap[k] = fmt.Sprintf("%v", val)
 			case []interface{}:
 				b, err := json.Marshal(&val)
 				if err != nil {

--- a/cli/parameter_internal_test.go
+++ b/cli/parameter_internal_test.go
@@ -60,7 +60,7 @@ func TestCreateParameterMapFromFile(t *testing.T) {
 		parameterMapFromFile, err := createParameterMapFromFile(parameterFile.Name())
 
 		assert.Nil(t, parameterMapFromFile)
-		assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `region ...` into map[string]string")
+		assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `region ...` into map[string]interface {}")
 
 		removeTmpDirUntilSuccess(t, tempDir)
 	})


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6582

This PR enables support for multiselect in CLI, so that `coder` can render rich parameter type `list(string)`.

<img width="281" alt="Screenshot 2023-03-16 at 13 08 10" src="https://user-images.githubusercontent.com/14044910/225613489-520bbf9f-897f-43b0-a4e0-743a115cd935.png">