### PR TITLE
test: Skip tests that send `os.Interrupt` to test pid

### DIFF
--- a/cli/cliui/provisionerjob_test.go
+++ b/cli/cliui/provisionerjob_test.go
@@ -82,6 +82,8 @@ func TestProvisionerJob(t *testing.T) {
 	// This cannot be ran in parallel because it uses a signal.
 	// nolint:paralleltest
 	t.Run("Cancel", func(t *testing.T) {
+		t.Skip("This test issues an interrupt signal which will propagate to the test runner.")
+
 		if runtime.GOOS == "windows" {
 			// Sending interrupt signal isn't supported on Windows!
 			t.SkipNow()

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1491,6 +1491,8 @@ func TestServer_Production(t *testing.T) {
 
 //nolint:tparallel,paralleltest // This test cannot be run in parallel due to signal handling.
 func TestServer_Shutdown(t *testing.T) {
+	t.Skip("This test issues an interrupt signal which will propagate to the test runner.")
+
 	if runtime.GOOS == "windows" {
 		// Sending interrupt signal isn't supported on Windows!
 		t.SkipNow()


### PR DESCRIPTION
This can cause test flakes due to clitest commands running in memory and listening to interrupt signals.

Example: https://github.com/coder/coder/actions/runs/5083425027/jobs/9134405616

Observe that multiple agents are triggered to shutdown (gracefully) almost immediately after being started, tests then time out much later.