### PR TITLE
fix: use CRC32 to shorten app subdomain

### DIFF
--- a/coderd/httpapi/url.go
+++ b/coderd/httpapi/url.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"fmt"
+	"hash/crc32"
 	"net"
 	"regexp"
 	"strings"
@@ -18,6 +19,8 @@ var (
 		nameRegex))
 
 	validHostnameLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+	crcTable = crc32.MakeTable(crc32.IEEE)
 )
 
 // ApplicationURL is a parsed application URL hostname.
@@ -39,7 +42,12 @@ func (a ApplicationURL) String() string {
 	_, _ = appURL.WriteString(a.WorkspaceName)
 	_, _ = appURL.WriteString("--")
 	_, _ = appURL.WriteString(a.Username)
-	return appURL.String()
+	hostname := appURL.String()
+
+	if len(hostname) < 64 { // max length for the subdomain level
+		return hostname
+	}
+	return fmt.Sprintf("app-%08x", crc32.Checksum([]byte(hostname), crcTable))
 }
 
 // ParseSubdomainAppURL parses an ApplicationURL from the given subdomain. If

--- a/coderd/httpapi/url_test.go
+++ b/coderd/httpapi/url_test.go
@@ -42,6 +42,16 @@ func TestApplicationURLString(t *testing.T) {
 			},
 			Expected: "8080--agent--workspace--user",
 		},
+		{
+			Name: "LongAppName",
+			URL: httpapi.ApplicationURL{
+				AppSlugOrPort: "0123456789012345678901234567890123456789",
+				AgentName:     "agent",
+				WorkspaceName: "workspace",
+				Username:      "user",
+			},
+			Expected: "app-90667f72",
+		},
 	}
 
 	for _, c := range testCases {

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -1366,7 +1366,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 		}, testutil.WaitLong, testutil.IntervalFast, "stats not reported")
 
 		assert.Equal(t, workspaceapps.AccessMethodPath, stats[0].AccessMethod)
-		assert.Equal(t, "test-app-owner", stats[0].SlugOrPort)
+		assert.Equal(t, proxyTestAppNameOwner, stats[0].SlugOrPort)
 		assert.Equal(t, 1, stats[0].Requests)
 	})
 }

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	proxyTestAgentName            = "agent-name"
-	proxyTestAppNameFake          = "test-app-fake"
-	proxyTestAppNameOwner         = "test-app-owner"
-	proxyTestAppNameAuthenticated = "test-app-authenticated"
-	proxyTestAppNamePublic        = "test-app-public"
+	proxyTestAppNameFake          = "taf"
+	proxyTestAppNameOwner         = "tao"
+	proxyTestAppNameAuthenticated = "taa"
+	proxyTestAppNamePublic        = "tap"
 	proxyTestAppQuery             = "query=true"
 	proxyTestAppBody              = "hello world from apps test"
 


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/8145

This PR fixes the bug in application URL generation and uses CRC32 instead of the subdomain exceeding the character limit.

Now: `0123456789012345678901234567890123456789--agent--workspace--user`
After merge: `app-90667f72`

_Note: I know that there was an idea to use [agent ID](https://github.com/coder/coder/issues/8145#issuecomment-1602769676), but as long as the ID may change anytime it might be harder to bookmark it. CRC32 seems to be a stable solution._