### PR TITLE
chore: update terraform-provider-coder to v0.6.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/codeclysm/extract v2.2.0+incompatible
 	github.com/coder/flog v1.0.0
 	github.com/coder/retry v1.3.1-0.20230210155434-e90a2e1e091d
-	github.com/coder/terraform-provider-coder v0.6.20
+	github.com/coder/terraform-provider-coder v0.6.21
 	github.com/coder/wgtunnel v0.1.5
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf

--- a/go.sum
+++ b/go.sum
@@ -380,8 +380,8 @@ github.com/coder/ssh v0.0.0-20220811105153-fcea99919338 h1:tN5GKFT68YLVzJoA8AHui
 github.com/coder/ssh v0.0.0-20220811105153-fcea99919338/go.mod h1:ZSS+CUoKHDrqVakTfTWUlKSr9MtMFkC4UvtQKD7O914=
 github.com/coder/tailscale v1.1.1-0.20230321171725-fed359a0cafa h1:EjRGgTz7BUECmbV8jHTi1/rKdDjJESGSlm1Jp7evvCQ=
 github.com/coder/tailscale v1.1.1-0.20230321171725-fed359a0cafa/go.mod h1:jpg+77g19FpXL43U1VoIqoSg1K/Vh5CVxycGldQ8KhA=
-github.com/coder/terraform-provider-coder v0.6.20 h1:bVyITX9JlbnGzKzTj0qi/JziUCGqD2DiN3cXaWyDcxE=
-github.com/coder/terraform-provider-coder v0.6.20/go.mod h1:UIfU3bYNeSzJJvHyJ30tEKjD6Z9utloI+HUM/7n94CY=
+github.com/coder/terraform-provider-coder v0.6.21 h1:TIH6+/VQFreT8q/CkRvpHtbIeM5cOAhuDS5Sh1Nm21Q=
+github.com/coder/terraform-provider-coder v0.6.21/go.mod h1:UIfU3bYNeSzJJvHyJ30tEKjD6Z9utloI+HUM/7n94CY=
 github.com/coder/wgtunnel v0.1.5 h1:WP3sCj/3iJ34eKvpMQEp1oJHvm24RYh0NHbj1kfUKfs=
 github.com/coder/wgtunnel v0.1.5/go.mod h1:bokoUrHnUFY4lu9KOeSYiIcHTI2MO1KwqumU4DPDyJI=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6734

<img width="912" alt="Screenshot 2023-03-22 at 18 46 20" src="https://user-images.githubusercontent.com/14044910/226993036-dff640f0-83b2-4d5e-9c36-6f3f86b90c09.png">

This PR bumps up the dependency on terraform-provider-coder, so that `legacy_variable_name` is exposed.

It can be tested with:

```tf
variable "security_groups" {
  type = list(string)
  default = [
    "Web Server Security Group",
    "Database Security Group",
    "Backend Security Group"
  ]
}

data "coder_parameter" "security_groups" {
  name        = "Security Groups 2"
  type        = "list(string)"
  description = "via old Terraform variable"
  mutable     = true

  legacy_variable      = jsonencode(var.security_groups)
  legacy_variable_name = "security_groups"
}
```