### PR TITLE
fix: make agent ssh session env var case insensitive

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -254,11 +254,13 @@ func (s *Server) sessionStart(session ssh.Session, extraEnv []string) (retErr er
 		magicType = strings.TrimPrefix(kv, MagicSessionTypeEnvironmentVariable+"=")
 		env = append(env[:index], env[index+1:]...)
 	}
-	switch magicType {
-	case MagicSessionTypeVSCode:
+
+	// Always force lowercase checking to be case-insensitive.
+	switch strings.ToLower(magicType) {
+	case strings.ToLower(MagicSessionTypeVSCode):
 		s.connCountVSCode.Add(1)
 		defer s.connCountVSCode.Add(-1)
-	case MagicSessionTypeJetBrains:
+	case strings.ToLower(MagicSessionTypeJetBrains):
 		s.connCountJetBrains.Add(1)
 		defer s.connCountJetBrains.Add(-1)
 	case "":

--- a/agent/agentssh/metrics.go
+++ b/agent/agentssh/metrics.go
@@ -1,6 +1,8 @@
 package agentssh
 
 import (
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -78,5 +80,6 @@ func magicTypeMetricLabel(magicType string) string {
 	default:
 		magicType = "unknown"
 	}
-	return magicType
+	// Always be case insensitive
+	return strings.ToLower(magicType)
 }


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/9673

I force the constants to lowercase too, even though they already are. Just incase someone messes with them...

Really wish there was case insensitive "switch" statement in go.