### PR TITLE
chore: add proxy health interval flag/env config

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -193,6 +193,10 @@ backed by Tailscale and WireGuard.
           The maximum lifetime duration users can specify when creating an API
           token.
 
+      --proxy-health-interval duration, $CODER_PROXY_HEALTH_INTERVAL (default: 1m0s)
+          The interval in which coderd should be checking the status of
+          workspace proxies.
+
       --session-duration duration, $CODER_SESSION_DURATION (default: 24h0m0s)
           The token expiry duration for browser sessions. Sessions may last
           longer if they are actively making requests, but this functionality

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -33,6 +33,9 @@ networking:
     # directly in the database.
     # (default: <unset>, type: bool)
     disablePasswordAuth: false
+    # The interval in which coderd should be checking the status of workspace proxies.
+    # (default: 1m0s, type: duration)
+    proxyHealthInterval: 1m0s
   # Configure TLS / HTTPS for your Coder deployment. If you're running
   #  Coder behind a TLS-terminating reverse proxy or are accessing Coder over a
   #  secure link, you can safely ignore these settings.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7209,6 +7209,9 @@ const docTemplate = `{
                 "provisioner": {
                     "$ref": "#/definitions/codersdk.ProvisionerConfig"
                 },
+                "proxy_health_status_interval": {
+                    "type": "integer"
+                },
                 "proxy_trusted_headers": {
                     "type": "array",
                     "items": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6441,6 +6441,9 @@
         "provisioner": {
           "$ref": "#/definitions/codersdk.ProvisionerConfig"
         },
+        "proxy_health_status_interval": {
+          "type": "integer"
+        },
         "proxy_trusted_headers": {
           "type": "array",
           "items": {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -163,6 +163,7 @@ type DeploymentValues struct {
 	SSHConfig                       SSHConfig                       `json:"config_ssh,omitempty" typescript:",notnull"`
 	WgtunnelHost                    clibase.String                  `json:"wgtunnel_host,omitempty" typescript:",notnull"`
 	DisableOwnerWorkspaceExec       clibase.Bool                    `json:"disable_owner_workspace_exec,omitempty" typescript:",notnull"`
+	ProxyHealthStatusInterval       clibase.Duration                `json:"proxy_health_status_interval,omitempty" typescript:",notnull"`
 
 	Config      clibase.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig clibase.Bool           `json:"write_config,omitempty" typescript:",notnull"`
@@ -1496,6 +1497,16 @@ Write out the current server config as YAML to stdout.`,
 			Value:       &c.WgtunnelHost,
 			Default:     "", // empty string means pick best server
 			Hidden:      true,
+		},
+		{
+			Name:        "Proxy Health Check Interval",
+			Description: "The interval in which coderd should be checking the status of workspace proxies.",
+			Flag:        "proxy-health-interval",
+			Env:         "CODER_PROXY_HEALTH_INTERVAL",
+			Default:     (time.Minute).String(),
+			Value:       &c.ProxyHealthStatusInterval,
+			Group:       &deploymentGroupNetworkingHTTP,
+			YAML:        "proxyHealthInterval",
 		},
 	}
 	return opts

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -283,6 +283,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "daemons": 0,
       "force_cancel_interval": 0
     },
+    "proxy_health_status_interval": 0,
     "proxy_trusted_headers": ["string"],
     "proxy_trusted_origins": ["string"],
     "rate_limit": {

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1947,6 +1947,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "daemons": 0,
       "force_cancel_interval": 0
     },
+    "proxy_health_status_interval": 0,
     "proxy_trusted_headers": ["string"],
     "proxy_trusted_origins": ["string"],
     "rate_limit": {
@@ -2273,6 +2274,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "daemons": 0,
     "force_cancel_interval": 0
   },
+  "proxy_health_status_interval": 0,
   "proxy_trusted_headers": ["string"],
   "proxy_trusted_origins": ["string"],
   "rate_limit": {
@@ -2389,6 +2391,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `pprof`                              | [codersdk.PprofConfig](#codersdkpprofconfig)                                               | false    |              |                                                                    |
 | `prometheus`                         | [codersdk.PrometheusConfig](#codersdkprometheusconfig)                                     | false    |              |                                                                    |
 | `provisioner`                        | [codersdk.ProvisionerConfig](#codersdkprovisionerconfig)                                   | false    |              |                                                                    |
+| `proxy_health_status_interval`       | integer                                                                                    | false    |              |                                                                    |
 | `proxy_trusted_headers`              | array of string                                                                            | false    |              |                                                                    |
 | `proxy_trusted_origins`              | array of string                                                                            | false    |              |                                                                    |
 | `rate_limit`                         | [codersdk.RateLimitConfig](#codersdkratelimitconfig)                                       | false    |              |                                                                    |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -586,6 +586,17 @@ Serve prometheus metrics on the address defined by prometheus address.
 
 Number of provisioner daemons to create on start. If builds are stuck in queued state for a long time, consider increasing this.
 
+### --proxy-health-interval
+
+|             |                                                  |
+| ----------- | ------------------------------------------------ |
+| Type        | <code>duration</code>                            |
+| Environment | <code>$CODER_PROXY_HEALTH_INTERVAL</code>        |
+| YAML        | <code>networking.http.proxyHealthInterval</code> |
+| Default     | <code>1m0s</code>                                |
+
+The interval in which coderd should be checking the status of workspace proxies.
+
 ### --proxy-trusted-headers
 
 |             |                                             |

--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -64,6 +64,7 @@ func (r *RootCmd) server() *clibase.Cmd {
 			DERPServerRelayAddress: options.DeploymentValues.DERP.Server.RelayURL.String(),
 			DERPServerRegionID:     int(options.DeploymentValues.DERP.Server.RegionID.Value()),
 			Options:                options,
+			ProxyHealthInterval:    options.DeploymentValues.ProxyHealthStatusInterval.Value(),
 		}
 
 		api, err := coderd.New(ctx, o)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -368,6 +368,7 @@ export interface DeploymentValues {
   readonly config_ssh?: SSHConfig
   readonly wgtunnel_host?: string
   readonly disable_owner_workspace_exec?: boolean
+  readonly proxy_health_status_interval?: number
   // This is likely an enum in an external package ("github.com/coder/coder/cli/clibase.YAMLConfigPath")
   readonly config?: string
   readonly write_config?: boolean


### PR DESCRIPTION
Allows manually changing the proxy health interval

`--proxy-health-interval=10m`