### PR TITLE
fix: fix --header flag in CLI

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -256,7 +256,8 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	var handler http.Handler
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mutex.RLock()
-		defer mutex.RUnlock()
+		handler := handler
+		mutex.RUnlock()
 		if handler != nil {
 			handler.ServeHTTP(w, r)
 		}

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -85,9 +85,8 @@ var loggableMimeTypes = map[string]struct{}{
 // New creates a Coder client for the provided URL.
 func New(serverURL *url.URL) *Client {
 	return &Client{
-		URL:          serverURL,
-		HTTPClient:   &http.Client{},
-		ExtraHeaders: make(http.Header),
+		URL:        serverURL,
+		HTTPClient: &http.Client{},
 	}
 }
 
@@ -96,9 +95,6 @@ func New(serverURL *url.URL) *Client {
 type Client struct {
 	mu           sync.RWMutex // Protects following.
 	sessionToken string
-
-	// ExtraHeaders are headers to add to every request.
-	ExtraHeaders http.Header
 
 	HTTPClient *http.Client
 	URL        *url.URL
@@ -192,8 +188,6 @@ func (c *Client) Request(ctx context.Context, method, path string, body interfac
 	if err != nil {
 		return nil, xerrors.Errorf("create request: %w", err)
 	}
-
-	req.Header = c.ExtraHeaders.Clone()
 
 	tokenHeader := c.SessionTokenHeader
 	if tokenHeader == "" {

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/creack/pty v1.1.18
+	github.com/dave/dst v0.27.2
 	github.com/elastic/go-sysinfo v1.11.0
 	github.com/fatih/color v1.15.0
 	github.com/fatih/structs v1.1.0
@@ -189,6 +190,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
@@ -206,6 +208,7 @@ require (
 	github.com/charmbracelet/bubbles v0.15.0 // indirect
 	github.com/charmbracelet/bubbletea v0.23.2 // indirect
 	github.com/clbanning/mxj/v2 v2.5.7 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/coreos/go-iptables v0.6.0 // indirect
@@ -217,6 +220,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/elastic/go-windows v1.0.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-gonic/gin v1.9.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -227,6 +231,7 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-test/deep v1.0.8 // indirect
 	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect
@@ -317,6 +322,7 @@ require (
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/tcnksm/go-httpstat v0.2.0 // indirect
 	github.com/tdewolff/parse/v2 v2.6.6 // indirect
+	github.com/tdewolff/test v1.0.9 // indirect
 	github.com/u-root/uio v0.0.0-20221213070652-c3537552635f // indirect
 	github.com/vishvananda/netlink v1.1.1-0.20211118161826-650dca95af54 // indirect
 	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect
@@ -346,22 +352,9 @@ require (
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	howett.net/plist v1.0.0 // indirect
 	inet.af/peercred v0.0.0-20210906144145-0893ea02156a // indirect
-)
-
-require (
-	github.com/dave/dst v0.27.2
-	github.com/gobwas/httphead v0.1.0
-)
-
-require (
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
-	github.com/cloudflare/circl v1.3.3 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
-	github.com/go-test/deep v1.0.8 // indirect
-	github.com/tdewolff/test v1.0.9 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
 )


### PR DESCRIPTION
The `--header` flag was changed from `key=value` to `key:value` in https://github.com/coder/coder/commit/43eee35ae8c974be02ea06da6707270623acb871 which is a breaking change.

This PR reverts the behavior to `key=value` as there doesn't seem to be a good reason for the breaking change.

The `ExtraHeaders` field is removed from `codersdk.Client` to match the prior behavior and to reduce the amount of ways headers can be set in the SDK to avoid confusion.

This regression would've been caught by an existing test, but the test was faulty and didn't catch the issue. The test has been fixed and improved, and a test has been added to make sure headers are sent to the DERP server to avoid breaking https://github.com/coder/coder/pull/6572.

Fixes #8021
Fixes https://github.com/coder/v2-customers/issues/203