### PR TITLE
feat(cli): add --id parameter to templates init command

### DIFF
--- a/cli/templateinit_test.go
+++ b/cli/templateinit_test.go
@@ -40,7 +40,7 @@ func TestTemplateInit(t *testing.T) {
 		inv, _ := clitest.New(t, "templates", "init", "--id", "thistemplatedoesnotexist", tempDir)
 		ptytest.New(t).Attach(inv)
 		err := inv.Run()
-		require.ErrorContains(t, err, "does not exist!")
+		require.ErrorContains(t, err, "invalid choice: thistemplatedoesnotexist, should be one of")
 		files, err := os.ReadDir(tempDir)
 		require.NoError(t, err)
 		require.Empty(t, files)

--- a/cli/templateinit_test.go
+++ b/cli/templateinit_test.go
@@ -22,4 +22,27 @@ func TestTemplateInit(t *testing.T) {
 		require.NoError(t, err)
 		require.Greater(t, len(files), 0)
 	})
+
+	t.Run("ExtractSpecific", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		inv, _ := clitest.New(t, "templates", "init", "--id", "docker", tempDir)
+		ptytest.New(t).Attach(inv)
+		clitest.Run(t, inv)
+		files, err := os.ReadDir(tempDir)
+		require.NoError(t, err)
+		require.Greater(t, len(files), 0)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		inv, _ := clitest.New(t, "templates", "init", "--id", "thistemplatedoesnotexist", tempDir)
+		ptytest.New(t).Attach(inv)
+		err := inv.Run()
+		require.ErrorContains(t, err, "does not exist!")
+		files, err := os.ReadDir(tempDir)
+		require.NoError(t, err)
+		require.Empty(t, files)
+	})
 }

--- a/cli/testdata/coder_templates_init_--help.golden
+++ b/cli/testdata/coder_templates_init_--help.golden
@@ -1,6 +1,10 @@
-Usage: coder templates init [directory]
+Usage: coder templates init [flags] [directory]
 
 Get started with a templated template.
+
+[1mOptions[0m
+      --id string
+          Specify a given example template by ID.
 
 ---
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_templates_init_--help.golden
+++ b/cli/testdata/coder_templates_init_--help.golden
@@ -3,7 +3,7 @@ Usage: coder templates init [flags] [directory]
 Get started with a templated template.
 
 [1mOptions[0m
-      --id string
+      --id aws-ecs-container|aws-linux|aws-windows|azure-linux|do-linux|docker|docker-with-dotfiles|fly-docker-image|gcp-linux|gcp-vm-container|gcp-windows|kubernetes
           Specify a given example template by ID.
 
 ---

--- a/docs/cli/templates_init.md
+++ b/docs/cli/templates_init.md
@@ -14,8 +14,8 @@ coder templates init [flags] [directory]
 
 ### --id
 
-|      |                     |
-| ---- | ------------------- |
-| Type | <code>string</code> |
+|      |                              |
+| ---- | ---------------------------- | --------- | ----------- | ----------- | -------- | ------ | -------------------- | ---------------- | --------- | ---------------- | ----------- | ------------------ |
+| Type | <code>enum[aws-ecs-container | aws-linux | aws-windows | azure-linux | do-linux | docker | docker-with-dotfiles | fly-docker-image | gcp-linux | gcp-vm-container | gcp-windows | kubernetes]</code> |
 
 Specify a given example template by ID.

--- a/docs/cli/templates_init.md
+++ b/docs/cli/templates_init.md
@@ -7,5 +7,15 @@ Get started with a templated template.
 ## Usage
 
 ```console
-coder templates init [directory]
+coder templates init [flags] [directory]
 ```
+
+## Options
+
+### --id
+
+|      |                     |
+| ---- | ------------------- |
+| Type | <code>string</code> |
+
+Specify a given example template by ID.

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -96,7 +96,7 @@ provision:
       [ ! -e ~/.config/coderv2/session ] && coder login http://localhost:3000 --first-user-username admin --first-user-email admin@coder.com --first-user-password $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c12 | tee ${HOME}/.config/coderv2/password)
       # Create an initial template
       temp_template_dir=$(mktemp -d)
-      echo code-server | coder templates init "${temp_template_dir}"
+      coder templates init --id docker "${temp_template_dir}"
       DOCKER_ARCH="amd64"
       if [ "$(arch)" = "aarch64" ]; then
         DOCKER_ARCH="arm64"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -151,7 +151,6 @@ fatal() {
 
 	# If we have docker available and the "docker" template doesn't already
 	# exist, then let's try to create a template!
-	example_template="code-server"
 	template_name="docker"
 	if docker info >/dev/null 2>&1 && ! "${CODER_DEV_SHIM}" templates versions list "${template_name}" >/dev/null 2>&1; then
 		# sometimes terraform isn't installed yet when we go to create the
@@ -159,7 +158,7 @@ fatal() {
 		sleep 5
 
 		temp_template_dir="$(mktemp -d)"
-		echo "${example_template}" | "${CODER_DEV_SHIM}" templates init "${temp_template_dir}"
+		"${CODER_DEV_SHIM}" templates init --id "${template_name}" "${temp_template_dir}"
 
 		DOCKER_HOST="$(docker context inspect --format '{{ .Endpoints.docker.Host }}')"
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" >"${temp_template_dir}/params.yaml"


### PR DESCRIPTION
#6849 broke `develop.sh` in a hard-to-debug manner.
To automatically import a working template, we used to run `echo $TEMPLATE_NAME | coder templates init $TEMP_DIR`. The assumption was that the `code-server` template would stay around. Unfortunately, the `echo name | coder templates init` is hard to troubleshoot as it has side-effects such as clearing terminal output.

This PR makes the following changes:
1) Adds an `--id` parameter to `coder templates init` so that you can non-interactively initialize a specific example template by ID (e.g. folder name)
2) Updates `develop.sh` and `lima/coder.yaml` to use this parameter to select the `docker` example template.