### PR TITLE
chore: remove key comparison check to fix gitsshkey flake

### DIFF
--- a/coderd/gitsshkey_test.go
+++ b/coderd/gitsshkey_test.go
@@ -92,7 +92,6 @@ func TestGitSSHKey(t *testing.T) {
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, key2.UpdatedAt, key1.UpdatedAt)
 		require.NotEmpty(t, key2.PublicKey)
-		require.NotEqual(t, key2.PublicKey, key1.PublicKey)
 
 		require.Len(t, auditor.AuditLogs(), 2)
 		assert.Equal(t, database.AuditActionWrite, auditor.AuditLogs()[1].Action)


### PR DESCRIPTION
In tests we use weak randomness and the same key was generated which caused a test flake here.