### PR TITLE
chore: Drop application host call, default to regions for info

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -149,6 +149,7 @@ const docTemplate = `{
                 ],
                 "summary": "Get applications host",
                 "operationId": "get-applications-host",
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -121,6 +121,7 @@
         "tags": ["Applications"],
         "summary": "Get applications host",
         "operationId": "get-applications-host",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "OK",

--- a/coderd/workspaceapps.go
+++ b/coderd/workspaceapps.go
@@ -27,6 +27,7 @@ import (
 // @Tags Applications
 // @Success 200 {object} codersdk.AppHostResponse
 // @Router /applications/host [get]
+// @Deprecated use api/v2/regions and see the primary proxy.
 func (api *API) appHost(rw http.ResponseWriter, r *http.Request) {
 	host := api.AppHostname
 	if host != "" && api.AccessURL.Port() != "" {

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -98,6 +98,8 @@ export const ProxyProvider: FC<PropsWithChildren> = ({ children }) => {
         proxy: experimentEnabled
           ? proxy
           : {
+              // If the experiment is disabled, then call 'getPreferredProxy' with the regions from
+              // the api call. The default behavior is to use the `primary` proxy.
               ...getPreferredProxy(proxiesResp?.regions || []),
             },
         proxies: proxiesResp?.regions,

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -70,7 +70,6 @@ export const ProxyProvider: FC<PropsWithChildren> = ({ children }) => {
     onSuccess: (resp) => {
       setAndSaveProxy(proxy.selectedProxy, resp.regions)
     },
-    enabled: experimentEnabled,
   })
 
   const setAndSaveProxy = (
@@ -93,35 +92,18 @@ export const ProxyProvider: FC<PropsWithChildren> = ({ children }) => {
     setProxy(preferred)
   }
 
-  // ******************************* //
-  // ** This code can be removed  **
-  // ** when the experimental is  **
-  // **       dropped             ** //
-  const appHostQueryKey = ["get-application-host"]
-  const {
-    data: applicationHostResult,
-    error: appHostError,
-    isLoading: appHostLoading,
-    isFetched: appHostFetched,
-  } = useQuery({
-    queryKey: appHostQueryKey,
-    queryFn: getApplicationsHost,
-    enabled: !experimentEnabled,
-  })
-
   return (
     <ProxyContext.Provider
       value={{
         proxy: experimentEnabled
           ? proxy
           : {
-              ...getPreferredProxy([]),
-              preferredWildcardHostname: applicationHostResult?.host || "",
+              ...getPreferredProxy(proxiesResp?.regions || []),
             },
-        proxies: experimentEnabled ? proxiesResp?.regions : [],
-        isLoading: experimentEnabled ? proxiesLoading : appHostLoading,
-        isFetched: experimentEnabled ? proxiesFetched : appHostFetched,
-        error: experimentEnabled ? proxiesError : appHostError,
+        proxies: proxiesResp?.regions,
+        isLoading: proxiesLoading,
+        isFetched: proxiesFetched,
+        error: proxiesError,
         // A function that takes the new proxies and selected proxy and updates
         // the state with the appropriate urls.
         setProxy: setAndSaveProxy,

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import { getApplicationsHost, getWorkspaceProxies } from "api/api"
+import { getWorkspaceProxies } from "api/api"
 import { Region } from "api/typesGenerated"
 import { useDashboard } from "components/Dashboard/DashboardProvider"
 import {


### PR DESCRIPTION
I made the `/regions` endpoint not experimentally gates. So the api route is always available, and we do not need to use the old one.

Fixes: https://github.com/coder/coder/issues/7309