### PR TITLE
fix: prevent error log when `pgcoord` query is canceled

### DIFF
--- a/coderd/database/errors.go
+++ b/coderd/database/errors.go
@@ -40,7 +40,7 @@ func IsUniqueViolation(err error, uniqueConstraints ...UniqueConstraint) bool {
 func IsQueryCanceledError(err error) bool {
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
-		return pqErr.Code.Name() == "query_canceled"
+		return pqErr.Code == "57014" // query_canceled
 	}
 
 	return false

--- a/coderd/database/errors.go
+++ b/coderd/database/errors.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"errors"
 
 	"github.com/lib/pq"
@@ -41,6 +42,8 @@ func IsQueryCanceledError(err error) bool {
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
 		return pqErr.Code == "57014" // query_canceled
+	} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
 	}
 
 	return false

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -424,7 +424,7 @@ func (b *binder) writeOne(bnd binding) error {
 	default:
 		panic("unhittable")
 	}
-	if err != nil && !pqErrIsCanceled(err) {
+	if err != nil && !database.IsQueryCanceledError(err) {
 		b.logger.Error(b.ctx, "failed to write binding to database",
 			slog.F("client_id", bnd.client),
 			slog.F("agent_id", bnd.agent),
@@ -432,12 +432,6 @@ func (b *binder) writeOne(bnd binding) error {
 			slog.Error(err))
 	}
 	return err
-}
-
-// This is returned when the context is canceled on a running query. pq does not
-// export an error for this.
-func pqErrIsCanceled(err error) bool {
-	return err.Error() == "pq: canceling statement due to user request"
 }
 
 // storeBinding stores the latest binding, where we interpret node == nil as removing the binding. This keeps the map

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -424,7 +424,7 @@ func (b *binder) writeOne(bnd binding) error {
 	default:
 		panic("unhittable")
 	}
-	if err != nil {
+	if err != nil && !pqErrIsCanceled(err) {
 		b.logger.Error(b.ctx, "failed to write binding to database",
 			slog.F("client_id", bnd.client),
 			slog.F("agent_id", bnd.agent),
@@ -432,6 +432,12 @@ func (b *binder) writeOne(bnd binding) error {
 			slog.Error(err))
 	}
 	return err
+}
+
+// This is returned when the context is canceled on a running query. pq does not
+// export an error for this.
+func pqErrIsCanceled(err error) bool {
+	return err.Error() == "pq: canceling statement due to user request"
 }
 
 // storeBinding stores the latest binding, where we interpret node == nil as removing the binding. This keeps the map


### PR DESCRIPTION
I believe this is what has been causing the `TestReplicas` flakes. There's a race condition where if a query was in flight while the `pgcoord` was closing, it would log an error. The error log then fails the test since somewhere along the line we're creating a `slogtest` logger.

```
2023-07-19T19:24:06.0298417Z     t.go:90: 2023-07-19 19:23:32.297 [erro]  pgcoord: failed to write binding to database  coordinator_id=a1483bf7-e24c-448d-bac0-9ce888b85ce2  client_id=00000000-0000-0000-0000-000000000000  agent_id=e1e3daed-4b0d-49c8-a9c9-17abc48811e5  node=""  error="pq: canceling statement due to user request"
```