### PR TITLE
docs: add default dir for VS Code Desktop

### DIFF
--- a/docs/ides.md
+++ b/docs/ides.md
@@ -22,6 +22,10 @@ Click `VS Code Desktop` in the dashboard to one-click enter a workspace. This au
 
 ![Demo](https://github.com/coder/vscode-coder/raw/main/demo.gif?raw=true)
 
+You can set the default directory in which VS Code opens via the `dir` argument on
+the `coder_agent` resource in your workspace template. See the [Terraform documentation
+for more details](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#dir).
+
 > The `VS Code Desktop` button can be hidden by enabling [Browser-only connections](./networking/index.md#Browser-only).
 
 ### Manual Installation


### PR DESCRIPTION
this PR documents how to set the default dir when opening a workspace via `VS Code Desktop` in Coder.