### PR TITLE
docs: add missing `last_seen_before` and `last_seen_after` search parameter

### DIFF
--- a/docs/admin/users.md
+++ b/docs/admin/users.md
@@ -158,8 +158,10 @@ In the Coder UI, you can filter your users using pre-defined filters or by utili
 
 - To find active users, use the filter `status:active`.
 - To find admin users, use the filter `role:admin`.
+- To find users have not been active since July 2023: `status:active last_seen_before:"2023-07-01T00:00:00Z"`
 
 The following filters are supported:
 
 - `status` - Indicates the status of the user. It can be either `active`, `dormant` or `suspended`.
 - `role` - Represents the role of the user. You can refer to the [TemplateRole documentation](https://pkg.go.dev/github.com/coder/coder/codersdk#TemplateRole) for a list of supported user roles.
+- `last_seen_before` and `last_seen_after` - The last time a used has used the platform (e.g. logging in, any API requests, connecting to workspaces). Uses the RFC3339Nano format.


### PR DESCRIPTION
We added this #8139 but haven't documented it. Thoughts on also adding a helper @Emyrk?

![image](https://github.com/coder/coder/assets/22407953/d18d08b3-3348-4edc-9db7-8ef3bfa9a8f5)


Also curious for your thoughts on ways we can add other search filters without missing docs. I don't think it has to be as complex as a linter rule or autogenerating these. Perhaps a comment could help?