### PR TITLE
feat: show update messages on workspace page

### DIFF
--- a/site/src/api/queries/templates.ts
+++ b/site/src/api/queries/templates.ts
@@ -56,3 +56,10 @@ export const templateVersion = (versionId: string) => {
     queryFn: () => API.getTemplateVersion(versionId),
   };
 };
+
+export const templateVersions = (templateId: string) => {
+  return {
+    queryKey: ["templateVersions", templateId],
+    queryFn: () => API.getTemplateVersions(templateId),
+  };
+};

--- a/site/src/api/queries/templates.ts
+++ b/site/src/api/queries/templates.ts
@@ -49,3 +49,10 @@ export const templateExamples = (orgId: string) => {
     queryFn: () => API.getTemplateExamples(orgId),
   };
 };
+
+export const templateVersion = (versionId: string) => {
+  return {
+    queryKey: ["templateVersion", versionId],
+    queryFn: () => API.getTemplateVersion(versionId),
+  };
+};

--- a/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -11,7 +11,7 @@ import InfoIcon from "@mui/icons-material/InfoOutlined";
 import { makeStyles } from "@mui/styles";
 import { colors } from "theme/colors";
 import { useQuery } from "@tanstack/react-query";
-import { getTemplate, getTemplateVersion } from "api/api";
+import { templateVersion } from "api/queries/templates";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import Link from "@mui/material/Link";
@@ -25,7 +25,7 @@ export const Language = {
 
 interface TooltipProps {
   onUpdateVersion: () => void;
-  templateId: string;
+  latestVersionId: string;
   templateName: string;
   ariaLabel?: string;
 }
@@ -33,20 +33,11 @@ interface TooltipProps {
 export const WorkspaceOutdatedTooltip: FC<TooltipProps> = ({
   onUpdateVersion,
   ariaLabel,
-  templateId,
+  latestVersionId,
   templateName,
 }) => {
   const styles = useStyles();
-  const { data: activeVersion } = useQuery({
-    queryFn: async () => {
-      const template = await getTemplate(templateId);
-      const activeVersion = await getTemplateVersion(
-        template.active_version_id,
-      );
-      return activeVersion;
-    },
-    queryKey: ["templates", templateId, "activeVersion"],
-  });
+  const { data: activeVersion } = useQuery(templateVersion(latestVersionId));
 
   return (
     <HelpTooltip

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -224,7 +224,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
           {workspace.outdated && (
             <Alert severity="info">
               <AlertTitle>An update is available for your workspace</AlertTitle>
-              {updateMessage}
+              {updateMessage && <AlertDetail>{updateMessage}</AlertDetail>}
             </Alert>
           )}
           {buildError}

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -60,6 +60,7 @@ export interface WorkspaceProps {
   builds?: TypesGen.WorkspaceBuild[];
   templateWarnings?: TypesGen.TemplateVersionWarning[];
   canUpdateWorkspace: boolean;
+  updateMessage?: string;
   canRetryDebugMode: boolean;
   canChangeVersions: boolean;
   hideSSHButton?: boolean;
@@ -93,6 +94,7 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
   resources,
   builds,
   canUpdateWorkspace,
+  updateMessage,
   canRetryDebugMode,
   canChangeVersions,
   workspaceErrors,
@@ -219,6 +221,12 @@ export const Workspace: FC<React.PropsWithChildren<WorkspaceProps>> = ({
           className={styles.firstColumnSpacer}
           spacing={4}
         >
+          {workspace.outdated && (
+            <Alert severity="info">
+              <AlertTitle>An update is available for your workspace</AlertTitle>
+              {updateMessage}
+            </Alert>
+          )}
           {buildError}
           {cancellationError}
           {workspace.latest_build.status === "running" &&

--- a/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
@@ -30,7 +30,7 @@ export const UpdateButton: FC<WorkspaceAction> = ({
       startIcon={<CloudQueueIcon />}
       onClick={handleAction}
     >
-      Update
+      Update&hellip;
     </LoadingButton>
   );
 };
@@ -125,7 +125,7 @@ export const RestartButton: FC<
         onClick={() => handleAction()}
         data-testid="workspace-restart-button"
       >
-        Restart
+        Restart&hellip;
       </LoadingButton>
       <BuildParametersPopover
         workspace={workspace}

--- a/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/Buttons.tsx
@@ -24,7 +24,7 @@ export const UpdateButton: FC<WorkspaceAction> = ({
   return (
     <LoadingButton
       loading={loading}
-      loadingIndicator="Updating..."
+      loadingIndicator={<>Updating&hellip;</>}
       loadingPosition="start"
       data-testid="workspace-update-button"
       startIcon={<CloudQueueIcon />}
@@ -42,7 +42,7 @@ export const ActivateButton: FC<WorkspaceAction> = ({
   return (
     <LoadingButton
       loading={loading}
-      loadingIndicator="Activating..."
+      loadingIndicator={<>Activating&hellip;</>}
       loadingPosition="start"
       startIcon={<PowerSettingsNewIcon />}
       onClick={handleAction}
@@ -70,7 +70,7 @@ export const StartButton: FC<
     >
       <LoadingButton
         loading={loading}
-        loadingIndicator="Starting..."
+        loadingIndicator={<>Starting&hellip;</>}
         loadingPosition="start"
         startIcon={<PlayCircleOutlineIcon />}
         onClick={() => handleAction()}
@@ -90,7 +90,7 @@ export const StopButton: FC<WorkspaceAction> = ({ handleAction, loading }) => {
   return (
     <LoadingButton
       loading={loading}
-      loadingIndicator="Stopping..."
+      loadingIndicator={<>Stopping&hellip;</>}
       loadingPosition="start"
       startIcon={<CropSquareIcon />}
       onClick={handleAction}
@@ -119,7 +119,7 @@ export const RestartButton: FC<
     >
       <LoadingButton
         loading={loading}
-        loadingIndicator="Restarting..."
+        loadingIndicator={<>Restarting&hellip;</>}
         loadingPosition="start"
         startIcon={<ReplayIcon />}
         onClick={() => handleAction()}

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -148,12 +148,12 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
           {canChangeVersions && (
             <MenuItem onClick={onMenuItemClick(handleChangeVersion)}>
               <HistoryOutlined />
-              Change version
+              Change version&hellip;
             </MenuItem>
           )}
           <MenuItem onClick={onMenuItemClick(handleDelete)}>
             <DeleteOutlined />
-            Delete
+            Delete&hellip;
           </MenuItem>
         </Menu>
       </div>

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -151,7 +151,10 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
               Change version&hellip;
             </MenuItem>
           )}
-          <MenuItem onClick={onMenuItemClick(handleDelete)}>
+          <MenuItem
+            onClick={onMenuItemClick(handleDelete)}
+            data-testid="delete-button"
+          >
             <DeleteOutlined />
             Delete&hellip;
           </MenuItem>

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -28,12 +28,12 @@ import {
   ConfirmDialog,
   ConfirmDialogProps,
 } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
-import { useMe } from "hooks/useMe";
-import Checkbox from "@mui/material/Checkbox";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import { workspaceBuildMachine } from "xServices/workspaceBuild/workspaceBuildXService";
 import * as TypesGen from "api/typesGenerated";
 import { WorkspaceBuildLogsSection } from "./WorkspaceBuildLogsSection";
+import { templateVersion } from "api/queries/templates";
+import { Alert } from "components/Alert/Alert";
+import { Stack } from "components/Stack/Stack";
 
 interface WorkspaceReadyPageProps {
   workspaceState: StateFrom<typeof workspaceMachine>;
@@ -54,7 +54,7 @@ export const WorkspaceReadyPage = ({
   const {
     workspace,
     template,
-    templateVersion,
+    templateVersion: currentVersion,
     deploymentValues,
     builds,
     getBuildsError,
@@ -76,18 +76,22 @@ export const WorkspaceReadyPage = ({
   const favicon = getFaviconByStatus(workspace.latest_build);
   const navigate = useNavigate();
   const [changeVersionDialogOpen, setChangeVersionDialogOpen] = useState(false);
-  const { data: templateVersions } = useQuery({
-    queryKey: ["template", "versions", workspace.template_id],
-    queryFn: () => getTemplateVersions(workspace.template_id),
-    enabled: changeVersionDialogOpen,
-  });
   const [isConfirmingUpdate, setIsConfirmingUpdate] = useState(false);
   const [confirmingRestart, setConfirmingRestart] = useState<{
     open: boolean;
     buildParameters?: TypesGen.WorkspaceBuildParameter[];
   }>({ open: false });
-  const user = useMe();
-  const { isWarningIgnored, ignoreWarning } = useIgnoreWarnings(user.id);
+
+  const { data: templateVersions } = useQuery({
+    queryKey: ["template", "versions", workspace.template_id],
+    queryFn: () => getTemplateVersions(workspace.template_id),
+    enabled: changeVersionDialogOpen,
+  });
+  const { data: latestVersion } = useQuery({
+    ...templateVersion(workspace.template_active_version_id),
+    enabled: workspace.outdated,
+  });
+
   const buildLogs = useBuildLogs(workspace);
   const shouldDisplayBuildLogs =
     hasJobError(workspace) ||
@@ -105,6 +109,7 @@ export const WorkspaceReadyPage = ({
   useEffect(() => {
     bannerSend({ type: "REFRESH_WORKSPACE", workspace });
   }, [bannerSend, workspace]);
+
   return (
     <>
       <Helmet>
@@ -150,18 +155,10 @@ export const WorkspaceReadyPage = ({
         handleStop={() => workspaceSend({ type: "STOP" })}
         handleDelete={() => workspaceSend({ type: "ASK_DELETE" })}
         handleRestart={(buildParameters) => {
-          if (isWarningIgnored("restart")) {
-            mutateRestartWorkspace({ workspace, buildParameters });
-          } else {
-            setConfirmingRestart({ open: true, buildParameters });
-          }
+          setConfirmingRestart({ open: true, buildParameters });
         }}
         handleUpdate={() => {
-          if (isWarningIgnored("update")) {
-            workspaceSend({ type: "UPDATE" });
-          } else {
-            setIsConfirmingUpdate(true);
-          }
+          setIsConfirmingUpdate(true);
         }}
         handleCancel={() => workspaceSend({ type: "CANCEL" })}
         handleSettings={() => navigate("settings")}
@@ -173,6 +170,7 @@ export const WorkspaceReadyPage = ({
         resources={workspace.latest_build.resources}
         builds={builds}
         canUpdateWorkspace={canUpdateWorkspace}
+        updateMessage={latestVersion?.message}
         canRetryDebugMode={canRetryDebugMode}
         canChangeVersions={canUpdateTemplate}
         hideSSHButton={featureVisibility["browser_only"]}
@@ -186,7 +184,7 @@ export const WorkspaceReadyPage = ({
         sshPrefix={sshPrefix}
         template={template}
         quotaBudget={quota?.budget}
-        templateWarnings={templateVersion?.warnings}
+        templateWarnings={currentVersion?.warnings}
         buildLogs={
           shouldDisplayBuildLogs && (
             <WorkspaceBuildLogsSection logs={buildLogs} />
@@ -237,25 +235,29 @@ export const WorkspaceReadyPage = ({
       />
       <WarningDialog
         open={isConfirmingUpdate}
-        onConfirm={(shouldIgnore) => {
-          if (shouldIgnore) {
-            ignoreWarning("update");
-          }
+        onConfirm={() => {
           workspaceSend({ type: "UPDATE" });
           setIsConfirmingUpdate(false);
         }}
         onClose={() => setIsConfirmingUpdate(false)}
-        title="Confirm update"
+        title="Update and restart?"
         confirmText="Update"
-        description="Are you sure you want to update your workspace? Updating your workspace will stop all running processes and delete non-persistent data."
+        description={
+          <Stack>
+            <p>
+              Restarting your workspace will stop all running processes and{" "}
+              <strong>delete non-persistent data</strong>.
+            </p>
+            {latestVersion && (
+              <Alert severity="info">{latestVersion.message}</Alert>
+            )}
+          </Stack>
+        }
       />
 
       <WarningDialog
         open={confirmingRestart.open}
-        onConfirm={(shouldIgnore) => {
-          if (shouldIgnore) {
-            ignoreWarning("restart");
-          }
+        onConfirm={() => {
           mutateRestartWorkspace({
             workspace,
             buildParameters: confirmingRestart.buildParameters,
@@ -263,84 +265,26 @@ export const WorkspaceReadyPage = ({
           setConfirmingRestart({ open: false });
         }}
         onClose={() => setConfirmingRestart({ open: false })}
-        title="Confirm restart"
+        title="Restart your workspace?"
         confirmText="Restart"
-        description="Are you sure you want to restart your workspace? Updating your workspace will stop all running processes and delete non-persistent data."
+        description={
+          <>
+            Restarting your workspace will stop all running processes and{" "}
+            <strong>delete non-persistent data</strong>.
+          </>
+        }
       />
     </>
   );
 };
 
-type IgnoredWarnings = Record<string, string>;
-
-const useIgnoreWarnings = (prefix: string) => {
-  const ignoredWarningsJSON = localStorage.getItem(`${prefix}_ignoredWarnings`);
-  let ignoredWarnings: IgnoredWarnings | undefined;
-  if (ignoredWarningsJSON) {
-    ignoredWarnings = JSON.parse(ignoredWarningsJSON);
-  }
-
-  const isWarningIgnored = (warningId: string) => {
-    return Boolean(ignoredWarnings?.[warningId]);
-  };
-
-  const ignoreWarning = (warningId: string) => {
-    if (!ignoredWarnings) {
-      ignoredWarnings = {};
-    }
-    ignoredWarnings[warningId] = new Date().toISOString();
-    localStorage.setItem(
-      `${prefix}_ignoredWarnings`,
-      JSON.stringify(ignoredWarnings),
-    );
-  };
-
-  return {
-    isWarningIgnored,
-    ignoreWarning,
-  };
-};
-
 const WarningDialog: FC<
   Pick<
     ConfirmDialogProps,
-    "open" | "onClose" | "title" | "confirmText" | "description"
-  > & { onConfirm: (shouldIgnore: boolean) => void }
-> = ({ open, onConfirm, onClose, title, confirmText, description }) => {
-  const [shouldIgnore, setShouldIgnore] = useState(false);
-
-  return (
-    <ConfirmDialog
-      type="info"
-      hideCancel={false}
-      open={open}
-      onConfirm={() => {
-        onConfirm(shouldIgnore);
-      }}
-      onClose={onClose}
-      title={title}
-      confirmText={confirmText}
-      description={
-        <>
-          <div>{description}</div>
-          <FormControlLabel
-            sx={{
-              marginTop: 2,
-            }}
-            control={
-              <Checkbox
-                size="small"
-                onChange={(e) => {
-                  setShouldIgnore(e.target.checked);
-                }}
-              />
-            }
-            label="Don't show me this message again"
-          />
-        </>
-      }
-    />
-  );
+    "open" | "onClose" | "title" | "confirmText" | "description" | "onConfirm"
+  >
+> = (props) => {
+  return <ConfirmDialog type="info" hideCancel={false} {...props} />;
 };
 
 const useBuildLogs = (workspace: TypesGen.Workspace) => {

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -23,7 +23,7 @@ import {
 import { UpdateBuildParametersDialog } from "./UpdateBuildParametersDialog";
 import { ChangeVersionDialog } from "./ChangeVersionDialog";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { getTemplateVersions, restartWorkspace } from "api/api";
+import { restartWorkspace } from "api/api";
 import {
   ConfirmDialog,
   ConfirmDialogProps,
@@ -31,7 +31,7 @@ import {
 import { workspaceBuildMachine } from "xServices/workspaceBuild/workspaceBuildXService";
 import * as TypesGen from "api/typesGenerated";
 import { WorkspaceBuildLogsSection } from "./WorkspaceBuildLogsSection";
-import { templateVersion } from "api/queries/templates";
+import { templateVersion, templateVersions } from "api/queries/templates";
 import { Alert } from "components/Alert/Alert";
 import { Stack } from "components/Stack/Stack";
 
@@ -82,9 +82,8 @@ export const WorkspaceReadyPage = ({
     buildParameters?: TypesGen.WorkspaceBuildParameter[];
   }>({ open: false });
 
-  const { data: templateVersions } = useQuery({
-    queryKey: ["template", "versions", workspace.template_id],
-    queryFn: () => getTemplateVersions(workspace.template_id),
+  const { data: allVersions } = useQuery({
+    ...templateVersions(workspace.template_id),
     enabled: changeVersionDialogOpen,
   });
   const { data: latestVersion } = useQuery({
@@ -216,9 +215,9 @@ export const WorkspaceReadyPage = ({
         }}
       />
       <ChangeVersionDialog
-        templateVersions={templateVersions?.reverse()}
+        templateVersions={allVersions?.reverse()}
         template={template}
-        defaultTemplateVersion={templateVersions?.find(
+        defaultTemplateVersion={allVersions?.find(
           (v) => workspace.latest_build.template_version_id === v.id,
         )}
         open={changeVersionDialogOpen}

--- a/site/src/pages/WorkspacePage/WorkspaceStats.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceStats.tsx
@@ -103,7 +103,7 @@ export const WorkspaceStats: FC<WorkspaceStatsProps> = ({
               {workspace.outdated && (
                 <WorkspaceOutdatedTooltip
                   templateName={workspace.template_name}
-                  templateId={workspace.template_id}
+                  latestVersionId={workspace.template_active_version_id}
                   onUpdateVersion={handleUpdate}
                   ariaLabel="update version"
                 />

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -177,7 +177,9 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
                             {workspace.outdated && (
                               <WorkspaceOutdatedTooltip
                                 templateName={workspace.template_name}
-                                templateId={workspace.template_id}
+                                latestVersionId={
+                                  workspace.template_active_version_id
+                                }
                                 onUpdateVersion={() => {
                                   onUpdateWorkspace(workspace);
                                 }}


### PR DESCRIPTION
Part of #8657

<img width="1790" alt="Screenshot 2023-09-15 at 11 54 34 AM" src="https://github.com/coder/coder/assets/418348/075fba87-a1bf-4cb8-9a2c-08c70d7f2725">
<img width="491" alt="Screenshot 2023-09-15 at 12 18 24 PM" src="https://github.com/coder/coder/assets/418348/64e20736-491c-4ead-8b61-3724e6e6872b">

- Get rid of the ignore-able warnings
- Refactor some existing message loading stuff
- Show an update alert when a workspace is outdated
- Show the update message in the update dialog
- Start adding `&hellip;` to ui elements which require further confirmation/action