### PR TITLE
feat: add empty state for SSO auth methods

### DIFF
--- a/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
@@ -8,7 +8,6 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import { convertToOAUTH } from "api/api";
 import { AuthMethods, LoginType, UserLoginType } from "api/typesGenerated";
-import Skeleton from "@mui/material/Skeleton";
 import { Stack } from "components/Stack/Stack";
 import { useMutation } from "@tanstack/react-query";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
@@ -116,73 +115,66 @@ export const SingleSignOnSection = ({
         description="Authenticate in Coder using one-click"
       >
         <Box display="grid" gap="16px">
-          {authMethods && userLoginType ? (
-            userLoginType.login_type === "password" ? (
-              <>
-                {authMethods.github.enabled && (
-                  <Button
-                    disabled={isUpdating}
-                    onClick={() => openConfirmation("github")}
-                    startIcon={<GitHubIcon sx={{ width: 16, height: 16 }} />}
-                    fullWidth
-                    size="large"
-                  >
-                    GitHub
-                  </Button>
-                )}
-                {authMethods.oidc.enabled && (
-                  <Button
-                    size="large"
-                    startIcon={<OIDCIcon authMethods={authMethods} />}
-                    fullWidth
-                    disabled={isUpdating}
-                    onClick={() => openConfirmation("oidc")}
-                  >
-                    {getOIDCLabel(authMethods)}
-                  </Button>
-                )}
-              </>
-            ) : (
-              <Box
-                sx={{
-                  background: (theme) => theme.palette.background.paper,
-                  borderRadius: 1,
-                  border: (theme) => `1px solid ${theme.palette.divider}`,
-                  padding: 2,
-                  display: "flex",
-                  gap: 2,
-                  alignItems: "center",
-                  fontSize: 14,
-                }}
-              >
-                <CheckCircleOutlined
-                  sx={{
-                    color: (theme) => theme.palette.success.light,
-                    fontSize: 16,
-                  }}
-                />
-                <span>
-                  Authenticated with{" "}
-                  <strong>
-                    {userLoginType.login_type === "github"
-                      ? "GitHub"
-                      : getOIDCLabel(authMethods)}
-                  </strong>
-                </span>
-                <Box sx={{ ml: "auto", lineHeight: 1 }}>
-                  {userLoginType.login_type === "github" ? (
-                    <GitHubIcon sx={{ width: 16, height: 16 }} />
-                  ) : (
-                    <OIDCIcon authMethods={authMethods} />
-                  )}
-                </Box>
-              </Box>
-            )
+          {userLoginType.login_type === "password" ? (
+            <>
+              {authMethods.github.enabled && (
+                <Button
+                  disabled={isUpdating}
+                  onClick={() => openConfirmation("github")}
+                  startIcon={<GitHubIcon sx={{ width: 16, height: 16 }} />}
+                  fullWidth
+                  size="large"
+                >
+                  GitHub
+                </Button>
+              )}
+              {authMethods.oidc.enabled && (
+                <Button
+                  size="large"
+                  startIcon={<OIDCIcon authMethods={authMethods} />}
+                  fullWidth
+                  disabled={isUpdating}
+                  onClick={() => openConfirmation("oidc")}
+                >
+                  {getOIDCLabel(authMethods)}
+                </Button>
+              )}
+            </>
           ) : (
-            <Skeleton
-              variant="rectangular"
-              sx={{ height: 40, borderRadius: 1 }}
-            />
+            <Box
+              sx={{
+                background: (theme) => theme.palette.background.paper,
+                borderRadius: 1,
+                border: (theme) => `1px solid ${theme.palette.divider}`,
+                padding: 2,
+                display: "flex",
+                gap: 2,
+                alignItems: "center",
+                fontSize: 14,
+              }}
+            >
+              <CheckCircleOutlined
+                sx={{
+                  color: (theme) => theme.palette.success.light,
+                  fontSize: 16,
+                }}
+              />
+              <span>
+                Authenticated with{" "}
+                <strong>
+                  {userLoginType.login_type === "github"
+                    ? "GitHub"
+                    : getOIDCLabel(authMethods)}
+                </strong>
+              </span>
+              <Box sx={{ ml: "auto", lineHeight: 1 }}>
+                {userLoginType.login_type === "github" ? (
+                  <GitHubIcon sx={{ width: 16, height: 16 }} />
+                ) : (
+                  <OIDCIcon authMethods={authMethods} />
+                )}
+              </Box>
+            </Box>
           )}
         </Box>
       </Section>

--- a/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
@@ -18,6 +18,10 @@ import { useMutation } from "@tanstack/react-query";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { getErrorMessage } from "api/errors";
 import CheckCircleOutlined from "@mui/icons-material/CheckCircleOutlined";
+import { EmptyState } from "components/EmptyState/EmptyState";
+import { makeStyles } from "@mui/styles";
+import Link from "@mui/material/Link";
+import { docs } from "utils/docs";
 
 type LoginTypeConfirmation =
   | {
@@ -97,6 +101,32 @@ export const useSingleSignOnSection = () => {
   };
 };
 
+const useEmptyStateStyles = makeStyles((theme) => ({
+  root: {
+    minHeight: 0,
+    padding: theme.spacing(6, 4),
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: theme.shape.borderRadius,
+  },
+}));
+
+function SSOEmptyState() {
+  const styles = useEmptyStateStyles();
+
+  return (
+    <EmptyState
+      className={styles.root}
+      message="No SSO Providers"
+      description="No SSO providers are configured with this Coder deployment."
+      cta={
+        <Link href={docs("/admin/auth")} target="_blank" rel="noreferrer">
+          Learn how to add a provider
+        </Link>
+      }
+    />
+  );
+}
+
 type SingleSignOnSectionProps = ReturnType<typeof useSingleSignOnSection> & {
   authMethods: AuthMethods;
   userLoginType: UserLoginType;
@@ -112,6 +142,12 @@ export const SingleSignOnSection = ({
   isConfirming,
   error,
 }: SingleSignOnSectionProps) => {
+  const authList = Object.values(
+    authMethods,
+  ) as (typeof authMethods)[keyof typeof authMethods][];
+
+  const noSsoEnabled = !authList.some((method) => method.enabled);
+
   return (
     <>
       <Section
@@ -133,6 +169,7 @@ export const SingleSignOnSection = ({
                   GitHub
                 </Button>
               )}
+
               {authMethods.oidc.enabled && (
                 <Button
                   size="large"
@@ -144,6 +181,8 @@ export const SingleSignOnSection = ({
                   {getOIDCLabel(authMethods.oidc)}
                 </Button>
               )}
+
+              {noSsoEnabled && <SSOEmptyState />}
             </>
           ) : (
             <Box

--- a/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
@@ -7,7 +7,12 @@ import KeyIcon from "@mui/icons-material/VpnKey";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import { convertToOAUTH } from "api/api";
-import { AuthMethods, LoginType, UserLoginType } from "api/typesGenerated";
+import {
+  AuthMethods,
+  LoginType,
+  OIDCAuthMethod,
+  UserLoginType,
+} from "api/typesGenerated";
 import { Stack } from "components/Stack/Stack";
 import { useMutation } from "@tanstack/react-query";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
@@ -133,10 +138,10 @@ export const SingleSignOnSection = ({
                   size="large"
                   fullWidth
                   disabled={isUpdating}
-                  startIcon={<OIDCIcon authMethods={authMethods} />}
+                  startIcon={<OIDCIcon oidcAuth={authMethods.oidc} />}
                   onClick={() => openConfirmation("oidc")}
                 >
-                  {getOIDCLabel(authMethods)}
+                  {getOIDCLabel(authMethods.oidc)}
                 </Button>
               )}
             </>
@@ -164,14 +169,14 @@ export const SingleSignOnSection = ({
                 <strong>
                   {userLoginType.login_type === "github"
                     ? "GitHub"
-                    : getOIDCLabel(authMethods)}
+                    : getOIDCLabel(authMethods.oidc)}
                 </strong>
               </span>
               <Box sx={{ ml: "auto", lineHeight: 1 }}>
                 {userLoginType.login_type === "github" ? (
                   <GitHubIcon sx={{ width: 16, height: 16 }} />
                 ) : (
-                  <OIDCIcon authMethods={authMethods} />
+                  <OIDCIcon oidcAuth={authMethods.oidc} />
                 )}
               </Box>
             </Box>
@@ -190,21 +195,23 @@ export const SingleSignOnSection = ({
   );
 };
 
-const OIDCIcon = ({ authMethods }: { authMethods: AuthMethods }) => {
-  return authMethods.oidc.iconUrl ? (
+const OIDCIcon = ({ oidcAuth }: { oidcAuth: OIDCAuthMethod }) => {
+  if (!oidcAuth.iconUrl) {
+    return <KeyIcon sx={{ width: 16, height: 16 }} />;
+  }
+
+  return (
     <Box
       component="img"
       alt="Open ID Connect icon"
-      src={authMethods.oidc.iconUrl}
+      src={oidcAuth.iconUrl}
       sx={{ width: 16, height: 16 }}
     />
-  ) : (
-    <KeyIcon sx={{ width: 16, height: 16 }} />
   );
 };
 
-const getOIDCLabel = (authMethods: AuthMethods) => {
-  return authMethods.oidc.signInText || "OpenID Connect";
+const getOIDCLabel = (oidcAuth: OIDCAuthMethod) => {
+  return oidcAuth.signInText || "OpenID Connect";
 };
 
 const ConfirmLoginTypeChangeModal = ({

--- a/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
+++ b/site/src/pages/UserSettingsPage/SecurityPage/SingleSignOnSection.tsx
@@ -119,11 +119,11 @@ export const SingleSignOnSection = ({
             <>
               {authMethods.github.enabled && (
                 <Button
-                  disabled={isUpdating}
-                  onClick={() => openConfirmation("github")}
-                  startIcon={<GitHubIcon sx={{ width: 16, height: 16 }} />}
-                  fullWidth
                   size="large"
+                  fullWidth
+                  disabled={isUpdating}
+                  startIcon={<GitHubIcon sx={{ width: 16, height: 16 }} />}
+                  onClick={() => openConfirmation("github")}
                 >
                   GitHub
                 </Button>
@@ -131,9 +131,9 @@ export const SingleSignOnSection = ({
               {authMethods.oidc.enabled && (
                 <Button
                   size="large"
-                  startIcon={<OIDCIcon authMethods={authMethods} />}
                   fullWidth
                   disabled={isUpdating}
+                  startIcon={<OIDCIcon authMethods={authMethods} />}
                   onClick={() => openConfirmation("oidc")}
                 >
                   {getOIDCLabel(authMethods)}


### PR DESCRIPTION
Closes #9444

Pretty small PR. If the timestamps on the commits looks funny, it's because I had some Git branch issues I had to figure out.

## Changes
- Added an empty state for the list of auth methods in the event that the user is using a password but doesn't have any auth methods enabled
- Removes some needless undefined checks
- Updates some of the OIDC functions/components to take only the OIDC auth method as input, rather than the entire auth methods object

## Notes
- Would definitely appreciate any feedback on the styling, or even just how I had MUI set up