### PR TITLE
fix: CLI do not ignore autostop

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -142,11 +142,18 @@ func create() *cobra.Command {
 				return err
 			}
 
+			var ttlMillis *int64
+			if stopAfter > 0 {
+				ttlMillis = ptr.Ref(stopAfter.Milliseconds())
+			} else if template.MaxTTLMillis > 0 {
+				ttlMillis = &template.MaxTTLMillis
+			}
+
 			workspace, err := client.CreateWorkspace(cmd.Context(), organization.ID, codersdk.Me, codersdk.CreateWorkspaceRequest{
 				TemplateID:          template.ID,
 				Name:                workspaceName,
 				AutostartSchedule:   schedSpec,
-				TTLMillis:           ptr.Ref(stopAfter.Milliseconds()),
+				TTLMillis:           ttlMillis,
 				ParameterValues:     buildParams.parameters,
 				RichParameterValues: buildParams.richParameters,
 			})
@@ -169,7 +176,7 @@ func create() *cobra.Command {
 	cliflag.StringVarP(cmd.Flags(), &parameterFile, "parameter-file", "", "CODER_PARAMETER_FILE", "", "Specify a file path with parameter values.")
 	cliflag.StringVarP(cmd.Flags(), &richParameterFile, "rich-parameter-file", "", "CODER_RICH_PARAMETER_FILE", "", "Specify a file path with values for rich parameters defined in the template.")
 	cliflag.StringVarP(cmd.Flags(), &startAt, "start-at", "", "CODER_WORKSPACE_START_AT", "", "Specify the workspace autostart schedule. Check `coder schedule start --help` for the syntax.")
-	cliflag.DurationVarP(cmd.Flags(), &stopAfter, "stop-after", "", "CODER_WORKSPACE_STOP_AFTER", 8*time.Hour, "Specify a duration after which the workspace should shut down (e.g. 8h).")
+	cliflag.DurationVarP(cmd.Flags(), &stopAfter, "stop-after", "", "CODER_WORKSPACE_STOP_AFTER", 0, "Specify a duration after which the workspace should shut down (e.g. 8h).")
 	return cmd
 }
 

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -84,6 +84,58 @@ func TestCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("InheritStopAfterFromTemplate", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionApply: provisionCompleteWithAgent,
+			ProvisionPlan:  provisionCompleteWithAgent,
+		})
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(ctr *codersdk.CreateTemplateRequest) {
+			var defaultTTLMillis int64 = 2 * 60 * 60 * 1000 // 2 hours
+			ctr.DefaultTTLMillis = &defaultTTLMillis
+		})
+		args := []string{
+			"create",
+			"my-workspace",
+			"--template", template.Name,
+		}
+		cmd, root := clitest.New(t, args...)
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t)
+		cmd.SetIn(pty.Input())
+		cmd.SetOut(pty.Output())
+		go func() {
+			defer close(doneChan)
+			err := cmd.Execute()
+			assert.NoError(t, err)
+		}()
+		matches := []struct {
+			match string
+			write string
+		}{
+			{match: "compute.main"},
+			{match: "smith (linux, i386)"},
+			{match: "Confirm create", write: "yes"},
+		}
+		for _, m := range matches {
+			pty.ExpectMatch(m.match)
+			if len(m.write) > 0 {
+				pty.WriteLine(m.write)
+			}
+		}
+		<-doneChan
+
+		ws, err := client.WorkspaceByOwnerAndName(context.Background(), "testuser", "my-workspace", codersdk.WorkspaceOptions{})
+		require.NoError(t, err, "expected workspace to be created")
+		assert.Equal(t, ws.TemplateName, template.Name)
+		assert.Equal(t, *ws.TTLMillis, template.DefaultTTLMillis)
+	})
+
 	t.Run("CreateFromListWithSkip", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -15,8 +15,7 @@ Flags:
                                                Consumes $CODER_WORKSPACE_START_AT
       --stop-after duration                    Specify a duration after which the workspace
                                                should shut down (e.g. 8h).
-                                               Consumes $CODER_WORKSPACE_STOP_AFTER (default
-                                               8h0m0s)
+                                               Consumes $CODER_WORKSPACE_STOP_AFTER
   -t, --template string                        Specify a template name.
                                                Consumes $CODER_TEMPLATE_NAME
   -y, --yes                                    Bypass prompts

--- a/docs/cli/coder_create.md
+++ b/docs/cli/coder_create.md
@@ -43,7 +43,7 @@ Specify a duration after which the workspace should shut down (e.g. 8h).
 | | |
 | --- | --- |
 | Consumes | <code>$CODER_WORKSPACE_STOP_AFTER</code> |
-| Default | <code>8h0m0s</code> |
+| Default | <code>0s</code> |
 
 ### --template, -t
 


### PR DESCRIPTION
Resolve: https://github.com/coder/coder/issues/6157

This PR adjusts the CLI behavior when a user doesn't provide `--stop-after` parameter when creating a workspace. In this case, the value should be fetched from the template settings.