### PR TITLE
refactor(site): make vscode dropdown button thiner

### DIFF
--- a/site/src/components/VSCodeDesktopButton/VSCodeDesktopButton.tsx
+++ b/site/src/components/VSCodeDesktopButton/VSCodeDesktopButton.tsx
@@ -69,6 +69,7 @@ export const VSCodeDesktopButton: FC<
           onClick={() => {
             setIsVariantMenuOpen(true)
           }}
+          sx={{ px: 0 }}
         >
           <KeyboardArrowDownIcon sx={{ fontSize: 16 }} />
         </PrimaryAgentButton>


### PR DESCRIPTION
Before/After

<img width="241" alt="Screen Shot 2023-06-01 at 11 46 28" src="https://github.com/coder/coder/assets/3165839/828558d3-6262-4162-b674-ee5be550baab">
<img width="236" alt="Screen Shot 2023-06-01 at 11 46 39" src="https://github.com/coder/coder/assets/3165839/7dde59cd-c2e0-47ae-b78b-04ff747c1a10">

