### PR TITLE
fix: dbauthz: fix RBAC call for GetTemplateVersionVariables

### DIFF
--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -735,7 +735,7 @@ func (q *querier) GetTemplateVersionVariables(ctx context.Context, templateVersi
 		object = tv.RBACObject(template)
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, object); err != nil {
+	if err := q.authorizeContext(ctx, rbac.ActionRead, object); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateVersionVariables(ctx, templateVersionID)

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -599,6 +599,16 @@ func (s *MethodTestSuite) TestTemplate() {
 		})
 		check.Args(tv.ID).Asserts(t1, rbac.ActionRead).Returns([]database.TemplateVersionParameter{})
 	}))
+	s.Run("GetTemplateVersionVariables", s.Subtest(func(db database.Store, check *expects) {
+		t1 := dbgen.Template(s.T(), db, database.Template{})
+		tv := dbgen.TemplateVersion(s.T(), db, database.TemplateVersion{
+			TemplateID: uuid.NullUUID{UUID: t1.ID, Valid: true},
+		})
+		tvv1 := dbgen.TemplateVersionVariable(s.T(), db, database.TemplateVersionVariable{
+			TemplateVersionID: tv.ID,
+		})
+		check.Args(tv.ID).Asserts(t1, rbac.ActionRead).Returns([]database.TemplateVersionVariable{tvv1})
+	}))
 	s.Run("GetTemplateGroupRoles", s.Subtest(func(db database.Store, check *expects) {
 		t1 := dbgen.Template(s.T(), db, database.Template{})
 		check.Args(t1.ID).Asserts(t1, rbac.ActionRead)


### PR DESCRIPTION
In `GetTemplateVersionVariables` we were effectively asking the provisionerd role to call `rbac.ActionCreate` on `rbac.ResourceTemplate`, which will never work. Updated this to be `rbac.ActionRead` instead.

Also, noting that the provisionerd role currently has `read, update` on `ResourceTemplate`.