### PR TITLE
test: fix flaky TestCreateValidateRichParameters/ValidateString

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -446,7 +446,9 @@ func TestCreateValidateRichParameters(t *testing.T) {
 			match := matches[i]
 			value := matches[i+1]
 			pty.ExpectMatch(match)
-			pty.WriteLine(value)
+			if value != "" {
+				pty.WriteLine(value)
+			}
 		}
 		<-doneChan
 	})
@@ -481,7 +483,6 @@ func TestCreateValidateRichParameters(t *testing.T) {
 			match := matches[i]
 			value := matches[i+1]
 			pty.ExpectMatch(match)
-
 			if value != "" {
 				pty.WriteLine(value)
 			}
@@ -519,7 +520,9 @@ func TestCreateValidateRichParameters(t *testing.T) {
 			match := matches[i]
 			value := matches[i+1]
 			pty.ExpectMatch(match)
-			pty.WriteLine(value)
+			if value != "" {
+				pty.WriteLine(value)
+			}
 		}
 		<-doneChan
 	})


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/actions/runs/6328948621/job/17188404038

```
    ptytest.go:131: 2023-09-27 16:54:38.747: cmd: "string_parameter"
    create_test.go:448: 2023-09-27 16:54:38.749: cmd: matched "string_parameter" = "string_parameter"
    create_test.go:449: 2023-09-27 16:54:38.749: cmd: stdin: "$$\r\n"
    ptytest.go:131: 2023-09-27 16:54:38.749: cmd: "> Enter a value (default: \"\"): can't validate build parameter \"string_parameter\": this is error (value \"$$\" does not match \"^[a-z]+$\")"
    create_test.go:448: 2023-09-27 16:54:38.749: cmd: matched "does not match" = "\n> Enter a value (default: \"\"): can't validate build parameter \"string_parameter\": this is error (value \"$$\" does not match"
    create_test.go:449: 2023-09-27 16:54:38.750: cmd: stdin: "\r\n"
    create_test.go:448: 2023-09-27 16:54:38.750: cmd: matched "Enter a value" = " \"^[a-z]+$\")\n> Enter a value"
    create_test.go:449: 2023-09-27 16:54:38.750: cmd: stdin: "abc\r\n"
    ptytest.go:131: 2023-09-27 16:54:38.750: cmd: "> Enter a value (default: \"\"): can't validate build parameter \"string_parameter\": this is error (value \"\" does not match \"^[a-z]+$\")"
    create_test.go:448: 2023-09-27 16:54:58.779: cmd: read error: match deadline exceeded: context deadline exceeded (wanted "Confirm create?"; got " (default: \"\"): can't validate build parameter \"string_parameter\": this is error (value \"\" does not match \"^[a-z]+$\")\n> Enter a value (default: \"\"): ")
```

An empty string (with `\r\n`) was treated as input value.