### PR TITLE
feat: add custom docs URL to deployment config

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -128,6 +128,9 @@ Use a YAML configuration file when your server launch become unwieldy.
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
+      --docs-url url, $CODER_DOCS_URL
+          Specifies the custom docs URL.
+
       --proxy-trusted-headers string-array, $CODER_PROXY_TRUSTED_HEADERS
           Headers to trust for forwarding IP addresses. e.g. Cf-Connecting-Ip,
           True-Client-Ip, X-Forwarded-For.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -6,6 +6,9 @@ networking:
   # "*.example.com".
   # (default: <unset>, type: url)
   wildcardAccessURL:
+  # Specifies the custom docs URL.
+  # (default: <unset>, type: url)
+  docsURL:
   # Specifies whether to redirect requests that do not match the access URL host.
   # (default: <unset>, type: bool)
   redirectToAccessURL: false

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7439,6 +7439,9 @@ const docTemplate = `{
                 "disable_session_expiry_refresh": {
                     "type": "boolean"
                 },
+                "docs_url": {
+                    "$ref": "#/definitions/clibase.URL"
+                },
                 "enable_terraform_debug_mode": {
                     "type": "boolean"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6644,6 +6644,9 @@
         "disable_session_expiry_refresh": {
           "type": "boolean"
         },
+        "docs_url": {
+          "$ref": "#/definitions/clibase.URL"
+        },
         "enable_terraform_debug_mode": {
           "type": "boolean"
         },

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -120,6 +120,7 @@ type DeploymentValues struct {
 	Verbose             clibase.Bool `json:"verbose,omitempty"`
 	AccessURL           clibase.URL  `json:"access_url,omitempty"`
 	WildcardAccessURL   clibase.URL  `json:"wildcard_access_url,omitempty"`
+	DocsURL             clibase.URL  `json:"docs_url,omitempty"`
 	RedirectToAccessURL clibase.Bool `json:"redirect_to_access_url,omitempty"`
 	// HTTPAddress is a string because it may be set to zero to disable.
 	HTTPAddress                     clibase.String                  `json:"http_address,omitempty" typescript:",notnull"`
@@ -532,6 +533,16 @@ when required by your organization's security policy.`,
 			Value:       &c.WildcardAccessURL,
 			Group:       &deploymentGroupNetworking,
 			YAML:        "wildcardAccessURL",
+			Annotations: clibase.Annotations{}.Mark(annotationExternalProxies, "true"),
+		},
+		{
+			Name:        "Docs URL",
+			Description: "Specifies the custom docs URL.",
+			Value:       &c.DocsURL,
+			Flag:        "docs-url",
+			Env:         "CODER_DOCS_URL",
+			Group:       &deploymentGroupNetworking,
+			YAML:        "docsURL",
 			Annotations: clibase.Annotations{}.Mark(annotationExternalProxies, "true"),
 		},
 		redirectToAccessURL,

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -196,6 +196,19 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "disable_password_auth": true,
     "disable_path_apps": true,
     "disable_session_expiry_refresh": true,
+    "docs_url": {
+      "forceQuery": true,
+      "fragment": "string",
+      "host": "string",
+      "omitHost": true,
+      "opaque": "string",
+      "path": "string",
+      "rawFragment": "string",
+      "rawPath": "string",
+      "rawQuery": "string",
+      "scheme": "string",
+      "user": {}
+    },
     "enable_terraform_debug_mode": true,
     "experiments": ["string"],
     "git_auth": {

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1902,6 +1902,19 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "disable_password_auth": true,
     "disable_path_apps": true,
     "disable_session_expiry_refresh": true,
+    "docs_url": {
+      "forceQuery": true,
+      "fragment": "string",
+      "host": "string",
+      "omitHost": true,
+      "opaque": "string",
+      "path": "string",
+      "rawFragment": "string",
+      "rawPath": "string",
+      "rawQuery": "string",
+      "scheme": "string",
+      "user": {}
+    },
     "enable_terraform_debug_mode": true,
     "experiments": ["string"],
     "git_auth": {
@@ -2239,6 +2252,19 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "disable_password_auth": true,
   "disable_path_apps": true,
   "disable_session_expiry_refresh": true,
+  "docs_url": {
+    "forceQuery": true,
+    "fragment": "string",
+    "host": "string",
+    "omitHost": true,
+    "opaque": "string",
+    "path": "string",
+    "rawFragment": "string",
+    "rawPath": "string",
+    "rawQuery": "string",
+    "scheme": "string",
+    "user": {}
+  },
   "enable_terraform_debug_mode": true,
   "experiments": ["string"],
   "git_auth": {
@@ -2438,6 +2464,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `disable_password_auth`              | boolean                                                                                    | false    |              |                                                                    |
 | `disable_path_apps`                  | boolean                                                                                    | false    |              |                                                                    |
 | `disable_session_expiry_refresh`     | boolean                                                                                    | false    |              |                                                                    |
+| `docs_url`                           | [clibase.URL](#clibaseurl)                                                                 | false    |              |                                                                    |
 | `enable_terraform_debug_mode`        | boolean                                                                                    | false    |              |                                                                    |
 | `experiments`                        | array of string                                                                            | false    |              |                                                                    |
 | `git_auth`                           | [clibase.Struct-array_codersdk_GitAuthConfig](#clibasestruct-array_codersdk_gitauthconfig) | false    |              |                                                                    |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -223,6 +223,16 @@ Disable workspace apps that are not served from subdomains. Path-based apps can 
 
 Disable automatic session expiry bumping due to activity. This forces all sessions to become invalid after the session expiry duration has been reached.
 
+### --docs-url
+
+|             |                                 |
+| ----------- | ------------------------------- |
+| Type        | <code>url</code>                |
+| Environment | <code>$CODER_DOCS_URL</code>    |
+| YAML        | <code>networking.docsURL</code> |
+
+Specifies the custom docs URL.
+
 ### --enable-terraform-debug-mode
 
 |             |                                                             |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -128,6 +128,9 @@ Use a YAML configuration file when your server launch become unwieldy.
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
+      --docs-url url, $CODER_DOCS_URL
+          Specifies the custom docs URL.
+
       --proxy-trusted-headers string-array, $CODER_PROXY_TRUSTED_HEADERS
           Headers to trust for forwarding IP addresses. e.g. Cf-Connecting-Ip,
           True-Client-Ip, X-Forwarded-For.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -332,6 +332,7 @@ export interface DeploymentValues {
   readonly verbose?: boolean
   readonly access_url?: string
   readonly wildcard_access_url?: string
+  readonly docs_url?: string
   readonly redirect_to_access_url?: boolean
   readonly http_address?: string
   readonly autobuild_poll_interval?: number


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5466

This PR introduces a custom docs URL, which can be used to replace the publicly hosted docs with internal/air-gapped ones.