### PR TITLE
feat: add 'derp only' text to proxy list in dashboard

### DIFF
--- a/site/src/components/DeploySettingsLayout/Badges.tsx
+++ b/site/src/components/DeploySettingsLayout/Badges.tsx
@@ -23,11 +23,15 @@ export const EntitledBadge: FC = () => {
   )
 }
 
-export const HealthyBadge: FC = () => {
+export const HealthyBadge: FC<{ derpOnly: boolean }> = ({ derpOnly }) => {
   const styles = useStyles()
+  let text = "Healthy"
+  if (derpOnly) {
+    text = "Healthy (DERP Only)"
+  }
   return (
     <span className={combineClasses([styles.badge, styles.enabledBadge])}>
-      Healthy
+      {text}
     </span>
   )
 }

--- a/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
+++ b/site/src/pages/UserSettingsPage/WorkspaceProxyPage/WorkspaceProxyRow.tsx
@@ -169,9 +169,14 @@ const DetailedProxyStatus: FC<{
     return <ProxyStatus proxy={proxy} />
   }
 
+  let derpOnly = false
+  if ("derp_only" in proxy) {
+    derpOnly = proxy.derp_only
+  }
+
   switch (proxy.status.status) {
     case "ok":
-      return <HealthyBadge />
+      return <HealthyBadge derpOnly={derpOnly} />
     case "unhealthy":
       return <NotHealthyBadge />
     case "unreachable":
@@ -189,7 +194,7 @@ const ProxyStatus: FC<{
 }> = ({ proxy }) => {
   let icon = <NotHealthyBadge />
   if (proxy.healthy) {
-    icon = <HealthyBadge />
+    icon = <HealthyBadge derpOnly={false} />
   }
 
   return icon


### PR DESCRIPTION
<img width="745" alt="image" src="https://github.com/coder/coder/assets/11241812/4051a7db-e9e9-4b43-a48b-8782f734ab9a">

Closes #8871 