### PR TITLE
feat: expose docs URL via static meta

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -310,6 +310,7 @@ func New(options *Options) *API {
 		Database:      options.Database,
 		SiteFS:        site.FS(),
 		OAuth2Configs: oauthConfigs,
+		DocsURL:       options.DeploymentValues.DocsURL.String(),
 	})
 	staticHandler.Experiments.Store(&experiments)
 

--- a/site/index.html
+++ b/site/index.html
@@ -20,7 +20,8 @@
   <meta property="entitlements" content="{{ .Entitlements }}" />
   <meta property="appearance" content="{{ .Appearance }}" />
   <meta property="experiments" content="{{ .Experiments }}" />
-  <meta property="regions" content="{{ .Regions }}" />
+  <meta property="regions" content="{{ .Regions }}" />  <meta property="regions" content="{{ .Regions }}" />
+  <meta property="docs-url" content="{{ .DocsURL }}" />
   <!-- We need to set data-react-helmet to be able to override it in the workspace page -->
   <link
     rel="alternate icon"

--- a/site/index.html
+++ b/site/index.html
@@ -20,7 +20,7 @@
   <meta property="entitlements" content="{{ .Entitlements }}" />
   <meta property="appearance" content="{{ .Appearance }}" />
   <meta property="experiments" content="{{ .Experiments }}" />
-  <meta property="regions" content="{{ .Regions }}" />  <meta property="regions" content="{{ .Regions }}" />
+  <meta property="regions" content="{{ .Regions }}" />
   <meta property="docs-url" content="{{ .DocsURL }}" />
   <!-- We need to set data-react-helmet to be able to override it in the workspace page -->
   <link

--- a/site/site.go
+++ b/site/site.go
@@ -66,6 +66,7 @@ type Options struct {
 	Database      database.Store
 	SiteFS        fs.FS
 	OAuth2Configs *httpmw.OAuth2Configs
+	DocsURL       string
 }
 
 func New(opts *Options) *Handler {
@@ -167,6 +168,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		// Token is the CSRF token for the given request
 		CSRF:      csrfState{Token: nosurf.Token(r)},
 		BuildInfo: h.buildInfoJSON,
+		DocsURL:   h.opts.DocsURL,
 	}
 
 	// First check if it's a file we have in our templates
@@ -236,6 +238,7 @@ type htmlState struct {
 	Appearance   string
 	Experiments  string
 	Regions      string
+	DocsURL      string
 }
 
 type csrfState struct {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5466

This PR exposes `CODER_DOCS_URL` via HTML static `<meta>`, so that site can use it to replace the current one. 