### PR TITLE
test: Fix generated workspace name length

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1069,7 +1069,12 @@ func NewAzureInstanceIdentity(t *testing.T, instanceID string) (x509.VerifyOptio
 func randomUsername(t testing.TB) string {
 	suffix, err := cryptorand.String(3)
 	require.NoError(t, err)
-	return strings.ReplaceAll(namesgenerator.GetRandomName(10), "_", "-") + "-" + suffix
+	suffix = "-" + suffix
+	n := strings.ReplaceAll(namesgenerator.GetRandomName(10), "_", "-") + suffix
+	if len(n) > 32 {
+		n = n[:32-len(suffix)] + suffix
+	}
+	return n
 }
 
 // Used to easily create an HTTP transport!

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -106,6 +106,9 @@ func TestWorkspace(t *testing.T) {
 		defer cancel()
 
 		want := ws1.Name + "-test"
+		if len(want) > 32 {
+			want = want[:32-5] + "-test"
+		}
 		err := client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
 			Name: want,
 		})


### PR DESCRIPTION
A recent change to add randomness was causing some rare test flakes due to our 32 character (user)name limit.

https://github.com/coder/coder/actions/runs/4756915278/jobs/8453103590
