### PR TITLE
ci: reduce Chromatic snapshot usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -569,10 +569,17 @@ jobs:
         with:
           buildScriptName: "storybook:build"
           exitOnceUploaded: true
+          # This will prevent CI from failing when Chromatic detects visual changes
+          exitZeroOnChanges: true
           # Chromatic states its fine to make this token public. See:
           # https://www.chromatic.com/docs/github-actions#forked-repositories
           projectToken: 695c25b6cb65
           workingDir: "./site"
+          # Prevent excessive build runs on minor version changes
+          skip: '@(renovate/**|dependabot/**)'
+          # Run TurboSnap to trace file dependencies to related stories
+          # and tell chromatic to only take snapshots of relevent stories
+          onlyChanged: true
 
       # This is a separate step for mainline only that auto accepts and changes
       # instead of holding CI up. Since we squash/merge, this is defensive to
@@ -588,9 +595,14 @@ jobs:
           STORYBOOK: true
         with:
           autoAcceptChanges: true
+          # This will prevent CI from failing when Chromatic detects visual changes
+          exitZeroOnChanges: true
           buildScriptName: "storybook:build"
           projectToken: 695c25b6cb65
           workingDir: "./site"
+          # Run TurboSnap to trace file dependencies to related stories
+          # and tell chromatic to only take snapshots of relevent stories
+          onlyChanged: true
 
   required:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Modified the Chromatic job configuration to reduce snapshot usage and only run Chromatic on necessary UI changes.