### PR TITLE
docs: remove unsupported legacy parameters

### DIFF
--- a/docs/templates/parameters.md
+++ b/docs/templates/parameters.md
@@ -203,7 +203,7 @@ In some cases, deleting a workspace with a hard dependency on a legacy parameter
 
 > ⚠️ Migration is available until v0.24.0 (Jun 2023) release.
 
-Terraform variables shouldn't be used for workspace scoped parameters anymore, and it's recommended to convert variables to `coder_parameter` resources. To make the migration smoother, there is a special property introduced -
+Terraform `variable` shouldn't be used for workspace scoped parameters anymore, and it's required to convert `variable` to `coder_parameter` resources. To make the migration smoother, there is a special property introduced -
 `legacy_variable` and `legacy_variable_name` , which can link `coder_parameter` with a legacy variable.
 
 ```hcl

--- a/docs/templates/parameters.md
+++ b/docs/templates/parameters.md
@@ -188,36 +188,20 @@ data "coder_parameter" "project_id" {
 
 ## Legacy
 
-Prior to Coder v0.16.0 (Jan 2023), parameters were defined via Terraform `variable` blocks. These "legacy parameters" can still be used in templates, but will be removed in May 2023.
+### Legacy parameters are unsupported now
 
-```hcl
-variable "use_kubeconfig" {
-  sensitive   = true # Template-level parameter (not editable when creating a workspace)
-  type        = bool
-  description = <<-EOF
-  Use host kubeconfig? (true/false)
-  EOF
-}
+In Coder, workspaces using legacy parameters can't be deployed anymore. To address this, it is necessary to either remove or adjust incompatible templates.
+In some cases, deleting a workspace with a hard dependency on a legacy parameter may be challenging. To cleanup unsupported workspaces, administrators are advised to take the following actions for affected templates:
 
-variable "cpu" {
-  sensitive   = false # User (workspace-level) parameter
-  description = "CPU (__ cores)"
-  default     = 2
-  validation {
-    condition = contains([
-      "2",
-      "4",
-      "6",
-      "8"
-    ], var.cpu)
-    error_message = "Invalid cpu!"
-  }
-}
-```
-
-> ⚠️ Legacy (`variable`) parameters and rich parameters can't be used in the same template.
+1. Enable the `feature_use_managed_variables` provider flag.
+2. Ensure that every legacy variable block has defined missing default values, or convert it to `coder_parameter`.
+3. Push the new template version using UI or CLI.
+4. Update unsupported workspaces to the newest template version.
+5. Delete the affected workspaces that have been updated to the newest template version.
 
 ### Migration
+
+> ⚠️ Migration is available until v0.24.0 (Jun 2023) release.
 
 Terraform variables shouldn't be used for workspace scoped parameters anymore, and it's recommended to convert variables to `coder_parameter` resources. To make the migration smoother, there is a special property introduced -
 `legacy_variable` and `legacy_variable_name` , which can link `coder_parameter` with a legacy variable.


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/7663

This PR adds a short paragraph describing admin actions to fix/delete unsupported workspaces if they weren't migrated in time.