### PR TITLE
ci: fix chocolatey manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -456,6 +456,9 @@ jobs:
           echo "Extracting ZIP..."
           Expand-Archive assets.zip -DestinationPath assets/
 
+          echo "Copying license file..."
+          Copy-Item "../LICENSE.enterprise" -Destination "tools/LICENSE.md"
+
           # No need to specify nuspec if there's only one in the directory.
           choco pack --version=$version binary_path=assets/coder.exe
 

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -14,14 +14,14 @@
     <version>$version$</version>
     <packageSourceUrl>https://github.com/coder/coder/blob/main/scripts/chocolatey</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
-    <owners>Coder Technologies\, Inc.</owners>
+    <owners>Coder Technologies, Inc.</owners>
     <!-- ============================== -->
 
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
     <title>Coder</title>
-    <authors>Coder Technologies\, Inc.</authors>
-		<copyright>Coder Technologies\, Inc.</copyright>
+    <authors>Coder Technologies, Inc.</authors>
+		<copyright>Coder Technologies, Inc.</copyright>
 
 		<iconUrl>https://github.com/coder/presskit/blob/main/logos/coder_logo_black_square.png?raw=true</iconUrl>
     <projectUrl>https://coder.com</projectUrl>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -24,7 +24,7 @@
     <projectUrl>https://coder.com</projectUrl>
     <iconUrl>https://github.com/coder/presskit/blob/main/logos/coder_logo_black_square.png?raw=true</iconUrl>
     <copyright>Coder Technologies, Inc.</copyright>
-    <licenseUrl>https://coder.com/legal/terms-of-service</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/coder/coder/main/LICENSE.enterprise</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -29,7 +29,8 @@
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>
     <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
-		<tags>coder remote-dev terraform development</tags>
+		<releaseNotes>https://github.com/coder/coder/releases/tag/v$version$</releaseNotes>
+    <tags>coder remote-dev terraform development</tags>
     <summary>Remote development environments on your infrastructure provisioned with Terraform</summary>
     <description>Remote development environments on your infrastructure provisioned with Terraform</description>
   </metadata>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -21,18 +21,22 @@
     <!-- This section is about the software itself -->
     <title>Coder</title>
     <authors>Coder Technologies\, Inc.</authors>
+		<copyright>Coder Technologies\, Inc.</copyright>
+
+		<iconUrl>https://github.com/coder/presskit/blob/main/logos/coder_logo_black_square.png?raw=true</iconUrl>
     <projectUrl>https://coder.com</projectUrl>
-    <iconUrl>https://github.com/coder/presskit/blob/main/logos/coder_logo_black_square.png?raw=true</iconUrl>
-    <copyright>Coder Technologies, Inc.</copyright>
-    <licenseUrl>https://raw.githubusercontent.com/coder/coder/main/LICENSE.enterprise</licenseUrl>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
-    <docsUrl>https://coder.com/docs/v2/latest</docsUrl>
-    <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
     <releaseNotes>https://github.com/coder/coder/releases/tag/v$version$</releaseNotes>
+		<docsUrl>https://coder.com/docs/v2/latest</docsUrl>
+    <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
+
     <tags>coder remote-dev terraform development vscode devcontainer devcontainers</tags>
     <summary>Remote development environments on your infrastructure provisioned with Terraform</summary>
     <description>Remote development environments on your infrastructure provisioned with Terraform</description>
+
+    <licenseUrl>https://raw.githubusercontent.com/coder/coder/main/LICENSE.enterprise</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
   </metadata>
   <files>
     <file src="$binary_path$" target="tools/coder.exe" />

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -29,7 +29,7 @@
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>
     <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
-		<releaseNotes>https://github.com/coder/coder/releases/tag/v$version$</releaseNotes>
+    <releaseNotes>https://github.com/coder/coder/releases/tag/v$version$</releaseNotes>
     <tags>coder remote-dev terraform development</tags>
     <summary>Remote development environments on your infrastructure provisioned with Terraform</summary>
     <description>Remote development environments on your infrastructure provisioned with Terraform</description>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -30,7 +30,7 @@
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>
     <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
     <releaseNotes>https://github.com/coder/coder/releases/tag/v$version$</releaseNotes>
-    <tags>coder remote-dev terraform development</tags>
+    <tags>coder remote-dev terraform development vscode devcontainer devcontainers</tags>
     <summary>Remote development environments on your infrastructure provisioned with Terraform</summary>
     <description>Remote development environments on your infrastructure provisioned with Terraform</description>
   </metadata>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -19,7 +19,7 @@
 
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
-    <title>Coder (Install)</title>
+    <title>Coder</title>
     <authors>Coder Technologies\, Inc.</authors>
     <projectUrl>https://coder.com</projectUrl>
     <iconUrl>https://github.com/coder/presskit/blob/main/logos/coder_logo_black_square.png?raw=true</iconUrl>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -22,14 +22,14 @@
     <title>Coder (Install)</title>
     <authors>Coder Technologies\, Inc.</authors>
     <projectUrl>https://coder.com</projectUrl>
-    <iconUrl>https://github.com/coder/presskit/raw/main/logos/coder%20logo%20black%20square.png?raw=true</iconUrl>
+    <iconUrl>https://github.com/coder/presskit/blob/main/logos/coder_logo_black_square.png?raw=true</iconUrl>
     <copyright>Coder Technologies, Inc.</copyright>
     <licenseUrl>https://coder.com/legal/terms-of-service</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/coder/coder.git</projectSourceUrl>
     <docsUrl>https://coder.com/docs/v2/latest</docsUrl>
     <bugTrackerUrl>https://github.com/coder/coder/issues</bugTrackerUrl>
-    <tags>coder remote-dev terraform development</tags>
+		<tags>coder remote-dev terraform development</tags>
     <summary>Remote development environments on your infrastructure provisioned with Terraform</summary>
     <description>Remote development environments on your infrastructure provisioned with Terraform</description>
   </metadata>

--- a/scripts/chocolatey/coder.nuspec
+++ b/scripts/chocolatey/coder.nuspec
@@ -36,5 +36,6 @@
   </metadata>
   <files>
     <file src="$binary_path$" target="tools/coder.exe" />
+    <file src="tools/**" target="tools" />
   </files>
 </package>

--- a/scripts/chocolatey/tools/VERIFICATION.md
+++ b/scripts/chocolatey/tools/VERIFICATION.md
@@ -2,4 +2,6 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-This package is [published automatically](https://github.com/coder/coder/blob/main/.github/workflows/release.yaml) by the software vendor/author using GitHub Actions. (see "publish-chocolatey" workflow)
+This package is automatically published by Coder Technologies, Inc., the vendor of this software.
+
+See the [coder/coder](https://github.com/coder/coder) [release](https://github.com/coder/coder/blob/main/.github/workflows/release.yaml) workflow.

--- a/scripts/chocolatey/tools/VERIFICATION.md
+++ b/scripts/chocolatey/tools/VERIFICATION.md
@@ -1,0 +1,5 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+This package is [published automatically](https://github.com/coder/coder/blob/main/.github/workflows/release.yaml) by the software vendor/author using GitHub Actions. (see "publish-chocolatey" workflow)


### PR DESCRIPTION
[![image](https://github.com/coder/coder/assets/57866459/7364c78c-68a5-4bab-9f6a-0a3b4b8f4a78)](https://community.chocolatey.org/packages/coder/2.1.1)

---

Now that the package does build, there are still some issues and the package is getting rejected automatically.

- [X] The IconUrl element in the nuspec file should be a valid Url. Please correct this [More...](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0031)
- [x] Binary files (.exe, .msi, .zip, etc) have been included without including a LICENSE.txt file. This file is required when including binaries [More...](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0005)
- [x] Binary files (.exe, .msi, .zip) have been included without including a VERIFICATION.txt file. This file is required when including binaries [More...](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0006)
- [x] Release Notes (releaseNotes) are a short description of changes in each version of a package. Please include releasenotes in the nuspec. NOTE: To prevent the need to continually update this field, providing a URL to an external list of Release Notes is perfectly acceptable.

I need to look into VERIFICATION.txt, but I'm pretty sure that it's simply a list of checksums or something similar.

---

On the other hand, we have the LICENSE problem again.
I did not know this but Chocolatey forces you to provide both a LICENSE.txt and a licenseUrl.

The options we have are:
1. Fetching the terms of service and adding them to a file (I don't like this because the terms of service weren't really a license in the first place)
2. Crafting a dual-license and exposing it somehow via the web (see LICENSE.mixed ideas from 
3. Rewriting the Chocolatey package to download directly from the GH source (this skips the need for LICENSE.txt and also allows more architectures than only x64)

I think the last two are the best options.

---

(cc: @bpmct)