### PR TITLE
fix(enterprise/coderd): prevent deadlock during entitlements update

### DIFF
--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -313,8 +313,9 @@ type API struct {
 	// ProxyHealth checks the reachability of all workspace proxies.
 	ProxyHealth *proxyhealth.ProxyHealth
 
-	entitlementsMu sync.RWMutex
-	entitlements   codersdk.Entitlements
+	entitlementsUpdateMu sync.Mutex
+	entitlementsMu       sync.RWMutex
+	entitlements         codersdk.Entitlements
 }
 
 func (api *API) Close() error {
@@ -329,8 +330,8 @@ func (api *API) Close() error {
 }
 
 func (api *API) updateEntitlements(ctx context.Context) error {
-	api.entitlementsMu.Lock()
-	defer api.entitlementsMu.Unlock()
+	api.entitlementsUpdateMu.Lock()
+	defer api.entitlementsUpdateMu.Unlock()
 
 	entitlements, err := license.Entitlements(
 		ctx, api.Database,
@@ -457,6 +458,8 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 		}
 	}
 
+	api.entitlementsMu.Lock()
+	defer api.entitlementsMu.Unlock()
 	api.entitlements = entitlements
 	api.AGPL.SiteHandler.Entitlements.Store(&entitlements)
 

--- a/enterprise/coderd/workspaceagents.go
+++ b/enterprise/coderd/workspaceagents.go
@@ -9,9 +9,9 @@ import (
 )
 
 func (api *API) shouldBlockNonBrowserConnections(rw http.ResponseWriter) bool {
-	api.entitlementsMu.Lock()
+	api.entitlementsMu.RLock()
 	browserOnly := api.entitlements.Features[codersdk.FeatureBrowserOnly].Enabled
-	api.entitlementsMu.Unlock()
+	api.entitlementsMu.RUnlock()
 	if browserOnly {
 		httpapi.Write(context.Background(), rw, http.StatusConflict, codersdk.Response{
 			Message: "Non-browser connections are disabled for your deployment.",


### PR DESCRIPTION
Not sure if this only applies to the in-memory database, but we had a situation where we were read locking the entitlements mutex inside a database transaction, but unable to because we had already taken the write lock for updating entitlements... which were doing database requests that were blocked due to the transaction.

https://github.com/coder/coder/actions/runs/5380614126/jobs/9763591306?pr=8170
