### PR TITLE
fix: allow ci to publish a package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: read
   deployments: none
   issues: none
-  packages: none
+  packages: write
   pull-requests: none
   repository-projects: none
   security-events: none


### PR DESCRIPTION
This was noted after #8832 in https://github.com/coder/coder/actions/runs/5738972720/job/15553643003#step:7:504
we need to have `package: write` to push a package.