### PR TITLE
fix(enterprise/replicasync): Avoid deadlock during Close^2

### DIFF
--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -371,8 +371,8 @@ func (m *Manager) Close() error {
 	}
 	close(m.closed)
 	m.closeCancel()
-	m.closeWait.Wait()
 	m.closeMutex.Unlock()
+	m.closeWait.Wait()
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
The fix in https://github.com/coder/coder/pull/7220 was incomplete since we still did the wg.Wait whilst holding the lock.
