### PR TITLE
test: Fix test timeouts due to contexts created too early

### DIFF
--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -572,8 +572,7 @@ func TestWorkspaceBuildState(t *testing.T) {
 
 func TestWorkspaceBuildStatus(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-	defer cancel()
+
 	auditor := audit.NewMock()
 	numLogs := len(auditor.AuditLogs())
 	client, closeDaemon, api := coderdtest.NewWithAPI(t, &coderdtest.Options{IncludeProvisionerDaemon: true, Auditor: auditor})
@@ -597,6 +596,10 @@ func TestWorkspaceBuildStatus(t *testing.T) {
 	closeDaemon = coderdtest.NewProvisionerDaemon(t, api)
 	// after successful build is "running"
 	_ = coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
 	workspace, err := client.Workspace(ctx, workspace.ID)
 	require.NoError(t, err)
 	require.EqualValues(t, codersdk.WorkspaceStatusRunning, workspace.LatestBuild.Status)

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -980,7 +980,6 @@ func TestReadFileWithTemplateUpdate(t *testing.T) {
 	t.Parallel()
 	t.Run("HasTemplateUpdate", func(t *testing.T) {
 		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitMedium)
 
 		// Upload a file
 		client := coderdenttest.New(t, nil)
@@ -990,6 +989,8 @@ func TestReadFileWithTemplateUpdate(t *testing.T) {
 				codersdk.FeatureTemplateRBAC: 1,
 			},
 		})
+
+		ctx := testutil.Context(t, testutil.WaitLong)
 
 		resp, err := client.Upload(ctx, codersdk.ContentTypeTar, bytes.NewReader(make([]byte, 1024)))
 		require.NoError(t, err)


### PR DESCRIPTION
We shouldn't create/start contexts before test setup is complete (i.e. before they're needed).

Can we lint this? Like if something is between ctx and use of ctx (except defer cancel), then error?