### PR TITLE
hotfix(ci): fix a syntax issue in contrib.yaml

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -57,14 +57,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           requireScope: false
-          types:
-            - feat
-            - chore
-            - fix
-            - hotfix
-            - refactor
-            - perf
-            - test
+          types: |
+            feat
+            chore
+            fix
+            hotfix
+            refactor
+            perf
+            test
 
   release-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After https://github.com/coder/coder/commit/867996aa18ed668612a6e0e9e8d78d9417c7ae5a [contrib.yaml](https://github.com/coder/coder/actions/workflows/contrib.yaml)
 the action was failing because of a syntax issue. This PR fixes that.