### PR TITLE
ci: move timing tests to nightly gauntlet

### DIFF
--- a/.github/workflows/nightly-flake.yaml
+++ b/.github/workflows/nightly-flake.yaml
@@ -1,13 +1,14 @@
-name: nightly-flake
+# The nightly-gauntlet runs tests that are either too flaky or too slow to block
+# every PR.
+name: nightly-gauntlet
 on:
   schedule:
     # Every day at midnight
     - cron: "0 0 * * *"
   workflow_dispatch:
-  # For testing purposes
-  # push:
-  #   paths:
-  # - ".github/workflows/nightly-flake.yaml"
+  push:
+    branch:
+      - nightly-gauntlet
 jobs:
   test-go-race:
     # While GitHub's toaster runners are likelier to flake, we want consistency
@@ -33,6 +34,23 @@ jobs:
           # due to correctness detection and its performance
           # impact.
           gotestsum --junitfile="gotests.xml" -- -timeout=240m -count=10 -race ./...
+
+      - uses: ./.github/actions/upload-datadog
+        if: always()
+        with:
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+
+  test-go-timing:
+    # We run these tests with p=1 so we don't need a lot of compute.
+    runs-on: "buildjet-2vcpu-ubuntu-2204"
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-go
+      - name: Run Tests
+        run: |
+          gotestsum --junitfile="gotests.xml" -- --tags="timing" -p=1 -run='_Timing/' ./...
 
       - uses: ./.github/actions/upload-datadog
         if: always()

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -10,7 +10,7 @@ on:
     branch:
       - nightly-gauntlet
 jobs:
-  test-go-race:
+  go-race:
     # While GitHub's toaster runners are likelier to flake, we want consistency
     # between this environment and the regular test environment for DataDog
     # statistics and to only show real workflow threats.
@@ -40,7 +40,7 @@ jobs:
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
-  test-go-timing:
+  go-timing:
     # We run these tests with p=1 so we don't need a lot of compute.
     runs-on: "buildjet-2vcpu-ubuntu-2204"
     timeout-minutes: 10

--- a/scaletest/agentconn/run_test.go
+++ b/scaletest/agentconn/run_test.go
@@ -109,6 +109,7 @@ func Test_Runner(t *testing.T) {
 
 //nolint:paralleltest // Measures timing as part of the test.
 func Test_Runner_Timing(t *testing.T) {
+	testutil.SkipIfNotTiming(t)
 	//nolint:paralleltest
 	t.Run("Direct+Hold", func(t *testing.T) {
 		client, agentID := setupRunnerTest(t)


### PR DESCRIPTION
Test_Runner_Timing accounted for 25% of our flakiness in the past day.