### PR TITLE
chore: update nix flake to include sqlc v1.19.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1689850295,
-        "narHash": "sha256-fUYf6WdQlhd2H+3aR8jST5dhFH1d0eE22aes8fNIfyk=",
+        "lastModified": 1690179384,
+        "narHash": "sha256-+arbgqFTAtoeKtepW9wCnA0njCOyoiDFyl0Q0SBSOtE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5df4d78d54f7a34e9ea1f84a22b4fd9baebc68d0",
+        "rev": "b12803b6d90e2e583429bb79b859ca53c348b39a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/245006

This PR updates dependency on sqlc v1.19.1 as currently `make gen` fails with:

```
generate
models.go:16:2: no required module provides package github.com/tabbed/pqtype; to add it:
	go get github.com/tabbed/pqtype
make: *** [Makefile:511: coderd/database/querier.go] Error 1
make: *** Deleting file 'coderd/database/querier.go
```