### PR TITLE
fix: use numeric comparison to check monotonicity

### DIFF
--- a/codersdk/richparameters.go
+++ b/codersdk/richparameters.go
@@ -1,6 +1,8 @@
 package codersdk
 
 import (
+	"strconv"
+
 	"golang.org/x/xerrors"
 
 	"github.com/coder/terraform-provider-coder/provider"
@@ -47,14 +49,24 @@ func ValidateWorkspaceBuildParameter(richParameter TemplateVersionParameter, bui
 	}
 
 	if lastBuildParameter != nil && richParameter.Type == "number" && len(richParameter.ValidationMonotonic) > 0 {
+		prev, err := strconv.Atoi(lastBuildParameter.Value)
+		if err != nil {
+			return xerrors.Errorf("Previous parameter value is not a number: %s", lastBuildParameter.Value)
+		}
+
+		current, err := strconv.Atoi(buildParameter.Value)
+		if err != nil {
+			return xerrors.Errorf("Current parameter value is not a number: %s", buildParameter.Value)
+		}
+
 		switch richParameter.ValidationMonotonic {
 		case MonotonicOrderIncreasing:
-			if lastBuildParameter.Value > buildParameter.Value {
-				return xerrors.Errorf("Parameter value must be equal or greater than previous value: %s", lastBuildParameter.Value)
+			if prev > current {
+				return xerrors.Errorf("Parameter value must be equal or greater than previous value: %d", prev)
 			}
 		case MonotonicOrderDecreasing:
-			if lastBuildParameter.Value < buildParameter.Value {
-				return xerrors.Errorf("Parameter value must be equal or lower than previous value: %s", lastBuildParameter.Value)
+			if prev < current {
+				return xerrors.Errorf("Parameter value must be equal or lower than previous value: %d", prev)
 			}
 		}
 	}

--- a/codersdk/richparameters_test.go
+++ b/codersdk/richparameters_test.go
@@ -201,13 +201,13 @@ func TestRichParameterValidation(t *testing.T) {
 
 		monotonicIncreasingNumberRichParameters := []codersdk.TemplateVersionParameter{
 			{Name: stringParameterName, Type: "string", Mutable: true},
-			{Name: numberParameterName, Type: "number", Mutable: true, ValidationMin: ptr.Ref(int32(3)), ValidationMax: ptr.Ref(int32(10)), ValidationMonotonic: "increasing"},
+			{Name: numberParameterName, Type: "number", Mutable: true, ValidationMin: ptr.Ref(int32(3)), ValidationMax: ptr.Ref(int32(100)), ValidationMonotonic: "increasing"},
 			{Name: boolParameterName, Type: "bool", Mutable: true},
 		}
 
 		monotonicDecreasingNumberRichParameters := []codersdk.TemplateVersionParameter{
 			{Name: stringParameterName, Type: "string", Mutable: true},
-			{Name: numberParameterName, Type: "number", Mutable: true, ValidationMin: ptr.Ref(int32(3)), ValidationMax: ptr.Ref(int32(10)), ValidationMonotonic: "decreasing"},
+			{Name: numberParameterName, Type: "number", Mutable: true, ValidationMin: ptr.Ref(int32(3)), ValidationMax: ptr.Ref(int32(100)), ValidationMonotonic: "decreasing"},
 			{Name: boolParameterName, Type: "bool", Mutable: true},
 		}
 
@@ -255,10 +255,14 @@ func TestRichParameterValidation(t *testing.T) {
 			{numberParameterName, "6", false, monotonicIncreasingNumberRichParameters},
 			{numberParameterName, "7", true, monotonicIncreasingNumberRichParameters},
 			{numberParameterName, "8", true, monotonicIncreasingNumberRichParameters},
+			{numberParameterName, "11", true, monotonicIncreasingNumberRichParameters},
+			{numberParameterName, "53", true, monotonicIncreasingNumberRichParameters},
 
 			{numberParameterName, "6", true, monotonicDecreasingNumberRichParameters},
 			{numberParameterName, "7", true, monotonicDecreasingNumberRichParameters},
 			{numberParameterName, "8", false, monotonicDecreasingNumberRichParameters},
+			{numberParameterName, "11", false, monotonicDecreasingNumberRichParameters},
+			{numberParameterName, "53", false, monotonicDecreasingNumberRichParameters},
 
 			{stringParameterName, "", true, stringRichParameters},
 			{stringParameterName, "foobar", true, stringRichParameters},


### PR DESCRIPTION
This PR fixes the monotonicity validation of coder parameters.

The function `ValidateWorkspaceBuildParameters` should perform a numeric comparison of values instead of a lexical one.