### PR TITLE
fix(healthcheck): remove `t.Parallel()` from healthcheck tests

### DIFF
--- a/coderd/healthcheck/derp_test.go
+++ b/coderd/healthcheck/derp_test.go
@@ -21,8 +21,11 @@ import (
 	"github.com/coder/coder/tailnet"
 )
 
+//nolint:tparallel
 func TestDERP(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping healthcheck test in short mode, they reach out over the network.")
+	}
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
These seem to sometimes fail under load, so don't run them in parallel with other tests.