### PR TITLE
fix: use AlwaysEnable for licenses with all features

### DIFF
--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -378,6 +378,53 @@ func TestEntitlements(t *testing.T) {
 		}
 	})
 
+	t.Run("AllFeaturesAlwaysEnable", func(t *testing.T) {
+		t.Parallel()
+		db := dbfake.New()
+		db.InsertLicense(context.Background(), database.InsertLicenseParams{
+			Exp: time.Now().Add(time.Hour),
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				AllFeatures: true,
+			}),
+		})
+		entitlements, err := license.Entitlements(context.Background(), db, slog.Logger{}, 1, 1, coderdenttest.Keys, empty)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.False(t, entitlements.Trial)
+		for _, featureName := range codersdk.FeatureNames {
+			if featureName == codersdk.FeatureUserLimit {
+				continue
+			}
+			feature := entitlements.Features[featureName]
+			require.Equal(t, featureName.AlwaysEnable(), feature.Enabled)
+			require.Equal(t, codersdk.EntitlementEntitled, feature.Entitlement)
+		}
+	})
+
+	t.Run("AllFeaturesGrace", func(t *testing.T) {
+		t.Parallel()
+		db := dbfake.New()
+		db.InsertLicense(context.Background(), database.InsertLicenseParams{
+			Exp: time.Now().Add(time.Hour),
+			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
+				AllFeatures: true,
+				GraceAt:     time.Now().Add(-time.Hour),
+				ExpiresAt:   time.Now().Add(time.Hour),
+			}),
+		})
+		entitlements, err := license.Entitlements(context.Background(), db, slog.Logger{}, 1, 1, coderdenttest.Keys, all)
+		require.NoError(t, err)
+		require.True(t, entitlements.HasLicense)
+		require.False(t, entitlements.Trial)
+		for _, featureName := range codersdk.FeatureNames {
+			if featureName == codersdk.FeatureUserLimit {
+				continue
+			}
+			require.True(t, entitlements.Features[featureName].Enabled)
+			require.Equal(t, codersdk.EntitlementGracePeriod, entitlements.Features[featureName].Entitlement)
+		}
+	})
+
 	t.Run("MultipleReplicasNoLicense", func(t *testing.T) {
 		t.Parallel()
 		db := dbfake.New()

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -382,7 +382,7 @@ func TestEntitlements(t *testing.T) {
 		t.Parallel()
 		db := dbfake.New()
 		db.InsertLicense(context.Background(), database.InsertLicenseParams{
-			Exp: time.Now().Add(time.Hour),
+			Exp: dbtime.Now().Add(time.Hour),
 			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
 				AllFeatures: true,
 			}),
@@ -405,11 +405,11 @@ func TestEntitlements(t *testing.T) {
 		t.Parallel()
 		db := dbfake.New()
 		db.InsertLicense(context.Background(), database.InsertLicenseParams{
-			Exp: time.Now().Add(time.Hour),
+			Exp: dbtime.Now().Add(time.Hour),
 			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{
 				AllFeatures: true,
-				GraceAt:     time.Now().Add(-time.Hour),
-				ExpiresAt:   time.Now().Add(time.Hour),
+				GraceAt:     dbtime.Now().Add(-time.Hour),
+				ExpiresAt:   dbtime.Now().Add(time.Hour),
 			}),
 		})
 		entitlements, err := license.Entitlements(context.Background(), db, slog.Logger{}, 1, 1, coderdenttest.Keys, all)


### PR DESCRIPTION
Fixes an issue where if you have a license for all features, it doesn't enable features with `AlwaysEnable() == true`

Also fixes an issue where we would set all features to entitled, even with a license in grace period.