### PR TITLE
chore: regenerate helm golden tests

### DIFF
--- a/helm/tests/testdata/default_values.golden
+++ b/helm/tests/testdata/default_values.golden
@@ -118,6 +118,8 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             {}
+          lifecycle:
+            {}
           env:
             - name: CODER_HTTP_ADDRESS
               value: "0.0.0.0:8080"

--- a/helm/tests/testdata/tls.golden
+++ b/helm/tests/testdata/tls.golden
@@ -122,6 +122,8 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             {}
+          lifecycle:
+            {}
           env:
             - name: CODER_HTTP_ADDRESS
               value: "0.0.0.0:8080"


### PR DESCRIPTION
#6432 was opened before the Helm tests were added, and so tests passed and the PR was merged without updating the golden files.