### PR TITLE
refactor(site): update versions table design

### DIFF
--- a/site/src/components/VersionsTable/VersionRow.tsx
+++ b/site/src/components/VersionsTable/VersionRow.tsx
@@ -15,12 +15,14 @@ import { combineClasses } from "utils/combineClasses"
 export interface VersionRowProps {
   version: TemplateVersion
   isActive: boolean
+  isLatest: boolean
   onPromoteClick?: (templateVersionId: string) => void
 }
 
 export const VersionRow: React.FC<VersionRowProps> = ({
   version,
   isActive,
+  isLatest,
   onPromoteClick,
 }) => {
   const styles = useStyles()
@@ -68,22 +70,24 @@ export const VersionRow: React.FC<VersionRowProps> = ({
               </span>
             </Stack>
           </Stack>
-          {isActive ? (
-            <Pill text="Active version" type="success" />
-          ) : (
-            onPromoteClick && (
+
+          <Stack direction="row" alignItems="center" spacing={2}>
+            {isActive && <Pill text="Active" type="success" />}
+            {isLatest && <Pill text="Newest" type="info" />}
+            {onPromoteClick && (
               <Button
                 className={styles.promoteButton}
+                disabled={isActive}
                 onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
                   onPromoteClick(version.id)
                 }}
               >
-                Promote version
+                Promote
               </Button>
-            )
-          )}
+            )}
+          </Stack>
         </Stack>
       </TableCell>
     </TimelineEntry>

--- a/site/src/components/VersionsTable/VersionsTable.tsx
+++ b/site/src/components/VersionsTable/VersionsTable.tsx
@@ -29,13 +29,25 @@ export const VersionsTable: FC<React.PropsWithChildren<VersionsTableProps>> = ({
   onPromoteClick,
   activeVersionId,
 }) => {
+  const latestVersionId = versions?.reduce(
+    (latestSoFar, against) => {
+      if (!latestSoFar) return against
+
+      return new Date(against.updated_at).getTime() >
+        new Date(latestSoFar.updated_at).getTime()
+        ? against
+        : latestSoFar
+    },
+    undefined as TypesGen.TemplateVersion | undefined,
+  )?.id
+
   return (
     <TableContainer>
       <Table data-testid="versions-table">
         <TableBody>
           {versions ? (
             <Timeline
-              items={versions.slice().reverse()}
+              items={[...versions].reverse()}
               getDate={(version) => new Date(version.created_at)}
               row={(version) => (
                 <VersionRow
@@ -43,6 +55,7 @@ export const VersionsTable: FC<React.PropsWithChildren<VersionsTableProps>> = ({
                   version={version}
                   key={version.id}
                   isActive={activeVersionId === version.id}
+                  isLatest={latestVersionId === version.id}
                 />
               )}
             />

--- a/site/src/components/VersionsTable/VersionsTable.tsx
+++ b/site/src/components/VersionsTable/VersionsTable.tsx
@@ -31,7 +31,9 @@ export const VersionsTable: FC<React.PropsWithChildren<VersionsTableProps>> = ({
 }) => {
   const latestVersionId = versions?.reduce(
     (latestSoFar, against) => {
-      if (!latestSoFar) return against
+      if (!latestSoFar) {
+        return against
+      }
 
       return new Date(against.updated_at).getTime() >
         new Date(latestSoFar.updated_at).getTime()


### PR DESCRIPTION
<img width="458" alt="Screenshot 2023-09-05 at 6 14 12 PM" src="https://github.com/coder/coder/assets/418348/ad6e6348-362f-4cc9-bec0-4e22d4b1a95d">
<img width="458" alt="Screenshot 2023-09-05 at 6 12 43 PM" src="https://github.com/coder/coder/assets/418348/7b245ed1-0561-4e4a-8325-79c11fecda76">

- get rid of redundant usage of the word "version"
- add a badge for the most recent version
- show a disabled "promote" button for the active version for vertical consistency

Just a couple minor things that make the page look a lot nicer imo