### PR TITLE
chore: enable exhaustruct linter for database param structs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,9 @@ linters-settings:
     include:
       # Gradually extend to cover more of the codebase.
       - 'httpmw\.\w+'
+      # We want to enforce all values are specified when inserting or updating
+      # a database row. Ref: #9936
+      - 'github.com/coder/coder/v2/coderd/database\.[^G][^e][^t]\w+Params'
   gocognit:
     min-complexity: 300
 

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -6,9 +6,10 @@ import (
 	"net/http/httptest"
 	"os"
 
+	"golang.org/x/xerrors"
+
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/codersdk"
-	"golang.org/x/xerrors"
 )
 
 func (RootCmd) errorExample() *clibase.Cmd {

--- a/coderd/apikey/apikey.go
+++ b/coderd/apikey/apikey.go
@@ -76,6 +76,7 @@ func Generate(params CreateParams) (database.InsertAPIKeyParams, string, error) 
 	return database.InsertAPIKeyParams{
 		ID:              keyID,
 		UserID:          params.UserID,
+		LastUsed:        time.Time{},
 		LifetimeSeconds: params.LifetimeSeconds,
 		IPAddress: pqtype.Inet{
 			IPNet: net.IPNet{

--- a/coderd/audit.go
+++ b/coderd/audit.go
@@ -101,14 +101,6 @@ func (api *API) generateFakeAuditLog(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgMem, err := api.Database.GetOrganizationMemberByUserID(ctx, database.GetOrganizationMemberByUserIDParams{
-		UserID: user.ID,
-	})
-	if err != nil {
-		httpapi.InternalServerError(rw, err)
-		return
-	}
-
 	diff, err := json.Marshal(codersdk.AuditDiff{
 		"foo": codersdk.AuditDiffField{Old: "bar", New: "baz"},
 	})
@@ -164,7 +156,7 @@ func (api *API) generateFakeAuditLog(rw http.ResponseWriter, r *http.Request) {
 		AdditionalFields: params.AdditionalFields,
 		RequestID:        uuid.Nil, // no request ID to attach this to
 		ResourceIcon:     "",
-		OrganizationID:   orgMem.OrganizationID,
+		OrganizationID:   uuid.New(),
 	})
 	if err != nil {
 		httpapi.InternalServerError(rw, err)

--- a/coderd/audit.go
+++ b/coderd/audit.go
@@ -101,6 +101,14 @@ func (api *API) generateFakeAuditLog(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	orgMem, err := api.Database.GetOrganizationMemberByUserID(ctx, database.GetOrganizationMemberByUserIDParams{
+		UserID: user.ID,
+	})
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
 	diff, err := json.Marshal(codersdk.AuditDiff{
 		"foo": codersdk.AuditDiffField{Old: "bar", New: "baz"},
 	})
@@ -154,9 +162,9 @@ func (api *API) generateFakeAuditLog(rw http.ResponseWriter, r *http.Request) {
 		Diff:             diff,
 		StatusCode:       http.StatusOK,
 		AdditionalFields: params.AdditionalFields,
-		OrganizationID:   uuid.Nil,
 		RequestID:        uuid.Nil, // no request ID to attach this to
 		ResourceIcon:     "",
+		OrganizationID:   orgMem.OrganizationID,
 	})
 	if err != nil {
 		httpapi.InternalServerError(rw, err)

--- a/coderd/audit.go
+++ b/coderd/audit.go
@@ -154,6 +154,9 @@ func (api *API) generateFakeAuditLog(rw http.ResponseWriter, r *http.Request) {
 		Diff:             diff,
 		StatusCode:       http.StatusOK,
 		AdditionalFields: params.AdditionalFields,
+		OrganizationID:   uuid.Nil,
+		RequestID:        uuid.Nil, // no request ID to attach this to
+		ResourceIcon:     "",
 	})
 	if err != nil {
 		httpapi.InternalServerError(rw, err)

--- a/coderd/coderdtest/oidctest/helper.go
+++ b/coderd/coderdtest/oidctest/helper.go
@@ -1,6 +1,7 @@
 package oidctest
 
 import (
+	"database/sql"
 	"net/http"
 	"testing"
 	"time"
@@ -69,11 +70,13 @@ func (*LoginHelper) ExpireOauthToken(t *testing.T, db database.Store, user *code
 
 	// Expire the oauth link for the given user.
 	updated, err := db.UpdateUserLink(ctx, database.UpdateUserLinkParams{
-		OAuthAccessToken:  link.OAuthAccessToken,
-		OAuthRefreshToken: link.OAuthRefreshToken,
-		OAuthExpiry:       time.Now().Add(time.Hour * -1),
-		UserID:            link.UserID,
-		LoginType:         link.LoginType,
+		OAuthAccessToken:       link.OAuthAccessToken,
+		OAuthAccessTokenKeyID:  sql.NullString{}, // dbcrypt will update as required
+		OAuthRefreshToken:      link.OAuthRefreshToken,
+		OAuthRefreshTokenKeyID: sql.NullString{}, // dbcrypt will update as required
+		OAuthExpiry:            time.Now().Add(time.Hour * -1),
+		UserID:                 link.UserID,
+		LoginType:              link.LoginType,
 	})
 	require.NoError(t, err, "expire user link")
 

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -4142,6 +4142,8 @@ func (q *FakeQuerier) InsertAllUsersGroup(ctx context.Context, orgID uuid.UUID) 
 		Name:           database.EveryoneGroup,
 		DisplayName:    "",
 		OrganizationID: orgID,
+		AvatarURL:      "",
+		QuotaAllowance: 0,
 	})
 }
 

--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -123,13 +123,15 @@ func (api *API) postExternalAuthDeviceByID(rw http.ResponseWriter, r *http.Reque
 		}
 
 		_, err = api.Database.InsertExternalAuthLink(ctx, database.InsertExternalAuthLinkParams{
-			ProviderID:        config.ID,
-			UserID:            apiKey.UserID,
-			CreatedAt:         dbtime.Now(),
-			UpdatedAt:         dbtime.Now(),
-			OAuthAccessToken:  token.AccessToken,
-			OAuthRefreshToken: token.RefreshToken,
-			OAuthExpiry:       token.Expiry,
+			ProviderID:             config.ID,
+			UserID:                 apiKey.UserID,
+			CreatedAt:              dbtime.Now(),
+			UpdatedAt:              dbtime.Now(),
+			OAuthAccessToken:       token.AccessToken,
+			OAuthAccessTokenKeyID:  sql.NullString{}, // dbcrypt will set as required
+			OAuthRefreshToken:      token.RefreshToken,
+			OAuthRefreshTokenKeyID: sql.NullString{}, // dbcrypt will set as required
+			OAuthExpiry:            token.Expiry,
 		})
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -140,12 +142,14 @@ func (api *API) postExternalAuthDeviceByID(rw http.ResponseWriter, r *http.Reque
 		}
 	} else {
 		_, err = api.Database.UpdateExternalAuthLink(ctx, database.UpdateExternalAuthLinkParams{
-			ProviderID:        config.ID,
-			UserID:            apiKey.UserID,
-			UpdatedAt:         dbtime.Now(),
-			OAuthAccessToken:  token.AccessToken,
-			OAuthRefreshToken: token.RefreshToken,
-			OAuthExpiry:       token.Expiry,
+			ProviderID:             config.ID,
+			UserID:                 apiKey.UserID,
+			UpdatedAt:              dbtime.Now(),
+			OAuthAccessToken:       token.AccessToken,
+			OAuthAccessTokenKeyID:  sql.NullString{}, // dbcrypt will update as required
+			OAuthRefreshToken:      token.RefreshToken,
+			OAuthRefreshTokenKeyID: sql.NullString{}, // dbcrypt will update as required
+			OAuthExpiry:            token.Expiry,
 		})
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -211,13 +215,15 @@ func (api *API) externalAuthCallback(externalAuthConfig *externalauth.Config) ht
 			}
 
 			_, err = api.Database.InsertExternalAuthLink(ctx, database.InsertExternalAuthLinkParams{
-				ProviderID:        externalAuthConfig.ID,
-				UserID:            apiKey.UserID,
-				CreatedAt:         dbtime.Now(),
-				UpdatedAt:         dbtime.Now(),
-				OAuthAccessToken:  state.Token.AccessToken,
-				OAuthRefreshToken: state.Token.RefreshToken,
-				OAuthExpiry:       state.Token.Expiry,
+				ProviderID:             externalAuthConfig.ID,
+				UserID:                 apiKey.UserID,
+				CreatedAt:              dbtime.Now(),
+				UpdatedAt:              dbtime.Now(),
+				OAuthAccessToken:       state.Token.AccessToken,
+				OAuthAccessTokenKeyID:  sql.NullString{}, // dbcrypt will set as required
+				OAuthRefreshToken:      state.Token.RefreshToken,
+				OAuthRefreshTokenKeyID: sql.NullString{}, // dbcrypt will set as required
+				OAuthExpiry:            state.Token.Expiry,
 			})
 			if err != nil {
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -228,12 +234,14 @@ func (api *API) externalAuthCallback(externalAuthConfig *externalauth.Config) ht
 			}
 		} else {
 			_, err = api.Database.UpdateExternalAuthLink(ctx, database.UpdateExternalAuthLinkParams{
-				ProviderID:        externalAuthConfig.ID,
-				UserID:            apiKey.UserID,
-				UpdatedAt:         dbtime.Now(),
-				OAuthAccessToken:  state.Token.AccessToken,
-				OAuthRefreshToken: state.Token.RefreshToken,
-				OAuthExpiry:       state.Token.Expiry,
+				ProviderID:             externalAuthConfig.ID,
+				UserID:                 apiKey.UserID,
+				UpdatedAt:              dbtime.Now(),
+				OAuthAccessToken:       state.Token.AccessToken,
+				OAuthAccessTokenKeyID:  sql.NullString{}, // dbcrypt will update as required
+				OAuthRefreshToken:      state.Token.RefreshToken,
+				OAuthRefreshTokenKeyID: sql.NullString{}, // dbcrypt will update as required
+				OAuthExpiry:            state.Token.Expiry,
 			})
 			if err != nil {
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -369,13 +369,15 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 		// If the API Key is associated with a user_link (e.g. Github/OIDC)
 		// then we want to update the relevant oauth fields.
 		if link.UserID != uuid.Nil {
-			// nolint:gocritic
+			// nolint:gocritic // system needs to update user link
 			link, err = cfg.DB.UpdateUserLink(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLinkParams{
-				UserID:            link.UserID,
-				LoginType:         link.LoginType,
-				OAuthAccessToken:  link.OAuthAccessToken,
-				OAuthRefreshToken: link.OAuthRefreshToken,
-				OAuthExpiry:       link.OAuthExpiry,
+				UserID:                 link.UserID,
+				LoginType:              link.LoginType,
+				OAuthAccessToken:       link.OAuthAccessToken,
+				OAuthAccessTokenKeyID:  sql.NullString{}, // dbcrypt will update as required
+				OAuthRefreshToken:      link.OAuthRefreshToken,
+				OAuthRefreshTokenKeyID: sql.NullString{}, // dbcrypt will update as required
+				OAuthExpiry:            link.OAuthExpiry,
 			})
 			if err != nil {
 				return write(http.StatusInternalServerError, codersdk.Response{
@@ -388,7 +390,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 		// We only want to update this occasionally to reduce DB write
 		// load. We update alongside the UserLink and APIKey since it's
 		// easier on the DB to colocate writes.
-		// nolint:gocritic
+		// nolint:gocritic // system needs to update user last seen at
 		_, err = cfg.DB.UpdateUserLastSeenAt(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLastSeenAtParams{
 			ID:         key.UserID,
 			LastSeenAt: dbtime.Now(),
@@ -405,7 +407,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 	// If the key is valid, we also fetch the user roles and status.
 	// The roles are used for RBAC authorize checks, and the status
 	// is to block 'suspended' users from accessing the platform.
-	// nolint:gocritic
+	// nolint:gocritic // system needs to update user roles
 	roles, err := cfg.DB.GetAuthorizationUserRoles(dbauthz.AsSystemRestricted(ctx), key.UserID)
 	if err != nil {
 		return write(http.StatusUnauthorized, codersdk.Response{

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -369,7 +369,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 		// If the API Key is associated with a user_link (e.g. Github/OIDC)
 		// then we want to update the relevant oauth fields.
 		if link.UserID != uuid.Nil {
-			// nolint:gocritic // system needs to update user link
+			//nolint:gocritic // system needs to update user link
 			link, err = cfg.DB.UpdateUserLink(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLinkParams{
 				UserID:                 link.UserID,
 				LoginType:              link.LoginType,
@@ -390,7 +390,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 		// We only want to update this occasionally to reduce DB write
 		// load. We update alongside the UserLink and APIKey since it's
 		// easier on the DB to colocate writes.
-		// nolint:gocritic // system needs to update user last seen at
+		//nolint:gocritic // system needs to update user last seen at
 		_, err = cfg.DB.UpdateUserLastSeenAt(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLastSeenAtParams{
 			ID:         key.UserID,
 			LastSeenAt: dbtime.Now(),
@@ -407,7 +407,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 	// If the key is valid, we also fetch the user roles and status.
 	// The roles are used for RBAC authorize checks, and the status
 	// is to block 'suspended' users from accessing the platform.
-	// nolint:gocritic // system needs to update user roles
+	//nolint:gocritic // system needs to update user roles
 	roles, err := cfg.DB.GetAuthorizationUserRoles(dbauthz.AsSystemRestricted(ctx), key.UserID)
 	if err != nil {
 		return write(http.StatusUnauthorized, codersdk.Response{

--- a/coderd/organizations.go
+++ b/coderd/organizations.go
@@ -68,10 +68,11 @@ func (api *API) postOrganizations(rw http.ResponseWriter, r *http.Request) {
 	var organization database.Organization
 	err = api.Database.InTx(func(tx database.Store) error {
 		organization, err = tx.InsertOrganization(ctx, database.InsertOrganizationParams{
-			ID:        uuid.New(),
-			Name:      req.Name,
-			CreatedAt: dbtime.Now(),
-			UpdatedAt: dbtime.Now(),
+			ID:          uuid.New(),
+			Name:        req.Name,
+			CreatedAt:   dbtime.Now(),
+			UpdatedAt:   dbtime.Now(),
+			Description: "",
 		})
 		if err != nil {
 			return xerrors.Errorf("create organization: %w", err)

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -656,11 +656,11 @@ func (s *server) UpdateJob(ctx context.Context, request *proto.UpdateJobRequest)
 	if len(request.Logs) > 0 {
 		insertParams := database.InsertProvisionerJobLogsParams{
 			JobID:     parsedID,
-			CreatedAt: []time.Time{},
-			Source:    []database.LogSource{},
-			Level:     []database.LogLevel{},
-			Stage:     []string{},
-			Output:    []string{},
+			CreatedAt: nil,
+			Source:    nil,
+			Level:     nil,
+			Stage:     nil,
+			Output:    nil,
 		}
 		for _, log := range request.Logs {
 			logLevel, err := convertLogLevel(log.Level)

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1035,7 +1035,6 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 		}
 
 		var completedError sql.NullString
-		var completedErrorCode sql.NullString
 
 		for _, externalAuthProvider := range jobType.TemplateImport.ExternalAuthProviders {
 			contains := false
@@ -1071,7 +1070,7 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 				Valid: true,
 			},
 			Error:     completedError,
-			ErrorCode: completedErrorCode,
+			ErrorCode: sql.NullString{},
 		})
 		if err != nil {
 			return nil, xerrors.Errorf("update provisioner job: %w", err)

--- a/coderd/unhanger/detector.go
+++ b/coderd/unhanger/detector.go
@@ -274,11 +274,11 @@ func unhangJob(ctx context.Context, log slog.Logger, db database.Store, pub pubs
 		// Insert the messages into the build log.
 		insertParams := database.InsertProvisionerJobLogsParams{
 			JobID:     job.ID,
-			CreatedAt: []time.Time{},
-			Source:    []database.LogSource{},
-			Level:     []database.LogLevel{},
-			Stage:     []string{},
-			Output:    []string{},
+			CreatedAt: nil,
+			Source:    nil,
+			Level:     nil,
+			Stage:     nil,
+			Output:    nil,
 		}
 		now := dbtime.Now()
 		for i, msg := range HungJobLogMessages {

--- a/coderd/unhanger/detector.go
+++ b/coderd/unhanger/detector.go
@@ -273,7 +273,12 @@ func unhangJob(ctx context.Context, log slog.Logger, db database.Store, pub pubs
 
 		// Insert the messages into the build log.
 		insertParams := database.InsertProvisionerJobLogsParams{
-			JobID: job.ID,
+			JobID:     job.ID,
+			CreatedAt: []time.Time{},
+			Source:    []database.LogSource{},
+			Level:     []database.LogLevel{},
+			Stage:     []string{},
+			Output:    []string{},
 		}
 		now := dbtime.Now()
 		for i, msg := range HungJobLogMessages {

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1327,14 +1327,16 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 		}
 
 		if link.UserID == uuid.Nil {
-			//nolint:gocritic
+			//nolint:gocritic // System needs to insert the user link (linked_id, oauth_token, oauth_expiry).
 			link, err = tx.InsertUserLink(dbauthz.AsSystemRestricted(ctx), database.InsertUserLinkParams{
-				UserID:            user.ID,
-				LoginType:         params.LoginType,
-				LinkedID:          params.LinkedID,
-				OAuthAccessToken:  params.State.Token.AccessToken,
-				OAuthRefreshToken: params.State.Token.RefreshToken,
-				OAuthExpiry:       params.State.Token.Expiry,
+				UserID:                 user.ID,
+				LoginType:              params.LoginType,
+				LinkedID:               params.LinkedID,
+				OAuthAccessToken:       params.State.Token.AccessToken,
+				OAuthAccessTokenKeyID:  sql.NullString{}, // set by dbcrypt if required
+				OAuthRefreshToken:      params.State.Token.RefreshToken,
+				OAuthRefreshTokenKeyID: sql.NullString{}, // set by dbcrypt if required
+				OAuthExpiry:            params.State.Token.Expiry,
 			})
 			if err != nil {
 				return xerrors.Errorf("insert user link: %w", err)
@@ -1342,13 +1344,15 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 		}
 
 		if link.UserID != uuid.Nil {
-			//nolint:gocritic
+			//nolint:gocritic // System needs to update the user link (linked_id, oauth_token, oauth_expiry).
 			link, err = tx.UpdateUserLink(dbauthz.AsSystemRestricted(ctx), database.UpdateUserLinkParams{
-				UserID:            user.ID,
-				LoginType:         params.LoginType,
-				OAuthAccessToken:  params.State.Token.AccessToken,
-				OAuthRefreshToken: params.State.Token.RefreshToken,
-				OAuthExpiry:       params.State.Token.Expiry,
+				UserID:                 user.ID,
+				LoginType:              params.LoginType,
+				OAuthAccessToken:       params.State.Token.AccessToken,
+				OAuthAccessTokenKeyID:  sql.NullString{}, // set by dbcrypt if required
+				OAuthRefreshToken:      params.State.Token.RefreshToken,
+				OAuthRefreshTokenKeyID: sql.NullString{}, // set by dbcrypt if required
+				OAuthExpiry:            params.State.Token.Expiry,
 			})
 			if err != nil {
 				return xerrors.Errorf("update user link: %w", err)

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1079,10 +1079,11 @@ func (api *API) CreateUser(ctx context.Context, store database.Store, req Create
 			}
 
 			organization, err := tx.InsertOrganization(ctx, database.InsertOrganizationParams{
-				ID:        uuid.New(),
-				Name:      req.Username,
-				CreatedAt: dbtime.Now(),
-				UpdatedAt: dbtime.Now(),
+				ID:          uuid.New(),
+				Name:        req.Username,
+				CreatedAt:   dbtime.Now(),
+				UpdatedAt:   dbtime.Now(),
+				Description: "",
 			})
 			if err != nil {
 				return xerrors.Errorf("create organization: %w", err)
@@ -1101,11 +1102,12 @@ func (api *API) CreateUser(ctx context.Context, store database.Store, req Create
 		}
 
 		params := database.InsertUserParams{
-			ID:        uuid.New(),
-			Email:     req.Email,
-			Username:  req.Username,
-			CreatedAt: dbtime.Now(),
-			UpdatedAt: dbtime.Now(),
+			ID:             uuid.New(),
+			Email:          req.Email,
+			Username:       req.Username,
+			CreatedAt:      dbtime.Now(),
+			UpdatedAt:      dbtime.Now(),
+			HashedPassword: []byte{},
 			// All new users are defaulted to members of the site.
 			RBACRoles: []string{},
 			LoginType: req.LoginType,

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -350,6 +351,8 @@ func (b *Builder) buildTx(authFunc func(action rbac.Action, object rbac.Objecter
 			Transition:        b.trans,
 			JobID:             provisionerJob.ID,
 			Reason:            b.reason,
+			Deadline:          time.Time{}, // set by provisioner upon completion
+			MaxDeadline:       time.Time{}, // set by provisioner upon completion
 		})
 		if err != nil {
 			return BuildError{http.StatusInternalServerError, "insert workspace build", err}

--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -425,8 +425,8 @@ func (m *Manager) Close() error {
 		Hostname:        m.self.Hostname,
 		Version:         m.self.Version,
 		Error:           m.self.Error,
-		DatabaseLatency: m.self.DatabaseLatency,
-		Primary:         m.self.Primary,
+		DatabaseLatency: 0,     // A stopped replica has no latency.
+		Primary:         false, // A stopped replica cannot be primary.
 	})
 	if err != nil {
 		return xerrors.Errorf("update replica: %w", err)

--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -420,11 +420,13 @@ func (m *Manager) Close() error {
 			Time:  dbtime.Now(),
 			Valid: true,
 		},
-		RelayAddress: m.self.RelayAddress,
-		RegionID:     m.self.RegionID,
-		Hostname:     m.self.Hostname,
-		Version:      m.self.Version,
-		Error:        m.self.Error,
+		RelayAddress:    m.self.RelayAddress,
+		RegionID:        m.self.RegionID,
+		Hostname:        m.self.Hostname,
+		Version:         m.self.Version,
+		Error:           m.self.Error,
+		DatabaseLatency: m.self.DatabaseLatency,
+		Primary:         m.self.Primary,
 	})
 	if err != nil {
 		return xerrors.Errorf("update replica: %w", err)


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/9936.

I chose to only enable this for database parameter structs that do not start with the string `Get`, as having to put in `//nolint` directives for all the times we specify `GetFooParams{}` would be exceedingly obnoxious.