### PR TITLE
chore: bump terraform from 1.3.4-r3 to r4 in image

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
 		bash \
 		git \
 		openssh-client \
-		terraform=1.3.4-r3 && \
+		terraform=1.3.4-r4 && \
 	addgroup \
 		-g 1000 \
 		coder && \


### PR DESCRIPTION
Looks like 1.3.4-r3 isn't available anymore, and 1.3.4-r4 is available instead.