### PR TITLE
feat: add middle click support for workspace rows

### DIFF
--- a/site/src/components/CopyableValue/CopyableValue.tsx
+++ b/site/src/components/CopyableValue/CopyableValue.tsx
@@ -15,7 +15,7 @@ export const CopyableValue: FC<CopyableValueProps> = ({
   ...props
 }) => {
   const { isCopied, copy } = useClipboard(value);
-  const clickableProps = useClickable(copy);
+  const clickableProps = useClickable<HTMLSpanElement>(copy);
   const styles = useStyles();
 
   return (

--- a/site/src/components/FileUpload/FileUpload.tsx
+++ b/site/src/components/FileUpload/FileUpload.tsx
@@ -65,7 +65,8 @@ export const FileUpload: FC<FileUploadProps> = ({
   const styles = useStyles();
   const inputRef = useRef<HTMLInputElement>(null);
   const tarDrop = useFileDrop(onUpload, fileTypeRequired);
-  const clickable = useClickable(() => {
+
+  const clickable = useClickable<HTMLDivElement>(() => {
     if (inputRef.current) {
       inputRef.current.click();
     }

--- a/site/src/components/Timeline/TimelineEntry.tsx
+++ b/site/src/components/Timeline/TimelineEntry.tsx
@@ -1,20 +1,23 @@
 import { makeStyles } from "@mui/styles";
 import TableRow, { TableRowProps } from "@mui/material/TableRow";
-import { PropsWithChildren } from "react";
+import { type PropsWithChildren, forwardRef } from "react";
 import { combineClasses } from "utils/combineClasses";
 
-interface TimelineEntryProps {
-  clickable?: boolean;
-}
+type TimelineEntryProps = PropsWithChildren<
+  TableRowProps & {
+    clickable?: boolean;
+  }
+>;
 
-export const TimelineEntry = ({
-  children,
-  clickable = true,
-  ...props
-}: PropsWithChildren<TimelineEntryProps & TableRowProps>): JSX.Element => {
+export const TimelineEntry = forwardRef(function TimelineEntry(
+  { children, clickable = true, ...props }: TimelineEntryProps,
+  ref?: React.ForwardedRef<HTMLTableRowElement>,
+) {
   const styles = useStyles();
+
   return (
     <TableRow
+      ref={ref}
       className={combineClasses({
         [styles.timelineEntry]: true,
         [styles.clickable]: clickable,
@@ -24,7 +27,7 @@ export const TimelineEntry = ({
       {children}
     </TableRow>
   );
-};
+});
 
 const useStyles = makeStyles((theme) => ({
   clickable: {

--- a/site/src/hooks/useClickable.ts
+++ b/site/src/hooks/useClickable.ts
@@ -45,7 +45,7 @@ export const useClickable = <
     // Most interactive elements automatically make Space/Enter trigger onClick
     // callbacks, but you explicitly have to add it for non-interactive elements
     onKeyDown: (event) => {
-      if (event.key === "Enter" || event.key === "Space") {
+      if (event.key === "Enter" || event.key === " ") {
         // Can't call onClick from here because onKeydown's keyboard event isn't
         // compatible with mouse events. Have to use a ref to simulate a click
         ref.current?.click();

--- a/site/src/hooks/useClickable.ts
+++ b/site/src/hooks/useClickable.ts
@@ -1,6 +1,6 @@
 import {
+  type KeyboardEventHandler,
   type MouseEventHandler,
-  type KeyboardEvent,
   type RefObject,
   useRef,
 } from "react";
@@ -17,14 +17,21 @@ export interface UseClickableResult<
   tabIndex: 0;
   role: "button";
   onClick: MouseEventHandler<T>;
-  onKeyDown: (event: KeyboardEvent) => void;
+  onKeyDown: KeyboardEventHandler<T>;
 }
 
+/**
+ * Exposes props to add basic click/interactive behavior to HTML elements that
+ * don't traditionally have support for them.
+ */
 export const useClickable = <
   // T doesn't have a default type to make it more obvious that the hook expects
   // a type argument in order to work at all
   T extends ClickableElement,
 >(
+  // Even though onClick isn't used in any of the internal calculations, it's
+  // still a required argument, just to make sure that useClickable can't
+  // accidentally be called in a component without also defining click behavior
   onClick: MouseEventHandler<T>,
 ): UseClickableResult<T> => {
   const ref = useRef<T>(null);
@@ -34,12 +41,16 @@ export const useClickable = <
     tabIndex: 0,
     role: "button",
     onClick,
-    onKeyDown: (event: KeyboardEvent) => {
-      if (event.key === "Enter") {
+
+    // Most interactive elements already have this logic baked in automatically,
+    // but you explicitly have to add it for non-interactive elements
+    onKeyDown: (event) => {
+      if (event.key === "Enter" || event.key === "Space") {
         // Can't call onClick directly because onClick needs to work with an
         // event, and mouse events + keyboard events aren't compatible; wouldn't
         // have a value to pass in. Have to use a ref to simulate a click
         ref.current?.click();
+        event.stopPropagation();
       }
     },
   };

--- a/site/src/hooks/useClickable.ts
+++ b/site/src/hooks/useClickable.ts
@@ -1,20 +1,45 @@
-import { KeyboardEvent } from "react";
+import {
+  type MouseEventHandler,
+  type KeyboardEvent,
+  type RefObject,
+  useRef,
+} from "react";
 
-export interface UseClickableResult {
+// Literally any object (ideally an HTMLElement) that has a .click method
+type ClickableElement = {
+  click: () => void;
+};
+
+export interface UseClickableResult<
+  T extends ClickableElement = ClickableElement,
+> {
+  ref: RefObject<T>;
   tabIndex: 0;
   role: "button";
-  onClick: () => void;
+  onClick: MouseEventHandler<T>;
   onKeyDown: (event: KeyboardEvent) => void;
 }
 
-export const useClickable = (onClick: () => void): UseClickableResult => {
+export const useClickable = <
+  // T doesn't have a default type to make it more obvious that the hook expects
+  // a type argument in order to work at all
+  T extends ClickableElement,
+>(
+  onClick: MouseEventHandler<T>,
+): UseClickableResult<T> => {
+  const ref = useRef<T>(null);
+
   return {
+    ref,
     tabIndex: 0,
     role: "button",
     onClick,
     onKeyDown: (event: KeyboardEvent) => {
       if (event.key === "Enter") {
-        onClick();
+        // Can't call onClick directly because onClick needs to work with an
+        // event, and mouse events + keyboard events aren't compatible; wouldn't
+        // have a value to pass in. Have to use a ref to simulate a click
+        ref.current?.click();
       }
     },
   };

--- a/site/src/hooks/useClickable.ts
+++ b/site/src/hooks/useClickable.ts
@@ -25,8 +25,8 @@ export interface UseClickableResult<
  * don't traditionally have support for them.
  */
 export const useClickable = <
-  // T doesn't have a default type to make it more obvious that the hook expects
-  // a type argument in order to work at all
+  // T doesn't have a default type on purpose; the hook should error out if it
+  // doesn't have an explicit type, or a type it can infer from onClick
   T extends ClickableElement,
 >(
   // Even though onClick isn't used in any of the internal calculations, it's
@@ -42,13 +42,12 @@ export const useClickable = <
     role: "button",
     onClick,
 
-    // Most interactive elements already have this logic baked in automatically,
-    // but you explicitly have to add it for non-interactive elements
+    // Most interactive elements automatically make Space/Enter trigger onClick
+    // callbacks, but you explicitly have to add it for non-interactive elements
     onKeyDown: (event) => {
       if (event.key === "Enter" || event.key === "Space") {
-        // Can't call onClick directly because onClick needs to work with an
-        // event, and mouse events + keyboard events aren't compatible; wouldn't
-        // have a value to pass in. Have to use a ref to simulate a click
+        // Can't call onClick from here because onKeydown's keyboard event isn't
+        // compatible with mouse events. Have to use a ref to simulate a click
         ref.current?.click();
         event.stopPropagation();
       }

--- a/site/src/hooks/useClickableTableRow.ts
+++ b/site/src/hooks/useClickableTableRow.ts
@@ -1,19 +1,29 @@
+import { type TableRowProps } from "@mui/material/TableRow";
 import { makeStyles } from "@mui/styles";
-import { useClickable, UseClickableResult } from "./useClickable";
+import { useClickable, type UseClickableResult } from "./useClickable";
 
-interface UseClickableTableRowResult extends UseClickableResult {
-  className: string;
-  hover: true;
-}
+type UseClickableTableRowResult = UseClickableResult<HTMLTableRowElement> &
+  TableRowProps & {
+    className: string;
+    hover: true;
+  };
 
-export const useClickableTableRow = (
-  onClick: () => void,
-): UseClickableTableRowResult => {
+type TableRowOnClickProps = {
+  [Key in keyof UseClickableTableRowResult as Key extends `on${string}Click`
+    ? Key
+    : never]: UseClickableTableRowResult[Key];
+};
+
+export const useClickableTableRow = ({
+  onClick,
+  ...optionalOnClickProps
+}: TableRowOnClickProps): UseClickableTableRowResult => {
   const styles = useStyles();
-  const clickable = useClickable(onClick);
+  const clickableProps = useClickable<HTMLTableRowElement>(onClick);
 
   return {
-    ...clickable,
+    ...clickableProps,
+    ...optionalOnClickProps,
     className: styles.row,
     hover: true,
   };

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
@@ -27,8 +27,9 @@ export const VersionRow: React.FC<VersionRowProps> = ({
 }) => {
   const styles = useStyles();
   const navigate = useNavigate();
-  const clickableProps = useClickableTableRow(() => {
-    navigate(version.name);
+
+  const clickableProps = useClickableTableRow({
+    onClick: () => navigate(version.name),
   });
 
   return (

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -83,10 +83,9 @@ const TemplateRow: FC<{ template: Template }> = ({ template }) => {
   const hasIcon = template.icon && template.icon !== "";
   const navigate = useNavigate();
   const styles = useStyles();
+
   const { className: clickableClassName, ...clickableRow } =
-    useClickableTableRow(() => {
-      navigate(templatePageLink);
-    });
+    useClickableTableRow({ onClick: () => navigate(templatePageLink) });
 
   return (
     <TableRow

--- a/site/src/pages/WorkspacePage/BuildRow.tsx
+++ b/site/src/pages/WorkspacePage/BuildRow.tsx
@@ -26,7 +26,7 @@ export const BuildRow: React.FC<BuildRowProps> = ({ build }) => {
   const styles = useStyles();
   const initiatedBy = getDisplayWorkspaceBuildInitiatedBy(build);
   const navigate = useNavigate();
-  const clickableProps = useClickable(() =>
+  const clickableProps = useClickable<HTMLTableRowElement>(() =>
     navigate(`builds/${build.build_number}`),
   );
 

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -250,15 +250,33 @@ const WorkspacesRow: FC<{
   checked: boolean;
 }> = ({ workspace, children, checked }) => {
   const navigate = useNavigate();
+
   const workspacePageLink = `/@${workspace.owner_name}/${workspace.name}`;
-  const clickable = useClickableTableRow(() => {
-    navigate(workspacePageLink);
+  const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
+
+  const clickableProps = useClickableTableRow({
+    onAuxClick: (event) => {
+      const userClickedMiddleButton = event.button === 1;
+      if (userClickedMiddleButton) {
+        openLinkInNewTab();
+      }
+    },
+    onClick: (event) => {
+      const shouldOpenInNewTab =
+        event.ctrlKey || event.shiftKey || event.metaKey;
+
+      if (shouldOpenInNewTab) {
+        openLinkInNewTab();
+      } else {
+        navigate(workspacePageLink);
+      }
+    },
   });
 
   return (
     <TableRow
+      {...clickableProps}
       data-testid={`workspace-${workspace.id}`}
-      {...clickable}
       sx={{
         backgroundColor: (theme) =>
           checked ? theme.palette.action.hover : undefined,

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -255,16 +255,13 @@ const WorkspacesRow: FC<{
   const openLinkInNewTab = () => window.open(workspacePageLink, "_blank");
 
   const clickableProps = useClickableTableRow({
-    onAuxClick: (event) => {
-      const isMiddleMouseButton = event.button === 1;
-      if (isMiddleMouseButton) {
-        openLinkInNewTab();
-      }
-    },
+    onMiddleClick: openLinkInNewTab,
     onClick: (event) => {
-      // Order of booleans actually matters here for Windows-Mac compatibility
+      // Order of booleans actually matters here for Windows-Mac compatibility;
+      // meta key is Cmd on Macs, but on Windows, it's either the Windows key,
+      // or the key does nothing at all (depends on the browser)
       const shouldOpenInNewTab =
-        event.ctrlKey || event.shiftKey || event.metaKey;
+        event.shiftKey || event.metaKey || event.ctrlKey;
 
       if (shouldOpenInNewTab) {
         openLinkInNewTab();

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -256,12 +256,13 @@ const WorkspacesRow: FC<{
 
   const clickableProps = useClickableTableRow({
     onAuxClick: (event) => {
-      const userClickedMiddleMouseButton = event.button === 1;
-      if (userClickedMiddleMouseButton) {
+      const isMiddleMouseButton = event.button === 1;
+      if (isMiddleMouseButton) {
         openLinkInNewTab();
       }
     },
     onClick: (event) => {
+      // Order of booleans actually matters here for Windows-Mac compatibility
       const shouldOpenInNewTab =
         event.ctrlKey || event.shiftKey || event.metaKey;
 

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -256,8 +256,8 @@ const WorkspacesRow: FC<{
 
   const clickableProps = useClickableTableRow({
     onAuxClick: (event) => {
-      const userClickedMiddleButton = event.button === 1;
-      if (userClickedMiddleButton) {
+      const userClickedMiddleMouseButton = event.button === 1;
+      if (userClickedMiddleMouseButton) {
         openLinkInNewTab();
       }
     },


### PR DESCRIPTION
Closes #9749

This seemed really easy at first – and getting the runtime logic updated was no problem – but it quickly turned into an ordeal because of all the TypeScript type parameters I had to juggle.

## Changes
- Adds middle-click + Cmd-/Ctrl-Click support to workspace rows, to make it easy to open workspace pages in new tabs
- Updates `useClickable` hook to expose a ref. This can be used in effects, but right now, the main point is to simulate a click for the element the props are attached to
- Updates `useClickableTableRow` to support `onClick`, `onDoubleClick` and `onAuxClick` callbacks (`onAuxClick` was needed for middle-clicks, so I figured I'd add support for everything)

## Out-of-scope changes for later
- Right now, the middle-click functionality isn't in place for the other components using the `useClickableTableRow` hook, but I tried to make it as  easy as possible to add that functionality later, if they need it