### PR TITLE
fix: standardize on CODER_PG_CONNECTION_URL

### DIFF
--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -238,7 +238,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *clibase.Cmd {
 
 	createAdminUserCommand.Options.Add(
 		clibase.Option{
-			Env:         "CODER_POSTGRES_URL",
+			Env:         "CODER_PG_CONNECTION_URL",
 			Flag:        "postgres-url",
 			Description: "URL of a PostgreSQL database. If empty, the built-in PostgreSQL deployment will be used (Coder must not be already running in this case).",
 			Value:       clibase.StringOf(&newUserDBURL),

--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -157,7 +157,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 		defer cancel()
 
 		inv, _ := clitest.New(t, "server", "create-admin-user")
-		inv.Environ.Set("CODER_POSTGRES_URL", connectionURL)
+		inv.Environ.Set("CODER_PG_CONNECTION_URL", connectionURL)
 		inv.Environ.Set("CODER_SSH_KEYGEN_ALGORITHM", "ed25519")
 		inv.Environ.Set("CODER_USERNAME", username)
 		inv.Environ.Set("CODER_EMAIL", email)

--- a/cli/testdata/coder_server_create-admin-user_--help.golden
+++ b/cli/testdata/coder_server_create-admin-user_--help.golden
@@ -12,7 +12,7 @@ to every organization.
           The password of the new user. If not specified, you will be prompted
           via stdin.
 
-      --postgres-url string, $CODER_POSTGRES_URL
+      --postgres-url string, $CODER_PG_CONNECTION_URL
           URL of a PostgreSQL database. If empty, the built-in PostgreSQL
           deployment will be used (Coder must not be already running in this
           case).

--- a/docs/cli/server_create-admin-user.md
+++ b/docs/cli/server_create-admin-user.md
@@ -32,10 +32,10 @@ The password of the new user. If not specified, you will be prompted via stdin.
 
 ### --postgres-url
 
-|             |                                  |
-| ----------- | -------------------------------- |
-| Type        | <code>string</code>              |
-| Environment | <code>$CODER_POSTGRES_URL</code> |
+|             |                                       |
+| ----------- | ------------------------------------- |
+| Type        | <code>string</code>                   |
+| Environment | <code>$CODER_PG_CONNECTION_URL</code> |
 
 URL of a PostgreSQL database. If empty, the built-in PostgreSQL deployment will be used (Coder must not be already running in this case).
 


### PR DESCRIPTION
Fixes #7513.

Opted to just change it but if the breaking change is an issue we could make `Env` take a slice so we can accept the old var as well.