### PR TITLE
fix(scaletest): adjust sessionAffinity and scenario resources

### DIFF
--- a/scaletest/terraform/coder.tf
+++ b/scaletest/terraform/coder.tf
@@ -121,6 +121,7 @@ coder:
     readOnlyRootFilesystem: true
   service:
     enable: true
+    sessionAffinity: None
     loadBalancerIP: "${local.coder_address}"
   volumeMounts:
   - mountPath: "/tmp"

--- a/scaletest/terraform/scenario-large.tfvars
+++ b/scaletest/terraform/scenario-large.tfvars
@@ -1,4 +1,6 @@
 nodepool_machine_type_coder      = "t2d-standard-8"
+nodepool_size_coder              = 3
 nodepool_machine_type_workspaces = "t2d-standard-8"
-coder_cpu                        = "7"    # Leaving 1 CPU for system workloads
-coder_mem                        = "28Gi" # Leaving 4GB for system workloads
+coder_cpu                        = "6000m" # Leaving 2 CPUs for system workloads
+coder_mem                        = "24Gi"  # Leaving 8 GB for system workloads
+coder_replicas                   = 3

--- a/scaletest/terraform/scenario-medium.tfvars
+++ b/scaletest/terraform/scenario-medium.tfvars
@@ -1,4 +1,4 @@
-nodepool_machine_type_coder      = "t2d-standard-4"
-nodepool_machine_type_workspaces = "t2d-standard-4"
-coder_cpu                        = "3000m" # Leaving 1 CPU for system workloads
-coder_mem                        = "12Gi"  # Leaving 4 GB for system workloads
+nodepool_machine_type_coder      = "t2d-standard-8"
+nodepool_machine_type_workspaces = "t2d-standard-8"
+coder_cpu                        = "6000m" # Leaving 2 CPUs for system workloads
+coder_mem                        = "24Gi"  # Leaving 8 GB for system workloads

--- a/scaletest/terraform/scenario-small.tfvars
+++ b/scaletest/terraform/scenario-small.tfvars
@@ -1,4 +1,4 @@
-nodepool_machine_type_coder      = "t2d-standard-2"
-nodepool_machine_type_workspaces = "t2d-standard-2"
-coder_cpu                        = "1000m" # Leaving 1 CPU for system workloads
-coder_mem                        = "4Gi"   # Leaving 4GB for system workloads
+nodepool_machine_type_coder      = "t2d-standard-4"
+nodepool_machine_type_workspaces = "t2d-standard-4"
+coder_cpu                        = "2000m" # Leaving 2 CPUs for system workloads
+coder_mem                        = "12Gi"  # Leaving 4GB for system workloads


### PR DESCRIPTION
- The default service session affinity is ClientIP, which means that we won't distribute traffic over multiple coderd replicas. Explicitly setting to None.
- Adjusting scenario resource definitions: small did not have sufficient CPU, so bumping instance type. Large is now medium with 3x coderd replicas.