### PR TITLE
feat(helm)!: set enableDeployments default to true

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -75,7 +75,7 @@ coder:
     workspacePerms: true
     # coder.serviceAccount.enableDeployments -- Provides the service account permission
     # to manage Kubernetes deployments.
-    enableDeployments: false
+    enableDeployments: true
     # coder.serviceAccount.annotations -- The Coder service account annotations.
     annotations: {}
     # coder.serviceAccount.name -- The service account name


### PR DESCRIPTION
as we move toward rolling out [logstream-kube solution](https://github.com/coder/coder-logstream-kube), setting `enableDeployments: true` as the default will remove a step for customers who are looking to migrate workspace to Deployments.

**NOTE**: this is a breaking change in our Helm chart.