### PR TITLE
fix: do not install strace on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,8 @@
           shellcheck
           shfmt
           sqlc
-          strace
+          # strace is not available on OSX
+          (if system == "aarch64-darwin" then null else strace)
           terraform
           typos
           vim


### PR DESCRIPTION
This PR adds a condition to `flake.nix` to skip installing `strace` on Darwin (OSX).