### PR TITLE
fix: fix coder stat mem

### DIFF
--- a/cli/clistat/cgroup.go
+++ b/cli/clistat/cgroup.go
@@ -22,7 +22,7 @@ const (
 	// CFS period for cgroup in MICROseconds
 	cgroupV1CFSPeriodUs = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
 	// Maximum memory usable by cgroup in bytes
-	cgroupV1MemoryMaxUsageBytes = "/sys/fs/cgroup/memory/memory.max_usage_in_bytes"
+	cgroupV1MemoryMaxUsageBytes = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 	// Current memory usage of cgroup in bytes
 	cgroupV1MemoryUsageBytes = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
 	// Other memory stats - we are interested in total_inactive_file


### PR DESCRIPTION
- For cgroups v1 the wrong cgroup file was being read to determine max memory. This commit updates the file from '/sys/fs/cgroup/memory/memory.max_usage_in_bytes' to '/sys/fs/cgroup/memory/memory.limit_in_bytes'

![image](https://github.com/coder/coder/assets/4856196/f0aa75bd-d8fb-4364-93b8-6519d509cd9a)

fixes #8592