### PR TITLE
test(site): print agent logs

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -316,16 +316,20 @@ export const startAgentWithCommand = async (
       CODER_AGENT_TOKEN: token,
     },
   })
-  let buffer = Buffer.of()
-  cp.stderr.on("data", (data: Buffer) => {
-    buffer = Buffer.concat([buffer, data])
+  cp.stdout.on("data", (data: Buffer) => {
+    // eslint-disable-next-line no-console -- Log agent activity
+    console.log(
+      `[agent] [stdout] [onData] ${data.toString().replace(/\n$/g, "")}`,
+    )
   })
-  try {
-    await page.getByTestId("agent-status-ready").waitFor({ state: "visible" })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The error is a string
-  } catch (ex: any) {
-    throw new Error(ex.toString() + "\n" + buffer.toString())
-  }
+  cp.stderr.on("data", (data: Buffer) => {
+    // eslint-disable-next-line no-console -- Log agent activity
+    console.log(
+      `[agent] [stderr] [onData] ${data.toString().replace(/\n$/g, "")}`,
+    )
+  })
+
+  await page.getByTestId("agent-status-ready").waitFor({ state: "visible" })
 }
 
 const coderMainPath = (): string => {

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -314,6 +314,8 @@ export const startAgentWithCommand = async (
       ...process.env,
       CODER_AGENT_URL: "http://localhost:" + port,
       CODER_AGENT_TOKEN: token,
+      CODER_AGENT_PPROF_ADDRESS: "127.0.0.1:2114",
+      CODER_AGENT_PROMETHEUS_ADDRESS: "127.0.0.1:6061",
     },
   })
   cp.stdout.on("data", (data: Buffer) => {

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
+    url: `http://localhost:${port}/api/v2/deployment/config`,
     command:
       `go run -tags embed ${coderMain} server ` +
       `--global-config $(mktemp -d -t e2e-XXXXXXXXXX) ` +
@@ -88,7 +89,6 @@ export default defineConfig({
         gitAuth.validatePath,
       ),
     },
-    port,
     reuseExistingServer: false,
   },
 })

--- a/site/e2e/reporter.ts
+++ b/site/e2e/reporter.ts
@@ -41,6 +41,10 @@ class CoderReporter implements Reporter {
   onTestEnd(test: TestCase, result: TestResult) {
     // eslint-disable-next-line no-console -- Helpful for debugging
     console.log(`Finished test ${test.title}: ${result.status}`)
+    if (result.status !== "passed") {
+      // eslint-disable-next-line no-console -- Helpful for debugging
+      console.log("errors", result.errors, "attachments", result.attachments)
+    }
   }
 
   onEnd(result: FullResult) {


### PR DESCRIPTION
This PR modifies `startAgentWithCommand` logic to expose agent logs.

I investigated some flaky issue, and it is unclear what is happening during the `ssh with agent...` test if the agent does not perform successful startup.

Additional changes:
* webServer: use specific `url` rather than `port` for
* agent: change ports for Prometheus and pprof