### PR TITLE
docs: add org scope to provisioner helm example

### DIFF
--- a/docs/admin/provisioners.md
+++ b/docs/admin/provisioners.md
@@ -135,6 +135,7 @@ will use in concert with the Helm chart for deploying the Coder server.
      tags:
        location: auh
        kind: k8s
+       scope: organization
    ```
 
    This example creates a deployment of 10 provisioner daemons (for 10


### PR DESCRIPTION
this PR adds the missing `scope: organization` line from the example Helm values in our provisioner documentation.