### PR TITLE
revert(enterprise): make `pgcoord` experimental again

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8021,7 +8021,7 @@ const docTemplate = `{
             "enum": [
                 "moons",
                 "workspace_actions",
-                "tailnet_ha_coordinator",
+                "tailnet_pg_coordinator",
                 "convert-to-oidc",
                 "single_tailnet",
                 "template_restart_requirement",
@@ -8030,7 +8030,7 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "ExperimentMoons",
                 "ExperimentWorkspaceActions",
-                "ExperimentTailnetHACoordinator",
+                "ExperimentTailnetPGCoordinator",
                 "ExperimentConvertToOIDC",
                 "ExperimentSingleTailnet",
                 "ExperimentTemplateRestartRequirement",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7182,7 +7182,7 @@
       "enum": [
         "moons",
         "workspace_actions",
-        "tailnet_ha_coordinator",
+        "tailnet_pg_coordinator",
         "convert-to-oidc",
         "single_tailnet",
         "template_restart_requirement",
@@ -7191,7 +7191,7 @@
       "x-enum-varnames": [
         "ExperimentMoons",
         "ExperimentWorkspaceActions",
-        "ExperimentTailnetHACoordinator",
+        "ExperimentTailnetPGCoordinator",
         "ExperimentConvertToOIDC",
         "ExperimentSingleTailnet",
         "ExperimentTemplateRestartRequirement",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1846,10 +1846,9 @@ const (
 	// https://github.com/coder/coder/milestone/19
 	ExperimentWorkspaceActions Experiment = "workspace_actions"
 
-	// ExperimentTailnetHACoordinator downgrades to the haCoordinator instead
-	// of PGCoord.  Should only be used if we see issues in prod with PGCoord
-	// which is now the default.
-	ExperimentTailnetHACoordinator Experiment = "tailnet_ha_coordinator"
+	// ExperimentTailnetPGCoordinator enables the PGCoord in favor of the pubsub-
+	// only Coordinator
+	ExperimentTailnetPGCoordinator Experiment = "tailnet_pg_coordinator"
 
 	// ExperimentConvertToOIDC enables users to convert from password to
 	// oidc.

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2672,7 +2672,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | ------------------------------ |
 | `moons`                        |
 | `workspace_actions`            |
-| `tailnet_ha_coordinator`       |
+| `tailnet_pg_coordinator`       |
 | `convert-to-oidc`              |
 | `single_tailnet`               |
 | `template_restart_requirement` |

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -535,10 +535,10 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 		var coordinator agpltailnet.Coordinator
 		if enabled {
 			var haCoordinator agpltailnet.Coordinator
-			if api.AGPL.Experiments.Enabled(codersdk.ExperimentTailnetHACoordinator) {
-				haCoordinator, err = tailnet.NewCoordinator(api.Logger, api.Pubsub)
-			} else {
+			if api.AGPL.Experiments.Enabled(codersdk.ExperimentTailnetPGCoordinator) {
 				haCoordinator, err = tailnet.NewPGCoord(api.ctx, api.Logger, api.Pubsub, api.Database)
+			} else {
+				haCoordinator, err = tailnet.NewCoordinator(api.Logger, api.Pubsub)
 			}
 			if err != nil {
 				api.Logger.Error(ctx, "unable to set up high availability coordinator", slog.Error(err))

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1563,7 +1563,7 @@ export type Experiment =
   | "convert-to-oidc"
   | "moons"
   | "single_tailnet"
-  | "tailnet_ha_coordinator"
+  | "tailnet_pg_coordinator"
   | "template_insights_page"
   | "template_restart_requirement"
   | "workspace_actions"
@@ -1571,7 +1571,7 @@ export const Experiments: Experiment[] = [
   "convert-to-oidc",
   "moons",
   "single_tailnet",
-  "tailnet_ha_coordinator",
+  "tailnet_pg_coordinator",
   "template_insights_page",
   "template_restart_requirement",
   "workspace_actions",


### PR DESCRIPTION
We had some customers running into issues with HA coordination, so reverting this is the best course of action for now.

See: https://github.com/coder/v2-customers/issues/237