### PR TITLE
fix(coderd): remove `CREATE INDEX CONCURRENTLY` from migrations

### DIFF
--- a/coderd/database/migrations/000074_workspace_resources_job_id_idx.up.sql
+++ b/coderd/database/migrations/000074_workspace_resources_job_id_idx.up.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY workspace_resources_job_id_idx ON workspace_resources USING btree (job_id);
+CREATE INDEX workspace_resources_job_id_idx ON workspace_resources USING btree (job_id);


### PR DESCRIPTION
This seems to cause deadlocks with parallel migrations, which is why migrations seem to fail with multiple coderds.

```
coder-db-1      | 2023-07-06 20:15:04.322 UTC [90] ERROR:  deadlock detected
coder-db-1      | 2023-07-06 20:15:04.322 UTC [90] DETAIL:  Process 90 waits for ExclusiveLock on advisory lock [16384,0,4187539795,1]; blocked by process 89.
coder-db-1      | 	Process 89 waits for ShareLock on virtual transaction 4/15; blocked by process 90.
coder-db-1      | 	Process 90: SELECT pg_advisory_lock($1)
coder-db-1      | 	Process 89: CREATE INDEX CONCURRENTLY workspace_resources_job_id_idx ON workspace_resources USING btree (job_id);
coder-db-1      |
coder-db-1      | 2023-07-06 20:15:04.322 UTC [90] HINT:  See server log for query details.
coder-db-1      | 2023-07-06 20:15:04.322 UTC [90] STATEMENT:  SELECT pg_advisory_lock($1)
```

Fixes https://github.com/coder/coder/issues/8210