### PR TITLE
fix(coderd/batchstats): use debug log on query cancellation in flush

### DIFF
--- a/coderd/batchstats/batcher.go
+++ b/coderd/batchstats/batcher.go
@@ -243,8 +243,8 @@ func (b *Batcher) flush(ctx context.Context, forced bool, reason string) {
 	err = b.store.InsertWorkspaceAgentStats(ctx, *b.buf)
 	elapsed := time.Since(start)
 	if err != nil {
-		if xerrors.Is(err, context.Canceled) {
-			b.log.Debug(ctx, "context canceled, skipping insert of workspace agent stats", slog.F("elapsed", elapsed))
+		if database.IsQueryCanceledError(err) {
+			b.log.Debug(ctx, "query canceled, skipping insert of workspace agent stats", slog.F("elapsed", elapsed))
 			return
 		}
 		b.log.Error(ctx, "error inserting workspace agent stats", slog.Error(err), slog.F("elapsed", elapsed))


### PR DESCRIPTION
The previous PR #9777, only fixed part of the issues reported in #9772. We now handle canceled queries as well.

Fixes #9772
