### PR TITLE
fix(site): increase provisioner-daemon-poll-interval

### DIFF
--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
       `--in-memory --telemetry=false ` +
       `--provisioner-daemons 10 ` +
       `--provisioner-daemons-echo ` +
-      `--provisioner-daemon-poll-interval 50ms`,
+      `--provisioner-daemon-poll-interval 1s`,
     env: {
       ...process.env,
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/8566
Related: https://github.com/coder/coder/issues/9345

_TL;DR Let's slow down the provisionerd._ 

I suspect that there is a race condition on the frontend side:
1. Workspace user starts the workspace.
2. Browser hits `/builds` and gets "pending".
3. Echo provisionerd finishes processing (build "running")
4. Browser observes `/watch`, but there won't be more events, as the build is running.

Not sure how we should solve the above scenario. Is it possible @BrunoQueresma?