### PR TITLE
fix: remove unnecessary newlines from the end of cli output

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -427,7 +427,7 @@ func (r *RootCmd) scaletestCleanup() *clibase.Cmd {
 
 			cliui.Errorf(inv.Stderr, "Found %d scaletest workspaces\n", len(workspaces))
 			if len(workspaces) != 0 {
-				cliui.Infof(inv.Stdout, "Deleting scaletest workspaces..."+"\n")
+				cliui.Infof(inv.Stdout, "Deleting scaletest workspaces...")
 				harness := harness.NewTestHarness(cleanupStrategy.toStrategy(), harness.ConcurrentExecutionStrategy{})
 
 				for i, w := range workspaces {
@@ -443,7 +443,7 @@ func (r *RootCmd) scaletestCleanup() *clibase.Cmd {
 					return xerrors.Errorf("run test harness to delete workspaces (harness failure, not a test failure): %w", err)
 				}
 
-				cliui.Infof(inv.Stdout, "Done deleting scaletest workspaces:"+"\n")
+				cliui.Infof(inv.Stdout, "Done deleting scaletest workspaces:")
 				res := harness.Results()
 				res.PrintText(inv.Stderr)
 
@@ -460,7 +460,7 @@ func (r *RootCmd) scaletestCleanup() *clibase.Cmd {
 
 			cliui.Errorf(inv.Stderr, "Found %d scaletest users\n", len(users))
 			if len(users) != 0 {
-				cliui.Infof(inv.Stdout, "Deleting scaletest users..."+"\n")
+				cliui.Infof(inv.Stdout, "Deleting scaletest users...")
 				harness := harness.NewTestHarness(cleanupStrategy.toStrategy(), harness.ConcurrentExecutionStrategy{})
 
 				for i, u := range users {
@@ -479,7 +479,7 @@ func (r *RootCmd) scaletestCleanup() *clibase.Cmd {
 					return xerrors.Errorf("run test harness to delete users (harness failure, not a test failure): %w", err)
 				}
 
-				cliui.Infof(inv.Stdout, "Done deleting scaletest users:"+"\n")
+				cliui.Infof(inv.Stdout, "Done deleting scaletest users:")
 				res := harness.Results()
 				res.PrintText(inv.Stderr)
 

--- a/cli/gitaskpass.go
+++ b/cli/gitaskpass.go
@@ -51,9 +51,9 @@ func (r *RootCmd) gitAskpass() *clibase.Cmd {
 			}
 			if token.URL != "" {
 				if err := openURL(inv, token.URL); err == nil {
-					cliui.Infof(inv.Stderr, "Your browser has been opened to authenticate with Git:\n\n%s\n", token.URL)
+					cliui.Infof(inv.Stderr, "Your browser has been opened to authenticate with Git:\n%s", token.URL)
 				} else {
-					cliui.Infof(inv.Stderr, "Open the following URL to authenticate with Git:\n\n%s\n", token.URL)
+					cliui.Infof(inv.Stderr, "Open the following URL to authenticate with Git:\n%s", token.URL)
 				}
 
 				for r := retry.New(250*time.Millisecond, 10*time.Second); r.Wait(ctx); {
@@ -61,7 +61,7 @@ func (r *RootCmd) gitAskpass() *clibase.Cmd {
 					if err != nil {
 						continue
 					}
-					cliui.Infof(inv.Stderr, "You've been authenticated with Git!\n")
+					cliui.Infof(inv.Stderr, "You've been authenticated with Git!")
 					break
 				}
 			}

--- a/cli/publickey.go
+++ b/cli/publickey.go
@@ -45,12 +45,12 @@ func (r *RootCmd) publickey() *clibase.Cmd {
 
 			cliui.Infof(inv.Stdout,
 				"This is your public key for using "+cliui.DefaultStyles.Field.Render("git")+" in "+
-					"Coder. All clones with SSH will be authenticated automatically 🪄.\n\n",
+					"Coder. All clones with SSH will be authenticated automatically 🪄.",
 			)
-			cliui.Infof(inv.Stdout, cliui.DefaultStyles.Code.Render(strings.TrimSpace(key.PublicKey))+"\n\n")
-			cliui.Infof(inv.Stdout, "Add to GitHub and GitLab:"+"\n")
-			cliui.Infof(inv.Stdout, cliui.DefaultStyles.Prompt.String()+"https://github.com/settings/ssh/new"+"\n")
-			cliui.Infof(inv.Stdout, cliui.DefaultStyles.Prompt.String()+"https://gitlab.com/-/profile/keys"+"\n")
+			cliui.Infof(inv.Stdout, cliui.DefaultStyles.Code.Render(strings.TrimSpace(key.PublicKey))+"\n")
+			cliui.Infof(inv.Stdout, "Add to GitHub and GitLab:")
+			cliui.Infof(inv.Stdout, cliui.DefaultStyles.Prompt.String()+"https://github.com/settings/ssh/new")
+			cliui.Infof(inv.Stdout, cliui.DefaultStyles.Prompt.String()+"https://gitlab.com/-/profile/keys")
 
 			return nil
 		},

--- a/cli/server.go
+++ b/cli/server.go
@@ -1030,7 +1030,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					defer wg.Done()
 
 					if ok, _ := inv.ParsedFlags().GetBool(varVerbose); ok {
-						cliui.Infof(inv.Stdout, "Shutting down provisioner daemon %d...\n", id)
+						cliui.Infof(inv.Stdout, "Shutting down provisioner daemon %d...", id)
 					}
 					err := shutdownWithTimeout(provisionerDaemon.Shutdown, 5*time.Second)
 					if err != nil {
@@ -1043,7 +1043,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 						return
 					}
 					if ok, _ := inv.ParsedFlags().GetBool(varVerbose); ok {
-						cliui.Infof(inv.Stdout, "Gracefully shut down provisioner daemon %d\n", id)
+						cliui.Infof(inv.Stdout, "Gracefully shut down provisioner daemon %d", id)
 					}
 				}()
 			}

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -51,7 +51,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *clibase.Cmd {
 			defer cancel()
 
 			if newUserDBURL == "" {
-				cliui.Infof(inv.Stdout, "Using built-in PostgreSQL (%s)\n", cfg.PostgresPath())
+				cliui.Infof(inv.Stdout, "Using built-in PostgreSQL (%s)", cfg.PostgresPath())
 				url, closePg, err := startBuiltinPostgres(ctx, cfg, logger)
 				if err != nil {
 					return err

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -85,14 +85,14 @@ func (r *RootCmd) speedtest() *clibase.Cmd {
 					}
 					peer := status.Peer[status.Peers()[0]]
 					if !p2p && direct {
-						cliui.Infof(inv.Stdout, "Waiting for a direct connection... (%dms via %s)\n", dur.Milliseconds(), peer.Relay)
+						cliui.Infof(inv.Stdout, "Waiting for a direct connection... (%dms via %s)", dur.Milliseconds(), peer.Relay)
 						continue
 					}
 					via := peer.Relay
 					if via == "" {
 						via = "direct"
 					}
-					cliui.Infof(inv.Stdout, "%dms via %s\n", dur.Milliseconds(), via)
+					cliui.Infof(inv.Stdout, "%dms via %s", dur.Milliseconds(), via)
 					break
 				}
 			} else {
@@ -107,7 +107,7 @@ func (r *RootCmd) speedtest() *clibase.Cmd {
 			default:
 				return xerrors.Errorf("invalid direction: %q", direction)
 			}
-			cliui.Infof(inv.Stdout, "Starting a %ds %s test...\n", int(duration.Seconds()), tsDir)
+			cliui.Infof(inv.Stdout, "Starting a %ds %s test...", int(duration.Seconds()), tsDir)
 			results, err := conn.Speedtest(ctx, tsDir, duration)
 			if err != nil {
 				return err


### PR DESCRIPTION
`Infof` already adds a newline, so we don't need to as well!
