### PR TITLE
chore(dependabot): automate frontend team assignment for dependabot PR reviews

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -59,7 +59,7 @@ updates:
       time: "06:00"
       timezone: "America/Chicago"
     reviewers:
-      - "coder/frontend"
+      - "coder/ts"
     commit-message:
       prefix: "chore"
     labels: []

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -58,6 +58,8 @@ updates:
       interval: "monthly"
       time: "06:00"
       timezone: "America/Chicago"
+    reviewers:
+      - "coder/frontend"
     commit-message:
       prefix: "chore"
     labels: []


### PR DESCRIPTION
This assigns @dependabot created frontend PRs automatically to members of the frontend team. 
Suggested by @BrunoQuaresma 