### PR TITLE
feat: Allow only workspace owner connections

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -636,6 +636,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					HostnamePrefix:   cfg.SSHConfig.DeploymentName.String(),
 					SSHConfigOptions: configSSHOptions,
 				},
+				WorkspaceOwnerConnectionOnly: cfg.WorkspaceOwnerConnectionOnly.Value(),
 			}
 			if tlsConfig != nil {
 				options.TLSCertificates = tlsConfig.Certificates

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -142,6 +142,8 @@ type Options struct {
 	SSHConfig codersdk.SSHConfigResponse
 
 	HTTPClient *http.Client
+
+	WorkspaceOwnerConnectionOnly bool
 }
 
 // @title Coder API

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -162,6 +162,7 @@ type DeploymentValues struct {
 	GitAuthProviders                clibase.Struct[[]GitAuthConfig] `json:"git_auth,omitempty" typescript:",notnull"`
 	SSHConfig                       SSHConfig                       `json:"config_ssh,omitempty" typescript:",notnull"`
 	WgtunnelHost                    clibase.String                  `json:"wgtunnel_host,omitempty" typescript:",notnull"`
+	WorkspaceOwnerConnectionOnly    clibase.Bool                    `json:"workspace_owner_connection_only,omitempty" typescript:",notnull"`
 
 	Config      clibase.String `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig clibase.Bool   `json:"write_config,omitempty" typescript:",notnull"`
@@ -1378,6 +1379,15 @@ Write out the current server configuration to the path specified by --config.`,
 			Value:       &c.WgtunnelHost,
 			Default:     "", // empty string means pick best server
 			Hidden:      true,
+		},
+		{
+			Name:        "Workspace Owner Connection Only",
+			Description: "Specifies whether owners only have access to their workspaces.",
+			Flag:        "workspace-owner-connection-only",
+			Env:         "CODER_WORKSPACE_OWNER_CONNECTION_ONLY",
+			Default:     "false",
+			Value:       &c.WorkspaceOwnerConnectionOnly,
+			YAML:        "workspaceOwnerConnectionOnly",
 		},
 	}
 	return opts

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -368,6 +368,7 @@ export interface DeploymentValues {
   readonly git_auth?: any
   readonly config_ssh?: SSHConfig
   readonly wgtunnel_host?: string
+  readonly owner_workspace_connection_only?: boolean
   readonly config?: string
   readonly write_config?: boolean
   // Named type "github.com/coder/coder/cli/clibase.HostPort" unknown, using "any"

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -368,7 +368,7 @@ export interface DeploymentValues {
   readonly git_auth?: any
   readonly config_ssh?: SSHConfig
   readonly wgtunnel_host?: string
-  readonly owner_workspace_connection_only?: boolean
+  readonly workspace_owner_connection_only?: boolean
   readonly config?: string
   readonly write_config?: boolean
   // Named type "github.com/coder/coder/cli/clibase.HostPort" unknown, using "any"


### PR DESCRIPTION
# Draft

This is a draft and I need some feedback. I suspect the best way to do this might be via permissions and RBCA but I need some guidance here. 

## Context

Currently, the owner role has the ability to connect to all workspaces. This is not ideal from a security perspective because it increases exposure as a compromised admin account has access to workspaces and can perform malicious actions.

## Intent

We want to only allow the workspace owner to have the ability to connect to their workspace.

## Changes

* Adding a server option `CODER_WORKSPACE_OWNER_CONNECTION_ONLY` to only allow workspace owners connection to their workspaces

## TODO

* Write tests
* Remove agent apps from the UI when non-owner views workspace (e.g. Terminal Link, SSH button)
* Handle connection errors when attempting to SSH