### PR TITLE
chore: prevent running ci when other workflows are updated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,8 @@ jobs:
               - "scripts/Dockerfile.base"
               - "scripts/helm.sh"
             ci:
-              - ".github/**"
+              - ".github/actions/**"
+              - ".github/workflows/ci.yaml"
       - id: debug
         run: |
           echo "${{ toJSON(steps.filter )}}"


### PR DESCRIPTION
This will prevent running ci on PRs and main if other actions for example pr-deploy.yaml are changed. 

