### PR TITLE
hotfix(.github): remove legacy title validator

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -47,25 +47,6 @@ jobs:
           branch: "main"
           allowlist: dependabot*
 
-  title:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    steps:
-      - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          requireScope: false
-          types: |
-            feat
-            chore
-            fix
-            hotfix
-            refactor
-            perf
-            test
-
   release-labels:
     runs-on: ubuntu-latest
     # Depend on lint so that title is Conventional Commits-compatible.

--- a/site/jest.config.js
+++ b/site/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  testTimeout: 10_000,
+  // Use a big timeout for CI.
+  testTimeout: 20_000,
   maxWorkers: 8,
   projects: [
     {


### PR DESCRIPTION
`cdr-bot` centralizes the behavior and can enforce stricter
standards.
