### PR TITLE
test(coderd/rbac): Use static name for tests

### DIFF
--- a/coderd/rbac/roles_internal_test.go
+++ b/coderd/rbac/roles_internal_test.go
@@ -206,13 +206,13 @@ func TestRoleByName(t *testing.T) {
 			{Role: builtInRoles[userAdmin]("")},
 			{Role: builtInRoles[auditor]("")},
 
-			{Role: builtInRoles[orgAdmin](uuid.New().String())},
-			{Role: builtInRoles[orgAdmin](uuid.New().String())},
-			{Role: builtInRoles[orgAdmin](uuid.New().String())},
+			{Role: builtInRoles[orgAdmin]("4592dac5-0945-42fd-828d-a903957d3dbb")},
+			{Role: builtInRoles[orgAdmin]("24c100c5-1920-49c0-8c38-1b640ac4b38c")},
+			{Role: builtInRoles[orgAdmin]("4a00f697-0040-4079-b3ce-d24470281a62")},
 
-			{Role: builtInRoles[orgMember](uuid.New().String())},
-			{Role: builtInRoles[orgMember](uuid.New().String())},
-			{Role: builtInRoles[orgMember](uuid.New().String())},
+			{Role: builtInRoles[orgMember]("3293c50e-fa5d-414f-a461-01112a4dfb6f")},
+			{Role: builtInRoles[orgMember]("f88dd23d-bdbd-469d-b82e-36ee06c3d1e1")},
+			{Role: builtInRoles[orgMember]("02cfd2a5-016c-4d8d-8290-301f5f18023d")},
 		}
 
 		for _, c := range testCases {

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -356,7 +356,8 @@ func TestRolePermissions(t *testing.T) {
 
 func TestIsOrgRole(t *testing.T) {
 	t.Parallel()
-	randomUUID := uuid.New()
+	randomUUID, err := uuid.Parse("cad8c09d-c099-4ec7-9263-7d52b1a3997a")
+	require.NoError(t, err)
 
 	testCases := []struct {
 		RoleName string


### PR DESCRIPTION
These tests were spamming CI stats by using new names every time.
