### PR TITLE
fix: only specify vscode proxy uri if app subdomains enabled

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -216,7 +216,9 @@ func (api *API) workspaceAgentManifest(rw http.ResponseWriter, r *http.Request) 
 		Username:      owner.Username,
 	}
 	vscodeProxyURI := api.AccessURL.Scheme + "://" + strings.ReplaceAll(api.AppHostname, "*", appHost.String())
-
+	if api.AppHostname == "" {
+		vscodeProxyURI += api.AccessURL.Hostname()
+	}
 	if api.AccessURL.Port() != "" {
 		vscodeProxyURI += fmt.Sprintf(":%s", api.AccessURL.Port())
 	}


### PR DESCRIPTION
Otherwise this generates an invalid URI that breaks code-server!
