### PR TITLE
chore(dogfood): Update sqlc version in dogfood image to match CI

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir --parents "$GOPATH" && \
 	# charts and values files
 	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.5.0 && \
 	# sqlc for Go code generation
-	go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.16.0 && \
+	go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.17.2 && \
 	# gcr-cleaner-cli used by CI to prune unused images
 	go install github.com/sethvargo/gcr-cleaner/cmd/gcr-cleaner-cli@v0.5.1 && \
 	# ruleguard for checking custom rules, without needing to run all of


### PR DESCRIPTION
We were not using the same version of sqlc in the dogfood image Dockerfile as we are using in CI, leading to test failures when running `make gen`.

- https://github.com/coder/coder/blob/0c074742a5a01189aafdad2d853d07cfe1aacd1f/.github/workflows/ci.yaml#L180
- https://github.com/coder/coder/blob/0c074742a5a01189aafdad2d853d07cfe1aacd1f/dogfood/Dockerfile#L56