### PR TITLE
feat: Fine-tune logs presentation

### DIFF
--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -347,7 +347,8 @@ func (api *API) followProvisionerJobLogs(actor rbac.Subject, jobID uuid.UUID) (<
 	logger := api.Logger.With(slog.F("job_id", jobID))
 
 	var (
-		bufferedLogs  = make(chan *database.ProvisionerJobLog, 128)
+		// With debug logging enabled length = 128 is insufficient
+		bufferedLogs  = make(chan *database.ProvisionerJobLog, 1024)
 		endOfLogs     atomic.Bool
 		lastSentLogID atomic.Int64
 	)

--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -236,7 +236,7 @@ func provisionEnv(config *proto.Provision_Config, params []*proto.ParameterValue
 	for _, gitAuth := range gitAuth {
 		env = append(env, provider.GitAuthAccessTokenEnvironmentVariable(gitAuth.Id)+"="+gitAuth.AccessToken)
 	}
-	env = append(env, "TF_LOG=JSON") // FIXME Remove before pushing PR
+	// FIXME env = append(env, "TF_LOG=JSON")
 	return env, nil
 }
 

--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -236,6 +236,7 @@ func provisionEnv(config *proto.Provision_Config, params []*proto.ParameterValue
 	for _, gitAuth := range gitAuth {
 		env = append(env, provider.GitAuthAccessTokenEnvironmentVariable(gitAuth.Id)+"="+gitAuth.AccessToken)
 	}
+	env = append(env, "TF_LOG=JSON") // FIXME Remove before pushing PR
 	return env, nil
 }
 

--- a/site/src/components/Logs/Logs.tsx
+++ b/site/src/components/Logs/Logs.tsx
@@ -108,7 +108,11 @@ const useStyles = makeStyles<
       backgroundColor: theme.palette.error.dark,
     },
 
-    "&.warning": {
+    "&.debug": {
+      backgroundColor: theme.palette.grey[900],
+    },
+
+    "&.warn": {
       backgroundColor: theme.palette.warning.dark,
     },
   },


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/4767

I'm working on enabling debug logging with Terraform via `TF_LOG=JSON` (equal to `TF_LOG=TRACE` with JSON format), and the first step is to adjust Coder UI.

Before:

<img width="1379" alt="Screenshot 2023-03-24 at 11 37 37" src="https://user-images.githubusercontent.com/14044910/227511229-55e89819-5f16-4d0d-a3e7-fbfb322055ed.png">

After (debug: grey, warn: orange?)

<img width="1488" alt="Screenshot 2023-03-24 at 12 28 14" src="https://user-images.githubusercontent.com/14044910/227511228-52ab47ff-01f0-4a4d-bd91-aff5272c3045.png">

