### PR TITLE
feat: purge old provisioner daemons periodically

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -786,6 +786,13 @@ func (q *querier) DeleteLicense(ctx context.Context, id int32) (int32, error) {
 	return id, nil
 }
 
+func (q *querier) DeleteOldProvisionerDaemons(ctx context.Context) error {
+	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceSystem); err != nil {
+		return err
+	}
+	return q.db.DeleteOldProvisionerDaemons(ctx)
+}
+
 func (q *querier) DeleteOldWorkspaceAgentStartupLogs(ctx context.Context) error {
 	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceSystem); err != nil {
 		return err

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -1169,6 +1169,11 @@ func (q *fakeQuerier) DeleteLicense(_ context.Context, id int32) (int32, error) 
 	return 0, sql.ErrNoRows
 }
 
+func (*fakeQuerier) DeleteOldProvisionerDaemons(_ context.Context) error {
+	// noop
+	return nil
+}
+
 func (*fakeQuerier) DeleteOldWorkspaceAgentStartupLogs(_ context.Context) error {
 	// noop
 	return nil

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -191,6 +191,13 @@ func (m metricsStore) DeleteLicense(ctx context.Context, id int32) (int32, error
 	return licenseID, err
 }
 
+func (m metricsStore) DeleteOldProvisionerDaemons(ctx context.Context) error {
+	start := time.Now()
+	r0 := m.s.DeleteOldProvisionerDaemons(ctx)
+	m.queryLatencies.WithLabelValues("DeleteOldProvisionerDaemons").Observe(time.Since(start).Seconds())
+	return r0
+}
+
 func (m metricsStore) DeleteOldWorkspaceAgentStartupLogs(ctx context.Context) error {
 	start := time.Now()
 	err := m.s.DeleteOldWorkspaceAgentStartupLogs(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -209,6 +209,20 @@ func (mr *MockStoreMockRecorder) DeleteLicense(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLicense", reflect.TypeOf((*MockStore)(nil).DeleteLicense), arg0, arg1)
 }
 
+// DeleteOldProvisionerDaemons mocks base method.
+func (m *MockStore) DeleteOldProvisionerDaemons(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOldProvisionerDaemons", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOldProvisionerDaemons indicates an expected call of DeleteOldProvisionerDaemons.
+func (mr *MockStoreMockRecorder) DeleteOldProvisionerDaemons(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOldProvisionerDaemons", reflect.TypeOf((*MockStore)(nil).DeleteOldProvisionerDaemons), arg0)
+}
+
 // DeleteOldWorkspaceAgentStartupLogs mocks base method.
 func (m *MockStore) DeleteOldWorkspaceAgentStartupLogs(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -45,6 +45,9 @@ func New(ctx context.Context, logger slog.Logger, db database.Store) io.Closer {
 			eg.Go(func() error {
 				return db.DeleteOldWorkspaceAgentStats(ctx)
 			})
+			eg.Go(func() error {
+				return db.DeleteOldProvisionerDaemons(ctx)
+			})
 			err := eg.Wait()
 			if err != nil {
 				if errors.Is(err, context.Canceled) {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -34,6 +34,7 @@ type sqlcQuerier interface {
 	DeleteGroupMemberFromGroup(ctx context.Context, arg DeleteGroupMemberFromGroupParams) error
 	DeleteGroupMembersByOrgAndUser(ctx context.Context, arg DeleteGroupMembersByOrgAndUserParams) error
 	DeleteLicense(ctx context.Context, id int32) (int32, error)
+	DeleteOldProvisionerDaemons(ctx context.Context) error
 	// If an agent hasn't connected in the last 7 days, we purge it's logs.
 	// Logs can take up a lot of space, so it's important we clean up frequently.
 	DeleteOldWorkspaceAgentStartupLogs(ctx context.Context) error

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -361,15 +361,12 @@ func TestQueuePosition(t *testing.T) {
 			Time:  database.Now(),
 			Valid: true,
 		},
-		Types: database.AllProvisionerTypeValues(),
-		WorkerID: uuid.NullUUID{
-			UUID:  uuid.New(),
-			Valid: true,
-		},
-		Tags: json.RawMessage("{}"),
+		Types:    database.AllProvisionerTypeValues(),
+		WorkerID: uuid.New(),
+		Tags:     json.RawMessage("{}"),
 	})
 	require.NoError(t, err)
-	require.Equal(t, jobs[0].ID, job.ID)
+	require.Equal(t, jobs[0].ID, job.ProvisionerJob.ID)
 
 	queued, err = db.GetProvisionerJobsByIDsWithQueuePosition(ctx, jobIDs)
 	require.NoError(t, err)

--- a/coderd/database/queries/provisionerdaemons.sql
+++ b/coderd/database/queries/provisionerdaemons.sql
@@ -15,3 +15,9 @@ INSERT INTO
 	)
 VALUES
 	($1, $2, $3, $4, $5) RETURNING *;
+
+-- name: DeleteOldProvisionerDaemons :exec
+DELETE FROM
+	provisioner_daemons
+WHERE
+	updated_at < NOW() - INTERVAL '7 days';

--- a/coderd/metricscache/metricscache_test.go
+++ b/coderd/metricscache/metricscache_test.go
@@ -383,14 +383,14 @@ func TestCache_BuildTime(t *testing.T) {
 
 				_, err = db.InsertWorkspaceBuild(ctx, database.InsertWorkspaceBuildParams{
 					TemplateVersionID: templateVersion.ID,
-					JobID:             job.ID,
+					JobID:             job.ProvisionerJob.ID,
 					Transition:        tt.args.transition,
 					Reason:            database.BuildReasonInitiator,
 				})
 				require.NoError(t, err)
 
 				err = db.UpdateProvisionerJobWithCompleteByID(ctx, database.UpdateProvisionerJobWithCompleteByIDParams{
-					ID:          job.ID,
+					ID:          job.ProvisionerJob.ID,
 					CompletedAt: sql.NullTime{Time: row.completedAt, Valid: true},
 				})
 				require.NoError(t, err)

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -478,11 +478,8 @@ func TestUpdateJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  uuid.New(),
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: uuid.New(),
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 		_, err = srv.UpdateJob(ctx, &proto.UpdateJobRequest{
@@ -500,11 +497,8 @@ func TestUpdateJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  srv.ID,
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: srv.ID,
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 		return job.ID
@@ -686,11 +680,8 @@ func TestFailJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  uuid.New(),
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: uuid.New(),
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 		_, err = srv.FailJob(ctx, &proto.FailedJob{
@@ -709,11 +700,8 @@ func TestFailJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  srv.ID,
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: srv.ID,
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 		err = srv.Database.UpdateProvisionerJobWithCompleteByID(ctx, database.UpdateProvisionerJobWithCompleteByIDParams{
@@ -760,11 +748,8 @@ func TestFailJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  srv.ID,
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: srv.ID,
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 
@@ -826,11 +811,8 @@ func TestCompleteJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  uuid.New(),
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: uuid.New(),
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 		_, err = srv.CompleteJob(ctx, &proto.CompletedJob{
@@ -856,11 +838,8 @@ func TestCompleteJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  srv.ID,
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: srv.ID,
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 		completeJob := func() {
@@ -1066,11 +1045,8 @@ func TestCompleteJob(t *testing.T) {
 					})),
 				})
 				_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-					WorkerID: uuid.NullUUID{
-						UUID:  srv.ID,
-						Valid: true,
-					},
-					Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+					WorkerID: srv.ID,
+					Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 				})
 				require.NoError(t, err)
 
@@ -1136,11 +1112,8 @@ func TestCompleteJob(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = srv.Database.AcquireProvisionerJob(ctx, database.AcquireProvisionerJobParams{
-			WorkerID: uuid.NullUUID{
-				UUID:  srv.ID,
-				Valid: true,
-			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			WorkerID: srv.ID,
+			Types:    []database.ProvisionerType{database.ProvisionerTypeEcho},
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
While cleaning these up I noticed that `updated_at` was never actually set, so I added it to the `AcquireProvisionerJob` query to reduce additional database load for more daemons.