### PR TITLE
docs: add note on log truncation

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -88,6 +88,8 @@ Coder stores macOS and Linux logs at the following locations:
 | `shutdown_script` | `/tmp/coder-shutdown-script.log` |
 | Agent             | `/tmp/coder-agent.log`           |
 
+> Note: Logs are truncated once they reach 5MB in size.
+
 ---
 
 ## Up next


### PR DESCRIPTION
documents agent log truncation at the 5MB threshold