### PR TITLE
ci: fix syntax issue in `pr-deploy.yaml`

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
             PR_TITLE=$(curl -sSL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/coder/coder/pulls/$PR_NUMBER" | jq -r '.title')
           else
             PR_NUMBER=${{ github.event.issue.number }}
-            PR_TITLE=${{ github.event.issue.title }}
+            PR_TITLE="${{ github.event.issue.title }}"
           fi
           echo "PR_URL=https://github.com/coder/coder/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://github.com/coder/coder/blob/eee4f835ec0b51fc6b3a87d264968a38142c6306/.github/workflows/pr-deploy.yaml#L45 needed to be quoted. thanks @coadler