### PR TITLE
feat: show queue position of pending workspace build

### DIFF
--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -98,6 +98,13 @@ export const WithoutUpdateAccess: Story = {
   },
 }
 
+export const PendingInQueue: Story = {
+  args: {
+    ...Running.args,
+    workspace: Mocks.MockPendingWorkspace,
+  },
+}
+
 export const Starting: Story = {
   args: {
     ...Running.args,

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -218,9 +218,10 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
               <AlertTitle>Workspace build is pending</AlertTitle>
               <AlertDetail>
                 <div className={styles.alertPendingInQueue}>
-                  This build job is waiting for a provisioner to become
-                  available. If you have been waiting for an extended period,
-                  contact your administrator for assistance.
+                  This workspace build job is waiting for a provisioner to
+                  become available. If you have been waiting for an extended
+                  period of time, please contact your administrator for
+                  assistance.
                 </div>
                 <div>
                   Position in queue:{" "}

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -31,6 +31,7 @@ import { ImpendingDeletionBanner } from "components/WorkspaceDeletion"
 import { useLocalStorage } from "hooks"
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne"
 import AlertTitle from "@mui/material/AlertTitle"
+import { Maybe } from "components/Conditionals/Maybe"
 
 export enum WorkspaceErrors {
   GET_BUILDS_ERROR = "getBuildsError",
@@ -207,6 +208,28 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
 
           <TemplateVersionWarnings warnings={templateWarnings} />
 
+          <Maybe
+            condition={
+              workspace.latest_build.status === "pending" &&
+              workspace.latest_build.job.queue_size > 0
+            }
+          >
+            <Alert severity="info">
+              <AlertTitle>Workspace build is pending</AlertTitle>
+              <AlertDetail>
+                <div className={styles.alertPendingInQueue}>
+                  This build job is waiting for a provisioner to become
+                  available. If you have been waiting for an extended period,
+                  contact your administrator for assistance.
+                </div>
+                <div>
+                  Position in queue:{" "}
+                  <strong>{workspace.latest_build.job.queue_position}</strong>
+                </div>
+              </AlertDetail>
+            </Alert>
+          </Maybe>
+
           {failedBuildLogs && (
             <Stack>
               <Alert
@@ -318,6 +341,10 @@ export const useStyles = makeStyles((theme) => {
 
     fullWidth: {
       width: "100%",
+    },
+
+    alertPendingInQueue: {
+      marginBottom: 12,
     },
   }
 })

--- a/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
+++ b/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
@@ -20,6 +20,7 @@ export const WorkspaceStatusBadge: FC<
 > = ({ workspace, className }) => {
   const { text, icon, type } = getDisplayWorkspaceStatus(
     workspace.latest_build.status,
+    workspace.latest_build.job,
   )
   return (
     <ChooseOne>
@@ -41,6 +42,8 @@ export const WorkspaceStatusText: FC<
   const { text, type } = getDisplayWorkspaceStatus(
     workspace.latest_build.status,
   )
+
+  workspace.latest_build.job.queue_size
 
   return (
     <ChooseOne>

--- a/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
+++ b/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
@@ -43,8 +43,6 @@ export const WorkspaceStatusText: FC<
     workspace.latest_build.status,
   )
 
-  workspace.latest_build.job.queue_size
-
   return (
     <ChooseOne>
       {/* <ImpendingDeletionText/> determines its own visibility */}

--- a/site/src/components/WorkspacesTable/WorkspacesTable.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesTable.tsx
@@ -13,7 +13,6 @@ const Language = {
   template: "Template",
   lastUsed: "Last Used",
   status: "Status",
-  lastBuiltBy: "Last Built By",
 }
 
 export interface WorkspacesTableProps {

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -15,6 +15,7 @@ import {
   MockExperiments,
   mockApiError,
   MockUser,
+  MockPendingProvisionerJob,
 } from "testHelpers/entities"
 import { WorkspacesPageView } from "./WorkspacesPageView"
 import { DashboardProviderContext } from "components/Dashboard/DashboardProvider"
@@ -33,6 +34,10 @@ const createWorkspace = (
     latest_build: {
       ...MockWorkspace.latest_build,
       status,
+      job:
+        status === "pending"
+          ? MockPendingProvisionerJob
+          : MockWorkspace.latest_build.job,
     },
     last_used_at: lastUsedAt,
   }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -310,6 +310,8 @@ export const MockRunningProvisionerJob: TypesGen.ProvisionerJob = {
 export const MockPendingProvisionerJob: TypesGen.ProvisionerJob = {
   ...MockProvisionerJob,
   status: "pending",
+  queue_position: 2,
+  queue_size: 4,
 }
 export const MockTemplateVersion: TypesGen.TemplateVersion = {
   id: "test-template-version",

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -275,7 +275,7 @@ const getPendingWorkspaceStatusText = (
   if (provisionerJob === undefined || provisionerJob.queue_size === 0) {
     return t("workspaceStatus.pending", { ns: "common" })
   }
-  return "Pending in queue: " + provisionerJob.queue_position
+  return "Position in queue: " + provisionerJob.queue_position
 }
 
 const LoadingIcon = () => {

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -194,6 +194,7 @@ export const getDisplayWorkspaceTemplateName = (
 
 export const getDisplayWorkspaceStatus = (
   workspaceStatus: TypesGen.WorkspaceStatus,
+  provisionerJob?: TypesGen.ProvisionerJob,
 ) => {
   const { t } = i18next
 
@@ -260,10 +261,21 @@ export const getDisplayWorkspaceStatus = (
     case "pending":
       return {
         type: "info",
-        text: t("workspaceStatus.pending", { ns: "common" }),
+        text: getPendingWorkspaceStatusText(provisionerJob),
         icon: <QueuedIcon />,
       } as const
   }
+}
+
+const getPendingWorkspaceStatusText = (
+  provisionerJob?: TypesGen.ProvisionerJob,
+): string => {
+  const { t } = i18next
+
+  if (provisionerJob === undefined || provisionerJob.queue_size === 0) {
+    return t("workspaceStatus.pending", { ns: "common" })
+  }
+  return "Pending in queue: " + provisionerJob.queue_position
 }
 
 const LoadingIcon = () => {

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -272,7 +272,7 @@ const getPendingWorkspaceStatusText = (
 ): string => {
   const { t } = i18next
 
-  if (provisionerJob === undefined || provisionerJob.queue_size === 0) {
+  if (!provisionerJob || provisionerJob.queue_size === 0) {
     return t("workspaceStatus.pending", { ns: "common" })
   }
   return "Position in queue: " + provisionerJob.queue_position


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6465

This PR exposes the queue position of a pending workspace build. It implements the action items from the [Build visibility RFC](https://www.notion.so/Build-visibility-0c8e9393aeb34a9994ca036715668a41). 

<img width="1228" alt="Screenshot 2023-06-28 at 13 36 01" src="https://github.com/coder/coder/assets/14044910/4ba718f1-672b-4505-858d-e3019ede0d39">

<img width="1449" alt="Screenshot 2023-06-28 at 13 15 29" src="https://github.com/coder/coder/assets/14044910/42098a4f-6f46-4726-b257-f7fa3a6d3f5a">
