### PR TITLE
feat(cli): add --output={text,json} to version cmd

### DIFF
--- a/cli/cliui/output.go
+++ b/cli/cliui/output.go
@@ -3,6 +3,7 @@ package cliui
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -170,4 +171,24 @@ func (jsonFormat) Format(_ context.Context, data any) (string, error) {
 	}
 
 	return string(outBytes), nil
+}
+
+type textFormat struct{}
+
+var _ OutputFormat = textFormat{}
+
+// TextFormat is a formatter that just outputs unstructured text.
+// It uses fmt.Sprintf under the hood.
+func TextFormat() OutputFormat {
+	return textFormat{}
+}
+
+func (textFormat) ID() string {
+	return "text"
+}
+
+func (textFormat) AttachOptions(_ *clibase.OptionSet) {}
+
+func (textFormat) Format(_ context.Context, data any) (string, error) {
+	return fmt.Sprintf("%s", data), nil
 }

--- a/cli/cliui/output_test.go
+++ b/cli/cliui/output_test.go
@@ -50,6 +50,9 @@ func Test_OutputFormatter(t *testing.T) {
 		require.Panics(t, func() {
 			cliui.NewOutputFormatter(cliui.JSONFormat())
 		})
+		require.NotPanics(t, func() {
+			cliui.NewOutputFormatter(cliui.JSONFormat(), cliui.TextFormat())
+		})
 	})
 
 	t.Run("NoMissingFormatID", func(t *testing.T) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -82,7 +82,7 @@ func (r *RootCmd) Core() []*clibase.Cmd {
 		r.templates(),
 		r.users(),
 		r.tokens(),
-		r.version(),
+		r.version(defaultVersionInfo),
 
 		// Workspace Commands
 		r.configSSH(),

--- a/cli/root.go
+++ b/cli/root.go
@@ -370,36 +370,6 @@ func LoggerFromContext(ctx context.Context) (slog.Logger, bool) {
 	return l, ok
 }
 
-// version prints the coder version
-func (*RootCmd) version() *clibase.Cmd {
-	return &clibase.Cmd{
-		Use:   "version",
-		Short: "Show coder version",
-		Handler: func(inv *clibase.Invocation) error {
-			var str strings.Builder
-			_, _ = str.WriteString("Coder ")
-			if buildinfo.IsAGPL() {
-				_, _ = str.WriteString("(AGPL) ")
-			}
-			_, _ = str.WriteString(buildinfo.Version())
-			buildTime, valid := buildinfo.Time()
-			if valid {
-				_, _ = str.WriteString(" " + buildTime.Format(time.UnixDate))
-			}
-			_, _ = str.WriteString("\r\n" + buildinfo.ExternalURL() + "\r\n\r\n")
-
-			if buildinfo.IsSlim() {
-				_, _ = str.WriteString(fmt.Sprintf("Slim build of Coder, does not support the %s subcommand.\n", cliui.Styles.Code.Render("server")))
-			} else {
-				_, _ = str.WriteString(fmt.Sprintf("Full build of Coder, supports the %s subcommand.\n", cliui.Styles.Code.Render("server")))
-			}
-
-			_, _ = fmt.Fprint(inv.Stdout, str.String())
-			return nil
-		},
-	}
-}
-
 func isTest() bool {
 	return flag.Lookup("test.v") != nil
 }

--- a/cli/testdata/coder_version_--help.golden
+++ b/cli/testdata/coder_version_--help.golden
@@ -1,6 +1,10 @@
-Usage: coder version
+Usage: coder version [flags]
 
 Show coder version
+
+[1mOptions[0m
+      --json bool
+          Emit version information in machine-readable JSON format.
 
 ---
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_version_--help.golden
+++ b/cli/testdata/coder_version_--help.golden
@@ -3,8 +3,8 @@ Usage: coder version [flags]
 Show coder version
 
 [1mOptions[0m
-      --json bool
-          Emit version information in machine-readable JSON format.
+  -o, --output string (default: text)
+          Output format. Available formats: text, json.
 
 ---
 Run `coder --help` for a list of global options.

--- a/cli/version.go
+++ b/cli/version.go
@@ -46,7 +46,7 @@ func (*RootCmd) version() *clibase.Cmd {
 			AGPL        bool   `json:"agpl"`
 		}{
 			Version:     buildinfo.Version(),
-			BuildTime:   buildTime.Format(time.UnixDate),
+			BuildTime:   buildTime.Format(time.RFC3339),
 			ExternalURL: buildinfo.ExternalURL(),
 			Slim:        buildinfo.IsSlim(),
 			AGPL:        buildinfo.IsAGPL(),

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/coder/coder/buildinfo"
+	"github.com/coder/coder/cli/clibase"
+	"github.com/coder/coder/cli/cliui"
+)
+
+// version prints the coder version
+func (*RootCmd) version() *clibase.Cmd {
+	handleHuman := func(inv *clibase.Invocation) error {
+		var str strings.Builder
+		_, _ = str.WriteString("Coder ")
+		if buildinfo.IsAGPL() {
+			_, _ = str.WriteString("(AGPL) ")
+		}
+		_, _ = str.WriteString(buildinfo.Version())
+		buildTime, valid := buildinfo.Time()
+		if valid {
+			_, _ = str.WriteString(" " + buildTime.Format(time.UnixDate))
+		}
+		_, _ = str.WriteString("\r\n" + buildinfo.ExternalURL() + "\r\n\r\n")
+
+		if buildinfo.IsSlim() {
+			_, _ = str.WriteString(fmt.Sprintf("Slim build of Coder, does not support the %s subcommand.\n", cliui.Styles.Code.Render("server")))
+		} else {
+			_, _ = str.WriteString(fmt.Sprintf("Full build of Coder, supports the %s subcommand.\n", cliui.Styles.Code.Render("server")))
+		}
+
+		_, _ = fmt.Fprint(inv.Stdout, str.String())
+		return nil
+	}
+
+	handleJSON := func(inv *clibase.Invocation) error {
+		buildTime, _ := buildinfo.Time()
+		versionInfo := struct {
+			Version     string `json:"version"`
+			BuildTime   string `json:"build_time"`
+			ExternalURL string `json:"external_url"`
+			Slim        bool   `json:"slim"`
+			AGPL        bool   `json:"agpl"`
+		}{
+			Version:     buildinfo.Version(),
+			BuildTime:   buildTime.Format(time.UnixDate),
+			ExternalURL: buildinfo.ExternalURL(),
+			Slim:        buildinfo.IsSlim(),
+			AGPL:        buildinfo.IsAGPL(),
+		}
+
+		enc := json.NewEncoder(inv.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(versionInfo)
+	}
+
+	var outputJSON bool
+
+	return &clibase.Cmd{
+		Use:   "version",
+		Short: "Show coder version",
+		Options: clibase.OptionSet{
+			{
+				Flag:        "json",
+				Description: "Emit version information in machine-readable JSON format.",
+				Value:       clibase.BoolOf(&outputJSON),
+			},
+		},
+		Handler: func(inv *clibase.Invocation) error {
+			if outputJSON {
+				return handleJSON(inv)
+			}
+			return handleHuman(inv)
+		},
+	}
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -11,69 +10,75 @@ import (
 	"github.com/coder/coder/cli/cliui"
 )
 
+// versionInfo wraps the stuff we get from buildinfo so that it's
+// easier to emit in different formats.
+type versionInfo struct {
+	Version     string    `json:"version"`
+	BuildTime   time.Time `json:"build_time"`
+	ExternalURL string    `json:"external_url"`
+	Slim        bool      `json:"slim"`
+	AGPL        bool      `json:"agpl"`
+}
+
+// String() implements Stringer
+func (vi versionInfo) String() string {
+	var str strings.Builder
+	_, _ = str.WriteString("Coder ")
+	if vi.AGPL {
+		_, _ = str.WriteString("(AGPL) ")
+	}
+	_, _ = str.WriteString(vi.Version)
+
+	if !vi.BuildTime.IsZero() {
+		_, _ = str.WriteString(" " + vi.BuildTime.Format(time.UnixDate))
+	}
+	_, _ = str.WriteString("\r\n" + vi.ExternalURL + "\r\n\r\n")
+
+	if vi.Slim {
+		_, _ = str.WriteString(fmt.Sprintf("Slim build of Coder, does not support the %s subcommand.", cliui.Styles.Code.Render("server")))
+	} else {
+		_, _ = str.WriteString(fmt.Sprintf("Full build of Coder, supports the %s subcommand.", cliui.Styles.Code.Render("server")))
+	}
+	return str.String()
+}
+
+func defaultVersionInfo() *versionInfo {
+	buildTime, _ := buildinfo.Time()
+	return &versionInfo{
+		Version:     buildinfo.Version(),
+		BuildTime:   buildTime,
+		ExternalURL: buildinfo.ExternalURL(),
+		Slim:        buildinfo.IsSlim(),
+		AGPL:        buildinfo.IsAGPL(),
+	}
+}
+
 // version prints the coder version
-func (*RootCmd) version() *clibase.Cmd {
-	handleHuman := func(inv *clibase.Invocation) error {
-		var str strings.Builder
-		_, _ = str.WriteString("Coder ")
-		if buildinfo.IsAGPL() {
-			_, _ = str.WriteString("(AGPL) ")
-		}
-		_, _ = str.WriteString(buildinfo.Version())
-		buildTime, valid := buildinfo.Time()
-		if valid {
-			_, _ = str.WriteString(" " + buildTime.Format(time.UnixDate))
-		}
-		_, _ = str.WriteString("\r\n" + buildinfo.ExternalURL() + "\r\n\r\n")
+func (*RootCmd) version(versionInfo func() *versionInfo) *clibase.Cmd {
+	var (
+		formatter = cliui.NewOutputFormatter(
+			cliui.TextFormat(),
+			cliui.JSONFormat(),
+		)
+		vi = versionInfo()
+	)
 
-		if buildinfo.IsSlim() {
-			_, _ = str.WriteString(fmt.Sprintf("Slim build of Coder, does not support the %s subcommand.\n", cliui.Styles.Code.Render("server")))
-		} else {
-			_, _ = str.WriteString(fmt.Sprintf("Full build of Coder, supports the %s subcommand.\n", cliui.Styles.Code.Render("server")))
-		}
-
-		_, _ = fmt.Fprint(inv.Stdout, str.String())
-		return nil
-	}
-
-	handleJSON := func(inv *clibase.Invocation) error {
-		buildTime, _ := buildinfo.Time()
-		versionInfo := struct {
-			Version     string `json:"version"`
-			BuildTime   string `json:"build_time"`
-			ExternalURL string `json:"external_url"`
-			Slim        bool   `json:"slim"`
-			AGPL        bool   `json:"agpl"`
-		}{
-			Version:     buildinfo.Version(),
-			BuildTime:   buildTime.Format(time.RFC3339),
-			ExternalURL: buildinfo.ExternalURL(),
-			Slim:        buildinfo.IsSlim(),
-			AGPL:        buildinfo.IsAGPL(),
-		}
-
-		enc := json.NewEncoder(inv.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(versionInfo)
-	}
-
-	var outputJSON bool
-
-	return &clibase.Cmd{
-		Use:   "version",
-		Short: "Show coder version",
-		Options: clibase.OptionSet{
-			{
-				Flag:        "json",
-				Description: "Emit version information in machine-readable JSON format.",
-				Value:       clibase.BoolOf(&outputJSON),
-			},
-		},
+	cmd := &clibase.Cmd{
+		Use:     "version",
+		Short:   "Show coder version",
+		Options: clibase.OptionSet{},
 		Handler: func(inv *clibase.Invocation) error {
-			if outputJSON {
-				return handleJSON(inv)
+			out, err := formatter.Format(inv.Context(), vi)
+			if err != nil {
+				return err
 			}
-			return handleHuman(inv)
+
+			_, err = fmt.Fprintln(inv.Stdout, out)
+			return err
 		},
 	}
+
+	formatter.AttachOptions(&cmd.Options)
+
+	return cmd
 }

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"bytes"
 	"context"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -15,16 +14,10 @@ import (
 
 func TestVersion(t *testing.T) {
 	t.Parallel()
-	ansiExpr := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
-	clean := func(s string) string {
-		s = ansiExpr.ReplaceAllString(s, "")
-		s = strings.Replace(s, "\r\n", "\n", -1)
-		return s
-	}
 	expectedHuman := `Coder v0.0.0-devel
 https://github.com/coder/coder
 
-Full build of Coder, supports the  server  subcommand.
+Full build of Coder, supports the  [;mserver[0m  subcommand.
 `
 	expectedJSON := `{
   "version": "v0.0.0-devel",
@@ -60,7 +53,8 @@ Full build of Coder, supports the  server  subcommand.
 			inv.Stdout = buf
 			err := inv.WithContext(ctx).Run()
 			require.NoError(t, err)
-			actual := clean(buf.String())
+			actual := buf.String()
+			actual = strings.Replace(actual, "\r\n", "\n", -1)
 			require.Equal(t, tt.Expected, actual)
 		})
 	}

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -28,7 +28,7 @@ Full build of Coder, supports the  server  subcommand.
 `
 	expectedJSON := `{
   "version": "v0.0.0-devel",
-  "build_time": "Mon Jan  1 00:00:00 UTC 0001",
+  "build_time": "0001-01-01T00:00:00Z",
   "external_url": "https://github.com/coder/coder",
   "slim": false,
   "agpl": false

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -1,0 +1,67 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/testutil"
+)
+
+func TestVersion(t *testing.T) {
+	t.Parallel()
+	ansiExpr := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+	clean := func(s string) string {
+		s = ansiExpr.ReplaceAllString(s, "")
+		s = strings.Replace(s, "\r\n", "\n", -1)
+		return s
+	}
+	expectedHuman := `Coder v0.0.0-devel
+https://github.com/coder/coder
+
+Full build of Coder, supports the  server  subcommand.
+`
+	expectedJSON := `{
+  "version": "v0.0.0-devel",
+  "build_time": "Mon Jan  1 00:00:00 UTC 0001",
+  "external_url": "https://github.com/coder/coder",
+  "slim": false,
+  "agpl": false
+}
+`
+	for _, tt := range []struct {
+		Name     string
+		Args     []string
+		Expected string
+	}{
+		{
+			Name:     "Defaults to human-readable output",
+			Args:     []string{"version"},
+			Expected: expectedHuman,
+		},
+		{
+			Name:     "JSON output",
+			Args:     []string{"version", "--json"},
+			Expected: expectedJSON,
+		},
+	} {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+			t.Cleanup(cancel)
+			inv, _ := clitest.New(t, tt.Args...)
+			buf := new(bytes.Buffer)
+			inv.Stdout = buf
+			err := inv.WithContext(ctx).Run()
+			require.NoError(t, err)
+			actual := clean(buf.String())
+			require.Equal(t, tt.Expected, actual)
+		})
+	}
+}

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestVersion(t *testing.T) {
 	t.Parallel()
-	expectedHuman := `Coder v0.0.0-devel
+	expectedText := `Coder v0.0.0-devel
 https://github.com/coder/coder
 
 Full build of Coder, supports the  [;mserver[0m  subcommand.
@@ -35,12 +35,17 @@ Full build of Coder, supports the  [;mserver[0m  subcommand.
 		{
 			Name:     "Defaults to human-readable output",
 			Args:     []string{"version"},
-			Expected: expectedHuman,
+			Expected: expectedText,
 		},
 		{
 			Name:     "JSON output",
-			Args:     []string{"version", "--json"},
+			Args:     []string{"version", "--output=json"},
 			Expected: expectedJSON,
+		},
+		{
+			Name:     "Text output",
+			Args:     []string{"version", "--output=text"},
+			Expected: expectedText,
 		},
 	} {
 		tt := tt

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -59,7 +59,7 @@ Full build of Coder, supports the  [;mserver[0m  subcommand.
 			err := inv.WithContext(ctx).Run()
 			require.NoError(t, err)
 			actual := buf.String()
-			actual = strings.Replace(actual, "\r\n", "\n", -1)
+			actual = strings.ReplaceAll(actual, "\r\n", "\n")
 			require.Equal(t, tt.Expected, actual)
 		})
 	}

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -12,10 +12,11 @@ coder version [flags]
 
 ## Options
 
-### --json
+### -o, --output
 
-|      |                   |
-| ---- | ----------------- |
-| Type | <code>bool</code> |
+|         |                     |
+| ------- | ------------------- |
+| Type    | <code>string</code> |
+| Default | <code>text</code>   |
 
-Emit version information in machine-readable JSON format.
+Output format. Available formats: text, json.

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -7,5 +7,15 @@ Show coder version
 ## Usage
 
 ```console
-coder version
+coder version [flags]
 ```
+
+## Options
+
+### --json
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+Emit version information in machine-readable JSON format.


### PR DESCRIPTION
```
$ build/coder-slim_$(./scripts/version.sh)_linux_amd64 version --output=text
Coder v0.21.3-devel+b099e5c58 Wed Apr  5 12:03:29 UTC 2023
https://github.com/coder/coder/commit/b099e5c58c9f8dbb2fbbded3d559da7923cab3f8

Slim build of Coder, does not support the  server  subcommand.
$ build/coder-slim_$(./scripts/version.sh)_linux_amd64 version --output=json
{
  "version": "v0.21.3-devel+b099e5c58",
  "build_time": "2023-04-05T12:03:29Z",
  "external_url": "https://github.com/coder/coder/commit/b099e5c58c9f8dbb2fbbded3d559da7923cab3f8",
  "slim": true,
  "agpl": false
}
```