### PR TITLE
chore: update `golang.org/x/exp/slices`

### DIFF
--- a/cli/clibase/cmd.go
+++ b/cli/clibase/cmd.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
+
+	"github.com/coder/coder/coderd/util/slice"
 )
 
 // Cmd describes an executable command.
@@ -102,11 +104,11 @@ func (c *Cmd) PrepareAll() error {
 		}
 	}
 
-	slices.SortFunc(c.Options, func(a, b Option) bool {
-		return a.Name < b.Name
+	slices.SortFunc(c.Options, func(a, b Option) int {
+		return slice.Ascending(a.Name, b.Name)
 	})
-	slices.SortFunc(c.Children, func(a, b *Cmd) bool {
-		return a.Name() < b.Name()
+	slices.SortFunc(c.Children, func(a, b *Cmd) int {
+		return slice.Ascending(a.Name(), b.Name())
 	})
 	for _, child := range c.Children {
 		child.Parent = c

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/cliui"
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/coder/coder/codersdk"
 )
 
@@ -367,8 +368,8 @@ func (r *RootCmd) configSSH() *clibase.Cmd {
 			}
 
 			// Ensure stable sorting of output.
-			slices.SortFunc(workspaceConfigs, func(a, b sshWorkspaceConfig) bool {
-				return a.Name < b.Name
+			slices.SortFunc(workspaceConfigs, func(a, b sshWorkspaceConfig) int {
+				return slice.Ascending(a.Name, b.Name)
 			})
 			for _, wc := range workspaceConfigs {
 				sort.Strings(wc.Hosts)

--- a/cli/create.go
+++ b/cli/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coder/coder/cli/clibase"
 	"github.com/coder/coder/cli/cliui"
 	"github.com/coder/coder/coderd/util/ptr"
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/coder/coder/codersdk"
 )
 
@@ -80,8 +81,8 @@ func (r *RootCmd) create() *clibase.Cmd {
 					return err
 				}
 
-				slices.SortFunc(templates, func(a, b codersdk.Template) bool {
-					return a.ActiveUserCount > b.ActiveUserCount
+				slices.SortFunc(templates, func(a, b codersdk.Template) int {
+					return slice.Descending(a.ActiveUserCount, b.ActiveUserCount)
 				})
 
 				templateNames := make([]string, 0, len(templates))

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -605,8 +605,8 @@ func uniqueSortedUUIDs(uuids []uuid.UUID) []uuid.UUID {
 	for id := range set {
 		unique = append(unique, id)
 	}
-	slices.SortFunc(unique, func(a, b uuid.UUID) bool {
-		return a.String() < b.String()
+	slices.SortFunc(unique, func(a, b uuid.UUID) int {
+		return slice.Ascending(a.String(), b.String())
 	})
 	return unique
 }
@@ -2060,8 +2060,8 @@ func (q *FakeQuerier) GetTemplateDailyInsights(_ context.Context, arg database.G
 		for templateID := range ds.templateIDSet {
 			templateIDs = append(templateIDs, templateID)
 		}
-		slices.SortFunc(templateIDs, func(a, b uuid.UUID) bool {
-			return a.String() < b.String()
+		slices.SortFunc(templateIDs, func(a, b uuid.UUID) int {
+			return slice.Ascending(a.String(), b.String())
 		})
 		result = append(result, database.GetTemplateDailyInsightsRow{
 			StartTime:   ds.startTime,
@@ -2119,8 +2119,8 @@ func (q *FakeQuerier) GetTemplateInsights(_ context.Context, arg database.GetTem
 	for templateID := range templateIDSet {
 		templateIDs = append(templateIDs, templateID)
 	}
-	slices.SortFunc(templateIDs, func(a, b uuid.UUID) bool {
-		return a.String() < b.String()
+	slices.SortFunc(templateIDs, func(a, b uuid.UUID) int {
+		return slice.Ascending(a.String(), b.String())
 	})
 	result := database.GetTemplateInsightsRow{
 		TemplateIDs: templateIDs,
@@ -2341,13 +2341,17 @@ func (q *FakeQuerier) GetTemplateVersionsByTemplateID(_ context.Context, arg dat
 	}
 
 	// Database orders by created_at
-	slices.SortFunc(version, func(a, b database.TemplateVersion) bool {
+	slices.SortFunc(version, func(a, b database.TemplateVersion) int {
 		if a.CreatedAt.Equal(b.CreatedAt) {
 			// Technically the postgres database also orders by uuid. So match
 			// that behavior
-			return a.ID.String() < b.ID.String()
+			return slice.Ascending(a.ID.String(), b.ID.String())
 		}
-		return a.CreatedAt.Before(b.CreatedAt)
+		if a.CreatedAt.Before(b.CreatedAt) {
+			return -1
+		} else {
+			return 1
+		}
 	})
 
 	if arg.AfterID != uuid.Nil {
@@ -2406,11 +2410,11 @@ func (q *FakeQuerier) GetTemplates(_ context.Context) ([]database.Template, erro
 	defer q.mutex.RUnlock()
 
 	templates := slices.Clone(q.templates)
-	slices.SortFunc(templates, func(i, j database.TemplateTable) bool {
-		if i.Name != j.Name {
-			return i.Name < j.Name
+	slices.SortFunc(templates, func(a, b database.TemplateTable) int {
+		if a.Name != b.Name {
+			return slice.Ascending(a.Name, b.Name)
 		}
-		return i.ID.String() < j.ID.String()
+		return slice.Ascending(a.ID.String(), b.ID.String())
 	})
 
 	return q.templatesWithUserNoLock(templates), nil
@@ -2523,8 +2527,8 @@ func (q *FakeQuerier) GetUserLatencyInsights(_ context.Context, arg database.Get
 		for templateID := range templateIDSet {
 			templateIDs = append(templateIDs, templateID)
 		}
-		slices.SortFunc(templateIDs, func(a, b uuid.UUID) bool {
-			return a.String() < b.String()
+		slices.SortFunc(templateIDs, func(a, b uuid.UUID) int {
+			return slice.Ascending(a.String(), b.String())
 		})
 		user, err := q.getUserByIDNoLock(userID)
 		if err != nil {
@@ -2540,8 +2544,8 @@ func (q *FakeQuerier) GetUserLatencyInsights(_ context.Context, arg database.Get
 		}
 		rows = append(rows, row)
 	}
-	slices.SortFunc(rows, func(a, b database.GetUserLatencyInsightsRow) bool {
-		return a.UserID.String() < b.UserID.String()
+	slices.SortFunc(rows, func(a, b database.GetUserLatencyInsightsRow) int {
+		return slice.Ascending(a.UserID.String(), b.UserID.String())
 	})
 
 	return rows, nil
@@ -2588,8 +2592,8 @@ func (q *FakeQuerier) GetUsers(_ context.Context, params database.GetUsersParams
 	copy(users, q.users)
 
 	// Database orders by username
-	slices.SortFunc(users, func(a, b database.User) bool {
-		return strings.ToLower(a.Username) < strings.ToLower(b.Username)
+	slices.SortFunc(users, func(a, b database.User) int {
+		return slice.Ascending(a.Username, b.Username)
 	})
 
 	// Filter out deleted since they should never be returned..
@@ -3126,9 +3130,9 @@ func (q *FakeQuerier) GetWorkspaceBuildsByWorkspaceID(_ context.Context,
 	}
 
 	// Order by build_number
-	slices.SortFunc(history, func(a, b database.WorkspaceBuild) bool {
-		// use greater than since we want descending order
-		return a.BuildNumber > b.BuildNumber
+	slices.SortFunc(history, func(a, b database.WorkspaceBuild) int {
+		return slice.Descending(a.BuildNumber, b.BuildNumber)
+
 	})
 
 	if params.AfterID != uuid.Nil {
@@ -3527,8 +3531,14 @@ func (q *FakeQuerier) InsertAuditLog(_ context.Context, arg database.InsertAudit
 	alog := database.AuditLog(arg)
 
 	q.auditLogs = append(q.auditLogs, alog)
-	slices.SortFunc(q.auditLogs, func(a, b database.AuditLog) bool {
-		return a.Time.Before(b.Time)
+	slices.SortFunc(q.auditLogs, func(a, b database.AuditLog) int {
+		if a.Time.Before(b.Time) {
+			return -1
+		} else if a.Time.Equal(b.Time) {
+			return 0
+		} else {
+			return 1
+		}
 	})
 
 	return alog, nil
@@ -5482,11 +5492,11 @@ func (q *FakeQuerier) GetAuthorizedTemplates(ctx context.Context, arg database.G
 		templates = append(templates, template)
 	}
 	if len(templates) > 0 {
-		slices.SortFunc(templates, func(i, j database.Template) bool {
-			if i.Name != j.Name {
-				return i.Name < j.Name
+		slices.SortFunc(templates, func(a, b database.Template) int {
+			if a.Name != b.Name {
+				return slice.Ascending(a.Name, b.Name)
 			}
-			return i.ID.String() < j.ID.String()
+			return slice.Ascending(a.ID.String(), b.ID.String())
 		})
 		return templates, nil
 	}

--- a/coderd/devtunnel/servers.go
+++ b/coderd/devtunnel/servers.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/coder/coder/cryptorand"
 )
 
@@ -115,8 +116,8 @@ func FindClosestNode(nodes []Node) (Node, error) {
 		return Node{}, err
 	}
 
-	slices.SortFunc(nodes, func(i, j Node) bool {
-		return i.AvgLatency < j.AvgLatency
+	slices.SortFunc(nodes, func(a, b Node) int {
+		return slice.Ascending(a.AvgLatency, b.AvgLatency)
 	})
 	return nodes[0], nil
 }

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/coder/coderd/database"
 	"github.com/coder/coder/coderd/httpapi"
 	"github.com/coder/coder/coderd/rbac"
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/coder/coder/codersdk"
 )
 
@@ -132,8 +133,8 @@ func (api *API) insightsUserLatency(rw http.ResponseWriter, r *http.Request) {
 	for templateID := range templateIDSet {
 		seenTemplateIDs = append(seenTemplateIDs, templateID)
 	}
-	slices.SortFunc(seenTemplateIDs, func(a, b uuid.UUID) bool {
-		return a.String() < b.String()
+	slices.SortFunc(seenTemplateIDs, func(a, b uuid.UUID) int {
+		return slice.Ascending(a.String(), b.String())
 	})
 
 	resp := codersdk.UserLatencyInsightsResponse{

--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -146,8 +146,14 @@ func convertDAUResponse[T dauRow](rows []T, tzOffset int) codersdk.DAUsResponse 
 	}
 
 	dates := maps.Keys(respMap)
-	slices.SortFunc(dates, func(a, b time.Time) bool {
-		return a.Before(b)
+	slices.SortFunc(dates, func(a, b time.Time) int {
+		if a.Before(b) {
+			return -1
+		} else if a.Equal(b) {
+			return 0
+		} else {
+			return 1
+		}
 	})
 
 	var resp codersdk.DAUsResponse

--- a/coderd/util/slice/slice.go
+++ b/coderd/util/slice/slice.go
@@ -1,5 +1,7 @@
 package slice
 
+import "golang.org/x/exp/constraints"
+
 // SameElements returns true if the 2 lists have the same elements in any
 // order.
 func SameElements[T comparable](a []T, b []T) bool {
@@ -66,4 +68,18 @@ func OverlapCompare[T any](a []T, b []T, equal func(a, b T) bool) bool {
 // New is a convenience method for creating []T.
 func New[T any](items ...T) []T {
 	return items
+}
+
+func Ascending[T constraints.Ordered](a, b T) int {
+	if a < b {
+		return -1
+	} else if a == b {
+		return 0
+	} else {
+		return 1
+	}
+}
+
+func Descending[T constraints.Ordered](a, b T) int {
+	return -Ascending[T](a, b)
 }

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -38,6 +38,7 @@ import (
 	"github.com/coder/coder/coderd/httpmw"
 	"github.com/coder/coder/coderd/rbac"
 	"github.com/coder/coder/coderd/util/ptr"
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/codersdk/agentsdk"
 	"github.com/coder/coder/tailnet"
@@ -1614,8 +1615,8 @@ func (api *API) watchWorkspaceAgentMetadata(rw http.ResponseWriter, r *http.Requ
 				})
 				return
 			}
-			slices.SortFunc(lastDBMeta, func(i, j database.WorkspaceAgentMetadatum) bool {
-				return i.Key < j.Key
+			slices.SortFunc(lastDBMeta, func(a, b database.WorkspaceAgentMetadatum) int {
+				return slice.Ascending(a.Key, b.Key)
 			})
 
 			// Avoid sending refresh if the client is about to get a

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coder/coder/coderd/database/dbauthz"
 	"github.com/coder/coder/coderd/database/pubsub"
 	"github.com/coder/coder/coderd/rbac"
+	"github.com/coder/coder/coderd/util/slice"
 	agpl "github.com/coder/coder/tailnet"
 )
 
@@ -1351,8 +1352,8 @@ func (c *pgCoord) htmlDebug(ctx context.Context) (agpl.HTMLDebug, error) {
 				Node: conn.Node,
 			})
 		}
-		slices.SortFunc(htmlAgent.Connections, func(a, b *agpl.HTMLClient) bool {
-			return a.Name < b.Name
+		slices.SortFunc(htmlAgent.Connections, func(a, b *agpl.HTMLClient) int {
+			return slice.Ascending(a.Name, b.Name)
 		})
 
 		data.Agents = append(data.Agents, htmlAgent)
@@ -1362,8 +1363,8 @@ func (c *pgCoord) htmlDebug(ctx context.Context) (agpl.HTMLDebug, error) {
 			Node: agent.Node,
 		})
 	}
-	slices.SortFunc(data.Agents, func(a, b *agpl.HTMLAgent) bool {
-		return a.Name < b.Name
+	slices.SortFunc(data.Agents, func(a, b *agpl.HTMLAgent) int {
+		return slice.Ascending(a.Name, b.Name)
 	})
 
 	for agentID, conns := range clients {
@@ -1389,14 +1390,14 @@ func (c *pgCoord) htmlDebug(ctx context.Context) (agpl.HTMLDebug, error) {
 				Node: conn.Node,
 			})
 		}
-		slices.SortFunc(agent.Connections, func(a, b *agpl.HTMLClient) bool {
-			return a.Name < b.Name
+		slices.SortFunc(agent.Connections, func(a, b *agpl.HTMLClient) int {
+			return slice.Ascending(a.Name, b.Name)
 		})
 
 		data.MissingAgents = append(data.MissingAgents, agent)
 	}
-	slices.SortFunc(data.MissingAgents, func(a, b *agpl.HTMLAgent) bool {
-		return a.Name < b.Name
+	slices.SortFunc(data.MissingAgents, func(a, b *agpl.HTMLAgent) int {
+		return slice.Ascending(a.Name, b.Name)
 	})
 
 	return data, nil

--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	go.uber.org/goleak v1.2.1
 	go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf
 	golang.org/x/crypto v0.11.0
-	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
+	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b
 	golang.org/x/mod v0.12.0
 	golang.org/x/net v0.12.0
 	golang.org/x/oauth2 v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a h1:Jw5wfR+h9mnIYH+OtGT2im5wV1YGGDora5vTv/aa5bE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/scripts/ci-report/main.go
+++ b/scripts/ci-report/main.go
@@ -12,6 +12,8 @@ import (
 
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/coderd/util/slice"
 )
 
 func main() {
@@ -161,9 +163,8 @@ func parseCIReport(report GotestsumReport) (CIReport, error) {
 	}
 	timeouts = timeoutsNorm
 
-	sortAZ := func(a, b string) bool { return a < b }
-	slices.SortFunc(packagesSortedByName, sortAZ)
-	slices.SortFunc(testSortedByName, sortAZ)
+	slices.SortFunc(packagesSortedByName, slice.Ascending[string])
+	slices.SortFunc(testSortedByName, slice.Ascending[string])
 
 	var rep CIReport
 

--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/coder/coderd/util/slice"
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/exp/slices"
@@ -683,14 +684,14 @@ func HTTPDebugFromLocal(
 				LastWriteAge: now.Sub(time.Unix(lastWrite, 0)).Round(time.Second),
 			})
 		}
-		slices.SortFunc(agent.Connections, func(a, b *HTMLClient) bool {
-			return a.Name < b.Name
+		slices.SortFunc(agent.Connections, func(a, b *HTMLClient) int {
+			return slice.Ascending(a.Name, b.Name)
 		})
 
 		data.Agents = append(data.Agents, agent)
 	}
-	slices.SortFunc(data.Agents, func(a, b *HTMLAgent) bool {
-		return a.Name < b.Name
+	slices.SortFunc(data.Agents, func(a, b *HTMLAgent) int {
+		return slice.Ascending(a.Name, b.Name)
 	})
 
 	for agentID, conns := range agentToConnectionSocketsMap {
@@ -719,14 +720,14 @@ func HTTPDebugFromLocal(
 				LastWriteAge: now.Sub(time.Unix(lastWrite, 0)).Round(time.Second),
 			})
 		}
-		slices.SortFunc(agent.Connections, func(a, b *HTMLClient) bool {
-			return a.Name < b.Name
+		slices.SortFunc(agent.Connections, func(a, b *HTMLClient) int {
+			return slice.Ascending(a.Name, b.Name)
 		})
 
 		data.MissingAgents = append(data.MissingAgents, agent)
 	}
-	slices.SortFunc(data.MissingAgents, func(a, b *HTMLAgent) bool {
-		return a.Name < b.Name
+	slices.SortFunc(data.MissingAgents, func(a, b *HTMLAgent) int {
+		return slice.Ascending(a.Name, b.Name)
 	})
 
 	for id, node := range nodesMap {
@@ -737,8 +738,8 @@ func HTTPDebugFromLocal(
 			Node: node,
 		})
 	}
-	slices.SortFunc(data.Nodes, func(a, b *HTMLNode) bool {
-		return a.Name+a.ID.String() < b.Name+b.ID.String()
+	slices.SortFunc(data.Nodes, func(a, b *HTMLNode) int {
+		return slice.Ascending(a.Name+a.ID.String(), b.Name+b.ID.String())
 	})
 
 	return data


### PR DESCRIPTION
This is necessary to bring us up to date with tailscale.