### PR TITLE
feat(cli): add --var shorthand for --variable

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -171,6 +171,11 @@ func (r *RootCmd) templateCreate() *clibase.Cmd {
 			Value:       clibase.StringArrayOf(&variables),
 		},
 		{
+			Flag:        "var",
+			Description: "Alias of --variable.",
+			Value:       clibase.StringArrayOf(&variables),
+		},
+		{
 			Flag:        "provisioner-tag",
 			Description: "Specify a set of tags to target provisioner daemons.",
 			Value:       clibase.StringArrayOf(&provisionerTags),

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -292,6 +292,11 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 			Value:       clibase.StringArrayOf(&variables),
 		},
 		{
+			Flag:        "var",
+			Description: "Alias of --variable.",
+			Value:       clibase.StringArrayOf(&variables),
+		},
+		{
 			Flag:        "provisioner-tag",
 			Description: "Specify a set of tags to target provisioner daemons.",
 			Value:       clibase.StringArrayOf(&provisionerTags),

--- a/cli/testdata/coder_templates_create_--help.golden
+++ b/cli/testdata/coder_templates_create_--help.golden
@@ -34,6 +34,9 @@ Create a template from the current directory or as specified by flag
       --provisioner-tag string-array
           Specify a set of tags to target provisioner daemons.
 
+      --var string-array
+          Alias of --variable.
+
       --variable string-array
           Specify a set of values for Terraform-managed variables.
 

--- a/cli/testdata/coder_templates_push_--help.golden
+++ b/cli/testdata/coder_templates_push_--help.golden
@@ -32,6 +32,9 @@ Push a new template version from the current directory or as specified by flag
       --provisioner-tag string-array
           Specify a set of tags to target provisioner daemons.
 
+      --var string-array
+          Alias of --variable.
+
       --variable string-array
           Specify a set of values for Terraform-managed variables.
 

--- a/docs/cli/templates_create.md
+++ b/docs/cli/templates_create.md
@@ -81,6 +81,14 @@ Disable the default behavior of granting template access to the 'everyone' group
 
 Specify a set of tags to target provisioner daemons.
 
+### --var
+
+|      |                           |
+| ---- | ------------------------- |
+| Type | <code>string-array</code> |
+
+Alias of --variable.
+
 ### --variable
 
 |      |                           |

--- a/docs/cli/templates_push.md
+++ b/docs/cli/templates_push.md
@@ -80,6 +80,14 @@ Specify a name for the new template version. It will be automatically generated 
 
 Specify a set of tags to target provisioner daemons.
 
+### --var
+
+|      |                           |
+| ---- | ------------------------- |
+| Type | <code>string-array</code> |
+
+Alias of --variable.
+
 ### --variable
 
 |      |                           |

--- a/docs/platforms/jfrog.md
+++ b/docs/platforms/jfrog.md
@@ -62,10 +62,10 @@ provider "artifactory" {
 }
 ```
 
-When pushing the template, you can pass in the variables using the `--variable` flag:
+When pushing the template, you can pass in the variables using the `-V` flag:
 
 ```sh
-coder templates push --variable 'jfrog_url=https://YYY.jfrog.io' --variable 'artifactory_access_token=XXX'
+coder templates push --var 'jfrog_url=https://YYY.jfrog.io' --var 'artifactory_access_token=XXX'
 ```
 
 ## Installing jf

--- a/examples/templates/envbox/README.md
+++ b/examples/templates/envbox/README.md
@@ -35,10 +35,10 @@ Coder. Consult the [migration](https://coder.com/docs/v2/latest/templates/parame
 documentation for details on how to do so.
 
 To supply values to existing existing Terraform variables you can specify the
-`--variable` flag. For example
+`-V` flag. For example
 
 ```bash
-coder templates create envbox --variable namespace="mynamespace" --variable max_cpus=2 --variable min_cpus=1 --variable max_memory=4 --variable min_memory=1
+coder templates create envbox --var namespace="mynamespace" --var max_cpus=2 --var min_cpus=1 --var max_memory=4 --var min_memory=1
 ```
 
 ## Contributions

--- a/examples/templates/fly-docker-image/README.md
+++ b/examples/templates/fly-docker-image/README.md
@@ -22,8 +22,8 @@ This template provisions a [code-server](https://github.com/coder/code-server) i
 
 ```bash
 coder templates create fly-docker-image \
-  --variable fly_api_token=$(flyctl auth token) \
-  --variable fly_org=personal
+  --var fly_api_token=$(flyctl auth token) \
+  --var fly_org=personal
 ```
 
 > If the Coder server is also running as a fly.io app, then instead of setting variable `fly_api_token` you can also set a fly.io secret with the name `FLY_API_TOKEN`


### PR DESCRIPTION
feat(cli): add --var shorthand for --variable

`--variable` is used frequently enough to deserve a shorthand. Unfortunately,
`-v` is taken by verbose, and `-V` is too easily confused with version or
verbose, so we're left with "--var".
