### PR TITLE
fix: use different terraform cache dir

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1183,7 +1183,7 @@ func newProvisionerDaemon(
 		return nil, xerrors.Errorf("mkdir %q: %w", cacheDir, err)
 	}
 
-	tfDir := filepath.Join(cacheDir, "terraform")
+	tfDir := filepath.Join(cacheDir, "tf")
 	err = os.MkdirAll(tfDir, 0o700)
 	if err != nil {
 		return nil, xerrors.Errorf("mkdir terraform dir: %w", err)


### PR DESCRIPTION
If coder automatically downloaded terraform, it would fail with
```
create provisioner daemon: mkdir terraform dir: mkdir /var/cache/coder/coder/provisioner-0/terraform: not a directory
```