### PR TITLE
chore: exclude generated files from vscode search by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -190,8 +190,15 @@
     "**/node_modules": true
   },
   "search.exclude": {
-    "scripts/metricsdocgen/metrics": true,
-    "docs/api/*.md": true
+    "**.pb.go": true,
+    "**/*.gen.json": true,
+    "**/testdata/*": true,
+    "**Generated.ts": true,
+    "coderd/apidoc/**": true,
+    "docs/api/*.md": true,
+    "docs/templates/*.md": true,
+    "LICENSE": true,
+    "scripts/metricsdocgen/metrics": true
   },
   // Ensure files always have a newline.
   "files.insertFinalNewline": true,


### PR DESCRIPTION
Anyone can feel free to revert some of these, but they were constantly
annoying when searching for symbols in our code.
