### PR TITLE
fix(site): fix redirection to login after logout/change password

### DIFF
--- a/site/.eslintrc.yaml
+++ b/site/.eslintrc.yaml
@@ -46,6 +46,9 @@ overrides:
   - files: ["e2e/**/*.[tj]s"]
     extends: ["plugin:testing-library/react", "plugin:testing-library/dom"]
     rules:
+      # Sometimes the eslint-plugin-testing-library believes playwright queries are
+      # also react-testing-library queries, which is not the case. So we disable this
+      # rule for all e2e tests.
       testing-library/prefer-screen-queries: "off"
 root: true
 rules:
@@ -111,16 +114,20 @@ rules:
     - error
     - paths:
         - name: "@material-ui/core"
-          message: "Use path imports to avoid pulling in unused modules. See:
+          message:
+            "Use path imports to avoid pulling in unused modules. See:
             https://material-ui.com/guides/minimizing-bundle-size/"
         - name: "@material-ui/icons"
-          message: "Use path imports to avoid pulling in unused modules. See:
+          message:
+            "Use path imports to avoid pulling in unused modules. See:
             https://material-ui.com/guides/minimizing-bundle-size/"
         - name: "@material-ui/styles"
-          message: "Use path imports to avoid pulling in unused modules. See:
+          message:
+            "Use path imports to avoid pulling in unused modules. See:
             https://material-ui.com/guides/minimizing-bundle-size/"
         - name: "@material-ui/core/Avatar"
-          message: "You should use the Avatar component provided on
+          message:
+            "You should use the Avatar component provided on
             components/Avatar/Avatar"
   no-unused-vars: "off"
   "object-curly-spacing": "off"

--- a/site/.eslintrc.yaml
+++ b/site/.eslintrc.yaml
@@ -43,6 +43,10 @@ overrides:
       # https://coder.com/docs/v2/latest/contributing/frontend#tests-getting-too-slow.
       testing-library/no-node-access: off
       testing-library/no-container: off
+  - files: ["e2e/**/*.[tj]s"]
+    extends: ["plugin:testing-library/react", "plugin:testing-library/dom"]
+    rules:
+      testing-library/prefer-screen-queries: "off"
 root: true
 rules:
   "@typescript-eslint/brace-style":
@@ -107,20 +111,16 @@ rules:
     - error
     - paths:
         - name: "@material-ui/core"
-          message:
-            "Use path imports to avoid pulling in unused modules. See:
+          message: "Use path imports to avoid pulling in unused modules. See:
             https://material-ui.com/guides/minimizing-bundle-size/"
         - name: "@material-ui/icons"
-          message:
-            "Use path imports to avoid pulling in unused modules. See:
+          message: "Use path imports to avoid pulling in unused modules. See:
             https://material-ui.com/guides/minimizing-bundle-size/"
         - name: "@material-ui/styles"
-          message:
-            "Use path imports to avoid pulling in unused modules. See:
+          message: "Use path imports to avoid pulling in unused modules. See:
             https://material-ui.com/guides/minimizing-bundle-size/"
         - name: "@material-ui/core/Avatar"
-          message:
-            "You should use the Avatar component provided on
+          message: "You should use the Avatar component provided on
             components/Avatar/Avatar"
   no-unused-vars: "off"
   "object-curly-spacing": "off"
@@ -156,7 +156,6 @@ rules:
         message: "Default React import not allowed",
       },
     ]
-
 settings:
   react:
     version: detect

--- a/site/e2e/tests/logout.spec.ts
+++ b/site/e2e/tests/logout.spec.ts
@@ -9,7 +9,9 @@ test("signing out redirects to login page", async ({ page, baseURL }) => {
   await page.getByTestId("user-dropdown-trigger").click()
   await page.getByRole("menuitem", { name: "Sign Out" }).click()
 
-  await expect(page.getByRole("heading", { name: "Sign in to Coder" })).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Sign in to Coder" }),
+  ).toBeVisible()
 
   expect(page.url()).toMatch(/\/login$/) // ensure we're on the login page with no query params
 })

--- a/site/e2e/tests/logout.spec.ts
+++ b/site/e2e/tests/logout.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test"
+import { getStatePath } from "../helpers"
+
+test.use({ storageState: getStatePath("authState") })
+
+test("signing out redirects to login page", async ({ page, baseURL }) => {
+  await page.goto(`${baseURL}/`, { waitUntil: "networkidle" })
+
+  await page.getByTestId("user-dropdown-trigger").click()
+  await page.getByRole("menuitem", { name: "Sign Out" }).click()
+
+  await expect(page.getByRole("heading", { name: "Sign in to Coder" })).toBeVisible()
+})

--- a/site/e2e/tests/logout.spec.ts
+++ b/site/e2e/tests/logout.spec.ts
@@ -10,4 +10,6 @@ test("signing out redirects to login page", async ({ page, baseURL }) => {
   await page.getByRole("menuitem", { name: "Sign Out" }).click()
 
   await expect(page.getByRole("heading", { name: "Sign in to Coder" })).toBeVisible()
+
+  expect(page.url()).toMatch(/\/login$/) // ensure we're on the login page with no query params
 })

--- a/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SecurityPage.test.tsx
@@ -47,6 +47,8 @@ describe("SecurityPage", () => {
       expect(successMessage).toBeDefined()
       expect(API.updateUserPassword).toBeCalledTimes(1)
       expect(API.updateUserPassword).toBeCalledWith(user.id, newData)
+
+      await waitFor(() => expect(window.location).toBeAt("/"))
     })
   })
 

--- a/site/src/xServices/auth/authXService.ts
+++ b/site/src/xServices/auth/authXService.ts
@@ -389,12 +389,10 @@ export const authMachine =
         }),
         redirect: (_, { data }) => {
           if (!("redirectUrl" in data)) {
-            throw new Error(
-              "Redirect only should be called with data.redirectUrl",
-            )
+            window.location.href = location.origin
+          } else {
+            window.location.replace(data.redirectUrl)
           }
-
-          window.location.replace(data.redirectUrl)
         },
       },
       guards: {

--- a/site/src/xServices/userSecuritySettings/userSecuritySettingsXService.ts
+++ b/site/src/xServices/userSecuritySettings/userSecuritySettingsXService.ts
@@ -68,7 +68,7 @@ export const userSecuritySettingsMachine = createMachine(
       }),
       redirectToHome: () => {
         window.location.href = location.origin
-      }
+      },
     },
   },
 )

--- a/site/src/xServices/userSecuritySettings/userSecuritySettingsXService.ts
+++ b/site/src/xServices/userSecuritySettings/userSecuritySettingsXService.ts
@@ -35,7 +35,7 @@ export const userSecuritySettingsMachine = createMachine(
           src: "updateSecurity",
           onDone: [
             {
-              actions: "notifyUpdate",
+              actions: ["notifyUpdate", "redirectToHome"],
               target: "idle",
             },
           ],
@@ -66,6 +66,9 @@ export const userSecuritySettingsMachine = createMachine(
       assignError: assign({
         error: (_, event) => event.data,
       }),
+      redirectToHome: () => {
+        window.location.href = location.origin
+      }
     },
   },
 )


### PR DESCRIPTION
Fix: #6133  and #6783 

In this pull request, we have addressed an issue where the user was not being redirected to the login page after logging out or changing their password. We have made the following changes:

1. Updated the logout function to ensure proper redirection to the login page.
2. Modified the password change success handling to direct the user to the login page.

## Tests
- Edit the security page integration test to check if the login page is being displayed after changing the password
- Created a e2e test handling logout