### PR TITLE
chore: add `ts_omit_aws` tag to remove aws dependency pulled in by tailscale

### DIFF
--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -99,10 +99,12 @@ ldflags=(
 	-X "'github.com/coder/coder/v2/buildinfo.tag=$version'"
 )
 
+# We use ts_omit_aws here because on Linux it prevents Tailscale from importing
+# github.com/aws/aws-sdk-go-v2/aws, which adds 7 MB to the binary.
 if [[ "$slim" == 0 ]]; then
-	build_args+=(-tags embed)
+	build_args+=(-tags "embed,ts_omit_aws")
 else
-	build_args+=(-tags slim)
+	build_args+=(-tags "slim,ts_omit_aws")
 fi
 if [[ "$agpl" == 1 ]]; then
 	# We don't use a tag to control AGPL because we don't want code to depend on


### PR DESCRIPTION
Ref: #9380

```
❯ ls -lha build
total 163M
drwxr-xr-x  2 coder coder 4.0K Sep  1 15:05 ./
drwxr-xr-x 30 coder coder 4.0K Sep  1 14:51 ../
-rwxr-xr-x  2 coder coder  52M Sep  1 15:05 coder-slim_2.1.4-devel+f051969d2_linux_amd64*
-rwxr-xr-x  1 coder coder  59M Sep  1 15:00 coder-slim_2.1.4-devel+f1f9cb030_linux_amd64*
```

(Unfortunately a Linux-only benefit.)