### PR TITLE
ci: run tests intelligently based on changes between consecutive commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             all:
               - "**"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,6 @@ name: ci
 
 on:
   push:
-    branches:
-      - main
-
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -123,3 +123,5 @@ We are always working on new integrations. Feel free to open an issue to request
 - [**Provision Coder with Terraform**](https://github.com/ElliotG/coder-oss-tf): Provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS, IBMCloud K8s, OVHCloud K8s, and Scaleway K8s Kapsule with Terraform
 - [**Coder GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
 - [**Various Templates**](./examples/templates/community-templates.md): Hetzner Cloud, Docker in Docker, and other templates the community has built.
+
+### Test heading remove it later

--- a/README.md
+++ b/README.md
@@ -123,5 +123,3 @@ We are always working on new integrations. Feel free to open an issue to request
 - [**Provision Coder with Terraform**](https://github.com/ElliotG/coder-oss-tf): Provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS, IBMCloud K8s, OVHCloud K8s, and Scaleway K8s Kapsule with Terraform
 - [**Coder GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
 - [**Various Templates**](./examples/templates/community-templates.md): Hetzner Cloud, Docker in Docker, and other templates the community has built.
-
-### Test heading remove it later


### PR DESCRIPTION
We are using [dorny/path-filter](https://github.com/marketplace/actions/paths-changes-filter) GitHub action to see which files are changed in our CI.
There is a scenario where it is not optimized.

### Current behavior

1. I change a go file in the first commit, and the path filter detects these changes and runs all go tests.
2. In 2nd commit, I change some docs and push, the paths filter compares the current PR branch with the `main` and again detects that a go file and some docs are changed so it runs all go tests

### Solution:
run on pushing to any branch.

```yaml
on:
  push
```
This will allow using a [`base`](https://github.com/dorny/paths-filter#usage) property to set the base as the current branch: `github.ref` and will detect changes between consecutive commits

This seems to work and is skipping other tests when only the .md file is changed
https://github.com/coder/coder/actions/workflows/ci.yaml?query=branch%3Amatifali%2Foptimize-ci

### New Behavior

1. I update a go file, changes is detected and and ci runs go tests.
2. I update docs, ci detects that only docs are changed so go tests are skipped.
3. I merge `main` and it has some go and ts files changes. ci runs all go and ts tests.
4. I again update only docs, ci skip go and tss tests.

This can save us some ci minutes.