### PR TITLE
fix(codersdk): handle API older than client for startup script behavior

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1126,7 +1126,7 @@ func convertWorkspaceAgent(derpMap *tailcfg.DERPMap, coordinator tailnet.Coordin
 		ConnectionTimeoutSeconds:     dbAgent.ConnectionTimeoutSeconds,
 		TroubleshootingURL:           troubleshootingURL,
 		LifecycleState:               codersdk.WorkspaceAgentLifecycle(dbAgent.LifecycleState),
-		LoginBeforeReady:             dbAgent.StartupScriptBehavior == database.StartupScriptBehaviorNonBlocking,
+		LoginBeforeReady:             dbAgent.StartupScriptBehavior != database.StartupScriptBehaviorBlocking,
 		StartupScriptBehavior:        codersdk.WorkspaceAgentStartupScriptBehavior(dbAgent.StartupScriptBehavior),
 		StartupScriptTimeoutSeconds:  dbAgent.StartupScriptTimeoutSeconds,
 		ShutdownScript:               dbAgent.ShutdownScript.String,


### PR DESCRIPTION
Regrettably, I didn't think about this case when creating the PRs for startup script behavior. If the API is older than the client, then the field may be missing. We now handle it in `codersdk`.
