### PR TITLE
chore: add exempt users to CLAbot allowlist

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -46,7 +46,8 @@ jobs:
           path-to-document: "https://github.com/coder/cla/blob/main/README.md"
           # branch should not be protected
           branch: "main"
-          allowlist: dependabot*
+          # Some users have signed a corporate CLA with Coder so are exempt from signing our community one.
+          allowlist: "coryb,aaronlehmann,dependabot*"
 
   release-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Some users have signed a corporate CLA with Coder so are exempt from signing our community one.

We can rethink how we do this if this list expands, but this is the quickest solution