### PR TITLE
hotfix(.github): fix dependency in `contrib.yaml`

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -49,8 +49,6 @@ jobs:
 
   release-labels:
     runs-on: ubuntu-latest
-    # Depend on lint so that title is Conventional Commits-compatible.
-    needs: [title]
     # Skip tagging for draft PRs.
     if: ${{ github.event_name == 'pull_request_target' && success() && !github.event.pull_request.draft }}
     steps:


### PR DESCRIPTION
`title` job was removed in #7743, so this job was falling.