### PR TITLE
feat(cli): support ephemeral parameters

### DIFF
--- a/cli/cliui/parameter.go
+++ b/cli/cliui/parameter.go
@@ -15,7 +15,12 @@ func RichParameter(inv *clibase.Invocation, templateVersionParameter codersdk.Te
 		label = templateVersionParameter.DisplayName
 	}
 
+	if templateVersionParameter.Ephemeral {
+		label += DefaultStyles.Warn.Render(" (build option)")
+	}
+
 	_, _ = fmt.Fprintln(inv.Stdout, DefaultStyles.Bold.Render(label))
+
 	if templateVersionParameter.DescriptionPlaintext != "" {
 		_, _ = fmt.Fprintln(inv.Stdout, "  "+strings.TrimSpace(strings.Join(strings.Split(templateVersionParameter.DescriptionPlaintext, "\n"), "\n  "))+"\n")
 	}

--- a/cli/create.go
+++ b/cli/create.go
@@ -23,6 +23,7 @@ func (r *RootCmd) create() *clibase.Cmd {
 		startAt           string
 		stopAfter         time.Duration
 		workspaceName     string
+		buildOptions      bool
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -123,6 +124,7 @@ func (r *RootCmd) create() *clibase.Cmd {
 				Template:          template,
 				RichParameterFile: richParameterFile,
 				NewWorkspaceName:  workspaceName,
+				BuildOptions:      buildOptions,
 			})
 			if err != nil {
 				return xerrors.Errorf("prepare build: %w", err)
@@ -189,6 +191,11 @@ func (r *RootCmd) create() *clibase.Cmd {
 			Description: "Specify a duration after which the workspace should shut down (e.g. 8h).",
 			Value:       clibase.DurationOf(&stopAfter),
 		},
+		clibase.Option{
+			Flag:        "build-options",
+			Description: "Prompt for one-time build options defined with ephemeral parameters.",
+			Value:       clibase.BoolOf(&buildOptions),
+		},
 		cliui.SkipPromptOption(),
 	)
 
@@ -202,6 +209,7 @@ type prepWorkspaceBuildArgs struct {
 	NewWorkspaceName   string
 
 	UpdateWorkspace bool
+	BuildOptions    bool
 	WorkspaceID     uuid.UUID
 }
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -258,7 +258,7 @@ PromptRichParamLoop:
 		}
 
 		// Param file is all or nothing
-		if !useParamFile {
+		if !useParamFile && !templateVersionParameter.Ephemeral {
 			for _, e := range args.ExistingRichParams {
 				if e.Name == templateVersionParameter.Name {
 					// If the param already exists, we do not need to prompt it again.

--- a/cli/create.go
+++ b/cli/create.go
@@ -240,6 +240,10 @@ func prepWorkspaceBuild(inv *clibase.Invocation, client *codersdk.Client, args p
 	richParameters := make([]codersdk.WorkspaceBuildParameter, 0)
 PromptRichParamLoop:
 	for _, templateVersionParameter := range templateVersionParameters {
+		if templateVersionParameter.Ephemeral {
+			continue
+		}
+
 		if !disclaimerPrinted {
 			_, _ = fmt.Fprintln(inv.Stdout, cliui.DefaultStyles.Paragraph.Render("This template has customizable parameters. Values can be changed after create, but may have unintended side effects (like data loss).")+"\r\n")
 			disclaimerPrinted = true

--- a/cli/create.go
+++ b/cli/create.go
@@ -23,7 +23,8 @@ func (r *RootCmd) create() *clibase.Cmd {
 		startAt           string
 		stopAfter         time.Duration
 		workspaceName     string
-		buildOptions      bool
+
+		parameterFlags workspaceParameterFlags
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -124,7 +125,7 @@ func (r *RootCmd) create() *clibase.Cmd {
 				Template:          template,
 				RichParameterFile: richParameterFile,
 				NewWorkspaceName:  workspaceName,
-				BuildOptions:      buildOptions,
+				BuildOptions:      parameterFlags.buildOptions,
 			})
 			if err != nil {
 				return xerrors.Errorf("prepare build: %w", err)
@@ -191,13 +192,9 @@ func (r *RootCmd) create() *clibase.Cmd {
 			Description: "Specify a duration after which the workspace should shut down (e.g. 8h).",
 			Value:       clibase.DurationOf(&stopAfter),
 		},
-		clibase.Option{
-			Flag:        "build-options",
-			Description: "Prompt for one-time build options defined with ephemeral parameters.",
-			Value:       clibase.BoolOf(&buildOptions),
-		},
 		cliui.SkipPromptOption(),
 	)
+	cmd.Options = append(cmd.Options, parameterFlags.options()...)
 
 	return cmd
 }

--- a/cli/create.go
+++ b/cli/create.go
@@ -248,7 +248,7 @@ func prepWorkspaceBuild(inv *clibase.Invocation, client *codersdk.Client, args p
 	richParameters := make([]codersdk.WorkspaceBuildParameter, 0)
 PromptRichParamLoop:
 	for _, templateVersionParameter := range templateVersionParameters {
-		if templateVersionParameter.Ephemeral {
+		if !args.BuildOptions && templateVersionParameter.Ephemeral {
 			continue
 		}
 

--- a/cli/restart.go
+++ b/cli/restart.go
@@ -33,7 +33,7 @@ func (r *RootCmd) restart() *clibase.Cmd {
 
 			template, err := client.Template(inv.Context(), workspace.TemplateID)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			buildParams, err := prepStartWorkspace(inv, client, prepStartWorkspaceArgs{
@@ -41,7 +41,7 @@ func (r *RootCmd) restart() *clibase.Cmd {
 				BuildOptions: parameterFlags.buildOptions,
 			})
 			if err != nil {
-				return nil
+				return err
 			}
 
 			_, err = cliui.Prompt(inv, cliui.PromptOptions{

--- a/cli/restart.go
+++ b/cli/restart.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (r *RootCmd) restart() *clibase.Cmd {
-	var buildOptions bool
+	var parameterFlags workspaceParameterFlags
 
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -21,14 +21,7 @@ func (r *RootCmd) restart() *clibase.Cmd {
 			clibase.RequireNArgs(1),
 			r.InitClient(client),
 		),
-		Options: clibase.OptionSet{
-			{
-				Flag:        "build-options",
-				Description: "Prompt for one-time build options defined with ephemeral parameters.",
-				Value:       clibase.BoolOf(&buildOptions),
-			},
-			cliui.SkipPromptOption(),
-		},
+		Options: append(parameterFlags.options(), cliui.SkipPromptOption()),
 		Handler: func(inv *clibase.Invocation) error {
 			ctx := inv.Context()
 			out := inv.Stdout
@@ -45,7 +38,7 @@ func (r *RootCmd) restart() *clibase.Cmd {
 
 			buildParams, err := prepStartWorkspace(inv, client, prepStartWorkspaceArgs{
 				Template:     template,
-				BuildOptions: buildOptions,
+				BuildOptions: parameterFlags.buildOptions,
 			})
 			if err != nil {
 				return nil

--- a/cli/restart_test.go
+++ b/cli/restart_test.go
@@ -3,16 +3,44 @@ package cli_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/cli/clitest"
 	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/provisioner/echo"
+	"github.com/coder/coder/provisionersdk/proto"
 	"github.com/coder/coder/pty/ptytest"
 	"github.com/coder/coder/testutil"
 )
 
 func TestRestart(t *testing.T) {
 	t.Parallel()
+
+	echoResponses := &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Provision_Response{
+			{
+				Type: &proto.Provision_Response_Complete{
+					Complete: &proto.Provision_Complete{
+						Parameters: []*proto.RichParameter{
+							{
+								Name:        ephemeralParameterName,
+								Description: ephemeralParameterDescription,
+								Mutable:     true,
+								Ephemeral:   true,
+							},
+						},
+					},
+				},
+			},
+		},
+		ProvisionApply: []*proto.Provision_Response{{
+			Type: &proto.Provision_Response_Complete{
+				Complete: &proto.Provision_Complete{},
+			},
+		}},
+	}
 
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
@@ -42,5 +70,45 @@ func TestRestart(t *testing.T) {
 
 		err := <-done
 		require.NoError(t, err, "execute failed")
+	})
+
+	t.Run("BuildOptions", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, echoResponses)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+
+		inv, root := clitest.New(t, "restart", workspace.Name, "--build-options")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t).Attach(inv)
+		go func() {
+			defer close(doneChan)
+			err := inv.Run()
+			assert.NoError(t, err)
+		}()
+
+		matches := []string{
+			ephemeralParameterDescription, ephemeralParameterValue,
+			"Confirm restart workspace?", "yes",
+			"Stopping workspace", "",
+			"Starting workspace", "",
+			"workspace has been restarted", "",
+		}
+		for i := 0; i < len(matches); i += 2 {
+			match := matches[i]
+			value := matches[i+1]
+			pty.ExpectMatch(match)
+
+			if value != "" {
+				pty.WriteLine(value)
+			}
+		}
+		<-doneChan
 	})
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -47,7 +47,7 @@ func (r *RootCmd) start() *clibase.Cmd {
 
 			template, err := client.Template(inv.Context(), workspace.TemplateID)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			buildParams, err := prepStartWorkspace(inv, client, prepStartWorkspaceArgs{
@@ -55,7 +55,7 @@ func (r *RootCmd) start() *clibase.Cmd {
 				BuildOptions: parameterFlags.buildOptions,
 			})
 			if err != nil {
-				return nil
+				return err
 			}
 
 			build, err := client.CreateWorkspaceBuild(inv.Context(), workspace.ID, codersdk.CreateWorkspaceBuildRequest{

--- a/cli/start.go
+++ b/cli/start.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/codersdk"
 )
 
 func (r *RootCmd) start() *clibase.Cmd {
+	var buildOptions bool
+
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
 		Annotations: workspaceCommand,
@@ -20,6 +24,11 @@ func (r *RootCmd) start() *clibase.Cmd {
 			r.InitClient(client),
 		),
 		Options: clibase.OptionSet{
+			{
+				Flag:        "build-options",
+				Description: "Prompt for one-time build options defined with ephemeral parameters.",
+				Value:       clibase.BoolOf(&buildOptions),
+			},
 			cliui.SkipPromptOption(),
 		},
 		Handler: func(inv *clibase.Invocation) error {
@@ -27,8 +36,23 @@ func (r *RootCmd) start() *clibase.Cmd {
 			if err != nil {
 				return err
 			}
+
+			template, err := client.Template(inv.Context(), workspace.TemplateID)
+			if err != nil {
+				return nil
+			}
+
+			buildParams, err := prepStartWorkspace(inv, client, prepStartWorkspaceArgs{
+				Template:     template,
+				BuildOptions: buildOptions,
+			})
+			if err != nil {
+				return nil
+			}
+
 			build, err := client.CreateWorkspaceBuild(inv.Context(), workspace.ID, codersdk.CreateWorkspaceBuildRequest{
-				Transition: codersdk.WorkspaceTransitionStart,
+				Transition:          codersdk.WorkspaceTransitionStart,
+				RichParameterValues: buildParams.richParameters,
 			})
 			if err != nil {
 				return err
@@ -44,4 +68,50 @@ func (r *RootCmd) start() *clibase.Cmd {
 		},
 	}
 	return cmd
+}
+
+type prepStartWorkspaceArgs struct {
+	Template     codersdk.Template
+	BuildOptions bool
+}
+
+func prepStartWorkspace(inv *clibase.Invocation, client *codersdk.Client, args prepStartWorkspaceArgs) (*buildParameters, error) {
+	ctx := inv.Context()
+
+	templateVersion, err := client.TemplateVersion(ctx, args.Template.ActiveVersionID)
+	if err != nil {
+		return nil, err
+	}
+
+	templateVersionParameters, err := client.TemplateVersionRichParameters(inv.Context(), templateVersion.ID)
+	if err != nil {
+		return nil, xerrors.Errorf("get template version rich parameters: %w", err)
+	}
+
+	richParameters := make([]codersdk.WorkspaceBuildParameter, 0)
+	if !args.BuildOptions {
+		return &buildParameters{
+			richParameters: richParameters,
+		}, nil
+	}
+
+	for _, templateVersionParameter := range templateVersionParameters {
+		if !templateVersionParameter.Ephemeral || !templateVersionParameter.Mutable {
+			continue
+		}
+
+		parameterValue, err := cliui.RichParameter(inv, templateVersionParameter)
+		if err != nil {
+			return nil, err
+		}
+
+		richParameters = append(richParameters, codersdk.WorkspaceBuildParameter{
+			Name:  templateVersionParameter.Name,
+			Value: parameterValue,
+		})
+	}
+
+	return &buildParameters{
+		richParameters: richParameters,
+	}, nil
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -104,7 +104,7 @@ func prepStartWorkspace(inv *clibase.Invocation, client *codersdk.Client, args p
 	}
 
 	for _, templateVersionParameter := range templateVersionParameters {
-		if !templateVersionParameter.Ephemeral || !templateVersionParameter.Mutable {
+		if !templateVersionParameter.Ephemeral {
 			continue
 		}
 

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -1,0 +1,85 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/coderd/coderdtest"
+	"github.com/coder/coder/provisioner/echo"
+	"github.com/coder/coder/provisionersdk/proto"
+	"github.com/coder/coder/pty/ptytest"
+)
+
+const (
+	ephemeralParameterName        = "ephemeral_parameter"
+	ephemeralParameterDescription = "This is ephemeral parameter"
+	ephemeralParameterValue       = "3"
+)
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+
+	echoResponses := &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Provision_Response{
+			{
+				Type: &proto.Provision_Response_Complete{
+					Complete: &proto.Provision_Complete{
+						Parameters: []*proto.RichParameter{
+							{
+								Name:        ephemeralParameterName,
+								Description: ephemeralParameterDescription,
+								Mutable:     true,
+								Ephemeral:   true,
+							},
+						},
+					},
+				},
+			},
+		},
+		ProvisionApply: []*proto.Provision_Response{{
+			Type: &proto.Provision_Response_Complete{
+				Complete: &proto.Provision_Complete{},
+			},
+		}},
+	}
+
+	t.Run("BuildOptions", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, echoResponses)
+		coderdtest.AwaitTemplateVersionJob(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
+
+		inv, root := clitest.New(t, "start", workspace.Name, "--build-options")
+		clitest.SetupConfig(t, client, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t).Attach(inv)
+		go func() {
+			defer close(doneChan)
+			err := inv.Run()
+			assert.NoError(t, err)
+		}()
+
+		matches := []string{
+			ephemeralParameterDescription, ephemeralParameterValue,
+			"workspace has been started", "",
+		}
+		for i := 0; i < len(matches); i += 2 {
+			match := matches[i]
+			value := matches[i+1]
+			pty.ExpectMatch(match)
+
+			if value != "" {
+				pty.WriteLine(value)
+			}
+		}
+		<-doneChan
+	})
+}

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -3,6 +3,9 @@ Usage: coder create [flags] [name]
 Create a workspace
 
 [1mOptions[0m
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the
           template.

--- a/cli/testdata/coder_restart_--help.golden
+++ b/cli/testdata/coder_restart_--help.golden
@@ -3,6 +3,9 @@ Usage: coder restart [flags] <workspace>
 Restart a workspace
 
 [1mOptions[0m
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+
   -y, --yes bool
           Bypass prompts.
 

--- a/cli/testdata/coder_start_--help.golden
+++ b/cli/testdata/coder_start_--help.golden
@@ -3,6 +3,9 @@ Usage: coder start [flags] <workspace>
 Start a workspace
 
 [1mOptions[0m
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+
   -y, --yes bool
           Bypass prompts.
 

--- a/cli/testdata/coder_update_--help.golden
+++ b/cli/testdata/coder_update_--help.golden
@@ -9,6 +9,9 @@ Use --always-prompt to change the parameter values of the workspace.
           Always prompt all parameters. Does not pull parameter values from
           existing workspace.
 
+      --build-options bool
+          Prompt for one-time build options defined with ephemeral parameters.
+
       --rich-parameter-file string, $CODER_RICH_PARAMETER_FILE
           Specify a file path with values for rich parameters defined in the
           template.

--- a/cli/update.go
+++ b/cli/update.go
@@ -11,7 +11,8 @@ func (r *RootCmd) update() *clibase.Cmd {
 	var (
 		richParameterFile string
 		alwaysPrompt      bool
-		buildOptions      bool
+
+		parameterFlags workspaceParameterFlags
 	)
 
 	client := new(codersdk.Client)
@@ -29,7 +30,7 @@ func (r *RootCmd) update() *clibase.Cmd {
 			if err != nil {
 				return err
 			}
-			if !workspace.Outdated && !alwaysPrompt && !buildOptions {
+			if !workspace.Outdated && !alwaysPrompt && !parameterFlags.buildOptions {
 				_, _ = fmt.Fprintf(inv.Stdout, "Workspace isn't outdated!\n")
 				return nil
 			}
@@ -55,7 +56,7 @@ func (r *RootCmd) update() *clibase.Cmd {
 				UpdateWorkspace: true,
 				WorkspaceID:     workspace.LatestBuild.ID,
 
-				BuildOptions: buildOptions,
+				BuildOptions: parameterFlags.buildOptions,
 			})
 			if err != nil {
 				return nil
@@ -97,11 +98,7 @@ func (r *RootCmd) update() *clibase.Cmd {
 			Env:         "CODER_RICH_PARAMETER_FILE",
 			Value:       clibase.StringOf(&richParameterFile),
 		},
-		{
-			Flag:        "build-options",
-			Description: "Prompt for one-time build options defined with ephemeral parameters.",
-			Value:       clibase.BoolOf(&buildOptions),
-		},
 	}
+	cmd.Options = append(cmd.Options, parameterFlags.options()...)
 	return cmd
 }

--- a/cli/update.go
+++ b/cli/update.go
@@ -36,14 +36,14 @@ func (r *RootCmd) update() *clibase.Cmd {
 			}
 			template, err := client.Template(inv.Context(), workspace.TemplateID)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			var existingRichParams []codersdk.WorkspaceBuildParameter
 			if !alwaysPrompt {
 				existingRichParams, err = client.WorkspaceBuildParameters(inv.Context(), workspace.LatestBuild.ID)
 				if err != nil {
-					return nil
+					return err
 				}
 			}
 
@@ -59,7 +59,7 @@ func (r *RootCmd) update() *clibase.Cmd {
 				BuildOptions: parameterFlags.buildOptions,
 			})
 			if err != nil {
-				return nil
+				return err
 			}
 
 			build, err := client.CreateWorkspaceBuild(inv.Context(), workspace.ID, codersdk.CreateWorkspaceBuildRequest{

--- a/cli/update.go
+++ b/cli/update.go
@@ -29,7 +29,7 @@ func (r *RootCmd) update() *clibase.Cmd {
 			if err != nil {
 				return err
 			}
-			if !workspace.Outdated && !alwaysPrompt {
+			if !workspace.Outdated && !alwaysPrompt && !buildOptions {
 				_, _ = fmt.Fprintf(inv.Stdout, "Workspace isn't outdated!\n")
 				return nil
 			}

--- a/cli/update.go
+++ b/cli/update.go
@@ -11,6 +11,7 @@ func (r *RootCmd) update() *clibase.Cmd {
 	var (
 		richParameterFile string
 		alwaysPrompt      bool
+		buildOptions      bool
 	)
 
 	client := new(codersdk.Client)
@@ -53,6 +54,8 @@ func (r *RootCmd) update() *clibase.Cmd {
 
 				UpdateWorkspace: true,
 				WorkspaceID:     workspace.LatestBuild.ID,
+
+				BuildOptions: buildOptions,
 			})
 			if err != nil {
 				return nil
@@ -86,14 +89,18 @@ func (r *RootCmd) update() *clibase.Cmd {
 		{
 			Flag:        "always-prompt",
 			Description: "Always prompt all parameters. Does not pull parameter values from existing workspace.",
-
-			Value: clibase.BoolOf(&alwaysPrompt),
+			Value:       clibase.BoolOf(&alwaysPrompt),
 		},
 		{
 			Flag:        "rich-parameter-file",
 			Description: "Specify a file path with values for rich parameters defined in the template.",
 			Env:         "CODER_RICH_PARAMETER_FILE",
 			Value:       clibase.StringOf(&richParameterFile),
+		},
+		{
+			Flag:        "build-options",
+			Description: "Prompt for one-time build options defined with ephemeral parameters.",
+			Value:       clibase.BoolOf(&buildOptions),
 		},
 	}
 	return cmd

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -12,6 +12,14 @@ coder create [flags] [name]
 
 ## Options
 
+### --build-options
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
 ### --rich-parameter-file
 
 |             |                                         |

--- a/docs/cli/restart.md
+++ b/docs/cli/restart.md
@@ -12,6 +12,14 @@ coder restart [flags] <workspace>
 
 ## Options
 
+### --build-options
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
 ### -y, --yes
 
 |      |                   |

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -12,6 +12,14 @@ coder start [flags] <workspace>
 
 ## Options
 
+### --build-options
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
 ### -y, --yes
 
 |      |                   |

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -26,6 +26,14 @@ Use --always-prompt to change the parameter values of the workspace.
 
 Always prompt all parameters. Does not pull parameter values from existing workspace.
 
+### --build-options
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+Prompt for one-time build options defined with ephemeral parameters.
+
 ### --rich-parameter-file
 
 |             |                                         |

--- a/docs/templates/parameters.md
+++ b/docs/templates/parameters.md
@@ -149,6 +149,24 @@ data "coder_parameter" "region" {
 It is allowed to modify the mutability state anytime. In case of emergency, template authors can temporarily allow for changing immutable parameters to fix an operational issue, but it is not
 advised to overuse this opportunity.
 
+## Ephemeral parameters
+
+Ephemeral parameters are introduced to users in the form of "build options." This functionality can be used to model
+specific behaviors within a Coder workspace, such as reverting to a previous image, restoring from a volume snapshot, or
+building a project without utilizing cache.
+
+As these parameters are ephemeral in nature, subsequent builds will proceed in the standard manner.
+
+```hcl
+data "coder_parameter" "force_rebuild" {
+  name         = "force_rebuild"
+  type         = "bool"
+  description  = "Rebuild the Docker image rather than use the cached one."
+  mutable      = true
+  ephemeral    = true
+}
+```
+
 ## Validation
 
 Rich parameters support multiple validation modes - min, max, monotonic numbers, and regular expressions.


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6828

This PR extends CLI to support _one-time parameters/ephemeral parameters/build_ options.

<img width="570" alt="Screenshot 2023-07-11 at 16 35 29" src="https://github.com/coder/coder/assets/14044910/5e3fbd14-16ca-4fe6-a287-08f251087b49">

The flag is available for:
* `coder update ...`
* `coder create ...`
* `coder start ...`
* `coder restart ...`

_I can rename the flag name  (`--build-options` ) to something more meaningful if anyone has an idea._

---

TODO:
- [x] `update` and `create`: skip ephemeral parameters unless the workspace user wants to set them (flag `--build-options`)
- [x] ... with unit tests
- [x] `start`: add `--build-options` flag to ask for ephemeral parameters
- [x] ... with unit tests
- [x] `restart`: add `--build-options` flag to ask for ephemeral parameters
- [x] ... with unit tests