### PR TITLE
docs: make template git auth example in sync with git auth setup example

### DIFF
--- a/docs/templates/open-in-coder.md
+++ b/docs/templates/open-in-coder.md
@@ -15,68 +15,70 @@ To support any infrastructure and software stack, Coder provides a generic appro
 
 1. Modify your template to auto-clone repos:
 
-   - If you want the template to clone a specific git repo
+> The id in the template's `coder_git_auth` data source must match the `CODER_GITAUTH_0_ID` in the Coder deployment configuration.
 
-     ```hcl
-     # Require git authentication to use this template
-     data "coder_git_auth" "github" {
-         id = "github"
-     }
+- If you want the template to clone a specific git repo
 
-     resource "coder_agent" "dev" {
-         # ...
-         dir = "~/coder"
-         startup_script =<<EOF
+  ```hcl
+  # Require git authentication to use this template
+  data "coder_git_auth" "github" {
+      id = "primary-github"
+  }
 
-         # Clone repo from GitHub
-         if [ ! -d "coder" ]
-         then
-             git clone https://github.com/coder/coder
-         fi
+  resource "coder_agent" "dev" {
+      # ...
+      dir = "~/coder"
+      startup_script =<<EOF
 
-         EOF
-     }
-     ```
+      # Clone repo from GitHub
+      if [ ! -d "coder" ]
+      then
+          git clone https://github.com/coder/coder
+      fi
 
-     > Note: The `dir` attribute can be set in multiple ways, for example:
-     >
-     > - `~/coder`
-     > - `/home/coder/coder`
-     > - `coder` (relative to the home directory)
+      EOF
+  }
+  ```
 
-   - If you want the template to support any repository via [parameters](./parameters.md)
+  > Note: The `dir` attribute can be set in multiple ways, for example:
+  >
+  > - `~/coder`
+  > - `/home/coder/coder`
+  > - `coder` (relative to the home directory)
 
-     ```hcl
-     # Require git authentication to use this template
-     data "coder_git_auth" "github" {
-         id = "github"
-     }
+- If you want the template to support any repository via [parameters](./parameters.md)
 
-     # Prompt the user for the git repo URL
-     data "coder_parameter" "git_repo" {
-         name          = "git_repo"
-         display_name  = "Git repository"
-         default       = "https://github.com/coder/coder"
-     }
+  ```hcl
+  # Require git authentication to use this template
+  data "coder_git_auth" "github" {
+      id = "primary-github"
+  }
 
-     locals {
-         folder_name = try(element(split("/", data.coder_parameter.git_repo.value), length(split("/", data.coder_parameter.git_repo.value)) - 1), "")
-     }
+  # Prompt the user for the git repo URL
+  data "coder_parameter" "git_repo" {
+      name          = "git_repo"
+      display_name  = "Git repository"
+      default       = "https://github.com/coder/coder"
+  }
 
-     resource "coder_agent" "dev" {
-         # ...
-         dir = "~/${local.folder_name}"
-         startup_script =<<EOF
+  locals {
+      folder_name = try(element(split("/", data.coder_parameter.git_repo.value), length(split("/", data.coder_parameter.git_repo.value)) - 1), "")
+  }
 
-         # Clone repo from GitHub
-         if [ ! -d "${local.folder_name}" ]
-         then
-             git clone ${data.coder_parameter.git_repo.value}
-         fi
+  resource "coder_agent" "dev" {
+      # ...
+      dir = "~/${local.folder_name}"
+      startup_script =<<EOF
 
-         EOF
-     }
-     ```
+      # Clone repo from GitHub
+      if [ ! -d "${local.folder_name}" ]
+      then
+          git clone ${data.coder_parameter.git_repo.value}
+      fi
+
+      EOF
+  }
+  ```
 
 1. Embed the "Open in Coder" button with Markdown
 


### PR DESCRIPTION
I witnessed a prospect's confusion in getting OAuth-based git authentication working in a template, because the docs example didn't match the deployment Git OAuth setup example.

In particular, the `id` in the `coder_git_auth` data source was `github` and not `primary-github` in the deployment configuration example.

Updating the docs to prevent future customer support calls.