### PR TITLE
chore: add tailscale magicsock debug logging controls

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1932,6 +1932,96 @@ func TestAgent_WriteVSCodeConfigs(t *testing.T) {
 	}, testutil.WaitShort, testutil.IntervalFast)
 }
 
+func TestAgent_DebugServer(t *testing.T) {
+	t.Parallel()
+
+	derpMap, _ := tailnettest.RunDERPAndSTUN(t)
+	//nolint:dogsled
+	conn, _, _, _, agnt := setupAgent(t, agentsdk.Manifest{
+		DERPMap: derpMap,
+	}, 0)
+
+	awaitReachableCtx := testutil.Context(t, testutil.WaitLong)
+	ok := conn.AwaitReachable(awaitReachableCtx)
+	require.True(t, ok)
+	_ = conn.Close()
+
+	srv := httptest.NewServer(agnt.HTTPDebug())
+	t.Cleanup(srv.Close)
+
+	t.Run("MagicsockDebug", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/magicsock", nil)
+		require.NoError(t, err)
+
+		res, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		resBody, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(resBody), "<h1>magicsock</h1>")
+	})
+
+	t.Run("MagicsockDebugLogging", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Enable", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/magicsock/debug-logging/t", nil)
+			require.NoError(t, err)
+
+			res, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			resBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Contains(t, string(resBody), "updated magicsock debug logging to true")
+		})
+
+		t.Run("Disable", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/magicsock/debug-logging/0", nil)
+			require.NoError(t, err)
+
+			res, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			resBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Contains(t, string(resBody), "updated magicsock debug logging to false")
+		})
+
+		t.Run("Invalid", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/magicsock/debug-logging/blah", nil)
+			require.NoError(t, err)
+
+			res, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			resBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Contains(t, string(resBody), `invalid state "blah", must be a boolean`)
+		})
+	})
+}
+
 func setupSSHCommand(t *testing.T, beforeArgs []string, afterArgs []string) (*ptytest.PTYCmd, pty.Process) {
 	//nolint:dogsled
 	agentConn, _, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
@@ -2013,7 +2103,7 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 	*agenttest.Client,
 	<-chan *agentsdk.Stats,
 	afero.Fs,
-	io.Closer,
+	agent.Agent,
 ) {
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	if metadata.DERPMap == nil {

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -186,9 +186,14 @@ func NewConn(options *Options) (conn *Conn, err error) {
 
 	if v, ok := os.LookupEnv(EnvMagicsockDebugLogging); ok {
 		vBool, err := strconv.ParseBool(v)
-		if err == nil {
+		if err != nil {
+			options.Logger.Debug(context.Background(), fmt.Sprintf("magicsock debug logging disabled due to invalid value %s=%q, use true or false", EnvMagicsockDebugLogging, v))
+		} else {
 			magicConn.SetDebugLoggingEnabled(vBool)
+			options.Logger.Debug(context.Background(), fmt.Sprintf("magicsock debug logging set by %s=%t", EnvMagicsockDebugLogging, vBool))
 		}
+	} else {
+		options.Logger.Debug(context.Background(), fmt.Sprintf("magicsock debug logging disabled, use %s=true to enable", EnvMagicsockDebugLogging))
 	}
 
 	// Update the keys for the magic connection!


### PR DESCRIPTION
Adds `/debug/magicsock/debug-logging/true` (and false) to the agent debug server. The route design is designed to be easily curlable without having to deal with `-X POST -H "Content-Type: application/json" --data '{"enabled": true}'`, which is why it's not REST-y.

Adds `CODER_MAGICSOCK_DEBUG_LOGGING` env var, which when combined with `coder -v` will enable magicsock debug logging.

The magicsock debug logging is VERY verbose which is why I don't want to enable it by default on both the client and the agent. It does have some useful data though so it's nice to have the option to view it.