### PR TITLE
docs: bump tf version in offline docs

### DIFF
--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -45,7 +45,7 @@ RUN mkdir -p /opt/terraform
 # The below step is optional if you wish to keep the existing version.
 # See https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24
 # for supported Terraform versions.
-ARG TERRAFORM_VERSION=1.3.0
+ARG TERRAFORM_VERSION=1.3.9
 RUN apk update && \
     apk del terraform && \
     curl -LOs https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \


### PR DESCRIPTION
we recently bumped our max supported Terraform version to `1.3.9` in #6995. this PR updates our offline Dockerfile accordingly.