### PR TITLE
fix: remove refresh oauth logic on OIDC login

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -693,7 +693,6 @@ func New(options *Options) *API {
 					r.Route("/github", func(r chi.Router) {
 						r.Use(
 							httpmw.ExtractOAuth2(options.GithubOAuth2Config, options.HTTPClient, nil),
-							apiKeyMiddlewareOptional,
 						)
 						r.Get("/callback", api.userOAuth2Github)
 					})
@@ -701,7 +700,6 @@ func New(options *Options) *API {
 				r.Route("/oidc/callback", func(r chi.Router) {
 					r.Use(
 						httpmw.ExtractOAuth2(options.OIDCConfig, options.HTTPClient, oidcAuthURLParams),
-						apiKeyMiddlewareOptional,
 					)
 					r.Get("/", api.userOIDC)
 				})

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1108,7 +1108,7 @@ func (cfg *OIDCConfig) Exchange(_ context.Context, code string, _ ...oauth2.Auth
 	}), nil
 }
 
-func (o *OIDCConfig) EncodeClaims(t *testing.T, claims jwt.MapClaims) string {
+func (cfg *OIDCConfig) EncodeClaims(t *testing.T, claims jwt.MapClaims) string {
 	t.Helper()
 
 	if _, ok := claims["exp"]; !ok {
@@ -1116,20 +1116,20 @@ func (o *OIDCConfig) EncodeClaims(t *testing.T, claims jwt.MapClaims) string {
 	}
 
 	if _, ok := claims["iss"]; !ok {
-		claims["iss"] = o.issuer
+		claims["iss"] = cfg.issuer
 	}
 
 	if _, ok := claims["sub"]; !ok {
 		claims["sub"] = "testme"
 	}
 
-	signed, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(o.key)
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(cfg.key)
 	require.NoError(t, err)
 
 	return base64.StdEncoding.EncodeToString([]byte(signed))
 }
 
-func (o *OIDCConfig) OIDCConfig(t *testing.T, userInfoClaims jwt.MapClaims, opts ...func(cfg *coderd.OIDCConfig)) *coderd.OIDCConfig {
+func (cfg *OIDCConfig) OIDCConfig(t *testing.T, userInfoClaims jwt.MapClaims, opts ...func(cfg *coderd.OIDCConfig)) *coderd.OIDCConfig {
 	// By default, the provider can be empty.
 	// This means it won't support any endpoints!
 	provider := &oidc.Provider{}
@@ -1147,9 +1147,9 @@ func (o *OIDCConfig) OIDCConfig(t *testing.T, userInfoClaims jwt.MapClaims, opts
 		provider = cfg.NewProvider(context.Background())
 	}
 	cfg := &coderd.OIDCConfig{
-		OAuth2Config: o,
-		Verifier: oidc.NewVerifier(o.issuer, &oidc.StaticKeySet{
-			PublicKeys: []crypto.PublicKey{o.key.Public()},
+		OAuth2Config: cfg,
+		Verifier: oidc.NewVerifier(cfg.issuer, &oidc.StaticKeySet{
+			PublicKeys: []crypto.PublicKey{cfg.key.Public()},
 		}, &oidc.Config{
 			SkipClientIDCheck: true,
 		}),

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1146,7 +1146,7 @@ func (cfg *OIDCConfig) OIDCConfig(t *testing.T, userInfoClaims jwt.MapClaims, op
 		}
 		provider = cfg.NewProvider(context.Background())
 	}
-	cfg := &coderd.OIDCConfig{
+	newCFG := &coderd.OIDCConfig{
 		OAuth2Config: cfg,
 		Verifier: oidc.NewVerifier(cfg.issuer, &oidc.StaticKeySet{
 			PublicKeys: []crypto.PublicKey{cfg.key.Public()},
@@ -1160,9 +1160,9 @@ func (cfg *OIDCConfig) OIDCConfig(t *testing.T, userInfoClaims jwt.MapClaims, op
 		GroupField:    "groups",
 	}
 	for _, opt := range opts {
-		opt(cfg)
+		opt(newCFG)
 	}
-	return cfg
+	return newCFG
 }
 
 // NewAzureInstanceIdentity returns a metadata client and ID token validator for faking

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/cookiejar"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/golang-jwt/jwt"
@@ -24,11 +25,93 @@ import (
 	"github.com/coder/coder/coderd/audit"
 	"github.com/coder/coder/coderd/coderdtest"
 	"github.com/coder/coder/coderd/database"
+	"github.com/coder/coder/coderd/database/dbauthz"
 	"github.com/coder/coder/coderd/database/dbgen"
 	"github.com/coder/coder/coderd/database/dbtestutil"
 	"github.com/coder/coder/codersdk"
 	"github.com/coder/coder/testutil"
 )
+
+// This test specifically tests logging in with OIDC when an expired
+// OIDC session token exists.
+// The token refreshing should not happen since we are reauthenticating.
+func TestOIDCOauthLoginWithExisting(t *testing.T) {
+	conf := coderdtest.NewOIDCConfig(t, "",
+		// Provide a refresh token so we use the refresh token flow
+		coderdtest.WithRefreshToken("refresh_token"),
+		// We need to set the expire in the future for the first api calls.
+		coderdtest.WithTokenExpires(func() time.Time {
+			return time.Now().Add(time.Hour).UTC()
+		}),
+		// No refresh should actually happen in this test.
+		coderdtest.WithTokenSource(func() (*oauth2.Token, error) {
+			return nil, xerrors.New("token should not require refresh")
+		}),
+	)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	auditor := audit.NewMock()
+	const username = "alice"
+	claims := jwt.MapClaims{
+		"email":              "alice@coder.com",
+		"email_verified":     true,
+		"preferred_username": username,
+	}
+	config := conf.OIDCConfig(t, claims)
+
+	config.AllowSignups = true
+	config.IgnoreUserInfo = true
+	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		Auditor:    auditor,
+		OIDCConfig: config,
+		Logger:     &logger,
+	})
+
+	// Signup alice
+	resp := oidcCallback(t, client, conf.EncodeClaims(t, claims))
+	// Set the client to use this OIDC context
+	authCookie := authCookieValue(resp.Cookies())
+	client.SetSessionToken(authCookie)
+	_ = resp.Body.Close()
+
+	ctx := testutil.Context(t, testutil.WaitLong*1000)
+	// Verify the user and oauth link
+	user, err := client.User(ctx, "me")
+	require.NoError(t, err)
+	require.Equal(t, username, user.Username)
+
+	// nolint:gocritic
+	link, err := api.Database.GetUserLinkByUserIDLoginType(dbauthz.AsSystemRestricted(ctx), database.GetUserLinkByUserIDLoginTypeParams{
+		UserID:    user.ID,
+		LoginType: database.LoginType(user.LoginType),
+	})
+	require.NoError(t, err, "failed to get user link")
+
+	// Expire the link
+	// nolint:gocritic
+	_, err = api.Database.UpdateUserLink(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLinkParams{
+		OAuthAccessToken:  link.OAuthAccessToken,
+		OAuthRefreshToken: link.OAuthRefreshToken,
+		OAuthExpiry:       time.Now().Add(time.Hour * -1).UTC(),
+		UserID:            link.UserID,
+		LoginType:         link.LoginType,
+	})
+	require.NoError(t, err, "failed to update user link")
+
+	// Log in again with OIDC
+	loginAgain := oidcCallbackWithState(t, client, conf.EncodeClaims(t, claims), "seconds_login", func(req *http.Request) {
+		req.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: authCookie,
+			Path:  "/",
+		})
+	})
+	require.Equal(t, http.StatusTemporaryRedirect, loginAgain.StatusCode)
+
+	// Try to use new login
+	client.SetSessionToken(authCookieValue(resp.Cookies()))
+	_, err = client.User(ctx, "me")
+	require.NoError(t, err, "use new session")
+}
 
 func TestUserLogin(t *testing.T) {
 	t.Parallel()
@@ -819,7 +902,7 @@ func TestUserOIDC(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		resp := oidcCallbackWithState(t, user, code, convertResponse.StateString)
+		resp := oidcCallbackWithState(t, user, code, convertResponse.StateString, nil)
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 	})
 
@@ -1045,10 +1128,10 @@ func oauth2Callback(t *testing.T, client *codersdk.Client) *http.Response {
 }
 
 func oidcCallback(t *testing.T, client *codersdk.Client, code string) *http.Response {
-	return oidcCallbackWithState(t, client, code, "somestate")
+	return oidcCallbackWithState(t, client, code, "somestate", nil)
 }
 
-func oidcCallbackWithState(t *testing.T, client *codersdk.Client, code, state string) *http.Response {
+func oidcCallbackWithState(t *testing.T, client *codersdk.Client, code, state string, modify func(r *http.Request)) *http.Response {
 	t.Helper()
 
 	client.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -1062,6 +1145,9 @@ func oidcCallbackWithState(t *testing.T, client *codersdk.Client, code, state st
 		Name:  codersdk.OAuth2StateCookie,
 		Value: state,
 	})
+	if modify != nil {
+		modify(req)
+	}
 	res, err := client.HTTPClient.Do(req)
 	require.NoError(t, err)
 	defer res.Body.Close()

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -73,7 +73,7 @@ func TestOIDCOauthLoginWithExisting(t *testing.T) {
 	client.SetSessionToken(authCookie)
 	_ = resp.Body.Close()
 
-	ctx := testutil.Context(t, testutil.WaitLong*1000)
+	ctx := testutil.Context(t, testutil.WaitLong)
 	// Verify the user and oauth link
 	user, err := client.User(ctx, "me")
 	require.NoError(t, err)

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -36,6 +36,8 @@ import (
 // OIDC session token exists.
 // The token refreshing should not happen since we are reauthenticating.
 func TestOIDCOauthLoginWithExisting(t *testing.T) {
+	t.Parallel()
+
 	conf := coderdtest.NewOIDCConfig(t, "",
 		// Provide a refresh token so we use the refresh token flow
 		coderdtest.WithRefreshToken("refresh_token"),
@@ -106,6 +108,7 @@ func TestOIDCOauthLoginWithExisting(t *testing.T) {
 		})
 	})
 	require.Equal(t, http.StatusTemporaryRedirect, loginAgain.StatusCode)
+	_ = loginAgain.Body.Close()
 
 	// Try to use new login
 	client.SetSessionToken(authCookieValue(resp.Cookies()))

--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -99,6 +99,7 @@ func TestUserOIDC(t *testing.T) {
 				"roles": []string{"random", oidcRoleName, rbac.RoleOwner()},
 			}))
 			require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+			_ = resp.Body.Close()
 			user, err := client.User(ctx, "alice")
 			require.NoError(t, err)
 
@@ -112,6 +113,7 @@ func TestUserOIDC(t *testing.T) {
 				"roles": []string{"random"},
 			}))
 			require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+			_ = resp.Body.Close()
 			user, err = client.User(ctx, "alice")
 			require.NoError(t, err)
 


### PR DESCRIPTION
`apiKeyMiddlewareOptional` was being used to log out users if they convert to OIDC. However this logic was also doing an `OIDC` refresh if the original token expired. This was a mistake. That logic should just pull the `APIKey` for logging out, and do not do anything else.

To fix this I just refactored `ExtractAPIKey` into a helper func to call and not do the refresh logic.

A unit test was added that fails on `main` and is now fixed. It matches the behavior of the reports.

Closes https://github.com/coder/coder/issues/8537
