### PR TITLE
fix: prevent repetition of template IDs in `template_usage_by_day`

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1399,21 +1399,17 @@ WITH d AS (
 	)
 	GROUP BY ts.from_, ts.to_, was.user_id
 ), template_ids AS (
-	SELECT
-		template_usage_by_day.from_,
-		array_agg(DISTINCT id) AS ids
-	FROM (
-		SELECT template_usage_by_day_unnested.from_, unnest(ids) AS id
-		FROM (
-			SELECT DISTINCT
-				from_,
-				array_agg(DISTINCT template_id) AS ids
-			FROM usage_by_day, unnest(template_ids) template_id
-			WHERE template_id IS NOT NULL
-			GROUP BY from_, template_ids
-		) AS template_usage_by_day_unnested
-	) AS template_usage_by_day
-	GROUP BY template_usage_by_day.from_
+    SELECT
+        template_usage_by_day.from_,
+        array_agg(template_id) AS ids
+    FROM (
+        SELECT DISTINCT
+            from_,
+            unnest(template_ids) AS template_id
+        FROM usage_by_day
+        WHERE usage_by_day.template_ids IS NOT NULL
+    ) AS template_usage_by_day
+    GROUP BY template_usage_by_day.from_
 )
 
 SELECT

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1400,11 +1400,20 @@ WITH d AS (
 	GROUP BY ts.from_, ts.to_, was.user_id
 ), template_ids AS (
 	SELECT
-		from_,
-		array_agg(DISTINCT template_id) AS ids
-	FROM usage_by_day, unnest(template_ids) template_id
-	WHERE template_id IS NOT NULL
-	GROUP BY from_, template_ids
+		template_usage_by_day.from_,
+		array_agg(DISTINCT id) AS ids
+	FROM (
+		SELECT template_usage_by_day_unnested.from_, unnest(ids) AS id
+		FROM (
+			SELECT DISTINCT
+				from_,
+				array_agg(DISTINCT template_id) AS ids
+			FROM usage_by_day, unnest(template_ids) template_id
+			WHERE template_id IS NOT NULL
+			GROUP BY from_, template_ids
+		) AS template_usage_by_day_unnested
+	) AS template_usage_by_day
+	GROUP BY template_usage_by_day.from_
 )
 
 SELECT

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1407,8 +1407,8 @@ WITH d AS (
 			from_,
 			unnest(template_ids) AS template_id
 		FROM usage_by_day
-		WHERE usage_by_day.template_ids IS NOT NULL
 	) AS template_usage_by_day
+	WHERE template_id IS NOT NULL
 	GROUP BY template_usage_by_day.from_
 )
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1399,17 +1399,17 @@ WITH d AS (
 	)
 	GROUP BY ts.from_, ts.to_, was.user_id
 ), template_ids AS (
-    SELECT
-        template_usage_by_day.from_,
-        array_agg(template_id) AS ids
-    FROM (
-        SELECT DISTINCT
-            from_,
-            unnest(template_ids) AS template_id
-        FROM usage_by_day
-        WHERE usage_by_day.template_ids IS NOT NULL
-    ) AS template_usage_by_day
-    GROUP BY template_usage_by_day.from_
+	SELECT
+		template_usage_by_day.from_,
+		array_agg(template_id) AS ids
+	FROM (
+		SELECT DISTINCT
+			from_,
+			unnest(template_ids) AS template_id
+		FROM usage_by_day
+		WHERE usage_by_day.template_ids IS NOT NULL
+	) AS template_usage_by_day
+	GROUP BY template_usage_by_day.from_
 )
 
 SELECT

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -95,17 +95,13 @@ WITH d AS (
 ), template_ids AS (
 	SELECT
 		template_usage_by_day.from_,
-		array_agg(DISTINCT id) AS ids
+		array_agg(template_id) AS ids
 	FROM (
-		SELECT template_usage_by_day_unnested.from_, unnest(ids) AS id
-		FROM (
-			SELECT DISTINCT
-				from_,
-				array_agg(DISTINCT template_id) AS ids
-			FROM usage_by_day, unnest(template_ids) template_id
-			WHERE template_id IS NOT NULL
-			GROUP BY from_, template_ids
-		) AS template_usage_by_day_unnested
+		SELECT DISTINCT
+			from_,
+			template_id
+		FROM usage_by_day, unnest(template_ids) template_id
+		WHERE template_id IS NOT NULL
 	) AS template_usage_by_day
 	GROUP BY template_usage_by_day.from_
 )

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -95,7 +95,7 @@ WITH d AS (
 ), template_ids AS (
 	SELECT
 		template_usage_by_day.from_,
-		array_agg(template_id) AS ids
+		array_agg(template_usage_by_day.template_id) AS ids
 	FROM (
 		SELECT DISTINCT
 			from_,

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -101,8 +101,8 @@ WITH d AS (
 			from_,
 			unnest(template_ids) AS template_id
 		FROM usage_by_day
-		WHERE usage_by_day.template_ids IS NOT NULL
 	) AS template_usage_by_day
+	WHERE template_id IS NOT NULL
 	GROUP BY template_usage_by_day.from_
 )
 

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -95,10 +95,19 @@ WITH d AS (
 ), template_ids AS (
 	SELECT
 		from_,
-		array_agg(DISTINCT template_id) AS ids
-	FROM usage_by_day, unnest(template_ids) template_id
-	WHERE template_id IS NOT NULL
-	GROUP BY from_, template_ids
+		array_agg(DISTINCT id) AS ids
+	FROM (
+		SELECT from_, unnest(ids) AS id
+		FROM (
+			SELECT DISTINCT
+				from_,
+				array_agg(DISTINCT template_id) AS ids
+			FROM usage_by_day, unnest(template_ids) template_id
+			WHERE template_id IS NOT NULL
+			GROUP BY from_, template_ids
+		) AS template_usage_by_day_unnested
+	) AS template_usage_by_day
+	GROUP BY from_
 )
 
 SELECT

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -93,17 +93,17 @@ WITH d AS (
 	)
 	GROUP BY ts.from_, ts.to_, was.user_id
 ), template_ids AS (
-    SELECT
-        template_usage_by_day.from_,
-        array_agg(template_id) AS ids
-    FROM (
-        SELECT DISTINCT
-            from_,
-            unnest(template_ids) AS template_id
-        FROM usage_by_day
-        WHERE usage_by_day.template_ids IS NOT NULL
-    ) AS template_usage_by_day
-    GROUP BY template_usage_by_day.from_
+	SELECT
+		template_usage_by_day.from_,
+		array_agg(template_id) AS ids
+	FROM (
+		SELECT DISTINCT
+			from_,
+			unnest(template_ids) AS template_id
+		FROM usage_by_day
+		WHERE usage_by_day.template_ids IS NOT NULL
+	) AS template_usage_by_day
+	GROUP BY template_usage_by_day.from_
 )
 
 SELECT

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -93,17 +93,17 @@ WITH d AS (
 	)
 	GROUP BY ts.from_, ts.to_, was.user_id
 ), template_ids AS (
-	SELECT
-		template_usage_by_day.from_,
-		array_agg(template_usage_by_day.template_id) AS ids
-	FROM (
-		SELECT DISTINCT
-			from_,
-			template_id
-		FROM usage_by_day, unnest(template_ids) template_id
-		WHERE template_id IS NOT NULL
-	) AS template_usage_by_day
-	GROUP BY template_usage_by_day.from_
+    SELECT
+        template_usage_by_day.from_,
+        array_agg(template_id) AS ids
+    FROM (
+        SELECT DISTINCT
+            from_,
+            unnest(template_ids) AS template_id
+        FROM usage_by_day
+        WHERE usage_by_day.template_ids IS NOT NULL
+    ) AS template_usage_by_day
+    GROUP BY template_usage_by_day.from_
 )
 
 SELECT

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -94,10 +94,10 @@ WITH d AS (
 	GROUP BY ts.from_, ts.to_, was.user_id
 ), template_ids AS (
 	SELECT
-		from_,
+		template_usage_by_day.from_,
 		array_agg(DISTINCT id) AS ids
 	FROM (
-		SELECT from_, unnest(ids) AS id
+		SELECT template_usage_by_day_unnested.from_, unnest(ids) AS id
 		FROM (
 			SELECT DISTINCT
 				from_,
@@ -107,7 +107,7 @@ WITH d AS (
 			GROUP BY from_, template_ids
 		) AS template_usage_by_day_unnested
 	) AS template_usage_by_day
-	GROUP BY from_
+	GROUP BY template_usage_by_day.from_
 )
 
 SELECT


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/8690

Here is the dump from [template_ids](https://github.com/coder/coder/blob/0f915e1e752b5607f4118170be84cfaa1869c44f/coderd/database/queries/insights.sql#L95):

```
coder-# SELECT * FROM template_ids;
         from_          |                                     ids                                     
------------------------+-----------------------------------------------------------------------------
 2023-07-19 00:00:00+00 | {0d286645-29aa-4eaf-9b52-cc5d2740c90b}
 2023-07-20 00:00:00+00 | {071f39f5-d956-44b0-8849-7715059e2b2e,0d286645-29aa-4eaf-9b52-cc5d2740c90b}
 2023-07-20 00:00:00+00 | {0d286645-29aa-4eaf-9b52-cc5d2740c90b}
 2023-07-21 00:00:00+00 | {071f39f5-d956-44b0-8849-7715059e2b2e,0d286645-29aa-4eaf-9b52-cc5d2740c90b}
 2023-07-21 00:00:00+00 | {0d286645-29aa-4eaf-9b52-cc5d2740c90b}
 2023-07-22 00:00:00+00 | {0d286645-29aa-4eaf-9b52-cc5d2740c90b}
(6 rows)
```

We need to have distinct records for every day in `from_`, otherwise [this part of the query](https://github.com/coder/coder/blob/0f915e1e752b5607f4118170be84cfaa1869c44f/coderd/database/queries/insights.sql#L107) fails with `more than one row returned by a subquery used as an expression`.
