### PR TITLE
feat: assign empty value to ephemeral, required parameter while stopping

### DIFF
--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -495,8 +495,10 @@ func (b *Builder) getParameters() (names, values []string, err error) {
 	if err != nil {
 		return nil, nil, BuildError{http.StatusBadRequest, "Unable to build workspace with unsupported parameters", err}
 	}
+
 	resolver := codersdk.ParameterResolver{
-		Rich: db2sdk.WorkspaceBuildParameters(lastBuildParameters),
+		Rich:       db2sdk.WorkspaceBuildParameters(lastBuildParameters),
+		Transition: codersdk.WorkspaceTransition(b.trans),
 	}
 	for _, templateVersionParameter := range templateVersionParameters {
 		tvp, err := db2sdk.TemplateVersionParameter(templateVersionParameter)

--- a/codersdk/richparameters_test.go
+++ b/codersdk/richparameters_test.go
@@ -379,7 +379,9 @@ func TestParameterResolver_ValidateResolve_Ephemeral_UseEmptyDefault(t *testing.
 
 func TestParameterResolver_ValidateResolve_Ephemeral_RequiredButMissing(t *testing.T) {
 	t.Parallel()
-	uut := codersdk.ParameterResolver{}
+	uut := codersdk.ParameterResolver{
+		Transition: codersdk.WorkspaceTransitionStart,
+	}
 	p := codersdk.TemplateVersionParameter{
 		Name:      "n",
 		Type:      "number",
@@ -392,5 +394,22 @@ func TestParameterResolver_ValidateResolve_Ephemeral_RequiredButMissing(t *testi
 	// consecutive workspace builds.
 	v, err := uut.ValidateResolve(p, nil)
 	require.Error(t, err) // Parameter is required, but not provided.
+	require.Equal(t, "", v)
+}
+
+func TestParameterResolver_ValidateResolve_Ephemeral_RequiredButMissing_StoppedWorkspace(t *testing.T) {
+	t.Parallel()
+	uut := codersdk.ParameterResolver{
+		Transition: codersdk.WorkspaceTransitionStop,
+	}
+	p := codersdk.TemplateVersionParameter{
+		Name:      "n",
+		Type:      "number",
+		Mutable:   true,
+		Required:  true,
+		Ephemeral: true,
+	}
+	v, err := uut.ValidateResolve(p, nil)
+	require.NoError(t, err) // Parameter is not provided, but resolver assumes an empty value.
 	require.Equal(t, "", v)
 }


### PR DESCRIPTION
… workspace

Related: https://github.com/coder/coder/issues/6828

Ephemeral parameters are still rich parameters, so they must undergo the same business logic rules.

Parameters with required values (= no default provided) force the workspace owner to provide these values before starting or updating the workspace (if the new template revision introduces a  new parameter). Whenever it is possible the value is pulled from the previous workspace build.

Ephemeral parameters don't pull values from previous builds, so in terms of required parameters, user input is obligatory on every workspace build. This PR bends this rule by assuming an empty value for "stop" and "delete" workspace builds.

Side note:

@bpmct It is a product question: maybe it is a better idea to mark properties `required=true` and `ephemeral=true` as conflicting. So far we identified only one business case:

> checkmark on every workspace build: I agree not to violate TOS and... 

Currently, only properties `mutable=false` and `ephemeral=true` are marked as conflicting.