### PR TITLE
docs: fix documentation of scim auth header

### DIFF
--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -214,7 +214,7 @@ and are not deleted. [Configure](./configure.md) your SCIM application with an
 auth key and supply it the Coder server.
 
 ```console
-CODER_SCIM_API_KEY="your-api-key"
+CODER_SCIM_AUTH_HEADER="your-api-key"
 ```
 
 ## TLS


### PR DESCRIPTION
Update the documentation to use the appropriate env var for the SCIM auth header

See: https://github.com/coder/coder/blob/8d4a8fde6688ecca6463fefdef15676a119e9108/codersdk/deployment.go#L1362