### PR TITLE
test(agent): use afero for motd tests to allow parallel execution

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -503,7 +503,7 @@ func (a *agent) setLifecycle(ctx context.Context, state codersdk.WorkspaceAgentL
 // not be fetched immediately; the expectation is that it is primed elsewhere
 // (and must be done before the session actually starts).
 func (a *agent) fetchServiceBannerLoop(ctx context.Context) {
-	ticker := time.NewTicker(adjustIntervalForTests(2*time.Minute, time.Millisecond*100))
+	ticker := time.NewTicker(adjustIntervalForTests(2*time.Minute, time.Millisecond*5))
 	defer ticker.Stop()
 	for {
 		select {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -429,7 +429,7 @@ func TestAgent_Session_TTY_MOTD_Update(t *testing.T) {
 	for _, test := range tests {
 		test := test
 
-		ready := make(chan struct{}, 1)
+		ready := make(chan struct{}, 2)
 		client.mu.Lock()
 		client.getServiceBanner = func() (codersdk.ServiceBannerConfig, error) {
 			select {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -269,13 +269,13 @@ func TestAgent_SessionTTYExitCode(t *testing.T) {
 }
 
 func TestAgent_Session_TTY_MOTD(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		// This might be our implementation, or ConPTY itself.
 		// It's difficult to find extensive tests for it, so
 		// it seems like it could be either.
 		t.Skip("ConPTY appears to be inconsistent on Windows.")
 	}
-	t.Parallel()
 
 	u, err := user.Current()
 	require.NoError(t, err, "get current user")
@@ -372,13 +372,13 @@ func TestAgent_Session_TTY_MOTD(t *testing.T) {
 }
 
 func TestAgent_Session_TTY_MOTD_Update(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		// This might be our implementation, or ConPTY itself.
 		// It's difficult to find extensive tests for it, so
 		// it seems like it could be either.
 		t.Skip("ConPTY appears to be inconsistent on Windows.")
 	}
-	t.Parallel()
 
 	// Only the banner updates dynamically; the MOTD file does not.
 	wantServiceBanner := "Service banner text goes here"

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -361,7 +361,7 @@ func (s *Server) startPTYSession(session ptySession, magicTypeLabel string, cmd 
 	if !isQuietLogin(session.RawCommand()) {
 		manifest := s.Manifest.Load()
 		if manifest != nil {
-			err := showMOTD(session, manifest.MOTDFile)
+			err := showMOTD(s.fs, session, manifest.MOTDFile)
 			if err != nil {
 				s.logger.Error(ctx, "agent failed to show MOTD", slog.Error(err))
 				s.metrics.sessionErrors.WithLabelValues(magicTypeLabel, "yes", "motd").Add(1)
@@ -796,12 +796,12 @@ func showServiceBanner(session io.Writer, banner *codersdk.ServiceBannerConfig) 
 // the given filename to dest, if the file exists.
 //
 // https://github.com/openssh/openssh-portable/blob/25bd659cc72268f2858c5415740c442ee950049f/session.c#L784
-func showMOTD(dest io.Writer, filename string) error {
+func showMOTD(fs afero.Fs, dest io.Writer, filename string) error {
 	if filename == "" {
 		return nil
 	}
 
-	f, err := os.Open(filename)
+	f, err := fs.Open(filename)
 	if err != nil {
 		if xerrors.Is(err, os.ErrNotExist) {
 			// This is not an error, there simply isn't a MOTD to show.


### PR DESCRIPTION
This PR uses `afero.Fs` to read mtod so that test can be run in parallel. A small race-issue is also fixed in the motd update test where we didn't have a guarantee that the service banner value had propagated yet.

Before:

```
ok  	github.com/coder/coder/agent	38.457s
```

After (additionally, these 10s are available for parallel execution of other tests):

```
ok  	github.com/coder/coder/agent	10.758s
```
