### PR TITLE
ci: lint against `dupl`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,10 @@
 # Over time we should try tightening some of these.
 
 linters-settings:
+  dupl:
+    # goal: 100
+    threshold: 412
+
   exhaustruct:
     include:
       # Gradually extend to cover more of the codebase.
@@ -268,3 +272,4 @@ linters:
     - typecheck
     - unconvert
     - unused
+    - dupl

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -602,13 +602,9 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		// Update the workspace
 		inv, root = clitest.New(t, "update", "my-workspace")
 		clitest.SetupConfig(t, client, root)
-		doneChan := make(chan struct{})
+
 		pty := ptytest.New(t).Attach(inv)
-		go func() {
-			defer close(doneChan)
-			err := inv.Run()
-			assert.NoError(t, err)
-		}()
+		clitest.Start(t, inv)
 
 		matches := []string{
 			stringParameterName, "second_option",
@@ -623,7 +619,6 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 				pty.WriteLine(value)
 			}
 		}
-		<-doneChan
 	})
 
 	t.Run("ParameterOptionDisappeared", func(t *testing.T) {
@@ -668,13 +663,8 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		// Update the workspace
 		inv, root = clitest.New(t, "update", "my-workspace")
 		clitest.SetupConfig(t, client, root)
-		doneChan := make(chan struct{})
 		pty := ptytest.New(t).Attach(inv)
-		go func() {
-			defer close(doneChan)
-			err := inv.Run()
-			assert.NoError(t, err)
-		}()
+		clitest.Start(t, inv)
 
 		matches := []string{
 			stringParameterName, "Third option",
@@ -689,7 +679,6 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 				pty.WriteLine(value)
 			}
 		}
-		<-doneChan
 	})
 
 	t.Run("ImmutableRequiredParameterExists_MutableRequiredParameterAdded", func(t *testing.T) {


### PR DESCRIPTION
ci: lint against `dupl`

This lint rule should help us keep Go code redundancy under control.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/coder/coder/pull/9357).
* #9359
* __->__ #9357