### PR TITLE
feat(helm): add commandArgs for custom entrypoint

### DIFF
--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -66,7 +66,9 @@ spec:
             {{- if .Values.coder.workspaceProxy }}
             - wsproxy
             {{- end }}
+            {{- if .Values.coder.enableArgs }}
             - server
+            {{- end }}
           resources:
             {{- toYaml .Values.coder.resources | nindent 12 }}
           lifecycle:

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -63,10 +63,14 @@ spec:
           command:
             {{- toYaml .Values.coder.command | nindent 12 }}
           args:
-            {{- if .Values.coder.workspaceProxy }}
-            - wsproxy
-            {{- end }}
+            {{- if .Values.coder.commandArgs }}
             {{- toYaml .Values.coder.commandArgs | nindent 12 }}
+            {{- else }}
+              {{ if .Values.coder.workspaceProxy }}
+            - wsproxy
+              {{- end }}
+            - server
+            {{- end }}
           resources:
             {{- toYaml .Values.coder.resources | nindent 12 }}
           lifecycle:

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -66,7 +66,7 @@ spec:
             {{- if .Values.coder.commandArgs }}
             {{- toYaml .Values.coder.commandArgs | nindent 12 }}
             {{- else }}
-              {{ if .Values.coder.workspaceProxy }}
+              {{- if .Values.coder.workspaceProxy }}
             - wsproxy
               {{- end }}
             - server

--- a/helm/templates/coder.yaml
+++ b/helm/templates/coder.yaml
@@ -66,9 +66,7 @@ spec:
             {{- if .Values.coder.workspaceProxy }}
             - wsproxy
             {{- end }}
-            {{- if .Values.coder.enableArgs }}
-            - server
-            {{- end }}
+            {{- toYaml .Values.coder.commandArgs | nindent 12 }}
           resources:
             {{- toYaml .Values.coder.resources | nindent 12 }}
           lifecycle:

--- a/helm/tests/chart_test.go
+++ b/helm/tests/chart_test.go
@@ -52,6 +52,10 @@ var TestCases = []TestCase{
 		name:          "command",
 		expectedError: "",
 	},
+	{
+		name:          "command_args",
+		expectedError: "",
+	},
 }
 
 type TestCase struct {

--- a/helm/tests/testdata/command_args.golden
+++ b/helm/tests/testdata/command_args.golden
@@ -137,7 +137,8 @@ spec:
           command:
             - /opt/coder
           args:
-            - server
+            - arg1
+            - arg2
           resources:
             {}
           lifecycle:

--- a/helm/tests/testdata/command_args.golden
+++ b/helm/tests/testdata/command_args.golden
@@ -1,0 +1,185 @@
+---
+# Source: coder/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "coder"
+  annotations: 
+    {}
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder"
+subjects:
+  - kind: ServiceAccount
+    name: "coder"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-workspace-perms
+---
+# Source: coder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  sessionAffinity: ClientIP
+  ports:
+    - name: "http"
+      port: 80
+      targetPort: "http"
+      protocol: TCP
+  externalTrafficPolicy: "Cluster"
+  selector:
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+---
+# Source: coder/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations: 
+    {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: coder
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: coder-0.1.0
+        app.kubernetes.io/name: coder
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/part-of: coder
+        app.kubernetes.io/version: "0.1.0"
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        {}
+    spec:
+      serviceAccountName: "coder"
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - coder
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+        - name: coder
+          image: "ghcr.io/coder/coder:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /opt/coder
+          args:
+            - server
+          resources:
+            {}
+          lifecycle:
+            {}
+          env:
+            - name: CODER_HTTP_ADDRESS
+              value: "0.0.0.0:8080"
+            - name: CODER_PROMETHEUS_ADDRESS
+              value: "0.0.0.0:2112"
+            # Set the default access URL so a `helm apply` works by default.
+            # See: https://github.com/coder/coder/issues/5024
+            - name: CODER_ACCESS_URL
+              value: "http://coder.default.svc.cluster.local"
+            # Used for inter-pod communication with high-availability.
+            - name: KUBE_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: CODER_DERP_SERVER_RELAY_URL
+              value: "http://$(KUBE_POD_IP):8080"
+            
+          ports:
+            - name: "http"
+              containerPort: 8080
+              protocol: TCP
+          securityContext: 
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: null
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: "http"
+              scheme: "HTTP"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: "http"
+              scheme: "HTTP"
+          volumeMounts: []
+      volumes: []

--- a/helm/tests/testdata/command_args.yaml
+++ b/helm/tests/testdata/command_args.yaml
@@ -1,4 +1,6 @@
 coder:
   image:
     tag: latest
-  commandArgs: []
+  commandArgs:
+    - arg1
+    - arg2

--- a/helm/tests/testdata/command_args.yaml
+++ b/helm/tests/testdata/command_args.yaml
@@ -1,0 +1,4 @@
+coder:
+  image:
+    tag: latest
+  commandArgs: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -277,6 +277,11 @@ coder:
   command:
     - /opt/coder
 
+  # coder.enableArgs -- Enables the `coder server` subcommand to be called as the
+  # entrypoint argument. Set this value to false if specifying a custom command above, e.g.
+  # /bin/sh -c echo "Hello World" /opt/coder server
+  enableArgs: true
+
 # extraTemplates -- Array of extra objects to deploy with the release. Strings
 # are evaluated as a template and can use template expansions and functions. All
 # other objects are used as yaml.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -275,7 +275,7 @@ coder:
   # coder.command -- The command to use when running the Coder container. Used
   # for customizing the location of the `coder` binary in your image.
   command:
-    - /opt/coder server
+    - /opt/coder
 
   # coder.commandArgs -- Set arguments for the entrypoint command of the Coder pod.
   commandArgs: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -275,12 +275,10 @@ coder:
   # coder.command -- The command to use when running the Coder container. Used
   # for customizing the location of the `coder` binary in your image.
   command:
-    - /opt/coder
+    - /opt/coder server
 
-  # coder.enableArgs -- Enables the `coder server` subcommand to be called as the
-  # entrypoint argument. Set this value to false if specifying a custom command above, e.g.
-  # /bin/sh -c echo "Hello World" /opt/coder server
-  enableArgs: true
+  # coder.commandArgs -- Set arguments for the entrypoint command of the Coder pod.
+  commandArgs: []
 
 # extraTemplates -- Array of extra objects to deploy with the release. Strings
 # are evaluated as a template and can use template expansions and functions. All


### PR DESCRIPTION
this PR adds the `commandArgs` value to support passing custom arguments into the Coder container.

one of our large customers needs this feature to pass in a custom PostgreSQL connection URL environment variable. they are looking to reference the database password from a volume mounted on the container. the below example meets this requirement:

```yaml
coder:
  command:
    - /bin/sh
    - -c 
    - CODER_PG_CONNECTION_URL=postgresql://coder:$(cat /mnt/postgres-pass/secret.json | jq -r .password)@coder-db.coder.svc.cluster.local:5432/coder /opt/coder server
  commandArgs: []
```