### PR TITLE
chore(UI): redirecting from workspace page if 404

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -9,6 +9,7 @@ import { firstOrItem } from "util/array"
 import { quotaMachine } from "xServices/quotas/quotasXService"
 import { workspaceMachine } from "xServices/workspace/workspaceXService"
 import { WorkspaceReadyPage } from "./WorkspaceReadyPage"
+import { RequirePermission } from "components/RequirePermission/RequirePermission"
 
 export const WorkspacePage: FC = () => {
   const { username: usernameQueryParam, workspace: workspaceQueryParam } =
@@ -42,46 +43,50 @@ export const WorkspacePage: FC = () => {
   }, [username, quotaSend])
 
   return (
-    <ChooseOne>
-      <Cond condition={workspaceState.matches("error")}>
-        <div className={styles.error}>
-          {Boolean(getWorkspaceError) && (
-            <AlertBanner severity="error" error={getWorkspaceError} />
-          )}
-          {Boolean(getTemplateWarning) && (
-            <AlertBanner severity="error" error={getTemplateWarning} />
-          )}
-          {Boolean(getTemplateParametersWarning) && (
-            <AlertBanner
-              severity="error"
-              error={getTemplateParametersWarning}
-            />
-          )}
-          {Boolean(checkPermissionsError) && (
-            <AlertBanner severity="error" error={checkPermissionsError} />
-          )}
-          {Boolean(getQuotaError) && (
-            <AlertBanner severity="error" error={getQuotaError} />
-          )}
-        </div>
-      </Cond>
-      <Cond
-        condition={
-          Boolean(workspace) &&
-          workspaceState.matches("ready") &&
-          quotaState.matches("success")
-        }
-      >
-        <WorkspaceReadyPage
-          workspaceState={workspaceState}
-          quotaState={quotaState}
-          workspaceSend={workspaceSend}
-        />
-      </Cond>
-      <Cond>
-        <Loader />
-      </Cond>
-    </ChooseOne>
+    <RequirePermission
+      isFeatureVisible={getWorkspaceError?.response?.status !== 404}
+    >
+      <ChooseOne>
+        <Cond condition={workspaceState.matches("error")}>
+          <div className={styles.error}>
+            {Boolean(getWorkspaceError) && (
+              <AlertBanner severity="error" error={getWorkspaceError} />
+            )}
+            {Boolean(getTemplateWarning) && (
+              <AlertBanner severity="error" error={getTemplateWarning} />
+            )}
+            {Boolean(getTemplateParametersWarning) && (
+              <AlertBanner
+                severity="error"
+                error={getTemplateParametersWarning}
+              />
+            )}
+            {Boolean(checkPermissionsError) && (
+              <AlertBanner severity="error" error={checkPermissionsError} />
+            )}
+            {Boolean(getQuotaError) && (
+              <AlertBanner severity="error" error={getQuotaError} />
+            )}
+          </div>
+        </Cond>
+        <Cond
+          condition={
+            Boolean(workspace) &&
+            workspaceState.matches("ready") &&
+            quotaState.matches("success")
+          }
+        >
+          <WorkspaceReadyPage
+            workspaceState={workspaceState}
+            quotaState={quotaState}
+            workspaceSend={workspaceSend}
+          />
+        </Cond>
+        <Cond>
+          <Loader />
+        </Cond>
+      </ChooseOne>
+    </RequirePermission>
   )
 }
 

--- a/site/src/xServices/workspace/workspaceXService.ts
+++ b/site/src/xServices/workspace/workspaceXService.ts
@@ -9,6 +9,7 @@ import {
   displayError,
   displaySuccess,
 } from "../../components/GlobalSnackbar/utils"
+import { AxiosError } from "axios"
 
 const latestBuild = (builds: TypesGen.WorkspaceBuild[]) => {
   // Cloning builds to not change the origin object with the sort()
@@ -56,7 +57,7 @@ export interface WorkspaceContext {
   workspace?: TypesGen.Workspace
   template?: TypesGen.Template
   build?: TypesGen.WorkspaceBuild
-  getWorkspaceError?: Error | unknown
+  getWorkspaceError?: AxiosError
   getTemplateWarning: Error | unknown
   getTemplateParametersWarning: Error | unknown
   // Builds
@@ -491,7 +492,7 @@ export const workspaceMachine = createMachine(
         workspace: (_, event) => event.data,
       }),
       assignGetWorkspaceError: assign({
-        getWorkspaceError: (_, event) => event.data,
+        getWorkspaceError: (_, event) => event.data as AxiosError,
       }),
       clearGetWorkspaceError: (context) =>
         assign({ ...context, getWorkspaceError: undefined }),


### PR DESCRIPTION
This is a new fix to take the place of #6786, which was reverted because it broke everything 😳

We now redirect if the `getWorkspace` request returns a 404. We can't explicitly authcheck a users' permission to read a workspace because we won't have that workspace ID (bc of the 404).

I have smoke-tested this a fair amount and would like to write some E2E tests, but I'm having trouble with Playwright as per usual (see #6879). Not sure how to move forward with those tests. We can either release this fix as smoke-tested only or hold off until we get E2E working, but I'm moving on for now.