### PR TITLE
chore: add examples templates to docs filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,10 @@ jobs:
             docs:
               - "docs/**"
               - "README.md"
-              # For testing:
-              # - ".github/**"
+              - "examples/templates/**"
+              - "examples/web-server/**"
+              - "examples/monitoring/**"
+              - "examples/lima/**"
             go:
               - "**.sql"
               - "**.go"


### PR DESCRIPTION
Add example templates to the docs filter to avoid running unnecessary checks in ci. 