### PR TITLE
chore: rm mac from docker quickstart

### DIFF
--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -6,9 +6,12 @@ Coder with Docker has the following advantages:
 - Workspace images are easily configured
 - Workspaces share resources for burst operations
 
+> Note that the below steps are only supported on a Linux distribution.
+> If on macOS, please [run Coder via the standalone binary](./binary.md).
+
 ## Requirements
 
-- A single macOS or Linux box
+- A Linux machine
 - A running Docker daemon
 
 ## Instructions


### PR DESCRIPTION
removes mac as a requirement from the Docker quickstart, and instructs users to leverage the standalone binary as the install route on macOS, as done in #6788 