### PR TITLE
feat: add deployment rbac perms in helm chart

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -27,7 +27,21 @@ rules:
     - patch
     - update
     - watch
-
+{{- if .Values.coder.serviceAccount.enableDeployments }}
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -73,6 +73,9 @@ coder:
     # It is recommended to keep this on if you are using Kubernetes templates
     # within Coder.
     workspacePerms: true
+    # coder.serviceAccount.enableDeployments -- Provides the service account permission
+    # to manage Kubernetes deployments.
+    enableDeployments: false
     # coder.serviceAccount.annotations -- The Coder service account annotations.
     annotations: {}
     # coder.serviceAccount.name -- The service account name


### PR DESCRIPTION
this PR adds the `coder.serviceAccount.enableDeployments` bool to allow for the SA to manage K8s deployments.

a customer is looking to move from "naked" worskpace pods to Deployments for their workspaces due to this [Azure security policy](https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/Kubernetes/BlockNakedPods.json). it's possible other future customers will have a similar requirement. in addition, our [solution to stream K8s event logs in the startup script](https://github.com/coder/coder-logstream-kube) works best with Deployments.

the default value is `false` to prevent a breaking change.