### PR TITLE
chore: use a cache to select best latency

### DIFF
--- a/site/src/contexts/useProxyLatency.ts
+++ b/site/src/contexts/useProxyLatency.ts
@@ -24,6 +24,29 @@ const proxyLatenciesReducer = (
   state: Record<string, ProxyLatencyReport>,
   action: ProxyLatencyAction,
 ): Record<string, ProxyLatencyReport> => {
+  // TODO: We should probably not read from local storage on every action.
+  const history = loadStoredLatencies()
+  const proxyHistory = history[action.proxyID] || []
+  const minReport = proxyHistory.reduce((min, report) => {
+    if(min.latencyMS === 0) {
+      // Not yet set, so use the new report.
+      return report
+    }
+    if(min.latencyMS < report.latencyMS) {
+      return min
+    }
+    return report
+  }, {} as ProxyLatencyReport)
+
+  if(minReport.latencyMS > 0 && minReport.latencyMS < action.report.latencyMS) {
+    // The new report is slower then the min report, so use the min report.
+    return {
+      ...state,
+      [action.proxyID]: minReport,
+    }
+  }
+
+  // Use the new report
   return {
     ...state,
     [action.proxyID]: action.report,
@@ -113,14 +136,17 @@ export const useProxyLatency = (
         )
         latencyMS = entry.duration
       }
-      dispatchProxyLatencies({
+      const update = {
         proxyID: check.id,
         report: {
           latencyMS,
           accurate,
           at: new Date(),
         },
-      })
+      }
+      dispatchProxyLatencies(update)
+      // Also save to local storage to persist the latency across page refreshes.
+      updateStoredLatencies(update)
 
       return
     }
@@ -140,6 +166,10 @@ export const useProxyLatency = (
     const proxyRequests = Object.keys(proxyChecks).map((latencyURL) => {
       return axios.get(latencyURL, {
         withCredentials: false,
+        // Must add a custom header to make the request not a "simple request".
+        // We want to force a preflight request.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
+          headers: { "X-LATENCY-CHECK": "true" },
       })
     })
 
@@ -156,6 +186,9 @@ export const useProxyLatency = (
         // At this point, we can be confident that all the proxy requests have been recorded
         // via the performance observer. So we can disconnect the observer.
         observer.disconnect()
+
+        // Local storage cleanup
+        garbageCollectStoredLatencies(proxies)
       })
   }, [proxies, latestFetchRequest])
 
@@ -164,3 +197,58 @@ export const useProxyLatency = (
     refetch,
   }
 }
+
+// Local storage functions
+
+// loadStoredLatencies will load the stored latencies from local storage.
+// Latencies are stored in local storage to minimize the impact of outliers.
+// If a single request is slow, we want to omit that latency check, and go with
+// a more accurate latency check.
+const loadStoredLatencies = (): Record<string, ProxyLatencyReport[]> => {
+  const str = localStorage.getItem("workspace-proxy-latencies")
+  if (!str) {
+    return {}
+  }
+
+  return JSON.parse(str)
+}
+
+const updateStoredLatencies =(action: ProxyLatencyAction): void => {
+  const latencies = loadStoredLatencies()
+  const reports = latencies[action.proxyID] || []
+
+  reports.push(action.report)
+  latencies[action.proxyID] = reports
+  localStorage.setItem("workspace-proxy-latencies", JSON.stringify(latencies))
+}
+
+// garbageCollectStoredLatencies will remove any latencies that are older then 1 week or latencies of proxies
+// that no longer exist. This is intended to keep the size of local storage down.
+const garbageCollectStoredLatencies = (regions: RegionsResponse): void => {
+  const latencies = loadStoredLatencies()
+  const now = Date.now()
+  console.log("Garbage collecting stored latencies")
+  const cleaned = cleanupLatencies(latencies, regions, new Date(now))
+
+  localStorage.setItem("workspace-proxy-latencies", JSON.stringify(cleaned))
+}
+
+const cleanupLatencies = (stored: Record<string, ProxyLatencyReport[]>, regions: RegionsResponse, now: Date): Record<string, ProxyLatencyReport[]> => {
+  Object.keys(stored).forEach((proxyID) => {
+    if(!regions.regions.find((region) => region.id === proxyID)) {
+      delete(stored[proxyID])
+      return
+    }
+    const reports = stored[proxyID]
+    const nowMS = now.getTime()
+    stored[proxyID] = reports.filter((report) => {
+      // Only keep the reports that are less then 1 week old.
+      return new Date(report.at).getTime() > nowMS - (1000 * 60 * 60 * 24 * 7)
+    })
+    // Only keep the 5 latest
+    stored[proxyID] = stored[proxyID].slice(-5)
+  })
+  return stored
+}
+
+


### PR DESCRIPTION
# Problem

Currently the latency report for workspace proxies is occasionally "slow", making it inconsistent. Some page loads have a very high latency on the preferred proxy closest to the user, instead selecting a slower proxy.

Debugging this has proved difficult.

There are 2 core issues with the current implementation:
1. Networks are inherently unreliable, so our latency check will always have the potential to misreport a proxy as "high latency".
2. We currently take the last latency report as fact, having no way to remove outliers.

This PR only intends to **begin to address # 2**. Collecting data on this has been challenging because it is all client side. 

# What this does

What this does is each time we load proxy latencies, we store the fetched latencies in local storage.

We always use **the minimum latency** from the cached latencies + the latest. We use the minimum as that best describes the best case round trip time. We might want to later change this to some sort of "median", or "average without outliers". 

We store at most 8 cached latencies, and remove any latencies gathered over 1 week ago.

## Debugging + Gathering Data

Honestly, I am unsure what the magic solution is here. Is minimum really the best? Is the average better? Etc etc.

Without some data, it is hard to know. And unfortunately my test deployments behave differently and appear to behave more consistently. So it is hard to gather data outside of production. And all this latency data is clientside, so we cannot push it into our telemetry or metrics.

To get some data to make these decisions, I added a local storage value called: `workspace-proxy-latencies-max`. This value can be set to any number, and your browser will save all latency checks made up to that amount into local storage. We can set it to something like 300, dogfood the product, and then download the data and see how inconsistent our latencies really are.

# Performance

Performance on this is probably not the best and can be improved. Local storage is the user's disk, so access is not as fast as memory. We can optimize this later if this proves to be a useful strategy.