### PR TITLE
ci: deduplicate language setup

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,0 +1,10 @@
+name: "Setup Go"
+description: |
+  Sets up the Go environment for tests, builds, etc.
+runs:
+  using: "composite"
+  steps:
+    - uses: buildjet/setup-go@v4
+      with:
+        cache: true
+        go-version: "~1.20"

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,0 +1,15 @@
+name: "Setup Node"
+description: |
+  Sets up the node environment for tests, builds, etc.
+runs:
+  using: "composite"
+  steps:
+    - uses: buildjet/setup-node@v3
+      with:
+        node-version: 16.16.0
+        # See https://github.com/actions/setup-node#caching-global-packages-data
+        cache: "yarn"
+        cache-dependency-path: "site/yarn.lock"
+    - name: Install node_modules
+      shell: bash
+      run: ./scripts/yarn_install.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  CODER_GO_VERSION: "~1.20"
-
 jobs:
   lint:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
@@ -36,11 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Install Go!
-      - uses: buildjet/setup-go@v4
-        with:
-          go-version: ${{ env.CODER_GO_VERSION }}
-          cache: true
+      - uses: ./.github/actions/setup-go
 
       # Check for any typos!
       - name: Check for typos
@@ -67,19 +60,7 @@ jobs:
         with:
           ignore: node_modules
 
-      # Lint our dashboard!
-      - name: Cache node_modules
-        id: cache-node
-        uses: buildjet/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .eslintcache
-          key: js-${{ runner.os }}-test-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            js-${{ runner.os }}-
-      - name: Install node_modules
-        run: ./scripts/yarn_install.sh
+      - uses: ./.github/actions/setup-node
       - name: Lint TypeScript
         run: yarn lint
         working-directory: site
@@ -139,42 +120,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache Node
-        id: cache-node
-        uses: buildjet/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .eslintcache
-          key: js-${{ runner.os }}-test-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            js-${{ runner.os }}-
-
-      - name: Install node_modules
-        run: ./scripts/yarn_install.sh
-
-      - uses: buildjet/setup-go@v4
-        with:
-          cache: false
-          go-version: ${{ env.CODER_GO_VERSION }}
-
-      - name: Echo Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Build Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOCACHE }}
-          key: ${{ github.job }}-go-build-${{ hashFiles('**/go.sum', '**/**.go') }}
-
-      - name: Go Mod Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ github.job }}-go-mod-${{ hashFiles('**/go.sum') }}
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-go
 
       - name: Install sqlc
         run: |
@@ -219,19 +166,8 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Cache Node
-        id: cache-node
-        uses: buildjet/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .eslintcache
-          key: js-${{ runner.os }}-test-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            js-${{ runner.os }}-
-
-      - name: Install node_modules
-        run: ./scripts/yarn_install.sh
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-go
 
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0
@@ -261,23 +197,7 @@ jobs:
           cache: false
           go-version: ${{ env.CODER_GO_VERSION }}
 
-      - name: Echo Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> ${{ runner.os == 'Windows' && '$env:' || '$' }}GITHUB_OUTPUT
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> ${{ runner.os == 'Windows' && '$env:' || '$' }}GITHUB_OUTPUT
-
-      - name: Go Build Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOCACHE }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.**', '**.go') }}
-
-      - name: Go Mod Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+      - uses: ./.github/actions/setup-go
 
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.10.0
@@ -345,28 +265,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: buildjet/setup-go@v4
-        with:
-          cache: false
-          go-version: ${{ env.CODER_GO_VERSION }}
-
-      - name: Echo Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Build Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOCACHE }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum', '**/**.go') }}
-
-      - name: Go Mod Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+      - uses: ./.github/actions/setup-go
 
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.10.0
@@ -442,34 +341,8 @@ jobs:
           cache: false
           go-version: ${{ env.CODER_GO_VERSION }}
 
-      - name: Echo Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Build Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOCACHE }}
-          key: ${{ runner.os }}-release-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-release-go-mod-${{ hashFiles('**/go.sum') }}
-
-      - name: Cache Node
-        id: cache-node
-        uses: buildjet/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .eslintcache
-          key: js-${{ runner.os }}-release-node-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            js-${{ runner.os }}-
+      - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-node
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
@@ -538,23 +411,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache Node
-        id: cache-node
-        uses: buildjet/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .eslintcache
-          key: js-${{ runner.os }}-test-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            js-${{ runner.os }}-
-
-      - uses: buildjet/setup-node@v3
-        with:
-          node-version: "16.16.0"
-
-      - name: Install node_modules
-        run: ./scripts/yarn_install.sh
+      - uses: ./.github/actions/setup-node
 
       - run: yarn test:ci --max-workers ${{ steps.cpu-cores.outputs.count }}
         working-directory: site
@@ -580,19 +437,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache Node
-        id: cache-node
-        uses: buildjet/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .eslintcache
-          key: js-${{ runner.os }}-e2e-${{ hashFiles('**/yarn.lock') }}
-
-      - uses: buildjet/setup-go@v4
-        with:
-          cache: false
-          go-version: ${{ env.CODER_GO_VERSION }}
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-go
 
       - uses: hashicorp/setup-terraform@v2
         with:
@@ -602,24 +448,6 @@ jobs:
       - uses: buildjet/setup-node@v3
         with:
           node-version: "16.16.0"
-
-      - name: Echo Go Cache Paths
-        id: go-cache-paths
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Build Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOCACHE }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: buildjet/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Build
         run: |
@@ -655,12 +483,7 @@ jobs:
           # only get 1 commit on shallow checkout.
           fetch-depth: 0
 
-      - uses: buildjet/setup-node@v3
-        with:
-          node-version: "16.16.0"
-
-      - name: Install dependencies
-        run: cd site && yarn
+      - uses: ./.github/actions/setup-node
 
       # This step is not meant for mainline because any detected changes to
       # storybook snapshots will require manual approval/review in order for

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
           files: ./gotests.coverage
           flags: unittest-go-${{ matrix.os }}
 
-  test-go-psql:
+  test-go-pg:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     # This timeout must be greater than the timeout set by `go test` in
     # `make test-postgres` to ensure we receive a trace of running
@@ -310,6 +310,23 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./gotests.coverage
           flags: unittest-go-postgres-linux
+
+  test-go-race:
+    runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-go
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.1.9
+          terraform_wrapper: false
+
+      - name: Run Tests
+        run: |
+          go test -race ./...
 
   deploy:
     name: "deploy"

--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,7 @@ test-postgres: test-clean test-postgres-docker
 		--packages="./..." -- \
 		-covermode=atomic -coverprofile="gotests.coverage" -timeout=20m \
 		-coverpkg=./... \
-		-race -failfast
+		-failfast
 .PHONY: test-postgres
 
 test-postgres-docker:


### PR DESCRIPTION
Previously, we were duplicating large portions of each job with language setup and caching. This change organizes the boilerplate into reusable, composite actions.

Also, this change splits up the `go-psql` test into `go-pg` and `go-race`. `go-psql` was a misnomer because it also ran the race detector. With the split we can take better advantage of CI concurrency and the workflow should complete faster.