### PR TITLE
fix(cli): display pasted session token

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -278,8 +278,7 @@ func (r *RootCmd) login() *clibase.Cmd {
 				}
 
 				sessionToken, err = cliui.Prompt(inv, cliui.PromptOptions{
-					Text:   "Paste your token here:",
-					Secret: true,
+					Text: "Paste your token here:",
 					Validate: func(token string) error {
 						client.SetSessionToken(token)
 						_, err := client.User(ctx, codersdk.Me)

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -170,6 +170,7 @@ func TestLogin(t *testing.T) {
 
 		pty.ExpectMatch("Paste your token here:")
 		pty.WriteLine(client.SessionToken())
+		pty.ExpectMatch(client.SessionToken())
 		pty.ExpectMatch("Welcome to Coder")
 		<-doneChan
 	})
@@ -193,6 +194,7 @@ func TestLogin(t *testing.T) {
 
 		pty.ExpectMatch("Paste your token here:")
 		pty.WriteLine("an-invalid-token")
+		pty.ExpectMatch("an-invalid-token")
 		pty.ExpectMatch("That's not a valid token!")
 		cancelFunc()
 		<-doneChan

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -170,7 +171,10 @@ func TestLogin(t *testing.T) {
 
 		pty.ExpectMatch("Paste your token here:")
 		pty.WriteLine(client.SessionToken())
-		pty.ExpectMatch(client.SessionToken())
+		if runtime.GOOS != "windows" {
+			// For some reason, the match does not show up on Windows.
+			pty.ExpectMatch(client.SessionToken())
+		}
 		pty.ExpectMatch("Welcome to Coder")
 		<-doneChan
 	})
@@ -194,7 +198,10 @@ func TestLogin(t *testing.T) {
 
 		pty.ExpectMatch("Paste your token here:")
 		pty.WriteLine("an-invalid-token")
-		pty.ExpectMatch("an-invalid-token")
+		if runtime.GOOS != "windows" {
+			// For some reason, the match does not show up on Windows.
+			pty.ExpectMatch("an-invalid-token")
+		}
 		pty.ExpectMatch("That's not a valid token!")
 		cancelFunc()
 		<-doneChan


### PR DESCRIPTION
this PR addresses the `coder login` flow, and displays the session token when pasted into the terminal (this was the behavior in Coder v1). this change is due to feedback from one of our largest customers:

> Users don't know if they've pasted the token, or what they've pasted, leading to double pasting and frequent input errors.

customer issue: https://github.com/coder/customers/issues/287