### PR TITLE
fix(site): make stats bar scrollable on smaller viewports

### DIFF
--- a/site/src/components/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/components/DeploymentBanner/DeploymentBannerView.tsx
@@ -268,12 +268,8 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 12,
     gap: theme.spacing(4),
     borderTop: `1px solid ${theme.palette.divider}`,
-
-    [theme.breakpoints.down("lg")]: {
-      flexDirection: "column",
-      gap: theme.spacing(1),
-      alignItems: "left",
-    },
+    overflowX: "auto",
+    whiteSpace: "nowrap",
   },
   group: {
     display: "flex",


### PR DESCRIPTION
Close https://github.com/coder/coder/issues/8681

Solution:
Make the stats bar scrollable instead of making it a column for small viewports. Make it a column, that will change the height breaking the current layout calculation for a few elements that are using the vh to compute their height.