### PR TITLE
chore: CORs option for yarn dev server

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7252,6 +7252,9 @@ const docTemplate = `{
         "codersdk.DangerousConfig": {
             "type": "object",
             "properties": {
+                "allow_all_cors": {
+                    "type": "boolean"
+                },
                 "allow_path_app_sharing": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6454,6 +6454,9 @@
     "codersdk.DangerousConfig": {
       "type": "object",
       "properties": {
+        "allow_all_cors": {
+          "type": "boolean"
+        },
         "allow_path_app_sharing": {
           "type": "boolean"
         },

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -799,6 +799,10 @@ func New(options *Options) *API {
 	// Add CSP headers to all static assets and pages. CSP headers only affect
 	// browsers, so these don't make sense on api routes.
 	cspMW := httpmw.CSPHeaders(func() []string {
+		if api.DeploymentValues.Dangerous.AllowAllCors {
+			// In this mode, allow all external requests
+			return []string{"*"}
+		}
 		if f := api.WorkspaceProxyHostsFn.Load(); f != nil {
 			return (*f)()
 		}
@@ -813,7 +817,7 @@ func New(options *Options) *API {
 	// This is the only route we add before all the middleware.
 	// We want to time the latency of the request, so any middleware will
 	// interfere with that timing.
-	rootRouter.Get("/latency-check", LatencyCheck(api.AccessURL))
+	rootRouter.Get("/latency-check", LatencyCheck(options.DeploymentValues.Dangerous.AllowAllCors.Value(), api.AccessURL))
 	rootRouter.Mount("/", r)
 	api.RootHandler = rootRouter
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -393,7 +393,7 @@ func New(options *Options) *API {
 
 	derpHandler := derphttp.Handler(api.DERPServer)
 	derpHandler, api.derpCloseFunc = tailnet.WithWebsocketSupport(api.DERPServer, derpHandler)
-	cors := httpmw.CorsMW(options.DeploymentValues.Dangerous.AllowAllCors.Value())
+	cors := httpmw.Cors(options.DeploymentValues.Dangerous.AllowAllCors.Value())
 
 	r.Use(
 		cors,

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -393,22 +393,7 @@ func New(options *Options) *API {
 
 	derpHandler := derphttp.Handler(api.DERPServer)
 	derpHandler, api.derpCloseFunc = tailnet.WithWebsocketSupport(api.DERPServer, derpHandler)
-
-	// By default, the app will never set any cors headers. If the AllowAllCors is provided, then
-	// we should add the appropriate cors headers.
-	cors := func(next http.Handler) http.Handler {
-		return next
-	}
-	if options.DeploymentValues.Dangerous.AllowAllCors {
-		cors = func(next http.Handler) http.Handler {
-			return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				rw.Header().Set("Access-Control-Allow-Origin", "*")
-				rw.Header().Set("Access-Control-Allow-Headers", "*")
-				rw.Header().Set("Access-Control-Allow-Methods", "*")
-				next.ServeHTTP(rw, r)
-			})
-		}
-	}
+	cors := httpmw.CorsMW(options.DeploymentValues.Dangerous.AllowAllCors.Value())
 
 	r.Use(
 		cors,

--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -1,8 +1,9 @@
 package httpmw
 
 import (
-	"github.com/go-chi/cors"
 	"net/http"
+
+	"github.com/go-chi/cors"
 )
 
 func CorsMW(allowAll bool, origins ...string) func(next http.Handler) http.Handler {

--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -7,7 +7,7 @@ import (
 )
 
 //nolint:revive
-func CorsMW(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
+func Cors(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
 	if len(origins) == 0 {
 		// The default behavior is '*', so putting the empty string defaults to
 		// the secure behavior of blocking CORs requests.

--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -1,0 +1,20 @@
+package httpmw
+
+import (
+	"github.com/go-chi/cors"
+	"net/http"
+)
+
+func CorsMW(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
+	if allowAll {
+		origins = []string{"*"}
+	}
+	return cors.Handler(cors.Options{
+		AllowedOrigins: origins,
+		// We only need GET for latency requests
+		AllowedMethods: []string{http.MethodOptions, http.MethodGet},
+		AllowedHeaders: []string{"Accept", "Content-Type", "X-LATENCY-CHECK", "X-CSRF-TOKEN"},
+		// Do not send any cookies
+		AllowCredentials: false,
+	})
+}

--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-chi/cors"
 )
 
+//nolint:revive
 func CorsMW(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
 	if len(origins) == 0 {
 		// The default behavior is '*', so putting the empty string defaults to

--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -7,6 +7,11 @@ import (
 )
 
 func CorsMW(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
+	if len(origins) == 0 {
+		// The default behavior is '*', so putting the empty string defaults to
+		// the secure behavior of blocking CORs requests.
+		origins = []string{""}
+	}
 	if allowAll {
 		origins = []string{"*"}
 	}

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -103,6 +103,10 @@ func CSPHeaders(websocketHosts func() []string) func(next http.Handler) http.Han
 			extraConnect := websocketHosts()
 			if len(extraConnect) > 0 {
 				for _, extraHost := range extraConnect {
+					if extraHost == "*" {
+						// '*' means all, which means we only need the prefixes.
+						extraHost = ""
+					}
 					cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", extraHost))
 					// We also require this to make http/https requests to the workspace proxy for latency checking.
 					cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("https://%[1]s http://%[1]s", extraHost))

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -104,8 +104,9 @@ func CSPHeaders(websocketHosts func() []string) func(next http.Handler) http.Han
 			if len(extraConnect) > 0 {
 				for _, extraHost := range extraConnect {
 					if extraHost == "*" {
-						// '*' means all, which means we only need the prefixes.
-						extraHost = ""
+						// '*' means all
+						cspSrcs.Append(cspDirectiveConnectSrc, "*")
+						continue
 					}
 					cspSrcs.Append(cspDirectiveConnectSrc, fmt.Sprintf("wss://%[1]s ws://%[1]s", extraHost))
 					// We also require this to make http/https requests to the workspace proxy for latency checking.

--- a/coderd/latencycheck.go
+++ b/coderd/latencycheck.go
@@ -9,6 +9,8 @@ import (
 // LatencyCheck is an endpoint for the web ui to measure latency with.
 // allowAll allows any Origin to get timing information. The allowAll should
 // only be set in dev modes.
+//
+//nolint:revive
 func LatencyCheck(allowAll bool, allowedOrigins ...*url.URL) http.HandlerFunc {
 	allowed := make([]string, 0, len(allowedOrigins))
 	for _, origin := range allowedOrigins {

--- a/coderd/latencycheck.go
+++ b/coderd/latencycheck.go
@@ -6,13 +6,19 @@ import (
 	"strings"
 )
 
-func LatencyCheck(allowedOrigins ...*url.URL) http.HandlerFunc {
+// LatencyCheck is an endpoint for the web ui to measure latency with.
+// allowAll allows any Origin to get timing information. The allowAll should
+// only be set in dev modes.
+func LatencyCheck(allowAll bool, allowedOrigins ...*url.URL) http.HandlerFunc {
 	allowed := make([]string, 0, len(allowedOrigins))
 	for _, origin := range allowedOrigins {
 		// Allow the origin without a path
 		tmp := *origin
 		tmp.Path = ""
 		allowed = append(allowed, strings.TrimSuffix(origin.String(), "/"))
+	}
+	if allowAll {
+		allowed = append(allowed, "*")
 	}
 	origins := strings.Join(allowed, ",")
 	return func(rw http.ResponseWriter, r *http.Request) {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -330,6 +330,7 @@ type LoggingConfig struct {
 type DangerousConfig struct {
 	AllowPathAppSharing         clibase.Bool `json:"allow_path_app_sharing" typescript:",notnull"`
 	AllowPathAppSiteOwnerAccess clibase.Bool `json:"allow_path_app_site_owner_access" typescript:",notnull"`
+	AllowAllCors                clibase.Bool `json:"allow_all_cors" typescript:",notnull"`
 }
 
 const (
@@ -1167,6 +1168,16 @@ when required by your organization's security policy.`,
 			Annotations: clibase.Annotations{}.Mark(annotationExternalProxies, "true"),
 		},
 		// ☢️ Dangerous settings
+		{
+			Name:        "DANGEROUS: Allow all CORs requests",
+			Description: "For security reasons, CORs requests are blocked. If external requests are required, setting this to true will set all cors headers as '*'. This should never be used in production.",
+			Flag:        "dangerous-allow-cors-requests",
+			Env:         "CODER_DANGEROUS_ALLOW_CORS_REQUESTS",
+			Hidden:      true, // Hidden, should only be used by yarn dev server
+			Value:       &c.Dangerous.AllowAllCors,
+			Group:       &deploymentGroupDangerous,
+			Annotations: clibase.Annotations{}.Mark(annotationExternalProxies, "true"),
+		},
 		{
 			Name:        "DANGEROUS: Allow Path App Sharing",
 			Description: "Allow workspace apps that are not served from subdomains to be shared. Path-based app sharing is DISABLED by default for security purposes. Path-based apps can make requests to the Coder API and pose a security risk when the workspace serves malicious JavaScript. Path-based apps can be disabled entirely with --disable-path-apps for further security.",

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -161,6 +161,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "sshconfigOptions": ["string"]
     },
     "dangerous": {
+      "allow_all_cors": true,
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true
     },

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1800,6 +1800,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 
 ```json
 {
+  "allow_all_cors": true,
   "allow_path_app_sharing": true,
   "allow_path_app_site_owner_access": true
 }
@@ -1809,6 +1810,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
 
 | Name                               | Type    | Required | Restrictions | Description |
 | ---------------------------------- | ------- | -------- | ------------ | ----------- |
+| `allow_all_cors`                   | boolean | false    |              |             |
 | `allow_path_app_sharing`           | boolean | false    |              |             |
 | `allow_path_app_site_owner_access` | boolean | false    |              |             |
 
@@ -1857,6 +1859,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
       "sshconfigOptions": ["string"]
     },
     "dangerous": {
+      "allow_all_cors": true,
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true
     },
@@ -2201,6 +2204,7 @@ CreateParameterRequest is a structure used to create a new parameter value for a
     "sshconfigOptions": ["string"]
   },
   "dangerous": {
+    "allow_all_cors": true,
     "allow_path_app_sharing": true,
     "allow_path_app_site_owner_access": true
   },

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -232,19 +232,20 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			}
 
 			proxy, err := wsproxy.New(ctx, &wsproxy.Options{
-				Logger:             logger,
-				HTTPClient:         httpClient,
-				DashboardURL:       primaryAccessURL.Value(),
-				AccessURL:          cfg.AccessURL.Value(),
-				AppHostname:        appHostname,
-				AppHostnameRegex:   appHostnameRegex,
-				RealIPConfig:       realIPConfig,
-				Tracing:            tracer,
-				PrometheusRegistry: prometheusRegistry,
-				APIRateLimit:       int(cfg.RateLimit.API.Value()),
-				SecureAuthCookie:   cfg.SecureAuthCookie.Value(),
-				DisablePathApps:    cfg.DisablePathApps.Value(),
-				ProxySessionToken:  proxySessionToken.Value(),
+				Logger:                logger,
+				HTTPClient:            httpClient,
+				DashboardURL:          primaryAccessURL.Value(),
+				AccessURL:             cfg.AccessURL.Value(),
+				AppHostname:           appHostname,
+				AppHostnameRegex:      appHostnameRegex,
+				RealIPConfig:          realIPConfig,
+				Tracing:               tracer,
+				PrometheusRegistry:    prometheusRegistry,
+				APIRateLimit:          int(cfg.RateLimit.API.Value()),
+				SecureAuthCookie:      cfg.SecureAuthCookie.Value(),
+				DisablePathApps:       cfg.DisablePathApps.Value(),
+				ProxySessionToken:     proxySessionToken.Value(),
+				DangerousAllowAllCors: cfg.Dangerous.AllowAllCors.Value(),
 			})
 			if err != nil {
 				return xerrors.Errorf("create workspace proxy: %w", err)

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -232,20 +232,20 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			}
 
 			proxy, err := wsproxy.New(ctx, &wsproxy.Options{
-				Logger:                logger,
-				HTTPClient:            httpClient,
-				DashboardURL:          primaryAccessURL.Value(),
-				AccessURL:             cfg.AccessURL.Value(),
-				AppHostname:           appHostname,
-				AppHostnameRegex:      appHostnameRegex,
-				RealIPConfig:          realIPConfig,
-				Tracing:               tracer,
-				PrometheusRegistry:    prometheusRegistry,
-				APIRateLimit:          int(cfg.RateLimit.API.Value()),
-				SecureAuthCookie:      cfg.SecureAuthCookie.Value(),
-				DisablePathApps:       cfg.DisablePathApps.Value(),
-				ProxySessionToken:     proxySessionToken.Value(),
-				DangerousAllowAllCors: cfg.Dangerous.AllowAllCors.Value(),
+				Logger:             logger,
+				HTTPClient:         httpClient,
+				DashboardURL:       primaryAccessURL.Value(),
+				AccessURL:          cfg.AccessURL.Value(),
+				AppHostname:        appHostname,
+				AppHostnameRegex:   appHostnameRegex,
+				RealIPConfig:       realIPConfig,
+				Tracing:            tracer,
+				PrometheusRegistry: prometheusRegistry,
+				APIRateLimit:       int(cfg.RateLimit.API.Value()),
+				SecureAuthCookie:   cfg.SecureAuthCookie.Value(),
+				DisablePathApps:    cfg.DisablePathApps.Value(),
+				ProxySessionToken:  proxySessionToken.Value(),
+				AllowAllCors:       cfg.Dangerous.AllowAllCors.Value(),
 			})
 			if err != nil {
 				return xerrors.Errorf("create workspace proxy: %w", err)

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -131,7 +131,7 @@ fatal() {
 	trap 'fatal "Script encountered an error"' ERR
 
 	cdroot
-	start_cmd API "" "${CODER_DEV_SHIM}" server --http-address 0.0.0.0:3000 --swagger-enable --access-url "http://127.0.0.1:3000" --experiments "*" "$@"
+	start_cmd API "" "${CODER_DEV_SHIM}" server --http-address 0.0.0.0:3000 --swagger-enable --access-url "http://127.0.0.1:3000" --dangerous-allow-cors-requests=true --experiments "*" "$@"
 
 	echo '== Waiting for Coder to become ready'
 	# Start the timeout in the background so interrupting this script
@@ -185,7 +185,7 @@ fatal() {
 			# Create the proxy
 			proxy_session_token=$("${CODER_DEV_SHIM}" wsproxy create --name=local-proxy --display-name="Local Proxy" --icon="/emojis/1f4bb.png" --only-token)
 			# Start the proxy
-			start_cmd PROXY "" "${CODER_DEV_SHIM}" wsproxy server --http-address=localhost:3010 --proxy-session-token="${proxy_session_token}" --primary-access-url=http://localhost:3000
+			start_cmd PROXY "" "${CODER_DEV_SHIM}" wsproxy server --dangerous-allow-cors-requests=true --http-address=localhost:3010 --proxy-session-token="${proxy_session_token}" --primary-access-url=http://localhost:3000
 		) || echo "Failed to create workspace proxy. No workspace proxy created."
 	fi
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -313,6 +313,7 @@ export interface DERPServerConfig {
 export interface DangerousConfig {
   readonly allow_path_app_sharing: boolean
   readonly allow_path_app_site_owner_access: boolean
+  readonly allow_all_cors: boolean
 }
 
 // From codersdk/deployment.go


### PR DESCRIPTION
Yarn dev server cannot request latency check endpoint because of CORs and CSP.
Add a flag to allow all external requests for yarn dev server to work correctly. This is a dangerous and hidden flag for dev use only.