### PR TITLE
chore: clidocgen: generate consistent docs

### DIFF
--- a/cli/config/file.go
+++ b/cli/config/file.go
@@ -125,5 +125,9 @@ func read(path string) ([]byte, error) {
 }
 
 func DefaultDir() string {
-	return configdir.LocalConfig("coderv2")
+	configDir := configdir.LocalConfig("coderv2")
+	if dir := os.Getenv("CLIDOCGEN_CONFIG_DIRECTORY"); dir != "" {
+		configDir = dir
+	}
+	return configDir
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -348,7 +348,9 @@ func DefaultCacheDir() string {
 		// For compatibility with systemd.
 		defaultCacheDir = dir
 	}
-
+	if dir := os.Getenv("CLIDOCGEN_CACHE_DIRECTORY"); dir != "" {
+		defaultCacheDir = dir
+	}
 	return filepath.Join(defaultCacheDir, "coder")
 }
 

--- a/scripts/clidocgen/main.go
+++ b/scripts/clidocgen/main.go
@@ -44,7 +44,7 @@ func prepareEnv() {
 	if err != nil {
 		panic(err)
 	}
-	_ = os.Setenv("CLIDOCGEN_CONFIG_DIRECTORY", "~/.config/coderv2")
+	err = os.Setenv("CLIDOCGEN_CONFIG_DIRECTORY", "~/.config/coderv2")
 	if err != nil {
 		panic(err)
 	}

--- a/scripts/clidocgen/main.go
+++ b/scripts/clidocgen/main.go
@@ -28,7 +28,8 @@ type manifest struct {
 	Routes   []route  `json:"routes,omitempty"`
 }
 
-func unsetCoderEnv() {
+func prepareEnv() {
+	// Unset CODER_ environment variables
 	for _, env := range os.Environ() {
 		if strings.HasPrefix(env, "CODER_") {
 			split := strings.SplitN(env, "=", 2)
@@ -36,6 +37,16 @@ func unsetCoderEnv() {
 				panic(err)
 			}
 		}
+	}
+
+	// Override default OS values to ensure the same generated results.
+	err := os.Setenv("CLIDOCGEN_CACHE_DIRECTORY", "~/.cache")
+	if err != nil {
+		panic(err)
+	}
+	_ = os.Setenv("CLIDOCGEN_CONFIG_DIRECTORY", "~/.config/coderv2")
+	if err != nil {
+		panic(err)
 	}
 }
 
@@ -63,7 +74,7 @@ func deleteEmptyDirs(dir string) error {
 }
 
 func main() {
-	unsetCoderEnv()
+	prepareEnv()
 
 	workdir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6839

This PR fixes the `clidocgen` to generate the same CLI docs on Mac and Linux. Without this change, paths on Mac look like: `~/Library/Application Support/coderv2` instead of `~/.config/coderv2`. 