### PR TITLE
fix(site): paginate audit logs

### DIFF
--- a/site/src/pages/AuditPage/AuditPage.test.tsx
+++ b/site/src/pages/AuditPage/AuditPage.test.tsx
@@ -15,6 +15,7 @@ import { server } from "testHelpers/server"
 
 import * as CreateDayString from "utils/createDayString"
 import AuditPage from "./AuditPage"
+import { DEFAULT_RECORDS_PER_PAGE } from "components/PaginationWidget/utils"
 
 interface RenderPageOptions {
   filter?: string
@@ -67,6 +68,29 @@ describe("AuditPage", () => {
     screen.getByTestId(`audit-log-row-${MockAuditLog2.id}`)
   })
 
+  it("renders page 5", async () => {
+    // Given
+    const page = 5
+    const getAuditLogsSpy = jest
+      .spyOn(API, "getAuditLogs")
+      .mockResolvedValue({
+        audit_logs: [MockAuditLog, MockAuditLog2],
+        count: 2,
+      })
+
+    // When
+    await renderPage({ page: page })
+
+    // Then
+    expect(getAuditLogsSpy).toBeCalledWith({
+      limit: DEFAULT_RECORDS_PER_PAGE,
+      offset: DEFAULT_RECORDS_PER_PAGE * (page - 1),
+      q: "",
+    })
+    screen.getByTestId(`audit-log-row-${MockAuditLog.id}`)
+    screen.getByTestId(`audit-log-row-${MockAuditLog2.id}`)
+  })
+
   describe("Filtering", () => {
     it("filters by URL", async () => {
       const getAuditLogsSpy = jest
@@ -76,7 +100,11 @@ describe("AuditPage", () => {
       const query = "resource_type:workspace action:create"
       await renderPage({ filter: query })
 
-      expect(getAuditLogsSpy).toBeCalledWith({ limit: 25, offset: 1, q: query })
+      expect(getAuditLogsSpy).toBeCalledWith({
+        limit: DEFAULT_RECORDS_PER_PAGE,
+        offset: 0,
+        q: query,
+      })
     })
 
     it("resets page to 1 when filter is changed", async () => {
@@ -91,8 +119,8 @@ describe("AuditPage", () => {
 
       await waitFor(() =>
         expect(getAuditLogsSpy).toBeCalledWith({
-          limit: 25,
-          offset: 1,
+          limit: DEFAULT_RECORDS_PER_PAGE,
+          offset: 0,
           q: query,
         }),
       )

--- a/site/src/pages/AuditPage/AuditPage.test.tsx
+++ b/site/src/pages/AuditPage/AuditPage.test.tsx
@@ -71,12 +71,10 @@ describe("AuditPage", () => {
   it("renders page 5", async () => {
     // Given
     const page = 5
-    const getAuditLogsSpy = jest
-      .spyOn(API, "getAuditLogs")
-      .mockResolvedValue({
-        audit_logs: [MockAuditLog, MockAuditLog2],
-        count: 2,
-      })
+    const getAuditLogsSpy = jest.spyOn(API, "getAuditLogs").mockResolvedValue({
+      audit_logs: [MockAuditLog, MockAuditLog2],
+      count: 2,
+    })
 
     // When
     await renderPage({ page: page })

--- a/site/src/pages/AuditPage/AuditPage.tsx
+++ b/site/src/pages/AuditPage/AuditPage.tsx
@@ -1,4 +1,7 @@
-import { nonInitialPage } from "components/PaginationWidget/utils"
+import {
+  DEFAULT_RECORDS_PER_PAGE,
+  nonInitialPage,
+} from "components/PaginationWidget/utils"
 import { useFeatureVisibility } from "hooks/useFeatureVisibility"
 import { FC } from "react"
 import { Helmet } from "react-helmet-async"
@@ -49,9 +52,11 @@ const AuditPage: FC = () => {
   const { data, error } = useQuery({
     queryKey: ["auditLogs", filter.query, pagination.page],
     queryFn: () => {
+      const limit = DEFAULT_RECORDS_PER_PAGE
+      const page = pagination.page
       return getAuditLogs({
-        offset: pagination.page,
-        limit: 25,
+        offset: page <= 0 ? 0 : (page - 1) * limit,
+        limit: limit,
         q: filter.query,
       })
     },


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/7995

This PR aligns the pagination used by the site with the API endpoint.

The "offset" is the number of records skipped, not the page number. When the site requested the first page with `offset=1`, actually it skipped the first record.