### PR TITLE
fix: fix PG Coordinator to update when heartbeats (re)start

### DIFF
--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -1146,10 +1146,10 @@ func (h *heartbeats) recvBeat(id uuid.UUID) {
 		h.logger.Debug(h.ctx, "set initial heartbeat timeout")
 		return
 	}
-	h.resetExpiryTimer()
+	h.resetExpiryTimerWithLock()
 }
 
-func (h *heartbeats) resetExpiryTimer() {
+func (h *heartbeats) resetExpiryTimerWithLock() {
 	var oldestTime time.Time
 	for _, t := range h.coordinators {
 		if oldestTime.IsZero() || t.Before(oldestTime) {
@@ -1186,7 +1186,7 @@ func (h *heartbeats) checkExpiry() {
 		}()
 	}
 	// we need to reset the timer for when the next oldest coordinator will expire, if any.
-	h.resetExpiryTimer()
+	h.resetExpiryTimerWithLock()
 }
 
 func (h *heartbeats) sendBeats() {


### PR DESCRIPTION
fixes #8161 

Also fixes a related issue I noticed with the heartbeats, where if there are multiple coordinators and one expires, we don't reschedule the check for others expiring unless a new heartbeat comes in, so if two coordinators stop beating around the same time, we'd only expire one of them.  Test updated to check for both this and the initial bug.