### PR TITLE
docs: reword latency explanation for HA

### DIFF
--- a/docs/admin/high-availability.md
+++ b/docs/admin/high-availability.md
@@ -6,19 +6,27 @@ endpoint. [GCP](https://cloud.google.com/sql/docs/postgres/high-availability), [
 and other cloud vendors offer fully-managed HA Postgres services that pair
 nicely with Coder.
 
-For Coder to operate correctly, every node must be within 10ms of each other
-and Postgres. We make a best-effort attempt to warn the user when inter-Coder
-latency is too high, but if requests start dropping, this is one metric to investigate.
+For Coder to operate correctly, Coderd instances should have low-latency connections
+to each other so that they can effectively relay traffic between users and workspaces no
+matter which Coderd instance users or workspaces connect to. We make a best-effort attempt
+to warn the user when inter-Coderd latency is too high, but if requests start dropping, this
+is one metric to investigate.
+
+We also recommend that you deploy all Coderd instances such that they have low-latency
+connections to Postgres. Coderd often makes several database round-trips while processing
+a single API request, so prioritizing low-latency between Coderd and Postgres is more important
+than low-latency between users and Coderd.
+
 Note that this latency requirement applies _only_ to Coder services. Coder will
-operate correctly even with few seconds of latency on
-workspace <-> Coder and user <-> Coder connections.
+operate correctly even with few seconds of latency on workspace <-> Coder and user <-> Coder
+connections.
 
 ## Setup
 
 Coder automatically enters HA mode when multiple instances simultaneously connect
 to the same Postgres endpoint.
 
-HA brings one configuration variable to set in each Coder
+HA brings one configuration variable to set in each Coderd
 node: `CODER_DERP_SERVER_RELAY_URL`. The HA nodes use these URLs to communicate
 with each other. Inter-node communication is only required while using the
 embedded relay (default). If you're using [custom relays](../networking/index.md#custom-relays), Coder ignores `CODER_DERP_SERVER_RELAY_URL` since Postgres is the sole rendezvous for the Coder nodes.


### PR DESCRIPTION
Removes references to a specific latency time, and instead explains what Coderd is doing that requires low-latency.