### PR TITLE
ci: disable caching in setup/go action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
       # Install Go!
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "~1.20"
 
       # Check for any typos!
@@ -152,6 +153,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "~1.20"
 
       - name: Echo Go Cache Paths
@@ -252,6 +254,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "~1.20"
 
       - name: Echo Go Cache Paths
@@ -339,6 +342,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "~1.20"
 
       - name: Echo Go Cache Paths
@@ -429,6 +433,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "~1.20"
 
       - name: Echo Go Cache Paths
@@ -558,6 +563,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "~1.20"
 
       - uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
       # Install Go!
       - uses: actions/setup-go@v4
         with:
-          cache: false
           go-version: "~1.20"
 
       # Check for any typos!


### PR DESCRIPTION
We already have our own caching and `actions/go` is significantly slower
![image](https://user-images.githubusercontent.com/6332295/233697485-58a083fa-7987-4826-a87a-8b61448fa43d.png)
