### PR TITLE
fix(site): maintain initial workspace list order

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -1,12 +1,13 @@
 import { useFilter } from "hooks/useFilter"
 import { usePagination } from "hooks/usePagination"
-import { FC } from "react"
+import { FC, useEffect, useState } from "react"
 import { Helmet } from "react-helmet-async"
 import { workspaceFilterQuery } from "utils/filters"
 import { pageTitle } from "utils/page"
 import { useWorkspacesData, useWorkspaceUpdate } from "./data"
 import { WorkspacesPageView } from "./WorkspacesPageView"
 import { useDashboard } from "components/Dashboard/DashboardProvider"
+import { Workspace } from "api/typesGenerated"
 
 const WorkspacesPage: FC = () => {
   const filter = useFilter(workspaceFilterQuery.me)
@@ -22,7 +23,48 @@ const WorkspacesPage: FC = () => {
     ...pagination,
     ...filter,
   })
+
   const updateWorkspace = useWorkspaceUpdate(queryKey)
+
+  const [displayedWorkspaces, setDisplayedWorkspaces] = useState<Workspace[]>(
+    [],
+  )
+
+  useEffect(() => {
+    const fetchedWorkspaces = data?.workspaces || []
+    if (fetchedWorkspaces) {
+      if (displayedWorkspaces.length === 0) {
+        setDisplayedWorkspaces(fetchedWorkspaces)
+      } else {
+        // Merge the fetched workspaces with the displayed onws, without changing the order of the existing items
+        const mergedItems = displayedWorkspaces
+          .map((item) => {
+            const fetchedItem = fetchedWorkspaces.find(
+              (fItem) => fItem.id === item.id,
+            )
+
+            if (!fetchedItem) {
+              return null
+            }
+
+            // If the fetched item already exists, update its data without changing its position
+            return { ...item, ...fetchedItem }
+          })
+          .filter((item) => item !== null) // Remove the removed items (null values)
+
+        // Add new items to the beginning of the list
+        fetchedWorkspaces.forEach((fetchedItem) => {
+          if (!mergedItems.some((item) => item?.id === fetchedItem.id)) {
+            mergedItems.unshift(fetchedItem)
+          }
+        })
+
+        setDisplayedWorkspaces(
+          mergedItems.filter((item) => item !== null) as Workspace[],
+        )
+      }
+    }
+  }, [data?.workspaces, displayedWorkspaces])
 
   return (
     <>
@@ -31,11 +73,11 @@ const WorkspacesPage: FC = () => {
       </Helmet>
 
       <WorkspacesPageView
-        workspaces={data?.workspaces}
+        workspaces={data && displayedWorkspaces}
         error={error}
         filter={filter.query}
         onFilter={filter.setFilter}
-        count={data?.count}
+        count={displayedWorkspaces.length}
         page={pagination.page}
         limit={pagination.limit}
         onPageChange={pagination.goToPage}


### PR DESCRIPTION
addresses the issue of annoying visual reorders in the workspace list by maintaining the initial order of workspaces fetched from the backend while handling updates, additions, and removals of workspaces in the list.

Changes:

1. Added a new state `displayedWorkspaces` to store the workspaces to be displayed on the screen.
2. Implemented a `useEffect` hook to update the `displayedWorkspaces` state based on the latest data fetched from the backend.
3. Updated the merging logic to:
   - Keep the order of the initially fetched workspaces.
   - Update the workspaces' data without changing their position in the list.
   - Add new workspaces to the beginning of the list.
   - Remove workspaces from the list if they are not present in the fetched data.

I usually try to avoid using `useEffect`as much as I can, but I believe this is an ok use-case for it. 