### PR TITLE
docs: add steps for postgres SSL cert config

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -179,6 +179,37 @@ In certain enterprise environments, the [Azure Application Gateway](https://lear
 - Websocket traffic (required for workspace connections)
 - TLS termination
 
+## PostgreSQL Certificates
+
+Your organization may require connecting to the database instance over SSL. To supply
+Coder with the appropriate certificates, and have it connect over SSL, follow the steps below:
+
+1. Create the certificate as a secret in your Kubernetes cluster, if not already present:
+
+```console
+$ kubectl create secret tls postgres-certs -n coder --key="postgres.key" --cert="postgres.crt"
+```
+
+1. Define the secret volume and volumeMounts in the Helm chart:
+
+```yaml
+coder:
+  volumes:
+  - name: "pg-certs-mount"
+    secret:
+      secretName: "postgres-certs"
+  volumeMounts:
+  - name: "pg-certs-mount"
+    mountPath: "$HOME/.postgresql"
+    readOnly: true
+```
+
+1. Lastly, your PG connection URL will look like:
+
+```console
+postgres://<user>:<password>@databasehost:<port>/<db-name>?sslmode=require&sslcert=$HOME/.postgresql/postgres.crt&sslkey=$HOME/.postgresql/postgres.key"
+```
+
 ## Upgrading Coder via Helm
 
 To upgrade Coder in the future or change values,

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -209,6 +209,7 @@ coder:
 ```console
 postgres://<user>:<password>@databasehost:<port>/<db-name>?sslmode=require&sslcert=$HOME/.postgresql/postgres.crt&sslkey=$HOME/.postgresql/postgres.key"
 ```
+
 > More information on connecting to PostgreSQL databases using certificates can be found [here](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-CLIENTCERT).
 
 ## Upgrading Coder via Helm

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -209,6 +209,7 @@ coder:
 ```console
 postgres://<user>:<password>@databasehost:<port>/<db-name>?sslmode=require&sslcert=$HOME/.postgresql/postgres.crt&sslkey=$HOME/.postgresql/postgres.key"
 ```
+> More information on connecting to PostgreSQL databases using certificates can be found [here](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-CLIENTCERT).
 
 ## Upgrading Coder via Helm
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -195,13 +195,13 @@ $ kubectl create secret tls postgres-certs -n coder --key="postgres.key" --cert=
 ```yaml
 coder:
   volumes:
-  - name: "pg-certs-mount"
-    secret:
-      secretName: "postgres-certs"
+    - name: "pg-certs-mount"
+      secret:
+        secretName: "postgres-certs"
   volumeMounts:
-  - name: "pg-certs-mount"
-    mountPath: "$HOME/.postgresql"
-    readOnly: true
+    - name: "pg-certs-mount"
+      mountPath: "$HOME/.postgresql"
+      readOnly: true
 ```
 
 1. Lastly, your PG connection URL will look like:


### PR DESCRIPTION
this PR documents configuration steps for connecting a Helm-based Coder install to postgreSQL via SSL using mounted certificates.