### PR TITLE
docs: expand jfrog platform and example template

### DIFF
--- a/docs/platforms/jfrog.md
+++ b/docs/platforms/jfrog.md
@@ -47,7 +47,7 @@ terraform {
 
 variable "jfrog_url" {
   type        = string
-  description = "The URL of the JFrog instance."
+  description = "The URL of the JFrog instance. e.g. YYY.jfrog.io"
 }
 
 variable "artifactory_access_token" {
@@ -143,7 +143,7 @@ Distribution URL:               https://cdr.jfrog.io/distribution/
 Xray URL:                       https://cdr.jfrog.io/xray/
 Mission Control URL:            https://cdr.jfrog.io/mc/
 Pipelines URL:                  https://cdr.jfrog.io/pipelines/
-User:                           ammar
+User:                           ammar@....com
 Access token:                   ...
 Default:                        true
 ```

--- a/docs/platforms/jfrog.md
+++ b/docs/platforms/jfrog.md
@@ -45,9 +45,9 @@ terraform {
   }
 }
 
-variable "jfrog_url" {
+variable "jfrog_host" {
   type        = string
-  description = "The URL of the JFrog instance. e.g. YYY.jfrog.io"
+  description = "JFrog instance hostname. e.g. YYY.jfrog.io"
 }
 
 variable "artifactory_access_token" {
@@ -57,7 +57,7 @@ variable "artifactory_access_token" {
 
 # Configure the Artifactory provider
 provider "artifactory" {
-  url           = "https://${var.jfrog_url}/artifactory"
+  url           = "https://${var.jfrog_host}/artifactory"
   access_token  = "${var.artifactory_access_token}"
 }
 ```
@@ -65,7 +65,7 @@ provider "artifactory" {
 When pushing the template, you can pass in the variables using the `--var` flag:
 
 ```sh
-coder templates push --var 'jfrog_url=YYY.jfrog.io' --var 'artifactory_access_token=XXX'
+coder templates push --var 'jfrog_host=YYY.jfrog.io' --var 'artifactory_access_token=XXX'
 ```
 
 ## Installing JFrog CLI
@@ -108,25 +108,25 @@ resource "coder_agent" "main" {
 
     jf c rm 0 || true
     echo ${artifactory_scoped_token.me.access_token} | \
-      jf c add --access-token-stdin --url https://${var.jfrog_url} 0
+      jf c add --access-token-stdin --url https://${var.jfrog_host} 0
 
     # Configure the `npm` CLI to use the Artifactory "npm" registry.
     cat << EOF > ~/.npmrc
     email = ${data.coder_workspace.me.owner_email}
-    registry = https://${var.jfrog_url}/artifactory/api/npm/${local.artifactory_registry_keys["npm"]}
+    registry = https://${var.jfrog_host}/artifactory/api/npm/${local.artifactory_registry_keys["npm"]}
     EOF
     jf rt curl /api/npm/auth >> .npmrc
 
     mkdir -p ~/.pip
     cat << EOF > ~/.pip/pip.conf
     [global]
-    index-url = https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_url}/artifactory/api/pypi/${local.artifactory_registry_keys["pypi"]}/simple
+    index-url = https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/pypi/${local.artifactory_registry_keys["pypi"]}/simple
     EOF
 
   EOT
   # Set GOPROXY to use the Artifactory "go" registry.
   env = {
-    GOPROXY : "https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_url}/artifactory/api/go/${local.artifactory_registry_keys["go"]}"
+    GOPROXY : "https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/go/${local.artifactory_registry_keys["go"]}"
   }
 }
 ```
@@ -173,7 +173,7 @@ Artifactory:
     # Configure the `npm` CLI to use the Artifactory "npm" registry.
     cat << EOF > ~/.npmrc
     email = ${data.coder_workspace.me.owner_email}
-    registry = https://${var.jfrog_url}/artifactory/api/npm/npm/
+    registry = https://${var.jfrog_host}/artifactory/api/npm/npm/
     EOF
     jf rt curl /api/npm/auth >> .npmrc
 ```
@@ -192,7 +192,7 @@ Artifactory:
     mkdir -p ~/.pip
     cat << EOF > ~/.pip/pip.conf
     [global]
-    index-url = https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_url}/artifactory/api/pypi/pypi/simple
+    index-url = https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/pypi/pypi/simple
     EOF
 ```
 
@@ -204,7 +204,7 @@ Add the following environment variable to your `coder_agent` block to configure 
 
 ```hcl
   env = {
-    GOPROXY : "https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_url}/artifactory/api/go/go"
+    GOPROXY : "https://${data.coder_workspace.me.owner}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/go/go"
   }
 ```
 

--- a/docs/platforms/jfrog.md
+++ b/docs/platforms/jfrog.md
@@ -137,12 +137,12 @@ running `jf c show`. It should display output like:
 ```text
 coder@jf:~$ jf c show
 Server ID:                      0
-JFrog Platform URL:             https://cdr.jfrog.io/
-Artifactory URL:                https://cdr.jfrog.io/artifactory/
-Distribution URL:               https://cdr.jfrog.io/distribution/
-Xray URL:                       https://cdr.jfrog.io/xray/
-Mission Control URL:            https://cdr.jfrog.io/mc/
-Pipelines URL:                  https://cdr.jfrog.io/pipelines/
+JFrog Platform URL:             https://YYY.jfrog.io/
+Artifactory URL:                https://YYY.jfrog.io/artifactory/
+Distribution URL:               https://YYY.jfrog.io/distribution/
+Xray URL:                       https://YYY.jfrog.io/xray/
+Mission Control URL:            https://YYY.jfrog.io/mc/
+Pipelines URL:                  https://YYY.jfrog.io/pipelines/
 User:                           ammar@....com
 Access token:                   ...
 Default:                        true

--- a/docs/platforms/jfrog.md
+++ b/docs/platforms/jfrog.md
@@ -14,7 +14,6 @@ The full example template can be found [here](https://github.com/coder/coder/tre
 - 1:1 mapping of users in Coder to users in Artifactory by email address and username
 - Repositories configured in Artifactory for each package manager you want to use
 
-
 <blockquote class="info">
 The admin-level access token is used to provision user tokens and is never exposed to
 developers or stored in workspaces.

--- a/examples/templates/jfrog-docker/build/Dockerfile
+++ b/examples/templates/jfrog-docker/build/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
 	curl \
 	git \
 	golang \
+	python3-pip \
 	sudo \
 	vim \
 	wget \

--- a/examples/templates/jfrog-docker/build/Dockerfile
+++ b/examples/templates/jfrog-docker/build/Dockerfile
@@ -4,13 +4,19 @@ RUN apt-get update \
 	&& apt-get install -y \
 	curl \
 	git \
-	golang \
 	python3-pip \
 	sudo \
 	vim \
 	wget \
 	npm \
 	&& rm -rf /var/lib/apt/lists/*
+
+ARG GO_VERSION=1.20.7
+RUN mkdir --parents /usr/local/go && curl --silent --show-error --location \
+	"https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /usr/local/go.tar.gz && \
+	tar --extract --gzip --directory=/usr/local/go --file=/usr/local/go.tar.gz --strip-components=1
+
+ENV PATH=$PATH:/usr/local/go/bin
 
 ARG USER=coder
 RUN useradd --groups sudo --no-create-home --shell /bin/bash ${USER} \

--- a/examples/templates/jfrog-docker/main.tf
+++ b/examples/templates/jfrog-docker/main.tf
@@ -17,9 +17,9 @@ terraform {
 
 locals {
   # if the jfrog username is same as the coder username, you can use the following
-  # username = data.coder_workspace.me.owner
+  # artifactory_username = data.coder_workspace.me.owner
   # if the username is same as email, you can use the following
-  # username = urlencode(data.coder_workspace.me.owner_email)
+  # artifactory_username = urlencode(data.coder_workspace.me.owner_email)
   artifactory_username = data.coder_workspace.me.owner
   artifactory_registry_keys = {
     "npm"    = "npm"

--- a/examples/templates/jfrog-docker/main.tf
+++ b/examples/templates/jfrog-docker/main.tf
@@ -21,7 +21,7 @@ locals {
   # if the username is same as email, you can use the following
   # artifactory_username = urlencode(data.coder_workspace.me.owner_email)
   artifactory_username = data.coder_workspace.me.owner
-  artifactory_registry_keys = {
+  artifactory_repository_keys = {
     "npm"    = "npm"
     "python" = "python"
     "go"     = "go"
@@ -77,24 +77,24 @@ resource "coder_agent" "main" {
     echo ${artifactory_scoped_token.me.access_token} | \
       jf c add --access-token-stdin --url https://${var.jfrog_host} 0
 
-    # Configure the `npm` CLI to use the Artifactory "npm" registry.
+    # Configure the `npm` CLI to use the Artifactory "npm" repository.
     cat << EOF > ~/.npmrc
     email = ${data.coder_workspace.me.owner_email}
-    registry = https://${var.jfrog_host}/artifactory/api/npm/${local.artifactory_registry_keys["npm"]}
+    registry = https://${var.jfrog_host}/artifactory/api/npm/${local.artifactory_repository_keys["npm"]}
     EOF
     jf rt curl /api/npm/auth >> .npmrc
 
-    # Configure the `pip` to use the Artifactory "pypi" registry.
+    # Configure the `pip` to use the Artifactory "python" repository.
     mkdir -p ~/.pip
     cat << EOF > ~/.pip/pip.conf
     [global]
-    index-url = https://${local.artifactory_username}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/pypi/${local.artifactory_registry_keys["python"]}/simple
+    index-url = https://${local.artifactory_username}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/pypi/${local.artifactory_repository_keys["python"]}/simple
     EOF
 
   EOT
-  # Set GOPROXY to use the Artifactory "go" registry.
+  # Set GOPROXY to use the Artifactory "go" repository.
   env = {
-    GOPROXY : "https://${local.artifactory_username}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/go/${local.artifactory_registry_keys["go"]}"
+    GOPROXY : "https://${local.artifactory_username}:${artifactory_scoped_token.me.access_token}@${var.jfrog_host}/artifactory/api/go/${local.artifactory_repository_keys["go"]}"
   }
 }
 


### PR DESCRIPTION
1. Updates to use `artifactory_scoped_token`
2. Updates the terraform provider
3. Adds examples for `Pypi` and `Go`.
4. Refactors the template to be usable with other package managers