### PR TITLE
test(cli): remove assertion for non-zero host CPU usage

### DIFF
--- a/cli/clistat/stat_internal_test.go
+++ b/cli/clistat/stat_internal_test.go
@@ -69,7 +69,7 @@ func TestStatter(t *testing.T) {
 			t.Parallel()
 			cpu, err := s.HostCPU()
 			require.NoError(t, err)
-			assert.NotZero(t, cpu.Used)
+			// assert.NotZero(t, cpu.Used) // HostCPU can sometimes be zero.
 			assert.NotZero(t, cpu.Total)
 			assert.Equal(t, "cores", cpu.Unit)
 		})

--- a/cli/stat_test.go
+++ b/cli/stat_test.go
@@ -95,7 +95,7 @@ func TestStatCPUCmd(t *testing.T) {
 		s := buf.String()
 		tmp := clistat.Result{}
 		require.NoError(t, json.NewDecoder(strings.NewReader(s)).Decode(&tmp))
-		require.NotZero(t, tmp.Used)
+		// require.NotZero(t, tmp.Used) // Host CPU can sometimes be zero.
 		require.NotNil(t, tmp.Total)
 		require.NotZero(t, *tmp.Total)
 		require.Equal(t, "cores", tmp.Unit)


### PR DESCRIPTION
Apparently host CPU usage is sometimes zero in an 100-millisecond interval. 

Fixes #8091.