### PR TITLE
feat: delay pending-in-queue banner

### DIFF
--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -137,8 +137,14 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
   const now = dayjs()
   useEffect(() => {
     if (
-      workspace.latest_build.status === "pending" &&
-      workspace.latest_build.job.queue_size > 0 &&
+      workspace.latest_build.status !== "pending" ||
+      workspace.latest_build.job.queue_size === 0
+    ) {
+      setShowAlertPendingInQueue(false)
+      return
+    }
+
+    if (
       dayjs(workspace.latest_build.created_at).isBefore(
         now.subtract(5, "seconds"),
       )
@@ -147,23 +153,12 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
       return
     }
 
-    if (
-      workspace.latest_build.status === "pending" &&
-      workspace.latest_build.job.queue_size > 0
-    ) {
-      const timer = setTimeout(() => {
-        if (
-          workspace.latest_build.status !== "pending" ||
-          workspace.latest_build.job.queue_size === 0
-        ) {
-          return
-        }
-        setShowAlertPendingInQueue(true)
-      }, 5000)
+    const timer = setTimeout(() => {
+      setShowAlertPendingInQueue(true)
+    }, 5000)
 
-      return () => {
-        clearTimeout(timer)
-      }
+    return () => {
+      clearTimeout(timer)
     }
   }, [workspace, now])
   return (

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -144,29 +144,24 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
         return
       }
 
-      // hideTimer
-      setTimeout(() => {
+      const hideTimer = setTimeout(() => {
         setShowAlertPendingInQueue(false)
       }, 250)
-      return
+      return () => {
+        clearTimeout(hideTimer)
+      }
     }
 
-    if (
-      dayjs(workspace.latest_build.created_at).isBefore(
-        now.subtract(5, "seconds"),
-      )
-    ) {
-      setShowAlertPendingInQueue(true)
-      return
-    }
-
+    const t = Math.max(
+      0,
+      5000 - dayjs().diff(dayjs(workspace.latest_build.created_at)),
+    )
     const showTimer = setTimeout(() => {
       setShowAlertPendingInQueue(true)
-    }, 5000)
+    }, t)
 
     return () => {
       clearTimeout(showTimer)
-      // hideTimer must time out naturally, otherwise the banner will be hidden immediately
     }
   }, [workspace, now, showAlertPendingInQueue])
   return (

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -140,7 +140,14 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
       workspace.latest_build.status !== "pending" ||
       workspace.latest_build.job.queue_size === 0
     ) {
-      setShowAlertPendingInQueue(false)
+      if (!showAlertPendingInQueue) {
+        return
+      }
+
+      // hideTimer
+      setTimeout(() => {
+        setShowAlertPendingInQueue(false)
+      }, 250)
       return
     }
 
@@ -153,14 +160,15 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
       return
     }
 
-    const timer = setTimeout(() => {
+    const showTimer = setTimeout(() => {
       setShowAlertPendingInQueue(true)
     }, 5000)
 
     return () => {
-      clearTimeout(timer)
+      clearTimeout(showTimer)
+      // hideTimer must time out naturally, otherwise the banner will be hidden immediately
     }
-  }, [workspace, now])
+  }, [workspace, now, showAlertPendingInQueue])
   return (
     <>
       <FullWidthPageHeader>

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -133,28 +133,37 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
     transitionStats = ActiveTransition(template, workspace)
   }
 
-  const [showAlertPendingInQueue, setShowAlertPendingInQueue] = useState(false);
+  const [showAlertPendingInQueue, setShowAlertPendingInQueue] = useState(false)
   const now = dayjs()
   useEffect(() => {
-    if (workspace.latest_build.status === "pending" &&
+    if (
+      workspace.latest_build.status === "pending" &&
       workspace.latest_build.job.queue_size > 0 &&
-      dayjs(workspace.latest_build.created_at).isBefore(now.subtract(5, 'seconds'))) {
-      setShowAlertPendingInQueue(true);
+      dayjs(workspace.latest_build.created_at).isBefore(
+        now.subtract(5, "seconds"),
+      )
+    ) {
+      setShowAlertPendingInQueue(true)
       return
     }
 
-    if (workspace.latest_build.status === "pending" &&
-      workspace.latest_build.job.queue_size > 0) {
-        const timer = setTimeout(() => {
-          if (workspace.latest_build.status !== "pending" || workspace.latest_build.job.queue_size === 0) {
-            return
-          }
-          setShowAlertPendingInQueue(true);
-        }, 5000)
-
-        return () => {
-          clearTimeout(timer);
+    if (
+      workspace.latest_build.status === "pending" &&
+      workspace.latest_build.job.queue_size > 0
+    ) {
+      const timer = setTimeout(() => {
+        if (
+          workspace.latest_build.status !== "pending" ||
+          workspace.latest_build.job.queue_size === 0
+        ) {
+          return
         }
+        setShowAlertPendingInQueue(true)
+      }, 5000)
+
+      return () => {
+        clearTimeout(timer)
+      }
     }
   }, [workspace, now])
   return (


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/8254

This PR adds the logic to show the pending-in-queue banner if the build is parked for more than 5 seconds. The idea is to reduce the blink effect if the workspace build is being processed after 1-2 sec after creation.

Notice: I'm not TypeScript/JS magician, so I apologize if I used the wrong concepts.