### PR TITLE
chore: Refactor common server cli components for reusability

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1986,7 +1986,6 @@ func configureHTTPServers(inv *clibase.Invocation, cfg *codersdk.DeploymentValue
 		if err != nil {
 			return nil, err
 		}
-		defer httpsListenerInner.Close()
 
 		httpServers.TLSConfig = tlsConfig
 		httpServers.TLSListener = tls.NewListener(httpsListenerInner, tlsConfig)

--- a/cli/server.go
+++ b/cli/server.go
@@ -352,7 +352,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				MetricsCacheRefreshInterval: cfg.MetricsCacheRefreshInterval.Value(),
 				AgentStatsRefreshInterval:   cfg.AgentStatRefreshInterval.Value(),
 				DeploymentValues:            cfg,
-				PrometheusRegistry:          prometheus.NewRegistry(),
+				PrometheusRegistry:          scd.PrometheusRegistry,
 				APIRateLimit:                int(cfg.RateLimit.API.Value()),
 				LoginRateLimit:              loginRateLimit,
 				FilesRateLimit:              filesRateLimit,

--- a/cli/server.go
+++ b/cli/server.go
@@ -33,15 +33,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/coreos/go-systemd/daemon"
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	"github.com/google/go-github/v43/github"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/afero"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/mod/semver"
@@ -236,8 +235,8 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}()
 			}
 
-			//If the access URL is empty, we attempt to run a reverse-proxy
-			//tunnel to make the initial setup really simple.
+			// If the access URL is empty, we attempt to run a reverse-proxy
+			// tunnel to make the initial setup really simple.
 			var (
 				tunnel     *tunnelsdk.Tunnel
 				tunnelDone <-chan struct{} = make(chan struct{}, 1)

--- a/cli/server.go
+++ b/cli/server.go
@@ -1215,6 +1215,7 @@ func SetupServerCmd(inv *clibase.Invocation, cfg *codersdk.DeploymentValues) (_ 
 	}
 	c.Ctx = ctx
 	c.HTTPClient = httpClient
+	c.addClose(c.HTTPClient.CloseIdleConnections)
 
 	// Warn the user if the access URL appears to be a loopback address.
 	isLocal, err := isLocalURL(ctx, cfg.AccessURL.Value())

--- a/cli/server.go
+++ b/cli/server.go
@@ -185,9 +185,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			defer scd.Close()
 			ctx := scd.Ctx
 
-			var (
-				logger = scd.Logger
-			)
+			logger := scd.Logger
 
 			// Disable rate limits if the `--dangerous-disable-rate-limits` flag
 			// was specified.


### PR DESCRIPTION
Workspace-proxy cmd needs to redo all of this, better to be shared.

See the workspace-proxy cmd (WIP): https://github.com/coder/coder/blob/a4254874e484dbb7837abd38adf0d0a9bd0f2f9a/enterprise/cli/workspaceproxy.go#L98-L131