### PR TITLE
feat: add spinner to latencies when refetching

### DIFF
--- a/site/src/components/AppLink/AppLink.stories.tsx
+++ b/site/src/components/AppLink/AppLink.stories.tsx
@@ -29,8 +29,8 @@ const Template: Story<AppLinkProps> = (args) => (
       clearProxy: () => {
         return
       },
-      refetchProxyLatencies: () => {
-        return
+      refetchProxyLatencies: (): Date => {
+        return new Date()
       },
     }}
   >

--- a/site/src/components/Navbar/NavbarView.tsx
+++ b/site/src/components/Navbar/NavbarView.tsx
@@ -24,6 +24,7 @@ import Skeleton from "@mui/material/Skeleton"
 import { BUTTON_SM_HEIGHT } from "theme/theme"
 import { ProxyStatusLatency } from "components/ProxyStatusLatency/ProxyStatusLatency"
 import { usePermissions } from "hooks/usePermissions"
+import { ProxyLatencyReport } from "contexts/useProxyLatency"
 
 export const USERS_LINK = `/users?filter=${encodeURIComponent("status:active")}`
 
@@ -188,6 +189,7 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
 }) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [isOpen, setIsOpen] = useState(false)
+  const [refetchDate, setRefetchDate] = useState<Date>()
   const selectedProxy = proxyContextValue.proxy.proxy
   const refreshLatencies = proxyContextValue.refetchProxyLatencies
   const closeMenu = () => setIsOpen(false)
@@ -196,6 +198,26 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
   const isLoadingLatencies = Object.keys(latencies).length === 0
   const isLoading = proxyContextValue.isLoading || isLoadingLatencies
   const permissions = usePermissions()
+  const proxyLatencyLoading = (proxy: TypesGen.Region): boolean => {
+    if (!refetchDate) {
+      // Only show loading if the user manually requested a refetch
+      return false
+    }
+
+    const latency = latencies?.[proxy.id]
+    // Only show a loading spinner if:
+    //  - A latency exists. This means the latency was fetched at some point, so the
+    //    loader *should* be resolved.
+    //  - The proxy is healthy. If it is not, the loader might never resolve.
+    //  - The latency reported is older than the refetch date. This means the latency
+    //    is stale and we should show a loading spinner until the new latency is
+    //    fetched.
+    if (proxy.healthy && latency && latency.at < refetchDate) {
+      return true
+    }
+
+    return false
+  }
 
   if (isLoading) {
     return (
@@ -234,6 +256,7 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
             {selectedProxy.display_name}
             <ProxyStatusLatency
               latency={latencies?.[selectedProxy.id]?.latencyMS}
+              isLoading={proxyLatencyLoading(selectedProxy)}
             />
           </Box>
         ) : (
@@ -277,7 +300,10 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
                 />
               </Box>
               {proxy.display_name}
-              <ProxyStatusLatency latency={latencies?.[proxy.id]?.latencyMS} />
+              <ProxyStatusLatency
+                latency={latencies?.[proxy.id]?.latencyMS}
+                isLoading={proxyLatencyLoading(proxy)}
+              />
             </Box>
           </MenuItem>
         ))}
@@ -298,7 +324,8 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
             // Stop the menu from closing
             e.stopPropagation()
             // Refresh the latencies.
-            refreshLatencies()
+            const refetchDate = refreshLatencies()
+            setRefetchDate(refetchDate)
           }}
         >
           Refresh Latencies

--- a/site/src/components/Navbar/NavbarView.tsx
+++ b/site/src/components/Navbar/NavbarView.tsx
@@ -24,7 +24,6 @@ import Skeleton from "@mui/material/Skeleton"
 import { BUTTON_SM_HEIGHT } from "theme/theme"
 import { ProxyStatusLatency } from "components/ProxyStatusLatency/ProxyStatusLatency"
 import { usePermissions } from "hooks/usePermissions"
-import { ProxyLatencyReport } from "contexts/useProxyLatency"
 
 export const USERS_LINK = `/users?filter=${encodeURIComponent("status:active")}`
 

--- a/site/src/components/ProxyStatusLatency/ProxyStatusLatency.tsx
+++ b/site/src/components/ProxyStatusLatency/ProxyStatusLatency.tsx
@@ -4,10 +4,28 @@ import Box from "@mui/material/Box"
 import Tooltip from "@mui/material/Tooltip"
 import { FC } from "react"
 import { getLatencyColor } from "utils/latency"
+import CircularProgress from "@mui/material/CircularProgress"
 
-export const ProxyStatusLatency: FC<{ latency?: number }> = ({ latency }) => {
+export const ProxyStatusLatency: FC<{
+  latency?: number
+  isLoading?: boolean
+}> = ({ latency, isLoading }) => {
   const theme = useTheme()
   const color = getLatencyColor(theme, latency)
+
+  if (isLoading) {
+    return (
+      <Tooltip title="Loading latency...">
+        <CircularProgress
+          size="14px"
+          sx={{
+            // Always use the no latency color for loading.
+            color: getLatencyColor(theme, undefined),
+          }}
+        />
+      </Tooltip>
+    )
+  }
 
   if (!latency) {
     return (

--- a/site/src/components/Resources/AgentRow.stories.tsx
+++ b/site/src/components/Resources/AgentRow.stories.tsx
@@ -68,8 +68,8 @@ const TemplateFC = (
         clearProxy: () => {
           return
         },
-        refetchProxyLatencies: () => {
-          return
+        refetchProxyLatencies: (): Date => {
+          return new Date()
         },
       }}
     >

--- a/site/src/components/Resources/ResourceCard.stories.tsx
+++ b/site/src/components/Resources/ResourceCard.stories.tsx
@@ -33,8 +33,8 @@ Example.args = {
         clearProxy: () => {
           return
         },
-        refetchProxyLatencies: () => {
-          return
+        refetchProxyLatencies: (): Date => {
+          return new Date()
         },
       }}
     >
@@ -106,8 +106,8 @@ BunchOfMetadata.args = {
         clearProxy: () => {
           return
         },
-        refetchProxyLatencies: () => {
-          return
+        refetchProxyLatencies: (): Date => {
+          return new Date()
         },
       }}
     >

--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -42,8 +42,8 @@ const meta: Meta<typeof Workspace> = {
             setProxy: () => {
               return
             },
-            refetchProxyLatencies: () => {
-              return
+            refetchProxyLatencies: (): Date => {
+              return new Date()
             },
           }}
         >

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -53,7 +53,7 @@ export interface ProxyContextValue {
   proxyLatencies: Record<string, ProxyLatencyReport>
   // refetchProxyLatencies will trigger refreshing of the proxy latencies. By default the latencies
   // are loaded once.
-  refetchProxyLatencies: () => void
+  refetchProxyLatencies: () => Date
   // setProxy is a function that sets the user's selected proxy. This function should
   // only be called if the user is manually selecting a proxy. This value is stored in local
   // storage and will persist across reloads and tabs.


### PR DESCRIPTION
If the proxy is unhealthy or unresponsive, then the loader never shows. So only healthy and reporting proxies get the little spinner. It was just hard to know if the latency was even updated before when you hit that button.

**This does not show on first load, it only affects the "refresh latency" button**

[Peek 2023-06-30 12-13.webm](https://github.com/coder/coder/assets/5446298/6faaaac0-c8c1-43c3-9091-e543faceec1e)

(I added a random delay for this little video, so the latency number is inaccurate to the time waited)