### PR TITLE
feat: add --disable-direct-connections flag to CLI

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -49,7 +49,13 @@ func (r *RootCmd) ping() *clibase.Cmd {
 				logger = slog.Make(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelDebug)
 			}
 
-			conn, err := client.DialWorkspaceAgent(ctx, workspaceAgent.ID, &codersdk.DialWorkspaceAgentOptions{Logger: logger})
+			if r.disableDirect {
+				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
+			}
+			conn, err := client.DialWorkspaceAgent(ctx, workspaceAgent.ID, &codersdk.DialWorkspaceAgentOptions{
+				Logger:         logger,
+				BlockEndpoints: r.disableDirect,
+			})
 			if err != nil {
 				return err
 			}

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -15,6 +15,9 @@ import (
 	"github.com/pion/udp"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+
 	"github.com/coder/coder/agent/agentssh"
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/cliui"
@@ -98,7 +101,18 @@ func (r *RootCmd) portForward() *clibase.Cmd {
 				return xerrors.Errorf("await agent: %w", err)
 			}
 
-			conn, err := client.DialWorkspaceAgent(ctx, workspaceAgent.ID, nil)
+			var logger slog.Logger
+			if r.verbose {
+				logger = slog.Make(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelDebug)
+			}
+
+			if r.disableDirect {
+				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
+			}
+			conn, err := client.DialWorkspaceAgent(ctx, workspaceAgent.ID, &codersdk.DialWorkspaceAgentOptions{
+				Logger:         logger,
+				BlockEndpoints: r.disableDirect,
+			})
 			if err != nil {
 				return err
 			}

--- a/cli/root.go
+++ b/cli/root.go
@@ -532,7 +532,7 @@ func (r *RootCmd) InitClient(client *codersdk.Client) clibase.MiddlewareFunc {
 				client.PlainLogger = os.Stderr
 				client.LogBodies = true
 			}
-			client.DisableDirect = r.disableDirect
+			client.DisableDirectConnections = r.disableDirect
 
 			// We send these requests in parallel to minimize latency.
 			var (

--- a/cli/root.go
+++ b/cli/root.go
@@ -60,6 +60,7 @@ const (
 	varNoFeatureWarning = "no-feature-warning"
 	varForceTty         = "force-tty"
 	varVerbose          = "verbose"
+	varDisableDirect    = "disable-direct"
 	notLoggedInMessage  = "You are not logged in. Try logging in using 'coder login <url>'."
 
 	envNoVersionCheck   = "CODER_NO_VERSION_WARNING"
@@ -367,6 +368,13 @@ func (r *RootCmd) Command(subcommands []*clibase.Cmd) (*clibase.Cmd, error) {
 			Group:         globalGroup,
 		},
 		{
+			Flag:        varDisableDirect,
+			Env:         "CODER_DISABLE_DIRECT",
+			Description: "Disable direct (P2P) connections to workspaces.",
+			Value:       clibase.BoolOf(&r.disableDirect),
+			Group:       globalGroup,
+		},
+		{
 			Flag:        "debug-http",
 			Description: "Debug codersdk HTTP requests.",
 			Value:       clibase.BoolOf(&r.debugHTTP),
@@ -412,16 +420,17 @@ func isTest() bool {
 
 // RootCmd contains parameters and helpers useful to all commands.
 type RootCmd struct {
-	clientURL    *url.URL
-	token        string
-	globalConfig string
-	header       []string
-	agentToken   string
-	agentURL     *url.URL
-	forceTTY     bool
-	noOpen       bool
-	verbose      bool
-	debugHTTP    bool
+	clientURL     *url.URL
+	token         string
+	globalConfig  string
+	header        []string
+	agentToken    string
+	agentURL      *url.URL
+	forceTTY      bool
+	noOpen        bool
+	verbose       bool
+	disableDirect bool
+	debugHTTP     bool
 
 	noVersionCheck   bool
 	noFeatureWarning bool

--- a/cli/root.go
+++ b/cli/root.go
@@ -60,7 +60,7 @@ const (
 	varNoFeatureWarning = "no-feature-warning"
 	varForceTty         = "force-tty"
 	varVerbose          = "verbose"
-	varDisableDirect    = "disable-direct"
+	varDisableDirect    = "disable-direct-connections"
 	notLoggedInMessage  = "You are not logged in. Try logging in using 'coder login <url>'."
 
 	envNoVersionCheck   = "CODER_NO_VERSION_WARNING"
@@ -369,7 +369,7 @@ func (r *RootCmd) Command(subcommands []*clibase.Cmd) (*clibase.Cmd, error) {
 		},
 		{
 			Flag:        varDisableDirect,
-			Env:         "CODER_DISABLE_DIRECT",
+			Env:         "CODER_DISABLE_DIRECT_CONNECTIONS",
 			Description: "Disable direct (P2P) connections to workspaces.",
 			Value:       clibase.BoolOf(&r.disableDirect),
 			Group:       globalGroup,
@@ -532,6 +532,7 @@ func (r *RootCmd) InitClient(client *codersdk.Client) clibase.MiddlewareFunc {
 				client.PlainLogger = os.Stderr
 				client.LogBodies = true
 			}
+			client.DisableDirect = r.disableDirect
 
 			// We send these requests in parallel to minimize latency.
 			var (

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -50,12 +50,17 @@ func (r *RootCmd) speedtest() *clibase.Cmd {
 			if err != nil && !xerrors.Is(err, cliui.AgentStartError) {
 				return xerrors.Errorf("await agent: %w", err)
 			}
+
 			logger, ok := LoggerFromContext(ctx)
 			if !ok {
 				logger = slog.Make(sloghuman.Sink(inv.Stderr))
 			}
 			if r.verbose {
 				logger = logger.Leveled(slog.LevelDebug)
+			}
+
+			if r.disableDirect {
+				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
 			}
 			conn, err := client.DialWorkspaceAgent(ctx, workspaceAgent.ID, &codersdk.DialWorkspaceAgentOptions{
 				Logger: logger,

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -195,8 +195,12 @@ func (r *RootCmd) ssh() *clibase.Cmd {
 				// We don't print the error because cliui.Agent does that for us.
 			}
 
+			if r.disableDirect {
+				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
+			}
 			conn, err := client.DialWorkspaceAgent(ctx, workspaceAgent.ID, &codersdk.DialWorkspaceAgentOptions{
-				Logger: logger,
+				Logger:         logger,
+				BlockEndpoints: r.disableDirect,
 			})
 			if err != nil {
 				return xerrors.Errorf("dial agent: %w", err)

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -51,6 +51,9 @@ variables or flags.
       --debug-options bool
           Print all options, how they're set, then exit.
 
+      --disable-direct-connections bool, $CODER_DISABLE_DIRECT_CONNECTIONS
+          Disable direct (P2P) connections to workspaces.
+
       --global-config string, $CODER_CONFIG_DIR (default: ~/.config/coderv2)
           Path to the global `coder` config directory.
 

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -118,9 +118,10 @@ type Client struct {
 	// This is useful for tracking a request end-to-end.
 	Trace bool
 
-	// DisableDirect forces any connections to workspaces to go through DERP,
-	// regardless of the BlockEndpoints setting on each connection.
-	DisableDirect bool
+	// DisableDirectConnections forces any connections to workspaces to go
+	// through DERP, regardless of the BlockEndpoints setting on each
+	// connection.
+	DisableDirectConnections bool
 }
 
 // SessionToken returns the currently set token for the client.

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -117,6 +117,10 @@ type Client struct {
 	// Trace can be enabled to propagate tracing spans to the Coder API.
 	// This is useful for tracking a request end-to-end.
 	Trace bool
+
+	// DisableDirect forces any connections to workspaces to go through DERP,
+	// regardless of the BlockEndpoints setting on each connection.
+	DisableDirect bool
 }
 
 // SessionToken returns the currently set token for the client.

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -209,7 +209,7 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 		DERPMap:        connInfo.DERPMap,
 		DERPHeader:     &header,
 		Logger:         options.Logger,
-		BlockEndpoints: c.DisableDirect || options.BlockEndpoints,
+		BlockEndpoints: c.DisableDirectConnections || options.BlockEndpoints,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("create tailnet: %w", err)

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -173,7 +173,8 @@ type WorkspaceAgentConnectionInfo struct {
 // @typescript-ignore DialWorkspaceAgentOptions
 type DialWorkspaceAgentOptions struct {
 	Logger slog.Logger
-	// BlockEndpoints forced a direct connection through DERP.
+	// BlockEndpoints forced a direct connection through DERP. The Client may
+	// have DisableDirect set which will override this value.
 	BlockEndpoints bool
 }
 
@@ -208,7 +209,7 @@ func (c *Client) DialWorkspaceAgent(ctx context.Context, agentID uuid.UUID, opti
 		DERPMap:        connInfo.DERPMap,
 		DERPHeader:     &header,
 		Logger:         options.Logger,
-		BlockEndpoints: options.BlockEndpoints,
+		BlockEndpoints: c.DisableDirect || options.BlockEndpoints,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("create tailnet: %w", err)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,6 +68,15 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 
 Print all options, how they're set, then exit.
 
+### --disable-direct-connections
+
+|             |                                                |
+| ----------- | ---------------------------------------------- |
+| Type        | <code>bool</code>                              |
+| Environment | <code>$CODER_DISABLE_DIRECT_CONNECTIONS</code> |
+
+Disable direct (P2P) connections to workspaces.
+
 ### --global-config
 
 |             |                                |

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -23,6 +23,9 @@ variables or flags.
       --debug-options bool
           Print all options, how they're set, then exit.
 
+      --disable-direct-connections bool, $CODER_DISABLE_DIRECT_CONNECTIONS
+          Disable direct (P2P) connections to workspaces.
+
       --global-config string, $CODER_CONFIG_DIR (default: ~/.config/coderv2)
           Path to the global `coder` config directory.
 


### PR DESCRIPTION
Adds global flag `--disable-direct` to CLI which forces all CLI connections to workspaces to be proxied through DERP.

Closes #7179 