### PR TITLE
chore: update concurrency to use PR number

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -29,7 +29,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref }}
+  group: ${{ github.workflow }}-PR-${{ (github.event.issue.number) || (github.event.inputs.pr_number) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This will hopefully run only 1 pr department per PR.