### PR TITLE
chore: If selecting an unhealthy proxy, default to primary

### DIFF
--- a/site/src/contexts/ProxyContext.test.ts
+++ b/site/src/contexts/ProxyContext.test.ts
@@ -2,6 +2,7 @@ import {
   MockPrimaryWorkspaceProxy,
   MockWorkspaceProxies,
   MockHealthyWildWorkspaceProxy,
+  MockUnhealthyWildWorkspaceProxy,
 } from "testHelpers/entities"
 import { getPreferredProxy } from "./ProxyContext"
 
@@ -35,6 +36,14 @@ describe("ProxyContextGetURLs", () => {
       "regions no select primary default",
       MockWorkspaceProxies,
       undefined,
+      "",
+      MockPrimaryWorkspaceProxy.wildcard_hostname,
+    ],
+    // Primary is the default if the selected is unhealthy
+    [
+      "unhealthy selection",
+      MockWorkspaceProxies,
+      MockUnhealthyWildWorkspaceProxy,
       "",
       MockPrimaryWorkspaceProxy.wildcard_hostname,
     ],

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -149,8 +149,8 @@ export const getPreferredProxy = (
     (proxy) => selectedProxy && proxy.id === selectedProxy.id,
   )
 
-  if (!selectedProxy) {
-    // If no proxy is selected, default to the primary proxy.
+  // If no proxy is selected, or the selected proxy is unhealthy default to the primary proxy.
+  if (!selectedProxy || !selectedProxy.healthy) {
     selectedProxy = proxies.find((proxy) => proxy.name === "primary")
   }
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -88,18 +88,20 @@ export const MockHealthyWildWorkspaceProxy: TypesGen.Region = {
   wildcard_hostname: "*.external.com",
 }
 
+export const MockUnhealthyWildWorkspaceProxy: TypesGen.Region =   {
+  id: "8444931c-0247-4171-842a-569d9f9cbadb",
+  name: "unhealthy",
+  display_name: "Unhealthy",
+  icon_url: "/emojis/1f92e.png",
+  healthy: false,
+  path_app_url: "https://unhealthy.coder.com",
+  wildcard_hostname: "*unhealthy..coder.com",
+}
+
 export const MockWorkspaceProxies: TypesGen.Region[] = [
   MockPrimaryWorkspaceProxy,
   MockHealthyWildWorkspaceProxy,
-  {
-    id: "8444931c-0247-4171-842a-569d9f9cbadb",
-    name: "unhealthy",
-    display_name: "Unhealthy",
-    icon_url: "/emojis/1f92e.png",
-    healthy: false,
-    path_app_url: "https://unhealthy.coder.com",
-    wildcard_hostname: "*unhealthy..coder.com",
-  },
+  MockUnhealthyWildWorkspaceProxy,
   {
     id: "26e84c16-db24-4636-a62d-aa1a4232b858",
     name: "nowildcard",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -88,7 +88,7 @@ export const MockHealthyWildWorkspaceProxy: TypesGen.Region = {
   wildcard_hostname: "*.external.com",
 }
 
-export const MockUnhealthyWildWorkspaceProxy: TypesGen.Region =   {
+export const MockUnhealthyWildWorkspaceProxy: TypesGen.Region = {
   id: "8444931c-0247-4171-842a-569d9f9cbadb",
   name: "unhealthy",
   display_name: "Unhealthy",


### PR DESCRIPTION
# What this does

Default to primary if the selectedProxy is unhealthy. Wrote a unit test to confirm this works.

Fixes: https://github.com/coder/coder/issues/7443