### PR TITLE
fix(site): prevent ExtractAPIKey from dirtying the HTML output

### DIFF
--- a/site/site_test.go
+++ b/site/site_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coder/coder/coderd/database/db2sdk"
 	"github.com/coder/coder/coderd/database/dbfake"
 	"github.com/coder/coder/coderd/database/dbgen"
+	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/site"
 	"github.com/coder/coder/testutil"
@@ -101,6 +102,12 @@ func TestInjectionFailureProducesCleanHTML(t *testing.T) {
 		BinFS:    binFs,
 		Database: db,
 		SiteFS:   siteFS,
+
+		// No OAuth2 configs, refresh will fail.
+		OAuth2Configs: &httpmw.OAuth2Configs{
+			Github: nil,
+			OIDC:   nil,
+		},
 	})
 
 	r := httptest.NewRequest("GET", "/", nil)

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -118,9 +118,9 @@ func TestInjectionFailureProducesCleanHTML(t *testing.T) {
 
 	// Ensure we get a clean HTML response with no user data or errors
 	// from httpmw.ExtractAPIKey.
-	require.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, http.StatusOK, rw.Code)
 	body := rw.Body.String()
-	require.Equal(t, "<html></html>", body)
+	assert.Equal(t, "<html></html>", body)
 }
 
 func TestCaching(t *testing.T) {

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -109,7 +109,7 @@ func TestInjectionFailureProducesCleanHTML(t *testing.T) {
 
 	handler.ServeHTTP(rw, r)
 
-	// Ensure we get a clean HTTML response with no user data or errors
+	// Ensure we get a clean HTML response with no user data or errors
 	// from httpmw.ExtractAPIKey.
 	require.Equal(t, http.StatusOK, rw.Code)
 	body := rw.Body.String()

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -76,7 +76,7 @@ func TestInjectionFailureProducesCleanHTML(t *testing.T) {
 
 	// Create an expired user with a refresh token, but provide no OAuth2
 	// configuration so that refresh is impossible, this should result in
-	// an error when ExtractAPIKey is called.
+	// an error when httpmw.ExtractAPIKey is called.
 	user := dbgen.User(t, db, database.User{})
 	_, token := dbgen.APIKey(t, db, database.APIKey{
 		UserID:    user.ID,


### PR DESCRIPTION
If `httpmw.ExtractAPIKey` fails when we are rendering an HTML page, the
HTML output will be dirtied with the error repsonse and the HTTP status
will also be wrong.

The use of this function in the `renderHTMLWithState` is additive, and
failure means we simply can't embed static data. To fix this, we can
simply pass a `http.ResponseWriter` that is no-op.

Fixes #8351
