### PR TITLE
chore: use correct prettier version in ci

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,6 +1,11 @@
 name: "Setup Node"
 description: |
   Sets up the node environment for tests, builds, etc.
+inputs:
+  yarn-install-flags:
+    description: "Flags to pass to yarn install"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -12,4 +17,4 @@ runs:
         cache-dependency-path: "site/yarn.lock"
     - name: Install node_modules
       shell: bash
-      run: ./scripts/yarn_install.sh
+      run: ./scripts/yarn_install.sh ${{ inputs.yarn-install-flags }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -3,7 +3,11 @@ description: |
   Sets up the node environment for tests, builds, etc.
 inputs:
   skip-yarn-install:
-    description: "Skip yarn install"
+    description: |
+      Skip 'yarn_install.sh' script. Be careful using this as it will not
+      install any dependencies. This is only useful if you do not need all
+      the dependencies installed, and will control the dependencies yourself.
+
     required: false
     default: "false"
 runs:

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,15 +1,6 @@
 name: "Setup Node"
 description: |
   Sets up the node environment for tests, builds, etc.
-inputs:
-  skip-yarn-install:
-    description: |
-      Skip 'yarn_install.sh' script. Be careful using this as it will not
-      install any dependencies. This is only useful if you do not need all
-      the dependencies installed, and will control the dependencies yourself.
-
-    required: false
-    default: "false"
 runs:
   using: "composite"
   steps:
@@ -22,4 +13,3 @@ runs:
     - name: Install node_modules
       shell: bash
       run: ./scripts/yarn_install.sh
-      if: ${{ inputs.skip-yarn-install != 'true' }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -6,10 +6,6 @@ inputs:
     description: "Skip yarn install"
     required: false
     default: "false"
-  yarn-install-flags:
-    description: "Flags to pass to yarn install"
-    required: false
-    default: ""
 runs:
   using: "composite"
   steps:
@@ -19,8 +15,7 @@ runs:
         # See https://github.com/actions/setup-node#caching-global-packages-data
         cache: "yarn"
         cache-dependency-path: "site/yarn.lock"
-#        key: buildjet-node-${{ inputs.yarn-install-flags  }}
     - name: Install node_modules
       shell: bash
-      run: ./scripts/yarn_install.sh ${{ inputs.yarn-install-flags }}
+      run: ./scripts/yarn_install.sh
       if: ${{ inputs.skip-yarn-install != 'true' }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -2,6 +2,10 @@ name: "Setup Node"
 description: |
   Sets up the node environment for tests, builds, etc.
 inputs:
+  skip-yarn-install:
+    description: "Skip yarn install"
+    required: false
+    default: "false"
   yarn-install-flags:
     description: "Flags to pass to yarn install"
     required: false
@@ -15,6 +19,8 @@ runs:
         # See https://github.com/actions/setup-node#caching-global-packages-data
         cache: "yarn"
         cache-dependency-path: "site/yarn.lock"
+#        key: buildjet-node-${{ inputs.yarn-install-flags  }}
     - name: Install node_modules
       shell: bash
       run: ./scripts/yarn_install.sh ${{ inputs.yarn-install-flags }}
+      if: ${{ inputs.skip-yarn-install != 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,16 +192,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-node
+      - uses: buildjet/setup-node@v3
         with:
-          # For yarn format, we only need the prettier dependency.
-          # Nothing else needs to be installed, so we can skip
-          # the custom yarn_install and handle it manually.
-          skip-yarn-install: "true"
+          node-version: 16.16.0
 
       - name: Install prettier
         run: cd site && yarn install --prettier
-        key: yarn
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-node
-        with:
+#        with:
           # Only install prettier dep for this job
 #          yarn-install-flags: "--prettier"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,8 +195,6 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           skip-yarn-install: "true"
-          # Only install prettier dep for this job
-          yarn-install-flags: "--prettier"
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,7 +200,7 @@ jobs:
           skip-yarn-install: "true"
 
       - name: Install prettier
-        run: yarn install --prettier
+        run: yarn global add prettier
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node
         with:
+          skip-yarn-install: "true"
           # Only install prettier dep for this job
           yarn-install-flags: "--prettier"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,7 +195,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           # Only install prettier dep for this job
-          yarn-install-flags: "--prettier"
+#          yarn-install-flags: "--prettier"
 
 
       - uses: buildjet/setup-go@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,7 +203,10 @@ jobs:
           go-version: 1.20.5
 
       - name: Install prettier
-        run: cd site && yarn install --prettier
+        # Install the same version of prettier that we have in our package.json
+        # We install it globally because we do not want to install all node_modules.
+        # There is no easy way to only install 1 dep from a package.json.
+        run: cd site && yarn global add prettier@$(cat ./package.json | jq -r '.devDependencies["prettier"]')
 
 
       - name: Install shfmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
         run: "make --output-sync -j -B gen"
 
       - name: Check for unstaged files
-        run: ./scripts/cgiheck_unstaged.sh
+        run: ./scripts/check_unstaged.sh
 
   fmt:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
@@ -203,10 +203,7 @@ jobs:
           go-version: 1.20.5
 
       - name: Install prettier
-        run: cd site && yarn --cache-folder=/tmp/yarn_pretty_cache install --prettier
-        with:
-          key: prettier
-          path: /tmp/yarn_pretty_cache
+        run: cd site && yarn install --prettier
 
 
       - name: Install shfmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,7 @@ jobs:
           # For yarn format, we only need the prettier dependency.
           # Nothing else needs to be installed, so we can skip
           # the custom yarn_install and handle it manually.
-          skip-yarn-install: "true"
+          skip-yarn-install: "false"
 
       - name: Install prettier
         run: cd site && yarn install --prettier

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,7 +208,6 @@ jobs:
         # There is no easy way to only install 1 dep from a package.json.
         run: cd site && yarn global add prettier@$(cat ./package.json | jq -r '.devDependencies["prettier"]')
 
-
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,7 @@ jobs:
           # For yarn format, we only need the prettier dependency.
           # Nothing else needs to be installed, so we can skip
           # the custom yarn_install and handle it manually.
-          skip-yarn-install: "false"
+          skip-yarn-install: "true"
 
       - name: Install prettier
         run: cd site && yarn install --prettier

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,10 +193,9 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-node
-#        with:
+        with:
           # Only install prettier dep for this job
-#          yarn-install-flags: "--prettier"
-
+          yarn-install-flags: "--prettier"
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,7 +200,7 @@ jobs:
           skip-yarn-install: "true"
 
       - name: Install prettier
-        run: yarn install --prettier
+        run: cd site && yarn install --prettier
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,10 +203,14 @@ jobs:
           go-version: 1.20.5
 
       - name: Install prettier
+        # We only need prettier for fmt, so do not install all dependencies.
+        # There is no way to install a single package with yarn, so we have to
+        # make a new package.json with only prettier listed as a dependency.
+        # Then running `yarn` will only install prettier.
         run: |
           cd site
           mv package.json package.json.bak
-          echo '{"dependencies": {"prettier": '"$(cat package.json.bak | jq '.devDependencies.prettier')"'}}' > package.json
+          jq '{dependencies: {prettier: .devDependencies.prettier}}' < package.json.bak > package.json
           yarn --frozen-lockfile
           mv package.json.bak package.json
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,6 +201,7 @@ jobs:
 
       - name: Install prettier
         run: cd site && yarn install --prettier
+        key: yarn
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,7 +200,7 @@ jobs:
           skip-yarn-install: "true"
 
       - name: Install prettier
-        run: yarn global add prettier
+        run: yarn install --prettier
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,7 +195,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           # Only install prettier dep for this job
-          yarn-install-flags: "prettier"
+          yarn-install-flags: "--prettier"
 
 
       - uses: buildjet/setup-go@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
         run: "make --output-sync -j -B gen"
 
       - name: Check for unstaged files
-        run: ./scripts/check_unstaged.sh
+        run: ./scripts/cgiheck_unstaged.sh
 
   fmt:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
@@ -203,7 +203,11 @@ jobs:
           go-version: 1.20.5
 
       - name: Install prettier
-        run: cd site && yarn install --prettier
+        run: cd site && yarn --cache-folder=/tmp/yarn_pretty_cache install --prettier
+        with:
+          key: prettier
+          path: /tmp/yarn_pretty_cache
+
 
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,10 +203,12 @@ jobs:
           go-version: 1.20.5
 
       - name: Install prettier
-        # Install the same version of prettier that we have in our package.json
-        # We install it globally because we do not want to install all node_modules.
-        # There is no easy way to only install 1 dep from a package.json.
-        run: cd site && yarn global add prettier@$(cat ./package.json | jq -r '.devDependencies["prettier"]')
+        run: |
+          cd site
+          mv package.json package.json.bak
+          echo '{"dependencies": {"prettier": '"$(cat package.json.bak | jq '.devDependencies.prettier')"'}}' > package.json
+          yarn --frozen-lockfile
+          mv package.json.bak package.json
 
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,7 +194,13 @@ jobs:
 
       - uses: ./.github/actions/setup-node
         with:
+          # For yarn format, we only need the prettier dependency.
+          # Nothing else needs to be installed, so we can skip
+          # the custom yarn_install and handle it manually.
           skip-yarn-install: "true"
+
+      - name: Install prettier
+        run: yarn install --prettier
 
       - uses: buildjet/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,18 +192,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: buildjet/setup-node@v3
+      - uses: ./.github/actions/setup-node
         with:
-          node-version: 16.16.0
+          # Only install prettier dep for this job
+          yarn-install-flags: "prettier"
+
 
       - uses: buildjet/setup-go@v4
         with:
           # This doesn't need caching. It's super fast anyways!
           cache: false
           go-version: 1.20.5
-
-      - name: Install prettier
-        run: npm install -g prettier
 
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,14 +196,14 @@ jobs:
         with:
           node-version: 16.16.0
 
-      - name: Install prettier
-        run: cd site && yarn install --prettier
-
       - uses: buildjet/setup-go@v4
         with:
           # This doesn't need caching. It's super fast anyways!
           cache: false
           go-version: 1.20.5
+
+      - name: Install prettier
+        run: cd site && yarn install --prettier
 
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.5.0


### PR DESCRIPTION
Install globally is ignoring the yarn.lock with the right prettier version

The downside is installing prettier takes 1min each time :thinking: 

# The caching thing

Let's get this green on `main`, then figure out how to get the prettier install to be quicker.