### PR TITLE
fix: fix TestPGCoordinatorDual_Mainline flake

### DIFF
--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
@@ -615,22 +616,13 @@ func assertEventuallyHasDERPs(ctx context.Context, t *testing.T, c *testConn, ex
 			derps = append(derps, n.PreferredDERP)
 		}
 		for _, e := range expected {
-			if !contains(derps, e) {
+			if !slices.Contains(derps, e) {
 				t.Logf("expected DERP %d to be in %v", e, derps)
 				continue
 			}
 		}
 		return
 	}
-}
-
-func contains(s []int, i int) bool {
-	for _, k := range s {
-		if k == i {
-			return true
-		}
-	}
-	return false
 }
 
 func assertEventuallyNoAgents(ctx context.Context, t *testing.T, store database.Store, agentID uuid.UUID) {

--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -227,7 +227,7 @@ func (t *TrackedConn) SendUpdates() {
 				return
 			}
 			if bytes.Equal(t.lastData, data) {
-				t.logger.Debug(t.ctx, "skipping duplicate update", slog.F("nodes", nodes))
+				t.logger.Debug(t.ctx, "skipping duplicate update", slog.F("nodes", string(data)))
 				continue
 			}
 
@@ -243,11 +243,12 @@ func (t *TrackedConn) SendUpdates() {
 			_, err = t.conn.Write(data)
 			if err != nil {
 				// often, this is just because the connection is closed/broken, so only log at debug.
-				t.logger.Debug(t.ctx, "could not write nodes to connection", slog.Error(err), slog.F("nodes", nodes))
+				t.logger.Debug(t.ctx, "could not write nodes to connection",
+					slog.Error(err), slog.F("nodes", string(data)))
 				_ = t.Close()
 				return
 			}
-			t.logger.Debug(t.ctx, "wrote nodes", slog.F("nodes", nodes))
+			t.logger.Debug(t.ctx, "wrote nodes", slog.F("nodes", string(data)))
 
 			// nhooyr.io/websocket has a bugged implementation of deadlines on a websocket net.Conn.  What they are
 			// *supposed* to do is set a deadline for any subsequent writes to complete, otherwise the call to Write()


### PR DESCRIPTION
Fixes the test flake seen here: https://github.com/coder/coder/actions/runs/5376578815/jobs/9753922291?pr=8195

What was happening is that there was a duplicate update pushed, due to races in the test between connecting the clients, agents, and initial heartbeats.  We attempt to suppress duplicates by serializing the updates to JSON, and comparing with the last update, but this is sensitive to ordering of the nodes.  

Ultimately, the updates are idempotent, so dupes are benign.  I'm not going to get super serious about suppressing duplicates by like, sorting into a canonical order or whatever.

Instead, I've just updated the test code to tolerate getting extra updates on the way to whatever final state it's looking for.