### PR TITLE
fix(site): use WebGL renderer for terminal

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -105,6 +105,7 @@
     "xterm-addon-fit": "0.7.0",
     "xterm-addon-unicode11": "0.5.0",
     "xterm-addon-web-links": "0.8.0",
+    "xterm-addon-webgl": "0.15.0",
     "yup": "1.2.0"
   },
   "devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -103,6 +103,7 @@
     "xterm": "5.2.1",
     "xterm-addon-canvas": "0.4.0",
     "xterm-addon-fit": "0.7.0",
+    "xterm-addon-unicode11": "0.5.0",
     "xterm-addon-web-links": "0.8.0",
     "yup": "1.2.0"
   },

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -231,6 +231,9 @@ dependencies:
   xterm-addon-web-links:
     specifier: 0.8.0
     version: 0.8.0(xterm@5.2.1)
+  xterm-addon-webgl:
+    specifier: 0.15.0
+    version: 0.15.0(xterm@5.2.1)
   yup:
     specifier: 1.2.0
     version: 1.2.0
@@ -13594,6 +13597,14 @@ packages:
 
   /xterm-addon-web-links@0.8.0(xterm@5.2.1):
     resolution: {integrity: sha512-J4tKngmIu20ytX9SEJjAP3UGksah7iALqBtfTwT9ZnmFHVplCumYQsUJfKuS+JwMhjsjH61YXfndenLNvjRrEw==}
+    peerDependencies:
+      xterm: ^5.0.0
+    dependencies:
+      xterm: 5.2.1
+    dev: false
+
+  /xterm-addon-webgl@0.15.0(xterm@5.2.1):
+    resolution: {integrity: sha512-ZLcqogMFHr4g/YRhcCh3xE8tTklnyut/M+O/XhVsFBRB/YCvYhPdLQ5/AQk54V0wjWAQpa8CF3W8DVR9OqyMCg==}
     peerDependencies:
       xterm: ^5.0.0
     dependencies:

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -225,6 +225,9 @@ dependencies:
   xterm-addon-fit:
     specifier: 0.7.0
     version: 0.7.0(xterm@5.2.1)
+  xterm-addon-unicode11:
+    specifier: 0.5.0
+    version: 0.5.0(xterm@5.2.1)
   xterm-addon-web-links:
     specifier: 0.8.0
     version: 0.8.0(xterm@5.2.1)
@@ -13575,6 +13578,14 @@ packages:
 
   /xterm-addon-fit@0.7.0(xterm@5.2.1):
     resolution: {integrity: sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==}
+    peerDependencies:
+      xterm: ^5.0.0
+    dependencies:
+      xterm: 5.2.1
+    dev: false
+
+  /xterm-addon-unicode11@0.5.0(xterm@5.2.1):
+    resolution: {integrity: sha512-Jm4/g4QiTxiKiTbYICQgC791ubhIZyoIwxAIgOW8z8HWFNY+lwk+dwaKEaEeGBfM48Vk8fklsUW9u/PlenYEBg==}
     peerDependencies:
       xterm: ^5.0.0
     dependencies:

--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -322,7 +322,7 @@ export const AppRouter: FC = () => {
             {/* Terminal and CLI auth pages don't have the dashboard layout */}
             <Route
               path="/:username/:workspace/terminal"
-              element={<TerminalPage renderer="canvas" />}
+              element={<TerminalPage renderer="webgl" />}
             />
             <Route path="cli-auth" element={<CliAuthenticationPage />} />
           </Route>

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { colors } from "theme/colors"
 import { v4 as uuidv4 } from "uuid"
 import * as XTerm from "xterm"
-import { CanvasAddon } from "xterm-addon-canvas"
+import { WebglAddon } from "xterm-addon-webgl"
 import { FitAddon } from "xterm-addon-fit"
 import { WebLinksAddon } from "xterm-addon-web-links"
 import { Unicode11Addon } from "xterm-addon-unicode11"
@@ -58,7 +58,7 @@ const useTerminalWarning = ({ agent }: { agent?: WorkspaceAgent }) => {
 }
 
 type TerminalPageProps = React.PropsWithChildren<{
-  renderer: "canvas" | "dom"
+  renderer: "webgl" | "dom"
 }>
 
 const TerminalPage: FC<TerminalPageProps> = ({ renderer }) => {
@@ -187,8 +187,8 @@ const TerminalPage: FC<TerminalPageProps> = ({ renderer }) => {
       },
     })
     // DOM is the default renderer.
-    if (renderer === "canvas") {
-      terminal.loadAddon(new CanvasAddon())
+    if (renderer === "webgl") {
+      terminal.loadAddon(new WebglAddon())
     }
     const fitAddon = new FitAddon()
     setFitAddon(fitAddon)

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -10,6 +10,7 @@ import * as XTerm from "xterm"
 import { CanvasAddon } from "xterm-addon-canvas"
 import { FitAddon } from "xterm-addon-fit"
 import { WebLinksAddon } from "xterm-addon-web-links"
+import { Unicode11Addon } from "xterm-addon-unicode11"
 import "xterm/css/xterm.css"
 import { MONOSPACE_FONT_FAMILY } from "../../theme/constants"
 import { pageTitle } from "../../utils/page"
@@ -176,6 +177,7 @@ const TerminalPage: FC<TerminalPageProps> = ({ renderer }) => {
       return
     }
     const terminal = new XTerm.Terminal({
+      allowProposedApi: true,
       allowTransparency: true,
       disableStdin: false,
       fontFamily: MONOSPACE_FONT_FAMILY,
@@ -191,6 +193,8 @@ const TerminalPage: FC<TerminalPageProps> = ({ renderer }) => {
     const fitAddon = new FitAddon()
     setFitAddon(fitAddon)
     terminal.loadAddon(fitAddon)
+    terminal.loadAddon(new Unicode11Addon())
+    terminal.unicode.activeVersion = "11"
     terminal.loadAddon(
       new WebLinksAddon((_, uri) => {
         handleWebLink(uri)


### PR DESCRIPTION
fix(site): use WebGL renderer for terminal

It's faster than Canvas.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/coder/coder/pull/9320).
* __->__ #9320
* #9259