### PR TITLE
chore: upgrade go version to 1.20.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,7 +198,7 @@ jobs:
         with:
           # This doesn't need caching. It's super fast anyways!
           cache: false
-          go-version: 1.20.5
+          go-version: 1.20.6
 
       - name: Install prettier
         # We only need prettier for fmt, so do not install all dependencies.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ env:
   # For some reason, setup-go won't actually pick up a new patch version if
   # it has an old one cached. We need to manually specify the versions so we
   # can get the latest release. Never use "~1.xx" here!
-  CODER_GO_VERSION: "1.20.5"
+  CODER_GO_VERSION: "1.20.6"
 
 jobs:
   release:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  CODER_GO_VERSION: "1.20.5"
+  CODER_GO_VERSION: "1.20.6"
 
 jobs:
   codeql:

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:jammy AS go
 
 RUN apt-get update && apt-get install --yes curl gcc
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.20.5
+ARG GO_VERSION=1.20.6
 RUN mkdir --parents /usr/local/go
 
 # Boring Go is needed to build FIPS-compliant binaries.


### PR DESCRIPTION
Go was upgraded to version 1.20.6 in #8433, but it was missed at following places
1. `dogfood/Dockerfile`
2. `.github/workflows/ci.yaml` in `fmt` step
3. `.github/workflows/security.yam`l
4. `.github/workflows/release.yaml`
