### PR TITLE
chore: add mockgen to nix env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             gotestsum
             jq
             kubernetes-helm
+            mockgen
             nfpm
             nodePackages.typescript
             nodePackages.typescript-language-server


### PR DESCRIPTION
This PR adds `nix` requirement to install `mockgen` (currently: 1.6.0).

Otherwise:

```bash
$ ./scripts/develop.sh
coderd/database/dbmock/doc.go:4: running "mockgen": exec: "mockgen": executable file not found in $PATH
make: *** [Makefile:483: coderd/database/dbmock/store.go] Error 1
```