### PR TITLE
docs: display Coder packages in install docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -62,6 +62,11 @@
           "path": "./install/offline.md"
         },
         {
+          "title": "Coder packages",
+          "description": "Deploy Coder with a single command",
+          "path": "../../../packages/blob/main/README.md"
+        },
+        {
           "title": "External database",
           "description": "Use external PostgreSQL database",
           "path": "./install/database.md"


### PR DESCRIPTION
This will display https://github.com/coder/packages/blob/main/README.md on the docs installation page https://coder.com/docs/v2/latest/install.