### PR TITLE
fix(site): log deletion of workspace in audit log

### DIFF
--- a/site/src/components/AuditLogRow/AuditLogDescription/BuildAuditDescription.tsx
+++ b/site/src/components/AuditLogRow/AuditLogDescription/BuildAuditDescription.tsx
@@ -10,14 +10,25 @@ export const BuildAuditDescription: FC<{ auditLog: AuditLog }> = ({
   const { t } = useTranslation("auditLog")
 
   const workspaceName = auditLog.additional_fields?.workspace_name?.trim()
-  // workspaces can be started/stopped by a user, or kicked off automatically by Coder
+  // workspaces can be started/stopped/deleted by a user, or kicked off automatically by Coder
   const user =
     auditLog.additional_fields?.build_reason &&
     auditLog.additional_fields?.build_reason !== "initiator"
       ? "Coder automatically"
       : auditLog.user?.username.trim()
 
-  const action = auditLog.action === "start" ? "started" : "stopped"
+  const action: string = (() => {
+    switch (auditLog.action) {
+      case "start":
+        return "started"
+      case "stop":
+        return "stopped"
+      case "delete":
+        return "deleted"
+      default:
+        return auditLog.action
+    }
+  })()
 
   if (auditLog.resource_link) {
     return (

--- a/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
+++ b/site/src/components/AuditLogRow/AuditLogRow.stories.tsx
@@ -64,9 +64,29 @@ WithLongDiffRow.args = {
   defaultIsDiffOpen: true,
 }
 
-export const WithWorkspaceBuild = Template.bind({})
-WithWorkspaceBuild.args = {
-  auditLog: MockAuditLogWithWorkspaceBuild,
+export const WithStoppedWorkspaceBuild = Template.bind({})
+WithStoppedWorkspaceBuild.args = {
+  auditLog: {
+    ...MockAuditLogWithWorkspaceBuild,
+    action: "stop",
+  },
+}
+
+export const WithStartedWorkspaceBuild = Template.bind({})
+WithStartedWorkspaceBuild.args = {
+  auditLog: {
+    ...MockAuditLogWithWorkspaceBuild,
+    action: "start",
+  },
+}
+
+export const WithDeletedWorkspaceBuild = Template.bind({})
+WithDeletedWorkspaceBuild.args = {
+  auditLog: {
+    ...MockAuditLogWithWorkspaceBuild,
+    action: "delete",
+    is_deleted: true,
+  },
 }
 
 export const DeletedResource = Template.bind({})


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/8025

This PR fixes the Audit log description for "Delete workspace" actions. Currently, "delete" actions are presented as "stop". 

<img width="1349" alt="Screenshot 2023-07-13 at 14 34 50" src="https://github.com/coder/coder/assets/14044910/44a8baf7-1f0d-4d7f-ac96-a6ac484c6caa">
