### PR TITLE
chore: touch ups to wsproxy UX

### DIFF
--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -95,7 +95,7 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 		),
 		Handler: func(inv *clibase.Invocation) error {
 			if !(primaryAccessURL.Scheme == "http" || primaryAccessURL.Scheme == "https") {
-				return xerrors.Errorf("primary access URL must be http or https: url=%s", primaryAccessURL.String())
+				return xerrors.Errorf("'--primary-access-url' value must be http or https: url=%s", primaryAccessURL.String())
 			}
 
 			var closers closers
@@ -174,20 +174,6 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			}
 			defer httpClient.CloseIdleConnections()
 			closers.Add(httpClient.CloseIdleConnections)
-
-			// Warn the user if the access URL appears to be a loopback address.
-			isLocal, err := cli.IsLocalURL(ctx, cfg.AccessURL.Value())
-			if isLocal || err != nil {
-				reason := "could not be resolved"
-				if isLocal {
-					reason = "isn't externally reachable"
-				}
-				cliui.Warnf(
-					inv.Stderr,
-					"The access URL %s %s, this may cause unexpected problems when creating workspaces. Generate a unique *.try.coder.app URL by not specifying an access URL.\n",
-					cliui.DefaultStyles.Field.Render(cfg.AccessURL.String()), reason,
-				)
-			}
 
 			// A newline is added before for visibility in terminal output.
 			cliui.Infof(inv.Stdout, "\nView the Web UI: %s", cfg.AccessURL.String())

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -18,8 +18,8 @@ func (r *RootCmd) workspaceProxy() *clibase.Cmd {
 		Use:   "workspace-proxy",
 		Short: "Workspace proxies provide low-latency experiences for geo-distributed teams.",
 		Long: "Workspace proxies provide low-latency experiences for geo-distributed teams. " +
-			"It will act as a connection gateway to your workspace providing a lower latency solution " +
-			"to connecting to your workspace if Coder and your workspace are deployed in different regions.",
+			"It will act as a connection gateway to your workspace. " +
+			"Best used if Coder and your workspace are deployed in different regions.",
 		Aliases: []string{"wsproxy"},
 		Hidden:  true,
 		Handler: func(inv *clibase.Invocation) error {

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -120,6 +120,7 @@ func (r *RootCmd) patchProxy() *clibase.Cmd {
 		Handler: func(inv *clibase.Invocation) error {
 			ctx := inv.Context()
 			if proxyIcon == "" && displayName == "" && proxyName == "" {
+				_ = inv.Command.HelpHandler(inv)
 				return xerrors.Errorf("specify at least one field to update")
 			}
 

--- a/enterprise/cli/workspaceproxy_test.go
+++ b/enterprise/cli/workspaceproxy_test.go
@@ -125,7 +125,7 @@ func Test_ProxyCRUD(t *testing.T) {
 
 		inv, conf := newCLI(
 			t,
-			"wsproxy", "delete", expectedName,
+			"wsproxy", "delete", "-y", expectedName,
 		)
 
 		pty := ptytest.New(t)

--- a/site/src/components/DeploySettingsLayout/Sidebar.tsx
+++ b/site/src/components/DeploySettingsLayout/Sidebar.tsx
@@ -84,7 +84,7 @@ export const Sidebar: React.FC = () => {
           href="workspace-proxies"
           icon={<SidebarNavItemIcon icon={HubOutlinedIcon} />}
         >
-          Workspace Proxy
+          Workspace Proxies
         </SidebarNavItem>
       )}
       <SidebarNavItem

--- a/site/src/components/Navbar/NavbarView.tsx
+++ b/site/src/components/Navbar/NavbarView.tsx
@@ -191,6 +191,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
   proxyContextValue,
 }) => {
+  const styles = useStyles()
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [refetchDate, setRefetchDate] = useState<Date>()
@@ -290,7 +291,9 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
         >
           <div>
             Reduce workspace latency by selecting the region nearest you.
-            <HelpTooltip>
+            {/* This was always on a newline below the text. This puts it on the same line.
+                It still doesn't look great, but it is marginally better.  */}
+            <HelpTooltip buttonClassName={styles.displayInitial}>
               <HelpTooltipTitle>Workspace Proxy Selection</HelpTooltipTitle>
               <HelpTooltipText>
                 Only applies to web connections. Local ssh connections will
@@ -366,6 +369,9 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
 }
 
 const useStyles = makeStyles((theme) => ({
+  displayInitial: {
+    display: "initial",
+  },
   root: {
     height: navHeight,
     background: theme.palette.background.paper,

--- a/site/src/components/Navbar/NavbarView.tsx
+++ b/site/src/components/Navbar/NavbarView.tsx
@@ -24,6 +24,11 @@ import Skeleton from "@mui/material/Skeleton"
 import { BUTTON_SM_HEIGHT } from "theme/theme"
 import { ProxyStatusLatency } from "components/ProxyStatusLatency/ProxyStatusLatency"
 import { usePermissions } from "hooks/usePermissions"
+import {
+  HelpTooltip,
+  HelpTooltipText,
+  HelpTooltipTitle,
+} from "components/Tooltips/HelpTooltip"
 
 export const USERS_LINK = `/users?filter=${encodeURIComponent("status:active")}`
 
@@ -283,7 +288,16 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
             e.stopPropagation()
           }}
         >
-          To improve workspace connections, select the closest region.
+          <div>
+            Reduce workspace latency by selecting the region nearest you.
+            <HelpTooltip>
+              <HelpTooltipTitle>Workspace Proxy Selection</HelpTooltipTitle>
+              <HelpTooltipText>
+                Only applies to web connections. Local ssh connections will
+                automatically select the nearest region based on latency.
+              </HelpTooltipText>
+            </HelpTooltip>
+          </div>
         </MenuItem>
         <Divider sx={{ borderColor: (theme) => theme.palette.divider }} />
         {proxyContextValue.proxies?.map((proxy) => (

--- a/site/src/components/Navbar/NavbarView.tsx
+++ b/site/src/components/Navbar/NavbarView.tsx
@@ -283,7 +283,7 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
             e.stopPropagation()
           }}
         >
-          Select the closest region to you to improve workspace connections.
+          To improve workspace connections, select the closest region.
         </MenuItem>
         <Divider sx={{ borderColor: (theme) => theme.palette.divider }} />
         {proxyContextValue.proxies?.map((proxy) => (

--- a/site/src/components/Navbar/NavbarView.tsx
+++ b/site/src/components/Navbar/NavbarView.tsx
@@ -269,6 +269,23 @@ const ProxyMenu: FC<{ proxyContextValue: ProxyContextValue }> = ({
         onClose={closeMenu}
         sx={{ "& .MuiMenu-paper": { py: 1 } }}
       >
+        <MenuItem
+          sx={[
+            { fontSize: 14 },
+            { "&:hover": { backgroundColor: "transparent" } },
+            { wordWrap: "break-word" },
+            { inlineSize: "200px" },
+            { whiteSpace: "normal" },
+            { textAlign: "center" },
+          ]}
+          onClick={(e) => {
+            // Stop the menu from closing
+            e.stopPropagation()
+          }}
+        >
+          Select the closest region to you to improve workspace connections.
+        </MenuItem>
+        <Divider sx={{ borderColor: (theme) => theme.palette.divider }} />
         {proxyContextValue.proxies?.map((proxy) => (
           <MenuItem
             onClick={() => {

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -1,9 +1,9 @@
-import { Region, WorkspaceProxy } from "api/typesGenerated"
+import { Region, Workspace, WorkspaceProxy } from "api/typesGenerated"
 import { AvatarData } from "components/AvatarData/AvatarData"
 import { Avatar } from "components/Avatar/Avatar"
 import TableCell from "@mui/material/TableCell"
 import TableRow from "@mui/material/TableRow"
-import { FC } from "react"
+import { FC, useState } from "react"
 import {
   HealthyBadge,
   NotHealthyBadge,
@@ -12,22 +12,52 @@ import {
 } from "components/DeploySettingsLayout/Badges"
 import { ProxyLatencyReport } from "contexts/useProxyLatency"
 import { getLatencyColor } from "utils/latency"
+import Collapse from "@mui/material/Collapse"
+import { makeStyles } from "@mui/styles"
+import { combineClasses } from "utils/combineClasses"
+import ListItem from "@mui/material/ListItem"
+import List from "@mui/material/List"
+import { Box, ListSubheader } from "@mui/material"
+import { Maybe } from "components/Conditionals/Maybe"
+import { CodeBlock } from "components/CodeBlock/CodeBlock"
+import { CodeExample } from "components/CodeExample/CodeExample"
 
 export const ProxyRow: FC<{
   latency?: ProxyLatencyReport
   proxy: Region
 }> = ({ proxy, latency }) => {
+  const styles = useStyles()
   // If we have a more specific proxy status, use that.
   // All users can see healthy/unhealthy, some can see more.
   let statusBadge = <ProxyStatus proxy={proxy} />
+  let shouldShowMessages = false
   if ("status" in proxy) {
-    statusBadge = <DetailedProxyStatus proxy={proxy as WorkspaceProxy} />
+    const wsproxy = proxy as WorkspaceProxy
+    statusBadge = <DetailedProxyStatus proxy={wsproxy} />
+    shouldShowMessages = Boolean(
+      (wsproxy.status?.report?.warnings &&
+        wsproxy.status?.report?.warnings.length > 0) ||
+        (wsproxy.status?.report?.errors &&
+          wsproxy.status?.report?.errors.length > 0),
+    )
   }
 
+  const [isMsgsOpen, setIsMsgsOpen] = useState(false)
+  const toggle = () => {
+    if (shouldShowMessages) {
+      setIsMsgsOpen((v) => !v)
+    }
+  }
   return (
     <>
-      <TableRow key={proxy.name} data-testid={`${proxy.name}`}>
-        <TableCell>
+      <TableRow
+        className={combineClasses({
+          [styles.clickable]: shouldShowMessages,
+        })}
+        key={proxy.name}
+        data-testid={`${proxy.name}`}
+      >
+        <TableCell onClick={toggle}>
           <AvatarData
             title={
               proxy.display_name && proxy.display_name.length > 0
@@ -44,6 +74,7 @@ export const ProxyRow: FC<{
                 />
               )
             }
+            subtitle={shouldShowMessages ? "Click to view details" : undefined}
           />
         </TableCell>
 
@@ -62,7 +93,58 @@ export const ProxyRow: FC<{
           {latency ? `${latency.latencyMS.toFixed(0)} ms` : "Not available"}
         </TableCell>
       </TableRow>
+      <Maybe condition={shouldShowMessages}>
+        <TableRow>
+          <TableCell colSpan={4} sx={{ padding: "0px !important" }}>
+            <Collapse in={isMsgsOpen}>
+              <ProxyMessagesRow proxy={proxy as WorkspaceProxy} />
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      </Maybe>
     </>
+  )
+}
+
+const ProxyMessagesRow: FC<{
+  proxy: WorkspaceProxy
+}> = ({ proxy }) => {
+  return (
+    <>
+      <ProxyMessagesList
+        title="Errors"
+        messages={proxy.status?.report?.errors}
+      />
+      <ProxyMessagesList
+        title="Warnings"
+        messages={proxy.status?.report?.warnings}
+      />
+    </>
+  )
+}
+
+const ProxyMessagesList: FC<{
+  title: string
+  messages?: string[]
+}> = ({ title, messages }) => {
+  if (!messages) {
+    return <></>
+  }
+  return (
+    <List
+      subheader={
+        <ListSubheader component="div" id="nested-list-subheader">
+          {title}
+        </ListSubheader>
+      }
+    >
+      {messages.map((error, index) => (
+        <ListItem key={"warning" + index}>
+          <CodeExample code={error} />
+          {/* <CodeBlock lines={[error]} /> */}
+        </ListItem>
+      ))}
+    </List>
   )
 }
 
@@ -100,3 +182,13 @@ const ProxyStatus: FC<{
 
   return icon
 }
+
+const useStyles = makeStyles((theme) => ({
+  clickable: {
+    cursor: "pointer",
+
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
+}))

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -138,9 +138,8 @@ const ProxyMessagesList: FC<{
       }
     >
       {messages.map((error, index) => (
-        <ListItem key={"warning" + index}>
+        <ListItem key={"message" + index}>
           <CodeExample code={error} />
-          {/* <CodeBlock lines={[error]} /> */}
         </ListItem>
       ))}
     </List>

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -17,7 +17,7 @@ import { makeStyles } from "@mui/styles"
 import { combineClasses } from "utils/combineClasses"
 import ListItem from "@mui/material/ListItem"
 import List from "@mui/material/List"
-import { ListSubheader } from "@mui/material"
+import ListSubheader from "@mui/material/ListSubheader"
 import { Maybe } from "components/Conditionals/Maybe"
 import { CodeExample } from "components/CodeExample/CodeExample"
 

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -1,4 +1,4 @@
-import { Region, Workspace, WorkspaceProxy } from "api/typesGenerated"
+import { Region, WorkspaceProxy } from "api/typesGenerated"
 import { AvatarData } from "components/AvatarData/AvatarData"
 import { Avatar } from "components/Avatar/Avatar"
 import TableCell from "@mui/material/TableCell"
@@ -17,9 +17,8 @@ import { makeStyles } from "@mui/styles"
 import { combineClasses } from "utils/combineClasses"
 import ListItem from "@mui/material/ListItem"
 import List from "@mui/material/List"
-import { Box, ListSubheader } from "@mui/material"
+import { ListSubheader } from "@mui/material"
 import { Maybe } from "components/Conditionals/Maybe"
-import { CodeBlock } from "components/CodeBlock/CodeBlock"
 import { CodeExample } from "components/CodeExample/CodeExample"
 
 export const ProxyRow: FC<{


### PR DESCRIPTION
Touchups



# Changes

# Small

- Wsproxy help wording
- Show command help if missing wsproxy edit fields
- remove localhost warning, and remove `*.try.coder` message.

## Wsproxy create text

![Screenshot from 2023-07-06 14-29-31](https://github.com/coder/coder/assets/5446298/8de2962a-0f62-4a47-9e58-1e9ff0d27f6f)
 

## Wsproxy help text in picker

**Styling could be improved**

![Screenshot from 2023-07-06 14-42-42](https://github.com/coder/coder/assets/5446298/6631242f-28eb-4ff1-8532-801ffa27b44c)


## Wsproxy confirm delete

![Screenshot from 2023-07-06 14-45-45](https://github.com/coder/coder/assets/5446298/8baf1e4a-c412-4beb-9bd8-b136d33647c0)

## Workspace proxy table details

**Needs styling**

[Peek 2023-07-06 15-37.webm](https://github.com/coder/coder/assets/5446298/05fcb92c-f9df-46de-9315-16beb32bde6c)


