### PR TITLE
chore: update storybook build script

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
     "playwright:test": "playwright test --config=e2e/playwright.config.ts",
     "gen:provisioner": "protoc --plugin=./node_modules/.bin/protoc-gen-ts-proto --ts_proto_out=./e2e/ --ts_proto_opt=outputJsonMethods=false,outputEncodeMethods=encode-no-creation,outputClientImpl=false,nestJs=false,outputPartialMethods=false,fileSuffix=Generated,suffix=hey -I ../provisionersdk/proto ../provisionersdk/proto/provisioner.proto && prettier --cache --write './e2e/provisionerGenerated.ts'",
     "storybook": "STORYBOOK=true storybook dev -p 6006",
-    "storybook:build": "storybook build",
+    "storybook:build": "storybook build --webpack-stats-json",
     "test": "jest --selectProjects test",
     "test:ci": "jest --selectProjects test --silent",
     "test:coverage": "jest --selectProjects test --collectCoverage",


### PR DESCRIPTION
TurboSnap is not running in Chromatic.

TurboSnap requires a preview-stats file to trace the Webpack dependencies.
Typically, the GitHub action adds the flag automatically.
However, when you add a custom build script `storybook:build`, you must add the CLI flag to your Storybook build script.

<img width="1507" alt="Screen Shot 2023-08-16 at 2 33 30 PM" src="https://github.com/ethriel3695/coder/assets/12070791/9414820a-7bd4-4093-8370-bc2e1ea76bb6">
