### PR TITLE
chore: fix broken docs links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,8 @@ jobs:
             docs:
               - "docs/**"
               - "README.md"
-              - "examples/templates/**"
-              - "examples/web-server/**"
-              - "examples/monitoring/**"
-              - "examples/lima/**"
+              # For testing:
+              # - ".github/**"
             go:
               - "**.sql"
               - "**.go"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,10 @@ jobs:
             docs:
               - "docs/**"
               - "README.md"
-              # For testing:
-              # - ".github/**"
+              - "examples/templates/**"
+              - "examples/web-server/**"
+              - "examples/monitoring/**"
+              - "examples/lima/**"
             go:
               - "**.sql"
               - "**.go"

--- a/docs/admin/audit-logs.md
+++ b/docs/admin/audit-logs.md
@@ -49,13 +49,13 @@ In addition to the user interface, there are multiple ways to consume or query a
 
 ## REST API
 
-Audit logs can be accessed through our REST API. You can find detailed information about this in our [endpoint documentation](../api/audit#get-audit-logs).
+Audit logs can be accessed through our REST API. You can find detailed information about this in our [endpoint documentation](../api/audit.md#get-audit-logs).
 
 ## Service Logs
 
 Audit trails are also dispatched as service logs and can be captured and categorized using any log management tool such as [Splunk](https://splunk.com).
 
-Example of a [JSON formatted](../cli/server#--log-json) audit log entry:
+Example of a [JSON formatted](../cli/server.md#--log-json) audit log entry:
 
 ```json
 {
@@ -90,7 +90,7 @@ Example of a [JSON formatted](../cli/server#--log-json) audit log entry:
 }
 ```
 
-Example of a [human readable](../cli/server#--log-human) audit log entry:
+Example of a [human readable](../cli/server.md#--log-human) audit log entry:
 
 ```sh
 2023-06-13 03:43:29.233 [info]  coderd: audit_log  ID=95f7c392-da3e-480c-a579-8909f145fbe2  Time="2023-06-13T03:43:29.230422Z"  UserID=6c405053-27e3-484a-9ad7-bcb64e7bfde6  OrganizationID=00000000-0000-0000-0000-000000000000  Ip=<nil>  UserAgent=<nil>  ResourceType=workspace_build  ResourceID=988ae133-5b73-41e3-a55e-e1e9d3ef0b66  ResourceTarget=""  Action=start  Diff="{}"  StatusCode=200  AdditionalFields="{\"workspace_name\":\"linux-container\",\"build_number\":\"7\",\"build_reason\":\"initiator\",\"workspace_owner\":\"\"}"  RequestID=9682b1b5-7b9f-4bf2-9a39-9463f8e41cd6  ResourceIcon=""

--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -100,7 +100,7 @@ must include credentials (set `credentials: "include"` if using `fetch`) or the
 requests cannot be authenticated and you will see an error resembling the
 following:
 
-> Access to fetch at 'https://dev.coder.com/api/v2/applications/auth-redirect' from origin 'https://8000--dev--user--apps.dev.coder.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
+> Access to fetch at 'https://coder.example.com/api/v2/applications/auth-redirect' from origin 'https://8000--dev--user--apps.coder.example.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 
 #### Headers
 
@@ -110,7 +110,7 @@ Below is a list of the cross-origin headers Coder sets with example values:
 access-control-allow-credentials: true
 access-control-allow-methods: PUT
 access-control-allow-headers: X-Custom-Header
-access-control-allow-origin: https://8000--dev--user--apps.dev.coder.com
+access-control-allow-origin: https://8000--dev--user--apps.coder.example.com
 vary: Origin
 vary: Access-Control-Request-Method
 vary: Access-Control-Request-Headers


### PR DESCRIPTION
Resolves
https://github.com/coder/coder/actions/runs/5376261240/jobs/9753175383

It looks like even though some links are valid. 
Our links validation doesn't like when we miss `.md` at the end of file names. 
Also, we check for all links to be available except `*.example.com` so please please consider using `coder.example.com` instead of `dev.coder.com` in examples. 