### PR TITLE
fix: Reconnecting PTY waits for command output or EOF

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1036,12 +1036,9 @@ func (a *agent) handleReconnectingPTY(ctx context.Context, logger slog.Logger, m
 			<-ctx.Done()
 			_ = process.Kill()
 		}()
-		go func() {
-			// If the process dies randomly, we should
-			// close the pty.
-			_ = process.Wait()
-			rpty.Close()
-		}()
+		// We don't need to separately monitor for the process exiting.
+		// When it exits, our ptty.OutputReader() will return EOF after
+		// reading all process output.
 		if err = a.trackConnGoroutine(func() {
 			buffer := make([]byte, 1024)
 			for {


### PR DESCRIPTION
Missed this PTY handling in ReconnectingPTY --- simplifying a la our SSH handling.

This should fix (some of) the intermittent failures we're seeing on main.