### PR TITLE
test(testutil): increase wait times to reduce flakes

### DIFF
--- a/testutil/duration.go
+++ b/testutil/duration.go
@@ -9,9 +9,9 @@ import (
 // Constants for timing out operations, usable for creating contexts
 // that timeout or in require.Eventually.
 const (
-	WaitShort     = 5 * time.Second
-	WaitMedium    = 10 * time.Second
-	WaitLong      = 15 * time.Second
+	WaitShort     = 10 * time.Second
+	WaitMedium    = 15 * time.Second
+	WaitLong      = 25 * time.Second
 	WaitSuperLong = 60 * time.Second
 )
 

--- a/testutil/duration_windows.go
+++ b/testutil/duration_windows.go
@@ -7,10 +7,10 @@ import "time"
 //
 // Windows durations are adjusted for slow CI workers.
 const (
-	WaitShort     = 10 * time.Second
+	WaitShort     = 15 * time.Second
 	WaitMedium    = 20 * time.Second
-	WaitLong      = 30 * time.Second
-	WaitSuperLong = 60 * time.Second
+	WaitLong      = 35 * time.Second
+	WaitSuperLong = 120 * time.Second
 )
 
 // Constants for delaying repeated operations, e.g. in


### PR DESCRIPTION
This is a test to see if https://github.com/coder/coder/pull/8561 is a culprit to increased flakeyness by improving in-memory networking performance enough to more easily cause 5-second delays due to WireGuard handshake retry.