### PR TITLE
feat: Allow unsetting ssh config options from deployment

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -62,7 +62,7 @@ func (o *sshConfigOptions) addOptions(options ...string) error {
 }
 
 func (o *sshConfigOptions) addOption(option string) error {
-	key, _, err := codersdk.ParseSSHConfigOption(option)
+	key, value, err := codersdk.ParseSSHConfigOption(option)
 	if err != nil {
 		return err
 	}
@@ -77,11 +77,20 @@ func (o *sshConfigOptions) addOption(option string) error {
 			continue
 		}
 		if strings.EqualFold(existingKey, key) {
-			o.sshOptions[i] = option
+			if value == "" {
+				// Delete existing option.
+				o.sshOptions = append(o.sshOptions[:i], o.sshOptions[i+1:]...)
+			} else {
+				// Override existing option.
+				o.sshOptions[i] = option
+			}
 			return nil
 		}
 	}
-	o.sshOptions = append(o.sshOptions, option)
+	// Only append the option if it is not empty.
+	if value != "" {
+		o.sshOptions = append(o.sshOptions, option)
+	}
 	return nil
 }
 

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -66,6 +66,7 @@ func TestConfigSSH(t *testing.T) {
 
 	const hostname = "test-coder."
 	const expectedKey = "ConnectionAttempts"
+	const removeKey = "ConnectionTimeout"
 	client := coderdtest.New(t, &coderdtest.Options{
 		IncludeProvisionerDaemon: true,
 		ConfigSSH: codersdk.SSHConfigResponse{
@@ -73,6 +74,7 @@ func TestConfigSSH(t *testing.T) {
 			SSHConfigOptions: map[string]string{
 				// Something we can test for
 				expectedKey: "3",
+				removeKey:   "",
 			},
 		},
 	})
@@ -176,6 +178,7 @@ func TestConfigSSH(t *testing.T) {
 	fileContents, err := os.ReadFile(sshConfigFile)
 	require.NoError(t, err, "read ssh config file")
 	require.Contains(t, string(fileContents), expectedKey, "ssh config file contains expected key")
+	require.NotContains(t, string(fileContents), removeKey, "ssh config file should not have removed key")
 
 	home := filepath.Dir(filepath.Dir(sshConfigFile))
 	// #nosec


### PR DESCRIPTION
This allows deleting ssh config options
Fixes https://github.com/coder/coder/issues/6826