### PR TITLE
fix(coderd/batchstats): use debug log on context cancellation in flush

### DIFF
--- a/coderd/batchstats/batcher.go
+++ b/coderd/batchstats/batcher.go
@@ -243,6 +243,10 @@ func (b *Batcher) flush(ctx context.Context, forced bool, reason string) {
 	err = b.store.InsertWorkspaceAgentStats(ctx, *b.buf)
 	elapsed := time.Since(start)
 	if err != nil {
+		if xerrors.Is(err, context.Canceled) {
+			b.log.Debug(ctx, "context canceled, skipping insert of workspace agent stats", slog.F("elapsed", elapsed))
+			return
+		}
 		b.log.Error(ctx, "error inserting workspace agent stats", slog.Error(err), slog.F("elapsed", elapsed))
 		return
 	}


### PR DESCRIPTION
This fixes a flake that kept occuring: https://github.com/coder/coder/actions/runs/6235651644/job/16925307599?pr=9729
