### PR TITLE
feat(draft): Add support for transferring workspace ownership

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -90,6 +90,7 @@ func (r *RootCmd) Core() []*clibase.Cmd {
 		r.ping(),
 		r.create(),
 		r.deleteWorkspace(),
+		r.transferWorkspace(),
 		r.list(),
 		r.schedules(),
 		r.show(),

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -38,6 +38,8 @@ Coder v0.0.0-devel — A tool for provisioning self-hosted development environme
     stop              Stop a workspace
     templates         Manage templates
     tokens            Manage personal access tokens
+    transfer          Will transfer ownership of a workspace to a different
+                      user.
     update            Will update and start a given workspace if it is out of
                       date
     users             Manage users

--- a/cli/testdata/coder_transfer_--help.golden
+++ b/cli/testdata/coder_transfer_--help.golden
@@ -1,0 +1,13 @@
+Usage: coder transfer [flags] --workspace <workspaceId> --owner <userId>
+
+Will transfer ownership of a workspace to a different user.
+
+[1mOptions[0m
+  -o, --owner string
+          Specifies the new user to own this workspace.
+
+  -w, --workspace string
+          Specifies the workspace to move.
+
+---
+Run `coder --help` for a list of global options.

--- a/cli/transfer.go
+++ b/cli/transfer.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/coder/coder/cli/clibase"
+	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/codersdk"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+)
+
+func (r *RootCmd) transferWorkspace() *clibase.Cmd {
+	var (
+		workspaceID string
+		toUserID    string
+	)
+	client := new(codersdk.Client)
+	cmd := &clibase.Cmd{
+		Use:   "transfer --workspace <workspaceId> --owner <userId>",
+		Short: "Will transfer ownership of a workspace to a different user.",
+		Middleware: clibase.Chain(
+			clibase.RequireNArgs(0),
+			r.InitClient(client),
+		),
+		Handler: func(inv *clibase.Invocation) error {
+			if workspaceID == "" {
+				w, err := cliui.Prompt(inv, cliui.PromptOptions{
+					Text: "Workspace Id:",
+				})
+				if err != nil {
+					return err
+				}
+				workspaceID = w
+			}
+			if toUserID == "" {
+				u, err := cliui.Prompt(inv, cliui.PromptOptions{
+					Text: "To User Id:",
+				})
+				if err != nil {
+					return err
+				}
+				toUserID = u
+			}
+
+			uid, err := uuid.Parse(toUserID)
+			if err != nil {
+				return xerrors.New("That's not a valid user id!")
+			}
+
+			wid, err := uuid.Parse(workspaceID)
+			if err != nil {
+				return xerrors.New("That's not a valid workspace id!")
+			}
+
+			err = client.UpdateWorkspaceOwnerByID(inv.Context(), wid, codersdk.TransferWorkspaceOwnerRequest{
+				OwnerID: uid,
+			})
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(inv.Stderr, `Workspace owner updated successfully.`)
+			return nil
+		},
+	}
+	cmd.Options = clibase.OptionSet{
+		{
+			Flag:          "workspace",
+			FlagShorthand: "w",
+			Description:   "Specifies the workspace to move.",
+			Value:         clibase.StringOf(&workspaceID),
+		},
+		{
+			Flag:          "owner",
+			FlagShorthand: "o",
+			Description:   "Specifies the new user to own this workspace.",
+			Value:         clibase.StringOf(&toUserID),
+		},
+	}
+	return cmd
+}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -663,6 +663,7 @@ func New(options *Options) *API {
 				})
 				r.Get("/watch", api.watchWorkspace)
 				r.Put("/extend", api.putExtendWorkspace)
+				r.Put("/transfer", api.putTransferWorkspace)
 			})
 		})
 		r.Route("/workspacebuilds/{workspacebuild}", func(r chi.Router) {

--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -1355,6 +1355,24 @@ func (q *querier) UpdateWorkspaceAgentStartupByID(ctx context.Context, arg datab
 	return q.db.UpdateWorkspaceAgentStartupByID(ctx, arg)
 }
 
+func (q *querier) UpdateWorkspaceOwnerByID(ctx context.Context, arg database.UpdateWorkspaceOwnerByIDParams) error {
+	agent, err := q.db.GetWorkspaceAgentByID(ctx, arg.ID)
+	if err != nil {
+		return err
+	}
+
+	workspace, err := q.db.GetWorkspaceByAgentID(ctx, agent.ID)
+	if err != nil {
+		return err
+	}
+
+	if err := q.authorizeContext(ctx, rbac.ActionUpdate, workspace); err != nil {
+		return err
+	}
+
+	return q.db.UpdateWorkspaceOwnerByID(ctx, arg)
+}
+
 func (q *querier) GetWorkspaceAppByAgentIDAndSlug(ctx context.Context, arg database.GetWorkspaceAppByAgentIDAndSlugParams) (database.WorkspaceApp, error) {
 	// If we can fetch the workspace, we can fetch the apps. Use the authorized call.
 	if _, err := q.GetWorkspaceByAgentID(ctx, arg.AgentID); err != nil {

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -3839,6 +3839,28 @@ func (q *fakeQuerier) UpdateWorkspaceTTL(_ context.Context, arg database.UpdateW
 	return sql.ErrNoRows
 }
 
+func (q *fakeQuerier) UpdateWorkspaceOwnerByID(_ context.Context, arg database.UpdateWorkspaceOwnerByIDParams) error {
+	if err := validateDatabaseType(arg); err != nil {
+		return err
+	}
+
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for index, workspace := range q.workspaces {
+		if workspace.ID != arg.ID {
+			continue
+		}
+		workspace.OwnerID = arg.OwnerID
+		workspace.UpdatedAt = database.Now()
+
+		q.workspaces[index] = workspace
+		return nil
+	}
+
+	return sql.ErrNoRows
+}
+
 func (q *fakeQuerier) UpdateWorkspaceLastUsedAt(_ context.Context, arg database.UpdateWorkspaceLastUsedAtParams) error {
 	if err := validateDatabaseType(arg); err != nil {
 		return err

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -240,6 +240,7 @@ type sqlcQuerier interface {
 	UpdateWorkspaceBuildCostByID(ctx context.Context, arg UpdateWorkspaceBuildCostByIDParams) (WorkspaceBuild, error)
 	UpdateWorkspaceDeletedByID(ctx context.Context, arg UpdateWorkspaceDeletedByIDParams) error
 	UpdateWorkspaceLastUsedAt(ctx context.Context, arg UpdateWorkspaceLastUsedAtParams) error
+	UpdateWorkspaceOwnerByID(ctx context.Context, arg UpdateWorkspaceOwnerByIDParams) error
 	UpdateWorkspaceTTL(ctx context.Context, arg UpdateWorkspaceTTLParams) error
 	UpdateWorkspaceTTLToBeWithinTemplateMax(ctx context.Context, arg UpdateWorkspaceTTLToBeWithinTemplateMaxParams) error
 	UpsertLastUpdateCheck(ctx context.Context, value string) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -8050,6 +8050,27 @@ func (q *sqlQuerier) UpdateWorkspaceLastUsedAt(ctx context.Context, arg UpdateWo
 	return err
 }
 
+const updateWorkspaceOwnerByID = `-- name: UpdateWorkspaceOwnerByID :exec
+UPDATE
+	workspaces
+SET
+	owner_id = $2,
+	updated_at = $3
+WHERE
+	id = $1
+`
+
+type UpdateWorkspaceOwnerByIDParams struct {
+	ID        uuid.UUID `db:"id" json:"id"`
+	OwnerID   uuid.UUID `db:"owner_id" json:"owner_id"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+}
+
+func (q *sqlQuerier) UpdateWorkspaceOwnerByID(ctx context.Context, arg UpdateWorkspaceOwnerByIDParams) error {
+	_, err := q.db.ExecContext(ctx, updateWorkspaceOwnerByID, arg.ID, arg.OwnerID, arg.UpdatedAt)
+	return err
+}
+
 const updateWorkspaceTTL = `-- name: UpdateWorkspaceTTL :exec
 UPDATE
 	workspaces

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -331,6 +331,15 @@ WHERE
 	-- workspace TTL is NULL.
 	AND ttl IS NOT NULL;
 
+-- name: UpdateWorkspaceOwnerByID :exec
+UPDATE
+	workspaces
+SET
+	owner_id = $2,
+	updated_at = $3
+WHERE
+	id = $1;
+
 -- name: GetDeploymentWorkspaceStats :one
 WITH workspaces_with_jobs AS (
 	SELECT

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1030,7 +1030,7 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 }
 
 // @Summary Transfer workspace owner by ID
-// @ID update-workspace-owner-by-id
+// @ID transfer-workspace-owner-by-id
 // @Security CoderSessionToken
 // @Accept json
 // @Tags Workspaces

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1059,19 +1059,12 @@ func (api *API) putTransferWorkspace(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := api.Database.InTx(func(s database.Store) error {
-		now := database.Now()
-		if err := s.UpdateWorkspaceOwnerByID(ctx, database.UpdateWorkspaceOwnerByIDParams{
-			ID:        workspace.ID,
-			OwnerID:   req.OwnerID,
-			UpdatedAt: now,
-		}); err != nil {
-			return xerrors.Errorf("transfer workspace owner: %w", err)
-		}
-
-		return nil
-	}, nil)
-	if err != nil {
+	now := database.Now()
+	if err := api.Database.UpdateWorkspaceOwnerByID(ctx, database.UpdateWorkspaceOwnerByIDParams{
+		ID:        workspace.ID,
+		OwnerID:   req.OwnerID,
+		UpdatedAt: now,
+	}); err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating workspace owner.",
 		})

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1029,7 +1029,7 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// @Summary Update workspace owner by ID
+// @Summary Transfer workspace owner by ID
 // @ID update-workspace-owner-by-id
 // @Security CoderSessionToken
 // @Accept json

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1030,7 +1030,7 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 }
 
 // @Summary Update workspace owner by ID
-// @ID transfer-workspace-owner-by-id
+// @ID update-workspace-owner-by-id
 // @Security CoderSessionToken
 // @Accept json
 // @Tags Workspaces

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -384,3 +384,22 @@ func (c *Client) WorkspaceQuota(ctx context.Context, userID string) (WorkspaceQu
 func WorkspaceNotifyChannel(id uuid.UUID) string {
 	return fmt.Sprintf("workspace:%s", id)
 }
+
+// TransferWorkspaceOwnerRequest is a request to update a workspace's owner.
+type TransferWorkspaceOwnerRequest struct {
+	OwnerID uuid.UUID `json:"owner_id" format:"uuid"`
+}
+
+// UpdateWorkspaceOwnerByID sets the owner for workspace by id.
+func (c *Client) UpdateWorkspaceOwnerByID(ctx context.Context, id uuid.UUID, req TransferWorkspaceOwnerRequest) error {
+	path := fmt.Sprintf("/api/v2/workspaces/%s/transfer", id.String())
+	res, err := c.Request(ctx, http.MethodPut, path, req)
+	if err != nil {
+		return xerrors.Errorf("updating workspace owner: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}


### PR DESCRIPTION
Note: Marking as WIP as to not distract team members with review.

---

This change aims to address the feature request in #6842, to support transferring a workspace between users.

This approach is lacking in what it would take to ship such a feature, but is a good place to start.

Items for discussion:

- There should be a web interface to this.
- The ability to transfer workspaces should be limited to certain user roles.
- Query executes as expected manually, but not within the given transaction. Would require some troubleshooting tips.