### PR TITLE
chore: avoid pushing `.terraform.lock.hcl` while creating the template

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -419,7 +419,6 @@ jobs:
 
           # Create template
           cd ./.github/pr-deployments/template
-          terraform init
           coder templates create -y --variable namespace=pr${{ env.PR_NUMBER }} kubernetes
 
           # Create workspace


### PR DESCRIPTION
This will allow upgrading the terraform version from the template editor.