### PR TITLE
fix: use the default value for a rich parameter if unset

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -2,7 +2,6 @@ import axios from "axios"
 import {
   MockTemplate,
   MockTemplateVersionParameter1,
-  MockTemplateVersionParameter2,
   MockWorkspace,
   MockWorkspaceBuild,
   MockWorkspaceBuildParameter1,
@@ -185,10 +184,7 @@ describe("api.ts", () => {
       jest.spyOn(api, "getWorkspaceBuildParameters").mockResolvedValue([])
       jest
         .spyOn(api, "getTemplateVersionRichParameters")
-        .mockResolvedValue([
-          MockTemplateVersionParameter1,
-          { ...MockTemplateVersionParameter2, mutable: false },
-        ])
+        .mockResolvedValue([MockTemplateVersionParameter1])
 
       let error = new Error()
       try {
@@ -198,8 +194,6 @@ describe("api.ts", () => {
       }
 
       expect(error).toBeInstanceOf(api.MissingBuildParameters)
-      // Verify if the correct missing parameters are being passed
-      // It should not require immutable parameters
       expect((error as api.MissingBuildParameters).parameters).toEqual([
         MockTemplateVersionParameter1,
       ])

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -976,9 +976,7 @@ const getMissingParameters = (
   templateParameters: TypesGen.TemplateVersionParameter[],
 ) => {
   const missingParameters: TypesGen.TemplateVersionParameter[] = []
-  const requiredParameters = templateParameters.filter(
-    (p) => p.required && p.mutable,
-  )
+  const requiredParameters = templateParameters.filter((p) => p.required)
 
   for (const parameter of requiredParameters) {
     // Check if there is a new value

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -37,7 +37,10 @@ export const WorkspaceSettingsForm: FC<{
           (p) => p.name === parameter.name,
         )
         if (!buildParameter) {
-          throw new Error("Missing build parameter for " + parameter.name)
+          return {
+            name: parameter.name,
+            value: parameter.default_value,
+          }
         }
         return buildParameter
       }),


### PR DESCRIPTION
This fixes an error thrown on the workspace settings page when a new parameter is added and the workspace hasn't been built yet.