### PR TITLE
docs: add AWS EKS load balancer setup steps

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -112,13 +112,25 @@ to log in and manage templates.
    > [values.yaml](https://github.com/coder/coder/blob/main/helm/values.yaml)
    > file directly.
 
-   If you are deploying Coder on AWS EKS and service is set to LoadBalancer, the load balancer external IP will be stuck in a pending status unless sessionAffinity is set to None.
+   If you are deploying Coder on AWS EKS and service is set to `LoadBalancer`, AWS will default to the Classic load balancer. The load balancer external IP will be stuck in a pending status unless sessionAffinity is set to None.
 
    ```yaml
    coder:
      service:
        type: LoadBalancer
        sessionAffinity: None
+   ```
+
+   AWS however recommends a Network load balancer in lieu of the Classic load balancer. Use the following `values.yaml` settings to request a Network load balancer:
+
+   ```yaml
+   coder:
+      service:
+      externalTrafficPolicy: Local
+      sessionAffinity: None
+      annotations: {
+         service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    }
    ```
 
 1. Run the following command to install the chart in your cluster.


### PR DESCRIPTION
This PR:

Documents how to provision a network load balancer for a AWS EKS deployment.

AWS recommends a network load balancer over the default classic load balancer to ensure header passthrough.