### PR TITLE
test(site): e2e: wait for empty workspaces

### DIFF
--- a/site/e2e/global.setup.ts
+++ b/site/e2e/global.setup.ts
@@ -14,4 +14,6 @@ test("create first user", async ({ page }) => {
 
   await expect(page).toHaveURL(/\/workspaces.*/);
   await page.context().storageState({ path: STORAGE_STATE });
+
+  await page.getByTestId("button-select-template").isVisible();
 });

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -112,6 +112,7 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
                       to="/templates"
                       startIcon={<AddOutlined />}
                       variant="contained"
+                      data-testid="button-select-template"
                     >
                       Select a Template
                     </Button>


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/9956

It looks like we're missing an assertion to check if the "workspaces" endpoint is healthy. We should be able to confirm it by waiting for the "+ Select Template" button.