### PR TITLE
chore: use gcr.io for postgres image in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -630,7 +630,7 @@ test-postgres-docker:
 		--name test-postgres-docker \
 		--restart no \
 		--detach \
-		postgres:13 \
+		gcr.io/coder-dev-1/postgres:13 \
 		-c shared_buffers=1GB \
 		-c work_mem=1GB \
 		-c effective_cache_size=1GB \

--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -68,7 +68,7 @@ func main() {
 			"run",
 			"--rm",
 			"--network=host",
-			fmt.Sprintf("postgres:%d", minimumPostgreSQLVersion),
+			fmt.Sprintf("gcr.io/coder-dev-1/postgres:%d", minimumPostgreSQLVersion),
 		}, cmdArgs...)
 	}
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //#nosec


### PR DESCRIPTION
Docker hub was erroring because we hit the free limit