### PR TITLE
docs: remove sysbox 16 pods max

### DIFF
--- a/docs/templates/docker-in-workspaces.md
+++ b/docs/templates/docker-in-workspaces.md
@@ -4,7 +4,7 @@ There are a few ways to run Docker within container-based Coder workspaces.
 
 | Method                                                     | Description                                                                                                                                                        | Limitations                                                                                                                                                                                                                                        |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Sysbox container runtime](#sysbox-container-runtime)      | Install the sysbox runtime on your Kubernetes nodes for secure docker-in-docker and systemd-in-docker. Works with GKE, EKS, AKS.                                   | Requires [compatible nodes](https://github.com/nestybox/sysbox#host-requirements). Max of 16 sysbox pods per node. [See all](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/limitations.md)                                        |
+| [Sysbox container runtime](#sysbox-container-runtime)      | Install the sysbox runtime on your Kubernetes nodes for secure docker-in-docker and systemd-in-docker. Works with GKE, EKS, AKS.                                   | Requires [compatible nodes](https://github.com/nestybox/sysbox#host-requirements).                                                                                                                                                                 |
 | [Envbox](#envbox)                                          | A container image with all the packages necessary to run an inner sysbox container. Removes the need to setup sysbox-runc on your nodes. Works with GKE, EKS, AKS. | Requires running the outer container as privileged (the inner container that acts as the workspace is locked down). Requires compatible [nodes](https://github.com/nestybox/sysbox/blob/master/docs/distro-compat.md#sysbox-distro-compatibility). |
 | [Rootless Podman](#rootless-podman)                        | Run podman inside Coder workspaces. Does not require a custom runtime or privileged containers. Works with GKE, EKS, AKS, RKE, OpenShift                           | Requires smarter-device-manager for FUSE mounts. [See all](https://github.com/containers/podman/blob/main/rootless.md#shortcomings-of-rootless-podman)                                                                                             |
 | [Privileged docker sidecar](#privileged-sidecar-container) | Run docker as a privileged sidecar container.                                                                                                                      | Requires a privileged container. Workspaces can break out to root on the host machine.                                                                                                                                                             |
@@ -121,11 +121,6 @@ resource "kubernetes_pod" "dev" {
   }
 }
 ```
-
-> Sysbox CE (Community Edition) supports a maximum of 16 pods (workspaces) per
-> node on Kubernetes. See the
-> [Sysbox documentation](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md#limitations)
-> for more details.
 
 ## Envbox
 


### PR DESCRIPTION
Sysbox has removed the limit of 16 pods per nodes in version `0.6.1`.

Changelog: https://github.com/nestybox/sysbox/blob/master/CHANGELOG.md#061---2023-04-07
Commit: https://github.com/nestybox/sysbox/commit/b27597294d3aa1c74ae724f558859c0d39acc4ff
