### PR TITLE
fix: do not wait for devcontainer template volume claim bound

### DIFF
--- a/examples/templates/devcontainer-kubernetes/main.tf
+++ b/examples/templates/devcontainer-kubernetes/main.tf
@@ -98,6 +98,7 @@ resource "kubernetes_persistent_volume_claim" "workspaces" {
       "coder.workspace_name_at_creation" = data.coder_workspace.me.name
     }
   }
+  wait_until_bound = false
   spec {
     access_modes = ["ReadWriteOnce"]
     resources {


### PR DESCRIPTION
Most of the other templates have this line in their templates. Without this line for me it would hang starting a workspace as the pod waits for the pvc and the pvc waits for the pod.