### PR TITLE
test(cli): ensure first option selected with  is expected

### DIFF
--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -603,7 +603,6 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		// Update the workspace
 		inv, root = clitest.New(t, "update", "my-workspace")
 		clitest.SetupConfig(t, client, root)
-
 		doneChan := make(chan struct{})
 		pty := ptytest.New(t).Attach(inv)
 		go func() {
@@ -613,7 +612,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		}()
 
 		matches := []string{
-			// UI select will pick "first_option".
+			// cliui.Select will pick "first_option".
 			"Planning workspace...", "",
 		}
 		for i := 0; i < len(matches); i += 2 {
@@ -650,8 +649,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		// Create new workspace
 		inv, root := clitest.New(t, "create", "my-workspace", "--yes", "--template", template.Name, "--parameter", fmt.Sprintf("%s=%s", stringParameterName, "2nd"))
 		clitest.SetupConfig(t, client, root)
-
-		pty := ptytest.New(t).Attach(inv)
+		ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.NoError(t, err)
 
@@ -674,10 +672,8 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		// Update the workspace
 		inv, root = clitest.New(t, "update", "my-workspace")
 		clitest.SetupConfig(t, client, root)
-		pty = ptytest.New(t).Attach(inv)
-
 		doneChan := make(chan struct{})
-		pty = ptytest.New(t).Attach(inv)
+		pty := ptytest.New(t).Attach(inv)
 		go func() {
 			defer close(doneChan)
 			err := inv.Run()
@@ -817,7 +813,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		}()
 
 		matches := []string{
-			// UI select will pick "thi".
+			// cliui.Select will pick "thi".
 			"Planning workspace...", "",
 		}
 		for i := 0; i < len(matches); i += 2 {

--- a/cli/update_test.go
+++ b/cli/update_test.go
@@ -586,6 +586,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 
 		// Update template
 		updatedTemplateParameters := []*proto.RichParameter{
+			// The order of rich parameter options must be maintained because `cliui.Select` automatically selects the first option during tests.
 			{Name: stringParameterName, Type: "string", Mutable: true, Required: true, Options: []*proto.RichParameterOption{
 				{Name: "first_option", Description: "This is first option", Value: "1"},
 				{Name: "second_option", Description: "This is second option", Value: "2"},
@@ -612,7 +613,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		}()
 
 		matches := []string{
-			// cliui.Select will pick "first_option".
+			// `cliui.Select` will automatically pick the first option
 			"Planning workspace...", "",
 		}
 		for i := 0; i < len(matches); i += 2 {
@@ -655,6 +656,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 
 		// Update template - 2nd option disappeared, 4th option added
 		updatedTemplateParameters := []*proto.RichParameter{
+			// The order of rich parameter options must be maintained because `cliui.Select` automatically selects the first option during tests.
 			{Name: stringParameterName, Type: "string", Mutable: true, Required: true, Options: []*proto.RichParameterOption{
 				{Name: "Third option", Description: "This is third option", Value: "3rd"},
 				{Name: "First option", Description: "This is first option", Value: "1st"},
@@ -681,6 +683,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		}()
 
 		matches := []string{
+			// `cliui.Select` will automatically pick the first option
 			"Planning workspace...", "",
 		}
 		for i := 0; i < len(matches); i += 2 {
@@ -787,6 +790,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		// Update template: add required, immutable parameter
 		updatedTemplateParameters := []*proto.RichParameter{
 			templateParameters[0],
+			// The order of rich parameter options must be maintained because `cliui.Select` automatically selects the first option during tests.
 			{Name: immutableParameterName, Type: "string", Mutable: false, Required: true, Options: []*proto.RichParameterOption{
 				{Name: "thi", Description: "This is third option for immutable parameter", Value: "III"},
 				{Name: "fir", Description: "This is first option for immutable parameter", Value: "I"},
@@ -813,7 +817,7 @@ func TestUpdateValidateRichParameters(t *testing.T) {
 		}()
 
 		matches := []string{
-			// cliui.Select will pick "thi".
+			// `cliui.Select` will automatically pick the first option
 			"Planning workspace...", "",
 		}
 		for i := 0; i < len(matches); i += 2 {


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/9748

This PR fine-tunes the CLI test to prevent flakiness.

Major changes:
* Wait for CLI commands to finish
* Re-arrange Rich Parameter options to be compliant with `cliui.Select` [limitation](https://github.com/coder/coder/blob/main/cli/cliui/select.go#L106-L110)