### PR TITLE
fix(pty): close output writer before reader on Windows to unblock close

### DIFF
--- a/pty/pty_windows.go
+++ b/pty/pty_windows.go
@@ -151,7 +151,6 @@ func (p *ptyWindows) closeConsoleNoLock() error {
 	// output reads can get to EOF.  In that case, we don't need to close it
 	// again here.
 	if p.console != windows.InvalidHandle {
-		//
 		// Because ClosePseudoConsole has no return value, we could ignore the
 		// error here, but we limit this either S_OK or S_FALSE as a safety-net
 		// in case other values could be returned.

--- a/pty/pty_windows.go
+++ b/pty/pty_windows.go
@@ -194,7 +194,7 @@ func (p *ptyWindows) Close() error {
 	// Note that this may result in a small amount of unprocessed output
 	// being lost, but the alternative is to wrap the reader or to handle
 	// this by all consumers.
-	_, _ = io.Copy(io.Discard, p.outputRead)
+	// _, _ = io.Copy(io.Discard, p.outputRead)
 
 	_ = p.outputRead.Close()
 	_ = p.inputWrite.Close()

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -354,7 +354,13 @@ type PTY struct {
 func (p *PTY) Close() error {
 	p.t.Helper()
 	pErr := p.PTY.Close()
-	eErr := p.outExpecter.close("close")
+	if pErr != nil {
+		p.logf("PTY Close PTY: %v", pErr)
+	}
+	eErr := p.outExpecter.close("PTY close")
+	if eErr != nil {
+		p.logf("PTY Close expecter: %v", eErr)
+	}
 	if pErr != nil {
 		return pErr
 	}
@@ -398,7 +404,13 @@ type PTYCmd struct {
 func (p *PTYCmd) Close() error {
 	p.t.Helper()
 	pErr := p.PTYCmd.Close()
-	eErr := p.outExpecter.close("close")
+	if pErr != nil {
+		p.logf("PTYCmd Close PTYCmd: %v", pErr)
+	}
+	eErr := p.outExpecter.close("PTYCmd close")
+	if eErr != nil {
+		p.logf("PTYCmd Close expecter: %v", eErr)
+	}
 	if pErr != nil {
 		return pErr
 	}

--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -355,11 +355,11 @@ func (p *PTY) Close() error {
 	p.t.Helper()
 	pErr := p.PTY.Close()
 	if pErr != nil {
-		p.logf("PTY Close PTY: %v", pErr)
+		p.logf("PTY: Close failed: %v", pErr)
 	}
 	eErr := p.outExpecter.close("PTY close")
 	if eErr != nil {
-		p.logf("PTY Close expecter: %v", eErr)
+		p.logf("PTY: close expecter failed: %v", eErr)
 	}
 	if pErr != nil {
 		return pErr
@@ -405,11 +405,11 @@ func (p *PTYCmd) Close() error {
 	p.t.Helper()
 	pErr := p.PTYCmd.Close()
 	if pErr != nil {
-		p.logf("PTYCmd Close PTYCmd: %v", pErr)
+		p.logf("PTYCmd: Close failed: %v", pErr)
 	}
 	eErr := p.outExpecter.close("PTYCmd close")
 	if eErr != nil {
-		p.logf("PTYCmd Close expecter: %v", eErr)
+		p.logf("PTYCmd: close expecter failed: %v", eErr)
 	}
 	if pErr != nil {
 		return pErr


### PR DESCRIPTION
I haven't reproduced the issue on Windows, but I'm hoping this is a fix for the following issue (stuck on calling Close):

https://github.com/coder/coder/actions/runs/5442614267/jobs/9898091930?pr=8280
