### PR TITLE
fix: improve filter on smaller screens

### DIFF
--- a/site/src/components/Filter/filter.tsx
+++ b/site/src/components/Filter/filter.tsx
@@ -154,7 +154,14 @@ export const Filter = ({
   }, [filter.query])
 
   return (
-    <Box display="flex" sx={{ gap: 1, mb: 2 }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexWrap: ["wrap", undefined, "nowrap"],
+        gap: 1,
+        mb: 2,
+      }}
+    >
       {isLoading ? (
         skeleton
       ) : (


### PR DESCRIPTION
Before:
<img width="500" alt="Screen Shot 2023-06-07 at 11 42 40" src="https://github.com/coder/coder/assets/3165839/e01a4f4c-3d21-41ab-8737-e82f029c60e5">

Now:
<img width="501" alt="Screen Shot 2023-06-07 at 11 42 49" src="https://github.com/coder/coder/assets/3165839/a5f4ff6a-eb30-4804-b80b-6e8c1e166754">

