### PR TITLE
feat(provisioner): bump the maximum terraform version

### DIFF
--- a/provisioner/terraform/install.go
+++ b/provisioner/terraform/install.go
@@ -22,7 +22,7 @@ var (
 	TerraformVersion = version.Must(version.NewVersion("1.3.4"))
 
 	minTerraformVersion = version.Must(version.NewVersion("1.1.0"))
-	maxTerraformVersion = version.Must(version.NewVersion("1.3.4"))
+	maxTerraformVersion = version.Must(version.NewVersion("1.3.9"))
 
 	terraformMinorVersionMismatch = xerrors.New("Terraform binary minor version mismatch.")
 )


### PR DESCRIPTION
This PR increases the maximum Terraform version allowed.

Terraform v1.3.4 includes a number of CVE vulnerabilities via the `goutils` dependency.

https://github.com/hashicorp/terraform/issues/32606