### PR TITLE
fix(cli): unskip test and explicitly set --host in test cmd invocation

### DIFF
--- a/cli/stat_test.go
+++ b/cli/stat_test.go
@@ -85,8 +85,6 @@ func TestStatCPUCmd(t *testing.T) {
 
 	t.Run("JSON", func(t *testing.T) {
 		t.Parallel()
-		t.Skip("https://github.com/coder/coder/issues/8091")
-
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		t.Cleanup(cancel)
 		inv, _ := clitest.New(t, "stat", "cpu", "--output=json")
@@ -111,7 +109,7 @@ func TestStatMemCmd(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		t.Cleanup(cancel)
-		inv, _ := clitest.New(t, "stat", "mem", "--output=text")
+		inv, _ := clitest.New(t, "stat", "mem", "--output=text", "--host")
 		buf := new(bytes.Buffer)
 		inv.Stdout = buf
 		err := inv.WithContext(ctx).Run()
@@ -124,7 +122,7 @@ func TestStatMemCmd(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		t.Cleanup(cancel)
-		inv, _ := clitest.New(t, "stat", "mem", "--output=json")
+		inv, _ := clitest.New(t, "stat", "mem", "--output=json", "--host")
 		buf := new(bytes.Buffer)
 		inv.Stdout = buf
 		err := inv.WithContext(ctx).Run()

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2036,6 +2036,9 @@ func TestWorkspaceExtend(t *testing.T) {
 
 func TestWorkspaceWatcher(t *testing.T) {
 	t.Parallel()
+	if testutil.RaceEnabled() {
+		t.Skip("Race detector enabled, skipping time-sensitive test")
+	}
 	client, closeFunc := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	defer closeFunc.Close()
 	user := coderdtest.CreateFirstUser(t, client)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2036,9 +2036,6 @@ func TestWorkspaceExtend(t *testing.T) {
 
 func TestWorkspaceWatcher(t *testing.T) {
 	t.Parallel()
-	if testutil.RaceEnabled() {
-		t.Skip("Race detector enabled, skipping time-sensitive test")
-	}
 	client, closeFunc := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 	defer closeFunc.Close()
 	user := coderdtest.CreateFirstUser(t, client)


### PR DESCRIPTION
- Un-skips the test
- Explicitly set  `--host` flag when running the `cli` tests for the `stat` command as when these are invoked inside a container without a CPU or memory limit set, these tests may fail.