### PR TITLE
chore: fix `Test_parseInsightsStartAndEndTime` test

### DIFF
--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -69,7 +69,7 @@ func Test_parseInsightsStartAndEndTime(t *testing.T) {
 				endTime:   thisHourRoundUp.Format(layout),
 			},
 			wantStartTime: time.Date(2023, 7, today.Day(), 0, 0, 0, 0, time.UTC),
-			wantEndTime:   time.Date(2023, 7, today.Day(), thisHourRoundUp.Hour(), 0, 0, 0, time.UTC),
+			wantEndTime:   time.Date(2023, 7, thisHourRoundUp.Day(), thisHourRoundUp.Hour(), 0, 0, 0, time.UTC),
 			wantOk:        true,
 		},
 		{


### PR DESCRIPTION
It would always fail between 23:00-00:00 UTC (which it currently is).