### PR TITLE
fix: add mui to vite exclude array

### DIFF
--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -82,4 +82,9 @@ export default defineConfig({
       xServices: path.resolve(__dirname, "./src/xServices"),
     },
   },
+  // https://github.com/vitejs/vite/issues/12434
+  // needed to fix Vite error: "outdated optimize dep"
+  optimizeDeps: {
+    exclude: ["@mui_material"],
+  },
 })


### PR DESCRIPTION
This (hopefully) fixes a bundling bug that Vite has that was blocking page load on port 8080:
https://github.com/vitejs/vite/issues/12434

![Screenshot 2023-05-11 at 2 49 51 PM](https://github.com/coder/coder/assets/19142439/d4e39c7b-1e22-436d-8116-20dba928be5b)
