### PR TITLE
chore: remove CPU usage calculation for hosts on cgroup v1

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -106,7 +106,9 @@ resource "coder_agent" "dev" {
         cusage=$(cat /sys/fs/cgroup/cpu.stat | head -n 1 | awk '{ print $2 }')
       else
         # cgroup v1
-        cusage=$(cat /sys/fs/cgroup/cpu,cpuacct/cpuacct.usage)
+#         cusage=$(cat /sys/fs/cgroup/cpu,cpuacct/cpuacct.usage)
+        echo "Coming Soon!"
+        exit 0
       fi
 
       # get previous usage


### PR DESCRIPTION
The logic calculate CPU usage was not working as expected on Coder US host which is on groups v1.

I plan to add this later when we have 'coder stat' ready and merged or I find a workaround. 