### PR TITLE
chore: support manual changelog and version 2.0 for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
 
           # Generate notes.
           release_notes_file="$(mktemp -t release_notes.XXXXXX)"
-          ./scripts/release/generate_release_notes.sh --old-version "$old_version" --new-version "$version" --ref "$ref" >> "$release_notes_file"
+          ./scripts/release/generate_release_notes.sh --check-for-changelog --old-version "$old_version" --new-version "$version" --ref "$ref" >> "$release_notes_file"
           echo CODER_RELEASE_NOTES_FILE="$release_notes_file" >> $GITHUB_ENV
 
       - name: Show release notes

--- a/docs/changelogs/README.md
+++ b/docs/changelogs/README.md
@@ -6,7 +6,7 @@ These changelogs are currently not kept in-sync with GitHub releases. Use [GitHu
 
 ## Writing a changelog
 
-Run this comamnd to generate release notes:
+Run this command to generate release notes:
 
 ```sh
 ./scripts/release/generate_release_notes.sh \

--- a/docs/changelogs/README.md
+++ b/docs/changelogs/README.md
@@ -1,0 +1,17 @@
+# Changelogs
+
+These are the changelogs used by [get-changelog.sh](https://github.com/coder/coder/blob/main/scripts/release/changelog.sh) for a release.
+
+These changelogs are currently not kept in-sync with GitHub releases. Use [GitHub releases](https://github.com/coder/coder/releases) for the latest information!
+
+## Writing a changelog
+
+Run this comamnd to generate release notes:
+
+```sh
+./scripts/release/generate_release_notes.sh \
+  --old-version=v0.27.0 \
+  --new-version=v0.28.0 \
+  --ref=$(git rev-parse --short "${ref:-origin/$branch}") \
+  > ./docs/changelogs/v0.28.0.md
+```

--- a/docs/changelogs/v0.25.0.md
+++ b/docs/changelogs/v0.25.0.md
@@ -7,22 +7,22 @@
 - The `coder stat` fetches workspace utilization metrics, even from within a container. Our example templates have been updated to use this to show CPU, memory, disk via [agent metadata](https://coder.com/docs/v2/latest/templates/agent-metadata) (#8005)
 - Helm: `coder.command` can specify a different command for the Coder pod (#8116)
 - Enterprise deployments can create templates without 'everyone' group access (#7982)
-    ![Disable "everyone"](https://github.com/coder/coder/assets/22407953/1c31cb9b-be5c-4bef-abee-324856734215)
+  ![Disable "everyone"](https://github.com/coder/coder/assets/22407953/1c31cb9b-be5c-4bef-abee-324856734215)
 - Add login type 'none' to prevent password login. This can come in handy for machine accounts for CI/CD pipelines or other automation (#8009)
 - Healthcheck endpoint has a database section: `/api/v2/debug/health`
 - Force DERP connections in CLI with `--disable-direct` flag (#8131)
 - Disable all direct connections for a Coder deployment with [--block-direct-connections](https://coder.com/docs/v2/latest/cli/server#--block-direct-connections) (#7936)
 - Search for workspaces based on last activity (#2658)
-    ```text
-    last_seen_before:"2023-01-14T23:59:59Z" last_seen_after:"2023-01-08T00:00:00Z"
-    ```
+  ```text
+  last_seen_before:"2023-01-14T23:59:59Z" last_seen_after:"2023-01-08T00:00:00Z"
+  ```
 - Queue position of pending workspace builds are shown in the dashboard (#8244)
-    <img width="1449" alt="Queue position" src="https://github.com/coder/coder/assets/22407953/44515a19-ddfb-4431-8c2a-203487c4efe8">
+  <img width="1449" alt="Queue position" src="https://github.com/coder/coder/assets/22407953/44515a19-ddfb-4431-8c2a-203487c4efe8">
 - Enable Terraform debug mode via deployment configuration (#8260)
 - Add github device flow for authentication (#8232)
 - Sort Coder parameters with [display_order](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/parameter) property (#8227)
 - Users can convert from username/password accounts to OIDC accounts in Account settings (#8105) (@Emyrk)
-    ![Convert account](https://github.com/coder/coder/assets/22407953/6ea28c1c-53d7-4eb5-8113-9a066739820c)
+  ![Convert account](https://github.com/coder/coder/assets/22407953/6ea28c1c-53d7-4eb5-8113-9a066739820c)
 - Show service banner in SSH/TTY sessions (#8186)
 - Helm chart now supports RBAC for deployments (#8233)
 
@@ -68,4 +68,3 @@ Compare: [`v0.24.1...v0.25.0`](https://github.com/coder/coder/compare/v0.24.1...
 ## Install/upgrade
 
 Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
-

--- a/docs/changelogs/v0.25.0.md
+++ b/docs/changelogs/v0.25.0.md
@@ -1,0 +1,71 @@
+## Changelog
+
+> **Warning**: This release has a known issue: #8351. Upgrade directly to v0.26.0 which includes a fix
+
+### Features
+
+- The `coder stat` fetches workspace utilization metrics, even from within a container. Our example templates have been updated to use this to show CPU, memory, disk via [agent metadata](https://coder.com/docs/v2/latest/templates/agent-metadata) (#8005)
+- Helm: `coder.command` can specify a different command for the Coder pod (#8116)
+- Enterprise deployments can create templates without 'everyone' group access (#7982)
+    ![Disable "everyone"](https://github.com/coder/coder/assets/22407953/1c31cb9b-be5c-4bef-abee-324856734215)
+- Add login type 'none' to prevent password login. This can come in handy for machine accounts for CI/CD pipelines or other automation (#8009)
+- Healthcheck endpoint has a database section: `/api/v2/debug/health`
+- Force DERP connections in CLI with `--disable-direct` flag (#8131)
+- Disable all direct connections for a Coder deployment with [--block-direct-connections](https://coder.com/docs/v2/latest/cli/server#--block-direct-connections) (#7936)
+- Search for workspaces based on last activity (#2658)
+    ```text
+    last_seen_before:"2023-01-14T23:59:59Z" last_seen_after:"2023-01-08T00:00:00Z"
+    ```
+- Queue position of pending workspace builds are shown in the dashboard (#8244)
+    <img width="1449" alt="Queue position" src="https://github.com/coder/coder/assets/22407953/44515a19-ddfb-4431-8c2a-203487c4efe8">
+- Enable Terraform debug mode via deployment configuration (#8260)
+- Add github device flow for authentication (#8232)
+- Sort Coder parameters with [display_order](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/parameter) property (#8227)
+- Users can convert from username/password accounts to OIDC accounts in Account settings (#8105) (@Emyrk)
+    ![Convert account](https://github.com/coder/coder/assets/22407953/6ea28c1c-53d7-4eb5-8113-9a066739820c)
+- Show service banner in SSH/TTY sessions (#8186)
+- Helm chart now supports RBAC for deployments (#8233)
+
+### Bug fixes
+
+- `coder logout` will not invalidate long-lived API tokens (#8275)
+- Helm: use `/healthz` for liveness and readiness probes instead of `/api/v2/buildinfo` (#8035)
+- Close output writer before reader on Windows to unblock close (#8299)
+- Resize terminal when dismissing warning (#8028)
+- Fix footer year (#8036)
+- Prevent filter input update when focused (#8102)
+- Fix filters errors display (#8103)
+- Show error when parameter is invalid (#8125)
+- Display correct user_limit on license ui (#8118)
+- Only collect prometheus database metrics when explicitly enabled (#8045)
+- Avoid missed logs when streaming startup logs (#8029)
+- Show git provider id instead of type (#8075)
+- Disable websocket compression for startup logs in Safari (#8087)
+- Revert to canvas renderer for xterm (#8138)
+
+### Documentation
+
+- Template inheritance with Terraform modules (#8328) (@bpmct)
+- Steps for configuring trusted headers & origins in Helm chart (#8031)
+- OIDC keycloak docs (#8042)
+- Steps for registering a github app with coder (#7976)
+- Prometheus scrape_config example (#8113)
+- `coder ping` example for troubleshooting (#8133)
+- Application logs (#8166)
+- Strip CORS headers from applications (#8057)
+- Max lifetime docs and refactor UI helper text (#8185)
+- Add default dir for VS Code Desktop (#8184)
+- Agent metadata is now GA (#8111) (@bpmct)
+- Note SSH key location in workspaces (#8264)
+- Update examples of IDEs: remove JetBrains Projector and add VS Code Server (#8310)
+
+Compare: [`v0.24.1...v0.25.0`](https://github.com/coder/coder/compare/v0.24.1...v0.25.0)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.25.0`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
+

--- a/docs/changelogs/v0.26.0.md
+++ b/docs/changelogs/v0.26.0.md
@@ -1,0 +1,42 @@
+## Changelog
+
+### Important changes
+
+- [Managed variables](https://coder.com/docs/v2/latest/templates/parameters#terraform-template-wide-variables) are enabled by default. The following block within templates is obsolete and can be removed from your templates:
+
+    ```diff
+    provider "coder" {
+    -  feature_use_managed_variables = "true"
+    }
+    ```
+    > The change does not affect your templates because this attribute was previously necessary to activate this additional feature.
+
+- Our scale test CLI is [experimental](https://coder.com/docs/v2/latest/contributing/feature-stages#experimental-features) to allow for rapid iteration. You can still interact with it via `coder exp scaletest` (#8339)
+
+### Features
+
+- [coder dotfiles](https://coder.com/docs/v2/latest/cli/dotfiles) can checkout a specific branch
+
+### Bug fixes
+
+- Delay "Workspace build is pending" banner to avoid quick re-render when a workspace is created (#8309)
+- `coder stat` handles cgroups with no limits
+- Remove concurrency to allow migrations when `coderd` runs on multiple replicas (#8353)
+- Pass oauth configs to site (#8390)
+- Improve error message for missing action in Audit log (#8335)
+- Add missing fields to extract api key config (#8393)
+- Resize terminal when alert is dismissed (#8368)
+- Report failed CompletedJob (#8318)
+- Resolve nil pointer dereference on missing oauth config (#8352)
+- Update fly.io example to remove deprecated parameters (#8194)
+
+Compare: [`v0.25.0...0.26.0`](https://github.com/coder/coder/compare/v0.25.0...v0.26.0)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.26.0`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
+

--- a/docs/changelogs/v0.26.0.md
+++ b/docs/changelogs/v0.26.0.md
@@ -4,12 +4,13 @@
 
 - [Managed variables](https://coder.com/docs/v2/latest/templates/parameters#terraform-template-wide-variables) are enabled by default. The following block within templates is obsolete and can be removed from your templates:
 
-    ```diff
-    provider "coder" {
-    -  feature_use_managed_variables = "true"
-    }
-    ```
-    > The change does not affect your templates because this attribute was previously necessary to activate this additional feature.
+  ```diff
+  provider "coder" {
+  -  feature_use_managed_variables = "true"
+  }
+  ```
+
+  > The change does not affect your templates because this attribute was previously necessary to activate this additional feature.
 
 - Our scale test CLI is [experimental](https://coder.com/docs/v2/latest/contributing/feature-stages#experimental-features) to allow for rapid iteration. You can still interact with it via `coder exp scaletest` (#8339)
 
@@ -39,4 +40,3 @@ Compare: [`v0.25.0...0.26.0`](https://github.com/coder/coder/compare/v0.25.0...v
 ## Install/upgrade
 
 Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
-

--- a/docs/changelogs/v0.26.1.md
+++ b/docs/changelogs/v0.26.1.md
@@ -1,0 +1,30 @@
+## Changelog
+
+### Features
+
+- [Devcontainer templates](https://coder.com/docs/v2/latest/templates/devcontainers) for Coder (#8256)
+- The dashboard will warn users when a workspace is unhealthy (#8422)
+- Audit logs `resource_target` search query allows you to search by resource name (#8423)
+
+### Refactors
+
+- [pgCoordinator](https://github.com/coder/coder/pull/8044) is generally available (#8419)
+
+### Bug fixes
+
+- Git device flow will persist user tokens (#8411)
+- Check shell on darwin via dscl (#8366)
+- Handle oauth config removed for existing auth (#8420)
+- Prevent ExtractAPIKey from dirtying the HTML output (#8450)
+- Document workspace filter query param correctly (#8408)
+- Use numeric comparison to check monotonicity (#8436)
+
+Compare: [`v0.26.0...v0.26.1`](https://github.com/coder/coder/compare/v0.26.0...v0.26.1)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.26.1`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.

--- a/docs/changelogs/v0.27.0.md
+++ b/docs/changelogs/v0.27.0.md
@@ -1,0 +1,114 @@
+## Changelog
+
+### Breaking changes
+
+Agent logs can be pushed after a workspace has started (#8528)
+
+> ⚠️ **Warning:** You will need to [update](https://coder.com/docs/v2/latest/install) your local Coder CLI v0.27 to connect via `coder ssh`.
+
+### Features
+
+- [Empeheral parameters](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/parameter#ephemeral) allow users to specify a value for a single build (#8415) (#8524)
+  ![Ephemeral parameters](https://github.com/coder/coder/assets/22407953/89df0888-9abc-453a-ac54-f5d0e221b0b9)
+  > Upgrade to Coder Terraform Provider v0.11.1 to use ephemeral parameters in your templates
+- Create template, if it doesn't exist with `templates push --create` (#8454)
+- Workspaces now appear `unhealthy` in the dashboard and CLI if one or more agents do not exist (#8541) (#8548)
+  ![Workspace health](https://github.com/coder/coder/assets/22407953/edbb1d70-61b5-4b45-bfe8-51abdab417cc)
+- Reverse port-forward with `coder ssh -R` (#8515)
+- Helm: custom command arguments in Helm chart (#8567)
+- Template version messages (#8435)
+  <img width="428" alt="252772262-087f1338-f1e2-49fb-81f2-358070a46484" src="https://github.com/coder/coder/assets/22407953/5f6e5e47-e61b-41f1-92fe-f624e92f8bd3">
+- TTL and max TTL validation increased to 30 days (#8258)
+- [Self-hosted docs](https://coder.com/docs/v2/latest/install/offline#offline-docs): Host your own copy of Coder's documentation in your own environment (#8527) (#8601)
+- Add custom coder bin path for `config-ssh` (#8425)
+- Admins can create workspaces for other users via the CLI (#8481)
+- `coder_app` supports localhost apps running https (#8585)
+- Base container image contains [jq](https://github.com/coder/coder/pull/8563) for parsing mounted JSON secrets
+
+### Bug fixes
+
+- Check agent metadata every second instead of minute (#8614)
+- `coder stat` fixes
+  - Read from alternate cgroup path (#8591)
+  - Improve detection of container environment (#8643)
+  - Unskip TestStatCPUCmd/JSON and explicitly set --host in test cmd invocation (#8558)
+- Avoid initial license reconfig if feature isn't enabled (#8586)
+- Audit log records delete workspace action properly (#8494)
+- Audit logs are properly paginated (#8513)
+- Fix bottom border on build logs (#8554)
+- Don't mark metadata with `interval: 0` as stale (#8627)
+- Add some missing workspace updates (#7790)
+
+### Documentation
+## Changelog
+
+### Breaking changes
+
+Agent logs can be pushed after a workspace has started (#8528)
+
+> ⚠️ **Warning:** You will need to [update](https://coder.com/docs/v2/latest/install) your local Coder CLI v0.27 to connect via `coder ssh`.
+
+### Features
+
+- [Empeheral parameters](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/parameter#ephemeral) allow users to specify a value for a single build (#8415) (#8524)
+  ![Ephemeral parameters](https://github.com/coder/coder/assets/22407953/89df0888-9abc-453a-ac54-f5d0e221b0b9)
+  > Upgrade to Coder Terraform Provider v0.11.1 to use ephemeral parameters in your templates
+- Create template, if it doesn't exist with `templates push --create` (#8454)
+- Workspaces now appear `unhealthy` in the dashboard and CLI if one or more agents do not exist (#8541) (#8548)
+  ![Workspace health](https://github.com/coder/coder/assets/22407953/edbb1d70-61b5-4b45-bfe8-51abdab417cc)
+- Reverse port-forward with `coder ssh -R` (#8515)
+- Helm: custom command arguments in Helm chart (#8567)
+- Template version messages (#8435)
+  <img width="428" alt="252772262-087f1338-f1e2-49fb-81f2-358070a46484" src="https://github.com/coder/coder/assets/22407953/5f6e5e47-e61b-41f1-92fe-f624e92f8bd3">
+- TTL and max TTL validation increased to 30 days (#8258)
+- [Self-hosted docs](https://coder.com/docs/v2/latest/install/offline#offline-docs): Host your own copy of Coder's documentation in your own environment (#8527) (#8601)
+- Add custom coder bin path for `config-ssh` (#8425)
+- Admins can create workspaces for other users via the CLI (#8481)
+- `coder_app` supports localhost apps running https (#8585)
+- Base container image contains [jq](https://github.com/coder/coder/pull/8563) for parsing mounted JSON secrets
+
+### Bug fixes
+
+- Check agent metadata every second instead of minute (#8614)
+- `coder stat` fixes
+  - Read from alternate cgroup path (#8591)
+  - Improve detection of container environment (#8643)
+  - Unskip TestStatCPUCmd/JSON and explicitly set --host in test cmd invocation (#8558)
+- Avoid initial license reconfig if feature isn't enabled (#8586)
+- Audit log records delete workspace action properly (#8494)
+- Audit logs are properly paginated (#8513)
+- Fix bottom border on build logs (#8554)
+- Don't mark metadata with `interval: 0` as stale (#8627)
+- Add some missing workspace updates (#7790)
+
+### Documentation
+
+- Custom API use cases (custom agent logs, CI/CD pipelines) (#8445)
+- Docs on using remote Docker hosts (#8479)
+- Added kubernetes option to workspace proxies (#8533)
+
+
+Compare: [`v0.26.1...v0.26.2`](https://github.com/coder/coder/compare/v0.26.1...v0.27.0)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.26.2`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
+
+- Custom API use cases (custom agent logs, CI/CD pipelines) (#8445)
+- Docs on using remote Docker hosts (#8479)
+- Added kubernetes option to workspace proxies (#8533)
+
+
+Compare: [`v0.26.1...v0.26.2`](https://github.com/coder/coder/compare/v0.26.1...v0.27.0)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.26.2`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.

--- a/docs/changelogs/v0.27.0.md
+++ b/docs/changelogs/v0.27.0.md
@@ -40,6 +40,7 @@ Agent logs can be pushed after a workspace has started (#8528)
 - Add some missing workspace updates (#7790)
 
 ### Documentation
+
 ## Changelog
 
 ### Breaking changes
@@ -87,7 +88,6 @@ Agent logs can be pushed after a workspace has started (#8528)
 - Docs on using remote Docker hosts (#8479)
 - Added kubernetes option to workspace proxies (#8533)
 
-
 Compare: [`v0.26.1...v0.26.2`](https://github.com/coder/coder/compare/v0.26.1...v0.27.0)
 
 ## Container image
@@ -101,7 +101,6 @@ Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upg
 - Custom API use cases (custom agent logs, CI/CD pipelines) (#8445)
 - Docs on using remote Docker hosts (#8479)
 - Added kubernetes option to workspace proxies (#8533)
-
 
 Compare: [`v0.26.1...v0.26.2`](https://github.com/coder/coder/compare/v0.26.1...v0.27.0)
 

--- a/docs/changelogs/v0.27.1.md
+++ b/docs/changelogs/v0.27.1.md
@@ -1,0 +1,24 @@
+## Changelog
+
+### Features
+
+- Check if dotfiles install script is executable (#8588)
+
+### Bug fixes
+
+- Send build parameters over the confirmation dialog on restart (#8660)
+
+### Documentation
+
+- Add steps for postgres SSL cert config (#8648)
+
+Compare: [`v0.27.0...v0.27.1`](https://github.com/coder/coder/compare/v0.27.0...v0.27.1)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.27.1`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
+

--- a/docs/changelogs/v0.27.1.md
+++ b/docs/changelogs/v0.27.1.md
@@ -21,4 +21,3 @@ Compare: [`v0.27.0...v0.27.1`](https://github.com/coder/coder/compare/v0.27.0...
 ## Install/upgrade
 
 Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.
-

--- a/docs/changelogs/v0.27.3.md
+++ b/docs/changelogs/v0.27.3.md
@@ -1,0 +1,17 @@
+# v0.27.3
+
+## Changelog
+
+### Bug fixes
+
+- be2e6f443 fix(enterprise): ensure creating a SCIM user is idempotent (#8730)
+
+Compare: [`v0.27.2...v0.27.3`](https://github.com/coder/coder/compare/v0.27.2...v0.27.3)
+
+## Container image
+
+- `docker pull ghcr.io/coder/coder:v0.27.3`
+
+## Install/upgrade
+
+Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -133,7 +133,7 @@ if ! [[ $continue_release =~ ^[Yy]$ ]]; then
 	exit 0
 fi
 
-release_notes="$(execrelative ./release/generate_release_notes.sh --old-version "$old_version" --new-version "$new_version" --ref "$ref")"
+release_notes="$(execrelative ./release/generate_release_notes.sh --check-for-changelog --old-version "$old_version" --new-version "$new_version" --ref "$ref")"
 
 read -p "Preview release notes? (y/n) " -n 1 -r show_reply
 log

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -18,11 +18,16 @@ source "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib.sh"
 old_version=
 new_version=
 ref=
+check_for_changelog=0
 
-args="$(getopt -o '' -l old-version:,new-version:,ref: -- "$@")"
+args="$(getopt -o '' -l check-for-changelog,old-version:,new-version:,ref: -- "$@")"
 eval set -- "$args"
 while true; do
 	case "$1" in
+	--check-for-changelog)
+		check_for_changelog=1
+		shift
+		;;
 	--old-version)
 		old_version="$2"
 		shift 2
@@ -59,6 +64,15 @@ if [[ $new_version != v* ]]; then
 fi
 if [[ -z $ref ]]; then
 	error "No ref specified"
+fi
+
+# Use a manual changelog, if present
+changelog_path="$(git rev-parse --show-toplevel)/docs/changelogs/$new_version.md"
+if [ "$check_for_changelog" -eq 1 ]; then
+  if [ -f "$changelog_path" ]; then
+    cat "$changelog_path"
+    exit 0
+  fi
 fi
 
 # shellcheck source=scripts/release/check_commit_metadata.sh

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -69,10 +69,10 @@ fi
 # Use a manual changelog, if present
 changelog_path="$(git rev-parse --show-toplevel)/docs/changelogs/$new_version.md"
 if [ "$check_for_changelog" -eq 1 ]; then
-  if [ -f "$changelog_path" ]; then
-    cat "$changelog_path"
-    exit 0
-  fi
+	if [ -f "$changelog_path" ]; then
+		cat "$changelog_path"
+		exit 0
+	fi
 fi
 
 # shellcheck source=scripts/release/check_commit_metadata.sh

--- a/scripts/release/tag_version.sh
+++ b/scripts/release/tag_version.sh
@@ -118,6 +118,8 @@ minor)
 	version_parts[2]=0
 	;;
 major)
+	# Jump from v0.x to v2.x to avoid naming conflicts
+	# with Coder v1 (https://coder.com/docs/v1)
 	if [ "${version_parts[0]}" -eq 0 ]; then
 		version_parts[0]=2
 	else

--- a/scripts/release/tag_version.sh
+++ b/scripts/release/tag_version.sh
@@ -118,7 +118,11 @@ minor)
 	version_parts[2]=0
 	;;
 major)
-	version_parts[0]=$((version_parts[0] + 1))
+	if [ "${version_parts[0]}" -eq 0 ]; then
+		version_parts[0]=2
+	else
+		version_parts[0]=$((version_parts[0] + 1))
+	fi
 	version_parts[1]=0
 	version_parts[2]=0
 	;;


### PR DESCRIPTION
This PR allows us to "bring our own" changelog instead of leveraging the automated one at release-time. If one does not exist, it will fall back to the generated one. This also adds support for us jumping to a v2.0 major version, skipping over 1.0 to avoid naming conflicts with Coder v1.

It's a bit hacky. I plan on working with @mafredri on a cleaner solution for this (+ patch releases) once he returns from PTO.