### PR TITLE
chore: use dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -116,6 +116,7 @@ updates:
       timezone: "America/Chicago"
     commit-message:
       prefix: "chore"
+    labels: []
     groups:
       dogfood-docker:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,7 +24,11 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch
-
+    groups:
+      github-actions:
+        patterns:
+          - "*" 
+    
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -39,6 +43,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
+    groups:
+      go:
+        patterns:
+          - "*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"
@@ -54,7 +62,10 @@ updates:
       # We need to coordinate terraform updates with the version hardcoded in
       # our Go code.
       - dependency-name: "terraform"
-
+    groups:
+      docker:
+        patterns:
+          - "*" 
   - package-ecosystem: "npm"
     directory: "/site/"
     schedule:
@@ -76,7 +87,11 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
-
+    groups:
+      site:
+        patterns:
+          - "*" 
+    
   - package-ecosystem: "terraform"
     directory: "/examples/templates"
     schedule:
@@ -89,7 +104,11 @@ updates:
     ignore:
       # We likely want to update this ourselves.
       - dependency-name: "coder/coder"
-
+    groups:
+      terraform:
+        patterns:
+          - "*" 
+          
   # Update dogfood.
   - package-ecosystem: "docker"
     directory: "/dogfood/"
@@ -99,7 +118,10 @@ updates:
       timezone: "America/Chicago"
     commit-message:
       prefix: "chore"
-    labels: []
+    groups:
+          docker:
+            patterns:
+              - "*" 
 
   - package-ecosystem: "terraform"
     directory: "/dogfood/"
@@ -110,5 +132,8 @@ updates:
     commit-message:
       prefix: "chore"
     labels: []
-    ignore:
-      - dependency-name: "coder/coder"
+    groups:
+      terraform:
+        patterns:
+          - "*" 
+    

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -131,7 +131,7 @@ updates:
     commit-message:
       prefix: "chore"
     labels: []
-    groups:
-      dogfood-terraform:
-        patterns:
-          - "*"
+    ignore:
+      # We likely want to update this ourselves.
+      - dependency-name: "coder/coder"
+      

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,6 +24,10 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -40,7 +44,7 @@ updates:
         update-types:
           - version-update:semver-patch
     groups:
-      otel:
+      go-otel:
         patterns:
           - "go.nhat.io/otelsql"
           - "go.opentelemetry.io/otel*"
@@ -63,6 +67,7 @@ updates:
       docker:
         patterns:
           - "*"
+          
   - package-ecosystem: "npm"
     directory: "/site/"
     schedule:
@@ -84,10 +89,6 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
-    groups:
-      site:
-        patterns:
-          - "*"
 
   - package-ecosystem: "terraform"
     directory: "/examples/templates"
@@ -102,7 +103,7 @@ updates:
       # We likely want to update this ourselves.
       - dependency-name: "coder/coder"
     groups:
-      terraform:
+      examples-terraform:
         patterns:
           - "*"
 
@@ -116,7 +117,7 @@ updates:
     commit-message:
       prefix: "chore"
     groups:
-      docker:
+      dogfood-docker:
         patterns:
           - "*"
 
@@ -130,6 +131,6 @@ updates:
       prefix: "chore"
     labels: []
     groups:
-      terraform:
+      dogfood-terraform:
         patterns:
           - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,10 +24,6 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch
-    groups:
-      github-actions:
-        patterns:
-          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -44,9 +40,10 @@ updates:
         update-types:
           - version-update:semver-patch
     groups:
-      go:
+      otel:
         patterns:
-          - "*"
+          - "go.nhat.io/otelsql"
+          - "go.opentelemetry.io/otel*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -67,7 +67,7 @@ updates:
       docker:
         patterns:
           - "*"
-          
+
   - package-ecosystem: "npm"
     directory: "/site/"
     schedule:
@@ -134,4 +134,3 @@ updates:
     ignore:
       # We likely want to update this ourselves.
       - dependency-name: "coder/coder"
-      

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,8 +27,8 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*" 
-    
+          - "*"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -65,7 +65,7 @@ updates:
     groups:
       docker:
         patterns:
-          - "*" 
+          - "*"
   - package-ecosystem: "npm"
     directory: "/site/"
     schedule:
@@ -90,8 +90,8 @@ updates:
     groups:
       site:
         patterns:
-          - "*" 
-    
+          - "*"
+
   - package-ecosystem: "terraform"
     directory: "/examples/templates"
     schedule:
@@ -107,8 +107,8 @@ updates:
     groups:
       terraform:
         patterns:
-          - "*" 
-          
+          - "*"
+
   # Update dogfood.
   - package-ecosystem: "docker"
     directory: "/dogfood/"
@@ -119,9 +119,9 @@ updates:
     commit-message:
       prefix: "chore"
     groups:
-          docker:
-            patterns:
-              - "*" 
+      docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "terraform"
     directory: "/dogfood/"
@@ -135,5 +135,4 @@ updates:
     groups:
       terraform:
         patterns:
-          - "*" 
-    
+          - "*"


### PR DESCRIPTION
See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/ for details. This will reduce the number of dependent PRs

For go and node dependencies, I leave the exact grouping to engineers who better know how they should be grouped.