### PR TITLE
chore: ignore sub directories in examples for go files check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
               - "cmd/**"
               - "coderd/**"
               - "enterprise/**"
-              - "examples/**"
+              - "examples/*"
               - "provisioner/**"
               - "provisionerd/**"
               - "provisionersdk/**"


### PR DESCRIPTION
There are no go files in any subdirectory in the examples directory.

✅ This will prevent running any go tests when we change example templates.
⚠️ This will prevent dogfood deployment when templates are changed, as they are now included in docs-only checks. 