### PR TITLE
chore: use names for all GitHub actions steps and use sqlc setup action

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -17,7 +17,8 @@ runs:
         restore-keys: |
           gotoolchain-${{ runner.os }}-
 
-    - uses: buildjet/setup-go@v4
+    - name: Setup Go
+      uses: buildjet/setup-go@v4
       with:
         # We do our own caching for implementation clarity.
         cache: false

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -4,7 +4,8 @@ description: |
 runs:
   using: "composite"
   steps:
-    - uses: buildjet/setup-node@v3
+    - name: Setup Node
+      uses: buildjet/setup-node@v3
       with:
         node-version: 16.20.1
         # See https://github.com/actions/setup-node#caching-global-packages-data

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,9 +154,9 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-go
 
-      - name: Install sqlc
-        run: |
-          curl -sSL https://github.com/kyleconroy/sqlc/releases/download/v1.18.0/sqlc_1.18.0_linux_amd64.tar.gz | sudo tar -C /usr/bin -xz sqlc
+      - uses: sqlc-dev/setup-sqlc@v3
+        with:
+          sqlc-version: '1.18.0'
 
       - name: go install tools
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,10 +151,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-go
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
-      - uses: sqlc-dev/setup-sqlc@v3
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup sqlc
+        uses: sqlc-dev/setup-sqlc@v3
         with:
           sqlc-version: "1.18.0"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,7 +245,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Setup Terraform
@@ -309,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Setup Terraform
@@ -352,7 +352,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Setup Terraform
@@ -397,7 +397,6 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
-
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,9 +101,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-go
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
-      - uses: ./.github/actions/setup-node
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - name: Get golangci-lint cache dir
         run: |
@@ -196,9 +198,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-node
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
-      - uses: buildjet/setup-go@v4
+      - name: Setup Go
+        uses: buildjet/setup-go@v4
         with:
           # This doesn't need caching. It's super fast anyways!
           cache: false
@@ -241,8 +245,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/setup-tf
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
 
       - name: Test with Mock Database
         id: test
@@ -302,8 +309,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/setup-tf
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
 
       - name: Test with PostgreSQL Database
         run: |
@@ -342,8 +352,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/setup-tf
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
 
       - name: Run Tests
         run: |
@@ -379,8 +392,12 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
 
-      - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/setup-node
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
@@ -451,7 +468,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-node
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - run: yarn test:ci --max-workers $(nproc)
         working-directory: site
@@ -476,9 +494,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/setup-tf
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
 
       - name: Build
         run: |
@@ -513,7 +536,8 @@ jobs:
           # only get 1 commit on shallow checkout.
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-node
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
       # This step is not meant for mainline because any detected changes to
       # storybook snapshots will require manual approval/review in order for

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
 
       - uses: sqlc-dev/setup-sqlc@v3
         with:
-          sqlc-version: '1.18.0'
+          sqlc-version: "1.18.0"
 
       - name: go install tools
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,8 +481,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
       - run: yarn test:ci --max-workers $(nproc)
         working-directory: site

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,11 @@ jobs:
       k8s: ${{ steps.filter.outputs.k8s }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@v2
+      - name: check changed files
+        uses: dorny/paths-filter@v2
         id: filter
         with:
           filters: |
@@ -151,7 +153,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs-only == 'false' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -243,7 +246,8 @@ jobs:
           - macos-latest
           - windows-2019
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -280,12 +284,14 @@ jobs:
           # so we need to print the test stats to the log.
           go run ./scripts/ci-report/main.go gotests.json | tee gotests_stats.json
 
-      - uses: ./.github/actions/upload-datadog
+      - name: Upload test stats to Datadog
+        uses: ./.github/actions/upload-datadog
         if: success() || failure()
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
-      - uses: codecov/codecov-action@v3
+      - name: Check code coverage
+        uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has
         # the `fail_ci_if_error` option that defaults to `false`, but
         # that is no guarantee, see:
@@ -307,7 +313,8 @@ jobs:
     # even if some of the preceding steps are slow.
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -327,12 +334,14 @@ jobs:
           # so we need to print the test stats to the log.
           go run ./scripts/ci-report/main.go gotests.json | tee gotests_stats.json
 
-      - uses: ./.github/actions/upload-datadog
+      - name: Upload test stats to Datadog
+        uses: ./.github/actions/upload-datadog
         if: success() || failure()
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
 
-      - uses: codecov/codecov-action@v3
+      - name: Check code coverage
+        uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has
         # the `fail_ci_if_error` option that defaults to `false`, but
         # that is no guarantee, see:
@@ -350,7 +359,8 @@ jobs:
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -362,7 +372,8 @@ jobs:
         run: |
           gotestsum --junitfile="gotests.xml" -- -race ./...
 
-      - uses: ./.github/actions/upload-datadog
+      - name: Upload test stats to Datadog
+        uses: ./.github/actions/upload-datadog
         if: always()
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
@@ -379,7 +390,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -450,7 +462,8 @@ jobs:
             echo "::endgroup::"
           done
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
         with:
           name: coder
           path: |
@@ -465,7 +478,8 @@ jobs:
     if: needs.changes.outputs.ts == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -473,7 +487,8 @@ jobs:
       - run: yarn test:ci --max-workers $(nproc)
         working-directory: site
 
-      - uses: codecov/codecov-action@v3
+      - name: Check code coverage
+        uses: codecov/codecov-action@v3
         # This action has a tendency to error out unexpectedly, it has
         # the `fail_ci_if_error` option that defaults to `false`, but
         # that is no guarantee, see:
@@ -491,7 +506,8 @@ jobs:
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ts == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -529,7 +545,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ts == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           # Required by Chromatic for build-over-build history, otherwise we
           # only get 1 commit on shallow checkout.

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -25,7 +25,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: hmarr/auto-approve-action@v3
+      - name: auto-approve dependabot
+        uses: hmarr/auto-approve-action@v3
         if: github.actor == 'dependabot[bot]'
 
   cla:
@@ -52,7 +53,8 @@ jobs:
     # Skip tagging for draft PRs.
     if: ${{ github.event_name == 'pull_request_target' && success() && !github.event.pull_request.draft }}
     steps:
-      - uses: actions/github-script@v6
+      - name: release-labels
+        uses: actions/github-script@v6
         with:
           # This script ensures PR title and labels are in sync:
           #

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -31,7 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'coder'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Docker login
         uses: docker/login-action@v2

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Setup Terraform
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Run Tests

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -16,7 +16,8 @@ jobs:
     # so 0.016 * 240 = 3.84 USD per run.
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -31,7 +32,8 @@ jobs:
           # impact.
           gotestsum --junitfile="gotests.xml" -- -timeout=240m -count=10 -race ./...
 
-      - uses: ./.github/actions/upload-datadog
+      - name: Upload test results to DataDog
+        uses: ./.github/actions/upload-datadog
         if: always()
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}
@@ -51,7 +53,8 @@ jobs:
         run: |
           gotestsum --junitfile="gotests.xml" -- --tags="timing" -p=1 -run='_Timing/' ./...
 
-      - uses: ./.github/actions/upload-datadog
+      - name: Upload test results to DataDog
+        uses: ./.github/actions/upload-datadog
         if: always()
         with:
           api-key: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/nightly-gauntlet.yaml
+++ b/.github/workflows/nightly-gauntlet.yaml
@@ -18,8 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/setup-tf
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
 
       - name: Run Tests
         run: |
@@ -38,9 +41,12 @@ jobs:
     runs-on: "buildjet-2vcpu-ubuntu-2204"
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-go
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
+
       - name: Run Tests
         run: |
           gotestsum --junitfile="gotests.xml" -- --tags="timing" -p=1 -run='_Timing/' ./...

--- a/.github/workflows/pr-auto-assign.yaml
+++ b/.github/workflows/pr-auto-assign.yaml
@@ -13,4 +13,5 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.6.2
+      - name: Assign author
+        uses: toshimaru/auto-author-assign@v1.6.2

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -102,7 +102,8 @@ jobs:
       CODER_IMAGE_TAG: ${{ needs.pr_commented.outputs.coder_image_tag }}
       PR_NUMBER: ${{ needs.pr_commented.outputs.pr_number }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -150,7 +151,8 @@ jobs:
       PR_TITLE: ${{ needs.pr_commented.outputs.PR_TITLE }}
       PR_URL: ${{ needs.pr_commented.outputs.PR_URL }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: "Set up kubeconfig"
         run: |

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -106,11 +106,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-go
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
-      - uses: ./.github/actions/setup-node
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
-      - uses: sqlc-dev/setup-sqlc@v3
+      - name: Setup sqlc
+        uses: sqlc-dev/setup-sqlc@v3
         with:
           sqlc-version: "1.18.0"
 

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -110,9 +110,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - name: Install sqlc
-        run: |
-          curl -sSL https://github.com/kyleconroy/sqlc/releases/download/v1.18.0/sqlc_1.18.0_linux_amd64.tar.gz | sudo tar -C /usr/bin -xz sqlc
+      - uses: sqlc-dev/setup-sqlc@v3
+        with:
+          sqlc-version: '1.18.0'
 
       - name: GHCR Login
         uses: docker/login-action@v2

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - uses: sqlc-dev/setup-sqlc@v3
         with:
-          sqlc-version: '1.18.0'
+          sqlc-version: "1.18.0"
 
       - name: GHCR Login
         uses: docker/login-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,8 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -336,7 +337,8 @@ jobs:
     runs-on: windows-latest
     needs: release
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/actions/setup-go
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
 
       - name: Cache Node
         id: cache-node

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Cache Node

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -78,8 +78,8 @@ jobs:
 
       - uses: sqlc-dev/setup-sqlc@v3
         with:
-          sqlc-version: '1.18.0'
-          
+          sqlc-version: "1.18.0"
+
       - name: Install yq
         run: go run github.com/mikefarah/yq/v4@v4.30.6
       - name: Install mockgen

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -76,9 +76,10 @@ jobs:
           restore-keys: |
             js-${{ runner.os }}-
 
-      - name: Install sqlc
-        run: |
-          curl -sSL https://github.com/kyleconroy/sqlc/releases/download/v1.18.0/sqlc_1.18.0_linux_amd64.tar.gz | sudo tar -C /usr/bin -xz sqlc
+      - uses: sqlc-dev/setup-sqlc@v3
+        with:
+          sqlc-version: '1.18.0'
+          
       - name: Install yq
         run: go run github.com/mikefarah/yq/v4@v4.30.6
       - name: Install mockgen

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -63,7 +63,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-go
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
 
       - name: Cache Node
         id: cache-node
@@ -76,7 +77,8 @@ jobs:
           restore-keys: |
             js-${{ runner.os }}-
 
-      - uses: sqlc-dev/setup-sqlc@v3
+      - name: Setup sqlc
+        uses: sqlc-dev/setup-sqlc@v3
         with:
           sqlc-version: "1.18.0"
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           languages: go, javascript
 
-      - name: Setup Go  
+      - name: Setup Go
         uses: ./.github/actions/setup-go
 
       # Workaround to prevent CodeQL from building the dashboard.

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -28,7 +28,8 @@ jobs:
   codeql:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
@@ -60,7 +61,8 @@ jobs:
   trivy:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,7 +35,8 @@ jobs:
         with:
           languages: go, javascript
 
-      - uses: ./.github/actions/setup-go
+      - name: Setup Go  
+        uses: ./.github/actions/setup-go
 
       # Workaround to prevent CodeQL from building the dashboard.
       - name: Remove Makefile

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,8 @@ jobs:
       pull-requests: write
       actions: write
     steps:
-      - uses: actions/stale@v8.0.0
+      - name: stale
+        uses: actions/stale@v8.0.0
         with:
           stale-issue-label: "stale"
           stale-pr-label: "stale"


### PR DESCRIPTION
1. Use the officially available sqlc-setup action in ci
https://docs.sqlc.dev/en/v1.19.0/howto/ci-cd.html#github-workflows
2. Name all steps in jobs