### PR TITLE
fix(coderd): avoid deadlock in `(*logFollower).follow`

### DIFF
--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -318,6 +318,10 @@ func (f *logFollower) follow() {
 			return
 		}
 		defer subCancel()
+		// Move cancel up the stack so it happens before unsubscribing,
+		// otherwise we can end up in a deadlock due to how the
+		// in-memory pubsub does mutex locking on send/unsubscribe.
+		defer cancel()
 
 		// we were provided `complete` prior to starting this subscription, so
 		// we also need to check whether the job is now complete, in case the


### PR DESCRIPTION
https://github.com/coder/coder/actions/runs/5246409984/jobs/9475217767?pr=7934

This is mostly an issue due to in memory pubsub, I doubt it is with postgres, but I could be wrong.

We should re-write publish in the in memory pubsub so that the mutex is not held while calling listeners, but we still need to prevent multiple concurrent calls to them (and ensure order).