### PR TITLE
feat(coderd/httpmw): log `start` timestamp for http requests

### DIFF
--- a/coderd/httpmw/logger.go
+++ b/coderd/httpmw/logger.go
@@ -26,9 +26,18 @@ func Logger(log slog.Logger) func(next http.Handler) http.Handler {
 				slog.F("path", r.URL.Path),
 				slog.F("proto", r.Proto),
 				slog.F("remote_addr", r.RemoteAddr),
+				// Include the start timestamp in the log so that we have the
+				// source of truth. There is at least a theoretical chance that
+				// there can be a delay between `next.ServeHTTP` ending and us
+				// actually logging the request. This can also be useful when
+				// filtering logs that started at a certain time (compared to
+				// trying to compute the value).
+				slog.F("start_timestamp", start),
 			)
 
 			next.ServeHTTP(sw, r)
+
+			end := time.Now()
 
 			// Don't log successful health check requests.
 			if r.URL.Path == "/api/v2" && sw.Status == http.StatusOK {
@@ -36,9 +45,9 @@ func Logger(log slog.Logger) func(next http.Handler) http.Handler {
 			}
 
 			httplog = httplog.With(
-				slog.F("took", time.Since(start)),
+				slog.F("took", end.Sub(start)),
 				slog.F("status_code", sw.Status),
-				slog.F("latency_ms", float64(time.Since(start)/time.Millisecond)),
+				slog.F("latency_ms", float64(end.Sub(start)/time.Millisecond)),
 			)
 
 			// For status codes 400 and higher we

--- a/coderd/httpmw/logger.go
+++ b/coderd/httpmw/logger.go
@@ -32,7 +32,7 @@ func Logger(log slog.Logger) func(next http.Handler) http.Handler {
 				// actually logging the request. This can also be useful when
 				// filtering logs that started at a certain time (compared to
 				// trying to compute the value).
-				slog.F("start_timestamp", start),
+				slog.F("start", start),
 			)
 
 			next.ServeHTTP(sw, r)


### PR DESCRIPTION
This PR adds a slog field, ~~`start_timestamp`~~ `start` that will give us a definitive source of truth for the request timestamp.

Having this would've been helpful in debugging https://github.com/coder/coder/pull/9729 to eliminate a potential, but unlikely, order of events (where the goroutine would be held up, resulting in a log that may have a timestamp later than one would expect).
