### PR TITLE
feat!: add table format to 'coder license ls'

### DIFF
--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -52,8 +52,17 @@ func (l *License) ExpiresAt() (time.Time, error) {
 	return time.Time{}, xerrors.Errorf("license_expires claim has unexpected type %T", expClaim)
 }
 
-// Features provides the feature claims in license.
-func (l *License) Features() (map[FeatureName]int64, error) {
+func (l *License) AllFeaturesClaim() bool {
+	if all, ok := l.Claims["all_features"].(bool); ok {
+		return all
+	}
+	return false
+}
+
+// FeaturesClaims provides the feature claims in license.
+// This only returns the explicit claims. If checking for actual usage,
+// also check `AllFeaturesClaim`.
+func (l *License) FeaturesClaims() (map[FeatureName]int64, error) {
 	strMap, ok := l.Claims["features"].(map[string]interface{})
 	if !ok {
 		return nil, xerrors.New("features key is unexpected type")

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -52,6 +52,13 @@ func (l *License) ExpiresAt() (time.Time, error) {
 	return time.Time{}, xerrors.Errorf("license_expires claim has unexpected type %T", expClaim)
 }
 
+func (l *License) Trail() bool {
+	if trail, ok := l.Claims["trail"].(bool); ok {
+		return trail
+	}
+	return false
+}
+
 func (l *License) AllFeaturesClaim() bool {
 	if all, ok := l.Claims["all_features"].(bool); ok {
 		return all

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -16,14 +16,14 @@ type AddLicenseRequest struct {
 }
 
 type License struct {
-	ID         int32     `json:"id"`
-	UUID       uuid.UUID `json:"uuid" format:"uuid"`
-	UploadedAt time.Time `json:"uploaded_at" format:"date-time"`
+	ID         int32     `json:"id" table:"id,default_sort"`
+	UUID       uuid.UUID `json:"uuid" table:"uuid" format:"uuid"`
+	UploadedAt time.Time `json:"uploaded_at" table:"uploaded_at" format:"date-time"`
 	// Claims are the JWT claims asserted by the license.  Here we use
 	// a generic string map to ensure that all data from the server is
 	// parsed verbatim, not just the fields this version of Coder
 	// understands.
-	Claims map[string]interface{} `json:"claims"`
+	Claims map[string]interface{} `json:"claims" table:"claims"`
 }
 
 // Features provides the feature claims in license.

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -52,7 +52,7 @@ func (l *License) ExpiresAt() (time.Time, error) {
 	return time.Time{}, xerrors.Errorf("license_expires claim has unexpected type %T", expClaim)
 }
 
-func (l *License) Trail() bool {
+func (l *License) Trial() bool {
 	if trail, ok := l.Claims["trail"].(bool); ok {
 		return trail
 	}

--- a/docs/cli/licenses_list.md
+++ b/docs/cli/licenses_list.md
@@ -11,5 +11,25 @@ Aliases:
 ## Usage
 
 ```console
-coder licenses list
+coder licenses list [flags]
 ```
+
+## Options
+
+### -c, --column
+
+|         |                                                   |
+| ------- | ------------------------------------------------- |
+| Type    | <code>string-array</code>                         |
+| Default | <code>UUID,Expires At,Uploaded At,Features</code> |
+
+Columns to display in table output. Available columns: id, uuid, uploaded at, features, expires at, trial.
+
+### -o, --output
+
+|         |                     |
+| ------- | ------------------- |
+| Type    | <code>string</code> |
+| Default | <code>table</code>  |
+
+Output format. Available formats: table, json.

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -136,6 +136,11 @@ func validJWT(s string) error {
 }
 
 func (r *RootCmd) licensesList() *clibase.Cmd {
+	formatter := cliui.NewOutputFormatter(
+		cliui.TableFormat([]codersdk.License{}, []string{"UUID", "Claims", "Uploaded At"}),
+		cliui.JSONFormat(),
+	)
+
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
 		Use:     "list",
@@ -163,11 +168,16 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 				licenses[i].Claims = newClaims
 			}
 
-			enc := json.NewEncoder(inv.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(licenses)
+			out, err := formatter.Format(inv.Context(), licenses)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintln(inv.Stdout, out)
+			return err
 		},
 	}
+	formatter.AttachOptions(&cmd.Options)
 	return cmd
 }
 

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -181,7 +181,20 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 				}
 				return out, nil
 			}),
-		cliui.JSONFormat(),
+		cliui.ChangeFormatterData(cliui.JSONFormat(), func(data any) (any, error) {
+			list, ok := data.([]codersdk.License)
+			if !ok {
+				return nil, xerrors.Errorf("invalid data type %T", data)
+			}
+			for i := range list {
+				humanExp, err := list[i].ExpiresAt()
+				if err == nil {
+					list[i].Claims[codersdk.LicenseExpiryClaim+"_human"] = humanExp.Format(time.RFC3339)
+				}
+			}
+
+			return list, nil
+		}),
 	)
 
 	client := new(codersdk.Client)

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -165,10 +165,15 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 					} else {
 						var strs []string
 						if lic.AllFeaturesClaim() {
-							strs = append(strs, "all")
-						}
-						for k, v := range features {
-							strs = append(strs, fmt.Sprintf("%s=%v", k, v))
+							// If all features are enabled, just include that
+							strs = append(strs, "all features")
+						} else {
+							for k, v := range features {
+								if v > 0 {
+									// Only include claims > 0
+									strs = append(strs, fmt.Sprintf("%s=%v", k, v))
+								}
+							}
 						}
 						formattedFeatures = strings.Join(strs, ", ")
 					}
@@ -181,7 +186,7 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 						UploadedAt: lic.UploadedAt,
 						Features:   formattedFeatures,
 						ExpiresAt:  exp,
-						Trial:      lic.Trail(),
+						Trial:      lic.Trial(),
 					})
 				}
 				return out, nil

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -145,6 +145,7 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 		// Used for the table view.
 		Features  string    `table:"features"`
 		ExpiresAt time.Time `table:"expires_at" format:"date-time"`
+		Trial     bool      `table:"trial"`
 	}
 
 	formatter := cliui.NewOutputFormatter(
@@ -180,6 +181,7 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 						UploadedAt: lic.UploadedAt,
 						Features:   formattedFeatures,
 						ExpiresAt:  exp,
+						Trial:      lic.Trail(),
 					})
 				}
 				return out, nil

--- a/enterprise/cli/licenses_test.go
+++ b/enterprise/cli/licenses_test.go
@@ -143,7 +143,7 @@ func TestLicensesListFake(t *testing.T) {
 		expectedLicenseExpires := time.Date(2024, 4, 6, 16, 53, 35, 0, time.UTC)
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
-		inv := setupFakeLicenseServerTest(t, "licenses", "list")
+		inv := setupFakeLicenseServerTest(t, "licenses", "list", "-o", "json")
 		stdout := new(bytes.Buffer)
 		inv.Stdout = stdout
 		errC := make(chan error)
@@ -159,9 +159,9 @@ func TestLicensesListFake(t *testing.T) {
 		assert.Equal(t, "claim1", licenses[0].Claims["h1"])
 		assert.Equal(t, int32(5), licenses[1].ID)
 		assert.Equal(t, "claim2", licenses[1].Claims["h2"])
-		expiresClaim := licenses[0].Claims["license_expires"]
+		expiresClaim := licenses[0].Claims["license_expires_human"]
 		expiresString, ok := expiresClaim.(string)
-		require.True(t, ok, "license_expires claim is not a string")
+		require.True(t, ok, "license_expires_human claim is not a string")
 		assert.NotEmpty(t, expiresClaim)
 		expiresTime, err := time.Parse(time.RFC3339, expiresString)
 		require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestLicensesListReal(t *testing.T) {
 		coderdtest.CreateFirstUser(t, client)
 		inv, conf := newCLI(
 			t,
-			"licenses", "list",
+			"licenses", "list", "-o", "json",
 		)
 		stdout := new(bytes.Buffer)
 		inv.Stdout = stdout

--- a/enterprise/cli/testdata/coder_licenses_list_--help.golden
+++ b/enterprise/cli/testdata/coder_licenses_list_--help.golden
@@ -1,8 +1,16 @@
-Usage: coder licenses list
+Usage: coder licenses list [flags]
 
 List licenses (including expired)
 
 Aliases: ls
+
+[1mOptions[0m
+  -c, --column string-array (default: UUID,Expires At,Uploaded At,Features)
+          Columns to display in table output. Available columns: id, uuid,
+          uploaded at, features, expires at, trial.
+
+  -o, --output string (default: table)
+          Output format. Available formats: table, json.
 
 ---
 Run `coder --help` for a list of global options.

--- a/enterprise/coderd/licenses_test.go
+++ b/enterprise/coderd/licenses_test.go
@@ -33,7 +33,7 @@ func TestPostLicense(t *testing.T) {
 		assert.GreaterOrEqual(t, respLic.ID, int32(0))
 		// just a couple spot checks for sanity
 		assert.Equal(t, "testing", respLic.Claims["account_id"])
-		features, err := respLic.Features()
+		features, err := respLic.FeaturesClaims()
 		require.NoError(t, err)
 		assert.EqualValues(t, 1, features[codersdk.FeatureAuditLog])
 	})
@@ -105,7 +105,7 @@ func TestGetLicense(t *testing.T) {
 		assert.Equal(t, int32(1), licenses[0].ID)
 		assert.Equal(t, "testing", licenses[0].Claims["account_id"])
 
-		features, err := licenses[0].Features()
+		features, err := licenses[0].FeaturesClaims()
 		require.NoError(t, err)
 		assert.Equal(t, map[codersdk.FeatureName]int64{
 			codersdk.FeatureAuditLog:     1,
@@ -117,7 +117,7 @@ func TestGetLicense(t *testing.T) {
 		assert.Equal(t, "testing2", licenses[1].Claims["account_id"])
 		assert.Equal(t, true, licenses[1].Claims["trial"])
 
-		features, err = licenses[1].Features()
+		features, err = licenses[1].FeaturesClaims()
 		require.NoError(t, err)
 		assert.Equal(t, map[codersdk.FeatureName]int64{
 			codersdk.FeatureUserLimit:   200,


### PR DESCRIPTION
# What this does

Closes https://github.com/coder/coder/issues/7697

```bash
UUID                                  UPLOADED AT           FEATURES      EXPIRES AT                 
c9d1cbfa-6a8c-49f7-8999-82fc64934aef  2023-02-03T18:24:27Z  all features  2024-02-03T13:21:02-05:00 
```

If anyone has an idea on a better way to format the claims, lmk.

We might want to just move the License struct to the `codersdk` so we can json unmarshal the claims easier.

# Behavior changes

- We changed the `license_expires` claim in the json payload from a unix timestamp to a RFC3339 string in the `-o json` output. I kept this, but moved it to `license_expires_human`. I did this to maintain the original rational, but also preserve the original payload. The original reasoning was probably because the table view did not exist.
- Table view is now the default. `coder licenses ls -o json` for the json output.