### PR TITLE
feat: add user search query param on last_seen

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -2686,6 +2686,26 @@ func (q *fakeQuerier) GetUsers(_ context.Context, params database.GetUsersParams
 		users = usersFilteredByRole
 	}
 
+	if !params.LastSeenBefore.IsZero() {
+		usersFilteredByLastSeen := make([]database.User, 0, len(users))
+		for i, user := range users {
+			if user.LastSeenAt.Before(params.LastSeenBefore) {
+				usersFilteredByLastSeen = append(usersFilteredByLastSeen, users[i])
+			}
+		}
+		users = usersFilteredByLastSeen
+	}
+
+	if !params.LastSeenAfter.IsZero() {
+		usersFilteredByLastSeen := make([]database.User, 0, len(users))
+		for i, user := range users {
+			if user.LastSeenAt.After(params.LastSeenAfter) {
+				usersFilteredByLastSeen = append(usersFilteredByLastSeen, users[i])
+			}
+		}
+		users = usersFilteredByLastSeen
+	}
+
 	beforePageCount := len(users)
 
 	if params.OffsetOpt > 0 {

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -206,6 +206,15 @@ func User(t testing.TB, db database.Store, orig database.User) database.User {
 		LoginType:      takeFirst(orig.LoginType, database.LoginTypePassword),
 	})
 	require.NoError(t, err, "insert user")
+
+	if !orig.LastSeenAt.IsZero() {
+		user, err = db.UpdateUserLastSeenAt(genCtx, database.UpdateUserLastSeenAtParams{
+			ID:         user.ID,
+			LastSeenAt: orig.LastSeenAt,
+			UpdatedAt:  user.UpdatedAt,
+		})
+		require.NoError(t, err, "user last seen")
+	}
 	return user
 }
 

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -387,3 +387,57 @@ func TestQueuePosition(t *testing.T) {
 		require.Equal(t, job.ProvisionerJob.ID, jobs[index].ID)
 	}
 }
+
+func TestUserLastSeenFilter(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Run("Before", func(t *testing.T) {
+		t.Parallel()
+		sqlDB := testSQLDB(t)
+		err := migrations.Up(sqlDB)
+		require.NoError(t, err)
+		db := database.New(sqlDB)
+		ctx := context.Background()
+		now := time.Now()
+
+		yesterday := dbgen.User(t, db, database.User{
+			LastSeenAt: now.Add(time.Hour * -25),
+		})
+		today := dbgen.User(t, db, database.User{
+			LastSeenAt: now,
+		})
+		lastWeek := dbgen.User(t, db, database.User{
+			LastSeenAt: now.Add((time.Hour * -24 * 7) + (-1 * time.Hour)),
+		})
+
+		beforeToday, err := db.GetUsers(ctx, database.GetUsersParams{
+			LastSeenBefore: now.Add(time.Hour * -24),
+		})
+		database.ConvertUserRows(beforeToday)
+
+		requireUsersMatch(t, []database.User{yesterday, lastWeek}, beforeToday, "before today")
+
+		justYesterday, err := db.GetUsers(ctx, database.GetUsersParams{
+			LastSeenBefore: now.Add(time.Hour * -24),
+			LastSeenAfter:  now.Add(time.Hour * -24 * 2),
+		})
+		requireUsersMatch(t, []database.User{yesterday}, justYesterday, "just yesterday")
+
+		all, err := db.GetUsers(ctx, database.GetUsersParams{
+			LastSeenBefore: now.Add(time.Hour),
+		})
+		requireUsersMatch(t, []database.User{today, yesterday, lastWeek}, all, "all")
+
+		allAfterLastWeek, err := db.GetUsers(ctx, database.GetUsersParams{
+			LastSeenAfter: now.Add(time.Hour * -24 * 7),
+		})
+		requireUsersMatch(t, []database.User{today, yesterday}, allAfterLastWeek, "after last week")
+	})
+}
+
+func requireUsersMatch(t testing.TB, expected []database.User, found []database.GetUsersRow, msg string) {
+	t.Helper()
+	require.ElementsMatch(t, expected, database.ConvertUserRows(found), msg)
+}

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -415,6 +415,7 @@ func TestUserLastSeenFilter(t *testing.T) {
 		beforeToday, err := db.GetUsers(ctx, database.GetUsersParams{
 			LastSeenBefore: now.Add(time.Hour * -24),
 		})
+		require.NoError(t, err)
 		database.ConvertUserRows(beforeToday)
 
 		requireUsersMatch(t, []database.User{yesterday, lastWeek}, beforeToday, "before today")
@@ -423,16 +424,19 @@ func TestUserLastSeenFilter(t *testing.T) {
 			LastSeenBefore: now.Add(time.Hour * -24),
 			LastSeenAfter:  now.Add(time.Hour * -24 * 2),
 		})
+		require.NoError(t, err)
 		requireUsersMatch(t, []database.User{yesterday}, justYesterday, "just yesterday")
 
 		all, err := db.GetUsers(ctx, database.GetUsersParams{
 			LastSeenBefore: now.Add(time.Hour),
 		})
+		require.NoError(t, err)
 		requireUsersMatch(t, []database.User{today, yesterday, lastWeek}, all, "all")
 
 		allAfterLastWeek, err := db.GetUsers(ctx, database.GetUsersParams{
 			LastSeenAfter: now.Add(time.Hour * -24 * 7),
 		})
+		require.NoError(t, err)
 		requireUsersMatch(t, []database.User{today, yesterday}, allAfterLastWeek, "after last week")
 	})
 }

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -181,6 +181,17 @@ WHERE
 		    rbac_roles && @rbac_role :: text[]
 		ELSE true
 	END
+	-- Filter by last_seen
+	AND CASE
+		WHEN @last_seen_before :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
+			last_seen_at <= @last_seen_before
+		ELSE true
+	END
+	AND CASE
+		WHEN @last_seen_after :: timestamp with time zone != '0001-01-01 00:00:00Z' THEN
+			last_seen_at >= @last_seen_after
+		ELSE true
+	END
 	-- End of filters
 ORDER BY
 	-- Deterministic and consistent ordering of all users. This is to ensure consistent pagination.

--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -308,10 +308,3 @@ func testQueryParams[T any](t *testing.T, testCases []queryParamTestCase[T], par
 		})
 	}
 }
-
-func must[T any](value T, err error) T {
-	if err != nil {
-		panic(err)
-	}
-	return value
-}

--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -85,7 +85,7 @@ func TestParseQueryParams(t *testing.T) {
 
 		parser := httpapi.NewQueryParamParser()
 		testQueryParams(t, expParams, parser, func(vals url.Values, def time.Time, queryParam string) time.Time {
-			return parser.Time(vals, time.Time{}, queryParam)
+			return parser.Time3339Nano(vals, time.Time{}, queryParam)
 		})
 	})
 

--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -69,13 +69,12 @@ func TestParseQueryParams(t *testing.T) {
 
 	t.Run("Time", func(t *testing.T) {
 		t.Parallel()
-		const layout = "2006-01-02"
 
 		expParams := []queryParamTestCase[time.Time]{
 			{
 				QueryParam: "date",
-				Value:      "2010-01-01",
-				Expected:   must(time.Parse(layout, "2010-01-01")),
+				Value:      "2023-01-16T00:00:00+12:00",
+				Expected:   time.Date(2023, 1, 15, 12, 0, 0, 0, time.UTC),
 			},
 			{
 				QueryParam:            "bad_date",
@@ -86,7 +85,7 @@ func TestParseQueryParams(t *testing.T) {
 
 		parser := httpapi.NewQueryParamParser()
 		testQueryParams(t, expParams, parser, func(vals url.Values, def time.Time, queryParam string) time.Time {
-			return parser.Time(vals, time.Time{}, queryParam, layout)
+			return parser.Time(vals, time.Time{}, queryParam)
 		})
 	})
 

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -59,9 +59,11 @@ func Users(query string) (database.GetUsersParams, []codersdk.ValidationError) {
 
 	parser := httpapi.NewQueryParamParser()
 	filter := database.GetUsersParams{
-		Search:   parser.String(values, "", "search"),
-		Status:   httpapi.ParseCustomList(parser, values, []database.UserStatus{}, "status", httpapi.ParseEnum[database.UserStatus]),
-		RbacRole: parser.Strings(values, []string{}, "role"),
+		Search:         parser.String(values, "", "search"),
+		Status:         httpapi.ParseCustomList(parser, values, []database.UserStatus{}, "status", httpapi.ParseEnum[database.UserStatus]),
+		RbacRole:       parser.Strings(values, []string{}, "role"),
+		LastSeenAfter:  parser.Time3339Nano(values, time.Time{}, "last_seen_after"),
+		LastSeenBefore: parser.Time3339Nano(values, time.Time{}, "last_seen_before"),
 	}
 	parser.ErrorExcessParams(values)
 	return filter, parser.Errors

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -199,12 +199,14 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	userRows, err := api.Database.GetUsers(ctx, database.GetUsersParams{
-		AfterID:   paginationParams.AfterID,
-		OffsetOpt: int32(paginationParams.Offset),
-		LimitOpt:  int32(paginationParams.Limit),
-		Search:    params.Search,
-		Status:    params.Status,
-		RbacRole:  params.RbacRole,
+		AfterID:        paginationParams.AfterID,
+		Search:         params.Search,
+		Status:         params.Status,
+		RbacRole:       params.RbacRole,
+		LastSeenBefore: params.LastSeenBefore,
+		LastSeenAfter:  params.LastSeenAfter,
+		OffsetOpt:      int32(paginationParams.Offset),
+		LimitOpt:       int32(paginationParams.Limit),
 	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/coderd/audit"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/database"
+	"github.com/coder/coder/coderd/database/dbauthz"
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/testutil"
@@ -1102,7 +1103,7 @@ func TestGetUser(t *testing.T) {
 func TestUsersFilter(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	first := coderdtest.CreateFirstUser(t, client)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -1111,6 +1112,13 @@ func TestUsersFilter(t *testing.T) {
 	firstUser, err := client.User(ctx, codersdk.Me)
 	require.NoError(t, err, "fetch me")
 
+	// Noon on Jan 18 is the "now" for this test for last_seen timestamps.
+	// All these values are equal
+	// 2023-01-18T12:00:00Z (UTC)
+	// 2023-01-18T07:00:00-05:00 (America/New_York)
+	// 2023-01-18T13:00:00+01:00 (Europe/Madrid)
+	// 2023-01-16T00:00:00+12:00 (Asia/Anadyr)
+	lastSeenNow := time.Date(2023, 1, 18, 12, 0, 0, 0, time.UTC)
 	users := make([]codersdk.User, 0)
 	users = append(users, firstUser)
 	for i := 0; i < 15; i++ {
@@ -1121,7 +1129,15 @@ func TestUsersFilter(t *testing.T) {
 		if i%3 == 0 {
 			roles = append(roles, "auditor")
 		}
-		userClient, _ := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, roles...)
+		userClient, userData := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, roles...)
+		// Set the last seen for each user to a unique day
+		_, err := api.Database.UpdateUserLastSeenAt(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLastSeenAtParams{
+			ID:         userData.ID,
+			LastSeenAt: lastSeenNow.Add(-1 * time.Hour * 24 * time.Duration(i)),
+			UpdatedAt:  time.Now(),
+		})
+		require.NoError(t, err, "set a last seen")
+
 		user, err := userClient.User(ctx, codersdk.Me)
 		require.NoError(t, err, "fetch me")
 
@@ -1260,6 +1276,26 @@ func TestUsersFilter(t *testing.T) {
 					}
 				}
 				return false
+			},
+		},
+		{
+			Name: "LastSeenBeforeNow",
+			Filter: codersdk.UsersRequest{
+				SearchQuery: `last_seen_before:"2023-01-16T00:00:00+12:00"`,
+			},
+			FilterF: func(_ codersdk.UsersRequest, u codersdk.User) bool {
+				return u.LastSeenAt.Before(lastSeenNow)
+			},
+		},
+		{
+			Name: "LastSeenLastWeek",
+			Filter: codersdk.UsersRequest{
+				SearchQuery: `last_seen_before:"2023-01-14T23:59:59Z" last_seen_after:"2023-01-08T00:00:00Z"`,
+			},
+			FilterF: func(_ codersdk.UsersRequest, u codersdk.User) bool {
+				start := time.Date(2023, 1, 8, 0, 0, 0, 0, time.UTC)
+				end := time.Date(2023, 1, 14, 23, 59, 59, 0, time.UTC)
+				return u.LastSeenAt.Before(end) && u.LastSeenAt.After(start)
 			},
 		},
 	}

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1131,6 +1131,7 @@ func TestUsersFilter(t *testing.T) {
 		}
 		userClient, userData := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, roles...)
 		// Set the last seen for each user to a unique day
+		// nolint:gocritic // Unit test
 		_, err := api.Database.UpdateUserLastSeenAt(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLastSeenAtParams{
 			ID:         userData.ID,
 			LastSeenAt: lastSeenNow.Add(-1 * time.Hour * 24 * time.Duration(i)),


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/7901

Example Query:
```
last_seen_before:"2023-01-14T23:59:59Z" last_seen_after:"2023-01-08T00:00:00Z"
```

# Notes

Uses RFC3339Nano format (`2006-01-02T15:04:05.999999999Z07:00`) which we used for our other endpoints.

The feature works, but there is a matter of usability that could be improved. Such as `last_seen_after:yesterday` or `last_seen_after:-24hr`, etc.

We can add better usability later if this ends up being used frequently. The usability can happen on the FE or BE. 