### PR TITLE
fix: increase timeout of `CreateTemplatePage` initial render

### DIFF
--- a/site/src/pages/CreateTemplatePage/CreateTemplatePage.test.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplatePage.test.tsx
@@ -24,7 +24,7 @@ const renderPage = async () => {
   })
   // It is lazy loaded, so we have to wait for it to be rendered to not get an
   // act error
-  await screen.findByLabelText("Icon")
+  await screen.findByLabelText("Icon", undefined, { timeout: 5000 })
   return result
 }
 


### PR DESCRIPTION
This might fix some test flakes we've been seeing!