### PR TITLE
fix(helm): set correct prom port in helm notes

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,7 @@ coder:
   # - CODER_TLS_ENABLE: set if tls.secretName is not empty.
   # - CODER_TLS_CERT_FILE: set if tls.secretName is not empty.
   # - CODER_TLS_KEY_FILE: set if tls.secretName is not empty.
-  # - CODER_PROMETHEUS_ADDRESS: set to 0.0.0.0:6060 and cannot be changed.
+  # - CODER_PROMETHEUS_ADDRESS: set to 0.0.0.0:2112 and cannot be changed.
   #   Prometheus must still be enabled by setting CODER_PROMETHEUS_ENABLE.
   # - KUBE_POD_IP
   # - CODER_DERP_SERVER_RELAY_URL


### PR DESCRIPTION
a customer pointed this out. by default, Coder exposes Prometheus metrics on `2112`, not `6060`. this PR corrects this in the `values.yaml` comments.