### PR TITLE
feat: add deleted_at field to workspace model

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,8 @@
     "codersdk",
     "cronstrue",
     "databasefake",
+    "dbfake",
+    "dbgen",
     "dbtype",
     "DERP",
     "derphttp",

--- a/cli/testdata/coder_list_--output_json.golden
+++ b/cli/testdata/coder_list_--output_json.golden
@@ -48,6 +48,7 @@
     "name": "test-workspace",
     "autostart_schedule": "CRON_TZ=US/Central 30 9 * * 1-5",
     "ttl_ms": 28800000,
-    "last_used_at": "[timestamp]"
+    "last_used_at": "[timestamp]",
+    "impending_deletion": "[timestamp]"
   }
 ]

--- a/cli/testdata/coder_list_--output_json.golden
+++ b/cli/testdata/coder_list_--output_json.golden
@@ -49,6 +49,6 @@
     "autostart_schedule": "CRON_TZ=US/Central 30 9 * * 1-5",
     "ttl_ms": 28800000,
     "last_used_at": "[timestamp]",
-    "impending_deletion": "[timestamp]"
+    "deleting_at": null
   }
 ]

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9326,6 +9326,10 @@ const docTemplate = `{
                     "type": "string",
                     "format": "uuid"
                 },
+                "impending_deletion": {
+                    "type": "string",
+                    "format": "date-time"
+                },
                 "last_used_at": {
                     "type": "string",
                     "format": "date-time"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9322,13 +9322,14 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time"
                 },
+                "deleting_at": {
+                    "description": "DeletingAt indicates the time of the upcoming workspace deletion, if applicable; otherwise it is nil.\nWorkspaces may have impending deletions if Template.InactivityTTL feature is turned on and the workspace is inactive.",
+                    "type": "string",
+                    "format": "date-time"
+                },
                 "id": {
                     "type": "string",
                     "format": "uuid"
-                },
-                "impending_deletion": {
-                    "type": "string",
-                    "format": "date-time"
                 },
                 "last_used_at": {
                     "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8389,6 +8389,10 @@
           "type": "string",
           "format": "uuid"
         },
+        "impending_deletion": {
+          "type": "string",
+          "format": "date-time"
+        },
         "last_used_at": {
           "type": "string",
           "format": "date-time"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8385,13 +8385,14 @@
           "type": "string",
           "format": "date-time"
         },
+        "deleting_at": {
+          "description": "DeletingAt indicates the time of the upcoming workspace deletion, if applicable; otherwise it is nil.\nWorkspaces may have impending deletions if Template.InactivityTTL feature is turned on and the workspace is inactive.",
+          "type": "string",
+          "format": "date-time"
+        },
         "id": {
           "type": "string",
           "format": "uuid"
-        },
-        "impending_deletion": {
-          "type": "string",
-          "format": "date-time"
         },
         "last_used_at": {
           "type": "string",

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1169,7 +1169,10 @@ func convertWorkspace(
 		autostartSchedule = &workspace.AutostartSchedule.String
 	}
 
-	ttlMillis := convertWorkspaceTTLMillis(workspace.Ttl)
+	var (
+		ttlMillis         = convertWorkspaceTTLMillis(workspace.Ttl)
+		impendingDeletion = calculateImpendingDeletion(workspace, template)
+	)
 	return codersdk.Workspace{
 		ID:                                   workspace.ID,
 		CreatedAt:                            workspace.CreatedAt,
@@ -1188,6 +1191,7 @@ func convertWorkspace(
 		AutostartSchedule:                    autostartSchedule,
 		TTLMillis:                            ttlMillis,
 		LastUsedAt:                           workspace.LastUsedAt,
+		ImpendingDeletion:                    impendingDeletion,
 	}
 }
 
@@ -1198,6 +1202,22 @@ func convertWorkspaceTTLMillis(i sql.NullInt64) *int64 {
 
 	millis := time.Duration(i.Int64).Milliseconds()
 	return &millis
+}
+
+// Calculate the time of the upcoming working deletion, if applicable; otherwise, return an empty time.Time struct.
+// Workspaces may have impending deletions if InactivityTTL feature is turned on and the workspace is inactive.
+func calculateImpendingDeletion(workspace database.Workspace, template database.Template) time.Time {
+	var (
+		year, month, day = time.Now().Date()
+		beginningOfToday = time.Date(year, month, day, 0, 0, 0, 0, time.Now().Location())
+	)
+	// If InactivityTTL is turned off (set to 0), if the workspace has already been deleted,
+	// or if the workspace was used sometime within the last day, there is no impending deletion
+	if template.InactivityTTL == 0 || workspace.Deleted || workspace.LastUsedAt.After(beginningOfToday) {
+		return time.Time{}
+	}
+
+	return workspace.LastUsedAt.Add(time.Duration(template.InactivityTTL) * time.Nanosecond)
 }
 
 func validWorkspaceTTLMillis(millis *int64, templateDefault, templateMax time.Duration) (sql.NullInt64, error) {

--- a/coderd/workspaces_internal_test.go
+++ b/coderd/workspaces_internal_test.go
@@ -1,0 +1,76 @@
+package coderd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/coderd/database"
+)
+
+func Test_calculateImpendingDeletion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		workspace database.Workspace
+		template  database.Template
+		expected  time.Time
+	}{
+		{
+			name: "ImpendingDeletion",
+			workspace: database.Workspace{
+				Deleted:    false,
+				LastUsedAt: time.Now().Add(time.Duration(-10) * time.Hour * 24), // 10 days ago
+			},
+			template: database.Template{
+				InactivityTTL: int64(9 * 24 * time.Hour), // 9 days
+			},
+			expected: time.Now().Add(time.Duration(-1) * time.Hour * 24), // yesterday
+		},
+		{
+			name: "InactivityTTLUnset",
+			workspace: database.Workspace{
+				Deleted:    false,
+				LastUsedAt: time.Now().Add(time.Duration(-10) * time.Hour * 24),
+			},
+			template: database.Template{
+				InactivityTTL: 0,
+			},
+			expected: time.Time{},
+		},
+		{
+			name: "DeletedWorkspace",
+			workspace: database.Workspace{
+				Deleted:    true,
+				LastUsedAt: time.Now().Add(time.Duration(-10) * time.Hour * 24),
+			},
+			template: database.Template{
+				InactivityTTL: int64(9 * 24 * time.Hour),
+			},
+			expected: time.Time{},
+		},
+		{
+			name: "ActiveWorkspace",
+			workspace: database.Workspace{
+				Deleted:    true,
+				LastUsedAt: time.Now().Add(time.Duration(-5) * time.Hour), // 5 hours ago
+			},
+			template: database.Template{
+				InactivityTTL: int64(1 * 24 * time.Hour), // 1 day
+			},
+			expected: time.Time{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			found := calculateImpendingDeletion(tc.workspace, tc.template)
+			require.WithinDuration(t, tc.expected, found, time.Second, "incorrect impending deletion")
+		})
+	}
+}

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -34,6 +34,7 @@ type Workspace struct {
 	AutostartSchedule                    *string        `json:"autostart_schedule,omitempty"`
 	TTLMillis                            *int64         `json:"ttl_ms,omitempty"`
 	LastUsedAt                           time.Time      `json:"last_used_at" format:"date-time"`
+	ImpendingDeletion                    time.Time      `json:"impending_deletion" format:"date-time"`
 }
 
 type WorkspacesRequest struct {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -34,7 +34,10 @@ type Workspace struct {
 	AutostartSchedule                    *string        `json:"autostart_schedule,omitempty"`
 	TTLMillis                            *int64         `json:"ttl_ms,omitempty"`
 	LastUsedAt                           time.Time      `json:"last_used_at" format:"date-time"`
-	ImpendingDeletion                    time.Time      `json:"impending_deletion" format:"date-time"`
+
+	// DeletingAt indicates the time of the upcoming workspace deletion, if applicable; otherwise it is nil.
+	// Workspaces may have impending deletions if Template.InactivityTTL feature is turned on and the workspace is inactive.
+	DeletingAt *time.Time `json:"deleting_at" format:"date-time"`
 }
 
 type WorkspacesRequest struct {

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -4573,6 +4573,7 @@ Parameter represents a set value for the scope.
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,
@@ -4714,6 +4715,7 @@ Parameter represents a set value for the scope.
 | `autostart_schedule`                        | string                                             | false    |              |             |
 | `created_at`                                | string                                             | false    |              |             |
 | `id`                                        | string                                             | false    |              |             |
+| `impending_deletion`                        | string                                             | false    |              |             |
 | `last_used_at`                              | string                                             | false    |              |             |
 | `latest_build`                              | [codersdk.WorkspaceBuild](#codersdkworkspacebuild) | false    |              |             |
 | `name`                                      | string                                             | false    |              |             |
@@ -5573,6 +5575,7 @@ Parameter represents a set value for the scope.
       "autostart_schedule": "string",
       "created_at": "2019-08-24T14:15:22Z",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "impending_deletion": "2019-08-24T14:15:22Z",
       "last_used_at": "2019-08-24T14:15:22Z",
       "latest_build": {
         "build_number": 0,

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -4572,8 +4572,8 @@ Parameter represents a set value for the scope.
 {
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
+  "deleting_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,
@@ -4710,26 +4710,26 @@ Parameter represents a set value for the scope.
 
 ### Properties
 
-| Name                                        | Type                                               | Required | Restrictions | Description |
-| ------------------------------------------- | -------------------------------------------------- | -------- | ------------ | ----------- |
-| `autostart_schedule`                        | string                                             | false    |              |             |
-| `created_at`                                | string                                             | false    |              |             |
-| `id`                                        | string                                             | false    |              |             |
-| `impending_deletion`                        | string                                             | false    |              |             |
-| `last_used_at`                              | string                                             | false    |              |             |
-| `latest_build`                              | [codersdk.WorkspaceBuild](#codersdkworkspacebuild) | false    |              |             |
-| `name`                                      | string                                             | false    |              |             |
-| `organization_id`                           | string                                             | false    |              |             |
-| `outdated`                                  | boolean                                            | false    |              |             |
-| `owner_id`                                  | string                                             | false    |              |             |
-| `owner_name`                                | string                                             | false    |              |             |
-| `template_allow_user_cancel_workspace_jobs` | boolean                                            | false    |              |             |
-| `template_display_name`                     | string                                             | false    |              |             |
-| `template_icon`                             | string                                             | false    |              |             |
-| `template_id`                               | string                                             | false    |              |             |
-| `template_name`                             | string                                             | false    |              |             |
-| `ttl_ms`                                    | integer                                            | false    |              |             |
-| `updated_at`                                | string                                             | false    |              |             |
+| Name                                        | Type                                               | Required | Restrictions | Description                                                                                                                                                                                                                  |
+| ------------------------------------------- | -------------------------------------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autostart_schedule`                        | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `created_at`                                | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `deleting_at`                               | string                                             | false    |              | Deleting at indicates the time of the upcoming workspace deletion, if applicable; otherwise it is nil. Workspaces may have impending deletions if Template.InactivityTTL feature is turned on and the workspace is inactive. |
+| `id`                                        | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `last_used_at`                              | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `latest_build`                              | [codersdk.WorkspaceBuild](#codersdkworkspacebuild) | false    |              |                                                                                                                                                                                                                              |
+| `name`                                      | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `organization_id`                           | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `outdated`                                  | boolean                                            | false    |              |                                                                                                                                                                                                                              |
+| `owner_id`                                  | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `owner_name`                                | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `template_allow_user_cancel_workspace_jobs` | boolean                                            | false    |              |                                                                                                                                                                                                                              |
+| `template_display_name`                     | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `template_icon`                             | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `template_id`                               | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `template_name`                             | string                                             | false    |              |                                                                                                                                                                                                                              |
+| `ttl_ms`                                    | integer                                            | false    |              |                                                                                                                                                                                                                              |
+| `updated_at`                                | string                                             | false    |              |                                                                                                                                                                                                                              |
 
 ## codersdk.WorkspaceAgent
 
@@ -5574,8 +5574,8 @@ Parameter represents a set value for the scope.
     {
       "autostart_schedule": "string",
       "created_at": "2019-08-24T14:15:22Z",
+      "deleting_at": "2019-08-24T14:15:22Z",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-      "impending_deletion": "2019-08-24T14:15:22Z",
       "last_used_at": "2019-08-24T14:15:22Z",
       "latest_build": {
         "build_number": 0,

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -57,6 +57,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,
@@ -229,6 +230,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,
@@ -424,6 +426,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
       "autostart_schedule": "string",
       "created_at": "2019-08-24T14:15:22Z",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "impending_deletion": "2019-08-24T14:15:22Z",
       "last_used_at": "2019-08-24T14:15:22Z",
       "latest_build": {
         "build_number": 0,
@@ -593,6 +596,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -56,8 +56,8 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
 {
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
+  "deleting_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,
@@ -229,8 +229,8 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
 {
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
+  "deleting_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,
@@ -425,8 +425,8 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
     {
       "autostart_schedule": "string",
       "created_at": "2019-08-24T14:15:22Z",
+      "deleting_at": "2019-08-24T14:15:22Z",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-      "impending_deletion": "2019-08-24T14:15:22Z",
       "last_used_at": "2019-08-24T14:15:22Z",
       "latest_build": {
         "build_number": 0,
@@ -595,8 +595,8 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
 {
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
+  "deleting_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "impending_deletion": "2019-08-24T14:15:22Z",
   "last_used_at": "2019-08-24T14:15:22Z",
   "latest_build": {
     "build_number": 0,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1104,7 +1104,7 @@ export interface Workspace {
   readonly autostart_schedule?: string
   readonly ttl_ms?: number
   readonly last_used_at: string
-  readonly impending_deletion: string
+  readonly deleting_at?: string
 }
 
 // From codersdk/workspaceagents.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1104,6 +1104,7 @@ export interface Workspace {
   readonly autostart_schedule?: string
   readonly ttl_ms?: number
   readonly last_used_at: string
+  readonly impending_deletion: string
 }
 
 // From codersdk/workspaceagents.go

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -719,6 +719,7 @@ export const MockWorkspace: TypesGen.Workspace = {
   ttl_ms: 2 * 60 * 60 * 1000,
   latest_build: MockWorkspaceBuild,
   last_used_at: "2022-05-16T15:29:10.302441433Z",
+  impending_deletion: "0001-01-01T00:00:00Z",
 }
 
 export const MockStoppedWorkspace: TypesGen.Workspace = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -719,7 +719,7 @@ export const MockWorkspace: TypesGen.Workspace = {
   ttl_ms: 2 * 60 * 60 * 1000,
   latest_build: MockWorkspaceBuild,
   last_used_at: "2022-05-16T15:29:10.302441433Z",
-  impending_deletion: "0001-01-01T00:00:00Z",
+  deleting_at: "0001-01-01T00:00:00Z",
 }
 
 export const MockStoppedWorkspace: TypesGen.Workspace = {


### PR DESCRIPTION
![Screenshot 2023-05-09 at 5 36 13 PM](https://github.com/coder/coder/assets/19142439/18d04ea0-9aa3-430e-9ab9-5e823a162ea7)

`deleted_at` is a calculated field on the `workspace` model that will return a `time.Time` if a workspace is scheduled for deletion. Workspaces are scheduled for deletion when the template's `inactivity_ttl` is set (when it's not 0) and when the workspace hasn't seen activity in the last day.

We will use this field to display notifications on the FE about upcoming workspace deletion.