### PR TITLE
chore: enhance tests for TemplateSchedulePage

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -1,4 +1,3 @@
-/*eslint eslint-comments/disable-enable-pair: error -- Remove after bottlenecks or causes of timeouts for testing have been figured out */
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as API from "api/api";
@@ -46,7 +45,6 @@ type FillAndSubmitConfig = {
     : never]?: TemplateScheduleFormValues[Key] | undefined;
 };
 
-/*eslint-disable no-console -- Start benchmarks */
 const fillAndSubmitForm = async ({
   default_ttl_ms,
   max_ttl_ms,
@@ -54,10 +52,8 @@ const fillAndSubmitForm = async ({
   time_til_dormant_ms,
   time_til_dormant_autodelete_ms,
 }: FillAndSubmitConfig) => {
-  console.time("form - full function");
   const user = userEvent.setup();
 
-  console.time("form - ttl");
   if (default_ttl_ms) {
     const defaultTtlField = await screen.findByLabelText(
       "Default autostop (hours)",
@@ -65,36 +61,28 @@ const fillAndSubmitForm = async ({
     await user.clear(defaultTtlField);
     await user.type(defaultTtlField, default_ttl_ms.toString());
   }
-  console.timeEnd("form - ttl");
 
-  console.time("form - max_ttl");
   if (max_ttl_ms) {
     const maxTtlField = await screen.findByLabelText("Max lifetime (hours)");
 
     await user.clear(maxTtlField);
     await user.type(maxTtlField, max_ttl_ms.toString());
   }
-  console.timeEnd("form - max_ttl");
 
-  console.time("form - failure_ttl");
   if (failure_ttl_ms) {
     const failureTtlField = screen.getByRole("checkbox", {
       name: /Failure Cleanup/i,
     });
     await user.type(failureTtlField, failure_ttl_ms.toString());
   }
-  console.timeEnd("form - failure_ttl");
 
-  console.time("form - dormant");
   if (time_til_dormant_ms) {
     const inactivityTtlField = screen.getByRole("checkbox", {
       name: /Dormancy Threshold/i,
     });
     await user.type(inactivityTtlField, time_til_dormant_ms.toString());
   }
-  console.timeEnd("form - dormant");
 
-  console.time("form - auto-delete");
   if (time_til_dormant_autodelete_ms) {
     const dormancyAutoDeletionField = screen.getByRole("checkbox", {
       name: /Dormancy Auto-Deletion/i,
@@ -104,24 +92,16 @@ const fillAndSubmitForm = async ({
       time_til_dormant_autodelete_ms.toString(),
     );
   }
-  console.timeEnd("form - auto-delete");
 
-  console.time("form - submit");
   const submitButton = await screen.findByText(
     FooterFormLanguage.defaultSubmitLabel,
   );
   await user.click(submitButton);
-  console.timeEnd("form - submit");
 
-  console.time("form - confirm");
   // User needs to confirm dormancy and auto-deletion fields.
   const confirmButton = await screen.findByTestId("confirm-button");
   await user.click(confirmButton);
-  console.timeEnd("form - confirm");
-
-  console.timeEnd("form - full function");
 };
-/*eslint-enable no-console -- End benchmarks */
 
 describe("TemplateSchedulePage", () => {
   beforeEach(() => {
@@ -142,7 +122,7 @@ describe("TemplateSchedulePage", () => {
 
     await fillAndSubmitForm(validFormValues);
     await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
-  }, 15_000);
+  });
 
   test("default and max ttl is converted to and from hours", async () => {
     await renderTemplateSchedulePage();

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -1,3 +1,4 @@
+/*eslint eslint-comments/disable-enable-pair: error -- Remove after bottlenecks or causes of timeouts for testing have been figured out */
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as API from "api/api";
@@ -36,21 +37,27 @@ const renderTemplateSchedulePage = async () => {
   await waitForLoaderToBeRemoved();
 };
 
+// Extracts all properties from TemplateScheduleFormValues that have a key that
+// ends in _ms, and makes those properties optional. Defined as mapped type to
+// ensure this stays in sync as TemplateScheduleFormValues changes
+type FillAndSubmitConfig = {
+  [Key in keyof TemplateScheduleFormValues as Key extends `${string}_ms`
+    ? Key
+    : never]?: TemplateScheduleFormValues[Key] | undefined;
+};
+
+/*eslint-disable no-console -- Start benchmarks */
 const fillAndSubmitForm = async ({
   default_ttl_ms,
   max_ttl_ms,
   failure_ttl_ms,
   time_til_dormant_ms,
   time_til_dormant_autodelete_ms,
-}: {
-  default_ttl_ms?: number;
-  max_ttl_ms?: number;
-  failure_ttl_ms?: number;
-  time_til_dormant_ms?: number;
-  time_til_dormant_autodelete_ms?: number;
-}) => {
+}: FillAndSubmitConfig) => {
+  console.time("form - full function");
   const user = userEvent.setup();
 
+  console.time("form - ttl");
   if (default_ttl_ms) {
     const defaultTtlField = await screen.findByLabelText(
       "Default autostop (hours)",
@@ -58,27 +65,36 @@ const fillAndSubmitForm = async ({
     await user.clear(defaultTtlField);
     await user.type(defaultTtlField, default_ttl_ms.toString());
   }
+  console.timeEnd("form - ttl");
 
+  console.time("form - max_ttl");
   if (max_ttl_ms) {
     const maxTtlField = await screen.findByLabelText("Max lifetime (hours)");
+
     await user.clear(maxTtlField);
     await user.type(maxTtlField, max_ttl_ms.toString());
   }
+  console.timeEnd("form - max_ttl");
 
+  console.time("form - failure_ttl");
   if (failure_ttl_ms) {
     const failureTtlField = screen.getByRole("checkbox", {
       name: /Failure Cleanup/i,
     });
     await user.type(failureTtlField, failure_ttl_ms.toString());
   }
+  console.timeEnd("form - failure_ttl");
 
+  console.time("form - dormant");
   if (time_til_dormant_ms) {
     const inactivityTtlField = screen.getByRole("checkbox", {
       name: /Dormancy Threshold/i,
     });
     await user.type(inactivityTtlField, time_til_dormant_ms.toString());
   }
+  console.timeEnd("form - dormant");
 
+  console.time("form - auto-delete");
   if (time_til_dormant_autodelete_ms) {
     const dormancyAutoDeletionField = screen.getByRole("checkbox", {
       name: /Dormancy Auto-Deletion/i,
@@ -88,16 +104,24 @@ const fillAndSubmitForm = async ({
       time_til_dormant_autodelete_ms.toString(),
     );
   }
+  console.timeEnd("form - auto-delete");
 
+  console.time("form - submit");
   const submitButton = await screen.findByText(
     FooterFormLanguage.defaultSubmitLabel,
   );
   await user.click(submitButton);
+  console.timeEnd("form - submit");
 
-  // User needs to confirm dormancy and autodeletion fields.
+  console.time("form - confirm");
+  // User needs to confirm dormancy and auto-deletion fields.
   const confirmButton = await screen.findByTestId("confirm-button");
   await user.click(confirmButton);
+  console.timeEnd("form - confirm");
+
+  console.timeEnd("form - full function");
 };
+/*eslint-enable no-console -- End benchmarks */
 
 describe("TemplateSchedulePage", () => {
   beforeEach(() => {
@@ -109,15 +133,16 @@ describe("TemplateSchedulePage", () => {
     jest.spyOn(API, "getExperiments").mockResolvedValue(["workspace_actions"]);
   });
 
-  it("succeeds", async () => {
+  it("Calls the API when user fills in and submits a form", async () => {
     await renderTemplateSchedulePage();
     jest.spyOn(API, "updateTemplateMeta").mockResolvedValueOnce({
       ...MockTemplate,
       ...validFormValues,
     });
+
     await fillAndSubmitForm(validFormValues);
     await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
-  });
+  }, 15_000);
 
   test("default and max ttl is converted to and from hours", async () => {
     await renderTemplateSchedulePage();

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -54,6 +54,15 @@ const fillAndSubmitForm = async ({
 }: FillAndSubmitConfig) => {
   const user = userEvent.setup();
 
+  const submitButton = screen.getByRole("button", {
+    name: FooterFormLanguage.defaultSubmitLabel,
+  });
+
+  // This should be removed once we start removing disabled states from the UI;
+  // not worried about this getting forgotten, because it will trigger an error
+  // at some point once that migration starts
+  expect(submitButton).toBeDisabled();
+
   if (default_ttl_ms) {
     const defaultTtlField = await screen.findByLabelText(
       "Default autostop (hours)",
@@ -93,9 +102,7 @@ const fillAndSubmitForm = async ({
     );
   }
 
-  const submitButton = await screen.findByText(
-    FooterFormLanguage.defaultSubmitLabel,
-  );
+  expect(submitButton).not.toBeDisabled();
   await user.click(submitButton);
 
   // User needs to confirm dormancy and auto-deletion fields.

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -54,15 +54,6 @@ const fillAndSubmitForm = async ({
 }: FillAndSubmitConfig) => {
   const user = userEvent.setup();
 
-  const submitButton = screen.getByRole("button", {
-    name: FooterFormLanguage.defaultSubmitLabel,
-  });
-
-  // This should be removed once we start removing disabled states from the UI;
-  // not worried about this getting forgotten, because it will trigger an error
-  // at some point once that migration starts
-  expect(submitButton).toBeDisabled();
-
   if (default_ttl_ms) {
     const defaultTtlField = await screen.findByLabelText(
       "Default autostop (hours)",
@@ -101,6 +92,10 @@ const fillAndSubmitForm = async ({
       time_til_dormant_autodelete_ms.toString(),
     );
   }
+
+  const submitButton = screen.getByRole("button", {
+    name: FooterFormLanguage.defaultSubmitLabel,
+  });
 
   expect(submitButton).not.toBeDisabled();
   await user.click(submitButton);

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, type waitForOptions } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as API from "api/api";
 import { Language as FooterFormLanguage } from "components/FormFooter/FormFooter";
@@ -103,6 +103,12 @@ const fillAndSubmitForm = async ({
   await user.click(confirmButton);
 };
 
+const waitForConfig = {
+  // Test averages about 13 seconds to complete; adding an extra three to
+  // account for spikes before definitely failing a test
+  timeout: 16_000,
+} as const satisfies waitForOptions;
+
 describe("TemplateSchedulePage", () => {
   beforeEach(() => {
     jest
@@ -121,7 +127,10 @@ describe("TemplateSchedulePage", () => {
     });
 
     await fillAndSubmitForm(validFormValues);
-    await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
+    await waitFor(
+      () => expect(API.updateTemplateMeta).toBeCalledTimes(1),
+      waitForConfig,
+    );
   });
 
   test("default and max ttl is converted to and from hours", async () => {
@@ -133,16 +142,20 @@ describe("TemplateSchedulePage", () => {
     });
 
     await fillAndSubmitForm(validFormValues);
-    await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
-    await waitFor(() =>
+    await waitFor(
+      () => expect(API.updateTemplateMeta).toBeCalledTimes(1),
+      waitForConfig,
+    );
+
+    await waitFor(() => {
       expect(API.updateTemplateMeta).toBeCalledWith(
         "test-template",
         expect.objectContaining({
           default_ttl_ms: (validFormValues.default_ttl_ms || 0) * 3600000,
           max_ttl_ms: (validFormValues.max_ttl_ms || 0) * 3600000,
         }),
-      ),
-    );
+      );
+    }, waitForConfig);
   });
 
   test("failure, dormancy, and dormancy auto-deletion converted to and from days", async () => {
@@ -154,8 +167,12 @@ describe("TemplateSchedulePage", () => {
     });
 
     await fillAndSubmitForm(validFormValues);
-    await waitFor(() => expect(API.updateTemplateMeta).toBeCalledTimes(1));
-    await waitFor(() =>
+    await waitFor(
+      () => expect(API.updateTemplateMeta).toBeCalledTimes(1),
+      waitForConfig,
+    );
+
+    await waitFor(() => {
       expect(API.updateTemplateMeta).toBeCalledWith(
         "test-template",
         expect.objectContaining({
@@ -165,8 +182,8 @@ describe("TemplateSchedulePage", () => {
           time_til_dormant_autodelete_ms:
             (validFormValues.time_til_dormant_autodelete_ms || 0) * 86400000,
         }),
-      ),
-    );
+      );
+    }, waitForConfig);
   });
 
   it("allows a default ttl of 7 days", () => {

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -105,12 +105,16 @@ const fillAndSubmitForm = async ({
   await user.click(confirmButton);
 };
 
+// One problem with the waitFor function is that if no additional config options
+// are passed in, it will hang indefinitely as it keeps retrying an assertion.
+// Even if Jest runs out of time and kills the test, you won't get a good error
+// message. Adding options to force test to give up before test timeout
 function waitForWithCutoff(callback: () => void | Promise<void>) {
   return waitFor(callback, {
-    // Test file averages about 13 seconds to complete; adding an extra three
-    // seconds to account for spikes before definitely failing a test. Still
-    // falls under global config of 20 seconds
-    timeout: 16_000,
+    // Defined to end 500ms before global cut-off time of 20s. Wanted to define
+    // this in terms of an exported constant from jest.config, but since Jest
+    // is CJS-based, that would've involved weird CJS-ESM interop issues
+    timeout: 19_500,
   });
 }
 

--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, type waitForOptions } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as API from "api/api";
 import { Language as FooterFormLanguage } from "components/FormFooter/FormFooter";
@@ -103,11 +103,14 @@ const fillAndSubmitForm = async ({
   await user.click(confirmButton);
 };
 
-const waitForConfig = {
-  // Test averages about 13 seconds to complete; adding an extra three to
-  // account for spikes before definitely failing a test
-  timeout: 16_000,
-} as const satisfies waitForOptions;
+function waitForWithCutoff(callback: () => void | Promise<void>) {
+  return waitFor(callback, {
+    // Test file averages about 13 seconds to complete; adding an extra three
+    // seconds to account for spikes before definitely failing a test. Still
+    // falls under global config of 20 seconds
+    timeout: 16_000,
+  });
+}
 
 describe("TemplateSchedulePage", () => {
   beforeEach(() => {
@@ -127,9 +130,8 @@ describe("TemplateSchedulePage", () => {
     });
 
     await fillAndSubmitForm(validFormValues);
-    await waitFor(
-      () => expect(API.updateTemplateMeta).toBeCalledTimes(1),
-      waitForConfig,
+    await waitForWithCutoff(() =>
+      expect(API.updateTemplateMeta).toBeCalledTimes(1),
     );
   });
 
@@ -142,12 +144,11 @@ describe("TemplateSchedulePage", () => {
     });
 
     await fillAndSubmitForm(validFormValues);
-    await waitFor(
-      () => expect(API.updateTemplateMeta).toBeCalledTimes(1),
-      waitForConfig,
+    await waitForWithCutoff(() =>
+      expect(API.updateTemplateMeta).toBeCalledTimes(1),
     );
 
-    await waitFor(() => {
+    await waitForWithCutoff(() => {
       expect(API.updateTemplateMeta).toBeCalledWith(
         "test-template",
         expect.objectContaining({
@@ -155,7 +156,7 @@ describe("TemplateSchedulePage", () => {
           max_ttl_ms: (validFormValues.max_ttl_ms || 0) * 3600000,
         }),
       );
-    }, waitForConfig);
+    });
   });
 
   test("failure, dormancy, and dormancy auto-deletion converted to and from days", async () => {
@@ -167,12 +168,11 @@ describe("TemplateSchedulePage", () => {
     });
 
     await fillAndSubmitForm(validFormValues);
-    await waitFor(
-      () => expect(API.updateTemplateMeta).toBeCalledTimes(1),
-      waitForConfig,
+    await waitForWithCutoff(() =>
+      expect(API.updateTemplateMeta).toBeCalledTimes(1),
     );
 
-    await waitFor(() => {
+    await waitForWithCutoff(() => {
       expect(API.updateTemplateMeta).toBeCalledWith(
         "test-template",
         expect.objectContaining({
@@ -183,7 +183,7 @@ describe("TemplateSchedulePage", () => {
             (validFormValues.time_til_dormant_autodelete_ms || 0) * 86400000,
         }),
       );
-    }, waitForConfig);
+    });
   });
 
   it("allows a default ttl of 7 days", () => {


### PR DESCRIPTION
Linked to #9793 – does not fully address the issue.

Ultimately, I wasn't able to figure out what was only sometimes causing the test to fail. I must have run the test 40+ times while I was kicking the tires and trying different things.

What I did end up doing, though, was adding a little bit more logic to the tests so that hopefully, if it does fail again, we'll get slightly more specific information.

## Changes
- Redefine one of the types to make sure that it never gets out of sync with the source type defined by the API
- Add a hard cutoff to the timeout for all the `waitFor` calls. The cutoff (16 seconds) is higher than the expected time it takes for the tests to run normally (13 seconds), but still below the globally-configured time (20 seconds)
  - The hope is that by making `waitFor` actually fail instead of hang indefinitely until Jest kills it, we'll get more information
- Add some small assertions to make sure that the `Submit` button used in the tests isn't disabled when it's clicked