### PR TITLE
chore: show basic experiment set value

### DIFF
--- a/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/GeneralSettingsPage/GeneralSettingsPageView.tsx
@@ -43,6 +43,7 @@ export const GeneralSettingsPageView = ({
             deploymentOptions,
             "Access URL",
             "Wildcard Access URL",
+            "Experiments",
           )}
         />
       </Stack>


### PR DESCRIPTION
This value is pre-parsed, meaning the experiments listed may not be valid. This is a very basic display for helping debuging purposes.

Closes: https://github.com/coder/coder/issues/8978#issuecomment-1670087202

# When an experiment is enabled


![Screenshot from 2023-08-08 13-51-04](https://github.com/coder/coder/assets/5446298/b401aa00-32d6-4a24-a2ee-854bae4aa24e)


# When none are enabled

![Screenshot from 2023-08-08 13-52-40](https://github.com/coder/coder/assets/5446298/aa18f043-5ffd-4505-b73f-86c84ff41964)

