### PR TITLE
test(cli): Fix TestTemplatePush/UseWorkingDir bad use of chdir

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -32,6 +32,17 @@ func (pf *templateUploadFlags) option() clibase.Option {
 	}
 }
 
+func (pf *templateUploadFlags) setWorkdir(wd string) {
+	if wd == "" {
+		return
+	}
+	if pf.directory == "" || pf.directory == "." {
+		pf.directory = wd
+	} else if !filepath.IsAbs(pf.directory) {
+		pf.directory = filepath.Join(wd, pf.directory)
+	}
+}
+
 func (pf *templateUploadFlags) stdin() bool {
 	return pf.directory == "-"
 }
@@ -98,6 +109,7 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 	var (
 		versionName     string
 		provisioner     string
+		workdir         string
 		parameterFile   string
 		variablesFile   string
 		variables       []string
@@ -114,6 +126,8 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 			r.InitClient(client),
 		),
 		Handler: func(inv *clibase.Invocation) error {
+			uploadFlags.setWorkdir(workdir)
+
 			organization, err := CurrentOrganization(inv, client)
 			if err != nil {
 				return err
@@ -174,11 +188,18 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 
 	cmd.Options = clibase.OptionSet{
 		{
-			Flag:          "test.provisioner",
-			FlagShorthand: "p",
-			Description:   "Customize the provisioner backend.",
-			Default:       "terraform",
-			Value:         clibase.StringOf(&provisioner),
+			Flag:        "test.provisioner",
+			Description: "Customize the provisioner backend.",
+			Default:     "terraform",
+			Value:       clibase.StringOf(&provisioner),
+			// This is for testing!
+			Hidden: true,
+		},
+		{
+			Flag:        "test.workdir",
+			Description: "Customize the working directory.",
+			Default:     "",
+			Value:       clibase.StringOf(&workdir),
 			// This is for testing!
 			Hidden: true,
 		},

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -159,6 +159,8 @@ func TestTemplatePush(t *testing.T) {
 	// This test modifies the working directory.
 	//nolint:paralleltest
 	t.Run("UseWorkingDir", func(t *testing.T) {
+		t.Parallel()
+
 		if runtime.GOOS == "windows" {
 			t.Skip(`On Windows this test flakes with: "The process cannot access the file because it is being used by another process"`)
 		}
@@ -179,15 +181,9 @@ func TestTemplatePush(t *testing.T) {
 				r.Name = filepath.Base(source)
 			})
 
-		oldDir, err := os.Getwd()
-		require.NoError(t, err)
-
-		os.Chdir(source)
-		defer os.Chdir(oldDir)
-
 		// Don't pass the name of the template, it should use the
 		// directory of the source.
-		inv, root := clitest.New(t, "templates", "push", "--test.provisioner", string(database.ProvisionerTypeEcho))
+		inv, root := clitest.New(t, "templates", "push", "--test.provisioner", string(database.ProvisionerTypeEcho), "--test.workdir", source)
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
 


### PR DESCRIPTION
Closes #7158

Fixes:

```
    server_test.go:1587: 
        	Error Trace:	/home/runner/work/coder/coder/cli/server_test.go:1587
        	Error:      	Received unexpected error:
        	            	open testdata/server-config.yaml.golden: no such file or directory
        	Test:       	TestServerYAMLConfig
```

As confirmed by:

```
    server_test.go:1592: failed to read golden file: open testdata/server-config.yaml.golden: no such file or directory, wd1=/tmp/TestTemplatePushUseWorkingDir1366428197/003, wd2=/tmp/TestTemplatePushUseWorkingDir1366428197/003
```
