### PR TITLE
feat: make urls relative

### DIFF
--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -14,6 +14,7 @@ if (process.env.STATS !== undefined) {
 }
 
 export default defineConfig({
+  base: "./",
   plugins: plugins,
   publicDir: path.resolve(__dirname, "./static"),
   build: {


### PR DESCRIPTION
Right now all UI urls are based of `/`, which make it impossible to run coder behind a reverse proxy under a subpath (e.g. `/coder/`), as can be seen here:

![image](https://user-images.githubusercontent.com/1201644/236493980-88e5efe4-3c64-4df5-8054-1a9cde0af01b.png)

Even though it seems from the documentation this should work: https://coder.com/docs/code-server/latest/guide#expose-code-server

![image](https://user-images.githubusercontent.com/1201644/236494142-2fa36b04-6785-4bdd-bce6-3d4d64128626.png)

Instead of Caddy, I am using Traefik, but this also has a strip prefix which I have configured:

![image](https://user-images.githubusercontent.com/1201644/236494278-6286bc66-c554-45b7-a4fd-d9790fd2b26a.png)

I saw coder is being built with `vite`, which has an option to define a basepath: https://vitejs.dev/config/shared-options.html#base

Others have gone before me on StackOverflow, and found out that the default is `/` (as described in vite docs) causing these root paths, and in order to make it relative this needs to be `./`: https://stackoverflow.com/questions/69744253/vite-build-always-using-static-paths/69746868#comment133768566_69746868

This PR configures the basepath so coder can run in any directory, whether it be root or subpath.