### PR TITLE
fix(site): display correct user_limit on license ui

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1006,7 +1006,7 @@ export const getWorkspaceBuildParameters = async (
   return response.data
 }
 type Claims = {
-  license_expires?: number
+  license_expires: number
   account_type?: string
   account_id?: string
   trial: boolean

--- a/site/src/components/LicenseCard/LicenseCard.test.tsx
+++ b/site/src/components/LicenseCard/LicenseCard.test.tsx
@@ -1,0 +1,70 @@
+import { screen } from "@testing-library/react"
+import { render } from "../../testHelpers/renderHelpers"
+import { LicenseCard } from "./LicenseCard"
+import { MockLicenseResponse } from "testHelpers/entities"
+
+describe("LicenseCard", () => {
+  it("renders (smoke test)", async () => {
+    // When
+    render(
+      <LicenseCard
+        license={MockLicenseResponse[0]}
+        userLimitActual={1}
+        userLimitLimit={10}
+        onRemove={() => null}
+        isRemoving={false}
+      />,
+    )
+
+    // Then
+    await screen.findByText("#1")
+    await screen.findByText("1 / 10")
+    await screen.findByText("Enterprise")
+  })
+
+  it("renders userLimit as unlimited if there is not user limit", async () => {
+    // When
+    render(
+      <LicenseCard
+        license={MockLicenseResponse[0]}
+        userLimitActual={1}
+        userLimitLimit={undefined}
+        onRemove={() => null}
+        isRemoving={false}
+      />,
+    )
+
+    // Then
+    await screen.findByText("#1")
+    await screen.findByText("1 / Unlimited")
+    await screen.findByText("Enterprise")
+  })
+
+  it("renders license's user_limit when it is available instead of using the default", async () => {
+    const licenseUserLimit = 3
+    const license = {
+      ...MockLicenseResponse[0],
+      claims: {
+        ...MockLicenseResponse[0].claims,
+        features: {
+          ...MockLicenseResponse[0].claims.features,
+          user_limit: licenseUserLimit,
+        },
+      },
+    }
+
+    // When
+    render(
+      <LicenseCard
+        license={license}
+        userLimitActual={1}
+        userLimitLimit={100} // This should not be used
+        onRemove={() => null}
+        isRemoving={false}
+      />,
+    )
+
+    // Then
+    await screen.findByText("1 / 3")
+  })
+})

--- a/site/src/components/LicenseCard/LicenseCard.tsx
+++ b/site/src/components/LicenseCard/LicenseCard.tsx
@@ -1,16 +1,16 @@
 import Button from "@mui/material/Button"
 import Paper from "@mui/material/Paper"
 import { makeStyles } from "@mui/styles"
-import { License } from "api/typesGenerated"
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog"
 import { Stack } from "components/Stack/Stack"
 import dayjs from "dayjs"
 import { useState } from "react"
 import { Pill } from "components/Pill/Pill"
 import { compareAsc } from "date-fns"
+import { GetLicensesResponse } from "api/api"
 
 type LicenseCardProps = {
-  license: License
+  license: GetLicensesResponse
   userLimitActual?: number
   userLimitLimit?: number
   onRemove: (licenseId: number) => void
@@ -29,6 +29,9 @@ export const LicenseCard = ({
   const [licenseIDMarkedForRemoval, setLicenseIDMarkedForRemoval] = useState<
     number | undefined
   >(undefined)
+
+  const currentUserLimit =
+    license.claims.features["user_limit"] || userLimitLimit
 
   return (
     <Paper key={license.id} elevation={2} className={styles.licenseCard}>
@@ -72,7 +75,7 @@ export const LicenseCard = ({
           <Stack direction="column" spacing={0} alignItems="center">
             <span className={styles.secondaryMaincolor}>Users</span>
             <span className={styles.userLimit}>
-              {userLimitActual} {` / ${userLimitLimit || "Unlimited"}`}
+              {userLimitActual} {` / ${currentUserLimit || "Unlimited"}`}
             </span>
           </Stack>
           <Stack
@@ -82,7 +85,7 @@ export const LicenseCard = ({
             width="134px" // standardize width of date column
           >
             {compareAsc(
-              new Date(license.claims.license_expires * 1000),
+              new Date((license.claims.license_expires as number) * 1000),
               new Date(),
             ) < 1 ? (
               <Pill
@@ -95,7 +98,7 @@ export const LicenseCard = ({
             )}
             <span className={styles.licenseExpires}>
               {dayjs
-                .unix(license.claims.license_expires)
+                .unix(license.claims.license_expires as number)
                 .format("MMMM D, YYYY")}
             </span>
           </Stack>

--- a/site/src/components/LicenseCard/LicenseCard.tsx
+++ b/site/src/components/LicenseCard/LicenseCard.tsx
@@ -85,7 +85,7 @@ export const LicenseCard = ({
             width="134px" // standardize width of date column
           >
             {compareAsc(
-              new Date((license.claims.license_expires as number) * 1000),
+              new Date(license.claims.license_expires * 1000),
               new Date(),
             ) < 1 ? (
               <Pill
@@ -98,7 +98,7 @@ export const LicenseCard = ({
             )}
             <span className={styles.licenseExpires}>
               {dayjs
-                .unix(license.claims.license_expires as number)
+                .unix(license.claims.license_expires)
                 .format("MMMM D, YYYY")}
             </span>
           </Stack>

--- a/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -71,8 +71,8 @@ const LicensesSettingsPageView: FC<Props> = ({
           {licenses
             ?.sort(
               (a, b) =>
-                new Date(b.claims.license_expires as number).valueOf() -
-                new Date(a.claims.license_expires as number).valueOf(),
+                new Date(b.claims.license_expires).valueOf() -
+                new Date(a.claims.license_expires).valueOf(),
             )
             .map((license) => (
               <LicenseCard


### PR DESCRIPTION
Fixes #7671 

So, when the license UI was created, we used to have a bug on the backend that would return each license's user_limit as the same as the maximum number of users allowed on all licenses. For that reason we only displayed that max value. The bug was fixed, but we never updated the UI to display the correct value of each license. This PR fixes that.