### PR TITLE
chore: wait 30 seconds before checking winget PR in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -407,6 +407,8 @@ jobs:
       - name: Comment on PR
         if: ${{ !inputs.dry_run }}
         run: |
+          # wait 30 seconds
+          Start-Sleep -Seconds 30.0
           # Find the PR that wingetcreate just made.
           $version = "${{ needs.release.outputs.version }}".Trim('v')
           $pr_list = gh pr list --repo microsoft/winget-pkgs --search "author:cdrci Coder.Coder version ${version}" --limit 1 --json number | `


### PR DESCRIPTION
During the release workflow, sometimes publish to winget job fails because the PR is not created, and we are trying to get it. This is not critical as it only fails to comment. PR is submitted, and a release is made successfully.
I propose we add 30 seconds of sleep before running this step
See logs here

1. https://github.com/coder/coder/actions/runs/5625677352/job/15245179929#step:6:16
2. https://github.com/coder/coder/actions/runs/5676393637/job/15383204607#step:6:16
3. https://github.com/coder/coder/actions/runs/5074190899/job/13740698923#step:6:16
