### PR TITLE
chore(UI): remove template link from workspaces page row

### DIFF
--- a/site/src/components/WorkspacesTable/WorkspacesRow.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesRow.tsx
@@ -5,15 +5,13 @@ import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import { AvatarData } from "components/AvatarData/AvatarData"
 import { WorkspaceStatusBadge } from "components/WorkspaceStatusBadge/WorkspaceStatusBadge"
 import { FC } from "react"
-import { useNavigate, Link as RouterLink } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
 import { getDisplayWorkspaceTemplateName } from "util/workspace"
 import { LastUsed } from "../LastUsed/LastUsed"
 import { Workspace } from "api/typesGenerated"
 import { OutdatedHelpTooltip } from "components/Tooltips/OutdatedHelpTooltip"
 import { Avatar } from "components/Avatar/Avatar"
 import { Stack } from "components/Stack/Stack"
-import TemplateLinkIcon from "@material-ui/icons/OpenInNewOutlined"
-import Link from "@material-ui/core/Link"
 import { useClickableTableRow } from "hooks/useClickableTableRow"
 
 export const WorkspacesRow: FC<{
@@ -58,20 +56,9 @@ export const WorkspacesRow: FC<{
       </TableCell>
 
       <TableCell>
-        <Link
-          component={RouterLink}
-          to={`/templates/${workspace.template_name}`}
-          className={styles.templateLink}
-          title={`Go to ${displayTemplateName} page`}
-          onClick={(e) => {
-            e.stopPropagation()
-          }}
-        >
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <TemplateLinkIcon className={styles.templateLinkIcon} />
-            <span>{displayTemplateName}</span>
-          </Stack>
-        </Link>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <span>{displayTemplateName}</span>
+        </Stack>
       </TableCell>
 
       <TableCell>
@@ -101,19 +88,5 @@ const useStyles = makeStyles((theme) => ({
   arrowCell: {
     display: "flex",
     paddingLeft: theme.spacing(2),
-  },
-
-  templateLink: {
-    color: theme.palette.text.secondary,
-
-    "&:hover": {
-      color: theme.palette.text.primary,
-      textDecoration: "none",
-    },
-  },
-
-  templateLinkIcon: {
-    width: theme.spacing(1.5),
-    height: theme.spacing(1.5),
   },
 }))

--- a/site/src/components/WorkspacesTable/WorkspacesRow.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesRow.tsx
@@ -55,11 +55,7 @@ export const WorkspacesRow: FC<{
         />
       </TableCell>
 
-      <TableCell>
-        <Stack direction="row" alignItems="center" spacing={1}>
-          <span>{displayTemplateName}</span>
-        </Stack>
-      </TableCell>
+      <TableCell>{displayTemplateName}</TableCell>
 
       <TableCell>
         <LastUsed lastUsedAt={workspace.last_used_at} />


### PR DESCRIPTION
Removing the link to the template page on the workspace row in `/workspaces` because it often is clicked unintentionally when one is trying to navigate to a workspace.