### PR TITLE
chore: remove disk metadata from Kubernetes examples

### DIFF
--- a/examples/templates/kubernetes-with-podman/main.tf
+++ b/examples/templates/kubernetes-with-podman/main.tf
@@ -95,17 +95,6 @@ resource "coder_agent" "dev" {
     podman ps
   EOF
 
-  metadata {
-    key          = "disk"
-    display_name = "Disk Usage"
-    interval     = 600 # every 10 minutes
-    timeout      = 30  # df can take a while on large filesystems
-    script       = <<-EOT
-      #!/bin/bash
-      set -e
-      df /home/podman | awk '$NF=="/"{printf "%s", $5}'
-    EOT
-  }
 }
 
 # code-server

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -118,17 +118,6 @@ resource "coder_agent" "main" {
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 
-  metadata {
-    key          = "disk"
-    display_name = "Disk Usage"
-    interval     = 600 # every 10 minutes
-    timeout      = 30  # df can take a while on large filesystems
-    script       = <<-EOT
-      #!/bin/bash
-      set -e
-      df /home/coder | awk '$NF=="/"{printf "%s", $5}'
-    EOT
-  }
 }
 
 # code-server


### PR DESCRIPTION
This was not working as expected, and until we get something like #6938 let's remove this metadata.