### PR TITLE
chore: improve postgres test time by removing cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,9 +608,8 @@ test-postgres: test-clean test-postgres-docker
 		--jsonfile="gotests.json" \
 		--packages="./..." -- \
 		-covermode=atomic -coverprofile="gotests.coverage" -timeout=20m \
-		-parallel=4 \
 		-coverpkg=./... \
-		-count=1 -race -failfast
+		-race -failfast
 .PHONY: test-postgres
 
 test-postgres-docker:
@@ -627,6 +626,8 @@ test-postgres-docker:
 		--detach \
 		postgres:13 \
 		-c shared_buffers=1GB \
+		-c work_mem=1GB \
+		-c effective_cache_size=1GB \
 		-c max_connections=1000 \
 		-c fsync=off \
 		-c synchronous_commit=off \

--- a/coderd/database/postgres/postgres.go
+++ b/coderd/database/postgres/postgres.go
@@ -46,13 +46,10 @@ func Open() (string, func(), error) {
 			return "", nil, xerrors.Errorf("create db with template: %w", err)
 		}
 
-		deleteDB := func() {
-			ddb, _ := sql.Open("postgres", dbURL)
-			defer ddb.Close()
-			_, _ = ddb.Exec("DROP DATABASE " + dbName)
-		}
-
-		return "postgres://postgres:postgres@127.0.0.1:5432/" + dbName + "?sslmode=disable", deleteDB, nil
+		return "postgres://postgres:postgres@127.0.0.1:5432/" + dbName + "?sslmode=disable", func() {
+			// We don't need to clean anything up here... it's just a database in a container,
+			// so cleaning up the container will clean up the database.
+		}, nil
 	}
 
 	pool, err := dockertest.NewPool("")


### PR DESCRIPTION
We don't need to delete databases on cleanup... and we don't need to always run without a cache either!