### PR TITLE
docs: add multi git providers to enterprise chart

### DIFF
--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -4,20 +4,20 @@ Coder is free to use and includes some features that are only accessible with a 
 [Contact Sales](https://coder.com/contact) for pricing or [get a free
 trial](https://coder.com/trial).
 
-| Category        | Feature                                                                       | Open Source | Enterprise |
-| --------------- | ----------------------------------------------------------------------------- | :---------: | :--------: |
-| User Management | [Groups](./admin/groups.md)                                                   |     ❌      |     ✅     |
-| User Management | [SCIM](./admin/auth.md#scim)                                                  |     ❌      |     ✅     |
-| Governance      | [Audit Logging](./admin/audit-logs.md)                                        |     ❌      |     ✅     |
-| Governance      | [Browser Only Connections](./networking/#browser-only-connections-enterprise) |     ❌      |     ✅     |
-| Governance      | [Template Access Control](./admin/rbac.md)                                    |     ❌      |     ✅     |
-| Cost Control    | [Quotas](./admin/quotas.md)                                                   |     ❌      |     ✅     |
-| Cost Control    | [Max Workspace Autostop](./templates/#configure-max-workspace-autostop)       |     ❌      |     ✅     |
-| Deployment      | [High Availability](./admin/high-availability.md)                             |     ❌      |     ✅     |
+| Category        | Feature                                                                              | Open Source | Enterprise |
+| --------------- | ------------------------------------------------------------------------------------ | :---------: | :--------: |
+| User Management | [Groups](./admin/groups.md)                                                          |     ❌      |     ✅     |
+| User Management | [SCIM](./admin/auth.md#scim)                                                         |     ❌      |     ✅     |
+| Governance      | [Audit Logging](./admin/audit-logs.md)                                               |     ❌      |     ✅     |
+| Governance      | [Browser Only Connections](./networking/#browser-only-connections-enterprise)        |     ❌      |     ✅     |
+| Governance      | [Template Access Control](./admin/rbac.md)                                           |     ❌      |     ✅     |
+| Cost Control    | [Quotas](./admin/quotas.md)                                                          |     ❌      |     ✅     |
+| Cost Control    | [Max Workspace Autostop](./templates/#configure-max-workspace-autostop)              |     ❌      |     ✅     |
+| Deployment      | [High Availability](./admin/high-availability.md)                                    |     ❌      |     ✅     |
 | Deployment      | [Multiple Git Providers](./admin/git-providers.md#multiple-git-providers-enterprise) |     ❌      |     ✅     |
-| Deployment      | [Appearance](./admin/appearance.md)                                           |     ❌      |     ✅     |
-| Deployment      | [Isolated Terraform Runners](./admin/provisioners.md)                         |     ❌      |     ✅     |
-| Deployment      | [Workspace Proxies](./admin/workspace-proxies.md)                             |     ❌      |     ✅     |
+| Deployment      | [Appearance](./admin/appearance.md)                                                  |     ❌      |     ✅     |
+| Deployment      | [Isolated Terraform Runners](./admin/provisioners.md)                                |     ❌      |     ✅     |
+| Deployment      | [Workspace Proxies](./admin/workspace-proxies.md)                                    |     ❌      |     ✅     |
 
 > Previous plans to restrict OIDC and Git Auth features in OSS have been removed
 > as of 2023-01-11

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -14,6 +14,7 @@ trial](https://coder.com/trial).
 | Cost Control    | [Quotas](./admin/quotas.md)                                                   |     ❌      |     ✅     |
 | Cost Control    | [Max Workspace Autostop](./templates/#configure-max-workspace-autostop)       |     ❌      |     ✅     |
 | Deployment      | [High Availability](./admin/high-availability.md)                             |     ❌      |     ✅     |
+| Deployment      | [Multiple Git Providers](./admin/git-providers.md#multiple-git-providers-enterprise) |     ❌      |     ✅     |
 | Deployment      | [Appearance](./admin/appearance.md)                                           |     ❌      |     ✅     |
 | Deployment      | [Isolated Terraform Runners](./admin/provisioners.md)                         |     ❌      |     ✅     |
 | Deployment      | [Workspace Proxies](./admin/workspace-proxies.md)                             |     ❌      |     ✅     |


### PR DESCRIPTION
multiple git providers was missing from our enterprise feature chart. this PR adds it in.