### PR TITLE
fix(cli): stat: explicitly specify resource SI prefix

### DIFF
--- a/cli/clistat/cgroup.go
+++ b/cli/clistat/cgroup.go
@@ -84,9 +84,10 @@ func (s *Statter) ContainerCPU() (*Result, error) {
 	}
 
 	r := &Result{
-		Unit:  "cores",
-		Used:  used2 - used1,
-		Total: ptr.To(total),
+		Unit:   "cores",
+		Used:   used2 - used1,
+		Total:  ptr.To(total),
+		Prefix: PrefixDefault,
 	}
 	return r, nil
 }
@@ -184,20 +185,20 @@ func (s *Statter) cGroupV1CPUUsed() (float64, error) {
 
 // ContainerMemory returns the memory usage of the container cgroup.
 // If the system is not containerized, this always returns nil.
-func (s *Statter) ContainerMemory() (*Result, error) {
+func (s *Statter) ContainerMemory(p Prefix) (*Result, error) {
 	if ok, err := IsContainerized(s.fs); err != nil || !ok {
 		return nil, nil //nolint:nilnil
 	}
 
 	if s.isCGroupV2() {
-		return s.cGroupV2Memory()
+		return s.cGroupV2Memory(p)
 	}
 
 	// Fall back to CGroupv1
-	return s.cGroupV1Memory()
+	return s.cGroupV1Memory(p)
 }
 
-func (s *Statter) cGroupV2Memory() (*Result, error) {
+func (s *Statter) cGroupV2Memory(p Prefix) (*Result, error) {
 	maxUsageBytes, err := readInt64(s.fs, cgroupV2MemoryMaxBytes)
 	if err != nil {
 		return nil, xerrors.Errorf("read memory total: %w", err)
@@ -214,13 +215,14 @@ func (s *Statter) cGroupV2Memory() (*Result, error) {
 	}
 
 	return &Result{
-		Total: ptr.To(float64(maxUsageBytes)),
-		Used:  float64(currUsageBytes - inactiveFileBytes),
-		Unit:  "B",
+		Total:  ptr.To(float64(maxUsageBytes)),
+		Used:   float64(currUsageBytes - inactiveFileBytes),
+		Unit:   "B",
+		Prefix: p,
 	}, nil
 }
 
-func (s *Statter) cGroupV1Memory() (*Result, error) {
+func (s *Statter) cGroupV1Memory(p Prefix) (*Result, error) {
 	maxUsageBytes, err := readInt64(s.fs, cgroupV1MemoryMaxUsageBytes)
 	if err != nil {
 		return nil, xerrors.Errorf("read memory total: %w", err)
@@ -239,9 +241,10 @@ func (s *Statter) cGroupV1Memory() (*Result, error) {
 
 	// Total memory used is usage - total_inactive_file
 	return &Result{
-		Total: ptr.To(float64(maxUsageBytes)),
-		Used:  float64(usageBytes - totalInactiveFileBytes),
-		Unit:  "B",
+		Total:  ptr.To(float64(maxUsageBytes)),
+		Used:   float64(usageBytes - totalInactiveFileBytes),
+		Unit:   "B",
+		Prefix: p,
 	}, nil
 }
 

--- a/cli/clistat/disk.go
+++ b/cli/clistat/disk.go
@@ -10,7 +10,7 @@ import (
 
 // Disk returns the disk usage of the given path.
 // If path is empty, it returns the usage of the root directory.
-func (*Statter) Disk(path string) (*Result, error) {
+func (*Statter) Disk(p Prefix, path string) (*Result, error) {
 	if path == "" {
 		path = "/"
 	}
@@ -22,5 +22,6 @@ func (*Statter) Disk(path string) (*Result, error) {
 	r.Total = ptr.To(float64(stat.Blocks * uint64(stat.Bsize)))
 	r.Used = float64(stat.Blocks-stat.Bfree) * float64(stat.Bsize)
 	r.Unit = "B"
+	r.Prefix = p
 	return &r, nil
 }

--- a/cli/clistat/disk_windows.go
+++ b/cli/clistat/disk_windows.go
@@ -7,7 +7,7 @@ import (
 
 // Disk returns the disk usage of the given path.
 // If path is empty, it defaults to C:\
-func (*Statter) Disk(path string) (*Result, error) {
+func (*Statter) Disk(p Prefix, path string) (*Result, error) {
 	if path == "" {
 		path = `C:\`
 	}
@@ -31,5 +31,6 @@ func (*Statter) Disk(path string) (*Result, error) {
 	r.Total = ptr.To(float64(totalBytes))
 	r.Used = float64(totalBytes - freeBytes)
 	r.Unit = "B"
+	r.Prefix = p
 	return &r, nil
 }

--- a/cli/clistat/stat_internal_test.go
+++ b/cli/clistat/stat_internal_test.go
@@ -33,19 +33,19 @@ func TestResultString(t *testing.T) {
 			Result:   Result{Used: 12.34, Total: nil, Unit: ""},
 		},
 		{
-			Expected: "1.54 kB",
-			Result:   Result{Used: 1536, Total: nil, Unit: "B"},
+			Expected: "1.5 KiB",
+			Result:   Result{Used: 1536, Total: nil, Unit: "B", Prefix: PrefixKibi},
 		},
 		{
 			Expected: "1.23 things",
 			Result:   Result{Used: 1.234, Total: nil, Unit: "things"},
 		},
 		{
-			Expected: "1 B/100 TB (0%)",
-			Result:   Result{Used: 1, Total: ptr.To(1000 * 1000 * 1000 * 1000 * 100.0), Unit: "B"},
+			Expected: "0/100 TiB (0%)",
+			Result:   Result{Used: 1, Total: ptr.To(100.0 * float64(PrefixTebi)), Unit: "B", Prefix: PrefixTebi},
 		},
 		{
-			Expected: "500 mcores/8 cores (6%)",
+			Expected: "0.5/8 cores (6%)",
 			Result:   Result{Used: 0.5, Total: ptr.To(8.0), Unit: "cores"},
 		},
 	} {
@@ -76,7 +76,7 @@ func TestStatter(t *testing.T) {
 
 		t.Run("HostMemory", func(t *testing.T) {
 			t.Parallel()
-			mem, err := s.HostMemory()
+			mem, err := s.HostMemory(PrefixDefault)
 			require.NoError(t, err)
 			assert.NotZero(t, mem.Used)
 			assert.NotZero(t, mem.Total)
@@ -85,7 +85,7 @@ func TestStatter(t *testing.T) {
 
 		t.Run("HostDisk", func(t *testing.T) {
 			t.Parallel()
-			disk, err := s.Disk("") // default to home dir
+			disk, err := s.Disk(PrefixDefault, "") // default to home dir
 			require.NoError(t, err)
 			assert.NotZero(t, disk.Used)
 			assert.NotZero(t, disk.Total)
@@ -159,7 +159,7 @@ func TestStatter(t *testing.T) {
 			fs := initFS(t, fsContainerCgroupV1)
 			s, err := New(WithFS(fs), withNoWait)
 			require.NoError(t, err)
-			mem, err := s.ContainerMemory()
+			mem, err := s.ContainerMemory(PrefixDefault)
 			require.NoError(t, err)
 			require.NotNil(t, mem)
 			assert.Equal(t, 268435456.0, mem.Used)
@@ -211,7 +211,7 @@ func TestStatter(t *testing.T) {
 			fs := initFS(t, fsContainerCgroupV2)
 			s, err := New(WithFS(fs), withNoWait)
 			require.NoError(t, err)
-			mem, err := s.ContainerMemory()
+			mem, err := s.ContainerMemory(PrefixDefault)
 			require.NoError(t, err)
 			require.NotNil(t, mem)
 			assert.Equal(t, 268435456.0, mem.Used)

--- a/cli/testdata/coder_stat_cpu_--help.golden
+++ b/cli/testdata/coder_stat_cpu_--help.golden
@@ -9,8 +9,5 @@ Show CPU usage, in cores.
   -o, --output string (default: text)
           Output format. Available formats: text, json.
 
-      --prefix string
-          Unit prefix.
-
 ---
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_stat_disk_--help.golden
+++ b/cli/testdata/coder_stat_disk_--help.golden
@@ -9,5 +9,8 @@ Show disk usage, in gigabytes.
       --path string (default: /)
           Path for which to check disk usage.
 
+      --prefix Ki|Mi|Gi|Ti (default: Gi)
+          SI Prefix for disk measurement.
+
 ---
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_stat_mem_--help.golden
+++ b/cli/testdata/coder_stat_mem_--help.golden
@@ -9,5 +9,8 @@ Show memory usage, in gigabytes.
   -o, --output string (default: text)
           Output format. Available formats: text, json.
 
+      --prefix Ki|Mi|Gi|Ti (default: Gi)
+          SI Prefix for memory measurement.
+
 ---
 Run `coder --help` for a list of global options.

--- a/docs/cli/stat_cpu.md
+++ b/docs/cli/stat_cpu.md
@@ -28,11 +28,3 @@ Force host CPU measurement.
 | Default | <code>text</code>   |
 
 Output format. Available formats: text, json.
-
-### --prefix
-
-|      |                     |
-| ---- | ------------------- |
-| Type | <code>string</code> |
-
-Unit prefix.

--- a/docs/cli/stat_disk.md
+++ b/docs/cli/stat_disk.md
@@ -29,3 +29,12 @@ Output format. Available formats: text, json.
 | Default | <code>/</code>      |
 
 Path for which to check disk usage.
+
+### --prefix
+
+|         |                 |
+| ------- | --------------- | --- | --- | ---------- |
+| Type    | <code>enum[Ki   | Mi  | Gi  | Ti]</code> |
+| Default | <code>Gi</code> |
+
+SI Prefix for disk measurement.

--- a/docs/cli/stat_mem.md
+++ b/docs/cli/stat_mem.md
@@ -28,3 +28,12 @@ Force host memory measurement.
 | Default | <code>text</code>   |
 
 Output format. Available formats: text, json.
+
+### --prefix
+
+|         |                 |
+| ------- | --------------- | --- | --- | ---------- |
+| Type    | <code>enum[Ki   | Mi  | Gi  | Ti]</code> |
+| Default | <code>Gi</code> |
+
+SI Prefix for memory measurement.


### PR DESCRIPTION
Previously we'd been attempting to automatically determine the correct SI prefix using `go-humanize`, but the library doesn't provide a convenient way to scale two numbers both with a consistent prefix. Adding explicit SI prefixes instead, and defaulting to `Gi`.