### PR TITLE
chore: fix permission for kubeconfig

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -110,6 +110,7 @@ jobs:
           set -euo pipefail
           mkdir -p ~/.kube
           echo "${{ secrets.PR_DEPLOYMENTS_KUBECONFIG }}" > ~/.kube/config
+          chmod 644 ~/.kube/config
           export KUBECONFIG=~/.kube/config
 
       - name: Check if the helm deployment already exists
@@ -257,6 +258,7 @@ jobs:
           set -euo pipefail
           mkdir -p ~/.kube
           echo "${{ secrets.PR_DEPLOYMENTS_KUBECONFIG }}" > ~/.kube/config
+          chmod 644 ~/.kube/config
           export KUBECONFIG=~/.kube/config
 
       - name: Check if image exists


### PR DESCRIPTION
fix permission for kubeconfig
to prevent 
```console
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/runner/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/runner/.kube/config
```