### PR TITLE
chore: use echo provisioners in logging tests

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1309,6 +1309,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
+				"--provisioner-daemons-echo", "true",
 				"--log-human", fiName,
 			)
 			clitest.Start(t, root)
@@ -1326,6 +1327,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
+				"--provisioner-daemons-echo", "true",
 				"--log-human", fi,
 			)
 			clitest.Start(t, root)
@@ -1343,6 +1345,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
+				"--provisioner-daemons-echo", "true",
 				"--log-json", fi,
 			)
 			clitest.Start(t, root)
@@ -1363,6 +1366,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
+				"--provisioner-daemons-echo", "true",
 				"--log-stackdriver", fi,
 			)
 			// Attach pty so we get debug output from the command if this test
@@ -1397,6 +1401,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
+				"--provisioner-daemons-echo", "true",
 				"--log-human", fi1,
 				"--log-json", fi2,
 				"--log-stackdriver", fi3,

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1309,7 +1309,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
-				"--provisioner-daemons-echo", "true",
+				"--provisioner-daemons-echo",
 				"--log-human", fiName,
 			)
 			clitest.Start(t, root)
@@ -1327,7 +1327,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
-				"--provisioner-daemons-echo", "true",
+				"--provisioner-daemons-echo",
 				"--log-human", fi,
 			)
 			clitest.Start(t, root)
@@ -1345,7 +1345,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
-				"--provisioner-daemons-echo", "true",
+				"--provisioner-daemons-echo",
 				"--log-json", fi,
 			)
 			clitest.Start(t, root)
@@ -1366,7 +1366,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
-				"--provisioner-daemons-echo", "true",
+				"--provisioner-daemons-echo",
 				"--log-stackdriver", fi,
 			)
 			// Attach pty so we get debug output from the command if this test
@@ -1401,7 +1401,7 @@ func TestServer(t *testing.T) {
 				"--in-memory",
 				"--http-address", ":0",
 				"--access-url", "http://example.com",
-				"--provisioner-daemons-echo", "true",
+				"--provisioner-daemons-echo",
 				"--log-human", fi1,
 				"--log-json", fi2,
 				"--log-stackdriver", fi3,


### PR DESCRIPTION
They don't need any provisioning anyways.