### PR TITLE
fix(helm): explode verbs instead of wildcarding

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -7,10 +7,26 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/tests/testdata/default_values.golden
+++ b/helm/tests/testdata/default_values.golden
@@ -22,10 +22,26 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/tests/testdata/labels_annotations.golden
+++ b/helm/tests/testdata/labels_annotations.golden
@@ -22,10 +22,26 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/tests/testdata/sa.golden
+++ b/helm/tests/testdata/sa.golden
@@ -22,10 +22,26 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/tests/testdata/tls.golden
+++ b/helm/tests/testdata/tls.golden
@@ -22,10 +22,26 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["*"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Kubernetes considers `*` to be of higher value than `[create delete deletecollection get list patch update watch]` which can lead to failures during installation if the user does not have the magic `*` permission on resources `pods` and `persistentvolumeclaims`.

Fix: explode the permissions explicitly in the role.

Validation (air-gapped cluster):
```
$ KUBECONFIG=~/src/kadduser/cian.kubeconfig helm install -n cian-ns coderv2 . --set coder.image.repo=reg.home:5000/ghcr.io/coder/coder --set coder.image.tag=v0.22.2
[...]
NOTES:
Enjoy Coder! Please create an issue at https://github.com/coder/coder if you run
into any problems! :)

$ helm list -n cian-ns
NAME   	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART      	APP VERSION
coderv2	cian-ns  	1       	2023-05-04 11:40:28.569403 +0100 IST	deployed	coder-0.1.0	0.1.0     

$ k -n cian-ns get role coder-workspace-perms -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  annotations:
    meta.helm.sh/release-name: coderv2
    meta.helm.sh/release-namespace: cian-ns
  creationTimestamp: "2023-05-04T10:42:29Z"
  labels:
    app.kubernetes.io/managed-by: Helm
  name: coder-workspace-perms
  namespace: cian-ns
  resourceVersion: "522562"
  uid: 69a1b2c2-b2ff-496f-b922-6ac1eb63d87b
rules:
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - create
  - delete
  - deletecollection
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims
  verbs:
  - create
  - delete
  - deletecollection
  - get
  - list
  - patch
  - update
  - watch

```