### PR TITLE
chore: group various npm dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -96,6 +96,7 @@ updates:
       npm-react:
         patterns:
           - "react*"
+          - "@types/react*"
       npm-xterm:
         patterns:
           - "xterm*"
@@ -118,7 +119,9 @@ updates:
           - "@typescript-eslint/parser"
       npm-jest:
         patterns:
-          - "jest
+          - "jest*"
+          - "@swc/jest"
+          - "@types/jest"
 
   - package-ecosystem: "terraform"
     directory: "/examples/templates"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -92,6 +92,33 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
+    groups:
+      npm-react:
+        patterns:
+          - "react*"
+      npm-xterm:
+        patterns:
+          - "xterm*"
+      npm-xstate:
+        patterns:
+          - "xstate"
+          - "@xstate*"
+      npm-mui:
+        patterns:
+          - "@mui*"
+      npm-storybook:
+        patterns:
+          - "@storybook*"
+          - "storybook*"
+      npm-eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint*"
+          - "@typescript-eslint/eslint-plugin"
+          - "@typescript-eslint/parser"
+      npm-jest:
+        patterns:
+          - "jest
 
   - package-ecosystem: "terraform"
     directory: "/examples/templates"


### PR DESCRIPTION
This PR groups various npm dependencies for dependabot PRs.

1. react
	  - "react*"
	  - "@types/react*"
2. xterm:   
 	 - "xterm*"
3. xstate:
	  - "xstate"
 	 - "@xstate*"
4. mui:
 	 - "@mui*"
5. storybook:
	  - "@storybook*"
 	 - "storybook*"
6. eslint:
	  - "eslint*"
	  - "@eslint*"
	  - "@typescript-eslint/eslint-plugin"
	  - "@typescript-eslint/parser"
7. jest:
	  - "jest*"
	  - "@swc/jest"
	  - "@types/jest"