### PR TITLE
fix(provisionersdk): allow `.terraform.lock.hcl` files to be archived

### DIFF
--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -73,7 +73,9 @@ func Tar(w io.Writer, directory string, limit int64) error {
 		if err != nil {
 			return err
 		}
-		if strings.HasPrefix(rel, ".") || strings.HasPrefix(filepath.Base(rel), ".") {
+		// We want to allow .terraform.lock.hcl files to be archived. This
+		// allows provider plugins to be cached.
+		if (strings.HasPrefix(rel, ".") || strings.HasPrefix(filepath.Base(rel), ".")) && filepath.Base(rel) != ".terraform.lock.hcl" {
 			if fileInfo.IsDir() && rel != "." {
 				// Don't archive hidden files!
 				return filepath.SkipDir


### PR DESCRIPTION
Without `.terraform.lock.hcl` present in the template, Terraform versions after v1.4.0 force all providers to be redownloaded each time. This allows `coder templates push` to push the lock file.