### PR TITLE
hotfix: remove cryptorand.Bool

### DIFF
--- a/cryptorand/errors_test.go
+++ b/cryptorand/errors_test.go
@@ -75,11 +75,6 @@ func TestRandError(t *testing.T) {
 		require.ErrorIs(t, err, io.ErrShortBuffer, "expected Float32 error")
 	})
 
-	t.Run("Bool", func(t *testing.T) {
-		_, err := cryptorand.Bool()
-		require.ErrorIs(t, err, io.ErrShortBuffer, "expected Bool error")
-	})
-
 	t.Run("StringCharset", func(t *testing.T) {
 		_, err := cryptorand.HexString(10)
 		require.ErrorIs(t, err, io.ErrShortBuffer, "expected HexString error")

--- a/cryptorand/numbers.go
+++ b/cryptorand/numbers.go
@@ -185,17 +185,6 @@ again:
 	return f, nil
 }
 
-// Bool returns a random true/false value as a bool.
-func Bool() (bool, error) {
-	i, err := Uint64()
-	if err != nil {
-		return false, err
-	}
-
-	// True if the least significant bit is 1
-	return i&1 == 1, nil
-}
-
 // Duration returns a random time.Duration value
 func Duration() (time.Duration, error) {
 	i, err := Int63()

--- a/cryptorand/numbers_test.go
+++ b/cryptorand/numbers_test.go
@@ -156,26 +156,6 @@ func TestFloat32(t *testing.T) {
 	}
 }
 
-func TestBool(t *testing.T) {
-	t.Parallel()
-
-	const iterations = 10000
-	trueCount := 0
-
-	for i := 0; i < iterations; i++ {
-		v, err := cryptorand.Bool()
-		require.NoError(t, err, "unexpected error from Bool")
-		if v {
-			trueCount++
-		}
-	}
-
-	percentage := (float64(trueCount) / iterations) * 100
-	t.Logf("number of true values: %d of %d total (%.2f%%)", trueCount, iterations, percentage)
-	require.True(t, percentage > 48, "expected more than 48 percent of values to be true")
-	require.True(t, percentage < 52, "expected less than 52 percent of values to be true")
-}
-
 func TestDuration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
It caused a CI flake and we we weren't using it anywhere.

`cryptorand.Float64() < 0.5` can be used in the future too.
