### PR TITLE
test(site): workaround for reattached xterm-rows

### DIFF
--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -45,6 +45,10 @@ test("web terminal", async ({ context, page }) => {
     state: "visible",
   });
 
+  // Workaround: delay next steps as "div.xterm-rows" can be recreated/reattached
+  // after a couple of milliseconds.
+  await terminal.waitForTimeout(2000);
+
   // Ensure that we can type in it
   await terminal.keyboard.type("echo he${justabreak}llo123456");
   await terminal.keyboard.press("Enter");


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/actions/runs/6236909229

This PR adds an extra timeout in the middle of webTerminal test. Apparently, `xterm-rows` div is being recreated and reattached, so we can't do a proper assertion on the executed command.