### PR TITLE
fix(enterprise/dbcrypt): do not skip deleted users when encrypting or deleting

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -664,6 +664,15 @@ func (q *querier) ActivityBumpWorkspace(ctx context.Context, arg uuid.UUID) erro
 	return update(q.log, q.auth, fetch, q.db.ActivityBumpWorkspace)(ctx, arg)
 }
 
+func (q *querier) AllUserIDs(ctx context.Context) ([]uuid.UUID, error) {
+	// Although this technically only reads users, only system-related functions should be
+	// allowed to call this.
+	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+		return nil, err
+	}
+	return q.db.AllUserIDs(ctx)
+}
+
 func (q *querier) CleanTailnetCoordinators(ctx context.Context) error {
 	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -812,7 +812,7 @@ func (q *FakeQuerier) ActivityBumpWorkspace(ctx context.Context, workspaceID uui
 	return sql.ErrNoRows
 }
 
-func (q *FakeQuerier) AllUserIDs(ctx context.Context) ([]uuid.UUID, error) {
+func (q *FakeQuerier) AllUserIDs(_ context.Context) ([]uuid.UUID, error) {
 	userIDs := make([]uuid.UUID, 0, len(q.users))
 	for idx := range q.users {
 		userIDs[idx] = q.users[idx].ID

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -813,6 +813,8 @@ func (q *FakeQuerier) ActivityBumpWorkspace(ctx context.Context, workspaceID uui
 }
 
 func (q *FakeQuerier) AllUserIDs(_ context.Context) ([]uuid.UUID, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
 	userIDs := make([]uuid.UUID, 0, len(q.users))
 	for idx := range q.users {
 		userIDs[idx] = q.users[idx].ID

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -812,6 +812,14 @@ func (q *FakeQuerier) ActivityBumpWorkspace(ctx context.Context, workspaceID uui
 	return sql.ErrNoRows
 }
 
+func (q *FakeQuerier) AllUserIDs(ctx context.Context) ([]uuid.UUID, error) {
+	userIDs := make([]uuid.UUID, 0, len(q.users))
+	for idx := range q.users {
+		userIDs[idx] = q.users[idx].ID
+	}
+	return userIDs, nil
+}
+
 func (*FakeQuerier) CleanTailnetCoordinators(_ context.Context) error {
 	return ErrUnimplemented
 }

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -227,7 +227,7 @@ func User(t testing.TB, db database.Store, orig database.User) database.User {
 
 	user, err = db.UpdateUserStatus(genCtx, database.UpdateUserStatusParams{
 		ID:        user.ID,
-		Status:    database.UserStatusActive,
+		Status:    takeFirst(orig.Status, database.UserStatusActive),
 		UpdatedAt: dbtime.Now(),
 	})
 	require.NoError(t, err, "insert user")

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -240,6 +240,14 @@ func User(t testing.TB, db database.Store, orig database.User) database.User {
 		})
 		require.NoError(t, err, "user last seen")
 	}
+
+	if orig.Deleted {
+		err = db.UpdateUserDeletedByID(genCtx, database.UpdateUserDeletedByIDParams{
+			ID:      user.ID,
+			Deleted: orig.Deleted,
+		})
+		require.NoError(t, err, "set user as deleted")
+	}
 	return user
 }
 

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -100,6 +100,13 @@ func (m metricsStore) ActivityBumpWorkspace(ctx context.Context, arg uuid.UUID) 
 	return r0
 }
 
+func (m metricsStore) AllUserIDs(ctx context.Context) ([]uuid.UUID, error) {
+	start := time.Now()
+	r0, r1 := m.s.AllUserIDs(ctx)
+	m.queryLatencies.WithLabelValues("AllUserIDs").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m metricsStore) CleanTailnetCoordinators(ctx context.Context) error {
 	start := time.Now()
 	err := m.s.CleanTailnetCoordinators(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -82,6 +82,21 @@ func (mr *MockStoreMockRecorder) ActivityBumpWorkspace(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivityBumpWorkspace", reflect.TypeOf((*MockStore)(nil).ActivityBumpWorkspace), arg0, arg1)
 }
 
+// AllUserIDs mocks base method.
+func (m *MockStore) AllUserIDs(arg0 context.Context) ([]uuid.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllUserIDs", arg0)
+	ret0, _ := ret[0].([]uuid.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllUserIDs indicates an expected call of AllUserIDs.
+func (mr *MockStoreMockRecorder) AllUserIDs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllUserIDs", reflect.TypeOf((*MockStore)(nil).AllUserIDs), arg0)
+}
+
 // CleanTailnetCoordinators mocks base method.
 func (m *MockStore) CleanTailnetCoordinators(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -31,6 +31,8 @@ type sqlcQuerier interface {
 	// We only bump if workspace shutdown is manual.
 	// We only bump when 5% of the deadline has elapsed.
 	ActivityBumpWorkspace(ctx context.Context, workspaceID uuid.UUID) error
+	// AllUserIDs returns all UserIDs regardless of user status or deletion.
+	AllUserIDs(ctx context.Context) ([]uuid.UUID, error)
 	CleanTailnetCoordinators(ctx context.Context) error
 	DeleteAPIKeyByID(ctx context.Context, id string) error
 	DeleteAPIKeysByUserID(ctx context.Context, userID uuid.UUID) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5840,6 +5840,34 @@ func (q *sqlQuerier) UpdateUserLinkedID(ctx context.Context, arg UpdateUserLinke
 	return i, err
 }
 
+const allUserIDs = `-- name: AllUserIDs :many
+SELECT DISTINCT id FROM USERS
+`
+
+// AllUserIDs returns all UserIDs regardless of user status or deletion.
+func (q *sqlQuerier) AllUserIDs(ctx context.Context) ([]uuid.UUID, error) {
+	rows, err := q.db.QueryContext(ctx, allUserIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getActiveUserCount = `-- name: GetActiveUserCount :one
 SELECT
 	COUNT(*)

--- a/coderd/database/queries/dbcrypt.sql
+++ b/coderd/database/queries/dbcrypt.sql
@@ -16,3 +16,4 @@ AND
 INSERT INTO dbcrypt_keys
 	(number, active_key_digest, created_at, test)
 VALUES (@number::int, @active_key_digest::text, CURRENT_TIMESTAMP, @test::text);
+

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -262,3 +262,8 @@ WHERE
     last_seen_at < @last_seen_after :: timestamp
     AND status = 'active'::user_status
 RETURNING id, email, last_seen_at;
+
+-- AllUserIDs returns all UserIDs regardless of user status or deletion.
+-- name: AllUserIDs :many
+SELECT DISTINCT id FROM USERS;
+

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -207,9 +207,17 @@ func TestServerDBCrypt(t *testing.T) {
 func genData(t *testing.T, db database.Store, n int) []database.User {
 	t.Helper()
 	var users []database.User
+	// Make some users
 	for i := 0; i < n; i++ {
+		status := database.UserStatusActive
+		if i%2 == 0 {
+			status = database.UserStatusSuspended
+		} else if i%3 == 0 {
+			status = database.UserStatusDormant
+		}
 		usr := dbgen.User(t, db, database.User{
 			LoginType: database.LoginTypeOIDC,
+			Status:    status,
 		})
 		_ = dbgen.UserLink(t, db, database.UserLink{
 			UserID:            usr.ID,

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -238,7 +238,18 @@ func genData(t *testing.T, db database.Store, n int) []database.User {
 
 func dumpUsers(t *testing.T, db *sql.DB, header string) {
 	t.Logf("%s %s %s", strings.Repeat("=", 20), header, strings.Repeat("=", 20))
-	rows, err := db.QueryContext(context.Background(), `select u.id, u.status, u.deleted, ul.oauth_access_token_key_id as uloatkid, ul.oauth_refresh_token_key_id as ulortkid, gal.oauth_access_token_key_id as galoatkid, gal.oauth_refresh_token_key_id as galortkid from users u left outer join user_links ul on u.id = ul.user_id left outer join git_auth_links gal on u.id = gal.user_id;`)
+	rows, err := db.QueryContext(context.Background(), `SELECT
+	u.id,
+	u.status,
+	u.deleted,
+	ul.oauth_access_token_key_id AS uloatkid,
+	ul.oauth_refresh_token_key_id AS ulortkid,
+	gal.oauth_access_token_key_id AS galoatkid,
+	gal.oauth_refresh_token_key_id AS galortkid
+FROM users u
+LEFT OUTER JOIN user_links ul ON u.id = ul.user_id
+LEFT OUTER JOIN git_auth_links gal ON u.id = gal.user_id
+ORDER BY u.created_at ASC;`)
 	require.NoError(t, err)
 	defer rows.Close()
 	for rows.Next() {

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/coder/coder/v2/pty/ptytest"
 )
 
+// TestServerDBCrypt tests end-to-end encryption, decryption, and deletion
+// of encrypted user data.
+//
 // nolint: paralleltest // use of t.Setenv
 func TestServerDBCrypt(t *testing.T) {
 	if !dbtestutil.WillUsePostgres() {
@@ -49,6 +52,7 @@ func TestServerDBCrypt(t *testing.T) {
 	})
 
 	// Populate the database with some unencrypted data.
+	t.Logf("Generating unencrypted data")
 	users := genData(t, db)
 
 	// Setup an initial cipher A
@@ -61,6 +65,7 @@ func TestServerDBCrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	// Populate the database with some encrypted data using cipher A.
+	t.Logf("Generating data encrypted with cipher A")
 	newUsers := genData(t, cryptdb)
 
 	// Validate that newly created users were encrypted with cipher A
@@ -70,6 +75,7 @@ func TestServerDBCrypt(t *testing.T) {
 	users = append(users, newUsers...)
 
 	// Encrypt all the data with the initial cipher.
+	t.Logf("Encrypting all data with cipher A")
 	inv, _ := newCLI(t, "server", "dbcrypt", "rotate",
 		"--postgres-url", connectionURL,
 		"--new-key", base64.StdEncoding.EncodeToString([]byte(keyA)),
@@ -90,9 +96,7 @@ func TestServerDBCrypt(t *testing.T) {
 	cipherBA, err := dbcrypt.NewCiphers([]byte(keyB), []byte(keyA))
 	require.NoError(t, err)
 
-	// Generate some more encrypted data using the new cipher
-	users = append(users, genData(t, db)...)
-
+	t.Logf("Enrypting all data with cipher B")
 	inv, _ = newCLI(t, "server", "dbcrypt", "rotate",
 		"--postgres-url", connectionURL,
 		"--new-key", base64.StdEncoding.EncodeToString([]byte(keyB)),
@@ -110,6 +114,7 @@ func TestServerDBCrypt(t *testing.T) {
 	}
 
 	// Assert that we can revoke the old key.
+	t.Logf("Revoking cipher A")
 	err = db.RevokeDBCryptKey(ctx, cipherA[0].HexDigest())
 	require.NoError(t, err, "failed to revoke old key")
 
@@ -125,6 +130,7 @@ func TestServerDBCrypt(t *testing.T) {
 	require.Empty(t, oldKey.ActiveKeyDigest.String, "expected the old key to not be active")
 
 	// Revoking the new key should fail.
+	t.Logf("Attempting to revoke cipher B should fail as it is still in use")
 	err = db.RevokeDBCryptKey(ctx, cipherBA[0].HexDigest())
 	require.Error(t, err, "expected to fail to revoke the new key")
 	var pgErr *pq.Error
@@ -132,6 +138,7 @@ func TestServerDBCrypt(t *testing.T) {
 	require.EqualValues(t, "23503", pgErr.Code, "expected a foreign key constraint violation error")
 
 	// Decrypt the data using only cipher B. This should result in the key being revoked.
+	t.Logf("Decrypting with cipher B")
 	inv, _ = newCLI(t, "server", "dbcrypt", "decrypt",
 		"--postgres-url", connectionURL,
 		"--keys", base64.StdEncoding.EncodeToString([]byte(keyB)),
@@ -160,6 +167,7 @@ func TestServerDBCrypt(t *testing.T) {
 	cipherC, err := dbcrypt.NewCiphers([]byte(keyC))
 	require.NoError(t, err)
 
+	t.Logf("Re-encrypting with cipher C")
 	inv, _ = newCLI(t, "server", "dbcrypt", "rotate",
 		"--postgres-url", connectionURL,
 		"--new-key", base64.StdEncoding.EncodeToString([]byte(keyC)),
@@ -177,6 +185,7 @@ func TestServerDBCrypt(t *testing.T) {
 	}
 
 	// Now delete all the encrypted data.
+	t.Logf("Deleting all encrypted data")
 	inv, _ = newCLI(t, "server", "dbcrypt", "delete",
 		"--postgres-url", connectionURL,
 		"--external-token-encryption-keys", base64.StdEncoding.EncodeToString([]byte(keyC)),

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -209,15 +209,19 @@ func genData(t *testing.T, db database.Store, n int) []database.User {
 	var users []database.User
 	// Make some users
 	for i := 0; i < n; i++ {
+		var deleted bool
 		status := database.UserStatusActive
 		if i%2 == 0 {
 			status = database.UserStatusSuspended
 		} else if i%3 == 0 {
 			status = database.UserStatusDormant
+		} else if i%5 == 0 {
+			deleted = true
 		}
 		usr := dbgen.User(t, db, database.User{
 			LoginType: database.LoginTypeOIDC,
 			Status:    status,
+			Deleted:   deleted,
 		})
 		_ = dbgen.UserLink(t, db, database.UserLink{
 			UserID:            usr.ID,


### PR DESCRIPTION
This PR fixes an issue where deleted users are not taken into account when encrypting or decrypting data. `GetUsers` will by default omit soft-deleted users.

- Broadens scope of data generation in TestServerDBCrypt over all user login types, statuses, and deletion status.
- Adds support for specifying user status / user deletion status in dbgen
- Adds more comprehensive logging in TestServerDBCrypt upon test failure
- Modifies dbcrypt to query all active userIDs directly. 