### PR TITLE
chore: Dynamic CSP connect-src to support terminals connecting to workspace proxies

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -797,10 +797,10 @@ func New(options *Options) *API {
 	// browsers, so these don't make sense on api routes.
 	cspMW := httpmw.CSPHeaders(func() []string {
 		if f := api.HealthyWorkspaceProxyHosts.Load(); f != nil {
-			// By default we do not add extra websocket connections to the CSP
-			return []string{}
+			return (*f)()
 		}
-		return nil
+		// By default we do not add extra websocket connections to the CSP
+		return []string{}
 	})
 	r.NotFound(cspMW(compressHandler(http.HandlerFunc(api.siteHandler.ServeHTTP))).ServeHTTP)
 	return api

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -793,7 +793,16 @@ func New(options *Options) *API {
 		r.Get("/swagger/*", globalHTTPSwaggerHandler)
 	}
 
-	r.NotFound(compressHandler(http.HandlerFunc(api.siteHandler.ServeHTTP)).ServeHTTP)
+	// Add CSP headers to all static assets and pages. CSP headers only affect
+	// browsers, so these don't make sense on api routes.
+	cspMW := httpmw.CSPHeaders(func() []string {
+		if f := api.HealthyWorkspaceProxyHosts.Load(); f != nil {
+			// By default we do not add extra websocket connections to the CSP
+			return []string{}
+		}
+		return nil
+	})
+	r.NotFound(cspMW(compressHandler(http.HandlerFunc(api.siteHandler.ServeHTTP))).ServeHTTP)
 	return api
 }
 
@@ -813,7 +822,12 @@ type API struct {
 	WorkspaceClientCoordinateOverride atomic.Pointer[func(rw http.ResponseWriter) bool]
 	TailnetCoordinator                atomic.Pointer[tailnet.Coordinator]
 	QuotaCommitter                    atomic.Pointer[proto.QuotaCommitter]
-	TemplateScheduleStore             *atomic.Pointer[schedule.TemplateScheduleStore]
+	// HealthyWorkspaceProxyHosts returns the hostnames of healthy workspace proxies
+	// for header reasons.
+	HealthyWorkspaceProxyHosts atomic.Pointer[func() []string]
+	// TemplateScheduleStore is a pointer to an atomic pointer because this is
+	// passed to another struct, and we want them all to be the same reference.
+	TemplateScheduleStore *atomic.Pointer[schedule.TemplateScheduleStore]
 
 	HTTPAuth *HTTPAuthorizer
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -822,7 +822,7 @@ type API struct {
 	WorkspaceClientCoordinateOverride atomic.Pointer[func(rw http.ResponseWriter) bool]
 	TailnetCoordinator                atomic.Pointer[tailnet.Coordinator]
 	QuotaCommitter                    atomic.Pointer[proto.QuotaCommitter]
-	// HealthyWorkspaceProxyHosts returns the hostnames of healthy workspace proxies
+	// HealthyWorkspaceProxyHosts returns the hosts of healthy workspace proxies
 	// for header reasons.
 	HealthyWorkspaceProxyHosts atomic.Pointer[func() []string]
 	// TemplateScheduleStore is a pointer to an atomic pointer because this is

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -796,7 +796,7 @@ func New(options *Options) *API {
 	// Add CSP headers to all static assets and pages. CSP headers only affect
 	// browsers, so these don't make sense on api routes.
 	cspMW := httpmw.CSPHeaders(func() []string {
-		if f := api.HealthyWorkspaceProxyHosts.Load(); f != nil {
+		if f := api.WorkspaceProxyHostsFn.Load(); f != nil {
 			return (*f)()
 		}
 		// By default we do not add extra websocket connections to the CSP
@@ -822,9 +822,9 @@ type API struct {
 	WorkspaceClientCoordinateOverride atomic.Pointer[func(rw http.ResponseWriter) bool]
 	TailnetCoordinator                atomic.Pointer[tailnet.Coordinator]
 	QuotaCommitter                    atomic.Pointer[proto.QuotaCommitter]
-	// HealthyWorkspaceProxyHosts returns the hosts of healthy workspace proxies
+	// WorkspaceProxyHostsFn returns the hosts of healthy workspace proxies
 	// for header reasons.
-	HealthyWorkspaceProxyHosts atomic.Pointer[func() []string]
+	WorkspaceProxyHostsFn atomic.Pointer[func() []string]
 	// TemplateScheduleStore is a pointer to an atomic pointer because this is
 	// passed to another struct, and we want them all to be the same reference.
 	TemplateScheduleStore *atomic.Pointer[schedule.TemplateScheduleStore]

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -98,10 +98,11 @@ func CSPHeaders(websocketHosts func() []string) func(next http.Handler) http.Han
 				cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", host))
 			}
 
+			// The terminal requires a websocket connection to the workspace proxy.
+			// Make sure we allow this connection to healthy proxies.
 			extraConnect := websocketHosts()
 			if len(extraConnect) > 0 {
 				for _, extraHost := range extraConnect {
-					fmt.Println("extraHost", extraHost)
 					cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", extraHost))
 				}
 			}

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -101,6 +101,7 @@ func CSPHeaders(websocketHosts func() []string) func(next http.Handler) http.Han
 			extraConnect := websocketHosts()
 			if len(extraConnect) > 0 {
 				for _, extraHost := range extraConnect {
+					fmt.Println("extraHost", extraHost)
 					cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", extraHost))
 				}
 			}

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -1,0 +1,117 @@
+package httpmw
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// cspDirectives is a map of all csp fetch directives to their values.
+// Each directive is a set of values that is joined by a space (' ').
+// All directives are semi-colon separated as a single string for the csp header.
+type cspDirectives map[CSPFetchDirective][]string
+
+func (s cspDirectives) Append(d CSPFetchDirective, values ...string) {
+	if _, ok := s[d]; !ok {
+		s[d] = make([]string, 0)
+	}
+	s[d] = append(s[d], values...)
+}
+
+// CSPFetchDirective is the list of all constant fetch directives that
+// can be used/appended to.
+type CSPFetchDirective string
+
+const (
+	cspDirectiveDefaultSrc  = "default-src"
+	cspDirectiveConnectSrc  = "connect-src"
+	cspDirectiveChildSrc    = "child-src"
+	cspDirectiveScriptSrc   = "script-src"
+	cspDirectiveFontSrc     = "font-src"
+	cspDirectiveStyleSrc    = "style-src"
+	cspDirectiveObjectSrc   = "object-src"
+	cspDirectiveManifestSrc = "manifest-src"
+	cspDirectiveFrameSrc    = "frame-src"
+	cspDirectiveImgSrc      = "img-src"
+	cspDirectiveReportURI   = "report-uri"
+	cspDirectiveFormAction  = "form-action"
+	cspDirectiveMediaSrc    = "media-src"
+	cspFrameAncestors       = "frame-ancestors"
+	cspDirectiveWorkerSrc   = "worker-src"
+)
+
+// CSPHeaders returns a middleware that sets the Content-Security-Policy header
+// for coderd. It takes a function that allows adding supported external websocket
+// hosts. This is primarily to support the terminal connecting to a workspace proxy.
+func CSPHeaders(websocketHosts func() []string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Content-Security-Policy disables loading certain content types and can prevent XSS injections.
+			// This site helps eval your policy for syntax and other common issues: https://csp-evaluator.withgoogle.com/
+			// If we ever want to render something like a PDF, we need to adjust "object-src"
+			//
+			//	The list of CSP options: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
+			cspSrcs := cspDirectives{
+				// All omitted fetch csp srcs default to this.
+				cspDirectiveDefaultSrc: {"'self'"},
+				cspDirectiveConnectSrc: {"'self'"},
+				cspDirectiveChildSrc:   {"'self'"},
+				// https://github.com/suren-atoyan/monaco-react/issues/168
+				cspDirectiveScriptSrc: {"'self'"},
+				cspDirectiveStyleSrc:  {"'self' 'unsafe-inline'"},
+				// data: is used by monaco editor on FE for Syntax Highlight
+				cspDirectiveFontSrc:   {"'self' data:"},
+				cspDirectiveWorkerSrc: {"'self' blob:"},
+				// object-src is needed to support code-server
+				cspDirectiveObjectSrc: {"'self'"},
+				// blob: for loading the pwa manifest for code-server
+				cspDirectiveManifestSrc: {"'self' blob:"},
+				cspDirectiveFrameSrc:    {"'self'"},
+				// data: for loading base64 encoded icons for generic applications.
+				// https: allows loading images from external sources. This is not ideal
+				// 	but is required for the templates page that renders readmes.
+				//	We should find a better solution in the future.
+				cspDirectiveImgSrc:     {"'self' https: data:"},
+				cspDirectiveFormAction: {"'self'"},
+				cspDirectiveMediaSrc:   {"'self'"},
+				// Report all violations back to the server to log
+				cspDirectiveReportURI: {"/api/v2/csp/reports"},
+				cspFrameAncestors:     {"'none'"},
+
+				// Only scripts can manipulate the dom. This prevents someone from
+				// naming themselves something like '<svg onload="alert(/cross-site-scripting/)" />'.
+				// "require-trusted-types-for" : []string{"'script'"},
+			}
+
+			// This extra connect-src addition is required to support old webkit
+			// based browsers (Safari).
+			// See issue: https://github.com/w3c/webappsec-csp/issues/7
+			// Once webkit browsers support 'self' on connect-src, we can remove this.
+			// When we remove this, the csp header can be static, as opposed to being
+			// dynamically generated for each request.
+			host := r.Host
+			// It is important r.Host is not an empty string.
+			if host != "" {
+				// We can add both ws:// and wss:// as browsers do not let https
+				// pages to connect to non-tls websocket connections. So this
+				// supports both http & https webpages.
+				cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", host))
+			}
+
+			extraConnect := websocketHosts()
+			if len(extraConnect) > 0 {
+				for _, extraHost := range extraConnect {
+					cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", extraHost))
+				}
+			}
+
+			var csp strings.Builder
+			for src, vals := range cspSrcs {
+				_, _ = fmt.Fprintf(&csp, "%s %s; ", src, strings.Join(vals, " "))
+			}
+
+			w.Header().Set("Content-Security-Policy", csp.String())
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/coderd/httpmw/csp_test.go
+++ b/coderd/httpmw/csp_test.go
@@ -1,0 +1,1 @@
+package httpmw_test

--- a/coderd/httpmw/csp_test.go
+++ b/coderd/httpmw/csp_test.go
@@ -1,1 +1,33 @@
 package httpmw_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/coderd/httpmw"
+)
+
+func TestCSPConnect(t *testing.T) {
+	t.Parallel()
+
+	expected := []string{"example.com", "coder.com"}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rw := httptest.NewRecorder()
+
+	httpmw.CSPHeaders(func() []string {
+		return expected
+	})(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rw, r)
+
+	require.NotEmpty(t, rw.Header().Get("Content-Security-Policy"), "Content-Security-Policy header should not be empty")
+	for _, e := range expected {
+		require.Containsf(t, rw.Header().Get("Content-Security-Policy"), fmt.Sprintf("ws://%s", e), "Content-Security-Policy header should contain ws://%s", e)
+		require.Containsf(t, rw.Header().Get("Content-Security-Policy"), fmt.Sprintf("wss://%s", e), "Content-Security-Policy header should contain wss://%s", e)
+	}
+}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -250,6 +250,10 @@ func New(ctx context.Context, options *Options) (*API, error) {
 		// Force the initial loading of the cache. Do this in a go routine in case
 		// the calls to the workspace proxies hang and this takes some time.
 		go api.forceWorkspaceProxyHealthUpdate(ctx)
+
+		// Use proxy health to return the healthy workspace proxy hostnames.
+		f := api.ProxyHealth.HealthyHostnames
+		api.AGPL.HealthyWorkspaceProxyHosts.Store(&f)
 	}
 
 	err = api.updateEntitlements(ctx)

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -252,7 +252,7 @@ func New(ctx context.Context, options *Options) (*API, error) {
 		go api.forceWorkspaceProxyHealthUpdate(ctx)
 
 		// Use proxy health to return the healthy workspace proxy hostnames.
-		f := api.ProxyHealth.HealthyHostnames
+		f := api.ProxyHealth.HealthyHosts
 		api.AGPL.HealthyWorkspaceProxyHosts.Store(&f)
 	}
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -252,8 +252,8 @@ func New(ctx context.Context, options *Options) (*API, error) {
 		go api.forceWorkspaceProxyHealthUpdate(ctx)
 
 		// Use proxy health to return the healthy workspace proxy hostnames.
-		f := api.ProxyHealth.HealthyHosts
-		api.AGPL.HealthyWorkspaceProxyHosts.Store(&f)
+		f := api.ProxyHealth.ProxyHosts
+		api.AGPL.WorkspaceProxyHostsFn.Store(&f)
 	}
 
 	err = api.updateEntitlements(ctx)

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -152,7 +152,6 @@ func (p *ProxyHealth) storeProxyHealth(statuses map[uuid.UUID]ProxyStatus) {
 
 	// Store the statuses in the cache before any other quick values.
 	p.cache.Store(&statuses)
-	fmt.Println(healthyHosts)
 	p.heathyHosts.Store(&healthyHosts)
 }
 

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -150,7 +150,6 @@ func (p *ProxyHealth) storeProxyHealth(statuses map[uuid.UUID]ProxyStatus) {
 		}
 	}
 
-	fmt.Println("healthyHosts", healthyHosts)
 	// Store the statuses in the cache before any other quick values.
 	p.cache.Store(&statuses)
 	p.heathyHosts.Store(&healthyHosts)

--- a/site/site.go
+++ b/site/site.go
@@ -125,11 +125,6 @@ func Handler(siteFS fs.FS, binFS http.FileSystem, binHashes map[string]string) h
 type handler struct {
 	fs fs.FS
 	// htmlFiles is the text/template for all *.html files.
-	// This is needed to support Content Security Policy headers.
-	// Due to material UI, we are forced to use a nonce to allow inline
-	// scripts, and that nonce is passed through a template.
-	// We only do this for html files to reduce the amount of in memory caching
-	// of duplicate files as `fs`.
 	htmlFiles     *htmlTemplates
 	h             http.Handler
 	buildInfoJSON string
@@ -152,13 +147,8 @@ func (h *handler) exists(filePath string) bool {
 }
 
 type htmlState struct {
-	CSP       cspState
 	CSRF      csrfState
 	BuildInfo string
-}
-
-type cspState struct {
-	Nonce string
 }
 
 type csrfState struct {

--- a/site/site.go
+++ b/site/site.go
@@ -265,104 +265,6 @@ func (t *htmlTemplates) renderWithState(filePath string, state htmlState) ([]byt
 	return buf.Bytes(), nil
 }
 
-// CSPDirectives is a map of all csp fetch directives to their values.
-// Each directive is a set of values that is joined by a space (' ').
-// All directives are semi-colon separated as a single string for the csp header.
-type CSPDirectives map[CSPFetchDirective][]string
-
-func (s CSPDirectives) Append(d CSPFetchDirective, values ...string) {
-	if _, ok := s[d]; !ok {
-		s[d] = make([]string, 0)
-	}
-	s[d] = append(s[d], values...)
-}
-
-// CSPFetchDirective is the list of all constant fetch directives that
-// can be used/appended to.
-type CSPFetchDirective string
-
-const (
-	CSPDirectiveDefaultSrc  = "default-src"
-	CSPDirectiveConnectSrc  = "connect-src"
-	CSPDirectiveChildSrc    = "child-src"
-	CSPDirectiveScriptSrc   = "script-src"
-	CSPDirectiveFontSrc     = "font-src"
-	CSPDirectiveStyleSrc    = "style-src"
-	CSPDirectiveObjectSrc   = "object-src"
-	CSPDirectiveManifestSrc = "manifest-src"
-	CSPDirectiveFrameSrc    = "frame-src"
-	CSPDirectiveImgSrc      = "img-src"
-	CSPDirectiveReportURI   = "report-uri"
-	CSPDirectiveFormAction  = "form-action"
-	CSPDirectiveMediaSrc    = "media-src"
-	CSPFrameAncestors       = "frame-ancestors"
-	CSPDirectiveWorkerSrc   = "worker-src"
-)
-
-func cspHeaders(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Content-Security-Policy disables loading certain content types and can prevent XSS injections.
-		// This site helps eval your policy for syntax and other common issues: https://csp-evaluator.withgoogle.com/
-		// If we ever want to render something like a PDF, we need to adjust "object-src"
-		//
-		//	The list of CSP options: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
-		cspSrcs := CSPDirectives{
-			// All omitted fetch csp srcs default to this.
-			CSPDirectiveDefaultSrc: {"'self'"},
-			CSPDirectiveConnectSrc: {"'self'"},
-			CSPDirectiveChildSrc:   {"'self'"},
-			// https://github.com/suren-atoyan/monaco-react/issues/168
-			CSPDirectiveScriptSrc: {"'self'"},
-			CSPDirectiveStyleSrc:  {"'self' 'unsafe-inline'"},
-			// data: is used by monaco editor on FE for Syntax Highlight
-			CSPDirectiveFontSrc:   {"'self' data:"},
-			CSPDirectiveWorkerSrc: {"'self' blob:"},
-			// object-src is needed to support code-server
-			CSPDirectiveObjectSrc: {"'self'"},
-			// blob: for loading the pwa manifest for code-server
-			CSPDirectiveManifestSrc: {"'self' blob:"},
-			CSPDirectiveFrameSrc:    {"'self'"},
-			// data: for loading base64 encoded icons for generic applications.
-			// https: allows loading images from external sources. This is not ideal
-			// 	but is required for the templates page that renders readmes.
-			//	We should find a better solution in the future.
-			CSPDirectiveImgSrc:     {"'self' https: data:"},
-			CSPDirectiveFormAction: {"'self'"},
-			CSPDirectiveMediaSrc:   {"'self'"},
-			// Report all violations back to the server to log
-			CSPDirectiveReportURI: {"/api/v2/csp/reports"},
-			CSPFrameAncestors:     {"'none'"},
-
-			// Only scripts can manipulate the dom. This prevents someone from
-			// naming themselves something like '<svg onload="alert(/cross-site-scripting/)" />'.
-			// "require-trusted-types-for" : []string{"'script'"},
-		}
-
-		// This extra connect-src addition is required to support old webkit
-		// based browsers (Safari).
-		// See issue: https://github.com/w3c/webappsec-csp/issues/7
-		// Once webkit browsers support 'self' on connect-src, we can remove this.
-		// When we remove this, the csp header can be static, as opposed to being
-		// dynamically generated for each request.
-		host := r.Host
-		// It is important r.Host is not an empty string.
-		if host != "" {
-			// We can add both ws:// and wss:// as browsers do not let https
-			// pages to connect to non-tls websocket connections. So this
-			// supports both http & https webpages.
-			cspSrcs.Append(CSPDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", host))
-		}
-
-		var csp strings.Builder
-		for src, vals := range cspSrcs {
-			_, _ = fmt.Fprintf(&csp, "%s %s; ", src, strings.Join(vals, " "))
-		}
-
-		w.Header().Set("Content-Security-Policy", csp.String())
-		next.ServeHTTP(w, r)
-	})
-}
-
 // secureHeaders is only needed for statically served files. We do not need this for api endpoints.
 // It adds various headers to enforce browser security features.
 func secureHeaders(next http.Handler) http.Handler {
@@ -394,7 +296,7 @@ func secureHeaders(next http.Handler) http.Handler {
 
 		// Prevent the browser from sending Referrer header with requests
 		ReferrerPolicy: "no-referrer",
-	}).Handler(cspHeaders(next))
+	}).Handler(next)
 }
 
 // htmlFiles recursively walks the file system passed finding all *.html files.


### PR DESCRIPTION
# What this does

The terminal app must be hosted by the primary coderd and communicate with the workspace proxy. CORs was setup correctly, but CSP was blocking the websocket connection.

This adds the CSP connect-src header to allow websocket connections to healthy workspace proxy domains.