### PR TITLE
fix: use `*string` instead of `error` in healthcheck response

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9953,7 +9953,12 @@ const docTemplate = `{
         "healthcheck.AccessURLReport": {
             "type": "object",
             "properties": {
-                "error": {},
+                "access_url": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
                 "healthy": {
                     "type": "boolean"
                 },
@@ -9978,7 +9983,9 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "array",
-                        "items": {}
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 },
                 "client_logs": {
@@ -9990,7 +9997,9 @@ const docTemplate = `{
                         }
                     }
                 },
-                "error": {},
+                "error": {
+                    "type": "string"
+                },
                 "healthy": {
                     "type": "boolean"
                 },
@@ -10014,7 +10023,9 @@ const docTemplate = `{
         "healthcheck.DERPRegionReport": {
             "type": "object",
             "properties": {
-                "error": {},
+                "error": {
+                    "type": "string"
+                },
                 "healthy": {
                     "type": "boolean"
                 },
@@ -10032,14 +10043,18 @@ const docTemplate = `{
         "healthcheck.DERPReport": {
             "type": "object",
             "properties": {
-                "error": {},
+                "error": {
+                    "type": "string"
+                },
                 "healthy": {
                     "type": "boolean"
                 },
                 "netcheck": {
                     "$ref": "#/definitions/netcheck.Report"
                 },
-                "netcheck_err": {},
+                "netcheck_err": {
+                    "type": "string"
+                },
                 "netcheck_logs": {
                     "type": "array",
                     "items": {
@@ -10069,7 +10084,9 @@ const docTemplate = `{
         "healthcheck.DatabaseReport": {
             "type": "object",
             "properties": {
-                "error": {},
+                "error": {
+                    "type": "string"
+                },
                 "healthy": {
                     "type": "boolean"
                 },
@@ -10087,6 +10104,10 @@ const docTemplate = `{
                 "access_url": {
                     "$ref": "#/definitions/healthcheck.AccessURLReport"
                 },
+                "coder_version": {
+                    "description": "The Coder version of the server that the report was generated on.",
+                    "type": "string"
+                },
                 "database": {
                     "$ref": "#/definitions/healthcheck.DatabaseReport"
                 },
@@ -10094,6 +10115,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/healthcheck.DERPReport"
                 },
                 "failing_sections": {
+                    "description": "FailingSections is a list of sections that have failed their healthcheck.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -10115,7 +10137,9 @@ const docTemplate = `{
         "healthcheck.WebsocketReport": {
             "type": "object",
             "properties": {
-                "error": {},
+                "error": {
+                    "type": "string"
+                },
                 "healthy": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9008,7 +9008,12 @@
     "healthcheck.AccessURLReport": {
       "type": "object",
       "properties": {
-        "error": {},
+        "access_url": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
         "healthy": {
           "type": "boolean"
         },
@@ -9033,7 +9038,9 @@
           "type": "array",
           "items": {
             "type": "array",
-            "items": {}
+            "items": {
+              "type": "string"
+            }
           }
         },
         "client_logs": {
@@ -9045,7 +9052,9 @@
             }
           }
         },
-        "error": {},
+        "error": {
+          "type": "string"
+        },
         "healthy": {
           "type": "boolean"
         },
@@ -9069,7 +9078,9 @@
     "healthcheck.DERPRegionReport": {
       "type": "object",
       "properties": {
-        "error": {},
+        "error": {
+          "type": "string"
+        },
         "healthy": {
           "type": "boolean"
         },
@@ -9087,14 +9098,18 @@
     "healthcheck.DERPReport": {
       "type": "object",
       "properties": {
-        "error": {},
+        "error": {
+          "type": "string"
+        },
         "healthy": {
           "type": "boolean"
         },
         "netcheck": {
           "$ref": "#/definitions/netcheck.Report"
         },
-        "netcheck_err": {},
+        "netcheck_err": {
+          "type": "string"
+        },
         "netcheck_logs": {
           "type": "array",
           "items": {
@@ -9124,7 +9139,9 @@
     "healthcheck.DatabaseReport": {
       "type": "object",
       "properties": {
-        "error": {},
+        "error": {
+          "type": "string"
+        },
         "healthy": {
           "type": "boolean"
         },
@@ -9142,6 +9159,10 @@
         "access_url": {
           "$ref": "#/definitions/healthcheck.AccessURLReport"
         },
+        "coder_version": {
+          "description": "The Coder version of the server that the report was generated on.",
+          "type": "string"
+        },
         "database": {
           "$ref": "#/definitions/healthcheck.DatabaseReport"
         },
@@ -9149,6 +9170,7 @@
           "$ref": "#/definitions/healthcheck.DERPReport"
         },
         "failing_sections": {
+          "description": "FailingSections is a list of sections that have failed their healthcheck.",
           "type": "array",
           "items": {
             "type": "string"
@@ -9170,7 +9192,9 @@
     "healthcheck.WebsocketReport": {
       "type": "object",
       "properties": {
-        "error": {},
+        "error": {
+          "type": "string"
+        },
         "healthy": {
           "type": "boolean"
         },

--- a/coderd/healthcheck/accessurl_test.go
+++ b/coderd/healthcheck/accessurl_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/healthcheck"
+	"github.com/coder/coder/coderd/util/ptr"
 )
 
 func TestAccessURL(t *testing.T) {
@@ -36,7 +37,7 @@ func TestAccessURL(t *testing.T) {
 		assert.True(t, report.Reachable)
 		assert.Equal(t, http.StatusOK, report.StatusCode)
 		assert.Equal(t, "OK", report.HealthzResponse)
-		assert.NoError(t, report.Error)
+		assert.Nil(t, report.Error)
 	})
 
 	t.Run("404", func(t *testing.T) {
@@ -66,7 +67,7 @@ func TestAccessURL(t *testing.T) {
 		assert.True(t, report.Reachable)
 		assert.Equal(t, http.StatusNotFound, report.StatusCode)
 		assert.Equal(t, string(resp), report.HealthzResponse)
-		assert.NoError(t, report.Error)
+		assert.Nil(t, report.Error)
 	})
 
 	t.Run("ClientErr", func(t *testing.T) {
@@ -102,7 +103,7 @@ func TestAccessURL(t *testing.T) {
 		assert.False(t, report.Reachable)
 		assert.Equal(t, 0, report.StatusCode)
 		assert.Equal(t, "", report.HealthzResponse)
-		assert.ErrorIs(t, report.Error, expErr)
+		assert.Equal(t, report.Error, ptr.Ref(expErr.Error()))
 	})
 }
 

--- a/coderd/healthcheck/accessurl_test.go
+++ b/coderd/healthcheck/accessurl_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/healthcheck"
-	"github.com/coder/coder/coderd/util/ptr"
 )
 
 func TestAccessURL(t *testing.T) {
@@ -103,7 +102,8 @@ func TestAccessURL(t *testing.T) {
 		assert.False(t, report.Reachable)
 		assert.Equal(t, 0, report.StatusCode)
 		assert.Equal(t, "", report.HealthzResponse)
-		assert.Equal(t, report.Error, ptr.Ref(expErr.Error()))
+		require.NotNil(t, report.Error)
+		assert.Contains(t, *report.Error, expErr.Error())
 	})
 }
 

--- a/coderd/healthcheck/database.go
+++ b/coderd/healthcheck/database.go
@@ -14,7 +14,7 @@ type DatabaseReport struct {
 	Healthy   bool          `json:"healthy"`
 	Reachable bool          `json:"reachable"`
 	Latency   time.Duration `json:"latency"`
-	Error     error         `json:"error"`
+	Error     *string       `json:"error"`
 }
 
 type DatabaseReportOptions struct {
@@ -31,7 +31,7 @@ func (r *DatabaseReport) Run(ctx context.Context, opts *DatabaseReportOptions) {
 	for i := 0; i < pingCount; i++ {
 		pong, err := opts.DB.Ping(ctx)
 		if err != nil {
-			r.Error = xerrors.Errorf("ping: %w", err)
+			r.Error = convertError(xerrors.Errorf("ping: %w", err))
 			return
 		}
 		pings = append(pings, pong)

--- a/coderd/healthcheck/database_test.go
+++ b/coderd/healthcheck/database_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/coderd/database/dbmock"
@@ -56,7 +57,8 @@ func TestDatabase(t *testing.T) {
 		assert.False(t, report.Healthy)
 		assert.False(t, report.Reachable)
 		assert.Zero(t, report.Latency)
-		assert.Nil(t, report.Error, err)
+		require.NotNil(t, report.Error)
+		assert.Contains(t, *report.Error, err.Error())
 	})
 
 	t.Run("Median", func(t *testing.T) {

--- a/coderd/healthcheck/database_test.go
+++ b/coderd/healthcheck/database_test.go
@@ -35,7 +35,7 @@ func TestDatabase(t *testing.T) {
 		assert.True(t, report.Healthy)
 		assert.True(t, report.Reachable)
 		assert.Equal(t, ping, report.Latency)
-		assert.NoError(t, report.Error)
+		assert.Nil(t, report.Error)
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestDatabase(t *testing.T) {
 		assert.False(t, report.Healthy)
 		assert.False(t, report.Reachable)
 		assert.Zero(t, report.Latency)
-		assert.ErrorIs(t, report.Error, err)
+		assert.Nil(t, report.Error, err)
 	})
 
 	t.Run("Median", func(t *testing.T) {
@@ -80,6 +80,6 @@ func TestDatabase(t *testing.T) {
 		assert.True(t, report.Healthy)
 		assert.True(t, report.Reachable)
 		assert.Equal(t, time.Millisecond, report.Latency)
-		assert.NoError(t, report.Error)
+		assert.Nil(t, report.Error)
 	})
 }

--- a/coderd/healthcheck/healthcheck_test.go
+++ b/coderd/healthcheck/healthcheck_test.go
@@ -155,6 +155,7 @@ func TestHealthcheck(t *testing.T) {
 			assert.Equal(t, c.checker.AccessURLReport.Healthy, report.AccessURL.Healthy)
 			assert.Equal(t, c.checker.WebsocketReport.Healthy, report.Websocket.Healthy)
 			assert.NotZero(t, report.Time)
+			assert.NotZero(t, report.CoderVersion)
 		})
 	}
 }

--- a/coderd/healthcheck/websocket_test.go
+++ b/coderd/healthcheck/websocket_test.go
@@ -37,7 +37,7 @@ func TestWebsocket(t *testing.T) {
 			APIKey:     "test",
 		})
 
-		require.NoError(t, wsReport.Error)
+		require.Nil(t, wsReport.Error)
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestWebsocket(t *testing.T) {
 			APIKey:     "test",
 		})
 
-		require.Error(t, wsReport.Error)
+		require.NotNil(t, wsReport.Error)
 		assert.Equal(t, wsReport.Response.Body, "test error")
 		assert.Equal(t, wsReport.Response.Code, http.StatusBadRequest)
 	})

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -40,20 +40,22 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
 ```json
 {
   "access_url": {
-    "error": null,
+    "access_url": "string",
+    "error": "string",
     "healthy": true,
     "healthz_response": "string",
     "reachable": true,
     "status_code": 0
   },
+  "coder_version": "string",
   "database": {
-    "error": null,
+    "error": "string",
     "healthy": true,
     "latency": 0,
     "reachable": true
   },
   "derp": {
-    "error": null,
+    "error": "string",
     "healthy": true,
     "netcheck": {
       "captivePortal": "string",
@@ -85,18 +87,18 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
       "udp": true,
       "upnP": "string"
     },
-    "netcheck_err": null,
+    "netcheck_err": "string",
     "netcheck_logs": ["string"],
     "regions": {
       "property1": {
-        "error": null,
+        "error": "string",
         "healthy": true,
         "node_reports": [
           {
             "can_exchange_messages": true,
-            "client_errs": [[null]],
+            "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "error": null,
+            "error": "string",
             "healthy": true,
             "node": {
               "certName": "string",
@@ -150,14 +152,14 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
         }
       },
       "property2": {
-        "error": null,
+        "error": "string",
         "healthy": true,
         "node_reports": [
           {
             "can_exchange_messages": true,
-            "client_errs": [[null]],
+            "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "error": null,
+            "error": "string",
             "healthy": true,
             "node": {
               "certName": "string",
@@ -216,7 +218,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
   "healthy": true,
   "time": "string",
   "websocket": {
-    "error": null,
+    "error": "string",
     "healthy": true,
     "response": {
       "body": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -5665,7 +5665,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "error": null,
+  "access_url": "string",
+  "error": "string",
   "healthy": true,
   "healthz_response": "string",
   "reachable": true,
@@ -5677,7 +5678,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 | Name               | Type    | Required | Restrictions | Description |
 | ------------------ | ------- | -------- | ------------ | ----------- |
-| `error`            | any     | false    |              |             |
+| `access_url`       | string  | false    |              |             |
+| `error`            | string  | false    |              |             |
 | `healthy`          | boolean | false    |              |             |
 | `healthz_response` | string  | false    |              |             |
 | `reachable`        | boolean | false    |              |             |
@@ -5688,9 +5690,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 ```json
 {
   "can_exchange_messages": true,
-  "client_errs": [[null]],
+  "client_errs": [["string"]],
   "client_logs": [["string"]],
-  "error": null,
+  "error": "string",
   "healthy": true,
   "node": {
     "certName": "string",
@@ -5727,7 +5729,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `can_exchange_messages` | boolean                                                  | false    |              |             |
 | `client_errs`           | array of array                                           | false    |              |             |
 | `client_logs`           | array of array                                           | false    |              |             |
-| `error`                 | any                                                      | false    |              |             |
+| `error`                 | string                                                   | false    |              |             |
 | `healthy`               | boolean                                                  | false    |              |             |
 | `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)                     | false    |              |             |
 | `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage)         | false    |              |             |
@@ -5739,14 +5741,14 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "error": null,
+  "error": "string",
   "healthy": true,
   "node_reports": [
     {
       "can_exchange_messages": true,
-      "client_errs": [[null]],
+      "client_errs": [["string"]],
       "client_logs": [["string"]],
-      "error": null,
+      "error": "string",
       "healthy": true,
       "node": {
         "certName": "string",
@@ -5805,7 +5807,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 | Name           | Type                                                              | Required | Restrictions | Description |
 | -------------- | ----------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `error`        | any                                                               | false    |              |             |
+| `error`        | string                                                            | false    |              |             |
 | `healthy`      | boolean                                                           | false    |              |             |
 | `node_reports` | array of [healthcheck.DERPNodeReport](#healthcheckderpnodereport) | false    |              |             |
 | `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                          | false    |              |             |
@@ -5814,7 +5816,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "error": null,
+  "error": "string",
   "healthy": true,
   "netcheck": {
     "captivePortal": "string",
@@ -5846,18 +5848,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "udp": true,
     "upnP": "string"
   },
-  "netcheck_err": null,
+  "netcheck_err": "string",
   "netcheck_logs": ["string"],
   "regions": {
     "property1": {
-      "error": null,
+      "error": "string",
       "healthy": true,
       "node_reports": [
         {
           "can_exchange_messages": true,
-          "client_errs": [[null]],
+          "client_errs": [["string"]],
           "client_logs": [["string"]],
-          "error": null,
+          "error": "string",
           "healthy": true,
           "node": {
             "certName": "string",
@@ -5911,14 +5913,14 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       }
     },
     "property2": {
-      "error": null,
+      "error": "string",
       "healthy": true,
       "node_reports": [
         {
           "can_exchange_messages": true,
-          "client_errs": [[null]],
+          "client_errs": [["string"]],
           "client_logs": [["string"]],
-          "error": null,
+          "error": "string",
           "healthy": true,
           "node": {
             "certName": "string",
@@ -5979,10 +5981,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 | Name               | Type                                                         | Required | Restrictions | Description |
 | ------------------ | ------------------------------------------------------------ | -------- | ------------ | ----------- |
-| `error`            | any                                                          | false    |              |             |
+| `error`            | string                                                       | false    |              |             |
 | `healthy`          | boolean                                                      | false    |              |             |
 | `netcheck`         | [netcheck.Report](#netcheckreport)                           | false    |              |             |
-| `netcheck_err`     | any                                                          | false    |              |             |
+| `netcheck_err`     | string                                                       | false    |              |             |
 | `netcheck_logs`    | array of string                                              | false    |              |             |
 | `regions`          | object                                                       | false    |              |             |
 | » `[any property]` | [healthcheck.DERPRegionReport](#healthcheckderpregionreport) | false    |              |             |
@@ -6009,7 +6011,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "error": null,
+  "error": "string",
   "healthy": true,
   "latency": 0,
   "reachable": true
@@ -6020,7 +6022,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 | Name        | Type    | Required | Restrictions | Description |
 | ----------- | ------- | -------- | ------------ | ----------- |
-| `error`     | any     | false    |              |             |
+| `error`     | string  | false    |              |             |
 | `healthy`   | boolean | false    |              |             |
 | `latency`   | integer | false    |              |             |
 | `reachable` | boolean | false    |              |             |
@@ -6030,20 +6032,22 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 ```json
 {
   "access_url": {
-    "error": null,
+    "access_url": "string",
+    "error": "string",
     "healthy": true,
     "healthz_response": "string",
     "reachable": true,
     "status_code": 0
   },
+  "coder_version": "string",
   "database": {
-    "error": null,
+    "error": "string",
     "healthy": true,
     "latency": 0,
     "reachable": true
   },
   "derp": {
-    "error": null,
+    "error": "string",
     "healthy": true,
     "netcheck": {
       "captivePortal": "string",
@@ -6075,18 +6079,18 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "udp": true,
       "upnP": "string"
     },
-    "netcheck_err": null,
+    "netcheck_err": "string",
     "netcheck_logs": ["string"],
     "regions": {
       "property1": {
-        "error": null,
+        "error": "string",
         "healthy": true,
         "node_reports": [
           {
             "can_exchange_messages": true,
-            "client_errs": [[null]],
+            "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "error": null,
+            "error": "string",
             "healthy": true,
             "node": {
               "certName": "string",
@@ -6140,14 +6144,14 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         }
       },
       "property2": {
-        "error": null,
+        "error": "string",
         "healthy": true,
         "node_reports": [
           {
             "can_exchange_messages": true,
-            "client_errs": [[null]],
+            "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "error": null,
+            "error": "string",
             "healthy": true,
             "node": {
               "certName": "string",
@@ -6206,7 +6210,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "healthy": true,
   "time": "string",
   "websocket": {
-    "error": null,
+    "error": "string",
     "healthy": true,
     "response": {
       "body": "string",
@@ -6218,21 +6222,22 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name               | Type                                                       | Required | Restrictions | Description                                      |
-| ------------------ | ---------------------------------------------------------- | -------- | ------------ | ------------------------------------------------ |
-| `access_url`       | [healthcheck.AccessURLReport](#healthcheckaccessurlreport) | false    |              |                                                  |
-| `database`         | [healthcheck.DatabaseReport](#healthcheckdatabasereport)   | false    |              |                                                  |
-| `derp`             | [healthcheck.DERPReport](#healthcheckderpreport)           | false    |              |                                                  |
-| `failing_sections` | array of string                                            | false    |              |                                                  |
-| `healthy`          | boolean                                                    | false    |              | Healthy is true if the report returns no errors. |
-| `time`             | string                                                     | false    |              | Time is the time the report was generated at.    |
-| `websocket`        | [healthcheck.WebsocketReport](#healthcheckwebsocketreport) | false    |              |                                                  |
+| Name               | Type                                                       | Required | Restrictions | Description                                                                |
+| ------------------ | ---------------------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------- |
+| `access_url`       | [healthcheck.AccessURLReport](#healthcheckaccessurlreport) | false    |              |                                                                            |
+| `coder_version`    | string                                                     | false    |              | The Coder version of the server that the report was generated on.          |
+| `database`         | [healthcheck.DatabaseReport](#healthcheckdatabasereport)   | false    |              |                                                                            |
+| `derp`             | [healthcheck.DERPReport](#healthcheckderpreport)           | false    |              |                                                                            |
+| `failing_sections` | array of string                                            | false    |              | Failing sections is a list of sections that have failed their healthcheck. |
+| `healthy`          | boolean                                                    | false    |              | Healthy is true if the report returns no errors.                           |
+| `time`             | string                                                     | false    |              | Time is the time the report was generated at.                              |
+| `websocket`        | [healthcheck.WebsocketReport](#healthcheckwebsocketreport) | false    |              |                                                                            |
 
 ## healthcheck.WebsocketReport
 
 ```json
 {
-  "error": null,
+  "error": "string",
   "healthy": true,
   "response": {
     "body": "string",
@@ -6245,7 +6250,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 | Name       | Type                                                           | Required | Restrictions | Description |
 | ---------- | -------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `error`    | any                                                            | false    |              |             |
+| `error`    | string                                                         | false    |              |             |
 | `healthy`  | boolean                                                        | false    |              |             |
 | `response` | [healthcheck.WebsocketResponse](#healthcheckwebsocketresponse) | false    |              |             |
 


### PR DESCRIPTION
`error`s marshal to `{}` for some reason, so this allows us to actually extract the error.