### PR TITLE
docs: explain why coder port-forward is more performant than dashboard and sshd

### DIFF
--- a/docs/networking/port-forwarding.md
+++ b/docs/networking/port-forwarding.md
@@ -10,7 +10,11 @@ There are three ways to forward ports in Coder:
 - Dashboard
 - SSH
 
-The `coder port-forward` command is generally more performant.
+The `coder port-forward` command is generally more performant than:
+
+1. The Dashboard which proxies traffic through the Coder control plane versus
+   peer-to-peer which is possible with the Coder CLI
+1. `sshd` which does double encryption of traffic with both Wireguard and SSH
 
 ## The `coder port-forward` command
 


### PR DESCRIPTION
The port-forwarding docs make a claim that `coder port-forward` is more performant.  

This PR provides additional explanations as why that is the case.

Thanks @deansheather for the answer and @mjasten32 for asking the question.