### PR TITLE
fix: scaletest: mount CODER_CACHE volume under /tmp

### DIFF
--- a/scaletest/terraform/coder.tf
+++ b/scaletest/terraform/coder.tf
@@ -130,7 +130,7 @@ coder:
     sessionAffinity: None
     loadBalancerIP: "${local.coder_address}"
   volumeMounts:
-  - mountPath: "/tmp/coder"
+  - mountPath: "/tmp"
     name: cache
     readOnly: false
   volumes:


### PR DESCRIPTION
Mounting the CODER_CACHE volume under /tmp/coder causes template creation to fail due to read-only tmp dir.