### PR TITLE
docs: add note on recommended Azure LB

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -174,12 +174,10 @@ coder:
 
 ### Azure
 
-We recommend deploying Coder with the [Azure Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview) instead of the Azure Load Balancer, as the Application Gateway supports:
+In certain enterprise environments, the [Azure Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview) was needed. The Application Gateway supports:
 
 - Websocket traffic (required for workspace connections)
 - TLS termination
-
-The Azure Load Balancer does not support the above and is only suited for TCP-only traffic.
 
 ## Upgrading Coder via Helm
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -121,7 +121,9 @@ to log in and manage templates.
        sessionAffinity: None
    ```
 
-### Load balancing considerations
+## Load balancing considerations
+
+### AWS
 
 AWS however recommends a Network load balancer in lieu of the Classic load balancer. Use the following `values.yaml` settings to request a Network load balancer:
 
@@ -169,6 +171,15 @@ coder:
    If you do not have a domain, you should set `CODER_ACCESS_URL`
    to this URL in the Helm chart and upgrade Coder (see below).
    This allows workspaces to connect to the proper Coder URL.
+
+### Azure
+
+We recommend deploying Coder with the [Azure Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview) instead of the Azure Load Balancer, as the Application Gateway supports:
+
+- Websocket traffic (required for workspace connections)
+- TLS termination
+
+The Azure Load Balancer does not support the above and is only suited for TCP-only traffic.
 
 ## Upgrading Coder via Helm
 


### PR DESCRIPTION
this PR adds to our existing "Load balancing considerations" section, noting the recommended Azure Application Gateway over the Azure Load Balancer.