### PR TITLE
fix(coderd/batchstats): fix init race and close flush

### DIFF
--- a/coderd/batchstats/batcher.go
+++ b/coderd/batchstats/batcher.go
@@ -105,6 +105,8 @@ func New(ctx context.Context, opts ...Option) (*Batcher, func(), error) {
 		b.tickCh = b.ticker.C
 	}
 
+	b.initBuf(b.batchSize)
+
 	cancelCtx, cancelFunc := context.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
@@ -172,7 +174,6 @@ func (b *Batcher) Add(
 
 // Run runs the batcher.
 func (b *Batcher) run(ctx context.Context) {
-	b.initBuf(b.batchSize)
 	// nolint:gocritic // This is only ever used for one thing - inserting agent stats.
 	authCtx := dbauthz.AsSystemRestricted(ctx)
 	for {

--- a/coderd/batchstats/batcher.go
+++ b/coderd/batchstats/batcher.go
@@ -175,7 +175,7 @@ func (b *Batcher) Add(
 // Run runs the batcher.
 func (b *Batcher) run(ctx context.Context) {
 	// nolint:gocritic // This is only ever used for one thing - inserting agent stats.
-	authCtx := dbauthz.AsSystemRestricted(ctx)
+	authCtx := dbauthz.AsSystemRestricted(context.Background())
 	for {
 		select {
 		case <-b.tickCh:

--- a/coderd/batchstats/batcher_internal_test.go
+++ b/coderd/batchstats/batcher_internal_test.go
@@ -31,7 +31,7 @@ func TestBatchStats(t *testing.T) {
 	deps1 := setupDeps(t, store)
 	deps2 := setupDeps(t, store)
 	tick := make(chan time.Time)
-	flushed := make(chan int)
+	flushed := make(chan int, 1)
 
 	b, closer, err := New(ctx,
 		WithStore(store),


### PR DESCRIPTION
Ran into two issues when working with the statsbatcher, a small race in init where the buffer may not yet be allocated when calling Add and flush using a cancelled context on close.

- fix race in batchstats batcher init
- fix flush after close in statsbatcher
