### PR TITLE
ci: change `ghcr.io/coder/coder-preview:main` tag to use version names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -701,7 +701,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -741,12 +741,9 @@ jobs:
             --push \
             build/coder_linux_amd64
 
-          # Get commit sha to be used as the package tag
-          new_package_tag=$(gh api repos/coder/coder/commits/main | jq -r '.sha[0:9]')
-
           # Tag image with new package tag and push
-          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag
-          docker push ghcr.io/coder/coder-preview:main-$new_package_tag
+          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$version
+          docker push ghcr.io/coder/coder-preview:main-$version
 
       - name: Prune old images
         uses: vlaurin/action-ghcr-prune@v0.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -741,8 +741,8 @@ jobs:
             --push \
             build/coder_linux_amd64
 
-          # Get commit sha to be used as package tag
-          new_package_tag=$(gh api repos/coder/coder/commits/main | jq -r '.sha[0:7]')
+          # Get commit sha to be used as the package tag
+          new_package_tag=$(gh api repos/coder/coder/commits/main | jq -r '.sha[0:9]')
 
           # Tag image with new package tag and push
           docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$new_package_tag


### PR DESCRIPTION
This aligns with how we currently name development versions on dev.coder.com