### PR TITLE
refactor(coderd/healthcheck): move derp report to derphealth package

### DIFF
--- a/cli/netcheck.go
+++ b/cli/netcheck.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/cli/clibase"
-	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -33,8 +33,8 @@ func (r *RootCmd) netcheck() *clibase.Cmd {
 
 			_, _ = fmt.Fprint(inv.Stderr, "Gathering a network report. This may take a few seconds...\n\n")
 
-			var report healthcheck.DERPReport
-			report.Run(ctx, &healthcheck.DERPReportOptions{
+			var report derphealth.Report
+			report.Run(ctx, &derphealth.ReportOptions{
 				DERPMap: connInfo.DERPMap,
 			})
 

--- a/cli/netcheck_test.go
+++ b/cli/netcheck_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
-	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
 	"github.com/coder/coder/v2/pty/ptytest"
 )
 
@@ -27,7 +27,7 @@ func TestNetcheck(t *testing.T) {
 
 	b := out.Bytes()
 	t.Log(string(b))
-	var report healthcheck.DERPReport
+	var report derphealth.Report
 	require.NoError(t, json.Unmarshal(b, &report))
 
 	assert.True(t, report.Healthy)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11400,30 +11400,7 @@ const docTemplate = `{
                 }
             }
         },
-        "healthcheck.AccessURLReport": {
-            "type": "object",
-            "properties": {
-                "access_url": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "healthy": {
-                    "type": "boolean"
-                },
-                "healthz_response": {
-                    "type": "string"
-                },
-                "reachable": {
-                    "type": "boolean"
-                },
-                "status_code": {
-                    "type": "integer"
-                }
-            }
-        },
-        "healthcheck.DERPNodeReport": {
+        "derphealth.NodeReport": {
             "type": "object",
             "properties": {
                 "can_exchange_messages": {
@@ -11466,14 +11443,14 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "stun": {
-                    "$ref": "#/definitions/healthcheck.DERPStunReport"
+                    "$ref": "#/definitions/derphealth.StunReport"
                 },
                 "uses_websocket": {
                     "type": "boolean"
                 }
             }
         },
-        "healthcheck.DERPRegionReport": {
+        "derphealth.RegionReport": {
             "type": "object",
             "properties": {
                 "error": {
@@ -11485,7 +11462,7 @@ const docTemplate = `{
                 "node_reports": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/healthcheck.DERPNodeReport"
+                        "$ref": "#/definitions/derphealth.NodeReport"
                     }
                 },
                 "region": {
@@ -11493,7 +11470,7 @@ const docTemplate = `{
                 }
             }
         },
-        "healthcheck.DERPReport": {
+        "derphealth.Report": {
             "type": "object",
             "properties": {
                 "error": {
@@ -11517,12 +11494,12 @@ const docTemplate = `{
                 "regions": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/healthcheck.DERPRegionReport"
+                        "$ref": "#/definitions/derphealth.RegionReport"
                     }
                 }
             }
         },
-        "healthcheck.DERPStunReport": {
+        "derphealth.StunReport": {
             "type": "object",
             "properties": {
                 "canSTUN": {
@@ -11533,6 +11510,29 @@ const docTemplate = `{
                 },
                 "error": {
                     "type": "string"
+                }
+            }
+        },
+        "healthcheck.AccessURLReport": {
+            "type": "object",
+            "properties": {
+                "access_url": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "healthz_response": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
+                },
+                "status_code": {
+                    "type": "integer"
                 }
             }
         },
@@ -11570,7 +11570,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/healthcheck.DatabaseReport"
                 },
                 "derp": {
-                    "$ref": "#/definitions/healthcheck.DERPReport"
+                    "$ref": "#/definitions/derphealth.Report"
                 },
                 "failing_sections": {
                     "description": "FailingSections is a list of sections that have failed their healthcheck.",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10366,30 +10366,7 @@
         }
       }
     },
-    "healthcheck.AccessURLReport": {
-      "type": "object",
-      "properties": {
-        "access_url": {
-          "type": "string"
-        },
-        "error": {
-          "type": "string"
-        },
-        "healthy": {
-          "type": "boolean"
-        },
-        "healthz_response": {
-          "type": "string"
-        },
-        "reachable": {
-          "type": "boolean"
-        },
-        "status_code": {
-          "type": "integer"
-        }
-      }
-    },
-    "healthcheck.DERPNodeReport": {
+    "derphealth.NodeReport": {
       "type": "object",
       "properties": {
         "can_exchange_messages": {
@@ -10432,14 +10409,14 @@
           "type": "integer"
         },
         "stun": {
-          "$ref": "#/definitions/healthcheck.DERPStunReport"
+          "$ref": "#/definitions/derphealth.StunReport"
         },
         "uses_websocket": {
           "type": "boolean"
         }
       }
     },
-    "healthcheck.DERPRegionReport": {
+    "derphealth.RegionReport": {
       "type": "object",
       "properties": {
         "error": {
@@ -10451,7 +10428,7 @@
         "node_reports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/healthcheck.DERPNodeReport"
+            "$ref": "#/definitions/derphealth.NodeReport"
           }
         },
         "region": {
@@ -10459,7 +10436,7 @@
         }
       }
     },
-    "healthcheck.DERPReport": {
+    "derphealth.Report": {
       "type": "object",
       "properties": {
         "error": {
@@ -10483,12 +10460,12 @@
         "regions": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/healthcheck.DERPRegionReport"
+            "$ref": "#/definitions/derphealth.RegionReport"
           }
         }
       }
     },
-    "healthcheck.DERPStunReport": {
+    "derphealth.StunReport": {
       "type": "object",
       "properties": {
         "canSTUN": {
@@ -10499,6 +10476,29 @@
         },
         "error": {
           "type": "string"
+        }
+      }
+    },
+    "healthcheck.AccessURLReport": {
+      "type": "object",
+      "properties": {
+        "access_url": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "healthz_response": {
+          "type": "string"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "status_code": {
+          "type": "integer"
         }
       }
     },
@@ -10536,7 +10536,7 @@
           "$ref": "#/definitions/healthcheck.DatabaseReport"
         },
         "derp": {
-          "$ref": "#/definitions/healthcheck.DERPReport"
+          "$ref": "#/definitions/derphealth.Report"
         },
         "failing_sections": {
           "description": "FailingSections is a list of sections that have failed their healthcheck.",

--- a/coderd/healthcheck/derphealth/derp_test.go
+++ b/coderd/healthcheck/derphealth/derp_test.go
@@ -1,4 +1,4 @@
-package healthcheck_test
+package derphealth_test
 
 import (
 	"context"
@@ -17,7 +17,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 
-	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -38,9 +38,9 @@ func TestDERP(t *testing.T) {
 
 		var (
 			ctx        = context.Background()
-			report     = healthcheck.DERPReport{}
+			report     = derphealth.Report{}
 			derpURL, _ = url.Parse(srv.URL)
-			opts       = &healthcheck.DERPReportOptions{
+			opts       = &derphealth.ReportOptions{
 				DERPMap: &tailcfg.DERPMap{Regions: map[int]*tailcfg.DERPRegion{
 					1: {
 						EmbeddedRelay: true,
@@ -95,8 +95,8 @@ func TestDERP(t *testing.T) {
 
 		var (
 			ctx    = context.Background()
-			report = healthcheck.DERPReport{}
-			opts   = &healthcheck.DERPReportOptions{
+			report = derphealth.Report{}
+			opts   = &derphealth.ReportOptions{
 				DERPMap: tsDERPMap(ctx, t),
 			}
 		)
@@ -145,9 +145,9 @@ func TestDERP(t *testing.T) {
 
 		var (
 			ctx        = context.Background()
-			report     = healthcheck.DERPReport{}
+			report     = derphealth.Report{}
 			derpURL, _ = url.Parse(srv.URL)
-			opts       = &healthcheck.DERPReportOptions{
+			opts       = &derphealth.ReportOptions{
 				DERPMap: &tailcfg.DERPMap{Regions: map[int]*tailcfg.DERPRegion{
 					1: {
 						EmbeddedRelay: true,
@@ -195,8 +195,8 @@ func TestDERP(t *testing.T) {
 
 		var (
 			ctx    = context.Background()
-			report = healthcheck.DERPReport{}
-			opts   = &healthcheck.DERPReportOptions{
+			report = derphealth.Report{}
+			opts   = &derphealth.ReportOptions{
 				DERPMap: &tailcfg.DERPMap{Regions: map[int]*tailcfg.DERPRegion{
 					1: {
 						EmbeddedRelay: true,

--- a/coderd/healthcheck/healthcheck.go
+++ b/coderd/healthcheck/healthcheck.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 )
 
@@ -23,7 +24,7 @@ const (
 )
 
 type Checker interface {
-	DERP(ctx context.Context, opts *DERPReportOptions) DERPReport
+	DERP(ctx context.Context, opts *derphealth.ReportOptions) derphealth.Report
 	AccessURL(ctx context.Context, opts *AccessURLReportOptions) AccessURLReport
 	Websocket(ctx context.Context, opts *WebsocketReportOptions) WebsocketReport
 	Database(ctx context.Context, opts *DatabaseReportOptions) DatabaseReport
@@ -38,10 +39,10 @@ type Report struct {
 	// FailingSections is a list of sections that have failed their healthcheck.
 	FailingSections []string `json:"failing_sections"`
 
-	DERP      DERPReport      `json:"derp"`
-	AccessURL AccessURLReport `json:"access_url"`
-	Websocket WebsocketReport `json:"websocket"`
-	Database  DatabaseReport  `json:"database"`
+	DERP      derphealth.Report `json:"derp"`
+	AccessURL AccessURLReport   `json:"access_url"`
+	Websocket WebsocketReport   `json:"websocket"`
+	Database  DatabaseReport    `json:"database"`
 
 	// The Coder version of the server that the report was generated on.
 	CoderVersion string `json:"coder_version"`
@@ -60,7 +61,7 @@ type ReportOptions struct {
 
 type defaultChecker struct{}
 
-func (defaultChecker) DERP(ctx context.Context, opts *DERPReportOptions) (report DERPReport) {
+func (defaultChecker) DERP(ctx context.Context, opts *derphealth.ReportOptions) (report derphealth.Report) {
 	report.Run(ctx, opts)
 	return report
 }
@@ -99,7 +100,7 @@ func Run(ctx context.Context, opts *ReportOptions) *Report {
 			}
 		}()
 
-		report.DERP = opts.Checker.DERP(ctx, &DERPReportOptions{
+		report.DERP = opts.Checker.DERP(ctx, &derphealth.ReportOptions{
 			DERPMap: opts.DERPMap,
 		})
 	}()

--- a/coderd/healthcheck/healthcheck_test.go
+++ b/coderd/healthcheck/healthcheck_test.go
@@ -7,16 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
 )
 
 type testChecker struct {
-	DERPReport      healthcheck.DERPReport
+	DERPReport      derphealth.Report
 	AccessURLReport healthcheck.AccessURLReport
 	WebsocketReport healthcheck.WebsocketReport
 	DatabaseReport  healthcheck.DatabaseReport
 }
 
-func (c *testChecker) DERP(context.Context, *healthcheck.DERPReportOptions) healthcheck.DERPReport {
+func (c *testChecker) DERP(context.Context, *derphealth.ReportOptions) derphealth.Report {
 	return c.DERPReport
 }
 
@@ -43,7 +44,7 @@ func TestHealthcheck(t *testing.T) {
 	}{{
 		name: "OK",
 		checker: &testChecker{
-			DERPReport: healthcheck.DERPReport{
+			DERPReport: derphealth.Report{
 				Healthy: true,
 			},
 			AccessURLReport: healthcheck.AccessURLReport{
@@ -61,7 +62,7 @@ func TestHealthcheck(t *testing.T) {
 	}, {
 		name: "DERPFail",
 		checker: &testChecker{
-			DERPReport: healthcheck.DERPReport{
+			DERPReport: derphealth.Report{
 				Healthy: false,
 			},
 			AccessURLReport: healthcheck.AccessURLReport{
@@ -79,7 +80,7 @@ func TestHealthcheck(t *testing.T) {
 	}, {
 		name: "AccessURLFail",
 		checker: &testChecker{
-			DERPReport: healthcheck.DERPReport{
+			DERPReport: derphealth.Report{
 				Healthy: true,
 			},
 			AccessURLReport: healthcheck.AccessURLReport{
@@ -97,7 +98,7 @@ func TestHealthcheck(t *testing.T) {
 	}, {
 		name: "WebsocketFail",
 		checker: &testChecker{
-			DERPReport: healthcheck.DERPReport{
+			DERPReport: derphealth.Report{
 				Healthy: true,
 			},
 			AccessURLReport: healthcheck.AccessURLReport{
@@ -115,7 +116,7 @@ func TestHealthcheck(t *testing.T) {
 	}, {
 		name: "DatabaseFail",
 		checker: &testChecker{
-			DERPReport: healthcheck.DERPReport{
+			DERPReport: derphealth.Report{
 				Healthy: true,
 			},
 			AccessURLReport: healthcheck.AccessURLReport{

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -6698,31 +6698,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `tokenBucketBytesPerSecond`                                                                | integer | false    |              | Tokenbucketbytespersecond is how many bytes per second the server says it will accept, including all framing bytes.      |
 | Zero means unspecified. There might be a limit, but the client need not try to respect it. |
 
-## healthcheck.AccessURLReport
-
-```json
-{
-  "access_url": "string",
-  "error": "string",
-  "healthy": true,
-  "healthz_response": "string",
-  "reachable": true,
-  "status_code": 0
-}
-```
-
-### Properties
-
-| Name               | Type    | Required | Restrictions | Description |
-| ------------------ | ------- | -------- | ------------ | ----------- |
-| `access_url`       | string  | false    |              |             |
-| `error`            | string  | false    |              |             |
-| `healthy`          | boolean | false    |              |             |
-| `healthz_response` | string  | false    |              |             |
-| `reachable`        | boolean | false    |              |             |
-| `status_code`      | integer | false    |              |             |
-
-## healthcheck.DERPNodeReport
+## derphealth.NodeReport
 
 ```json
 {
@@ -6763,21 +6739,21 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name                    | Type                                                     | Required | Restrictions | Description |
-| ----------------------- | -------------------------------------------------------- | -------- | ------------ | ----------- |
-| `can_exchange_messages` | boolean                                                  | false    |              |             |
-| `client_errs`           | array of array                                           | false    |              |             |
-| `client_logs`           | array of array                                           | false    |              |             |
-| `error`                 | string                                                   | false    |              |             |
-| `healthy`               | boolean                                                  | false    |              |             |
-| `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)                     | false    |              |             |
-| `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage)         | false    |              |             |
-| `round_trip_ping`       | string                                                   | false    |              |             |
-| `round_trip_ping_ms`    | integer                                                  | false    |              |             |
-| `stun`                  | [healthcheck.DERPStunReport](#healthcheckderpstunreport) | false    |              |             |
-| `uses_websocket`        | boolean                                                  | false    |              |             |
+| Name                    | Type                                             | Required | Restrictions | Description |
+| ----------------------- | ------------------------------------------------ | -------- | ------------ | ----------- |
+| `can_exchange_messages` | boolean                                          | false    |              |             |
+| `client_errs`           | array of array                                   | false    |              |             |
+| `client_logs`           | array of array                                   | false    |              |             |
+| `error`                 | string                                           | false    |              |             |
+| `healthy`               | boolean                                          | false    |              |             |
+| `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)             | false    |              |             |
+| `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage) | false    |              |             |
+| `round_trip_ping`       | string                                           | false    |              |             |
+| `round_trip_ping_ms`    | integer                                          | false    |              |             |
+| `stun`                  | [derphealth.StunReport](#derphealthstunreport)   | false    |              |             |
+| `uses_websocket`        | boolean                                          | false    |              |             |
 
-## healthcheck.DERPRegionReport
+## derphealth.RegionReport
 
 ```json
 {
@@ -6848,14 +6824,14 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name           | Type                                                              | Required | Restrictions | Description |
-| -------------- | ----------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `error`        | string                                                            | false    |              |             |
-| `healthy`      | boolean                                                           | false    |              |             |
-| `node_reports` | array of [healthcheck.DERPNodeReport](#healthcheckderpnodereport) | false    |              |             |
-| `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                          | false    |              |             |
+| Name           | Type                                                    | Required | Restrictions | Description |
+| -------------- | ------------------------------------------------------- | -------- | ------------ | ----------- |
+| `error`        | string                                                  | false    |              |             |
+| `healthy`      | boolean                                                 | false    |              |             |
+| `node_reports` | array of [derphealth.NodeReport](#derphealthnodereport) | false    |              |             |
+| `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                | false    |              |             |
 
-## healthcheck.DERPReport
+## derphealth.Report
 
 ```json
 {
@@ -7028,17 +7004,17 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name               | Type                                                         | Required | Restrictions | Description |
-| ------------------ | ------------------------------------------------------------ | -------- | ------------ | ----------- |
-| `error`            | string                                                       | false    |              |             |
-| `healthy`          | boolean                                                      | false    |              |             |
-| `netcheck`         | [netcheck.Report](#netcheckreport)                           | false    |              |             |
-| `netcheck_err`     | string                                                       | false    |              |             |
-| `netcheck_logs`    | array of string                                              | false    |              |             |
-| `regions`          | object                                                       | false    |              |             |
-| » `[any property]` | [healthcheck.DERPRegionReport](#healthcheckderpregionreport) | false    |              |             |
+| Name               | Type                                               | Required | Restrictions | Description |
+| ------------------ | -------------------------------------------------- | -------- | ------------ | ----------- |
+| `error`            | string                                             | false    |              |             |
+| `healthy`          | boolean                                            | false    |              |             |
+| `netcheck`         | [netcheck.Report](#netcheckreport)                 | false    |              |             |
+| `netcheck_err`     | string                                             | false    |              |             |
+| `netcheck_logs`    | array of string                                    | false    |              |             |
+| `regions`          | object                                             | false    |              |             |
+| » `[any property]` | [derphealth.RegionReport](#derphealthregionreport) | false    |              |             |
 
-## healthcheck.DERPStunReport
+## derphealth.StunReport
 
 ```json
 {
@@ -7055,6 +7031,30 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `canSTUN` | boolean | false    |              |             |
 | `enabled` | boolean | false    |              |             |
 | `error`   | string  | false    |              |             |
+
+## healthcheck.AccessURLReport
+
+```json
+{
+  "access_url": "string",
+  "error": "string",
+  "healthy": true,
+  "healthz_response": "string",
+  "reachable": true,
+  "status_code": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description |
+| ------------------ | ------- | -------- | ------------ | ----------- |
+| `access_url`       | string  | false    |              |             |
+| `error`            | string  | false    |              |             |
+| `healthy`          | boolean | false    |              |             |
+| `healthz_response` | string  | false    |              |             |
+| `reachable`        | boolean | false    |              |             |
+| `status_code`      | integer | false    |              |             |
 
 ## healthcheck.DatabaseReport
 
@@ -7283,7 +7283,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `access_url`       | [healthcheck.AccessURLReport](#healthcheckaccessurlreport) | false    |              |                                                                            |
 | `coder_version`    | string                                                     | false    |              | The Coder version of the server that the report was generated on.          |
 | `database`         | [healthcheck.DatabaseReport](#healthcheckdatabasereport)   | false    |              |                                                                            |
-| `derp`             | [healthcheck.DERPReport](#healthcheckderpreport)           | false    |              |                                                                            |
+| `derp`             | [derphealth.Report](#derphealthreport)                     | false    |              |                                                                            |
 | `failing_sections` | array of string                                            | false    |              | Failing sections is a list of sections that have failed their healthcheck. |
 | `healthy`          | boolean                                                    | false    |              | Healthy is true if the report returns no errors.                           |
 | `time`             | string                                                     | false    |              | Time is the time the report was generated at.                              |

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/workspaceapps/apptest"
 	"github.com/coder/coder/v2/codersdk"
@@ -295,8 +295,8 @@ resourceLoop:
 				}
 
 				ctx := testutil.Context(t, testutil.WaitLong)
-				report := healthcheck.DERPReport{}
-				report.Run(ctx, &healthcheck.DERPReportOptions{
+				report := derphealth.Report{}
+				report.Run(ctx, &derphealth.ReportOptions{
 					DERPMap: derpMap,
 				})
 

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	baseDirs = [...]string{"./codersdk", "./coderd/healthcheck"}
+	baseDirs = [...]string{"./codersdk", "./coderd/healthcheck", "./coderd/healthcheck/derphealth"}
 	indent   = "  "
 )
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1985,54 +1985,6 @@ export interface HealthcheckAccessURLReport {
   readonly error?: string
 }
 
-// From healthcheck/derp.go
-export interface HealthcheckDERPNodeReport {
-  readonly healthy: boolean
-  // Named type "tailscale.com/tailcfg.DERPNode" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly node?: any
-  // Named type "tailscale.com/derp.ServerInfoMessage" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly node_info: any
-  readonly can_exchange_messages: boolean
-  readonly round_trip_ping: string
-  readonly round_trip_ping_ms: number
-  readonly uses_websocket: boolean
-  readonly client_logs: string[][]
-  readonly client_errs: string[][]
-  readonly error?: string
-  readonly stun: HealthcheckDERPStunReport
-}
-
-// From healthcheck/derp.go
-export interface HealthcheckDERPRegionReport {
-  readonly healthy: boolean
-  // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly region?: any
-  readonly node_reports: HealthcheckDERPNodeReport[]
-  readonly error?: string
-}
-
-// From healthcheck/derp.go
-export interface HealthcheckDERPReport {
-  readonly healthy: boolean
-  readonly regions: Record<number, HealthcheckDERPRegionReport>
-  // Named type "tailscale.com/net/netcheck.Report" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly netcheck?: any
-  readonly netcheck_err?: string
-  readonly netcheck_logs: string[]
-  readonly error?: string
-}
-
-// From healthcheck/derp.go
-export interface HealthcheckDERPStunReport {
-  readonly Enabled: boolean
-  readonly CanSTUN: boolean
-  readonly Error?: string
-}
-
 // From healthcheck/database.go
 export interface HealthcheckDatabaseReport {
   readonly healthy: boolean
@@ -2047,7 +1999,9 @@ export interface HealthcheckReport {
   readonly time: string
   readonly healthy: boolean
   readonly failing_sections: string[]
-  readonly derp: HealthcheckDERPReport
+  // Named type "github.com/coder/coder/v2/coderd/healthcheck/derphealth.Report" unknown, using "any"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
+  readonly derp: any
   readonly access_url: HealthcheckAccessURLReport
   readonly websocket: HealthcheckWebsocketReport
   readonly database: HealthcheckDatabaseReport
@@ -2060,4 +2014,54 @@ export interface HealthcheckWebsocketReport {
   readonly body: string
   readonly code: number
   readonly error?: string
+}
+
+// The code below is generated from coderd/healthcheck/derphealth.
+
+// From derphealth/derp.go
+export interface DerphealthNodeReport {
+  readonly healthy: boolean
+  // Named type "tailscale.com/tailcfg.DERPNode" unknown, using "any"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
+  readonly node?: any
+  // Named type "tailscale.com/derp.ServerInfoMessage" unknown, using "any"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
+  readonly node_info: any
+  readonly can_exchange_messages: boolean
+  readonly round_trip_ping: string
+  readonly round_trip_ping_ms: number
+  readonly uses_websocket: boolean
+  readonly client_logs: string[][]
+  readonly client_errs: string[][]
+  readonly error?: string
+  readonly stun: DerphealthStunReport
+}
+
+// From derphealth/derp.go
+export interface DerphealthRegionReport {
+  readonly healthy: boolean
+  // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
+  readonly region?: any
+  readonly node_reports: DerphealthNodeReport[]
+  readonly error?: string
+}
+
+// From derphealth/derp.go
+export interface DerphealthReport {
+  readonly healthy: boolean
+  readonly regions: Record<number, DerphealthRegionReport>
+  // Named type "tailscale.com/net/netcheck.Report" unknown, using "any"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
+  readonly netcheck?: any
+  readonly netcheck_err?: string
+  readonly netcheck_logs: string[]
+  readonly error?: string
+}
+
+// From derphealth/derp.go
+export interface DerphealthStunReport {
+  readonly Enabled: boolean
+  readonly CanSTUN: boolean
+  readonly Error?: string
 }


### PR DESCRIPTION
This change helps remove one indirect use of coderd/database in the slim
CLI.

No size change (yet).

Ref: #9380

This could potentially be moved into the `tailnet` package as well.
