### PR TITLE
fix: set default parameter value during update prompt

### DIFF
--- a/site/src/pages/WorkspacePage/UpdateBuildParametersDialog.tsx
+++ b/site/src/pages/WorkspacePage/UpdateBuildParametersDialog.tsx
@@ -34,8 +34,7 @@ export const UpdateBuildParametersDialog: FC<
   const styles = useStyles()
   const form = useFormik({
     initialValues: {
-      rich_parameter_values:
-        selectInitialRichParametersValues(missedParameters),
+      rich_parameter_values: []
     },
     validationSchema: Yup.object({
       rich_parameter_values: useValidationSchemaForRichParameters(
@@ -47,6 +46,12 @@ export const UpdateBuildParametersDialog: FC<
       onUpdate(values.rich_parameter_values)
     },
   })
+
+  // Set initial values for missing parameters, once fetched
+  if (missedParameters && form.values.rich_parameter_values.length === 0) {
+    form.setFieldValue("rich_parameter_values", selectInitialRichParametersValues(missedParameters))
+  }
+
   const getFieldHelpers = getFormHelpers(form)
   const { t } = useTranslation("workspacePage")
 
@@ -83,7 +88,7 @@ export const UpdateBuildParametersDialog: FC<
                     )}
                     key={parameter.name}
                     parameter={parameter}
-                    initialValue=""
+                    initialValue={parameter.default_value}
                     index={index}
                     onChange={async (value) => {
                       await form.setFieldValue(

--- a/site/src/pages/WorkspacePage/UpdateBuildParametersDialog.tsx
+++ b/site/src/pages/WorkspacePage/UpdateBuildParametersDialog.tsx
@@ -34,7 +34,7 @@ export const UpdateBuildParametersDialog: FC<
   const styles = useStyles()
   const form = useFormik({
     initialValues: {
-      rich_parameter_values: []
+      rich_parameter_values: [],
     },
     validationSchema: Yup.object({
       rich_parameter_values: useValidationSchemaForRichParameters(
@@ -49,7 +49,10 @@ export const UpdateBuildParametersDialog: FC<
 
   // Set initial values for missing parameters, once fetched
   if (missedParameters && form.values.rich_parameter_values.length === 0) {
-    form.setFieldValue("rich_parameter_values", selectInitialRichParametersValues(missedParameters))
+    form.setFieldValue(
+      "rich_parameter_values",
+      selectInitialRichParametersValues(missedParameters),
+    )
   }
 
   const getFieldHelpers = getFormHelpers(form)

--- a/site/src/pages/WorkspacePage/UpdateBuildParametersDialog.tsx
+++ b/site/src/pages/WorkspacePage/UpdateBuildParametersDialog.tsx
@@ -4,7 +4,7 @@ import DialogContent from "@material-ui/core/DialogContent"
 import DialogContentText from "@material-ui/core/DialogContentText"
 import DialogTitle from "@material-ui/core/DialogTitle"
 import { DialogProps } from "components/Dialogs/Dialog"
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { getFormHelpers } from "utils/formUtils"
 import { FormFields, VerticalForm } from "components/Form/Form"
 import {
@@ -47,13 +47,14 @@ export const UpdateBuildParametersDialog: FC<
     },
   })
 
-  // Set initial values for missing parameters, once fetched
-  if (missedParameters && form.values.rich_parameter_values.length === 0) {
-    form.setFieldValue(
-      "rich_parameter_values",
-      selectInitialRichParametersValues(missedParameters),
-    )
-  }
+  useEffect(() => {
+    if (missedParameters && form.values.rich_parameter_values.length === 0) {
+      void form.setFieldValue(
+        "rich_parameter_values",
+        selectInitialRichParametersValues(missedParameters),
+      )
+    }
+  }, [form, missedParameters])
 
   const getFieldHelpers = getFormHelpers(form)
   const { t } = useTranslation("workspacePage")


### PR DESCRIPTION
fixes #7288

Feels hacky how I had to avoid using intialValues and also set the initialValue per component. However, it seemed like both were necessary as the form is initialized before the missing values are fetched. Before, when I submitted without changing the value, nothing happened.