### PR TITLE
feat: add default github auth provider

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -467,7 +467,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 
 				logger.Debug(
 					ctx, "loaded default git auth config",
-					slog.F("id", gitauth.CoderGitHubAppConfig.ID),
+					"id", gitauth.CoderGitHubAppConfig.ID,
 				)
 			}
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -111,7 +111,9 @@ func ReadGitAuthProvidersFromEnv(environ []string) ([]codersdk.GitAuthConfig, er
 
 		providerNum, err := strconv.Atoi(tokens[0])
 		if err != nil {
-			return nil, xerrors.Errorf("parse number: %s", v.Name)
+			// Configuration options are available that are non-numbers!
+			// e.g. CODER_GITAUTH_BUILTIN_GITHUB
+			continue
 		}
 
 		var provider codersdk.GitAuthConfig
@@ -458,6 +460,14 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				logger.Debug(
 					ctx, "loaded git auth config",
 					slog.F("id", c.ID),
+				)
+			}
+			if cfg.GitAuthBuiltinGitHub.Value() {
+				gitAuthConfigs = append(gitAuthConfigs, gitauth.CoderGitHubAppConfig)
+
+				logger.Debug(
+					ctx, "loaded default git auth config",
+					slog.F("id", gitauth.CoderGitHubAppConfig.ID),
 				)
 			}
 

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7454,6 +7454,9 @@ const docTemplate = `{
                 "git_auth": {
                     "$ref": "#/definitions/clibase.Struct-array_codersdk_GitAuthConfig"
                 },
+                "git_auth_builtin_github": {
+                    "type": "boolean"
+                },
                 "http_address": {
                     "description": "HTTPAddress is a string because it may be set to zero to disable.",
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6659,6 +6659,9 @@
         "git_auth": {
           "$ref": "#/definitions/clibase.Struct-array_codersdk_GitAuthConfig"
         },
+        "git_auth_builtin_github": {
+          "type": "boolean"
+        },
         "http_address": {
           "description": "HTTPAddress is a string because it may be set to zero to disable.",
           "type": "string"

--- a/coderd/gitauth/config.go
+++ b/coderd/gitauth/config.go
@@ -19,6 +19,30 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
+var (
+	// CoderGitHubAppConfig facilitates GitHub device auth
+	// using https://github.com/apps/coder to authenticate private repos.
+	// No need for a GitHub App or callback URL.
+	// Works even on localhost if Coder can reach GitHub.
+	CoderGitHubAppConfig = &Config{
+		OAuth2Config: &oauth2.Config{
+			ClientID: "Iv1.6a2b4b4aec4f4fe7",
+			Endpoint: endpoint[codersdk.GitProviderGitHub],
+		},
+		ID:                  "github-coder",
+		Regex:               regex[codersdk.GitProviderGitHub],
+		Type:                codersdk.GitProviderGitHub,
+		ValidateURL:         validateURL[codersdk.GitProviderGitHub],
+		AppInstallURL:       "https://github.com/apps/coder/installations/new",
+		AppInstallationsURL: appInstallationsURL[codersdk.GitProviderGitHub],
+		DeviceAuth: &DeviceAuth{
+			ClientID: "Iv1.6a2b4b4aec4f4fe7",
+			TokenURL: endpoint[codersdk.GitProviderGitHub].TokenURL,
+			CodeURL:  deviceAuthURL[codersdk.GitProviderGitHub],
+		},
+	}
+)
+
 type OAuth2Config interface {
 	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
 	Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)

--- a/coderd/gitauth/config.go
+++ b/coderd/gitauth/config.go
@@ -19,29 +19,27 @@ import (
 	"github.com/coder/coder/codersdk"
 )
 
-var (
-	// CoderGitHubAppConfig facilitates GitHub device auth
-	// using https://github.com/apps/coder to authenticate private repos.
-	// No need for a GitHub App or callback URL.
-	// Works even on localhost if Coder can reach GitHub.
-	CoderGitHubAppConfig = &Config{
-		OAuth2Config: &oauth2.Config{
-			ClientID: "Iv1.6a2b4b4aec4f4fe7",
-			Endpoint: endpoint[codersdk.GitProviderGitHub],
-		},
-		ID:                  "github-coder",
-		Regex:               regex[codersdk.GitProviderGitHub],
-		Type:                codersdk.GitProviderGitHub,
-		ValidateURL:         validateURL[codersdk.GitProviderGitHub],
-		AppInstallURL:       "https://github.com/apps/coder/installations/new",
-		AppInstallationsURL: appInstallationsURL[codersdk.GitProviderGitHub],
-		DeviceAuth: &DeviceAuth{
-			ClientID: "Iv1.6a2b4b4aec4f4fe7",
-			TokenURL: endpoint[codersdk.GitProviderGitHub].TokenURL,
-			CodeURL:  deviceAuthURL[codersdk.GitProviderGitHub],
-		},
-	}
-)
+// CoderGitHubAppConfig facilitates GitHub device auth
+// using https://github.com/apps/coder to authenticate private repos.
+// No need for a GitHub App or callback URL.
+// Works even on localhost if Coder can reach GitHub.
+var CoderGitHubAppConfig = &Config{
+	OAuth2Config: &oauth2.Config{
+		ClientID: "Iv1.6a2b4b4aec4f4fe7",
+		Endpoint: endpoint[codersdk.GitProviderGitHub],
+	},
+	ID:                  "github-coder",
+	Regex:               regex[codersdk.GitProviderGitHub],
+	Type:                codersdk.GitProviderGitHub,
+	ValidateURL:         validateURL[codersdk.GitProviderGitHub],
+	AppInstallURL:       "https://github.com/apps/coder/installations/new",
+	AppInstallationsURL: appInstallationsURL[codersdk.GitProviderGitHub],
+	DeviceAuth: &DeviceAuth{
+		ClientID: "Iv1.6a2b4b4aec4f4fe7",
+		TokenURL: endpoint[codersdk.GitProviderGitHub].TokenURL,
+		CodeURL:  deviceAuthURL[codersdk.GitProviderGitHub],
+	},
+}
 
 type OAuth2Config interface {
 	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -161,6 +161,7 @@ type DeploymentValues struct {
 	DisablePasswordAuth             clibase.Bool                    `json:"disable_password_auth,omitempty" typescript:",notnull"`
 	Support                         SupportConfig                   `json:"support,omitempty" typescript:",notnull"`
 	GitAuthProviders                clibase.Struct[[]GitAuthConfig] `json:"git_auth,omitempty" typescript:",notnull"`
+	GitAuthBuiltinGitHub            clibase.Bool                    `json:"git_auth_builtin_github,omitempty" typescript:",notnull"`
 	SSHConfig                       SSHConfig                       `json:"config_ssh,omitempty" typescript:",notnull"`
 	WgtunnelHost                    clibase.String                  `json:"wgtunnel_host,omitempty" typescript:",notnull"`
 	DisableOwnerWorkspaceExec       clibase.Bool                    `json:"disable_owner_workspace_exec,omitempty" typescript:",notnull"`
@@ -1549,6 +1550,15 @@ Write out the current server config as YAML to stdout.`,
 			// YAML:        "gitAuthProviders",
 			Value:  &c.GitAuthProviders,
 			Hidden: true,
+		},
+		{
+			Name:        "Git Auth Built-In GitHub",
+			Description: "Turns on/off the built-in GitHub App used for authenticating users with private repositories. Enabled by default.",
+			Flag:        "gitauth-builtin-github",
+			Env:         "CODER_GITAUTH_BUILTIN_GITHUB",
+			Default:     "true",
+			Value:       &c.GitAuthBuiltinGitHub,
+			Group:       &deploymentGroupConfig,
 		},
 		{
 			Name:        "Custom wgtunnel Host",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1553,7 +1553,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Git Auth Built-In GitHub",
-			Description: "Turns on/off the built-in GitHub App used for authenticating users with private repositories. Enabled by default.",
+			Description: "Toggles the built-in GitHub App used for authenticating users with private repositories.",
 			Flag:        "gitauth-builtin-github",
 			Env:         "CODER_GITAUTH_BUILTIN_GITHUB",
 			Default:     "true",

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -217,6 +217,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
         }
       ]
     },
+    "git_auth_builtin_github": true,
     "http_address": "string",
     "in_memory_database": true,
     "job_hang_detector_interval": 0,

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1921,6 +1921,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
         }
       ]
     },
+    "git_auth_builtin_github": true,
     "http_address": "string",
     "in_memory_database": true,
     "job_hang_detector_interval": 0,
@@ -2258,6 +2259,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       }
     ]
   },
+  "git_auth_builtin_github": true,
   "http_address": "string",
   "in_memory_database": true,
   "job_hang_detector_interval": 0,
@@ -2439,6 +2441,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `enable_terraform_debug_mode`        | boolean                                                                                    | false    |              |                                                                    |
 | `experiments`                        | array of string                                                                            | false    |              |                                                                    |
 | `git_auth`                           | [clibase.Struct-array_codersdk_GitAuthConfig](#clibasestruct-array_codersdk_gitauthconfig) | false    |              |                                                                    |
+| `git_auth_builtin_github`            | boolean                                                                                    | false    |              |                                                                    |
 | `http_address`                       | string                                                                                     | false    |              | Http address is a string because it may be set to zero to disable. |
 | `in_memory_database`                 | boolean                                                                                    | false    |              |                                                                    |
 | `job_hang_detector_interval`         | integer                                                                                    | false    |              |                                                                    |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -273,7 +273,7 @@ Time to force cancel provisioning tasks that are stuck.
 | Environment | <code>$CODER_GITAUTH_BUILTIN_GITHUB</code> |
 | Default     | <code>true</code>                          |
 
-Turns on/off the built-in GitHub App used for authenticating users with private repositories. Enabled by default.
+Toggles the built-in GitHub App used for authenticating users with private repositories.
 
 ### --http-address
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -265,6 +265,16 @@ Enable one or more experiments. These are not ready for production. Separate mul
 
 Time to force cancel provisioning tasks that are stuck.
 
+### --gitauth-builtin-github
+
+|             |                                            |
+| ----------- | ------------------------------------------ |
+| Type        | <code>bool</code>                          |
+| Environment | <code>$CODER_GITAUTH_BUILTIN_GITHUB</code> |
+| Default     | <code>true</code>                          |
+
+Turns on/off the built-in GitHub App used for authenticating users with private repositories. Enabled by default.
+
 ### --http-address
 
 |             |                                          |

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -366,6 +366,7 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 	api.entitlementsUpdateMu.Lock()
 	defer api.entitlementsUpdateMu.Unlock()
 
+	// The built-in auth isn't licensed so we don't count it.
 	gitAuthConfigs := 0
 	for _, config := range api.GitAuthConfigs {
 		if config.ID == gitauth.CoderGitHubAppConfig.ID {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -378,6 +378,7 @@ export interface DeploymentValues {
   // Named type "github.com/coder/coder/cli/clibase.Struct[[]github.com/coder/coder/codersdk.GitAuthConfig]" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly git_auth?: any
+  readonly git_auth_builtin_github?: boolean
   readonly config_ssh?: SSHConfig
   readonly wgtunnel_host?: string
   readonly disable_owner_workspace_exec?: boolean


### PR DESCRIPTION
This allows users to authenticate with private repositories without needing to set up a GitHub OAuth app.