### PR TITLE
fix: revert "fix: set default sshMaxTimeout to 60s (#7532)"

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -263,7 +263,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 		},
 		{
 			Flag:        "ssh-max-timeout",
-			Default:     "60s",
+			Default:     "0",
 			Env:         "CODER_AGENT_SSH_MAX_TIMEOUT",
 			Description: "Specify the max timeout for a SSH connection.",
 			Value:       clibase.DurationOf(&sshMaxTimeout),

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -21,7 +21,7 @@ Starts the Coder workspace agent.
       --prometheus-address string, $CODER_AGENT_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve Prometheus metrics.
 
-      --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 60s)
+      --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 0)
           Specify the max timeout for a SSH connection.
 
       --tailnet-listen-port int, $CODER_AGENT_TAILNET_LISTEN_PORT (default: 0)


### PR DESCRIPTION
This reverts commit 049e557675135774ca1c0fad26fae40dc26e54fd.

Related: https://github.com/coder/coder/issues/6724

from Bruno Quaresma:
> The SSH connection for me today is kinda slow, and it is reconnecting and connecting quite frequently. I changed between my two networks and I get the same result. Anyone else is seeing this problem?

from Spike Curtis:
> I'm also seeing very frequent disconnects
Did anything networky get merged yesterday?
