### PR TITLE
fix(agent): refactor `trackScriptLogs` to avoid deadlock

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1035,7 +1035,7 @@ func (a *agent) trackScriptLogs(ctx context.Context, reader io.ReadCloser) (chan
 			queue = nil
 		}
 		if err := s.Err(); err != nil {
-			a.logger.Error(ctx, "scan startup logs failed", slog.Error(err))
+			a.logger.Warn(ctx, "scan startup logs ended unexpectedly", slog.Error(err))
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
During agent close it was possible for the startup script logs consumer
to enter a deadlock state where by agent close was waiting via
`a.trackConnGoroutine` and the log reader for a flush event.

This refactor removes the mutex in favor of channel communication and
relies on two goroutines without shared state.

https://github.com/coder/coder/actions/runs/5313851600/jobs/9620310022?pr=8082

**NOTE:** Observe PR target is not `main`.