### PR TITLE
test(pty/ptytest): fix error message on deadline exceeded

### DIFF
--- a/pty/ptytest/ptytest.go
+++ b/pty/ptytest/ptytest.go
@@ -158,9 +158,9 @@ func (e *outExpecter) ExpectMatchContext(ctx context.Context, str string) string
 	e.t.Helper()
 
 	var buffer bytes.Buffer
-	err := e.doMatchWithDeadline(ctx, "ExpectMatchContext", func() error {
+	err := e.doMatchWithDeadline(ctx, "ExpectMatchContext", func(rd *bufio.Reader) error {
 		for {
-			r, _, err := e.runeReader.ReadRune()
+			r, _, err := rd.ReadRune()
 			if err != nil {
 				return err
 			}
@@ -186,9 +186,9 @@ func (e *outExpecter) ExpectNoMatchBefore(ctx context.Context, match, before str
 	e.t.Helper()
 
 	var buffer bytes.Buffer
-	err := e.doMatchWithDeadline(ctx, "ExpectNoMatchBefore", func() error {
+	err := e.doMatchWithDeadline(ctx, "ExpectNoMatchBefore", func(rd *bufio.Reader) error {
 		for {
-			r, _, err := e.runeReader.ReadRune()
+			r, _, err := rd.ReadRune()
 			if err != nil {
 				return err
 			}
@@ -218,9 +218,9 @@ func (e *outExpecter) Peek(ctx context.Context, n int) []byte {
 	e.t.Helper()
 
 	var out []byte
-	err := e.doMatchWithDeadline(ctx, "Peek", func() error {
+	err := e.doMatchWithDeadline(ctx, "Peek", func(rd *bufio.Reader) error {
 		var err error
-		out, err = e.runeReader.Peek(n)
+		out, err = rd.Peek(n)
 		return err
 	})
 	if err != nil {
@@ -235,9 +235,9 @@ func (e *outExpecter) ReadRune(ctx context.Context) rune {
 	e.t.Helper()
 
 	var r rune
-	err := e.doMatchWithDeadline(ctx, "ReadRune", func() error {
+	err := e.doMatchWithDeadline(ctx, "ReadRune", func(rd *bufio.Reader) error {
 		var err error
-		r, _, err = e.runeReader.ReadRune()
+		r, _, err = rd.ReadRune()
 		return err
 	})
 	if err != nil {
@@ -252,9 +252,9 @@ func (e *outExpecter) ReadLine(ctx context.Context) string {
 	e.t.Helper()
 
 	var buffer bytes.Buffer
-	err := e.doMatchWithDeadline(ctx, "ReadLine", func() error {
+	err := e.doMatchWithDeadline(ctx, "ReadLine", func(rd *bufio.Reader) error {
 		for {
-			r, _, err := e.runeReader.ReadRune()
+			r, _, err := rd.ReadRune()
 			if err != nil {
 				return err
 			}
@@ -267,14 +267,14 @@ func (e *outExpecter) ReadLine(ctx context.Context) string {
 
 				// Unicode code points can be up to 4 bytes, but the
 				// ones we're looking for are only 1 byte.
-				b, _ := e.runeReader.Peek(1)
+				b, _ := rd.Peek(1)
 				if len(b) == 0 {
 					return nil
 				}
 
 				r, _ = utf8.DecodeRune(b)
 				if r == '\n' {
-					_, _, err = e.runeReader.ReadRune()
+					_, _, err = rd.ReadRune()
 					if err != nil {
 						return err
 					}
@@ -297,7 +297,7 @@ func (e *outExpecter) ReadLine(ctx context.Context) string {
 	return buffer.String()
 }
 
-func (e *outExpecter) doMatchWithDeadline(ctx context.Context, name string, fn func() error) error {
+func (e *outExpecter) doMatchWithDeadline(ctx context.Context, name string, fn func(*bufio.Reader) error) error {
 	e.t.Helper()
 
 	// A timeout is mandatory, caller can decide by passing a context
@@ -314,14 +314,15 @@ func (e *outExpecter) doMatchWithDeadline(ctx context.Context, name string, fn f
 	match := make(chan error, 1)
 	go func() {
 		defer close(match)
-		match <- fn()
+		match <- fn(e.runeReader)
 	}()
 	select {
 	case err := <-match:
 		return err
 	case <-ctx.Done():
-		// Ensure goroutine is cleaned up before test exit.
-		_ = e.close("match deadline exceeded")
+		// Ensure goroutine is cleaned up before test exit, do not call
+		// (*outExpecter).close here to let the caller decide.
+		_ = e.out.Close()
 		<-match
 
 		return xerrors.Errorf("match deadline exceeded: %w", ctx.Err())


### PR DESCRIPTION
Previously the error message from expecter was not useful since we were immediately closing it on timeout instead of letting the calling code explain what went wrong.

```
        ptytest.go:95: 2023-07-06 11:46:49.834: cmd: closing expecter: match deadline exceeded
        ptytest.go:100: 2023-07-06 11:46:54.834: cmd: close: copy did not close in time
        ptytest.go:100:
                Error Trace:    /home/mafredri/src/coder/coder/pty/ptytest/ptytest.go:346
                                                        /home/mafredri/src/coder/coder/pty/ptytest/ptytest.go:100
                                                        /home/mafredri/src/coder/coder/pty/ptytest/ptytest.go:324
                                                        /home/mafredri/src/coder/coder/pty/ptytest/ptytest.go:161
                                                        /home/mafredri/src/coder/coder/cli/templatepush_test.go:110
                Error:          close
                Test:           TestTemplatePush/Message_too_long,_warn_but_continue
                Messages:       copy did not close in time
```

vs now:

```
        templatepush_test.go:107: 2023-07-06 11:51:10.889: cmd: read error: match deadline exceeded: context deadline exceeded (wanted "Message too long"; got "> Upload \"/tmp/TestTemplatePushMessage_too_long,_warn_but_continue1906856437/003\"? (yes/no) ")
        templatepush_test.go:107:
                Error Trace:    /home/mafredri/src/coder/coder/pty/ptytest/ptytest.go:346
                                                        /home/mafredri/src/coder/coder/pty/ptytest/ptytest.go:177
                                                        /home/mafredri/src/coder/coder/cli/templatepush_test.go:107
                Error:          read error
                Test:           TestTemplatePush/Message_too_long,_warn_but_continue
                Messages:       match deadline exceeded: context deadline exceeded (wanted "Message too long"; got "> Upload \"/tmp/TestTemplatePushMessage_too_long,_warn_but_continue1906856437/003\"? (yes/no) ")
```
