### PR TITLE
refactor(cli)!: remove reset-password from slim binary

### DIFF
--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -1,3 +1,5 @@
+//go:build !slim
+
 package cli
 
 import (

--- a/cli/resetpassword_slim.go
+++ b/cli/resetpassword_slim.go
@@ -3,22 +3,21 @@
 package cli
 
 import (
-	agplcli "github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
 )
 
-func (r *RootCmd) provisionerDaemons() *clibase.Cmd {
-	cmd := &clibase.Cmd{
-		Use:   "provisionerd",
-		Short: "Manage provisioner daemons",
+func (*RootCmd) resetPassword() *clibase.Cmd {
+	root := &clibase.Cmd{
+		Use:   "reset-password <username>",
+		Short: "Directly connect to the database to reset a user's password",
 		// We accept RawArgs so all commands and flags are accepted.
 		RawArgs: true,
 		Hidden:  true,
 		Handler: func(inv *clibase.Invocation) error {
-			agplcli.SlimUnsupported(inv.Stderr, "provisionerd")
+			SlimUnsupported(inv.Stderr, "reset-password")
 			return nil
 		},
 	}
 
-	return cmd
+	return root
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -1019,3 +1019,14 @@ func (p *prettyErrorFormatter) printf(style lipgloss.Style, format string, a ...
 		),
 	)
 }
+
+//nolint:unused
+func SlimUnsupported(w io.Writer, cmd string) {
+	_, _ = fmt.Fprintf(w, "You are using a 'slim' build of Coder, which does not support the %s subcommand.\n", cliui.DefaultStyles.Code.Render(cmd))
+	_, _ = fmt.Fprintln(w, "")
+	_, _ = fmt.Fprintln(w, "Please use a build of Coder from GitHub releases:")
+	_, _ = fmt.Fprintln(w, "  https://github.com/coder/coder/releases")
+
+	//nolint:revive
+	os.Exit(1)
+}

--- a/cli/server_slim.go
+++ b/cli/server_slim.go
@@ -3,12 +3,7 @@
 package cli
 
 import (
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/coder/coder/v2/cli/clibase"
-	"github.com/coder/coder/v2/cli/cliui"
 )
 
 func (r *RootCmd) Server(_ func()) *clibase.Cmd {
@@ -19,18 +14,10 @@ func (r *RootCmd) Server(_ func()) *clibase.Cmd {
 		RawArgs: true,
 		Hidden:  true,
 		Handler: func(inv *clibase.Invocation) error {
-			serverUnsupported(inv.Stderr)
+			SlimUnsupported(inv.Stderr, "server")
 			return nil
 		},
 	}
 
 	return root
-}
-
-func serverUnsupported(w io.Writer) {
-	_, _ = fmt.Fprintf(w, "You are using a 'slim' build of Coder, which does not support the %s subcommand.\n", cliui.DefaultStyles.Code.Render("server"))
-	_, _ = fmt.Fprintln(w, "")
-	_, _ = fmt.Fprintln(w, "Please use a build of Coder from GitHub releases:")
-	_, _ = fmt.Fprintln(w, "  https://github.com/coder/coder/releases")
-	os.Exit(1)
 }

--- a/enterprise/cli/proxyserver_slim.go
+++ b/enterprise/cli/proxyserver_slim.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	agplcli "github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
 )
 
@@ -15,7 +16,7 @@ func (r *RootCmd) proxyServer() *clibase.Cmd {
 		RawArgs: true,
 		Hidden:  true,
 		Handler: func(inv *clibase.Invocation) error {
-			slimUnsupported(inv.Stderr, "workspace-proxy server")
+			agplcli.SlimUnsupported(inv.Stderr, "workspace-proxy server")
 			return nil
 		},
 	}

--- a/enterprise/cli/root.go
+++ b/enterprise/cli/root.go
@@ -1,13 +1,8 @@
 package cli
 
 import (
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
-	"github.com/coder/coder/v2/cli/cliui"
 )
 
 type RootCmd struct {
@@ -28,15 +23,4 @@ func (r *RootCmd) enterpriseOnly() []*clibase.Cmd {
 func (r *RootCmd) EnterpriseSubcommands() []*clibase.Cmd {
 	all := append(r.Core(), r.enterpriseOnly()...)
 	return all
-}
-
-//nolint:unused
-func slimUnsupported(w io.Writer, cmd string) {
-	_, _ = fmt.Fprintf(w, "You are using a 'slim' build of Coder, which does not support the %s subcommand.\n", cliui.DefaultStyles.Code.Render(cmd))
-	_, _ = fmt.Fprintln(w, "")
-	_, _ = fmt.Fprintln(w, "Please use a build of Coder from GitHub releases:")
-	_, _ = fmt.Fprintln(w, "  https://github.com/coder/coder/releases")
-
-	//nolint:revive
-	os.Exit(1)
 }


### PR DESCRIPTION
This is an alternative approach to #9519 and removes 2 MB instead of 1
MB (1.2 MB accounted for by embedded migration SQL files).

Combined with #9481, #9506, #9508, #9517, a total of 5 MB is removed.

Ref: #9380

```
❯ ls -lh build
-rwxr-xr-x 1 coder coder 44M Sep  4 16:12 coder-slim_2.1.4-devel+ad23d33f2_linux_amd64*
-rwxr-xr-x 1 coder coder 42M Sep  4 16:12 coder-slim_2.1.4-devel+ef51f8dcf_linux_amd64*
-rwxr-xr-x 2 coder coder 39M Sep  4 16:12 coder-slim_2.1.4-devel+17960ddc7_linux_amd64*
```
