### PR TITLE
chore: fix one broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ coder server --postgres-url <url> --access-url <url>
 
 > <sup>1</sup> For production deployments, set up an external PostgreSQL instance for reliability.
 
-Use `coder --help` to get a list of flags and environment variables. Use our [install guides](https://coder.com/docs/v2/latest/guides) for a full walkthrough.
+Use `coder --help` to get a list of flags and environment variables. Use our [install guides](https://coder.com/docs/v2/latest/install) for a full walkthrough.
 
 ## Documentation
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -88,7 +88,7 @@ an PostgreSQL container and volume.
 
 ### Docker-based workspace is stuck in "Connecting..."
 
-Ensure you have an externally-reachable `CODER_ACCESS_URL` set. See [troubleshooting templates](../templates.md#creating-and-troubleshooting-templates) for more steps.
+Ensure you have an externally-reachable `CODER_ACCESS_URL` set. See [troubleshooting templates](../templates/README.md#troubleshooting-templates) for more steps.
 
 ### Permission denied while trying to connect to the Docker daemon socket
 


### PR DESCRIPTION
Looks like there is just one. The JetBrains plugin site happens to be down: https://github.com/coder/coder/actions/runs/4701820219/jobs/8339114684