### PR TITLE
test: fix cleanup order on provisioner daemon work dir

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -459,6 +459,12 @@ func NewWithAPI(t testing.TB, options *Options) (*codersdk.Client, io.Closer, *c
 func NewProvisionerDaemon(t testing.TB, coderAPI *coderd.API) io.Closer {
 	t.Helper()
 
+	// t.Cleanup runs in last added, first called order. t.TempDir() will delete
+	// the directory on cleanup, so we want to make sure the echoServer is closed
+	// before we go ahead an attempt to delete it's work directory.
+	// seems t.TempDir() is not safe to call from a different goroutine
+	workDir := t.TempDir()
+
 	echoClient, echoServer := provisionersdk.MemTransportPipe()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(func() {
@@ -466,8 +472,7 @@ func NewProvisionerDaemon(t testing.TB, coderAPI *coderd.API) io.Closer {
 		_ = echoServer.Close()
 		cancelFunc()
 	})
-	// seems t.TempDir() is not safe to call from a different goroutine
-	workDir := t.TempDir()
+
 	go func() {
 		err := echo.Serve(ctx, &provisionersdk.ServeOptions{
 			Listener:      echoServer,

--- a/provisionersdk/session.go
+++ b/provisionersdk/session.go
@@ -230,6 +230,15 @@ func (s *Session) extractArchive() error {
 		if mode == 0 {
 			mode = 0o600
 		}
+
+		// Always check for context cancellation before reading the next header.
+		// This is mainly important for unit tests, since a canceled context means
+		// the underlying directory is going to be deleted. There still exists
+		// the small race condition that the context is cancelled after this, and
+		// before the disk write.
+		if ctx.Err() != nil {
+			return xerrors.Errorf("context canceled: %w", ctx.Err())
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
 			err = os.MkdirAll(headerPath, mode)


### PR DESCRIPTION
Attempting to fix _some_ of the error here: https://github.com/coder/coder/issues/9379. **I think other categories of this test flake exist.** I was only investigating the provisioner daemon route.

In unit tests our provisioner daemon creates a working directory. For some unit tests (like one of the ones in the issue), we do not wait for the template version job to complete before ending the test. So a provisioner job can exist when the test is closing.

The previous cleanup order tried to delete the working directory first, and then close the priovisioner, which can cause the race condition of a job writing files when the delete happens.

This PR fixes the `t.Cleanup` order, however I think there is still a race condition because in the job runner, we do not check the context when extracting an archive:

https://github.com/coder/coder/blob/c7d66d3da90a54602104ce05e04b34088e889caf/provisionersdk/session.go#L201-L201


----

A small race condition still exists. The for loop loops over the tar file, writing each file to disk. I added a check for the context cancelled to abort the loop early and stop writing files if it fails, but I did not remove the race condition entirely (see comment).