### PR TITLE
chore: reduce the log output of skipped tests

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1020,7 +1020,7 @@ func TestAgentMetadata_Timing(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// Shell scripting in Windows is a pain, and we have already tested
 		// that the OS logic works in the simpler tests.
-		t.Skip()
+		t.SkipNow()
 	}
 	testutil.SkipIfNotTiming(t)
 	t.Parallel()

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -34,7 +34,7 @@ func TestMigrate(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 		return
 	}
 
@@ -198,7 +198,7 @@ func TestMigrateUpWithFixtures(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 		return
 	}
 

--- a/coderd/database/postgres/postgres_test.go
+++ b/coderd/database/postgres/postgres_test.go
@@ -23,7 +23,7 @@ func TestPostgres(t *testing.T) {
 	// t.Parallel()
 
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 		return
 	}
 

--- a/coderd/database/pubsub_test.go
+++ b/coderd/database/pubsub_test.go
@@ -24,7 +24,7 @@ func TestPubsub(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 		return
 	}
 

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -63,11 +63,6 @@ type Deployment struct {
 	SDKClient      *codersdk.Client
 	FirstUser      codersdk.CreateFirstUserResponse
 	PathAppBaseURL *url.URL
-
-	// AppHostIsPrimary is true if the app host is also the primary coder API
-	// server. This disables any tests that test API passthrough or rely on the
-	// app server not being the API server.
-	AppHostIsPrimary bool
 }
 
 // DeploymentFactory generates a deployment with an API client, a path base URL,

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -252,7 +252,7 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 func TestWorkspaceApps(t *testing.T) {
 	t.Parallel()
 
-	apptest.Run(t, func(t *testing.T, opts *apptest.DeploymentOptions) *apptest.Deployment {
+	apptest.Run(t, true, func(t *testing.T, opts *apptest.DeploymentOptions) *apptest.Deployment {
 		deploymentValues := coderdtest.DeploymentValues(t)
 		deploymentValues.DisablePathApps = clibase.Bool(opts.DisablePathApps)
 		deploymentValues.Dangerous.AllowPathAppSharing = clibase.Bool(opts.DangerousAllowPathAppSharing)
@@ -280,11 +280,10 @@ func TestWorkspaceApps(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 
 		return &apptest.Deployment{
-			Options:          opts,
-			SDKClient:        client,
-			FirstUser:        user,
-			PathAppBaseURL:   client.URL,
-			AppHostIsPrimary: true,
+			Options:        opts,
+			SDKClient:      client,
+			FirstUser:      user,
+			PathAppBaseURL: client.URL,
 		}
 	})
 }

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -16,7 +16,7 @@ import (
 func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 	t.Parallel()
 
-	apptest.Run(t, func(t *testing.T, opts *apptest.DeploymentOptions) *apptest.Deployment {
+	apptest.Run(t, false, func(t *testing.T, opts *apptest.DeploymentOptions) *apptest.Deployment {
 		deploymentValues := coderdtest.DeploymentValues(t)
 		deploymentValues.DisablePathApps = clibase.Bool(opts.DisablePathApps)
 		deploymentValues.Dangerous.AllowPathAppSharing = clibase.Bool(opts.DangerousAllowPathAppSharing)
@@ -61,11 +61,10 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 		})
 
 		return &apptest.Deployment{
-			Options:          opts,
-			SDKClient:        client,
-			FirstUser:        user,
-			PathAppBaseURL:   proxyAPI.Options.AccessURL,
-			AppHostIsPrimary: false,
+			Options:        opts,
+			SDKClient:      client,
+			FirstUser:      user,
+			PathAppBaseURL: proxyAPI.Options.AccessURL,
 		}
 	})
 }


### PR DESCRIPTION
With the introduction of the workspace proxy tests there was a lot of output if a test was eventually skipped.