### PR TITLE
feat(draft): add user notifications

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -593,6 +593,7 @@ func New(options *Options) *API {
 					})
 					r.Get("/gitsshkey", api.gitSSHKey)
 					r.Put("/gitsshkey", api.regenerateGitSSHKey)
+					r.Get("/notifications", api.userNotifications)
 				})
 			})
 		})

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1110,10 +1110,7 @@ func (api *API) userNotifications(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaces := database.ConvertWorkspaceRows(workspaceRows)
-	if err != nil {
-		sendErrorEvent(err, "Internal error getting user resources.")
-		return
-	}
+
 	// defines channel name (e.g. pub sub "topic") and its callback for listening to events
 	var subscriptionListeners = make(map[string]database.Listener)
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -164,6 +164,16 @@ export const deleteToken = async (keyId: string): Promise<void> => {
   await axios.delete("/api/v2/users/me/keys/" + keyId)
 }
 
+/**
+ * An event source that emits user notifications.
+ */
+export const getNotifications = async() => {
+    return new EventSource(
+      `${location.protocol}//${location.host}/api/v2/users/me/notifications`,
+      { withCredentials: true },
+    )
+}
+
 export const createToken = async (
   params: TypesGen.CreateTokenRequest,
 ): Promise<TypesGen.GenerateAPIKeyResponse> => {


### PR DESCRIPTION
This adds SSE events for `/users/{user}/notifications`, which currently streams a collection of template version updates. The frontend can use this for displaying notifications across all active workspaces! We can also use this endpoint for displaying other activity, too, such as an activity log of other users in the same group / organization. 

Note: This is a draft for an assignment, and I'm not expecting an entire feature like this to be merged. 😄 