### PR TITLE
fix: extend regex for template version name

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -44,7 +44,7 @@ func init() {
 		valid := NameValid(str)
 		return valid == nil
 	}
-	for _, tag := range []string{"username", "template_name", "workspace_name", "template_version_name"} {
+	for _, tag := range []string{"username", "template_name", "workspace_name"} {
 		err := Validate.RegisterValidation(tag, nameValidator)
 		if err != nil {
 			panic(err)
@@ -61,6 +61,20 @@ func init() {
 		return valid == nil
 	}
 	err := Validate.RegisterValidation("template_display_name", templateDisplayNameValidator)
+	if err != nil {
+		panic(err)
+	}
+
+	templateVersionNameValidator := func(fl validator.FieldLevel) bool {
+		f := fl.Field().Interface()
+		str, ok := f.(string)
+		if !ok {
+			return false
+		}
+		valid := TemplateVersionNameValid(str)
+		return valid == nil
+	}
+	err = Validate.RegisterValidation("template_version_name", templateVersionNameValidator)
 	if err != nil {
 		panic(err)
 	}

--- a/coderd/httpapi/name.go
+++ b/coderd/httpapi/name.go
@@ -12,6 +12,7 @@ var (
 	UsernameValidRegex = regexp.MustCompile("^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$")
 	usernameReplace    = regexp.MustCompile("[^a-zA-Z0-9-]*")
 
+	templateVersionName = regexp.MustCompile(`^[a-zA-Z0-9]+(?:[_.-]{1}[a-zA-Z0-9]+)*$`)
 	templateDisplayName = regexp.MustCompile(`^[^\s](.*[^\s])?$`)
 )
 
@@ -48,6 +49,18 @@ func NameValid(str string) error {
 	matched := UsernameValidRegex.MatchString(str)
 	if !matched {
 		return xerrors.New("must be alphanumeric with hyphens")
+	}
+	return nil
+}
+
+// TemplateVersionNameValid returns whether the input string is a valid template version name.
+func TemplateVersionNameValid(str string) error {
+	if len(str) > 64 {
+		return xerrors.New("must be <= 64 characters")
+	}
+	matched := templateVersionName.MatchString(str)
+	if !matched {
+		return xerrors.New("must be alphanumeric with underscores and dots")
 	}
 	return nil
 }

--- a/coderd/httpapi/name_test.go
+++ b/coderd/httpapi/name_test.go
@@ -3,6 +3,7 @@ package httpapi_test
 import (
 	"testing"
 
+	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/httpapi"
@@ -117,6 +118,57 @@ func TestTemplateDisplayNameValid(t *testing.T) {
 			valid := httpapi.TemplateDisplayNameValid(testCase.Name)
 			require.Equal(t, testCase.Valid, valid == nil)
 		})
+	}
+}
+
+func TestTemplateVersionNameValid(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name  string
+		Valid bool
+	}{
+		{"1", true},
+		{"12", true},
+		{"1_2", true},
+		{"1-2", true},
+		{"cray", true},
+		{"123_456", true},
+		{"123-456", true},
+		{"1234_678901234567890", true},
+		{"1234-678901234567890", true},
+		{"S", true},
+		{"a1", true},
+		{"a1K2", true},
+		{"fuzzy_bear3", true},
+		{"fuzzy-bear3", true},
+		{"v1.0.0", true},
+		{"heuristic_cray2", true},
+
+		{"", false},
+		{".v1", false},
+		{"v1..0", false},
+		{"4--4", false},
+		{"<b> </b>", false},
+		{"!!!!1 ?????", false},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+			valid := httpapi.TemplateVersionNameValid(testCase.Name)
+			require.Equal(t, testCase.Valid, valid == nil)
+		})
+	}
+}
+
+func TestGeneratedTemplateVersionNameValid(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 1000; i++ {
+		name := namesgenerator.GetRandomName(1)
+		err := httpapi.TemplateVersionNameValid(name)
+		require.NoError(t, err, "invalid template version name: %s", name)
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6857

This PR extends the regexp for the template version name validator making it a bit more permissive.

Allowed names:

```
heuristic_cray2
v1.0.0
foo-bar
```