### PR TITLE
refactor(dogfood): run `personalize` before dotfiles

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -189,15 +189,17 @@ resource "coder_agent" "dev" {
     fi
 
     sudo service docker start
-    DOTFILES_URI="${data.coder_parameter.dotfiles_url.value}"
+
     rm -f ~/.personalize.log
-    if [ -n "$${DOTFILES_URI// }" ]; then
-      coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee -a ~/.personalize.log
-    fi
     if [ -x ~/personalize ]; then
       ~/personalize 2>&1 | tee -a ~/.personalize.log
     elif [ -f ~/personalize ]; then
       echo "~/personalize is not executable, skipping..." | tee -a ~/.personalize.log
+    fi
+
+    DOTFILES_URI="${data.coder_parameter.dotfiles_url.value}"
+    if [ -n "$${DOTFILES_URI// }" ]; then
+      coder dotfiles "$DOTFILES_URI" -y 2>&1 | tee -a ~/.personalize.log
     fi
   EOT
 }


### PR DESCRIPTION
I need to run some preparation scripts when my dotfiles install since some dependencies are missing and ZSH is not at the expected path.

My dotfiles start with a shebang to `/usr/bin/zsh`, but it's not at that path, since it's installed by Nix.
I would need to symlink or install zsh before running my dotfiles, but I can't.

---

If this causes issues, we can also add a ``personalize.pre`` script that runs before dotfiles.

(cc: @kylecarbs)