### PR TITLE
chore: remove invalid dependabot config for example templates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -93,23 +93,6 @@ updates:
         update-types:
           - version-update:semver-major
 
-  - package-ecosystem: "terraform"
-    directory: "/examples/templates"
-    schedule:
-      interval: "monthly"
-      time: "06:00"
-      timezone: "America/Chicago"
-    commit-message:
-      prefix: "chore"
-    labels: []
-    ignore:
-      # We likely want to update this ourselves.
-      - dependency-name: "coder/coder"
-    groups:
-      examples-terraform:
-        patterns:
-          - "*"
-
   # Update dogfood.
   - package-ecosystem: "docker"
     directory: "/dogfood/"


### PR DESCRIPTION
`dependabot` doesn't support checking files in subdirectories and requires all supported files to be in the root.
This was an invalid configuration and wasn't working as expected. 
See: https://github.com/coder/coder/network/updates/691253040