### PR TITLE
chore: remove dbtestutil in favor of testutil

### DIFF
--- a/cli/clitest/golden.go
+++ b/cli/clitest/golden.go
@@ -18,7 +18,6 @@ import (
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/config"
 	"github.com/coder/coder/coderd/coderdtest"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/testutil"
 )
@@ -177,7 +176,7 @@ func prepareTestData(t *testing.T) (*codersdk.Client, map[string]string) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	db, pubsub := dbtestutil.NewDB(t)
+	db, pubsub := testutil.NewDB(t)
 	rootClient := coderdtest.New(t, &coderdtest.Options{
 		Database:                 db,
 		Pubsub:                   pubsub,

--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coder/coder/coderd/audit"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/database"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/testutil"
 )
@@ -150,7 +149,7 @@ func TestSessionExpiry(t *testing.T) {
 	defer cancel()
 	dc := coderdtest.DeploymentValues(t)
 
-	db, pubsub := dbtestutil.NewDB(t)
+	db, pubsub := testutil.NewDB(t)
 	adminClient := coderdtest.New(t, &coderdtest.Options{
 		DeploymentValues: dc,
 		Database:         db,

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -58,7 +58,6 @@ import (
 	"github.com/coder/coder/coderd/awsidentity"
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/dbauthz"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/coderd/gitauth"
 	"github.com/coder/coder/coderd/gitsshkey"
 	"github.com/coder/coder/coderd/healthcheck"
@@ -203,7 +202,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	}
 
 	if options.Database == nil {
-		options.Database, options.Pubsub = dbtestutil.NewDB(t)
+		options.Database, options.Pubsub = testutil.NewDB(t)
 		options.Database = dbauthz.New(options.Database, options.Authorizer, slogtest.Make(t, nil).Leveled(slog.LevelDebug))
 	}
 

--- a/coderd/httpmw/authorize_test.go
+++ b/coderd/httpmw/authorize_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/tabbed/pqtype"
 
 	"github.com/coder/coder/coderd/database"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/testutil"
 )
 
 func TestExtractUserRoles(t *testing.T) {
@@ -112,7 +112,7 @@ func TestExtractUserRoles(t *testing.T) {
 			t.Parallel()
 
 			var (
-				db, _                 = dbtestutil.NewDB(t)
+				db, _                 = testutil.NewDB(t)
 				user, expRoles, token = c.AddUser(db)
 				rw                    = httptest.NewRecorder()
 				rtr                   = chi.NewRouter()

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/dbgen"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/testutil"
 )
@@ -866,7 +865,7 @@ func TestUserLogout(t *testing.T) {
 
 	// Create a custom database so it's easier to make scoped tokens for
 	// testing.
-	db, pubSub := dbtestutil.NewDB(t)
+	db, pubSub := testutil.NewDB(t)
 
 	client := coderdtest.New(t, &coderdtest.Options{
 		Database: db,

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/dbgen"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/coderd/workspaceapps"
 	"github.com/coder/coder/coderd/workspaceapps/apptest"
@@ -185,7 +184,7 @@ func TestWorkspaceApplicationAuth(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			db, pubsub := dbtestutil.NewDB(t)
+			db, pubsub := testutil.NewDB(t)
 
 			accessURL, err := url.Parse(c.accessURL)
 			require.NoError(t, err)

--- a/coderd/workspaceproxies_test.go
+++ b/coderd/workspaceproxies_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/coderd/coderdtest"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/testutil"
 )
@@ -19,7 +18,7 @@ func TestRegions(t *testing.T) {
 		t.Parallel()
 		const appHostname = "*.apps.coder.test"
 
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		deploymentID := uuid.New()
 
 		ctx := testutil.Context(t, testutil.WaitLong)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/dbauthz"
 	"github.com/coder/coder/coderd/database/dbgen"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/coderd/database/dbtype"
 	"github.com/coder/coder/coderd/parameter"
 	"github.com/coder/coder/coderd/rbac"
@@ -573,7 +572,7 @@ func TestWorkspaceFilterAllStatus(t *testing.T) {
 	// For this test, we do not care about permissions.
 	// nolint:gocritic // unit testing
 	ctx := dbauthz.AsSystemRestricted(context.Background())
-	db, pubsub := dbtestutil.NewDB(t)
+	db, pubsub := testutil.NewDB(t)
 	client := coderdtest.New(t, &coderdtest.Options{
 		Database: db,
 		Pubsub:   pubsub,

--- a/enterprise/coderd/replicas_test.go
+++ b/enterprise/coderd/replicas_test.go
@@ -11,7 +11,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 
 	"github.com/coder/coder/coderd/coderdtest"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/enterprise/coderd/license"
@@ -22,7 +21,7 @@ func TestReplicas(t *testing.T) {
 	t.Parallel()
 	t.Run("ErrorWithoutLicense", func(t *testing.T) {
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		firstClient := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				IncludeProvisionerDaemon: true,
@@ -49,7 +48,7 @@ func TestReplicas(t *testing.T) {
 	})
 	t.Run("ConnectAcrossMultiple", func(t *testing.T) {
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		firstClient := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				IncludeProvisionerDaemon: true,
@@ -91,7 +90,7 @@ func TestReplicas(t *testing.T) {
 	})
 	t.Run("ConnectAcrossMultipleTLS", func(t *testing.T) {
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		certificates := []tls.Certificate{testutil.GenerateTLSCertificate(t, "localhost")}
 		firstClient := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -18,7 +18,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/agent"
 	"github.com/coder/coder/coderd/coderdtest"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/coderd/workspaceapps"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/codersdk/agentsdk"
@@ -43,7 +42,7 @@ func TestRegions(t *testing.T) {
 			"*",
 		}
 
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 
 		client := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -87,7 +86,7 @@ func TestRegions(t *testing.T) {
 			"*",
 		}
 
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 
 		client, closer, api := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -181,7 +180,7 @@ func TestRegions(t *testing.T) {
 			"*",
 		}
 
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 
@@ -336,7 +335,7 @@ func TestIssueSignedAppToken(t *testing.T) {
 		"*",
 	}
 
-	db, pubsub := dbtestutil.NewDB(t)
+	db, pubsub := testutil.NewDB(t)
 	client := coderdenttest.New(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{
 			DeploymentValues:         dv,
@@ -444,7 +443,7 @@ func TestReconnectingPTYSignedToken(t *testing.T) {
 		"*",
 	}
 
-	db, pubsub := dbtestutil.NewDB(t)
+	db, pubsub := testutil.NewDB(t)
 	client, closer, api := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{
 			DeploymentValues:         dv,

--- a/enterprise/replicasync/replicasync_test.go
+++ b/enterprise/replicasync/replicasync_test.go
@@ -17,7 +17,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/dbfake"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/enterprise/replicasync"
 	"github.com/coder/coder/testutil"
 )
@@ -31,7 +30,7 @@ func TestReplica(t *testing.T) {
 	t.Run("CreateOnNew", func(t *testing.T) {
 		// This ensures that a new replica is created on New.
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		closeChan := make(chan struct{}, 1)
 		cancel, err := pubsub.Subscribe(replicasync.PubsubEvent, func(ctx context.Context, message []byte) {
 			closeChan <- struct{}{}
@@ -54,7 +53,7 @@ func TestReplica(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer srv.Close()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		peer, err := db.InsertReplica(context.Background(), database.InsertReplicaParams{
 			ID:           uuid.New(),
 			CreatedAt:    database.Now(),
@@ -96,7 +95,7 @@ func TestReplica(t *testing.T) {
 		srv.TLS = tlsConfig
 		srv.StartTLS()
 		defer srv.Close()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		peer, err := db.InsertReplica(context.Background(), database.InsertReplicaParams{
 			ID:           uuid.New(),
 			CreatedAt:    database.Now(),
@@ -120,7 +119,7 @@ func TestReplica(t *testing.T) {
 	})
 	t.Run("ConnectsToFakePeerWithError", func(t *testing.T) {
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		peer, err := db.InsertReplica(context.Background(), database.InsertReplicaParams{
 			ID:        uuid.New(),
 			CreatedAt: database.Now().Add(time.Minute),
@@ -147,7 +146,7 @@ func TestReplica(t *testing.T) {
 	t.Run("RefreshOnPublish", func(t *testing.T) {
 		// Refresh when a new replica appears!
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		ctx, cancelCtx := context.WithCancel(context.Background())
 		defer cancelCtx()
 		server, err := replicasync.New(ctx, slogtest.Make(t, nil), db, pubsub, nil)
@@ -174,7 +173,7 @@ func TestReplica(t *testing.T) {
 	})
 	t.Run("DeletesOld", func(t *testing.T) {
 		t.Parallel()
-		db, pubsub := dbtestutil.NewDB(t)
+		db, pubsub := testutil.NewDB(t)
 		_, err := db.InsertReplica(context.Background(), database.InsertReplicaParams{
 			ID:        uuid.New(),
 			UpdatedAt: database.Now().Add(-time.Hour),

--- a/enterprise/tailnet/coordinator_test.go
+++ b/enterprise/tailnet/coordinator_test.go
@@ -11,7 +11,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 
 	"github.com/coder/coder/coderd/database"
-	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/enterprise/tailnet"
 	agpl "github.com/coder/coder/tailnet"
 	"github.com/coder/coder/testutil"
@@ -168,7 +167,7 @@ func TestCoordinatorHA(t *testing.T) {
 	t.Run("AgentWithClient", func(t *testing.T) {
 		t.Parallel()
 
-		_, pubsub := dbtestutil.NewDB(t)
+		_, pubsub := testutil.NewDB(t)
 
 		coordinator1, err := tailnet.NewCoordinator(slogtest.Make(t, nil), pubsub)
 		require.NoError(t, err)

--- a/testutil/database.go
+++ b/testutil/database.go
@@ -1,4 +1,4 @@
-package dbtestutil
+package testutil
 
 import (
 	"context"


### PR DESCRIPTION
There was no point in having two packages with the same purpose.