### PR TITLE
chore: avoid logging http.ErrAbortHandler panics

### DIFF
--- a/coderd/httpmw/recover.go
+++ b/coderd/httpmw/recover.go
@@ -15,7 +15,13 @@ func Recover(log slog.Logger) func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				r := recover()
-				if r != nil {
+
+				// Reverse proxying (among other things) may panic with
+				// http.ErrAbortHandler when the request is aborted. It's not a
+				// real panic so we shouldn't log them.
+				//
+				//nolint:errorlint // this is how the stdlib does the check
+				if r != nil && r != http.ErrAbortHandler {
 					log.Warn(context.Background(),
 						"panic serving http request (recovered)",
 						slog.F("panic", r),


### PR DESCRIPTION
`httputil.ReverseProxy` will panic with `http.ErrAbortHandler` when it can't copy the response properly ([source](https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/net/http/httputil/reverseproxy.go;l=509-519;drc=20e9b7f1b53d49fd66e0344b1d0d42d3cf5e47b6)). This could be because the client closed their browser window or killed the CLI etc.

This isn't a traditional panic caused by a developer error, and is unavoidable in production so we should avoid logging them.

The `err == http.ErrAbortHandler` check is also how the recover handler built into the stdlib operates ([source](https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/net/http/server.go;l=1860;drc=20e9b7f1b53d49fd66e0344b1d0d42d3cf5e47b6;bpv=1;bpt=1)).

chi's recovery middleware also functions the same way ([source](https://github.com/go-chi/chi/blob/51068a747f1a32dbce24c499561a0f5ecb7f7158/middleware/recoverer.go#L26)).