### PR TITLE
fix(cli): correctly print deprecated warnings

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1148,7 +1148,7 @@ func PrintDeprecatedOptions() clibase.MiddlewareFunc {
 					continue
 				}
 
-				if opt.Value.String() == opt.Default {
+				if opt.ValueSource == clibase.ValueSourceNone || opt.ValueSource == clibase.ValueSourceDefault {
 					continue
 				}
 


### PR DESCRIPTION
fix(cli): correctly print deprecated warnings

In the previous implementation, it was possible for default-set values
to trigger the deprecation warning.
