### PR TITLE
feat(workspaces): change sorting order of the workspace list

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1147,9 +1147,16 @@ func convertWorkspaces(workspaces []database.Workspace, data workspaceData) ([]c
 			&owner,
 		))
 	}
-	sort.Slice(apiWorkspaces, func(i, j int) bool {
-		iw := apiWorkspaces[i]
-		jw := apiWorkspaces[j]
+
+	sortWorkspaces(apiWorkspaces)
+
+	return apiWorkspaces, nil
+}
+
+func sortWorkspaces(workspaces []codersdk.Workspace) {
+	sort.Slice(workspaces, func(i, j int) bool {
+		iw := workspaces[i]
+		jw := workspaces[j]
 
 		if iw.LatestBuild.Status == codersdk.WorkspaceStatusRunning && jw.LatestBuild.Status != codersdk.WorkspaceStatusRunning {
 			return true
@@ -1168,8 +1175,6 @@ func convertWorkspaces(workspaces []database.Workspace, data workspaceData) ([]c
 		}
 		return iw.LastUsedAt.After(jw.LastUsedAt)
 	})
-
-	return apiWorkspaces, nil
 }
 
 func convertWorkspace(

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1150,6 +1150,19 @@ func convertWorkspaces(workspaces []database.Workspace, data workspaceData) ([]c
 	sort.Slice(apiWorkspaces, func(i, j int) bool {
 		iw := apiWorkspaces[i]
 		jw := apiWorkspaces[j]
+
+		if iw.LatestBuild.Status == codersdk.WorkspaceStatusRunning && jw.LatestBuild.Status != codersdk.WorkspaceStatusRunning {
+			return true
+		}
+
+		if jw.LatestBuild.Status == codersdk.WorkspaceStatusRunning && iw.LatestBuild.Status != codersdk.WorkspaceStatusRunning {
+			return false
+		}
+
+		if iw.OwnerID != jw.OwnerID {
+			return iw.OwnerName < jw.OwnerName
+		}
+
 		if jw.LastUsedAt.IsZero() && iw.LastUsedAt.IsZero() {
 			return iw.Name < jw.Name
 		}

--- a/coderd/workspaces_internal_test.go
+++ b/coderd/workspaces_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/database"
@@ -98,10 +97,10 @@ func TestSortWorkspaces(t *testing.T) {
 
 		sortWorkspaces(workspaces)
 
-		assert.Equal(t, workspaces[0].LatestBuild.Status, codersdk.WorkspaceStatusRunning)
-		assert.Equal(t, workspaces[1].LatestBuild.Status, codersdk.WorkspaceStatusRunning)
-		assert.Equal(t, workspaces[2].LatestBuild.Status, codersdk.WorkspaceStatusPending)
-		assert.Equal(t, workspaces[3].LatestBuild.Status, codersdk.WorkspaceStatusPending)
+		require.Equal(t, workspaces[0].LatestBuild.Status, codersdk.WorkspaceStatusRunning)
+		require.Equal(t, workspaces[1].LatestBuild.Status, codersdk.WorkspaceStatusRunning)
+		require.Equal(t, workspaces[2].LatestBuild.Status, codersdk.WorkspaceStatusPending)
+		require.Equal(t, workspaces[3].LatestBuild.Status, codersdk.WorkspaceStatusPending)
 	})
 
 	t.Run("Then sort by owner Name", func(t *testing.T) {
@@ -117,9 +116,9 @@ func TestSortWorkspaces(t *testing.T) {
 		t.Log("uuid ", uuid.New().String())
 		t.Log("uuid ", uuid.New().String())
 
-		assert.Equal(t, "userA", workspaces[0].OwnerName)
-		assert.Equal(t, "userB", workspaces[1].OwnerName)
-		assert.Equal(t, "userZ", workspaces[2].OwnerName)
+		require.Equal(t, "userA", workspaces[0].OwnerName)
+		require.Equal(t, "userB", workspaces[1].OwnerName)
+		require.Equal(t, "userZ", workspaces[2].OwnerName)
 	})
 
 	t.Run("Then sort by last used at (recent first)", func(t *testing.T) {
@@ -135,10 +134,10 @@ func TestSortWorkspaces(t *testing.T) {
 		sortWorkspaces(workspaces)
 
 		// in this case, the last used at is the creation time
-		assert.Equal(t, workspaces[0].Name, "test-workspace-sort-4")
-		assert.Equal(t, workspaces[1].Name, "test-workspace-sort-3")
-		assert.Equal(t, workspaces[2].Name, "test-workspace-sort-2")
-		assert.Equal(t, workspaces[3].Name, "test-workspace-sort-1")
+		require.Equal(t, workspaces[0].Name, "test-workspace-sort-4")
+		require.Equal(t, workspaces[1].Name, "test-workspace-sort-3")
+		require.Equal(t, workspaces[2].Name, "test-workspace-sort-2")
+		require.Equal(t, workspaces[3].Name, "test-workspace-sort-1")
 	})
 }
 

--- a/coderd/workspaces_internal_test.go
+++ b/coderd/workspaces_internal_test.go
@@ -108,8 +108,8 @@ func TestSortWorkspaces(t *testing.T) {
 	workspaceRunningUserA := workspaceFactory(t, "running-userA", userAuuid, "userA", codersdk.WorkspaceStatusRunning, time.Now())
 	workspaceRunningUserB := workspaceFactory(t, "running-userB", uuid.New(), "userB", codersdk.WorkspaceStatusRunning, time.Now())
 	workspacePendingUserC := workspaceFactory(t, "pending-userC", uuid.New(), "userC", codersdk.WorkspaceStatusPending, time.Now())
-	workspaceRunningUserA2 := workspaceFactory(t, "running-userA2", userAuuid, "userA", codersdk.WorkspaceStatusRunning, time.Now())
-	workspaceRunningUserZ := workspaceFactory(t, "running-userZ", uuid.New(), "userZ", codersdk.WorkspaceStatusRunning, time.Now().Add(time.Minute))
+	workspaceRunningUserA2 := workspaceFactory(t, "running-userA2", userAuuid, "userA", codersdk.WorkspaceStatusRunning, time.Now().Add(time.Minute))
+	workspaceRunningUserZ := workspaceFactory(t, "running-userZ", uuid.New(), "userZ", codersdk.WorkspaceStatusRunning, time.Now())
 	workspaceRunningUserA3 := workspaceFactory(t, "running-userA3", userAuuid, "userA", codersdk.WorkspaceStatusRunning, time.Now().Add(time.Hour))
 
 	testCases := []struct {

--- a/coderd/workspaces_internal_test.go
+++ b/coderd/workspaces_internal_test.go
@@ -113,9 +113,6 @@ func TestSortWorkspaces(t *testing.T) {
 
 		sortWorkspaces(workspaces)
 
-		t.Log("uuid ", uuid.New().String())
-		t.Log("uuid ", uuid.New().String())
-
 		require.Equal(t, "userA", workspaces[0].OwnerName)
 		require.Equal(t, "userB", workspaces[1].OwnerName)
 		require.Equal(t, "userZ", workspaces[2].OwnerName)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -239,6 +239,10 @@ func TestWorkspacesSortOrder(t *testing.T) {
 	require.Equal(t, codersdk.WorkspaceStatusStopped, workspacesResponse.Workspaces[2].LatestBuild.Status, "The stopped one should be last")
 
 	require.Equal(t, workspace3.ID, workspacesResponse.Workspaces[0].ID, "If both are running, and have the same owner, sort by last used (in this case, the last one created)")
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 }
 
 func TestPostWorkspacesByOrganization(t *testing.T) {

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -198,6 +198,49 @@ func TestAdminViewAllWorkspaces(t *testing.T) {
 	require.Equal(t, 0, len(memberViewWorkspaces.Workspaces), "member in other org should see 0 workspaces")
 }
 
+func TestWorkspacesSortOrder(t *testing.T) {
+	// the correct sorting order is:
+	// 1. first show workspaces that are currently running,
+	// 2. then sort by user_name,
+	// 3. then sort by last_used_at (descending),
+	t.Parallel()
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	firstUser := coderdtest.CreateFirstUser(t, client)
+	version := coderdtest.CreateTemplateVersion(t, client, firstUser.OrganizationID, nil)
+	coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, firstUser.OrganizationID, version.ID)
+	workspace1 := coderdtest.CreateWorkspace(t, client, firstUser.OrganizationID, template.ID, func(ctr *codersdk.CreateWorkspaceRequest) {
+		ctr.Name = "test-workspace-sort-1"
+	})
+	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace1.LatestBuild.ID)
+
+	workspace2 := coderdtest.CreateWorkspace(t, client, firstUser.OrganizationID, template.ID, func(ctr *codersdk.CreateWorkspaceRequest) {
+		ctr.Name = "test-workspace-sort-2"
+	})
+	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace2.LatestBuild.ID)
+
+	build2 := coderdtest.CreateWorkspaceBuild(t, client, workspace2, database.WorkspaceTransitionStop)
+	coderdtest.AwaitWorkspaceBuildJob(t, client, build2.ID)
+
+	workspace3 := coderdtest.CreateWorkspace(t, client, firstUser.OrganizationID, template.ID, func(ctr *codersdk.CreateWorkspaceRequest) {
+		ctr.Name = "test-workspace-sort-3"
+	})
+	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace3.LatestBuild.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	workspacesResponse, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{})
+	require.NoError(t, err, "(first) fetch workspaces")
+	require.Equal(t, 3, len(workspacesResponse.Workspaces), "should be 3 workspaces present")
+
+	require.Equal(t, codersdk.WorkspaceStatusRunning, workspacesResponse.Workspaces[0].LatestBuild.Status, "first should be running ones")
+	require.Equal(t, codersdk.WorkspaceStatusRunning, workspacesResponse.Workspaces[1].LatestBuild.Status, "Running workspaces should be first")
+	require.Equal(t, codersdk.WorkspaceStatusStopped, workspacesResponse.Workspaces[2].LatestBuild.Status, "The stopped one should be last")
+
+	require.Equal(t, workspace3.ID, workspacesResponse.Workspaces[0].ID, "If both are running, and have the same owner, sort by last used (in this case, the last one created)")
+}
+
 func TestPostWorkspacesByOrganization(t *testing.T) {
 	t.Parallel()
 	t.Run("InvalidTemplate", func(t *testing.T) {

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -234,15 +234,12 @@ func TestWorkspacesSortOrder(t *testing.T) {
 	require.NoError(t, err, "(first) fetch workspaces")
 	require.Equal(t, 3, len(workspacesResponse.Workspaces), "should be 3 workspaces present")
 
-	require.Equal(t, codersdk.WorkspaceStatusRunning, workspacesResponse.Workspaces[0].LatestBuild.Status, "first should be running ones")
-	require.Equal(t, codersdk.WorkspaceStatusRunning, workspacesResponse.Workspaces[1].LatestBuild.Status, "Running workspaces should be first")
-	require.Equal(t, codersdk.WorkspaceStatusStopped, workspacesResponse.Workspaces[2].LatestBuild.Status, "The stopped one should be last")
+	require.Equal(t, codersdk.WorkspaceStatusRunning, workspacesResponse.Workspaces[0].LatestBuild.Status, "should be the first item in the list because it is running")
+	require.Equal(t, codersdk.WorkspaceStatusRunning, workspacesResponse.Workspaces[1].LatestBuild.Status)
+	require.Equal(t, codersdk.WorkspaceStatusStopped, workspacesResponse.Workspaces[2].LatestBuild.Status, "The stopped workspace should be last")
 
 	require.Equal(t, workspace3.ID, workspacesResponse.Workspaces[0].ID, "If both are running, and have the same owner, sort by last used (in this case, the last one created)")
-<<<<<<< Updated upstream
-=======
 
->>>>>>> Stashed changes
 }
 
 func TestPostWorkspacesByOrganization(t *testing.T) {


### PR DESCRIPTION
changes to the sorting order of the workspace list. The new sorting order is as follows:

1. First, display workspaces that are currently running.
2. Next, sort by user_name.
3. Finally, sort by last_used_at in descending order.

That order was suggested in this conversation: https://github.com/coder/coder/pull/7590#pullrequestreview-1432741949. 