### PR TITLE
docs: add `CODER_TLS_ADDRESS` to documentation for TLS setup

### DIFF
--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -139,8 +139,7 @@ you can configure the server by setting the following variables in
 CODER_ACCESS_URL=https://coder.example.com
 
 # String. Address to serve the API and dashboard.
-# Use 0.0.0.0:3000 for non-local connections
-CODER_HTTP_ADDRESS=127.0.0.1:3000
+CODER_HTTP_ADDRESS=0.0.0.0:3000
 
 # String. The URL of a PostgreSQL database to connect to. If empty, PostgreSQL binaries
 # will be downloaded from Maven (https://repo1.maven.org/maven2) and store all
@@ -150,7 +149,7 @@ CODER_PG_CONNECTION_URL=
 # Boolean. Specifies if TLS will be enabled.
 CODER_TLS_ENABLE=
 
-# If CODER_TLS_ENABLE=true && Opening access to outside or want to change TLS port:
+# If CODER_TLS_ENABLE=true, also set:
 CODER_TLS_ADDRESS=0.0.0.0:3443
 
 # String. Specifies the path to the certificate for TLS. It requires a PEM-encoded file.
@@ -185,6 +184,10 @@ sudo systemctl restart coder
 To configure Coder behind a corporate proxy, set the environment variables
 `HTTP_PROXY` and `HTTPS_PROXY`. Be sure to restart the server. Lowercase values
 (e.g. `http_proxy`) are also respected in this case.
+
+## Configuring Coder behinf a revrese proxy
+
+To configure Coder behind a revres proxy, see our [web-server](https://github.com/RaineAllDay/coder/tree/main/examples/web-server) example docs.
 
 ## Up Next
 

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -187,7 +187,9 @@ To configure Coder behind a corporate proxy, set the environment variables
 
 ## Configuring Coder behinf a revrese proxy
 
-To configure Coder behind a revres proxy, see our [web-server](https://github.com/RaineAllDay/coder/tree/main/examples/web-server) example docs.
+To configure Coder behind a revres proxy, see our
+[web-server](https://github.com/RaineAllDay/coder/tree/main/examples/web-server)
+example docs.
 
 ## Up Next
 

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -185,7 +185,7 @@ To configure Coder behind a corporate proxy, set the environment variables
 `HTTP_PROXY` and `HTTPS_PROXY`. Be sure to restart the server. Lowercase values
 (e.g. `http_proxy`) are also respected in this case.
 
-## Configuring Coder behinf a revrese proxy
+## Configuring Coder behind a reverse proxy
 
 To configure Coder behind a revres proxy, see our
 [web-server](https://github.com/RaineAllDay/coder/tree/main/examples/web-server)

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -139,7 +139,8 @@ you can configure the server by setting the following variables in
 CODER_ACCESS_URL=https://coder.example.com
 
 # String. Address to serve the API and dashboard.
-CODER_HTTP_ADDRESS=127.0.0.1:3000
+# Use 0.0.0.0:3000 for non-local connections
+CODER_HTTP_ADDRESS=127.0.0.1:3000 
 
 # String. The URL of a PostgreSQL database to connect to. If empty, PostgreSQL binaries
 # will be downloaded from Maven (https://repo1.maven.org/maven2) and store all
@@ -148,6 +149,9 @@ CODER_PG_CONNECTION_URL=
 
 # Boolean. Specifies if TLS will be enabled.
 CODER_TLS_ENABLE=
+
+# If TLS_ENABLE=true && Opening access to outside or want to change TLS port:
+CODER_TLS_ADDRESS=0.0.0.0:3443
 
 # String. Specifies the path to the certificate for TLS. It requires a PEM-encoded file.
 # To configure the listener to use a CA certificate, concatenate the primary

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -185,12 +185,6 @@ To configure Coder behind a corporate proxy, set the environment variables
 `HTTP_PROXY` and `HTTPS_PROXY`. Be sure to restart the server. Lowercase values
 (e.g. `http_proxy`) are also respected in this case.
 
-## Configuring Coder behind a reverse proxy
-
-To configure Coder behind a revres proxy, see our
-[reverse-proxy](https://coder.com/docs/v2/latest/admin/configure#tls--reverse-proxy)
-example docs.
-
 ## Up Next
 
 - [Learn how to upgrade Coder](./upgrade.md).

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -188,7 +188,7 @@ To configure Coder behind a corporate proxy, set the environment variables
 ## Configuring Coder behind a reverse proxy
 
 To configure Coder behind a revres proxy, see our
-[web-server](https://github.com/RaineAllDay/coder/tree/main/examples/web-server)
+[reverse-proxy](https://coder.com/docs/v2/latest/admin/configure#tls--reverse-proxy)
 example docs.
 
 ## Up Next

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -140,7 +140,7 @@ CODER_ACCESS_URL=https://coder.example.com
 
 # String. Address to serve the API and dashboard.
 # Use 0.0.0.0:3000 for non-local connections
-CODER_HTTP_ADDRESS=127.0.0.1:3000 
+CODER_HTTP_ADDRESS=127.0.0.1:3000
 
 # String. The URL of a PostgreSQL database to connect to. If empty, PostgreSQL binaries
 # will be downloaded from Maven (https://repo1.maven.org/maven2) and store all

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -150,7 +150,7 @@ CODER_PG_CONNECTION_URL=
 # Boolean. Specifies if TLS will be enabled.
 CODER_TLS_ENABLE=
 
-# If TLS_ENABLE=true && Opening access to outside or want to change TLS port:
+# If CODER_TLS_ENABLE=true && Opening access to outside or want to change TLS port:
 CODER_TLS_ADDRESS=0.0.0.0:3443
 
 # String. Specifies the path to the certificate for TLS. It requires a PEM-encoded file.


### PR DESCRIPTION
Updated TLS instructions to include CODER_TLS_ADDRESS