### PR TITLE
fix: rename group GET request

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -787,12 +787,12 @@ const docTemplate = `{
                 "tags": [
                     "Enterprise"
                 ],
-                "summary": "Get group by name",
-                "operationId": "get-group-by-name",
+                "summary": "Get group by ID",
+                "operationId": "get-group-by-id",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Group name",
+                        "description": "Group id",
                         "name": "group",
                         "in": "path",
                         "required": true

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -675,12 +675,12 @@
         ],
         "produces": ["application/json"],
         "tags": ["Enterprise"],
-        "summary": "Get group by name",
-        "operationId": "get-group-by-name",
+        "summary": "Get group by ID",
+        "operationId": "get-group-by-id",
         "parameters": [
           {
             "type": "string",
-            "description": "Group name",
+            "description": "Group id",
             "name": "group",
             "in": "path",
             "required": true

--- a/docs/api/enterprise.md
+++ b/docs/api/enterprise.md
@@ -148,7 +148,7 @@ curl -X GET http://coder-server:8080/api/v2/entitlements \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Get group by name
+## Get group by ID
 
 ### Code samples
 
@@ -165,7 +165,7 @@ curl -X GET http://coder-server:8080/api/v2/groups/{group} \
 
 | Name    | In   | Type   | Required | Description |
 | ------- | ---- | ------ | -------- | ----------- |
-| `group` | path | string | true     | Group name  |
+| `group` | path | string | true     | Group id    |
 
 ### Example responses
 

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -320,12 +320,12 @@ func (api *API) groupByOrganization(rw http.ResponseWriter, r *http.Request) {
 	api.group(rw, r)
 }
 
-// @Summary Get group by name
-// @ID get-group-by-name
+// @Summary Get group by ID
+// @ID get-group-by-id
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Enterprise
-// @Param group path string true "Group name"
+// @Param group path string true "Group id"
 // @Success 200 {object} codersdk.Group
 // @Router /groups/{group} [get]
 func (api *API) group(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
this PR fixes the naming & description of the `/groups/{group}` route. the endpoint is incorrectly described as "Get group by name", whereas the API call expects the group UUID to be passed in.

@mtojek this is my first PR against the API code. please let me know if I missed anything.