### PR TITLE
fix: use getTemplateByIDNoLock

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -3758,7 +3758,7 @@ func (q *FakeQuerier) GetWorkspacesEligibleForTransition(ctx context.Context, no
 			continue
 		}
 
-		template, err := q.GetTemplateByID(ctx, workspace.TemplateID)
+		template, err := q.getTemplateByIDNoLock(ctx, workspace.TemplateID)
 		if err != nil {
 			return nil, xerrors.Errorf("get template by ID: %w", err)
 		}


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/pull/9469

I was investigating the problem of blank, white pages happening in E2E tests, and found out that `coder server` is not responding if there request contains `coder_session_token`. I enabled pprof in Github action, and dumped goroutines.

It looks like we're calling the `RLock` twice:

```
1 @ 0x43ddf6 0x44f5cf 0x44f5a6 0x46e206 0x47ec51 0x2485acc 0x249cfbf 0x1ce51b3 0x246b48b 0x246b04f 0x472961
#	0x46e205	sync.runtime_SemacquireRWMutexR+0x25										/opt/hostedtoolcache/go/1.20.7/x64/src/runtime/sema.go:82
#	0x47ec50	sync.(*RWMutex).RLock+0x30											/opt/hostedtoolcache/go/1.20.7/x64/src/sync/rwmutex.go:71
#	0x2485acb	github.com/coder/coder/v2/coderd/database/dbfake.(*FakeQuerier).GetTemplateByID+0x8b				/home/runner/actions-runner/_work/coder/coder/coderd/database/dbfake/dbfake.go:2162
#	0x249cfbe	github.com/coder/coder/v2/coderd/database/dbfake.(*FakeQuerier).GetWorkspacesEligibleForTransition+0x8be	/home/runner/actions-runner/_work/coder/coder/coderd/database/dbfake/dbfake.go:3761
#	0x1ce51b2	github.com/coder/coder/v2/coderd/database/dbauthz.(*querier).GetWorkspacesEligibleForTransition+0x32		/home/runner/actions-runner/_work/coder/coder/coderd/database/dbauthz/dbauthz.go:1820
#	0x246b48a	github.com/coder/coder/v2/coderd/autobuild.(*Executor).runOnce+0x1ea						/home/runner/actions-runner/_work/coder/coder/coderd/autobuild/lifecycle_executor.go:113
#	0x246b04e	github.com/coder/coder/v2/coderd/autobuild.(*Executor).Run.func1+0x2ae	
```