### PR TITLE
fix: keep "workspace create" form when rendering errors

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -149,73 +149,68 @@ export const CreateWorkspacePageView: FC<
     return <Loader />
   }
 
-  if (props.hasTemplateErrors) {
-    return (
-      <Stack>
-        {Boolean(
-          props.createWorkspaceErrors[
-            CreateWorkspaceErrors.GET_TEMPLATES_ERROR
-          ],
-        ) && (
-          <AlertBanner
-            severity="error"
-            error={
-              props.createWorkspaceErrors[
-                CreateWorkspaceErrors.GET_TEMPLATES_ERROR
-              ]
-            }
-          />
-        )}
-        {Boolean(
-          props.createWorkspaceErrors[
-            CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
-          ],
-        ) && (
-          <AlertBanner
-            severity="error"
-            error={
-              props.createWorkspaceErrors[
-                CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
-              ]
-            }
-          />
-        )}
-        {Boolean(
-          props.createWorkspaceErrors[
-            CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
-          ],
-        ) && (
-          <AlertBanner
-            severity="error"
-            error={
-              props.createWorkspaceErrors[
-                CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
-              ]
-            }
-          />
-        )}
-      </Stack>
-    )
-  }
-
-  if (
-    props.createWorkspaceErrors[CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR]
-  ) {
-    return (
-      <AlertBanner
-        severity="error"
-        error={
-          props.createWorkspaceErrors[
-            CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR
-          ]
-        }
-      />
-    )
-  }
-
   return (
     <FullPageHorizontalForm title="New workspace" onCancel={props.onCancel}>
+
       <HorizontalForm onSubmit={form.handleSubmit}>
+
+        {Boolean(props.hasTemplateErrors) && (<Stack>
+          {Boolean(
+            props.createWorkspaceErrors[
+            CreateWorkspaceErrors.GET_TEMPLATES_ERROR
+            ],
+          ) && (
+              <AlertBanner
+                severity="error"
+                error={
+                  props.createWorkspaceErrors[
+                  CreateWorkspaceErrors.GET_TEMPLATES_ERROR
+                  ]
+                }
+              />
+            )}
+          {Boolean(
+            props.createWorkspaceErrors[
+            CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
+            ],
+          ) && (
+              <AlertBanner
+                severity="error"
+                error={
+                  props.createWorkspaceErrors[
+                  CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
+                  ]
+                }
+              />
+            )}
+          {Boolean(
+            props.createWorkspaceErrors[
+            CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
+            ],
+          ) && (
+              <AlertBanner
+                severity="error"
+                error={
+                  props.createWorkspaceErrors[
+                  CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
+                  ]
+                }
+              />
+            )}
+        </Stack>
+        )}
+
+        {Boolean(props.createWorkspaceErrors[CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR]) && (
+          <AlertBanner
+            severity="error"
+            error={
+              props.createWorkspaceErrors[
+              CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR
+              ]
+            }
+          />
+        )}
+
         {/* General info */}
         <FormSection
           title="General info"

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -151,61 +151,64 @@ export const CreateWorkspacePageView: FC<
 
   return (
     <FullPageHorizontalForm title="New workspace" onCancel={props.onCancel}>
-
       <HorizontalForm onSubmit={form.handleSubmit}>
-
-        {Boolean(props.hasTemplateErrors) && (<Stack>
-          {Boolean(
-            props.createWorkspaceErrors[
-            CreateWorkspaceErrors.GET_TEMPLATES_ERROR
-            ],
-          ) && (
+        {Boolean(props.hasTemplateErrors) && (
+          <Stack>
+            {Boolean(
+              props.createWorkspaceErrors[
+                CreateWorkspaceErrors.GET_TEMPLATES_ERROR
+              ],
+            ) && (
               <AlertBanner
                 severity="error"
                 error={
                   props.createWorkspaceErrors[
-                  CreateWorkspaceErrors.GET_TEMPLATES_ERROR
+                    CreateWorkspaceErrors.GET_TEMPLATES_ERROR
                   ]
                 }
               />
             )}
-          {Boolean(
-            props.createWorkspaceErrors[
-            CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
-            ],
-          ) && (
+            {Boolean(
+              props.createWorkspaceErrors[
+                CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
+              ],
+            ) && (
               <AlertBanner
                 severity="error"
                 error={
                   props.createWorkspaceErrors[
-                  CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
+                    CreateWorkspaceErrors.GET_TEMPLATE_SCHEMA_ERROR
                   ]
                 }
               />
             )}
-          {Boolean(
-            props.createWorkspaceErrors[
-            CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
-            ],
-          ) && (
+            {Boolean(
+              props.createWorkspaceErrors[
+                CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
+              ],
+            ) && (
               <AlertBanner
                 severity="error"
                 error={
                   props.createWorkspaceErrors[
-                  CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
+                    CreateWorkspaceErrors.GET_TEMPLATE_GITAUTH_ERROR
                   ]
                 }
               />
             )}
-        </Stack>
+          </Stack>
         )}
 
-        {Boolean(props.createWorkspaceErrors[CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR]) && (
+        {Boolean(
+          props.createWorkspaceErrors[
+            CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR
+          ],
+        ) && (
           <AlertBanner
             severity="error"
             error={
               props.createWorkspaceErrors[
-              CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR
+                CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR
               ]
             }
           />

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -75,6 +75,17 @@ export const CreateWorkspacePageView: FC<
     // to disappear.
     setGitAuthErrors({})
   }, [props.templateGitAuth])
+
+  const workspaceErrors =
+    props.createWorkspaceErrors[CreateWorkspaceErrors.CREATE_WORKSPACE_ERROR]
+
+  // Scroll to top of page if errors are present
+  useEffect(() => {
+    if (props.hasTemplateErrors || Boolean(workspaceErrors)) {
+      window.scrollTo(0, 0)
+    }
+  }, [props.hasTemplateErrors, workspaceErrors])
+
   const { t } = useTranslation("createWorkspacePage")
   const styles = useStyles()
 


### PR DESCRIPTION
fixes #7286

What is the best way to scroll up the page when a user submits and there is an error? Right now, it's hard to tell if there is an error on the top of the page.

https://user-images.githubusercontent.com/22407953/234439937-488a5d8a-c112-4265-aaf9-333ffcb63909.mov

