### PR TITLE
feat: return better error if file size is too big to upload

### DIFF
--- a/coderd/util/xio/limitwriter.go
+++ b/coderd/util/xio/limitwriter.go
@@ -1,0 +1,43 @@
+package xio
+
+import (
+	"io"
+
+	"golang.org/x/xerrors"
+)
+
+var ErrLimitReached = xerrors.Errorf("i/o limit reached")
+
+// LimitWriter will only write bytes to the underlying writer until the limit is reached.
+type LimitWriter struct {
+	Limit int64
+	N     int64
+	W     io.Writer
+}
+
+func NewLimitWriter(w io.Writer, n int64) *LimitWriter {
+	// If anyone tries this, just make a 0 writer.
+	if n < 0 {
+		n = 0
+	}
+	return &LimitWriter{
+		Limit: n,
+		N:     0,
+		W:     w,
+	}
+}
+
+func (l *LimitWriter) Write(p []byte) (int, error) {
+	if l.N >= l.Limit {
+		return 0, ErrLimitReached
+	}
+
+	// Write 0 bytes if the limit is to be exceeded.
+	if int64(len(p)) > l.Limit-l.N {
+		return 0, ErrLimitReached
+	}
+
+	n, err := l.W.Write(p)
+	l.N += int64(n)
+	return n, err
+}

--- a/coderd/util/xio/limitwriter_test.go
+++ b/coderd/util/xio/limitwriter_test.go
@@ -1,0 +1,136 @@
+package xio_test
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/coderd/util/xio"
+)
+
+func TestLimitWriter(t *testing.T) {
+	type writeCase struct {
+		N    int
+		ExpN int
+		Err  bool
+	}
+
+	// testCases will do multiple writes to the same limit writer and check the output.
+	testCases := []struct {
+		Name   string
+		L      int64
+		Writes []writeCase
+		N      int
+		ExpN   int
+	}{
+		{
+			Name: "Empty",
+			L:    1000,
+			Writes: []writeCase{
+				// A few empty writes
+				{N: 0, ExpN: 0}, {N: 0, ExpN: 0}, {N: 0, ExpN: 0},
+			},
+		},
+		{
+			Name: "NotFull",
+			L:    1000,
+			Writes: []writeCase{
+				{N: 250, ExpN: 250},
+				{N: 250, ExpN: 250},
+				{N: 250, ExpN: 250},
+			},
+		},
+		{
+			Name: "Short",
+			L:    1000,
+			Writes: []writeCase{
+				{N: 250, ExpN: 250},
+				{N: 250, ExpN: 250},
+				{N: 250, ExpN: 250},
+				{N: 250, ExpN: 250},
+				{N: 250, ExpN: 0, Err: true},
+			},
+		},
+		{
+			Name: "Exact",
+			L:    1000,
+			Writes: []writeCase{
+				{
+					N:    1000,
+					ExpN: 1000,
+				},
+				{
+					N:   1000,
+					Err: true,
+				},
+			},
+		},
+		{
+			Name: "Over",
+			L:    1000,
+			Writes: []writeCase{
+				{
+					N:    5000,
+					ExpN: 0,
+					Err:  true,
+				},
+				{
+					N:   5000,
+					Err: true,
+				},
+				{
+					N:   5000,
+					Err: true,
+				},
+			},
+		},
+		{
+			Name: "Strange",
+			L:    -1,
+			Writes: []writeCase{
+				{
+					N:    5,
+					ExpN: 0,
+					Err:  true,
+				},
+				{
+					N:    0,
+					ExpN: 0,
+					Err:  true,
+				},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.Name, func(t *testing.T) {
+			buf := bytes.NewBuffer([]byte{})
+			allBuff := bytes.NewBuffer([]byte{})
+			w := xio.NewLimitWriter(buf, c.L)
+
+			for _, wc := range c.Writes {
+				data := make([]byte, wc.N)
+
+				n, err := cryptorand.Read(data)
+				require.NoError(t, err, "crand read")
+				require.Equal(t, wc.N, n, "correct bytes read")
+				max := data[:wc.ExpN]
+				n, err = w.Write(data)
+				if wc.Err {
+					require.Error(t, err, "exp error")
+				} else {
+					require.NoError(t, err, "write")
+				}
+
+				// Need to use this to compare across multiple writes.
+				// Each write appends to the expected output.
+				allBuff.Write(max)
+
+				require.Equal(t, wc.ExpN, n, "correct bytes written")
+				require.Equal(t, allBuff.Bytes(), buf.Bytes(), "expected data")
+			}
+		})
+	}
+}

--- a/coderd/util/xio/limitwriter_test.go
+++ b/coderd/util/xio/limitwriter_test.go
@@ -107,9 +107,10 @@ func TestLimitWriter(t *testing.T) {
 	}
 
 	for _, c := range testCases {
+		c := c
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			buf := bytes.NewBuffer([]byte{})
 			allBuff := bytes.NewBuffer([]byte{})
 			w := xio.NewLimitWriter(buf, c.L)

--- a/coderd/util/xio/limitwriter_test.go
+++ b/coderd/util/xio/limitwriter_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestLimitWriter(t *testing.T) {
+	t.Parallel()
+
 	type writeCase struct {
 		N    int
 		ExpN int
@@ -106,6 +108,8 @@ func TestLimitWriter(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			
 			buf := bytes.NewBuffer([]byte{})
 			allBuff := bytes.NewBuffer([]byte{})
 			w := xio.NewLimitWriter(buf, c.L)

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -115,6 +115,9 @@ func Tar(w io.Writer, directory string, limit int64) error {
 		return data.Close()
 	})
 	if err != nil {
+		if xerrors.Is(err, xio.ErrLimitReached) {
+			return xerrors.Errorf("Archive too big. Must be <= %d bytes", limit)
+		}
 		return err
 	}
 	err = tarWriter.Flush()

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -34,8 +34,8 @@ func dirHasExt(dir string, ext string) (bool, error) {
 
 // Tar archives a Terraform directory.
 func Tar(w io.Writer, directory string, limit int64) error {
-	// The total bytes written must be under the limit.
-	w = xio.NewLimitWriter(w, limit)
+	// The total bytes written must be under the limit, so use -1
+	w = xio.NewLimitWriter(w, limit-1)
 	tarWriter := tar.NewWriter(w)
 
 	const tfExt = ".tf"

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -97,7 +97,7 @@ func Tar(w io.Writer, directory string, limit int64) error {
 			return nil
 		}
 		// Before we even open the file, check if it is going to exceed our limit.
-		if fileInfo.Size()+totalSize >= limit {
+		if fileInfo.Size()+totalSize > limit {
 			return fileTooBigError
 		}
 		data, err := os.Open(file)
@@ -110,7 +110,7 @@ func Tar(w io.Writer, directory string, limit int64) error {
 			return err
 		}
 		totalSize += wrote
-		if limit != 0 && totalSize >= limit {
+		if limit != 0 && totalSize > limit {
 			return fileTooBigError
 		}
 		return data.Close()


### PR DESCRIPTION
fixes: https://github.com/coder/coder/issues/7071

The issue was the error condition was only checked after the bytes have been written. So the coderd side was returning an api error for the content being too large before the cli could do the same client side check.

To fix this, I just check if we are going to exceed the limit with the `fileInfo.Size` before we write.