### PR TITLE
ci: further improve pr deployments

### DIFF
--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,4 +1,4 @@
-name: Cleanup PR
+name: Cleanup PR deployment and image
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -1,4 +1,4 @@
-# This action will trigger when a PR is commentted containing /review-pr by a member of the org.
+# This action will trigger when a PR is commented on with `/deploy` or when the workflow is manually triggered.
 name: Deploy PR
 on:
   issue_comment:

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -1,4 +1,4 @@
-# This action will trigger when a PR is commented on with `/deploy` or when the workflow is manually triggered.
+# This action will trigger when a PR is commented on with `/deploy-pr` or when the workflow is manually triggered.
 name: Deploy PR
 on:
   issue_comment:

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -61,8 +61,8 @@ if $dryRun; then
 	echo "branchName: ${branchName}"
 	echo "prNumber: ${prNumber}"
 	echo "skipBuild: ${skipBuild}"
-	echo "gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}""
+	echo "gh workflow run pr-deploy.yaml --ref ${branchName} -f pr_number=${prNumber} -f skip_build=${skipBuild}"
 	exit 0
 fi
 
-gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}"
+gh workflow run pr-deploy.yaml --ref ${branchName} -f pr_number=${prNumber} -f skip_build=${skipBuild}

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Usage: ./deploy-pr.sh  --skip-build
+# Usage: ./deploy-pr.sh  --skip-build[os -s] --dry-run[or -n] --yes[or -y]
 # deploys the current branch to a PR environment and posts login credentials to
 # [#pr-deployments](https://codercom.slack.com/archives/C05DNE982E8) Slack channel
 # if --skip-build is passed, the build step will be skipped and the last build image will be used
@@ -19,7 +19,7 @@ fi
 branchName=$(gh pr view --json headRefName | jq -r .headRefName)
 prNumber=$(gh pr view --json number | jq -r .number)
 
-if [[ "$*" == *--skip-build* ]]; then
+if [[ "$*" == *--skip-build* ]] || [[ "$*" == *-s* ]]; then
 	skipBuild=true
 	#check if the image exists
 	foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1) || true

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -11,34 +11,33 @@ dryRun=false
 confirm=true
 
 # parse arguments
-for arg in "$@"
-do
-    case $arg in
-        -s|--skip-build)
-        skipBuild=true
-        shift # Remove --skip-build from processing
-        ;;
-        -n|--dry-run)
-        dryRun=true
-        shift # Remove --dry-run from processing
-        ;;
-        -y|--yes)
-        confirm=false
-        shift # Remove --yes from processing
-        ;;
-        *)
-        shift # Remove generic argument from processing
-        ;;
-    esac
+for arg in "$@"; do
+	case $arg in
+	-s | --skip-build)
+		skipBuild=true
+		shift # Remove --skip-build from processing
+		;;
+	-n | --dry-run)
+		dryRun=true
+		shift # Remove --dry-run from processing
+		;;
+	-y | --yes)
+		confirm=false
+		shift # Remove --yes from processing
+		;;
+	*)
+		shift # Remove generic argument from processing
+		;;
+	esac
 done
 
 # confirm if not passed -y or --yes
 if $confirm; then
-    read -p "Are you sure you want to deploy? (y/n) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
-    fi
+	read -p "Are you sure you want to deploy? (y/n) " -n 1 -r
+	echo
+	if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		exit 1
+	fi
 fi
 
 # get branch name and pr number
@@ -46,24 +45,24 @@ branchName=$(gh pr view --json headRefName | jq -r .headRefName)
 prNumber=$(gh pr view --json number | jq -r .number)
 
 if $skipBuild; then
-    #check if the image exists
-    foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1) || true
-    echo "foundTag is: '${foundTag}'"
-    if [[ -z "${foundTag}" ]]; then
-        echo "Image not found"
-        echo "${prNumber} tag not found in ghcr.io/coder/coder-preview"
-        echo "Please remove --skip-build and try again"
-        exit 1
-    fi
+	#check if the image exists
+	foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1) || true
+	echo "foundTag is: '${foundTag}'"
+	if [[ -z "${foundTag}" ]]; then
+		echo "Image not found"
+		echo "${prNumber} tag not found in ghcr.io/coder/coder-preview"
+		echo "Please remove --skip-build and try again"
+		exit 1
+	fi
 fi
 
 if $dryRun; then
-    echo "dry run"
-    echo "branchName: ${branchName}"
-    echo "prNumber: ${prNumber}"
-    echo "skipBuild: ${skipBuild}"
-    echo "gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}""
-    exit 0
+	echo "dry run"
+	echo "branchName: ${branchName}"
+	echo "prNumber: ${prNumber}"
+	echo "skipBuild: ${skipBuild}"
+	echo "gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}""
+	exit 0
 fi
 
 gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}"

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -5,7 +5,7 @@
 # if --skip-build is passed, the build step will be skipped and the last build image will be used
 # if --yes or -y is passed, the script will not ask for confirmation before deploying
 
-set -euox pipefail
+set -euo pipefail
 
 # ask for user confirmation before deploying also skip confirmation if --yes or -y is passed
 if [[ "$*" != *--yes* ]] && [[ "$*" != *-y* ]]; then
@@ -22,8 +22,9 @@ prNumber=$(gh pr view --json number | jq -r .number)
 if [[ "$*" == *--skip-build* ]]; then
 	skipBuild=true
 	#check if the image exists
-	foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1)
-	if [ -z "${foundTag}" ]; then
+	foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1) || true
+	echo "foundTag is: '${foundTag}'"
+	if [[ -z "${foundTag}" ]]; then
 		echo "Image not found"
 		echo "${prNumber} tag not found in ghcr.io/coder/coder-preview"
 		echo "Please remove --skip-build and try again"
@@ -31,6 +32,17 @@ if [[ "$*" == *--skip-build* ]]; then
 	fi
 else
 	skipBuild=false
+fi
+
+## dry run with --dry-run or -n
+
+if [[ "$*" == *--dry-run* ]] || [[ "$*" == *-n* ]]; then
+	echo "dry run"
+	echo "branchName: ${branchName}"
+	echo "prNumber: ${prNumber}"
+	echo "skipBuild: ${skipBuild}"
+	echo "gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}""
+	exit 0
 fi
 
 gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}"

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -1,48 +1,69 @@
 #!/usr/bin/env bash
-# Usage: ./deploy-pr.sh  --skip-build[os -s] --dry-run[or -n] --yes[or -y]
+# Usage: ./deploy-pr.sh  [--skip-build -s] [--dry-run -n] [--yes -y]
 # deploys the current branch to a PR environment and posts login credentials to
 # [#pr-deployments](https://codercom.slack.com/archives/C05DNE982E8) Slack channel
-# if --skip-build is passed, the build step will be skipped and the last build image will be used
-# if --yes or -y is passed, the script will not ask for confirmation before deploying
 
 set -euo pipefail
 
-# ask for user confirmation before deploying also skip confirmation if --yes or -y is passed
-if [[ "$*" != *--yes* ]] && [[ "$*" != *-y* ]]; then
-	read -p "Are you sure you want to deploy? (y/n) " -n 1 -r
-	echo
-	if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-		exit 1
-	fi
+# default settings
+skipBuild=false
+dryRun=false
+confirm=true
+
+# parse arguments
+for arg in "$@"
+do
+    case $arg in
+        -s|--skip-build)
+        skipBuild=true
+        shift # Remove --skip-build from processing
+        ;;
+        -n|--dry-run)
+        dryRun=true
+        shift # Remove --dry-run from processing
+        ;;
+        -y|--yes)
+        confirm=false
+        shift # Remove --yes from processing
+        ;;
+        *)
+        shift # Remove generic argument from processing
+        ;;
+    esac
+done
+
+# confirm if not passed -y or --yes
+if $confirm; then
+    read -p "Are you sure you want to deploy? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
 fi
 
+# get branch name and pr number
 branchName=$(gh pr view --json headRefName | jq -r .headRefName)
 prNumber=$(gh pr view --json number | jq -r .number)
 
-if [[ "$*" == *--skip-build* ]] || [[ "$*" == *-s* ]]; then
-	skipBuild=true
-	#check if the image exists
-	foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1) || true
-	echo "foundTag is: '${foundTag}'"
-	if [[ -z "${foundTag}" ]]; then
-		echo "Image not found"
-		echo "${prNumber} tag not found in ghcr.io/coder/coder-preview"
-		echo "Please remove --skip-build and try again"
-		exit 1
-	fi
-else
-	skipBuild=false
+if $skipBuild; then
+    #check if the image exists
+    foundTag=$(curl -fsSL https://github.com/coder/coder/pkgs/container/coder-preview | grep -o "$prNumber" | head -n 1) || true
+    echo "foundTag is: '${foundTag}'"
+    if [[ -z "${foundTag}" ]]; then
+        echo "Image not found"
+        echo "${prNumber} tag not found in ghcr.io/coder/coder-preview"
+        echo "Please remove --skip-build and try again"
+        exit 1
+    fi
 fi
 
-## dry run with --dry-run or -n
-
-if [[ "$*" == *--dry-run* ]] || [[ "$*" == *-n* ]]; then
-	echo "dry run"
-	echo "branchName: ${branchName}"
-	echo "prNumber: ${prNumber}"
-	echo "skipBuild: ${skipBuild}"
-	echo "gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}""
-	exit 0
+if $dryRun; then
+    echo "dry run"
+    echo "branchName: ${branchName}"
+    echo "prNumber: ${prNumber}"
+    echo "skipBuild: ${skipBuild}"
+    echo "gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}""
+    exit 0
 fi
 
 gh workflow run pr-deploy.yaml --ref "${branchName}" -f pr_number="${prNumber}" -f skip_build="${skipBuild}"

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -61,8 +61,7 @@ if $dryRun; then
 	echo "branchName: ${branchName}"
 	echo "prNumber: ${prNumber}"
 	echo "skipBuild: ${skipBuild}"
-	echo "gh workflow run pr-deploy.yaml --ref ${branchName} -f pr_number=${prNumber} -f skip_build=${skipBuild}"
 	exit 0
 fi
 
-gh workflow run pr-deploy.yaml --ref ${branchName} -f pr_number=${prNumber} -f skip_build=${skipBuild}
+gh workflow run pr-deploy.yaml --ref "${branchName}" -f "pr_number=${prNumber}" -f "skip_build=${skipBuild}"


### PR DESCRIPTION
We clean up the namespace and the image tag whenever the PR is closed/merged.
IF we want to support deploying any branch or main without an open PR, this makes the clean up process tedious.

This PR. 
1. Remove the ability to deploy the `main` to help clean up.
2. Adds confirmation and dry-run to `./secripts/deploy-pr.sh`