### PR TITLE
fix(coderd): ensure that user API keys are deleted when a user is

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -129,6 +129,34 @@ CREATE TYPE workspace_transition AS ENUM (
     'delete'
 );
 
+CREATE FUNCTION delete_deleted_user_api_keys() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+BEGIN
+	IF (NEW.deleted) THEN
+		DELETE FROM api_keys
+		WHERE user_id = OLD.id;
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION insert_apikey_fail_if_user_deleted() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+
+DECLARE
+BEGIN
+	IF (NEW.user_id IS NOT NULL) THEN
+		IF (SELECT deleted FROM users WHERE id = NEW.user_id LIMIT 1) THEN
+			RAISE EXCEPTION 'Cannot create API key for deleted user';
+		END IF;
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
 CREATE TABLE api_keys (
     id text NOT NULL,
     hashed_secret bytea NOT NULL,
@@ -894,6 +922,10 @@ CREATE UNIQUE INDEX workspace_proxies_lower_name_idx ON workspace_proxies USING 
 CREATE INDEX workspace_resources_job_id_idx ON workspace_resources USING btree (job_id);
 
 CREATE UNIQUE INDEX workspaces_owner_id_lower_idx ON workspaces USING btree (owner_id, lower((name)::text)) WHERE (deleted = false);
+
+CREATE TRIGGER trigger_insert_apikeys BEFORE INSERT ON api_keys FOR EACH ROW EXECUTE FUNCTION insert_apikey_fail_if_user_deleted();
+
+CREATE TRIGGER trigger_update_users AFTER INSERT OR UPDATE ON users FOR EACH ROW WHEN ((new.deleted = true)) EXECUTE FUNCTION delete_deleted_user_api_keys();
 
 ALTER TABLE ONLY api_keys
     ADD CONSTRAINT api_keys_user_id_uuid_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/coderd/database/migrations/000120_trigger_delete_user_apikey.down.sql
+++ b/coderd/database/migrations/000120_trigger_delete_user_apikey.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP TRIGGER IF EXISTS trigger_update_users ON users;
+DROP FUNCTION IF EXISTS delete_deleted_user_api_keys;
+
+DROP TRIGGER IF EXISTS trigger_insert_apikeys ON api_keys;
+DROP FUNCTION IF EXISTS insert_apikey_fail_if_user_deleted;
+
+COMMIT;

--- a/coderd/database/migrations/000120_trigger_delete_user_apikey.up.sql
+++ b/coderd/database/migrations/000120_trigger_delete_user_apikey.up.sql
@@ -1,0 +1,55 @@
+BEGIN;
+
+-- We need to delete all existing API keys for soft-deleted users.
+DELETE FROM
+	api_keys
+WHERE
+	user_id
+IN (
+	SELECT id FROM users WHERE deleted
+);
+
+
+-- When we soft-delete a user, we also want to delete their API key.
+CREATE FUNCTION delete_deleted_user_api_keys() RETURNS trigger
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+BEGIN
+	IF (NEW.deleted) THEN
+		DELETE FROM api_keys
+		WHERE user_id = OLD.id;
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+
+CREATE TRIGGER trigger_update_users
+AFTER INSERT OR UPDATE ON users
+FOR EACH ROW
+WHEN (NEW.deleted = true)
+EXECUTE PROCEDURE delete_deleted_user_api_keys();
+
+-- When we insert a new api key, we want to fail if the user is soft-deleted.
+CREATE FUNCTION insert_apikey_fail_if_user_deleted() RETURNS trigger
+	LANGUAGE plpgsql
+	AS $$
+
+DECLARE
+BEGIN
+	IF (NEW.user_id IS NOT NULL) THEN
+		IF (SELECT deleted FROM users WHERE id = NEW.user_id LIMIT 1) THEN
+			RAISE EXCEPTION 'Cannot create API key for deleted user';
+		END IF;
+	END IF;
+	RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trigger_insert_apikeys
+BEFORE INSERT ON api_keys
+FOR EACH ROW
+EXECUTE PROCEDURE insert_apikey_fail_if_user_deleted();
+
+COMMIT;


### PR DESCRIPTION
Fixes an issue where API tokens belonging to a deleted user were not invalidated:
- Adds a trigger to delete rows from the api_key stable when the column deleted is set to true in the users table.
- Adds a trigger to the api_keys table to ensure that new rows may not be added where user_id corresponds to a deleted user.
- Adds a migration to delete all API keys from deleted users.
- Adds tests + dbfake implementation for the above.