### PR TITLE
revert: downgrade alpine to `v3.18.3`

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -1,7 +1,7 @@
 # This is the base image used for Coder images. It's a multi-arch image that is
 # built in depot.dev for all supported architectures. Since it's built on real
 # hardware and not cross-compiled, it can have "RUN" commands.
-FROM alpine:3.18.4
+FROM alpine:3.18.3
 
 # We use a single RUN command to reduce the number of layers in the image.
 # NOTE: Keep the Terraform version in sync with minTerraformVersion and


### PR DESCRIPTION
Apparently it hasn't made its way to Dockerhub yet.

This reverts commit 92c023789989f5cb21fdb19d98ad2e6aa3c532dd.