### PR TITLE
chore: add `UNLOGGED` to tables where durability doesn't matter

### DIFF
--- a/coderd/database/migrations/000111_unlogged_tables.down.sql
+++ b/coderd/database/migrations/000111_unlogged_tables.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE workspace_agent_stats SET LOGGED;
+ALTER TABLE workspace_agent_startup_logs SET LOGGED;
+ALTER TABLE provisioner_job_logs SET LOGGED;

--- a/coderd/database/migrations/000111_unlogged_tables.up.sql
+++ b/coderd/database/migrations/000111_unlogged_tables.up.sql
@@ -1,0 +1,5 @@
+-- On tables where data loss isn't a massive deal, we can make them unlogged
+-- to dramatically improve performance.
+ALTER TABLE workspace_agent_stats SET UNLOGGED;
+ALTER TABLE workspace_agent_startup_logs SET UNLOGGED;
+ALTER TABLE provisioner_job_logs SET UNLOGGED;


### PR DESCRIPTION
This should improve performance when writing many many logs to these tables!