### PR TITLE
ci: add Chocolatey support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -422,8 +422,8 @@ jobs:
       # From https://chocolatey.org
       - name: Install Chocolatey
         run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force;
-          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
 
           iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -329,6 +329,7 @@ jobs:
     name: Publish to winget-pkgs
     runs-on: windows-latest
     needs: release
+    if: ${{ !inputs.dry_run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -364,12 +365,6 @@ jobs:
           echo "Installer URL: ${installer_url}"
           echo "Package version: ${version}"
 
-          # Bail if dry-run.
-          if ($env:CODER_DRY_RUN -match "t") {
-            echo "Skipping submission due to dry-run."
-            exit 0
-          }
-
           # The URL "|X64" suffix forces the architecture as it cannot be
           # sniffed properly from the URL. wingetcreate checks both the URL and
           # binary magic bytes for the architecture and they need to both match,
@@ -393,7 +388,6 @@ jobs:
           WINGET_GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
 
       - name: Comment on PR
-        if: ${{ !inputs.dry_run }}
         run: |
           # wait 30 seconds
           Start-Sleep -Seconds 30.0
@@ -414,6 +408,7 @@ jobs:
     name: Publish to Chocolatey
     runs-on: windows-latest
     needs: release
+    if: ${{ !inputs.dry_run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -460,12 +455,6 @@ jobs:
 
           # No need to specify nuspec if there's only one in the directory.
           choco pack --version=$version binary_path=assets/coder.exe
-
-          # Bail if dry-run.
-          if ($env:CODER_DRY_RUN -match "t") {
-            echo "Skipping submission due to dry-run."
-            exit 0
-          }
 
           choco apikey --api-key $env:CHOCO_API_KEY -source https://push.chocolatey.org/
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -409,3 +409,70 @@ jobs:
           # For gh CLI. We need a real token since we're commenting on a PR in a
           # different repo.
           GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
+
+  publish-chocolatey:
+    name: Publish to Chocolatey
+    runs-on: windows-latest
+    needs: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Same reason as for release.
+      - name: Fetch git tags
+        run: git fetch --tags --force
+
+      # From https://chocolatey.org
+      - name: Install Chocolatey
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force;
+          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+
+          iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+      - name: Build chocolatey package
+        run: |
+          cd scripts/chocolatey
+
+          # The package version is the same as the tag minus the leading "v".
+          # The version in this output already has the leading "v" removed but
+          # we do it again to be safe.
+          $version = "${{ needs.release.outputs.version }}".Trim('v')
+
+          $release_assets = gh release view --repo coder/coder "v${version}" --json assets | `
+            ConvertFrom-Json
+
+          # Get the URL for the Windows ZIP from the release assets.
+          $zip_url = $release_assets.assets | `
+            Where-Object name -Match ".*_windows_amd64.zip$" | `
+            Select -ExpandProperty url
+
+          echo "ZIP URL: ${zip_url}"
+          echo "Package version: ${version}"
+
+          echo "Downloading ZIP..."
+          Invoke-WebRequest $zip_url -OutFile assets.zip
+
+          echo "Extracting ZIP..."
+          Expand-Archive assets.zip -DestinationPath assets/
+
+          # No need to specify nuspec if there's only one in the directory.
+          choco pack --version=$version binary_path=assets/coder.exe
+
+          # Bail if dry-run.
+          if ($env:CODER_DRY_RUN -match "t") {
+            echo "Skipping submission due to dry-run."
+            exit 0
+          }
+
+          choco apikey --api-key $env:CHOCO_API_KEY -source https://push.chocolatey.org/
+
+          # No need to specify nupkg if there's only one in the directory.
+          choco push --source https://push.chocolatey.org/
+
+        env:
+          # For gh CLI. We need a real token since we're commenting on a PR in a
+          # different repo.
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -462,6 +462,4 @@ jobs:
           choco push --source https://push.chocolatey.org/
 
         env:
-          # For gh CLI. We need a real token since we're commenting on a PR in a
-          # different repo.
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -456,7 +456,7 @@ jobs:
           # No need to specify nuspec if there's only one in the directory.
           choco pack --version=$version binary_path=assets/coder.exe
 
-          choco apikey --api-key $env:CHOCO_API_KEY -source https://push.chocolatey.org/
+          choco apikey --api-key $env:CHOCO_API_KEY --source https://push.chocolatey.org/
 
           # No need to specify nupkg if there's only one in the directory.
           choco push --source https://push.chocolatey.org/

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -24,7 +24,7 @@
     <projectUrl>https://coder.com</projectUrl>
     <iconUrl>https://github.com/coder/presskit/raw/main/logos/coder%20logo%20black%20square.png?raw=true</iconUrl>
     <copyright>Coder Technologies, Inc.</copyright>
-    <licenseUrl>https://github.com/coder/coder/blob/main/LICENSE.enterprise</licenseUrl>
+    <licenseUrl>https://coder.com/legal/terms-of-service</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
+<!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://community.chocolatey.org/packages). -->
+
+<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <!-- This section is about this package, although id and version have ties back to the software -->
+    <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
+    <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
+    <id>coder</id>
+    <version>$version$</version>
+    <packageSourceUrl>https://github.com/coder/coder/blob/main/scripts/chocolatey</packageSourceUrl>
+    <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
+    <owners>Coder Technologies\, Inc.</owners>
+    <!-- ============================== -->
+
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <!-- This section is about the software itself -->
+    <title>Coder (Install)</title>
+    <authors>Coder Technologies\, Inc.</authors>
+    <projectUrl>https://coder.com</projectUrl>
+    <iconUrl>https://github.com/coder/presskit/raw/main/logos/coder%20logo%20black%20square.png?raw=true</iconUrl>
+    <copyright>Coder Technologies, Inc.</copyright>
+    <licenseUrl>https://github.com/coder/coder/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
+    <docsUrl>https://coder.com/docs/v2/latest</docsUrl>
+    <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
+    <tags>coder remote-dev terraform development</tags>
+    <summary>Remote development environments on your infrastructure provisioned with Terraform</summary>
+    <description>Remote development environments on your infrastructure provisioned with Terraform</description>
+  </metadata>
+  <files>
+    <file src="$binary_path$" target="tools/coder.exe" />
+  </files>
+</package>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -24,7 +24,7 @@
     <projectUrl>https://coder.com</projectUrl>
     <iconUrl>https://github.com/coder/presskit/raw/main/logos/coder%20logo%20black%20square.png?raw=true</iconUrl>
     <copyright>Coder Technologies, Inc.</copyright>
-    <licenseUrl>https://github.com/coder/coder/blob/main/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/coder/coder/blob/main/LICENSE.enterprise</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>


### PR DESCRIPTION
Hello all, I'm finally contributing Chocolatey building (#3714) to the project long after I said I would do it.

This is a draft because there are some questions that need to be answered by the team:
1. should ``copyright`` be uncommented ? ([L26 of `coder.nuspec`](https://github.com/coder/coder/blob/513c3a6bfcb172f9b8fbfe6a0d9c5ebad0d6b161/scripts/chocolatey/coder.nuspec#L26)) (I think it should be removed since this is the community edition right ?
2. should ``requireLicenseAcceptance`` be uncommented ? ([L28 of `coder.nuspec`](https://github.com/coder/coder/blob/513c3a6bfcb172f9b8fbfe6a0d9c5ebad0d6b161/scripts/chocolatey/coder.nuspec#L28))
3. someone from the coder team (cc: @bpmct) needs to create an account @ https://community.chocolatey.org and define the ``CHOCO_API_KEY`` GH secret with the [API key](https://community.chocolatey.org/account).

Other than that, I have tested all the PowerShell code in PS v7 and it works like intended (except for `choco push`).
I could not get the GH action to run in my repository, so that's the only thing I see that might cause issues, because the action itself was not tested. @matifali recommended that I don't bother trying to get the action running in my own repo, so here I am!

---

Now that I'm looking at this, there is another question I would like asking, does the winget job actually need to checkout and fetch tags ? from what I see it doesn't actually need the repo to be cloned at all.