### PR TITLE
feat: add metric for provisioner daemons

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -822,6 +822,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}
 				provisionerDaemons = append(provisionerDaemons, daemon)
 			}
+			provisionerdMetrics.Runner.NumDaemons.Set(float64(len(provisionerDaemons)))
 
 			shutdownConnsCtx, shutdownConns := context.WithCancel(ctx)
 			defer shutdownConns()

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -140,6 +140,12 @@ func NewMetrics(reg prometheus.Registerer) Metrics {
 				Name:      "jobs_current",
 				Help:      "The number of currently running provisioner jobs.",
 			}, []string{"provisioner"}),
+			NumDaemons: auto.NewGauge(prometheus.GaugeOpts{
+				Namespace: "coderd",
+				Subsystem: "provisionerd",
+				Name:      "num_daemons",
+				Help:      "The number of provisioner daemons.",
+			}),
 			JobTimings: auto.NewHistogramVec(prometheus.HistogramOpts{
 				Namespace: "coderd",
 				Subsystem: "provisionerd",

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -88,6 +88,7 @@ type Runner struct {
 
 type Metrics struct {
 	ConcurrentJobs *prometheus.GaugeVec
+	NumDaemons     prometheus.Gauge
 	// JobTimings also counts the total amount of jobs.
 	JobTimings *prometheus.HistogramVec
 	// WorkspaceBuilds counts workspace build successes and failures.


### PR DESCRIPTION
So we can alert on provisioner saturation/capacity.