### PR TITLE
fix: checkout correct branch for PR deployment

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -86,9 +86,23 @@ jobs:
       CODER_IMAGE_TAG: ${{ needs.pr_commented.outputs.coder_image_tag }}
       PR_NUMBER: ${{ needs.pr_commented.outputs.pr_number }}
     steps:
+      - name: Get PR branch name
+        id: pr_branch
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pr = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ env.PR_NUMBER }}
+            });
+            return pr.data.head.ref;
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ steps.pr_branch.outputs.result }}
           fetch-depth: 0
 
       - name: Setup Node

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -28,26 +28,29 @@ jobs:
       PR_NUMBER: ${{ steps.pr_number.outputs.PR_NUMBER }}
       PR_TITLE: ${{ steps.pr_number.outputs.PR_TITLE }}
       PR_URL: ${{ steps.pr_number.outputs.PR_URL }}
+      PR_BRANCH: ${{ steps.pr_number.outputs.PR_BRANCH }}
       COMMENT_ID: ${{ steps.comment_id.outputs.comment-id }}
       CODER_BASE_IMAGE_TAG: ${{ steps.set_tags.outputs.CODER_BASE_IMAGE_TAG }}
       CODER_IMAGE_TAG: ${{ steps.set_tags.outputs.CODER_IMAGE_TAG }}
 
     runs-on: "ubuntu-latest"
     steps:
-      - name: Get PR number and title
+      - name: Get PR number, title, and branch name
         id: pr_number
         run: |
           set -euxo pipefail
           if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
             PR_NUMBER=${{ github.event.inputs.pr_number }}
-            PR_TITLE=$(curl -sSL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/coder/coder/pulls/$PR_NUMBER" | jq -r '.title')
+            PR_TITLE=$(gh pr view $PR_NUMBER --json title | jq -r '.title')
           else
             PR_NUMBER=${{ github.event.issue.number }}
             PR_TITLE='${{ github.event.issue.title }}'
           fi
+          PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName | jq -r '.headRefName')
           echo "PR_URL=https://github.com/coder/coder/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_OUTPUT
+          echo "PR_BRANCH=$PR_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Set required tags
         id: set_tags
@@ -85,24 +88,12 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       CODER_IMAGE_TAG: ${{ needs.pr_commented.outputs.coder_image_tag }}
       PR_NUMBER: ${{ needs.pr_commented.outputs.pr_number }}
+      PR_BRANCH: ${{ needs.pr_commented.outputs.pr_branch }}
     steps:
-      - name: Get PR branch name
-        id: pr_branch
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const pr = await github.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: ${{ env.PR_NUMBER }}
-            });
-            return pr.data.head.ref;
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.pr_branch.outputs.result }}
+          ref: ${{ env.PR_BRANCH }}
           fetch-depth: 0
 
       - name: Setup Node


### PR DESCRIPTION
@BrunoQuaresma noticed that `deploy-pr.yaml` was deploying the latest main instead of the PR branch.

By default `actions/checkout` fetches the current branch of PR, but only if the vent trigger is a PR. Here event trigger is `issue_comment` or `workflow_dispatch` so we need to add a branch name specifically.
```yaml
uses: actions/checkout@v3
with:
+ ref: branch-name
  fetch-depth: 0
```
