### PR TITLE
chore: Refactor accepting websocket connections to track for close

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -784,8 +784,8 @@ type API struct {
 
 	siteHandler http.Handler
 
-	WebsocketWaitMutex sync.Mutex
 	WebsocketWaitGroup sync.WaitGroup
+	WebsocketWatch     *ActiveWebsockets
 	derpCloseFunc      func()
 
 	metricsCache          *metricscache.Cache
@@ -805,9 +805,7 @@ func (api *API) Close() error {
 	api.cancel()
 	api.derpCloseFunc()
 
-	api.WebsocketWaitMutex.Lock()
 	api.WebsocketWaitGroup.Wait()
-	api.WebsocketWaitMutex.Unlock()
 
 	api.metricsCache.Close()
 	if api.updateChecker != nil {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -786,7 +786,6 @@ type API struct {
 	siteHandler http.Handler
 
 	WebsocketWatch *activewebsockets.Active
-	derpCloseFunc  func()
 
 	metricsCache          *metricscache.Cache
 	workspaceAgentCache   *wsconncache.Cache
@@ -803,7 +802,6 @@ type API struct {
 // Close waits for all WebSocket connections to drain before returning.
 func (api *API) Close() error {
 	api.cancel()
-	api.derpCloseFunc()
 
 	api.WebsocketWatch.Close()
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -356,7 +356,7 @@ func New(options *Options) *API {
 	apiRateLimiter := httpmw.RateLimit(options.APIRateLimit, time.Minute)
 
 	derpHandler := derphttp.Handler(api.DERPServer)
-	derpHandler = tailnet.WithWebsocketSupport(api.WebsocketWatch, api.DERPServer, derpHandler)
+	derpHandler = tailnet.WithWebsocketSupport(api.WebsocketWatch.Accept, api.DERPServer, derpHandler)
 
 	r.Use(
 		httpmw.Recover(api.Logger),

--- a/coderd/healthcheck/derp_test.go
+++ b/coderd/healthcheck/derp_test.go
@@ -132,7 +132,7 @@ func TestDERP(t *testing.T) {
 		defer derpSrv.Close()
 
 		sockets := activewebsockets.New(ctx)
-		handler := tailnet.WithWebsocketSupport(sockets, derpSrv, derphttp.Handler(derpSrv))
+		handler := tailnet.WithWebsocketSupport(sockets.Accept, derpSrv, derphttp.Handler(derpSrv))
 		defer sockets.Close()
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -113,9 +113,7 @@ func (api *API) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 		logs = []database.ProvisionerJobLog{}
 	}
 
-	api.WebsocketWaitMutex.Lock()
 	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
 	defer api.WebsocketWaitGroup.Done()
 	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {

--- a/coderd/sockets.go
+++ b/coderd/sockets.go
@@ -1,0 +1,81 @@
+package coderd
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"nhooyr.io/websocket"
+
+	"github.com/coder/coder/coderd/httpapi"
+	"github.com/coder/coder/codersdk"
+)
+
+// ActiveWebsockets is a helper struct that can be used to track active
+// websocket connections.
+type ActiveWebsockets struct {
+	ctx    context.Context
+	cancel func()
+
+	wg sync.WaitGroup
+}
+
+func NewActiveWebsockets(ctx context.Context, cancel func()) *ActiveWebsockets {
+	return &ActiveWebsockets{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// Accept accepts a websocket connection and calls f with the connection.
+// The function will be tracked by the ActiveWebsockets struct and will be
+// closed when the parent context is canceled.
+func (a *ActiveWebsockets) Accept(rw http.ResponseWriter, r *http.Request, options *websocket.AcceptOptions, f func(conn *websocket.Conn)) {
+	// Ensure we are still accepting websocket connections, and not shutting down.
+	if err := a.ctx.Err(); err != nil {
+		httpapi.Write(context.Background(), rw, http.StatusBadRequest, codersdk.Response{
+			Message: "No longer accepting websocket requests.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	// Ensure we decrement the wait group when we are done.
+	a.wg.Add(1)
+	defer a.wg.Done()
+
+	// Accept the websocket connection
+	conn, err := websocket.Accept(rw, r, options)
+	if err != nil {
+		httpapi.Write(context.Background(), rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Failed to accept websocket.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	// Always track the connection before allowing the caller to handle it.
+	// This ensures the connection is closed when the parent context is canceled.
+	// This new context will end if the parent context is cancelled or if
+	// the connection is closed.
+	ctx, cancel := context.WithCancel(a.ctx)
+	defer cancel()
+	a.track(ctx, conn)
+
+	// Handle the websocket connection
+	f(conn)
+}
+
+// Track runs a go routine that will close a given websocket connection when
+// the parent context is canceled.
+func (a *ActiveWebsockets) track(ctx context.Context, conn *websocket.Conn) {
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close(websocket.StatusNormalClosure, "")
+		}
+	}()
+}
+
+func (a *ActiveWebsockets) Close() {
+	a.cancel()
+	a.wg.Wait()
+}

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -185,9 +185,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	api.AGPL.WebsocketWaitMutex.Lock()
 	api.AGPL.WebsocketWaitGroup.Add(1)
-	api.AGPL.WebsocketWaitMutex.Unlock()
 	defer api.AGPL.WebsocketWaitGroup.Done()
 
 	conn, err := websocket.Accept(rw, r, &websocket.AcceptOptions{

--- a/tailnet/derp.go
+++ b/tailnet/derp.go
@@ -2,71 +2,50 @@ package tailnet
 
 import (
 	"bufio"
-	"context"
-	"log"
 	"net/http"
 	"strings"
-	"sync"
 
 	"nhooyr.io/websocket"
 	"tailscale.com/derp"
 	"tailscale.com/net/wsconn"
+
+	"github.com/coder/coder/coderd/activewebsockets"
 )
 
 // WithWebsocketSupport returns an http.Handler that upgrades
 // connections to the "derp" subprotocol to WebSockets and
 // passes them to the DERP server.
 // Taken from: https://github.com/tailscale/tailscale/blob/e3211ff88ba85435f70984cf67d9b353f3d650d8/cmd/derper/websocket.go#L21
-func WithWebsocketSupport(s *derp.Server, base http.Handler) (http.Handler, func()) {
-	var mu sync.Mutex
-	var waitGroup sync.WaitGroup
-	ctx, cancelFunc := context.WithCancel(context.Background())
-
+func WithWebsocketSupport(sockets *activewebsockets.Active, s *derp.Server, base http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			up := strings.ToLower(r.Header.Get("Upgrade"))
+		up := strings.ToLower(r.Header.Get("Upgrade"))
 
-			// Very early versions of Tailscale set "Upgrade: WebSocket" but didn't actually
-			// speak WebSockets (they still assumed DERP's binary framing). So to distinguish
-			// clients that actually want WebSockets, look for an explicit "derp" subprotocol.
-			if up != "websocket" || !strings.Contains(r.Header.Get("Sec-Websocket-Protocol"), "derp") {
-				base.ServeHTTP(w, r)
-				return
-			}
-
-			mu.Lock()
-			if ctx.Err() != nil {
-				mu.Unlock()
-				return
-			}
-			waitGroup.Add(1)
-			mu.Unlock()
-			defer waitGroup.Done()
-			c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-				Subprotocols:   []string{"derp"},
-				OriginPatterns: []string{"*"},
-				// Disable compression because we transmit WireGuard messages that
-				// are not compressible.
-				// Additionally, Safari has a broken implementation of compression
-				// (see https://github.com/nhooyr/websocket/issues/218) that makes
-				// enabling it actively harmful.
-				CompressionMode: websocket.CompressionDisabled,
-			})
-			if err != nil {
-				log.Printf("websocket.Accept: %v", err)
-				return
-			}
-			defer c.Close(websocket.StatusInternalError, "closing")
-			if c.Subprotocol() != "derp" {
-				c.Close(websocket.StatusPolicyViolation, "client must speak the derp subprotocol")
-				return
-			}
-			wc := wsconn.NetConn(ctx, c, websocket.MessageBinary)
-			brw := bufio.NewReadWriter(bufio.NewReader(wc), bufio.NewWriter(wc))
-			s.Accept(ctx, wc, brw, r.RemoteAddr)
-		}), func() {
-			cancelFunc()
-			mu.Lock()
-			waitGroup.Wait()
-			mu.Unlock()
+		// Very early versions of Tailscale set "Upgrade: WebSocket" but didn't actually
+		// speak WebSockets (they still assumed DERP's binary framing). So to distinguish
+		// clients that actually want WebSockets, look for an explicit "derp" subprotocol.
+		if up != "websocket" || !strings.Contains(r.Header.Get("Sec-Websocket-Protocol"), "derp") {
+			base.ServeHTTP(w, r)
+			return
 		}
+
+		sockets.Accept(w, r, &websocket.AcceptOptions{
+			Subprotocols:   []string{"derp"},
+			OriginPatterns: []string{"*"},
+			// Disable compression because we transmit WireGuard messages that
+			// are not compressible.
+			// Additionally, Safari has a broken implementation of compression
+			// (see https://github.com/nhooyr/websocket/issues/218) that makes
+			// enabling it actively harmful.
+			CompressionMode: websocket.CompressionDisabled,
+		}, func(conn *websocket.Conn) {
+			defer conn.Close(websocket.StatusInternalError, "closing")
+			if conn.Subprotocol() != "derp" {
+				conn.Close(websocket.StatusPolicyViolation, "client must speak the derp subprotocol")
+				return
+			}
+			wc := wsconn.NetConn(r.Context(), conn, websocket.MessageBinary)
+			brw := bufio.NewReadWriter(bufio.NewReader(wc), bufio.NewWriter(wc))
+			s.Accept(r.Context(), wc, brw, r.RemoteAddr)
+		})
+	})
 }

--- a/tailnet/tailnettest/tailnettest.go
+++ b/tailnet/tailnettest/tailnettest.go
@@ -78,7 +78,7 @@ func RunDERPOnlyWebSockets(t *testing.T) *tailcfg.DERPMap {
 	defer cancel()
 	sockets := activewebsockets.New(ctx)
 
-	handler = tailnet.WithWebsocketSupport(sockets, d, handler)
+	handler = tailnet.WithWebsocketSupport(sockets.Accept, d, handler)
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/derp" {
 			handler.ServeHTTP(w, r)


### PR DESCRIPTION
This is an idea I had.

The problem is that the Coderd `API` struct calls `Wait()` on a waitgroup for all websockets to close before the `Close()` method returns. The `Close()` method calls `cancel` on the parent context, but this context is not actually controlling the lifecycle of the individual request for a given websocket.

So `Close()` **does not** tell a websocket to end. It was achieving this because the parent context is tied to `*wsconncache.Cache` which kills the tailnet connections from the parent context.

To make this work more directly, I implemented [ActiveWebsockets](https://github.com/coder/coder/blob/stevenmasley/websocket_tracking/coderd/sockets.go#L18). This struct takes the parent context. When you call `Accept` on this struct, it launches a go routine that will force close the websocket if the parent context is cancelled. This all happens when you call `Close()` on the `ActiveWebsocket` struct.

This also means we can pass this struct in places like `WithWebsocketSupport`: https://github.com/coder/coder/blob/bf64a43ae2962178a6cb9b3960d7fc4116c12ba8/tailnet/derp.go#L21-L22

Right now we just duplicate the `sync.WaitGroup` logic and return a `Wait()` which is just kinda annoying.

This isn't 100% better, but it does handle the tracking:

https://github.com/coder/coder/blob/15ed4676e99a938687f5c672b8c855f6d973f902/tailnet/derp.go#L13-L21

-----

Thoughts?