### PR TITLE
fix: read system certificates into client

### DIFF
--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -167,7 +167,6 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 				ctx,
 				cfg.TLS.ClientCertFile.String(),
 				cfg.TLS.ClientKeyFile.String(),
-				cfg.TLS.ClientCAFile.String(),
 			)
 			if err != nil {
 				return xerrors.Errorf("configure http client: %w", err)


### PR DESCRIPTION
This covers the case where CAs are added into the appropriate directory but not placed into the bundle with something like update-ca-certificates.

1. Rename `configureCAPool` to `configureClientCAPool`.
2. Add `configureRootCAPool`.
3. Call the first for the server and the second for client.
4. Ended up not copying v1; instead used `x509.SystemCertPool()` which appears to do the same thing except for more platforms.  However, see the comment below.
 
Closes https://github.com/coder/coder/issues/7194.