### PR TITLE
feat: add boringcrypto builds for linux

### DIFF
--- a/buildinfo/boring.go
+++ b/buildinfo/boring.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package buildinfo
+
+import "crypto/boring"
+
+var boringcrypto = boring.Enabled()

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -87,6 +87,10 @@ func IsAGPL() bool {
 	return strings.Contains(agpl, "t")
 }
 
+func IsBoringCrypto() bool {
+	return boringcrypto
+}
+
 // ExternalURL returns a URL referencing the current Coder version.
 // For production builds, this will link directly to a release.
 // For development builds, this will link to a commit.

--- a/buildinfo/notboring.go
+++ b/buildinfo/notboring.go
@@ -1,0 +1,5 @@
+//go:build !boringcrypto
+
+package buildinfo
+
+var boringcrypto = false

--- a/cli/version.go
+++ b/cli/version.go
@@ -13,11 +13,12 @@ import (
 // versionInfo wraps the stuff we get from buildinfo so that it's
 // easier to emit in different formats.
 type versionInfo struct {
-	Version     string    `json:"version"`
-	BuildTime   time.Time `json:"build_time"`
-	ExternalURL string    `json:"external_url"`
-	Slim        bool      `json:"slim"`
-	AGPL        bool      `json:"agpl"`
+	Version      string    `json:"version"`
+	BuildTime    time.Time `json:"build_time"`
+	ExternalURL  string    `json:"external_url"`
+	Slim         bool      `json:"slim"`
+	AGPL         bool      `json:"agpl"`
+	BoringCrypto bool      `json:"boring_crypto"`
 }
 
 // String() implements Stringer
@@ -28,6 +29,9 @@ func (vi versionInfo) String() string {
 		_, _ = str.WriteString("(AGPL) ")
 	}
 	_, _ = str.WriteString(vi.Version)
+	if vi.BoringCrypto {
+		_, _ = str.WriteString(" BoringCrypto")
+	}
 
 	if !vi.BuildTime.IsZero() {
 		_, _ = str.WriteString(" " + vi.BuildTime.Format(time.UnixDate))
@@ -45,11 +49,12 @@ func (vi versionInfo) String() string {
 func defaultVersionInfo() *versionInfo {
 	buildTime, _ := buildinfo.Time()
 	return &versionInfo{
-		Version:     buildinfo.Version(),
-		BuildTime:   buildTime,
-		ExternalURL: buildinfo.ExternalURL(),
-		Slim:        buildinfo.IsSlim(),
-		AGPL:        buildinfo.IsAGPL(),
+		Version:      buildinfo.Version(),
+		BuildTime:    buildTime,
+		ExternalURL:  buildinfo.ExternalURL(),
+		Slim:         buildinfo.IsSlim(),
+		AGPL:         buildinfo.IsAGPL(),
+		BoringCrypto: buildinfo.IsBoringCrypto(),
 	}
 }
 

--- a/cli/version_test.go
+++ b/cli/version_test.go
@@ -34,7 +34,8 @@ Full build of Coder, supports the [40m [0m[91;40mserver[0m[40m [0m subcomm
   "build_time": "0001-01-01T00:00:00Z",
   "external_url": "https://github.com/coder/coder",
   "slim": false,
-  "agpl": false
+  "agpl": false,
+  "boring_crypto": false
 }
 `
 	for _, tt := range []struct {


### PR DESCRIPTION
Fixes #9087 

This reverts commit da0ef92f771f68ecb63a280b36d94f76a023847d.

This reinstates _optional_ boringcrypto builds, but **does not alter the Makefile to use them**.  This will allow us to produce boringcrypto builds for testing and evaluation, and we can decide at a later date whether to ship them at all, in addition to, or in substitute of the current, static binaries.