### PR TITLE
chore: add workspace actions entitlement and experiment

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7397,10 +7397,12 @@ const docTemplate = `{
         "codersdk.Experiment": {
             "type": "string",
             "enum": [
-                "moons"
+                "moons",
+                "workspace_actions"
             ],
             "x-enum-varnames": [
-                "ExperimentMoons"
+                "ExperimentMoons",
+                "ExperimentWorkspaceActions"
             ]
         },
         "codersdk.Feature": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6613,8 +6613,8 @@
     },
     "codersdk.Experiment": {
       "type": "string",
-      "enum": ["moons"],
-      "x-enum-varnames": ["ExperimentMoons"]
+      "enum": ["moons", "workspace_actions"],
+      "x-enum-varnames": ["ExperimentMoons", "ExperimentWorkspaceActions"]
     },
     "codersdk.Feature": {
       "type": "object",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1670,6 +1670,9 @@ const (
 	// feature is not yet complete in functionality.
 	ExperimentMoons Experiment = "moons"
 
+	// https://github.com/coder/coder/milestone/19
+	ExperimentWorkspaceActions Experiment = "workspace_actions"
+
 	// Add new experiments here!
 	// ExperimentExample Experiment = "example"
 )

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -46,6 +46,7 @@ const (
 	FeatureAppearance                 FeatureName = "appearance"
 	FeatureAdvancedTemplateScheduling FeatureName = "advanced_template_scheduling"
 	FeatureWorkspaceProxy             FeatureName = "workspace_proxy"
+	FeatureWorkspaceActions           FeatureName = "workspace_actions"
 )
 
 // FeatureNames must be kept in-sync with the Feature enum above.
@@ -61,6 +62,7 @@ var FeatureNames = []FeatureName{
 	FeatureAppearance,
 	FeatureAdvancedTemplateScheduling,
 	FeatureWorkspaceProxy,
+	FeatureWorkspaceActions,
 }
 
 // Humanize returns the feature name in a human-readable format.

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2502,9 +2502,10 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 
 #### Enumerated Values
 
-| Value   |
-| ------- |
-| `moons` |
+| Value               |
+| ------------------- |
+| `moons`             |
+| `workspace_actions` |
 
 ## codersdk.Feature
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -322,6 +322,7 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 			codersdk.FeatureExternalProvisionerDaemons: true,
 			codersdk.FeatureAdvancedTemplateScheduling: true,
 			codersdk.FeatureWorkspaceProxy:             true,
+			codersdk.FeatureWorkspaceActions:           true,
 		})
 	if err != nil {
 		return err

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -54,6 +54,7 @@ func TestEntitlements(t *testing.T) {
 				codersdk.FeatureExternalProvisionerDaemons: 1,
 				codersdk.FeatureAdvancedTemplateScheduling: 1,
 				codersdk.FeatureWorkspaceProxy:             1,
+				codersdk.FeatureWorkspaceActions:           1,
 			},
 			GraceAt: time.Now().Add(59 * 24 * time.Hour),
 		})

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1361,8 +1361,8 @@ export const Entitlements: Entitlement[] = [
 ]
 
 // From codersdk/deployment.go
-export type Experiment = "moons"
-export const Experiments: Experiment[] = ["moons"]
+export type Experiment = "moons" | "workspace_actions"
+export const Experiments: Experiment[] = ["moons", "workspace_actions"]
 
 // From codersdk/deployment.go
 export type FeatureName =

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1376,6 +1376,7 @@ export type FeatureName =
   | "scim"
   | "template_rbac"
   | "user_limit"
+  | "workspace_actions"
   | "workspace_proxy"
 export const FeatureNames: FeatureName[] = [
   "advanced_template_scheduling",
@@ -1388,6 +1389,7 @@ export const FeatureNames: FeatureName[] = [
   "scim",
   "template_rbac",
   "user_limit",
+  "workspace_actions",
   "workspace_proxy",
 ]
 


### PR DESCRIPTION
resolves #7354

To run the server with the workspace actions experiment enabled, use:
`CODER_EXPERIMENTS='workspace_actions' ./scripts/develop.sh`
![Screenshot 2023-05-01 at 3 27 17 PM](https://user-images.githubusercontent.com/19142439/235519613-75faa1e7-223a-4926-b7b0-6a3261b2abcd.png)
![Screenshot 2023-05-01 at 3 43 39 PM](https://user-images.githubusercontent.com/19142439/235519624-744fdbc8-423a-42fa-8c4a-c55ffb7aada8.png)


