### PR TITLE
feat: add regions endpoint for proxies feature

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1727,6 +1727,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/regions": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceProxies"
+                ],
+                "summary": "Get site-wide regions for workspace connections",
+                "operationId": "get-site-wide-regions-for-workspace-connections",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.RegionsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/replicas": {
             "get": {
                 "security": [
@@ -8313,6 +8338,46 @@ const docTemplate = `{
                 },
                 "disable_all": {
                     "type": "boolean"
+                }
+            }
+        },
+        "codersdk.Region": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "icon_url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "path_app_url": {
+                    "description": "PathAppURL is the URL to the base path for path apps. Optional\nunless wildcard_hostname is set.\nE.g. https://us.example.com",
+                    "type": "string"
+                },
+                "wildcard_hostname": {
+                    "description": "WildcardHostname is the wildcard hostname for subdomain apps.\nE.g. *.us.example.com\nE.g. *--suffix.au.example.com\nOptional. Does not need to be on the same domain as PathAppURL.",
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.RegionsResponse": {
+            "type": "object",
+            "properties": {
+                "regions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.Region"
+                    }
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1501,6 +1501,27 @@
         }
       }
     },
+    "/regions": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["WorkspaceProxies"],
+        "summary": "Get site-wide regions for workspace connections",
+        "operationId": "get-site-wide-regions-for-workspace-connections",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/codersdk.RegionsResponse"
+            }
+          }
+        }
+      }
+    },
     "/replicas": {
       "get": {
         "security": [
@@ -7452,6 +7473,46 @@
         },
         "disable_all": {
           "type": "boolean"
+        }
+      }
+    },
+    "codersdk.Region": {
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "type": "string"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "icon_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path_app_url": {
+          "description": "PathAppURL is the URL to the base path for path apps. Optional\nunless wildcard_hostname is set.\nE.g. https://us.example.com",
+          "type": "string"
+        },
+        "wildcard_hostname": {
+          "description": "WildcardHostname is the wildcard hostname for subdomain apps.\nE.g. *.us.example.com\nE.g. *--suffix.au.example.com\nOptional. Does not need to be on the same domain as PathAppURL.",
+          "type": "string"
+        }
+      }
+    },
+    "codersdk.RegionsResponse": {
+      "type": "object",
+      "properties": {
+        "regions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.Region"
+          }
         }
       }
     },

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -461,6 +461,11 @@ func New(options *Options) *API {
 		r.Post("/csp/reports", api.logReportCSPViolations)
 
 		r.Get("/buildinfo", buildInfo(api.AccessURL))
+		// /regions is overridden in the enterprise version
+		r.Group(func(r chi.Router) {
+			r.Use(apiKeyMiddleware)
+			r.Get("/regions", api.regions)
+		})
 		r.Route("/deployment", func(r chi.Router) {
 			r.Use(apiKeyMiddleware)
 			r.Get("/config", api.deploymentValues)

--- a/coderd/workspaceproxies.go
+++ b/coderd/workspaceproxies.go
@@ -1,0 +1,67 @@
+package coderd
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/coderd/database/dbauthz"
+	"github.com/coder/coder/coderd/httpapi"
+	"github.com/coder/coder/codersdk"
+)
+
+func (api *API) PrimaryRegion(ctx context.Context) (codersdk.Region, error) {
+	deploymentIDStr, err := api.Database.GetDeploymentID(ctx)
+	if xerrors.Is(err, sql.ErrNoRows) {
+		// This shouldn't happen but it's pretty easy to avoid this causing
+		// issues by falling back to a nil UUID.
+		deploymentIDStr = uuid.Nil.String()
+	} else if err != nil {
+		return codersdk.Region{}, xerrors.Errorf("get deployment ID: %w", err)
+	}
+	deploymentID, err := uuid.Parse(deploymentIDStr)
+	if err != nil {
+		// This also shouldn't happen but we fallback to nil UUID.
+		deploymentID = uuid.Nil
+	}
+
+	return codersdk.Region{
+		ID: deploymentID,
+		// TODO: provide some way to customize these fields for the primary
+		// region
+		Name:             "primary",
+		DisplayName:      "Default",
+		IconURL:          "/emojis/1f60e.png", // face with sunglasses
+		Healthy:          true,
+		PathAppURL:       api.AccessURL.String(),
+		WildcardHostname: api.AppHostname,
+	}, nil
+}
+
+// @Summary Get site-wide regions for workspace connections
+// @ID get-site-wide-regions-for-workspace-connections
+// @Security CoderSessionToken
+// @Produce json
+// @Tags WorkspaceProxies
+// @Success 200 {object} codersdk.RegionsResponse
+// @Router /regions [get]
+func (api *API) regions(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	//nolint:gocritic // this route intentionally requests resources that users
+	// cannot usually access in order to give them a full list of available
+	// regions.
+	ctx = dbauthz.AsSystemRestricted(ctx)
+
+	region, err := api.PrimaryRegion(ctx)
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.RegionsResponse{
+		Regions: []codersdk.Region{region},
+	})
+}

--- a/coderd/workspaceproxies_test.go
+++ b/coderd/workspaceproxies_test.go
@@ -1,0 +1,67 @@
+package coderd_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/coderd/database/dbtestutil"
+	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/testutil"
+)
+
+func TestRegions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		const appHostname = "*.apps.coder.test"
+
+		db, pubsub := dbtestutil.NewDB(t)
+		deploymentID := uuid.New()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		err := db.InsertDeploymentID(ctx, deploymentID.String())
+		require.NoError(t, err)
+
+		client := coderdtest.New(t, &coderdtest.Options{
+			AppHostname: appHostname,
+			Database:    db,
+			Pubsub:      pubsub,
+		})
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		regions, err := client.Regions(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, regions, 1)
+		require.NotEqual(t, uuid.Nil, regions[0].ID)
+		require.Equal(t, regions[0].ID, deploymentID)
+		require.Equal(t, "primary", regions[0].Name)
+		require.Equal(t, "Default", regions[0].DisplayName)
+		require.NotEmpty(t, regions[0].IconURL)
+		require.True(t, regions[0].Healthy)
+		require.Equal(t, client.URL.String(), regions[0].PathAppURL)
+		require.Equal(t, appHostname, regions[0].WildcardHostname)
+
+		// Ensure the primary region ID is constant.
+		regions2, err := client.Regions(ctx)
+		require.NoError(t, err)
+		require.Equal(t, regions[0].ID, regions2[0].ID)
+	})
+
+	t.Run("RequireAuth", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		unauthedClient := codersdk.New(client.URL)
+		regions, err := unauthedClient.Regions(ctx)
+		require.Error(t, err)
+		require.Empty(t, regions)
+	})
+}

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3480,6 +3480,56 @@ Parameter represents a set value for the scope.
 | `api`         | integer | false    |              |             |
 | `disable_all` | boolean | false    |              |             |
 
+## codersdk.Region
+
+```json
+{
+  "display_name": "string",
+  "healthy": true,
+  "icon_url": "string",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "name": "string",
+  "path_app_url": "string",
+  "wildcard_hostname": "string"
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description                                                                                                                                                                        |
+| ------------------- | ------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `display_name`      | string  | false    |              |                                                                                                                                                                                    |
+| `healthy`           | boolean | false    |              |                                                                                                                                                                                    |
+| `icon_url`          | string  | false    |              |                                                                                                                                                                                    |
+| `id`                | string  | false    |              |                                                                                                                                                                                    |
+| `name`              | string  | false    |              |                                                                                                                                                                                    |
+| `path_app_url`      | string  | false    |              | Path app URL is the URL to the base path for path apps. Optional unless wildcard_hostname is set. E.g. https://us.example.com                                                      |
+| `wildcard_hostname` | string  | false    |              | Wildcard hostname is the wildcard hostname for subdomain apps. E.g. _.us.example.com E.g. _--suffix.au.example.com Optional. Does not need to be on the same domain as PathAppURL. |
+
+## codersdk.RegionsResponse
+
+```json
+{
+  "regions": [
+    {
+      "display_name": "string",
+      "healthy": true,
+      "icon_url": "string",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "name": "string",
+      "path_app_url": "string",
+      "wildcard_hostname": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name      | Type                                        | Required | Restrictions | Description |
+| --------- | ------------------------------------------- | -------- | ------------ | ----------- |
+| `regions` | array of [codersdk.Region](#codersdkregion) | false    |              |             |
+
 ## codersdk.Replica
 
 ```json

--- a/docs/api/workspaceproxies.md
+++ b/docs/api/workspaceproxies.md
@@ -1,0 +1,42 @@
+# WorkspaceProxies
+
+## Get site-wide regions for workspace connections
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/regions \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /regions`
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "regions": [
+    {
+      "display_name": "string",
+      "healthy": true,
+      "icon_url": "string",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "name": "string",
+      "path_app_url": "string",
+      "wildcard_hostname": "string"
+    }
+  ]
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                         |
+| ------ | ------------------------------------------------------- | ----------- | -------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.RegionsResponse](schemas.md#codersdkregionsresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -467,6 +467,10 @@
           "path": "./api/users.md"
         },
         {
+          "title": "WorkspaceProxies",
+          "path": "./api/workspaceproxies.md"
+        },
+        {
           "title": "Workspaces",
           "path": "./api/workspaces.md"
         }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -707,6 +707,22 @@ export interface RateLimitConfig {
   readonly api: number
 }
 
+// From codersdk/workspaceproxy.go
+export interface Region {
+  readonly id: string
+  readonly name: string
+  readonly display_name: string
+  readonly icon_url: string
+  readonly healthy: boolean
+  readonly path_app_url: string
+  readonly wildcard_hostname: string
+}
+
+// From codersdk/workspaceproxy.go
+export interface RegionsResponse {
+  readonly regions: Region[]
+}
+
 // From codersdk/replicas.go
 export interface Replica {
   readonly id: string


### PR DESCRIPTION
Adds `/api/v2/regions` which returns a list of regions that clients may use when connecting to workspaces.

In AGPL, this endpoint only returns the primary region. In enterprise, the route is overridden in the router and returns the primary region + any workspace proxies.