### PR TITLE
ci: prevent running pr-deploy.yaml on all comments

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -128,7 +128,7 @@ jobs:
   deploy:
     needs: [build, pr_commented]
     # Run deploy job only if build job was successful or skipped
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.pr_commented.result == 'success'
     runs-on: "ubuntu-latest"
     env:
       CODER_IMAGE_TAG: ${{ needs.pr_commented.outputs.CODER_IMAGE_TAG }}


### PR DESCRIPTION
This was a side effect of introducing --skip-build