### PR TITLE
feat(cli): integrate chromedp actions into scaletest dashboard

### DIFF
--- a/scaletest/dashboard/config.go
+++ b/scaletest/dashboard/config.go
@@ -1,11 +1,12 @@
 package dashboard
 
 import (
+	"context"
 	"time"
 
-	"golang.org/x/xerrors"
-
 	"cdr.dev/slog"
+
+	"golang.org/x/xerrors"
 )
 
 type Config struct {
@@ -17,8 +18,10 @@ type Config struct {
 	Trace bool `json:"trace"`
 	// Logger is the logger to use.
 	Logger slog.Logger `json:"-"`
-	// RollTable is the set of actions to perform
-	RollTable RollTable `json:"roll_table"`
+	// Headless controls headless mode for chromedp.
+	Headless bool `json:"no_headless"`
+	// ActionFunc is a function that returns an action to run.
+	ActionFunc func(ctx context.Context) (Label, Action, error) `json:"-"`
 }
 
 func (c Config) Validate() error {
@@ -32,6 +35,10 @@ func (c Config) Validate() error {
 
 	if c.MinWait > c.MaxWait {
 		return xerrors.Errorf("validate duration_min: must be less than duration_max")
+	}
+
+	if c.ActionFunc == nil {
+		return xerrors.Errorf("validate action func: must not be nil")
 	}
 
 	return nil

--- a/scaletest/dashboard/metrics.go
+++ b/scaletest/dashboard/metrics.go
@@ -9,13 +9,11 @@ import (
 type Metrics interface {
 	ObserveDuration(action string, d time.Duration)
 	IncErrors(action string)
-	IncStatuses(action string, code string)
 }
 
 type PromMetrics struct {
 	durationSeconds *prometheus.HistogramVec
 	errors          *prometheus.CounterVec
-	statuses        *prometheus.CounterVec
 }
 
 func NewMetrics(reg prometheus.Registerer) *PromMetrics {
@@ -30,16 +28,10 @@ func NewMetrics(reg prometheus.Registerer) *PromMetrics {
 			Subsystem: "scaletest_dashboard",
 			Name:      "errors_total",
 		}, []string{"action"}),
-		statuses: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "coderd",
-			Subsystem: "scaletest_dashboard",
-			Name:      "statuses_total",
-		}, []string{"action", "code"}),
 	}
 
 	reg.MustRegister(m.durationSeconds)
 	reg.MustRegister(m.errors)
-	reg.MustRegister(m.statuses)
 	return m
 }
 
@@ -49,8 +41,4 @@ func (p *PromMetrics) ObserveDuration(action string, d time.Duration) {
 
 func (p *PromMetrics) IncErrors(action string) {
 	p.errors.WithLabelValues(action).Inc()
-}
-
-func (p *PromMetrics) IncStatuses(action string, code string) {
-	p.statuses.WithLabelValues(action, code).Inc()
 }

--- a/scaletest/dashboard/run.go
+++ b/scaletest/dashboard/run.go
@@ -2,7 +2,6 @@ package dashboard
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"math/rand"
 	"time"
@@ -35,46 +34,46 @@ func NewRunner(client *codersdk.Client, metrics Metrics, cfg Config) *Runner {
 }
 
 func (r *Runner) Run(ctx context.Context, _ string, _ io.Writer) error {
+	if r.client == nil {
+		return xerrors.Errorf("client is nil")
+	}
 	me, err := r.client.User(ctx, codersdk.Me)
 	if err != nil {
-		return err
+		return xerrors.Errorf("get scaletest user: %w", err)
 	}
+	r.cfg.Logger.Info(ctx, "running as user", slog.F("username", me.Username))
 	if len(me.OrganizationIDs) == 0 {
 		return xerrors.Errorf("user has no organizations")
 	}
 
-	c := &cache{}
-	if err := c.fill(ctx, r.client); err != nil {
-		return err
+	cdpCtx, cdpCancel, err := initChromeDPCtx(ctx, r.client.URL, r.client.SessionToken(), r.cfg.Headless)
+	if err != nil {
+		return xerrors.Errorf("init chromedp ctx: %w", err)
 	}
-
-	p := &Params{
-		client: r.client,
-		me:     me,
-		c:      c,
-	}
-	rolls := make(chan int)
-	go func() {
-		t := time.NewTicker(r.randWait())
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				rolls <- rand.Intn(r.cfg.RollTable.max() + 1) // nolint:gosec
-				t.Reset(r.randWait())
-			}
-		}
-	}()
-
+	defer cdpCancel()
+	t := time.NewTicker(1) // First one should be immediate
+	defer t.Stop()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-cdpCtx.Done():
 			return nil
-		case n := <-rolls:
-			act := r.cfg.RollTable.choose(n)
-			go r.do(ctx, act, p)
+		case <-t.C:
+			t.Reset(r.randWait())
+			l, act, err := r.cfg.ActionFunc(cdpCtx)
+			if err != nil {
+				r.cfg.Logger.Error(ctx, "calling ActionFunc", slog.Error(err))
+				continue
+			}
+			start := time.Now()
+			err = act(cdpCtx)
+			elapsed := time.Since(start)
+			r.metrics.ObserveDuration(string(l), elapsed)
+			if err != nil {
+				r.metrics.IncErrors(string(l))
+				r.cfg.Logger.Error(ctx, "action failed", slog.F("label", l), slog.Error(err))
+			} else {
+				r.cfg.Logger.Info(ctx, "action success", slog.F("label", l))
+			}
 		}
 	}
 }
@@ -83,49 +82,12 @@ func (*Runner) Cleanup(_ context.Context, _ string) error {
 	return nil
 }
 
-func (r *Runner) do(ctx context.Context, act RollTableEntry, p *Params) {
-	select {
-	case <-ctx.Done():
-		r.cfg.Logger.Info(ctx, "context done, stopping")
-		return
-	default:
-		var errored bool
-		cancelCtx, cancel := context.WithTimeout(ctx, r.cfg.MaxWait)
-		defer cancel()
-		start := time.Now()
-		err := act.Fn(cancelCtx, p)
-		cancel()
-		elapsed := time.Since(start)
-		if err != nil {
-			errored = true
-			r.cfg.Logger.Error( //nolint:gocritic
-				ctx, "action failed",
-				slog.Error(err),
-				slog.F("action", act.Label),
-				slog.F("elapsed", elapsed),
-			)
-		} else {
-			r.cfg.Logger.Info(ctx, "completed successfully",
-				slog.F("action", act.Label),
-				slog.F("elapsed", elapsed),
-			)
-		}
-		codeLabel := "200"
-		if apiErr, ok := codersdk.AsError(err); ok {
-			codeLabel = fmt.Sprintf("%d", apiErr.StatusCode())
-		} else if xerrors.Is(err, context.Canceled) {
-			codeLabel = "timeout"
-		}
-		r.metrics.ObserveDuration(act.Label, elapsed)
-		r.metrics.IncStatuses(act.Label, codeLabel)
-		if errored {
-			r.metrics.IncErrors(act.Label)
-		}
-	}
-}
-
 func (r *Runner) randWait() time.Duration {
 	// nolint:gosec // This is not for cryptographic purposes. Chill, gosec. Chill.
-	wait := time.Duration(rand.Intn(int(r.cfg.MaxWait) - int(r.cfg.MinWait)))
+	var wait time.Duration
+	if r.cfg.MaxWait > r.cfg.MinWait {
+		wait = time.Duration(rand.Intn(int(r.cfg.MaxWait) - int(r.cfg.MinWait)))
+	}
+
 	return r.cfg.MinWait + wait
 }

--- a/scaletest/dashboard/run_test.go
+++ b/scaletest/dashboard/run_test.go
@@ -2,6 +2,7 @@ package dashboard_test
 
 import (
 	"context"
+	"math/rand"
 	"runtime"
 	"sync"
 	"testing"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -19,7 +19,6 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	t.Skip("To be fixed by https://github.com/coder/coder/issues/9131")
 	if testutil.RaceEnabled() {
 		t.Skip("skipping timing-sensitive test because of race detector")
 	}
@@ -27,35 +26,34 @@ func Test_Run(t *testing.T) {
 		t.Skip("skipping test on Windows")
 	}
 
-	client := coderdtest.New(t, nil)
-	_ = coderdtest.CreateFirstUser(t, client)
-
-	successfulAction := func(context.Context, *dashboard.Params) error {
+	successAction := func(_ context.Context) error {
+		<-time.After(testutil.IntervalFast)
 		return nil
 	}
-	failingAction := func(context.Context, *dashboard.Params) error {
-		return xerrors.Errorf("failed")
-	}
-	hangingAction := func(ctx context.Context, _ *dashboard.Params) error {
-		<-ctx.Done()
-		return ctx.Err()
+
+	failAction := func(_ context.Context) error {
+		<-time.After(testutil.IntervalMedium)
+		return assert.AnError
 	}
 
-	testActions := []dashboard.RollTableEntry{
-		{0, successfulAction, "succeeds"},
-		{1, failingAction, "fails"},
-		{2, hangingAction, "hangs"},
-	}
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
 
 	log := slogtest.Make(t, &slogtest.Options{
 		IgnoreErrors: true,
 	})
 	m := &testMetrics{}
 	cfg := dashboard.Config{
-		MinWait:   time.Millisecond,
-		MaxWait:   10 * time.Millisecond,
-		Logger:    log,
-		RollTable: testActions,
+		MinWait:  100 * time.Millisecond,
+		MaxWait:  500 * time.Millisecond,
+		Logger:   log,
+		Headless: true,
+		ActionFunc: func(ctx context.Context) (dashboard.Label, dashboard.Action, error) {
+			if rand.Intn(2) == 0 { //nolint:gosec // just for testing
+				return "fails", failAction, nil
+			}
+			return "succeeds", successAction, nil
+		},
 	}
 	r := dashboard.NewRunner(client, m, cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
@@ -69,23 +67,14 @@ func Test_Run(t *testing.T) {
 	assert.True(t, ok)
 	require.NoError(t, err)
 
-	if assert.NotEmpty(t, m.ObservedDurations["succeeds"]) {
-		assert.NotZero(t, m.ObservedDurations["succeeds"][0])
+	for _, dur := range m.ObservedDurations["succeeds"] {
+		assert.NotZero(t, dur)
 	}
-
-	if assert.NotEmpty(t, m.ObservedDurations["fails"]) {
-		assert.NotZero(t, m.ObservedDurations["fails"][0])
-	}
-
-	if assert.NotEmpty(t, m.ObservedDurations["hangs"]) {
-		assert.GreaterOrEqual(t, m.ObservedDurations["hangs"][0], cfg.MaxWait.Seconds())
+	for _, dur := range m.ObservedDurations["fails"] {
+		assert.NotZero(t, dur)
 	}
 	assert.Zero(t, m.Errors["succeeds"])
 	assert.NotZero(t, m.Errors["fails"])
-	assert.NotZero(t, m.Errors["hangs"])
-	assert.NotEmpty(t, m.Statuses["succeeds"])
-	assert.NotEmpty(t, m.Statuses["fails"])
-	assert.NotEmpty(t, m.Statuses["hangs"])
 }
 
 type testMetrics struct {


### PR DESCRIPTION
This commit integrates the chromedp actions in the previous commit
into the scaletest dashboard command, and re-enables the previously
disabled unit test.

Note that this unit test does not actually run headless chrome, nor
does it test the actual scaletest actions yet, as coderdtest only
exposes an API and does not expose the actual site.

---

**Stack**:
- #9915
- #9914 ⬅
- #9913
- #9920


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*