### PR TITLE
chore: do not cancel in progress runs in `pr-deploy.yaml`

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pr_commented:


### PR DESCRIPTION
Cancelling in progress was useful when the developer wants to have a new build but it was also canceling the actual build if anew new comment is made or deleted.