### PR TITLE
fix: pubsub ordering

### DIFF
--- a/coderd/database/pubsub.go
+++ b/coderd/database/pubsub.go
@@ -25,11 +25,16 @@ type Pubsub interface {
 
 // Pubsub implementation using PostgreSQL.
 type pgPubsub struct {
+	ctx        context.Context
 	pgListener *pq.Listener
 	db         *sql.DB
 	mut        sync.Mutex
-	listeners  map[string]map[uuid.UUID]Listener
+	listeners  map[string]map[uuid.UUID]chan<- []byte
 }
+
+// messageBufferSize is the maximum number of unhandled messages we will buffer
+// for a subscriber before blocking the pgPubsub.
+const messageBufferSize = 2048
 
 // Subscribe calls the listener when an event matching the name is received.
 func (p *pgPubsub) Subscribe(event string, listener Listener) (cancel func(), err error) {
@@ -45,25 +50,22 @@ func (p *pgPubsub) Subscribe(event string, listener Listener) (cancel func(), er
 		return nil, xerrors.Errorf("listen: %w", err)
 	}
 
-	var eventListeners map[uuid.UUID]Listener
+	var eventListeners map[uuid.UUID]chan<- []byte
 	var ok bool
 	if eventListeners, ok = p.listeners[event]; !ok {
-		eventListeners = map[uuid.UUID]Listener{}
+		eventListeners = make(map[uuid.UUID]chan<- []byte)
 		p.listeners[event] = eventListeners
 	}
 
-	var id uuid.UUID
-	for {
-		id = uuid.New()
-		if _, ok = eventListeners[id]; !ok {
-			break
-		}
-	}
-
-	eventListeners[id] = listener
+	ctx, cancelCallbacks := context.WithCancel(p.ctx)
+	messages := make(chan []byte, messageBufferSize)
+	go messagesToListener(ctx, messages, listener)
+	id := uuid.New()
+	eventListeners[id] = messages
 	return func() {
 		p.mut.Lock()
 		defer p.mut.Unlock()
+		cancelCallbacks()
 		listeners := p.listeners[event]
 		delete(listeners, id)
 
@@ -109,11 +111,11 @@ func (p *pgPubsub) listen(ctx context.Context) {
 		if notif == nil {
 			continue
 		}
-		p.listenReceive(ctx, notif)
+		p.listenReceive(notif)
 	}
 }
 
-func (p *pgPubsub) listenReceive(ctx context.Context, notif *pq.Notification) {
+func (p *pgPubsub) listenReceive(notif *pq.Notification) {
 	p.mut.Lock()
 	defer p.mut.Unlock()
 	listeners, ok := p.listeners[notif.Channel]
@@ -122,7 +124,7 @@ func (p *pgPubsub) listenReceive(ctx context.Context, notif *pq.Notification) {
 	}
 	extra := []byte(notif.Extra)
 	for _, listener := range listeners {
-		go listener(ctx, extra)
+		listener <- extra
 	}
 }
 
@@ -150,11 +152,23 @@ func NewPubsub(ctx context.Context, database *sql.DB, connectURL string) (Pubsub
 		return nil, ctx.Err()
 	}
 	pgPubsub := &pgPubsub{
+		ctx:        ctx,
 		db:         database,
 		pgListener: listener,
-		listeners:  make(map[string]map[uuid.UUID]Listener),
+		listeners:  make(map[string]map[uuid.UUID]chan<- []byte),
 	}
 	go pgPubsub.listen(ctx)
 
 	return pgPubsub, nil
+}
+
+func messagesToListener(ctx context.Context, messages <-chan []byte, listener Listener) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case m := <-messages:
+			listener(ctx, m)
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes the pubsub so that it calls back messages in order.

This is important for applications that depend on message order (as opposed to just using the pubsub as a kick to go load updates).

In particular, the streaming provisioner job logs endpoint is _very_ complicated and still broken (c.f. #7371) trying to deal with out of order messages.

As a second example, the `haCoordinator` will fail even the most trivial example of a client or agent sending multiple node updates if the pubsub messages get reordered.

This PR creates an in-order queue of messages per subscriber (just a fixed size `chan`) and runs a goroutine per subscriber (instead of per subscriber _per message_) to deliver them.

If the queue gets backed up, we drop messages rather than block.  This was chosen rather than blocking the whole pubsub for a single Listener that isn't keeping up.  Since the `pg.Listener` is, under the covers, handling DB reconnects, the pubsub can already drop messages, so from a design standpoint it's nothing new.  In another PR I plan to add the capability for subscribers to get notified if messages are dropped.