### PR TITLE
docs: fix broken templates_init table

### DIFF
--- a/docs/cli/templates_init.md
+++ b/docs/cli/templates_init.md
@@ -15,7 +15,7 @@ coder templates init [flags] [directory]
 ### --id
 
 |      |                              |
-| ---- | ---------------------------- | --------- | ----------- | ----------- | -------- | ------ | -------------------- | ---------------- | --------- | ---------------- | ----------- | ------------------ |
-| Type | <code>enum[aws-ecs-container | aws-linux | aws-windows | azure-linux | do-linux | docker | docker-with-dotfiles | fly-docker-image | gcp-linux | gcp-vm-container | gcp-windows | kubernetes]</code> |
+| ---- | ---------------------------- | 
+| Type | <code>enum[aws-ecs-container \| aws-linux \| aws-windows \| azure-linux \| do-linux \| docker \| docker-with-dotfiles \| fly-docker-image \| gcp-linux \| gcp-vm-container \| gcp-windows \| kubernetes]</code> |
 
 Specify a given example template by ID.


### PR DESCRIPTION
Fixing broken markdown

| Before | After |
|--------|-------|
|     <img width="1365" alt="Screenshot 2023-08-04 at 19 54 00" src="https://github.com/coder/coder/assets/2318450/e20bed9f-2477-4783-9a75-1b1bae961ba3">   |  <img width="1367" alt="Screenshot 2023-08-04 at 19 53 43" src="https://github.com/coder/coder/assets/2318450/61d926e5-c5d4-4525-9b77-1c1009202c69">     |
