### PR TITLE
docs: correct community-templates.md to include the new link

### DIFF
--- a/examples/templates/community-templates.md
+++ b/examples/templates/community-templates.md
@@ -23,7 +23,7 @@ templates.
   and API examples.
 - [bpmct/coder-templates](https://github.com/bpmct/coder-templates) -
   Kubernetes, OpenStack, podman, Docker, VM, AWS, Google Cloud, Azure templates.
-- [kozmiknano/vscode-server-template](https://github.com/KozmikNano/vscode-server-template) -
+- [thewilloftheshadow/vscode-server-template](https://github.com/thewilloftheshadow/vscode-server-template) -
   Run the full VS Code server within docker! (Built-in settings sync and
   Microsoft Marketplace enabled)
 - [atnomoverflow/coder-template](https://github.com/atnomoverflow/coder-template) -


### PR DESCRIPTION
Thought it was weird that the old link stopped working, so I updated it to the first result on github search that has the same name and seems to definitely be a coder template.

The new repo: https://github.com/thewilloftheshadow/vscode-server-template