### PR TITLE
docs: add k8s & aws to offline Dockerfile

### DIFF
--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -27,10 +27,9 @@ First, build and push a container image extending our official image with the fo
 > Note: Coder includes the latest [supported version](https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24) of Terraform in the official Docker images.
 > If you need to bundle a different version of terraform, you can do so by customizing the image.
 
-Here's an example:
+Here's an example Dockerfile:
 
 ```Dockerfile
-# Dockerfile
 FROM ghcr.io/coder/coder:latest
 
 USER root
@@ -57,21 +56,18 @@ ENV PATH=/opt/terraform:${PATH}
 
 # Additionally, a Terraform mirror needs to be configured
 # to download the Terraform providers used in Coder templates.
-#
 # There are two options:
 
 # Option 1) Use a filesystem mirror. We can seed this at build-time
 #    or by mounting a volume to /opt/terraform/plugins in the container.
 #    https://developer.hashicorp.com/terraform/cli/config/config-file#filesystem_mirror
-#
 #    Be sure to add all the providers you use in your templates to /opt/terraform/plugins
 
 RUN mkdir -p /opt/terraform/plugins
 ADD filesystem-mirror-example.tfrc /opt/terraform/config.tfrc
 
 # Optionally, we can "seed" the filesystem mirror with common providers.
-# Coder and Docker. Comment out lines 40-49 if you plan on only using a
-# volume or network mirror:
+# Comment out lines 40-49 if you plan on only using a volume or network mirror:
 RUN mkdir -p /opt/terraform/plugins/registry.terraform.io
 WORKDIR /opt/terraform/plugins/registry.terraform.io
 ARG CODER_PROVIDER_VERSION=0.6.10
@@ -82,13 +78,20 @@ ARG DOCKER_PROVIDER_VERSION=3.0.1
 RUN echo "Adding kreuzwerker/docker v${DOCKER_PROVIDER_VERSION}" \
     && mkdir -p kreuzwerker/docker && cd kreuzwerker/docker \
     && curl -LOs https://github.com/kreuzwerker/terraform-provider-docker/releases/download/v${DOCKER_PROVIDER_VERSION}/terraform-provider-docker_${DOCKER_PROVIDER_VERSION}_linux_amd64.zip
+ARG KUBERNETES_PROVIDER_VERSION=2.18.1
+RUN echo "Adding kubernetes/kubernetes v${KUBERNETES_PROVIDER_VERSION}" \
+    && mkdir -p kubernetes/kubernetes && cd kubernetes/kubernetes \
+    && curl -LOs https://releases.hashicorp.com/terraform-provider-kubernetes/${KUBERNETES_PROVIDER_VERSION}/terraform-provider-kubernetes_${KUBERNETES_PROVIDER_VERSION}_linux_amd64.zip
+ARG AWS_PROVIDER_VERSION=4.59.0
+RUN echo "Adding aws/aws v${AWS_PROVIDER_VERSION}" \
+    && mkdir -p aws/aws && cd aws/aws \
+    && curl -LOs https://releases.hashicorp.com/terraform-provider-aws/${AWS_PROVIDER_VERSION}/terraform-provider-aws_${AWS_PROVIDER_VERSION}_linux_amd64.zip
 
 RUN chown -R coder:coder /opt/terraform/plugins
 WORKDIR /home/coder
 
 # Option 2) Use a network mirror.
 #    https://developer.hashicorp.com/terraform/cli/config/config-file#network_mirror
-
 #    Be sure uncomment line 60 and edit network-mirror-example.tfrc to
 #    specify the HTTPS base URL of your mirror.
 


### PR DESCRIPTION
adds the K8s & AWS terraform provider installs into the offline `Dockerfile` example.