### PR TITLE
feat(helm): add labels for coder pod

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -27,7 +27,9 @@ spec:
     metadata:
       labels:
         {{- include "coder.labels" . | nindent 8 }}
-        {{- toYaml .Values.coder.labels | nindent 8 }}
+        {{- with .Values.coder.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- toYaml .Values.coder.podAnnotations | nindent 8  }}
     spec:

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -27,6 +27,7 @@ spec:
     metadata:
       labels:
         {{- include "coder.labels" . | nindent 8 }}
+        {{- toYaml .Values.coder.labels | nindent 8 }}
       annotations:
         {{- toYaml .Values.coder.podAnnotations | nindent 8  }}
     spec:

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         {{- include "coder.labels" . | nindent 8 }}
-        {{- with .Values.coder.labels }}
+        {{- with .Values.coder.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,13 +38,13 @@ coder:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   labels: {}
 
-  # coder.podLabels -- The Coder pod labels. See:
-  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-  podlabels: {}
-
   # coder.podAnnotations -- The Coder pod annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}
+
+  # coder.podLabels -- The Coder pod labels. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podlabels: {}
 
   # coder.serviceAccount -- Configuration for the automatically created service
   # account. Creation of the service account cannot be disabled.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,6 +38,10 @@ coder:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   labels: {}
 
+  # coder.podLabels -- The Coder pod labels. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podlabels: {}
+
   # coder.podAnnotations -- The Coder pod annotations. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -44,7 +44,7 @@ coder:
 
   # coder.podLabels -- The Coder pod labels. See:
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-  podlabels: {}
+  podLabels: {}
 
   # coder.serviceAccount -- Configuration for the automatically created service
   # account. Creation of the service account cannot be disabled.


### PR DESCRIPTION
adds support for labeling the coder pod via the existing `coder.labels`. @deansheather let me know if you think it's best to have a separate value from the deployment label.