### PR TITLE
refactor: improve flag interpretation for install.sh

### DIFF
--- a/docs/install/install.sh.md
+++ b/docs/install/install.sh.md
@@ -34,6 +34,87 @@ manually via `coder server` or as a system package.
 By default, the Coder server runs on `http://127.0.0.1:3000` and uses a
 [public tunnel](../admin/configure.md#tunnel) for workspace connections.
 
+## `PATH` conflicts
+
+It's possible to end up in situations where you have multiple `coder`
+binaries in your `PATH`, and your system may use a version that you don't
+intend. Your `PATH` is a variable that tells your shell where to look for
+programs to run.
+
+You can check where all of the versions are by running `which -a coder`.
+
+For example, a common conflict on macOS might be between a version
+installed by Homebrew, and a version installed manually to the /usr/local/bin
+directory.
+
+```console
+$ which -a coder
+/usr/local/bin/coder
+/opt/homebrew/bin/coder
+```
+
+Whichever binary comes first in this list will be used when running `coder` commands.
+
+### Reordering your `PATH`
+
+If you use bash or zsh, you can update your `PATH` like this:
+
+```shell
+# You might want to add this line to the end of your ~/.bashrc or ~/.zshrc file!
+export PATH="/opt/homebrew/bin:$PATH"
+```
+
+If you use fish, you can update your `PATH` like this:
+
+```shell
+# You might want to add this line to the end of your ~/.config/fish/config.fish file!
+fish_add_path "/opt/homebrew/bin"
+```
+
+> ℹ If you ran install.sh with a `--prefix` flag, you can replace `/opt/homebrew`
+> with whatever value you used there. Make sure to leave the `/bin` at the end!
+
+Now we can observe that the order has changed:
+
+```console
+$ which -a coder
+/opt/homebrew/bin/coder
+/usr/local/bin/coder
+```
+
+### Removing unneeded binaries
+
+If you want to uninstall a version of `coder` that you installed with a package manager,
+you can run whichever one of these commands applies:
+
+```shell
+# On macOS, with Homebrew installed
+brew uninstall coder
+```
+
+```shell
+# On Debian/Ubuntu based systems
+sudo dpkg -r coder
+```
+
+```shell
+# On Fedora/RHEL-like systems
+sudo rpm -e coder
+```
+
+```shell
+# On Alpine
+sudo apk del coder
+```
+
+If the conflicting binary is not installed by your system package manager,
+you can just delete it.
+
+```shell
+# You might not need `sudo`, depending on the location
+sudo rm /usr/local/bin/coder
+```
+
 ## Next steps
 
 - [Configuring Coder](../admin/configure.md)

--- a/docs/install/install.sh.md
+++ b/docs/install/install.sh.md
@@ -36,16 +36,14 @@ By default, the Coder server runs on `http://127.0.0.1:3000` and uses a
 
 ## `PATH` conflicts
 
-It's possible to end up in situations where you have multiple `coder`
-binaries in your `PATH`, and your system may use a version that you don't
-intend. Your `PATH` is a variable that tells your shell where to look for
-programs to run.
+It's possible to end up in situations where you have multiple `coder` binaries
+in your `PATH`, and your system may use a version that you don't intend. Your
+`PATH` is a variable that tells your shell where to look for programs to run.
 
 You can check where all of the versions are by running `which -a coder`.
 
-For example, a common conflict on macOS might be between a version
-installed by Homebrew, and a version installed manually to the /usr/local/bin
-directory.
+For example, a common conflict on macOS might be between a version installed by
+Homebrew, and a version installed manually to the /usr/local/bin directory.
 
 ```console
 $ which -a coder
@@ -53,7 +51,8 @@ $ which -a coder
 /opt/homebrew/bin/coder
 ```
 
-Whichever binary comes first in this list will be used when running `coder` commands.
+Whichever binary comes first in this list will be used when running `coder`
+commands.
 
 ### Reordering your `PATH`
 
@@ -71,8 +70,9 @@ If you use fish, you can update your `PATH` like this:
 fish_add_path "/opt/homebrew/bin"
 ```
 
-> ℹ If you ran install.sh with a `--prefix` flag, you can replace `/opt/homebrew`
-> with whatever value you used there. Make sure to leave the `/bin` at the end!
+> ℹ If you ran install.sh with a `--prefix` flag, you can replace
+> `/opt/homebrew` with whatever value you used there. Make sure to leave the
+> `/bin` at the end!
 
 Now we can observe that the order has changed:
 
@@ -84,8 +84,8 @@ $ which -a coder
 
 ### Removing unneeded binaries
 
-If you want to uninstall a version of `coder` that you installed with a package manager,
-you can run whichever one of these commands applies:
+If you want to uninstall a version of `coder` that you installed with a package
+manager, you can run whichever one of these commands applies:
 
 ```shell
 # On macOS, with Homebrew installed
@@ -107,8 +107,8 @@ sudo rpm -e coder
 sudo apk del coder
 ```
 
-If the conflicting binary is not installed by your system package manager,
-you can just delete it.
+If the conflicting binary is not installed by your system package manager, you
+can just delete it.
 
 ```shell
 # You might not need `sudo`, depending on the location

--- a/install.sh
+++ b/install.sh
@@ -175,7 +175,6 @@ To run a Coder server:
   # Or just run the server directly
   $ coder server
 
-  Default URL: http://127.0.0.1:3000
   Configuring Coder: https://coder.com/docs/v2/latest/admin/configure
 
 To connect to a Coder deployment:
@@ -196,13 +195,13 @@ EOF
 
 echo_path_conflict() {
 	cath <<EOF
-There is another binary in your PATH that conflicts with the binary we've installed:
+There is another binary in your PATH that conflicts with the binary we've installed.
 
   $1
 
-You'll need to update your PATH:
+This is likely because of an existing installation of Coder. See our documentation for suggests on how to resolve this.
 
-  $ PATH="$2/bin:\$PATH"
+	https://coder.com/docs/v2/latest/install/install.sh#path-conflicts
 
 EOF
 }

--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,13 @@ echo_brew_postinstall() {
 		return
 	fi
 
+	CODER_COMMAND="$(command -v "coder")"
+	BREW_PREFIX="$(brew --prefix)"
+
+	if [ "$CODER_COMMAND" != "$BREW_PREFIX/bin/coder" ]; then
+		echo_path_conflict "$CODER_COMMAND" "$BREW_PREFIX"
+	fi
+
 	cath <<EOF
 Homebrew formula has been installed.
 


### PR DESCRIPTION
- Make some smarter decisions about installation method based on what flags are being given
- Detect `PATH` conflicts when installing via Homebrew or standalone
- Add a section to our documentation about dealing with `PATH` conflicts

I may have gone a little overboard with this one 😝