### PR TITLE
feat(agentssh): Gracefully close SSH sessions on Close

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -615,6 +615,9 @@ func (s *Server) Close() error {
 	// Close all active sessions to gracefully
 	// terminate client connections.
 	for ss := range s.sessions {
+		// We call Close on the underlying channel here because we don't
+		// want to send an exit status to the client (via Exit()).
+		// Typically OpenSSH clients will return 255 as the exit status.
 		_ = ss.Close()
 	}
 

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -155,7 +155,8 @@ func (s *Server) ConnStats() ConnStats {
 
 func (s *Server) sessionHandler(session ssh.Session) {
 	if !s.trackSession(session, true) {
-		session.Exit(MagicSessionErrorCode)
+		// See (*Server).Close() for why we call Close instead of Exit.
+		_ = session.Close()
 		return
 	}
 	defer s.trackSession(session, false)


### PR DESCRIPTION
By tracking and closing sessions manually before closing the underlying
connections, we ensure that the termination is propagated to SSH/SFTP
clients and they're not left waiting for a connection timeout.

Refs: #6177

This PR targets: #7004
