### PR TITLE
feat(site): add view activity on user context menu

### DIFF
--- a/site/src/components/UsersTable/UsersTable.tsx
+++ b/site/src/components/UsersTable/UsersTable.tsx
@@ -27,6 +27,7 @@ export interface UsersTableProps {
   onActivateUser: (user: TypesGen.User) => void
   onDeleteUser: (user: TypesGen.User) => void
   onListWorkspaces: (user: TypesGen.User) => void
+  onViewActivity: (user: TypesGen.User) => void
   onResetUserPassword: (user: TypesGen.User) => void
   onUpdateUserRoles: (
     user: TypesGen.User,
@@ -42,6 +43,7 @@ export const UsersTable: FC<React.PropsWithChildren<UsersTableProps>> = ({
   onSuspendUser,
   onDeleteUser,
   onListWorkspaces,
+  onViewActivity,
   onActivateUser,
   onResetUserPassword,
   onUpdateUserRoles,
@@ -80,6 +82,7 @@ export const UsersTable: FC<React.PropsWithChildren<UsersTableProps>> = ({
             onActivateUser={onActivateUser}
             onDeleteUser={onDeleteUser}
             onListWorkspaces={onListWorkspaces}
+            onViewActivity={onViewActivity}
             onResetUserPassword={onResetUserPassword}
             onSuspendUser={onSuspendUser}
             onUpdateUserRoles={onUpdateUserRoles}

--- a/site/src/components/UsersTable/UsersTableBody.tsx
+++ b/site/src/components/UsersTable/UsersTableBody.tsx
@@ -37,6 +37,7 @@ interface UsersTableBodyProps {
   onSuspendUser: (user: TypesGen.User) => void
   onDeleteUser: (user: TypesGen.User) => void
   onListWorkspaces: (user: TypesGen.User) => void
+  onViewActivity: (user: TypesGen.User) => void
   onActivateUser: (user: TypesGen.User) => void
   onResetUserPassword: (user: TypesGen.User) => void
   onUpdateUserRoles: (
@@ -55,6 +56,7 @@ export const UsersTableBody: FC<
   onSuspendUser,
   onDeleteUser,
   onListWorkspaces,
+  onViewActivity,
   onActivateUser,
   onResetUserPassword,
   onUpdateUserRoles,
@@ -184,13 +186,18 @@ export const UsersTableBody: FC<
                               disabled: user.id === actorID,
                             },
                             {
+                              label: t("resetPasswordMenuItem"),
+                              onClick: onResetUserPassword,
+                              disabled: false,
+                            },
+                            {
                               label: t("listWorkspacesMenuItem"),
                               onClick: onListWorkspaces,
                               disabled: false,
                             },
                             {
-                              label: t("resetPasswordMenuItem"),
-                              onClick: onResetUserPassword,
+                              label: "View activity",
+                              onClick: onViewActivity,
                               disabled: false,
                             },
                           )

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -112,6 +112,11 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
               encodeURIComponent(`owner:${user.username}`),
           )
         }}
+        onViewActivity={(user) => {
+          navigate(
+            "/audit?filter=" + encodeURIComponent(`username:${user.username}`),
+          )
+        }}
         onDeleteUser={(user) => {
           usersSend({
             type: "DELETE_USER",

--- a/site/src/pages/UsersPage/UsersPageView.tsx
+++ b/site/src/pages/UsersPage/UsersPageView.tsx
@@ -23,6 +23,7 @@ export interface UsersPageViewProps {
   onSuspendUser: (user: TypesGen.User) => void
   onDeleteUser: (user: TypesGen.User) => void
   onListWorkspaces: (user: TypesGen.User) => void
+  onViewActivity: (user: TypesGen.User) => void
   onActivateUser: (user: TypesGen.User) => void
   onResetUserPassword: (user: TypesGen.User) => void
   onUpdateUserRoles: (
@@ -44,6 +45,7 @@ export const UsersPageView: FC<React.PropsWithChildren<UsersPageViewProps>> = ({
   onSuspendUser,
   onDeleteUser,
   onListWorkspaces,
+  onViewActivity,
   onActivateUser,
   onResetUserPassword,
   onUpdateUserRoles,
@@ -86,6 +88,7 @@ export const UsersPageView: FC<React.PropsWithChildren<UsersPageViewProps>> = ({
         onSuspendUser={onSuspendUser}
         onDeleteUser={onDeleteUser}
         onListWorkspaces={onListWorkspaces}
+        onViewActivity={onViewActivity}
         onActivateUser={onActivateUser}
         onResetUserPassword={onResetUserPassword}
         onUpdateUserRoles={onUpdateUserRoles}


### PR DESCRIPTION
Based on user feedback, I noticed that admins usually want to see user activity to track engagement and gain a better understanding of Coder usage. Therefore, I have added a button labeled “View activity” in the user row. This button redirects to the audit log page, filtering the results specifically for the selected user.

https://github.com/coder/coder/assets/3165839/1e602681-2d33-4d61-bc07-c2ad20c58e99



