### PR TITLE
feat: expand wsproxy settings page by default

### DIFF
--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -3,7 +3,7 @@ import { AvatarData } from "components/AvatarData/AvatarData"
 import { Avatar } from "components/Avatar/Avatar"
 import TableCell from "@mui/material/TableCell"
 import TableRow from "@mui/material/TableRow"
-import { FC, ReactNode, useState } from "react"
+import { FC, ReactNode } from "react"
 import {
   HealthyBadge,
   NotHealthyBadge,
@@ -12,9 +12,7 @@ import {
 } from "components/DeploySettingsLayout/Badges"
 import { ProxyLatencyReport } from "contexts/useProxyLatency"
 import { getLatencyColor } from "utils/latency"
-import Collapse from "@mui/material/Collapse"
 import { Maybe } from "components/Conditionals/Maybe"
-import { useClickableTableRow } from "hooks"
 import Box from "@mui/material/Box"
 
 export const ProxyRow: FC<{
@@ -36,18 +34,9 @@ export const ProxyRow: FC<{
     )
   }
 
-  const [isMsgsOpen, setIsMsgsOpen] = useState(true)
-  const toggle = () => {
-    if (shouldShowMessages) {
-      setIsMsgsOpen((v) => !v)
-    }
-  }
-  const clickableProps = useClickableTableRow(toggle)
-  const rowProps = shouldShowMessages ? clickableProps : undefined
-
   return (
     <>
-      <TableRow key={proxy.name} data-testid={proxy.name} {...rowProps}>
+      <TableRow key={proxy.name} data-testid={proxy.name}>
         <TableCell>
           <AvatarData
             title={
@@ -64,11 +53,6 @@ export const ProxyRow: FC<{
                   fitImage
                 />
               )
-            }
-            subtitle={
-              shouldShowMessages
-                ? `Click to ${isMsgsOpen ? "hide" : "show"} details`
-                : undefined
             }
           />
         </TableCell>
@@ -94,9 +78,7 @@ export const ProxyRow: FC<{
             colSpan={4}
             sx={{ padding: "0px !important", borderBottom: 0 }}
           >
-            <Collapse in={isMsgsOpen}>
-              <ProxyMessagesRow proxy={proxy as WorkspaceProxy} />
-            </Collapse>
+            <ProxyMessagesRow proxy={proxy as WorkspaceProxy} />
           </TableCell>
         </TableRow>
       </Maybe>

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -36,7 +36,7 @@ export const ProxyRow: FC<{
     )
   }
 
-  const [isMsgsOpen, setIsMsgsOpen] = useState(false)
+  const [isMsgsOpen, setIsMsgsOpen] = useState(true)
   const toggle = () => {
     if (shouldShowMessages) {
       setIsMsgsOpen((v) => !v)
@@ -65,7 +65,7 @@ export const ProxyRow: FC<{
                 />
               )
             }
-            subtitle={shouldShowMessages ? "Click to view details" : undefined}
+            subtitle={shouldShowMessages ? "Click to hide details" : undefined}
           />
         </TableCell>
 

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -65,7 +65,11 @@ export const ProxyRow: FC<{
                 />
               )
             }
-            subtitle={shouldShowMessages ? "Click to hide details" : undefined}
+            subtitle={
+              shouldShowMessages
+                ? `Click to ${isMsgsOpen ? "hide" : "show"} details`
+                : undefined
+            }
           />
         </TableCell>
 


### PR DESCRIPTION
Collapse component removed, always expanded
