### PR TITLE
hotfix: initial options as empty array

### DIFF
--- a/site/src/pages/WorkspacesPage/filter/autocompletes.ts
+++ b/site/src/pages/WorkspacesPage/filter/autocompletes.ts
@@ -63,7 +63,7 @@ const useAutocomplete = <TOption extends BaseOption = BaseOption>({
       return undefined
     }
 
-    let options = searchOptionsQuery.data as TOption[]
+    let options = searchOptionsQuery.data ?? []
 
     if (selectedOption) {
       options = options.filter(


### PR DESCRIPTION
This could cause a major UI error if the options are not returned for any reason like a wrong filter or any issue in the endpoint. It is still an error but those errors should be handled "locally" in the component instead. I noticed that when playing around with a few endpoints.