### PR TITLE
feat: added URL param name to allow setting workspace name

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -44,6 +44,7 @@ const CreateWorkspacePage: FC = () => {
   } = createWorkspaceState.context
   const [searchParams] = useSearchParams()
   const defaultParameterValues = getDefaultParameterValues(searchParams)
+  const name = getName(searchParams)
 
   return (
     <>
@@ -51,6 +52,7 @@ const CreateWorkspacePage: FC = () => {
         <title>{pageTitle("Create Workspace")}</title>
       </Helmet>
       <CreateWorkspacePageView
+        name={name}
         defaultParameterValues={defaultParameterValues}
         loadingTemplates={createWorkspaceState.matches("gettingTemplates")}
         loadingTemplateSchema={createWorkspaceState.matches(
@@ -94,6 +96,12 @@ const CreateWorkspacePage: FC = () => {
       />
     </>
   )
+}
+
+const getName = (
+  urlSearchParams: URLSearchParams,
+): string => {
+  return urlSearchParams.get("name") ?? ""
 }
 
 const getDefaultParameterValues = (

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -98,9 +98,7 @@ const CreateWorkspacePage: FC = () => {
   )
 }
 
-const getName = (
-  urlSearchParams: URLSearchParams,
-): string => {
+const getName = (urlSearchParams: URLSearchParams): string => {
   return urlSearchParams.get("name") ?? ""
 }
 

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -35,6 +35,7 @@ export enum CreateWorkspaceErrors {
 }
 
 export interface CreateWorkspacePageViewProps {
+  name: string
   loadingTemplates: boolean
   loadingTemplateSchema: boolean
   creatingWorkspace: boolean
@@ -92,7 +93,7 @@ export const CreateWorkspacePageView: FC<
   const form: FormikContextType<TypesGen.CreateWorkspaceRequest> =
     useFormik<TypesGen.CreateWorkspaceRequest>({
       initialValues: {
-        name: "",
+        name: props.name,
         template_id: props.selectedTemplate ? props.selectedTemplate.id : "",
         rich_parameter_values: initialRichParameterValues,
       },


### PR DESCRIPTION
# Description

This is a **draft** feature request open for RFC. This PR enables user to set the workspace **name** field in the CreateWorkspacePageView.

I already talked @BrunoQuaresma about this topic. This is currently **untested**! But @BrunoQuaresma  had look and thinks this is fine.

# UseCase

We want to create a workspace from a GitHub repository. We've created an Chrome extension to create a link to open the  CreateWorkspacePage. We already pass GitHub **owner** and GitHub **repository** to the template via URL parameter. This new parameter **name** should be filled too.

# Follow up

As follow up feature we want add the ability to extend the given workspace name via URL param with a random suffix. This has to be enabled as the default is off. This enables to open multiple workspace instances from the repository at the same time as all workspace names are uniqe. Last but not least we want a feature to skip the confirmation on the CreateWorkspacePage and jump directly to the workspace page. 