### PR TITLE
fix(coderd): fix template insight intervals

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -2326,10 +2326,13 @@ func (q *FakeQuerier) GetUserLatencyInsights(_ context.Context, arg database.Get
 		if len(arg.TemplateIDs) > 0 && !slices.Contains(arg.TemplateIDs, s.TemplateID) {
 			continue
 		}
-		if !arg.StartTime.Equal(s.CreatedAt) && !(s.CreatedAt.After(arg.StartTime) && s.CreatedAt.Before(arg.EndTime)) {
+		if !arg.StartTime.Equal(s.CreatedAt) && (s.CreatedAt.Before(arg.StartTime) || s.CreatedAt.After(arg.EndTime)) {
 			continue
 		}
 		if s.ConnectionCount == 0 {
+			continue
+		}
+		if s.ConnectionMedianLatencyMS <= 0 {
 			continue
 		}
 

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -168,11 +168,17 @@ func TestUserLatencyInsights(t *testing.T) {
 	defer r.Close()
 	defer w.Close()
 	sess.Stdin = r
+	sess.Stdout = io.Discard
 	err = sess.Start("cat")
 	require.NoError(t, err)
 
 	var userLatencies codersdk.UserLatencyInsightsResponse
 	require.Eventuallyf(t, func() bool {
+		// Keep connection active.
+		_, err := w.Write([]byte("hello world\n"))
+		if !assert.NoError(t, err) {
+			return false
+		}
 		userLatencies, err = client.UserLatencyInsights(ctx, codersdk.UserLatencyInsightsRequest{
 			StartTime:   today,
 			EndTime:     time.Now().UTC().Truncate(time.Hour).Add(time.Hour), // Round up to include the current hour.

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -182,7 +182,7 @@ func TestUserLatencyInsights(t *testing.T) {
 			return false
 		}
 		return len(userLatencies.Report.Users) > 0 && userLatencies.Report.Users[0].LatencyMS.P50 > 0
-	}, testutil.WaitShort, testutil.IntervalFast, "user latency is missing")
+	}, testutil.WaitMedium, testutil.IntervalFast, "user latency is missing")
 
 	// We got our latency data, close the connection.
 	_ = sess.Close()
@@ -318,8 +318,8 @@ func TestTemplateInsights(t *testing.T) {
 			return false
 		}
 	}
-	require.Eventually(t, waitForAppSeconds("reconnecting-pty"), testutil.WaitShort, testutil.IntervalFast, "reconnecting-pty seconds missing")
-	require.Eventually(t, waitForAppSeconds("ssh"), testutil.WaitShort, testutil.IntervalFast, "ssh seconds missing")
+	require.Eventually(t, waitForAppSeconds("reconnecting-pty"), testutil.WaitMedium, testutil.IntervalFast, "reconnecting-pty seconds missing")
+	require.Eventually(t, waitForAppSeconds("ssh"), testutil.WaitMedium, testutil.IntervalFast, "ssh seconds missing")
 
 	// We got our data, close down sessions and connections.
 	_ = rpty.Close()


### PR DESCRIPTION
For a range like `start_time=2023-07-20T00:00:00Z` and `end_time=2023-07-21T00:00:00Z`, `generate_series` created an additional range with `start_time=2023-07-21T00:00:00Z` and `end_time=2023-07-22T00:00:00Z` (outside the range). We fix this by subracting one second from the end time.

The interval report query also had a bug in how relevant template_ids were being selected.
