### PR TITLE
fix: fix PG coordinator context and RBAC subject

### DIFF
--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -417,7 +417,7 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 		if enabled {
 			var haCoordinator agpltailnet.Coordinator
 			if api.AGPL.Experiments.Enabled(codersdk.ExperimentTailnetPGCoordinator) {
-				haCoordinator, err = tailnet.NewPGCoord(ctx, api.Logger, api.Pubsub, api.Database)
+				haCoordinator, err = tailnet.NewPGCoord(api.ctx, api.Logger, api.Pubsub, api.Database)
 			} else {
 				haCoordinator, err = tailnet.NewCoordinator(api.Logger, api.Pubsub)
 			}


### PR DESCRIPTION
Fixes two integration issues in the PG Coordinator noticed during system/scale testing:

1. use the API context for the coordinator, so that it will stay alive for the lifetime of the API
2. set the RBAC subject so that it has authorization to modify TailnetCoordinator resources and no others