### PR TITLE
fix(helm): use /healthz for liveness and readiness probes instead of /api/v2/buildinfo

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -126,12 +126,12 @@ spec:
           securityContext: {{ toYaml .Values.coder.securityContext | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           livenessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           {{- include "coder.volumeMounts" . | nindent 10 }}

--- a/helm/tests/testdata/default_values.golden
+++ b/helm/tests/testdata/default_values.golden
@@ -173,12 +173,12 @@ spec:
               type: RuntimeDefault
           readinessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           livenessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           volumeMounts: []

--- a/helm/tests/testdata/labels_annotations.golden
+++ b/helm/tests/testdata/labels_annotations.golden
@@ -179,12 +179,12 @@ spec:
               type: RuntimeDefault
           readinessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           livenessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           volumeMounts: []

--- a/helm/tests/testdata/sa.golden
+++ b/helm/tests/testdata/sa.golden
@@ -173,12 +173,12 @@ spec:
               type: RuntimeDefault
           readinessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           livenessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           volumeMounts: []

--- a/helm/tests/testdata/tls.golden
+++ b/helm/tests/testdata/tls.golden
@@ -188,12 +188,12 @@ spec:
               type: RuntimeDefault
           readinessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           livenessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           volumeMounts:

--- a/helm/tests/testdata/workspace_proxy.golden
+++ b/helm/tests/testdata/workspace_proxy.golden
@@ -181,12 +181,12 @@ spec:
               type: RuntimeDefault
           readinessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           livenessProbe:
             httpGet:
-              path: /api/v2/buildinfo
+              path: /healthz
               port: "http"
               scheme: "HTTP"
           volumeMounts: []


### PR DESCRIPTION
Using /api/v2/buildinfo will cause the pod to fail liveness checks if the database is temporarily unavailable.

Apparently the /healthz endpoint was handled by the UI at one point.
This no longer appears to be the case, as we do have a dedicated [/healthz](https://github.com/coder/coder/blob/cj/helm-healthz/coderd/coderd.go#L445) endpoint for a while now.