### PR TITLE
fix: ensure user always belongs to an organization

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1165,8 +1165,8 @@ func convertUsers(users []database.User, organizationIDsByUserID map[uuid.UUID][
 
 func userOrganizationIDs(ctx context.Context, api *API, user database.User) ([]uuid.UUID, error) {
 	organizationIDsByMemberIDsRows, err := api.Database.GetOrganizationIDsByMemberIDs(ctx, []uuid.UUID{user.ID})
-	if errors.Is(err, sql.ErrNoRows) || len(organizationIDsByMemberIDsRows) == 0 {
-		return []uuid.UUID{}, nil
+	if errors.Is(err, sql.ErrNoRows) {
+		return []uuid.UUID{}, xerrors.Errorf("user %q must be a member of at least one organization", user.Email)
 	}
 	if err != nil {
 		return []uuid.UUID{}, err


### PR DESCRIPTION
This PR modifies `userOrganizationIDs` to assume that the user should always belong to an organization.

Note:

I'm trying to bisect the problem with [failing e2e tests](https://github.com/coder/coder/actions/runs/6223854655/job/16890761081) when `/api/v2/users/me` does not return organization IDs:

```
2023-09-18T14:26:13.8439845Z [stdout] [restart workspace with ephemeral parameters]: [onResponse] url=http://localhost:3000/api/v2/users/me status=200 body={"id":"493bc069-93c0-4576-b3c1-48fd4674989d","username":"admin","email":"admin@coder.com","created_at":"2023-09-18T14:24:41.251247Z","last_seen_at":"2023-09-18T14:24:41.426339Z","status":"active","organization_ids":[],"roles":[{"name":"owner","display_name":"Owner"}],"avatar_url":"","login_type":"password"}
```
