### PR TITLE
fix: call agent directly in cli tests

### DIFF
--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -7,15 +7,20 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/pion/udp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -312,24 +317,23 @@ func runAgent(t *testing.T, client *codersdk.Client, userID uuid.UUID) codersdk.
 	workspace := coderdtest.CreateWorkspace(t, client, orgID, template.ID)
 	coderdtest.AwaitWorkspaceBuildJob(t, client, workspace.LatestBuild.ID)
 
-	// Start workspace agent in a goroutine
-	inv, root := clitest.New(t, "agent", "--agent-token", agentToken, "--agent-url", client.URL.String())
-	clitest.SetupConfig(t, client, root)
-	pty := ptytest.New(t)
-	inv.Stdin = pty.Input()
-	inv.Stdout = pty.Output()
-	inv.Stderr = pty.Output()
-	errC := make(chan error)
-	agentCtx, agentCancel := context.WithCancel(ctx)
-	t.Cleanup(func() {
-		agentCancel()
-		err := <-errC
-		require.NoError(t, err)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug).Named("agent")
+	agentClient := agentsdk.New(client.URL)
+	agentClient.SDK.SetLogger(logger)
+	agentClient.SDK.SetSessionToken(agentToken)
+	agnt := agent.New(agent.Options{
+		Client: agentClient,
+		Logger: logger,
+		LogDir: t.TempDir(),
+		ExchangeToken: func(ctx context.Context) (string, error) {
+			return agentToken, nil
+		},
+		SSHMaxTimeout: time.Second * 60,
 	})
-	go func() {
-		errC <- inv.WithContext(agentCtx).Run()
-	}()
-
+	t.Cleanup(func() {
+		err := agnt.Close()
+		assert.NoError(t, err)
+	})
 	coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 
 	return workspace

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -170,6 +170,7 @@ func TestDERPHeaders(t *testing.T) {
 
 	// Connect with the headers set as args.
 	args := []string{
+		"-v",
 		"--no-feature-warning",
 		"--no-version-warning",
 		"ping", workspace.Name,


### PR DESCRIPTION
Tests like TestDERPHeaders create an agent, and then run a CLI command that communicates with it.

Prior to this change, we used the CLI itself to start the agent.  This 

a) is needlessly complicated as it interjects the cli-invocation and pseudoterminal packages
b) makes it impossible to tell which logs came from the agent and which from the CLI command under test, since they both get generically logged by the ptytest package.  c.f. https://github.com/coder/coder/actions/runs/6221630697/job/16883998408?pr=9717

So instead, we just start the agent directly with a named logger.

I also start the CLI command under test in TestDERPHeaders with `-v` so that we get debug logs from it.