### PR TITLE
fix: do terminal emulation in reconnecting pty tests

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1630,12 +1630,12 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 			//nolint:dogsled
 			conn, _, _, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
 			id := uuid.New()
-			netConn1, err := conn.ReconnectingPTY(ctx, id, 100, 100, "bash")
+			netConn1, err := conn.ReconnectingPTY(ctx, id, 80, 80, "bash")
 			require.NoError(t, err)
 			defer netConn1.Close()
 
 			// A second simultaneous connection.
-			netConn2, err := conn.ReconnectingPTY(ctx, id, 100, 100, "bash")
+			netConn2, err := conn.ReconnectingPTY(ctx, id, 80, 80, "bash")
 			require.NoError(t, err)
 			defer netConn2.Close()
 
@@ -1674,7 +1674,7 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 
 			_ = netConn1.Close()
 			_ = netConn2.Close()
-			netConn3, err := conn.ReconnectingPTY(ctx, id, 100, 100, "bash")
+			netConn3, err := conn.ReconnectingPTY(ctx, id, 80, 80, "bash")
 			require.NoError(t, err)
 			defer netConn3.Close()
 
@@ -1698,7 +1698,7 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 			require.ErrorIs(t, testutil.ReadUntil(ctx, t, netConn3, nil), io.EOF)
 
 			// Try a non-shell command.  It should output then immediately exit.
-			netConn4, err := conn.ReconnectingPTY(ctx, uuid.New(), 100, 100, "echo test")
+			netConn4, err := conn.ReconnectingPTY(ctx, uuid.New(), 80, 80, "echo test")
 			require.NoError(t, err)
 			defer netConn4.Close()
 

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -64,8 +64,8 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			testReconnectingPTY(ctx, t, client, codersdk.WorkspaceAgentReconnectingPTYOpts{
 				AgentID:   appDetails.Agent.ID,
 				Reconnect: uuid.New(),
-				Height:    80,
-				Width:     80,
+				Height:    100,
+				Width:     100,
 				Command:   "bash",
 			})
 		})
@@ -98,8 +98,8 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			testReconnectingPTY(ctx, t, unauthedAppClient, codersdk.WorkspaceAgentReconnectingPTYOpts{
 				AgentID:     appDetails.Agent.ID,
 				Reconnect:   uuid.New(),
-				Height:      80,
-				Width:       80,
+				Height:      100,
+				Width:       100,
 				Command:     "bash",
 				SignedToken: issueRes.SignedToken,
 			})
@@ -1360,8 +1360,8 @@ func testReconnectingPTY(ctx context.Context, t *testing.T, client *codersdk.Cli
 	// First attempt to resize the TTY.
 	// The websocket will close if it fails!
 	data, err := json.Marshal(codersdk.ReconnectingPTYRequest{
-		Height: 250,
-		Width:  250,
+		Height: 80,
+		Width:  80,
 	})
 	require.NoError(t, err)
 	_, err = conn.Write(data)

--- a/testutil/pty.go
+++ b/testutil/pty.go
@@ -55,10 +55,14 @@ func ReadUntil(ctx context.Context, t *testing.T, r io.Reader, matcher func(line
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+		if matcher == nil {
+			// A nil matcher means to read until EOF.
+			continue
+		}
 		got := term.String()
 		lines := strings.Split(got, "\n")
 		for _, line := range lines {
-			if matcher != nil && matcher(line) {
+			if matcher(line) {
 				return nil
 			}
 		}

--- a/testutil/pty.go
+++ b/testutil/pty.go
@@ -10,7 +10,8 @@ import (
 )
 
 // ReadUntilString emulates a terminal and reads one byte at a time until we
-// either see the string we want, or the context expires.
+// either see the string we want, or the context expires.  The PTY must be sized
+// to 80x80 or there could be unexpected results.
 func ReadUntilString(ctx context.Context, t *testing.T, want string, r io.Reader) error {
 	return ReadUntil(ctx, t, r, func(line string) bool {
 		return strings.TrimSpace(line) == want
@@ -19,6 +20,7 @@ func ReadUntilString(ctx context.Context, t *testing.T, want string, r io.Reader
 
 // ReadUntil emulates a terminal and reads one byte at a time until the matcher
 // returns true or the context expires.  If the matcher is nil, read until EOF.
+// The PTY must be sized to 80x80 or there could be unexpected results.
 func ReadUntil(ctx context.Context, t *testing.T, r io.Reader, matcher func(line string) bool) error {
 	// output can contain virtual terminal sequences, so we need to parse these
 	// to correctly interpret getting what we want.

--- a/testutil/pty.go
+++ b/testutil/pty.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/hinshun/vt10x"
+)
+
+// ReadUntilString emulates a terminal and reads one byte at a time until we
+// either see the string we want, or the context expires.
+func ReadUntilString(ctx context.Context, t *testing.T, want string, r io.Reader) error {
+	return ReadUntil(ctx, t, r, func(line string) bool {
+		return strings.TrimSpace(line) == want
+	})
+}
+
+// ReadUntil emulates a terminal and reads one byte at a time until the matcher
+// returns true or the context expires.  If the matcher is nil, read until EOF.
+func ReadUntil(ctx context.Context, t *testing.T, r io.Reader, matcher func(line string) bool) error {
+	// output can contain virtual terminal sequences, so we need to parse these
+	// to correctly interpret getting what we want.
+	term := vt10x.New(vt10x.WithSize(80, 80))
+	readErrs := make(chan error, 1)
+	defer func() {
+		// Dump the terminal contents since they can be helpful for debugging, but
+		// skip empty lines since much of the terminal will usually be blank.
+		got := term.String()
+		lines := strings.Split(got, "\n")
+		for _, line := range lines {
+			if strings.TrimSpace(line) != "" {
+				t.Logf("got: %v", line)
+			}
+		}
+	}()
+	for {
+		b := make([]byte, 1)
+		go func() {
+			_, err := r.Read(b)
+			readErrs <- err
+		}()
+		select {
+		case err := <-readErrs:
+			if err != nil {
+				return err
+			}
+			_, err = term.Write(b)
+			if err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		got := term.String()
+		lines := strings.Split(got, "\n")
+		for _, line := range lines {
+			if matcher != nil && matcher(line) {
+				return nil
+			}
+		}
+	}
+}


### PR DESCRIPTION
It looks like it is possible for screen to use control sequences instead of literal newlines which fails the tests.

This reuses the existing readUntil function used in other pty tests.

All credit to @spikecurtis for identifying the cause!