### PR TITLE
feat(site): add descriptions for each auth method to the selection menu

### DIFF
--- a/site/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/site/src/components/CreateUserForm/CreateUserForm.tsx
@@ -105,33 +105,13 @@ export const CreateUserForm: FC<
   )
 
   const styles = useStyles()
-  // This, unfortunately, cannot be an actual component because mui requires
-  // that all `MenuItem`s must be direct children of the `Select` they belong to
-  const authMethodSelect = (value: keyof typeof authMethodLanguage) => {
-    const language = authMethodLanguage[value]
-    return (
-      <MenuItem key={value} id={"item-" + value} value={value}>
-        <Stack spacing={0} maxWidth={400}>
-          {language.displayName}
-          <span className={styles.labelDescription}>
-            {language.description}
-          </span>
-        </Stack>
-      </MenuItem>
-    )
-  }
 
-  const methods = []
-  if (authMethods?.password.enabled) {
-    methods.push(authMethodSelect("password"))
-  }
-  if (authMethods?.oidc.enabled) {
-    methods.push(authMethodSelect("oidc"))
-  }
-  if (authMethods?.github.enabled) {
-    methods.push(authMethodSelect("github"))
-  }
-  methods.push(authMethodSelect("none"))
+  const methods = [
+    authMethods?.password.enabled && "password",
+    authMethods?.oidc.enabled && "oidc",
+    authMethods?.github.enabled && "github",
+    "none",
+  ].filter(Boolean) as Array<keyof typeof authMethodLanguage>
 
   return (
     <FullPageForm title="Create user">
@@ -177,7 +157,19 @@ export const CreateUserForm: FC<
                   ?.displayName ?? "",
             }}
           >
-            {methods}
+            {methods.map((value) => {
+              const language = authMethodLanguage[value]
+              return (
+                <MenuItem key={value} id={"item-" + value} value={value}>
+                  <Stack spacing={0} maxWidth={400}>
+                    {language.displayName}
+                    <span className={styles.labelDescription}>
+                      {language.description}
+                    </span>
+                  </Stack>
+                </MenuItem>
+              )
+            })}
           </TextField>
           <TextField
             {...getFieldHelpers(

--- a/site/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/site/src/components/CreateUserForm/CreateUserForm.tsx
@@ -16,7 +16,7 @@ import { hasApiFieldErrors, isApiError } from "api/errors"
 import MenuItem from "@mui/material/MenuItem"
 import { makeStyles } from "@mui/styles"
 import { Theme } from "@mui/material/styles"
-import { Link } from "@mui/material/Link"
+import Link from "@mui/material/Link"
 
 export const Language = {
   emailLabel: "Email",

--- a/site/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/site/src/components/CreateUserForm/CreateUserForm.tsx
@@ -106,7 +106,7 @@ export const CreateUserForm: FC<
 
   const styles = useStyles()
   // This, unfortunately, cannot be an actual component because mui requires
-  // that all `MenuItem`s but be direct children of the `Select` they belong to
+  // that all `MenuItem`s must be direct children of the `Select` they belong to
   const authMethodSelect = (value: keyof typeof authMethodLanguage) => {
     const language = authMethodLanguage[value]
     return (

--- a/site/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/site/src/components/CreateUserForm/CreateUserForm.tsx
@@ -106,7 +106,7 @@ export const CreateUserForm: FC<
 
   const styles = useStyles()
   // This, unfortunately, cannot be an actual component because mui requires
-  // that all `MenuItem`s but be direct children of the `Select` the belong to
+  // that all `MenuItem`s but be direct children of the `Select` they belong to
   const authMethodSelect = (value: keyof typeof authMethodLanguage) => {
     const language = authMethodLanguage[value]
     return (

--- a/site/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/site/src/components/CreateUserForm/CreateUserForm.tsx
@@ -16,8 +16,7 @@ import { hasApiFieldErrors, isApiError } from "api/errors"
 import MenuItem from "@mui/material/MenuItem"
 import { makeStyles } from "@mui/styles"
 import { Theme } from "@mui/material/styles"
-import { Link } from "@mui/material"
-import { Link as RouterLink } from "react-router-dom"
+import { Link } from "@mui/material/Link"
 
 export const Language = {
   emailLabel: "Email",
@@ -49,7 +48,6 @@ export const authMethodLanguage = {
       <>
         Disable authentication for this user (See the{" "}
         <Link
-          component={RouterLink}
           target="_blank"
           rel="noopener"
           to="https://coder.com/docs/v2/latest/admin/auth#disable-built-in-authentication"

--- a/site/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/site/src/components/CreateUserForm/CreateUserForm.tsx
@@ -50,7 +50,7 @@ export const authMethodLanguage = {
         <Link
           target="_blank"
           rel="noopener"
-          to="https://coder.com/docs/v2/latest/admin/auth#disable-built-in-authentication"
+          href="https://coder.com/docs/v2/latest/admin/auth#disable-built-in-authentication"
         >
           documentation
         </Link>{" "}


### PR DESCRIPTION
<img width="458" alt="Screenshot 2023-08-22 at 11 57 30 AM" src="https://github.com/coder/coder/assets/418348/ee76715c-72df-40f8-a67a-03432376f1a4">

Mostly motivated by the fact that just saying "None" was really cryptic and confusing.