### PR TITLE
test(agent/agentssh):  close SSH servers in all tests

### DIFF
--- a/agent/agentssh/agentssh_internal_test.go
+++ b/agent/agentssh/agentssh_internal_test.go
@@ -39,6 +39,7 @@ func Test_sessionStart_orphan(t *testing.T) {
 	logger := slogtest.Make(t, nil)
 	s, err := NewServer(ctx, logger, prometheus.NewRegistry(), afero.NewMemMapFs(), 0, "")
 	require.NoError(t, err)
+	defer s.Close()
 
 	// Here we're going to call the handler directly with a faked SSH session
 	// that just uses io.Pipes instead of a network socket.  There is a large

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -36,6 +36,7 @@ func TestNewServer_ServeClient(t *testing.T) {
 	logger := slogtest.Make(t, nil)
 	s, err := agentssh.NewServer(ctx, logger, prometheus.NewRegistry(), afero.NewMemMapFs(), 0, "")
 	require.NoError(t, err)
+	defer s.Close()
 
 	// The assumption is that these are set before serving SSH connections.
 	s.AgentToken = func() string { return "" }
@@ -77,6 +78,7 @@ func TestNewServer_CloseActiveConnections(t *testing.T) {
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	s, err := agentssh.NewServer(ctx, logger, prometheus.NewRegistry(), afero.NewMemMapFs(), 0, "")
 	require.NoError(t, err)
+	defer s.Close()
 
 	// The assumption is that these are set before serving SSH connections.
 	s.AgentToken = func() string { return "" }


### PR DESCRIPTION
Potentially solves the flake seen here:

https://github.com/coder/coder/actions/runs/5167029213/jobs/9307647816.