### PR TITLE
docs: add steps for configuring trusted headers & origins in Helm chart

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -133,6 +133,21 @@ to log in and manage templates.
     }
    ```
 
+   By default, Coder will set the `externalTrafficPolicy` to `Cluster` which will
+   mask client IP addresses in the Audit log. To preserve the source IP, you can either
+   set this value to `Local`, or pass through the client IP via the X-Forwarded-For
+   header. To configure the latter, set the following environment
+   variables:
+
+  ```yaml
+  coder:
+    env:
+    - name: CODER_PROXY_TRUSTED_HEADERS
+      value: X-Forwarded-For
+    - name: CODER_PROXY_TRUSTED_ORIGINS
+      value: 10.0.0.1/8 # this will be the CIDR range of your Load Balancer IP address
+  ```
+
 1. Run the following command to install the chart in your cluster.
 
    ```console

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -121,6 +121,8 @@ to log in and manage templates.
        sessionAffinity: None
    ```
 
+### Load balancing considerations
+
    AWS however recommends a Network load balancer in lieu of the Classic load balancer. Use the following `values.yaml` settings to request a Network load balancer:
 
    ```yaml

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -123,23 +123,23 @@ to log in and manage templates.
 
 ### Load balancing considerations
 
-   AWS however recommends a Network load balancer in lieu of the Classic load balancer. Use the following `values.yaml` settings to request a Network load balancer:
+AWS however recommends a Network load balancer in lieu of the Classic load balancer. Use the following `values.yaml` settings to request a Network load balancer:
 
-   ```yaml
-   coder:
-      service:
-      externalTrafficPolicy: Local
-      sessionAffinity: None
-      annotations: {
-         service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    }
-   ```
+```yaml
+coder:
+   service:
+   externalTrafficPolicy: Local
+   sessionAffinity: None
+   annotations: {
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+ }
+```
 
-   By default, Coder will set the `externalTrafficPolicy` to `Cluster` which will
-   mask client IP addresses in the Audit log. To preserve the source IP, you can either
-   set this value to `Local`, or pass through the client IP via the X-Forwarded-For
-   header. To configure the latter, set the following environment
-   variables:
+By default, Coder will set the `externalTrafficPolicy` to `Cluster` which will
+mask client IP addresses in the Audit log. To preserve the source IP, you can either
+set this value to `Local`, or pass through the client IP via the X-Forwarded-For
+header. To configure the latter, set the following environment
+variables:
 
 ```yaml
 coder:

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -139,14 +139,14 @@ to log in and manage templates.
    header. To configure the latter, set the following environment
    variables:
 
-  ```yaml
-  coder:
-    env:
+```yaml
+coder:
+  env:
     - name: CODER_PROXY_TRUSTED_HEADERS
       value: X-Forwarded-For
     - name: CODER_PROXY_TRUSTED_ORIGINS
       value: 10.0.0.1/8 # this will be the CIDR range of your Load Balancer IP address
-  ```
+```
 
 1. Run the following command to install the chart in your cluster.
 


### PR DESCRIPTION
this PR documents steps for setting the `X-Forwarded-For` header and trusted proxy origins in the Helm chart. our [v1 Helm chart supports this natively](https://github.com/coder/enterprise-helm/blob/b096a369fe2d1b2de75a0b85af01fa9e272b221e/values.yaml#L101-L118).

a customer struggled to find documentation on this, as they were looking to preserve the client IP in the audit logs while maintaining a `Cluster` level `externalTrafficPolicy`.