### PR TITLE
feat: add PSK for external provisionerd auth

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -373,6 +373,10 @@ updating, and deleting workspace resources.
       --provisioner-daemon-poll-jitter duration, $CODER_PROVISIONER_DAEMON_POLL_JITTER (default: 100ms)
           Random jitter added to the poll interval.
 
+      --provisioner-daemon-psk string, $CODER_PROVISIONER_DAEMON_PSK
+          Pre-shared key to authenticate external provisioner daemons to Coder
+          server.
+
       --provisioner-daemons int, $CODER_PROVISIONER_DAEMONS (default: 3)
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -327,6 +327,9 @@ provisioning:
   # Time to force cancel provisioning tasks that are stuck.
   # (default: 10m0s, type: duration)
   forceCancelInterval: 10m0s
+  # Pre-shared key to authenticate external provisioner daemons to Coder server.
+  # (default: <unset>, type: string)
+  daemonPSK: ""
 # Enable one or more experiments. These are not ready for production. Separate
 # multiple experiments with commas, or enter '*' to opt-in to all available
 # experiments.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8747,6 +8747,9 @@ const docTemplate = `{
                 "daemon_poll_jitter": {
                     "type": "integer"
                 },
+                "daemon_psk": {
+                    "type": "string"
+                },
                 "daemons": {
                     "type": "integer"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7857,6 +7857,9 @@
         "daemon_poll_jitter": {
           "type": "integer"
         },
+        "daemon_psk": {
+          "type": "string"
+        },
         "daemons": {
           "type": "integer"
         },

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -497,7 +497,11 @@ func NewExternalProvisionerDaemon(t *testing.T, client *codersdk.Client, org uui
 	}()
 
 	closer := provisionerd.New(func(ctx context.Context) (provisionerdproto.DRPCProvisionerDaemonClient, error) {
-		return client.ServeProvisionerDaemon(ctx, org, []codersdk.ProvisionerType{codersdk.ProvisionerTypeEcho}, tags)
+		return client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
+			Organization: org,
+			Provisioners: []codersdk.ProvisionerType{codersdk.ProvisionerTypeEcho},
+			Tags:         tags,
+		})
 	}, &provisionerd.Options{
 		Filesystem:          fs,
 		Logger:              slogtest.Make(t, nil).Named("provisionerd").Leveled(slog.LevelDebug),

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -71,6 +71,9 @@ const (
 	// command that was invoked to produce the request. It is for internal use
 	// only.
 	CLITelemetryHeader = "Coder-CLI-Telemetry"
+
+	// ProvisionerDaemonPSK contains the authentication pre-shared key for an external provisioner daemon
+	ProvisionerDaemonPSK = "Coder-Provisioner-Daemon-PSK"
 )
 
 // loggableMimeTypes is a list of MIME types that are safe to log

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -328,6 +328,7 @@ type ProvisionerConfig struct {
 	DaemonPollInterval  clibase.Duration `json:"daemon_poll_interval" typescript:",notnull"`
 	DaemonPollJitter    clibase.Duration `json:"daemon_poll_jitter" typescript:",notnull"`
 	ForceCancelInterval clibase.Duration `json:"force_cancel_interval" typescript:",notnull"`
+	DaemonPSK           clibase.String   `json:"daemon_psk" typescript:",notnull"`
 }
 
 type RateLimitConfig struct {
@@ -1229,6 +1230,15 @@ when required by your organization's security policy.`,
 			Value:       &c.Provisioner.ForceCancelInterval,
 			Group:       &deploymentGroupProvisioning,
 			YAML:        "forceCancelInterval",
+		},
+		{
+			Name:        "Provisioner Daemon Pre-shared Key (PSK)",
+			Description: "Pre-shared key to authenticate external provisioner daemons to Coder server.",
+			Flag:        "provisioner-daemon-psk",
+			Env:         "CODER_PROVISIONER_DAEMON_PSK",
+			Value:       &c.Provisioner.DaemonPSK,
+			Group:       &deploymentGroupProvisioning,
+			YAML:        "daemonPSK",
 		},
 		// RateLimit settings
 		{

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -149,10 +149,11 @@ func (c *Client) Organization(ctx context.Context, id uuid.UUID) (Organization, 
 	return organization, json.NewDecoder(res.Body).Decode(&organization)
 }
 
-// ProvisionerDaemonsByOrganization returns provisioner daemons available for an organization.
+// ProvisionerDaemons returns provisioner daemons available.
 func (c *Client) ProvisionerDaemons(ctx context.Context) ([]ProvisionerDaemon, error) {
 	res, err := c.Request(ctx, http.MethodGet,
-		"/api/v2/provisionerdaemons",
+		// TODO: the organization path parameter is currently ignored.
+		"/api/v2/organizations/default/provisionerdaemons",
 		nil,
 	)
 	if err != nil {

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -164,38 +164,61 @@ func (c *Client) provisionerJobLogsAfter(ctx context.Context, path string, after
 	}), nil
 }
 
-// ListenProvisionerDaemon returns the gRPC service for a provisioner daemon
+// ServeProvisionerDaemonRequest are the parameters to call ServeProvisionerDaemon with
+// @typescript-ignore ServeProvisionerDaemonRequest
+type ServeProvisionerDaemonRequest struct {
+	// Organization is the organization for the URL.  At present provisioner daemons ARE NOT scoped to organizations
+	// and so the organization ID is optional.
+	Organization uuid.UUID `json:"organization" format:"uuid"`
+	// Provisioners is a list of provisioner types hosted by the provisioner daemon
+	Provisioners []ProvisionerType `json:"provisioners"`
+	// Tags is a map of key-value pairs that tag the jobs this provisioner daemon can handle
+	Tags map[string]string `json:"tags"`
+	// PreSharedKey is an authentication key to use on the API instead of the normal session token from the client.
+	PreSharedKey string `json:"pre_shared_key"`
+}
+
+// ServeProvisionerDaemon returns the gRPC service for a provisioner daemon
 // implementation. The context is during dial, not during the lifetime of the
 // client. Client should be closed after use.
-func (c *Client) ServeProvisionerDaemon(ctx context.Context, organization uuid.UUID, provisioners []ProvisionerType, tags map[string]string) (proto.DRPCProvisionerDaemonClient, error) {
-	serverURL, err := c.URL.Parse(fmt.Sprintf("/api/v2/organizations/%s/provisionerdaemons/serve", organization))
+func (c *Client) ServeProvisionerDaemon(ctx context.Context, req ServeProvisionerDaemonRequest) (proto.DRPCProvisionerDaemonClient, error) {
+	serverURL, err := c.URL.Parse(fmt.Sprintf("/api/v2/organizations/%s/provisionerdaemons/serve", req.Organization))
 	if err != nil {
 		return nil, xerrors.Errorf("parse url: %w", err)
 	}
 	query := serverURL.Query()
-	for _, provisioner := range provisioners {
+	for _, provisioner := range req.Provisioners {
 		query.Add("provisioner", string(provisioner))
 	}
-	for key, value := range tags {
+	for key, value := range req.Tags {
 		query.Add("tag", fmt.Sprintf("%s=%s", key, value))
 	}
 	serverURL.RawQuery = query.Encode()
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		return nil, xerrors.Errorf("create cookie jar: %w", err)
-	}
-	jar.SetCookies(serverURL, []*http.Cookie{{
-		Name:  SessionTokenCookie,
-		Value: c.SessionToken(),
-	}})
 	httpClient := &http.Client{
-		Jar:       jar,
 		Transport: c.HTTPClient.Transport,
 	}
+	headers := http.Header{}
+
+	if req.PreSharedKey == "" {
+		// use session token if we don't have a PSK.
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			return nil, xerrors.Errorf("create cookie jar: %w", err)
+		}
+		jar.SetCookies(serverURL, []*http.Cookie{{
+			Name:  SessionTokenCookie,
+			Value: c.SessionToken(),
+		}})
+		httpClient.Jar = jar
+	} else {
+		headers.Set(ProvisionerDaemonPSK, req.PreSharedKey)
+	}
+
 	conn, res, err := websocket.Dial(ctx, serverURL.String(), &websocket.DialOptions{
 		HTTPClient: httpClient,
 		// Need to disable compression to avoid a data-race.
 		CompressionMode: websocket.CompressionDisabled,
+		HTTPHeader:      headers,
 	})
 	if err != nil {
 		if res == nil {

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -305,6 +305,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "provisioner": {
       "daemon_poll_interval": 0,
       "daemon_poll_jitter": 0,
+      "daemon_psk": "string",
       "daemons": 0,
       "daemons_echo": true,
       "force_cancel_interval": 0

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2096,6 +2096,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "provisioner": {
       "daemon_poll_interval": 0,
       "daemon_poll_jitter": 0,
+      "daemon_psk": "string",
       "daemons": 0,
       "daemons_echo": true,
       "force_cancel_interval": 0
@@ -2453,6 +2454,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "provisioner": {
     "daemon_poll_interval": 0,
     "daemon_poll_jitter": 0,
+    "daemon_psk": "string",
     "daemons": 0,
     "daemons_echo": true,
     "force_cancel_interval": 0
@@ -3480,6 +3482,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 {
   "daemon_poll_interval": 0,
   "daemon_poll_jitter": 0,
+  "daemon_psk": "string",
   "daemons": 0,
   "daemons_echo": true,
   "force_cancel_interval": 0
@@ -3492,6 +3495,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | ----------------------- | ------- | -------- | ------------ | ----------- |
 | `daemon_poll_interval`  | integer | false    |              |             |
 | `daemon_poll_jitter`    | integer | false    |              |             |
+| `daemon_psk`            | string  | false    |              |             |
 | `daemons`               | integer | false    |              |             |
 | `daemons_echo`          | boolean | false    |              |             |
 | `force_cancel_interval` | integer | false    |              |             |

--- a/docs/cli/provisionerd_start.md
+++ b/docs/cli/provisionerd_start.md
@@ -42,6 +42,15 @@ How often to poll for provisioner jobs.
 
 How much to jitter the poll interval by.
 
+### --psk
+
+|             |                                            |
+| ----------- | ------------------------------------------ |
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_PSK</code> |
+
+Pre-shared key to authenticate with Coder server.
+
 ### -t, --tag
 
 |             |                                       |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -668,6 +668,16 @@ Collect database metrics (may increase charges for metrics storage).
 
 Serve prometheus metrics on the address defined by prometheus address.
 
+### --provisioner-daemon-psk
+
+|             |                                            |
+| ----------- | ------------------------------------------ |
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_PSK</code> |
+| YAML        | <code>provisioning.daemonPSK</code>        |
+
+Pre-shared key to authenticate external provisioner daemons to Coder server.
+
 ### --provisioner-daemons
 
 |             |                                         |

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -1,0 +1,56 @@
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/cli/clitest"
+	"github.com/coder/coder/codersdk"
+	"github.com/coder/coder/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/enterprise/coderd/license"
+	"github.com/coder/coder/pty/ptytest"
+	"github.com/coder/coder/testutil"
+)
+
+func TestProvisionerDaemon_PSK(t *testing.T) {
+	t.Parallel()
+
+	client, _ := coderdenttest.New(t, &coderdenttest.Options{
+		ProvisionerDaemonPSK: "provisionersftw",
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureExternalProvisionerDaemons: 1,
+			},
+		},
+	})
+	inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw")
+	err := conf.URL().Write(client.URL.String())
+	require.NoError(t, err)
+	pty := ptytest.New(t).Attach(inv)
+	ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
+	defer cancel()
+	clitest.Start(t, inv)
+	pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+}
+
+func TestProvisionerDaemon_SessionToken(t *testing.T) {
+	t.Parallel()
+
+	client, _ := coderdenttest.New(t, &coderdenttest.Options{
+		ProvisionerDaemonPSK: "provisionersftw",
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureExternalProvisionerDaemons: 1,
+			},
+		},
+	})
+	inv, conf := newCLI(t, "provisionerd", "start")
+	clitest.SetupConfig(t, client, conf)
+	pty := ptytest.New(t).Attach(inv)
+	ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
+	defer cancel()
+	clitest.Start(t, inv)
+	pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+}

--- a/enterprise/cli/server.go
+++ b/enterprise/cli/server.go
@@ -66,6 +66,7 @@ func (r *RootCmd) server() *clibase.Cmd {
 			DERPServerRegionID:        int(options.DeploymentValues.DERP.Server.RegionID.Value()),
 			ProxyHealthInterval:       options.DeploymentValues.ProxyHealthStatusInterval.Value(),
 			DefaultQuietHoursSchedule: options.DeploymentValues.UserQuietHoursSchedule.DefaultSchedule.Value(),
+			ProvisionerDaemonPSK:      options.DeploymentValues.Provisioner.DaemonPSK.Value(),
 		}
 
 		api, err := coderd.New(ctx, o)

--- a/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
+++ b/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
@@ -12,6 +12,9 @@ Run a provisioner daemon
       --poll-jitter duration, $CODER_PROVISIONERD_POLL_JITTER (default: 100ms)
           How much to jitter the poll interval by.
 
+      --psk string, $CODER_PROVISIONER_DAEMON_PSK
+          Pre-shared key to authenticate with Coder server.
+
   -t, --tag string-array, $CODER_PROVISIONERD_TAGS
           Tags to filter provisioner jobs by.
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -373,6 +373,10 @@ updating, and deleting workspace resources.
       --provisioner-daemon-poll-jitter duration, $CODER_PROVISIONER_DAEMON_POLL_JITTER (default: 100ms)
           Random jitter added to the poll interval.
 
+      --provisioner-daemon-psk string, $CODER_PROVISIONER_DAEMON_PSK
+          Pre-shared key to authenticate external provisioner daemons to Coder
+          server.
+
       --provisioner-daemons int, $CODER_PROVISIONER_DAEMONS (default: 3)
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -56,6 +56,7 @@ type Options struct {
 	DontAddLicense              bool
 	DontAddFirstUser            bool
 	ReplicaSyncUpdateInterval   time.Duration
+	ProvisionerDaemonPSK        string
 }
 
 // New constructs a codersdk client connected to an in-memory Enterprise API instance.
@@ -94,6 +95,7 @@ func NewWithAPI(t *testing.T, options *Options) (
 		Keys:                       Keys,
 		ProxyHealthInterval:        options.ProxyHealthInterval,
 		DefaultQuietHoursSchedule:  oop.DeploymentValues.UserQuietHoursSchedule.DefaultSchedule.Value(),
+		ProvisionerDaemonPSK:       options.ProvisionerDaemonPSK,
 	})
 	require.NoError(t, err)
 	setHandler(coderAPI.AGPL.RootHandler)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -710,6 +710,7 @@ export interface ProvisionerConfig {
   readonly daemon_poll_interval: number
   readonly daemon_poll_jitter: number
   readonly force_cancel_interval: number
+  readonly daemon_psk: string
 }
 
 // From codersdk/provisionerdaemons.go


### PR DESCRIPTION
fixes #8861 

One oddball thing I noticed while implementing is that `provisionerdaemon/serve` is under an `organization/{organization}` route, but Provisioner Daemons are not scoped to organizations in the DB or RBAC.

I've chosen to keep the existing route, in part to avoid a breaking change on the API, and in part since if we implement multiple organizations in future, provisioner daemons will probably be (at least optionally) scoped by org.

But, because the PSK is not scoped to any organization, I've chosen to make the API just ignore the organization ID in the URL (for all requests, not just those that use the PSK).  So `/organizations/default/provisionerdaemon/serve` is perfectly valid, as is `/organizations/54b9c769-67eb-4529-9bf9-1363ca34f4a3/provisionerdaemon/serve`.  This avoids me having to query the database about whether the organization ID is real, and avoids leaking any information about org IDs, but is a little odd and surprising.