### PR TITLE
fix(tailnet): lower `TrackedConn` update buffer size

### DIFF
--- a/tailnet/trackedconn.go
+++ b/tailnet/trackedconn.go
@@ -46,9 +46,9 @@ func NewTrackedConn(ctx context.Context, cancel func(),
 ) *TrackedConn {
 	// buffer updates so they don't block, since we hold the
 	// coordinator mutex while queuing.  Node updates don't
-	// come quickly, so 512 should be plenty for all but
+	// come quickly, so 64 should be plenty for all but
 	// the most pathological cases.
-	updates := make(chan []*Node, 512)
+	updates := make(chan []*Node, 64)
 	now := time.Now().Unix()
 	return &TrackedConn{
 		ctx:        ctx,


### PR DESCRIPTION
This seemed to have unintentionally high memory usage. From a customer deploy with about 224 `TrackedConns`, it accounted for ~200MB of memory and about 25% of total usage.

```
      File: coder
Type: inuse_space
Time: Oct 2, 2023 at 3:38pm (CDT)
Showing nodes accounting for 766.85MB, 100% of 766.85MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                          189.18MB 97.91% |   github.com/coder/coder/v2/enterprise/tailnet.(*haCoordinator).ServeClient /home/runner/actions-runner/_work/coder/coder/enterprise/tailnet/coordinator.go:160
                                            4.05MB  2.09% |   github.com/coder/coder/v2/enterprise/tailnet.(*haCoordinator).ServeAgent /home/runner/actions-runner/_work/coder/coder/enterprise/tailnet/coordinator.go:303
  193.22MB 25.20% 25.20%   193.22MB 25.20%                | github.com/coder/coder/v2/tailnet.NewTrackedConn /home/runner/actions-runner/_work/coder/coder/tailnet/trackedconn.go:43
----------------------------------------------------------+-------------
```