### PR TITLE
chore: enable exhaustruct linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -195,6 +195,7 @@ issues:
         # We use assertions rather than explicitly checking errors in tests
         - errcheck
         - forcetypeassert
+        - exhaustruct # This is unhelpful in tests.
 
   fix: true
   max-issues-per-linter: 0
@@ -219,6 +220,7 @@ linters:
     - errcheck
     - errname
     - errorlint
+    - exhaustruct
     - exportloopref
     - forcetypeassert
     - gocritic

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,14 @@
 # Over time we should try tightening some of these.
 
 linters-settings:
+  exhaustruct:
+    exclude:
+      - 'clibase\.Cmd'
+      - 'clibase\.Option'
+      - 'codersdk\.Response'
+      - 'codersdk\.\w+Request'
+      - 'http\.Client'
+      - "TypescriptType"
   gocognit:
     min-complexity: 46 # Min code complexity (def 30).
 
@@ -196,6 +204,9 @@ issues:
         - errcheck
         - forcetypeassert
         - exhaustruct # This is unhelpful in tests.
+    - path: scripts/*
+      linters:
+        - exhaustruct
 
   fix: true
   max-issues-per-linter: 0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,13 +3,9 @@
 
 linters-settings:
   exhaustruct:
-    exclude:
-      - 'clibase\.Cmd'
-      - 'clibase\.Option'
-      - 'codersdk\.Response'
-      - 'codersdk\.\w+Request'
-      - 'http\.Client'
-      - "TypescriptType"
+    include:
+      # Gradually extend to cover more of the codebase.
+      - 'httpmw\.\w+'
   gocognit:
     min-complexity: 46 # Min code complexity (def 30).
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -390,7 +390,7 @@ func New(options *Options) *API {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    false,
-		SessionTokenFunc:            nil, // Default behaviour
+		SessionTokenFunc:            nil, // Default behavior
 	})
 	// Same as above but it redirects to the login page.
 	apiKeyMiddlewareRedirect := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -399,7 +399,7 @@ func New(options *Options) *API {
 		RedirectToLogin:             true,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    false,
-		SessionTokenFunc:            nil, // Default behaviour
+		SessionTokenFunc:            nil, // Default behavior
 	})
 	// Same as the first but it's optional.
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -408,7 +408,7 @@ func New(options *Options) *API {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    true,
-		SessionTokenFunc:            nil, // Default behaviour
+		SessionTokenFunc:            nil, // Default behavior
 	})
 
 	// API rate limit middleware. The counter is local and not shared between

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -390,6 +390,7 @@ func New(options *Options) *API {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    false,
+		SessionTokenFunc:            nil, // Default behaviour
 	})
 	// Same as above but it redirects to the login page.
 	apiKeyMiddlewareRedirect := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -398,6 +399,7 @@ func New(options *Options) *API {
 		RedirectToLogin:             true,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    false,
+		SessionTokenFunc:            nil, // Default behaviour
 	})
 	// Same as the first but it's optional.
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -406,6 +408,7 @@ func New(options *Options) *API {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    true,
+		SessionTokenFunc:            nil, // Default behaviour
 	})
 
 	// API rate limit middleware. The counter is local and not shared between

--- a/coderd/httpmw/hsts.go
+++ b/coderd/httpmw/hsts.go
@@ -20,7 +20,7 @@ type HSTSConfig struct {
 func HSTSConfigOptions(maxAge int, options []string) (HSTSConfig, error) {
 	if maxAge <= 0 {
 		// No header, so no need to build the header string.
-		return HSTSConfig{}, nil
+		return HSTSConfig{HeaderValue: ""}, nil
 	}
 
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -57,8 +57,8 @@ func ExtractRealIP(config *RealIPConfig) func(next http.Handler) http.Handler {
 func ExtractRealIPAddress(config *RealIPConfig, req *http.Request) (net.IP, error) {
 	if config == nil {
 		config = &RealIPConfig{
-			TrustedOrigins: []*net.IPNet{},
-			TrustedHeaders: []string{},
+			TrustedOrigins: nil,
+			TrustedHeaders: nil,
 		}
 	}
 
@@ -85,8 +85,8 @@ func ExtractRealIPAddress(config *RealIPConfig, req *http.Request) (net.IP, erro
 func FilterUntrustedOriginHeaders(config *RealIPConfig, req *http.Request) {
 	if config == nil {
 		config = &RealIPConfig{
-			TrustedOrigins: []*net.IPNet{},
-			TrustedHeaders: []string{},
+			TrustedOrigins: nil,
+			TrustedHeaders: nil,
 		}
 	}
 

--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -56,7 +56,10 @@ func ExtractRealIP(config *RealIPConfig) func(next http.Handler) http.Handler {
 // configuration and headers. It does not mutate the original request.
 func ExtractRealIPAddress(config *RealIPConfig, req *http.Request) (net.IP, error) {
 	if config == nil {
-		config = &RealIPConfig{}
+		config = &RealIPConfig{
+			TrustedOrigins: []*net.IPNet{},
+			TrustedHeaders: []string{},
+		}
 	}
 
 	cf := isContainedIn(config.TrustedOrigins, getRemoteAddress(req.RemoteAddr))
@@ -208,7 +211,10 @@ func RealIP(ctx context.Context) *RealIPState {
 // ParseRealIPConfig takes a raw string array of headers and origins
 // to produce a config.
 func ParseRealIPConfig(headers, origins []string) (*RealIPConfig, error) {
-	config := &RealIPConfig{}
+	config := &RealIPConfig{
+		TrustedOrigins: []*net.IPNet{},
+		TrustedHeaders: []string{},
+	}
 	for _, origin := range origins {
 		_, network, err := net.ParseCIDR(origin)
 		if err != nil {

--- a/coderd/httpmw/realip.go
+++ b/coderd/httpmw/realip.go
@@ -84,7 +84,10 @@ func ExtractRealIPAddress(config *RealIPConfig, req *http.Request) (net.IP, erro
 // of each proxy header is set.
 func FilterUntrustedOriginHeaders(config *RealIPConfig, req *http.Request) {
 	if config == nil {
-		config = &RealIPConfig{}
+		config = &RealIPConfig{
+			TrustedOrigins: []*net.IPNet{},
+			TrustedHeaders: []string{},
+		}
 	}
 
 	cf := isContainedIn(config.TrustedOrigins, getRemoteAddress(req.RemoteAddr))

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -88,7 +88,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    false,
-		SessionTokenFunc:            nil, // Default behaviour
+		SessionTokenFunc:            nil, // Default behavior
 	})
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
 		DB:                          options.Database,
@@ -96,7 +96,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    true,
-		SessionTokenFunc:            nil, // Default behaviour
+		SessionTokenFunc:            nil, // Default behavior
 	})
 
 	deploymentID, err := options.Database.GetDeploymentID(ctx)

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -88,6 +88,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    false,
+		SessionTokenFunc:            nil, // Default behaviour
 	})
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
 		DB:                          options.Database,
@@ -95,6 +96,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		RedirectToLogin:             false,
 		DisableSessionExpiryRefresh: options.DeploymentValues.DisableSessionExpiryRefresh.Value(),
 		Optional:                    true,
+		SessionTokenFunc:            nil, // Default behaviour
 	})
 
 	deploymentID, err := options.Database.GetDeploymentID(ctx)

--- a/install.sh
+++ b/install.sh
@@ -527,6 +527,7 @@ distro() {
 
 	if [ -f /etc/os-release ]; then
 		(
+			# shellcheck disable=SC1091
 			. /etc/os-release
 			if [ "${ID_LIKE-}" ]; then
 				for id_like in $ID_LIKE; do
@@ -553,6 +554,7 @@ distro_name() {
 
 	if [ -f /etc/os-release ]; then
 		(
+			# shellcheck disable=SC1091
 			. /etc/os-release
 			echo "$PRETTY_NAME"
 		)

--- a/site/site.go
+++ b/site/site.go
@@ -291,13 +291,13 @@ func (h *Handler) renderHTMLWithState(rw http.ResponseWriter, r *http.Request, f
 	// Cookies are sent when requesting HTML, so we can get the user
 	// and pre-populate the state for the frontend to reduce requests.
 	apiKey, actor, _ := httpmw.ExtractAPIKey(rw, r, httpmw.ExtractAPIKeyConfig{
-		DB:              h.opts.Database,
-		OAuth2Configs:   h.opts.OAuth2Configs,
-		RedirectToLogin: false,
+		Optional:      true,
+		DB:            h.opts.Database,
+		OAuth2Configs: h.opts.OAuth2Configs,
 		// Special case for site, we can always disable refresh here because
 		// the frontend will perform API requests if this fails.
 		DisableSessionExpiryRefresh: true,
-		Optional:                    true,
+		RedirectToLogin:             false,
 		SessionTokenFunc:            nil,
 	})
 	if apiKey != nil && actor != nil {

--- a/site/site.go
+++ b/site/site.go
@@ -291,12 +291,14 @@ func (h *Handler) renderHTMLWithState(rw http.ResponseWriter, r *http.Request, f
 	// Cookies are sent when requesting HTML, so we can get the user
 	// and pre-populate the state for the frontend to reduce requests.
 	apiKey, actor, _ := httpmw.ExtractAPIKey(rw, r, httpmw.ExtractAPIKeyConfig{
-		Optional:      true,
-		DB:            h.opts.Database,
-		OAuth2Configs: h.opts.OAuth2Configs,
+		DB:              h.opts.Database,
+		OAuth2Configs:   h.opts.OAuth2Configs,
+		RedirectToLogin: false,
 		// Special case for site, we can always disable refresh here because
 		// the frontend will perform API requests if this fails.
 		DisableSessionExpiryRefresh: true,
+		Optional:                    true,
+		SessionTokenFunc:            nil,
 	})
 	if apiKey != nil && actor != nil {
 		ctx := dbauthz.As(r.Context(), actor.Actor)


### PR DESCRIPTION
Just enabling on `httpmw\.\w+` for now. We can add coverage as we go.