### PR TITLE
chore(scripts/dbgen): only add arg validation for dbfake

### DIFF
--- a/scripts/dbgen/main.go
+++ b/scripts/dbgen/main.go
@@ -220,7 +220,9 @@ func orderAndStubDatabaseFunctions(filePath, receiver, structName string, stub f
 
 	for _, fn := range funcs {
 		var bodyStmts []dst.Stmt
-		if len(fn.Func.Params.List) == 2 && fn.Func.Params.List[1].Names[0].Name == "arg" {
+
+		// Add input validation, only relevant for dbfake.
+		if strings.Contains(filePath, "dbfake") && len(fn.Func.Params.List) == 2 && fn.Func.Params.List[1].Names[0].Name == "arg" {
 			/*
 				err := validateDatabaseType(arg)
 				if err != nil {


### PR DESCRIPTION
This function is undefined for e.g. `dbauthz` and `dbmetrics`.