### PR TITLE
feat: add level support for startup logs

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5646,6 +5646,9 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "level": {
+                    "$ref": "#/definitions/codersdk.LogLevel"
+                },
                 "output": {
                     "type": "string"
                 }
@@ -9157,6 +9160,9 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "integer"
+                },
+                "level": {
+                    "$ref": "#/definitions/codersdk.LogLevel"
                 },
                 "output": {
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4991,6 +4991,9 @@
         "created_at": {
           "type": "string"
         },
+        "level": {
+          "$ref": "#/definitions/codersdk.LogLevel"
+        },
         "output": {
           "type": "string"
         }
@@ -8261,6 +8264,9 @@
         },
         "id": {
           "type": "integer"
+        },
+        "level": {
+          "$ref": "#/definitions/codersdk.LogLevel"
         },
         "output": {
           "type": "string"

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -3706,6 +3706,7 @@ func (q *fakeQuerier) InsertWorkspaceAgentStartupLogs(_ context.Context, arg dat
 			ID:        id,
 			AgentID:   arg.AgentID,
 			CreatedAt: arg.CreatedAt[index],
+			Level:     arg.Level[index],
 			Output:    output,
 		})
 		outputLength += int32(len(output))

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -501,7 +501,8 @@ CREATE TABLE workspace_agent_startup_logs (
     agent_id uuid NOT NULL,
     created_at timestamp with time zone NOT NULL,
     output character varying(1024) NOT NULL,
-    id bigint NOT NULL
+    id bigint NOT NULL,
+    level log_level DEFAULT 'info'::log_level NOT NULL
 );
 
 CREATE SEQUENCE workspace_agent_startup_logs_id_seq

--- a/coderd/database/migrations/000116_startup_logs_level.down.sql
+++ b/coderd/database/migrations/000116_startup_logs_level.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_agent_startup_logs
+	DROP COLUMN level;

--- a/coderd/database/migrations/000116_startup_logs_level.up.sql
+++ b/coderd/database/migrations/000116_startup_logs_level.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_agent_startup_logs
+	ADD COLUMN level log_level NOT NULL DEFAULT 'info'::log_level;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1601,6 +1601,7 @@ type WorkspaceAgentStartupLog struct {
 	CreatedAt time.Time `db:"created_at" json:"created_at"`
 	Output    string    `db:"output" json:"output"`
 	ID        int64     `db:"id" json:"id"`
+	Level     LogLevel  `db:"level" json:"level"`
 }
 
 type WorkspaceAgentStat struct {

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -111,6 +111,7 @@ func TestInsertWorkspaceAgentStartupLogs(t *testing.T) {
 		AgentID:   agent.ID,
 		CreatedAt: []time.Time{database.Now()},
 		Output:    []string{"first"},
+		Level:     []database.LogLevel{database.LogLevelInfo},
 		// 1 MB is the max
 		OutputLength: 1 << 20,
 	})
@@ -121,6 +122,7 @@ func TestInsertWorkspaceAgentStartupLogs(t *testing.T) {
 		AgentID:      agent.ID,
 		CreatedAt:    []time.Time{database.Now()},
 		Output:       []string{"second"},
+		Level:        []database.LogLevel{database.LogLevelInfo},
 		OutputLength: 1,
 	})
 	require.True(t, database.IsStartupLogsLimitError(err))

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5574,7 +5574,7 @@ func (q *sqlQuerier) GetWorkspaceAgentMetadata(ctx context.Context, workspaceAge
 
 const getWorkspaceAgentStartupLogsAfter = `-- name: GetWorkspaceAgentStartupLogsAfter :many
 SELECT
-	agent_id, created_at, output, id
+	agent_id, created_at, output, id, level
 FROM
 	workspace_agent_startup_logs
 WHERE
@@ -5603,6 +5603,7 @@ func (q *sqlQuerier) GetWorkspaceAgentStartupLogsAfter(ctx context.Context, arg 
 			&i.CreatedAt,
 			&i.Output,
 			&i.ID,
+			&i.Level,
 		); err != nil {
 			return nil, err
 		}
@@ -5964,21 +5965,23 @@ func (q *sqlQuerier) InsertWorkspaceAgentMetadata(ctx context.Context, arg Inser
 const insertWorkspaceAgentStartupLogs = `-- name: InsertWorkspaceAgentStartupLogs :many
 WITH new_length AS (
 	UPDATE workspace_agents SET
-	startup_logs_length = startup_logs_length + $4 WHERE workspace_agents.id = $1
+	startup_logs_length = startup_logs_length + $5 WHERE workspace_agents.id = $1
 )
 INSERT INTO
-		workspace_agent_startup_logs
+		workspace_agent_startup_logs (agent_id, created_at, output, level)
 	SELECT
 		$1 :: uuid AS agent_id,
 		unnest($2 :: timestamptz [ ]) AS created_at,
-		unnest($3 :: VARCHAR(1024) [ ]) AS output
-	RETURNING workspace_agent_startup_logs.agent_id, workspace_agent_startup_logs.created_at, workspace_agent_startup_logs.output, workspace_agent_startup_logs.id
+		unnest($3 :: VARCHAR(1024) [ ]) AS output,
+		unnest($4 :: log_level [ ]) AS level
+	RETURNING workspace_agent_startup_logs.agent_id, workspace_agent_startup_logs.created_at, workspace_agent_startup_logs.output, workspace_agent_startup_logs.id, workspace_agent_startup_logs.level
 `
 
 type InsertWorkspaceAgentStartupLogsParams struct {
 	AgentID      uuid.UUID   `db:"agent_id" json:"agent_id"`
 	CreatedAt    []time.Time `db:"created_at" json:"created_at"`
 	Output       []string    `db:"output" json:"output"`
+	Level        []LogLevel  `db:"level" json:"level"`
 	OutputLength int32       `db:"output_length" json:"output_length"`
 }
 
@@ -5987,6 +5990,7 @@ func (q *sqlQuerier) InsertWorkspaceAgentStartupLogs(ctx context.Context, arg In
 		arg.AgentID,
 		pq.Array(arg.CreatedAt),
 		pq.Array(arg.Output),
+		pq.Array(arg.Level),
 		arg.OutputLength,
 	)
 	if err != nil {
@@ -6001,6 +6005,7 @@ func (q *sqlQuerier) InsertWorkspaceAgentStartupLogs(ctx context.Context, arg In
 			&i.CreatedAt,
 			&i.Output,
 			&i.ID,
+			&i.Level,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -151,11 +151,12 @@ WITH new_length AS (
 	startup_logs_length = startup_logs_length + @output_length WHERE workspace_agents.id = @agent_id
 )
 INSERT INTO
-		workspace_agent_startup_logs
+		workspace_agent_startup_logs (agent_id, created_at, output, level)
 	SELECT
 		@agent_id :: uuid AS agent_id,
 		unnest(@created_at :: timestamptz [ ]) AS created_at,
-		unnest(@output :: VARCHAR(1024) [ ]) AS output
+		unnest(@output :: VARCHAR(1024) [ ]) AS output,
+		unnest(@level :: log_level [ ]) AS level
 	RETURNING workspace_agent_startup_logs.*;
 
 -- If an agent hasn't connected in the last 7 days, we purge it's logs.

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -545,8 +545,9 @@ func (c *Client) PostStartup(ctx context.Context, req PostStartupRequest) error 
 }
 
 type StartupLog struct {
-	CreatedAt time.Time `json:"created_at"`
-	Output    string    `json:"output"`
+	CreatedAt time.Time         `json:"created_at"`
+	Output    string            `json:"output"`
+	Level     codersdk.LogLevel `json:"level"`
 }
 
 type PatchStartupLogs struct {

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -510,4 +510,5 @@ type WorkspaceAgentStartupLog struct {
 	ID        int64     `json:"id"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	Output    string    `json:"output"`
+	Level     LogLevel  `json:"level"`
 }

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -701,6 +701,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/sta
   {
     "created_at": "2019-08-24T14:15:22Z",
     "id": 0,
+    "level": "trace",
     "output": "string"
   }
 ]
@@ -716,11 +717,22 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/sta
 
 Status Code **200**
 
-| Name           | Type              | Required | Restrictions | Description |
-| -------------- | ----------------- | -------- | ------------ | ----------- |
-| `[array item]` | array             | false    |              |             |
-| `» created_at` | string(date-time) | false    |              |             |
-| `» id`         | integer           | false    |              |             |
-| `» output`     | string            | false    |              |             |
+| Name           | Type                                             | Required | Restrictions | Description |
+| -------------- | ------------------------------------------------ | -------- | ------------ | ----------- |
+| `[array item]` | array                                            | false    |              |             |
+| `» created_at` | string(date-time)                                | false    |              |             |
+| `» id`         | integer                                          | false    |              |             |
+| `» level`      | [codersdk.LogLevel](schemas.md#codersdkloglevel) | false    |              |             |
+| `» output`     | string                                           | false    |              |             |
+
+#### Enumerated Values
+
+| Property | Value   |
+| -------- | ------- |
+| `level`  | `trace` |
+| `level`  | `debug` |
+| `level`  | `info`  |
+| `level`  | `warn`  |
+| `level`  | `error` |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -217,6 +217,7 @@
   "logs": [
     {
       "created_at": "string",
+      "level": "trace",
       "output": "string"
     }
   ]
@@ -302,16 +303,18 @@
 ```json
 {
   "created_at": "string",
+  "level": "trace",
   "output": "string"
 }
 ```
 
 ### Properties
 
-| Name         | Type   | Required | Restrictions | Description |
-| ------------ | ------ | -------- | ------------ | ----------- |
-| `created_at` | string | false    |              |             |
-| `output`     | string | false    |              |             |
+| Name         | Type                                   | Required | Restrictions | Description |
+| ------------ | -------------------------------------- | -------- | ------------ | ----------- |
+| `created_at` | string                                 | false    |              |             |
+| `level`      | [codersdk.LogLevel](#codersdkloglevel) | false    |              |             |
+| `output`     | string                                 | false    |              |             |
 
 ## agentsdk.Stats
 
@@ -4766,17 +4769,19 @@ Parameter represents a set value for the scope.
 {
   "created_at": "2019-08-24T14:15:22Z",
   "id": 0,
+  "level": "trace",
   "output": "string"
 }
 ```
 
 ### Properties
 
-| Name         | Type    | Required | Restrictions | Description |
-| ------------ | ------- | -------- | ------------ | ----------- |
-| `created_at` | string  | false    |              |             |
-| `id`         | integer | false    |              |             |
-| `output`     | string  | false    |              |             |
+| Name         | Type                                   | Required | Restrictions | Description |
+| ------------ | -------------------------------------- | -------- | ------------ | ----------- |
+| `created_at` | string                                 | false    |              |             |
+| `id`         | integer                                | false    |              |             |
+| `level`      | [codersdk.LogLevel](#codersdkloglevel) | false    |              |             |
+| `output`     | string                                 | false    |              |             |
 
 ## codersdk.WorkspaceAgentStatus
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1131,6 +1131,7 @@ export interface WorkspaceAgentStartupLog {
   readonly id: number
   readonly created_at: string
   readonly output: string
+  readonly level: LogLevel
 }
 
 // From codersdk/workspaceapps.go

--- a/site/src/xServices/workspaceAgentLogs/workspaceAgentLogsXService.ts
+++ b/site/src/xServices/workspaceAgentLogs/workspaceAgentLogsXService.ts
@@ -73,7 +73,7 @@ export const workspaceAgentLogsMachine = createMachine(
         API.getWorkspaceAgentStartupLogs(ctx.agentID).then((data) =>
           data.map((log) => ({
             id: log.id,
-            level: "info" as TypesGen.LogLevel,
+            level: log.level || "info",
             output: log.output,
             time: log.created_at,
           })),


### PR DESCRIPTION
This allows external services like our devcontainer support to display errors and warnings with custom styles to indicate failures to users.