### PR TITLE
chore(scripts): use slim and always run make in `coder-dev.sh`

### DIFF
--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -10,7 +10,11 @@ source "${SCRIPT_DIR}/lib.sh"
 
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
-RELATIVE_BINARY_PATH="build/coder-slim_${GOOS}_${GOARCH}"
+BINARY_TYPE=coder-slim
+if [[ $1 == server ]]; then
+	BINARY_TYPE=coder
+fi
+RELATIVE_BINARY_PATH="build/${BINARY_TYPE}_${GOOS}_${GOARCH}"
 
 # To preserve the CWD when running the binary, we need to use pushd and popd to
 # get absolute paths to everything.
@@ -20,6 +24,26 @@ CODER_DEV_BIN="$(realpath "$RELATIVE_BINARY_PATH")"
 CODER_DEV_DIR="$(realpath ./.coderv2)"
 popd
 
-make -j "${RELATIVE_BINARY_PATH}"
+case $BINARY_TYPE in
+coder-slim)
+	# Ensure the coder slim binary is always up-to-date with local
+	# changes, this simplifies usage of this script for development.
+	make -j "${RELATIVE_BINARY_PATH}"
+	;;
+coder)
+	if [[ ! -x "${CODER_DEV_BIN}" ]]; then
+		# A feature requiring the full binary was requested and the
+		# binary is missing, normally it's built by `develop.sh`, but
+		# it's an expensive operation, so we require manual action here.
+		echo "Running \"coder $1\" requires the full binary, please run \"develop.sh\" first or build the binary manually:"
+		echo "  make $RELATIVE_BINARY_PATH"
+		exit 1
+	fi
+	;;
+*)
+	echo "Unknown binary type: $BINARY_TYPE"
+	exit 1
+	;;
+esac
 
 exec "${CODER_DEV_BIN}" --global-config "${CODER_DEV_DIR}" "$@"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -35,8 +35,8 @@ coder)
 		# A feature requiring the full binary was requested and the
 		# binary is missing, normally it's built by `develop.sh`, but
 		# it's an expensive operation, so we require manual action here.
-		echo "Running \"coder $1\" requires the full binary, please run \"develop.sh\" first or build the binary manually:"
-		echo "  make $RELATIVE_BINARY_PATH"
+		echo "Running \"coder $1\" requires the full binary, please run \"develop.sh\" first or build the binary manually:" 1>&2
+		echo "  make $RELATIVE_BINARY_PATH" 1>&2
 		exit 1
 	fi
 	;;

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}/lib.sh"
 
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
-RELATIVE_BINARY_PATH="build/coder_${GOOS}_${GOARCH}"
+RELATIVE_BINARY_PATH="build/coder-slim_${GOOS}_${GOARCH}"
 
 # To preserve the CWD when running the binary, we need to use pushd and popd to
 # get absolute paths to everything.
@@ -20,10 +20,6 @@ CODER_DEV_BIN="$(realpath "$RELATIVE_BINARY_PATH")"
 CODER_DEV_DIR="$(realpath ./.coderv2)"
 popd
 
-if [[ ! -x "${CODER_DEV_BIN}" ]]; then
-	echo "Run this command first:"
-	echo "  make $RELATIVE_BINARY_PATH"
-	exit 1
-fi
+make -j "${RELATIVE_BINARY_PATH}"
 
 exec "${CODER_DEV_BIN}" --global-config "${CODER_DEV_DIR}" "$@"


### PR DESCRIPTION
When developing, it's hard to keep track of if the coder client is up-to-date when making local changes and running the server via `scripts/develop.sh`. This changes `scripts/coder-dev.sh` such that it no longer uses the full (fat) binary and instead performs a `make` each time, ensuring the slim binary is up-to-date.

This change has the repercussion that if there are changes, running it can take a long time (`make generate`, etc).

Otherwise, the overhead of using `make` is quite small:

```
❯ time make build/coder-slim_linux_amd64
make build/coder-slim_linux_amd64  0.32s user 0.10s system 92% cpu 0.450 total
```
