### PR TITLE
chore: rename "InsertOrUpdate" to Upsert around the codebase

### DIFF
--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -340,18 +340,18 @@ func (q *querier) InsertLicense(ctx context.Context, arg database.InsertLicenseP
 	return q.db.InsertLicense(ctx, arg)
 }
 
-func (q *querier) InsertOrUpdateLogoURL(ctx context.Context, value string) error {
+func (q *querier) UpsertLogoURL(ctx context.Context, value string) error {
 	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
-	return q.db.InsertOrUpdateLogoURL(ctx, value)
+	return q.db.UpsertLogoURL(ctx, value)
 }
 
-func (q *querier) InsertOrUpdateServiceBanner(ctx context.Context, value string) error {
+func (q *querier) UpsertServiceBanner(ctx context.Context, value string) error {
 	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
-	return q.db.InsertOrUpdateServiceBanner(ctx, value)
+	return q.db.UpsertServiceBanner(ctx, value)
 }
 
 func (q *querier) GetLicenseByID(ctx context.Context, id int32) (database.License, error) {

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -312,10 +312,10 @@ func (s *MethodTestSuite) TestLicense() {
 		check.Args(database.InsertLicenseParams{}).
 			Asserts(rbac.ResourceLicense, rbac.ActionCreate)
 	}))
-	s.Run("InsertOrUpdateLogoURL", s.Subtest(func(db database.Store, check *expects) {
+	s.Run("UpsertLogoURL", s.Subtest(func(db database.Store, check *expects) {
 		check.Args("value").Asserts(rbac.ResourceDeploymentValues, rbac.ActionCreate)
 	}))
-	s.Run("InsertOrUpdateServiceBanner", s.Subtest(func(db database.Store, check *expects) {
+	s.Run("UpsertServiceBanner", s.Subtest(func(db database.Store, check *expects) {
 		check.Args("value").Asserts(rbac.ResourceDeploymentValues, rbac.ActionCreate)
 	}))
 	s.Run("GetLicenseByID", s.Subtest(func(db database.Store, check *expects) {
@@ -336,12 +336,12 @@ func (s *MethodTestSuite) TestLicense() {
 		check.Args().Asserts().Returns("")
 	}))
 	s.Run("GetLogoURL", s.Subtest(func(db database.Store, check *expects) {
-		err := db.InsertOrUpdateLogoURL(context.Background(), "value")
+		err := db.UpsertLogoURL(context.Background(), "value")
 		require.NoError(s.T(), err)
 		check.Args().Asserts().Returns("value")
 	}))
 	s.Run("GetServiceBanner", s.Subtest(func(db database.Store, check *expects) {
-		err := db.InsertOrUpdateServiceBanner(context.Background(), "value")
+		err := db.UpsertServiceBanner(context.Background(), "value")
 		require.NoError(s.T(), err)
 		check.Args().Asserts().Returns("value")
 	}))

--- a/coderd/database/dbauthz/system.go
+++ b/coderd/database/dbauthz/system.go
@@ -228,11 +228,11 @@ func (q *querier) UpdateWorkspaceBuildCostByID(ctx context.Context, arg database
 	return q.db.UpdateWorkspaceBuildCostByID(ctx, arg)
 }
 
-func (q *querier) InsertOrUpdateLastUpdateCheck(ctx context.Context, value string) error {
+func (q *querier) UpsertLastUpdateCheck(ctx context.Context, value string) error {
 	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
-	return q.db.InsertOrUpdateLastUpdateCheck(ctx, value)
+	return q.db.UpsertLastUpdateCheck(ctx, value)
 }
 
 func (q *querier) GetLastUpdateCheck(ctx context.Context) (string, error) {

--- a/coderd/database/dbauthz/system_test.go
+++ b/coderd/database/dbauthz/system_test.go
@@ -102,11 +102,11 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 			DailyCost: 10,
 		}).Asserts(rbac.ResourceSystem, rbac.ActionUpdate).Returns(o)
 	}))
-	s.Run("InsertOrUpdateLastUpdateCheck", s.Subtest(func(db database.Store, check *expects) {
+	s.Run("UpsertLastUpdateCheck", s.Subtest(func(db database.Store, check *expects) {
 		check.Args("value").Asserts(rbac.ResourceSystem, rbac.ActionUpdate)
 	}))
 	s.Run("GetLastUpdateCheck", s.Subtest(func(db database.Store, check *expects) {
-		err := db.InsertOrUpdateLastUpdateCheck(context.Background(), "value")
+		err := db.UpsertLastUpdateCheck(context.Background(), "value")
 		require.NoError(s.T(), err)
 		check.Args().Asserts(rbac.ResourceSystem, rbac.ActionRead)
 	}))

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -4287,7 +4287,7 @@ func (q *fakeQuerier) GetDERPMeshKey(_ context.Context) (string, error) {
 	return q.derpMeshKey, nil
 }
 
-func (q *fakeQuerier) InsertOrUpdateLastUpdateCheck(_ context.Context, data string) error {
+func (q *fakeQuerier) UpsertLastUpdateCheck(_ context.Context, data string) error {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
@@ -4305,7 +4305,7 @@ func (q *fakeQuerier) GetLastUpdateCheck(_ context.Context) (string, error) {
 	return string(q.lastUpdateCheck), nil
 }
 
-func (q *fakeQuerier) InsertOrUpdateServiceBanner(_ context.Context, data string) error {
+func (q *fakeQuerier) UpsertServiceBanner(_ context.Context, data string) error {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
@@ -4324,7 +4324,7 @@ func (q *fakeQuerier) GetServiceBanner(_ context.Context) (string, error) {
 	return string(q.serviceBanner), nil
 }
 
-func (q *fakeQuerier) InsertOrUpdateLogoURL(_ context.Context, data string) error {
+func (q *fakeQuerier) UpsertLogoURL(_ context.Context, data string) error {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -166,9 +166,9 @@ type sqlcQuerier interface {
 	InsertGroup(ctx context.Context, arg InsertGroupParams) (Group, error)
 	InsertGroupMember(ctx context.Context, arg InsertGroupMemberParams) error
 	InsertLicense(ctx context.Context, arg InsertLicenseParams) (License, error)
-	InsertOrUpdateLastUpdateCheck(ctx context.Context, value string) error
-	InsertOrUpdateLogoURL(ctx context.Context, value string) error
-	InsertOrUpdateServiceBanner(ctx context.Context, value string) error
+	UpsertLastUpdateCheck(ctx context.Context, value string) error
+	UpsertLogoURL(ctx context.Context, value string) error
+	UpsertServiceBanner(ctx context.Context, value string) error
 	InsertOrganization(ctx context.Context, arg InsertOrganizationParams) (Organization, error)
 	InsertOrganizationMember(ctx context.Context, arg InsertOrganizationMemberParams) (OrganizationMember, error)
 	InsertParameterSchema(ctx context.Context, arg InsertParameterSchemaParams) (ParameterSchema, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -166,9 +166,6 @@ type sqlcQuerier interface {
 	InsertGroup(ctx context.Context, arg InsertGroupParams) (Group, error)
 	InsertGroupMember(ctx context.Context, arg InsertGroupMemberParams) error
 	InsertLicense(ctx context.Context, arg InsertLicenseParams) (License, error)
-	UpsertLastUpdateCheck(ctx context.Context, value string) error
-	UpsertLogoURL(ctx context.Context, value string) error
-	UpsertServiceBanner(ctx context.Context, value string) error
 	InsertOrganization(ctx context.Context, arg InsertOrganizationParams) (Organization, error)
 	InsertOrganizationMember(ctx context.Context, arg InsertOrganizationMemberParams) (OrganizationMember, error)
 	InsertParameterSchema(ctx context.Context, arg InsertParameterSchemaParams) (ParameterSchema, error)
@@ -241,6 +238,9 @@ type sqlcQuerier interface {
 	UpdateWorkspaceLastUsedAt(ctx context.Context, arg UpdateWorkspaceLastUsedAtParams) error
 	UpdateWorkspaceTTL(ctx context.Context, arg UpdateWorkspaceTTLParams) error
 	UpdateWorkspaceTTLToBeWithinTemplateMax(ctx context.Context, arg UpdateWorkspaceTTLToBeWithinTemplateMaxParams) error
+	UpsertLastUpdateCheck(ctx context.Context, value string) error
+	UpsertLogoURL(ctx context.Context, value string) error
+	UpsertServiceBanner(ctx context.Context, value string) error
 }
 
 var _ sqlcQuerier = (*sqlQuerier)(nil)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3103,33 +3103,33 @@ func (q *sqlQuerier) InsertDeploymentID(ctx context.Context, value string) error
 	return err
 }
 
-const UpsertLastUpdateCheck = `-- name: UpsertLastUpdateCheck :exec
+const upsertLastUpdateCheck = `-- name: UpsertLastUpdateCheck :exec
 INSERT INTO site_configs (key, value) VALUES ('last_update_check', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'last_update_check'
 `
 
 func (q *sqlQuerier) UpsertLastUpdateCheck(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, UpsertLastUpdateCheck, value)
+	_, err := q.db.ExecContext(ctx, upsertLastUpdateCheck, value)
 	return err
 }
 
-const UpsertLogoURL = `-- name: UpsertLogoURL :exec
+const upsertLogoURL = `-- name: UpsertLogoURL :exec
 INSERT INTO site_configs (key, value) VALUES ('logo_url', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'logo_url'
 `
 
 func (q *sqlQuerier) UpsertLogoURL(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, UpsertLogoURL, value)
+	_, err := q.db.ExecContext(ctx, upsertLogoURL, value)
 	return err
 }
 
-const UpsertServiceBanner = `-- name: UpsertServiceBanner :exec
+const upsertServiceBanner = `-- name: UpsertServiceBanner :exec
 INSERT INTO site_configs (key, value) VALUES ('service_banner', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'service_banner'
 `
 
 func (q *sqlQuerier) UpsertServiceBanner(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, UpsertServiceBanner, value)
+	_, err := q.db.ExecContext(ctx, upsertServiceBanner, value)
 	return err
 }
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3103,33 +3103,33 @@ func (q *sqlQuerier) InsertDeploymentID(ctx context.Context, value string) error
 	return err
 }
 
-const insertOrUpdateLastUpdateCheck = `-- name: InsertOrUpdateLastUpdateCheck :exec
+const UpsertLastUpdateCheck = `-- name: UpsertLastUpdateCheck :exec
 INSERT INTO site_configs (key, value) VALUES ('last_update_check', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'last_update_check'
 `
 
-func (q *sqlQuerier) InsertOrUpdateLastUpdateCheck(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, insertOrUpdateLastUpdateCheck, value)
+func (q *sqlQuerier) UpsertLastUpdateCheck(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, UpsertLastUpdateCheck, value)
 	return err
 }
 
-const insertOrUpdateLogoURL = `-- name: InsertOrUpdateLogoURL :exec
+const UpsertLogoURL = `-- name: UpsertLogoURL :exec
 INSERT INTO site_configs (key, value) VALUES ('logo_url', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'logo_url'
 `
 
-func (q *sqlQuerier) InsertOrUpdateLogoURL(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, insertOrUpdateLogoURL, value)
+func (q *sqlQuerier) UpsertLogoURL(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, UpsertLogoURL, value)
 	return err
 }
 
-const insertOrUpdateServiceBanner = `-- name: InsertOrUpdateServiceBanner :exec
+const UpsertServiceBanner = `-- name: UpsertServiceBanner :exec
 INSERT INTO site_configs (key, value) VALUES ('service_banner', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'service_banner'
 `
 
-func (q *sqlQuerier) InsertOrUpdateServiceBanner(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, insertOrUpdateServiceBanner, value)
+func (q *sqlQuerier) UpsertServiceBanner(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, UpsertServiceBanner, value)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -10,21 +10,21 @@ INSERT INTO site_configs (key, value) VALUES ('derp_mesh_key', $1);
 -- name: GetDERPMeshKey :one
 SELECT value FROM site_configs WHERE key = 'derp_mesh_key';
 
--- name: InsertOrUpdateLastUpdateCheck :exec
+-- name: UpsertLastUpdateCheck :exec
 INSERT INTO site_configs (key, value) VALUES ('last_update_check', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'last_update_check';
 
 -- name: GetLastUpdateCheck :one
 SELECT value FROM site_configs WHERE key = 'last_update_check';
 
--- name: InsertOrUpdateServiceBanner :exec
+-- name: UpsertServiceBanner :exec
 INSERT INTO site_configs (key, value) VALUES ('service_banner', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'service_banner';
 
 -- name: GetServiceBanner :one
 SELECT value FROM site_configs WHERE key = 'service_banner';
 
--- name: InsertOrUpdateLogoURL :exec
+-- name: UpsertLogoURL :exec
 INSERT INTO site_configs (key, value) VALUES ('logo_url', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'logo_url';
 

--- a/coderd/updatecheck/updatecheck.go
+++ b/coderd/updatecheck/updatecheck.go
@@ -211,7 +211,7 @@ func (c *Checker) update() (r Result, err error) {
 	}
 
 	// nolint:gocritic // Inserting the last update check is a system function.
-	err = c.db.InsertOrUpdateLastUpdateCheck(dbauthz.AsSystemRestricted(ctx), string(b))
+	err = c.db.UpsertLastUpdateCheck(dbauthz.AsSystemRestricted(ctx), string(b))
 	if err != nil {
 		return r, err
 	}

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -148,7 +148,7 @@ func (api *API) putAppearance(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = api.Database.InsertOrUpdateServiceBanner(ctx, string(serviceBannerJSON))
+	err = api.Database.UpsertServiceBanner(ctx, string(serviceBannerJSON))
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: fmt.Sprintf("database error: %+v", err),
@@ -156,7 +156,7 @@ func (api *API) putAppearance(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = api.Database.InsertOrUpdateLogoURL(ctx, appearance.LogoURL)
+	err = api.Database.UpsertLogoURL(ctx, appearance.LogoURL)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: fmt.Sprintf("database error: %+v", err),


### PR DESCRIPTION
The shorter name uses up less line width, is easier to read
and is used more often.
