### PR TITLE
docs: clarify that resetting a user password must run on the coderd host

### DIFF
--- a/docs/admin/users.md
+++ b/docs/admin/users.md
@@ -119,3 +119,13 @@ You can also reset a password via the CLI:
 # run `coder reset-password <username> --help` for usage instructions
 coder reset-password <username>
 ```
+
+> Resetting a user's password, e.g., the initial `owner` role-based user, only works when run on the host running the Coder control plane.
+
+### Resetting a password on Kubernetes
+
+```sh
+kubectl exec -it deployment/coder /bin/bash -n coder
+
+coder reset-password <username>
+```


### PR DESCRIPTION
This PR:

1. Addresses user experience friction where prospects and customers do not know how to reset a user's password. We have seen several inquiries where the context of running this command is misunderstood (it's a direct connect to PostgreSQL so must run on the coderd control plane)
2. In particular, if an `owner` role-based user has to be reset on a Kubernetes deployment, adding an `kubectl` example. A current Coder customer ran into this problem today asking for help

This will eliminate inbound support questions that clog up Coder's support organization so that users can self-service and get unblocked.

<img width="404" alt="image" src="https://github.com/coder/coder/assets/2022166/0886691d-5ad3-4019-99fd-46f85fcc4f2b">

<img width="392" alt="image" src="https://github.com/coder/coder/assets/2022166/15e5259d-90f6-4201-947b-af8f39d70d82">
