### PR TITLE
feat: warn users when renaming workspaces

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -6,7 +6,7 @@ import {
   HorizontalForm,
 } from "components/Form/Form";
 import { useFormik } from "formik";
-import { type FC, useState } from "react";
+import { type FC } from "react";
 import * as Yup from "yup";
 import {
   nameValidator,
@@ -41,10 +41,6 @@ export const WorkspaceSettingsForm: FC<{
     error,
   );
 
-  // We can't use `form.touched` unfortunately, because it only gets updated
-  // when a field loses focus, not when it gets changed.
-  const [nameModified, setNameModified] = useState(false);
-
   return (
     <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
       <FormSection title="General" description="The name of your workspace.">
@@ -52,14 +48,12 @@ export const WorkspaceSettingsForm: FC<{
           <TextField
             {...getFieldHelpers("name")}
             disabled={form.isSubmitting}
-            onChange={onChangeTrimmed(form, (value) =>
-              setNameModified(value !== form.initialValues.name),
-            )}
+            onChange={onChangeTrimmed(form)}
             autoFocus
             fullWidth
             label="Name"
           />
-          {nameModified && (
+          {form.values.name !== form.initialValues.name && (
             <Alert severity="warning">
               Depending on the template, renaming your workspace may be
               destructive

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -1,3 +1,4 @@
+import TextField from "@mui/material/TextField";
 import {
   FormFields,
   FormFooter,
@@ -5,15 +6,15 @@ import {
   HorizontalForm,
 } from "components/Form/Form";
 import { useFormik } from "formik";
-import { FC } from "react";
+import { type FC, useState } from "react";
 import * as Yup from "yup";
 import {
   nameValidator,
   getFormHelpers,
   onChangeTrimmed,
 } from "utils/formUtils";
-import TextField from "@mui/material/TextField";
 import { Workspace } from "api/typesGenerated";
+import { Alert } from "components/Alert/Alert";
 
 export type WorkspaceSettingsFormValues = {
   name: string;
@@ -40,21 +41,30 @@ export const WorkspaceSettingsForm: FC<{
     error,
   );
 
+  // We can't use `form.touched` unfortunately, because it only gets updated
+  // when a field loses focus, not when it gets changed.
+  const [nameModified, setNameModified] = useState(false);
+
   return (
     <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
-      <FormSection
-        title="General info"
-        description="The name of your new workspace."
-      >
+      <FormSection title="General" description="The name of your workspace.">
         <FormFields>
           <TextField
             {...getFieldHelpers("name")}
             disabled={form.isSubmitting}
-            onChange={onChangeTrimmed(form)}
+            onChange={onChangeTrimmed(form, (value) =>
+              setNameModified(value !== form.initialValues.name),
+            )}
             autoFocus
             fullWidth
             label="Name"
           />
+          {nameModified && (
+            <Alert severity="warning">
+              Depending on the template, renaming your workspace may be
+              destructive
+            </Alert>
+          )}
         </FormFields>
       </FormSection>
       <FormFooter onCancel={onCancel} isLoading={isSubmitting} />

--- a/site/src/utils/formUtils.ts
+++ b/site/src/utils/formUtils.ts
@@ -64,11 +64,11 @@ export const getFormHelpers =
   };
 
 export const onChangeTrimmed =
-  <T>(form: FormikContextType<T>, callback?: () => void) =>
+  <T>(form: FormikContextType<T>, callback?: (value: string) => void) =>
   (event: ChangeEvent<HTMLInputElement>): void => {
     event.target.value = event.target.value.trim();
     form.handleChange(event);
-    callback && callback();
+    callback?.(event.target.value);
   };
 
 // REMARK: Keep these consts in sync with coderd/httpapi/httpapi.go


### PR DESCRIPTION
Closes #9062 

Renaming workspaces can be destructive, depending on the configuration of the template. We should warn people about that!

<img width="647" alt="Screenshot 2023-10-03 at 12 47 00 PM" src="https://github.com/coder/coder/assets/418348/f5856eb3-6171-47be-8286-3b30c0ba79fe">
