### PR TITLE
fix: vite fatals on receiving HTTP4xx

### DIFF
--- a/coderd/httpmw/httpmw.go
+++ b/coderd/httpmw/httpmw.go
@@ -26,7 +26,7 @@ func parseUUID(rw http.ResponseWriter, r *http.Request, param string) (uuid.UUID
 	parsed, err := uuid.Parse(rawID)
 	if err != nil {
 		httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf("Invalid UUID %q.", param),
+			Message: fmt.Sprintf("Invalid UUID %q.", rawID),
 			Detail:  err.Error(),
 		})
 		return uuid.UUID{}, false

--- a/coderd/httpmw/httpmw_internal_test.go
+++ b/coderd/httpmw/httpmw_internal_test.go
@@ -1,0 +1,55 @@
+package httpmw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/codersdk"
+)
+
+const (
+	testParam            = "workspaceagent"
+	testWorkspaceAgentID = "8a70c576-12dc-42bc-b791-112a32b5bd43"
+)
+
+func TestParseUUID_Valid(t *testing.T) {
+	t.Parallel()
+
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/{workspaceagent}", nil)
+
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add(testParam, testWorkspaceAgentID)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, ctx))
+
+	parsed, ok := parseUUID(rw, r, "workspaceagent")
+	assert.True(t, ok, "UUID should be parsed")
+	assert.Equal(t, testWorkspaceAgentID, parsed.String())
+}
+
+func TestParseUUID_Invalid(t *testing.T) {
+	t.Parallel()
+
+	rw := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/{workspaceagent}", nil)
+
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add(testParam, "wrong-id")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, ctx))
+
+	_, ok := parseUUID(rw, r, "workspaceagent")
+	assert.False(t, ok, "UUID should not be parsed")
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+
+	var response codersdk.Response
+	err := json.Unmarshal(rw.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Contains(t, response.Message, `Invalid UUID "wrong-id"`)
+}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -447,7 +447,10 @@ func (api *API) workspaceAgentStartupLogs(rw http.ResponseWriter, r *http.Reques
 	api.WebsocketWaitGroup.Add(1)
 	api.WebsocketWaitMutex.Unlock()
 	defer api.WebsocketWaitGroup.Done()
-	conn, err := websocket.Accept(rw, r, nil)
+	conn, err := websocket.Accept(rw, r, &websocket.AcceptOptions{
+		// Vite in development mode can't cross-access this port.
+		OriginPatterns: []string{"localhost:8080"},
+	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to accept websocket.",

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -447,10 +447,7 @@ func (api *API) workspaceAgentStartupLogs(rw http.ResponseWriter, r *http.Reques
 	api.WebsocketWaitGroup.Add(1)
 	api.WebsocketWaitMutex.Unlock()
 	defer api.WebsocketWaitGroup.Done()
-	conn, err := websocket.Accept(rw, r, &websocket.AcceptOptions{
-		// Vite in development mode can't cross-access this port.
-		OriginPatterns: []string{"localhost:8080"},
-	})
+	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to accept websocket.",

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -41,11 +41,11 @@ export default defineConfig({
           // Vite does not catch socket errors, and stops the webserver.
           // As /startup-logs endpoint can return HTTP 4xx status, we need to embrace
           // Vite with a custom error handler to prevent from quitting.
-          proxy.on('proxyReqWs', (proxyReq, req, socket) => {
-            socket.on('error', (error) => {
-              console.error(error);
-            });
-          });
+          proxy.on("proxyReqWs", (proxyReq, req, socket) => {
+            socket.on("error", (error) => {
+              console.error(error)
+            })
+          })
         },
       },
       "/swagger": {

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -43,7 +43,10 @@ export default defineConfig({
           // Vite with a custom error handler to prevent from quitting.
           proxy.on("proxyReqWs", (proxyReq, req, socket) => {
             if (process.env.NODE_ENV === "development") {
-              proxyReq.setHeader('origin', process.env.CODER_HOST || "http://localhost:3000");
+              proxyReq.setHeader(
+                "origin",
+                process.env.CODER_HOST || "http://localhost:3000",
+              )
             }
 
             socket.on("error", (error) => {

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
           // As /startup-logs endpoint can return HTTP 4xx status, we need to embrace
           // Vite with a custom error handler to prevent from quitting.
           proxy.on("proxyReqWs", (proxyReq, req, socket) => {
+            if (process.env.NODE_ENV === "development") {
+              proxyReq.setHeader('origin', process.env.CODER_HOST || "http://localhost:3000");
+            }
+
             socket.on("error", (error) => {
               console.error(error)
             })

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -37,6 +37,16 @@ export default defineConfig({
         changeOrigin: true,
         target: process.env.CODER_HOST || "http://localhost:3000",
         secure: process.env.NODE_ENV === "production",
+        configure: (proxy) => {
+          // Vite does not catch socket errors, and stops the webserver.
+          // As /startup-logs endpoint can return HTTP 4xx status, we need to embrace
+          // Vite with a custom error handler to prevent from quitting.
+          proxy.on('proxyReqWs', (proxyReq, req, socket) => {
+            socket.on('error', (error) => {
+              console.error(error);
+            });
+          });
+        },
       },
       "/swagger": {
         target: process.env.CODER_HOST || "http://localhost:3000",


### PR DESCRIPTION
This PR fixes connectivity issues between Vite and coderd WebSocket.

Changes:
* coderd: cover `parseUUID` middleware with unit tests (and fix bad message)
* ~~coderd `startup-logs`: add new cross-origin pattern (`localhost:8080`)~~ moved to Vite
* vite config: add missing error handler. It's a [bug](https://github.com/vitejs/vite/issues/12664) in vitejs, this is a workaround.

Without these changes, Vite quits the process with:

```bash
  ➜  Local:   http://localhost:8080/
  ➜  Network: http://192.168.0.21:8080/
  vite:proxy /api/v2/workspaceagents/1/startup-logs?follow&after=0 -> ws http://localhost:3000 +0ms
node:events:491
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:217:20)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -54,
  code: 'ECONNRESET',
  syscall: 'read'
}

Node.js v18.14.2
error Command failed with exit code 1.
```