### PR TITLE
fix(site): remove duplicate input for logo url

### DIFF
--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -126,13 +126,6 @@ export const AppearanceSettingsPageView = ({
         button={!isEntitled && <Button disabled>Submit</Button>}
       >
         <TextField
-          {...logoFieldHelpers("application_name")}
-          defaultValue={appearance.application_name}
-          fullWidth
-          placeholder='Leave empty to display "Coder".'
-          disabled={!isEntitled}
-        />
-        <TextField
           {...logoFieldHelpers("logo_url")}
           defaultValue={appearance.logo_url}
           fullWidth


### PR DESCRIPTION
This PR removes the duplicate input for the Logo URL in Appearance.