### PR TITLE
feat(cli): add 'coder upgrade' command

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -81,6 +81,7 @@ func (r *RootCmd) Core() []*clibase.Cmd {
 		r.resetPassword(),
 		r.state(),
 		r.templates(),
+		r.upgrade(),
 		r.users(),
 		r.tokens(),
 		r.version(defaultVersionInfo),

--- a/cli/root.go
+++ b/cli/root.go
@@ -678,7 +678,7 @@ func (r *RootCmd) checkVersions(i *clibase.Invocation, client *codersdk.Client) 
 	if runtime.GOOS == "windows" {
 		fmtWarningText += `download the server version from: https://github.com/coder/coder/releases/v%s`
 	} else {
-		fmtWarningText += `download the server version with: 'curl -L https://coder.com/install.sh | sh -s -- --version %s'`
+		fmtWarningText += `download the server version with: 'curl -L https://coder.com/install.sh | sh -s -- --version %s' or run 'coder upgrade'`
 	}
 
 	if !buildinfo.VersionsMatch(clientVersion, info.Version) {

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -40,6 +40,8 @@ Coder v0.0.0-devel — A tool for provisioning self-hosted development environme
     tokens            Manage personal access tokens
     update            Will update and start a given workspace if it is out of
                       date
+    upgrade           Upgrade the Coder CLI to match the version of a
+                      deployment.
     users             Manage users
     version           Show coder version
 

--- a/cli/testdata/coder_upgrade_--help.golden
+++ b/cli/testdata/coder_upgrade_--help.golden
@@ -1,0 +1,6 @@
+Usage: coder upgrade [flags]
+
+Upgrade the Coder CLI to match the version of a deployment.
+
+---
+Run `coder --help` for a list of global options.

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/coder/coder/cli/clibase"
+)
+
+func (r *RootCmd) upgrade() *clibase.Cmd {
+	cmd := &clibase.Cmd{
+		Use:   "upgrade",
+		Short: "Upgrade the Coder CLI to match the version of a deployment.",
+		Handler: func(inv *clibase.Invocation) error {
+
+			resp, err := http.Get("https://coder.com/install.sh")
+			if err != nil {
+				panic(err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				panic(fmt.Sprintf("code %d", resp.StatusCode))
+			}
+			defer resp.Body.Close()
+
+			script, err := io.ReadAll(resp.Body)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println("script: ", string(script))
+
+			cmd := exec.Command("sh", "-s", "--", "--version", "0.22.2")
+			cmd.Stdin = bytes.NewReader(script)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Run()
+			if err != nil {
+				panic(err)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -17,9 +17,7 @@ import (
 )
 
 func (r *RootCmd) upgrade() *clibase.Cmd {
-	var (
-		scriptURL string
-	)
+	var scriptURL string
 	cmd := &clibase.Cmd{
 		Use:   "upgrade",
 		Short: "Upgrade the Coder CLI to match the version of a deployment.",

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -1,39 +1,60 @@
 package cli
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"golang.org/x/mod/semver"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/cli/clibase"
+	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/codersdk"
 )
 
 func (r *RootCmd) upgrade() *clibase.Cmd {
+	var (
+		scriptURL string
+	)
 	cmd := &clibase.Cmd{
-		Use:     "upgrade",
-		Short:   "Upgrade the Coder CLI to match the version of a deployment.",
-		Options: clibase.OptionSet{},
+		Use:   "upgrade",
+		Short: "Upgrade the Coder CLI to match the version of a deployment.",
+		Options: clibase.OptionSet{
+			{
+				Flag:        "install-script-url",
+				Description: "Download URL of install script (useful for testing).",
+				Value:       clibase.StringOf(&scriptURL),
+				Default:     "https://dev.coder.com/install.sh",
+				Hidden:      true,
+			},
+		},
 		Handler: func(inv *clibase.Invocation) error {
 			var (
-				ctx  = inv.Context()
-				curl = r.clientURL.String()
+				ctx       = inv.Context()
+				serverURL = r.clientURL.String()
 			)
 
 			var err error
-			if curl == "" {
-				curl, err = r.createConfig().URL().Read()
-				if err != nil {
+			if serverURL == "" {
+				serverURL, err = r.createConfig().URL().Read()
+				if err != nil || strings.TrimSpace(serverURL) == "" {
+					_, _ = fmt.Fprintln(inv.Stderr, cliui.Styles.Error.Render(
+						"No deployment URL provided. You must either login using",
+						cliui.Styles.Code.Render("coder login"),
+						cliui.Styles.Error.Render("or specify a URL with the"),
+						cliui.Styles.Code.Render("--url"),
+						cliui.Styles.Error.Render("flag."),
+					))
+
 					return xerrors.Errorf("read config url: %w", err)
 				}
 			}
 
-			uri, err := url.Parse(curl)
+			uri, err := url.Parse(serverURL)
 			if err != nil {
 				return xerrors.Errorf("parse url: %w", err)
 			}
@@ -44,7 +65,27 @@ func (r *RootCmd) upgrade() *clibase.Cmd {
 				return xerrors.Errorf("build info: %w", err)
 			}
 
-			resp, err := http.Get("https://coder.com/install.sh")
+			version := semver.Canonical(serverInfo.Version)
+			version = strings.TrimSuffix(version, "-devel")
+			version = strings.TrimPrefix(version, "v")
+
+			if runtime.GOOS == "windows" {
+				_, _ = fmt.Fprintln(inv.Stdout,
+					cliui.Styles.Code.Render("coder upgrade "),
+					"is not currently supported on Windows.\n",
+					fmt.Sprintf("Download the installer at %s to upgrade your client.", cliui.Styles.Keyword.Render(windowsInstallerURL(version))),
+				)
+				return nil
+			}
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Detected server version %q, downloading version %q from %s\n", serverInfo.Version, version, scriptURL)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, scriptURL, nil)
+			if err != nil {
+				return xerrors.Errorf("new http request: %w", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return xerrors.Errorf("fetch install script: %w", err)
 			}
@@ -54,15 +95,13 @@ func (r *RootCmd) upgrade() *clibase.Cmd {
 				return xerrors.Errorf("unexpected error code %d while fetching install script: %w", resp.StatusCode, err)
 			}
 
-			version := semver.Canonical(serverInfo.Version)
-			version = strings.TrimSuffix(version, "-devel")
-			version = strings.TrimPrefix(version, "v")
-
 			// nolint: gosec
 			cmd := exec.Command("sh", "-s", "--", "--version", version)
+			// TODO: should output print the script prior to executing it and require
+			// the user to confirm they want to run it?
 			cmd.Stdin = resp.Body
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
+			cmd.Stdout = inv.Stdout
+			cmd.Stderr = inv.Stderr
 			err = cmd.Run()
 			if err != nil {
 				return xerrors.Errorf("run install script: %w", err)
@@ -73,4 +112,13 @@ func (r *RootCmd) upgrade() *clibase.Cmd {
 	}
 
 	return cmd
+}
+
+func windowsInstallerURL(version string) string {
+	return fmt.Sprintf(
+		"https://github.com/coder/coder/releases/download/v%s/coder_%s_windows_%s_installer.exe",
+		version,
+		version,
+		runtime.GOARCH,
+	)
 }

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -1,44 +1,71 @@
 package cli
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"strings"
+
+	"golang.org/x/mod/semver"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/cli/clibase"
+	"github.com/coder/coder/codersdk"
 )
 
 func (r *RootCmd) upgrade() *clibase.Cmd {
 	cmd := &clibase.Cmd{
-		Use:   "upgrade",
-		Short: "Upgrade the Coder CLI to match the version of a deployment.",
+		Use:     "upgrade",
+		Short:   "Upgrade the Coder CLI to match the version of a deployment.",
+		Options: clibase.OptionSet{},
 		Handler: func(inv *clibase.Invocation) error {
+			var (
+				ctx  = inv.Context()
+				curl = r.clientURL.String()
+			)
+
+			var err error
+			if curl == "" {
+				curl, err = r.createConfig().URL().Read()
+				if err != nil {
+					return xerrors.Errorf("read config url: %w", err)
+				}
+			}
+
+			uri, err := url.Parse(curl)
+			if err != nil {
+				return xerrors.Errorf("parse url: %w", err)
+			}
+
+			client := codersdk.New(uri)
+			serverInfo, err := client.BuildInfo(ctx)
+			if err != nil {
+				return xerrors.Errorf("build info: %w", err)
+			}
 
 			resp, err := http.Get("https://coder.com/install.sh")
 			if err != nil {
-				panic(err)
-			}
-			if resp.StatusCode != http.StatusOK {
-				panic(fmt.Sprintf("code %d", resp.StatusCode))
+				return xerrors.Errorf("fetch install script: %w", err)
 			}
 			defer resp.Body.Close()
 
-			script, err := io.ReadAll(resp.Body)
-			if err != nil {
-				panic(err)
+			if resp.StatusCode != http.StatusOK {
+				return xerrors.Errorf("unexpected error code %d while fetching install script: %w", resp.StatusCode, err)
 			}
-			fmt.Println("script: ", string(script))
 
-			cmd := exec.Command("sh", "-s", "--", "--version", "0.22.2")
-			cmd.Stdin = bytes.NewReader(script)
+			version := semver.Canonical(serverInfo.Version)
+			version = strings.TrimSuffix(version, "-devel")
+			version = strings.TrimPrefix(version, "v")
+
+			// nolint: gosec
+			cmd := exec.Command("sh", "-s", "--", "--version", version)
+			cmd.Stdin = resp.Body
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			err = cmd.Run()
 			if err != nil {
-				panic(err)
+				return xerrors.Errorf("run install script: %w", err)
 			}
 
 			return nil

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -28,7 +28,7 @@ func (r *RootCmd) upgrade() *clibase.Cmd {
 				Flag:        "install-script-url",
 				Description: "Download URL of install script (useful for testing).",
 				Value:       clibase.StringOf(&scriptURL),
-				Default:     "https://dev.coder.com/install.sh",
+				Default:     "https://coder.com/install.sh",
 				Hidden:      true,
 			},
 		},

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -1,0 +1,111 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/pty/ptytest"
+	"github.com/coder/coder/testutil"
+)
+
+func TestUpgrade(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skipf("Detected Windows OS, skipping upgrade tests")
+		return
+	}
+
+	// startFakeDeployment starts and returns a fake deployment
+	// that returns the specified version when the upgrade command
+	// requests build info.
+	startFakeDeployment := func(t *testing.T, version string) string {
+		t.Helper()
+		s := httptest.NewServer(
+			http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					err := json.NewEncoder(w).Encode(codersdk.BuildInfoResponse{
+						Version: version,
+					})
+					require.NoError(t, err)
+				},
+			),
+		)
+		t.Cleanup(s.Close)
+		return s.URL
+	}
+
+	// startFakeInstallServer starts and returns a fake server
+	// that returns the specified script that is used to "install"
+	// coder.
+	startFakeInstallServer := func(t *testing.T, script string) string {
+		t.Helper()
+		s := httptest.NewServer(
+			http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					_, err := w.Write([]byte(script))
+					require.NoError(t, err)
+				}),
+		)
+		t.Cleanup(s.Close)
+		return s.URL
+	}
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			serverVersion   = "v1.2.3-devel+f72d8e95"
+			expectedVersion = "1.2.3"
+			script          = fmt.Sprintf(`#!/usr/bin/env bash
+		echo "testing 123"
+		echo %s`, expectedVersion)
+		)
+
+		serverURL := startFakeDeployment(t, serverVersion)
+		installURL := startFakeInstallServer(t, script)
+
+		inv, _ := clitest.New(t, "upgrade", "--url", serverURL, "--install-script-url", installURL)
+		pty := ptytest.New(t).Attach(inv)
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		done := make(chan any)
+		go func() {
+			errC := inv.WithContext(ctx).Run()
+			assert.NoError(t, errC)
+			close(done)
+		}()
+		pty.ExpectMatch(fmt.Sprintf("Detected server version %q, downloading version %q from %s", serverVersion, expectedVersion, installURL))
+		pty.ExpectMatch("testing 123")
+		pty.ExpectMatch(expectedVersion)
+		<-done
+	})
+
+	t.Run("NoServerURL", func(t *testing.T) {
+		t.Parallel()
+
+		inv, _ := clitest.New(t, "upgrade")
+		pty := ptytest.New(t).Attach(inv)
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		done := make(chan any)
+		go func() {
+			errC := inv.WithContext(ctx).Run()
+			assert.Error(t, errC)
+			close(done)
+		}()
+
+		pty.ExpectMatch("No deployment URL provided. You must either login using")
+		<-done
+	})
+}

--- a/cli/upgrade_test.go
+++ b/cli/upgrade_test.go
@@ -78,17 +78,11 @@ func TestUpgrade(t *testing.T) {
 		pty := ptytest.New(t).Attach(inv)
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
-
-		done := make(chan any)
-		go func() {
-			errC := inv.WithContext(ctx).Run()
-			assert.NoError(t, errC)
-			close(done)
-		}()
+		errC := inv.WithContext(ctx).Run()
+		assert.NoError(t, errC)
 		pty.ExpectMatch(fmt.Sprintf("Detected server version %q, downloading version %q from %s", serverVersion, expectedVersion, installURL))
 		pty.ExpectMatch("testing 123")
 		pty.ExpectMatch(expectedVersion)
-		<-done
 	})
 
 	t.Run("NoServerURL", func(t *testing.T) {
@@ -98,14 +92,8 @@ func TestUpgrade(t *testing.T) {
 		pty := ptytest.New(t).Attach(inv)
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
-		done := make(chan any)
-		go func() {
-			errC := inv.WithContext(ctx).Run()
-			assert.Error(t, errC)
-			close(done)
-		}()
-
+		errC := inv.WithContext(ctx).Run()
+		assert.Error(t, errC)
 		pty.ExpectMatch("No deployment URL provided. You must either login using")
-		<-done
 	})
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 | [<code>templates</code>](./cli/templates.md)           | Manage templates                                                       |
 | [<code>tokens</code>](./cli/tokens.md)                 | Manage personal access tokens                                          |
 | [<code>update</code>](./cli/update.md)                 | Will update and start a given workspace if it is out of date           |
+| [<code>upgrade</code>](./cli/upgrade.md)               | Upgrade the Coder CLI to match the version of a deployment.            |
 | [<code>users</code>](./cli/users.md)                   | Manage users                                                           |
 | [<code>version</code>](./cli/version.md)               | Show coder version                                                     |
 

--- a/docs/cli/upgrade.md
+++ b/docs/cli/upgrade.md
@@ -1,0 +1,11 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# upgrade
+
+Upgrade the Coder CLI to match the version of a deployment.
+
+## Usage
+
+```console
+coder upgrade [flags]
+```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -808,6 +808,11 @@
           "path": "cli/update.md"
         },
         {
+          "title": "upgrade",
+          "description": "Upgrade the Coder CLI to match the version of a deployment.",
+          "path": "cli/upgrade.md"
+        },
+        {
           "title": "users",
           "description": "Manage users",
           "path": "cli/users.md"


### PR DESCRIPTION
fixes #2744 

This PR provides a command to sync a `coder` client with a deployment. It is mostly an alias for `curl -L https://coder.com/install.sh | sh -s -- --version <version>` It does not currently support Windows but I believe it should be possible to support. I'll try to get my hands on a Windows laptop tomorrow and try it out.