### PR TITLE
fix: set default sshMaxTimeout to 60s

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -263,7 +263,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 		},
 		{
 			Flag:        "ssh-max-timeout",
-			Default:     "0",
+			Default:     "60s",
 			Env:         "CODER_AGENT_SSH_MAX_TIMEOUT",
 			Description: "Specify the max timeout for a SSH connection.",
 			Value:       clibase.DurationOf(&sshMaxTimeout),

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -21,7 +21,7 @@ Starts the Coder workspace agent.
       --prometheus-address string, $CODER_AGENT_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve Prometheus metrics.
 
-      --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 0)
+      --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 60s)
           Specify the max timeout for a SSH connection.
 
       --tailnet-listen-port int, $CODER_AGENT_TAILNET_LISTEN_PORT (default: 0)


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6724
Related: https://github.com/coder/coder/issues/7512

This PR sets the default SSH max timeout to a finite value. Without this setting, SSH connections can hang indefinitely, so in case of any failure, the connection is left as is and causes https://github.com/coder/coder/issues/7512.

Once we enable the timeout, coder agent will be able to report any troubles with broken agent connections:

```
2023-05-15 14:24:39.305 [debu]  ssh-server: copy output done  bytes=37025  error=EOF
2023-05-15 14:24:39.305 [warn]  ssh-server: ssh session failed ...
    error= copy error:
               github.com/coder/coder/agent/agentssh.(*Server).startPTYSession
                   /Users/mtojek/code/coder/agent/agentssh/agentssh.go:355
             - EOF
```

Otherwise, the agent assumes that the connection gets back to life eventually (hence no error trace in logs)