### PR TITLE
fix(scaletest): cleanup: attempt to cancel in-progress jobs

### DIFF
--- a/scaletest/workspacebuild/run.go
+++ b/scaletest/workspacebuild/run.go
@@ -123,23 +123,16 @@ func (r *CleanupRunner) Run(ctx context.Context, _ string, logs io.Writer) error
 	}
 
 	build, err := r.client.WorkspaceBuild(ctx, ws.LatestBuild.ID)
-	var canceled bool
-	if err == nil {
-		if build.Job.Status.Active() {
-			// mark the build as canceled
-			if err = r.client.CancelWorkspaceBuild(ctx, build.ID); err != nil {
-				logger.Warn(ctx, "failed to cancel workspace build, attempting to delete anyway", slog.Error(err))
-			} else {
-				canceled = true
-			}
+	if err == nil && build.Job.Status.Active() {
+		// mark the build as canceled
+		if err = r.client.CancelWorkspaceBuild(ctx, build.ID); err == nil {
+			// Wait for the job to cancel before we delete it
+			_ = waitForBuild(ctx, logs, r.client, build.ID) // it will return a "build canceled" error
+		} else {
+			logger.Warn(ctx, "failed to cancel workspace build, attempting to delete anyway", slog.Error(err))
 		}
 	} else {
 		logger.Warn(ctx, "unable to lookup latest workspace build, attempting to delete anyway", slog.Error(err))
-	}
-
-	if canceled {
-		// Wait for the job to cancel before we delete it
-		_ = waitForBuild(ctx, logs, r.client, build.ID) // it will return a "build canceled" error
 	}
 
 	build, err = r.client.CreateWorkspaceBuild(ctx, r.workspaceID, codersdk.CreateWorkspaceBuildRequest{

--- a/scaletest/workspacebuild/run.go
+++ b/scaletest/workspacebuild/run.go
@@ -112,7 +112,37 @@ func (r *CleanupRunner) Run(ctx context.Context, _ string, logs io.Writer) error
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	build, err := r.client.CreateWorkspaceBuild(ctx, r.workspaceID, codersdk.CreateWorkspaceBuildRequest{
+	logs = loadtestutil.NewSyncWriter(logs)
+	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
+	r.client.SetLogger(logger)
+	r.client.SetLogBodies(true)
+
+	ws, err := r.client.Workspace(ctx, r.workspaceID)
+	if err != nil {
+		return err
+	}
+
+	build, err := r.client.WorkspaceBuild(ctx, ws.LatestBuild.ID)
+	var canceled bool
+	if err == nil {
+		if build.Job.Status.Active() {
+			// mark the build as canceled
+			if err = r.client.CancelWorkspaceBuild(ctx, build.ID); err != nil {
+				logger.Warn(ctx, "failed to cancel workspace build, attempting to delete anyway", slog.Error(err))
+			} else {
+				canceled = true
+			}
+		}
+	} else {
+		logger.Warn(ctx, "unable to lookup latest workspace build, attempting to delete anyway", slog.Error(err))
+	}
+
+	if canceled {
+		// Wait for the job to cancel before we delete it
+		_ = waitForBuild(ctx, logs, r.client, build.ID) // it will return a "build canceled" error
+	}
+
+	build, err = r.client.CreateWorkspaceBuild(ctx, r.workspaceID, codersdk.CreateWorkspaceBuildRequest{
 		Transition: codersdk.WorkspaceTransitionDelete,
 	})
 	if err != nil {


### PR DESCRIPTION
It's possible to end up in a situation where, after running a `scaletest create-workspaces`, you over-estimate your capacity and end up with a bunch of pending workspace builds.

It's possible to hack around with this using some `curl` and `jq`, but that's neither ideal nor user-friendly:

```shell
for BUILD_ID in $(curl -H "Coder-Session-Token: ${CODER_SESSION_TOKEN}" "https://${CODER_URL}/api/v2/workspaces?limit=100" | jq -r '.workspaces[] | select(.name | startswith("scaletest")) | .latest_build | select(.status=="pending") | .id'); do echo curl -H "Coder-Session-Token: ${CODER_SESSION_TOKEN}" -X PATCH "https://${CODER_URL}/api/v2/workspacebuilds/${BUILD_ID}/cancel"; done
```

This change modifies the cleanup behaviour to make a best-effort attempt to cancel the in-progress scaletest workspace build jobs before deleting them.