### PR TITLE
chore(scripts): use fake semver when using sapling

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -17,7 +17,7 @@ cdroot
 
 # If in Sapling, just print the commit since we don't have tags.
 if [ -d ".sl" ]; then
-	sl log -l 1 | awk '/changeset/ { print substr($2, 0, 16) }'
+	sl log -l 1 | awk '/changeset/ { printf "0.0.0+sl-%s\n", substr($2, 0, 16) }'
 	exit 0
 fi
 


### PR DESCRIPTION
chore(scripts): use fake semver when using sapling

The fact that the Sapling commit didn't conform to semver
broke the agent handshake with coderd.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/coder/coder/pull/8747).
* #8748
* __->__ #8747