### PR TITLE
chore: add filebrowser to dogfood

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -178,7 +178,7 @@ resource "coder_agent" "dev" {
 
     # Install and launch filebrowser
     curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
-    filebrowser --noauth --root /home/coder >/tmp/filebrowser.log 2>&1 &
+    filebrowser --noauth --root /home/coder --port 8080 >/tmp/filebrowser.log 2>&1 &
 
     if [ ! -d ${data.coder_parameter.repo_dir.value} ]; then
       mkdir -p ${data.coder_parameter.repo_dir.value}

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -176,6 +176,9 @@ resource "coder_agent" "dev" {
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.8.3
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
 
+    # Install and launch filebrowser
+    curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
+    filebrowser --noauth --root /home/coder >/tmp/filebrowser.log 2>&1 &
 
     if [ ! -d ${data.coder_parameter.repo_dir.value} ]; then
       mkdir -p ${data.coder_parameter.repo_dir.value}
@@ -211,6 +214,16 @@ resource "coder_app" "code-server" {
     interval  = 3
     threshold = 10
   }
+}
+
+resource "coder_app" "filebrowser" {
+  agent_id     = coder_agent.dev.id
+  display_name = "File Browser"
+  slug         = "filebrowser"
+  url          = "http://localhost:8080/"
+  icon         = "https://raw.githubusercontent.com/matifali/logos/main/database.svg"
+  subdomain    = true
+  share        = "owner"
 }
 
 resource "docker_volume" "home_volume" {

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -200,7 +200,7 @@ resource "coder_agent" "dev" {
       echo "~/personalize is not executable, skipping..." | tee -a ~/.personalize.log
     fi
 
-    # chnage back to repo_dir
+    # change back to repo_dir
     cd ${data.coder_parameter.repo_dir.value}
 
   EOT

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -197,6 +197,7 @@ resource "coder_agent" "dev" {
     elif [ -f ~/personalize ]; then
       echo "~/personalize is not executable, skipping..." | tee -a ~/.personalize.log
     fi
+    cd ${data.coder_parameter.repo_dir.value}
   EOT
 }
 

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -85,7 +85,7 @@ data "coder_workspace" "me" {}
 resource "coder_agent" "dev" {
   arch = "amd64"
   os   = "linux"
-  dir = "${data.coder_parameter.repo_dir.value}"
+  dir  = data.coder_parameter.repo_dir.value
   env = {
     GITHUB_TOKEN : data.coder_git_auth.github.access_token,
     OIDC_TOKEN : data.coder_workspace.me.owner_oidc_access_token,

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -85,8 +85,7 @@ data "coder_workspace" "me" {}
 resource "coder_agent" "dev" {
   arch = "amd64"
   os   = "linux"
-
-  dir = "/home/coder"
+  dir = "${data.coder_parameter.repo_dir.value}"
   env = {
     GITHUB_TOKEN : data.coder_git_auth.github.access_token,
     OIDC_TOKEN : data.coder_workspace.me.owner_oidc_access_token,
@@ -172,6 +171,9 @@ resource "coder_agent" "dev" {
   startup_script         = <<-EOT
     set -eux -o pipefail
 
+    # change to home
+    cd /home/coder
+
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.8.3
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
@@ -197,7 +199,10 @@ resource "coder_agent" "dev" {
     elif [ -f ~/personalize ]; then
       echo "~/personalize is not executable, skipping..." | tee -a ~/.personalize.log
     fi
+
+    # chnage back to repo_dir
     cd ${data.coder_parameter.repo_dir.value}
+
   EOT
 }
 
@@ -221,7 +226,7 @@ resource "coder_app" "filebrowser" {
   agent_id     = coder_agent.dev.id
   display_name = "File Browser"
   slug         = "filebrowser"
-  url          = "http://localhost:8080/"
+  url          = "http://localhost:8080"
   icon         = "https://raw.githubusercontent.com/matifali/logos/main/database.svg"
   subdomain    = true
   share        = "owner"

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -86,7 +86,7 @@ resource "coder_agent" "dev" {
   arch = "amd64"
   os   = "linux"
 
-  dir = data.coder_parameter.repo_dir.value
+  dir = "/home/coder"
   env = {
     GITHUB_TOKEN : data.coder_git_auth.github.access_token,
     OIDC_TOKEN : data.coder_workspace.me.owner_oidc_access_token,

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -172,7 +172,7 @@ resource "coder_agent" "dev" {
     set -eux -o pipefail
 
     # change to home
-    cd /home/coder
+    cd "$HOME"
 
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.8.3
@@ -180,7 +180,7 @@ resource "coder_agent" "dev" {
 
     # Install and launch filebrowser
     curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
-    filebrowser --noauth --root /home/coder --port 8080 >/tmp/filebrowser.log 2>&1 &
+    filebrowser --noauth --root /home/coder --port 13338 >/tmp/filebrowser.log 2>&1 &
 
     if [ ! -d ${data.coder_parameter.repo_dir.value} ]; then
       mkdir -p ${data.coder_parameter.repo_dir.value}
@@ -199,10 +199,6 @@ resource "coder_agent" "dev" {
     elif [ -f ~/personalize ]; then
       echo "~/personalize is not executable, skipping..." | tee -a ~/.personalize.log
     fi
-
-    # change back to repo_dir
-    cd ${data.coder_parameter.repo_dir.value}
-
   EOT
 }
 
@@ -226,7 +222,7 @@ resource "coder_app" "filebrowser" {
   agent_id     = coder_agent.dev.id
   display_name = "File Browser"
   slug         = "filebrowser"
-  url          = "http://localhost:8080"
+  url          = "http://localhost:13338"
   icon         = "https://raw.githubusercontent.com/matifali/logos/main/database.svg"
   subdomain    = true
   share        = "owner"


### PR DESCRIPTION
Adds https://github.com/filebrowser/filebrowser to dogfood template.

### Screenshot

![image](https://github.com/coder/coder/assets/10648092/6691509f-3e11-4569-bf7b-0aeb8a140d55)

Apparently, it isn't working on the subpath and I had to use `subdomain=true`