### PR TITLE
fix: update tag name for `coder-preview` image in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -741,8 +741,9 @@ jobs:
             build/coder_linux_amd64
 
           # Tag image with new package tag and push
-          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$version
-          docker push ghcr.io/coder/coder-preview:main-$version
+          tag=$(echo "$version" | sed 's/+/-/g')
+          docker tag ghcr.io/coder/coder-preview:main ghcr.io/coder/coder-preview:main-$tag
+          docker push ghcr.io/coder/coder-preview:main-$tag
 
       - name: Prune old images
         uses: vlaurin/action-ghcr-prune@v0.5.0


### PR DESCRIPTION
docker doesn't allow a `+` in tag names. So I am replacing `+` with a `-`
```shell
version=$(./scripts/version.sh)
echo $version
0.27.1-devel+b0aaa69f2
tag=$(echo "$version" | sed 's/+/-/g')
echo $tag
0.27.1-devel-b0aaa69f2
```