### PR TITLE
feat: show service banner in SSH/TTY sessions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -192,6 +192,7 @@ func (a *agent) init(ctx context.Context) {
 	sshSrv.Env = a.envVars
 	sshSrv.AgentToken = func() string { return *a.sessionToken.Load() }
 	sshSrv.Manifest = &a.manifest
+	sshSrv.GetServiceBanner = a.client.GetServiceBanner
 	a.sshServer = sshSrv
 
 	go a.runLoop(ctx)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -503,7 +503,7 @@ func (a *agent) setLifecycle(ctx context.Context, state codersdk.WorkspaceAgentL
 // not be fetched immediately; the expectation is that it is primed elsewhere
 // (and must be done before the session actually starts).
 func (a *agent) fetchServiceBannerLoop(ctx context.Context) {
-	ticker := time.NewTicker(adjustIntervalForTests(15*time.Second, time.Millisecond*100))
+	ticker := time.NewTicker(adjustIntervalForTests(2*time.Minute, time.Millisecond*100))
 	defer ticker.Stop()
 	for {
 		select {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -499,7 +499,9 @@ func (a *agent) setLifecycle(ctx context.Context, state codersdk.WorkspaceAgentL
 	}
 }
 
-// fetchServiceBannerLoop fetches the service banner on an interval.
+// fetchServiceBannerLoop fetches the service banner on an interval.  It will
+// not be fetched immediately; the expectation is that it is primed elsewhere
+// (and must be done before the session actually starts).
 func (a *agent) fetchServiceBannerLoop(ctx context.Context) {
 	ticker := time.NewTicker(adjustIntervalForTests(15*time.Second, time.Millisecond*100))
 	defer ticker.Stop()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -510,7 +510,10 @@ func (a *agent) fetchServiceBannerLoop(ctx context.Context) {
 		case <-ticker.C:
 			serviceBanner, err := a.client.GetServiceBanner(ctx)
 			if err != nil {
-				a.logger.Warn(ctx, "failed to fetch service banner")
+				if ctx.Err() != nil {
+					return
+				}
+				a.logger.Error(ctx, "failed to update service banner", slog.Error(err))
 				continue
 			}
 			a.serviceBanner.Store(&serviceBanner)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -77,6 +77,7 @@ type Client interface {
 	PostStartup(ctx context.Context, req agentsdk.PostStartupRequest) error
 	PostMetadata(ctx context.Context, key string, req agentsdk.PostMetadataRequest) error
 	PatchStartupLogs(ctx context.Context, req agentsdk.PatchStartupLogs) error
+	GetServiceBanner(ctx context.Context) (codersdk.ServiceBannerConfig, error)
 }
 
 type Agent interface {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -192,7 +192,7 @@ func (a *agent) init(ctx context.Context) {
 	sshSrv.Env = a.envVars
 	sshSrv.AgentToken = func() string { return *a.sessionToken.Load() }
 	sshSrv.Manifest = &a.manifest
-	sshSrv.GetServiceBanner = a.client.GetServiceBanner
+	sshSrv.ServiceBanner = a.client.GetServiceBanner
 	a.sshServer = sshSrv
 
 	go a.runLoop(ctx)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -164,7 +164,9 @@ type agent struct {
 
 	envVars map[string]string
 	// manifest is atomic because values can change after reconnection.
-	manifest      atomic.Pointer[agentsdk.Manifest]
+	manifest atomic.Pointer[agentsdk.Manifest]
+	// serviceBanner is atomic because it can change.
+	serviceBanner atomic.Pointer[codersdk.ServiceBannerConfig]
 	sessionToken  atomic.Pointer[string]
 	sshServer     *agentssh.Server
 	sshMaxTimeout time.Duration
@@ -192,7 +194,7 @@ func (a *agent) init(ctx context.Context) {
 	sshSrv.Env = a.envVars
 	sshSrv.AgentToken = func() string { return *a.sessionToken.Load() }
 	sshSrv.Manifest = &a.manifest
-	sshSrv.ServiceBanner = a.client.GetServiceBanner
+	sshSrv.ServiceBanner = &a.serviceBanner
 	a.sshServer = sshSrv
 
 	go a.runLoop(ctx)
@@ -205,6 +207,7 @@ func (a *agent) init(ctx context.Context) {
 func (a *agent) runLoop(ctx context.Context) {
 	go a.reportLifecycleLoop(ctx)
 	go a.reportMetadataLoop(ctx)
+	go a.fetchServiceBannerLoop(ctx)
 
 	for retrier := retry.New(100*time.Millisecond, 10*time.Second); retrier.Wait(ctx); {
 		a.logger.Info(ctx, "connecting to coderd")
@@ -277,14 +280,15 @@ func (a *agent) collectMetadata(ctx context.Context, md codersdk.WorkspaceAgentM
 	return result
 }
 
-func adjustIntervalForTests(i int64) time.Duration {
+// adjustIntervalForTests returns a duration of testInterval milliseconds long
+// for tests and interval seconds long otherwise.
+func adjustIntervalForTests(interval time.Duration, testInterval time.Duration) time.Duration {
 	// In tests we want to set shorter intervals because engineers are
 	// impatient.
-	base := time.Second
 	if flag.Lookup("test.v") != nil {
-		base = time.Millisecond * 100
+		return testInterval
 	}
-	return time.Duration(i) * base
+	return interval
 }
 
 type metadataResultAndKey struct {
@@ -308,7 +312,7 @@ func (t *trySingleflight) Do(key string, fn func()) {
 }
 
 func (a *agent) reportMetadataLoop(ctx context.Context) {
-	baseInterval := adjustIntervalForTests(1)
+	baseInterval := adjustIntervalForTests(time.Second, time.Millisecond*100)
 
 	const metadataLimit = 128
 
@@ -385,7 +389,9 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 				}
 				// The last collected value isn't quite stale yet, so we skip it.
 				if collectedAt.Add(
-					adjustIntervalForTests(md.Interval),
+					adjustIntervalForTests(
+						time.Duration(md.Interval)*time.Second,
+						time.Duration(md.Interval)*time.Millisecond*100),
 				).After(time.Now()) {
 					continue
 				}
@@ -493,6 +499,25 @@ func (a *agent) setLifecycle(ctx context.Context, state codersdk.WorkspaceAgentL
 	}
 }
 
+// fetchServiceBannerLoop fetches the service banner on an interval.
+func (a *agent) fetchServiceBannerLoop(ctx context.Context) {
+	ticker := time.NewTicker(adjustIntervalForTests(15*time.Second, time.Millisecond*100))
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			serviceBanner, err := a.client.GetServiceBanner(ctx)
+			if err != nil {
+				a.logger.Warn(ctx, "failed to fetch service banner")
+				continue
+			}
+			a.serviceBanner.Store(&serviceBanner)
+		}
+	}
+}
+
 func (a *agent) run(ctx context.Context) error {
 	// This allows the agent to refresh it's token if necessary.
 	// For instance identity this is required, since the instance
@@ -502,6 +527,12 @@ func (a *agent) run(ctx context.Context) error {
 		return xerrors.Errorf("exchange token: %w", err)
 	}
 	a.sessionToken.Store(&sessionToken)
+
+	serviceBanner, err := a.client.GetServiceBanner(ctx)
+	if err != nil {
+		return xerrors.Errorf("fetch service banner: %w", err)
+	}
+	a.serviceBanner.Store(&serviceBanner)
 
 	manifest, err := a.client.Manifest(ctx)
 	if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -191,7 +191,7 @@ func TestAgent_Stats_Magic(t *testing.T) {
 
 func TestAgent_SessionExec(t *testing.T) {
 	t.Parallel()
-	session := setupSSHSession(t, agentsdk.Manifest{})
+	session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{})
 
 	command := "echo test"
 	if runtime.GOOS == "windows" {
@@ -204,7 +204,7 @@ func TestAgent_SessionExec(t *testing.T) {
 
 func TestAgent_GitSSH(t *testing.T) {
 	t.Parallel()
-	session := setupSSHSession(t, agentsdk.Manifest{})
+	session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{})
 	command := "sh -c 'echo $GIT_SSH_COMMAND'"
 	if runtime.GOOS == "windows" {
 		command = "cmd.exe /c echo %GIT_SSH_COMMAND%"
@@ -224,7 +224,7 @@ func TestAgent_SessionTTYShell(t *testing.T) {
 		// it seems like it could be either.
 		t.Skip("ConPTY appears to be inconsistent on Windows.")
 	}
-	session := setupSSHSession(t, agentsdk.Manifest{})
+	session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{})
 	command := "sh"
 	if runtime.GOOS == "windows" {
 		command = "cmd.exe"
@@ -247,7 +247,7 @@ func TestAgent_SessionTTYShell(t *testing.T) {
 
 func TestAgent_SessionTTYExitCode(t *testing.T) {
 	t.Parallel()
-	session := setupSSHSession(t, agentsdk.Manifest{})
+	session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{})
 	command := "areallynotrealcommand"
 	err := session.RequestPty("xterm", 128, 128, ssh.TerminalModes{})
 	require.NoError(t, err)
@@ -277,6 +277,7 @@ func TestAgent_Session_TTY_MOTD(t *testing.T) {
 	}
 
 	wantMOTD := "Welcome to your Coder workspace!"
+	wantServiceBanner := "Service banner text goes here"
 
 	tmpdir := t.TempDir()
 	name := filepath.Join(tmpdir, "motd")
@@ -286,25 +287,84 @@ func TestAgent_Session_TTY_MOTD(t *testing.T) {
 	// Set HOME so we can ensure no ~/.hushlogin is present.
 	t.Setenv("HOME", tmpdir)
 
-	session := setupSSHSession(t, agentsdk.Manifest{
-		MOTDFile: name,
-	})
-	err = session.RequestPty("xterm", 128, 128, ssh.TerminalModes{})
-	require.NoError(t, err)
+	tests := []struct {
+		name       string
+		manifest   agentsdk.Manifest
+		banner     codersdk.ServiceBannerConfig
+		expected   []string
+		unexpected []string
+	}{
+		{
+			name:       "WithoutServiceBanner",
+			manifest:   agentsdk.Manifest{MOTDFile: name},
+			banner:     codersdk.ServiceBannerConfig{},
+			expected:   []string{wantMOTD},
+			unexpected: []string{wantServiceBanner},
+		},
+		{
+			name:     "WithServiceBanner",
+			manifest: agentsdk.Manifest{MOTDFile: name},
+			banner: codersdk.ServiceBannerConfig{
+				Enabled: true,
+				Message: wantServiceBanner,
+			},
+			expected: []string{wantMOTD, wantServiceBanner},
+		},
+		{
+			name:     "ServiceBannerDisabled",
+			manifest: agentsdk.Manifest{MOTDFile: name},
+			banner: codersdk.ServiceBannerConfig{
+				Enabled: false,
+				Message: wantServiceBanner,
+			},
+			expected:   []string{wantMOTD},
+			unexpected: []string{wantServiceBanner},
+		},
+		{
+			name:     "ServiceBannerOnly",
+			manifest: agentsdk.Manifest{},
+			banner: codersdk.ServiceBannerConfig{
+				Enabled: true,
+				Message: wantServiceBanner,
+			},
+			expected:   []string{wantServiceBanner},
+			unexpected: []string{wantMOTD},
+		},
+		{
+			name:       "None",
+			manifest:   agentsdk.Manifest{},
+			banner:     codersdk.ServiceBannerConfig{},
+			unexpected: []string{wantServiceBanner, wantMOTD},
+		},
+	}
 
-	ptty := ptytest.New(t)
-	var stdout bytes.Buffer
-	session.Stdout = &stdout
-	session.Stderr = ptty.Output()
-	session.Stdin = ptty.Input()
-	err = session.Shell()
-	require.NoError(t, err)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			session := setupSSHSession(t, test.manifest, test.banner)
+			err = session.RequestPty("xterm", 128, 128, ssh.TerminalModes{})
+			require.NoError(t, err)
 
-	ptty.WriteLine("exit 0")
-	err = session.Wait()
-	require.NoError(t, err)
+			ptty := ptytest.New(t)
+			var stdout bytes.Buffer
+			session.Stdout = &stdout
+			session.Stderr = ptty.Output()
+			session.Stdin = ptty.Input()
+			err = session.Shell()
+			require.NoError(t, err)
 
-	require.Contains(t, stdout.String(), wantMOTD, "should show motd")
+			ptty.WriteLine("exit 0")
+			err = session.Wait()
+			require.NoError(t, err)
+
+			for _, unexpected := range test.unexpected {
+				require.NotContains(t, stdout.String(), unexpected, "should not show motd")
+			}
+			for _, expect := range test.expected {
+				require.Contains(t, stdout.String(), expect, "should show motd")
+			}
+		})
+	}
 }
 
 //nolint:paralleltest // This test sets an environment variable.
@@ -317,6 +377,7 @@ func TestAgent_Session_TTY_Hushlogin(t *testing.T) {
 	}
 
 	wantNotMOTD := "Welcome to your Coder workspace!"
+	wantNotServiceBanner := "Service banner text goes here"
 
 	tmpdir := t.TempDir()
 	name := filepath.Join(tmpdir, "motd")
@@ -334,6 +395,9 @@ func TestAgent_Session_TTY_Hushlogin(t *testing.T) {
 
 	session := setupSSHSession(t, agentsdk.Manifest{
 		MOTDFile: name,
+	}, codersdk.ServiceBannerConfig{
+		Enabled: true,
+		Message: wantNotServiceBanner,
 	})
 	err = session.RequestPty("xterm", 128, 128, ssh.TerminalModes{})
 	require.NoError(t, err)
@@ -351,6 +415,7 @@ func TestAgent_Session_TTY_Hushlogin(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotContains(t, stdout.String(), wantNotMOTD, "should not show motd")
+	require.NotContains(t, stdout.String(), wantNotServiceBanner, "should not show service banner")
 }
 
 func TestAgent_Session_TTY_FastCommandHasOutput(t *testing.T) {
@@ -797,7 +862,7 @@ func TestAgent_EnvironmentVariables(t *testing.T) {
 		EnvironmentVariables: map[string]string{
 			key: value,
 		},
-	})
+	}, codersdk.ServiceBannerConfig{})
 	command := "sh -c 'echo $" + key + "'"
 	if runtime.GOOS == "windows" {
 		command = "cmd.exe /c echo %" + key + "%"
@@ -814,7 +879,7 @@ func TestAgent_EnvironmentVariableExpansion(t *testing.T) {
 		EnvironmentVariables: map[string]string{
 			key: "$SOMETHINGNOTSET",
 		},
-	})
+	}, codersdk.ServiceBannerConfig{})
 	command := "sh -c 'echo $" + key + "'"
 	if runtime.GOOS == "windows" {
 		command = "cmd.exe /c echo %" + key + "%"
@@ -837,7 +902,7 @@ func TestAgent_CoderEnvVars(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			t.Parallel()
 
-			session := setupSSHSession(t, agentsdk.Manifest{})
+			session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{})
 			command := "sh -c 'echo $" + key + "'"
 			if runtime.GOOS == "windows" {
 				command = "cmd.exe /c echo %" + key + "%"
@@ -860,7 +925,7 @@ func TestAgent_SSHConnectionEnvVars(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			t.Parallel()
 
-			session := setupSSHSession(t, agentsdk.Manifest{})
+			session := setupSSHSession(t, agentsdk.Manifest{}, codersdk.ServiceBannerConfig{})
 			command := "sh -c 'echo $" + key + "'"
 			if runtime.GOOS == "windows" {
 				command = "cmd.exe /c echo %" + key + "%"
@@ -1666,11 +1731,18 @@ func setupSSHCommand(t *testing.T, beforeArgs []string, afterArgs []string) (*pt
 	return ptytest.Start(t, cmd)
 }
 
-func setupSSHSession(t *testing.T, options agentsdk.Manifest) *ssh.Session {
+func setupSSHSession(
+	t *testing.T,
+	options agentsdk.Manifest,
+	serviceBanner codersdk.ServiceBannerConfig,
+) *ssh.Session {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 	//nolint:dogsled
-	conn, _, _, _, _ := setupAgent(t, options, 0)
+	conn, client, _, _, _ := setupAgent(t, options, 0)
+	client.getServiceBanner = func() (codersdk.ServiceBannerConfig, error) {
+		return serviceBanner, nil
+	}
 	sshClient, err := conn.SSHClient(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -1809,6 +1881,7 @@ type client struct {
 	coordinator        tailnet.Coordinator
 	lastWorkspaceAgent func()
 	patchWorkspaceLogs func() error
+	getServiceBanner   func() (codersdk.ServiceBannerConfig, error)
 
 	mu              sync.Mutex // Protects following.
 	lifecycleStates []codersdk.WorkspaceAgentLifecycle
@@ -1928,6 +2001,15 @@ func (c *client) PatchStartupLogs(_ context.Context, logs agentsdk.PatchStartupL
 	}
 	c.logs = append(c.logs, logs.Logs...)
 	return nil
+}
+
+func (c *client) GetServiceBanner(_ context.Context) (codersdk.ServiceBannerConfig, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.getServiceBanner != nil {
+		return c.getServiceBanner()
+	}
+	return codersdk.ServiceBannerConfig{}, nil
 }
 
 // tempDirUnixSocket returns a temporary directory that can safely hold unix

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -495,23 +495,23 @@ func TestAgent_Session_TTY_QuietLogin(t *testing.T) {
 		require.Contains(t, string(output), wantEcho, "should show echo")
 		require.NotContains(t, string(output), wantNotMOTD, "should not show motd")
 		require.NotContains(t, string(output), wantServiceBanner, "should not show service banner")
+	})
 
+	// Only the MOTD should be silenced.
+	t.Run("Hushlogin", func(t *testing.T) {
 		// Create hushlogin to silence motd.
 		f, err := os.Create(filepath.Join(tmpdir, ".hushlogin"))
 		require.NoError(t, err, "create .hushlogin file")
 		err = f.Close()
 		require.NoError(t, err, "close .hushlogin file")
-	})
 
-	// Only the MOTD should be silenced.
-	t.Run("Hushlogin", func(t *testing.T) {
 		session := setupSSHSession(t, agentsdk.Manifest{
 			MOTDFile: name,
 		}, codersdk.ServiceBannerConfig{
 			Enabled: true,
 			Message: wantServiceBanner,
 		})
-		err := session.RequestPty("xterm", 128, 128, ssh.TerminalModes{})
+		err = session.RequestPty("xterm", 128, 128, ssh.TerminalModes{})
 		require.NoError(t, err)
 
 		ptty := ptytest.New(t)

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -64,10 +64,10 @@ type Server struct {
 	srv          *ssh.Server
 	x11SocketDir string
 
-	Env              map[string]string
-	AgentToken       func() string
-	Manifest         *atomic.Pointer[agentsdk.Manifest]
-	GetServiceBanner func(ctx context.Context) (codersdk.ServiceBannerConfig, error)
+	Env           map[string]string
+	AgentToken    func() string
+	Manifest      *atomic.Pointer[agentsdk.Manifest]
+	ServiceBanner func(ctx context.Context) (codersdk.ServiceBannerConfig, error)
 
 	connCountVSCode     atomic.Int64
 	connCountJetBrains  atomic.Int64
@@ -436,7 +436,7 @@ func (s *Server) startPTYSession(session ptySession, magicTypeLabel string, cmd 
 }
 
 func (s *Server) showServiceBanner(ctx context.Context, session io.Writer) error {
-	banner, err := s.GetServiceBanner(ctx)
+	banner, err := s.ServiceBanner(ctx)
 	if err != nil {
 		return err
 	}

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -349,10 +349,12 @@ func (s *Server) startPTYSession(session ptySession, magicTypeLabel string, cmd 
 
 	if !isQuietLogin(session.RawCommand()) {
 		serviceBanner := s.ServiceBanner.Load()
-		err := showServiceBanner(session, serviceBanner)
-		if err != nil {
-			s.logger.Error(ctx, "agent failed to show service banner", slog.Error(err))
-			s.metrics.sessionErrors.WithLabelValues(magicTypeLabel, "yes", "service_banner").Add(1)
+		if serviceBanner != nil {
+			err := showServiceBanner(session, serviceBanner)
+			if err != nil {
+				s.logger.Error(ctx, "agent failed to show service banner", slog.Error(err))
+				s.metrics.sessionErrors.WithLabelValues(magicTypeLabel, "yes", "service_banner").Add(1)
+			}
 		}
 		manifest := s.Manifest.Load()
 		if manifest != nil {

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -444,8 +444,11 @@ func (s *Server) showServiceBanner(ctx context.Context, session io.Writer) error
 		// The banner supports Markdown so we might want to parse it but Markdown is
 		// still fairly readable in its raw form.
 		_, err = io.WriteString(session, banner.Message+"\n\n\r")
+		if err != nil {
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 func (s *Server) sftpHandler(session ssh.Session) {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -674,7 +674,10 @@ func New(options *Options) *API {
 			r.Post("/google-instance-identity", api.postWorkspaceAuthGoogleInstanceIdentity)
 			r.Get("/connection", api.workspaceAgentConnectionGeneric)
 			r.Route("/me", func(r chi.Router) {
-				r.Use(httpmw.ExtractWorkspaceAgent(options.Database))
+				r.Use(httpmw.ExtractWorkspaceAgent(httpmw.ExtractWorkspaceAgentConfig{
+					DB:       options.Database,
+					Optional: false,
+				}))
 				r.Get("/manifest", api.workspaceAgentManifest)
 				// This route is deprecated and will be removed in a future release.
 				// New agents will use /me/manifest instead.

--- a/coderd/httpmw/actor.go
+++ b/coderd/httpmw/actor.go
@@ -35,3 +35,32 @@ func RequireAPIKeyOrWorkspaceProxyAuth() func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// RequireAPIKeyOrWorkspaceAgent is middleware that should be inserted after
+// optional ExtractAPIKey and ExtractWorkspaceAgent middlewares to ensure one of
+// the two is provided.
+//
+// If both are provided an error is returned to avoid misuse.
+func RequireAPIKeyOrWorkspaceAgent() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, hasAPIKey := APIKeyOptional(r)
+			_, hasWorkspaceAgent := WorkspaceAgentOptional(r)
+
+			if hasAPIKey && hasWorkspaceAgent {
+				httpapi.Write(r.Context(), w, http.StatusBadRequest, codersdk.Response{
+					Message: "API key and workspace agent token provided, but only one is allowed",
+				})
+				return
+			}
+			if !hasAPIKey && !hasWorkspaceAgent {
+				httpapi.Write(r.Context(), w, http.StatusUnauthorized, codersdk.Response{
+					Message: "API key or workspace agent token required, but none provided",
+				})
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/coderd/httpmw/workspaceagent.go
+++ b/coderd/httpmw/workspaceagent.go
@@ -18,40 +18,67 @@ import (
 
 type workspaceAgentContextKey struct{}
 
+func WorkspaceAgentOptional(r *http.Request) (database.WorkspaceAgent, bool) {
+	user, ok := r.Context().Value(workspaceAgentContextKey{}).(database.WorkspaceAgent)
+	return user, ok
+}
+
 // WorkspaceAgent returns the workspace agent from the ExtractAgent handler.
 func WorkspaceAgent(r *http.Request) database.WorkspaceAgent {
-	user, ok := r.Context().Value(workspaceAgentContextKey{}).(database.WorkspaceAgent)
+	user, ok := WorkspaceAgentOptional(r)
 	if !ok {
 		panic("developer error: agent middleware not provided")
 	}
 	return user
 }
 
+type ExtractWorkspaceAgentConfig struct {
+	DB database.Store
+	// Optional indicates whether the middleware should be optional.  If true, any
+	// requests without the a token or with an invalid token will be allowed to
+	// continue and no workspace agent will be set on the request context.
+	Optional bool
+}
+
 // ExtractWorkspaceAgent requires authentication using a valid agent token.
-func ExtractWorkspaceAgent(db database.Store) func(http.Handler) http.Handler {
+func ExtractWorkspaceAgent(opts ExtractWorkspaceAgentConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+
+			// optionalWrite wraps httpapi.Write but runs the next handler if the
+			// token is optional.
+			//
+			// It should be used when the token is not provided or is invalid, but not
+			// when there are other errors.
+			optionalWrite := func(code int, response codersdk.Response) {
+				if opts.Optional {
+					next.ServeHTTP(rw, r)
+					return
+				}
+				httpapi.Write(ctx, rw, code, response)
+			}
+
 			tokenValue := APITokenFromRequest(r)
 			if tokenValue == "" {
-				httpapi.Write(ctx, rw, http.StatusUnauthorized, codersdk.Response{
+				optionalWrite(http.StatusUnauthorized, codersdk.Response{
 					Message: fmt.Sprintf("Cookie %q must be provided.", codersdk.SessionTokenCookie),
 				})
 				return
 			}
 			token, err := uuid.Parse(tokenValue)
 			if err != nil {
-				httpapi.Write(ctx, rw, http.StatusUnauthorized, codersdk.Response{
+				optionalWrite(http.StatusUnauthorized, codersdk.Response{
 					Message: "Workspace agent token invalid.",
 					Detail:  fmt.Sprintf("An agent token must be a valid UUIDv4. (len %d)", len(tokenValue)),
 				})
 				return
 			}
 			//nolint:gocritic // System needs to be able to get workspace agents.
-			agent, err := db.GetWorkspaceAgentByAuthToken(dbauthz.AsSystemRestricted(ctx), token)
+			agent, err := opts.DB.GetWorkspaceAgentByAuthToken(dbauthz.AsSystemRestricted(ctx), token)
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
-					httpapi.Write(ctx, rw, http.StatusUnauthorized, codersdk.Response{
+					optionalWrite(http.StatusUnauthorized, codersdk.Response{
 						Message: "Workspace agent not authorized.",
 						Detail:  "The agent cannot authenticate until the workspace provision job has been completed. If the job is no longer running, this agent is invalid.",
 					})
@@ -66,7 +93,7 @@ func ExtractWorkspaceAgent(db database.Store) func(http.Handler) http.Handler {
 			}
 
 			//nolint:gocritic // System needs to be able to get workspace agents.
-			subject, err := getAgentSubject(dbauthz.AsSystemRestricted(ctx), db, agent)
+			subject, err := getAgentSubject(dbauthz.AsSystemRestricted(ctx), opts.DB, agent)
 			if err != nil {
 				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 					Message: "Internal error fetching workspace agent.",

--- a/coderd/httpmw/workspaceagent.go
+++ b/coderd/httpmw/workspaceagent.go
@@ -27,7 +27,7 @@ func WorkspaceAgentOptional(r *http.Request) (database.WorkspaceAgent, bool) {
 func WorkspaceAgent(r *http.Request) database.WorkspaceAgent {
 	user, ok := WorkspaceAgentOptional(r)
 	if !ok {
-		panic("developer error: agent middleware not provided")
+		panic("developer error: agent middleware not provided or was made optional")
 	}
 	return user
 }

--- a/coderd/httpmw/workspaceagent_test.go
+++ b/coderd/httpmw/workspaceagent_test.go
@@ -30,7 +30,10 @@ func TestWorkspaceAgent(t *testing.T) {
 		db := dbfake.New()
 		rtr := chi.NewRouter()
 		rtr.Use(
-			httpmw.ExtractWorkspaceAgent(db),
+			httpmw.ExtractWorkspaceAgent(httpmw.ExtractWorkspaceAgentConfig{
+				DB:       db,
+				Optional: false,
+			}),
 		)
 		rtr.Get("/", nil)
 		r := setup(db, uuid.New())
@@ -65,7 +68,10 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		rtr := chi.NewRouter()
 		rtr.Use(
-			httpmw.ExtractWorkspaceAgent(db),
+			httpmw.ExtractWorkspaceAgent(httpmw.ExtractWorkspaceAgentConfig{
+				DB:       db,
+				Optional: false,
+			}),
 		)
 		rtr.Get("/", func(rw http.ResponseWriter, r *http.Request) {
 			_ = httpmw.WorkspaceAgent(r)

--- a/coderd/wsconncache/wsconncache_test.go
+++ b/coderd/wsconncache/wsconncache_test.go
@@ -257,3 +257,7 @@ func (*client) PostStartup(_ context.Context, _ agentsdk.PostStartupRequest) err
 func (*client) PatchStartupLogs(_ context.Context, _ agentsdk.PatchStartupLogs) error {
 	return nil
 }
+
+func (*client) GetServiceBanner(_ context.Context) (codersdk.ServiceBannerConfig, error) {
+	return codersdk.ServiceBannerConfig{}, nil
+}

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -593,6 +593,24 @@ func (c *Client) PatchStartupLogs(ctx context.Context, req PatchStartupLogs) err
 	return nil
 }
 
+// GetServiceBanner relays the service banner config.
+func (c *Client) GetServiceBanner(ctx context.Context) (codersdk.ServiceBannerConfig, error) {
+	res, err := c.SDK.Request(ctx, http.MethodGet, "/api/v2/appearance", nil)
+	if err != nil {
+		return codersdk.ServiceBannerConfig{}, err
+	}
+	defer res.Body.Close()
+	// If the route does not exist then Enterprise code is not enabled.
+	if res.StatusCode == http.StatusNotFound {
+		return codersdk.ServiceBannerConfig{}, nil
+	}
+	if res.StatusCode != http.StatusOK {
+		return codersdk.ServiceBannerConfig{}, codersdk.ReadBodyAsError(res)
+	}
+	var cfg codersdk.AppearanceConfig
+	return cfg.ServiceBanner, json.NewDecoder(res.Body).Decode(&cfg)
+}
+
 type GitAuthResponse struct {
 	Username string `json:"username"`
 	Password string `json:"password"`

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -125,6 +125,17 @@ func TestServiceBanners(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, cfg.ServiceBanner, banner)
 
+		// No enterprise means a 404 on the endpoint meaning no banner.
+		client = coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+		})
+		agentClient = agentsdk.New(client.URL)
+		agentClient.SetSessionToken(authToken)
+		banner, err = agentClient.GetServiceBanner(ctx)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.ServiceBannerConfig{}, banner)
+
+		// No license means no banner.
 		client.DeleteLicense(ctx, license.ID)
 		banner, err = agentClient.GetServiceBanner(ctx)
 		require.NoError(t, err)

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -11,68 +11,125 @@ import (
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/codersdk/agentsdk"
 	"github.com/coder/coder/enterprise/coderd"
 	"github.com/coder/coder/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/enterprise/coderd/license"
+	"github.com/coder/coder/provisioner/echo"
 	"github.com/coder/coder/testutil"
+	"github.com/google/uuid"
 )
 
 func TestServiceBanners(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-	defer cancel()
+	t.Run("User", func(t *testing.T) {
+		t.Parallel()
 
-	adminClient := coderdenttest.New(t, &coderdenttest.Options{})
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
 
-	adminUser := coderdtest.CreateFirstUser(t, adminClient)
+		adminClient := coderdenttest.New(t, &coderdenttest.Options{})
 
-	// Even without a license, the banner should return as disabled.
-	sb, err := adminClient.Appearance(ctx)
-	require.NoError(t, err)
-	require.False(t, sb.ServiceBanner.Enabled)
+		adminUser := coderdtest.CreateFirstUser(t, adminClient)
 
-	coderdenttest.AddLicense(t, adminClient, coderdenttest.LicenseOptions{
-		Features: license.Features{
-			codersdk.FeatureAppearance: 1,
-		},
+		// Even without a license, the banner should return as disabled.
+		sb, err := adminClient.Appearance(ctx)
+		require.NoError(t, err)
+		require.False(t, sb.ServiceBanner.Enabled)
+
+		coderdenttest.AddLicense(t, adminClient, coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureAppearance: 1,
+			},
+		})
+
+		// Default state
+		sb, err = adminClient.Appearance(ctx)
+		require.NoError(t, err)
+		require.False(t, sb.ServiceBanner.Enabled)
+
+		basicUserClient, _ := coderdtest.CreateAnotherUser(t, adminClient, adminUser.OrganizationID)
+
+		uac := codersdk.UpdateAppearanceConfig{
+			ServiceBanner: sb.ServiceBanner,
+		}
+		// Regular user should be unable to set the banner
+		uac.ServiceBanner.Enabled = true
+
+		err = basicUserClient.UpdateAppearance(ctx, uac)
+		require.Error(t, err)
+		var sdkError *codersdk.Error
+		require.True(t, errors.As(err, &sdkError))
+		require.Equal(t, http.StatusForbidden, sdkError.StatusCode())
+
+		// But an admin can
+		wantBanner := uac
+		wantBanner.ServiceBanner.Enabled = true
+		wantBanner.ServiceBanner.Message = "Hey"
+		wantBanner.ServiceBanner.BackgroundColor = "#00FF00"
+		err = adminClient.UpdateAppearance(ctx, wantBanner)
+		require.NoError(t, err)
+		gotBanner, err := adminClient.Appearance(ctx)
+		require.NoError(t, err)
+		gotBanner.SupportLinks = nil // clean "support links" before comparison
+		require.Equal(t, wantBanner.ServiceBanner, gotBanner.ServiceBanner)
+
+		// But even an admin can't give a bad color
+		wantBanner.ServiceBanner.BackgroundColor = "#bad color"
+		err = adminClient.UpdateAppearance(ctx, wantBanner)
+		require.Error(t, err)
 	})
 
-	// Default state
-	sb, err = adminClient.Appearance(ctx)
-	require.NoError(t, err)
-	require.False(t, sb.ServiceBanner.Enabled)
+	t.Run("Agent", func(t *testing.T) {
+		t.Parallel()
 
-	basicUserClient, _ := coderdtest.CreateAnotherUser(t, adminClient, adminUser.OrganizationID)
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
 
-	uac := codersdk.UpdateAppearanceConfig{
-		ServiceBanner: sb.ServiceBanner,
-	}
-	// Regular user should be unable to set the banner
-	uac.ServiceBanner.Enabled = true
+		client := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+			},
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+		license := coderdenttest.AddLicense(t, client, coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureAppearance: 1,
+			},
+		})
+		cfg := codersdk.UpdateAppearanceConfig{
+			ServiceBanner: codersdk.ServiceBannerConfig{
+				Enabled:         true,
+				Message:         "Hey",
+				BackgroundColor: "#00FF00",
+			},
+		}
+		err := client.UpdateAppearance(ctx, cfg)
+		require.NoError(t, err)
 
-	err = basicUserClient.UpdateAppearance(ctx, uac)
-	require.Error(t, err)
-	var sdkError *codersdk.Error
-	require.True(t, errors.As(err, &sdkError))
-	require.Equal(t, http.StatusForbidden, sdkError.StatusCode())
+		authToken := uuid.NewString()
+		agentClient := agentsdk.New(client.URL)
+		agentClient.SetSessionToken(authToken)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionPlan:  echo.ProvisionComplete,
+			ProvisionApply: echo.ProvisionApplyWithAgent(authToken),
+		})
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
-	// But an admin can
-	wantBanner := uac
-	wantBanner.ServiceBanner.Enabled = true
-	wantBanner.ServiceBanner.Message = "Hey"
-	wantBanner.ServiceBanner.BackgroundColor = "#00FF00"
-	err = adminClient.UpdateAppearance(ctx, wantBanner)
-	require.NoError(t, err)
-	gotBanner, err := adminClient.Appearance(ctx)
-	require.NoError(t, err)
-	gotBanner.SupportLinks = nil // clean "support links" before comparison
-	require.Equal(t, wantBanner.ServiceBanner, gotBanner.ServiceBanner)
+		banner, err := agentClient.GetServiceBanner(ctx)
+		require.NoError(t, err)
+		require.Equal(t, cfg.ServiceBanner, banner)
 
-	// But even an admin can't give a bad color
-	wantBanner.ServiceBanner.BackgroundColor = "#bad color"
-	err = adminClient.UpdateAppearance(ctx, wantBanner)
-	require.Error(t, err)
+		client.DeleteLicense(ctx, license.ID)
+		banner, err = agentClient.GetServiceBanner(ctx)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.ServiceBannerConfig{}, banner)
+	})
 }
 
 func TestCustomSupportLinks(t *testing.T) {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -78,6 +78,12 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		OAuth2Configs:   oauthConfigs,
 		RedirectToLogin: false,
 	})
+	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+		DB:              options.Database,
+		OAuth2Configs:   oauthConfigs,
+		RedirectToLogin: false,
+		Optional:        true,
+	})
 
 	deploymentID, err := options.Database.GetDeploymentID(ctx)
 	if err != nil {
@@ -192,11 +198,23 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			})
 		})
 		r.Route("/appearance", func(r chi.Router) {
-			r.Use(
-				apiKeyMiddleware,
-			)
-			r.Get("/", api.appearance)
-			r.Put("/", api.putAppearance)
+			r.Group(func(r chi.Router) {
+				r.Use(
+					apiKeyMiddlewareOptional,
+					httpmw.ExtractWorkspaceAgent(httpmw.ExtractWorkspaceAgentConfig{
+						DB:       options.Database,
+						Optional: true,
+					}),
+					httpmw.RequireAPIKeyOrWorkspaceAgent(),
+				)
+				r.Get("/", api.appearance)
+			})
+			r.Group(func(r chi.Router) {
+				r.Use(
+					apiKeyMiddleware,
+				)
+				r.Put("/", api.putAppearance)
+			})
 		})
 	})
 


### PR DESCRIPTION
- [X] Show banner
- [X] Test banner
- [x] Handle non-enterprise (from what I can tell our pattern is to just check the 404?)
- [x] Test auth changes
- [ ] Parse markdown?

Closes #7652.