### PR TITLE
fix: add `CODER_AGENT_TAILNET_LISTEN_PORT` for specifying a static tailnet port

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -30,11 +30,12 @@ import (
 
 func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 	var (
-		auth          string
-		logDir        string
-		pprofAddress  string
-		noReap        bool
-		sshMaxTimeout time.Duration
+		auth              string
+		logDir            string
+		pprofAddress      string
+		noReap            bool
+		sshMaxTimeout     time.Duration
+		tailnetListenPort int64
 	)
 	cmd := &clibase.Cmd{
 		Use:   "agent",
@@ -187,9 +188,10 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 			}
 
 			closer := agent.New(agent.Options{
-				Client: client,
-				Logger: logger,
-				LogDir: logDir,
+				Client:            client,
+				Logger:            logger,
+				LogDir:            logDir,
+				TailnetListenPort: uint16(tailnetListenPort),
 				ExchangeToken: func(ctx context.Context) (string, error) {
 					if exchangeToken == nil {
 						return client.SDK.SessionToken(), nil
@@ -247,6 +249,13 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 			Env:         "CODER_AGENT_SSH_MAX_TIMEOUT",
 			Description: "Specify the max timeout for a SSH connection.",
 			Value:       clibase.DurationOf(&sshMaxTimeout),
+		},
+		{
+			Flag:        "tailnet-listen-port",
+			Default:     "0",
+			Env:         "CODER_AGENT_TAILNET_LISTEN_PORT",
+			Description: "Specify a static port for Tailscale to use for listening.",
+			Value:       clibase.Int64Of(&tailnetListenPort),
 		},
 	}
 

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -18,5 +18,8 @@ Starts the Coder workspace agent.
       --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 0)
           Specify the max timeout for a SSH connection.
 
+      --tailnet-listen-port int, $CODER_AGENT_TAILNET_LISTEN_PORT (default: 0)
+          Specify a static port for Tailscale to use for listening.
+
 ---
 Run `coder --help` for a list of global options.

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -59,6 +59,7 @@ type Options struct {
 	// If so, only DERPs can establish connections.
 	BlockEndpoints bool
 	Logger         slog.Logger
+	ListenPort     uint16
 }
 
 // NewConn constructs a new Wireguard server that will accept connections from the addresses provided.
@@ -137,6 +138,7 @@ func NewConn(options *Options) (conn *Conn, err error) {
 	wireguardEngine, err := wgengine.NewUserspaceEngine(Logger(options.Logger.Named("wgengine")), wgengine.Config{
 		LinkMonitor: wireguardMonitor,
 		Dialer:      dialer,
+		ListenPort:  options.ListenPort,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("create wgengine: %w", err)


### PR DESCRIPTION
Fixes #5175.