### PR TITLE
docs: clarify quota allocation

### DIFF
--- a/docs/admin/quotas.md
+++ b/docs/admin/quotas.md
@@ -5,8 +5,9 @@ templates and assigning budgets to users. Users that exceed their budget will be
 blocked from launching more workspaces until they either delete their other workspaces
 or get their budget extended.
 
-For example: A template is configured with a cost of 5 credits per day, and the user is
-granted a budget of 15 credits per day. This budget limits the user to 3 concurrent workspaces.
+For example: A template is configured with a cost of 5 credits per day,
+and the user is granted 15 credits, which can be consumed by both started and
+stopped workspaces. This budget limits the user to 3 concurrent workspaces.
 
 Quotas are licensed with [Groups](./groups.md).
 


### PR DESCRIPTION
this PR removes language around "daily" quota allocation, since the quota is fixed, and is not refreshed or rolled over on a daily basis.