### PR TITLE
fix(enterprise/audit): improve error message for missing action

### DIFF
--- a/enterprise/audit/table.go
+++ b/enterprise/audit/table.go
@@ -2,7 +2,9 @@ package audit
 
 import (
 	"fmt"
+	"os"
 	"reflect"
+	"runtime"
 
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/codersdk"
@@ -235,7 +237,8 @@ func entry(v any, f map[string]Action) (string, map[string]Action) {
 			continue
 		}
 		if _, ok := fcpy[jsonTag]; !ok {
-			panic(fmt.Sprintf("audit table entry missing action for field %q in type %q", d.FieldType.Name, name))
+			_, _ = fmt.Fprintf(os.Stderr, "ERROR: Audit table entry missing action for field %q in type %q\nPlease update the auditable resource types in: %s\n", d.FieldType.Name, name, self())
+			os.Exit(1)
 		}
 		delete(fcpy, jsonTag)
 	}
@@ -251,4 +254,9 @@ func entry(v any, f map[string]Action) (string, map[string]Action) {
 
 func (t Action) String() string {
 	return string(t)
+}
+
+func self() string {
+	_, file, _, _ := runtime.Caller(1)
+	return file
 }

--- a/enterprise/audit/table.go
+++ b/enterprise/audit/table.go
@@ -238,6 +238,7 @@ func entry(v any, f map[string]Action) (string, map[string]Action) {
 		}
 		if _, ok := fcpy[jsonTag]; !ok {
 			_, _ = fmt.Fprintf(os.Stderr, "ERROR: Audit table entry missing action for field %q in type %q\nPlease update the auditable resource types in: %s\n", d.FieldType.Name, name, self())
+			//nolint:revive
 			os.Exit(1)
 		}
 		delete(fcpy, jsonTag)
@@ -257,6 +258,7 @@ func (t Action) String() string {
 }
 
 func self() string {
+	//nolint:dogsled
 	_, file, _, _ := runtime.Caller(1)
 	return file
 }


### PR DESCRIPTION
Before:

```
❯ make gen
panic: audit table entry missing action for field "Message" in type "github.com/coder/coder/coderd/database.TemplateVersion"

goroutine 1 [running]:
github.com/coder/coder/enterprise/audit.entry({0x23b2260?, 0xc00055a820}, 0xc0007214d0)
        /home/mafredri/src/coder/coder/enterprise/audit/table.go:238 +0x505
github.com/coder/coder/enterprise/audit.auditMap(0xc000721440)
        /home/mafredri/src/coder/coder/enterprise/audit/table.go:197 +0xb9
github.com/coder/coder/enterprise/audit.init()
        /home/mafredri/src/coder/coder/enterprise/audit/table.go:48 +0x2bee
exit status 2
```

Now:

```
❯ make gen
ERROR: Audit table entry missing action for field "Message" in type "github.com/coder/coder/coderd/database.TemplateVersion"
Please update the auditable resource types in: /home/mafredri/src/coder/coder/enterprise/audit/table.go
exit status 1
```
