### PR TITLE
chore: bump openssl in base image

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -12,6 +12,8 @@ RUN apk add --no-cache \
 		bash \
 		jq \
 		git \
+		# Fixes CVE-2023-3446 and CVE-2023-2975. Only necessary until Alpine 3.18.3.
+		openssl \
 		openssh-client && \
 	# Use the edge repo, since Terraform doesn't seem to be backported to 3.18.
 	apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2023-2975 and https://nvd.nist.gov/vuln/detail/CVE-2023-3446