### PR TITLE
docs(admin/workspace-proxies): add instructions to run using the Docker image

### DIFF
--- a/docs/admin/workspace-proxies.md
+++ b/docs/admin/workspace-proxies.md
@@ -90,13 +90,13 @@ CODER_TLS_KEY_FILE="<key_file_location>"
 coder wsproxy server
 ```
 
-### Running from the Docker image
+### Running in Docker
 
-Modify the default entrypoint to run the workspace proxy.
+Modify the default entrypoint to run a workspace proxy server instead of a regular Coder server.
 
 #### Docker Compose
 
-change the provided [`docker-compose.yml`](https://github.com/coder/coder/blob/main/docker-compose.yaml) file to include the workspace proxy.
+Change the provided [`docker-compose.yml`](https://github.com/coder/coder/blob/main/docker-compose.yaml) file to include a custom entrypoint:
 
 ```diff
   image: ghcr.io/coder/coder:${CODER_VERSION:-latest}
@@ -121,11 +121,3 @@ ENTRYPOINT ["/opt/coder", "wsproxy", "server"]
 Users can navigate to their account settings to select a workspace proxy. Workspace proxy preferences are cached by the web browser. If a proxy goes offline, the session will fall back to the primary proxy. This could take up to 60 seconds.
 
 ![Workspace proxy picker](../images/admin/workspace-proxy-picker.png)
-
-```
-
-```
-
-```
-
-```

--- a/docs/admin/workspace-proxies.md
+++ b/docs/admin/workspace-proxies.md
@@ -92,10 +92,28 @@ coder wsproxy server
 
 ### Running from the Docker image
 
-Modify the entrypoint to
+Modify the default entrypoint to run the workspace proxy.
+
+#### Docker Compose
+
+change the provided [`docker-compose.yml`](https://github.com/coder/coder/blob/main/docker-compose.yaml) file to include the workspace proxy.
+
+```diff
+  image: ghcr.io/coder/coder:${CODER_VERSION:-latest}
++ entrypoint: /opt/coder wsproxy server
+```
+
+#### Docker run
 
 ```bash
-entrypoint = ["/opt/coder", "wsproxy", "server"]
+docker run --rm -it --entrypoint /opt/coder ghcr.io/coder/coder:latest wsproxy server
+```
+
+#### Custom Dockerfile
+
+```Dockerfile
+FROM ghcr.io/coder/coder:latest
+ENTRYPOINT ["/opt/coder", "wsproxy", "server"]
 ```
 
 ### Selecting a proxy
@@ -103,3 +121,11 @@ entrypoint = ["/opt/coder", "wsproxy", "server"]
 Users can navigate to their account settings to select a workspace proxy. Workspace proxy preferences are cached by the web browser. If a proxy goes offline, the session will fall back to the primary proxy. This could take up to 60 seconds.
 
 ![Workspace proxy picker](../images/admin/workspace-proxy-picker.png)
+
+```
+
+```
+
+```
+
+```

--- a/docs/admin/workspace-proxies.md
+++ b/docs/admin/workspace-proxies.md
@@ -90,6 +90,13 @@ CODER_TLS_KEY_FILE="<key_file_location>"
 coder wsproxy server
 ```
 
+### Running from the Docker image
+
+Modify the entrypoint to
+```bash
+entrypoint = ["/opt/coder", "wsproxy", "server"]
+```
+
 ### Selecting a proxy
 
 Users can navigate to their account settings to select a workspace proxy. Workspace proxy preferences are cached by the web browser. If a proxy goes offline, the session will fall back to the primary proxy. This could take up to 60 seconds.

--- a/docs/admin/workspace-proxies.md
+++ b/docs/admin/workspace-proxies.md
@@ -93,6 +93,7 @@ coder wsproxy server
 ### Running from the Docker image
 
 Modify the entrypoint to
+
 ```bash
 entrypoint = ["/opt/coder", "wsproxy", "server"]
 ```


### PR DESCRIPTION
Add instructions to change the entrypoint of the image when running as a workspace proxy.