### PR TITLE
fix: revert "fix: change auto-start to automatically update workspaces"

### DIFF
--- a/coderd/autobuild/executor/lifecycle_executor.go
+++ b/coderd/autobuild/executor/lifecycle_executor.go
@@ -308,7 +308,7 @@ func build(ctx context.Context, store database.Store, workspace database.Workspa
 			CreatedAt:         now,
 			UpdatedAt:         now,
 			WorkspaceID:       workspace.ID,
-			TemplateVersionID: template.ActiveVersionID,
+			TemplateVersionID: priorHistory.TemplateVersionID,
 			BuildNumber:       priorBuildNumber + 1,
 			ProvisionerState:  priorHistory.ProvisionerState,
 			InitiatorID:       workspace.OwnerID,

--- a/coderd/autobuild/executor/lifecycle_executor_test.go
+++ b/coderd/autobuild/executor/lifecycle_executor_test.go
@@ -97,14 +97,14 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 		close(tickCh)
 	}()
 
-	// Then: the workspace is started using the new template version, not the old one.
+	// Then: the workspace should be started using the previous template version, and not the updated version.
 	stats := <-statsCh
 	assert.NoError(t, stats.Error)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[workspace.ID])
 	ws := coderdtest.MustWorkspace(t, client, workspace.ID)
-	assert.Equal(t, newVersion.ID, ws.LatestBuild.TemplateVersionID, "expected workspace build to be using the new template version")
+	assert.Equal(t, workspace.LatestBuild.TemplateVersionID, ws.LatestBuild.TemplateVersionID, "expected workspace build to be using the old template version")
 }
 
 func TestExecutorAutostartAlreadyRunning(t *testing.T) {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/7073#issuecomment-1503297091
Introduced in: https://github.com/coder/coder/pull/6053

As we identified a serious issue with the autostop flow, let's disable updating for now. At the moment it isn't possible to autostop workspaces built using templates with parameters. 

This reverts commit bdddc3e7aea78b00a1ac9404af4dc500600bb8a8.