### PR TITLE
chore: pin terraform to 1.5.2

### DIFF
--- a/.github/actions/setup-tf/action.yaml
+++ b/.github/actions/setup-tf/action.yaml
@@ -1,0 +1,11 @@
+name: "Setup Go"
+description: |
+  Sets up Terraform for tests, builds, etc.
+runs:
+  using: "composite"
+  steps:
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.5.2
+        terraform_wrapper: false

--- a/.github/actions/setup-tf/action.yaml
+++ b/.github/actions/setup-tf/action.yaml
@@ -1,4 +1,4 @@
-name: "Setup Go"
+name: "Setup Terraform"
 description: |
   Sets up Terraform for tests, builds, etc.
 runs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,11 +231,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-go
-
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.5.1
-          terraform_wrapper: false
+      - uses: ./.github/actions/setup-tf
 
       - name: Test with Mock Database
         id: test
@@ -296,11 +292,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-go
-
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.5.1
-          terraform_wrapper: false
+      - uses: ./.github/actions/setup-tf
 
       - name: Test with PostgreSQL Database
         run: |
@@ -340,11 +332,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-go
-
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.5.1
-          terraform_wrapper: false
+      - uses: ./.github/actions/setup-tf
 
       - name: Run Tests
         run: |
@@ -479,11 +467,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-go
-
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.5.1
-          terraform_wrapper: false
+      - uses: ./.github/actions/setup-tf
 
       - name: Build
         run: |

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -19,11 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-go
-
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.1.9
-          terraform_wrapper: false
+      - uses: ./.github/actions/setup-tf
 
       - name: Run Tests
         run: |

--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -13,11 +13,8 @@ RUN apk add --no-cache \
 		git \
 		openssh-client && \
 	# Use the edge repo, since Terraform doesn't seem to be backported to 3.18.
-	# TODO: remove =~
-	# For some reason alpine's ARM builders are offline, so ARM builds will have
-	# to fall back to 1.5.0.
 	apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-		terraform=~1.5-r0 && \
+		terraform=1.5.2-r0 && \
 	addgroup \
 		-g 1000 \
 		coder && \


### PR DESCRIPTION
The Alpine ARM builders are no longer behind on releases.