### PR TITLE
fix(coderd/workspaceapps/apptest): bump sleep in testReconnectingPTY 

### DIFF
--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -1419,7 +1419,7 @@ func testReconnectingPTY(ctx context.Context, t *testing.T, client *codersdk.Cli
 
 	// Brief pause to reduce the likelihood that we send keystrokes while
 	// the shell is simultaneously sending a prompt.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	data, err = json.Marshal(codersdk.ReconnectingPTYRequest{
 		Data: "echo test\r\n",


### PR DESCRIPTION
There have been a number of flakes relating to ReconnectingPTY today:

https://github.com/coder/coder/actions/runs/6307298449/job/17123720595
https://github.com/coder/coder/actions/runs/6311073023/job/17134881807
https://github.com/coder/coder/actions/runs/6310493820/job/17132579563

There's a 100-millisecond sleep in `testReconnectingPTY()` to make sure that we don't try writing while there's a prompt.

Instead of sleeping, we could wait for the prompt, but that would require a `t.Setenv` to set the prompt to some known value, and removing `t.Parallel()` in a bunch of places. 

Instead opting to simply bump the sleep duration and hope this helps.

This WILL NOT un-break https://github.com/coder/coder/issues/9764 but should hopefully significantly reduce its occurrence.