### PR TITLE
ci: get PR number correctly from pull_request event in `pr-cleanup.yaml`

### DIFF
--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -19,7 +19,7 @@ jobs:
         id: pr_number
         run: |
           if [ -z "${{ github.event.pull_request.number }}" ]; then
-            echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
             echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Get PR number correctly when the vent trigger is pull_request in `pr_cleanup.yaml`