### PR TITLE
fix(scripts): check if PR list is empty

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -84,7 +84,7 @@ main() {
 	)"
 
 	declare -A authors labels
-	if [ -n "$pr_list_out" ]; then
+	if [[ -n $pr_list_out ]]; then
 		mapfile -t pr_metadata_raw <<<"$pr_list_out"
 
 		for entry in "${pr_metadata_raw[@]}"; do

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -82,16 +82,20 @@ main() {
 			--json mergeCommit,labels,author \
 			--jq '.[] | "\( .mergeCommit.oid ) author:\( .author.login ) labels:\(["label:\( .labels[].name )"] | join(" "))"'
 	)"
-	mapfile -t pr_metadata_raw <<<"$pr_list_out"
+
 	declare -A authors labels
-	for entry in "${pr_metadata_raw[@]}"; do
-		commit_sha_long=${entry%% *}
-		commit_author=${entry#* author:}
-		commit_author=${commit_author%% *}
-		authors[$commit_sha_long]=$commit_author
-		all_labels=${entry#* labels:}
-		labels[$commit_sha_long]=$all_labels
-	done
+	if [ -n "$pr_list_out" ]; then
+		mapfile -t pr_metadata_raw <<<"$pr_list_out"
+
+		for entry in "${pr_metadata_raw[@]}"; do
+			commit_sha_long=${entry%% *}
+			commit_author=${entry#* author:}
+			commit_author=${commit_author%% *}
+			authors[$commit_sha_long]=$commit_author
+			all_labels=${entry#* labels:}
+			labels[$commit_sha_long]=$all_labels
+		done
+	fi
 
 	for commit in "${commits[@]}"; do
 		mapfile -d ' ' -t parts <<<"$commit"


### PR DESCRIPTION
I am currently (= finally) working on a PR for chocolatey support.

During testing, It occured to me that the release notes were always failing, that is because ``check_commit_metadata.sh`` tries to loop over ``$pr_metadata_raw`` even if it is empty, this causes an issue because PRs don't ususally have PRs.
This PR makes it so that it checks if the PR list is empty before looping. 