### PR TITLE
fix: consider all 'devel' builds as 'dev' builds

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -71,9 +71,9 @@ func Version() string {
 // disregarded. If it detects that either version is a developer build it
 // returns true.
 func VersionsMatch(v1, v2 string) bool {
-	// Developer versions are disregarded...hopefully they know what they are
-	// doing.
-	if IsDevVersion(v1) || IsDevVersion(v2) {
+	// If no version is attached, then it is a dev build outside of CI. The version
+	// will be disregarded... hopefully they know what they are doing.
+	if strings.Contains(v1, noVersion) || strings.Contains(v2, noVersion) {
 		return true
 	}
 

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -30,8 +30,14 @@ var (
 )
 
 const (
-	// develPrefix is prefixed to developer versions of the application.
-	develPrefix = "v0.0.0-devel"
+	// noVersion is the reported version when the version cannot be determined.
+	// Usually because `go build` is run instead of `make build`.
+	noVersion = "v0.0.0"
+
+	// develPreRelease is the pre-release tag for developer versions of the application.
+	// The pre-release tag should be appended to the version with a "-".
+	// Example: v0.0.0-devel
+	develPreRelease = "devel"
 )
 
 // Version returns the semantic version of the build.
@@ -45,7 +51,8 @@ func Version() string {
 		if tag == "" {
 			// This occurs when the tag hasn't been injected,
 			// like when using "go run".
-			version = develPrefix + revision
+			// <version>-<pre-release>+<revision>
+			version = fmt.Sprintf("%s-%s%s", noVersion, develPreRelease, revision)
 			return
 		}
 		version = "v" + tag
@@ -65,16 +72,21 @@ func Version() string {
 func VersionsMatch(v1, v2 string) bool {
 	// Developer versions are disregarded...hopefully they know what they are
 	// doing.
-	if strings.HasPrefix(v1, develPrefix) || strings.HasPrefix(v2, develPrefix) {
+	if IsDevVersion(v1) || IsDevVersion(v2) {
 		return true
 	}
 
 	return semver.MajorMinor(v1) == semver.MajorMinor(v2)
 }
 
+func IsDevVersion(v string) bool {
+	return strings.Contains(v, "-"+develPreRelease)
+}
+
 // IsDev returns true if this is a development build.
+// CI builds are also considered development builds.
 func IsDev() bool {
-	return strings.HasPrefix(Version(), develPrefix)
+	return IsDevVersion(Version())
 }
 
 // IsSlim returns true if this is a slim build.

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -34,8 +34,9 @@ const (
 	// Usually because `go build` is run instead of `make build`.
 	noVersion = "v0.0.0"
 
-	// develPreRelease is the pre-release tag for developer versions of the application.
-	// The pre-release tag should be appended to the version with a "-".
+	// develPreRelease is the pre-release tag for developer versions of the
+	// application. This includes CI builds. The pre-release tag should be appended
+	// to the version with a "-".
 	// Example: v0.0.0-devel
 	develPreRelease = "devel"
 )

--- a/buildinfo/buildinfo_test.go
+++ b/buildinfo/buildinfo_test.go
@@ -57,11 +57,17 @@ func TestBuildInfo(t *testing.T) {
 				expectMatch: true,
 			},
 			// Our CI instance uses a "-devel" prerelease
-			// flag. This is considered the same as a developer WIP build.
+			// flag.
 			{
-				name:        "DevelPreleaseIgnored",
+				name:        "DevelPreleaseMajor",
 				v1:          "v1.1.1-devel+123abac",
 				v2:          "v1.2.3",
+				expectMatch: false,
+			},
+			{
+				name:        "DevelPreleaseSame",
+				v1:          "v1.1.1-devel+123abac",
+				v2:          "v1.1.9",
 				expectMatch: true,
 			},
 			{

--- a/buildinfo/buildinfo_test.go
+++ b/buildinfo/buildinfo_test.go
@@ -57,12 +57,12 @@ func TestBuildInfo(t *testing.T) {
 				expectMatch: true,
 			},
 			// Our CI instance uses a "-devel" prerelease
-			// flag. This is not the same as a developer WIP build.
+			// flag. This is considered the same as a developer WIP build.
 			{
-				name:        "DevelPreleaseNotIgnored",
+				name:        "DevelPreleaseIgnored",
 				v1:          "v1.1.1-devel+123abac",
 				v2:          "v1.2.3",
-				expectMatch: false,
+				expectMatch: true,
 			},
 			{
 				name:        "MajorMismatch",


### PR DESCRIPTION
If CI needs to be distinguished from a dev build, we should add a different pre-release tag for those builds.