### PR TITLE
chore: prevent running chromatic on all merged PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -543,7 +543,7 @@ jobs:
     # REMARK: this is only used to build storybook and deploy it to Chromatic.
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.ts == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    if: needs.changes.outputs.ts == 'true' || needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
As per discussion with @BrunoQuaresma, We want to reduce our chromatic costs and only want to run chromatic job on some merged PRs. This change will only run for PRs that target *.ts files.