### PR TITLE
chore: group `golang.org/x/*` dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -48,6 +48,9 @@ updates:
         patterns:
           - "go.nhat.io/otelsql"
           - "go.opentelemetry.io/otel*"
+        golang-x:
+          patterns:
+          - "golang.org/x/*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,11 +44,11 @@ updates:
         update-types:
           - version-update:semver-patch
     groups:
-      go-otel:
-        patterns:
-          - "go.nhat.io/otelsql"
-          - "go.opentelemetry.io/otel*"
-        golang-x:
+      - go-otel:
+          patterns:
+            - "go.nhat.io/otelsql"
+            - "go.opentelemetry.io/otel*"
+      - golang-x:
           patterns:
             - "golang.org/x/*"
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,13 +44,13 @@ updates:
         update-types:
           - version-update:semver-patch
     groups:
-      - go-otel:
-          patterns:
-            - "go.nhat.io/otelsql"
-            - "go.opentelemetry.io/otel*"
-      - golang-x:
-          patterns:
-            - "golang.org/x/*"
+      go-otel:
+        patterns:
+          - "go.nhat.io/otelsql"
+          - "go.opentelemetry.io/otel*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -50,7 +50,7 @@ updates:
           - "go.opentelemetry.io/otel*"
         golang-x:
           patterns:
-          - "golang.org/x/*"
+            - "golang.org/x/*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"


### PR DESCRIPTION
Group all golang.org/x dependencies.
We have a quıte few of them.
```console
golang.org/x/crypto
golang.org/x/exp
golang.org/x/mod
golang.org/x/oauth2
golang.org/x/sync
golang.org/x/sys
golang.org/x/term
golang.org/x/tools
golang.org/x/xerrors
golang.org/x/net
golang.org/x/text
golang.org/x/time
```