### PR TITLE
fix: use ephemeral port for postgres, except for TestPubsub_Disconnect

### DIFF
--- a/coderd/database/postgres/postgres.go
+++ b/coderd/database/postgres/postgres.go
@@ -3,10 +3,8 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
-	"net"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -17,10 +15,6 @@ import (
 	"github.com/coder/coder/coderd/database/migrations"
 	"github.com/coder/coder/cryptorand"
 )
-
-// Required to prevent port collision during container creation.
-// Super unlikely, but it happened. See: https://github.com/coder/coder/runs/5375197003
-var openPortMutex sync.Mutex
 
 // Open creates a new PostgreSQL database instance.  With DB_FROM environment variable set, it clones a database
 // from the provided template.  With the environment variable unset, it creates a new Docker container running postgres.
@@ -68,17 +62,6 @@ func OpenContainerized(port int) (string, func(), error) {
 		return "", nil, xerrors.Errorf("create tempdir: %w", err)
 	}
 
-	openPortMutex.Lock()
-	if port == 0 {
-		// Pick an explicit port on the host to connect to 5432.
-		// This is necessary so we can configure the port to only use ipv4.
-		port, err = getFreePort()
-		if err != nil {
-			openPortMutex.Unlock()
-			return "", nil, xerrors.Errorf("get free port: %w", err)
-		}
-	}
-
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
 		Tag:        "13",
@@ -114,10 +97,8 @@ func OpenContainerized(port int) (string, func(), error) {
 		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
 	})
 	if err != nil {
-		openPortMutex.Unlock()
 		return "", nil, xerrors.Errorf("could not start resource: %w", err)
 	}
-	openPortMutex.Unlock()
 
 	hostAndPort := resource.GetHostPort("5432/tcp")
 	dbURL := fmt.Sprintf("postgres://postgres:postgres@%s/postgres?sslmode=disable", hostAndPort)
@@ -165,19 +146,4 @@ func OpenContainerized(port int) (string, func(), error) {
 		_ = pool.Purge(resource)
 		_ = os.RemoveAll(tempDir)
 	}, nil
-}
-
-// getFreePort asks the kernel for a free open port that is ready to use.
-func getFreePort() (port int, err error) {
-	// Binding to port 0 tells the OS to grab a port for us:
-	// https://stackoverflow.com/questions/1365265/on-localhost-how-do-i-pick-a-free-port-number
-	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-
-	defer listener.Close()
-	// This is always a *net.TCPAddr.
-	// nolint:forcetypeassert
-	return listener.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
Fixes #7752 

Our implementation of starting postgres on ephemeral ports is racy: it 

1. opens a TCP listener with port 0, which asks the OS to allocate a free port
2. stores the port number
3. starts a Docker container with that port as the host mapping

However, between 2 and 3 another process can come in and snatch the port.

Docker itself accepts 0 as a port mapping, and it asks the OS to allocate a free port.  This closes the race.

A second issue is that we were using an ephemeral port for TestPubsub_Disconnect where we kill the postgres container and then restart it on the same port.  It suffers from a similar race, where another process could snatch the port while postgres is down.  To solve this, we use a hardcoded, arbitrary high port number, but one outside the Linux ephemeral range.
