### PR TITLE
feat: add cli first class validation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -138,7 +138,9 @@ linters-settings:
       - name: blank-imports
       - name: bool-literal-in-expr
       - name: call-to-gc
-      - name: confusing-naming
+      # This inconsistently marks struct methods as confusing if they have
+      # the same name... which for interfaces they do.
+#      - name: confusing-naming
       - name: confusing-results
       - name: constant-logical-expr
       - name: context-as-argument

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -138,9 +138,7 @@ linters-settings:
       - name: blank-imports
       - name: bool-literal-in-expr
       - name: call-to-gc
-      # This inconsistently marks struct methods as confusing if they have
-      # the same name... which for interfaces they do.
-#      - name: confusing-naming
+      - name: confusing-naming
       - name: confusing-results
       - name: constant-logical-expr
       - name: context-as-argument

--- a/cli/clibase/cmd.go
+++ b/cli/clibase/cmd.go
@@ -311,6 +311,18 @@ func (inv *Invocation) run(state *runState) error {
 		return xerrors.Errorf("setting defaults: %w", err)
 	}
 
+	// All options should be set. Check all required options have sources,
+	// meaning they were set by the user in some way (env, flag, etc).
+	var missing []string
+	for _, opt := range inv.Command.Options {
+		if opt.Required && opt.ValueSource == ValueSourceNone {
+			missing = append(missing, opt.Flag)
+		}
+	}
+	if len(missing) > 0 {
+		return xerrors.Errorf("Missing values for the required flags: %s", strings.Join(missing, ", "))
+	}
+
 	// Run child command if found (next child only)
 	// We must do subcommand detection after flag parsing so we don't mistake flag
 	// values for subcommand names.

--- a/cli/clibase/cmd.go
+++ b/cli/clibase/cmd.go
@@ -311,18 +311,6 @@ func (inv *Invocation) run(state *runState) error {
 		return xerrors.Errorf("setting defaults: %w", err)
 	}
 
-	// All options should be set. Check all required options have sources,
-	// meaning they were set by the user in some way (env, flag, etc).
-	var missing []string
-	for _, opt := range inv.Command.Options {
-		if opt.Required && opt.ValueSource == ValueSourceNone {
-			missing = append(missing, opt.Flag)
-		}
-	}
-	if len(missing) > 0 {
-		return xerrors.Errorf("Missing values for the required flags: %s", strings.Join(missing, ", "))
-	}
-
 	// Run child command if found (next child only)
 	// We must do subcommand detection after flag parsing so we don't mistake flag
 	// values for subcommand names.
@@ -343,6 +331,18 @@ func (inv *Invocation) run(state *runState) error {
 			state.allArgs,
 			inv.Command.FullName(), state.flagParseErr,
 		)
+	}
+
+	// All options should be set. Check all required options have sources,
+	// meaning they were set by the user in some way (env, flag, etc).
+	var missing []string
+	for _, opt := range inv.Command.Options {
+		if opt.Required && opt.ValueSource == ValueSourceNone {
+			missing = append(missing, opt.Flag)
+		}
+	}
+	if len(missing) > 0 {
+		return xerrors.Errorf("Missing values for the required flags: %s", strings.Join(missing, ", "))
 	}
 
 	if inv.Command.RawArgs {

--- a/cli/clibase/cmd_test.go
+++ b/cli/clibase/cmd_test.go
@@ -38,6 +38,8 @@ func TestCommand(t *testing.T) {
 			verbose bool
 			lower   bool
 			prefix  string
+			reqBool bool
+			reqStr  string
 		)
 		return &clibase.Cmd{
 			Use: "root [subcommand]",
@@ -55,6 +57,28 @@ func TestCommand(t *testing.T) {
 			},
 			Children: []*clibase.Cmd{
 				{
+					Use:   "required-flag --req-bool=true --req-string=foo",
+					Short: "Example with required flags",
+					Options: clibase.OptionSet{
+						clibase.Option{
+							Name:     "req-bool",
+							Flag:     "req-bool",
+							Value:    clibase.BoolOf(&reqBool),
+							Required: true,
+						},
+						clibase.Option{
+							Name:     "req-string",
+							Flag:     "req-string",
+							Value:    clibase.StringOf(&reqStr),
+							Required: true,
+						},
+					},
+					Handler: func(i *clibase.Invocation) error {
+						_, _ = i.Stdout.Write([]byte(fmt.Sprintf("%s-%t", reqStr, reqBool)))
+						return nil
+					},
+				},
+				{
 					Use:   "toupper [word]",
 					Short: "Converts a word to upper case",
 					Middleware: clibase.Chain(
@@ -68,8 +92,8 @@ func TestCommand(t *testing.T) {
 							Value: clibase.BoolOf(&lower),
 						},
 					},
-					Handler: (func(i *clibase.Invocation) error {
-						i.Stdout.Write([]byte(prefix))
+					Handler: func(i *clibase.Invocation) error {
+						_, _ = i.Stdout.Write([]byte(prefix))
 						w := i.Args[0]
 						if lower {
 							w = strings.ToLower(w)
@@ -85,7 +109,7 @@ func TestCommand(t *testing.T) {
 							i.Stdout.Write([]byte("!!!"))
 						}
 						return nil
-					}),
+					},
 				},
 			},
 		}
@@ -212,6 +236,49 @@ func TestCommand(t *testing.T) {
 		)
 		fio := fakeIO(i)
 		require.Error(t, i.Run(), fio.Stdout.String())
+	})
+
+	t.Run("RequiredFlagsMissing", func(t *testing.T) {
+		t.Parallel()
+		i := cmd().Invoke(
+			"required-flag",
+		)
+		fio := fakeIO(i)
+		err := i.Run()
+		require.Error(t, err, fio.Stdout.String())
+		require.ErrorContains(t, err, "Missing values")
+	})
+
+	t.Run("RequiredFlagsMissingBool", func(t *testing.T) {
+		t.Parallel()
+		i := cmd().Invoke(
+			"required-flag", "--req-string", "foo",
+		)
+		fio := fakeIO(i)
+		err := i.Run()
+		require.Error(t, err, fio.Stdout.String())
+		require.ErrorContains(t, err, "Missing values for the required flags: req-bool")
+	})
+
+	t.Run("RequiredFlagsMissingString", func(t *testing.T) {
+		t.Parallel()
+		i := cmd().Invoke(
+			"required-flag", "--req-bool", "true",
+		)
+		fio := fakeIO(i)
+		err := i.Run()
+		require.Error(t, err, fio.Stdout.String())
+		require.ErrorContains(t, err, "Missing values for the required flags: req-string")
+	})
+
+	t.Run("RequiredFlagsOK", func(t *testing.T) {
+		t.Parallel()
+		i := cmd().Invoke(
+			"required-flag", "--req-bool", "true", "--req-string", "foo",
+		)
+		fio := fakeIO(i)
+		err := i.Run()
+		require.NoError(t, err, fio.Stdout.String())
 	})
 }
 

--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -23,6 +23,10 @@ const (
 type Option struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
+	// Required means this value must be set by some means. It requires
+	// `ValueSource != ValueSourceNone`
+	// If `Default` is set, then `Required` is ignored.
+	Required bool `json:"required,omitempty"`
 
 	// Flag is the long name of the flag used to configure this option. If unset,
 	// flag configuring is disabled.

--- a/cli/clibase/values.go
+++ b/cli/clibase/values.go
@@ -24,8 +24,17 @@ type Validator[T pflag.Value] struct {
 	validate func(T) error
 }
 
-func Validate[T pflag.Value](opt T, validate func(value T) error) *Validator[T] {
-	return &Validator[T]{Value: opt, validate: validate}
+func Validate[T pflag.Value](opt T, validate ...func(value T) error) *Validator[T] {
+	return &Validator[T]{Value: opt, validate: func(value T) error {
+		// Run all validate functions
+		for _, v := range validate {
+			err := v(value)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}}
 }
 
 func (i *Validator[T]) String() string {

--- a/cli/clibase/values.go
+++ b/cli/clibase/values.go
@@ -16,6 +16,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// NoOptDefValuer describes behavior when no
+// option is passed into the flag.
+//
+// This is useful for boolean or otherwise binary flags.
+type NoOptDefValuer interface {
+	NoOptDefValue() string
+}
+
 // Validator is a wrapper around a pflag.Value that allows for validation
 // of the value after or before it has been set.
 type Validator[T pflag.Value] struct {
@@ -57,14 +65,6 @@ func (i *Validator[T]) Set(input string) error {
 
 func (i *Validator[T]) Type() string {
 	return i.Value.Type()
-}
-
-// NoOptDefValuer describes behavior when no
-// option is passed into the flag.
-//
-// This is useful for boolean or otherwise binary flags.
-type NoOptDefValuer interface {
-	NoOptDefValue() string
 }
 
 // values.go contains a standard set of value types that can be used as
@@ -372,10 +372,12 @@ type Struct[T any] struct {
 	Value T
 }
 
+//nolint:revive
 func (s *Struct[T]) Set(v string) error {
 	return yaml.Unmarshal([]byte(v), &s.Value)
 }
 
+//nolint:revive
 func (s *Struct[T]) String() string {
 	byt, err := yaml.Marshal(s.Value)
 	if err != nil {
@@ -404,6 +406,7 @@ func (s *Struct[T]) UnmarshalYAML(n *yaml.Node) error {
 	return n.Decode(&s.Value)
 }
 
+//nolint:revive
 func (s *Struct[T]) Type() string {
 	return fmt.Sprintf("struct[%T]", s.Value)
 }

--- a/cli/clibase/values.go
+++ b/cli/clibase/values.go
@@ -20,10 +20,10 @@ import (
 // of the value after or before it has been set.
 type Validator[T pflag.Value] struct {
 	Value T
-	// ValidateBefore is called before the value is set.
-	ValidateBefore func(input string) error
-	// ValidateAfter is called after the value is set.
-	ValidateAfter func(T) error
+	// validateBefore is called before the value is set.
+	validateBefore func(input string) error
+	// validateAfter is called after the value is set.
+	validateAfter func(T) error
 }
 
 func Validate[T pflag.Value](opt T) *Validator[T] {
@@ -31,12 +31,12 @@ func Validate[T pflag.Value](opt T) *Validator[T] {
 }
 
 func (i *Validator[T]) Before(fn func(input string) error) *Validator[T] {
-	i.ValidateBefore = fn
+	i.validateBefore = fn
 	return i
 }
 
 func (i *Validator[T]) After(fn func(value T) error) *Validator[T] {
-	i.ValidateAfter = fn
+	i.validateAfter = fn
 	return i
 }
 
@@ -45,8 +45,8 @@ func (i *Validator[T]) String() string {
 }
 
 func (i *Validator[T]) Set(input string) error {
-	if i.ValidateBefore != nil {
-		err := i.ValidateBefore(input)
+	if i.validateBefore != nil {
+		err := i.validateBefore(input)
 		if err != nil {
 			return err
 		}
@@ -56,8 +56,8 @@ func (i *Validator[T]) Set(input string) error {
 	if err != nil {
 		return err
 	}
-	if i.ValidateAfter != nil {
-		err = i.ValidateAfter(i.Value)
+	if i.validateAfter != nil {
+		err = i.validateAfter(i.Value)
 		if err != nil {
 			return err
 		}

--- a/cli/clibase/values.go
+++ b/cli/clibase/values.go
@@ -32,17 +32,8 @@ type Validator[T pflag.Value] struct {
 	validate func(T) error
 }
 
-func Validate[T pflag.Value](opt T, validate ...func(value T) error) *Validator[T] {
-	return &Validator[T]{Value: opt, validate: func(value T) error {
-		// Run all validate functions
-		for _, v := range validate {
-			err := v(value)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}}
+func Validate[T pflag.Value](opt T, validate func(value T) error) *Validator[T] {
+	return &Validator[T]{Value: opt, validate: validate}
 }
 
 func (i *Validator[T]) String() string {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6274,6 +6274,10 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "required": {
+                    "description": "Required means this value must be set by some means. It requires\n` + "`" + `ValueSource != ValueSourceNone` + "`" + `\nIf ` + "`" + `Default` + "`" + ` is set, then ` + "`" + `Required` + "`" + ` is ignored.",
+                    "type": "boolean"
+                },
                 "use_instead": {
                     "description": "UseInstead is a list of options that should be used instead of this one.\nThe field is used to generate a deprecation warning.",
                     "type": "array",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5559,6 +5559,10 @@
         "name": {
           "type": "string"
         },
+        "required": {
+          "description": "Required means this value must be set by some means. It requires\n`ValueSource != ValueSourceNone`\nIf `Default` is set, then `Required` is ignored.",
+          "type": "boolean"
+        },
         "use_instead": {
           "description": "UseInstead is a list of options that should be used instead of this one.\nThe field is used to generate a deprecation warning.",
           "type": "array",

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -398,6 +398,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       },
       "hidden": true,
       "name": "string",
+      "required": true,
       "use_instead": [{}],
       "value": null,
       "value_source": "",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -533,6 +533,7 @@
   },
   "hidden": true,
   "name": "string",
+  "required": true,
   "use_instead": [
     {
       "annotations": {
@@ -557,6 +558,7 @@
       },
       "hidden": true,
       "name": "string",
+      "required": true,
       "use_instead": [],
       "value": null,
       "value_source": "",
@@ -571,21 +573,22 @@
 
 ### Properties
 
-| Name             | Type                                       | Required | Restrictions | Description                                                                                                                    |
-| ---------------- | ------------------------------------------ | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `annotations`    | [clibase.Annotations](#clibaseannotations) | false    |              | Annotations enable extensions to clibase higher up in the stack. It's useful for help formatting and documentation generation. |
-| `default`        | string                                     | false    |              | Default is parsed into Value if set.                                                                                           |
-| `description`    | string                                     | false    |              |                                                                                                                                |
-| `env`            | string                                     | false    |              | Env is the environment variable used to configure this option. If unset, environment configuring is disabled.                  |
-| `flag`           | string                                     | false    |              | Flag is the long name of the flag used to configure this option. If unset, flag configuring is disabled.                       |
-| `flag_shorthand` | string                                     | false    |              | Flag shorthand is the one-character shorthand for the flag. If unset, no shorthand is used.                                    |
-| `group`          | [clibase.Group](#clibasegroup)             | false    |              | Group is a group hierarchy that helps organize this option in help, configs and other documentation.                           |
-| `hidden`         | boolean                                    | false    |              |                                                                                                                                |
-| `name`           | string                                     | false    |              |                                                                                                                                |
-| `use_instead`    | array of [clibase.Option](#clibaseoption)  | false    |              | Use instead is a list of options that should be used instead of this one. The field is used to generate a deprecation warning. |
-| `value`          | any                                        | false    |              | Value includes the types listed in values.go.                                                                                  |
-| `value_source`   | [clibase.ValueSource](#clibasevaluesource) | false    |              |                                                                                                                                |
-| `yaml`           | string                                     | false    |              | Yaml is the YAML key used to configure this option. If unset, YAML configuring is disabled.                                    |
+| Name             | Type                                       | Required | Restrictions | Description                                                                                                                                        |
+| ---------------- | ------------------------------------------ | -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `annotations`    | [clibase.Annotations](#clibaseannotations) | false    |              | Annotations enable extensions to clibase higher up in the stack. It's useful for help formatting and documentation generation.                     |
+| `default`        | string                                     | false    |              | Default is parsed into Value if set.                                                                                                               |
+| `description`    | string                                     | false    |              |                                                                                                                                                    |
+| `env`            | string                                     | false    |              | Env is the environment variable used to configure this option. If unset, environment configuring is disabled.                                      |
+| `flag`           | string                                     | false    |              | Flag is the long name of the flag used to configure this option. If unset, flag configuring is disabled.                                           |
+| `flag_shorthand` | string                                     | false    |              | Flag shorthand is the one-character shorthand for the flag. If unset, no shorthand is used.                                                        |
+| `group`          | [clibase.Group](#clibasegroup)             | false    |              | Group is a group hierarchy that helps organize this option in help, configs and other documentation.                                               |
+| `hidden`         | boolean                                    | false    |              |                                                                                                                                                    |
+| `name`           | string                                     | false    |              |                                                                                                                                                    |
+| `required`       | boolean                                    | false    |              | Required means this value must be set by some means. It requires `ValueSource != ValueSourceNone` If `Default` is set, then `Required` is ignored. |
+| `use_instead`    | array of [clibase.Option](#clibaseoption)  | false    |              | Use instead is a list of options that should be used instead of this one. The field is used to generate a deprecation warning.                     |
+| `value`          | any                                        | false    |              | Value includes the types listed in values.go.                                                                                                      |
+| `value_source`   | [clibase.ValueSource](#clibasevaluesource) | false    |              |                                                                                                                                                    |
+| `yaml`           | string                                     | false    |              | Yaml is the YAML key used to configure this option. If unset, YAML configuring is disabled.                                                        |
 
 ## clibase.Struct-array_codersdk_GitAuthConfig
 
@@ -2097,6 +2100,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       },
       "hidden": true,
       "name": "string",
+      "required": true,
       "use_instead": [{}],
       "value": null,
       "value_source": "",

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -65,7 +65,7 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			Flag:        "proxy-session-token",
 			Env:         "CODER_PROXY_SESSION_TOKEN",
 			YAML:        "proxySessionToken",
-			Default:     "",
+			Required:    true,
 			Value:       &proxySessionToken,
 			Group:       &externalProxyOptionGroup,
 			Hidden:      false,
@@ -77,10 +77,15 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			Flag:        "primary-access-url",
 			Env:         "CODER_PRIMARY_ACCESS_URL",
 			YAML:        "primaryAccessURL",
-			Default:     "",
-			Value:       &primaryAccessURL,
-			Group:       &externalProxyOptionGroup,
-			Hidden:      false,
+			Required:    true,
+			Value: clibase.Validate(&primaryAccessURL).After(func(value *clibase.URL) error {
+				if !(value.Scheme == "http" || value.Scheme == "https") {
+					return xerrors.Errorf("'--primary-access-url' value must be http or https: url=%s", primaryAccessURL.String())
+				}
+				return nil
+			}),
+			Group:  &externalProxyOptionGroup,
+			Hidden: false,
 		},
 	)
 
@@ -94,10 +99,6 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			clibase.RequireNArgs(0),
 		),
 		Handler: func(inv *clibase.Invocation) error {
-			if !(primaryAccessURL.Scheme == "http" || primaryAccessURL.Scheme == "https") {
-				return xerrors.Errorf("'--primary-access-url' value must be http or https: url=%s", primaryAccessURL.String())
-			}
-
 			var closers closers
 			// Main command context for managing cancellation of running
 			// services.

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -78,7 +78,7 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			Env:         "CODER_PRIMARY_ACCESS_URL",
 			YAML:        "primaryAccessURL",
 			Required:    true,
-			Value: clibase.Validate(&primaryAccessURL).After(func(value *clibase.URL) error {
+			Value: clibase.Validate(&primaryAccessURL, func(value *clibase.URL) error {
 				if !(value.Scheme == "http" || value.Scheme == "https") {
 					return xerrors.Errorf("'--primary-access-url' value must be http or https: url=%s", primaryAccessURL.String())
 				}

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -235,8 +235,8 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 		noPrompts   bool
 		formatter   = newUpdateProxyResponseFormatter()
 	)
-	validateIcon := func(s string) error {
-		if !(strings.HasPrefix(s, "/emojis/") || strings.HasPrefix(s, "http")) {
+	validateIcon := func(s *clibase.String) error {
+		if !(strings.HasPrefix(s.Value(), "/emojis/") || strings.HasPrefix(s, "http")) {
 			return xerrors.New("icon must be a relative path to an emoji or a publicly hosted image URL")
 		}
 		return nil
@@ -274,9 +274,11 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 
 			if proxyIcon == "" && !noPrompts {
 				proxyIcon, err = cliui.Prompt(inv, cliui.PromptOptions{
-					Text:     "Icon URL:",
-					Default:  "/emojis/1f5fa.png",
-					Validate: validateIcon,
+					Text:    "Icon URL:",
+					Default: "/emojis/1f5fa.png",
+					Validate: func(s string) error {
+						return validateIcon(clibase.StringOf(&s))
+					},
 				})
 				if err != nil {
 					return err
@@ -320,7 +322,7 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 		clibase.Option{
 			Flag:        "icon",
 			Description: "Display icon of the proxy.",
-			Value:       clibase.Validate(clibase.StringOf(&proxyIcon)).Before(validateIcon),
+			Value:       clibase.Validate(clibase.StringOf(&proxyIcon), validateIcon),
 		},
 		clibase.Option{
 			Flag:        "no-prompt",

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -236,7 +236,7 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 		formatter   = newUpdateProxyResponseFormatter()
 	)
 	validateIcon := func(s *clibase.String) error {
-		if !(strings.HasPrefix(s.Value(), "/emojis/") || strings.HasPrefix(s, "http")) {
+		if !(strings.HasPrefix(s.Value(), "/emojis/") || strings.HasPrefix(s.Value(), "http")) {
 			return xerrors.New("icon must be a relative path to an emoji or a publicly hosted image URL")
 		}
 		return nil

--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -235,6 +235,12 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 		noPrompts   bool
 		formatter   = newUpdateProxyResponseFormatter()
 	)
+	validateIcon := func(s string) error {
+		if !(strings.HasPrefix(s, "/emojis/") || strings.HasPrefix(s, "http")) {
+			return xerrors.New("icon must be a relative path to an emoji or a publicly hosted image URL")
+		}
+		return nil
+	}
 
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -268,14 +274,9 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 
 			if proxyIcon == "" && !noPrompts {
 				proxyIcon, err = cliui.Prompt(inv, cliui.PromptOptions{
-					Text:    "Icon URL:",
-					Default: "/emojis/1f5fa.png",
-					Validate: func(s string) error {
-						if !(strings.HasPrefix(s, "/emojis/") || strings.HasPrefix(s, "http")) {
-							return xerrors.New("icon must be a relative path to an emoji or a publicly hosted image URL")
-						}
-						return nil
-					},
+					Text:     "Icon URL:",
+					Default:  "/emojis/1f5fa.png",
+					Validate: validateIcon,
 				})
 				if err != nil {
 					return err
@@ -319,7 +320,7 @@ func (r *RootCmd) createProxy() *clibase.Cmd {
 		clibase.Option{
 			Flag:        "icon",
 			Description: "Display icon of the proxy.",
-			Value:       clibase.StringOf(&proxyIcon),
+			Value:       clibase.Validate(clibase.StringOf(&proxyIcon)).Before(validateIcon),
 		},
 		clibase.Option{
 			Flag:        "no-prompt",


### PR DESCRIPTION
# What this does

A standard way to validate cli flags. 

# Problem

Validating cli flags tends to be in the cli handler body. This just adds some extra `if !valid { return err }` type code blocks that add length to the handlers. We also do `if flag == "" { return xerrors.Errorf("<flag> must be specified")}` errors.

These validation & required errors are not standardized. So the messaging & display of these errors really depends on how much care the developer put in at the time.

This PR aims to standardize how we handle cli flag validation and "require" such that all returned errors will be standard and ideally all errors are returned in a group if possible (this needs to get better on the cmd handling).

# Future work

Make the returned standard errors pretty.

# Example

An example of requiring a value be set, and adding validation to said value.

```golang
clibase.Option{
	Name:        "Coderd (Primary) Access URL",
	Description: "URL to communicate with coderd. This should match the access URL of the Coder deployment.",
	Flag:        "primary-access-url",
	Env:         "CODER_PRIMARY_ACCESS_URL",
	YAML:        "primaryAccessURL",
	// Makes the user provide a value for this option.
	Required:    true,
	// Standard way to validate the input values from the user.
	Value: clibase.Validate(&primaryAccessURL, func(value *clibase.URL) error {
		if !(value.Scheme == "http" || value.Scheme == "https") {
			return xerrors.Errorf("'--primary-access-url' value must be http or https: url=%s", primaryAccessURL.String())
		}
		return nil
	}),
	Group:  &externalProxyOptionGroup,
	Hidden: false,
},
```

# Before

![Screenshot from 2023-07-07 10-39-49](https://github.com/coder/coder/assets/5446298/5ff13bf1-75d9-4075-a44c-0fc71ee28511)

# After

![Screenshot from 2023-07-07 10-40-24](https://github.com/coder/coder/assets/5446298/25d27442-58fd-419c-be8e-2d6bbf97b312)

![Screenshot from 2023-07-07 11-10-19](https://github.com/coder/coder/assets/5446298/34e8ffa9-b36b-4df2-a639-5e9cb0b74650)

