### PR TITLE
feat(agent): Expose magicsock metrics

### DIFF
--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -15,6 +15,9 @@ Starts the Coder workspace agent.
       --pprof-address string, $CODER_AGENT_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The address to serve pprof.
 
+      --prometheus-address string, $CODER_AGENT_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
+          The bind address to serve Prometheus metrics.
+
       --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 0)
           Specify the max timeout for a SSH connection.
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6724

This PR enables _magicsock_ metrics from `wgengine` via the agent internal endpoint. They might be useful for investigating network connectivity issues. 

I collected these metrics by randomly playing with `ping`, `scaletest`, `reconnectingpty`, and `code-server`.
```
$ curl -s localhost:2112 | grep -v " 0" | grep -v TYPE
magicsock_disco_recv_bad_peer 1
magicsock_disco_recv_callmemaybe 10
magicsock_disco_recv_derp 39
magicsock_disco_recv_ping 370
magicsock_disco_recv_pong 143
magicsock_disco_recv_udp 484
magicsock_disco_send_derp 32
magicsock_disco_send_udp 494
magicsock_disco_sent_callmemaybe 3
magicsock_disco_sent_derp 32
magicsock_disco_sent_ping 153
magicsock_disco_sent_pong 370
magicsock_disco_sent_udp 494
magicsock_netmap_num_peers 3
magicsock_num_derp_conns 1
magicsock_recv_data_derp 4
magicsock_recv_data_ipv4 4675
magicsock_restun_calls 12
magicsock_send_data 6025
magicsock_send_derp 34
magicsock_send_derp_queued 34
magicsock_send_udp 494
magicsock_update_endpoints 12
netcheck_report 11
netcheck_report_full 2
netcheck_stun_recv_ipv4 13
netcheck_stun_send_ipv4 13
portmap_pcp_sent 11
portmap_pmp_sent 11
portmap_upnp_sent 11
tstun_in_from_wg 4668
tstun_in_from_wg_drop 4668
tstun_out_to_wg 6018
```