### PR TITLE
docs: add note about SSH key location in workspaces

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -34,6 +34,9 @@ Users can view their public key in their account settings:
 
 ![SSH keys in account settings](./images/ssh-keys.png)
 
+> Note: SSH keys are never stored in Coder workspaces, and are fetched only when
+> SSH is invoked. The keys are held in-memory and never written to disk.
+
 ## Dynamic Secrets
 
 Dynamic secrets are attached to the workspace lifecycle and automatically


### PR DESCRIPTION
this PR adds a note stating SSH keys are never stored in workspaces, and fetched only on-demand.