### PR TITLE
chore: show yaml option in deployment page

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1033,6 +1033,7 @@ export interface DeploymentOption {
   readonly hidden: boolean;
   readonly group?: DeploymentGroup;
   readonly env?: string;
+  readonly yaml?: string;
 }
 
 export type DeploymentConfig = {

--- a/site/src/components/DeploySettingsLayout/OptionsTable.tsx
+++ b/site/src/components/DeploySettingsLayout/OptionsTable.tsx
@@ -75,6 +75,12 @@ const OptionsTable: FC<{
                         {option.env}
                       </OptionConfig>
                     )}
+                    {option.yaml && (
+                      <OptionConfig>
+                        <OptionConfigFlag>YAML</OptionConfigFlag>
+                        {option.yaml}
+                      </OptionConfig>
+                    )}
                   </Box>
                 </TableCell>
 


### PR DESCRIPTION
Did we intentionally omit the yaml option?

![Screenshot from 2023-09-28 14-55-59](https://github.com/coder/coder/assets/5446298/04833fba-79c8-403e-bb14-47a50ed53ff1)
