### PR TITLE
chore: add e2e test for backwards client ssh compatibility

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -70,17 +70,13 @@ export const sshIntoWorkspace = async (
 ): Promise<ssh.Client> => {
   const sessionToken = await findSessionToken(page)
   return new Promise<ssh.Client>((resolve, reject) => {
-    const cp = spawn(
-      binaryPath,
-      [...binaryArgs, "ssh", "--stdio", workspace],
-      {
-        env: {
-          ...process.env,
-          CODER_SESSION_TOKEN: sessionToken,
-          CODER_URL: "http://localhost:3000",
-        },
+    const cp = spawn(binaryPath, [...binaryArgs, "ssh", "--stdio", workspace], {
+      env: {
+        ...process.env,
+        CODER_SESSION_TOKEN: sessionToken,
+        CODER_URL: "http://localhost:3000",
       },
-    )
+    })
     cp.on("error", (err) => reject(err))
     const proxyStream = new Duplex({
       read: (size) => {

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -65,12 +65,14 @@ export const createTemplate = async (
 export const sshIntoWorkspace = async (
   page: Page,
   workspace: string,
+  binaryPath = "go",
+  binaryArgs = ["run", coderMainPath()],
 ): Promise<ssh.Client> => {
   const sessionToken = await findSessionToken(page)
   return new Promise<ssh.Client>((resolve, reject) => {
     const cp = spawn(
-      "go",
-      ["run", coderMainPath(), "ssh", "--stdio", workspace],
+      binaryPath,
+      [...binaryArgs, "ssh", "--stdio", workspace],
       {
         env: {
           ...process.env,

--- a/site/e2e/tests/outdatedCLI.spec.ts
+++ b/site/e2e/tests/outdatedCLI.spec.ts
@@ -1,0 +1,52 @@
+import { test } from "@playwright/test"
+import { randomUUID } from "crypto"
+import {
+  createTemplate,
+  createWorkspace,
+  downloadCoderVersion,
+  sshIntoWorkspace,
+  startAgent,
+} from "../helpers"
+
+const clientVersion = "v0.14.0"
+
+test("ssh with client " + clientVersion, async ({ page }) => {
+  const token = randomUUID()
+  const template = await createTemplate(page, {
+    apply: [
+      {
+        complete: {
+          resources: [
+            {
+              agents: [
+                {
+                  token,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  })
+  const workspace = await createWorkspace(page, template)
+  await startAgent(page, token)
+  const binaryPath = await downloadCoderVersion(clientVersion)
+
+  const client = await sshIntoWorkspace(page, workspace, binaryPath)
+  await new Promise<void>((resolve, reject) => {
+    // We just exec a command to be certain the agent is running!
+    client.exec("exit 0", (err, stream) => {
+      if (err) {
+        return reject(err)
+      }
+      stream.on("exit", (code) => {
+        if (code !== 0) {
+          return reject(new Error(`Command exited with code ${code}`))
+        }
+        client.end()
+        resolve()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This was discussed as part of our regression review for outdated
agents, so here is the reverse with an extremely old client.
