### PR TITLE
feat(provisioner): add support for .tf.json templates

### DIFF
--- a/provisioner/terraform/parameters.go
+++ b/provisioner/terraform/parameters.go
@@ -27,13 +27,17 @@ func rawRichParameterNames(workdir string) ([]string, error) {
 
 	var coderParameterNames []string
 	for _, entry := range entries {
-		if !strings.HasSuffix(entry.Name(), ".tf") {
+		if !strings.HasSuffix(entry.Name(), ".tf") || !strings.HasSuffix(entry.Name(), ".tf.json") {
 			continue
 		}
 
 		hclFilepath := path.Join(workdir, entry.Name())
 		parser := hclparse.NewParser()
-		parsedHCL, diags := parser.ParseHCLFile(hclFilepath)
+		if strings.HasSuffix(entry.Name(), ".tf.json") {
+			parsedHCL, diags := parser.ParseJSONFile(hclFilepath)
+		} else {
+			parsedHCL, diags := parser.ParseHCLFile(hclFilepath)
+		}
 		if diags.HasErrors() {
 			return nil, hcl.Diagnostics{
 				{

--- a/provisioner/terraform/parameters.go
+++ b/provisioner/terraform/parameters.go
@@ -31,12 +31,14 @@ func rawRichParameterNames(workdir string) ([]string, error) {
 			continue
 		}
 
+		var parsedHCL *hcl.File
+		var diags hcl.Diagnostics
 		hclFilepath := path.Join(workdir, entry.Name())
 		parser := hclparse.NewParser()
 		if strings.HasSuffix(entry.Name(), ".tf.json") {
-			parsedHCL, diags := parser.ParseJSONFile(hclFilepath)
+			parsedHCL, diags = parser.ParseJSONFile(hclFilepath)
 		} else {
-			parsedHCL, diags := parser.ParseHCLFile(hclFilepath)
+			parsedHCL, diags = parser.ParseHCLFile(hclFilepath)
 		}
 		if diags.HasErrors() {
 			return nil, hcl.Diagnostics{

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -103,7 +103,7 @@ func loadEnabledFeatures(moduleDir string) (map[string]bool, hcl.Diagnostics) {
 
 	var found bool
 	for _, entry := range entries {
-		if !strings.HasSuffix(entry.Name(), ".tf") || !strings.HasSuffix(entry.Name(), ".tf.json") {
+		if !strings.HasSuffix(entry.Name(), ".tf") && !strings.HasSuffix(entry.Name(), ".tf.json") {
 			continue
 		}
 

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -131,10 +131,11 @@ func parseFeatures(hclFilepath string) (map[string]bool, bool, hcl.Diagnostics) 
 	}
 
 	parser := hclparse.NewParser()
+	var parsedHCL *hcl.File
 	if strings.HasSuffix(hclFilepath, ".tf.json") {
-		parsedHCL, diags := parser.ParseJSONFile(hclFilepath)
+		parsedHCL, diags = parser.ParseJSONFile(hclFilepath)
 	} else {
-		parsedHCL, diags := parser.ParseHCLFile(hclFilepath)
+		parsedHCL, diags = parser.ParseHCLFile(hclFilepath)
 	}
 	if diags.HasErrors() {
 		return flags, false, diags

--- a/provisioner/terraform/parse.go
+++ b/provisioner/terraform/parse.go
@@ -103,7 +103,7 @@ func loadEnabledFeatures(moduleDir string) (map[string]bool, hcl.Diagnostics) {
 
 	var found bool
 	for _, entry := range entries {
-		if !strings.HasSuffix(entry.Name(), ".tf") {
+		if !strings.HasSuffix(entry.Name(), ".tf") || !strings.HasSuffix(entry.Name(), ".tf.json") {
 			continue
 		}
 
@@ -131,7 +131,11 @@ func parseFeatures(hclFilepath string) (map[string]bool, bool, hcl.Diagnostics) 
 	}
 
 	parser := hclparse.NewParser()
-	parsedHCL, diags := parser.ParseHCLFile(hclFilepath)
+	if strings.HasSuffix(hclFilepath, ".tf.json") {
+		parsedHCL, diags := parser.ParseJSONFile(hclFilepath)
+	} else {
+		parsedHCL, diags := parser.ParseHCLFile(hclFilepath)
+	}
 	if diags.HasErrors() {
 		return flags, false, diags
 	}

--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -255,6 +255,31 @@ func TestProvision(t *testing.T) {
 			Apply: true,
 		},
 		{
+			Name: "single-resource-json",
+			Files: map[string]string{
+				"main.tf.json": `{
+					"resource": {
+						"null_resource": {
+							"A": [
+								{}
+							]
+						}
+					}
+				}`,
+			},
+			Response: &proto.Provision_Response{
+				Type: &proto.Provision_Response_Complete{
+					Complete: &proto.Provision_Complete{
+						Resources: []*proto.Resource{{
+							Name: "A",
+							Type: "null_resource",
+						}},
+					},
+				},
+			},
+			Apply: true,
+		},
+		{
 			Name: "bad-syntax-1",
 			Files: map[string]string{
 				"main.tf": `a`,
@@ -339,6 +364,88 @@ func TestProvision(t *testing.T) {
 								Name:         "Example",
 								Type:         "string",
 								DefaultValue: "foobar",
+							},
+						},
+						Resources: []*proto.Resource{{
+							Name: "example",
+							Type: "null_resource",
+						}},
+					},
+				},
+			},
+		},
+		{
+			Name: "rich-parameter-with-value-json",
+			Files: map[string]string{
+				"main.tf.json": `{
+					"data": {
+						"coder_parameter": {
+							"example": [
+								{
+									"default": "foobar",
+									"name": "Example",
+									"type": "string"
+								}
+							],
+							"sample": [
+								{
+									"default": "foobaz",
+									"name": "Sample",
+									"type": "string"
+								}
+							]
+						}
+					},
+					"resource": {
+						"null_resource": {
+							"example": [
+								{
+									"triggers": {
+										"misc": "${data.coder_parameter.example.value}"
+									}
+								}
+							]
+						}
+					},
+					"terraform": [
+						{
+							"required_providers": [
+								{
+									"coder": {
+										"source": "coder/coder",
+										"version": "0.6.20"
+									}
+								}
+							]
+						}
+					]
+				}`,
+			},
+			Request: &proto.Provision_Plan{
+				RichParameterValues: []*proto.RichParameterValue{
+					{
+						Name:  "Example",
+						Value: "foobaz",
+					},
+					{
+						Name:  "Sample",
+						Value: "foofoo",
+					},
+				},
+			},
+			Response: &proto.Provision_Response{
+				Type: &proto.Provision_Response_Complete{
+					Complete: &proto.Provision_Complete{
+						Parameters: []*proto.RichParameter{
+							{
+								Name:         "Example",
+								Type:         "string",
+								DefaultValue: "foobar",
+							},
+							{
+								Name:         "Sample",
+								Type:         "string",
+								DefaultValue: "foobaz",
 							},
 						},
 						Resources: []*proto.Resource{{

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -15,15 +15,17 @@ const (
 	TemplateArchiveLimit = 1 << 20
 )
 
-func dirHasExt(dir string, ext string) (bool, error) {
+func dirHasExt(dir string, exts ...string) (bool, error) {
 	dirEnts, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
 
 	for _, fi := range dirEnts {
-		if strings.HasSuffix(fi.Name(), ext) {
-			return true, nil
+		for _, ext := range exts {
+			if strings.HasSuffix(fi.Name(), ext) {
+				return true, nil
+			}
 		}
 	}
 
@@ -35,8 +37,8 @@ func Tar(w io.Writer, directory string, limit int64) error {
 	tarWriter := tar.NewWriter(w)
 	totalSize := int64(0)
 
-	const tfExt = ".tf"
-	hasTf, err := dirHasExt(directory, tfExt)
+	tfExts := []string{".tf", ".tf.json"}
+	hasTf, err := dirHasExt(directory, tfExts...)
 	if err != nil {
 		return err
 	}
@@ -50,7 +52,7 @@ func Tar(w io.Writer, directory string, limit int64) error {
 		// useless.
 		return xerrors.Errorf(
 			"%s is not a valid template since it has no %s files",
-			absPath, tfExt,
+			absPath, tfExts,
 		)
 	}
 

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -33,6 +33,15 @@ func TestTar(t *testing.T) {
 		err = provisionersdk.Tar(io.Discard, dir, 1024)
 		require.NoError(t, err)
 	})
+	t.Run("ValidJSON", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		file, err := os.CreateTemp(dir, "*.tf.json")
+		require.NoError(t, err)
+		_ = file.Close()
+		err = provisionersdk.Tar(io.Discard, dir, 1024)
+		require.NoError(t, err)
+	})
 	t.Run("HiddenFiles", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()


### PR DESCRIPTION
Quick draft to extend #7744 to support .tf.json for rich parameters.
This uses hclparse's `ParseJSONFile` method on .tf.json files as a "replacement" for `ParseHCLFile`, so the output is identical.

## Context
Original issue: #7700
Revert because of missing rich parameter support: #7829 