### PR TITLE
fix(enterprise/replicasync): Avoid deadlock during Close

### DIFF
--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -216,6 +216,12 @@ func (m *Manager) subscribe(ctx context.Context) error {
 
 func (m *Manager) syncReplicas(ctx context.Context) error {
 	m.closeMutex.Lock()
+	select {
+	case <-m.closed:
+		m.closeMutex.Unlock()
+		return xerrors.New("manager is closed")
+	default:
+	}
 	m.closeWait.Add(1)
 	m.closeMutex.Unlock()
 	defer m.closeWait.Done()


### PR DESCRIPTION
After we fixed fakedb, we still had deadlocks which were pointing towards replicasync.

We now avoid starting a new sync after close.

https://github.com/coder/coder/actions/runs/4753933653/jobs/8446129663
