### PR TITLE
fix: avoid logging env in unit tests

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -161,7 +161,6 @@ func (r *RootCmd) Command(subcommands []*clibase.Cmd) (*clibase.Cmd, error) {
 			},
 		),
 		Handler: func(i *clibase.Invocation) error {
-			// fmt.Fprintf(i.Stderr, "env debug: %+v", i.Environ)
 			// The GIT_ASKPASS environment variable must point at
 			// a binary with no arguments. To prevent writing
 			// cross-platform scripts to invoke the Coder binary

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -368,7 +368,7 @@ func TestSSH(t *testing.T) {
 		// Ensure that SSH_AUTH_SOCK is set.
 		// Linux: /tmp/auth-agent3167016167/listener.sock
 		// macOS: /var/folders/ng/m1q0wft14hj0t3rtjxrdnzsr0000gn/T/auth-agent3245553419/listener.sock
-		pty.WriteLine(`grep --perl-regexp --binary-files=text 'SSH_AUTH_SOCK=[^\x00]+' /proc/self/environ`)
+		pty.WriteLine(`echo -n SSH_AUTH_SOCK=${SSH_AUTH_SOCK}`)
 		pty.ExpectMatch("SSH_AUTH_SOCK=")
 		// Ensure that ssh-add lists our key.
 		pty.WriteLine("ssh-add -L")

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -368,7 +368,7 @@ func TestSSH(t *testing.T) {
 		// Ensure that SSH_AUTH_SOCK is set.
 		// Linux: /tmp/auth-agent3167016167/listener.sock
 		// macOS: /var/folders/ng/m1q0wft14hj0t3rtjxrdnzsr0000gn/T/auth-agent3245553419/listener.sock
-		pty.WriteLine(`echo -n SSH_AUTH_SOCK=${SSH_AUTH_SOCK}`)
+		pty.WriteLine(`env | grep SSH_AUTH_SOCK=`)
 		pty.ExpectMatch("SSH_AUTH_SOCK=")
 		// Ensure that ssh-add lists our key.
 		pty.WriteLine("ssh-add -L")

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -368,7 +368,7 @@ func TestSSH(t *testing.T) {
 		// Ensure that SSH_AUTH_SOCK is set.
 		// Linux: /tmp/auth-agent3167016167/listener.sock
 		// macOS: /var/folders/ng/m1q0wft14hj0t3rtjxrdnzsr0000gn/T/auth-agent3245553419/listener.sock
-		pty.WriteLine("env")
+		pty.WriteLine(`grep --perl-regexp --binary-files=text 'SSH_AUTH_SOCK=[^\x00]+' /proc/self/environ`)
 		pty.ExpectMatch("SSH_AUTH_SOCK=")
 		// Ensure that ssh-add lists our key.
 		pty.WriteLine("ssh-add -L")

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -54,7 +54,7 @@ func TestStart(t *testing.T) {
 				Height: 24,
 			},
 		}))
-		pty, ps := ptytest.Start(t, pty.Command("env"), opts)
+		pty, ps := ptytest.Start(t, pty.Command("grep", "--binary-files=text", `SSH_TTY=/dev/`, "/proc/self/environ"), opts)
 		pty.ExpectMatch("SSH_TTY=/dev/")
 		err := ps.Wait()
 		require.NoError(t, err)

--- a/pty/start_other_test.go
+++ b/pty/start_other_test.go
@@ -54,7 +54,7 @@ func TestStart(t *testing.T) {
 				Height: 24,
 			},
 		}))
-		pty, ps := ptytest.Start(t, pty.Command("grep", "--binary-files=text", `SSH_TTY=/dev/`, "/proc/self/environ"), opts)
+		pty, ps := ptytest.Start(t, pty.Command(`/bin/sh`, `-c`, `env | grep SSH_TTY`), opts)
 		pty.ExpectMatch("SSH_TTY=/dev/")
 		err := ps.Wait()
 		require.NoError(t, err)


### PR DESCRIPTION
Seen here: https://github.com/coder/coder/actions/runs/6317011693/job/17152855571#step:5:4736

Although Github Actions does auto-censor this sort of thing, better safe than sorry.