### PR TITLE
chore(rbac): use global cache for subject ast value

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -144,7 +144,7 @@ var (
 			},
 		}),
 		Scope: rbac.ScopeAll,
-	}.WithCachedASTValue()
+	}
 
 	subjectAutostart = rbac.Subject{
 		ID: uuid.Nil.String(),
@@ -162,7 +162,7 @@ var (
 			},
 		}),
 		Scope: rbac.ScopeAll,
-	}.WithCachedASTValue()
+	}
 
 	subjectSystemRestricted = rbac.Subject{
 		ID: uuid.Nil.String(),
@@ -190,7 +190,7 @@ var (
 			},
 		}),
 		Scope: rbac.ScopeAll,
-	}.WithCachedASTValue()
+	}
 )
 
 // AsProvisionerd returns a context with an actor that has permissions required

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -379,7 +379,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 			Roles:  rbac.RoleNames(roles.Roles),
 			Groups: roles.Groups,
 			Scope:  rbac.ScopeName(key.Scope),
-		}.WithCachedASTValue(),
+		},
 	}
 
 	return &key, &authz, true

--- a/coderd/httpmw/workspaceagent.go
+++ b/coderd/httpmw/workspaceagent.go
@@ -110,5 +110,5 @@ func getAgentSubject(ctx context.Context, db database.Store, agent database.Work
 		Roles:  rbac.RoleNames(roles.Roles),
 		Groups: roles.Groups,
 		Scope:  rbac.WorkspaceAgentScope(workspace.ID, user.ID),
-	}.WithCachedASTValue(), nil
+	}, nil
 }

--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -77,20 +77,6 @@ type Subject struct {
 	Roles  ExpandableRoles
 	Groups []string
 	Scope  ExpandableScope
-
-	// cachedASTValue is the cached ast value for this subject.
-	cachedASTValue ast.Value
-}
-
-// WithCachedASTValue can be called if the subject is static. This will compute
-// the ast value once and cache it for future calls.
-func (s Subject) WithCachedASTValue() Subject {
-	tmp := s
-	v, err := tmp.regoValue()
-	if err == nil {
-		tmp.cachedASTValue = v
-	}
-	return tmp
 }
 
 func (s Subject) Equal(b Subject) bool {

--- a/coderd/rbac/authz_test.go
+++ b/coderd/rbac/authz_test.go
@@ -87,21 +87,6 @@ func benchmarkUserCases() (cases []benchmarkCase, users uuid.UUID, orgs []uuid.U
 			},
 		},
 		{
-			Name: "ManyRolesCachedSubject",
-			Actor: rbac.Subject{
-				// Admin of many orgs
-				Roles: rbac.RoleNames{
-					rbac.RoleOrgMember(orgs[0]), rbac.RoleOrgAdmin(orgs[0]),
-					rbac.RoleOrgMember(orgs[1]), rbac.RoleOrgAdmin(orgs[1]),
-					rbac.RoleOrgMember(orgs[2]), rbac.RoleOrgAdmin(orgs[2]),
-					rbac.RoleMember(),
-				},
-				ID:     user.String(),
-				Scope:  rbac.ScopeAll,
-				Groups: noiseGroups,
-			}.WithCachedASTValue(),
-		},
-		{
 			Name: "AdminWithScope",
 			Actor: rbac.Subject{
 				// Give some extra roles that an admin might have
@@ -124,20 +109,6 @@ func benchmarkUserCases() (cases []benchmarkCase, users uuid.UUID, orgs []uuid.U
 				Scope:  rbac.ScopeAll,
 				Groups: noiseGroups,
 			},
-		},
-		{
-			// This test should only use static roles. AKA no org roles.
-			Name: "StaticRolesWithCache",
-			Actor: rbac.Subject{
-				// Give some extra roles that an admin might have
-				Roles: rbac.RoleNames{
-					"auditor", rbac.RoleOwner(), rbac.RoleMember(),
-					rbac.RoleTemplateAdmin(), rbac.RoleUserAdmin(),
-				},
-				ID:     user.String(),
-				Scope:  rbac.ScopeAll,
-				Groups: noiseGroups,
-			}.WithCachedASTValue(),
 		},
 	}
 	return benchCases, users, orgs


### PR DESCRIPTION
UsersMe benchmark results:

|    Test    |   /tmp/b1   |   /tmp/b2   |   Change   |
|:----------:|:-----------:|:-----------:|:----------:|
| **sec/op** | 470.3µ ± 1% | 400.9µ ± 1% | -14.76%    |
| **B/op**   | 51.00Ki ± 0%| 35.86Ki ± 0%| -29.68%    |
| **allocs/op** | 755.0 ± 0% | 392.0 ± 0% | -48.08%    |
