### PR TITLE
test(cli): Add debugging to figure out why TestServerYAMLConfig fails

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1583,7 +1583,13 @@ func TestServerYAMLConfig(t *testing.T) {
 		return
 	}
 
+	wd1, _ := os.Getwd()
 	got, err := os.ReadFile(goldenPath)
+	wd2, _ := os.Getwd()
+	// Debugging to figure out why this test fails.
+	if err != nil {
+		t.Errorf("failed to read golden file: %v, wd1=%s, wd2=%s", err, wd1, wd2)
+	}
 	require.NoError(t, err)
 	got = normalizeGoldenFile(t, got)
 

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1587,6 +1587,7 @@ func TestServerYAMLConfig(t *testing.T) {
 	got, err := os.ReadFile(goldenPath)
 	wd2, _ := os.Getwd()
 	// Debugging to figure out why this test fails.
+	// https://github.com/coder/coder/pull/7158
 	if err != nil {
 		t.Errorf("failed to read golden file: %v, wd1=%s, wd2=%s", err, wd1, wd2)
 	}


### PR DESCRIPTION
Maybe we can narrow down the cause of this failure:

```
    server_test.go:1587: 
        	Error Trace:	/home/runner/work/coder/coder/cli/server_test.go:1587
        	Error:      	Received unexpected error:
        	            	open testdata/server-config.yaml.golden: no such file or directory
        	Test:       	TestServerYAMLConfig
```