### PR TITLE
fix(cli): Fix postgres TDE failing version check

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1754,7 +1754,7 @@ func connectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 	}
 	_ = version.Close()
 
-	if versionNum >= 130000 {
+	if versionNum < 130000 {
 		return nil, xerrors.New("PostgreSQL version must be v13.0.0 or higher!")
 	}
 	logger.Debug(ctx, "connected to postgresql", slog.F("version", versionNum))

--- a/cli/server.go
+++ b/cli/server.go
@@ -1753,7 +1753,7 @@ func connectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 		return nil, xerrors.Errorf("scan version: %w", err)
 	}
 	_ = version.Close()
-	
+
 	if versionNum >= 130000 {
 		return nil, xerrors.New("PostgreSQL version must be v13.0.0 or higher!")
 	}

--- a/cli/server.go
+++ b/cli/server.go
@@ -1755,7 +1755,7 @@ func connectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 	_ = version.Close()
 
 	if versionNum < 130000 {
-		return nil, xerrors.New("PostgreSQL version must be v13.0.0 or higher!")
+		return nil, xerrors.Errorf("PostgreSQL version must be v13.0.0 or higher! Got: %d", versionNum)
 	}
 	logger.Debug(ctx, "connected to postgresql", slog.F("version", versionNum))
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -1740,24 +1740,24 @@ func connectToPostgres(ctx context.Context, logger slog.Logger, driver string, d
 	}
 
 	// Ensure the PostgreSQL version is >=13.0.0!
-	version, err := sqlDB.QueryContext(ctx, "SHOW server_version;")
+	version, err := sqlDB.QueryContext(ctx, "SHOW server_version_num;")
 	if err != nil {
 		return nil, xerrors.Errorf("get postgres version: %w", err)
 	}
 	if !version.Next() {
 		return nil, xerrors.Errorf("no rows returned for version select")
 	}
-	var versionStr string
-	err = version.Scan(&versionStr)
+	var versionNum int
+	err = version.Scan(&versionNum)
 	if err != nil {
 		return nil, xerrors.Errorf("scan version: %w", err)
 	}
 	_ = version.Close()
-	versionStr = strings.Split(versionStr, " ")[0]
-	if semver.Compare("v"+versionStr, "v13") < 0 {
+	
+	if versionNum >= 130000 {
 		return nil, xerrors.New("PostgreSQL version must be v13.0.0 or higher!")
 	}
-	logger.Debug(ctx, "connected to postgresql", slog.F("version", versionStr))
+	logger.Debug(ctx, "connected to postgresql", slog.F("version", versionNum))
 
 	err = migrations.Up(sqlDB)
 	if err != nil {


### PR DESCRIPTION
Hi,

I am running postgres 13 TDE and ran into the issue coder reporting the version is not v13 or higher.

After a bit of investigating I noticed coder uses "SHOW server_version".
Unfortunately the postgres TDE build reports it version other than a normal postgres build.
Postgres 13 TDE: "13.10_TDE_1.0.5 (Ubuntu.....)"
Postgres 12: "12.13 (Ubuntu...)"

In cli/server.go the version check splits at the space and proceeds to compare it with semver, which does not seem to like the additional content.

I addressed this by changing the server_version to server_version_num, as this is a number and the TDE information is not present. This also simplifies the comparison of the versions.
