### PR TITLE
feat(site)!: avoid window.open for coder apps

### DIFF
--- a/site/src/components/Resources/AppLink/AppLink.tsx
+++ b/site/src/components/Resources/AppLink/AppLink.tsx
@@ -95,11 +95,9 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
           href={href}
           target="_blank"
           className={canClick ? styles.link : styles.disabledLink}
-          onClick={
-            (event) => {
-              !canClick && event.preventDefault();
-            }
-          }
+          onClick={(event) => {
+            !canClick && event.preventDefault();
+          }}
         >
           {button}
         </Link>

--- a/site/src/components/Resources/AppLink/AppLink.tsx
+++ b/site/src/components/Resources/AppLink/AppLink.tsx
@@ -7,15 +7,9 @@ import { PrimaryAgentButton } from "components/Resources/AgentButton";
 import { FC } from "react";
 import { combineClasses } from "utils/combineClasses";
 import * as TypesGen from "../../../api/typesGenerated";
-import { generateRandomString } from "../../../utils/random";
 import { BaseIcon } from "./BaseIcon";
 import { ShareIcon } from "./ShareIcon";
 import { useProxy } from "contexts/ProxyContext";
-
-const Language = {
-  appTitle: (appName: string, identifier: string): string =>
-    `${appName} - ${identifier}`,
-};
 
 export interface AppLinkProps {
   workspace: TypesGen.Workspace;
@@ -102,16 +96,9 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
           target="_blank"
           className={canClick ? styles.link : styles.disabledLink}
           onClick={
-            canClick
-              ? (event) => {
-                  event.preventDefault();
-                  window.open(
-                    href,
-                    Language.appTitle(appDisplayName, generateRandomString(12)),
-                    "width=900,height=600",
-                  );
-                }
-              : undefined
+            (event) => {
+              !canClick && event.preventDefault();
+            }
           }
         >
           {button}


### PR DESCRIPTION
The current implementation of `AppLink` opens the specified application in a small popup instead of a new browser tab. The experience is not good because you lose all the browser toolbars. Also, if you open external links like `vscode://`, VSCode is opened but an empty browser window is left as leftover.