### PR TITLE
fix(server): prevent otel tracer provider from immediately being closed

### DIFF
--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -21,6 +21,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+
 	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/cliui"
@@ -136,7 +138,12 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			defer http.DefaultClient.CloseIdleConnections()
 			closers.Add(http.DefaultClient.CloseIdleConnections)
 
-			tracer, _ := cli.ConfigureTraceProvider(ctx, logger, inv, cfg)
+			tracer, _, closeTracing := cli.ConfigureTraceProvider(ctx, logger, inv, cfg)
+			defer func() {
+				logger.Debug(ctx, "closing tracing")
+				traceCloseErr := shutdownWithTimeout(closeTracing, 5*time.Second)
+				logger.Debug(ctx, "tracing closed", slog.Error(traceCloseErr))
+			}()
 
 			httpServers, err := cli.ConfigureHTTPServers(inv, cfg)
 			if err != nil {
@@ -344,4 +351,10 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 	}
 
 	return cmd
+}
+
+func shutdownWithTimeout(shutdown func(context.Context) error, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return shutdown(ctx)
 }

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
-
 	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/cliui"


### PR DESCRIPTION
Looks like a recent refactor broke tracing.