### PR TITLE
chore: print page content on failed promise

### DIFF
--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -41,7 +41,7 @@ test("web terminal", async ({ context, page }) => {
   const terminal = await pagePromise;
   await terminal.waitForLoadState("domcontentloaded");
 
-  const xtermRows = await terminal.waitForSelector("div.xterm-rows", {
+  await terminal.waitForSelector("div.xterm-rows", {
     state: "visible",
   });
 
@@ -52,9 +52,9 @@ test("web terminal", async ({ context, page }) => {
   // Check if "echo" command was executed
   // try-catch is used temporarily to find the root cause: https://github.com/coder/coder/actions/runs/6176958762/job/16767089943
   try {
-    await xtermRows.waitForSelector('div:text-matches("hello")', {
+    await terminal.waitForSelector('div.xterm-rows div:text-matches("hello")', {
       state: "visible",
-      timeout: 5 * 1000,
+      timeout: 10 * 1000,
     });
   } catch (error) {
     const pageContent = await terminal.content();

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -54,6 +54,7 @@ test("web terminal", async ({ context, page }) => {
   try {
     await xtermRows.waitForSelector('div:text-matches("hello")', {
       state: "visible",
+      timeout: 30 * 1000,
     });
   } catch (error) {
     const pageContent = await terminal.content();

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -46,13 +46,13 @@ test("web terminal", async ({ context, page }) => {
   });
 
   // Ensure that we can type in it
-  await terminal.keyboard.type("echo he${justabreak}llo");
+  await terminal.keyboard.type("echo he${justabreak}llo123456");
   await terminal.keyboard.press("Enter");
 
   // Check if "echo" command was executed
   // try-catch is used temporarily to find the root cause: https://github.com/coder/coder/actions/runs/6176958762/job/16767089943
   try {
-    await terminal.waitForSelector('div.xterm-rows div:text-matches("hello")', {
+    await terminal.waitForSelector('div.xterm-rows div:text-matches("hello123456")', {
       state: "visible",
       timeout: 10 * 1000,
     });

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -54,7 +54,7 @@ test("web terminal", async ({ context, page }) => {
   try {
     await xtermRows.waitForSelector('div:text-matches("hello")', {
       state: "visible",
-      timeout: 30 * 1000,
+      timeout: 5 * 1000,
     });
   } catch (error) {
     const pageContent = await terminal.content();

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -50,9 +50,17 @@ test("web terminal", async ({ context, page }) => {
   await terminal.keyboard.press("Enter");
 
   // Check if "echo" command was executed
-  await xtermRows.waitForSelector('div:text-matches("hello")', {
-    state: "visible",
-  });
+  // try-catch is used temporarily to find the root cause: https://github.com/coder/coder/actions/runs/6176958762/job/16767089943
+  try {
+    await xtermRows.waitForSelector('div:text-matches("hello")', {
+      state: "visible",
+    });
+  } catch (error) {
+    const pageContent = await terminal.content();
+    // eslint-disable-next-line no-console -- Let's see what is inside of xterm-rows
+    console.log("Unable to find echoed text:", pageContent);
+    throw error;
+  }
 
   await stopAgent(agent);
 });

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -52,10 +52,13 @@ test("web terminal", async ({ context, page }) => {
   // Check if "echo" command was executed
   // try-catch is used temporarily to find the root cause: https://github.com/coder/coder/actions/runs/6176958762/job/16767089943
   try {
-    await terminal.waitForSelector('div.xterm-rows div:text-matches("hello123456")', {
-      state: "visible",
-      timeout: 10 * 1000,
-    });
+    await terminal.waitForSelector(
+      'div.xterm-rows div:text-matches("hello123456")',
+      {
+        state: "visible",
+        timeout: 10 * 1000,
+      },
+    );
   } catch (error) {
     const pageContent = await terminal.content();
     // eslint-disable-next-line no-console -- Let's see what is inside of xterm-rows


### PR DESCRIPTION
There was some flakiness around web terminal test:
https://github.com/coder/coder/actions/runs/6175038560
https://github.com/coder/coder/actions/runs/6176958762/job/16767089943

Note 1: ~~It looks like a missing `xterm-rows` entry, but it should be there according to the video.~~ Let's print the page content to see what is inside.
Note 2: I managed to dump the terminal page, but it contains `xterm-rows`. My assumption is that `xterm-rows` was recreated/reattached in DOM.
