### PR TITLE
chore: change cli error message handling

### DIFF
--- a/cli/errors.go
+++ b/cli/errors.go
@@ -25,8 +25,10 @@ func (RootCmd) errorExample() *clibase.Cmd {
 	recorder := httptest.NewRecorder()
 	recorder.WriteHeader(http.StatusBadRequest)
 	resp := recorder.Result()
+	_ = resp.Body.Close()
 	resp.Request, _ = http.NewRequest(http.MethodPost, "http://example.com", nil)
 	apiError := codersdk.ReadBodyAsError(resp)
+	//nolint:errorlint
 	apiError.(*codersdk.Error).Response = codersdk.Response{
 		Message: "Top level sdk error message.",
 		Detail:  "magic dust unavailable, please try again later",
@@ -37,6 +39,7 @@ func (RootCmd) errorExample() *clibase.Cmd {
 			},
 		},
 	}
+	//nolint:errorlint
 	apiError.(*codersdk.Error).Helper = "Have you tried turning it off and on again?"
 
 	// Some flags

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"io"
+	"os"
+
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/codersdk"
+	"golang.org/x/xerrors"
+)
+
+func (r *RootCmd) errorExample() *clibase.Cmd {
+	errorCmd := func(use string, err error) *clibase.Cmd {
+		return &clibase.Cmd{
+			Use: use,
+			Handler: func(inv *clibase.Invocation) error {
+				return err
+			},
+		}
+	}
+
+	cmd := &clibase.Cmd{
+		Use:   "example-error",
+		Short: "Shows what different error messages look like",
+		Long: "This command is pretty pointless, but without it testing errors is" +
+			"difficult to visually inspect. Error message formatting is inherently" +
+			"visual, so we need a way to quickly see what they look like.",
+		Handler: func(inv *clibase.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Children: []*clibase.Cmd{
+			// Typical codersdk error
+			errorCmd("sdk", &codersdk.Error{
+				Response: codersdk.Response{
+					Message: "Top level sdk error message.",
+					Detail:  "magic dust unavailable, please try again later",
+					Validations: []codersdk.ValidationError{
+						{
+							Field:  "region",
+							Detail: "magic dust is not available in your region",
+						},
+					},
+				},
+				Helper: "Have you tried turning it off and on again?",
+			}),
+
+			// Typical cli error
+			errorCmd("cmd", xerrors.Errorf("some error: %w", errorWithStackTrace())),
+
+			// A multi-error
+			{
+				Use: "multi-error",
+				Handler: func(inv *clibase.Invocation) error {
+					// Closing the stdin file descriptor will cause the next close
+					// to fail. This is joined to the returned Command error.
+					if f, ok := inv.Stdin.(*os.File); ok {
+						_ = f.Close()
+					}
+
+					return xerrors.Errorf("some error: %w", errorWithStackTrace())
+				},
+			},
+		},
+	}
+
+	return cmd
+}
+
+type errorClose struct {
+	io.ReadCloser
+}
+
+func (e errorClose) Close() error {
+	err := e.ReadCloser.Close()
+	if err == nil {
+		return xerrors.Errorf("always close error")
+	}
+	return err
+}
+
+func errorWithStackTrace() error {
+	return xerrors.Errorf("function decided not to work, and it never will")
+}

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -28,7 +28,7 @@ func (RootCmd) errorExample() *clibase.Cmd {
 	_ = resp.Body.Close()
 	resp.Request, _ = http.NewRequest(http.MethodPost, "http://example.com", nil)
 	apiError := codersdk.ReadBodyAsError(resp)
-	//nolint:errorlint
+	//nolint:errorlint,forcetypeassert
 	apiError.(*codersdk.Error).Response = codersdk.Response{
 		Message: "Top level sdk error message.",
 		Detail:  "magic dust unavailable, please try again later",
@@ -39,7 +39,7 @@ func (RootCmd) errorExample() *clibase.Cmd {
 			},
 		},
 	}
-	//nolint:errorlint
+	//nolint:errorlint,forcetypeassert
 	apiError.(*codersdk.Error).Helper = "Have you tried turning it off and on again?"
 
 	// Some flags

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +20,8 @@ func (RootCmd) errorExample() *clibase.Cmd {
 			},
 		}
 	}
+
+	// Make an api error
 	recorder := httptest.NewRecorder()
 	recorder.WriteHeader(http.StatusBadRequest)
 	resp := recorder.Result()
@@ -35,6 +38,9 @@ func (RootCmd) errorExample() *clibase.Cmd {
 		},
 	}
 	apiError.(*codersdk.Error).Helper = "Have you tried turning it off and on again?"
+
+	// Some flags
+	var magicWord clibase.String
 
 	cmd := &clibase.Cmd{
 		Use:   "example-error",
@@ -63,6 +69,26 @@ func (RootCmd) errorExample() *clibase.Cmd {
 					}
 
 					return xerrors.Errorf("some error: %w", errorWithStackTrace())
+				},
+			},
+
+			{
+				Use: "validation",
+				Options: clibase.OptionSet{
+					clibase.Option{
+						Name:        "magic-word",
+						Description: "Take a good guess.",
+						Required:    true,
+						Flag:        "magic-word",
+						Default:     "",
+						Value: clibase.Validate(&magicWord, func(value *clibase.String) error {
+							return xerrors.Errorf("magic word is incorrect")
+						}),
+					},
+				},
+				Handler: func(i *clibase.Invocation) error {
+					_, _ = fmt.Fprint(i.Stdout, "Try setting the --magic-word flag\n")
+					return nil
 				},
 			},
 		},

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,7 +10,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func (r *RootCmd) errorExample() *clibase.Cmd {
+func (RootCmd) errorExample() *clibase.Cmd {
 	errorCmd := func(use string, err error) *clibase.Cmd {
 		return &clibase.Cmd{
 			Use: use,
@@ -70,18 +69,6 @@ func (r *RootCmd) errorExample() *clibase.Cmd {
 	}
 
 	return cmd
-}
-
-type errorClose struct {
-	io.ReadCloser
-}
-
-func (e errorClose) Close() error {
-	err := e.ReadCloser.Close()
-	if err == nil {
-		return xerrors.Errorf("always close error")
-	}
-	return err
 }
 
 func errorWithStackTrace() error {

--- a/cli/exp.go
+++ b/cli/exp.go
@@ -12,6 +12,7 @@ func (r *RootCmd) expCmd() *clibase.Cmd {
 		Hidden: true,
 		Children: []*clibase.Cmd{
 			r.scaletestCmd(),
+			r.errorExample(),
 		},
 	}
 	return cmd

--- a/cli/root.go
+++ b/cli/root.go
@@ -1032,7 +1032,7 @@ func formatMultiError(multi []error, opts *formatOpts) string {
 
 	// Write errors out
 	var str strings.Builder
-	str.WriteString(headLineStyle().Render(fmt.Sprintf("%d errors encountered:", len(multi))))
+	_, _ = str.WriteString(headLineStyle().Render(fmt.Sprintf("%d errors encountered:", len(multi))))
 	for i, errStr := range errorStrings {
 		// Indent each error
 		errStr = strings.ReplaceAll(errStr, "\n", "\n"+indent)
@@ -1048,7 +1048,7 @@ func formatMultiError(multi []error, opts *formatOpts) string {
 		// Now looks like
 		// |1.<line>
 		// |  <line>
-		str.WriteString("\n" + errStr)
+		_, _ = str.WriteString("\n" + errStr)
 	}
 	return str.String()
 }
@@ -1059,15 +1059,15 @@ func formatMultiError(multi []error, opts *formatOpts) string {
 // formatter and add it to cliHumanFormatError function.
 func formatRunCommandError(err *clibase.RunCommandError, opts *formatOpts) string {
 	var str strings.Builder
-	str.WriteString(headLineStyle().Render(fmt.Sprintf("Encountered an error running %q", err.Cmd.FullName())))
+	_, _ = str.WriteString(headLineStyle().Render(fmt.Sprintf("Encountered an error running %q", err.Cmd.FullName())))
 
 	msgString := fmt.Sprintf("%v", err.Err)
 	if opts.Verbose {
 		// '%+v' includes stack traces
 		msgString = fmt.Sprintf("%+v", err.Err)
 	}
-	str.WriteString("\n")
-	str.WriteString(tailLineStyle().Render(msgString))
+	_, _ = str.WriteString("\n")
+	_, _ = str.WriteString(tailLineStyle().Render(msgString))
 	return str.String()
 }
 
@@ -1076,19 +1076,19 @@ func formatRunCommandError(err *clibase.RunCommandError, opts *formatOpts) strin
 func formatCoderSDKError(err *codersdk.Error, opts *formatOpts) string {
 	var str strings.Builder
 	if opts.Verbose {
-		str.WriteString(headLineStyle().Render(fmt.Sprintf("API request error to \"%s:%s\". Status code %d", err.Method(), err.URL(), err.StatusCode())))
-		str.WriteString("\n")
+		_, _ = str.WriteString(headLineStyle().Render(fmt.Sprintf("API request error to \"%s:%s\". Status code %d", err.Method(), err.URL(), err.StatusCode())))
+		_, _ = str.WriteString("\n")
 	}
 
-	str.WriteString(headLineStyle().Render(err.Message))
+	_, _ = str.WriteString(headLineStyle().Render(err.Message))
 	if err.Helper != "" {
-		str.WriteString("\n")
-		str.WriteString(tailLineStyle().Render(err.Helper))
+		_, _ = str.WriteString("\n")
+		_, _ = str.WriteString(tailLineStyle().Render(err.Helper))
 	}
 	// By default we do not show the Detail with the helper.
 	if opts.Verbose || (err.Helper == "" && err.Detail != "") {
-		str.WriteString("\n")
-		str.WriteString(tailLineStyle().Render(err.Detail))
+		_, _ = str.WriteString("\n")
+		_, _ = str.WriteString(tailLineStyle().Render(err.Detail))
 	}
 	return str.String()
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -1039,7 +1039,7 @@ func formatMultiError(multi []error, opts *formatOpts) string {
 		// Error now looks like
 		// |  <line>
 		// |  <line>
-		var prefix = fmt.Sprintf("%d. ", i+1)
+		prefix := fmt.Sprintf("%d. ", i+1)
 		if len(prefix) < len(indent) {
 			// Indent the prefix to match the indent
 			prefix = prefix + strings.Repeat(" ", len(indent)-len(prefix))

--- a/cli/root.go
+++ b/cli/root.go
@@ -131,14 +131,13 @@ func (r *RootCmd) RunMain(subcommands []*clibase.Cmd) {
 	if err != nil {
 		panic(err)
 	}
-
 	err = cmd.Invoke().WithOS().Run()
 	if err != nil {
 		if errors.Is(err, cliui.Canceled) {
 			//nolint:revive
 			os.Exit(1)
 		}
-		f := prettyErrorFormatter{w: os.Stderr}
+		f := prettyErrorFormatter{w: os.Stderr, verbose: r.verbose}
 		f.format(err)
 		//nolint:revive
 		os.Exit(1)
@@ -951,58 +950,18 @@ func isConnectionError(err error) bool {
 
 type prettyErrorFormatter struct {
 	w io.Writer
+	// verbose turns on more detailed error logs, such as stack traces.
+	verbose bool
 }
 
+// format formats the error to the console. This error should be human
+// readable.
 func (p *prettyErrorFormatter) format(err error) {
-	errTail := errors.Unwrap(err)
-
-	//nolint:errorlint
-	if _, ok := err.(*clibase.RunCommandError); ok && errTail != nil {
-		// Avoid extra nesting.
-		p.format(errTail)
-		return
-	}
-
-	var headErr string
-	if errTail != nil {
-		headErr = strings.TrimSuffix(err.Error(), ": "+errTail.Error())
-	} else {
-		headErr = err.Error()
-	}
-
-	var msg string
-	var sdkError *codersdk.Error
-	if errors.As(err, &sdkError) {
-		// We don't want to repeat the same error message twice, so we
-		// only show the SDK error on the top of the stack.
-		msg = sdkError.Message
-		if sdkError.Helper != "" {
-			msg = msg + "\n" + sdkError.Helper
-		} else if sdkError.Detail != "" {
-			msg = msg + "\n" + sdkError.Detail
-		}
-		// The SDK error is usually good enough, and we don't want to overwhelm
-		// the user with output.
-		errTail = nil
-	} else {
-		msg = headErr
-	}
-
-	headStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#D16644"))
-	p.printf(
-		headStyle,
-		"%s",
-		msg,
-	)
-
-	tailStyle := headStyle.Copy().Foreground(lipgloss.Color("#969696"))
-
-	if errTail != nil {
-		p.printf(headStyle, ": ")
-		// Grey out the less important, deep errors.
-		p.printf(tailStyle, "%s", errTail.Error())
-	}
-	p.printf(tailStyle, "\n")
+	output := cliHumanFormatError(err, &formatOpts{
+		Verbose: p.verbose,
+	})
+	// always trail with a newline
+	_, _ = p.w.Write([]byte(output + "\n"))
 }
 
 func (p *prettyErrorFormatter) printf(style lipgloss.Style, format string, a ...interface{}) {
@@ -1012,6 +971,135 @@ func (p *prettyErrorFormatter) printf(style lipgloss.Style, format string, a ...
 			s,
 		),
 	)
+}
+
+type formatOpts struct {
+	Verbose bool
+}
+
+const indent = "    "
+
+// cliHumanFormatError formats an error for the CLI. Newlines and styling are
+// included.
+func cliHumanFormatError(err error, opts *formatOpts) string {
+	if opts == nil {
+		opts = &formatOpts{}
+	}
+
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		multiErrors := multi.Unwrap()
+		if len(multiErrors) == 1 {
+			// Format as a single error
+			return cliHumanFormatError(multiErrors[0], opts)
+		}
+		return formatMultiError(multiErrors, opts)
+	}
+
+	// First check for sentinel errors that we want to handle specially.
+	// Order does matter! We want to check for the most specific errors first.
+	var sdkError *codersdk.Error
+	if errors.As(err, &sdkError) {
+		return formatCoderSDKError(sdkError, opts)
+	}
+
+	var cmdErr *clibase.RunCommandError
+	if errors.As(err, &cmdErr) {
+		return formatRunCommandError(cmdErr, opts)
+	}
+
+	// Default just printing the error. Use +v for verbose to handle stack
+	// traces of xerrors.
+	if opts.Verbose {
+		return headLineStyle().Render(fmt.Sprintf("%+v", err))
+	}
+
+	return headLineStyle().Render(fmt.Sprintf("%v", err))
+}
+
+// formatMultiError formats a multi-error. It formats it as a list of errors.
+//
+//	Multiple Errors:
+//	<# errors encountered>:
+//		1. <heading error message>
+//		   <verbose error message>
+//		2. <heading error message>
+//		   <verbose error message>
+func formatMultiError(multi []error, opts *formatOpts) string {
+	var errorStrings []string
+	for _, err := range multi {
+		errorStrings = append(errorStrings, cliHumanFormatError(err, opts))
+	}
+
+	// Write errors out
+	var str strings.Builder
+	str.WriteString(headLineStyle().Render(fmt.Sprintf("%d errors encountered:", len(multi))))
+	for i, errStr := range errorStrings {
+		// Indent each error
+		errStr = strings.ReplaceAll(errStr, "\n", "\n"+indent)
+		// Error now looks like
+		// |  <line>
+		// |  <line>
+		var prefix = fmt.Sprintf("%d. ", i+1)
+		if len(prefix) < len(indent) {
+			// Indent the prefix to match the indent
+			prefix = prefix + strings.Repeat(" ", len(indent)-len(prefix))
+		}
+		errStr = prefix + errStr
+		// Now looks like
+		// |1.<line>
+		// |  <line>
+		str.WriteString("\n" + errStr)
+	}
+	return str.String()
+}
+
+// formatRunCommandError are cli command errors. This kind of error is very
+// broad, as it contains all errors that occur when running a command.
+// If you know the error is something else, like a codersdk.Error, make a new
+// formatter and add it to cliHumanFormatError function.
+func formatRunCommandError(err *clibase.RunCommandError, opts *formatOpts) string {
+	var str strings.Builder
+	str.WriteString(headLineStyle().Render(fmt.Sprintf("Encountered an error running %q", err.Cmd.FullName())))
+
+	msgString := fmt.Sprintf("%v", err.Err)
+	if opts.Verbose {
+		// '%+v' includes stack traces
+		msgString = fmt.Sprintf("%+v", err.Err)
+	}
+	str.WriteString("\n")
+	str.WriteString(tailLineStyle().Render(msgString))
+	return str.String()
+}
+
+// formatCoderSDKError come from API requests. In verbose mode, add the
+// request debug information.
+func formatCoderSDKError(err *codersdk.Error, opts *formatOpts) string {
+	var str strings.Builder
+	if opts.Verbose {
+		str.WriteString(headLineStyle().Render(fmt.Sprintf("API request error to \"%s:%s\". Status code %d", err.Method(), err.URL(), err.StatusCode())))
+		str.WriteString("\n")
+	}
+
+	str.WriteString(headLineStyle().Render(err.Message))
+	if err.Helper != "" {
+		str.WriteString("\n")
+		str.WriteString(tailLineStyle().Render(err.Helper))
+	}
+	// By default we do not show the Detail with the helper.
+	if opts.Verbose || (err.Helper == "" && err.Detail != "") {
+		str.WriteString("\n")
+		str.WriteString(tailLineStyle().Render(err.Detail))
+	}
+	return str.String()
+}
+
+// These styles are arbitrary.
+func headLineStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("#D16644"))
+}
+
+func tailLineStyle() lipgloss.Style {
+	return headLineStyle().Copy().Foreground(lipgloss.Color("#969696"))
 }
 
 //nolint:unused

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -359,6 +359,8 @@ func ReadBodyAsError(res *http.Response) error {
 		}
 		return &Error{
 			statusCode: res.StatusCode,
+			method:     requestMethod,
+			url:        requestURL,
 			Response: Response{
 				Message: fmt.Sprintf("unexpected non-JSON response %q", contentType),
 				Detail:  string(resp),
@@ -412,6 +414,14 @@ type Error struct {
 
 func (e *Error) StatusCode() int {
 	return e.statusCode
+}
+
+func (e *Error) Method() string {
+	return e.method
+}
+
+func (e *Error) URL() string {
+	return e.url
 }
 
 func (e *Error) Friendly() string {

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/charmbracelet/glamour v0.6.0
 	// In later at least v0.7.1, lipgloss changes its terminal detection
 	// which breaks most of our CLI golden files tests.
-	github.com/charmbracelet/lipgloss v0.8.0
+	github.com/charmbracelet/lipgloss v0.8.0 // indirect
 	github.com/cli/safeexec v1.0.1
 	github.com/codeclysm/extract/v3 v3.1.1
 	github.com/coder/flog v1.1.0


### PR DESCRIPTION
# What this does

This changes how we format cli error messages, and adds a hidden command to easily get these errors on the UI. I was trying to run commands with bad args to test the visuals, and it was annoying.

Basically, instead of trying to handle errors as a general construct, I just wrote a formatter for each error type we expect to encounter. If we add more sentinel errors, we can just write a custom formatter here. It is easier then trying to be "smart" and general.

I am writing these all in 1 spot rather than making some `CliError() string` method to share styles and keep it all together. I think we will modify this more as we tailor the look of things.

The biggest thing here is that verbosity is now a flag passed to the formatter.

# Closes: 

<details>
  <summary>#9492</summary>


![Screenshot from 2023-09-29 14-47-19](https://github.com/coder/coder/assets/5446298/bded6895-be56-4262-969b-e4a83610fd35)

</details>

<details>
  <summary>#9577</summary>

![Screenshot from 2023-09-29 14-50-17](https://github.com/coder/coder/assets/5446298/580ff63f-95a7-42ea-9a22-8a32bb6cc2f0)

</details>

# Error examples

## Multi-Errors

These would be very rare. Before on left, after on right.

![Screenshot from 2023-09-29 14-20-09](https://github.com/coder/coder/assets/5446298/b2ebd022-99cd-4b80-bfdf-68a1c9de6af4)

## CMD Errors

Very common. All cmd errors are wrapped as RunCommandErrors.

![Screenshot from 2023-09-29 14-25-36](https://github.com/coder/coder/assets/5446298/9817db7f-484f-479c-9ebf-eaa571de6f46)

## API Errors

![Screenshot from 2023-09-29 14-39-49](https://github.com/coder/coder/assets/5446298/084cc36a-5857-4aa2-a8ce-6f6c8f0bfe6b)


## Missing required flag

![Screenshot from 2023-09-29 15-00-22](https://github.com/coder/coder/assets/5446298/8c402301-4588-4b5f-a40b-6ea2b7a88e0e)

## Flag validation

This one sucks. The error from pflag is opaque: https://github.com/spf13/pflag/blob/master/flag.go#L478

:cry: The package is very unmaintained. Might be worth forking and adding some better errors for us.

There is some conversation on the maintenance of it, but who knows what will come of that.
https://github.com/spf13/pflag/issues/385

Issue that is related to what we want here: https://github.com/spf13/pflag/issues/269

https://github.com/spf13/pflag/pulls?q=is%3Apr+is%3Aclosed



![Screenshot from 2023-09-29 15-04-52](https://github.com/coder/coder/assets/5446298/06c5ce2c-a30f-4809-93ff-194e93df549a)

