### PR TITLE
chore: add benchmark for prometheusmetrics.MetricsAggregator

### DIFF
--- a/coderd/prometheusmetrics/aggregator_test.go
+++ b/coderd/prometheusmetrics/aggregator_test.go
@@ -181,7 +181,7 @@ func TestUpdateMetrics_MetricsExpire(t *testing.T) {
 func Benchmark_MetricsAggregator_Run(b *testing.B) {
 	// Number of metrics to generate and send in each iteration.
 	// Hard-coded to 1024 to avoid overflowing the queue in the metrics aggregator.
-	var numMetrics = 1024
+	numMetrics := 1024
 
 	// given
 	registry := prometheus.NewRegistry()


### PR DESCRIPTION
```
$ go test -run=XXX -bench=. -benchmem
goos: linux
goarch: amd64
pkg: github.com/coder/coder/coderd/prometheusmetrics
cpu: AMD EPYC 7502P 32-Core Processor               
Benchmark_MetricsAggregator_Run-16            44          43735448 ns/op         1297092 B/op      31282 allocs/op
--- BENCH: Benchmark_MetricsAggregator_Run-16
    aggregator_test.go:214: N=1 generating 1024 metrics
    aggregator_test.go:220: N=1 sending 1024 metrics
    aggregator_test.go:233: N=1 got 1024 metrics
    aggregator_test.go:214: N=44 generating 1024 metrics
    aggregator_test.go:220: N=44 sending 1024 metrics
    aggregator_test.go:233: N=44 got 1024 metrics
    aggregator_test.go:214: N=44 generating 1024 metrics
    aggregator_test.go:220: N=44 sending 1024 metrics
    aggregator_test.go:233: N=44 got 1024 metrics
    aggregator_test.go:214: N=44 generating 1024 metrics
        ... [output truncated]
PASS
ok      github.com/coder/coder/coderd/prometheusmetrics 3.020s
```