### PR TITLE
test(agent): fix `TestAgent_Metadata/Once` flake

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -339,6 +339,7 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 			if err != nil {
 				a.logger.Error(ctx, "agent failed to report metadata", slog.Error(err))
 			}
+			continue
 		case <-baseTicker.C:
 		}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -410,7 +410,9 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 						// Fallback to the report interval
 						timeout = interval
 					} else {
-						// If the interval is still 0, default to 5.
+						// If the interval is still 0 (possible if the interval
+						// is less than a second), default to 5. This was
+						// randomly picked.
 						timeout = 5
 					}
 				}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -344,7 +344,6 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case mr := <-metadataResults:
-
 			err := a.client.PostMetadata(ctx, mr.key, *mr.result)
 			if err != nil {
 				a.logger.Error(ctx, "agent failed to report metadata", slog.Error(err))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -337,7 +337,9 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case mr := <-metadataResults:
+			lastCollectedAtMu.Lock()
 			lastCollectedAts[mr.key] = mr.result.CollectedAt
+			lastCollectedAtMu.Unlock()
 			err := a.client.PostMetadata(ctx, mr.key, *mr.result)
 			if err != nil {
 				a.logger.Error(ctx, "agent failed to report metadata", slog.Error(err))
@@ -439,6 +441,7 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 					key:    md.Key,
 					result: a.collectMetadata(ctx, md),
 				}:
+					logger.Debug(ctx, "sent metadata")
 				}
 			})
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -337,7 +337,7 @@ func (a *agent) reportMetadataLoop(ctx context.Context) {
 	// a goroutine running for a given key. This is to prevent a build-up of
 	// goroutines waiting on Do when the script takes many multiples of
 	// baseInterval to run.
-	var flight = trySingleflight{m: map[string]struct{}{}}
+	flight := trySingleflight{m: map[string]struct{}{}}
 
 	for {
 		select {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1905,7 +1905,7 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 	})
 	statsCh := make(chan *agentsdk.Stats, 50)
 	fs := afero.NewMemMapFs()
-	c := agenttest.NewClient(t, logger, metadata.AgentID, metadata, statsCh, coordinator)
+	c := agenttest.NewClient(t, logger.Named("agent"), metadata.AgentID, metadata, statsCh, coordinator)
 
 	options := agent.Options{
 		Client:                 c,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1066,6 +1066,7 @@ func TestAgent_StartupScript(t *testing.T) {
 		t.Parallel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		client := agenttest.NewClient(t,
+			logger,
 			uuid.New(),
 			agentsdk.Manifest{
 				StartupScript: command,
@@ -1097,6 +1098,7 @@ func TestAgent_StartupScript(t *testing.T) {
 		t.Parallel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		client := agenttest.NewClient(t,
+			logger,
 			uuid.New(),
 			agentsdk.Manifest{
 				StartupScript: command,
@@ -1470,6 +1472,7 @@ func TestAgent_Lifecycle(t *testing.T) {
 		derpMap, _ := tailnettest.RunDERPAndSTUN(t)
 
 		client := agenttest.NewClient(t,
+			logger,
 			uuid.New(),
 			agentsdk.Manifest{
 				DERPMap:        derpMap,
@@ -1742,6 +1745,7 @@ func TestAgent_Reconnect(t *testing.T) {
 	statsCh := make(chan *agentsdk.Stats, 50)
 	derpMap, _ := tailnettest.RunDERPAndSTUN(t)
 	client := agenttest.NewClient(t,
+		logger,
 		agentID,
 		agentsdk.Manifest{
 			DERPMap: derpMap,
@@ -1776,6 +1780,7 @@ func TestAgent_WriteVSCodeConfigs(t *testing.T) {
 	defer coordinator.Close()
 
 	client := agenttest.NewClient(t,
+		logger,
 		uuid.New(),
 		agentsdk.Manifest{
 			GitAuthConfigs: 1,
@@ -1900,7 +1905,7 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 	})
 	statsCh := make(chan *agentsdk.Stats, 50)
 	fs := afero.NewMemMapFs()
-	c := agenttest.NewClient(t, metadata.AgentID, metadata, statsCh, coordinator)
+	c := agenttest.NewClient(t, logger, metadata.AgentID, metadata, statsCh, coordinator)
 
 	options := agent.Options{
 		Client:                 c,

--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -18,6 +18,7 @@ import (
 )
 
 func NewClient(t testing.TB,
+	logger slog.Logger,
 	agentID uuid.UUID,
 	manifest agentsdk.Manifest,
 	statsChan chan *agentsdk.Stats,
@@ -28,6 +29,7 @@ func NewClient(t testing.TB,
 	}
 	return &Client{
 		t:           t,
+		logger:      logger.Named("client"),
 		agentID:     agentID,
 		manifest:    manifest,
 		statsChan:   statsChan,
@@ -37,6 +39,7 @@ func NewClient(t testing.TB,
 
 type Client struct {
 	t                    testing.TB
+	logger               slog.Logger
 	agentID              uuid.UUID
 	manifest             agentsdk.Manifest
 	metadata             map[string]agentsdk.PostMetadataRequest
@@ -110,14 +113,16 @@ func (c *Client) GetLifecycleStates() []codersdk.WorkspaceAgentLifecycle {
 	return c.lifecycleStates
 }
 
-func (c *Client) PostLifecycle(_ context.Context, req agentsdk.PostLifecycleRequest) error {
+func (c *Client) PostLifecycle(ctx context.Context, req agentsdk.PostLifecycleRequest) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.lifecycleStates = append(c.lifecycleStates, req.State)
+	c.logger.Debug(ctx, "post lifecycle", slog.F("req", req))
 	return nil
 }
 
-func (*Client) PostAppHealth(_ context.Context, _ agentsdk.PostAppHealthsRequest) error {
+func (c *Client) PostAppHealth(ctx context.Context, req agentsdk.PostAppHealthsRequest) error {
+	c.logger.Debug(ctx, "post app health", slog.F("req", req))
 	return nil
 }
 
@@ -133,20 +138,22 @@ func (c *Client) GetMetadata() map[string]agentsdk.PostMetadataRequest {
 	return maps.Clone(c.metadata)
 }
 
-func (c *Client) PostMetadata(_ context.Context, key string, req agentsdk.PostMetadataRequest) error {
+func (c *Client) PostMetadata(ctx context.Context, key string, req agentsdk.PostMetadataRequest) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.metadata == nil {
 		c.metadata = make(map[string]agentsdk.PostMetadataRequest)
 	}
 	c.metadata[key] = req
+	c.logger.Debug(ctx, "post metadata", slog.F("key", key), slog.F("req", req))
 	return nil
 }
 
-func (c *Client) PostStartup(_ context.Context, startup agentsdk.PostStartupRequest) error {
+func (c *Client) PostStartup(ctx context.Context, startup agentsdk.PostStartupRequest) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.startup = startup
+	c.logger.Debug(ctx, "post startup", slog.F("req", startup))
 	return nil
 }
 
@@ -156,13 +163,14 @@ func (c *Client) GetStartupLogs() []agentsdk.StartupLog {
 	return c.logs
 }
 
-func (c *Client) PatchStartupLogs(_ context.Context, logs agentsdk.PatchStartupLogs) error {
+func (c *Client) PatchStartupLogs(ctx context.Context, logs agentsdk.PatchStartupLogs) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.PatchWorkspaceLogs != nil {
 		return c.PatchWorkspaceLogs()
 	}
 	c.logs = append(c.logs, logs.Logs...)
+	c.logger.Debug(ctx, "patch startup logs", slog.F("req", logs))
 	return nil
 }
 
@@ -173,9 +181,10 @@ func (c *Client) SetServiceBannerFunc(f func() (codersdk.ServiceBannerConfig, er
 	c.GetServiceBannerFunc = f
 }
 
-func (c *Client) GetServiceBanner(_ context.Context) (codersdk.ServiceBannerConfig, error) {
+func (c *Client) GetServiceBanner(ctx context.Context) (codersdk.ServiceBannerConfig, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.logger.Debug(ctx, "get service banner")
 	if c.GetServiceBannerFunc != nil {
 		return c.GetServiceBannerFunc()
 	}

--- a/coderd/tailnet_test.go
+++ b/coderd/tailnet_test.go
@@ -137,7 +137,7 @@ func setupAgent(t *testing.T, agentAddresses []netip.Prefix) (uuid.UUID, agent.A
 		_ = coord.Close()
 	})
 
-	c := agenttest.NewClient(t, manifest.AgentID, manifest, make(chan *agentsdk.Stats, 50), coord)
+	c := agenttest.NewClient(t, logger, manifest.AgentID, manifest, make(chan *agentsdk.Stats, 50), coord)
 
 	options := agent.Options{
 		Client:     c,


### PR DESCRIPTION
There's a race condition between checking `lastCollectedAts` and spawning the singleflight that could cause a metadata to execute multiple times, even if specified to run once. This moves the `lastCollectedAts` check to inside the singleflight to actually ensure the validity of the checks.

Also fixes an issue where the context timeout could be 0.

[Latest failure](https://github.com/coder/coder/actions/runs/5604743672/jobs/10253076364)