### PR TITLE
chore: use defer instead of `t.Cleanup` for `chdir`

### DIFF
--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -178,10 +178,7 @@ func TestTemplatePush(t *testing.T) {
 		require.NoError(t, err)
 
 		os.Chdir(source)
-
-		t.Cleanup(func() {
-			os.Chdir(oldDir)
-		})
+		defer os.Chdir(oldDir)
 
 		// Don't pass the name of the template, it should use the
 		// directory of the source.


### PR DESCRIPTION
This _might_ resolve the races in `TestTemplatePush`.