### PR TITLE
docs: fix git credentials file name

### DIFF
--- a/docs/templates/modules.md
+++ b/docs/templates/modules.md
@@ -40,7 +40,7 @@ If you are running Coder on a VM, make sure you have `git` installed and the `co
 ```
 
 ```sh
-# /home/coder/.gitconfig
+# /home/coder/.git-credentials
 
 # GitHub example:
 https://your-github-username:your-github-pat@github.com


### PR DESCRIPTION
The git credentials file was listed as having the name `.gitconfig` instead of `.git-credentials`