### PR TITLE
fix: change oauth convert oidc cookie to SameSite=Lax

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -184,7 +184,9 @@ func (api *API) postConvertLoginType(rw http.ResponseWriter, r *http.Request) {
 		Expires:  claims.ExpiresAt.Time,
 		Secure:   api.SecureAuthCookie,
 		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
+		// Must be SameSite to work on the redirected auth flow from the
+		// oauth provider.
+		SameSite: http.SameSiteLaxMode,
 	})
 	httpapi.Write(ctx, rw, http.StatusCreated, codersdk.OAuthConversionResponse{
 		StateString: stateString,


### PR DESCRIPTION
The strict mode was blocking the cookie from being sent on the redirect flow. This worked on localhost because cookies behave differently on localhost

Closes https://github.com/coder/coder/issues/9057

---

Testing on localhost never exercised the bug and was confusing the heck out of me. Thanks @ericpaulsen for the debug environment that reproduced it!

I manually tested this, and unfortunately cannot really exercise this in a unit test. It's browser specific behavior.

The error occurs when you click "Login" on the OIDC portal and you get redirected back to coder. This redirect does not send Strict cookies.