### PR TITLE
test(coderd/rbac): Increase TestFilter timeout

### DIFF
--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -249,14 +249,15 @@ func TestFilter(t *testing.T) {
 			localObjects := make([]fakeObject, len(objects))
 			copy(localObjects, objects)
 
-			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
-			defer cancel()
 			auth := NewAuthorizer(prometheus.NewRegistry())
 
 			if actor.Scope == nil {
 				// Default to ScopeAll
 				actor.Scope = ScopeAll
 			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+			defer cancel()
 
 			// Run auth 1 by 1
 			var allowedCount int


### PR DESCRIPTION
These tests occasionally timeout, the trace is not very helpful in informing us if it's a deadlock or just slow runners so we increase timeout and move init closer to where it's used.

https://github.com/coder/coder/actions/runs/5089948168/jobs/9149449786?pr=7693
