### PR TITLE
fix(templates): Add lower() to docker container naming

### DIFF
--- a/examples/templates/docker-code-server/main.tf
+++ b/examples/templates/docker-code-server/main.tf
@@ -89,7 +89,7 @@ resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
   image = "codercom/code-server:latest"
   # Uses lower() to avoid Docker restriction on container names.
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -117,7 +117,7 @@ resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
   image = docker_image.coder_image.image_id
   # Uses lower() to avoid Docker restriction on container names.
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1

--- a/examples/templates/docker-image-builds/main.tf
+++ b/examples/templates/docker-image-builds/main.tf
@@ -103,7 +103,7 @@ resource "docker_volume" "home_volume" {
 }
 
 resource "docker_image" "coder_image" {
-  name = "coder-base-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-base-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   build {
     context    = "./images/"
     dockerfile = "${data.coder_parameter.docker_image.value}.Dockerfile"

--- a/examples/templates/docker-with-dotfiles/main.tf
+++ b/examples/templates/docker-with-dotfiles/main.tf
@@ -94,7 +94,7 @@ resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
   image = data.coder_parameter.docker_image.value
   # Uses lower() to avoid Docker restriction on container names.
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -109,7 +109,7 @@ resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
   image = docker_image.main.name
   # Uses lower() to avoid Docker restriction on container names.
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = data.coder_workspace.me.name
   # Use the docker gateway if the access URL is 127.0.0.1


### PR DESCRIPTION
This pr will correct an issue that occurs when creating a docker container. If a user had a capital letter in their username, docker creation would fail.