### PR TITLE
chore: fuzzy match alpine terraform version

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 		openssh-client && \
 	# Use the edge repo, since Terraform doesn't seem to be backported to 3.18.
 	apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-		terraform=1.5.2-r0 && \
+		terraform=~1.5 && \
 	addgroup \
 		-g 1000 \
 		coder && \


### PR DESCRIPTION
Old releases disappear, making the old versions not reproducible.