### PR TITLE
docs: fix a broken link in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,5 +104,5 @@ Azure, Google Cloud, Kubernetes, and more.
 
 ## Up next
 
-- Learn about [Templates](./templates.md)
+- Learn about [Templates](./templates/README.md)
 - [Install Coder](./install/install.sh.md)


### PR DESCRIPTION
This PR hopefully fixes the last broken link.
```console
FILE: docs/README.md
[✖] ./templates.md → Status: 400 [Error: ENOENT: no such file or directory, access '/github/workspace/docs/templates.md'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'access',
  path: '/github/workspace/docs/templates.md'
}

12 links checked.

ERROR: 1 dead links found!
[✖] ./templates.md → Status: 400
```