### PR TITLE
chore: increment `GOCACHE` key

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -48,15 +48,16 @@ runs:
       with:
         path: |
           ${{ env.GOCACHE }}
-        # Job name must be included in the key for effective
-        # test cache reuse.
+        # Job name must be included in the key for effective test cache reuse.
         # The key format is intentionally different than GOMODCACHE, because any
-        # time a Go file changes we invalidate this cache, whereas GOMODCACHE
-        # is only invalidated when go.sum changes.
-        key: gocache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.go', 'go.**') }}
+        # time a Go file changes we invalidate this cache, whereas GOMODCACHE is
+        # only invalidated when go.sum changes.
+        # The number in the key is incremented when the cache gets too large,
+        # since this technically grows without bound.
+        key: gocache2-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.go', 'go.**') }}
         restore-keys: |
-          gocache-${{ runner.os }}-${{ github.job }}-
-          gocache-${{ runner.os }}-
+          gocache2-${{ runner.os }}-${{ github.job }}-
+          gocache2-${{ runner.os }}-
 
     - name: Install gotestsum
       shell: bash

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -39,9 +39,9 @@ runs:
         path: |
           ${{ env.GOMODCACHE }}
         key: gomodcache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.job }}
-        restore-keys: |
-          gomodcache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
-          gomodcache-${{ runner.os }}-
+        # restore-keys aren't used because it causes the cache to grow
+        # infinitely. go.sum changes very infrequently, so rebuilding from
+        # scratch every now and then isn't terrible.
 
     - name: Cache $GOCACHE
       uses: buildjet/cache@v3


### PR DESCRIPTION
It seems like this just boundlessly grows. Right now it's `~3535 MB (3707029742 B)`. Another alternative is to just remove this entirely since I really doubt this helps much, but this seems to be the easiest for now.