### PR TITLE
feat(site): add documentation links to webterminal notifications

### DIFF
--- a/site/src/components/WarningAlert/WarningAlert.stories.tsx
+++ b/site/src/components/WarningAlert/WarningAlert.stories.tsx
@@ -1,18 +1,21 @@
-import { Story } from "@storybook/react"
-import { WarningAlert, WarningAlertProps } from "./WarningAlert"
+import { Meta, StoryObj } from "@storybook/react"
+import { WarningAlert } from "./WarningAlert"
 import Button from "@mui/material/Button"
 
-export default {
+const meta: Meta<typeof WarningAlert> = {
   title: "components/WarningAlert",
   component: WarningAlert,
 }
 
-const Template: Story<WarningAlertProps> = (args) => <WarningAlert {...args} />
+export default meta
 
-export const ExampleWithDismiss = Template.bind({})
-ExampleWithDismiss.args = {
-  text: "This is a warning",
-  dismissible: true,
+type Story = StoryObj<typeof WarningAlert>
+
+export const ExampleWithDismiss: Story = {
+  args: {
+    text: "This is a warning",
+    dismissible: true,
+  },
 }
 
 const ExampleAction = (
@@ -21,15 +24,17 @@ const ExampleAction = (
   </Button>
 )
 
-export const ExampleWithAction = Template.bind({})
-ExampleWithAction.args = {
-  text: "This is a warning",
-  actions: [ExampleAction],
+export const ExampleWithAction = {
+  args: {
+    text: "This is a warning",
+    actions: [ExampleAction],
+  },
 }
 
-export const ExampleWithActionAndDismiss = Template.bind({})
-ExampleWithActionAndDismiss.args = {
-  text: "This is a warning",
-  actions: [ExampleAction],
-  dismissible: true,
+export const ExampleWithActionAndDismiss = {
+  args: {
+    text: "This is a warning",
+    actions: [ExampleAction],
+    dismissible: true,
+  },
 }

--- a/site/src/pages/TerminalPage/TerminalPageAlert.stories.tsx
+++ b/site/src/pages/TerminalPage/TerminalPageAlert.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import TerminalPageAlert from "./TerminalPageAlert"
+
+const meta: Meta<typeof TerminalPageAlert> = {
+  component: TerminalPageAlert,
+  title: "components/TerminalPageAlert",
+  argTypes: {
+    alertType: {
+      control: {
+        type: "radio",
+      },
+      options: ["error", "starting", "success"],
+    },
+  },
+}
+type Story = StoryObj<typeof TerminalPageAlert>
+
+export const Error: Story = {
+  args: {
+    alertType: "error",
+  },
+}
+
+export const Starting: Story = {
+  args: {
+    alertType: "starting",
+  },
+}
+
+export const Success: Story = {
+  args: {
+    alertType: "success",
+  },
+}
+
+export default meta

--- a/site/src/pages/TerminalPage/TerminalPageAlert.tsx
+++ b/site/src/pages/TerminalPage/TerminalPageAlert.tsx
@@ -1,4 +1,3 @@
-import RefreshOutlined from "@mui/icons-material/RefreshOutlined"
 import { AlertColor } from "@mui/material/Alert/Alert"
 import Button from "@mui/material/Button"
 import Link from "@mui/material/Link"
@@ -96,8 +95,8 @@ export default ({ alertType }: { alertType: TerminalPageAlertType }) => {
       actions={[
         <Button
           key="refresh-session"
-          startIcon={<RefreshOutlined />}
           size="small"
+          variant="text"
           onClick={() => {
             // By redirecting the user without the session in the URL we
             // create a new one

--- a/site/src/pages/TerminalPage/TerminalPageAlert.tsx
+++ b/site/src/pages/TerminalPage/TerminalPageAlert.tsx
@@ -1,0 +1,114 @@
+import RefreshOutlined from "@mui/icons-material/RefreshOutlined"
+import { AlertColor } from "@mui/material/Alert/Alert"
+import Button from "@mui/material/Button"
+import Link from "@mui/material/Link"
+import { Alert } from "components/Alert/Alert"
+import { ReactNode } from "react"
+
+export type TerminalPageAlertType = "error" | "starting" | "success"
+
+type MapAlertTypeToComponent = {
+  [key in TerminalPageAlertType]: {
+    severity: AlertColor
+    children: ReactNode | undefined
+  }
+}
+
+const mapAlertTypeToText: MapAlertTypeToComponent = {
+  error: {
+    severity: "warning",
+    children: (
+      <>
+        The workspace{" "}
+        <Link
+          title="startup script has exited with an error"
+          href="https://coder.com/docs/v2/latest/templates#startup-script-exited-with-an-error"
+          target="_blank"
+          rel="noreferrer"
+        >
+          startup script has exited with an error
+        </Link>
+        , we recommend reloading this session and{" "}
+        <Link
+          title=" debugging the startup script"
+          href="https://coder.com/docs/v2/latest/templates#debugging-the-startup-script"
+          target="_blank"
+          rel="noreferrer"
+        >
+          debugging the startup script
+        </Link>{" "}
+        because{" "}
+        <Link
+          title="your workspace may be incomplete."
+          href="https://coder.com/docs/v2/latest/templates#your-workspace-may-be-incomplete"
+          target="_blank"
+          rel="noreferrer"
+        >
+          your workspace may be incomplete.
+        </Link>{" "}
+      </>
+    ),
+  },
+  starting: {
+    severity: "info",
+    children: (
+      <>
+        Startup script is still running. You can continue using this terminal,
+        but{" "}
+        <Link
+          title="your workspace may be incomplete."
+          href="https://coder.com/docs/v2/latest/templates#your-workspace-may-be-incomplete"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {" "}
+          your workspace may be incomplete.
+        </Link>
+      </>
+    ),
+  },
+  success: {
+    severity: "success",
+    children: (
+      <>
+        Startup script has completed successfully. The workspace is ready but
+        this{" "}
+        <Link
+          title="session was started before the startup script finished"
+          href="https://coder.com/docs/v2/latest/templates#your-workspace-may-be-incomplete"
+          target="_blank"
+          rel="noreferrer"
+        >
+          session was started before the startup script finished.
+        </Link>{" "}
+        To ensure your shell environment is up-to-date, we recommend reloading
+        this session.
+      </>
+    ),
+  },
+}
+
+export default ({ alertType }: { alertType: TerminalPageAlertType }) => {
+  return (
+    <Alert
+      severity={mapAlertTypeToText[alertType].severity}
+      dismissible
+      actions={[
+        <Button
+          key="refresh-session"
+          startIcon={<RefreshOutlined />}
+          size="small"
+          onClick={() => {
+            // By redirecting the user without the session in the URL we
+            // create a new one
+            window.location.href = window.location.pathname
+          }}
+        >
+          Refresh session
+        </Button>,
+      ]}
+    >
+      {mapAlertTypeToText[alertType].children}
+    </Alert>
+  )
+}


### PR DESCRIPTION
Fixes #7760 and #7766 

- refactor web terminal notifications to their own component, leveraging the existing component Alert
- create stories for the new component
- changed notifications to be dismissable
- changed notifications copy and links to documentation
- added code to detect and display a notification for when the startup script finishes running successfully

updated notifications:
<img width="916" alt="image" src="https://github.com/coder/coder/assets/2081077/41739ac6-d149-46b2-95a3-f77d8af9c1e4">
<img width="906" alt="image" src="https://github.com/coder/coder/assets/2081077/9a1afe23-a49b-4f46-be8a-96de1b16a133">

new notification:
<img width="887" alt="image" src="https://github.com/coder/coder/assets/2081077/9222696f-715f-406f-913d-bb7e7398d5eb">
