### PR TITLE
chore: make default workspace proxy editable

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -206,6 +206,10 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		options.Database = dbauthz.New(options.Database, options.Authorizer, slogtest.Make(t, nil).Leveled(slog.LevelDebug))
 	}
 
+	// Some routes expect a deployment ID
+	err := options.Database.InsertDeploymentID(dbauthz.AsSystemRestricted(context.Background()), uuid.NewString())
+	require.NoError(t, err, "insert a deployment id")
+
 	if options.DeploymentValues == nil {
 		options.DeploymentValues = DeploymentValues(t)
 	}

--- a/coderd/database/dbauthz/querier.go
+++ b/coderd/database/dbauthz/querier.go
@@ -369,6 +369,11 @@ func (q *querier) DeleteLicense(ctx context.Context, id int32) (int32, error) {
 	return id, nil
 }
 
+func (q *querier) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaultProxyConfigRow, error) {
+	// No authz checks
+	return q.db.GetDefaultProxyConfig(ctx)
+}
+
 func (q *querier) GetDeploymentID(ctx context.Context) (string, error) {
 	// No authz checks
 	return q.db.GetDeploymentID(ctx)

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -335,6 +335,9 @@ func (s *MethodTestSuite) TestLicense() {
 	s.Run("GetDeploymentID", s.Subtest(func(db database.Store, check *expects) {
 		check.Args().Asserts().Returns("")
 	}))
+	s.Run("GetDefaultProxyConfig", s.Subtest(func(db database.Store, check *expects) {
+		check.Args().Asserts().Returns(database.GetDefaultProxyConfigRow{})
+	}))
 	s.Run("GetLogoURL", s.Subtest(func(db database.Store, check *expects) {
 		err := db.UpsertLogoURL(context.Background(), "value")
 		require.NoError(s.T(), err)

--- a/coderd/database/dbauthz/querier_test.go
+++ b/coderd/database/dbauthz/querier_test.go
@@ -336,7 +336,10 @@ func (s *MethodTestSuite) TestLicense() {
 		check.Args().Asserts().Returns("")
 	}))
 	s.Run("GetDefaultProxyConfig", s.Subtest(func(db database.Store, check *expects) {
-		check.Args().Asserts().Returns(database.GetDefaultProxyConfigRow{})
+		check.Args().Asserts().Returns(database.GetDefaultProxyConfigRow{
+			DisplayName: "Default",
+			IconUrl:     "/emojis/1f3e1.png",
+		})
 	}))
 	s.Run("GetLogoURL", s.Subtest(func(db database.Store, check *expects) {
 		err := db.UpsertLogoURL(context.Background(), "value")

--- a/coderd/database/dbauthz/system.go
+++ b/coderd/database/dbauthz/system.go
@@ -431,3 +431,10 @@ func (q *querier) GetWorkspaceProxyByHostname(ctx context.Context, params databa
 	}
 	return q.db.GetWorkspaceProxyByHostname(ctx, params)
 }
+
+func (q *querier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDefaultProxyParams) error {
+	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+		return err
+	}
+	return q.db.UpsertDefaultProxy(ctx, arg)
+}

--- a/coderd/database/dbauthz/system_test.go
+++ b/coderd/database/dbauthz/system_test.go
@@ -25,6 +25,9 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 			LoginType: database.LoginTypeGithub,
 		}).Asserts(rbac.ResourceSystem, rbac.ActionUpdate).Returns(l)
 	}))
+	s.Run("UpsertDefaultProxy", s.Subtest(func(db database.Store, check *expects) {
+		check.Args(database.UpsertDefaultProxyParams{}).Asserts(rbac.ResourceSystem, rbac.ActionUpdate).Returns()
+	}))
 	s.Run("GetUserLinkByLinkedID", s.Subtest(func(db database.Store, check *expects) {
 		l := dbgen.UserLink(s.T(), db, database.UserLink{})
 		check.Args(l.LinkedID).Asserts(rbac.ResourceSystem, rbac.ActionRead).Returns(l)

--- a/coderd/database/dbfake/databasefake.go
+++ b/coderd/database/dbfake/databasefake.go
@@ -5176,14 +5176,14 @@ func isNotNull(v interface{}) bool {
 	return reflect.ValueOf(v).FieldByName("Valid").Bool()
 }
 
-func (q *fakeQuerier) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaultProxyConfigRow, error) {
+func (q *fakeQuerier) GetDefaultProxyConfig(_ context.Context) (database.GetDefaultProxyConfigRow, error) {
 	return database.GetDefaultProxyConfigRow{
 		DisplayName: q.defaultProxyDisplayName,
 		IconUrl:     q.defaultProxyIconURL,
 	}, nil
 }
 
-func (q *fakeQuerier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDefaultProxyParams) error {
+func (q *fakeQuerier) UpsertDefaultProxy(_ context.Context, arg database.UpsertDefaultProxyParams) error {
 	q.defaultProxyDisplayName = arg.DisplayName
 	q.defaultProxyIconURL = arg.IconUrl
 	return nil

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -1518,3 +1518,17 @@ func (m metricsStore) GetAuthorizedUserCount(ctx context.Context, arg database.G
 	m.queryLatencies.WithLabelValues("GetAuthorizedUserCount").Observe(time.Since(start).Seconds())
 	return count, err
 }
+
+func (m metricsStore) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDefaultProxyParams) error {
+	start := time.Now()
+	err := m.s.UpsertDefaultProxy(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpsertDefaultProxy").Observe(time.Since(start).Seconds())
+	return err
+}
+
+func (m metricsStore) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaultProxyConfigRow, error) {
+	start := time.Now()
+	resp, err := m.s.GetDefaultProxyConfig(ctx)
+	m.queryLatencies.WithLabelValues("GetDefaultProxyConfig").Observe(time.Since(start).Seconds())
+	return resp, err
+}

--- a/coderd/database/dbmock/store.go
+++ b/coderd/database/dbmock/store.go
@@ -418,6 +418,21 @@ func (mr *MockStoreMockRecorder) GetDERPMeshKey(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDERPMeshKey", reflect.TypeOf((*MockStore)(nil).GetDERPMeshKey), arg0)
 }
 
+// GetDefaultProxyConfig mocks base method.
+func (m *MockStore) GetDefaultProxyConfig(arg0 context.Context) (database.GetDefaultProxyConfigRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultProxyConfig", arg0)
+	ret0, _ := ret[0].(database.GetDefaultProxyConfigRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDefaultProxyConfig indicates an expected call of GetDefaultProxyConfig.
+func (mr *MockStoreMockRecorder) GetDefaultProxyConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultProxyConfig", reflect.TypeOf((*MockStore)(nil).GetDefaultProxyConfig), arg0)
+}
+
 // GetDeploymentDAUs mocks base method.
 func (m *MockStore) GetDeploymentDAUs(arg0 context.Context, arg1 int32) ([]database.GetDeploymentDAUsRow, error) {
 	m.ctrl.T.Helper()
@@ -3086,6 +3101,20 @@ func (m *MockStore) UpsertAppSecurityKey(arg0 context.Context, arg1 string) erro
 func (mr *MockStoreMockRecorder) UpsertAppSecurityKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertAppSecurityKey", reflect.TypeOf((*MockStore)(nil).UpsertAppSecurityKey), arg0, arg1)
+}
+
+// UpsertDefaultProxy mocks base method.
+func (m *MockStore) UpsertDefaultProxy(arg0 context.Context, arg1 database.UpsertDefaultProxyParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertDefaultProxy", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertDefaultProxy indicates an expected call of UpsertDefaultProxy.
+func (mr *MockStoreMockRecorder) UpsertDefaultProxy(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDefaultProxy", reflect.TypeOf((*MockStore)(nil).UpsertDefaultProxy), arg0, arg1)
 }
 
 // UpsertLastUpdateCheck mocks base method.

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -186,6 +186,10 @@ func (w WorkspaceProxy) RBACObject() rbac.Object {
 		WithID(w.ID)
 }
 
+func (w WorkspaceProxy) IsPrimary() bool {
+	return w.Name == "primary"
+}
+
 func (f File) RBACObject() rbac.Object {
 	return rbac.ResourceFile.
 		WithID(f.ID).

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -54,6 +54,7 @@ type sqlcQuerier interface {
 	// are included.
 	GetAuthorizationUserRoles(ctx context.Context, userID uuid.UUID) (GetAuthorizationUserRolesRow, error)
 	GetDERPMeshKey(ctx context.Context) (string, error)
+	GetDefaultProxyConfig(ctx context.Context) (GetDefaultProxyConfigRow, error)
 	GetDeploymentDAUs(ctx context.Context, tzOffset int32) ([]GetDeploymentDAUsRow, error)
 	GetDeploymentID(ctx context.Context) (string, error)
 	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
@@ -254,6 +255,10 @@ type sqlcQuerier interface {
 	UpdateWorkspaceTTL(ctx context.Context, arg UpdateWorkspaceTTLParams) error
 	UpdateWorkspaceTTLToBeWithinTemplateMax(ctx context.Context, arg UpdateWorkspaceTTLToBeWithinTemplateMaxParams) error
 	UpsertAppSecurityKey(ctx context.Context, value string) error
+	// The default proxy is implied and not actually stored in the database.
+	// So we need to store it's configuration here for display purposes.
+	// The functional values are immutable and controlled implicitly.
+	UpsertDefaultProxy(ctx context.Context, arg UpsertDefaultProxyParams) error
 	UpsertLastUpdateCheck(ctx context.Context, value string) error
 	UpsertLogoURL(ctx context.Context, value string) error
 	UpsertServiceBanner(ctx context.Context, value string) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3122,7 +3122,7 @@ const upsertDefaultProxy = `-- name: UpsertDefaultProxy :exec
 INSERT INTO site_configs (key, value)
 VALUES
     ('default_proxy_display_name', $1 :: text),
-	('default_proxy_icon_url', $2 :: text)
+    ('default_proxy_icon_url', $2 :: text)
 ON CONFLICT
     (key)
 DO UPDATE SET value = EXCLUDED.value WHERE site_configs.key = EXCLUDED.key

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -1,3 +1,23 @@
+-- name: UpsertDefaultProxy :exec
+-- The default proxy is implied and not actually stored in the database.
+-- So we need to store it's configuration here for display purposes.
+-- The functional values are immutable and controlled implicitly.
+INSERT INTO site_configs (key, value)
+VALUES
+    ('default_proxy_display_name', @display_name :: text),
+	('default_proxy_icon_url', @icon_url :: text)
+ON CONFLICT
+    (key)
+DO UPDATE SET value = EXCLUDED.value WHERE site_configs.key = EXCLUDED.key
+;
+
+-- name: GetDefaultProxyConfig :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'default_proxy_display_name'), 'Default') :: text AS display_name,
+	COALESCE((SELECT value FROM site_configs WHERE key = 'default_proxy_icon_url'), '/emojis/1f3e1.png') :: text AS icon_url
+;
+
+
 -- name: InsertDeploymentID :exec
 INSERT INTO site_configs (key, value) VALUES ('deployment_id', $1);
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -5,7 +5,7 @@
 INSERT INTO site_configs (key, value)
 VALUES
     ('default_proxy_display_name', @display_name :: text),
-	('default_proxy_icon_url', @icon_url :: text)
+    ('default_proxy_icon_url', @icon_url :: text)
 ON CONFLICT
     (key)
 DO UPDATE SET value = EXCLUDED.value WHERE site_configs.key = EXCLUDED.key

--- a/coderd/workspaceproxies.go
+++ b/coderd/workspaceproxies.go
@@ -29,12 +29,10 @@ func (api *API) PrimaryRegion(ctx context.Context) (codersdk.Region, error) {
 	}
 
 	return codersdk.Region{
-		ID: deploymentID,
-		// TODO: provide some way to customize these fields for the primary
-		// region
+		ID:               deploymentID,
 		Name:             "primary",
 		DisplayName:      "Default",
-		IconURL:          "/emojis/1f60e.png", // face with sunglasses
+		IconURL:          "/emojis/1f3e1.png", // House with garden
 		Healthy:          true,
 		PathAppURL:       api.AccessURL.String(),
 		WildcardHostname: api.AppHostname,

--- a/coderd/workspaceproxies.go
+++ b/coderd/workspaceproxies.go
@@ -3,9 +3,10 @@ package coderd
 import (
 	"context"
 	"database/sql"
+	"net/http"
+
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
-	"net/http"
 
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/dbauthz"

--- a/enterprise/cli/workspaceproxy_test.go
+++ b/enterprise/cli/workspaceproxy_test.go
@@ -82,8 +82,15 @@ func Test_ProxyCRUD(t *testing.T) {
 		// Also check via the api
 		proxies, err := client.WorkspaceProxies(ctx)
 		require.NoError(t, err, "failed to get workspace proxies")
-		require.Len(t, proxies, 1, "expected 1 proxy")
-		require.Equal(t, expectedName, proxies[0].Name, "expected proxy name to match")
+		// Include primary
+		require.Len(t, proxies, 2, "expected 1 proxy")
+		found := false
+		for _, proxy := range proxies {
+			if proxy.Name == expectedName {
+				found = true
+			}
+		}
+		require.True(t, found, "expected proxy to be found")
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -130,6 +137,6 @@ func Test_ProxyCRUD(t *testing.T) {
 
 		proxies, err := client.WorkspaceProxies(ctx)
 		require.NoError(t, err, "failed to get workspace proxies")
-		require.Len(t, proxies, 0, "expected no proxies")
+		require.Len(t, proxies, 1, "expected only primary proxy")
 	})
 }

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -72,6 +72,11 @@ func New(ctx context.Context, options *Options) (*API, error) {
 		RedirectToLogin: false,
 	})
 
+	deploymentID, err := options.Database.GetDeploymentID(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get deployment ID: %w", err)
+	}
+
 	api.AGPL.APIHandler.Group(func(r chi.Router) {
 		r.Get("/entitlements", api.serveEntitlements)
 		// /regions overrides the AGPL /regions endpoint
@@ -118,7 +123,7 @@ func New(ctx context.Context, options *Options) (*API, error) {
 			r.Route("/{workspaceproxy}", func(r chi.Router) {
 				r.Use(
 					apiKeyMiddleware,
-					httpmw.ExtractWorkspaceProxyParam(api.Database),
+					httpmw.ExtractWorkspaceProxyParam(api.Database, deploymentID, api.AGPL.PrimaryWorkspaceProxy),
 				)
 
 				r.Get("/", api.workspaceProxy)
@@ -225,7 +230,6 @@ func New(ctx context.Context, options *Options) (*API, error) {
 		RootCAs:      meshRootCA,
 		ServerName:   options.AccessURL.Hostname(),
 	}
-	var err error
 	api.replicaManager, err = replicasync.New(ctx, options.Logger, options.Database, options.Pubsub, &replicasync.Options{
 		ID:           api.AGPL.ID,
 		RelayAddress: options.DERPServerRelayAddress,

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -409,7 +409,7 @@ func (api *API) workspaceProxies(rw http.ResponseWriter, r *http.Request) {
 		httpapi.InternalServerError(rw, err)
 		return
 	}
-	proxies = append(proxies, primaryProxy)
+	proxies = append([]database.WorkspaceProxy{primaryProxy}, proxies...)
 
 	statues := api.ProxyHealth.HealthStatus()
 	httpapi.Write(ctx, rw, http.StatusOK, convertProxies(proxies, statues))

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -136,7 +136,7 @@ func (api *API) patchWorkspaceProxy(rw http.ResponseWriter, r *http.Request) {
 	var updatedProxy database.WorkspaceProxy
 	if proxy.ID.String() == deploymentIDStr {
 		// User is editing the default primary proxy.
-		if req.Name != "" {
+		if req.Name != "" && req.Name != proxy.Name {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Cannot update name of default primary proxy, did you mean to update the 'display name'?",
 				Validations: []codersdk.ValidationError{

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -325,7 +325,8 @@ func TestWorkspaceProxyCRUD(t *testing.T) {
 
 		proxies, err := client.WorkspaceProxies(ctx)
 		require.NoError(t, err)
-		require.Len(t, proxies, 0)
+		// Default proxy is always there
+		require.Len(t, proxies, 1)
 	})
 }
 

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -44,11 +44,6 @@ func TestRegions(t *testing.T) {
 		}
 
 		db, pubsub := dbtestutil.NewDB(t)
-		deploymentID := uuid.New()
-
-		ctx := testutil.Context(t, testutil.WaitLong)
-		err := db.InsertDeploymentID(ctx, deploymentID.String())
-		require.NoError(t, err)
 
 		client := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -58,14 +53,18 @@ func TestRegions(t *testing.T) {
 				DeploymentValues: dv,
 			},
 		})
+
 		_ = coderdtest.CreateFirstUser(t, client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		deploymentID, err := db.GetDeploymentID(ctx)
+		require.NoError(t, err, "get deployment ID")
 
 		regions, err := client.Regions(ctx)
 		require.NoError(t, err)
 
 		require.Len(t, regions, 1)
 		require.NotEqual(t, uuid.Nil, regions[0].ID)
-		require.Equal(t, regions[0].ID, deploymentID)
+		require.Equal(t, regions[0].ID.String(), deploymentID)
 		require.Equal(t, "primary", regions[0].Name)
 		require.Equal(t, "Default", regions[0].DisplayName)
 		require.NotEmpty(t, regions[0].IconURL)
@@ -89,11 +88,6 @@ func TestRegions(t *testing.T) {
 		}
 
 		db, pubsub := dbtestutil.NewDB(t)
-		deploymentID := uuid.New()
-
-		ctx := testutil.Context(t, testutil.WaitLong)
-		err := db.InsertDeploymentID(ctx, deploymentID.String())
-		require.NoError(t, err)
 
 		client, closer, api := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -106,6 +100,9 @@ func TestRegions(t *testing.T) {
 		t.Cleanup(func() {
 			_ = closer.Close()
 		})
+		ctx := testutil.Context(t, testutil.WaitLong)
+		deploymentID, err := db.GetDeploymentID(ctx)
+		require.NoError(t, err, "get deployment ID")
 		_ = coderdtest.CreateFirstUser(t, client)
 		_ = coderdenttest.AddLicense(t, client, coderdenttest.LicenseOptions{
 			Features: license.Features{
@@ -131,7 +128,7 @@ func TestRegions(t *testing.T) {
 
 		// Region 0 is the primary	require.Len(t, regions, 1)
 		require.NotEqual(t, uuid.Nil, regions[0].ID)
-		require.Equal(t, regions[0].ID, deploymentID)
+		require.Equal(t, regions[0].ID.String(), deploymentID)
 		require.Equal(t, "primary", regions[0].Name)
 		require.Equal(t, "Default", regions[0].DisplayName)
 		require.NotEmpty(t, regions[0].IconURL)

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -385,11 +385,10 @@ func TestIssueSignedAppToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	proxyClient := wsproxysdk.New(client.URL)
-	proxyClient.SetSessionToken(proxyRes.ProxyToken)
-
 	t.Run("BadAppRequest", func(t *testing.T) {
 		t.Parallel()
+		proxyClient := wsproxysdk.New(client.URL)
+		proxyClient.SetSessionToken(proxyRes.ProxyToken)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		_, err = proxyClient.IssueSignedAppToken(ctx, workspaceapps.IssueTokenRequest{
@@ -410,6 +409,8 @@ func TestIssueSignedAppToken(t *testing.T) {
 	}
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
+		proxyClient := wsproxysdk.New(client.URL)
+		proxyClient.SetSessionToken(proxyRes.ProxyToken)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		_, err = proxyClient.IssueSignedAppToken(ctx, goodRequest)
@@ -418,6 +419,8 @@ func TestIssueSignedAppToken(t *testing.T) {
 
 	t.Run("OKHTML", func(t *testing.T) {
 		t.Parallel()
+		proxyClient := wsproxysdk.New(client.URL)
+		proxyClient.SetSessionToken(proxyRes.ProxyToken)
 
 		rw := httptest.NewRecorder()
 		ctx := testutil.Context(t, testutil.WaitLong)


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/7718

# How it works

Stores the display name and icon url in the `site_configs` table. The other proxy fields are computed and not able to be changed.

# Extra

`wsproxy ls` now includes the default.