### PR TITLE
refactor(coderd/telemetry): move CLI telemetry to cli/telemetry

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -36,7 +36,7 @@ import (
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/cli/gitauth"
-	"github.com/coder/coder/v2/coderd/telemetry"
+	"github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 )
@@ -467,17 +467,17 @@ func addTelemetryHeader(client *codersdk.Client, inv *clibase.Invocation) {
 		client.HTTPClient.Transport = transport
 	}
 
-	var topts []telemetry.CLIOption
+	var topts []telemetry.Option
 	for _, opt := range inv.Command.FullOptions() {
 		if opt.ValueSource == clibase.ValueSourceNone || opt.ValueSource == clibase.ValueSourceDefault {
 			continue
 		}
-		topts = append(topts, telemetry.CLIOption{
+		topts = append(topts, telemetry.Option{
 			Name:        opt.Name,
 			ValueSource: string(opt.ValueSource),
 		})
 	}
-	ti := telemetry.CLIInvocation{
+	ti := telemetry.Invocation{
 		Command:   inv.Command.FullName(),
 		Options:   topts,
 		InvokedAt: time.Now(),

--- a/cli/telemetry/telemetry.go
+++ b/cli/telemetry/telemetry.go
@@ -1,0 +1,15 @@
+package telemetry
+
+import "time"
+
+type Option struct {
+	Name        string `json:"name"`
+	ValueSource string `json:"value_source"`
+}
+
+type Invocation struct {
+	Command string   `json:"command"`
+	Options []Option `json:"options"`
+	// InvokedAt is provided for deduplication purposes.
+	InvokedAt time.Time `json:"invoked_at"`
+}

--- a/coderd/httpmw/clitelemetry.go
+++ b/coderd/httpmw/clitelemetry.go
@@ -11,6 +11,7 @@ import (
 	"tailscale.com/tstime/rate"
 
 	"cdr.dev/slog"
+	clitelemetry "github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -30,7 +31,7 @@ func ReportCLITelemetry(log slog.Logger, rep telemetry.Reporter) func(http.Handl
 		//
 		// This approach just helps us reduce storage and ingest fees, and doesn't
 		// change the correctness.
-		queue = make(map[string]telemetry.CLIInvocation)
+		queue = make(map[string]clitelemetry.Invocation)
 	)
 
 	log = log.Named("cli-telemetry")
@@ -55,7 +56,7 @@ func ReportCLITelemetry(log slog.Logger, rep telemetry.Reporter) func(http.Handl
 				return
 			}
 
-			var inv telemetry.CLIInvocation
+			var inv clitelemetry.Invocation
 			err = json.Unmarshal(byt, &inv)
 			if err != nil {
 				log.Error(

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -23,6 +23,7 @@ import (
 
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/buildinfo"
+	clitelemetry "github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 )
@@ -714,7 +715,7 @@ type Snapshot struct {
 	WorkspaceResources        []WorkspaceResource         `json:"workspace_resources"`
 	WorkspaceResourceMetadata []WorkspaceResourceMetadata `json:"workspace_resource_metadata"`
 	WorkspaceProxies          []WorkspaceProxy            `json:"workspace_proxies"`
-	CLIInvocations            []CLIInvocation             `json:"cli_invocations"`
+	CLIInvocations            []clitelemetry.Invocation   `json:"cli_invocations"`
 }
 
 // Deployment contains information about the host running Coder.
@@ -888,18 +889,6 @@ type ParameterSchema struct {
 type License struct {
 	UploadedAt time.Time `json:"uploaded_at"`
 	UUID       uuid.UUID `json:"uuid"`
-}
-
-type CLIOption struct {
-	Name        string `json:"name"`
-	ValueSource string `json:"value_source"`
-}
-
-type CLIInvocation struct {
-	Command string      `json:"command"`
-	Options []CLIOption `json:"options"`
-	// InvokedAt is provided for deduplication purposes.
-	InvokedAt time.Time `json:"invoked_at"`
 }
 
 type WorkspaceProxy struct {


### PR DESCRIPTION
This change removes an indirect import of `coderd/database` from the
slim binary.

No size change (yet).

Ref: #9380
