### PR TITLE
feat!: add `sections` parameter to template insights

### DIFF
--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -257,9 +257,9 @@ func (api *API) insightsTemplates(rw http.ResponseWriter, r *http.Request) {
 		endTimeString   = p.String(vals, "", "end_time")
 		intervalString  = p.String(vals, "", "interval")
 		templateIDs     = p.UUIDs(vals, []uuid.UUID{}, "template_ids")
-		sections        = codersdk.StringsAsTemplateInsightsSections(
+		sections        = stringsAsTemplateInsightsSections(
 			p.Strings(vals,
-				codersdk.TemplateInsightsSectionAsStrings(codersdk.TemplateInsightsSectionIntervalReports, codersdk.TemplateInsightsSectionReport),
+				templateInsightsSectionAsStrings(codersdk.TemplateInsightsSectionIntervalReports, codersdk.TemplateInsightsSectionReport),
 				"sections")...)
 	)
 	p.ErrorExcessParams(vals)
@@ -673,4 +673,20 @@ func lastReportIntervalHasAtLeastSixDays(startTime, endTime time.Time) bool {
 	// Ensure that the last interval has at least 6 days, or check the special case, forward DST change,
 	// when the duration can be shorter than 6 days: 5 days 23 hours.
 	return lastReportIntervalDays >= 6*24*time.Hour || startTime.AddDate(0, 0, 6).Equal(endTime)
+}
+
+func templateInsightsSectionAsStrings(sections ...codersdk.TemplateInsightsSection) []string {
+	t := make([]string, len(sections))
+	for i, s := range sections {
+		t[i] = string(s)
+	}
+	return t
+}
+
+func stringsAsTemplateInsightsSections(sections ...string) []codersdk.TemplateInsightsSection {
+	t := make([]codersdk.TemplateInsightsSection, len(sections))
+	for i, s := range sections {
+		t[i] = codersdk.TemplateInsightsSection(s)
+	}
+	return t
 }

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -381,16 +381,20 @@ func (api *API) insightsTemplates(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := codersdk.TemplateInsightsResponse{
-		Report: codersdk.TemplateInsightsReport{
+		IntervalReports: []codersdk.TemplateInsightsIntervalReport{},
+	}
+
+	if slices.Contains(sections, codersdk.TemplateInsightsSectionReport) {
+		resp.Report = &codersdk.TemplateInsightsReport{
 			StartTime:       startTime,
 			EndTime:         endTime,
 			TemplateIDs:     convertTemplateInsightsTemplateIDs(usage, appUsage),
 			ActiveUsers:     convertTemplateInsightsActiveUsers(usage, appUsage),
 			AppsUsage:       convertTemplateInsightsApps(usage, appUsage),
 			ParametersUsage: parametersUsage,
-		},
-		IntervalReports: []codersdk.TemplateInsightsIntervalReport{},
+		}
 	}
+
 	for _, row := range dailyUsage {
 		resp.IntervalReports = append(resp.IntervalReports, codersdk.TemplateInsightsIntervalReport{
 			// NOTE(mafredri): This might not be accurate over DST since the

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -1135,6 +1135,30 @@ func TestTemplateInsights_Golden(t *testing.T) {
 						}
 					},
 				},
+				{
+					name: "three weeks second template only report",
+					makeRequest: func(templates []*testTemplate) codersdk.TemplateInsightsRequest {
+						return codersdk.TemplateInsightsRequest{
+							TemplateIDs: []uuid.UUID{templates[1].id},
+							StartTime:   frozenWeekAgo.AddDate(0, 0, -14),
+							EndTime:     frozenWeekAgo.AddDate(0, 0, 7),
+							Interval:    codersdk.InsightsReportIntervalWeek,
+							Sections:    []codersdk.TemplateInsightsSection{codersdk.TemplateInsightsSectionReport},
+						}
+					},
+				},
+				{
+					name: "three weeks second template only interval reports",
+					makeRequest: func(templates []*testTemplate) codersdk.TemplateInsightsRequest {
+						return codersdk.TemplateInsightsRequest{
+							TemplateIDs: []uuid.UUID{templates[1].id},
+							StartTime:   frozenWeekAgo.AddDate(0, 0, -14),
+							EndTime:     frozenWeekAgo.AddDate(0, 0, 7),
+							Interval:    codersdk.InsightsReportIntervalWeek,
+							Sections:    []codersdk.TemplateInsightsSection{codersdk.TemplateInsightsSectionIntervalReports},
+						}
+					},
+				},
 			},
 		},
 		{

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -2073,6 +2073,14 @@ func TestTemplateInsights_BadRequest(t *testing.T) {
 		Interval:  codersdk.InsightsReportIntervalWeek,
 	})
 	assert.Error(t, err, "last report interval must have at least 6 days")
+
+	_, err = client.TemplateInsights(ctx, codersdk.TemplateInsightsRequest{
+		StartTime: today.AddDate(0, 0, -1),
+		EndTime:   today,
+		Interval:  codersdk.InsightsReportIntervalWeek,
+		Sections:  []codersdk.TemplateInsightsSection{"invalid"},
+	})
+	assert.Error(t, err, "want error for bad section")
 }
 
 func TestTemplateInsights_RBAC(t *testing.T) {

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_interval_reports.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_interval_reports.json.golden
@@ -1,0 +1,29 @@
+{
+  "interval_reports": [
+    {
+      "start_time": "2023-08-01T00:00:00Z",
+      "end_time": "2023-08-08T00:00:00Z",
+      "template_ids": [
+        "00000000-0000-0000-0000-000000000002"
+      ],
+      "interval": "week",
+      "active_users": 1
+    },
+    {
+      "start_time": "2023-08-08T00:00:00Z",
+      "end_time": "2023-08-15T00:00:00Z",
+      "template_ids": [],
+      "interval": "week",
+      "active_users": 0
+    },
+    {
+      "start_time": "2023-08-15T00:00:00Z",
+      "end_time": "2023-08-22T00:00:00Z",
+      "template_ids": [
+        "00000000-0000-0000-0000-000000000002"
+      ],
+      "interval": "week",
+      "active_users": 1
+    }
+  ]
+}

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_report.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_report.json.golden
@@ -59,6 +59,5 @@
       }
     ],
     "parameters_usage": []
-  },
-  "interval_reports": []
+  }
 }

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_report.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_report.json.golden
@@ -1,0 +1,64 @@
+{
+  "report": {
+    "start_time": "2023-08-01T00:00:00Z",
+    "end_time": "2023-08-22T00:00:00Z",
+    "template_ids": [
+      "00000000-0000-0000-0000-000000000002"
+    ],
+    "active_users": 1,
+    "apps_usage": [
+      {
+        "template_ids": [
+          "00000000-0000-0000-0000-000000000002"
+        ],
+        "type": "builtin",
+        "display_name": "Visual Studio Code",
+        "slug": "vscode",
+        "icon": "/icon/code.svg",
+        "seconds": 3600
+      },
+      {
+        "template_ids": [
+          "00000000-0000-0000-0000-000000000002"
+        ],
+        "type": "builtin",
+        "display_name": "JetBrains",
+        "slug": "jetbrains",
+        "icon": "/icon/intellij.svg",
+        "seconds": 0
+      },
+      {
+        "template_ids": [
+          "00000000-0000-0000-0000-000000000002"
+        ],
+        "type": "builtin",
+        "display_name": "Web Terminal",
+        "slug": "reconnecting-pty",
+        "icon": "/icon/terminal.svg",
+        "seconds": 7200
+      },
+      {
+        "template_ids": [
+          "00000000-0000-0000-0000-000000000002"
+        ],
+        "type": "builtin",
+        "display_name": "SSH",
+        "slug": "ssh",
+        "icon": "/icon/terminal.svg",
+        "seconds": 10800
+      },
+      {
+        "template_ids": [
+          "00000000-0000-0000-0000-000000000002"
+        ],
+        "type": "app",
+        "display_name": "app1",
+        "slug": "app1",
+        "icon": "/icon1.png",
+        "seconds": 21600
+      }
+    ],
+    "parameters_usage": []
+  },
+  "interval_reports": []
+}

--- a/coderd/testdata/insights/template/parameters_two_days_ago,_no_data.json.golden
+++ b/coderd/testdata/insights/template/parameters_two_days_ago,_no_data.json.golden
@@ -39,6 +39,5 @@
       }
     ],
     "parameters_usage": []
-  },
-  "interval_reports": []
+  }
 }

--- a/coderd/testdata/insights/template/parameters_yesterday_and_today_deployment_wide.json.golden
+++ b/coderd/testdata/insights/template/parameters_yesterday_and_today_deployment_wide.json.golden
@@ -160,6 +160,5 @@
         ]
       }
     ]
-  },
-  "interval_reports": []
+  }
 }

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -186,7 +186,7 @@ func (c *Client) UserActivityInsights(ctx context.Context, req UserActivityInsig
 // TemplateInsightsResponse is the response from the template insights endpoint.
 type TemplateInsightsResponse struct {
 	Report          *TemplateInsightsReport          `json:"report,omitempty"`
-	IntervalReports []TemplateInsightsIntervalReport `json:"interval_reports"`
+	IntervalReports []TemplateInsightsIntervalReport `json:"interval_reports,omitempty"`
 }
 
 // TemplateInsightsReport is the report from the template insights endpoint.

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -47,24 +47,6 @@ const (
 	TemplateInsightsSectionReport          TemplateInsightsSection = "report"
 )
 
-// TemplateInsightsSectionAsStrings converts section enums into a slice of strings.
-func TemplateInsightsSectionAsStrings(sections ...TemplateInsightsSection) []string {
-	t := make([]string, len(sections))
-	for i, s := range sections {
-		t[i] = string(s)
-	}
-	return t
-}
-
-// StringsAsTemplateInsightsSections converts a slice of strings into section enums.
-func StringsAsTemplateInsightsSections(sections ...string) []TemplateInsightsSection {
-	t := make([]TemplateInsightsSection, len(sections))
-	for i, s := range sections {
-		t[i] = TemplateInsightsSection(s)
-	}
-	return t
-}
-
 // UserLatencyInsightsResponse is the response from the user latency insights
 // endpoint.
 type UserLatencyInsightsResponse struct {

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -38,6 +38,33 @@ const (
 	InsightsReportIntervalWeek InsightsReportInterval = "week"
 )
 
+// TemplateInsightsSection defines the section to be included in the template insights response.
+type TemplateInsightsSection string
+
+// TemplateInsightsSection enums.
+const (
+	TemplateInsightsSectionIntervalReports TemplateInsightsSection = "interval_reports"
+	TemplateInsightsSectionReport          TemplateInsightsSection = "report"
+)
+
+// TemplateInsightsSectionAsStrings converts section enums into a slice of strings.
+func TemplateInsightsSectionAsStrings(sections ...TemplateInsightsSection) []string {
+	t := make([]string, len(sections))
+	for i, s := range sections {
+		t[i] = string(s)
+	}
+	return t
+}
+
+// StringsAsTemplateInsightsSections converts a slice of strings into section enums.
+func StringsAsTemplateInsightsSections(sections ...string) []TemplateInsightsSection {
+	t := make([]TemplateInsightsSection, len(sections))
+	for i, s := range sections {
+		t[i] = TemplateInsightsSection(s)
+	}
+	return t
+}
+
 // UserLatencyInsightsResponse is the response from the user latency insights
 // endpoint.
 type UserLatencyInsightsResponse struct {

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -185,7 +185,7 @@ func (c *Client) UserActivityInsights(ctx context.Context, req UserActivityInsig
 
 // TemplateInsightsResponse is the response from the template insights endpoint.
 type TemplateInsightsResponse struct {
-	Report          TemplateInsightsReport           `json:"report"`
+	Report          *TemplateInsightsReport          `json:"report,omitempty"`
 	IntervalReports []TemplateInsightsIntervalReport `json:"interval_reports"`
 }
 
@@ -248,10 +248,11 @@ type TemplateParameterValue struct {
 }
 
 type TemplateInsightsRequest struct {
-	StartTime   time.Time              `json:"start_time" format:"date-time"`
-	EndTime     time.Time              `json:"end_time" format:"date-time"`
-	TemplateIDs []uuid.UUID            `json:"template_ids" format:"uuid"`
-	Interval    InsightsReportInterval `json:"interval" example:"day"`
+	StartTime   time.Time                 `json:"start_time" format:"date-time"`
+	EndTime     time.Time                 `json:"end_time" format:"date-time"`
+	TemplateIDs []uuid.UUID               `json:"template_ids" format:"uuid"`
+	Interval    InsightsReportInterval    `json:"interval" example:"day"`
+	Sections    []TemplateInsightsSection `json:"sections" example:"report"`
 }
 
 func (c *Client) TemplateInsights(ctx context.Context, req TemplateInsightsRequest) (TemplateInsightsResponse, error) {
@@ -267,6 +268,13 @@ func (c *Client) TemplateInsights(ctx context.Context, req TemplateInsightsReque
 	}
 	if req.Interval != "" {
 		qp.Add("interval", string(req.Interval))
+	}
+	if len(req.Sections) > 0 {
+		var sections []string
+		for _, sec := range req.Sections {
+			sections = append(sections, string(sec))
+		}
+		qp.Add("sections", strings.Join(sections, ","))
 	}
 
 	reqURL := fmt.Sprintf("/api/v2/insights/templates?%s", qp.Encode())

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -970,7 +970,7 @@ export interface TemplateInsightsRequest {
 // From codersdk/insights.go
 export interface TemplateInsightsResponse {
   readonly report?: TemplateInsightsReport;
-  readonly interval_reports: TemplateInsightsIntervalReport[];
+  readonly interval_reports?: TemplateInsightsIntervalReport[];
 }
 
 // From codersdk/insights.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1877,6 +1877,13 @@ export const ServerSentEventTypes: ServerSentEventType[] = [
 export type TemplateAppsType = "app" | "builtin";
 export const TemplateAppsTypes: TemplateAppsType[] = ["app", "builtin"];
 
+// From codersdk/insights.go
+export type TemplateInsightsSection = "interval_reports" | "report";
+export const TemplateInsightsSections: TemplateInsightsSection[] = [
+  "interval_reports",
+  "report",
+];
+
 // From codersdk/templates.go
 export type TemplateRole = "" | "admin" | "use";
 export const TemplateRoles: TemplateRole[] = ["", "admin", "use"];

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -964,11 +964,12 @@ export interface TemplateInsightsRequest {
   readonly end_time: string;
   readonly template_ids: string[];
   readonly interval: InsightsReportInterval;
+  readonly sections: TemplateInsightsSection[];
 }
 
 // From codersdk/insights.go
 export interface TemplateInsightsResponse {
-  readonly report: TemplateInsightsReport;
+  readonly report?: TemplateInsightsReport;
   readonly interval_reports: TemplateInsightsIntervalReport[];
 }
 

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -589,12 +589,14 @@ function mapToDAUsResponse(
 ): DAUsResponse {
   return {
     tz_hour_offset: 0,
-    entries: data ? data.map((d) => {
-      return {
-        amount: d.active_users,
-        date: d.start_time,
-      };
-    }) : [],
+    entries: data
+      ? data.map((d) => {
+          return {
+            amount: d.active_users,
+            date: d.start_time,
+          };
+        })
+      : [],
   };
 }
 

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -20,6 +20,7 @@ import { getTemplatePageTitle } from "../utils";
 import { Loader } from "components/Loader/Loader";
 import {
   DAUsResponse,
+  TemplateAppUsage,
   TemplateInsightsResponse,
   TemplateParameterUsage,
   TemplateParameterValue,
@@ -105,11 +106,11 @@ export const TemplateInsightsPageView = ({
         <UserLatencyPanel data={userLatency} />
         <TemplateUsagePanel
           sx={{ gridColumn: "span 3" }}
-          data={templateInsights?.report.apps_usage}
+          data={templateInsights?.report?.apps_usage}
         />
         <TemplateParametersUsagePanel
           sx={{ gridColumn: "span 3" }}
-          data={templateInsights?.report.parameters_usage}
+          data={templateInsights?.report?.parameters_usage}
         />
       </Box>
     </>
@@ -202,7 +203,7 @@ const TemplateUsagePanel = ({
   data,
   ...panelProps
 }: PanelProps & {
-  data: TemplateInsightsResponse["report"]["apps_usage"] | undefined;
+  data: TemplateAppUsage[] | undefined;
 }) => {
   const validUsage = data?.filter((u) => u.seconds > 0);
   const totalInSeconds =
@@ -293,7 +294,7 @@ const TemplateParametersUsagePanel = ({
   data,
   ...panelProps
 }: PanelProps & {
-  data: TemplateInsightsResponse["report"]["parameters_usage"] | undefined;
+  data: TemplateParameterUsage[] | undefined;
 }) => {
   return (
     <Panel {...panelProps}>

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -589,12 +589,12 @@ function mapToDAUsResponse(
 ): DAUsResponse {
   return {
     tz_hour_offset: 0,
-    entries: data.map((d) => {
+    entries: data ? data.map((d) => {
       return {
         amount: d.active_users,
         date: d.start_time,
       };
-    }),
+    }) : [],
   };
 }
 


### PR DESCRIPTION
Related #9495 

This PR adds `sections` parameter to template insights. The idea is to shrink the endpoint response, and reduce the number of DB calls.

Changes:
* API breaking change: `report` and `interval_reports` can be omitted in `/insights/templates`
* expose `sections` HTTP parameter for `/insights/templates` (values: `report`, `interval_reports`)
* golden files for testing purposes
* FE adjustments to allow for undefined `report`