### PR TITLE
chore: rework derpmap getter

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -73,7 +73,7 @@ type Options struct {
 type Client interface {
 	Manifest(ctx context.Context) (agentsdk.Manifest, error)
 	Listen(ctx context.Context) (net.Conn, error)
-	DERPMapUpdates(ctx context.Context) (<-chan agentsdk.DERPMapUpdate, io.Closer, error)
+	DERPMapUpdates(ctx context.Context) (<-chan codersdk.DERPMapUpdate, io.Closer, error)
 	ReportStats(ctx context.Context, log slog.Logger, statsChan <-chan *agentsdk.Stats, setInterval func(time.Duration)) (io.Closer, error)
 	PostLifecycle(ctx context.Context, state agentsdk.PostLifecycleRequest) error
 	PostAppHealth(ctx context.Context, req agentsdk.PostAppHealthsRequest) error

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1813,7 +1813,7 @@ func TestAgent_UpdatedDERP(t *testing.T) {
 	}
 
 	// Push a new DERP map to the agent.
-	err := client.PushDERPMapUpdate(agentsdk.DERPMapUpdate{
+	err := client.PushDERPMapUpdate(codersdk.DERPMapUpdate{
 		DERPMap: newDerpMap,
 	})
 	require.NoError(t, err)

--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -36,7 +36,7 @@ func NewClient(t testing.TB,
 		manifest:       manifest,
 		statsChan:      statsChan,
 		coordinator:    coordinator,
-		derpMapUpdates: make(chan agentsdk.DERPMapUpdate),
+		derpMapUpdates: make(chan codersdk.DERPMapUpdate),
 	}
 }
 
@@ -56,7 +56,7 @@ type Client struct {
 	lifecycleStates []codersdk.WorkspaceAgentLifecycle
 	startup         agentsdk.PostStartupRequest
 	logs            []agentsdk.Log
-	derpMapUpdates  chan agentsdk.DERPMapUpdate
+	derpMapUpdates  chan codersdk.DERPMapUpdate
 }
 
 func (c *Client) Manifest(_ context.Context) (agentsdk.Manifest, error) {
@@ -195,7 +195,7 @@ func (c *Client) GetServiceBanner(ctx context.Context) (codersdk.ServiceBannerCo
 	return codersdk.ServiceBannerConfig{}, nil
 }
 
-func (c *Client) PushDERPMapUpdate(update agentsdk.DERPMapUpdate) error {
+func (c *Client) PushDERPMapUpdate(update codersdk.DERPMapUpdate) error {
 	timer := time.NewTimer(testutil.WaitShort)
 	defer timer.Stop()
 	select {
@@ -207,7 +207,7 @@ func (c *Client) PushDERPMapUpdate(update agentsdk.DERPMapUpdate) error {
 	return nil
 }
 
-func (c *Client) DERPMapUpdates(_ context.Context) (<-chan agentsdk.DERPMapUpdate, io.Closer, error) {
+func (c *Client) DERPMapUpdates(_ context.Context) (<-chan codersdk.DERPMapUpdate, io.Closer, error) {
 	closed := make(chan struct{})
 	return c.derpMapUpdates, closeFunc(func() error {
 		close(closed)

--- a/cli/server.go
+++ b/cli/server.go
@@ -826,7 +826,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 
 			if cfg.Prometheus.Enable {
 				// Agent metrics require reference to the tailnet coordinator, so must be initiated after Coder API.
-				closeAgentsFunc, err := prometheusmetrics.Agents(ctx, logger, options.PrometheusRegistry, coderAPI.Database, &coderAPI.TailnetCoordinator, coderAPI.DERPMap, coderAPI.Options.AgentInactiveDisconnectTimeout, 0)
+				closeAgentsFunc, err := prometheusmetrics.Agents(ctx, logger, options.PrometheusRegistry, coderAPI.Database, &coderAPI.TailnetCoordinator, coderAPI.DERPMapProvider, coderAPI.Options.AgentInactiveDisconnectTimeout, 0)
 				if err != nil {
 					return xerrors.Errorf("register agents prometheus metric: %w", err)
 				}

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -398,7 +398,6 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			TrialGenerator:              options.TrialGenerator,
 			TailnetCoordinator:          options.Coordinator,
 			BaseDERPMap:                 derpMap,
-			DERPMapUpdateFrequency:      150 * time.Millisecond,
 			MetricsCacheRefreshInterval: options.MetricsCacheRefreshInterval,
 			AgentStatsRefreshInterval:   options.AgentStatsRefreshInterval,
 			DeploymentValues:            options.DeploymentValues,

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -142,7 +142,7 @@ func Workspaces(ctx context.Context, registerer prometheus.Registerer, db databa
 }
 
 // Agents tracks the total number of workspaces with labels on status.
-func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Registerer, db database.Store, coordinator *atomic.Pointer[tailnet.Coordinator], derpMapFn func() *tailcfg.DERPMap, agentInactiveDisconnectTimeout, duration time.Duration) (func(), error) {
+func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Registerer, db database.Store, coordinator *atomic.Pointer[tailnet.Coordinator], derpMapProvider *atomic.Pointer[tailnet.DERPMapProvider], agentInactiveDisconnectTimeout, duration time.Duration) (func(), error) {
 	if duration == 0 {
 		duration = 1 * time.Minute
 	}
@@ -223,7 +223,7 @@ func Agents(ctx context.Context, logger slog.Logger, registerer prometheus.Regis
 
 			logger.Debug(ctx, "agent metrics collection is starting")
 			timer := prometheus.NewTimer(metricsCollectorAgents)
-			derpMap := derpMapFn()
+			derpMap := (*derpMapProvider.Load()).Get()
 
 			workspaceRows, err := db.GetWorkspaces(ctx, database.GetWorkspacesParams{
 				AgentInactiveDisconnectTimeoutSeconds: int64(agentInactiveDisconnectTimeout.Seconds()),

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -149,7 +149,8 @@ func (api *API) provisionerJobResources(rw http.ResponseWriter, r *http.Request,
 			}
 
 			apiAgent, err := convertWorkspaceAgent(
-				api.DERPMap(), *api.TailnetCoordinator.Load(), agent, convertApps(dbApps), api.AgentInactiveDisconnectTimeout,
+				(*api.DERPMapProvider.Load()).Get(),
+				*api.TailnetCoordinator.Load(), agent, convertApps(dbApps), api.AgentInactiveDisconnectTimeout,
 				api.DeploymentValues.AgentFallbackTroubleshootingURL.String(),
 			)
 			if err != nil {

--- a/coderd/tailnet_test.go
+++ b/coderd/tailnet_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
@@ -225,11 +226,15 @@ func setupAgent(t *testing.T, agentAddresses []netip.Prefix) (uuid.UUID, agent.A
 		}), nil
 	}, 0)
 
+	dmProvider := &atomic.Pointer[tailnet.DERPMapProvider]{}
+	dmProviderStatic := tailnet.NewDERPMapProviderStatic(manifest.DERPMap)
+	dmProvider.Store(&dmProviderStatic)
+
 	serverTailnet, err := coderd.NewServerTailnet(
 		context.Background(),
 		logger,
 		derpServer,
-		manifest.DERPMap,
+		dmProvider,
 		func(context.Context) (tailnet.MultiAgentConn, error) { return coord.ServeMultiAgent(uuid.New()), nil },
 		cache,
 	)

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -832,7 +832,8 @@ func (api *API) convertWorkspaceBuild(
 		for _, agent := range agents {
 			apps := appsByAgentID[agent.ID]
 			apiAgent, err := convertWorkspaceAgent(
-				api.DERPMap(), *api.TailnetCoordinator.Load(), agent, convertApps(apps), api.AgentInactiveDisconnectTimeout,
+				(*api.DERPMapProvider.Load()).Get(),
+				*api.TailnetCoordinator.Load(), agent, convertApps(apps), api.AgentInactiveDisconnectTimeout,
 				api.DeploymentValues.AgentFallbackTroubleshootingURL.String(),
 			)
 			if err != nil {

--- a/coderd/wsconncache/wsconncache_test.go
+++ b/coderd/wsconncache/wsconncache_test.go
@@ -229,9 +229,9 @@ func (c *closer) Close() error {
 	return c.closeFunc()
 }
 
-func (*client) DERPMapUpdates(_ context.Context) (<-chan agentsdk.DERPMapUpdate, io.Closer, error) {
+func (*client) DERPMapUpdates(_ context.Context) (<-chan codersdk.DERPMapUpdate, io.Closer, error) {
 	closed := make(chan struct{})
-	return make(<-chan agentsdk.DERPMapUpdate), &closer{
+	return make(<-chan codersdk.DERPMapUpdate), &closer{
 		closeFunc: func() error {
 			close(closed)
 			return nil

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -314,11 +314,12 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 	if api.AGPL.Experiments.Enabled(codersdk.ExperimentMoons) {
 		// Proxy health is a moon feature.
 		api.ProxyHealth, err = proxyhealth.New(&proxyhealth.Options{
-			Interval:   options.ProxyHealthInterval,
-			DB:         api.Database,
-			Logger:     options.Logger.Named("proxyhealth"),
-			Client:     api.HTTPClient,
-			Prometheus: api.PrometheusRegistry,
+			Interval:        options.ProxyHealthInterval,
+			DB:              api.Database,
+			Logger:          options.Logger.Named("proxyhealth"),
+			Client:          api.HTTPClient,
+			Prometheus:      api.PrometheusRegistry,
+			DERPMapProvider: api.AGPL.DERPMapProvider,
 		})
 		if err != nil {
 			return nil, xerrors.Errorf("initialize proxy health: %w", err)

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -87,7 +87,7 @@ func NewWithAPI(t *testing.T, options *Options) (
 		BrowserOnly:                options.BrowserOnly,
 		SCIMAPIKey:                 options.SCIMAPIKey,
 		DERPServerRelayAddress:     oop.AccessURL.String(),
-		DERPServerRegionID:         oop.BaseDERPMap.RegionIDs()[0],
+		DERPServerRegionID:         int(oop.DeploymentValues.DERP.Server.RegionID.Value()),
 		ReplicaSyncUpdateInterval:  options.ReplicaSyncUpdateInterval,
 		Options:                    oop,
 		EntitlementsUpdateInterval: options.EntitlementsUpdateInterval,

--- a/scripts/rules.go
+++ b/scripts/rules.go
@@ -391,3 +391,12 @@ func slogError(m dsl.Matcher) {
 		Where(m["name"].Const && m["value"].Type.Is("error") && !m["name"].Text.Matches(`^"internal_error"$`)).
 		Report(`Error should be logged using "slog.Error" instead.`)
 }
+
+// baseDERPMap ensures that fields named BaseDERPMap are never used. The
+// DERPMapProvider should be used instead.
+func baseDERPMap(m dsl.Matcher) {
+	m.Match(
+		`$_.BaseDERPMap`,
+	).
+		Report(`BaseDERPMap should not be used. Use DERPMapProvider instead.`)
+}

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -395,6 +395,12 @@ func (c *Conn) SetNodeCallback(callback func(node *Node)) {
 func (c *Conn) SetDERPMap(derpMap *tailcfg.DERPMap) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+	select {
+	case <-c.Closed():
+		return
+	default:
+	}
+
 	c.logger.Debug(context.Background(), "updating derp map", slog.F("derp_map", derpMap))
 	c.wireguardEngine.SetDERPMap(derpMap)
 	c.netMap.DERPMap = derpMap

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -58,7 +58,9 @@ func init() {
 }
 
 type Options struct {
-	Addresses  []netip.Prefix
+	Addresses []netip.Prefix
+	// DERPMap is the initial DERP map to use. May be nil. Can be updated via
+	// SetDERPMap().
 	DERPMap    *tailcfg.DERPMap
 	DERPHeader *http.Header
 
@@ -76,9 +78,6 @@ func NewConn(options *Options) (conn *Conn, err error) {
 	}
 	if len(options.Addresses) == 0 {
 		return nil, xerrors.New("At least one IP range must be provided")
-	}
-	if options.DERPMap == nil {
-		return nil, xerrors.New("DERPMap must be provided")
 	}
 
 	nodePrivateKey := key.NewNode()
@@ -199,7 +198,9 @@ func NewConn(options *Options) (conn *Conn, err error) {
 	}
 	netStack.ProcessLocalIPs = true
 	wireguardEngine = wgengine.NewWatchdog(wireguardEngine)
-	wireguardEngine.SetDERPMap(options.DERPMap)
+	if options.DERPMap != nil {
+		wireguardEngine.SetDERPMap(options.DERPMap)
+	}
 	netMapCopy := *netMap
 	options.Logger.Debug(context.Background(), "updating network map")
 	wireguardEngine.SetNetworkMap(&netMapCopy)


### PR DESCRIPTION
## TODO:
- [ ] Tests for DERPMapProvider
- [ ] Rewrite all instances of `api.DERPMap()` to use `(*api.DERPMapProvider.Load())`
- [ ] Rewrite all tests that change the DERP map to use the new interface
- [ ] Create `DERPMapProvider` for wsproxy (using reconnecting websocket to `/api/v2/derp-map`)
    - [ ] Tests
