### PR TITLE
feat(helm): add `coder.command` to control pod command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -359,16 +359,3 @@ require (
 	howett.net/plist v1.0.0 // indirect
 	inet.af/peercred v0.0.0-20210906144145-0893ea02156a // indirect
 )
-
-require (
-	github.com/dave/dst v0.27.2
-	github.com/gobwas/httphead v0.1.0
-)
-
-require (
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
-	github.com/cloudflare/circl v1.3.3 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
-)

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -61,7 +61,7 @@ spec:
           image: {{ include "coder.image" . | quote }}
           imagePullPolicy: {{ .Values.coder.image.pullPolicy }}
           command:
-            - /opt/coder
+            {{- toYaml .Values.coder.command | nindent 12 }}
           args:
             {{- if .Values.coder.workspaceProxy }}
             - wsproxy

--- a/helm/tests/chart_test.go
+++ b/helm/tests/chart_test.go
@@ -48,6 +48,10 @@ var TestCases = []TestCase{
 		name:          "workspace_proxy",
 		expectedError: "",
 	},
+	{
+		name:          "command",
+		expectedError: "",
+	},
 }
 
 type TestCase struct {

--- a/helm/tests/testdata/command.golden
+++ b/helm/tests/testdata/command.golden
@@ -1,0 +1,185 @@
+---
+# Source: coder/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "coder"
+  annotations: 
+    {}
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder"
+subjects:
+  - kind: ServiceAccount
+    name: "coder"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-workspace-perms
+---
+# Source: coder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  sessionAffinity: ClientIP
+  ports:
+    - name: "http"
+      port: 80
+      targetPort: "http"
+      protocol: TCP
+  externalTrafficPolicy: "Cluster"
+  selector:
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+---
+# Source: coder/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations: 
+    {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coder
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: coder-0.1.0
+        app.kubernetes.io/name: coder
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/part-of: coder
+        app.kubernetes.io/version: "0.1.0"
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        {}
+    spec:
+      serviceAccountName: "coder"
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - coder
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+        - name: coder
+          image: "ghcr.io/coder/coder:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/colin
+          args:
+            - server
+          resources:
+            {}
+          lifecycle:
+            {}
+          env:
+            - name: CODER_HTTP_ADDRESS
+              value: "0.0.0.0:8080"
+            - name: CODER_PROMETHEUS_ADDRESS
+              value: "0.0.0.0:2112"
+            # Set the default access URL so a `helm apply` works by default.
+            # See: https://github.com/coder/coder/issues/5024
+            - name: CODER_ACCESS_URL
+              value: "http://coder.default.svc.cluster.local"
+            # Used for inter-pod communication with high-availability.
+            - name: KUBE_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: CODER_DERP_SERVER_RELAY_URL
+              value: "http://$(KUBE_POD_IP):8080"
+            
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: TCP
+          securityContext: 
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: null
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: "http"
+              scheme: "HTTP"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: "http"
+              scheme: "HTTP"
+          volumeMounts: []
+      volumes: []

--- a/helm/tests/testdata/command.yaml
+++ b/helm/tests/testdata/command.yaml
@@ -1,0 +1,5 @@
+coder:
+  image:
+    tag: latest
+  command:
+    - /opt/colin

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -269,6 +269,11 @@ coder:
       # use for the wildcard host.
       wildcardSecretName: ""
 
+  # coder.command -- The command to use when running the Coder container. Used
+  # for customizing the location of the `coder` binary in your image.
+  command:
+    - /opt/coder
+
 # extraTemplates -- Array of extra objects to deploy with the release. Strings
 # are evaluated as a template and can use template expansions and functions. All
 # other objects are used as yaml.


### PR DESCRIPTION
Closes: https://github.com/coder/coder/issues/7869

Useful when the `coder` binary is in a different location.