### PR TITLE
fix: removing prettier path in vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -211,6 +211,5 @@
   "go.testFlags": ["-short", "-coverpkg=./..."],
   // We often use a version of TypeScript that's ahead of the version shipped
   // with VS Code.
-  "typescript.tsdk": "./site/node_modules/typescript/lib",
-  "prettier.prettierPath": "./node_modules/prettier"
+  "typescript.tsdk": "./site/node_modules/typescript/lib"
 }


### PR DESCRIPTION
It looks like we set the prettier path in our VS Code config at some point, probably to get around [this bug](https://github.com/prettier/prettier-vscode/issues/3020).
The latest version of VS Code contains a fix for this issue, and so we should take this path out, as it actually now breaks Prettier if you upgrade.