### PR TITLE
fix(coderd): emit CollectedAt as UTC in convertWorkspaceAgentMetadata

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1804,6 +1804,9 @@ func convertWorkspaceAgentMetadata(db []database.WorkspaceAgentMetadatum) []code
 	// An empty array is easier for clients to handle than a null.
 	result := []codersdk.WorkspaceAgentMetadata{}
 	for _, datum := range db {
+		if datum.CollectedAt.UTC().IsZero() {
+			datum.CollectedAt = datum.CollectedAt.UTC()
+		}
 		result = append(result, codersdk.WorkspaceAgentMetadata{
 			Result: codersdk.WorkspaceAgentMetadataResult{
 				Value:       datum.Value,

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1804,14 +1804,11 @@ func convertWorkspaceAgentMetadata(db []database.WorkspaceAgentMetadatum) []code
 	// An empty array is easier for clients to handle than a null.
 	result := []codersdk.WorkspaceAgentMetadata{}
 	for _, datum := range db {
-		if datum.CollectedAt.UTC().IsZero() {
-			datum.CollectedAt = datum.CollectedAt.UTC()
-		}
 		result = append(result, codersdk.WorkspaceAgentMetadata{
 			Result: codersdk.WorkspaceAgentMetadataResult{
 				Value:       datum.Value,
 				Error:       datum.Error,
-				CollectedAt: datum.CollectedAt,
+				CollectedAt: datum.CollectedAt.UTC(),
 				Age:         int64(time.Since(datum.CollectedAt).Seconds()),
 			},
 			Description: codersdk.WorkspaceAgentMetadataDescription{

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -1185,12 +1184,8 @@ func TestWorkspaceAgent_LifecycleState(t *testing.T) {
 func TestWorkspaceAgent_Metadata(t *testing.T) {
 	t.Parallel()
 
-	// nolint:gocritic // https://github.com/coder/coder/issues/9682
-	db, ps := dbtestutil.NewDB(t, dbtestutil.WithTimezone("UTC"))
 	client := coderdtest.New(t, &coderdtest.Options{
 		IncludeProvisionerDaemon: true,
-		Database:                 db,
-		Pubsub:                   ps,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()


### PR DESCRIPTION
I'm open to alternative suggestions on how to prevent this, but this appeared to be the least intrusive way to fix this database timezone-related test flake.