### PR TITLE
chore: rename dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,7 +44,7 @@ updates:
         update-types:
           - version-update:semver-patch
     groups:
-      go-otel:
+      otel:
         patterns:
           - "go.nhat.io/otelsql"
           - "go.opentelemetry.io/otel*"
@@ -67,7 +67,7 @@ updates:
       # our Go code.
       - dependency-name: "terraform"
     groups:
-      docker:
+      scripts-docker:
         patterns:
           - "*"
 
@@ -93,31 +93,31 @@ updates:
         update-types:
           - version-update:semver-major
     groups:
-      npm-react:
+      react:
         patterns:
           - "react*"
           - "@types/react*"
-      npm-xterm:
+      xterm:
         patterns:
           - "xterm*"
-      npm-xstate:
+      xstate:
         patterns:
           - "xstate"
           - "@xstate*"
-      npm-mui:
+      mui:
         patterns:
           - "@mui*"
-      npm-storybook:
+      storybook:
         patterns:
           - "@storybook*"
           - "storybook*"
-      npm-eslint:
+      eslint:
         patterns:
           - "eslint*"
           - "@eslint*"
           - "@typescript-eslint/eslint-plugin"
           - "@typescript-eslint/parser"
-      npm-jest:
+      jest:
         patterns:
           - "jest*"
           - "@swc/jest"


### PR DESCRIPTION
Some group names made PR titles exceed 100 characters and needed to look nicer. 