### PR TITLE
chore: wrap audit logs in a mutex to fix data race

### DIFF
--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -25,7 +25,7 @@ func TestTokenCRUD(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 	auditor := audit.NewMock()
-	numLogs := len(auditor.AuditLogs)
+	numLogs := len(auditor.AuditLogs())
 	client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
 	_ = coderdtest.CreateFirstUser(t, client)
 	numLogs++ // add an audit log for user creation
@@ -58,9 +58,9 @@ func TestTokenCRUD(t *testing.T) {
 	require.Empty(t, keys)
 
 	// ensure audit log count is correct
-	require.Len(t, auditor.AuditLogs, numLogs)
-	require.Equal(t, database.AuditActionCreate, auditor.AuditLogs[numLogs-2].Action)
-	require.Equal(t, database.AuditActionDelete, auditor.AuditLogs[numLogs-1].Action)
+	require.Len(t, auditor.AuditLogs(), numLogs)
+	require.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[numLogs-2].Action)
+	require.Equal(t, database.AuditActionDelete, auditor.AuditLogs()[numLogs-1].Action)
 }
 
 func TestTokenScoped(t *testing.T) {

--- a/coderd/audit/audit.go
+++ b/coderd/audit/audit.go
@@ -39,13 +39,21 @@ func NewMock() *MockAuditor {
 
 type MockAuditor struct {
 	mutex     sync.Mutex
-	AuditLogs []database.AuditLog
+	auditLogs []database.AuditLog
+}
+
+func (a *MockAuditor) AuditLogs() []database.AuditLog {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	logs := make([]database.AuditLog, len(a.auditLogs))
+	copy(logs, a.auditLogs)
+	return logs
 }
 
 func (a *MockAuditor) Export(_ context.Context, alog database.AuditLog) error {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
-	a.AuditLogs = append(a.AuditLogs, alog)
+	a.auditLogs = append(a.auditLogs, alog)
 	return nil
 }
 

--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -94,8 +94,8 @@ func TestGitSSHKey(t *testing.T) {
 		require.NotEmpty(t, key2.PublicKey)
 		require.NotEqual(t, key2.PublicKey, key1.PublicKey)
 
-		require.Len(t, auditor.AuditLogs, 2)
-		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs[1].Action)
+		require.Len(t, auditor.AuditLogs(), 2)
+		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[1].Action)
 	})
 }
 

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -62,11 +62,11 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		assert.Equal(t, expected.Name, got.Name)
 		assert.Equal(t, expected.Description, got.Description)
 
-		require.Len(t, auditor.AuditLogs, 4)
-		assert.Equal(t, database.AuditActionLogin, auditor.AuditLogs[0].Action)
-		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs[1].Action)
-		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs[2].Action)
-		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs[3].Action)
+		require.Len(t, auditor.AuditLogs(), 4)
+		assert.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[0].Action)
+		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[1].Action)
+		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[2].Action)
+		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[3].Action)
 	})
 
 	t.Run("AlreadyExists", func(t *testing.T) {
@@ -376,8 +376,8 @@ func TestPatchTemplateMeta(t *testing.T) {
 		assert.Equal(t, req.DefaultTTLMillis, updated.DefaultTTLMillis)
 		assert.False(t, req.AllowUserCancelWorkspaceJobs)
 
-		require.Len(t, auditor.AuditLogs, 5)
-		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs[4].Action)
+		require.Len(t, auditor.AuditLogs(), 5)
+		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[4].Action)
 	})
 
 	t.Run("NoDefaultTTL", func(t *testing.T) {
@@ -677,8 +677,8 @@ func TestDeleteTemplate(t *testing.T) {
 		err := client.DeleteTemplate(ctx, template.ID)
 		require.NoError(t, err)
 
-		require.Len(t, auditor.AuditLogs, 5)
-		assert.Equal(t, database.AuditActionDelete, auditor.AuditLogs[4].Action)
+		require.Len(t, auditor.AuditLogs(), 5)
+		assert.Equal(t, database.AuditActionDelete, auditor.AuditLogs()[4].Action)
 	})
 
 	t.Run("Workspaces", func(t *testing.T) {

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -135,8 +135,8 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 		require.Equal(t, "bananas", version.Name)
 		require.Equal(t, provisionerdserver.ScopeOrganization, version.Job.Tags[provisionerdserver.TagScope])
 
-		require.Len(t, auditor.AuditLogs, 2)
-		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs[1].Action)
+		require.Len(t, auditor.AuditLogs(), 2)
+		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[1].Action)
 	})
 	t.Run("Example", func(t *testing.T) {
 		t.Parallel()
@@ -715,8 +715,8 @@ func TestPatchActiveTemplateVersion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, auditor.AuditLogs, 5)
-		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs[4].Action)
+		require.Len(t, auditor.AuditLogs(), 5)
+		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[4].Action)
 	})
 }
 

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -243,7 +243,7 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 			},
 		})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
@@ -257,9 +257,9 @@ func TestUserOAuth2Github(t *testing.T) {
 		require.Equal(t, "kyle", user.Username)
 		require.Equal(t, "/hello-world", user.AvatarURL)
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.NotEqual(t, auditor.AuditLogs[numLogs-1].UserID, uuid.Nil)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.NotEqual(t, auditor.AuditLogs()[numLogs-1].UserID, uuid.Nil)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 	t.Run("SignupAllowedTeam", func(t *testing.T) {
 		t.Parallel()
@@ -296,14 +296,14 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 			},
 		})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 	t.Run("SignupAllowedTeamInFirstOrganization", func(t *testing.T) {
 		t.Parallel()
@@ -348,14 +348,14 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 			},
 		})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 	t.Run("SignupAllowedTeamInSecondOrganization", func(t *testing.T) {
 		t.Parallel()
@@ -400,14 +400,14 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 			},
 		})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 	t.Run("SignupAllowEveryone", func(t *testing.T) {
 		t.Parallel()
@@ -438,14 +438,14 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 			},
 		})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 	t.Run("SignupFailedInactiveInOrg", func(t *testing.T) {
 		t.Parallel()
@@ -659,7 +659,7 @@ func TestUserOIDC(t *testing.T) {
 				Auditor:    auditor,
 				OIDCConfig: config,
 			})
-			numLogs := len(auditor.AuditLogs)
+			numLogs := len(auditor.AuditLogs())
 
 			resp := oidcCallback(t, client, conf.EncodeClaims(t, tc.IDTokenClaims))
 			numLogs++ // add an audit log for login
@@ -673,9 +673,9 @@ func TestUserOIDC(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.Username, user.Username)
 
-				require.Len(t, auditor.AuditLogs, numLogs)
-				require.NotEqual(t, auditor.AuditLogs[numLogs-1].UserID, uuid.Nil)
-				require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+				require.Len(t, auditor.AuditLogs(), numLogs)
+				require.NotEqual(t, auditor.AuditLogs()[numLogs-1].UserID, uuid.Nil)
+				require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 			}
 
 			if tc.AvatarURL != "" {
@@ -684,8 +684,8 @@ func TestUserOIDC(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.AvatarURL, user.AvatarURL)
 
-				require.Len(t, auditor.AuditLogs, numLogs)
-				require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+				require.Len(t, auditor.AuditLogs(), numLogs)
+				require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 			}
 		})
 	}
@@ -702,7 +702,7 @@ func TestUserOIDC(t *testing.T) {
 			Auditor:    auditor,
 			OIDCConfig: config,
 		})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		code := conf.EncodeClaims(t, jwt.MapClaims{
 			"email": "jon@coder.com",
@@ -735,8 +735,8 @@ func TestUserOIDC(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(user.Username, "jon-"), "username %q should have prefix %q", user.Username, "jon-")
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 
 	t.Run("Disabled", func(t *testing.T) {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -109,7 +109,7 @@ func TestPostLogin(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -130,15 +130,15 @@ func TestPostLogin(t *testing.T) {
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 
 	t.Run("Suspended", func(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 		first := coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for create user
 		numLogs++ // add an audit log for login
@@ -173,8 +173,8 @@ func TestPostLogin(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
 		require.Contains(t, apiErr.Message, "suspended")
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 
 	t.Run("DisabledPasswordAuth", func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestPostLogin(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -246,8 +246,8 @@ func TestPostLogin(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-1].Action)
 	})
 
 	t.Run("Lifetime&Expire", func(t *testing.T) {
@@ -347,7 +347,7 @@ func TestPostLogout(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		admin := coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for login
@@ -370,8 +370,8 @@ func TestPostLogout(t *testing.T) {
 		res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionLogout, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionLogout, auditor.AuditLogs()[numLogs-1].Action)
 
 		cookies := res.Cookies()
 
@@ -475,7 +475,7 @@ func TestPostUsers(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		user := coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for user create
@@ -492,9 +492,9 @@ func TestPostUsers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionCreate, auditor.AuditLogs[numLogs-1].Action)
-		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs[numLogs-2].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[numLogs-1].Action)
+		require.Equal(t, database.AuditActionLogin, auditor.AuditLogs()[numLogs-2].Action)
 	})
 
 	t.Run("LastSeenAt", func(t *testing.T) {
@@ -574,7 +574,7 @@ func TestUpdateUserProfile(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for login
@@ -590,8 +590,8 @@ func TestUpdateUserProfile(t *testing.T) {
 		require.Equal(t, userProfile.Username, "newusername")
 		numLogs++ // add an audit log for user update
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[numLogs-1].Action)
 	})
 }
 
@@ -643,7 +643,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		admin := coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for user create
@@ -663,8 +663,8 @@ func TestUpdateUserPassword(t *testing.T) {
 
 		require.NoError(t, err, "member should be able to update own password")
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[numLogs-1].Action)
 	})
 	t.Run("MemberCantUpdateOwnPasswordWithoutOldPassword", func(t *testing.T) {
 		t.Parallel()
@@ -684,7 +684,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		_ = coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for login
@@ -699,8 +699,8 @@ func TestUpdateUserPassword(t *testing.T) {
 
 		require.NoError(t, err, "admin should be able to update own password without providing old password")
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[numLogs-1].Action)
 	})
 
 	t.Run("ChangingPasswordDeletesKeys", func(t *testing.T) {
@@ -972,7 +972,7 @@ func TestPutUserSuspend(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
 		client := coderdtest.New(t, &coderdtest.Options{Auditor: auditor})
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		me := coderdtest.CreateFirstUser(t, client)
 		numLogs++ // add an audit log for user create
@@ -989,8 +989,8 @@ func TestPutUserSuspend(t *testing.T) {
 		require.Equal(t, user.Status, codersdk.UserStatusSuspended)
 		numLogs++ // add an audit log for user update
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs[numLogs-1].Action)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[numLogs-1].Action)
 	})
 
 	t.Run("SuspendItSelf", func(t *testing.T) {

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -575,7 +575,7 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 	auditor := audit.NewMock()
-	numLogs := len(auditor.AuditLogs)
+	numLogs := len(auditor.AuditLogs())
 	client, closeDaemon, api := coderdtest.NewWithAPI(t, &coderdtest.Options{IncludeProvisionerDaemon: true, Auditor: auditor})
 	user := coderdtest.CreateFirstUser(t, client)
 	numLogs++ // add an audit log for login
@@ -612,8 +612,8 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 
 	// assert an audit log has been created for workspace stopping
 	numLogs++ // add an audit log for workspace_build stop
-	require.Len(t, auditor.AuditLogs, numLogs)
-	require.Equal(t, database.AuditActionStop, auditor.AuditLogs[numLogs-1].Action)
+	require.Len(t, auditor.AuditLogs(), numLogs)
+	require.Equal(t, database.AuditActionStop, auditor.AuditLogs()[numLogs-1].Action)
 
 	_ = closeDaemon.Close()
 	// after successful cancel is "canceled"

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -276,10 +276,10 @@ func TestPostWorkspacesByOrganization(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
 		require.Eventually(t, func() bool {
-			if len(auditor.AuditLogs) < 6 {
+			if len(auditor.AuditLogs()) < 6 {
 				return false
 			}
-			return auditor.AuditLogs[4].Action == database.AuditActionCreate
+			return auditor.AuditLogs()[4].Action == database.AuditActionCreate
 		}, testutil.WaitMedium, testutil.IntervalFast)
 	})
 
@@ -1262,11 +1262,11 @@ func TestWorkspaceUpdateAutostart(t *testing.T) {
 			require.Equal(t, testCase.expectedInterval, interval, "unexpected interval")
 
 			require.Eventually(t, func() bool {
-				if len(auditor.AuditLogs) < 7 {
+				if len(auditor.AuditLogs()) < 7 {
 					return false
 				}
-				return auditor.AuditLogs[6].Action == database.AuditActionWrite ||
-					auditor.AuditLogs[5].Action == database.AuditActionWrite
+				return auditor.AuditLogs()[6].Action == database.AuditActionWrite ||
+					auditor.AuditLogs()[5].Action == database.AuditActionWrite
 			}, testutil.WaitShort, testutil.IntervalFast)
 		})
 	}
@@ -1382,11 +1382,11 @@ func TestWorkspaceUpdateTTL(t *testing.T) {
 			require.Equal(t, testCase.ttlMillis, updated.TTLMillis, "expected autostop ttl to equal requested")
 
 			require.Eventually(t, func() bool {
-				if len(auditor.AuditLogs) != 7 {
+				if len(auditor.AuditLogs()) != 7 {
 					return false
 				}
-				return auditor.AuditLogs[6].Action == database.AuditActionWrite ||
-					auditor.AuditLogs[5].Action == database.AuditActionWrite
+				return auditor.AuditLogs()[6].Action == database.AuditActionWrite ||
+					auditor.AuditLogs()[5].Action == database.AuditActionWrite
 			}, testutil.WaitMedium, testutil.IntervalFast, "expected audit log to be written")
 		})
 	}

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -65,15 +65,15 @@ func TestCreateGroup(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 		group, err := client.CreateGroup(ctx, user.OrganizationID, codersdk.CreateGroupRequest{
 			Name: "hi",
 		})
 		require.NoError(t, err)
 		numLogs++
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionCreate, auditor.AuditLogs[numLogs-1].Action)
-		require.Equal(t, group.ID, auditor.AuditLogs[numLogs-1].ResourceID)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[numLogs-1].Action)
+		require.Equal(t, group.ID, auditor.AuditLogs()[numLogs-1].ResourceID)
 	})
 
 	t.Run("Conflict", func(t *testing.T) {
@@ -278,16 +278,16 @@ func TestPatchGroup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 		group, err = client.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
 			Name: "bye",
 		})
 		require.NoError(t, err)
 		numLogs++
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs[numLogs-1].Action)
-		require.Equal(t, group.ID, auditor.AuditLogs[numLogs-1].ResourceID)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[numLogs-1].Action)
+		require.Equal(t, group.ID, auditor.AuditLogs()[numLogs-1].ResourceID)
 	})
 	t.Run("NameConflict", func(t *testing.T) {
 		t.Parallel()
@@ -731,14 +731,14 @@ func TestDeleteGroup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 		err = client.DeleteGroup(ctx, group.ID)
 		require.NoError(t, err)
 		numLogs++
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionDelete, auditor.AuditLogs[numLogs-1].Action)
-		require.Equal(t, group.ID, auditor.AuditLogs[numLogs-1].ResourceID)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionDelete, auditor.AuditLogs()[numLogs-1].Action)
+		require.Equal(t, group.ID, auditor.AuditLogs()[numLogs-1].ResourceID)
 	})
 
 	t.Run("allUsers", func(t *testing.T) {

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -591,7 +591,7 @@ func TestUpdateTemplateACL(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		numLogs := len(auditor.AuditLogs)
+		numLogs := len(auditor.AuditLogs())
 
 		req := codersdk.UpdateTemplateACL{
 			GroupPerms: map[string]codersdk.TemplateRole{
@@ -602,9 +602,9 @@ func TestUpdateTemplateACL(t *testing.T) {
 		require.NoError(t, err)
 		numLogs++
 
-		require.Len(t, auditor.AuditLogs, numLogs)
-		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs[numLogs-1].Action)
-		require.Equal(t, template.ID, auditor.AuditLogs[numLogs-1].ResourceID)
+		require.Len(t, auditor.AuditLogs(), numLogs)
+		require.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[numLogs-1].Action)
+		require.Equal(t, template.ID, auditor.AuditLogs()[numLogs-1].ResourceID)
 	})
 
 	t.Run("DeleteUser", func(t *testing.T) {


### PR DESCRIPTION
This was seen in `main`!