### PR TITLE
fix: Parse `CODER_GITAUTH_N_NO_REFRESH` env var value instead of key

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -142,7 +142,7 @@ func ReadGitAuthProvidersFromEnv(environ []string) ([]codersdk.GitAuthConfig, er
 		case "REGEX":
 			provider.Regex = v.Value
 		case "NO_REFRESH":
-			b, err := strconv.ParseBool(key)
+			b, err := strconv.ParseBool(v.Value)
 			if err != nil {
 				return nil, xerrors.Errorf("parse bool: %s", v.Value)
 			}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -80,6 +80,7 @@ func TestReadGitAuthProvidersFromEnv(t *testing.T) {
 			"CODER_GITAUTH_1_TOKEN_URL=google.com",
 			"CODER_GITAUTH_1_VALIDATE_URL=bing.com",
 			"CODER_GITAUTH_1_SCOPES=repo:read repo:write",
+			"CODER_GITAUTH_1_NO_REFRESH=true",
 		})
 		require.NoError(t, err)
 		require.Len(t, providers, 2)
@@ -95,6 +96,7 @@ func TestReadGitAuthProvidersFromEnv(t *testing.T) {
 		assert.Equal(t, "google.com", providers[1].TokenURL)
 		assert.Equal(t, "bing.com", providers[1].ValidateURL)
 		assert.Equal(t, []string{"repo:read", "repo:write"}, providers[1].Scopes)
+		assert.Equal(t, true, providers[1].NoRefresh)
 	})
 }
 


### PR DESCRIPTION
I noticed in Coder v0.21.3 that setting the `CODER_GITAUTH_N_NO_REFRESH` environment variable in our server's `/etc/coder.d/coder.env` configuration file to prevent Coder from automatically refreshing gitauth tokens caused the Coder server to fail to launch with the error:

```
Apr 03 22:14:23 coder coder[3334506]: read git auth providers from env: parse bool: true
Apr 03 22:14:23 coder systemd[1]: coder.service: Main process exited, code=exited, status=1/FAILURE
```

This PR updates an existing test to capture the affected code path and then fixes the issue by changing the parsing code to parse the environment variable's value instead of the environment variable's name/key.