### PR TITLE
fix: fix aws_linux template

### DIFF
--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -159,6 +159,7 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "coder_agent" "dev" {
+  count                  = data.coder_workspace.me.start_count
   arch                   = "amd64"
   auth                   = "aws-instance-identity"
   os                     = "linux"
@@ -195,7 +196,8 @@ resource "coder_agent" "dev" {
 }
 
 resource "coder_app" "code-server" {
-  agent_id     = coder_agent.dev.id
+  count        = data.coder_workspace.me.start_count
+  agent_id     = coder_agent.dev[0].id
   slug         = "code-server"
   display_name = "code-server"
   url          = "http://localhost:13337/?folder=/home/coder"
@@ -211,9 +213,8 @@ resource "coder_app" "code-server" {
 }
 
 locals {
-  linux_user = "coder" # Ensure this user/group does not exist in your VM image
-  # User data is used to run the init_script
-  user_data = <<EOT
+  linux_user = "coder"
+  user_data = data.coder_workspace.me.start_count > 0 ? trimspace(<<EOT
 Content-Type: multipart/mixed; boundary="//"
 MIME-Version: 1.0
 
@@ -239,9 +240,10 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash
-sudo -u ${local.linux_user} sh -c '${coder_agent.dev.init_script}'
+sudo -u ${local.linux_user} sh -c '${coder_agent.dev[0].init_script}'
 --//--
 EOT
+  ) : ""
 }
 
 resource "aws_instance" "dev" {

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -158,7 +158,7 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
-resource "coder_agent" "main" {
+resource "coder_agent" "dev" {
   arch                   = "amd64"
   auth                   = "aws-instance-identity"
   os                     = "linux"
@@ -195,7 +195,7 @@ resource "coder_agent" "main" {
 }
 
 resource "coder_app" "code-server" {
-  agent_id     = coder_agent.main.id
+  agent_id     = coder_agent.dev.id
   slug         = "code-server"
   display_name = "code-server"
   url          = "http://localhost:13337/?folder=/home/coder"
@@ -239,7 +239,7 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash
-sudo -u ${local.linux_user} sh -c '${coder_agent.main.init_script}'
+sudo -u ${local.linux_user} sh -c '${coder_agent.dev.init_script}'
 --//--
 EOT
 }
@@ -249,7 +249,7 @@ resource "aws_instance" "dev" {
   availability_zone = "${data.coder_parameter.region.value}a"
   instance_type     = data.coder_parameter.instance_type.value
 
-  user_data = local.user_data_start
+  user_data = local.user_data
   tags = {
     Name = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}"
     # Required if you are using our example policy, see template README


### PR DESCRIPTION
Continuation of #9325

1. There was a typo after refactoring the aws_linux.
2. Fixes coder agent showing unhealthy when the workspace is in the stopped state. 

![image](https://github.com/coder/coder/assets/10648092/13bec339-dc75-48b2-a36d-119f095848a2)
