### PR TITLE
feat: add header-process flag

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -76,7 +76,7 @@ func (r *RootCmd) login() *clibase.Cmd {
 				serverURL.Scheme = "https"
 			}
 
-			client, err := r.createUnauthenticatedClient(serverURL)
+			client, err := r.createUnauthenticatedClient(ctx, serverURL)
 			if err != nil {
 				return err
 			}

--- a/cli/root.go
+++ b/cli/root.go
@@ -56,7 +56,7 @@ const (
 	varAgentToken       = "agent-token"
 	varAgentURL         = "agent-url"
 	varHeader           = "header"
-	varHeaderProcess    = "header-process"
+	varHeaderCommand    = "header-command"
 	varNoOpen           = "no-open"
 	varNoVersionCheck   = "no-version-warning"
 	varNoFeatureWarning = "no-feature-warning"
@@ -359,10 +359,10 @@ func (r *RootCmd) Command(subcommands []*clibase.Cmd) (*clibase.Cmd, error) {
 			Group:       globalGroup,
 		},
 		{
-			Flag:        varHeaderProcess,
-			Env:         "CODER_HEADER_PROCESS",
+			Flag:        varHeaderCommand,
+			Env:         "CODER_HEADER_COMMAND",
 			Description: "An external process that outputs JSON-encoded key-value pairs to be used as additional HTTP headers added to all requests.",
-			Value:       clibase.StringOf(&r.headerProcess),
+			Value:       clibase.StringOf(&r.headerCommand),
 			Group:       globalGroup,
 		},
 		{
@@ -446,7 +446,7 @@ type RootCmd struct {
 	token         string
 	globalConfig  string
 	header        []string
-	headerProcess string
+	headerCommand string
 	agentToken    string
 	agentURL      *url.URL
 	forceTTY      bool
@@ -612,7 +612,7 @@ func (r *RootCmd) setClient(ctx context.Context, client *codersdk.Client, server
 		}
 		transport.header.Add(parts[0], parts[1])
 	}
-	if r.headerProcess != "" {
+	if r.headerCommand != "" {
 		shell := "sh"
 		caller := "-c"
 		if runtime.GOOS == "windows" {
@@ -620,7 +620,7 @@ func (r *RootCmd) setClient(ctx context.Context, client *codersdk.Client, server
 			caller = "/c"
 		}
 		// #nosec
-		cmd := exec.CommandContext(ctx, shell, caller, r.headerProcess)
+		cmd := exec.CommandContext(ctx, shell, caller, r.headerCommand)
 		cmd.Env = append(os.Environ(), "CODER_URL="+serverURL.String())
 		out, err := cmd.Output()
 		if err != nil {

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -94,7 +94,7 @@ func TestRoot(t *testing.T) {
 			"--no-version-warning",
 			"--header", "X-Testing=wow",
 			"--header", "Cool-Header=Dean was Here!",
-			"--header-process", "printf '{\"X-Process-Testing\": \"very-wow-'"+coderURLEnv+"'\"}'",
+			"--header-command", "printf '{\"X-Process-Testing\": \"very-wow-'"+coderURLEnv+"'\"}'",
 			"login", srv.URL,
 		)
 		inv.Stdout = buf
@@ -107,7 +107,7 @@ func TestRoot(t *testing.T) {
 }
 
 // TestDERPHeaders ensures that the client sends the global `--header`s and
-// `--header-process` to the DERP server when connecting.
+// `--header-command` to the DERP server when connecting.
 func TestDERPHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -169,7 +169,7 @@ func TestDERPHeaders(t *testing.T) {
 		"--no-version-warning",
 		"ping", workspace.Name,
 		"-n", "1",
-		"--header-process", "printf '{\"X-Process-Testing\": \"very-wow\"}'",
+		"--header-command", "printf '{\"X-Process-Testing\": \"very-wow\"}'",
 	}
 	for k, v := range expectedHeaders {
 		if k != "X-Process-Testing" {

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -80,6 +80,7 @@ func TestRoot(t *testing.T) {
 			assert.Equal(t, "wow", r.Header.Get("X-Testing"))
 			assert.Equal(t, "Dean was Here!", r.Header.Get("Cool-Header"))
 			assert.Equal(t, "very-wow-"+url, r.Header.Get("X-Process-Testing"))
+			assert.Equal(t, "more-wow", r.Header.Get("X-Process-Testing2"))
 			w.WriteHeader(http.StatusGone)
 		}))
 		defer srv.Close()
@@ -94,7 +95,7 @@ func TestRoot(t *testing.T) {
 			"--no-version-warning",
 			"--header", "X-Testing=wow",
 			"--header", "Cool-Header=Dean was Here!",
-			"--header-command", "printf '{\"X-Process-Testing\": \"very-wow-'"+coderURLEnv+"'\"}'",
+			"--header-command", "printf X-Process-Testing=very-wow-"+coderURLEnv+"'\\r\\n'X-Process-Testing2=more-wow",
 			"login", srv.URL,
 		)
 		inv.Stdout = buf
@@ -169,7 +170,7 @@ func TestDERPHeaders(t *testing.T) {
 		"--no-version-warning",
 		"ping", workspace.Name,
 		"-n", "1",
-		"--header-command", "printf '{\"X-Process-Testing\": \"very-wow\"}'",
+		"--header-command", "printf X-Process-Testing=very-wow",
 	}
 	for k, v := range expectedHeaders {
 		if k != "X-Process-Testing" {

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -63,8 +63,9 @@ variables or flags.
           Can be specified multiple times.
 
       --header-command string, $CODER_HEADER_COMMAND
-          An external command that outputs JSON-encoded key-value pairs to be
-          used as additional HTTP headers added to all requests.
+          An external command that outputs additional HTTP headers added to all
+          requests. The command must output each header as `key=value` on its
+          own line.
 
       --no-feature-warning bool, $CODER_NO_FEATURE_WARNING
           Suppress warnings about unlicensed features.

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -62,8 +62,8 @@ variables or flags.
           Additional HTTP headers added to all requests. Provide as key=value.
           Can be specified multiple times.
 
-      --header-process string, $CODER_HEADER_PROCESS
-          An external process that outputs JSON-encoded key-value pairs to be
+      --header-command string, $CODER_HEADER_COMMAND
+          An external command that outputs JSON-encoded key-value pairs to be
           used as additional HTTP headers added to all requests.
 
       --no-feature-warning bool, $CODER_NO_FEATURE_WARNING

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -62,6 +62,10 @@ variables or flags.
           Additional HTTP headers added to all requests. Provide as key=value.
           Can be specified multiple times.
 
+      --header-process string, $CODER_HEADER_PROCESS
+          An external process that outputs JSON-encoded key-value pairs to be
+          used as additional HTTP headers added to all requests.
+
       --no-feature-warning bool, $CODER_NO_FEATURE_WARNING
           Suppress warnings about unlicensed features.
 

--- a/cli/vscodessh.go
+++ b/cli/vscodessh.go
@@ -86,7 +86,7 @@ func (r *RootCmd) vscodeSSH() *clibase.Cmd {
 			client.SetSessionToken(string(sessionToken))
 
 			// This adds custom headers to the request!
-			err = r.setClient(client, serverURL)
+			err = r.setClient(ctx, client, serverURL)
 			if err != nil {
 				return xerrors.Errorf("set client: %w", err)
 			}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -103,7 +103,7 @@ Additional HTTP headers added to all requests. Provide as key=value. Can be spec
 | Type        | <code>string</code>                |
 | Environment | <code>$CODER_HEADER_COMMAND</code> |
 
-An external command that outputs JSON-encoded key-value pairs to be used as additional HTTP headers added to all requests.
+An external command that outputs additional HTTP headers added to all requests. The command must output each header as `key=value` on its own line.
 
 ### --no-feature-warning
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,6 +96,15 @@ Path to the global `coder` config directory.
 
 Additional HTTP headers added to all requests. Provide as key=value. Can be specified multiple times.
 
+### --header-process
+
+|             |                                    |
+| ----------- | ---------------------------------- |
+| Type        | <code>string</code>                |
+| Environment | <code>$CODER_HEADER_PROCESS</code> |
+
+An external process that outputs JSON-encoded key-value pairs to be used as additional HTTP headers added to all requests.
+
 ### --no-feature-warning
 
 |             |                                        |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,14 +96,14 @@ Path to the global `coder` config directory.
 
 Additional HTTP headers added to all requests. Provide as key=value. Can be specified multiple times.
 
-### --header-process
+### --header-command
 
 |             |                                    |
 | ----------- | ---------------------------------- |
 | Type        | <code>string</code>                |
-| Environment | <code>$CODER_HEADER_PROCESS</code> |
+| Environment | <code>$CODER_HEADER_COMMAND</code> |
 
-An external process that outputs JSON-encoded key-value pairs to be used as additional HTTP headers added to all requests.
+An external command that outputs JSON-encoded key-value pairs to be used as additional HTTP headers added to all requests.
 
 ### --no-feature-warning
 

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -34,8 +34,9 @@ variables or flags.
           Can be specified multiple times.
 
       --header-command string, $CODER_HEADER_COMMAND
-          An external command that outputs JSON-encoded key-value pairs to be
-          used as additional HTTP headers added to all requests.
+          An external command that outputs additional HTTP headers added to all
+          requests. The command must output each header as `key=value` on its
+          own line.
 
       --no-feature-warning bool, $CODER_NO_FEATURE_WARNING
           Suppress warnings about unlicensed features.

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -33,8 +33,8 @@ variables or flags.
           Additional HTTP headers added to all requests. Provide as key=value.
           Can be specified multiple times.
 
-      --header-process string, $CODER_HEADER_PROCESS
-          An external process that outputs JSON-encoded key-value pairs to be
+      --header-command string, $CODER_HEADER_COMMAND
+          An external command that outputs JSON-encoded key-value pairs to be
           used as additional HTTP headers added to all requests.
 
       --no-feature-warning bool, $CODER_NO_FEATURE_WARNING

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -33,6 +33,10 @@ variables or flags.
           Additional HTTP headers added to all requests. Provide as key=value.
           Can be specified multiple times.
 
+      --header-process string, $CODER_HEADER_PROCESS
+          An external process that outputs JSON-encoded key-value pairs to be
+          used as additional HTTP headers added to all requests.
+
       --no-feature-warning bool, $CODER_NO_FEATURE_WARNING
           Suppress warnings about unlicensed features.
 


### PR DESCRIPTION
This allows specifying a command to run that can output headers for cases where users require dynamic headers (like to authenticate to their VPN).

The primary use case is to add this flag in SSH configs created by the VS Code plugin, although maybe config-ssh should do the same.

This is required to complete https://github.com/coder/vscode-coder/pull/119, which in turn is meant to close https://github.com/coder/vscode-coder/issues/76.