### PR TITLE
fix(cli/server): apply log filter to both log message and name

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1845,7 +1845,7 @@ func (f *debugFilterSink) compile(res []string) error {
 func (f *debugFilterSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 	if ent.Level == slog.LevelDebug {
 		logName := strings.Join(ent.LoggerNames, ".")
-		if f.re != nil && !f.re.MatchString(logName) {
+		if f.re != nil && !f.re.MatchString(logName) && !f.re.MatchString(ent.Message) {
 			return
 		}
 	}


### PR DESCRIPTION
fix(cli/server): apply log filter to log message as well as name

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/coder/coder/pull/9232).
* #9233
* __->__ #9232