### PR TITLE
revert: "ci: cache datadog-ci (#9702)"

### DIFF
--- a/.github/actions/upload-datadog/action.yaml
+++ b/.github/actions/upload-datadog/action.yaml
@@ -1,4 +1,4 @@
-name: Upload tests to Datadog
+name: Upload tests to datadog
 if: always()
 inputs:
   api-key:
@@ -7,26 +7,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set work dir
-      shell: bash
-      run: |
-        WORK_DIR=${{ runner.temp }}/datadog-ci
-        mkdir -p $WORK_DIR
-        echo "WORK_DIR=$WORK_DIR" >> $GITHUB_ENV
-    # The npm install was taking 30s to 1m, accounting for 20+% of the total
-    # job time.
-    - name: Cache datadog-ci
-      uses: buildjet/cache@v3
-      with:
-        path: |
-          ${{ env.WORK_DIR }}
-        key: datadog-ci-${{ runner.os }}
-        restore-keys: |
-          datadog-ci-${{ runner.os }}-
-          datadog-ci-
     - shell: bash
       run: |
-        cd ${{ env.WORK_DIR }}
         owner=${{ github.repository_owner	 }}
         echo "owner: $owner"
         if [[  $owner != "coder" ]]; then
@@ -38,8 +20,8 @@ runs:
           echo "No API key provided, skipping..."
           exit 0
         fi
-        npm install @datadog/datadog-ci@2.10.0
-        npm x -- datadog-ci junit upload --service coder ./gotests.xml \
+        npm install -g @datadog/datadog-ci@2.10.0
+        datadog-ci junit upload --service coder ./gotests.xml \
           --tags os:${{runner.os}} --tags runner_name:${{runner.name}}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}


### PR DESCRIPTION
revert: "ci: cache datadog-ci (#9702)"

Original commit changeset: b104e0ec0c6d

Seems that this broke the test failure uploads.
