### PR TITLE
ci: fix commit type prefix regexp in release script

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -45,7 +45,7 @@ main() {
 	# If a commit contains this title prefix or the source PR contains the
 	# label, patch releases will not be allowed.
 	# This regex matches both `feat!:` and `feat(site)!:`.
-	breaking_title="^[a-z]+(\([a-z]*\))?!:"
+	breaking_title="^[a-z]+(\([^)]+\))?!:"
 	breaking_label=release/breaking
 	breaking_category=breaking
 	experimental_label=release/experimental

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -40,7 +40,7 @@ ignore_missing_metadata=${CODER_IGNORE_MISSING_COMMIT_METADATA:-0}
 
 main() {
 	# Match a commit prefix pattern, e.g. feat: or feat(site):.
-	prefix_pattern="^([a-z]+)(\([^)]*\))?:"
+	prefix_pattern="^([a-z]+)(\([^)]+\))?:"
 
 	# If a commit contains this title prefix or the source PR contains the
 	# label, patch releases will not be allowed.

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -40,7 +40,7 @@ ignore_missing_metadata=${CODER_IGNORE_MISSING_COMMIT_METADATA:-0}
 
 main() {
 	# Match a commit prefix pattern, e.g. feat: or feat(site):.
-	prefix_pattern="^([a-z]+)(\([a-z]*\))?:"
+	prefix_pattern="^([a-z]+)(\([^)]*\))?:"
 
 	# If a commit contains this title prefix or the source PR contains the
 	# label, patch releases will not be allowed.


### PR DESCRIPTION
Previously we were incorrectly categorizing `fix(a/b): ...` as other
because the regexp only expected letters, not `/`. Now we accept any
input within the parenthesis.
