### PR TITLE
docs: fix psk secret cmd

### DIFF
--- a/docs/admin/provisioners.md
+++ b/docs/admin/provisioners.md
@@ -101,7 +101,7 @@ will use in concert with the Helm chart for deploying the Coder server.
    secret
 
    ```shell
-   kubectl create secret generic coder-provisioner-psk --from-literal=psk=$(openssl rand -base64 32)
+   kubectl create secret generic coder-provisioner-psk --from-literal=psk=`head /dev/urandom | base64 | tr -dc A-Za-z0-9 | head -c 26`
    ```
 
 1. Modify your Coder `values.yaml` to include

--- a/docs/admin/provisioners.md
+++ b/docs/admin/provisioners.md
@@ -101,7 +101,7 @@ will use in concert with the Helm chart for deploying the Coder server.
    secret
 
    ```shell
-   kubectl create secret generic coder-provisioner-psk --from-literal=psk=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 26`
+   kubectl create secret generic coder-provisioner-psk --from-literal=psk=$(openssl rand -base64 32)
    ```
 
 1. Modify your Coder `values.yaml` to include


### PR DESCRIPTION
this PR fixes the `kubectl` command to create the PSK secret needed to run a provisioner daemon. i received several errors when running the command, including:

```
head: illegal byte count -- 26`
error: exactly one NAME is required, got 2
tr: Illegal byte sequence
```

by leveraging the `openssl rand` command with the `$()` syntax, the secret creates successfully with no errors. in addition, I successfully tested a deployment with the created secret.