### PR TITLE
feat(site): add warning for unhealthy workspace

### DIFF
--- a/site/src/components/Workspace/Workspace.stories.tsx
+++ b/site/src/components/Workspace/Workspace.stories.tsx
@@ -234,6 +234,20 @@ export const CancellationError: Story = {
   },
 }
 
+export const Unhealthy: Story = {
+  args: {
+    ...Running.args,
+    workspace: {
+      ...Mocks.MockWorkspace,
+      latest_build: { ...Mocks.MockWorkspace.latest_build, status: "running" },
+      health: {
+        healthy: false,
+        failing_agents: [],
+      },
+    },
+  },
+}
+
 function makeFailedBuildLogs(): ProvisionerJobLog[] {
   return [
     {

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -228,7 +228,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
           {workspace.latest_build.status === "running" &&
             !workspace.health.healthy && (
               <Alert severity="warning">
-                <AlertTitle>Workspace is unhealty</AlertTitle>
+                <AlertTitle>Workspace is unhealthy</AlertTitle>
                 <AlertDetail>
                   Your workspace is running but some agents had failed during
                   initialization.

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -230,8 +230,11 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
               <Alert severity="warning">
                 <AlertTitle>Workspace is unhealthy</AlertTitle>
                 <AlertDetail>
-                  Your workspace is running but some agents had failed during
-                  initialization.
+                  Your workspace is running but{" "}
+                  {workspace.health.failing_agents.length > 1
+                    ? `${workspace.health.failing_agents.length} agents are unhealthy`
+                    : `1 agent is unhealthy`}
+                  .
                 </AlertDetail>
               </Alert>
             )}

--- a/site/src/components/Workspace/Workspace.tsx
+++ b/site/src/components/Workspace/Workspace.tsx
@@ -225,6 +225,16 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
         >
           {buildError}
           {cancellationError}
+          {workspace.latest_build.status === "running" &&
+            !workspace.health.healthy && (
+              <Alert severity="warning">
+                <AlertTitle>Workspace is unhealty</AlertTitle>
+                <AlertDetail>
+                  Your workspace is running but some agents had failed during
+                  initialization.
+                </AlertDetail>
+              </Alert>
+            )}
 
           <ChooseOne>
             <Cond condition={workspace.latest_build.status === "deleted"}>

--- a/site/src/components/WorkspacesTable/WorkspacesRow.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesRow.tsx
@@ -96,7 +96,7 @@ export const UnhealthyTooltip = () => {
       iconClassName={styles.unhealthyIcon}
       buttonClassName={styles.unhealthyButton}
     >
-      <HelpTooltipTitle>Workspace is unhealty</HelpTooltipTitle>
+      <HelpTooltipTitle>Workspace is unhealthy</HelpTooltipTitle>
       <HelpTooltipText>
         Your workspace is running but some agents had failed during
         initialization.

--- a/site/src/components/WorkspacesTable/WorkspacesRow.tsx
+++ b/site/src/components/WorkspacesTable/WorkspacesRow.tsx
@@ -13,6 +13,14 @@ import { OutdatedHelpTooltip } from "components/Tooltips/OutdatedHelpTooltip"
 import { Avatar } from "components/Avatar/Avatar"
 import { Stack } from "components/Stack/Stack"
 import { useClickableTableRow } from "hooks/useClickableTableRow"
+import {
+  HelpTooltip,
+  HelpTooltipText,
+  HelpTooltipTitle,
+} from "components/Tooltips/HelpTooltip"
+import InfoIcon from "@mui/icons-material/InfoOutlined"
+import { colors } from "theme/colors"
+import Box from "@mui/material/Box"
 
 export const WorkspacesRow: FC<{
   workspace: Workspace
@@ -62,7 +70,11 @@ export const WorkspacesRow: FC<{
       </TableCell>
 
       <TableCell>
-        <WorkspaceStatusBadge workspace={workspace} />
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <WorkspaceStatusBadge workspace={workspace} />
+          {workspace.latest_build.status === "running" &&
+            !workspace.health.healthy && <UnhealthyTooltip />}
+        </Box>
       </TableCell>
 
       <TableCell>
@@ -71,6 +83,25 @@ export const WorkspacesRow: FC<{
         </div>
       </TableCell>
     </TableRow>
+  )
+}
+
+export const UnhealthyTooltip = () => {
+  const styles = useStyles()
+
+  return (
+    <HelpTooltip
+      size="small"
+      icon={InfoIcon}
+      iconClassName={styles.unhealthyIcon}
+      buttonClassName={styles.unhealthyButton}
+    >
+      <HelpTooltipTitle>Workspace is unhealty</HelpTooltipTitle>
+      <HelpTooltipText>
+        Your workspace is running but some agents had failed during
+        initialization.
+      </HelpTooltipText>
+    </HelpTooltip>
   )
 }
 
@@ -84,5 +115,17 @@ const useStyles = makeStyles((theme) => ({
   arrowCell: {
     display: "flex",
     paddingLeft: theme.spacing(2),
+  },
+
+  unhealthyIcon: {
+    color: colors.yellow[5],
+  },
+
+  unhealthyButton: {
+    opacity: 1,
+
+    "&:hover": {
+      opacity: 1,
+    },
   },
 }))

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -145,6 +145,20 @@ export const NoSearchResults: Story = {
   },
 }
 
+export const UnhealthyWorkspace: Story = {
+  args: {
+    workspaces: [
+      {
+        ...createWorkspace("running"),
+        health: {
+          healthy: false,
+          failing_agents: [],
+        },
+      },
+    ],
+  },
+}
+
 export const Error: Story = {
   args: {
     error: mockApiError({ message: "Something went wrong" }),


### PR DESCRIPTION
Added a warning in the workspace page:
<img width="1655" alt="Screen Shot 2023-07-11 at 10 07 25" src="https://github.com/coder/coder/assets/3165839/59e263ab-deb8-4bca-b376-b468328b99f5">

Added a warning icon as we do when showing the outdated warning:
<img width="1377" alt="Screen Shot 2023-07-11 at 10 04 02" src="https://github.com/coder/coder/assets/3165839/f7f55c41-d864-4cc7-9a8a-f99e77fcc8e5">

Close https://github.com/coder/coder/issues/8343
