### PR TITLE
fix(cli): clistat: accept positional arg for stat disk cmd

### DIFF
--- a/cli/stat.go
+++ b/cli/stat.go
@@ -233,8 +233,16 @@ func (*RootCmd) statDisk(s *clistat.Statter) *clibase.Cmd {
 		},
 		Handler: func(inv *clibase.Invocation) error {
 			pfx := clistat.ParsePrefix(prefixArg)
+			// Users may also call `coder stat disk <path>`.
+			if len(inv.Args) > 0 {
+				pathArg = inv.Args[0]
+			}
 			ds, err := s.Disk(pfx, pathArg)
 			if err != nil {
+				if os.IsNotExist(err) {
+					// fmt.Errorf produces a more concise error.
+					return fmt.Errorf("not found: %q", pathArg)
+				}
 				return err
 			}
 

--- a/cli/stat_test.go
+++ b/cli/stat_test.go
@@ -170,4 +170,16 @@ func TestStatDiskCmd(t *testing.T) {
 		require.NotZero(t, *tmp.Total)
 		require.Equal(t, "B", tmp.Unit)
 	})
+
+	t.Run("PosArg", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		t.Cleanup(cancel)
+		inv, _ := clitest.New(t, "stat", "disk", "/this/path/does/not/exist", "--output=text")
+		buf := new(bytes.Buffer)
+		inv.Stdout = buf
+		err := inv.WithContext(ctx).Run()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no such file or directory")
+	})
 }

--- a/cli/stat_test.go
+++ b/cli/stat_test.go
@@ -180,6 +180,6 @@ func TestStatDiskCmd(t *testing.T) {
 		inv.Stdout = buf
 		err := inv.WithContext(ctx).Run()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no such file or directory")
+		require.Contains(t, err.Error(), `not found: "/this/path/does/not/exist"`)
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/8680.

You can now do `coder stat disk /some/path` as well as `coder stat disk --path /some/path`.
You can also, confusingly, also do `coder stat disk --path /some/path /some/other/path`, in which case the positional arg `/some/other/path` will take precedence.

Changing this behaviour (i.e. making path a required arg for this command) would be breaking, so preserving existing behaviour.

Additionally, statting a nonexistent path now looks somewhat nicer:
```
coder stat disk /foo
running command "coder stat disk": not found: "/foo"
```