### PR TITLE
fix: FE show correct config-ssh prefix

### DIFF
--- a/site/src/components/Resources/AgentRow.tsx
+++ b/site/src/components/Resources/AgentRow.tsx
@@ -44,6 +44,7 @@ export interface AgentRowProps {
   applicationsHost: string | undefined
   showApps: boolean
   hideSSHButton?: boolean
+  sshPrefix?: string
   hideVSCodeDesktopButton?: boolean
   serverVersion: string
   onUpdateAgent: () => void
@@ -61,6 +62,7 @@ export const AgentRow: FC<AgentRowProps> = ({
   serverVersion,
   onUpdateAgent,
   storybookStartupLogs,
+  sshPrefix,
 }) => {
   const styles = useStyles()
   const { t } = useTranslation("agent")
@@ -308,6 +310,7 @@ export const AgentRow: FC<AgentRowProps> = ({
                 <SSHButton
                   workspaceName={workspace.name}
                   agentName={agent.name}
+                  sshPrefix={sshPrefix}
                 />
               )}
               {!hideVSCodeDesktopButton && (

--- a/site/src/components/SSHButton/SSHButton.stories.tsx
+++ b/site/src/components/SSHButton/SSHButton.stories.tsx
@@ -13,6 +13,7 @@ export const Closed = Template.bind({})
 Closed.args = {
   workspaceName: MockWorkspace.name,
   agentName: MockWorkspaceAgent.name,
+  sshPrefix: "coder.",
 }
 
 export const Opened = Template.bind({})
@@ -20,4 +21,5 @@ Opened.args = {
   workspaceName: MockWorkspace.name,
   agentName: MockWorkspaceAgent.name,
   defaultIsOpen: true,
+  sshPrefix: "coder.",
 }

--- a/site/src/components/SSHButton/SSHButton.tsx
+++ b/site/src/components/SSHButton/SSHButton.tsx
@@ -15,12 +15,14 @@ export interface SSHButtonProps {
   workspaceName: string
   agentName: string
   defaultIsOpen?: boolean
+  sshPrefix?: string
 }
 
 export const SSHButton: React.FC<React.PropsWithChildren<SSHButtonProps>> = ({
   workspaceName,
   agentName,
   defaultIsOpen = false,
+  sshPrefix,
 }) => {
   const anchorRef = useRef<HTMLButtonElement>(null)
   const [isOpen, setIsOpen] = useState(defaultIsOpen)
@@ -79,7 +81,7 @@ export const SSHButton: React.FC<React.PropsWithChildren<SSHButtonProps>> = ({
                 Connect to the agent:
               </strong>
             </HelpTooltipText>
-            <CodeExample code={`ssh coder.${workspaceName}.${agentName}`} />
+            <CodeExample code={`ssh ${sshPrefix}${workspaceName}.${agentName}`} />
           </div>
         </Stack>
 

--- a/site/src/components/SSHButton/SSHButton.tsx
+++ b/site/src/components/SSHButton/SSHButton.tsx
@@ -81,7 +81,9 @@ export const SSHButton: React.FC<React.PropsWithChildren<SSHButtonProps>> = ({
                 Connect to the agent:
               </strong>
             </HelpTooltipText>
-            <CodeExample code={`ssh ${sshPrefix}${workspaceName}.${agentName}`} />
+            <CodeExample
+              code={`ssh ${sshPrefix}${workspaceName}.${agentName}`}
+            />
           </div>
         </Stack>
 

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -53,6 +53,7 @@ export interface WorkspaceProps {
   workspaceErrors: Partial<Record<WorkspaceErrors, Error | unknown>>
   buildInfo?: TypesGen.BuildInfoResponse
   applicationsHost?: string
+  sshPrefix?: string
   template?: TypesGen.Template
   quota_budget?: number
 }
@@ -78,6 +79,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
   hideVSCodeDesktopButton,
   buildInfo,
   applicationsHost,
+  sshPrefix,
   template,
   quota_budget,
 }) => {
@@ -193,6 +195,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
                 agent={agent}
                 workspace={workspace}
                 applicationsHost={applicationsHost}
+                sshPrefix={sshPrefix}
                 showApps={canUpdateWorkspace}
                 hideSSHButton={hideSSHButton}
                 hideVSCodeDesktopButton={hideVSCodeDesktopButton}

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -51,6 +51,7 @@ export const WorkspaceReadyPage = ({
     buildError,
     cancellationError,
     applicationsHost,
+    sshPrefix,
     permissions,
     missedParameters,
   } = workspaceState.context
@@ -124,6 +125,7 @@ export const WorkspaceReadyPage = ({
         }}
         buildInfo={buildInfo}
         applicationsHost={applicationsHost}
+        sshPrefix={sshPrefix}
         template={template}
         quota_budget={quotaState.context.quota?.budget}
       />


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6881

API Response:
```json
{"hostname_prefix":"test.","ssh_config_options":{}}
```

![Screenshot from 2023-03-30 15-34-20](https://user-images.githubusercontent.com/5446298/228957987-971617a2-2e15-4bcd-923f-a8da8c500370.png)
