### PR TITLE
feat: use named loggers in `coderd`

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -166,7 +166,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 					Reason(reason)
 
 				if _, _, err := builder.Build(e.ctx, tx, nil); err != nil {
-					log.Error(e.ctx, "unable to transition workspace",
+					log.Error(e.ctx, "workspace build error",
 						slog.F("transition", nextTransition),
 						slog.Error(err),
 					)

--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -45,7 +45,7 @@ func NewExecutor(ctx context.Context, db database.Store, tss *atomic.Pointer[sch
 		db:                    db,
 		templateScheduleStore: tss,
 		tick:                  tick,
-		log:                   log,
+		log:                   log.Named("autobuild"),
 	}
 	return le
 }

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/sloggers/slogtest"
+
 	"github.com/coder/coder/coderd"
 	"github.com/coder/coder/coderd/audit"
 	"github.com/coder/coder/coderd/coderdtest"
@@ -747,9 +749,11 @@ func TestUserOIDC(t *testing.T) {
 			config.IgnoreEmailVerified = tc.IgnoreEmailVerified
 			config.IgnoreUserInfo = tc.IgnoreUserInfo
 
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 			client := coderdtest.New(t, &coderdtest.Options{
 				Auditor:    auditor,
 				OIDCConfig: config,
+				Logger:     &logger,
 			})
 			numLogs := len(auditor.AuditLogs())
 

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/database/db2sdk"
 	"github.com/coder/coder/coderd/database/dbauthz"
@@ -348,6 +350,10 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	)
 	var buildErr wsbuilder.BuildError
 	if xerrors.As(err, &buildErr) {
+		if buildErr.Status == http.StatusInternalServerError {
+			api.Logger.Error(ctx, "workspace build error", slog.Error(buildErr.Wrapped))
+		}
+
 		httpapi.Write(ctx, rw, buildErr.Status, codersdk.Response{
 			Message: buildErr.Message,
 			Detail:  buildErr.Error(),

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -454,6 +454,10 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 	}, nil)
 	var bldErr wsbuilder.BuildError
 	if xerrors.As(err, &bldErr) {
+		if bldErr.Status == http.StatusInternalServerError {
+			api.Logger.Error(ctx, "workspace build error", slog.Error(bldErr.Wrapped))
+		}
+
 		httpapi.Write(ctx, rw, bldErr.Status, codersdk.Response{
 			Message: bldErr.Message,
 			Detail:  bldErr.Error(),


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6726

This PR modifies logger configuration to use named loggers. The idea is to allow DevOps or admins to configure log alarms (catchphrases) for specific issues:

* `[erro]` `coderd` `workspace build error` 
* `[erro]` `coderd.autobuild` `workspace build error` 
* `[erro]` `coderd.provisionerd-%s`
* `[erro]` `coderd.userauth`
* `[erro]` `coderd.prometheusmetrics`