### PR TITLE
chore: Only run `deploy_template` after `deploy_image` has been completed

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -50,7 +50,6 @@ jobs:
           cache-to: type=inline
   deploy_template:
     needs: deploy_image
-    if: ${{ needs.deploy_image.result == 'success' || needs.deploy_image.result == 'skipped' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -49,6 +49,8 @@ jobs:
           cache-from: type=registry,ref=codercom/oss-dogfood:latest
           cache-to: type=inline
   deploy_template:
+    needs: deploy_image
+    if: ${{ needs.deploy_image.result == 'success' || needs.deploy_image.result == 'skipped' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This resolves #7662