### PR TITLE
refactor(cli): use codersdk for provisioner types

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -256,7 +256,7 @@ func createValidTemplateVersion(inv *clibase.Invocation, args createValidTemplat
 		Message:            args.Message,
 		StorageMethod:      codersdk.ProvisionerStorageMethodFile,
 		FileID:             args.FileID,
-		Provisioner:        codersdk.ProvisionerType(args.Provisioner),
+		Provisioner:        args.Provisioner,
 		ProvisionerTags:    args.ProvisionerTags,
 		UserVariableValues: variableValues,
 	}

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -16,10 +16,8 @@ import (
 
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/cliui"
-	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/provisionerd"
 )
 
 func (r *RootCmd) templateCreate() *clibase.Cmd {
@@ -111,7 +109,7 @@ func (r *RootCmd) templateCreate() *clibase.Cmd {
 				Message:         message,
 				Client:          client,
 				Organization:    organization,
-				Provisioner:     database.ProvisionerType(provisioner),
+				Provisioner:     codersdk.ProvisionerType(provisioner),
 				FileID:          resp.ID,
 				ProvisionerTags: tags,
 				VariablesFile:   variablesFile,
@@ -224,7 +222,7 @@ type createValidTemplateVersionArgs struct {
 	Message      string
 	Client       *codersdk.Client
 	Organization codersdk.Organization
-	Provisioner  database.ProvisionerType
+	Provisioner  codersdk.ProvisionerType
 	FileID       uuid.UUID
 
 	VariablesFile string
@@ -284,7 +282,10 @@ func createValidTemplateVersion(inv *clibase.Invocation, args createValidTemplat
 	})
 	if err != nil {
 		var jobErr *cliui.ProvisionerJobError
-		if errors.As(err, &jobErr) && !provisionerd.IsMissingParameterErrorCode(string(jobErr.Code)) {
+		if errors.As(err, &jobErr) && !codersdk.JobIsMissingParameterErrorCode(jobErr.Code) {
+			return nil, err
+		}
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/cliui"
-	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionersdk"
 )
@@ -216,7 +215,7 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 				Message:         message,
 				Client:          client,
 				Organization:    organization,
-				Provisioner:     database.ProvisionerType(provisioner),
+				Provisioner:     codersdk.ProvisionerType(provisioner),
 				FileID:          resp.ID,
 				ProvisionerTags: tags,
 				VariablesFile:   variablesFile,

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -17,6 +17,7 @@ import (
 	"nhooyr.io/websocket"
 
 	"github.com/coder/coder/v2/provisionerd/proto"
+	"github.com/coder/coder/v2/provisionerd/runner"
 	"github.com/coder/coder/v2/provisionersdk"
 )
 
@@ -71,6 +72,12 @@ type JobErrorCode string
 const (
 	RequiredTemplateVariables JobErrorCode = "REQUIRED_TEMPLATE_VARIABLES"
 )
+
+// JobIsMissingParameterErrorCode returns whether the error is a missing parameter error.
+// This can indicate to consumers that they should check parameters.
+func JobIsMissingParameterErrorCode(code JobErrorCode) bool {
+	return string(code) == runner.MissingParameterErrorCode
+}
 
 // ProvisionerJob describes the job executed by the provisioning daemon.
 type ProvisionerJob struct {

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -29,12 +29,6 @@ import (
 	"github.com/coder/retry"
 )
 
-// IsMissingParameterErrorCode returns whether the error is a missing parameter error.
-// This can indicate to consumers that they should check parameters.
-func IsMissingParameterErrorCode(code string) bool {
-	return code == runner.MissingParameterErrorCode
-}
-
 // Dialer represents the function to create a daemon client connection.
 type Dialer func(ctx context.Context) (proto.DRPCProvisionerDaemonClient, error)
 


### PR DESCRIPTION
This change removes one use of `coderd/database` from the slim binary
and more correctly uses codersdk instead of database or provisionerd
packages.

No size change (yet).

Ref: #9380
