### PR TITLE
chore: use tailscale extra small buildflags

### DIFF
--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -101,10 +101,11 @@ ldflags=(
 
 # We use ts_omit_aws here because on Linux it prevents Tailscale from importing
 # github.com/aws/aws-sdk-go-v2/aws, which adds 7 MB to the binary.
+TS_EXTRA_SMALL="ts_omit_aws,ts_omit_bird,ts_omit_tap,ts_omit_kube"
 if [[ "$slim" == 0 ]]; then
-	build_args+=(-tags "embed,ts_omit_aws")
+	build_args+=(-tags "embed,$TS_EXTRA_SMALL")
 else
-	build_args+=(-tags "slim,ts_omit_aws")
+	build_args+=(-tags "slim,$TS_EXTRA_SMALL")
 fi
 if [[ "$agpl" == 1 ]]; then
 	# We don't use a tag to control AGPL because we don't want code to depend on


### PR DESCRIPTION
Ref: #9380

Noticed tailscale had a few more flags, what they call "extra small" build. This helps a tiny bit:

```
❯ command ls -l build
-rwxr-xr-x 1 coder coder 45371392 Sep  1 18:32 coder-slim_2.1.4-devel+27ab0d9a8_linux_amd64
-rwxr-xr-x 2 coder coder 45244416 Sep  1 18:32 coder-slim_2.1.4-devel+2bfd91454_linux_amd64
```
