### PR TITLE
fix: allow overridding default string array

### DIFF
--- a/cli/clibase/cmd.go
+++ b/cli/clibase/cmd.go
@@ -172,8 +172,8 @@ type Invocation struct {
 
 // WithOS returns the invocation as a main package, filling in the invocation's unset
 // fields with OS defaults.
-func (i *Invocation) WithOS() *Invocation {
-	return i.with(func(i *Invocation) {
+func (inv *Invocation) WithOS() *Invocation {
+	return inv.with(func(i *Invocation) {
 		i.Stdout = os.Stdout
 		i.Stderr = os.Stderr
 		i.Stdin = os.Stdin
@@ -182,18 +182,18 @@ func (i *Invocation) WithOS() *Invocation {
 	})
 }
 
-func (i *Invocation) Context() context.Context {
-	if i.ctx == nil {
+func (inv *Invocation) Context() context.Context {
+	if inv.ctx == nil {
 		return context.Background()
 	}
-	return i.ctx
+	return inv.ctx
 }
 
-func (i *Invocation) ParsedFlags() *pflag.FlagSet {
-	if i.parsedFlags == nil {
+func (inv *Invocation) ParsedFlags() *pflag.FlagSet {
+	if inv.parsedFlags == nil {
 		panic("flags not parsed, has Run() been called?")
 	}
-	return i.parsedFlags
+	return inv.parsedFlags
 }
 
 type runState struct {
@@ -403,33 +403,33 @@ func findArg(want string, args []string, fs *pflag.FlagSet) (int, error) {
 // If two command share a flag name, the first command wins.
 //
 //nolint:revive
-func (i *Invocation) Run() (err error) {
+func (inv *Invocation) Run() (err error) {
 	defer func() {
 		// Pflag is panicky, so additional context is helpful in tests.
 		if flag.Lookup("test.v") == nil {
 			return
 		}
 		if r := recover(); r != nil {
-			err = xerrors.Errorf("panic recovered for %s: %v", i.Command.FullName(), r)
+			err = xerrors.Errorf("panic recovered for %s: %v", inv.Command.FullName(), r)
 			panic(err)
 		}
 	}()
-	err = i.run(&runState{
-		allArgs: i.Args,
+	err = inv.run(&runState{
+		allArgs: inv.Args,
 	})
 	return err
 }
 
 // WithContext returns a copy of the Invocation with the given context.
-func (i *Invocation) WithContext(ctx context.Context) *Invocation {
-	return i.with(func(i *Invocation) {
+func (inv *Invocation) WithContext(ctx context.Context) *Invocation {
+	return inv.with(func(i *Invocation) {
 		i.ctx = ctx
 	})
 }
 
 // with returns a copy of the Invocation with the given function applied.
-func (i *Invocation) with(fn func(*Invocation)) *Invocation {
-	i2 := *i
+func (inv *Invocation) with(fn func(*Invocation)) *Invocation {
+	i2 := *inv
 	fn(&i2)
 	return &i2
 }

--- a/cli/clibase/cmd.go
+++ b/cli/clibase/cmd.go
@@ -264,14 +264,11 @@ func (i *Invocation) run(state *runState) error {
 
 	// Set defaults for flags that weren't set by the user.
 	skipDefaults := make(map[string]struct{}, len(i.Command.Options))
-	i.parsedFlags.VisitAll(func(f *pflag.Flag) {
-		if !f.Changed {
-			return
-		}
-		skipDefaults[f.Name] = struct{}{}
-	})
 	for _, opt := range i.Command.Options {
-		if opt.envSet {
+		if fl := i.parsedFlags.Lookup(opt.Flag); fl != nil && fl.Changed {
+			skipDefaults[opt.Name] = struct{}{}
+		}
+		if opt.envChanged {
 			skipDefaults[opt.Name] = struct{}{}
 		}
 	}

--- a/cli/clibase/cmd_test.go
+++ b/cli/clibase/cmd_test.go
@@ -247,6 +247,7 @@ func TestCommand_FlagOverride(t *testing.T) {
 		Use: "1",
 		Options: clibase.OptionSet{
 			{
+				Name:  "flag",
 				Flag:  "f",
 				Value: clibase.DiscardValue,
 			},
@@ -256,6 +257,7 @@ func TestCommand_FlagOverride(t *testing.T) {
 				Use: "2",
 				Options: clibase.OptionSet{
 					{
+						Name:  "flag",
 						Flag:  "f",
 						Value: clibase.StringOf(&flag),
 					},
@@ -527,11 +529,17 @@ func TestCommand_EmptySlice(t *testing.T) {
 		}
 	}
 
-	// Base-case
+	// Base-case, uses default.
 	err := cmd("bad", "bad", "bad").Invoke().Run()
 	require.NoError(t, err)
 
+	// Reset to nothing at all.
 	inv := cmd().Invoke("--arr", "")
+	err = inv.Run()
+	require.NoError(t, err)
+
+	// Override
+	inv = cmd("great").Invoke("--arr", "great")
 	err = inv.Run()
 	require.NoError(t, err)
 }

--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -146,25 +146,19 @@ func (s *OptionSet) ParseEnv(vs []EnvVar) error {
 	return merr.ErrorOrNil()
 }
 
-// SetDefaults sets the default values for each Option.
-// It should be called before all parsing (e.g. ParseFlags, ParseEnv).
-func (s *OptionSet) SetDefaults(skip map[string]struct{}) error {
+// SetDefaults sets the default values for each Option, skipping values
+// that have already been set as indiciated by the skip map.
+func (s *OptionSet) SetDefaults(skip map[int]struct{}) error {
 	if s == nil {
 		return nil
 	}
 
 	var merr *multierror.Error
 
-	for _, opt := range *s {
+	for i, opt := range *s {
 		// Skip values that may have already been set by the user.
 		if len(skip) > 0 {
-			if opt.Name == "" {
-				merr = multierror.Append(
-					merr, xerrors.Errorf("parse: no Name field set"),
-				)
-				continue
-			}
-			if _, ok := skip[opt.Name]; ok {
+			if _, ok := skip[i]; ok {
 				continue
 			}
 		}

--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -156,14 +156,17 @@ func (s *OptionSet) SetDefaults(skip map[string]struct{}) error {
 	var merr *multierror.Error
 
 	for _, opt := range *s {
-		if opt.Name == "" {
-			merr = multierror.Append(
-				merr, xerrors.Errorf("parse: no Name field set"),
-			)
-			continue
-		}
-		if _, ok := skip[opt.Name]; ok {
-			continue
+		// Skip values that may have already been set by the user.
+		if len(skip) > 0 {
+			if opt.Name == "" {
+				merr = multierror.Append(
+					merr, xerrors.Errorf("parse: no Name field set"),
+				)
+				continue
+			}
+			if _, ok := skip[opt.Name]; ok {
+				continue
+			}
 		}
 
 		if opt.Default == "" {

--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -47,7 +47,7 @@ type Option struct {
 
 	Hidden bool `json:"hidden,omitempty"`
 
-	envSet bool
+	envChanged bool
 }
 
 // OptionSet is a group of options that can be applied to a command.
@@ -135,7 +135,7 @@ func (s *OptionSet) ParseEnv(vs []EnvVar) error {
 			continue
 		}
 
-		opt.envSet = true
+		opt.envChanged = true
 		if err := opt.Value.Set(envVal); err != nil {
 			merr = multierror.Append(
 				merr, xerrors.Errorf("parse %q: %w", opt.Name, err),

--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -147,7 +147,7 @@ func (s *OptionSet) ParseEnv(vs []EnvVar) error {
 }
 
 // SetDefaults sets the default values for each Option, skipping values
-// that have already been set as indiciated by the skip map.
+// that have already been set as indicated by the skip map.
 func (s *OptionSet) SetDefaults(skip map[int]struct{}) error {
 	if s == nil {
 		return nil

--- a/cli/clibase/option_test.go
+++ b/cli/clibase/option_test.go
@@ -49,7 +49,7 @@ func TestOptionSet_ParseFlags(t *testing.T) {
 			},
 		}
 
-		err := os.SetDefaults()
+		err := os.SetDefaults(nil)
 		require.NoError(t, err)
 
 		err = os.FlagSet().Parse([]string{"--name", "foo", "--name", "bar"})
@@ -111,7 +111,7 @@ func TestOptionSet_ParseEnv(t *testing.T) {
 			},
 		}
 
-		err := os.SetDefaults()
+		err := os.SetDefaults(nil)
 		require.NoError(t, err)
 
 		err = os.ParseEnv(clibase.ParseEnviron([]string{"CODER_WORKSPACE_NAME="}, "CODER_"))

--- a/cli/clibase/yaml_test.go
+++ b/cli/clibase/yaml_test.go
@@ -44,7 +44,7 @@ func TestOption_ToYAML(t *testing.T) {
 			},
 		}
 
-		err := os.SetDefaults()
+		err := os.SetDefaults(nil)
 		require.NoError(t, err)
 
 		n, err := os.ToYAML()

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1075,7 +1075,7 @@ QastnN77KfUwdj3SJt44U/uh1jAIv4oSLBr8HYUkbnI8
 func DeploymentValues(t *testing.T) *codersdk.DeploymentValues {
 	var cfg codersdk.DeploymentValues
 	opts := cfg.Options()
-	err := opts.SetDefaults()
+	err := opts.SetDefaults(nil)
 	require.NoError(t, err)
 	return &cfg
 }


### PR DESCRIPTION
- [ ] Use index instead of name in skip map to reduce dependency on `.Name` being set