### PR TITLE
fix: use more reasonable restart limit for systemd service

### DIFF
--- a/scripts/linux-pkg/coder.service
+++ b/scripts/linux-pkg/coder.service
@@ -4,7 +4,7 @@ Documentation=https://coder.com/docs/coder-oss
 Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty=/etc/coder.d/coder.env
-StartLimitIntervalSec=60
+StartLimitIntervalSec=10
 StartLimitBurst=3
 
 [Service]


### PR DESCRIPTION
## Previous behavior

When the Coder server fails, it attempted to restart every 5 seconds. However, we also had a limit of only 3 starts per 60 seconds. This caused the server to fail:

```sh
Aug 26 22:05:42 ben-coder systemd[1]: Failed to start "Coder - Self-hosted developer workspaces on your infra".
Aug 26 22:05:43 ben-coder systemd[1]: coder.service: Start request repeated too quickly.
Aug 26 22:05:43 ben-coder systemd[1]: coder.service: Failed with result 'exit-code'.
``` 

This also made it difficult to fix errors while configuring Coder (e.g. invalid OIDC issuer URL). The admin has to stop the Coder server, wait, and then start it.

## Current behavior

The server still attempts to restart every 5 seconds, but a max of 3 restarts per 10 seconds is allowed. I'm open to other rules though