### PR TITLE
test(site): e2e: use IPv4 address for web server

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -569,7 +569,10 @@ export const createServer = async (
   port: number,
 ): Promise<ReturnType<typeof express>> => {
   const e = express();
-  await new Promise<void>((r) => e.listen(port, r));
+  // We need to specify the local IP address as the web server
+  // tends to fail with IPv6 related error:
+  // listen EADDRINUSE: address already in use :::50516
+  await new Promise<void>((r) => e.listen(port, "0.0.0.0", r));
   return e;
 };
 


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/actions/runs/6276760791/job/17047153224

This PR sets the hostname address to `0.0.0.0` while creating the web server. We noticed that `localhost` can be randomly resolved as IPv6 and there are some troubles with starting the express listener.