### PR TITLE
fix(site): remove tar file type limitation

### DIFF
--- a/site/src/utils/tar.test.ts
+++ b/site/src/utils/tar.test.ts
@@ -1,4 +1,4 @@
-import { TarReader, TarWriter, ITarFileInfo, TarFileType } from "./tar"
+import { TarReader, TarWriter, ITarFileInfo, TarFileTypeCodes } from "./tar"
 
 const mtime = 1666666666666
 
@@ -56,5 +56,5 @@ function verifyFile(
 
 function verifyFolder(info: ITarFileInfo, expected: { name: string }) {
   expect(info.name).toEqual(expected.name)
-  expect(info.type).toEqual(TarFileType.Dir)
+  expect(info.type).toEqual(TarFileTypeCodes.Dir)
 }

--- a/site/src/utils/tar.ts
+++ b/site/src/utils/tar.ts
@@ -1,8 +1,10 @@
 // Based on https://github.com/gera2ld/tarjs
 // and https://github.com/ankitrohatgi/tarballjs/blob/master/tarball.js
-export enum TarFileType {
-  File = "0",
-  Dir = "5",
+type TarFileType = string
+// Added the most common codes
+export const TarFileTypeCodes = {
+  File: "0",
+  Dir: "5",
 }
 const encoder = new TextEncoder()
 const utf8Encode = (input: string) => encoder.encode(input)
@@ -131,13 +133,7 @@ export class TarReader {
   private readFileType(offset: number) {
     const typeView = new Uint8Array(this.buffer, offset + 156, 1)
     const typeStr = String.fromCharCode(typeView[0])
-    if (typeStr === "0") {
-      return TarFileType.File
-    } else if (typeStr === "5") {
-      return TarFileType.Dir
-    } else {
-      throw new Error("No supported file type")
-    }
+    return typeStr
   }
 
   private readFileSize(offset: number) {
@@ -192,7 +188,7 @@ export class TarWriter {
     const size = (data as ArrayBuffer).byteLength ?? (file as Blob).size
     const item: ITarWriteItem = {
       name,
-      type: TarFileType.File,
+      type: TarFileTypeCodes.File,
       data,
       size,
       opts,
@@ -203,7 +199,7 @@ export class TarWriter {
   addFolder(name: string, opts?: Partial<ITarWriteOptions>) {
     this.fileData.push({
       name,
-      type: TarFileType.Dir,
+      type: TarFileTypeCodes.Dir,
       data: null,
       size: 0,
       opts,
@@ -315,7 +311,7 @@ export class TarWriter {
     const { uid, gid, mode, mtime, user, group } = {
       uid: 1000,
       gid: 1000,
-      mode: fileType === TarFileType.File ? 0o664 : 0o775,
+      mode: fileType === TarFileTypeCodes.File ? 0o664 : 0o775,
       mtime: ~~(Date.now() / 1000),
       user: "tarballjs",
       group: "tarballjs",


### PR DESCRIPTION
There are many file types supported by tar so I think we don't need to restrict them only to files or directories.

More info about tar: https://en.wikipedia.org/wiki/Tar_(computing)