### PR TITLE
fix: fix free disk space reported by agent metadata in fly.io example

### DIFF
--- a/examples/templates/fly-docker-image/main.tf
+++ b/examples/templates/fly-docker-image/main.tf
@@ -284,10 +284,11 @@ resource "coder_agent" "main" {
     code-server --auth none >/tmp/code-server.log 2>&1 &
     # Set the hostname to the workspace name
     sudo hostname -b "${data.coder_workspace.me.name}-fly"
+    echo "127.0.0.1  ${data.coder_workspace.me.name}-fly" | sudo tee -a /etc/hosts
     # Install the Fly CLI and add it to the PATH
     curl -L https://fly.io/install.sh | sh
-    echo "export PATH=$PATH:/home/coder/.fly/bin" >> ~/.bashrc
-    source ~/.bashrc
+    echo "export PATH=$PATH:/home/coder/.fly/bin" >> /home/coder/.bashrc
+    source /home/coder/.bashrc
   EOT
 
   metadata {
@@ -320,7 +321,7 @@ resource "coder_agent" "main" {
     script       = <<-EOT
       #!/bin/bash
       set -e
-      df /home/coder | awk '$NF=="/"{printf "%s", $5}'
+      df | awk '$NF=="/home/coder" {printf "%s", $5}'
     EOT
   }
 }


### PR DESCRIPTION
This will now report the correct disk usage of the mounted `fly_volume` resource on `/home/coder`
