### PR TITLE
fix(docs): fix broken markdown links

### DIFF
--- a/docs/admin/provisioners.md
+++ b/docs/admin/provisioners.md
@@ -1,6 +1,6 @@
 # External provisioners
 
-By default, the Coder server runs [built-in provisioner daemons](../cli/coder_server.md#provisioner-daemons), which execute `terraform` during workspace and template builds. However, there are sometimes benefits to running external provisioner daemons:
+By default, the Coder server runs [built-in provisioner daemons](../cli/server.md#provisioner-daemons), which execute `terraform` during workspace and template builds. However, there are sometimes benefits to running external provisioner daemons:
 
 - **Secure build environments:** Run build jobs in isolated containers, preventing malicious templates from gaining shell access to the Coder host.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,39 +23,39 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 
 ## Subcommands
 
-| Name                                                | Purpose                                                                |
-| --------------------------------------------------- | ---------------------------------------------------------------------- |
-| [<code>config-ssh</code>](./cli/config-ssh)         | Add an SSH Host entry for your workspaces "ssh coder.workspace"        |
-| [<code>create</code>](./cli/create)                 | Create a workspace                                                     |
-| [<code>delete</code>](./cli/delete)                 | Delete a workspace                                                     |
-| [<code>dotfiles</code>](./cli/dotfiles)             | Personalize your workspace by applying a canonical dotfiles repository |
-| [<code>features</code>](./cli/features)             | List Enterprise features                                               |
-| [<code>groups</code>](./cli/groups)                 | Manage groups                                                          |
-| [<code>licenses</code>](./cli/licenses)             | Add, delete, and list licenses                                         |
-| [<code>list</code>](./cli/list)                     | List workspaces                                                        |
-| [<code>login</code>](./cli/login)                   | Authenticate with Coder deployment                                     |
-| [<code>logout</code>](./cli/logout)                 | Unauthenticate your local session                                      |
-| [<code>ping</code>](./cli/ping)                     | Ping a workspace                                                       |
-| [<code>port-forward</code>](./cli/port-forward)     | Forward ports from machine to a workspace                              |
-| [<code>provisionerd</code>](./cli/provisionerd)     | Manage provisioner daemons                                             |
-| [<code>publickey</code>](./cli/publickey)           | Output your Coder public key used for Git operations                   |
-| [<code>rename</code>](./cli/rename)                 | Rename a workspace                                                     |
-| [<code>reset-password</code>](./cli/reset-password) | Directly connect to the database to reset a user's password            |
-| [<code>restart</code>](./cli/restart)               | Restart a workspace                                                    |
-| [<code>scaletest</code>](./cli/scaletest)           | Run a scale test against the Coder API                                 |
-| [<code>schedule</code>](./cli/schedule)             | Schedule automated start and stop times for workspaces                 |
-| [<code>server</code>](./cli/server)                 | Start a Coder server                                                   |
-| [<code>show</code>](./cli/show)                     | Display details of a workspace's resources and agents                  |
-| [<code>speedtest</code>](./cli/speedtest)           | Run upload and download tests from your machine to a workspace         |
-| [<code>ssh</code>](./cli/ssh)                       | Start a shell into a workspace                                         |
-| [<code>start</code>](./cli/start)                   | Start a workspace                                                      |
-| [<code>state</code>](./cli/state)                   | Manually manage Terraform state to fix broken workspaces               |
-| [<code>stop</code>](./cli/stop)                     | Stop a workspace                                                       |
-| [<code>templates</code>](./cli/templates)           | Manage templates                                                       |
-| [<code>tokens</code>](./cli/tokens)                 | Manage personal access tokens                                          |
-| [<code>update</code>](./cli/update)                 | Will update and start a given workspace if it is out of date           |
-| [<code>users</code>](./cli/users)                   | Manage users                                                           |
-| [<code>version</code>](./cli/version)               | Show coder version                                                     |
+| Name                                                   | Purpose                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| [<code>config-ssh</code>](./cli/config-ssh.md)         | Add an SSH Host entry for your workspaces "ssh coder.workspace"        |
+| [<code>create</code>](./cli/create.md)                 | Create a workspace                                                     |
+| [<code>delete</code>](./cli/delete.md)                 | Delete a workspace                                                     |
+| [<code>dotfiles</code>](./cli/dotfiles.md)             | Personalize your workspace by applying a canonical dotfiles repository |
+| [<code>features</code>](./cli/features.md)             | List Enterprise features                                               |
+| [<code>groups</code>](./cli/groups.md)                 | Manage groups                                                          |
+| [<code>licenses</code>](./cli/licenses.md)             | Add, delete, and list licenses                                         |
+| [<code>list</code>](./cli/list.md)                     | List workspaces                                                        |
+| [<code>login</code>](./cli/login.md)                   | Authenticate with Coder deployment                                     |
+| [<code>logout</code>](./cli/logout.md)                 | Unauthenticate your local session                                      |
+| [<code>ping</code>](./cli/ping.md)                     | Ping a workspace                                                       |
+| [<code>port-forward</code>](./cli/port-forward.md)     | Forward ports from machine to a workspace                              |
+| [<code>provisionerd</code>](./cli/provisionerd.md)     | Manage provisioner daemons                                             |
+| [<code>publickey</code>](./cli/publickey.md)           | Output your Coder public key used for Git operations                   |
+| [<code>rename</code>](./cli/rename.md)                 | Rename a workspace                                                     |
+| [<code>reset-password</code>](./cli/reset-password.md) | Directly connect to the database to reset a user's password            |
+| [<code>restart</code>](./cli/restart.md)               | Restart a workspace                                                    |
+| [<code>scaletest</code>](./cli/scaletest.md)           | Run a scale test against the Coder API                                 |
+| [<code>schedule</code>](./cli/schedule.md)             | Schedule automated start and stop times for workspaces                 |
+| [<code>server</code>](./cli/server.md)                 | Start a Coder server                                                   |
+| [<code>show</code>](./cli/show.md)                     | Display details of a workspace's resources and agents                  |
+| [<code>speedtest</code>](./cli/speedtest.md)           | Run upload and download tests from your machine to a workspace         |
+| [<code>ssh</code>](./cli/ssh.md)                       | Start a shell into a workspace                                         |
+| [<code>start</code>](./cli/start.md)                   | Start a workspace                                                      |
+| [<code>state</code>](./cli/state.md)                   | Manually manage Terraform state to fix broken workspaces               |
+| [<code>stop</code>](./cli/stop.md)                     | Stop a workspace                                                       |
+| [<code>templates</code>](./cli/templates.md)           | Manage templates                                                       |
+| [<code>tokens</code>](./cli/tokens.md)                 | Manage personal access tokens                                          |
+| [<code>update</code>](./cli/update.md)                 | Will update and start a given workspace if it is out of date           |
+| [<code>users</code>](./cli/users.md)                   | Manage users                                                           |
+| [<code>version</code>](./cli/version.md)               | Show coder version                                                     |
 
 ## Options
 

--- a/docs/cli/features.md
+++ b/docs/cli/features.md
@@ -16,6 +16,6 @@ coder features
 
 ## Subcommands
 
-| Name                                 | Purpose |
-| ------------------------------------ | ------- |
-| [<code>list</code>](./features_list) |         |
+| Name                                    | Purpose |
+| --------------------------------------- | ------- |
+| [<code>list</code>](./features_list.md) |         |

--- a/docs/cli/groups.md
+++ b/docs/cli/groups.md
@@ -16,9 +16,9 @@ coder groups
 
 ## Subcommands
 
-| Name                                   | Purpose             |
-| -------------------------------------- | ------------------- |
-| [<code>create</code>](./groups_create) | Create a user group |
-| [<code>delete</code>](./groups_delete) | Delete a user group |
-| [<code>edit</code>](./groups_edit)     | Edit a user group   |
-| [<code>list</code>](./groups_list)     | List user groups    |
+| Name                                      | Purpose             |
+| ----------------------------------------- | ------------------- |
+| [<code>create</code>](./groups_create.md) | Create a user group |
+| [<code>delete</code>](./groups_delete.md) | Delete a user group |
+| [<code>edit</code>](./groups_edit.md)     | Edit a user group   |
+| [<code>list</code>](./groups_list.md)     | List user groups    |

--- a/docs/cli/licenses.md
+++ b/docs/cli/licenses.md
@@ -16,8 +16,8 @@ coder licenses
 
 ## Subcommands
 
-| Name                                     | Purpose                           |
-| ---------------------------------------- | --------------------------------- |
-| [<code>add</code>](./licenses_add)       | Add license to Coder deployment   |
-| [<code>delete</code>](./licenses_delete) | Delete license by ID              |
-| [<code>list</code>](./licenses_list)     | List licenses (including expired) |
+| Name                                        | Purpose                           |
+| ------------------------------------------- | --------------------------------- |
+| [<code>add</code>](./licenses_add.md)       | Add license to Coder deployment   |
+| [<code>delete</code>](./licenses_delete.md) | Delete license by ID              |
+| [<code>list</code>](./licenses_list.md)     | List licenses (including expired) |

--- a/docs/cli/provisionerd.md
+++ b/docs/cli/provisionerd.md
@@ -12,6 +12,6 @@ coder provisionerd
 
 ## Subcommands
 
-| Name                                       | Purpose                  |
-| ------------------------------------------ | ------------------------ |
-| [<code>start</code>](./provisionerd_start) | Run a provisioner daemon |
+| Name                                          | Purpose                  |
+| --------------------------------------------- | ------------------------ |
+| [<code>start</code>](./provisionerd_start.md) | Run a provisioner daemon |

--- a/docs/cli/scaletest.md
+++ b/docs/cli/scaletest.md
@@ -12,7 +12,7 @@ coder scaletest
 
 ## Subcommands
 
-| Name                                                            | Purpose                                                                                                                                                                                                             |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [<code>cleanup</code>](./scaletest_cleanup)                     | Cleanup scaletest workspaces, then cleanup scaletest users.                                                                                                                                                         |
-| [<code>create-workspaces</code>](./scaletest_create-workspaces) | Creates many users, then creates a workspace for each user and waits for them finish building and fully come online. Optionally runs a command inside each workspace, and connects to the workspace over WireGuard. |
+| Name                                                               | Purpose                                                                                                                                                                                                             |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [<code>cleanup</code>](./scaletest_cleanup.md)                     | Cleanup scaletest workspaces, then cleanup scaletest users.                                                                                                                                                         |
+| [<code>create-workspaces</code>](./scaletest_create-workspaces.md) | Creates many users, then creates a workspace for each user and waits for them finish building and fully come online. Optionally runs a command inside each workspace, and connects to the workspace over WireGuard. |

--- a/docs/cli/schedule.md
+++ b/docs/cli/schedule.md
@@ -12,9 +12,9 @@ coder schedule { show | start | stop | override } <workspace>
 
 ## Subcommands
 
-| Name                                                   | Purpose                                                           |
-| ------------------------------------------------------ | ----------------------------------------------------------------- |
-| [<code>override-stop</code>](./schedule_override-stop) | Override the stop time of a currently running workspace instance. |
-| [<code>show</code>](./schedule_show)                   | Show workspace schedule                                           |
-| [<code>start</code>](./schedule_start)                 | Edit workspace start schedule                                     |
-| [<code>stop</code>](./schedule_stop)                   | Edit workspace stop schedule                                      |
+| Name                                                      | Purpose                                                           |
+| --------------------------------------------------------- | ----------------------------------------------------------------- |
+| [<code>override-stop</code>](./schedule_override-stop.md) | Override the stop time of a currently running workspace instance. |
+| [<code>show</code>](./schedule_show.md)                   | Show workspace schedule                                           |
+| [<code>start</code>](./schedule_start.md)                 | Edit workspace start schedule                                     |
+| [<code>stop</code>](./schedule_stop.md)                   | Edit workspace stop schedule                                      |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -12,11 +12,11 @@ coder server [flags]
 
 ## Subcommands
 
-| Name                                                                   | Purpose                                                                                                |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| [<code>create-admin-user</code>](./server_create-admin-user)           | Create a new admin user with the given username, email and password and adds it to every organization. |
-| [<code>postgres-builtin-serve</code>](./server_postgres-builtin-serve) | Run the built-in PostgreSQL deployment.                                                                |
-| [<code>postgres-builtin-url</code>](./server_postgres-builtin-url)     | Output the connection URL for the built-in PostgreSQL deployment.                                      |
+| Name                                                                      | Purpose                                                                                                |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [<code>create-admin-user</code>](./server_create-admin-user.md)           | Create a new admin user with the given username, email and password and adds it to every organization. |
+| [<code>postgres-builtin-serve</code>](./server_postgres-builtin-serve.md) | Run the built-in PostgreSQL deployment.                                                                |
+| [<code>postgres-builtin-url</code>](./server_postgres-builtin-url.md)     | Output the connection URL for the built-in PostgreSQL deployment.                                      |
 
 ## Options
 

--- a/docs/cli/state.md
+++ b/docs/cli/state.md
@@ -12,7 +12,7 @@ coder state
 
 ## Subcommands
 
-| Name                              | Purpose                                       |
-| --------------------------------- | --------------------------------------------- |
-| [<code>pull</code>](./state_pull) | Pull a Terraform state file from a workspace. |
-| [<code>push</code>](./state_push) | Push a Terraform state file to a workspace.   |
+| Name                                 | Purpose                                       |
+| ------------------------------------ | --------------------------------------------- |
+| [<code>pull</code>](./state_pull.md) | Pull a Terraform state file from a workspace. |
+| [<code>push</code>](./state_push.md) | Push a Terraform state file to a workspace.   |

--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -33,14 +33,14 @@ Templates are written in standard Terraform and describe the infrastructure for 
 
 ## Subcommands
 
-| Name                                          | Purpose                                                                        |
-| --------------------------------------------- | ------------------------------------------------------------------------------ |
-| [<code>create</code>](./templates_create)     | Create a template from the current directory or as specified by flag           |
-| [<code>delete</code>](./templates_delete)     | Delete templates                                                               |
-| [<code>edit</code>](./templates_edit)         | Edit the metadata of a template by name.                                       |
-| [<code>init</code>](./templates_init)         | Get started with a templated template.                                         |
-| [<code>list</code>](./templates_list)         | List all the templates available for the organization                          |
-| [<code>plan</code>](./templates_plan)         | Plan a template push from the current directory                                |
-| [<code>pull</code>](./templates_pull)         | Download the latest version of a template to a path.                           |
-| [<code>push</code>](./templates_push)         | Push a new template version from the current directory or as specified by flag |
-| [<code>versions</code>](./templates_versions) | Manage different versions of the specified template                            |
+| Name                                             | Purpose                                                                        |
+| ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [<code>create</code>](./templates_create.md)     | Create a template from the current directory or as specified by flag           |
+| [<code>delete</code>](./templates_delete.md)     | Delete templates                                                               |
+| [<code>edit</code>](./templates_edit.md)         | Edit the metadata of a template by name.                                       |
+| [<code>init</code>](./templates_init.md)         | Get started with a templated template.                                         |
+| [<code>list</code>](./templates_list.md)         | List all the templates available for the organization                          |
+| [<code>plan</code>](./templates_plan.md)         | Plan a template push from the current directory                                |
+| [<code>pull</code>](./templates_pull.md)         | Download the latest version of a template to a path.                           |
+| [<code>push</code>](./templates_push.md)         | Push a new template version from the current directory or as specified by flag |
+| [<code>versions</code>](./templates_versions.md) | Manage different versions of the specified template                            |

--- a/docs/cli/templates_versions.md
+++ b/docs/cli/templates_versions.md
@@ -24,6 +24,6 @@ coder templates versions
 
 ## Subcommands
 
-| Name                                           | Purpose                                         |
-| ---------------------------------------------- | ----------------------------------------------- |
-| [<code>list</code>](./templates_versions_list) | List all the versions of the specified template |
+| Name                                              | Purpose                                         |
+| ------------------------------------------------- | ----------------------------------------------- |
+| [<code>list</code>](./templates_versions_list.md) | List all the versions of the specified template |

--- a/docs/cli/tokens.md
+++ b/docs/cli/tokens.md
@@ -33,8 +33,8 @@ Tokens are used to authenticate automated clients to Coder.
 
 ## Subcommands
 
-| Name                                   | Purpose        |
-| -------------------------------------- | -------------- |
-| [<code>create</code>](./tokens_create) | Create a token |
-| [<code>list</code>](./tokens_list)     | List tokens    |
-| [<code>remove</code>](./tokens_remove) | Delete a token |
+| Name                                      | Purpose        |
+| ----------------------------------------- | -------------- |
+| [<code>create</code>](./tokens_create.md) | Create a token |
+| [<code>list</code>](./tokens_list.md)     | List tokens    |
+| [<code>remove</code>](./tokens_remove.md) | Delete a token |

--- a/docs/cli/users.md
+++ b/docs/cli/users.md
@@ -16,10 +16,10 @@ coder users [subcommand]
 
 ## Subcommands
 
-| Name                                      | Purpose                                                                               |
-| ----------------------------------------- | ------------------------------------------------------------------------------------- |
-| [<code>activate</code>](./users_activate) | Update a user's status to 'active'. Active users can fully interact with the platform |
-| [<code>create</code>](./users_create)     |                                                                                       |
-| [<code>list</code>](./users_list)         |                                                                                       |
-| [<code>show</code>](./users_show)         | Show a single user. Use 'me' to indicate the currently authenticated user.            |
-| [<code>suspend</code>](./users_suspend)   | Update a user's status to 'suspended'. A suspended user cannot log into the platform  |
+| Name                                         | Purpose                                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [<code>activate</code>](./users_activate.md) | Update a user's status to 'active'. Active users can fully interact with the platform |
+| [<code>create</code>](./users_create.md)     |                                                                                       |
+| [<code>list</code>](./users_list.md)         |                                                                                       |
+| [<code>show</code>](./users_show.md)         | Show a single user. Use 'me' to indicate the currently authenticated user.            |
+| [<code>suspend</code>](./users_suspend.md)   | Update a user's status to 'suspended'. A suspended user cannot log into the platform  |

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -51,7 +51,7 @@ is no special geo-distribution configuration. To speed up direct connections,
 move the user and workspace closer together.
 
 If a direct connection is not available (e.g. client or server is behind NAT), Coder
-will use a relayed connection. By default, [Coder uses Google's public STUN server](./cli/coder_server#--derp-server-stun-addresses), but
+will use a relayed connection. By default, [Coder uses Google's public STUN server](./cli/server.md#--derp-server-stun-addresses), but
 this can be disabled or changed for [offline deployments](./install/offline.md).
 
 ### Relayed connections

--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -7,7 +7,7 @@ Coder with Docker has the following advantages:
 - Workspaces share resources for burst operations
 
 > Note that the below steps are only supported on a Linux distribution.
-> If on macOS, please [run Coder via the standalone binary](./binary.md).
+> If on macOS, please [run Coder via the standalone binary](../install//binary.md).
 
 ## Requirements
 

--- a/docs/platforms/kubernetes/index.md
+++ b/docs/platforms/kubernetes/index.md
@@ -4,7 +4,7 @@ Coder's control plane and/or workspaces can be deployed on Kubernetes.
 
 ## Installation
 
-Refer to our [Helm install docs](../install/kubernetes.md) to deploy Coder on Kubernetes. The default helm values will provision the following:
+Refer to our [Helm install docs](../../install/kubernetes.md) to deploy Coder on Kubernetes. The default helm values will provision the following:
 
 - Coder control plane (as a `Deployment`)
 - ServiceAccount + Role + RoleBinding to provision pods + PVCS in the current namespace (used for Kubernetes workspaces)

--- a/docs/platforms/other.md
+++ b/docs/platforms/other.md
@@ -1,11 +1,11 @@
 # Other platforms
 
-Coder is highly extensible and is not limited to the platforms outlined in these docs. The control plane can be provisioned on any VM or container compute, and workspaces can include any Terraform resource. See our [architecture diagram](./about/architecture.md) for more details.
+Coder is highly extensible and is not limited to the platforms outlined in these docs. The control plane can be provisioned on any VM or container compute, and workspaces can include any Terraform resource. See our [architecture diagram](../about/architecture.md) for more details.
 
 The following resources may help as you're deploying Coder.
 
 - [Coder packages: one-click install on cloud providers](https://github.com/coder/packages)
 - [Run Coder as a system service](../install/packages.md)
-- [Deploy Coder offline](../enterprise/offline.md)
+- [Deploy Coder offline](../install/offline.md)
 - [Supported resources (Terraform registry)](https://registry.terraform.io)
 - [Writing custom templates](../templates.md)

--- a/docs/templates/resource-metadata.md
+++ b/docs/templates/resource-metadata.md
@@ -121,4 +121,4 @@ Read more [here](./agent-metadata.md).
 ## Up next
 
 - Learn about [secrets](../secrets.md)
-- Learn about [Agent Metadata](../agent-metadata.md)
+- Learn about [Agent Metadata](./agent-metadata.md)

--- a/scripts/clidocgen/gen.go
+++ b/scripts/clidocgen/gen.go
@@ -55,10 +55,7 @@ func init() {
 				return fmt.Sprintf("<code>%s</code>", s)
 			},
 			"commandURI": func(cmd *clibase.Cmd) string {
-				return strings.TrimSuffix(
-					fmtDocFilename(cmd),
-					".md",
-				)
+				return fmtDocFilename(cmd)
 			},
 			"fullName": fullName,
 			"tableHeader": func() string {


### PR DESCRIPTION
More than half of them were actually valid links but, due to missing file extensions were flagged as invalid. I added a file extension, so it should pass now.