### PR TITLE
fix(site): workaround: reload page every 3sec

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -39,6 +39,7 @@ export const createWorkspace = async (
 
   await expect(page).toHaveURL("/@admin/" + name)
 
+  // FIXME: workaround for https://github.com/coder/coder/issues/8566
   const reloadTimer = setInterval(async () => {
     await page.reload()
   }, 3000)

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -38,12 +38,17 @@ export const createWorkspace = async (
   await page.getByTestId("form-submit").click()
 
   await expect(page).toHaveURL("/@admin/" + name)
+
+  const reloadTimer = setInterval(async () => {
+    await page.reload()
+  }, 3000)
   await page.waitForSelector(
     "span[data-testid='build-status'] >> text=Running",
     {
       state: "visible",
     },
   )
+  clearInterval(reloadTimer)
   return name
 }
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/8566
Related: https://github.com/coder/coder/issues/9345

This PR adds a workaround for e2e tests helper `createWorkspace`. Due to the bug https://github.com/coder/coder/issues/8566, it is required to reload the page to see if the workspace build was successful.