### PR TITLE
feat: include coder_parameters from external modules

### DIFF
--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -738,15 +738,16 @@ func orderedRichParametersResources(tfResourcesRichParameters []*tfjson.StateRes
 	// Those parameters will be prepended to the "ordered" list.
 	var external []*tfjson.StateResource
 	for _, resource := range tfResourcesRichParameters {
+		isExternal := true
 		for _, o := range ordered {
 			if resource.Name == o.Name {
-				goto next
+				isExternal = false
+				break
 			}
 		}
-
-		// This is external parameter.
-		external = append(external, resource)
-	next:
+		if isExternal {
+			external = append(external, resource)
+		}
 	}
 
 	if len(external) > 0 {
@@ -754,10 +755,7 @@ func orderedRichParametersResources(tfResourcesRichParameters []*tfjson.StateRes
 			return external[i].Name < external[j].Name
 		})
 
-		withExternal := make([]*tfjson.StateResource, 0, len(ordered)+len(external))
-		withExternal = append(withExternal, external...)
-		withExternal = append(withExternal, ordered...)
-		ordered = withExternal
+		ordered = append(external, ordered...)
 	}
 	return ordered
 }

--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -724,11 +724,11 @@ func orderedRichParametersResources(tfResourcesRichParameters []*tfjson.StateRes
 		return tfResourcesRichParameters
 	}
 
-	ordered := make([]*tfjson.StateResource, len(orderedNames))
-	for i, name := range orderedNames {
+	var ordered []*tfjson.StateResource
+	for _, name := range orderedNames {
 		for _, resource := range tfResourcesRichParameters {
 			if resource.Name == name {
-				ordered[i] = resource
+				ordered = append(ordered, resource)
 			}
 		}
 	}
@@ -758,21 +758,6 @@ func orderedRichParametersResources(tfResourcesRichParameters []*tfjson.StateRes
 		withExternal = append(withExternal, external...)
 		withExternal = append(withExternal, ordered...)
 		ordered = withExternal
-	}
-
-	// There's an edge case possible for us to have a parameter name that isn't
-	// present in the state, since the ordered names come statically from
-	// parsing the Terraform file. We need to filter out the nil values if there
-	// are any present.
-	if len(tfResourcesRichParameters) != len(orderedNames) {
-		nonNil := make([]*tfjson.StateResource, 0, len(ordered))
-		for _, resource := range ordered {
-			if resource != nil {
-				nonNil = append(nonNil, resource)
-			}
-		}
-
-		ordered = nonNil
 	}
 	return ordered
 }

--- a/provisioner/terraform/resources.go
+++ b/provisioner/terraform/resources.go
@@ -733,12 +733,38 @@ func orderedRichParametersResources(tfResourcesRichParameters []*tfjson.StateRes
 		}
 	}
 
-	if len(tfResourcesRichParameters) != len(orderedNames) {
-		// There's an edge case possible for us to have a parameter name that isn't
-		// present in the state, since the ordered names come statically from
-		// parsing the Terraform file. We need to filter out the nil values if there
-		// are any present.
+	// Edge case: a parameter is present in an external module (Git repository, static files, etc.),
+	// which can't be easily parsed to check the parameter order.
+	// Those parameters will be prepended to the "ordered" list.
+	var external []*tfjson.StateResource
+	for _, resource := range tfResourcesRichParameters {
+		for _, o := range ordered {
+			if resource.Name == o.Name {
+				goto next
+			}
+		}
 
+		// This is external parameter.
+		external = append(external, resource)
+	next:
+	}
+
+	if len(external) > 0 {
+		sort.Slice(external, func(i, j int) bool {
+			return external[i].Name < external[j].Name
+		})
+
+		withExternal := make([]*tfjson.StateResource, 0, len(ordered)+len(external))
+		withExternal = append(withExternal, external...)
+		withExternal = append(withExternal, ordered...)
+		ordered = withExternal
+	}
+
+	// There's an edge case possible for us to have a parameter name that isn't
+	// present in the state, since the ordered names come statically from
+	// parsing the Terraform file. We need to filter out the nil values if there
+	// are any present.
+	if len(tfResourcesRichParameters) != len(orderedNames) {
 		nonNil := make([]*tfjson.StateResource, 0, len(ordered))
 		for _, resource := range ordered {
 			if resource != nil {
@@ -747,33 +773,6 @@ func orderedRichParametersResources(tfResourcesRichParameters []*tfjson.StateRes
 		}
 
 		ordered = nonNil
-
-		// Another edge case: a parameter is present in an external module (Git repository, static files, etc.),
-		// which can't be easily parsed to check the parameter order.
-		// Those parameters will be prepended to the "ordered" list.
-		var external []*tfjson.StateResource
-		for _, resource := range tfResourcesRichParameters {
-			for _, o := range ordered {
-				if resource.Name == o.Name {
-					goto next
-				}
-			}
-
-			// This is external parameter.
-			external = append(external, resource)
-		next:
-		}
-
-		if len(external) > 0 {
-			sort.Slice(external, func(i, j int) bool {
-				return external[i].Name < external[j].Name
-			})
-
-			withExternal := make([]*tfjson.StateResource, 0, len(ordered)+len(external))
-			withExternal = append(withExternal, external...)
-			withExternal = append(withExternal, ordered...)
-			ordered = withExternal
-		}
 	}
 	return ordered
 }

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -318,6 +318,30 @@ func TestConvertResources(t *testing.T) {
 				}},
 			}},
 			parameters: []*proto.RichParameter{{
+				Name:         "First parameter from child module",
+				Type:         "string",
+				Description:  "First parameter from child module",
+				Mutable:      true,
+				DefaultValue: "abcdef",
+			}, {
+				Name:         "Second parameter from child module",
+				Type:         "string",
+				Description:  "Second parameter from child module",
+				Mutable:      true,
+				DefaultValue: "ghijkl",
+			}, {
+				Name:         "First parameter from module",
+				Type:         "string",
+				Description:  "First parameter from module",
+				Mutable:      true,
+				DefaultValue: "abcdef",
+			}, {
+				Name:         "Second parameter from module",
+				Type:         "string",
+				Description:  "Second parameter from module",
+				Mutable:      true,
+				DefaultValue: "ghijkl",
+			}, {
 				Name: "Example",
 				Type: "string",
 				Options: []*proto.RichParameterOption{{

--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-for d in */; do
+for d in "rich-parameters/"; do
 	pushd "$d"
 	name=$(basename "$(pwd)")
 

--- a/provisioner/terraform/testdata/generate.sh
+++ b/provisioner/terraform/testdata/generate.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-for d in "rich-parameters/"; do
+for d in */; do
 	pushd "$d"
 	name=$(basename "$(pwd)")
 

--- a/provisioner/terraform/testdata/rich-parameters/external-module/child-external-module/main.tf
+++ b/provisioner/terraform/testdata/rich-parameters/external-module/child-external-module/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "0.7.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.22"
+    }
+  }
+}
+
+data "coder_parameter" "child_first_parameter_from_module" {
+  name        = "First parameter from child module"
+  mutable     = true
+  type        = "string"
+  description = "First parameter from child module"
+  default     = "abcdef"
+}
+
+data "coder_parameter" "child_second_parameter_from_module" {
+  name        = "Second parameter from child module"
+  mutable     = true
+  type        = "string"
+  description = "Second parameter from child module"
+  default     = "ghijkl"
+}

--- a/provisioner/terraform/testdata/rich-parameters/external-module/main.tf
+++ b/provisioner/terraform/testdata/rich-parameters/external-module/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "0.7.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.22"
+    }
+  }
+}
+
+data "coder_parameter" "first_parameter_from_module" {
+  name        = "First parameter from module"
+  mutable     = true
+  type        = "string"
+  description = "First parameter from module"
+  default     = "abcdef"
+}
+
+data "coder_parameter" "second_parameter_from_module" {
+  name        = "Second parameter from module"
+  mutable     = true
+  type        = "string"
+  description = "Second parameter from module"
+  default     = "ghijkl"
+}

--- a/provisioner/terraform/testdata/rich-parameters/external-module/main.tf
+++ b/provisioner/terraform/testdata/rich-parameters/external-module/main.tf
@@ -11,6 +11,10 @@ terraform {
   }
 }
 
+module "this_is_external_child_module" {
+  source = "./child-external-module"
+}
+
 data "coder_parameter" "first_parameter_from_module" {
   name        = "First parameter from module"
   mutable     = true

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tf
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tf
@@ -7,6 +7,10 @@ terraform {
   }
 }
 
+module "this_is_external_module" {
+  source = "./external-module"
+}
+
 data "coder_parameter" "sample" {
   name        = "Sample"
   type        = "string"

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.dot
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.dot
@@ -9,6 +9,8 @@ digraph {
 		"[root] data.coder_parameter.number_example_min_max (expand)" [label = "data.coder_parameter.number_example_min_max", shape = "box"]
 		"[root] data.coder_parameter.number_example_min_zero (expand)" [label = "data.coder_parameter.number_example_min_zero", shape = "box"]
 		"[root] data.coder_parameter.sample (expand)" [label = "data.coder_parameter.sample", shape = "box"]
+		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.first_parameter_from_module", shape = "box"]
+		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.second_parameter_from_module", shape = "box"]
 		"[root] null_resource.dev (expand)" [label = "null_resource.dev", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
@@ -19,6 +21,12 @@ digraph {
 		"[root] data.coder_parameter.number_example_min_max (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] data.coder_parameter.number_example_min_zero (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] data.coder_parameter.sample (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
+		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
+		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
+		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
+		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] null_resource.dev (expand)" -> "[root] coder_agent.dev (expand)"
 		"[root] null_resource.dev (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
@@ -28,7 +36,10 @@ digraph {
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.number_example_min_max (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.number_example_min_zero (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.sample (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.dev (expand)"
+		"[root] root" -> "[root] module.this_is_external_module (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
 	}

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.dot
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.dot
@@ -11,6 +11,8 @@ digraph {
 		"[root] data.coder_parameter.sample (expand)" [label = "data.coder_parameter.sample", shape = "box"]
 		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.first_parameter_from_module", shape = "box"]
 		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.second_parameter_from_module", shape = "box"]
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)" [label = "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module", shape = "box"]
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)" [label = "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module", shape = "box"]
 		"[root] null_resource.dev (expand)" [label = "null_resource.dev", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
@@ -23,10 +25,18 @@ digraph {
 		"[root] data.coder_parameter.sample (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
 		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
+		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module (close)"
 		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
 		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
 		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module.module.this_is_external_child_module (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module (expand)" -> "[root] module.this_is_external_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)" -> "[root] module.this_is_external_module.module.this_is_external_child_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)" -> "[root] module.this_is_external_module.module.this_is_external_child_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] null_resource.dev (expand)" -> "[root] coder_agent.dev (expand)"
 		"[root] null_resource.dev (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
@@ -38,6 +48,8 @@ digraph {
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.sample (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.dev (expand)"
 		"[root] root" -> "[root] module.this_is_external_module (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.json
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.json
@@ -127,7 +127,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "62a57280-032d-4528-9705-c663e6971d9d",
+              "id": "39ffc3cf-47a6-40f0-89ed-35b5000ccaa5",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -170,7 +170,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "37b849a7-1830-4662-b804-e23a6fb0a0dd",
+              "id": "0813ad0d-5e92-4f8d-9cbc-e4d86b081fa2",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -195,7 +195,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "21eddf29-7529-4ea4-9416-c0c6c156c3ad",
+              "id": "d1756aa8-9bdc-4cfd-97b2-3db501c346f7",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -232,7 +232,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "826afb7f-80fe-4563-95d3-1f8da1f8c274",
+              "id": "e352b95e-c510-40b4-98b7-b69a46a539c7",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -269,7 +269,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "9656b8ff-4e7b-4ba0-8377-569b358ff110",
+              "id": "a8b5cfc6-c428-4e2e-8920-f3c27961a980",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -306,7 +306,7 @@
               "description": "blah blah",
               "display_name": null,
               "icon": null,
-              "id": "07dd798d-22fe-437d-ae78-2092d01f4b0b",
+              "id": "cf4d916c-3b20-4427-9f7f-c4d01c62ac61",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -319,6 +319,63 @@
             },
             "sensitive_values": {}
           }
+        ],
+        "child_modules": [
+          {
+            "resources": [
+              {
+                "address": "module.this_is_external_module.data.coder_parameter.first_parameter_from_module",
+                "mode": "data",
+                "type": "coder_parameter",
+                "name": "first_parameter_from_module",
+                "provider_name": "registry.terraform.io/coder/coder",
+                "schema_version": 0,
+                "values": {
+                  "default": "abcdef",
+                  "description": "First parameter from module",
+                  "display_name": null,
+                  "icon": null,
+                  "id": "20767647-94e4-414b-a7cd-34eadd0c7b62",
+                  "legacy_variable": null,
+                  "legacy_variable_name": null,
+                  "mutable": true,
+                  "name": "First parameter from module",
+                  "option": null,
+                  "optional": true,
+                  "type": "string",
+                  "validation": null,
+                  "value": "abcdef"
+                },
+                "sensitive_values": {}
+              },
+              {
+                "address": "module.this_is_external_module.data.coder_parameter.second_parameter_from_module",
+                "mode": "data",
+                "type": "coder_parameter",
+                "name": "second_parameter_from_module",
+                "provider_name": "registry.terraform.io/coder/coder",
+                "schema_version": 0,
+                "values": {
+                  "default": "ghijkl",
+                  "description": "Second parameter from module",
+                  "display_name": null,
+                  "icon": null,
+                  "id": "e0d6df8e-8feb-42c8-94e1-1f8f4c3a87c4",
+                  "legacy_variable": null,
+                  "legacy_variable_name": null,
+                  "mutable": true,
+                  "name": "Second parameter from module",
+                  "option": null,
+                  "optional": true,
+                  "type": "string",
+                  "validation": null,
+                  "value": "ghijkl"
+                },
+                "sensitive_values": {}
+              }
+            ],
+            "address": "module.this_is_external_module"
+          }
         ]
       }
     }
@@ -329,6 +386,12 @@
         "name": "coder",
         "full_name": "registry.terraform.io/coder/coder",
         "version_constraint": "0.7.0"
+      },
+      "module.this_is_external_module:docker": {
+        "name": "docker",
+        "full_name": "registry.terraform.io/kreuzwerker/docker",
+        "version_constraint": "~> 2.22",
+        "module_address": "module.this_is_external_module"
       },
       "null": {
         "name": "null",
@@ -526,7 +589,66 @@
           },
           "schema_version": 0
         }
-      ]
+      ],
+      "module_calls": {
+        "this_is_external_module": {
+          "source": "./external-module",
+          "module": {
+            "resources": [
+              {
+                "address": "data.coder_parameter.first_parameter_from_module",
+                "mode": "data",
+                "type": "coder_parameter",
+                "name": "first_parameter_from_module",
+                "provider_config_key": "coder",
+                "expressions": {
+                  "default": {
+                    "constant_value": "abcdef"
+                  },
+                  "description": {
+                    "constant_value": "First parameter from module"
+                  },
+                  "mutable": {
+                    "constant_value": true
+                  },
+                  "name": {
+                    "constant_value": "First parameter from module"
+                  },
+                  "type": {
+                    "constant_value": "string"
+                  }
+                },
+                "schema_version": 0
+              },
+              {
+                "address": "data.coder_parameter.second_parameter_from_module",
+                "mode": "data",
+                "type": "coder_parameter",
+                "name": "second_parameter_from_module",
+                "provider_config_key": "coder",
+                "expressions": {
+                  "default": {
+                    "constant_value": "ghijkl"
+                  },
+                  "description": {
+                    "constant_value": "Second parameter from module"
+                  },
+                  "mutable": {
+                    "constant_value": true
+                  },
+                  "name": {
+                    "constant_value": "Second parameter from module"
+                  },
+                  "type": {
+                    "constant_value": "string"
+                  }
+                },
+                "schema_version": 0
+              }
+            ]
+          }
+        }
+      }
     }
   }
 }

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.json
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfplan.json
@@ -127,7 +127,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "39ffc3cf-47a6-40f0-89ed-35b5000ccaa5",
+              "id": "5b7b6210-ce5d-4cc4-bbd6-0b329ca1c04f",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -170,7 +170,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "0813ad0d-5e92-4f8d-9cbc-e4d86b081fa2",
+              "id": "72a5396c-0b3f-427d-b491-2700b025b3a1",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -195,7 +195,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "d1756aa8-9bdc-4cfd-97b2-3db501c346f7",
+              "id": "63769975-a1e0-42ed-92c1-e003af6b4c54",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -232,7 +232,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "e352b95e-c510-40b4-98b7-b69a46a539c7",
+              "id": "2fce5c05-7018-402b-b653-98d75ad076a2",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -269,7 +269,7 @@
               "description": null,
               "display_name": null,
               "icon": null,
-              "id": "a8b5cfc6-c428-4e2e-8920-f3c27961a980",
+              "id": "4408d7e5-3353-4434-810c-d8c913f29edd",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -306,7 +306,7 @@
               "description": "blah blah",
               "display_name": null,
               "icon": null,
-              "id": "cf4d916c-3b20-4427-9f7f-c4d01c62ac61",
+              "id": "2b05e465-b243-4ae0-9210-634cf0f65d20",
               "legacy_variable": null,
               "legacy_variable_name": null,
               "mutable": false,
@@ -335,7 +335,7 @@
                   "description": "First parameter from module",
                   "display_name": null,
                   "icon": null,
-                  "id": "20767647-94e4-414b-a7cd-34eadd0c7b62",
+                  "id": "fc0491e2-ea2e-4fa7-9b0b-08298fb768f4",
                   "legacy_variable": null,
                   "legacy_variable_name": null,
                   "mutable": true,
@@ -360,7 +360,7 @@
                   "description": "Second parameter from module",
                   "display_name": null,
                   "icon": null,
-                  "id": "e0d6df8e-8feb-42c8-94e1-1f8f4c3a87c4",
+                  "id": "693fb916-39ed-4798-8724-0e751a2458e4",
                   "legacy_variable": null,
                   "legacy_variable_name": null,
                   "mutable": true,
@@ -374,7 +374,64 @@
                 "sensitive_values": {}
               }
             ],
-            "address": "module.this_is_external_module"
+            "address": "module.this_is_external_module",
+            "child_modules": [
+              {
+                "resources": [
+                  {
+                    "address": "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module",
+                    "mode": "data",
+                    "type": "coder_parameter",
+                    "name": "child_first_parameter_from_module",
+                    "provider_name": "registry.terraform.io/coder/coder",
+                    "schema_version": 0,
+                    "values": {
+                      "default": "abcdef",
+                      "description": "First parameter from child module",
+                      "display_name": null,
+                      "icon": null,
+                      "id": "8014f515-a467-4dfe-ac63-8c7eadfc3521",
+                      "legacy_variable": null,
+                      "legacy_variable_name": null,
+                      "mutable": true,
+                      "name": "First parameter from child module",
+                      "option": null,
+                      "optional": true,
+                      "type": "string",
+                      "validation": null,
+                      "value": "abcdef"
+                    },
+                    "sensitive_values": {}
+                  },
+                  {
+                    "address": "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module",
+                    "mode": "data",
+                    "type": "coder_parameter",
+                    "name": "child_second_parameter_from_module",
+                    "provider_name": "registry.terraform.io/coder/coder",
+                    "schema_version": 0,
+                    "values": {
+                      "default": "ghijkl",
+                      "description": "Second parameter from child module",
+                      "display_name": null,
+                      "icon": null,
+                      "id": "e94a306e-c1aa-47f5-833f-19719868d9ce",
+                      "legacy_variable": null,
+                      "legacy_variable_name": null,
+                      "mutable": true,
+                      "name": "Second parameter from child module",
+                      "option": null,
+                      "optional": true,
+                      "type": "string",
+                      "validation": null,
+                      "value": "ghijkl"
+                    },
+                    "sensitive_values": {}
+                  }
+                ],
+                "address": "module.this_is_external_module.module.this_is_external_child_module"
+              }
+            ]
           }
         ]
       }
@@ -645,7 +702,66 @@
                 },
                 "schema_version": 0
               }
-            ]
+            ],
+            "module_calls": {
+              "this_is_external_child_module": {
+                "source": "./child-external-module",
+                "module": {
+                  "resources": [
+                    {
+                      "address": "data.coder_parameter.child_first_parameter_from_module",
+                      "mode": "data",
+                      "type": "coder_parameter",
+                      "name": "child_first_parameter_from_module",
+                      "provider_config_key": "coder",
+                      "expressions": {
+                        "default": {
+                          "constant_value": "abcdef"
+                        },
+                        "description": {
+                          "constant_value": "First parameter from child module"
+                        },
+                        "mutable": {
+                          "constant_value": true
+                        },
+                        "name": {
+                          "constant_value": "First parameter from child module"
+                        },
+                        "type": {
+                          "constant_value": "string"
+                        }
+                      },
+                      "schema_version": 0
+                    },
+                    {
+                      "address": "data.coder_parameter.child_second_parameter_from_module",
+                      "mode": "data",
+                      "type": "coder_parameter",
+                      "name": "child_second_parameter_from_module",
+                      "provider_config_key": "coder",
+                      "expressions": {
+                        "default": {
+                          "constant_value": "ghijkl"
+                        },
+                        "description": {
+                          "constant_value": "Second parameter from child module"
+                        },
+                        "mutable": {
+                          "constant_value": true
+                        },
+                        "name": {
+                          "constant_value": "Second parameter from child module"
+                        },
+                        "type": {
+                          "constant_value": "string"
+                        }
+                      },
+                      "schema_version": 0
+                    }
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.dot
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.dot
@@ -9,6 +9,8 @@ digraph {
 		"[root] data.coder_parameter.number_example_min_max (expand)" [label = "data.coder_parameter.number_example_min_max", shape = "box"]
 		"[root] data.coder_parameter.number_example_min_zero (expand)" [label = "data.coder_parameter.number_example_min_zero", shape = "box"]
 		"[root] data.coder_parameter.sample (expand)" [label = "data.coder_parameter.sample", shape = "box"]
+		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.first_parameter_from_module", shape = "box"]
+		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.second_parameter_from_module", shape = "box"]
 		"[root] null_resource.dev (expand)" [label = "null_resource.dev", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
@@ -19,6 +21,12 @@ digraph {
 		"[root] data.coder_parameter.number_example_min_max (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] data.coder_parameter.number_example_min_zero (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] data.coder_parameter.sample (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
+		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
+		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
+		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
+		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] null_resource.dev (expand)" -> "[root] coder_agent.dev (expand)"
 		"[root] null_resource.dev (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
@@ -28,7 +36,10 @@ digraph {
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.number_example_min_max (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.number_example_min_zero (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.sample (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.dev (expand)"
+		"[root] root" -> "[root] module.this_is_external_module (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)"
 	}

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.dot
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.dot
@@ -11,6 +11,8 @@ digraph {
 		"[root] data.coder_parameter.sample (expand)" [label = "data.coder_parameter.sample", shape = "box"]
 		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.first_parameter_from_module", shape = "box"]
 		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" [label = "module.this_is_external_module.data.coder_parameter.second_parameter_from_module", shape = "box"]
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)" [label = "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module", shape = "box"]
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)" [label = "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module", shape = "box"]
 		"[root] null_resource.dev (expand)" [label = "null_resource.dev", shape = "box"]
 		"[root] provider[\"registry.terraform.io/coder/coder\"]" [label = "provider[\"registry.terraform.io/coder/coder\"]", shape = "diamond"]
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"]" [label = "provider[\"registry.terraform.io/hashicorp/null\"]", shape = "diamond"]
@@ -23,10 +25,18 @@ digraph {
 		"[root] data.coder_parameter.sample (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
 		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
+		"[root] module.this_is_external_module (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module (close)"
 		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
 		"[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] module.this_is_external_module (expand)"
 		"[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module.module.this_is_external_child_module (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module (expand)" -> "[root] module.this_is_external_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)" -> "[root] module.this_is_external_module.module.this_is_external_child_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)" -> "[root] module.this_is_external_module.module.this_is_external_child_module (expand)"
+		"[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)" -> "[root] provider[\"registry.terraform.io/coder/coder\"]"
 		"[root] null_resource.dev (expand)" -> "[root] coder_agent.dev (expand)"
 		"[root] null_resource.dev (expand)" -> "[root] provider[\"registry.terraform.io/hashicorp/null\"]"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] coder_agent.dev (expand)"
@@ -38,6 +48,8 @@ digraph {
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] data.coder_parameter.sample (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.first_parameter_from_module (expand)"
 		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.data.coder_parameter.second_parameter_from_module (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module (expand)"
+		"[root] provider[\"registry.terraform.io/coder/coder\"] (close)" -> "[root] module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module (expand)"
 		"[root] provider[\"registry.terraform.io/hashicorp/null\"] (close)" -> "[root] null_resource.dev (expand)"
 		"[root] root" -> "[root] module.this_is_external_module (close)"
 		"[root] root" -> "[root] provider[\"registry.terraform.io/coder/coder\"] (close)"

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.json
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.json
@@ -16,7 +16,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "211d3d9a-b131-42d7-b0e7-30b194bbfb35",
+            "id": "ca194a3d-90c5-4a74-8b9f-c299bc4dad33",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -59,7 +59,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "229a50ba-e1df-4fa7-8790-86f04b8caa43",
+            "id": "c1a68d9c-5a5e-4560-9319-053addb068af",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -84,7 +84,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "a2ef64c1-3f91-402c-a1b7-10e0056fd9e7",
+            "id": "04492d05-0c3b-4fc1-a8b7-da70499ff7b6",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -121,7 +121,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "5f23857a-62f7-4a4e-82cb-18873a73b85e",
+            "id": "852d5fc8-6d3b-4279-8165-fc6942e361f3",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -158,7 +158,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "5aedf1af-ce43-4eac-af9e-4c50c680bd8e",
+            "id": "b811e107-17b2-44bd-a2aa-58586ba3725f",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -195,7 +195,7 @@
             "description": "blah blah",
             "display_name": null,
             "icon": null,
-            "id": "011b009e-9d6e-4be4-b209-0f318c7a1201",
+            "id": "60d8c0b7-8442-4751-a4b3-0bff927fdbcb",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -221,7 +221,7 @@
             "connection_timeout": 120,
             "dir": null,
             "env": null,
-            "id": "b91a350f-5f8a-4e3d-b203-637983b915e2",
+            "id": "4c9d79a7-73e9-4f4f-8efb-464a393d64cd",
             "init_script": "",
             "login_before_ready": true,
             "metadata": [],
@@ -231,7 +231,7 @@
             "shutdown_script_timeout": 300,
             "startup_script": null,
             "startup_script_timeout": 300,
-            "token": "cb825ffb-869b-4c3e-b0db-152c257ec798",
+            "token": "c31a5e7a-f0f2-4e61-aae8-82ae2456358b",
             "troubleshooting_url": null
           },
           "sensitive_values": {
@@ -246,7 +246,7 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "7399774983467665930",
+            "id": "3848665340553657624",
             "triggers": null
           },
           "sensitive_values": {},
@@ -270,7 +270,7 @@
                 "description": "First parameter from module",
                 "display_name": null,
                 "icon": null,
-                "id": "ee0fbe84-0497-4bd3-b4d3-97610cbad6b9",
+                "id": "3f49f2f3-0a0a-49ff-9b7d-e34867f0f515",
                 "legacy_variable": null,
                 "legacy_variable_name": null,
                 "mutable": true,
@@ -295,7 +295,7 @@
                 "description": "Second parameter from module",
                 "display_name": null,
                 "icon": null,
-                "id": "dc8a50d1-1b52-4bb4-bfbd-e2718b0dccb0",
+                "id": "d1a6e987-b032-4107-88fd-f0aee0f3c1d3",
                 "legacy_variable": null,
                 "legacy_variable_name": null,
                 "mutable": true,
@@ -309,7 +309,64 @@
               "sensitive_values": {}
             }
           ],
-          "address": "module.this_is_external_module"
+          "address": "module.this_is_external_module",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_first_parameter_from_module",
+                  "mode": "data",
+                  "type": "coder_parameter",
+                  "name": "child_first_parameter_from_module",
+                  "provider_name": "registry.terraform.io/coder/coder",
+                  "schema_version": 0,
+                  "values": {
+                    "default": "abcdef",
+                    "description": "First parameter from child module",
+                    "display_name": null,
+                    "icon": null,
+                    "id": "79d7a875-18e2-4fcd-ac9a-ad6de9f00c20",
+                    "legacy_variable": null,
+                    "legacy_variable_name": null,
+                    "mutable": true,
+                    "name": "First parameter from child module",
+                    "option": null,
+                    "optional": true,
+                    "type": "string",
+                    "validation": null,
+                    "value": "abcdef"
+                  },
+                  "sensitive_values": {}
+                },
+                {
+                  "address": "module.this_is_external_module.module.this_is_external_child_module.data.coder_parameter.child_second_parameter_from_module",
+                  "mode": "data",
+                  "type": "coder_parameter",
+                  "name": "child_second_parameter_from_module",
+                  "provider_name": "registry.terraform.io/coder/coder",
+                  "schema_version": 0,
+                  "values": {
+                    "default": "ghijkl",
+                    "description": "Second parameter from child module",
+                    "display_name": null,
+                    "icon": null,
+                    "id": "b71db658-46c0-4dca-8530-1d4f464b7ad6",
+                    "legacy_variable": null,
+                    "legacy_variable_name": null,
+                    "mutable": true,
+                    "name": "Second parameter from child module",
+                    "option": null,
+                    "optional": true,
+                    "type": "string",
+                    "validation": null,
+                    "value": "ghijkl"
+                  },
+                  "sensitive_values": {}
+                }
+              ],
+              "address": "module.this_is_external_module.module.this_is_external_child_module"
+            }
+          ]
         }
       ]
     }

--- a/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.json
+++ b/provisioner/terraform/testdata/rich-parameters/rich-parameters.tfstate.json
@@ -16,7 +16,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "5860f577-b0e7-4bb6-a4de-9de71a801ba0",
+            "id": "211d3d9a-b131-42d7-b0e7-30b194bbfb35",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -59,7 +59,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "ecac8658-4def-424a-a24e-0a8c906cf8e8",
+            "id": "229a50ba-e1df-4fa7-8790-86f04b8caa43",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -84,7 +84,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "6996b908-2bd9-4043-8821-59aada8fa202",
+            "id": "a2ef64c1-3f91-402c-a1b7-10e0056fd9e7",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -121,7 +121,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "a368fde8-b9ab-479f-92fb-776f4d5d3e53",
+            "id": "5f23857a-62f7-4a4e-82cb-18873a73b85e",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -158,7 +158,7 @@
             "description": null,
             "display_name": null,
             "icon": null,
-            "id": "55ff394f-995a-43d8-b05f-9fbf72f62d18",
+            "id": "5aedf1af-ce43-4eac-af9e-4c50c680bd8e",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -195,7 +195,7 @@
             "description": "blah blah",
             "display_name": null,
             "icon": null,
-            "id": "6a1fb6c7-eb4d-443b-9968-1813668794d0",
+            "id": "011b009e-9d6e-4be4-b209-0f318c7a1201",
             "legacy_variable": null,
             "legacy_variable_name": null,
             "mutable": false,
@@ -221,7 +221,7 @@
             "connection_timeout": 120,
             "dir": null,
             "env": null,
-            "id": "9e190fb1-8087-4c64-b99d-1e0bd1067ed8",
+            "id": "b91a350f-5f8a-4e3d-b203-637983b915e2",
             "init_script": "",
             "login_before_ready": true,
             "metadata": [],
@@ -231,7 +231,7 @@
             "shutdown_script_timeout": 300,
             "startup_script": null,
             "startup_script_timeout": 300,
-            "token": "1e09aaa2-0700-4968-abbd-0b8ab8f9fefc",
+            "token": "cb825ffb-869b-4c3e-b0db-152c257ec798",
             "troubleshooting_url": null
           },
           "sensitive_values": {
@@ -246,13 +246,70 @@
           "provider_name": "registry.terraform.io/hashicorp/null",
           "schema_version": 0,
           "values": {
-            "id": "7817924891856217249",
+            "id": "7399774983467665930",
             "triggers": null
           },
           "sensitive_values": {},
           "depends_on": [
             "coder_agent.dev"
           ]
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.this_is_external_module.data.coder_parameter.first_parameter_from_module",
+              "mode": "data",
+              "type": "coder_parameter",
+              "name": "first_parameter_from_module",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 0,
+              "values": {
+                "default": "abcdef",
+                "description": "First parameter from module",
+                "display_name": null,
+                "icon": null,
+                "id": "ee0fbe84-0497-4bd3-b4d3-97610cbad6b9",
+                "legacy_variable": null,
+                "legacy_variable_name": null,
+                "mutable": true,
+                "name": "First parameter from module",
+                "option": null,
+                "optional": true,
+                "type": "string",
+                "validation": null,
+                "value": "abcdef"
+              },
+              "sensitive_values": {}
+            },
+            {
+              "address": "module.this_is_external_module.data.coder_parameter.second_parameter_from_module",
+              "mode": "data",
+              "type": "coder_parameter",
+              "name": "second_parameter_from_module",
+              "provider_name": "registry.terraform.io/coder/coder",
+              "schema_version": 0,
+              "values": {
+                "default": "ghijkl",
+                "description": "Second parameter from module",
+                "display_name": null,
+                "icon": null,
+                "id": "dc8a50d1-1b52-4bb4-bfbd-e2718b0dccb0",
+                "legacy_variable": null,
+                "legacy_variable_name": null,
+                "mutable": true,
+                "name": "Second parameter from module",
+                "option": null,
+                "optional": true,
+                "type": "string",
+                "validation": null,
+                "value": "ghijkl"
+              },
+              "sensitive_values": {}
+            }
+          ],
+          "address": "module.this_is_external_module"
         }
       ]
     }


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/8090

This PR modifies the `ConvertResources` logic to include `coder_parameter`s from external modules. It also refactors the routine to prevent `nil` resources.