### PR TITLE
fix: catch missed output with reconnecting PTY

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1134,7 +1134,7 @@ func (a *agent) handleReconnectingPTY(ctx context.Context, logger slog.Logger, m
 			rpty.Wait()
 			a.reconnectingPTYs.Delete(msg.ID)
 		}); err != nil {
-			rpty.Close(err.Error())
+			rpty.Close(err)
 			return xerrors.Errorf("start routine: %w", err)
 		}
 

--- a/agent/reconnectingpty/reconnectingpty.go
+++ b/agent/reconnectingpty/reconnectingpty.go
@@ -48,7 +48,7 @@ type ReconnectingPTY interface {
 	// still be exiting.
 	Wait()
 	// Close kills the reconnecting pty process.
-	Close(reason string)
+	Close(err error)
 }
 
 // New sets up a new reconnecting pty that wraps the provided command.  Any
@@ -171,12 +171,7 @@ func (s *ptyState) waitForState(state State) (State, error) {
 func (s *ptyState) waitForStateOrContext(ctx context.Context, state State) (State, error) {
 	s.cond.L.Lock()
 	defer s.cond.L.Unlock()
-	return s.waitForStateOrContextLocked(ctx, state)
-}
 
-// waitForStateOrContextLocked is the same as waitForStateOrContext except it
-// assumes the caller has already locked cond.
-func (s *ptyState) waitForStateOrContextLocked(ctx context.Context, state State) (State, error) {
 	nevermind := make(chan struct{})
 	defer close(nevermind)
 	go func() {


### PR DESCRIPTION
This is currently failing the tests pretty reliably.

I forgot that waiting on the cond releases the lock so it was possible to get pty output after writing the buffer but before adding the pty to the map.  To fix, add the pty to the map while under the same lock where we read from the buffer.

The rest does not need to be behind the lock so I moved it out of doAttach, and that also means we no longer need
waitForStateOrContextLocked.