### PR TITLE
ci: use coder binary from the server

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -57,14 +57,13 @@ jobs:
       - name: Get short commit SHA
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: "Install latest Coder"
+      - name: "Get latest Coder binary from the server"
         run: |
-          curl -L https://coder.com/install.sh | sh
-        # env:
-        #   VERSION: 0.x
+          curl -fsSL "https://dev.coder.com/bin/coder-linux-amd64" -o "./coder"
+          chmod +x "./coder"
       - name: "Push template"
         run: |
-          coder templates push $CODER_TEMPLATE_NAME --directory $CODER_TEMPLATE_DIR --yes --name=$CODER_TEMPLATE_VERSION
+          ./coder templates push $CODER_TEMPLATE_NAME --directory $CODER_TEMPLATE_DIR --yes --name=$CODER_TEMPLATE_VERSION
         env:
           # Consumed by Coder CLI
           CODER_URL: https://dev.coder.com


### PR DESCRIPTION
1. This PR downloads the latest coder binary from the server instead of installing the latest stable release.
2. This will keep the client and server in sync and will possibly solve issues like this https://github.com/coder/coder/actions/runs/5179549578/jobs/9333160091