### PR TITLE
fix(ci): manually select Go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,6 @@ on:
       - main
 
   pull_request:
-
   workflow_dispatch:
 
 permissions:
@@ -27,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  CODER_GO_VERSION: "~1.20"
+
 jobs:
   lint:
     runs-on: ${{ github.repository_owner == 'coder' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
@@ -37,7 +39,7 @@ jobs:
       # Install Go!
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.20"
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       # Check for any typos!
       - name: Check for typos
@@ -153,7 +155,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
-          go-version: "~1.20"
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       - name: Echo Go Cache Paths
         id: go-cache-paths
@@ -256,7 +258,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
-          go-version: "~1.20"
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       - name: Echo Go Cache Paths
         id: go-cache-paths
@@ -345,7 +347,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
-          go-version: "~1.20"
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       - name: Echo Go Cache Paths
         id: go-cache-paths
@@ -437,7 +439,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
-          go-version: "~1.20"
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       - name: Echo Go Cache Paths
         id: go-cache-paths
@@ -589,7 +591,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           cache: false
-          go-version: "~1.20"
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       - uses: hashicorp/setup-terraform@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      # For some reason, setup-go won't actually pick up a new patch version if
+      # it has an old one cached. We need to manually specify the versions so we
+      # can get the latest release.
       go_version:
         description: "Go version to use for building."
         required: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
     inputs:
       # For some reason, setup-go won't actually pick up a new patch version if
       # it has an old one cached. We need to manually specify the versions so we
-      # can get the latest release.
+      # can get the latest release. Never use "~1.xx" here!
       go_version:
         description: "Go version to use for building."
         required: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      go_version:
+        description: "Go version to use for building."
+        required: false
+        default: "1.20.4"
       dry_run:
         description: Perform a dry-run release (devel). Note that ref must be an annotated tag when run without dry-run.
         type: boolean
@@ -92,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.20"
+          go-version: ${{ inputs.go_version }}
 
       - name: Cache Node
         id: cache-node

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-security
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  CODER_GO_VERSION: "1.20.4"
+
 jobs:
   codeql:
     runs-on: ${{ github.repository_owner == 'coder' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
@@ -32,18 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "~1.20"
-
-      - name: Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Mod Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-release-go-mod-${{ hashFiles('**/go.sum') }}
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       # Workaround to prevent CodeQL from building the dashboard.
       - name: Remove Makefile
@@ -73,18 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "~1.20"
-
-      - name: Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Mod Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-release-go-mod-${{ hashFiles('**/go.sum') }}
+          go-version: ${{ env.CODER_GO_VERSION }}
 
       - name: Cache Node
         id: cache-node

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:jammy AS go
 
 RUN apt-get update && apt-get install --yes curl gcc
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.20.4
 RUN mkdir --parents /usr/local/go
 
 # Boring Go is needed to build FIPS-compliant binaries.


### PR DESCRIPTION
For some reason, `setup-go` won't actually pick up a new patch version if it has an old one cached. We need to manually specify the versions so we can get the latest release.

See: https://github.com/coder/coder/actions/runs/5026963985/jobs/9015878483#step:8:15