### PR TITLE
chore: restyle provisioner job output format

### DIFF
--- a/cmd/cliui/main.go
+++ b/cmd/cliui/main.go
@@ -272,7 +272,7 @@ func main() {
 		},
 	})
 
-	err := root.Invoke(os.Args[1:]...).Run()
+	err := root.Invoke(os.Args[1:]...).WithOS().Run()
 	if err != nil {
 		_, _ = fmt.Println(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Reduce colors and formatting to reduce bugs and increase UNIX feel.

When I initially made this, I tried it make it _pretty_, but it was just buggy, and I'm not sure anyone wants pretty.

New output:

```bash
dev ~/p/c/coder (mergegen *s =) go run ./cmd/cliui job
==> ⧗ Queued
Some log 0
Some log 1
Some log 2
Some log 3
Some log 4
Some log 5
Some log 6
Some log 7
Some log 8
Some log 9
=== ✔ Queued [1100ms]
==> ⧗ Setting Up
Some log 11
Some log 12
Some log 13
Some log 14
Some log 15
Some log 16
Some log 17
Some log 18
Some log 19
=== ✔ Setting Up [1000ms]
==> ⧗ Executing Hook
Some log 21
Some log 22
Some log 23
Some log 24
Some log 25
Some log 26
Some log 27
Some log 28
Some log 29
=== ✔ Executing Hook [1000ms]
==> ⧗ Parsing Variables
Some log 31
Some log 32
Some log 33
Some log 34
Some log 35
Some log 36
Some log 37
Some log 38
=== ✔ Parsing Variables [899ms]
```