### PR TITLE
fix(site): format numbers in pagination text

### DIFF
--- a/site/src/components/PaginationStatus/PaginationStatus.tsx
+++ b/site/src/components/PaginationStatus/PaginationStatus.tsx
@@ -32,7 +32,8 @@ export const PaginationStatus = ({
     >
       {!isLoading ? (
         <>
-          Showing <strong>{showing}</strong> of <strong>{total}</strong> {label}
+          Showing <strong>{showing}</strong> of{" "}
+          <strong>{total?.toLocaleString()}</strong> {label}
         </>
       ) : (
         <Box sx={{ height: 24, display: "flex", alignItems: "center" }}>


### PR DESCRIPTION
Before:
<img width="234" alt="Screen Shot 2023-06-07 at 11 54 35" src="https://github.com/coder/coder/assets/3165839/4bf80988-9d4e-43d6-b2ea-0ce0d6533d2d">

After:
<img width="230" alt="Screen Shot 2023-06-07 at 11 54 39" src="https://github.com/coder/coder/assets/3165839/1fb42fad-d1c9-40d6-b489-e68dea5313a0">
