### PR TITLE
fix: hide experiment CTA from OIDC copy

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1521,7 +1521,7 @@ func clearOAuthConvertCookie() *http.Cookie {
 func wrongLoginTypeHTTPError(user database.LoginType, params database.LoginType) httpError {
 	addedMsg := ""
 	if user == database.LoginTypePassword {
-		addedMsg = " You can convert your account to use this login type by visiting your account settings."
+		addedMsg = " Try logging in with your password."
 	}
 	return httpError{
 		code:             http.StatusForbidden,


### PR DESCRIPTION
Since the feature is experimental, we should not instruct users to change their login type. Of course, this should be reverted once it is moved out of `CODER_EXPERIMENTS` (#8327). 