### PR TITLE
feat: add provisionerd deployment to helm chart

### DIFF
--- a/helm/templates/provisionerd.yaml
+++ b/helm/templates/provisionerd.yaml
@@ -1,0 +1,99 @@
+{{- if gt (int .Values.provisionerd.replicaCount) 0 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.provisionerd.serviceAccount.name | quote }}
+  annotations: {{ toYaml .Values.provisionerd.serviceAccount.annotations | nindent 4 }}
+  labels:
+    {{- include "coder.labels" . | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder-provisionerd
+  labels:
+    {{- include "coder.labels" . | nindent 4 }}
+    {{- with .Values.provisionerd.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations: {{ toYaml .Values.provisionerd.annotations | nindent 4}}
+spec:
+  replicas: {{ .Values.provisionerd.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "coder.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "coder.labels" . | nindent 8 }}
+        {{- with .Values.provisionerd.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- toYaml .Values.provisionerd.podAnnotations | nindent 8  }}
+    spec:
+      serviceAccountName: {{ .Values.provisionerd.serviceAccount.name | quote }}
+      restartPolicy: Always
+      {{- with .Values.provisionerd.image.pullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      {{- with .Values.provisionerd.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisionerd.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisionerd.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisionerd.initContainers }}
+      initContainers:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: coder
+          image: {{ include "provisionerd.image" . | quote }}
+          imagePullPolicy: {{ .Values.provisionerd.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.provisionerd.command | nindent 12 }}
+          args:
+            - provisionerd
+            - start
+          resources:
+            {{- toYaml .Values.provisionerd.resources | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.provisionerd.lifecycle | nindent 12 }}
+          env:
+            - name: CODER_PROMETHEUS_ADDRESS
+              value: "0.0.0.0:2112"
+            {{- with .Values.provisionerd.env -}}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            {{- range .Values.provisionerd.env }}
+            {{- if eq .name "CODER_PROMETHEUS_ENABLE" }}
+            {{/*
+            This sadly has to be nested to avoid evaluating the second part
+            of the condition too early and potentially getting type errors if
+            the value is not a string (like a `valueFrom`). We do not support
+            `valueFrom` for this env var specifically.
+            */}}
+            {{- if eq .value "true" }}
+            - name: "prometheus-http"
+              containerPort: 2112
+              protocol: TCP
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          securityContext: {{ toYaml .Values.provisionerd.securityContext | nindent 12 }}
+          {{/* TODO: readiness and liveness probes */}}
+          {{- include "provisionerd.volumeMounts" . | nindent 10 }}
+
+      {{- include "provisionerd.volumes" . | nindent 6 }}
+{{- end }}

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -5,6 +5,10 @@ kind: Role
 metadata:
   name: coder-workspace-perms
 rules:
+  {{/*
+    IF YOU CHANGE THESE PERMISSIONS PLEASE ALSO UPDATE THE PERMISSIONS FOR
+    PROVISIONERDS BELOW.
+  */}}
   - apiGroups: [""]
     resources: ["pods"]
     verbs:
@@ -54,4 +58,62 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: coder-workspace-perms
+{{- end }}
+
+{{- if and (gt (int .Values.provisionerd.replicaCount) 0) .Values.provisionerd.serviceAccount.workspacePerms }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-provisionerd-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- if .Values.provisionerd.serviceAccount.enableDeployments }}
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.provisionerd.serviceAccount.name | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.provisionerd.serviceAccount.name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-provisionerd-workspace-perms
 {{- end }}

--- a/helm/tests/chart_test.go
+++ b/helm/tests/chart_test.go
@@ -52,6 +52,18 @@ var TestCases = []TestCase{
 		name:          "command",
 		expectedError: "",
 	},
+	{
+		name:          "provisionerd_basic",
+		expectedError: "",
+	},
+	{
+		name:          "provisionerd_missing_values",
+		expectedError: `You must specify the provisionerd.image.tag value if you're installing the Helm chart directly from Git and you have at least one provisionerd replica.`,
+	},
+	{
+		name:          "provisionerd_full",
+		expectedError: "",
+	},
 }
 
 type TestCase struct {

--- a/helm/tests/testdata/command.golden
+++ b/helm/tests/testdata/command.golden
@@ -20,6 +20,7 @@ kind: Role
 metadata:
   name: coder-workspace-perms
 rules:
+  
   - apiGroups: [""]
     resources: ["pods"]
     verbs:

--- a/helm/tests/testdata/default_values.golden
+++ b/helm/tests/testdata/default_values.golden
@@ -20,6 +20,7 @@ kind: Role
 metadata:
   name: coder-workspace-perms
 rules:
+  
   - apiGroups: [""]
     resources: ["pods"]
     verbs:

--- a/helm/tests/testdata/labels_annotations.golden
+++ b/helm/tests/testdata/labels_annotations.golden
@@ -20,6 +20,7 @@ kind: Role
 metadata:
   name: coder-workspace-perms
 rules:
+  
   - apiGroups: [""]
     resources: ["pods"]
     verbs:

--- a/helm/tests/testdata/provisionerd_basic.golden
+++ b/helm/tests/testdata/provisionerd_basic.golden
@@ -3,9 +3,24 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "coder-service-account"
+  name: "coder"
   annotations: 
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/coder-service-account
+    {}
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: coder/templates/provisionerd.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "coder-provisionerd"
+  annotations: 
+    {}
   labels:
     helm.sh/chart: coder-0.1.0
     app.kubernetes.io/name: coder
@@ -46,16 +61,58 @@ rules:
 ---
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-provisionerd-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "coder-service-account"
+  name: "coder"
 subjects:
   - kind: ServiceAccount
-    name: "coder-service-account"
+    name: "coder"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: coder-workspace-perms
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder-provisionerd"
+subjects:
+  - kind: ServiceAccount
+    name: "coder-provisionerd"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-provisionerd-workspace-perms
 ---
 # Source: coder/templates/service.yaml
 apiVersion: v1
@@ -116,7 +173,7 @@ spec:
       annotations:
         {}
     spec:
-      serviceAccountName: "coder-service-account"
+      serviceAccountName: "coder"
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
       affinity:
@@ -182,5 +239,81 @@ spec:
               path: /healthz
               port: "http"
               scheme: "HTTP"
+          volumeMounts: []
+      volumes: []
+---
+# Source: coder/templates/provisionerd.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder-provisionerd
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations: 
+    {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coder
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: coder-0.1.0
+        app.kubernetes.io/name: coder
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/part-of: coder
+        app.kubernetes.io/version: "0.1.0"
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        {}
+    spec:
+      serviceAccountName: "coder-provisionerd"
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - coder-provisionerd
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+        - name: coder
+          image: "ghcr.io/coder/coder:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/coder
+          args:
+            - provisionerd
+            - start
+          resources:
+            {}
+          lifecycle:
+            {}
+          env:
+            - name: CODER_PROMETHEUS_ADDRESS
+              value: "0.0.0.0:2112"
+          ports:
+          securityContext: 
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: null
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          
           volumeMounts: []
       volumes: []

--- a/helm/tests/testdata/provisionerd_basic.yaml
+++ b/helm/tests/testdata/provisionerd_basic.yaml
@@ -1,0 +1,8 @@
+coder:
+  image:
+    tag: latest
+
+provisionerd:
+  replicaCount: 1
+  image:
+    tag: latest

--- a/helm/tests/testdata/provisionerd_full.golden
+++ b/helm/tests/testdata/provisionerd_full.golden
@@ -3,9 +3,25 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "coder-service-account"
+  name: "coder"
   annotations: 
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/coder-service-account
+    {}
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: coder/templates/provisionerd.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "coder-provisioner-custom-name"
+  annotations: 
+    service-account-annotation-test-1: service-account-annotation-test-1 value
+    service-account-annotation-test-2: service-account-annotation-test-2 value
   labels:
     helm.sh/chart: coder-0.1.0
     app.kubernetes.io/name: coder
@@ -48,10 +64,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "coder-service-account"
+  name: "coder"
 subjects:
   - kind: ServiceAccount
-    name: "coder-service-account"
+    name: "coder"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -116,7 +132,7 @@ spec:
       annotations:
         {}
     spec:
-      serviceAccountName: "coder-service-account"
+      serviceAccountName: "coder"
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
       affinity:
@@ -184,3 +200,133 @@ spec:
               scheme: "HTTP"
           volumeMounts: []
       volumes: []
+---
+# Source: coder/templates/provisionerd.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder-provisionerd
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    label-test-1: label-test-1 value
+    label-test-2: label-test-2 value
+  annotations: 
+    annotation-test-1: annotation-test-1 value
+    annotation-test-2: annotation-test-2 value
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coder
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: coder-0.1.0
+        app.kubernetes.io/name: coder
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/part-of: coder
+        app.kubernetes.io/version: "0.1.0"
+        app.kubernetes.io/managed-by: Helm
+        pod-label-test-1: pod-label-test-1 value
+        pod-label-test-2: pod-label-test-2 value
+      annotations:
+        pod-annotation-test-1: pod-annotation-test-1 value
+        pod-annotation-test-2: pod-annotation-test-2 value
+    spec:
+      serviceAccountName: "coder-provisioner-custom-name"
+      restartPolicy: Always
+      imagePullSecrets:
+        - name: hi
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - coder-provisionerd-custom
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: key
+          operator: Equal
+          value: value
+      nodeSelector:
+      
+        key: value
+      initContainers:
+      
+        - command:
+          - sh
+          - -c
+          - sleep 2
+          image: busybox:1.28
+          name: init-container
+      containers:
+        - name: coder
+          image: "codercom/provisionerd:latest"
+          imagePullPolicy: Always
+          command:
+            - /opt/coder2
+          args:
+            - provisionerd
+            - start
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - echo postStart
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - echo preStart
+          env:
+            - name: CODER_PROMETHEUS_ADDRESS
+              value: "0.0.0.0:2112"
+            - name: TEST
+              value: test
+          ports:
+          securityContext: 
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: false
+            runAsUser: 1001
+            seccompProfile:
+              type: CoolProfile
+          
+          volumeMounts:
+          - name: "ca-cert-my-ca-bundle"
+            mountPath: "/etc/ssl/certs/my-ca-bundle.crt"
+            subPath: "ca-bundle.crt"
+            readOnly: true
+          - mountPath: /coder-provisioner-volume
+            name: coder-provisioner-volume
+          
+      volumes:
+      - name: "ca-cert-my-ca-bundle"
+        secret:
+          secretName: "my-ca-bundle"
+      - emptyDir: {}
+        name: coder-provisioner-volume

--- a/helm/tests/testdata/provisionerd_full.yaml
+++ b/helm/tests/testdata/provisionerd_full.yaml
@@ -1,0 +1,91 @@
+coder:
+  image:
+    tag: latest
+
+provisionerd:
+  replicaCount: 3
+  env:
+    - name: TEST
+      value: "test"
+  image:
+    repo: codercom/provisionerd
+    tag: latest
+    pullPolicy: Always
+    pullSecrets:
+      - name: hi
+  initContainers:
+    - name: init-container
+      image: busybox:1.28
+      command: ['sh', '-c', 'sleep 2']
+  annotations:
+    annotation-test-1: "annotation-test-1 value"
+    annotation-test-2: "annotation-test-2 value"
+  labels:
+    label-test-1: "label-test-1 value"
+    label-test-2: "label-test-2 value"
+  podAnnotations:
+    pod-annotation-test-1: "pod-annotation-test-1 value"
+    pod-annotation-test-2: "pod-annotation-test-2 value"
+  podLabels:
+    pod-label-test-1: "pod-label-test-1 value"
+    pod-label-test-2: "pod-label-test-2 value"
+  serviceAccount:
+    workspacePerms: false
+    enableDeployments: true
+    annotations:
+      service-account-annotation-test-1: "service-account-annotation-test-1 value"
+      service-account-annotation-test-2: "service-account-annotation-test-2 value"
+    name: "coder-provisioner-custom-name"
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 1001
+    runAsGroup: 1001
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: "CoolProfile"
+    allowPrivilegeEscalation: true
+  volumes:
+    - name: "coder-provisioner-volume"
+      emptyDir: {}
+  volumeMounts:
+    - name: "coder-provisioner-volume"
+      mountPath: "/coder-provisioner-volume"
+  lifecycle:
+    postStart:
+      exec:
+        command: ["/bin/sh", "-c", "echo postStart"]
+    preStop:
+      exec:
+        command: ["/bin/sh","-c","echo preStart"]
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  certs:
+    secrets:
+      - name: "my-ca-bundle"
+        key: "ca-bundle.crt"
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - "coder-provisionerd-custom"
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+  tolerations:
+    - key: "key"
+      operator: "Equal"
+      value: "value"
+      effect: "NoSchedule"
+  nodeSelector:
+    key: "value"
+  command:
+    - /opt/coder2

--- a/helm/tests/testdata/provisionerd_missing_values.yaml
+++ b/helm/tests/testdata/provisionerd_missing_values.yaml
@@ -1,0 +1,7 @@
+coder:
+  image:
+    tag: latest
+
+provisionerd:
+  replicaCount: 1
+  # no image tag set (default)

--- a/helm/tests/testdata/tls.golden
+++ b/helm/tests/testdata/tls.golden
@@ -20,6 +20,7 @@ kind: Role
 metadata:
   name: coder-workspace-perms
 rules:
+  
   - apiGroups: [""]
     resources: ["pods"]
     verbs:

--- a/helm/tests/testdata/workspace_proxy.golden
+++ b/helm/tests/testdata/workspace_proxy.golden
@@ -20,6 +20,7 @@ kind: Role
 metadata:
   name: coder-workspace-perms
 rules:
+  
   - apiGroups: [""]
     resources: ["pods"]
     verbs:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -204,7 +204,7 @@ coder:
   # coder.tolerations -- Tolerations for tainted nodes.
   # See: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations:
-    {}
+    []
     # - key: "key"
     #   operator: "Equal"
     #   value: "value"
@@ -274,6 +274,196 @@ coder:
 
   # coder.command -- The command to use when running the Coder container. Used
   # for customizing the location of the `coder` binary in your image.
+  command:
+    - /opt/coder
+
+# provisionerd -- The configuration for the external provisionerd server. Note
+# that this is optional and requires an enterprise license to use.
+provisionerd:
+  # provisionerd.replicaCount -- The number of provisionerd replicas to run. If
+  # set to 0, the Deployment and shared Secret key will not be created.
+  #
+  # If you are using external provisioner daemons, you should set
+  # `CODER_PROVISIONER_DAEMONS` to `0` in `coder.env` to disable the built-in
+  # provisioners.
+  replicaCount: 0
+
+  # provisionerd.env -- The environment variables to set for provisionerd.
+  env: []
+  # - name: "CODER_ACCESS_URL"
+  #   value: "https://coder.example.com"
+
+  # provisionerd.image -- The image to use for provisionerd.
+  image:
+    # provisionerd.image.repo -- The repository of the image.
+    repo: "ghcr.io/coder/coder"
+    # provisionerd.image.tag -- The tag of the image, defaults to
+    # {{.Chart.AppVersion}} if not set. If you're using the chart directly from
+    # git, the default app version will not work and you'll need to set this
+    # value. The helm chart helpfully fails quickly in this case.
+    tag: ""
+    # provisionerd.image.pullPolicy -- The pull policy to use for the image.
+    # See:
+    # https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: IfNotPresent
+    # provisionerd.image.pullSecrets -- The secrets used for pulling the Coder
+    # image from a private registry.
+    pullSecrets: []
+    #  - name: "pull-secret"
+
+  # provisionerd.initContainers -- Init containers for the deployment. See:
+  # https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  initContainers:
+    []
+    # - name: init-container
+    #   image: busybox:1.28
+    #   command: ['sh', '-c', "sleep 2"]
+
+  # provisionerd.annotations -- The Deployment annotations. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  annotations: {}
+
+  # provisionerd.labels -- The Deployment labels. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  labels: {}
+
+  # provisionerd.podAnnotations -- The pod annotations. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+
+  # provisionerd.podLabels -- The pod labels. See:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  # provisionerd.serviceAccount -- Configuration for the automatically created
+  # service account. Creation of the service account cannot be disabled.
+  serviceAccount:
+    # provisionerd.serviceAccount.workspacePerms -- Whether or not to grant the
+    # provisionerd service account permissions to manage workspaces. This
+    # includes permission to manage pods and persistent volume claims in the
+    # deployment namespace.
+    #
+    # It is recommended to keep this on if you are using Kubernetes templates
+    # within Coder.
+    workspacePerms: true
+    # provisionerd.serviceAccount.enableDeployments -- Provides the service
+    # account permission to manage Kubernetes deployments.
+    enableDeployments: false
+    # provisionerd.serviceAccount.annotations -- The service account
+    # annotations.
+    annotations: {}
+    # provisionerd.serviceAccount.name -- The service account name.
+    name: coder-provisionerd
+
+  # provisionerd.securityContext -- Fields related to the container's security
+  # context (as opposed to the pod). Some fields are also present in the pod
+  # security context, in which case these values will take precedence.
+  securityContext:
+    # provisionerd.securityContext.runAsNonRoot -- Requires that the coder
+    # container runs as an unprivileged user. If setting runAsUser to 0 (root),
+    # this will need to be set to false.
+    runAsNonRoot: true
+    # provisionerd.securityContext.runAsUser -- Sets the user id of the
+    # container. For security reasons, we recommend using a non-root user.
+    runAsUser: 1000
+    # provisionerd.securityContext.runAsGroup -- Sets the group id of the
+    # container.  For security reasons, we recommend using a non-root group.
+    runAsGroup: 1000
+    # provisionerd.securityContext.readOnlyRootFilesystem -- Mounts the
+    # container's root filesystem as read-only.
+    readOnlyRootFilesystem: null
+    # provisionerd.securityContext.seccompProfile -- Sets the seccomp profile
+    # for the provisionerd container.
+    seccompProfile:
+      type: RuntimeDefault
+    # provisionerd.securityContext.allowPrivilegeEscalation -- Controls whether
+    # the container can gain additional privileges, such as escalating to
+    # root. It is recommended to leave this setting disabled in production.
+    allowPrivilegeEscalation: false
+
+  # provisionerd.volumes -- A list of extra volumes to add to each pod.
+  volumes: []
+  # - name: "my-volume"
+  #   emptyDir: {}
+
+  # provisionerd.volumeMounts -- A list of extra volume mounts to add to each
+  # pod.
+  volumeMounts: []
+  # - name: "my-volume"
+  #   mountPath: "/mnt/my-volume"
+
+  # provisionerd.lifecycle -- container lifecycle handlers for the Coder
+  # container, allowing for lifecycle events such as postStart and preStop
+  # events
+  # See: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+  lifecycle:
+    {}
+    # postStart:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "echo postStart"]
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh","-c","echo preStart"]
+
+  # provisionerd.resources -- The resources to request for each replica. These
+  # are optional and are not set by default.
+  resources:
+    {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # provisionerd.certs -- CA bundles to mount inside each pod.
+  certs:
+    # provisionerd.certs.secrets -- A list of CA bundle secrets to mount into
+    # each pod. The secrets should exist in the same namespace as the Helm
+    # deployment.
+    #
+    # The given key in each secret is mounted at
+    # `/etc/ssl/certs/{secret_name}.crt`.
+    secrets:
+      []
+      # - name: "my-ca-bundle"
+      #   key: "ca-bundle.crt"
+
+  # provisionerd.affinity -- Allows specifying an affinity rule for the
+  # `provisionerd` deployment. The default rule prefers to schedule coder pods
+  # on different nodes, which is only applicable if `provisionerd.replicaCount`
+  # is greater than 1.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - "coder-provisionerd"
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+
+  # provisionerd.tolerations -- Tolerations for tainted nodes.
+  # See: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations:
+    []
+    # - key: "key"
+    #   operator: "Equal"
+    #   value: "value"
+    #   effect: "NoSchedule"
+
+  # provisionerd.nodeSelector -- Node labels for constraining provisionerd pods
+  # to nodes.
+  # See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+  #  kubernetes.io/os: linux
+
+  # provisionerd.command -- The command to use when running the provisionerd
+  # container.  Used for customizing the location of the `coder` binary in your
+  # image.
   command:
     - /opt/coder
 


### PR DESCRIPTION
## TODO:

- [x] Add provisionerd deployment to helm chart with the same settings as coderd deployment (minus TLS, service, ingress etc.)
- [ ] Add auto-generated shared secret to both coder and provisionerd deployments if replicaCount > 0
- [ ] Allow connections to provisionerd endpoints with the shared key
- [ ] Add ability to start multiple provisionerds in a single replica via env var (aka. concurrency)
- [ ] Test in Kubernetes