### PR TITLE
chore: add offlinedocs to `ts` filter in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,7 @@ jobs:
             ts:
               - "site/**"
               - "Makefile"
+              - "offlinedocs/**"
             k8s:
               - "helm/**"
               - "scripts/Dockerfile"


### PR DESCRIPTION
This adds offlinedocs to `ts` filter in ci.yaml