### PR TITLE
fix: Validate template version name

### DIFF
--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -859,11 +859,22 @@ func (q *querier) UpdateTemplateScheduleByID(ctx context.Context, arg database.U
 }
 
 func (q *querier) UpdateTemplateVersionByID(ctx context.Context, arg database.UpdateTemplateVersionByIDParams) (database.TemplateVersion, error) {
-	template, err := q.db.GetTemplateByID(ctx, arg.TemplateID.UUID)
+	// An actor is allowed to update the template version if they are authorized to update the template.
+	tv, err := q.db.GetTemplateVersionByID(ctx, arg.ID)
 	if err != nil {
 		return database.TemplateVersion{}, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+	var obj rbac.Objecter
+	if !tv.TemplateID.Valid {
+		obj = rbac.ResourceTemplate.InOrg(tv.OrganizationID)
+	} else {
+		tpl, err := q.db.GetTemplateByID(ctx, tv.TemplateID.UUID)
+		if err != nil {
+			return database.TemplateVersion{}, err
+		}
+		obj = tpl
+	}
+	if err := q.authorizeContext(ctx, rbac.ActionUpdate, obj); err != nil {
 		return database.TemplateVersion{}, err
 	}
 	return q.db.UpdateTemplateVersionByID(ctx, arg)

--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -44,7 +44,7 @@ func init() {
 		valid := NameValid(str)
 		return valid == nil
 	}
-	for _, tag := range []string{"username", "template_name", "workspace_name"} {
+	for _, tag := range []string{"username", "template_name", "workspace_name", "template_version_name"} {
 		err := Validate.RegisterValidation(tag, nameValidator)
 		if err != nil {
 			panic(err)

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1413,12 +1413,10 @@ func TestTemplateVersionPatch(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
-		updatedVersion2, err := client.UpdateTemplateVersion(ctx, version2.ID, codersdk.PatchTemplateVersionRequest{
+		_, err := client.UpdateTemplateVersion(ctx, version2.ID, codersdk.PatchTemplateVersionRequest{
 			Name: version1.Name,
 		})
-		require.NoError(t, err)
-		assert.NotEqual(t, version1.Name, version2.Name)     // version names remain different
-		assert.Equal(t, version2.Name, updatedVersion2.Name) // version name doesn't change
+		require.Error(t, err)
 	})
 
 	t.Run("Rename the unassigned template", func(t *testing.T) {

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -1347,7 +1347,7 @@ func TestTemplateVersionPatch(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		const newName = "new_name"
+		const newName = "new-name"
 		updatedVersion, err := client.UpdateTemplateVersion(ctx, version.ID, codersdk.PatchTemplateVersionRequest{
 			Name: newName,
 		})
@@ -1434,5 +1434,21 @@ func TestTemplateVersionPatch(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, commonTemplateVersionName, updatedVersion1.Name)
+	})
+
+	t.Run("Use incorrect template version name", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		version1 := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		const incorrectTemplateVersionName = "incorrect/name"
+		_, err := client.UpdateTemplateVersion(ctx, version1.ID, codersdk.PatchTemplateVersionRequest{
+			Name: incorrectTemplateVersionName,
+		})
+		require.Error(t, err)
 	})
 }

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -42,7 +42,7 @@ type OrganizationMember struct {
 
 // CreateTemplateVersionRequest enables callers to create a new Template Version.
 type CreateTemplateVersionRequest struct {
-	Name string `json:"name,omitempty" validate:"omitempty,template_name"`
+	Name string `json:"name,omitempty" validate:"omitempty,template_version_name"`
 	// TemplateID optionally associates a version with a template.
 	TemplateID      uuid.UUID                `json:"template_id,omitempty" format:"uuid"`
 	StorageMethod   ProvisionerStorageMethod `json:"storage_method" validate:"oneof=file,required" enums:"file"`

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -77,7 +77,7 @@ type TemplateVersionVariable struct {
 }
 
 type PatchTemplateVersionRequest struct {
-	Name string `json:"name"`
+	Name string `json:"name" validate:"omitempty,template_version_name"`
 }
 
 // TemplateVersion returns a template version by ID.


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6781

Changes:
* fix RBAC: consider that a template may not be assigned
* validate template version name
* check if the template version name is unique (template ID, name)