### PR TITLE
fix: remove extra parenthesis in deploy-pr.yaml

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   pr_commented:
-    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/deploy-pr') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')) || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/deploy-pr') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER') || github.event_name == 'workflow_dispatch'
     outputs:
       PR_NUMBER: ${{ steps.pr_number.outputs.PR_NUMBER }}
       PR_TITLE: ${{ steps.pr_number.outputs.PR_TITLE }}


### PR DESCRIPTION
Also, would you like to add more options for [`author_association`](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation)