### PR TITLE
fix(clitest): use slogtest for logging stdin and stdout

### DIFF
--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -20,7 +20,6 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
-
 	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/config"

--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -18,6 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+
 	"github.com/coder/coder/cli"
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/config"
@@ -39,7 +42,7 @@ func New(t *testing.T, args ...string) (*clibase.Invocation, config.Root) {
 
 type logWriter struct {
 	prefix string
-	t      *testing.T
+	log    slog.Logger
 }
 
 func (l *logWriter) Write(p []byte) (n int, err error) {
@@ -47,8 +50,9 @@ func (l *logWriter) Write(p []byte) (n int, err error) {
 	if trimmed == "" {
 		return len(p), nil
 	}
-	l.t.Log(
-		l.prefix + ": " + trimmed,
+	l.log.Info(
+		context.Background(),
+		l.prefix+": "+trimmed,
 	)
 	return len(p), nil
 }
@@ -57,12 +61,13 @@ func NewWithCommand(
 	t *testing.T, cmd *clibase.Cmd, args ...string,
 ) (*clibase.Invocation, config.Root) {
 	configDir := config.Root(t.TempDir())
+	logger := slogtest.Make(t, nil)
 	i := &clibase.Invocation{
 		Command: cmd,
 		Args:    append([]string{"--global-config", string(configDir)}, args...),
 		Stdin:   io.LimitReader(nil, 0),
-		Stdout:  (&logWriter{prefix: "stdout", t: t}),
-		Stderr:  (&logWriter{prefix: "stderr", t: t}),
+		Stdout:  (&logWriter{prefix: "stdout", log: logger}),
+		Stderr:  (&logWriter{prefix: "stderr", log: logger}),
 	}
 	t.Logf("invoking command: %s %s", cmd.Name(), strings.Join(i.Args, " "))
 


### PR DESCRIPTION
https://github.com/coder/coder/actions/runs/5159866775/jobs/9295338703?pr=7824#step:5:1109

`slogtest` has already mitigated the race condition above, so just use that directly instead.