### PR TITLE
fix: remove irrelevant help info from `coder tokens create`

### DIFF
--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"golang.org/x/exp/slices"
@@ -67,14 +66,7 @@ func (r *RootCmd) createToken() *clibase.Cmd {
 				return xerrors.Errorf("create tokens: %w", err)
 			}
 
-			cliui.Infof(
-				inv.Stdout,
-				"Here is your token. 🪄\n\n",
-			)
-			cliui.Infof(inv.Stdout, cliui.Styles.Code.Render(strings.TrimSpace(res.Key))+"\n\n")
-			cliui.Infof(inv.Stdout,
-				"You can use this token by setting the --%s CLI flag, the %s environment variable, or the %q HTTP header.", varToken, envSessionToken, codersdk.SessionTokenHeader,
-			)
+			_, _ = fmt.Fprintln(inv.Stdout, res.Key)
 
 			return nil
 		},

--- a/cli/tokens_test.go
+++ b/cli/tokens_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,11 +40,7 @@ func TestTokens(t *testing.T) {
 	require.NoError(t, err)
 	res = buf.String()
 	require.NotEmpty(t, res)
-	// find API key in format "XXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXX"
-	r := regexp.MustCompile("[a-zA-Z0-9]{10}-[a-zA-Z0-9]{22}")
-	require.Regexp(t, r, res)
-	key := r.FindString(res)
-	id := key[:10]
+	id := res[:10]
 
 	inv, root = clitest.New(t, "tokens", "ls")
 	clitest.SetupConfig(t, client, root)


### PR DESCRIPTION
The additional text didn't help much, and made it much harder to script around.