### PR TITLE
feat(cli): add `--create` flag to `templates push`

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -163,6 +163,7 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 		provisionerTags []string
 		uploadFlags     templateUploadFlags
 		activate        bool
+		create          bool
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -289,6 +290,12 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 			Description: "Whether the new template will be marked active.",
 			Default:     "true",
 			Value:       clibase.BoolOf(&activate),
+		},
+		{
+			Flag:        "create",
+			Description: "Create the template if it does not exist.",
+			Default:     "false",
+			Value:       clibase.BoolOf(&create),
 		},
 		cliui.SkipPromptOption(),
 	}

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -189,11 +189,10 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 			var createTemplate bool
 			template, err := client.TemplateByName(inv.Context(), organization.ID, name)
 			if err != nil {
-				if create {
-					createTemplate = true
-				} else {
+				if !create {
 					return err
 				}
+				createTemplate = true
 			}
 
 			err = uploadFlags.checkForLockfile(inv)

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -644,10 +644,13 @@ func TestTemplatePush(t *testing.T) {
 				write string
 			}{
 				{match: "Upload", write: "yes"},
+				{match: "template has been created"},
 			}
 			for _, m := range matches {
 				pty.ExpectMatch(m.match)
-				pty.WriteLine(m.write)
+				if m.write != "" {
+					pty.WriteLine(m.write)
+				}
 			}
 
 			waiter.RequireSuccess()

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -654,6 +655,7 @@ func TestTemplatePush(t *testing.T) {
 			template, err := client.TemplateByName(context.Background(), user.OrganizationID, templateName)
 			require.NoError(t, err)
 			require.Equal(t, templateName, template.Name)
+			require.NotEqual(t, uuid.Nil, template.ActiveVersionID)
 		})
 	})
 }

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -613,6 +613,48 @@ func TestTemplatePush(t *testing.T) {
 			require.Equal(t, "second_variable", templateVariables[1].Name)
 			require.Equal(t, "foobar", templateVariables[1].Value)
 		})
+
+		t.Run("CreateTemplate", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			user := coderdtest.CreateFirstUser(t, client)
+			source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+				Parse:          echo.ParseComplete,
+				ProvisionApply: provisionCompleteWithAgent,
+			})
+
+			const templateName = "my-template"
+			args := []string{
+				"templates",
+				"push",
+				templateName,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--create",
+			}
+			inv, root := clitest.New(t, args...)
+			clitest.SetupConfig(t, client, root)
+			pty := ptytest.New(t).Attach(inv)
+
+			waiter := clitest.StartWithWaiter(t, inv)
+
+			matches := []struct {
+				match string
+				write string
+			}{
+				{match: "Upload", write: "yes"},
+			}
+			for _, m := range matches {
+				pty.ExpectMatch(m.match)
+				pty.WriteLine(m.write)
+			}
+
+			waiter.RequireSuccess()
+
+			template, err := client.TemplateByName(context.Background(), user.OrganizationID, templateName)
+			require.NoError(t, err)
+			require.Equal(t, templateName, template.Name)
+		})
 	})
 }
 

--- a/cli/testdata/coder_templates_push_--help.golden
+++ b/cli/testdata/coder_templates_push_--help.golden
@@ -10,6 +10,9 @@ Push a new template version from the current directory or as specified by flag
           Always prompt all parameters. Does not pull parameter values from
           active template version.
 
+      --create bool (default: false)
+          Create the template if it does not exist.
+
   -d, --directory string (default: .)
           Specify the directory to create from, use '-' to read tar from stdin.
 

--- a/docs/cli/templates_push.md
+++ b/docs/cli/templates_push.md
@@ -29,6 +29,15 @@ Whether the new template will be marked active.
 
 Always prompt all parameters. Does not pull parameter values from active template version.
 
+### --create
+
+|         |                    |
+| ------- | ------------------ |
+| Type    | <code>bool</code>  |
+| Default | <code>false</code> |
+
+Create the template if it does not exist.
+
 ### -d, --directory
 
 |         |                     |


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6851

This PR allows to automatically create a template while using the `coder templates push` command. To simplify workflow, it uses default flags for all TTLs and `DisableEveryoneGroupAccess`.