### PR TITLE
fix: use `expires_in` field for git device refresh

### DIFF
--- a/coderd/gitauth_test.go
+++ b/coderd/gitauth_test.go
@@ -200,9 +200,7 @@ func TestGitAuthDevice(t *testing.T) {
 		require.Equal(t, "authorization_pending", sdkErr.Detail)
 
 		resp = gitauth.ExchangeDeviceCodeResponse{
-			Token: &oauth2.Token{
-				AccessToken: "hey",
-			},
+			AccessToken: "hey",
 		}
 
 		err = client.GitAuthDeviceExchange(context.Background(), "test", codersdk.GitAuthDeviceExchange{


### PR DESCRIPTION
This was causing git auth to never refresh after the token
became expired after 8hrs.
