### PR TITLE
fix(clibase): allow string-array properties to be unset by environment variable

### DIFF
--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -105,7 +105,7 @@ func (s *OptionSet) ParseEnv(vs []EnvVar) error {
 		return nil
 	}
 
-	var stringArrayType = StringArray{}.Type()
+	stringArrayType := StringArray{}.Type()
 
 	var merr *multierror.Error
 

--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -105,6 +105,8 @@ func (s *OptionSet) ParseEnv(vs []EnvVar) error {
 		return nil
 	}
 
+	var stringArrayType = StringArray{}.Type()
+
 	var merr *multierror.Error
 
 	// We parse environment variables first instead of using a nested loop to
@@ -126,7 +128,7 @@ func (s *OptionSet) ParseEnv(vs []EnvVar) error {
 		// way for a user to change a Default value to an empty string from
 		// the environment. Unfortunately, we have old configuration files
 		// that rely on the faulty behavior.
-		if !ok || envVal == "" {
+		if !ok || (envVal == "" && opt.Value.Type() != stringArrayType) {
 			continue
 		}
 

--- a/cli/clibase/option_test.go
+++ b/cli/clibase/option_test.go
@@ -118,4 +118,26 @@ func TestOptionSet_ParseEnv(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, "defname", workspaceName)
 	})
+
+	t.Run("EmptyStringArrayValue", func(t *testing.T) {
+		t.Parallel()
+
+		var workspaceNames clibase.StringArray
+
+		os := clibase.OptionSet{
+			clibase.Option{
+				Name:    "Workspace Names",
+				Value:   &workspaceNames,
+				Default: "defname",
+				Env:     "WORKSPACE_NAMES",
+			},
+		}
+
+		err := os.SetDefaults()
+		require.NoError(t, err)
+
+		err = os.ParseEnv(clibase.ParseEnviron([]string{"CODER_WORKSPACE_NAMES="}, "CODER_"))
+		require.NoError(t, err)
+		require.EqualValues(t, []string{}, workspaceNames)
+	})
 }

--- a/cli/clibase/values.go
+++ b/cli/clibase/values.go
@@ -146,6 +146,11 @@ func writeAsCSV(vals []string) string {
 }
 
 func (s *StringArray) Set(v string) error {
+	if v == "" {
+		*s = []string{}
+		return nil
+	}
+
 	ss, err := readAsCSV(v)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/6791

This PR modifies the environment variable parsing logic to handle an empty string for `string-array` values.