### PR TITLE
ci: allow running other jobs in the matrix if one of them fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,6 +240,7 @@ jobs:
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest


### PR DESCRIPTION
I have observed a [Windows `test-pg` job](https://github.com/coder/coder/actions/runs/5612329012/job/15206182379) was canceled because the macOS test-go job failed. This will allow keeping other jobs running in the matrix. GitHub now allows only [running failed jobs](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs#re-running-failed-jobs-in-a-workflow), so it will save us some runner minutes given we have flaky tests.

Reference: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures