### PR TITLE
fix: correctly assess quota for stopped resources

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1339,7 +1339,7 @@ func newProvisionerDaemon(
 					Listener: terraformServer,
 				},
 				CachePath: tfDir,
-				Logger:    logger,
+				Logger:    logger.Named("terraform"),
 				Tracer:    tracer,
 			})
 			if err != nil && !xerrors.Is(err, context.Canceled) {


### PR DESCRIPTION
fix: correctly assess quota for stopped resources

https://github.com/coder/coder/pull/5710 introduced a bug whereby
old resources were included in the Terraform provisioner's plan, even
when transition was set to stop.
