### PR TITLE
fix(enterprise/replicasync): fix data race in Manager.Regional

### DIFF
--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -375,7 +375,13 @@ func (m *Manager) InRegion(regionID int32) []database.Replica {
 
 // Regional returns all replicas in the same region excluding itself.
 func (m *Manager) Regional() []database.Replica {
-	return m.InRegion(m.self.RegionID)
+	return m.InRegion(m.regionID())
+}
+
+func (m *Manager) regionID() int32 {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.self.RegionID
 }
 
 // SetCallback sets a function to execute whenever new peers


### PR DESCRIPTION
Sample data race:
```
WARNING: DATA RACE
Read at 0x00c001b86f48 by goroutine 156137:
  github.com/coder/coder/enterprise/replicasync.(*Manager).Regional()
      /home/cian/src/coder/coder/enterprise/replicasync/replicasync.go:378 +0x3c
  github.com/coder/coder/enterprise/replicasync_test.TestReplica.func5.2()
      /home/cian/src/coder/coder/enterprise/replicasync/replicasync_test.go:186 +0x4d
  github.com/stretchr/testify/assert.Eventually.func1()
      /home/cian/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1852 +0x39

Previous write at 0x00c001b86f48 by goroutine 151346:
  github.com/coder/coder/enterprise/replicasync.(*Manager).syncReplicas()
      /home/cian/src/coder/coder/enterprise/replicasync/replicasync.go:329 +0x1956
  github.com/coder/coder/enterprise/replicasync.(*Manager).subscribe.func1()
      /home/cian/src/coder/coder/enterprise/replicasync/replicasync.go:191 +0xa6

Goroutine 156137 (running) created at:
  github.com/stretchr/testify/assert.Eventually()
      /home/cian/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1852 +0x3a5
  github.com/stretchr/testify/require.Eventually()
      /home/cian/go/pkg/mod/github.com/stretchr/testify@v1.8.4/require/require.go:401 +0xb8
  github.com/coder/coder/enterprise/replicasync_test.TestReplica.func5()
      /home/cian/src/coder/coder/enterprise/replicasync/replicasync_test.go:185 +0x6af
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x47

Goroutine 151346 (running) created at:
  github.com/coder/coder/enterprise/replicasync.(*Manager).subscribe.func2()
      /home/cian/src/coder/coder/enterprise/replicasync/replicasync.go:221 +0x454
  github.com/coder/coder/coderd/database/pubsub.genericListener.send()
      /home/cian/src/coder/coder/coderd/database/pubsub/pubsub_memory.go:18 +0x83
  github.com/coder/coder/coderd/database/pubsub.(*MemoryPubsub).Publish.func1()
      /home/cian/src/coder/coder/coderd/database/pubsub/pubsub_memory.go:79 +0xf9
==================

```

`Regional()` accesses `m.self.regionID` outside of a locked context, which can be mutated concurrently by `syncReplicas()`.