### PR TITLE
refactor(cli): remove scaletest from slim binary

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1,3 +1,5 @@
+//go:build !slim
+
 package cli
 
 import (

--- a/cli/exp_scaletest_slim.go
+++ b/cli/exp_scaletest_slim.go
@@ -1,0 +1,20 @@
+//go:build slim
+
+package cli
+
+import "github.com/coder/coder/v2/cli/clibase"
+
+func (r *RootCmd) scaletestCmd() *clibase.Cmd {
+	cmd := &clibase.Cmd{
+		Use:     "scaletest",
+		Short:   "Run a scale test against the Coder API",
+		RawArgs: true, // We accept RawArgs so all commands and flags are accepted.
+		Hidden:  true,
+		Handler: func(inv *clibase.Invocation) error {
+			SlimUnsupported(inv.Stderr, "exp scaletest")
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
This change removes 3 MB when combined with #9483.

Ref: #9380, #9483

```
❯ ls -lha build
total 2.3G
drwxr-xr-x  2 coder coder 4.0K Sep  1 13:23 ./
drwxr-xr-x 30 coder coder 4.0K Sep  1 13:19 ../
-rw-r--r--  1 coder coder 366M Sep  1 13:21 coder-slim_2.1.4-devel+2089ddad8.tar
-rw-r--r--  1 coder coder  99M Sep  1 13:21 coder-slim_2.1.4-devel+2089ddad8.tar.zst
-rw-r--r--  1 coder coder  434 Sep  1 13:21 coder-slim_2.1.4-devel+2089ddad8_checksums.sha1
-rwxr-xr-x  1 coder coder  53M Sep  1 13:20 coder-slim_2.1.4-devel+2089ddad8_darwin_amd64*
-rwxr-xr-x  1 coder coder  53M Sep  1 13:20 coder-slim_2.1.4-devel+2089ddad8_darwin_arm64*
-rwxr-xr-x  1 coder coder  57M Sep  1 13:20 coder-slim_2.1.4-devel+2089ddad8_linux_amd64*
-rwxr-xr-x  1 coder coder  55M Sep  1 13:20 coder-slim_2.1.4-devel+2089ddad8_linux_arm64*
-rwxr-xr-x  1 coder coder  54M Sep  1 13:20 coder-slim_2.1.4-devel+2089ddad8_linux_armv7*
-rwxr-xr-x  1 coder coder  49M Sep  1 13:21 coder-slim_2.1.4-devel+2089ddad8_windows_amd64.exe*
-rwxr-xr-x  1 coder coder  47M Sep  1 13:21 coder-slim_2.1.4-devel+2089ddad8_windows_arm64.exe*
-rwxr-xr-x  1 coder coder 218M Sep  1 13:22 coder_2.1.4-devel+2089ddad8_darwin_amd64*
-rwxr-xr-x  1 coder coder 219M Sep  1 13:22 coder_2.1.4-devel+2089ddad8_darwin_arm64*
-rwxr-xr-x  1 coder coder 220M Sep  1 13:21 coder_2.1.4-devel+2089ddad8_linux_amd64*
-rwxr-xr-x  1 coder coder 216M Sep  1 13:21 coder_2.1.4-devel+2089ddad8_linux_arm64*
-rwxr-xr-x  1 coder coder 215M Sep  1 13:22 coder_2.1.4-devel+2089ddad8_linux_armv7*
-rwxr-xr-x  1 coder coder 212M Sep  1 13:22 coder_2.1.4-devel+2089ddad8_windows_amd64.exe*
-rwxr-xr-x  1 coder coder 209M Sep  1 13:23 coder_2.1.4-devel+2089ddad8_windows_arm64.exe*
```
