### PR TITLE
chore: Make better error message if missing license

### DIFF
--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -293,7 +293,9 @@ func (api *API) moonsEnabledMW(next http.Handler) http.Handler {
 		proxy := api.entitlements.Features[codersdk.FeatureWorkspaceProxy].Enabled
 		api.entitlementsMu.RUnlock()
 		if !proxy {
-			httpapi.RouteNotFound(rw)
+			httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
+				Message: "External workspace providers is an Enterprise feature. Contact sales!",
+			})
 			return
 		}
 

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -294,7 +294,7 @@ func (api *API) moonsEnabledMW(next http.Handler) http.Handler {
 		api.entitlementsMu.RUnlock()
 		if !proxy {
 			httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-				Message: "External workspace providers is an Enterprise feature. Contact sales!",
+				Message: "External workspace proxies is an Enterprise feature. Contact sales!",
 			})
 			return
 		}


### PR DESCRIPTION
```bash
$ coder proxy ls
External workspace providers is an Enterprise feature. Contact sales!

```