### PR TITLE
docs: add GHE token & auth URLs

### DIFF
--- a/docs/admin/git-providers.md
+++ b/docs/admin/git-providers.md
@@ -31,6 +31,16 @@ CODER_GITAUTH_0_CLIENT_ID=xxxxxx
 CODER_GITAUTH_0_CLIENT_SECRET=xxxxxxx
 ```
 
+### GitHub Enterprise
+
+GitHub Enterprise requires the following authentication and token URLs:
+
+```console
+CODER_GITAUTH_0_VALIDATE_URL="http://github.example.com/login/oauth/access_token/info"
+CODER_GITAUTH_0_AUTH_URL="http://github.example.com/login/oauth/authorize"
+CODER_GITAUTH_0_TOKEN_URL="http://github.example.com/login/oauth/access_token"
+```
+
 ### Self-managed git providers
 
 Custom authentication and token URLs should be
@@ -70,8 +80,9 @@ CODER_GITAUTH_1_TYPE=github
 CODER_GITAUTH_1_CLIENT_ID=xxxxxx
 CODER_GITAUTH_1_CLIENT_SECRET=xxxxxxx
 CODER_GITAUTH_1_REGEX=github.example.com
-CODER_GITAUTH_1_AUTH_URL="https://github.example.com/oauth/authorize"
-CODER_GITAUTH_1_TOKEN_URL="https://github.example.com/oauth/token"
+CODER_GITAUTH_1_AUTH_URL="https://github.example.com/login/oauth/authorize"
+CODER_GITAUTH_1_TOKEN_URL="https://github.example.com/login/oauth/access_token"
+CODER_GITAUTH_0_VALIDATE_URL="http://github.example.com/login/oauth/access_token/info"
 ```
 
 To support regex matching for paths (e.g. github.com/orgname), you'll need to add this to the [Coder agent startup script](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#startup_script):

--- a/docs/admin/git-providers.md
+++ b/docs/admin/git-providers.md
@@ -36,9 +36,9 @@ CODER_GITAUTH_0_CLIENT_SECRET=xxxxxxx
 GitHub Enterprise requires the following authentication and token URLs:
 
 ```console
-CODER_GITAUTH_0_VALIDATE_URL="http://github.example.com/login/oauth/access_token/info"
-CODER_GITAUTH_0_AUTH_URL="http://github.example.com/login/oauth/authorize"
-CODER_GITAUTH_0_TOKEN_URL="http://github.example.com/login/oauth/access_token"
+CODER_GITAUTH_0_VALIDATE_URL="https://github.example.com/login/oauth/access_token/info"
+CODER_GITAUTH_0_AUTH_URL="https://github.example.com/login/oauth/authorize"
+CODER_GITAUTH_0_TOKEN_URL="https://github.example.com/login/oauth/access_token"
 ```
 
 ### Self-managed git providers
@@ -82,7 +82,7 @@ CODER_GITAUTH_1_CLIENT_SECRET=xxxxxxx
 CODER_GITAUTH_1_REGEX=github.example.com
 CODER_GITAUTH_1_AUTH_URL="https://github.example.com/login/oauth/authorize"
 CODER_GITAUTH_1_TOKEN_URL="https://github.example.com/login/oauth/access_token"
-CODER_GITAUTH_0_VALIDATE_URL="http://github.example.com/login/oauth/access_token/info"
+CODER_GITAUTH_1_VALIDATE_URL="https://github.example.com/login/oauth/access_token/info"
 ```
 
 To support regex matching for paths (e.g. github.com/orgname), you'll need to add this to the [Coder agent startup script](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#startup_script):


### PR DESCRIPTION
GHE does not accept the generic auth & token vars we have documented for self-hosted git providers. this PR adds the GHE-specific config. tested on GHE Server 3.7.6.

reference documentation: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps