### PR TITLE
revert(provisionersdk): remove support for `.tf.json` files

### DIFF
--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -15,17 +15,15 @@ const (
 	TemplateArchiveLimit = 1 << 20
 )
 
-func dirHasExt(dir string, exts ...string) (bool, error) {
+func dirHasExt(dir string, ext string) (bool, error) {
 	dirEnts, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
 
 	for _, fi := range dirEnts {
-		for _, ext := range exts {
-			if strings.HasSuffix(fi.Name(), ext) {
-				return true, nil
-			}
+		if strings.HasSuffix(fi.Name(), ext) {
+			return true, nil
 		}
 	}
 
@@ -37,8 +35,8 @@ func Tar(w io.Writer, directory string, limit int64) error {
 	tarWriter := tar.NewWriter(w)
 	totalSize := int64(0)
 
-	tfExts := []string{".tf", ".tf.json"}
-	hasTf, err := dirHasExt(directory, tfExts...)
+	const tfExt = ".tf"
+	hasTf, err := dirHasExt(directory, tfExt)
 	if err != nil {
 		return err
 	}
@@ -52,7 +50,7 @@ func Tar(w io.Writer, directory string, limit int64) error {
 		// useless.
 		return xerrors.Errorf(
 			"%s is not a valid template since it has no %s files",
-			absPath, tfExts,
+			absPath, tfExt,
 		)
 	}
 

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -33,15 +33,6 @@ func TestTar(t *testing.T) {
 		err = provisionersdk.Tar(io.Discard, dir, 1024)
 		require.NoError(t, err)
 	})
-	t.Run("ValidJSON", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		file, err := os.CreateTemp(dir, "*.tf.json")
-		require.NoError(t, err)
-		_ = file.Close()
-		err = provisionersdk.Tar(io.Discard, dir, 1024)
-		require.NoError(t, err)
-	})
 	t.Run("HiddenFiles", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()


### PR DESCRIPTION
I noticed while looking through the code that rich parameters has hardcoded support only for `.tf` files. This means rich parameters won't work with non-hcl templates: https://github.com/coder/coder/blob/2114cd1621228c38b5056c0079d4ff01d5880968/provisioner/terraform/parameters.go#L30

This will need to be resolved before allowing `.tf.json` files again.