### PR TITLE
fix: strip CORS headers from applications

### DIFF
--- a/coderd/httpmw/cors.go
+++ b/coderd/httpmw/cors.go
@@ -10,6 +10,20 @@ import (
 	"github.com/coder/coder/coderd/httpapi"
 )
 
+const (
+	// Server headers.
+	AccessControlAllowOriginHeader      = "Access-Control-Allow-Origin"
+	AccessControlAllowCredentialsHeader = "Access-Control-Allow-Credentials"
+	AccessControlAllowMethodsHeader     = "Access-Control-Allow-Methods"
+	AccessControlAllowHeadersHeader     = "Access-Control-Allow-Headers"
+	VaryHeader                          = "Vary"
+
+	// Client headers.
+	OriginHeader                      = "Origin"
+	AccessControlRequestMethodsHeader = "Access-Control-Request-Methods"
+	AccessControlRequestHeadersHeader = "Access-Control-Request-Headers"
+)
+
 //nolint:revive
 func Cors(allowAll bool, origins ...string) func(next http.Handler) http.Handler {
 	if len(origins) == 0 {

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -124,12 +124,12 @@ will echo whatever the request sends.
 
 These cross-origin headers are not configurable by administrative settings.
 
-Applications can set their own headers which will override the defaults but this
-will only apply to non-preflight requests. Preflight requests through the
-dashboard are never sent to applications and thus cannot be modified by
-them. Read more about the difference between simple requests and requests that
-trigger preflights
-[here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests).
+If applications set any of the above headers they will be stripped from the
+response except for `Vary` headers that are set to a value other than the ones
+listed above.
+
+In other words, CORS behavior through the dashboard is not currently
+configurable by either admins or users.
 
 #### Allowed by default
 


### PR DESCRIPTION
This is a followup to https://github.com/coder/coder/pull/7688

The problem is that if applications send their own CORS headers the headers get doubled up (not overwritten) and browsers do not like multiple values for the allowed origin even though it appears the spec allows for it.

We could prefer the application's headers instead of ours but since we control OPTIONS I think preferring ours will by the more consistent experience across the board and also aligns with the original RFC.

Closes https://github.com/coder/coder/issues/8010.