### PR TITLE
docs: add TLS config steps for K8s

### DIFF
--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -66,6 +66,9 @@ You must have the certificate `.key` and `.crt` files in your working directory 
 kubectl create secret tls coder-tls -n <coder-namespace> --key="tls.key" --cert="tls.crt"
 ```
 
+> You can use a single certificate for the both the access URL and wildcard access URL.
+> The certificate CN must match the wildcard domain, such as `*.example.coder.com`.
+
 1. Reference the TLS secret in your Coder Helm chart values
 
 ```yaml
@@ -74,7 +77,7 @@ coder:
     secretName:
       - coder-tls
 
-  # alternatively, if you use an Ingress controller to terminate TLS,
+  # Alternatively, if you use an Ingress controller to terminate TLS,
   # set the following values:
   ingress:
     enable: true

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -55,6 +55,33 @@ The Coder server can directly use TLS certificates with `CODER_TLS_ENABLE` and a
 - [Caddy](https://github.com/coder/coder/tree/main/examples/web-server/caddy)
 - [NGINX](https://github.com/coder/coder/tree/main/examples/web-server/nginx)
 
+### Kubernetes TLS configuration
+
+Below are the steps to configure Coder to terminate TLS when running on Kubernetes.
+You must have the certificate `.key` and `.crt` files in your working directory prior to step 1.
+
+1. Create the TLS secret in your Kubernetes cluster
+
+```console
+kubectl create secret tls coder-tls -n <coder-namespace> --key="tls.key" --cert="tls.crt"
+```
+
+1. Reference the TLS secret in your Coder Helm chart values
+
+```yaml
+coder:
+  tls:
+    secretName:
+      - coder-tls
+
+  # alternatively, if you use an Ingress controller to terminate TLS,
+  # set the following values:
+  ingress:
+    enable: true
+    secretName: coder-tls
+    wildcardSecretName: coder-tls
+```
+
 ## PostgreSQL Database
 
 Coder uses a PostgreSQL database to store users, workspace metadata, and other deployment information.


### PR DESCRIPTION
this PR adds steps for configuring TLS in a K8s deployment of Coder. Coder will terminate TLS when these values are set.