### PR TITLE
chore: de-flake TestWorkspaceAgent_Metadata (round 2)

### DIFF
--- a/agent/reaper/reaper_test.go
+++ b/agent/reaper/reaper_test.go
@@ -23,7 +23,7 @@ func TestReap(t *testing.T) {
 	// Don't run the reaper test in CI. It does weird
 	// things like forkexecing which may have unintended
 	// consequences in CI.
-	if _, ok := os.LookupEnv("CI"); ok {
+	if testutil.InCI() {
 		t.Skip("Detected CI, skipping reaper tests")
 	}
 
@@ -73,7 +73,7 @@ func TestReapInterrupt(t *testing.T) {
 	// Don't run the reaper test in CI. It does weird
 	// things like forkexecing which may have unintended
 	// consequences in CI.
-	if _, ok := os.LookupEnv("CI"); ok {
+	if testutil.InCI() {
 		t.Skip("Detected CI, skipping reaper tests")
 	}
 

--- a/helm/tests/chart_test.go
+++ b/helm/tests/chart_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/testutil"
 )
 
 // These tests run `helm template` with the values file specified in each test
@@ -54,7 +56,7 @@ func TestRenderChart(t *testing.T) {
 	if *UpdateGoldenFiles {
 		t.Skip("Golden files are being updated. Skipping test.")
 	}
-	if _, runningInCI := os.LookupEnv("CI"); runningInCI {
+	if testutil.InCI() {
 		switch runtime.GOOS {
 		case "windows", "darwin":
 			t.Skip("Skipping tests on Windows and macOS in CI")

--- a/testutil/ci.go
+++ b/testutil/ci.go
@@ -1,0 +1,16 @@
+package testutil
+
+import (
+	"flag"
+	"os"
+)
+
+func InCI() bool {
+	_, ok := os.LookupEnv("CI")
+	return ok
+}
+
+func InRaceMode() bool {
+	fl := flag.Lookup("race")
+	return fl != nil && fl.Value.String() == "true"
+}

--- a/testutil/duration.go
+++ b/testutil/duration.go
@@ -2,7 +2,9 @@
 
 package testutil
 
-import "time"
+import (
+	"time"
+)
 
 // Constants for timing out operations, usable for creating contexts
 // that timeout or in require.Eventually.


### PR DESCRIPTION
This time, we keep the timing / "racey" tests, but avoid running
them in the harsher CI conditions.
