### PR TITLE
chore: cleanup extraneous logging

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1359,7 +1359,7 @@ func newProvisionerDaemon(
 		// in provisionerdserver.go to learn more!
 		return coderAPI.CreateInMemoryProvisionerDaemon(ctx, debounce)
 	}, &provisionerd.Options{
-		Logger:              logger,
+		Logger:              logger.Named("provisionerd"),
 		JobPollInterval:     cfg.Provisioner.DaemonPollInterval.Value(),
 		JobPollJitter:       cfg.Provisioner.DaemonPollJitter.Value(),
 		JobPollDebounce:     debounce,

--- a/coderd/batchstats/batcher.go
+++ b/coderd/batchstats/batcher.go
@@ -183,7 +183,7 @@ func (b *Batcher) run(ctx context.Context) {
 			// If the flush lever is depressed, flush the buffer immediately.
 			b.flush(authCtx, true, "reaching capacity")
 		case <-ctx.Done():
-			b.log.Warn(ctx, "context done, flushing before exit")
+			b.log.Debug(ctx, "context done, flushing before exit")
 			b.flush(authCtx, true, "exit")
 			return
 		}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -211,7 +211,13 @@ func (api *API) postWorkspaceAgentStartup(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	api.Logger.Info(ctx, "post workspace agent version", slog.F("agent_id", apiAgent.ID), slog.F("agent_version", req.Version))
+	api.Logger.Debug(
+		ctx,
+		"post workspace agent version",
+		slog.F("agent_id", apiAgent.ID),
+		slog.F("agent_version", req.Version),
+		slog.F("remote_addr", r.RemoteAddr),
+	)
 
 	if !semver.IsValid(req.Version) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/docs/admin/provisioners.md
+++ b/docs/admin/provisioners.md
@@ -124,8 +124,8 @@ for deploying the Coder server.
        --values provisioner-values.yaml
    ```
 
-   You can verify that your provisioner daemons have successfully connected to Coderd by looking for a log with message
-   `provisionerd successfully connected to coderd` from each Pod.
+   You can verify that your provisioner daemons have successfully connected to Coderd by looking for a debug log message that says
+   `provisionerd: successfully connected to coderd` from each Pod.
 
 ## Example: Running an external provisioner on a VM
 

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -204,7 +204,7 @@ func (p *Server) connect(ctx context.Context) {
 		p.clientValue.Store(ptr.Ref(client))
 		p.mutex.Unlock()
 
-		p.opts.Logger.Info(ctx, "provisionerd successfully connected to coderd")
+		p.opts.Logger.Debug(ctx, "successfully connected to coderd")
 		break
 	}
 	select {


### PR DESCRIPTION
chore: cleanup extraneous logging

* The batchstats warning went out on every Ctrl+C in my development

Rule of silence:

The provisioner and connect messages messages were sent out on every startup
without a corresponding user event, making them annoying and more-so
debug messages.
