### PR TITLE
chore: fix flake in apptest reconnecting-pty test

### DIFF
--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -385,32 +385,55 @@ func (c *Client) IssueReconnectingPTYSignedToken(ctx context.Context, req IssueR
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
+// @typescript-ignore:WorkspaceAgentReconnectingPTYOpts
+type WorkspaceAgentReconnectingPTYOpts struct {
+	AgentID   uuid.UUID
+	Reconnect uuid.UUID
+	Width     uint16
+	Height    uint16
+	Command   string
+
+	// SignedToken is an optional signed token from the
+	// issue-reconnecting-pty-signed-token endpoint. If set, the session token
+	// on the client will not be sent.
+	SignedToken string
+}
+
 // WorkspaceAgentReconnectingPTY spawns a PTY that reconnects using the token provided.
 // It communicates using `agent.ReconnectingPTYRequest` marshaled as JSON.
 // Responses are PTY output that can be rendered.
-func (c *Client) WorkspaceAgentReconnectingPTY(ctx context.Context, agentID, reconnect uuid.UUID, height, width uint16, command string) (net.Conn, error) {
-	serverURL, err := c.URL.Parse(fmt.Sprintf("/api/v2/workspaceagents/%s/pty", agentID))
+func (c *Client) WorkspaceAgentReconnectingPTY(ctx context.Context, opts WorkspaceAgentReconnectingPTYOpts) (net.Conn, error) {
+	serverURL, err := c.URL.Parse(fmt.Sprintf("/api/v2/workspaceagents/%s/pty", opts.AgentID))
 	if err != nil {
 		return nil, xerrors.Errorf("parse url: %w", err)
 	}
 	q := serverURL.Query()
-	q.Set("reconnect", reconnect.String())
-	q.Set("height", strconv.Itoa(int(height)))
-	q.Set("width", strconv.Itoa(int(width)))
-	q.Set("command", command)
+	q.Set("reconnect", opts.Reconnect.String())
+	q.Set("width", strconv.Itoa(int(opts.Width)))
+	q.Set("height", strconv.Itoa(int(opts.Height)))
+	q.Set("command", opts.Command)
+	// If we're using a signed token, set the query parameter.
+	if opts.SignedToken != "" {
+		q.Set(SignedAppTokenQueryParameter, opts.SignedToken)
+	}
 	serverURL.RawQuery = q.Encode()
 
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		return nil, xerrors.Errorf("create cookie jar: %w", err)
-	}
-	jar.SetCookies(serverURL, []*http.Cookie{{
-		Name:  SessionTokenCookie,
-		Value: c.SessionToken(),
-	}})
-	httpClient := &http.Client{
-		Jar:       jar,
-		Transport: c.HTTPClient.Transport,
+	// If we're not using a signed token, we need to set the session token as a
+	// cookie.
+	httpClient := c.HTTPClient
+	if opts.SignedToken == "" {
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			return nil, xerrors.Errorf("create cookie jar: %w", err)
+		}
+		jar.SetCookies(serverURL, []*http.Cookie{{
+			Name:  SessionTokenCookie,
+			Value: c.SessionToken(),
+		}})
+		httpClient = &http.Client{
+			Jar:       jar,
+			Transport: c.HTTPClient.Transport,
+		}
 	}
 	conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
 		HTTPClient: httpClient,

--- a/scaletest/reconnectingpty/run.go
+++ b/scaletest/reconnectingpty/run.go
@@ -64,7 +64,13 @@ func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) error {
 	_, _ = fmt.Fprintf(logs, "\tHeight:  %d\n", height)
 	_, _ = fmt.Fprintf(logs, "\tCommand: %q\n\n", r.cfg.Init.Command)
 
-	conn, err := r.client.WorkspaceAgentReconnectingPTY(ctx, r.cfg.AgentID, id, width, height, r.cfg.Init.Command)
+	conn, err := r.client.WorkspaceAgentReconnectingPTY(ctx, codersdk.WorkspaceAgentReconnectingPTYOpts{
+		AgentID:   r.cfg.AgentID,
+		Reconnect: id,
+		Width:     width,
+		Height:    height,
+		Command:   r.cfg.Init.Command,
+	})
 	if err != nil {
 		return xerrors.Errorf("open reconnecting PTY: %w", err)
 	}


### PR DESCRIPTION
Makes the tests identical because the other ones work. I had to change the codersdk methods a bit to accomplish this.

https://github.com/coder/coder/actions/runs/4786259967/jobs/8510272554