### PR TITLE
chore(dogfood): update docker tf provider and metadata

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -40,9 +40,10 @@ data "coder_parameter" "dotfiles_url" {
 }
 
 data "coder_parameter" "region" {
-  type = "string"
-  name = "Region"
-  icon = "/emojis/1f30e.png"
+  type    = "string"
+  name    = "Region"
+  icon    = "/emojis/1f30e.png"
+  default = "us-pittsburgh"
   option {
     icon  = "/emojis/1f1fa-1f1f8.png"
     name  = "Pittsburgh"
@@ -325,5 +326,9 @@ resource "coder_metadata" "container_info" {
   item {
     key   = "runtime"
     value = docker_container.workspace[0].runtime
+  }
+  item {
+    key   = "region"
+    value = data.coder_parameter.region.option[index(data.coder_parameter.region.option.*.value, data.coder_parameter.region.value)].name
   }
 }

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 2.22.0"
+      version = "~> 3.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR,
1. updates docker terrfaorm provider to v3.0.0
2. Add a new metadat entry to show currently selected region

The version has been pre-tested on dev.coder.com