### PR TITLE
test(site): e2e: improve webTerminal test

### DIFF
--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
   use: {
     baseURL: `http://localhost:${port}`,
     video: "retain-on-failure",
+    launchOptions: {
+      args: ["--use-angle=egl"],
+    },
   },
   webServer: {
     url: `http://localhost:${port}/api/v2/deployment/config`,

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     baseURL: `http://localhost:${port}`,
     video: "retain-on-failure",
     launchOptions: {
-      args: ["--use-angle=egl"],
+      args: ["--disable-gpu"],
     },
   },
   webServer: {

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     baseURL: `http://localhost:${port}`,
     video: "retain-on-failure",
     launchOptions: {
-      args: ["--use-gl=nothing"],
+      args: ["--disable-webgl"],
     },
   },
   webServer: {

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     baseURL: `http://localhost:${port}`,
     video: "retain-on-failure",
     launchOptions: {
-      args: ["--disable-gpu"],
+      args: ["--use-gl=nothing"],
     },
   },
   webServer: {

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -41,14 +41,18 @@ test("web terminal", async ({ context, page }) => {
   const terminal = await pagePromise;
   await terminal.waitForLoadState("domcontentloaded");
 
-  // FIXME Wait until $ is present.
+  const xtermRows = await terminal.waitForSelector("div.xterm-rows", {
+    state: "visible",
+  });
 
   // Ensure that we can type in it
   await terminal.keyboard.type("echo he${justabreak}llo");
   await terminal.keyboard.press("Enter");
 
   // Check if "echo" command was executed
-  await terminal.waitForSelector("text=hello"); // FIXME it is canvas, it won't work
+  await xtermRows.waitForSelector('div:text-matches("hello")', {
+    state: "visible",
+  });
 
   await stopAgent(agent);
 });

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -41,19 +41,14 @@ test("web terminal", async ({ context, page }) => {
   const terminal = await pagePromise;
   await terminal.waitForLoadState("domcontentloaded");
 
+  // FIXME Wait until $ is present.
+
   // Ensure that we can type in it
-  await terminal.keyboard.type("echo hello");
+  await terminal.keyboard.type("echo he${justabreak}llo");
   await terminal.keyboard.press("Enter");
 
-  const locator = terminal.locator("text=hello");
+  // Check if "echo" command was executed
+  await terminal.waitForSelector("text=hello"); // FIXME it is canvas, it won't work
 
-  for (let i = 0; i < 10; i++) {
-    const items = await locator.all();
-    // Make sure the text came back
-    if (items.length === 2) {
-      break;
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
   await stopAgent(agent);
 });


### PR DESCRIPTION
Changes:
* Disable WebGL permanently. Without `--disable-webgl` playright enables GL in headed mode (mtojek: also in headless?)
* Embrace the webTerminal test