### PR TITLE
Add default values to parameters so template build

### DIFF
--- a/examples/templates/envbox/main.tf
+++ b/examples/templates/envbox/main.tf
@@ -34,48 +34,56 @@ variable "use_kubeconfig" {
   Set this to true if the Coder host is running outside the Kubernetes cluster
   for workspaces.  A valid "~/.kube/config" must be present on the Coder host.
   EOF
+  default     = false
 }
 
 variable "namespace" {
   type        = string
   sensitive   = true
   description = "The namespace to create workspaces in (must exist prior to creating workspaces)"
+  default     = "default"
 }
 
 variable "create_tun" {
   type        = bool
   sensitive   = true
   description = "Add a TUN device to the workspace."
+  default     = false
 }
 
 variable "create_fuse" {
   type        = bool
   description = "Add a FUSE device to the workspace."
   sensitive   = true
+  default     = false
 }
 
 variable "max_cpus" {
   type        = string
   sensitive   = true
   description = "Max number of CPUs the workspace may use (e.g. 2)."
+  default     = "2"
 }
 
 variable "min_cpus" {
   type        = string
   sensitive   = true
   description = "Minimum number of CPUs the workspace may use (e.g. .1)."
+  default     = "2"
 }
 
 variable "max_memory" {
   type        = string
   description = "Maximum amount of memory to allocate the workspace (in GB)."
   sensitive   = true
+  default     = "4"
 }
 
 variable "min_memory" {
   type        = string
   description = "Minimum amount of memory to allocate the workspace (in GB)."
   sensitive   = true
+  default     = "4"
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
Without default values, when editing this template in the Coder UI, the "Build Template" button produces a "parameter not defined" error. This resolves the error and allows the template to build.

Not sure if there's a better way but this worked for me.