### PR TITLE
feat(coderd/tracing): allow configuring trace sample

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9665,6 +9665,9 @@ const docTemplate = `{
                 },
                 "honeycomb_api_key": {
                     "type": "string"
+                },
+                "sample_percent": {
+                    "type": "integer"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8731,6 +8731,9 @@
         },
         "honeycomb_api_key": {
           "type": "string"
+        },
+        "sample_percent": {
+          "type": "integer"
         }
       }
     },

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1193,4 +1193,3 @@ ALTER TABLE ONLY workspaces
 
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_template_id_fkey FOREIGN KEY (template_id) REFERENCES templates(id) ON DELETE RESTRICT;
-

--- a/coderd/tracing/exporter.go
+++ b/coderd/tracing/exporter.go
@@ -78,7 +78,7 @@ func TracerProvider(ctx context.Context, service string, opts TracerOpts) (*sdkt
 	} else if opts.SamplePercent >= 100 {
 		sampler = sdktrace.AlwaysSample()
 	} else {
-		rat := float64(100) / opts.SamplePercent
+		rat := float64(opts.SamplePercent) / 100.0
 		sampler = sdktrace.ParentBased(sdktrace.TraceIDRatioBased(rat))
 	}
 	tracerOpts = append(tracerOpts, sdktrace.WithSampler(sampler))

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -298,6 +298,7 @@ type TraceConfig struct {
 	Enable          clibase.Bool   `json:"enable" typescript:",notnull"`
 	HoneycombAPIKey clibase.String `json:"honeycomb_api_key" typescript:",notnull"`
 	CaptureLogs     clibase.Bool   `json:"capture_logs" typescript:",notnull"`
+	SamplePercent   clibase.Int64  `json:"sample_percent" typescript:",notnull"`
 }
 
 type GitAuthConfig struct {
@@ -1122,6 +1123,18 @@ when required by your organization's security policy.`,
 			Value:       &c.Trace.CaptureLogs,
 			Group:       &deploymentGroupIntrospectionTracing,
 			YAML:        "captureLogs",
+			Annotations: clibase.Annotations{}.Mark(annotationExternalProxies, "true"),
+		},
+		{
+			Name: "Trace Sample Percentage",
+			Description: "Sample a percentage of traces. This is useful if your" +
+				" deployment produces a large amount of traces. Should be a whole " +
+				"number between 0 and 100.",
+			Flag:        "trace-sample-percent",
+			Env:         "CODER_TRACE_SAMPLE_PERCENT",
+			Value:       &c.Trace.SamplePercent,
+			Group:       &deploymentGroupIntrospectionTracing,
+			YAML:        "samplePercent",
 			Annotations: clibase.Annotations{}.Mark(annotationExternalProxies, "true"),
 		},
 		// Provisioner settings

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -367,7 +367,8 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "trace": {
       "capture_logs": true,
       "enable": true,
-      "honeycomb_api_key": "string"
+      "honeycomb_api_key": "string",
+      "sample_percent": 0
     },
     "update_check": true,
     "user_quiet_hours_schedule": {

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2094,7 +2094,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "trace": {
       "capture_logs": true,
       "enable": true,
-      "honeycomb_api_key": "string"
+      "honeycomb_api_key": "string",
+      "sample_percent": 0
     },
     "update_check": true,
     "user_quiet_hours_schedule": {
@@ -2447,7 +2448,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "trace": {
     "capture_logs": true,
     "enable": true,
-    "honeycomb_api_key": "string"
+    "honeycomb_api_key": "string",
+    "sample_percent": 0
   },
   "update_check": true,
   "user_quiet_hours_schedule": {
@@ -4577,7 +4579,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 {
   "capture_logs": true,
   "enable": true,
-  "honeycomb_api_key": "string"
+  "honeycomb_api_key": "string",
+  "sample_percent": 0
 }
 ```
 
@@ -4588,6 +4591,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `capture_logs`      | boolean | false    |              |             |
 | `enable`            | boolean | false    |              |             |
 | `honeycomb_api_key` | string  | false    |              |             |
+| `sample_percent`    | integer | false    |              |             |
 
 ## codersdk.TransitionStats
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1050,6 +1050,7 @@ export interface TraceConfig {
   readonly enable: boolean
   readonly honeycomb_api_key: string
   readonly capture_logs: boolean
+  readonly sample_percent: number
 }
 
 // From codersdk/templates.go


### PR DESCRIPTION
When tracing, it's often useful to enable sampling so that you don't end up throwing every single trace at your backend. This can help reduce costs.

https://opentelemetry.io/docs/instrumentation/go/sampling/

https://next.redhat.com/2021/10/20/opentelemetry-tracing-in-kubernetes-core/

Note from `WithSampler()`:

```
// This option overrides the Sampler configured through the OTEL_TRACES_SAMPLER
// and OTEL_TRACES_SAMPLER_ARG environment variables. If this option is not used
// and the sampler is not configured through environment variables or the environment
// contains invalid/unsupported configuration, the TracerProvider will use a
// ParentBased(AlwaysSample) Sampler by default.
```