### PR TITLE
fix(cli/clistat): improve detection of container environment

### DIFF
--- a/cli/clistat/cgroup.go
+++ b/cli/clistat/cgroup.go
@@ -338,7 +338,7 @@ func readInt64Prefix(fs afero.Fs, path, prefix string) (int64, error) {
 
 	scn := bufio.NewScanner(bytes.NewReader(data))
 	for scn.Scan() {
-		line := scn.Text()
+		line := strings.TrimSpace(scn.Text())
 		if !strings.HasPrefix(line, prefix) {
 			continue
 		}

--- a/cli/clistat/container.go
+++ b/cli/clistat/container.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	procMounts    = "/proc/mounts"
-	procOneCgroup = "/proc/1/cgroup"
+	procMounts                           = "/proc/mounts"
+	procOneCgroup                        = "/proc/1/cgroup"
+	kubernetesDefaultServiceAccountToken = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 // IsContainerized returns whether the host is containerized.
@@ -36,6 +37,14 @@ func IsContainerized(fs afero.Fs) (ok bool, err error) {
 			bytes.Contains(line, []byte("kubepods")) {
 			return true, nil
 		}
+	}
+
+	// Sometimes the above method of sniffing /proc/1/cgroup isn't reliable.
+	// If a Kubernetes service account token is present, that's
+	// also a good indication that we are in a container.
+	_, err = afero.ReadFile(fs, kubernetesDefaultServiceAccountToken)
+	if err == nil {
+		return true, nil
 	}
 
 	// Last-ditch effort to detect Sysbox containers.

--- a/cli/clistat/container.go
+++ b/cli/clistat/container.go
@@ -12,7 +12,7 @@ import (
 const (
 	procMounts                           = "/proc/mounts"
 	procOneCgroup                        = "/proc/1/cgroup"
-	kubernetesDefaultServiceAccountToken = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	kubernetesDefaultServiceAccountToken = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec
 )
 
 // IsContainerized returns whether the host is containerized.


### PR DESCRIPTION
In some Kubernetes environments, `/proc/1/cgroup` just ends up as `0::/` which means the current logic falls down. The presence of a file under the path `/var/run/secrets/kubernetes.io/serviceaccount/token` is a good indicator of being run inside a container, so adding this as another detection method.