### PR TITLE
chore: remove fast metric cache interval for apps tests

### DIFF
--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -175,11 +175,9 @@ func setupProxyTest(t *testing.T, opts *setupProxyTestOpts) (*codersdk.Client, c
 	deploymentValues.Dangerous.AllowPathAppSiteOwnerAccess = clibase.Bool(opts.DangerousAllowPathAppSiteOwnerAccess)
 
 	client := coderdtest.New(t, &coderdtest.Options{
-		DeploymentValues:            deploymentValues,
-		AppHostname:                 opts.AppHost,
-		IncludeProvisionerDaemon:    true,
-		AgentStatsRefreshInterval:   time.Millisecond * 100,
-		MetricsCacheRefreshInterval: time.Millisecond * 100,
+		DeploymentValues:         deploymentValues,
+		AppHostname:              opts.AppHost,
+		IncludeProvisionerDaemon: true,
 		RealIPConfig: &httpmw.RealIPConfig{
 			TrustedOrigins: []*net.IPNet{{
 				IP:   net.ParseIP("127.0.0.1"),


### PR DESCRIPTION
This wasn't helping CI run fast, that's for sure!