### PR TITLE
chore: fix low hanging lint issues

### DIFF
--- a/coderd/httpmw/workspaceagent_test.go
+++ b/coderd/httpmw/workspaceagent_test.go
@@ -52,6 +52,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		req.Header.Set(codersdk.SessionTokenHeader, authToken.String())
 		rtr.ServeHTTP(rw, req)
 
+		//nolint:bodyclose // Closed in `t.Cleanup`
 		res := rw.Result()
 		t.Cleanup(func() { _ = res.Body.Close() })
 		require.Equal(t, http.StatusOK, res.StatusCode)

--- a/coderd/oauthpki/oidcpki.go
+++ b/coderd/oauthpki/oidcpki.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -243,7 +242,7 @@ func (src *jwtTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	if unmarshalError != nil {
-		return nil, fmt.Errorf("oauth2: cannot unmarshal token: %w", err)
+		return nil, xerrors.Errorf("oauth2: cannot unmarshal token: %w", err)
 	}
 
 	newToken := &oauth2.Token{
@@ -264,7 +263,7 @@ func (src *jwtTokenSource) Token() (*oauth2.Token, error) {
 		// decode returned id token to get expiry
 		claimSet, err := jws.Decode(v)
 		if err != nil {
-			return nil, fmt.Errorf("oauth2: error decoding JWT token: %w", err)
+			return nil, xerrors.Errorf("oauth2: error decoding JWT token: %w", err)
 		}
 		newToken.Expiry = time.Unix(claimSet.Exp, 0)
 	}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -807,7 +807,7 @@ func (api *API) runEntitlementsLoop(ctx context.Context) {
 	subscribed := false
 
 	defer func() {
-		// If this function ends, it means the context was cancelled and this
+		// If this function ends, it means the context was canceled and this
 		// coderd is shutting down. In this case, post a pubsub message to
 		// tell other coderd's to resync their entitlements. This is required to
 		// make sure things like replica counts are updated in the UI.


### PR DESCRIPTION
just running `make lint` results in a diff that seems pretty harmless, so we should include these changes (I think)