### PR TITLE
ci: publish main commit tag to `ghcr.io/coder/coder-preview`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -697,7 +697,7 @@ jobs:
     # This build and publihes ghcr.io/coder/coder-preview:main for each merge commit to main branch.
     # We are only building this for amd64 plateform. (>95% pulls are for amd64)
     needs: changes
-    # if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -742,7 +742,7 @@ jobs:
             build/coder_linux_amd64
 
           # Get commit sha to be used as package tag
-          new_package_tag=$(gh api repos/coder/coder/commits/main --jq '.sha[0:7]]')
+          new_package_tag=$(gh api repos/coder/coder/commits/main | jq -r '.sha[0:7]')
 
           # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -757,6 +757,7 @@ jobs:
           container: coder-preview
           dry-run: true
           keep-younger-than: 7 # days
+          keep-last: 2 # keeps the last 2 images
           keep-tags-regexes: ^pr
           prune-tags-regexes: ^main-
           prune-untagged: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -736,7 +736,6 @@ jobs:
           ./scripts/build_docker.sh \
             --arch amd64 \
             --target ghcr.io/coder/coder-preview:main \
-            --target
             --version $version \
             --push \
             build/coder_linux_amd64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -697,7 +697,7 @@ jobs:
     # This build and publihes ghcr.io/coder/coder-preview:main for each merge commit to main branch.
     # We are only building this for amd64 plateform. (>95% pulls are for amd64)
     needs: changes
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
+    # if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false' # uncomment before merging
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -755,8 +755,7 @@ jobs:
           organization: coder
           container: coder-preview
           dry-run: true
-          keep-younger-than: 7 # days
-          keep-last: 2 # keeps the last 2 images
+          keep-younger-than: 3 # days
           keep-tags-regexes: ^pr
           prune-tags-regexes: ^main-
           prune-untagged: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -746,18 +746,17 @@ jobs:
           new_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.sha[:8]')
 
           # Tag image with new package tag and push
-          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:$new_package_tag
-          docker push ghcr.io/coder/coder-preview:$new_package_tag
+          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag
+          docker push ghcr.io/coder/coder-preview:main-$new_package_tag
 
-          # Get old package tag
-          previous_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.parents[0].sha[:8]')
-          echo "previous_package_tag=$previous_package_tag" >> GITHUB_OUTPUT
-
-      - name: Delete image
-        continue-on-error: true
-        uses: bots-house/ghcr-delete-image-action@v1.1.0
+      - name: Prune old images
+        uses: vlaurin/action-ghcr-prune@v0.5.0
         with:
-          owner: coder
-          name: coder-preview
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.build_and_push.outputs.previous_package_tag }}
+          organization: coder
+          container: coder-preview
+          dry-run: true
+          keep-younger-than: 7 # days
+          keep-tags-regexes: ^pr-
+          prune-tags-regexes: ^main-
+          prune-untagged: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -701,6 +701,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -741,7 +742,7 @@ jobs:
             build/coder_linux_amd64
 
           # Get commit sha to be used as package tag
-          new_package_tag=$(git rev-parse --short HEAD)
+          new_package_tag=$(gh api repos/coder/coder-preview/commits/main --jq '.sha[0:7]]')
 
           # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -755,7 +755,8 @@ jobs:
           organization: coder
           container: coder-preview
           dry-run: true
-          keep-younger-than: 3 # days
+          # keep-younger-than: 3 # days
+          keep-last: 5
           keep-tags-regexes: ^pr
           prune-tags-regexes: ^main-
           prune-untagged: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -742,7 +742,7 @@ jobs:
             build/coder_linux_amd64
 
           # Get commit sha to be used as package tag
-          new_package_tag=$(gh api repos/coder/coder-preview/commits/main --jq '.sha[0:7]]')
+          new_package_tag=$(gh api repos/coder/coder/commits/main --jq '.sha[0:7]]')
 
           # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -697,7 +697,7 @@ jobs:
     # This build and publihes ghcr.io/coder/coder-preview:main for each merge commit to main branch.
     # We are only building this for amd64 plateform. (>95% pulls are for amd64)
     needs: changes
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
+    # if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -743,7 +743,7 @@ jobs:
             build/coder_linux_amd64
 
           # Get commit sha to be used as package tag
-          new_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.sha[:8]')
+          new_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.sha[:7]')
 
           # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -701,7 +701,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -743,7 +742,7 @@ jobs:
             build/coder_linux_amd64
 
           # Get commit sha to be used as package tag
-          new_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.sha[:7]')
+          new_package_tag=$(git rev-parse --short HEAD)
 
           # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -697,7 +697,7 @@ jobs:
     # This build and publihes ghcr.io/coder/coder-preview:main for each merge commit to main branch.
     # We are only building this for amd64 plateform. (>95% pulls are for amd64)
     needs: changes
-    # if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false' # uncomment before merging
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -755,7 +755,6 @@ jobs:
           organization: coder
           container: coder-preview
           dry-run: true
-          # keep-younger-than: 3 # days
           keep-last: 5
           keep-tags-regexes: ^pr
           prune-tags-regexes: ^main-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -701,6 +701,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -735,6 +736,21 @@ jobs:
           ./scripts/build_docker.sh \
             --arch amd64 \
             --target ghcr.io/coder/coder-preview:main \
+            --target
             --version $version \
             --push \
             build/coder_linux_amd64
+
+          # Get old package id and tag
+          old_commit_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.parents[0].sha[:8]')
+          old_package_id=$(gh api /orgs/coder/packages/container/coder-preview/versions | jq -r '.[0].id')
+          old_package_tag=$(gh api /orgs/coder/packages/container/coder-preview/versions/$old_package_id | jq -r '.metadata.container.tags[0]')    
+          
+          new_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.sha[:8]')
+          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:$new_package_tag
+          docker push ghcr.io/coder/coder-preview:$new_package_tag
+
+          # Delete Old package
+          if [[ old_commit_tag ]]
+
+          

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: read
   deployments: none
   issues: none
-  packages: delete
+  packages: write
   pull-requests: none
   repository-projects: none
   security-events: none

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -754,8 +754,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: coder
           container: coder-preview
-          dry-run: true
-          keep-last: 5
+          keep-younger-than: 7 # days
           keep-tags-regexes: ^pr
           prune-tags-regexes: ^main-
           prune-untagged: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -757,6 +757,6 @@ jobs:
           container: coder-preview
           dry-run: true
           keep-younger-than: 7 # days
-          keep-tags-regexes: ^pr-
+          keep-tags-regexes: ^pr
           prune-tags-regexes: ^main-
           prune-untagged: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: read
   deployments: none
   issues: none
-  packages: write
+  packages: delete
   pull-requests: none
   repository-projects: none
   security-events: none
@@ -725,6 +725,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Linux amd64 Docker image
+        id: build_and_push
         run: |
           set -euxo pipefail
           go mod download
@@ -741,16 +742,22 @@ jobs:
             --push \
             build/coder_linux_amd64
 
-          # Get old package id and tag
-          old_commit_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.parents[0].sha[:8]')
-          old_package_id=$(gh api /orgs/coder/packages/container/coder-preview/versions | jq -r '.[0].id')
-          old_package_tag=$(gh api /orgs/coder/packages/container/coder-preview/versions/$old_package_id | jq -r '.metadata.container.tags[0]')    
-          
+          # Get commit sha to be used as package tag
           new_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.sha[:8]')
+
+          # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:$new_package_tag
           docker push ghcr.io/coder/coder-preview:$new_package_tag
 
-          # Delete Old package
-          if [[ old_commit_tag ]]
+          # Get old package tag
+          previous_package_tag=$(gh api /repos/coder/coder/commits/main | jq -r '.parents[0].sha[:8]')
+          echo "previous_package_tag=$previous_package_tag" >> GITHUB_OUTPUT
 
-          
+      - name: Delete image
+        continue-on-error: true
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: coder
+          name: coder-preview
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.build_and_push.outputs.previous_package_tag }}


### PR DESCRIPTION
This will publish 2 tags `ghcr.io/coder/coder-preview:main` and `ghcr.io/coder/coder-preview:main-shortsha` on each merge to main.
Also, it will prune `ghcr.io/coder/coder-preview` for all previous tags that are older than 7 days while preserving any `pr1234` tags and custom tags like `gvisor-fix`.