### PR TITLE
feat: add telemetry support for workspace agent subsystem

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1463,12 +1463,12 @@ func expandDirectory(dir string) (string, error) {
 // EnvAgentSubsystem is the environment variable used to denote the
 // specialized environment in which the agent is running
 // (e.g. envbox, envbuilder).
-const EnvAgentSubsytem = "CODER_AGENT_SUBSYSTEM"
+const EnvAgentSubsystem = "CODER_AGENT_SUBSYSTEM"
 
 // SubsystemFromEnv returns the subsystem (if any) the agent
 // is running inside of.
 func SubsystemFromEnv() agentsdk.AgentSubsystem {
-	ss := os.Getenv(EnvAgentSubsytem)
+	ss := os.Getenv(EnvAgentSubsystem)
 	switch agentsdk.AgentSubsystem(ss) {
 	case agentsdk.AgentSubsystemEnvbox:
 		return agentsdk.AgentSubsystemEnvbox

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1464,15 +1464,3 @@ func expandDirectory(dir string) (string, error) {
 // specialized environment in which the agent is running
 // (e.g. envbox, envbuilder).
 const EnvAgentSubsystem = "CODER_AGENT_SUBSYSTEM"
-
-// SubsystemFromEnv returns the subsystem (if any) the agent
-// is running inside of.
-func SubsystemFromEnv() codersdk.AgentSubsystem {
-	ss := os.Getenv(EnvAgentSubsystem)
-	switch codersdk.AgentSubsystem(ss) {
-	case codersdk.AgentSubsystemEnvbox:
-		return codersdk.AgentSubsystemEnvbox
-	default:
-		return ""
-	}
-}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -491,6 +491,7 @@ func (a *agent) run(ctx context.Context) error {
 	err = a.client.PostStartup(ctx, agentsdk.PostStartupRequest{
 		Version:           buildinfo.Version(),
 		ExpandedDirectory: manifest.Directory,
+		Subsystem:         a.subsystem,
 	})
 	if err != nil {
 		return xerrors.Errorf("update workspace agent version: %w", err)
@@ -1180,7 +1181,6 @@ func (a *agent) startReportingConnectionStats(ctx context.Context) {
 		stats := &agentsdk.Stats{
 			ConnectionCount:    int64(len(networkStats)),
 			ConnectionsByProto: map[string]int64{},
-			Subsystem:          a.subsystem,
 		}
 		for conn, counts := range networkStats {
 			stats.ConnectionsByProto[conn.Proto.String()]++

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -62,7 +62,7 @@ type Options struct {
 	IgnorePorts            map[int]string
 	SSHMaxTimeout          time.Duration
 	TailnetListenPort      uint16
-	Subsystem              agentsdk.AgentSubsystem
+	Subsystem              codersdk.AgentSubsystem
 }
 
 type Client interface {
@@ -138,7 +138,7 @@ type agent struct {
 	// listing all listening ports. This is helpful to hide ports that
 	// are used by the agent, that the user does not care about.
 	ignorePorts map[int]string
-	subsystem   agentsdk.AgentSubsystem
+	subsystem   codersdk.AgentSubsystem
 
 	reconnectingPTYs       sync.Map
 	reconnectingPTYTimeout time.Duration
@@ -1467,11 +1467,11 @@ const EnvAgentSubsystem = "CODER_AGENT_SUBSYSTEM"
 
 // SubsystemFromEnv returns the subsystem (if any) the agent
 // is running inside of.
-func SubsystemFromEnv() agentsdk.AgentSubsystem {
+func SubsystemFromEnv() codersdk.AgentSubsystem {
 	ss := os.Getenv(EnvAgentSubsystem)
-	switch agentsdk.AgentSubsystem(ss) {
-	case agentsdk.AgentSubsystemEnvbox:
-		return agentsdk.AgentSubsystemEnvbox
+	switch codersdk.AgentSubsystem(ss) {
+	case codersdk.AgentSubsystemEnvbox:
+		return codersdk.AgentSubsystemEnvbox
 	default:
 		return ""
 	}

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coder/coder/agent/reaper"
 	"github.com/coder/coder/buildinfo"
 	"github.com/coder/coder/cli/clibase"
+	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/codersdk/agentsdk"
 )
 
@@ -197,6 +198,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 				return xerrors.Errorf("add executable to $PATH: %w", err)
 			}
 
+			subsystem := inv.Environ.Get(agent.EnvAgentSubsystem)
 			agnt := agent.New(agent.Options{
 				Client:            client,
 				Logger:            logger,
@@ -218,7 +220,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 				},
 				IgnorePorts:   ignorePorts,
 				SSHMaxTimeout: sshMaxTimeout,
-				Subsystem:     agent.SubsystemFromEnv(),
+				Subsystem:     codersdk.AgentSubsystem(subsystem),
 			})
 
 			debugSrvClose := ServeHandler(ctx, logger, agnt.HTTPDebug(), debugAddress, "debug")

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -218,6 +218,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 				},
 				IgnorePorts:   ignorePorts,
 				SSHMaxTimeout: sshMaxTimeout,
+				Subsystem:     agent.SubsystemFromEnv(),
 			})
 
 			debugSrvClose := ServeHandler(ctx, logger, agnt.HTTPDebug(), debugAddress, "debug")

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5800,6 +5800,15 @@ const docTemplate = `{
                 "AgentMetricTypeGauge"
             ]
         },
+        "agentsdk.AgentSubsystem": {
+            "type": "string",
+            "enum": [
+                "envbox"
+            ],
+            "x-enum-varnames": [
+                "AgentSubsystemEnvbox"
+            ]
+        },
         "agentsdk.AuthenticateResponse": {
             "type": "object",
             "properties": {
@@ -5965,6 +5974,9 @@ const docTemplate = `{
             "properties": {
                 "expanded_directory": {
                     "type": "string"
+                },
+                "subsystem": {
+                    "$ref": "#/definitions/agentsdk.AgentSubsystem"
                 },
                 "version": {
                     "type": "string"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5800,15 +5800,6 @@ const docTemplate = `{
                 "AgentMetricTypeGauge"
             ]
         },
-        "agentsdk.AgentSubsystem": {
-            "type": "string",
-            "enum": [
-                "envbox"
-            ],
-            "x-enum-varnames": [
-                "AgentSubsystemEnvbox"
-            ]
-        },
         "agentsdk.AuthenticateResponse": {
             "type": "object",
             "properties": {
@@ -5976,7 +5967,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "subsystem": {
-                    "$ref": "#/definitions/agentsdk.AgentSubsystem"
+                    "$ref": "#/definitions/codersdk.AgentSubsystem"
                 },
                 "version": {
                     "type": "string"
@@ -6417,6 +6408,15 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "codersdk.AgentSubsystem": {
+            "type": "string",
+            "enum": [
+                "envbox"
+            ],
+            "x-enum-varnames": [
+                "AgentSubsystemEnvbox"
+            ]
         },
         "codersdk.AppHostResponse": {
             "type": "object",
@@ -9638,6 +9638,9 @@ const docTemplate = `{
                 },
                 "status": {
                     "$ref": "#/definitions/codersdk.WorkspaceAgentStatus"
+                },
+                "subsystem": {
+                    "$ref": "#/definitions/codersdk.AgentSubsystem"
                 },
                 "troubleshooting_url": {
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5097,6 +5097,11 @@
       "enum": ["counter", "gauge"],
       "x-enum-varnames": ["AgentMetricTypeCounter", "AgentMetricTypeGauge"]
     },
+    "agentsdk.AgentSubsystem": {
+      "type": "string",
+      "enum": ["envbox"],
+      "x-enum-varnames": ["AgentSubsystemEnvbox"]
+    },
     "agentsdk.AuthenticateResponse": {
       "type": "object",
       "properties": {
@@ -5257,6 +5262,9 @@
       "properties": {
         "expanded_directory": {
           "type": "string"
+        },
+        "subsystem": {
+          "$ref": "#/definitions/agentsdk.AgentSubsystem"
         },
         "version": {
           "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5097,11 +5097,6 @@
       "enum": ["counter", "gauge"],
       "x-enum-varnames": ["AgentMetricTypeCounter", "AgentMetricTypeGauge"]
     },
-    "agentsdk.AgentSubsystem": {
-      "type": "string",
-      "enum": ["envbox"],
-      "x-enum-varnames": ["AgentSubsystemEnvbox"]
-    },
     "agentsdk.AuthenticateResponse": {
       "type": "object",
       "properties": {
@@ -5264,7 +5259,7 @@
           "type": "string"
         },
         "subsystem": {
-          "$ref": "#/definitions/agentsdk.AgentSubsystem"
+          "$ref": "#/definitions/codersdk.AgentSubsystem"
         },
         "version": {
           "type": "string"
@@ -5683,6 +5678,11 @@
           "type": "string"
         }
       }
+    },
+    "codersdk.AgentSubsystem": {
+      "type": "string",
+      "enum": ["envbox"],
+      "x-enum-varnames": ["AgentSubsystemEnvbox"]
     },
     "codersdk.AppHostResponse": {
       "type": "object",
@@ -8672,6 +8672,9 @@
         },
         "status": {
           "$ref": "#/definitions/codersdk.WorkspaceAgentStatus"
+        },
+        "subsystem": {
+          "$ref": "#/definitions/codersdk.AgentSubsystem"
         },
         "troubleshooting_url": {
           "type": "string"

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -1029,7 +1029,8 @@ func (s *MethodTestSuite) TestWorkspace() {
 		res := dbgen.WorkspaceResource(s.T(), db, database.WorkspaceResource{JobID: build.JobID})
 		agt := dbgen.WorkspaceAgent(s.T(), db, database.WorkspaceAgent{ResourceID: res.ID})
 		check.Args(database.UpdateWorkspaceAgentStartupByIDParams{
-			ID: agt.ID,
+			ID:        agt.ID,
+			Subsystem: database.WorkspaceAgentSubsystemNone,
 		}).Asserts(ws, rbac.ActionUpdate).Returns()
 	}))
 	s.Run("GetWorkspaceAgentStartupLogsAfter", s.Subtest(func(db database.Store, check *expects) {

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -3690,7 +3689,6 @@ func (q *fakeQuerier) UpdateWorkspaceAgentConnectionByID(_ context.Context, arg 
 
 func (q *fakeQuerier) UpdateWorkspaceAgentStartupByID(_ context.Context, arg database.UpdateWorkspaceAgentStartupByIDParams) error {
 	if err := validateDatabaseType(arg); err != nil {
-		debug.PrintStack()
 		return err
 	}
 

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -3689,6 +3690,7 @@ func (q *fakeQuerier) UpdateWorkspaceAgentConnectionByID(_ context.Context, arg 
 
 func (q *fakeQuerier) UpdateWorkspaceAgentStartupByID(_ context.Context, arg database.UpdateWorkspaceAgentStartupByIDParams) error {
 	if err := validateDatabaseType(arg); err != nil {
+		debug.PrintStack()
 		return err
 	}
 
@@ -3702,6 +3704,7 @@ func (q *fakeQuerier) UpdateWorkspaceAgentStartupByID(_ context.Context, arg dat
 
 		agent.Version = arg.Version
 		agent.ExpandedDirectory = arg.ExpandedDirectory
+		agent.Subsystem = arg.Subsystem
 		q.workspaceAgents[index] = agent
 		return nil
 	}

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -116,6 +116,12 @@ CREATE TYPE workspace_agent_lifecycle_state AS ENUM (
     'off'
 );
 
+CREATE TYPE workspace_agent_subsystem AS ENUM (
+    'envbuilder',
+    'envbox',
+    'none'
+);
+
 CREATE TYPE workspace_app_health AS ENUM (
     'disabled',
     'initializing',
@@ -563,7 +569,8 @@ CREATE TABLE workspace_agent_stats (
     session_count_vscode bigint DEFAULT 0 NOT NULL,
     session_count_jetbrains bigint DEFAULT 0 NOT NULL,
     session_count_reconnecting_pty bigint DEFAULT 0 NOT NULL,
-    session_count_ssh bigint DEFAULT 0 NOT NULL
+    session_count_ssh bigint DEFAULT 0 NOT NULL,
+    subsystem workspace_agent_subsystem DEFAULT 'none'::workspace_agent_subsystem NOT NULL
 );
 
 CREATE TABLE workspace_agents (

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -569,8 +569,7 @@ CREATE TABLE workspace_agent_stats (
     session_count_vscode bigint DEFAULT 0 NOT NULL,
     session_count_jetbrains bigint DEFAULT 0 NOT NULL,
     session_count_reconnecting_pty bigint DEFAULT 0 NOT NULL,
-    session_count_ssh bigint DEFAULT 0 NOT NULL,
-    subsystem workspace_agent_subsystem DEFAULT 'none'::workspace_agent_subsystem NOT NULL
+    session_count_ssh bigint DEFAULT 0 NOT NULL
 );
 
 CREATE TABLE workspace_agents (
@@ -604,6 +603,7 @@ CREATE TABLE workspace_agents (
     shutdown_script_timeout_seconds integer DEFAULT 0 NOT NULL,
     startup_logs_length integer DEFAULT 0 NOT NULL,
     startup_logs_overflowed boolean DEFAULT false NOT NULL,
+    subsystem workspace_agent_subsystem DEFAULT 'none'::workspace_agent_subsystem NOT NULL,
     CONSTRAINT max_startup_logs_length CHECK ((startup_logs_length <= 1048576))
 );
 

--- a/coderd/database/migrations/000123_workspace_agent_subsystem.down.sql
+++ b/coderd/database/migrations/000123_workspace_agent_subsystem.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE workspace_agents DROP COLUMN subsystem;
+DROP TYPE workspace_agent_subsystem;
+COMMIT;

--- a/coderd/database/migrations/000123_workspace_agent_subsystem.up.sql
+++ b/coderd/database/migrations/000123_workspace_agent_subsystem.up.sql
@@ -1,4 +1,4 @@
 BEGIN;
 CREATE TYPE workspace_agent_subsystem AS ENUM ('envbuilder', 'envbox', 'none');
-ALTER TABLE workspace_agent_stats ADD COLUMN subsystem workspace_agent_subsystem NOT NULL default 'none';
+ALTER TABLE workspace_agents ADD COLUMN subsystem workspace_agent_subsystem NOT NULL default 'none';
 COMMIT;

--- a/coderd/database/migrations/000123_workspace_agent_subsystem.up.sql
+++ b/coderd/database/migrations/000123_workspace_agent_subsystem.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+CREATE TYPE workspace_agent_subsystem AS ENUM ('envbuilder', 'envbox', 'none');
+ALTER TABLE workspace_agent_stats ADD COLUMN subsystem workspace_agent_subsystem NOT NULL default 'none';
+COMMIT;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1096,6 +1096,67 @@ func AllWorkspaceAgentLifecycleStateValues() []WorkspaceAgentLifecycleState {
 	}
 }
 
+type WorkspaceAgentSubsystem string
+
+const (
+	WorkspaceAgentSubsystemEnvbuilder WorkspaceAgentSubsystem = "envbuilder"
+	WorkspaceAgentSubsystemEnvbox     WorkspaceAgentSubsystem = "envbox"
+	WorkspaceAgentSubsystemNone       WorkspaceAgentSubsystem = "none"
+)
+
+func (e *WorkspaceAgentSubsystem) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = WorkspaceAgentSubsystem(s)
+	case string:
+		*e = WorkspaceAgentSubsystem(s)
+	default:
+		return fmt.Errorf("unsupported scan type for WorkspaceAgentSubsystem: %T", src)
+	}
+	return nil
+}
+
+type NullWorkspaceAgentSubsystem struct {
+	WorkspaceAgentSubsystem WorkspaceAgentSubsystem
+	Valid                   bool // Valid is true if WorkspaceAgentSubsystem is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullWorkspaceAgentSubsystem) Scan(value interface{}) error {
+	if value == nil {
+		ns.WorkspaceAgentSubsystem, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.WorkspaceAgentSubsystem.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullWorkspaceAgentSubsystem) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.WorkspaceAgentSubsystem), nil
+}
+
+func (e WorkspaceAgentSubsystem) Valid() bool {
+	switch e {
+	case WorkspaceAgentSubsystemEnvbuilder,
+		WorkspaceAgentSubsystemEnvbox,
+		WorkspaceAgentSubsystemNone:
+		return true
+	}
+	return false
+}
+
+func AllWorkspaceAgentSubsystemValues() []WorkspaceAgentSubsystem {
+	return []WorkspaceAgentSubsystem{
+		WorkspaceAgentSubsystemEnvbuilder,
+		WorkspaceAgentSubsystemEnvbox,
+		WorkspaceAgentSubsystemNone,
+	}
+}
+
 type WorkspaceAppHealth string
 
 const (
@@ -1611,23 +1672,24 @@ type WorkspaceAgentStartupLog struct {
 }
 
 type WorkspaceAgentStat struct {
-	ID                          uuid.UUID       `db:"id" json:"id"`
-	CreatedAt                   time.Time       `db:"created_at" json:"created_at"`
-	UserID                      uuid.UUID       `db:"user_id" json:"user_id"`
-	AgentID                     uuid.UUID       `db:"agent_id" json:"agent_id"`
-	WorkspaceID                 uuid.UUID       `db:"workspace_id" json:"workspace_id"`
-	TemplateID                  uuid.UUID       `db:"template_id" json:"template_id"`
-	ConnectionsByProto          json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
-	ConnectionCount             int64           `db:"connection_count" json:"connection_count"`
-	RxPackets                   int64           `db:"rx_packets" json:"rx_packets"`
-	RxBytes                     int64           `db:"rx_bytes" json:"rx_bytes"`
-	TxPackets                   int64           `db:"tx_packets" json:"tx_packets"`
-	TxBytes                     int64           `db:"tx_bytes" json:"tx_bytes"`
-	ConnectionMedianLatencyMS   float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
-	SessionCountVSCode          int64           `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountJetBrains       int64           `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY int64           `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	SessionCountSSH             int64           `db:"session_count_ssh" json:"session_count_ssh"`
+	ID                          uuid.UUID               `db:"id" json:"id"`
+	CreatedAt                   time.Time               `db:"created_at" json:"created_at"`
+	UserID                      uuid.UUID               `db:"user_id" json:"user_id"`
+	AgentID                     uuid.UUID               `db:"agent_id" json:"agent_id"`
+	WorkspaceID                 uuid.UUID               `db:"workspace_id" json:"workspace_id"`
+	TemplateID                  uuid.UUID               `db:"template_id" json:"template_id"`
+	ConnectionsByProto          json.RawMessage         `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount             int64                   `db:"connection_count" json:"connection_count"`
+	RxPackets                   int64                   `db:"rx_packets" json:"rx_packets"`
+	RxBytes                     int64                   `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets                   int64                   `db:"tx_packets" json:"tx_packets"`
+	TxBytes                     int64                   `db:"tx_bytes" json:"tx_bytes"`
+	ConnectionMedianLatencyMS   float64                 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
+	SessionCountVSCode          int64                   `db:"session_count_vscode" json:"session_count_vscode"`
+	SessionCountJetBrains       int64                   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
+	SessionCountReconnectingPTY int64                   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	SessionCountSSH             int64                   `db:"session_count_ssh" json:"session_count_ssh"`
+	Subsystem                   WorkspaceAgentSubsystem `db:"subsystem" json:"subsystem"`
 }
 
 type WorkspaceApp struct {

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1648,7 +1648,8 @@ type WorkspaceAgent struct {
 	// Total length of startup logs
 	StartupLogsLength int32 `db:"startup_logs_length" json:"startup_logs_length"`
 	// Whether the startup logs overflowed in length
-	StartupLogsOverflowed bool `db:"startup_logs_overflowed" json:"startup_logs_overflowed"`
+	StartupLogsOverflowed bool                    `db:"startup_logs_overflowed" json:"startup_logs_overflowed"`
+	Subsystem             WorkspaceAgentSubsystem `db:"subsystem" json:"subsystem"`
 }
 
 type WorkspaceAgentMetadatum struct {
@@ -1672,24 +1673,23 @@ type WorkspaceAgentStartupLog struct {
 }
 
 type WorkspaceAgentStat struct {
-	ID                          uuid.UUID               `db:"id" json:"id"`
-	CreatedAt                   time.Time               `db:"created_at" json:"created_at"`
-	UserID                      uuid.UUID               `db:"user_id" json:"user_id"`
-	AgentID                     uuid.UUID               `db:"agent_id" json:"agent_id"`
-	WorkspaceID                 uuid.UUID               `db:"workspace_id" json:"workspace_id"`
-	TemplateID                  uuid.UUID               `db:"template_id" json:"template_id"`
-	ConnectionsByProto          json.RawMessage         `db:"connections_by_proto" json:"connections_by_proto"`
-	ConnectionCount             int64                   `db:"connection_count" json:"connection_count"`
-	RxPackets                   int64                   `db:"rx_packets" json:"rx_packets"`
-	RxBytes                     int64                   `db:"rx_bytes" json:"rx_bytes"`
-	TxPackets                   int64                   `db:"tx_packets" json:"tx_packets"`
-	TxBytes                     int64                   `db:"tx_bytes" json:"tx_bytes"`
-	ConnectionMedianLatencyMS   float64                 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
-	SessionCountVSCode          int64                   `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountJetBrains       int64                   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY int64                   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	SessionCountSSH             int64                   `db:"session_count_ssh" json:"session_count_ssh"`
-	Subsystem                   WorkspaceAgentSubsystem `db:"subsystem" json:"subsystem"`
+	ID                          uuid.UUID       `db:"id" json:"id"`
+	CreatedAt                   time.Time       `db:"created_at" json:"created_at"`
+	UserID                      uuid.UUID       `db:"user_id" json:"user_id"`
+	AgentID                     uuid.UUID       `db:"agent_id" json:"agent_id"`
+	WorkspaceID                 uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID                  uuid.UUID       `db:"template_id" json:"template_id"`
+	ConnectionsByProto          json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount             int64           `db:"connection_count" json:"connection_count"`
+	RxPackets                   int64           `db:"rx_packets" json:"rx_packets"`
+	RxBytes                     int64           `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets                   int64           `db:"tx_packets" json:"tx_packets"`
+	TxBytes                     int64           `db:"tx_bytes" json:"tx_bytes"`
+	ConnectionMedianLatencyMS   float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
+	SessionCountVSCode          int64           `db:"session_count_vscode" json:"session_count_vscode"`
+	SessionCountJetBrains       int64           `db:"session_count_jetbrains" json:"session_count_jetbrains"`
+	SessionCountReconnectingPTY int64           `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	SessionCountSSH             int64           `db:"session_count_ssh" json:"session_count_ssh"`
 }
 
 type WorkspaceApp struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5553,7 +5553,7 @@ func (q *sqlQuerier) DeleteOldWorkspaceAgentStartupLogs(ctx context.Context) err
 
 const getWorkspaceAgentByAuthToken = `-- name: GetWorkspaceAgentByAuthToken :one
 SELECT
-	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed
+	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed, subsystem
 FROM
 	workspace_agents
 WHERE
@@ -5596,13 +5596,14 @@ func (q *sqlQuerier) GetWorkspaceAgentByAuthToken(ctx context.Context, authToken
 		&i.ShutdownScriptTimeoutSeconds,
 		&i.StartupLogsLength,
 		&i.StartupLogsOverflowed,
+		&i.Subsystem,
 	)
 	return i, err
 }
 
 const getWorkspaceAgentByID = `-- name: GetWorkspaceAgentByID :one
 SELECT
-	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed
+	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed, subsystem
 FROM
 	workspace_agents
 WHERE
@@ -5643,13 +5644,14 @@ func (q *sqlQuerier) GetWorkspaceAgentByID(ctx context.Context, id uuid.UUID) (W
 		&i.ShutdownScriptTimeoutSeconds,
 		&i.StartupLogsLength,
 		&i.StartupLogsOverflowed,
+		&i.Subsystem,
 	)
 	return i, err
 }
 
 const getWorkspaceAgentByInstanceID = `-- name: GetWorkspaceAgentByInstanceID :one
 SELECT
-	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed
+	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed, subsystem
 FROM
 	workspace_agents
 WHERE
@@ -5692,6 +5694,7 @@ func (q *sqlQuerier) GetWorkspaceAgentByInstanceID(ctx context.Context, authInst
 		&i.ShutdownScriptTimeoutSeconds,
 		&i.StartupLogsLength,
 		&i.StartupLogsOverflowed,
+		&i.Subsystem,
 	)
 	return i, err
 }
@@ -5786,7 +5789,7 @@ func (q *sqlQuerier) GetWorkspaceAgentStartupLogsAfter(ctx context.Context, arg 
 
 const getWorkspaceAgentsByResourceIDs = `-- name: GetWorkspaceAgentsByResourceIDs :many
 SELECT
-	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed
+	id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed, subsystem
 FROM
 	workspace_agents
 WHERE
@@ -5833,6 +5836,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []
 			&i.ShutdownScriptTimeoutSeconds,
 			&i.StartupLogsLength,
 			&i.StartupLogsOverflowed,
+			&i.Subsystem,
 		); err != nil {
 			return nil, err
 		}
@@ -5848,7 +5852,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []
 }
 
 const getWorkspaceAgentsCreatedAfter = `-- name: GetWorkspaceAgentsCreatedAfter :many
-SELECT id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed FROM workspace_agents WHERE created_at > $1
+SELECT id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed, subsystem FROM workspace_agents WHERE created_at > $1
 `
 
 func (q *sqlQuerier) GetWorkspaceAgentsCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceAgent, error) {
@@ -5891,6 +5895,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsCreatedAfter(ctx context.Context, created
 			&i.ShutdownScriptTimeoutSeconds,
 			&i.StartupLogsLength,
 			&i.StartupLogsOverflowed,
+			&i.Subsystem,
 		); err != nil {
 			return nil, err
 		}
@@ -5907,7 +5912,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsCreatedAfter(ctx context.Context, created
 
 const getWorkspaceAgentsInLatestBuildByWorkspaceID = `-- name: GetWorkspaceAgentsInLatestBuildByWorkspaceID :many
 SELECT
-	workspace_agents.id, workspace_agents.created_at, workspace_agents.updated_at, workspace_agents.name, workspace_agents.first_connected_at, workspace_agents.last_connected_at, workspace_agents.disconnected_at, workspace_agents.resource_id, workspace_agents.auth_token, workspace_agents.auth_instance_id, workspace_agents.architecture, workspace_agents.environment_variables, workspace_agents.operating_system, workspace_agents.startup_script, workspace_agents.instance_metadata, workspace_agents.resource_metadata, workspace_agents.directory, workspace_agents.version, workspace_agents.last_connected_replica_id, workspace_agents.connection_timeout_seconds, workspace_agents.troubleshooting_url, workspace_agents.motd_file, workspace_agents.lifecycle_state, workspace_agents.login_before_ready, workspace_agents.startup_script_timeout_seconds, workspace_agents.expanded_directory, workspace_agents.shutdown_script, workspace_agents.shutdown_script_timeout_seconds, workspace_agents.startup_logs_length, workspace_agents.startup_logs_overflowed
+	workspace_agents.id, workspace_agents.created_at, workspace_agents.updated_at, workspace_agents.name, workspace_agents.first_connected_at, workspace_agents.last_connected_at, workspace_agents.disconnected_at, workspace_agents.resource_id, workspace_agents.auth_token, workspace_agents.auth_instance_id, workspace_agents.architecture, workspace_agents.environment_variables, workspace_agents.operating_system, workspace_agents.startup_script, workspace_agents.instance_metadata, workspace_agents.resource_metadata, workspace_agents.directory, workspace_agents.version, workspace_agents.last_connected_replica_id, workspace_agents.connection_timeout_seconds, workspace_agents.troubleshooting_url, workspace_agents.motd_file, workspace_agents.lifecycle_state, workspace_agents.login_before_ready, workspace_agents.startup_script_timeout_seconds, workspace_agents.expanded_directory, workspace_agents.shutdown_script, workspace_agents.shutdown_script_timeout_seconds, workspace_agents.startup_logs_length, workspace_agents.startup_logs_overflowed, workspace_agents.subsystem
 FROM
 	workspace_agents
 JOIN
@@ -5966,6 +5971,7 @@ func (q *sqlQuerier) GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx context.Co
 			&i.ShutdownScriptTimeoutSeconds,
 			&i.StartupLogsLength,
 			&i.StartupLogsOverflowed,
+			&i.Subsystem,
 		); err != nil {
 			return nil, err
 		}
@@ -6006,7 +6012,7 @@ INSERT INTO
 		shutdown_script_timeout_seconds
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) RETURNING id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) RETURNING id, created_at, updated_at, name, first_connected_at, last_connected_at, disconnected_at, resource_id, auth_token, auth_instance_id, architecture, environment_variables, operating_system, startup_script, instance_metadata, resource_metadata, directory, version, last_connected_replica_id, connection_timeout_seconds, troubleshooting_url, motd_file, lifecycle_state, login_before_ready, startup_script_timeout_seconds, expanded_directory, shutdown_script, shutdown_script_timeout_seconds, startup_logs_length, startup_logs_overflowed, subsystem
 `
 
 type InsertWorkspaceAgentParams struct {
@@ -6089,6 +6095,7 @@ func (q *sqlQuerier) InsertWorkspaceAgent(ctx context.Context, arg InsertWorkspa
 		&i.ShutdownScriptTimeoutSeconds,
 		&i.StartupLogsLength,
 		&i.StartupLogsOverflowed,
+		&i.Subsystem,
 	)
 	return i, err
 }
@@ -6275,19 +6282,26 @@ UPDATE
 	workspace_agents
 SET
 	version = $2,
-	expanded_directory = $3
+	expanded_directory = $3,
+	subsystem = $4
 WHERE
 	id = $1
 `
 
 type UpdateWorkspaceAgentStartupByIDParams struct {
-	ID                uuid.UUID `db:"id" json:"id"`
-	Version           string    `db:"version" json:"version"`
-	ExpandedDirectory string    `db:"expanded_directory" json:"expanded_directory"`
+	ID                uuid.UUID               `db:"id" json:"id"`
+	Version           string                  `db:"version" json:"version"`
+	ExpandedDirectory string                  `db:"expanded_directory" json:"expanded_directory"`
+	Subsystem         WorkspaceAgentSubsystem `db:"subsystem" json:"subsystem"`
 }
 
 func (q *sqlQuerier) UpdateWorkspaceAgentStartupByID(ctx context.Context, arg UpdateWorkspaceAgentStartupByIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateWorkspaceAgentStartupByID, arg.ID, arg.Version, arg.ExpandedDirectory)
+	_, err := q.db.ExecContext(ctx, updateWorkspaceAgentStartupByID,
+		arg.ID,
+		arg.Version,
+		arg.ExpandedDirectory,
+		arg.Subsystem,
+	)
 	return err
 }
 
@@ -6378,7 +6392,7 @@ WITH agent_stats AS (
 		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
 		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, subsystem, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
 	) AS a WHERE a.rn = 1
 )
@@ -6478,7 +6492,7 @@ WITH agent_stats AS (
 		coalesce(SUM(session_count_jetbrains), 0)::bigint AS session_count_jetbrains,
 		coalesce(SUM(session_count_reconnecting_pty), 0)::bigint AS session_count_reconnecting_pty
 	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, subsystem, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats WHERE created_at > $1
 	) AS a WHERE a.rn = 1 GROUP BY a.user_id, a.agent_id, a.workspace_id, a.template_id
 )
@@ -6561,7 +6575,7 @@ WITH agent_stats AS (
 		coalesce(SUM(connection_count), 0)::bigint AS connection_count,
 		coalesce(MAX(connection_median_latency_ms), 0)::float AS connection_median_latency_ms
 	 FROM (
-		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, subsystem, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
+		SELECT id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, ROW_NUMBER() OVER(PARTITION BY agent_id ORDER BY created_at DESC) AS rn
 		FROM workspace_agent_stats
 		-- The greater than 0 is to support legacy agents that don't report connection_median_latency_ms.
 		WHERE created_at > $1 AND connection_median_latency_ms > 0
@@ -6661,32 +6675,30 @@ INSERT INTO
 		session_count_jetbrains,
 		session_count_reconnecting_pty,
 		session_count_ssh,
-		connection_median_latency_ms,
-		subsystem
+		connection_median_latency_ms
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) RETURNING id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, subsystem
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) RETURNING id, created_at, user_id, agent_id, workspace_id, template_id, connections_by_proto, connection_count, rx_packets, rx_bytes, tx_packets, tx_bytes, connection_median_latency_ms, session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh
 `
 
 type InsertWorkspaceAgentStatParams struct {
-	ID                          uuid.UUID               `db:"id" json:"id"`
-	CreatedAt                   time.Time               `db:"created_at" json:"created_at"`
-	UserID                      uuid.UUID               `db:"user_id" json:"user_id"`
-	WorkspaceID                 uuid.UUID               `db:"workspace_id" json:"workspace_id"`
-	TemplateID                  uuid.UUID               `db:"template_id" json:"template_id"`
-	AgentID                     uuid.UUID               `db:"agent_id" json:"agent_id"`
-	ConnectionsByProto          json.RawMessage         `db:"connections_by_proto" json:"connections_by_proto"`
-	ConnectionCount             int64                   `db:"connection_count" json:"connection_count"`
-	RxPackets                   int64                   `db:"rx_packets" json:"rx_packets"`
-	RxBytes                     int64                   `db:"rx_bytes" json:"rx_bytes"`
-	TxPackets                   int64                   `db:"tx_packets" json:"tx_packets"`
-	TxBytes                     int64                   `db:"tx_bytes" json:"tx_bytes"`
-	SessionCountVSCode          int64                   `db:"session_count_vscode" json:"session_count_vscode"`
-	SessionCountJetBrains       int64                   `db:"session_count_jetbrains" json:"session_count_jetbrains"`
-	SessionCountReconnectingPTY int64                   `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
-	SessionCountSSH             int64                   `db:"session_count_ssh" json:"session_count_ssh"`
-	ConnectionMedianLatencyMS   float64                 `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
-	Subsystem                   WorkspaceAgentSubsystem `db:"subsystem" json:"subsystem"`
+	ID                          uuid.UUID       `db:"id" json:"id"`
+	CreatedAt                   time.Time       `db:"created_at" json:"created_at"`
+	UserID                      uuid.UUID       `db:"user_id" json:"user_id"`
+	WorkspaceID                 uuid.UUID       `db:"workspace_id" json:"workspace_id"`
+	TemplateID                  uuid.UUID       `db:"template_id" json:"template_id"`
+	AgentID                     uuid.UUID       `db:"agent_id" json:"agent_id"`
+	ConnectionsByProto          json.RawMessage `db:"connections_by_proto" json:"connections_by_proto"`
+	ConnectionCount             int64           `db:"connection_count" json:"connection_count"`
+	RxPackets                   int64           `db:"rx_packets" json:"rx_packets"`
+	RxBytes                     int64           `db:"rx_bytes" json:"rx_bytes"`
+	TxPackets                   int64           `db:"tx_packets" json:"tx_packets"`
+	TxBytes                     int64           `db:"tx_bytes" json:"tx_bytes"`
+	SessionCountVSCode          int64           `db:"session_count_vscode" json:"session_count_vscode"`
+	SessionCountJetBrains       int64           `db:"session_count_jetbrains" json:"session_count_jetbrains"`
+	SessionCountReconnectingPTY int64           `db:"session_count_reconnecting_pty" json:"session_count_reconnecting_pty"`
+	SessionCountSSH             int64           `db:"session_count_ssh" json:"session_count_ssh"`
+	ConnectionMedianLatencyMS   float64         `db:"connection_median_latency_ms" json:"connection_median_latency_ms"`
 }
 
 func (q *sqlQuerier) InsertWorkspaceAgentStat(ctx context.Context, arg InsertWorkspaceAgentStatParams) (WorkspaceAgentStat, error) {
@@ -6708,7 +6720,6 @@ func (q *sqlQuerier) InsertWorkspaceAgentStat(ctx context.Context, arg InsertWor
 		arg.SessionCountReconnectingPTY,
 		arg.SessionCountSSH,
 		arg.ConnectionMedianLatencyMS,
-		arg.Subsystem,
 	)
 	var i WorkspaceAgentStat
 	err := row.Scan(
@@ -6729,7 +6740,6 @@ func (q *sqlQuerier) InsertWorkspaceAgentStat(ctx context.Context, arg InsertWor
 		&i.SessionCountJetBrains,
 		&i.SessionCountReconnectingPTY,
 		&i.SessionCountSSH,
-		&i.Subsystem,
 	)
 	return i, err
 }

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -82,7 +82,8 @@ UPDATE
 	workspace_agents
 SET
 	version = $2,
-	expanded_directory = $3
+	expanded_directory = $3,
+	subsystem = $4
 WHERE
 	id = $1;
 

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -17,10 +17,11 @@ INSERT INTO
 		session_count_jetbrains,
 		session_count_reconnecting_pty,
 		session_count_ssh,
-		connection_median_latency_ms
+		connection_median_latency_ms,
+		subsystem
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) RETURNING *;
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) RETURNING *;
 
 -- name: GetTemplateDAUs :many
 SELECT

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -17,11 +17,10 @@ INSERT INTO
 		session_count_jetbrains,
 		session_count_reconnecting_pty,
 		session_count_ssh,
-		connection_median_latency_ms,
-		subsystem
+		connection_median_latency_ms
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) RETURNING *;
+	($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) RETURNING *;
 
 -- name: GetTemplateDAUs :many
 SELECT

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -562,6 +562,7 @@ func ConvertWorkspaceAgent(agent database.WorkspaceAgent) WorkspaceAgent {
 		Directory:                agent.Directory != "",
 		ConnectionTimeoutSeconds: agent.ConnectionTimeoutSeconds,
 		ShutdownScript:           agent.ShutdownScript.Valid,
+		Subsystem:                string(agent.Subsystem),
 	}
 	if agent.FirstConnectedAt.Valid {
 		snapAgent.FirstConnectedAt = &agent.FirstConnectedAt.Time
@@ -783,6 +784,7 @@ type WorkspaceAgent struct {
 	DisconnectedAt           *time.Time `json:"disconnected_at"`
 	ConnectionTimeoutSeconds int32      `json:"connection_timeout_seconds"`
 	ShutdownScript           bool       `json:"shutdown_script"`
+	Subsystem                string     `json:"subystem"`
 }
 
 type WorkspaceAgentStat struct {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -784,7 +784,7 @@ type WorkspaceAgent struct {
 	DisconnectedAt           *time.Time `json:"disconnected_at"`
 	ConnectionTimeoutSeconds int32      `json:"connection_timeout_seconds"`
 	ShutdownScript           bool       `json:"shutdown_script"`
-	Subsystem                string     `json:"subystem"`
+	Subsystem                string     `json:"subsystem"`
 }
 
 type WorkspaceAgentStat struct {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1130,6 +1130,7 @@ func convertWorkspaceAgent(derpMap *tailcfg.DERPMap, coordinator tailnet.Coordin
 		StartupScriptTimeoutSeconds:  dbAgent.StartupScriptTimeoutSeconds,
 		ShutdownScript:               dbAgent.ShutdownScript.String,
 		ShutdownScriptTimeoutSeconds: dbAgent.ShutdownScriptTimeoutSeconds,
+		Subsystem:                    codersdk.AgentSubsystem(dbAgent.Subsystem),
 	}
 	node := coordinator.Node(dbAgent.ID)
 	if node != nil {
@@ -1985,9 +1986,9 @@ func convertWorkspaceAgentStartupLog(logEntry database.WorkspaceAgentStartupLog)
 	}
 }
 
-func convertWorkspaceAgentSubsystem(ss agentsdk.AgentSubsystem) database.WorkspaceAgentSubsystem {
+func convertWorkspaceAgentSubsystem(ss codersdk.AgentSubsystem) database.WorkspaceAgentSubsystem {
 	switch ss {
-	case agentsdk.AgentSubsystemEnvbox:
+	case codersdk.AgentSubsystemEnvbox:
 		return database.WorkspaceAgentSubsystemEnvbox
 	default:
 		return database.WorkspaceAgentSubsystemNone

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -220,6 +220,7 @@ func (api *API) postWorkspaceAgentStartup(rw http.ResponseWriter, r *http.Reques
 		ID:                apiAgent.ID,
 		Version:           req.Version,
 		ExpandedDirectory: req.ExpandedDirectory,
+		Subsystem:         convertWorkspaceAgentSubsystem(req.Subsystem),
 	}); err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Error setting agent version",
@@ -1240,7 +1241,6 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 			SessionCountReconnectingPTY: req.SessionCountReconnectingPTY,
 			SessionCountSSH:             req.SessionCountSSH,
 			ConnectionMedianLatencyMS:   req.ConnectionMedianLatencyMS,
-			Subsystem:                   convertWorkspaceAgentSubsystem(req.Subsystem),
 		})
 		if err != nil {
 			return xerrors.Errorf("can't insert workspace agent stat: %w", err)
@@ -1988,7 +1988,7 @@ func convertWorkspaceAgentStartupLog(logEntry database.WorkspaceAgentStartupLog)
 func convertWorkspaceAgentSubsystem(ss agentsdk.AgentSubsystem) database.WorkspaceAgentSubsystem {
 	switch ss {
 	case agentsdk.AgentSubsystemEnvbox:
-		return database.WorkspaceAgentSubsystemEnvbuilder
+		return database.WorkspaceAgentSubsystemEnvbox
 	default:
 		return database.WorkspaceAgentSubsystemNone
 	}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1240,6 +1240,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 			SessionCountReconnectingPTY: req.SessionCountReconnectingPTY,
 			SessionCountSSH:             req.SessionCountSSH,
 			ConnectionMedianLatencyMS:   req.ConnectionMedianLatencyMS,
+			Subsystem:                   convertWorkspaceAgentSubsystem(req.Subsystem),
 		})
 		if err != nil {
 			return xerrors.Errorf("can't insert workspace agent stat: %w", err)
@@ -1981,5 +1982,14 @@ func convertWorkspaceAgentStartupLog(logEntry database.WorkspaceAgentStartupLog)
 		CreatedAt: logEntry.CreatedAt,
 		Output:    logEntry.Output,
 		Level:     codersdk.LogLevel(logEntry.Level),
+	}
+}
+
+func convertWorkspaceAgentSubsystem(ss agentsdk.AgentSubsystem) database.WorkspaceAgentSubsystem {
+	switch ss {
+	case agentsdk.AgentSubsystemEnvbox:
+		return database.WorkspaceAgentSubsystemEnvbuilder
+	default:
+		return database.WorkspaceAgentSubsystemNone
 	}
 }

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -453,12 +453,6 @@ func (c *Client) ReportStats(ctx context.Context, log slog.Logger, statsChan <-c
 	}), nil
 }
 
-type AgentSubsystem string
-
-const (
-	AgentSubsystemEnvbox AgentSubsystem = "envbox"
-)
-
 // Stats records the Agent's network connection statistics for use in
 // user-facing metrics and debugging.
 type Stats struct {
@@ -550,9 +544,9 @@ func (c *Client) PostLifecycle(ctx context.Context, req PostLifecycleRequest) er
 }
 
 type PostStartupRequest struct {
-	Version           string         `json:"version"`
-	ExpandedDirectory string         `json:"expanded_directory"`
-	Subsystem         AgentSubsystem `json:"subsystem"`
+	Version           string                  `json:"version"`
+	ExpandedDirectory string                  `json:"expanded_directory"`
+	Subsystem         codersdk.AgentSubsystem `json:"subsystem"`
 }
 
 func (c *Client) PostStartup(ctx context.Context, req PostStartupRequest) error {

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -552,7 +552,7 @@ func (c *Client) PostLifecycle(ctx context.Context, req PostLifecycleRequest) er
 type PostStartupRequest struct {
 	Version           string         `json:"version"`
 	ExpandedDirectory string         `json:"expanded_directory"`
-	Subsystem         AgentSubsystem `json:"subsytem"`
+	Subsystem         AgentSubsystem `json:"subsystem"`
 }
 
 func (c *Client) PostStartup(ctx context.Context, req PostStartupRequest) error {

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -488,8 +488,7 @@ type Stats struct {
 	SessionCountReconnectingPTY int64 `json:"session_count_reconnecting_pty"`
 	// SessionCountSSH is the number of connections received by an agent
 	// that are normal, non-tagged SSH sessions.
-	SessionCountSSH int64          `json:"session_count_ssh"`
-	Subsystem       AgentSubsystem `json:"subsystem"`
+	SessionCountSSH int64 `json:"session_count_ssh"`
 
 	// Metrics collected by the agent
 	Metrics []AgentMetric `json:"metrics"`
@@ -551,8 +550,9 @@ func (c *Client) PostLifecycle(ctx context.Context, req PostLifecycleRequest) er
 }
 
 type PostStartupRequest struct {
-	Version           string `json:"version"`
-	ExpandedDirectory string `json:"expanded_directory"`
+	Version           string         `json:"version"`
+	ExpandedDirectory string         `json:"expanded_directory"`
+	Subsystem         AgentSubsystem `json:"subsytem"`
 }
 
 func (c *Client) PostStartup(ctx context.Context, req PostStartupRequest) error {

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -453,6 +453,12 @@ func (c *Client) ReportStats(ctx context.Context, log slog.Logger, statsChan <-c
 	}), nil
 }
 
+type AgentSubsystem string
+
+const (
+	AgentSubsystemEnvbox AgentSubsystem = "envbox"
+)
+
 // Stats records the Agent's network connection statistics for use in
 // user-facing metrics and debugging.
 type Stats struct {
@@ -482,7 +488,8 @@ type Stats struct {
 	SessionCountReconnectingPTY int64 `json:"session_count_reconnecting_pty"`
 	// SessionCountSSH is the number of connections received by an agent
 	// that are normal, non-tagged SSH sessions.
-	SessionCountSSH int64 `json:"session_count_ssh"`
+	SessionCountSSH int64          `json:"session_count_ssh"`
+	Subsystem       AgentSubsystem `json:"subsystem"`
 
 	// Metrics collected by the agent
 	Metrics []AgentMetric `json:"metrics"`

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -130,9 +130,10 @@ type WorkspaceAgent struct {
 	// LoginBeforeReady if true, the agent will delay logins until it is ready (e.g. executing startup script has ended).
 	LoginBeforeReady bool `json:"login_before_ready"`
 	// StartupScriptTimeoutSeconds is the number of seconds to wait for the startup script to complete. If the script does not complete within this time, the agent lifecycle will be marked as start_timeout.
-	StartupScriptTimeoutSeconds  int32  `json:"startup_script_timeout_seconds"`
-	ShutdownScript               string `json:"shutdown_script,omitempty"`
-	ShutdownScriptTimeoutSeconds int32  `json:"shutdown_script_timeout_seconds"`
+	StartupScriptTimeoutSeconds  int32          `json:"startup_script_timeout_seconds"`
+	ShutdownScript               string         `json:"shutdown_script,omitempty"`
+	ShutdownScriptTimeoutSeconds int32          `json:"shutdown_script_timeout_seconds"`
+	Subsystem                    AgentSubsystem `json:"subsytem"`
 }
 
 type DERPRegion struct {
@@ -553,3 +554,9 @@ type WorkspaceAgentStartupLog struct {
 	Output    string    `json:"output"`
 	Level     LogLevel  `json:"level"`
 }
+
+type AgentSubsystem string
+
+const (
+	AgentSubsystemEnvbox AgentSubsystem = "envbox"
+)

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -133,7 +133,7 @@ type WorkspaceAgent struct {
 	StartupScriptTimeoutSeconds  int32          `json:"startup_script_timeout_seconds"`
 	ShutdownScript               string         `json:"shutdown_script,omitempty"`
 	ShutdownScriptTimeoutSeconds int32          `json:"shutdown_script_timeout_seconds"`
-	Subsystem                    AgentSubsystem `json:"subsytem"`
+	Subsystem                    AgentSubsystem `json:"subsystem"`
 }
 
 type DERPRegion struct {

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -474,6 +474,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent} \
   "startup_script": "string",
   "startup_script_timeout_seconds": 0,
   "status": "connecting",
+  "subsystem": "envbox",
   "troubleshooting_url": "string",
   "updated_at": "2019-08-24T14:15:22Z",
   "version": "string"

--- a/docs/api/builds.md
+++ b/docs/api/builds.md
@@ -111,6 +111,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
           "startup_script": "string",
           "startup_script_timeout_seconds": 0,
           "status": "connecting",
+          "subsystem": "envbox",
           "troubleshooting_url": "string",
           "updated_at": "2019-08-24T14:15:22Z",
           "version": "string"
@@ -263,6 +264,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild} \
           "startup_script": "string",
           "startup_script_timeout_seconds": 0,
           "status": "connecting",
+          "subsystem": "envbox",
           "troubleshooting_url": "string",
           "updated_at": "2019-08-24T14:15:22Z",
           "version": "string"
@@ -556,6 +558,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/res
         "startup_script": "string",
         "startup_script_timeout_seconds": 0,
         "status": "connecting",
+        "subsystem": "envbox",
         "troubleshooting_url": "string",
         "updated_at": "2019-08-24T14:15:22Z",
         "version": "string"
@@ -638,6 +641,7 @@ Status Code **200**
 | `»» startup_script`                  | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» startup_script_timeout_seconds`  | integer                                                                          | false    |              | »startup script timeout seconds is the number of seconds to wait for the startup script to complete. If the script does not complete within this time, the agent lifecycle will be marked as start_timeout.                                    |
 | `»» status`                          | [codersdk.WorkspaceAgentStatus](schemas.md#codersdkworkspaceagentstatus)         | false    |              |                                                                                                                                                                                                                                                |
+| `»» subsystem`                       | [codersdk.AgentSubsystem](schemas.md#codersdkagentsubsystem)                     | false    |              |                                                                                                                                                                                                                                                |
 | `»» troubleshooting_url`             | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» updated_at`                      | string(date-time)                                                                | false    |              |                                                                                                                                                                                                                                                |
 | `»» version`                         | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
@@ -679,6 +683,7 @@ Status Code **200**
 | `status`               | `connected`        |
 | `status`               | `disconnected`     |
 | `status`               | `timeout`          |
+| `subsystem`            | `envbox`           |
 | `workspace_transition` | `start`            |
 | `workspace_transition` | `stop`             |
 | `workspace_transition` | `delete`           |
@@ -794,6 +799,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/sta
           "startup_script": "string",
           "startup_script_timeout_seconds": 0,
           "status": "connecting",
+          "subsystem": "envbox",
           "troubleshooting_url": "string",
           "updated_at": "2019-08-24T14:15:22Z",
           "version": "string"
@@ -951,6 +957,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
             "startup_script": "string",
             "startup_script_timeout_seconds": 0,
             "status": "connecting",
+            "subsystem": "envbox",
             "troubleshooting_url": "string",
             "updated_at": "2019-08-24T14:15:22Z",
             "version": "string"
@@ -1067,6 +1074,7 @@ Status Code **200**
 | `»»» startup_script`                  | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»»» startup_script_timeout_seconds`  | integer                                                                          | false    |              | »»startup script timeout seconds is the number of seconds to wait for the startup script to complete. If the script does not complete within this time, the agent lifecycle will be marked as start_timeout.                                   |
 | `»»» status`                          | [codersdk.WorkspaceAgentStatus](schemas.md#codersdkworkspaceagentstatus)         | false    |              |                                                                                                                                                                                                                                                |
+| `»»» subsystem`                       | [codersdk.AgentSubsystem](schemas.md#codersdkagentsubsystem)                     | false    |              |                                                                                                                                                                                                                                                |
 | `»»» troubleshooting_url`             | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»»» updated_at`                      | string(date-time)                                                                | false    |              |                                                                                                                                                                                                                                                |
 | `»»» version`                         | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
@@ -1128,6 +1136,7 @@ Status Code **200**
 | `status`               | `connected`                   |
 | `status`               | `disconnected`                |
 | `status`               | `timeout`                     |
+| `subsystem`            | `envbox`                      |
 | `workspace_transition` | `start`                       |
 | `workspace_transition` | `stop`                        |
 | `workspace_transition` | `delete`                      |
@@ -1286,6 +1295,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
           "startup_script": "string",
           "startup_script_timeout_seconds": 0,
           "status": "connecting",
+          "subsystem": "envbox",
           "troubleshooting_url": "string",
           "updated_at": "2019-08-24T14:15:22Z",
           "version": "string"

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -56,20 +56,6 @@
 | `counter` |
 | `gauge`   |
 
-## agentsdk.AgentSubsystem
-
-```json
-"envbox"
-```
-
-### Properties
-
-#### Enumerated Values
-
-| Value    |
-| -------- |
-| `envbox` |
-
 ## agentsdk.AuthenticateResponse
 
 ```json
@@ -351,7 +337,7 @@
 | Name                 | Type                                               | Required | Restrictions | Description |
 | -------------------- | -------------------------------------------------- | -------- | ------------ | ----------- |
 | `expanded_directory` | string                                             | false    |              |             |
-| `subsystem`          | [agentsdk.AgentSubsystem](#agentsdkagentsubsystem) | false    |              |             |
+| `subsystem`          | [codersdk.AgentSubsystem](#codersdkagentsubsystem) | false    |              |             |
 | `version`            | string                                             | false    |              |             |
 
 ## agentsdk.StartupLog
@@ -798,6 +784,20 @@
 | Name      | Type   | Required | Restrictions | Description |
 | --------- | ------ | -------- | ------------ | ----------- |
 | `license` | string | true     |              |             |
+
+## codersdk.AgentSubsystem
+
+```json
+"envbox"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value    |
+| -------- |
+| `envbox` |
 
 ## codersdk.AppHostResponse
 
@@ -4714,6 +4714,7 @@ Parameter represents a set value for the scope.
             "startup_script": "string",
             "startup_script_timeout_seconds": 0,
             "status": "connecting",
+            "subsystem": "envbox",
             "troubleshooting_url": "string",
             "updated_at": "2019-08-24T14:15:22Z",
             "version": "string"
@@ -4844,6 +4845,7 @@ Parameter represents a set value for the scope.
   "startup_script": "string",
   "startup_script_timeout_seconds": 0,
   "status": "connecting",
+  "subsystem": "envbox",
   "troubleshooting_url": "string",
   "updated_at": "2019-08-24T14:15:22Z",
   "version": "string"
@@ -4881,6 +4883,7 @@ Parameter represents a set value for the scope.
 | `startup_script`                  | string                                                               | false    |              |                                                                                                                                                                                                            |
 | `startup_script_timeout_seconds`  | integer                                                              | false    |              | Startup script timeout seconds is the number of seconds to wait for the startup script to complete. If the script does not complete within this time, the agent lifecycle will be marked as start_timeout. |
 | `status`                          | [codersdk.WorkspaceAgentStatus](#codersdkworkspaceagentstatus)       | false    |              |                                                                                                                                                                                                            |
+| `subsystem`                       | [codersdk.AgentSubsystem](#codersdkagentsubsystem)                   | false    |              |                                                                                                                                                                                                            |
 | `troubleshooting_url`             | string                                                               | false    |              |                                                                                                                                                                                                            |
 | `updated_at`                      | string                                                               | false    |              |                                                                                                                                                                                                            |
 | `version`                         | string                                                               | false    |              |                                                                                                                                                                                                            |
@@ -5235,6 +5238,7 @@ Parameter represents a set value for the scope.
           "startup_script": "string",
           "startup_script_timeout_seconds": 0,
           "status": "connecting",
+          "subsystem": "envbox",
           "troubleshooting_url": "string",
           "updated_at": "2019-08-24T14:15:22Z",
           "version": "string"
@@ -5516,6 +5520,7 @@ Parameter represents a set value for the scope.
       "startup_script": "string",
       "startup_script_timeout_seconds": 0,
       "status": "connecting",
+      "subsystem": "envbox",
       "troubleshooting_url": "string",
       "updated_at": "2019-08-24T14:15:22Z",
       "version": "string"
@@ -5714,6 +5719,7 @@ Parameter represents a set value for the scope.
                 "startup_script": "string",
                 "startup_script_timeout_seconds": 0,
                 "status": "connecting",
+                "subsystem": "envbox",
                 "troubleshooting_url": "string",
                 "updated_at": "2019-08-24T14:15:22Z",
                 "version": "string"

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -56,6 +56,20 @@
 | `counter` |
 | `gauge`   |
 
+## agentsdk.AgentSubsystem
+
+```json
+"envbox"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value    |
+| -------- |
+| `envbox` |
+
 ## agentsdk.AuthenticateResponse
 
 ```json
@@ -327,16 +341,18 @@
 ```json
 {
   "expanded_directory": "string",
+  "subsystem": "envbox",
   "version": "string"
 }
 ```
 
 ### Properties
 
-| Name                 | Type   | Required | Restrictions | Description |
-| -------------------- | ------ | -------- | ------------ | ----------- |
-| `expanded_directory` | string | false    |              |             |
-| `version`            | string | false    |              |             |
+| Name                 | Type                                               | Required | Restrictions | Description |
+| -------------------- | -------------------------------------------------- | -------- | ------------ | ----------- |
+| `expanded_directory` | string                                             | false    |              |             |
+| `subsystem`          | [agentsdk.AgentSubsystem](#agentsdkagentsubsystem) | false    |              |             |
+| `version`            | string                                             | false    |              |             |
 
 ## agentsdk.StartupLog
 

--- a/docs/api/templates.md
+++ b/docs/api/templates.md
@@ -1680,6 +1680,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
         "startup_script": "string",
         "startup_script_timeout_seconds": 0,
         "status": "connecting",
+        "subsystem": "envbox",
         "troubleshooting_url": "string",
         "updated_at": "2019-08-24T14:15:22Z",
         "version": "string"
@@ -1762,6 +1763,7 @@ Status Code **200**
 | `»» startup_script`                  | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» startup_script_timeout_seconds`  | integer                                                                          | false    |              | »startup script timeout seconds is the number of seconds to wait for the startup script to complete. If the script does not complete within this time, the agent lifecycle will be marked as start_timeout.                                    |
 | `»» status`                          | [codersdk.WorkspaceAgentStatus](schemas.md#codersdkworkspaceagentstatus)         | false    |              |                                                                                                                                                                                                                                                |
+| `»» subsystem`                       | [codersdk.AgentSubsystem](schemas.md#codersdkagentsubsystem)                     | false    |              |                                                                                                                                                                                                                                                |
 | `»» troubleshooting_url`             | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» updated_at`                      | string(date-time)                                                                | false    |              |                                                                                                                                                                                                                                                |
 | `»» version`                         | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
@@ -1803,6 +1805,7 @@ Status Code **200**
 | `status`               | `connected`        |
 | `status`               | `disconnected`     |
 | `status`               | `timeout`          |
+| `subsystem`            | `envbox`           |
 | `workspace_transition` | `start`            |
 | `workspace_transition` | `stop`             |
 | `workspace_transition` | `delete`           |
@@ -2109,6 +2112,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/r
         "startup_script": "string",
         "startup_script_timeout_seconds": 0,
         "status": "connecting",
+        "subsystem": "envbox",
         "troubleshooting_url": "string",
         "updated_at": "2019-08-24T14:15:22Z",
         "version": "string"
@@ -2191,6 +2195,7 @@ Status Code **200**
 | `»» startup_script`                  | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» startup_script_timeout_seconds`  | integer                                                                          | false    |              | »startup script timeout seconds is the number of seconds to wait for the startup script to complete. If the script does not complete within this time, the agent lifecycle will be marked as start_timeout.                                    |
 | `»» status`                          | [codersdk.WorkspaceAgentStatus](schemas.md#codersdkworkspaceagentstatus)         | false    |              |                                                                                                                                                                                                                                                |
+| `»» subsystem`                       | [codersdk.AgentSubsystem](schemas.md#codersdkagentsubsystem)                     | false    |              |                                                                                                                                                                                                                                                |
 | `»» troubleshooting_url`             | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» updated_at`                      | string(date-time)                                                                | false    |              |                                                                                                                                                                                                                                                |
 | `»» version`                         | string                                                                           | false    |              |                                                                                                                                                                                                                                                |
@@ -2232,6 +2237,7 @@ Status Code **200**
 | `status`               | `connected`        |
 | `status`               | `disconnected`     |
 | `status`               | `timeout`          |
+| `subsystem`            | `envbox`           |
 | `workspace_transition` | `start`            |
 | `workspace_transition` | `stop`             |
 | `workspace_transition` | `delete`           |

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -144,6 +144,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
             "startup_script": "string",
             "startup_script_timeout_seconds": 0,
             "status": "connecting",
+            "subsystem": "envbox",
             "troubleshooting_url": "string",
             "updated_at": "2019-08-24T14:15:22Z",
             "version": "string"
@@ -317,6 +318,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
             "startup_script": "string",
             "startup_script_timeout_seconds": 0,
             "status": "connecting",
+            "subsystem": "envbox",
             "troubleshooting_url": "string",
             "updated_at": "2019-08-24T14:15:22Z",
             "version": "string"
@@ -509,6 +511,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
                 "startup_script": "string",
                 "startup_script_timeout_seconds": 0,
                 "status": "connecting",
+                "subsystem": "envbox",
                 "troubleshooting_url": "string",
                 "updated_at": "2019-08-24T14:15:22Z",
                 "version": "string"
@@ -683,6 +686,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
             "startup_script": "string",
             "startup_script_timeout_seconds": 0,
             "status": "connecting",
+            "subsystem": "envbox",
             "troubleshooting_url": "string",
             "updated_at": "2019-08-24T14:15:22Z",
             "version": "string"

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1147,6 +1147,7 @@ export interface WorkspaceAgent {
   readonly startup_script_timeout_seconds: number
   readonly shutdown_script?: string
   readonly shutdown_script_timeout_seconds: number
+  readonly subsystem: AgentSubsystem
 }
 
 // From codersdk/workspaceagentconn.go
@@ -1340,6 +1341,10 @@ export interface WorkspacesResponse {
 // From codersdk/apikey.go
 export type APIKeyScope = "all" | "application_connect"
 export const APIKeyScopes: APIKeyScope[] = ["all", "application_connect"]
+
+// From codersdk/workspaceagents.go
+export type AgentSubsystem = "envbox"
+export const AgentSubsystems: AgentSubsystem[] = ["envbox"]
 
 // From codersdk/audit.go
 export type AuditAction =

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -501,6 +501,7 @@ export const MockWorkspaceAgent: TypesGen.WorkspaceAgent = {
   startup_logs_overflowed: false,
   startup_script_timeout_seconds: 120,
   shutdown_script_timeout_seconds: 120,
+  subsystem: "envbox",
 }
 
 export const MockWorkspaceAgentDisconnected: TypesGen.WorkspaceAgent = {


### PR DESCRIPTION
This PR adds a "subsystem" field to the workspace agent that can be used to identify workspaces that are being run via custom solutions such as `envbox` or `envbuilder`. In order to register a subsystem a `CODER_AGENT_SUBSYSTEM` env var must be set to a valid value.

fixes #6802 