### PR TITLE
fix: validate that parameter names are unique

### DIFF
--- a/coderd/util/strings/strings.go
+++ b/coderd/util/strings/strings.go
@@ -1,0 +1,19 @@
+package strings
+
+import (
+	"fmt"
+	"strings"
+)
+
+// JoinWithConjunction joins a slice of strings with commas except for the last
+// two which are joined with "and".
+func JoinWithConjunction(s []string) string {
+	last := len(s) - 1
+	if last == 0 {
+		return s[last]
+	}
+	return fmt.Sprintf("%s and %s",
+		strings.Join(s[:last], ", "),
+		s[last],
+	)
+}

--- a/coderd/util/strings/strings_test.go
+++ b/coderd/util/strings/strings_test.go
@@ -1,0 +1,16 @@
+package strings_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/coderd/util/strings"
+)
+
+func TestJoinWithConjunction(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "foo", strings.JoinWithConjunction([]string{"foo"}))
+	require.Equal(t, "foo and bar", strings.JoinWithConjunction([]string{"foo", "bar"}))
+	require.Equal(t, "foo, bar and baz", strings.JoinWithConjunction([]string{"foo", "bar", "baz"}))
+}


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/7291

Without this check it will fail on the database insert (as the names must be unique) and the template create will hang.

I am not sure if the wording is that great, if there are any ideas let me know.

![dupe](https://github.com/coder/coder/assets/45609798/cb72961e-fb7e-4b62-b161-d667f6d1ad02)

