### PR TITLE
refactor(enterprise/cli): remove provisionerd from slim binary

### DIFF
--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -1,3 +1,5 @@
+//go:build !slim
+
 package cli
 
 import (

--- a/enterprise/cli/provisionerdaemons_slim.go
+++ b/enterprise/cli/provisionerdaemons_slim.go
@@ -6,19 +6,18 @@ import (
 	"github.com/coder/coder/v2/cli/clibase"
 )
 
-func (r *RootCmd) proxyServer() *clibase.Cmd {
-	root := &clibase.Cmd{
-		Use:     "server",
-		Short:   "Start a workspace proxy server",
-		Aliases: []string{},
+func (r *RootCmd) provisionerDaemons() *clibase.Cmd {
+	cmd := &clibase.Cmd{
+		Use:   "provisionerd",
+		Short: "Manage provisioner daemons",
 		// We accept RawArgs so all commands and flags are accepted.
 		RawArgs: true,
 		Hidden:  true,
 		Handler: func(inv *clibase.Invocation) error {
-			slimUnsupported(inv.Stderr, "workspace-proxy server")
+			slimUnsupported(inv.Stderr, "coder provisionerd")
 			return nil
 		},
 	}
 
-	return root
+	return cmd
 }

--- a/enterprise/cli/root.go
+++ b/enterprise/cli/root.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/cliui"
 )
 
 type RootCmd struct {
@@ -23,4 +28,15 @@ func (r *RootCmd) enterpriseOnly() []*clibase.Cmd {
 func (r *RootCmd) EnterpriseSubcommands() []*clibase.Cmd {
 	all := append(r.Core(), r.enterpriseOnly()...)
 	return all
+}
+
+//nolint:unused
+func slimUnsupported(w io.Writer, cmd string) {
+	_, _ = fmt.Fprintf(w, "You are using a 'slim' build of Coder, which does not support the %s subcommand.\n", cliui.DefaultStyles.Code.Render(cmd))
+	_, _ = fmt.Fprintln(w, "")
+	_, _ = fmt.Fprintln(w, "Please use a build of Coder from GitHub releases:")
+	_, _ = fmt.Fprintln(w, "  https://github.com/coder/coder/releases")
+
+	//nolint:revive
+	os.Exit(1)
 }


### PR DESCRIPTION
This change saves 8 MB in the slim binary.

Ref: #9380

```
❯ ls -lha build
total 2.0G
drwxr-xr-x  2 coder coder 4.0K Sep  1 17:28 ./
drwxr-xr-x 30 coder coder 4.0K Sep  1 17:23 ../
-rw-r--r--  1 coder coder 300M Sep  1 17:26 coder-slim_2.1.4-devel+5524374ef.tar
-rw-r--r--  1 coder coder  79M Sep  1 17:26 coder-slim_2.1.4-devel+5524374ef.tar.zst
-rw-r--r--  1 coder coder  434 Sep  1 17:26 coder-slim_2.1.4-devel+5524374ef_checksums.sha1
-rwxr-xr-x  1 coder coder  46M Sep  1 17:25 coder-slim_2.1.4-devel+5524374ef_darwin_amd64*
-rwxr-xr-x  1 coder coder  46M Sep  1 17:25 coder-slim_2.1.4-devel+5524374ef_darwin_arm64*
-rwxr-xr-x  1 coder coder  44M Sep  1 17:24 coder-slim_2.1.4-devel+5524374ef_linux_amd64*
-rwxr-xr-x  1 coder coder  42M Sep  1 17:24 coder-slim_2.1.4-devel+5524374ef_linux_arm64*
-rwxr-xr-x  1 coder coder  41M Sep  1 17:25 coder-slim_2.1.4-devel+5524374ef_linux_armv7*
-rwxr-xr-x  1 coder coder  43M Sep  1 17:26 coder-slim_2.1.4-devel+5524374ef_windows_amd64.exe*
-rwxr-xr-x  1 coder coder  41M Sep  1 17:26 coder-slim_2.1.4-devel+5524374ef_windows_arm64.exe*
-rwxr-xr-x  1 coder coder 199M Sep  1 17:27 coder_2.1.4-devel+5524374ef_darwin_amd64*
-rwxr-xr-x  1 coder coder 199M Sep  1 17:27 coder_2.1.4-devel+5524374ef_darwin_arm64*
-rwxr-xr-x  1 coder coder 193M Sep  1 17:26 coder_2.1.4-devel+5524374ef_linux_amd64*
-rwxr-xr-x  1 coder coder 190M Sep  1 17:27 coder_2.1.4-devel+5524374ef_linux_arm64*
-rwxr-xr-x  1 coder coder 188M Sep  1 17:27 coder_2.1.4-devel+5524374ef_linux_armv7*
-rwxr-xr-x  1 coder coder 193M Sep  1 17:28 coder_2.1.4-devel+5524374ef_windows_amd64.exe*
-rwxr-xr-x  1 coder coder 189M Sep  1 17:28 coder_2.1.4-devel+5524374ef_windows_arm64.exe*
```

Assuming this doesn't break any workflows or use-cases, it would be a worthwhile change.
