### PR TITLE
chore(dogfood): update the dogfood template to add workspace CPU and RAM usage from `cgroup`

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -161,16 +161,19 @@ resource "coder_agent" "dev" {
   metadata {
     display_name = "Load Average (Host)"
     key          = "4_load_host"
-    script       = "awk '{print $1}' /proc/loadavg"
-    interval     = 10
-    timeout      = 1
+    # get laod avg scaled by number of cores
+    script   = <<EOT
+      echo "`cat /proc/loadavg | awk '{ print $1 }'` `nproc`" | awk '{ printf "%0.2f", $1/$2 }'
+    EOT
+    interval = 10
+    timeout  = 1
   }
 
   metadata {
     display_name = "Disk Usage (Host)"
     key          = "5_disk_host"
     script       = <<EOT
-      cat /sys/fs/cgroup/cpuacct.usage"
+      df --output=pcent / | sed -n "2p"
     EOT
     interval     = 600
     timeout      = 10 #getting disk usage can take a while

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -110,7 +110,7 @@ resource "coder_agent" "dev" {
         cusage=$(cat /sys/fs/cgroup/cpu.stat | head -n 1 | awk '{ print $2 }')
       else
         # cgroup v1
-        cusage=$(cat /sys/fs/cgroup/cpuacct,cpu/cpuacct.usage)
+        cusage=$(cat /sys/fs/cgroup/cpu,cpuacct/cpuacct.usage)
       fi
       echo "$cusage $cusage_p $interval $ncores" | awk '{ printf "%2.0f%%\n", (($1 - $2)/$3/$4)*100 }'
       echo $cusage > /tmp/cusage

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -105,7 +105,7 @@ resource "coder_agent" "dev" {
       ncores=$(nproc)
       cusage_p=$(cat /tmp/cusage || echo 0)
       # check if we are in cgroup v2 or v1
-      if [ -d /sys/fs/cgroup/cpu.stat ]; then
+      if [ -e /sys/fs/cgroup/cpu.stat ]; then
         # cgroup v2
         cusage=$(cat /sys/fs/cgroup/cpu.stat | head -n 1 | awk '{ print $2 }')
       else

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -161,7 +161,7 @@ resource "coder_agent" "dev" {
   metadata {
     display_name = "Load Average (Host)"
     key          = "4_load_host"
-    # get laod avg scaled by number of cores
+    # get load avg scaled by number of cores
     script   = <<EOT
       echo "`cat /proc/loadavg | awk '{ print $1 }'` `nproc`" | awk '{ printf "%0.2f", $1/$2 }'
     EOT

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -110,8 +110,8 @@ resource "coder_agent" "dev" {
       fi
 
       # get previous usage
-      if [ -f /tmp/cpu_usage ]; then
-        cusage_p=$(cat /tmp/cpu_usage)
+      if [ -e /tmp/cusage ]; then
+        cusage_p=$(cat /tmp/cusage)
       else
         echo $cusage > /tmp/cusage
         echo "Unknown"
@@ -134,7 +134,7 @@ resource "coder_agent" "dev" {
     script       = <<EOT
       #!/bin/bash
       # first check if we are in cgroup v2 or v1
-      if [ -d /sys/fs/cgroup/memory.max ]; then
+      if [ -e /sys/fs/cgroup/memory.stat ]; then
         # cgroup v2
         echo "`cat /sys/fs/cgroup/memory.current` `cat /sys/fs/cgroup/memory.max`" | awk '{ used=$1/1024/1024/1024; total=$2/1024/1024/1024; printf "%0.2f / %0.2f GB\n", used, total }'
       else


### PR DESCRIPTION
This currently does not work on US Pittsburgh because of being on Ubuntu Focal and Kernel 5.4.
But works fine in all other dogfood regions
See related issue: #7076 