### PR TITLE
docs: clarify mac docker install

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -7,7 +7,7 @@ Docker is required. See the [official installation documentation](https://docs.d
 ## Run Coder with the built-in database (quick)
 
 For proof-of-concept deployments, you can run a complete Coder instance with
-the following command:
+the following command. Note that if you are on Mac, you will need to run Coder via [Docker compose](#run-coder-with-docker-compose).
 
 ```console
 export CODER_DATA=$HOME/.config/coderv2-docker

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -4,7 +4,7 @@ You can install and run Coder using the official Docker images published on [Git
 
 Docker is required. See the [official installation documentation](https://docs.docker.com/install/).
 
-> Note that the below steps are only supported on a Linux distribution. If on Mac, please [run Coder via the standalone binary](./binary.md).
+> Note that the below steps are only supported on a Linux distribution. If on macOS, please [run Coder via the standalone binary](./binary.md).
 
 ## Run Coder with the built-in database (quick)
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -4,10 +4,12 @@ You can install and run Coder using the official Docker images published on [Git
 
 Docker is required. See the [official installation documentation](https://docs.docker.com/install/).
 
+> Note that the below steps are only supported on a Linux distribution. If on Mac, please [run Coder via the standalone binary](./binary.md).
+
 ## Run Coder with the built-in database (quick)
 
 For proof-of-concept deployments, you can run a complete Coder instance with
-the following command. Note that if you are on Mac, you will need to run Coder via [Docker compose](#run-coder-with-docker-compose).
+the following command.
 
 ```console
 export CODER_DATA=$HOME/.config/coderv2-docker


### PR DESCRIPTION
the command to install and run Coder via `docker run` does not work with Mac OS, due to the Docker group configuration. this PR notes that users on Mac should install Coder via the standalone binary.