### PR TITLE
ci: delete old workflow runs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
-          retain_days: 30
-          keep_minimum_runs: 6
+          retain_days: 7
+          keep_minimum_runs: 1
           delete_workflow_pattern: pr-deploy.yaml
       

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,4 @@
-name: Stale Issue and Branch Cleanup
+name: Stale Issue, Banch and Old Workflows Cleanup
 on:
   schedule:
     # Every day at midnight
@@ -10,6 +10,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
     steps:
       - uses: actions/stale@v8.0.0
         with:
@@ -42,3 +43,15 @@ jobs:
           delete_tags: false
           # extra_protected_branch_regex: ^(foo|bar)$
           exclude_open_pr_branches: true
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 30
+          keep_minimum_runs: 6
+          delete_workflow_pattern: pr-deploy.yaml
+      

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
-          retain_days: 7
+          retain_days: 1
           keep_minimum_runs: 1
-          delete_workflow_pattern: pr-deploy.yaml
+          delete_workflow_pattern: pr-cleanup.yaml
       

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -54,4 +54,3 @@ jobs:
           retain_days: 1
           keep_minimum_runs: 1
           delete_workflow_pattern: pr-cleanup.yaml
-      


### PR DESCRIPTION
This cleans up old workflow runs for `pr-cleanup.yaml` as this action runs on every PR close event, so we have a lot of failed workflow logs as it tried to clean up every pr, and we do not have deployments for every pr.

More workflows can be added by appending to the list e.g.
`delete_workflow_pattern: ["pr-deploy.yaml", "pr-cleanup.yaml"]`