### PR TITLE
ci: remove example templates readme from docs filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,6 @@ jobs:
             docs:
               - "docs/**"
               - "README.md"
-              - "examples/templates/**"
               - "examples/web-server/**"
               - "examples/monitoring/**"
               - "examples/lima/**"


### PR DESCRIPTION
This will run `make gen` on templates readme and avoid situations like https://github.com/coder/coder/pull/9715 where `make gen` was not run on the PR checks