### PR TITLE
feat: increase autostop deadline if it passes autostart

### DIFF
--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -243,9 +243,8 @@ func TestScheduleOverride(t *testing.T) {
 		require.NoError(t, err)
 		expectedDeadline := time.Now().Add(10 * time.Hour)
 
-		// Assert test invariant: workspace build has a deadline set equal to now plus ttl
-		initDeadline := time.Now().Add(time.Duration(*workspace.TTLMillis) * time.Millisecond)
-		require.WithinDuration(t, initDeadline, workspace.LatestBuild.Deadline.Time, time.Minute)
+		// Assert test invariant: workspace build has a deadline set
+		require.False(t, workspace.LatestBuild.Deadline.IsZero())
 
 		inv, root := clitest.New(t, cmdArgs...)
 		clitest.SetupConfig(t, client, root)
@@ -282,10 +281,6 @@ func TestScheduleOverride(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 		workspace, err = client.Workspace(ctx, workspace.ID)
 		require.NoError(t, err)
-
-		// Assert test invariant: workspace build has a deadline set equal to now plus ttl
-		initDeadline := time.Now().Add(time.Duration(*workspace.TTLMillis) * time.Millisecond)
-		require.WithinDuration(t, initDeadline, workspace.LatestBuild.Deadline.Time, time.Minute)
 
 		inv, root := clitest.New(t, cmdArgs...)
 		clitest.SetupConfig(t, client, root)

--- a/coderd/activitybump_internal_test.go
+++ b/coderd/activitybump_internal_test.go
@@ -32,13 +32,15 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name                string
-		transition          database.WorkspaceTransition
-		jobCompletedAt      sql.NullTime
-		buildDeadlineOffset *time.Duration
-		maxDeadlineOffset   *time.Duration
-		workspaceTTL        time.Duration
-		expectedBump        time.Duration
+		name                         string
+		transition                   database.WorkspaceTransition
+		jobCompletedAt               sql.NullTime
+		buildDeadlineOffset          *time.Duration
+		maxDeadlineOffset            *time.Duration
+		workspaceTTL                 time.Duration
+		templateDisallowUserAutostop bool // inverted
+		templateTTL                  time.Duration
+		expectedBump                 time.Duration
 	}{
 		{
 			name:                "NotFinishedYet",
@@ -69,6 +71,7 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 			jobCompletedAt:      sql.NullTime{Valid: true, Time: dbtime.Now().Add(-24 * time.Minute)},
 			buildDeadlineOffset: ptr.Ref(8*time.Hour - 24*time.Minute),
 			workspaceTTL:        8 * time.Hour,
+			templateTTL:         6 * time.Hour, // unused
 			expectedBump:        8 * time.Hour,
 		},
 		{
@@ -98,6 +101,18 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 			buildDeadlineOffset: ptr.Ref(-time.Minute),
 			workspaceTTL:        8 * time.Hour,
 			expectedBump:        0,
+		},
+		{
+			// If the template disallows user autostop, then the TTL of the
+			// template should be used.
+			name:                         "TemplateDisallowsUserAutostop",
+			transition:                   database.WorkspaceTransitionStart,
+			jobCompletedAt:               sql.NullTime{Valid: true, Time: dbtime.Now().Add(-24 * time.Minute)},
+			buildDeadlineOffset:          ptr.Ref(8*time.Hour - 24*time.Minute),
+			workspaceTTL:                 6 * time.Hour,
+			templateDisallowUserAutostop: true,
+			templateTTL:                  8 * time.Hour,
+			expectedBump:                 8 * time.Hour,
 		},
 	} {
 		tt := tt
@@ -144,6 +159,15 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 					buildID = uuid.New()
 				)
 
+				err := db.UpdateTemplateScheduleByID(ctx, database.UpdateTemplateScheduleByIDParams{
+					ID:                template.ID,
+					UpdatedAt:         dbtime.Now(),
+					AllowUserAutostop: !tt.templateDisallowUserAutostop,
+					DefaultTTL:        int64(tt.templateTTL),
+					// The other fields don't matter.
+				})
+				require.NoError(t, err)
+
 				var buildNumber int32 = 1
 				// Insert a number of previous workspace builds.
 				for i := 0; i < 5; i++ {
@@ -162,7 +186,7 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 				if tt.maxDeadlineOffset != nil {
 					maxDeadline = now.Add(*tt.maxDeadlineOffset)
 				}
-				err := db.InsertWorkspaceBuild(ctx, database.InsertWorkspaceBuildParams{
+				err = db.InsertWorkspaceBuild(ctx, database.InsertWorkspaceBuildParams{
 					ID:                buildID,
 					CreatedAt:         dbtime.Now(),
 					UpdatedAt:         dbtime.Now(),

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1915,8 +1915,8 @@ func (q *querier) GetWorkspaces(ctx context.Context, arg database.GetWorkspacesP
 	return q.db.GetAuthorizedWorkspaces(ctx, arg, prep)
 }
 
-func (q *querier) GetWorkspacesEligibleForTransition(ctx context.Context, now time.Time) ([]database.Workspace, error) {
-	return q.db.GetWorkspacesEligibleForTransition(ctx, now)
+func (q *querier) GetWorkspacesEligibleForTransition(ctx context.Context) ([]database.Workspace, error) {
+	return q.db.GetWorkspacesEligibleForTransition(ctx)
 }
 
 func (q *querier) InsertAPIKey(ctx context.Context, arg database.InsertAPIKeyParams) (database.APIKey, error) {

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -1117,9 +1117,9 @@ func (m metricsStore) GetWorkspaces(ctx context.Context, arg database.GetWorkspa
 	return workspaces, err
 }
 
-func (m metricsStore) GetWorkspacesEligibleForTransition(ctx context.Context, now time.Time) ([]database.Workspace, error) {
+func (m metricsStore) GetWorkspacesEligibleForTransition(ctx context.Context) ([]database.Workspace, error) {
 	start := time.Now()
-	workspaces, err := m.s.GetWorkspacesEligibleForTransition(ctx, now)
+	workspaces, err := m.s.GetWorkspacesEligibleForTransition(ctx)
 	m.queryLatencies.WithLabelValues("GetWorkspacesEligibleForAutoStartStop").Observe(time.Since(start).Seconds())
 	return workspaces, err
 }

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2334,18 +2334,18 @@ func (mr *MockStoreMockRecorder) GetWorkspaces(arg0, arg1 interface{}) *gomock.C
 }
 
 // GetWorkspacesEligibleForTransition mocks base method.
-func (m *MockStore) GetWorkspacesEligibleForTransition(arg0 context.Context, arg1 time.Time) ([]database.Workspace, error) {
+func (m *MockStore) GetWorkspacesEligibleForTransition(arg0 context.Context) ([]database.Workspace, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspacesEligibleForTransition", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetWorkspacesEligibleForTransition", arg0)
 	ret0, _ := ret[0].([]database.Workspace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspacesEligibleForTransition indicates an expected call of GetWorkspacesEligibleForTransition.
-func (mr *MockStoreMockRecorder) GetWorkspacesEligibleForTransition(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspacesEligibleForTransition(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspacesEligibleForTransition", reflect.TypeOf((*MockStore)(nil).GetWorkspacesEligibleForTransition), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspacesEligibleForTransition", reflect.TypeOf((*MockStore)(nil).GetWorkspacesEligibleForTransition), arg0)
 }
 
 // InTx mocks base method.

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -28,7 +28,8 @@ CREATE TYPE build_reason AS ENUM (
     'autostop',
     'autolock',
     'failedstop',
-    'autodelete'
+    'autodelete',
+    'bump'
 );
 
 CREATE TYPE display_app AS ENUM (

--- a/coderd/database/migrations/000160_workspace_build_reason_bump.down.sql
+++ b/coderd/database/migrations/000160_workspace_build_reason_bump.down.sql
@@ -1,0 +1,1 @@
+-- Cannot drop values from enum type.

--- a/coderd/database/migrations/000160_workspace_build_reason_bump.up.sql
+++ b/coderd/database/migrations/000160_workspace_build_reason_bump.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE build_reason ADD VALUE IF NOT EXISTS 'bump';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -220,6 +220,7 @@ const (
 	BuildReasonAutolock   BuildReason = "autolock"
 	BuildReasonFailedstop BuildReason = "failedstop"
 	BuildReasonAutodelete BuildReason = "autodelete"
+	BuildReasonBump       BuildReason = "bump"
 )
 
 func (e *BuildReason) Scan(src interface{}) error {
@@ -264,7 +265,8 @@ func (e BuildReason) Valid() bool {
 		BuildReasonAutostop,
 		BuildReasonAutolock,
 		BuildReasonFailedstop,
-		BuildReasonAutodelete:
+		BuildReasonAutodelete,
+		BuildReasonBump:
 		return true
 	}
 	return false
@@ -278,6 +280,7 @@ func AllBuildReasonValues() []BuildReason {
 		BuildReasonAutolock,
 		BuildReasonFailedstop,
 		BuildReasonAutodelete,
+		BuildReasonBump,
 	}
 }
 

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -28,6 +28,7 @@ type sqlcQuerier interface {
 	// as the TTL wraps. For example, if I set the TTL to 12 hours, sign off
 	// work at midnight, come back at 10am, I would want another full day
 	// of uptime.
+	// We only bump if the raw interval is positive and non-zero.
 	// We only bump if workspace shutdown is manual.
 	// We only bump when 5% of the deadline has elapsed.
 	ActivityBumpWorkspace(ctx context.Context, workspaceID uuid.UUID) error
@@ -224,7 +225,7 @@ type sqlcQuerier interface {
 	GetWorkspaceResourcesByJobIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceResource, error)
 	GetWorkspaceResourcesCreatedAfter(ctx context.Context, createdAt time.Time) ([]WorkspaceResource, error)
 	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]GetWorkspacesRow, error)
-	GetWorkspacesEligibleForTransition(ctx context.Context, now time.Time) ([]Workspace, error)
+	GetWorkspacesEligibleForTransition(ctx context.Context) ([]Workspace, error)
 	InsertAPIKey(ctx context.Context, arg InsertAPIKeyParams) (APIKey, error)
 	// We use the organization_id as the id
 	// for simplicity since all users is

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -23,12 +23,21 @@ WITH latest AS (
 		workspace_builds.max_deadline::timestamp with time zone AS build_max_deadline,
 		workspace_builds.transition AS build_transition,
 		provisioner_jobs.completed_at::timestamp with time zone AS job_completed_at,
-		(workspaces.ttl / 1000 / 1000 / 1000 || ' seconds')::interval AS ttl_interval
+		(
+			CASE
+				WHEN templates.allow_user_autostop
+				THEN workspaces.ttl
+				ELSE templates.default_ttl
+			END
+		) AS raw_ttl_interval,
+		(raw_ttl_interval / 1000 / 1000 / 1000 || ' seconds')::interval AS ttl_interval
 	FROM workspace_builds
 	JOIN provisioner_jobs
 		ON provisioner_jobs.id = workspace_builds.job_id
 	JOIN workspaces
 		ON workspaces.id = workspace_builds.workspace_id
+	JOIN templates
+		ON templates.id = workspaces.template_id
 	WHERE workspace_builds.workspace_id = $1::uuid
 	ORDER BY workspace_builds.build_number DESC
 	LIMIT 1
@@ -46,6 +55,7 @@ FROM latest l
 WHERE wb.id = l.build_id
 AND l.job_completed_at IS NOT NULL
 AND l.build_transition = 'start'
+AND l.raw_ttl_interval > 0
 AND l.build_deadline != '0001-01-01 00:00:00+00'
 AND l.build_deadline - (l.ttl_interval * 0.95) < NOW()
 `
@@ -54,6 +64,7 @@ AND l.build_deadline - (l.ttl_interval * 0.95) < NOW()
 // as the TTL wraps. For example, if I set the TTL to 12 hours, sign off
 // work at midnight, come back at 10am, I would want another full day
 // of uptime.
+// We only bump if the raw interval is positive and non-zero.
 // We only bump if workspace shutdown is manual.
 // We only bump when 5% of the deadline has elapsed.
 func (q *sqlQuerier) ActivityBumpWorkspace(ctx context.Context, workspaceID uuid.UUID) error {
@@ -9554,6 +9565,119 @@ func (q *sqlQuerier) InsertWorkspaceResourceMetadata(ctx context.Context, arg In
 	return items, nil
 }
 
+const getWorkspaceAgentScriptsByAgentIDs = `-- name: GetWorkspaceAgentScriptsByAgentIDs :many
+SELECT workspace_agent_id, log_source_id, log_path, created_at, script, cron, start_blocks_login, run_on_start, run_on_stop, timeout_seconds FROM workspace_agent_scripts WHERE workspace_agent_id = ANY($1 :: uuid [ ])
+`
+
+func (q *sqlQuerier) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAgentScript, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentScriptsByAgentIDs, pq.Array(ids))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []WorkspaceAgentScript
+	for rows.Next() {
+		var i WorkspaceAgentScript
+		if err := rows.Scan(
+			&i.WorkspaceAgentID,
+			&i.LogSourceID,
+			&i.LogPath,
+			&i.CreatedAt,
+			&i.Script,
+			&i.Cron,
+			&i.StartBlocksLogin,
+			&i.RunOnStart,
+			&i.RunOnStop,
+			&i.TimeoutSeconds,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const insertWorkspaceAgentScripts = `-- name: InsertWorkspaceAgentScripts :many
+INSERT INTO
+	workspace_agent_scripts (workspace_agent_id, created_at, log_source_id, log_path, script, cron, start_blocks_login, run_on_start, run_on_stop, timeout_seconds)
+SELECT
+	$1 :: uuid AS workspace_agent_id,
+	$2 :: timestamptz AS created_at,
+	unnest($3 :: uuid [ ]) AS log_source_id,
+	unnest($4 :: text [ ]) AS log_path,
+	unnest($5 :: text [ ]) AS script,
+	unnest($6 :: text [ ]) AS cron,
+	unnest($7 :: boolean [ ]) AS start_blocks_login,
+	unnest($8 :: boolean [ ]) AS run_on_start,
+	unnest($9 :: boolean [ ]) AS run_on_stop,
+	unnest($10 :: integer [ ]) AS timeout_seconds
+RETURNING workspace_agent_scripts.workspace_agent_id, workspace_agent_scripts.log_source_id, workspace_agent_scripts.log_path, workspace_agent_scripts.created_at, workspace_agent_scripts.script, workspace_agent_scripts.cron, workspace_agent_scripts.start_blocks_login, workspace_agent_scripts.run_on_start, workspace_agent_scripts.run_on_stop, workspace_agent_scripts.timeout_seconds
+`
+
+type InsertWorkspaceAgentScriptsParams struct {
+	WorkspaceAgentID uuid.UUID   `db:"workspace_agent_id" json:"workspace_agent_id"`
+	CreatedAt        time.Time   `db:"created_at" json:"created_at"`
+	LogSourceID      []uuid.UUID `db:"log_source_id" json:"log_source_id"`
+	LogPath          []string    `db:"log_path" json:"log_path"`
+	Script           []string    `db:"script" json:"script"`
+	Cron             []string    `db:"cron" json:"cron"`
+	StartBlocksLogin []bool      `db:"start_blocks_login" json:"start_blocks_login"`
+	RunOnStart       []bool      `db:"run_on_start" json:"run_on_start"`
+	RunOnStop        []bool      `db:"run_on_stop" json:"run_on_stop"`
+	TimeoutSeconds   []int32     `db:"timeout_seconds" json:"timeout_seconds"`
+}
+
+func (q *sqlQuerier) InsertWorkspaceAgentScripts(ctx context.Context, arg InsertWorkspaceAgentScriptsParams) ([]WorkspaceAgentScript, error) {
+	rows, err := q.db.QueryContext(ctx, insertWorkspaceAgentScripts,
+		arg.WorkspaceAgentID,
+		arg.CreatedAt,
+		pq.Array(arg.LogSourceID),
+		pq.Array(arg.LogPath),
+		pq.Array(arg.Script),
+		pq.Array(arg.Cron),
+		pq.Array(arg.StartBlocksLogin),
+		pq.Array(arg.RunOnStart),
+		pq.Array(arg.RunOnStop),
+		pq.Array(arg.TimeoutSeconds),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []WorkspaceAgentScript
+	for rows.Next() {
+		var i WorkspaceAgentScript
+		if err := rows.Scan(
+			&i.WorkspaceAgentID,
+			&i.LogSourceID,
+			&i.LogPath,
+			&i.CreatedAt,
+			&i.Script,
+			&i.Cron,
+			&i.StartBlocksLogin,
+			&i.RunOnStart,
+			&i.RunOnStop,
+			&i.TimeoutSeconds,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getDeploymentWorkspaceStats = `-- name: GetDeploymentWorkspaceStats :one
 WITH workspaces_with_jobs AS (
 	SELECT
@@ -10157,14 +10281,16 @@ WHERE
 
 	(
 		-- If the workspace build was a start transition, the workspace is
-		-- potentially eligible for autostop if it's past the deadline. The
-		-- deadline is computed at build time upon success and is bumped based
-		-- on activity (up the max deadline if set). We don't need to check
-		-- license here since that's done when the values are written to the build.
+		-- potentially eligible for:
+		-- - an autostop if it's past the deadline
+		-- - a deadline bump if it's currently running and has a deadline
+		-- The deadline is computed at build time upon success and is bumped
+		-- based on activity (up the max deadline if set). We don't need to
+		-- check license here since that's done when the values are written to
+		-- the build.
 		(
 			workspace_builds.transition = 'start'::workspace_transition AND
-			workspace_builds.deadline IS NOT NULL AND
-			workspace_builds.deadline < $1 :: timestamptz
+			workspace_builds.deadline IS NOT NULL
 		) OR
 
 		-- If the workspace build was a stop transition, the workspace is
@@ -10200,8 +10326,8 @@ WHERE
 	) AND workspaces.deleted = 'false'
 `
 
-func (q *sqlQuerier) GetWorkspacesEligibleForTransition(ctx context.Context, now time.Time) ([]Workspace, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspacesEligibleForTransition, now)
+func (q *sqlQuerier) GetWorkspacesEligibleForTransition(ctx context.Context) ([]Workspace, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspacesEligibleForTransition)
 	if err != nil {
 		return nil, err
 	}
@@ -10501,117 +10627,4 @@ type UpdateWorkspacesDormantDeletingAtByTemplateIDParams struct {
 func (q *sqlQuerier) UpdateWorkspacesDormantDeletingAtByTemplateID(ctx context.Context, arg UpdateWorkspacesDormantDeletingAtByTemplateIDParams) error {
 	_, err := q.db.ExecContext(ctx, updateWorkspacesDormantDeletingAtByTemplateID, arg.TimeTilDormantAutodeleteMs, arg.DormantAt, arg.TemplateID)
 	return err
-}
-
-const getWorkspaceAgentScriptsByAgentIDs = `-- name: GetWorkspaceAgentScriptsByAgentIDs :many
-SELECT workspace_agent_id, log_source_id, log_path, created_at, script, cron, start_blocks_login, run_on_start, run_on_stop, timeout_seconds FROM workspace_agent_scripts WHERE workspace_agent_id = ANY($1 :: uuid [ ])
-`
-
-func (q *sqlQuerier) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]WorkspaceAgentScript, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspaceAgentScriptsByAgentIDs, pq.Array(ids))
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []WorkspaceAgentScript
-	for rows.Next() {
-		var i WorkspaceAgentScript
-		if err := rows.Scan(
-			&i.WorkspaceAgentID,
-			&i.LogSourceID,
-			&i.LogPath,
-			&i.CreatedAt,
-			&i.Script,
-			&i.Cron,
-			&i.StartBlocksLogin,
-			&i.RunOnStart,
-			&i.RunOnStop,
-			&i.TimeoutSeconds,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const insertWorkspaceAgentScripts = `-- name: InsertWorkspaceAgentScripts :many
-INSERT INTO
-	workspace_agent_scripts (workspace_agent_id, created_at, log_source_id, log_path, script, cron, start_blocks_login, run_on_start, run_on_stop, timeout_seconds)
-SELECT
-	$1 :: uuid AS workspace_agent_id,
-	$2 :: timestamptz AS created_at,
-	unnest($3 :: uuid [ ]) AS log_source_id,
-	unnest($4 :: text [ ]) AS log_path,
-	unnest($5 :: text [ ]) AS script,
-	unnest($6 :: text [ ]) AS cron,
-	unnest($7 :: boolean [ ]) AS start_blocks_login,
-	unnest($8 :: boolean [ ]) AS run_on_start,
-	unnest($9 :: boolean [ ]) AS run_on_stop,
-	unnest($10 :: integer [ ]) AS timeout_seconds
-RETURNING workspace_agent_scripts.workspace_agent_id, workspace_agent_scripts.log_source_id, workspace_agent_scripts.log_path, workspace_agent_scripts.created_at, workspace_agent_scripts.script, workspace_agent_scripts.cron, workspace_agent_scripts.start_blocks_login, workspace_agent_scripts.run_on_start, workspace_agent_scripts.run_on_stop, workspace_agent_scripts.timeout_seconds
-`
-
-type InsertWorkspaceAgentScriptsParams struct {
-	WorkspaceAgentID uuid.UUID   `db:"workspace_agent_id" json:"workspace_agent_id"`
-	CreatedAt        time.Time   `db:"created_at" json:"created_at"`
-	LogSourceID      []uuid.UUID `db:"log_source_id" json:"log_source_id"`
-	LogPath          []string    `db:"log_path" json:"log_path"`
-	Script           []string    `db:"script" json:"script"`
-	Cron             []string    `db:"cron" json:"cron"`
-	StartBlocksLogin []bool      `db:"start_blocks_login" json:"start_blocks_login"`
-	RunOnStart       []bool      `db:"run_on_start" json:"run_on_start"`
-	RunOnStop        []bool      `db:"run_on_stop" json:"run_on_stop"`
-	TimeoutSeconds   []int32     `db:"timeout_seconds" json:"timeout_seconds"`
-}
-
-func (q *sqlQuerier) InsertWorkspaceAgentScripts(ctx context.Context, arg InsertWorkspaceAgentScriptsParams) ([]WorkspaceAgentScript, error) {
-	rows, err := q.db.QueryContext(ctx, insertWorkspaceAgentScripts,
-		arg.WorkspaceAgentID,
-		arg.CreatedAt,
-		pq.Array(arg.LogSourceID),
-		pq.Array(arg.LogPath),
-		pq.Array(arg.Script),
-		pq.Array(arg.Cron),
-		pq.Array(arg.StartBlocksLogin),
-		pq.Array(arg.RunOnStart),
-		pq.Array(arg.RunOnStop),
-		pq.Array(arg.TimeoutSeconds),
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []WorkspaceAgentScript
-	for rows.Next() {
-		var i WorkspaceAgentScript
-		if err := rows.Scan(
-			&i.WorkspaceAgentID,
-			&i.LogSourceID,
-			&i.LogPath,
-			&i.CreatedAt,
-			&i.Script,
-			&i.Cron,
-			&i.StartBlocksLogin,
-			&i.RunOnStart,
-			&i.RunOnStop,
-			&i.TimeoutSeconds,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }

--- a/coderd/database/queries/activitybump.sql
+++ b/coderd/database/queries/activitybump.sql
@@ -10,12 +10,21 @@ WITH latest AS (
 		workspace_builds.max_deadline::timestamp with time zone AS build_max_deadline,
 		workspace_builds.transition AS build_transition,
 		provisioner_jobs.completed_at::timestamp with time zone AS job_completed_at,
-		(workspaces.ttl / 1000 / 1000 / 1000 || ' seconds')::interval AS ttl_interval
+		(
+			CASE
+				WHEN templates.allow_user_autostop
+				THEN workspaces.ttl
+				ELSE templates.default_ttl
+			END
+		) AS raw_ttl_interval,
+		(raw_ttl_interval / 1000 / 1000 / 1000 || ' seconds')::interval AS ttl_interval
 	FROM workspace_builds
 	JOIN provisioner_jobs
 		ON provisioner_jobs.id = workspace_builds.job_id
 	JOIN workspaces
 		ON workspaces.id = workspace_builds.workspace_id
+	JOIN templates
+		ON templates.id = workspaces.template_id
 	WHERE workspace_builds.workspace_id = @workspace_id::uuid
 	ORDER BY workspace_builds.build_number DESC
 	LIMIT 1
@@ -33,6 +42,8 @@ FROM latest l
 WHERE wb.id = l.build_id
 AND l.job_completed_at IS NOT NULL
 AND l.build_transition = 'start'
+-- We only bump if the raw interval is positive and non-zero.
+AND l.raw_ttl_interval > 0
 -- We only bump if workspace shutdown is manual.
 AND l.build_deadline != '0001-01-01 00:00:00+00'
 -- We only bump when 5% of the deadline has elapsed.

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -451,14 +451,16 @@ WHERE
 
 	(
 		-- If the workspace build was a start transition, the workspace is
-		-- potentially eligible for autostop if it's past the deadline. The
-		-- deadline is computed at build time upon success and is bumped based
-		-- on activity (up the max deadline if set). We don't need to check
-		-- license here since that's done when the values are written to the build.
+		-- potentially eligible for:
+		-- - an autostop if it's past the deadline
+		-- - a deadline bump if it's currently running and has a deadline
+		-- The deadline is computed at build time upon success and is bumped
+		-- based on activity (up the max deadline if set). We don't need to
+		-- check license here since that's done when the values are written to
+		-- the build.
 		(
 			workspace_builds.transition = 'start'::workspace_transition AND
-			workspace_builds.deadline IS NOT NULL AND
-			workspace_builds.deadline < @now :: timestamptz
+			workspace_builds.deadline IS NOT NULL
 		) OR
 
 		-- If the workspace build was a stop transition, the workspace is

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/schedule"
+	"github.com/coder/coder/v2/coderd/schedule/autostop"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
@@ -1106,7 +1107,7 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 				return getWorkspaceError
 			}
 
-			autoStop, err := schedule.CalculateAutostop(ctx, schedule.CalculateAutostopParams{
+			autoStop, err := autostop.CalculateAutostop(ctx, autostop.CalculateAutostopParams{
 				Database:                    db,
 				TemplateScheduleStore:       *s.TemplateScheduleStore.Load(),
 				UserQuietHoursScheduleStore: *s.UserQuietHoursScheduleStore.Load(),

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1234,8 +1234,8 @@ func TestCompleteJob(t *testing.T) {
 		now := time.Now()
 
 		// NOTE: if you're looking for more in-depth deadline/max_deadline
-		// calculation testing, see the schedule package. The provsiionerdserver
-		// package calls `schedule.CalculateAutostop()` to generate the deadline
+		// calculation testing, see the schedule package. The provisionerdserver
+		// package calls `autostop.CalculateAutostop()` to generate the deadline
 		// and max_deadline.
 
 		// Wednesday the 8th of February 2023 at midnight. This date was

--- a/coderd/schedule/template.go
+++ b/coderd/schedule/template.go
@@ -187,10 +187,14 @@ func (*agplTemplateScheduleStore) Set(ctx context.Context, db database.Store, tp
 			AutostopRequirementDaysOfWeek: tpl.AutostopRequirementDaysOfWeek,
 			AutostopRequirementWeeks:      tpl.AutostopRequirementWeeks,
 			AllowUserAutostart:            tpl.AllowUserAutostart,
-			AllowUserAutostop:             tpl.AllowUserAutostop,
-			FailureTTL:                    tpl.FailureTTL,
-			TimeTilDormant:                tpl.TimeTilDormant,
-			TimeTilDormantAutoDelete:      tpl.TimeTilDormantAutoDelete,
+			// This value always gets set back to true because it's used in the
+			// ActivityBumpWorkspace query. If we didn't set this back to true
+			// then the template could be permanently stuck in the false state
+			// and activity bumps would evaluate as such.
+			AllowUserAutostop:        true,
+			FailureTTL:               tpl.FailureTTL,
+			TimeTilDormant:           tpl.TimeTilDormant,
+			TimeTilDormantAutoDelete: tpl.TimeTilDormantAutoDelete,
 		})
 		if err != nil {
 			return xerrors.Errorf("update template schedule: %w", err)

--- a/coderd/schedule/workspace.go
+++ b/coderd/schedule/workspace.go
@@ -1,0 +1,77 @@
+package schedule
+
+import (
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/schedule/cron"
+)
+
+// GetWorkspaceAutostartSchedule will return the workspace's autostart schedule
+// if it is eligible for autostart. If the workspace is not eligible for
+// autostart it will return nil.
+func GetWorkspaceAutostartSchedule(templateSchedule TemplateScheduleOptions, workspace database.Workspace) (*cron.Schedule, error) {
+	if !templateSchedule.UserAutostartEnabled || !workspace.AutostartSchedule.Valid || workspace.AutostartSchedule.String == "" {
+		return nil, nil
+	}
+
+	sched, err := cron.Weekly(workspace.AutostartSchedule.String)
+	if err != nil {
+		return nil, xerrors.Errorf("parse workspace autostart schedule %q: %w", workspace.AutostartSchedule.String, err)
+	}
+
+	return sched, nil
+}
+
+// WorkspaceTTL returns the workspace's TTL or the template's default TTL if the
+// template forbids the user from setting their own TTL.
+func WorkspaceTTL(templateSchedule TemplateScheduleOptions, ws database.Workspace) time.Duration {
+	var ttl time.Duration
+	if ws.Ttl.Valid && ws.Ttl.Int64 > 0 {
+		ttl = time.Duration(ws.Ttl.Int64)
+	}
+	if !templateSchedule.UserAutostopEnabled {
+		ttl = 0
+		if templateSchedule.DefaultTTL > 0 {
+			ttl = templateSchedule.DefaultTTL
+		}
+	}
+	return ttl
+}
+
+// MaybeBumpDeadline may bump the deadline of the workspace if the deadline
+// exceeds the next autostart time. The returned time if non-zero if it should
+// be used as the new deadline.
+//
+// The MaxDeadline is not taken into account.
+func MaybeBumpDeadline(autostartSchedule *cron.Schedule, deadline time.Time, ttl time.Duration) time.Time {
+	// Calculate the next autostart after (build.deadline - ttl). If this value
+	// is before the current deadline + 1h, we should bump the deadline.
+	autostartTime := autostartSchedule.Next(deadline.Add(-ttl))
+	if !autostartTime.Before(deadline.Add(time.Hour)) {
+		return time.Time{}
+	}
+
+	// Calculate the expected new deadline.
+	newDeadline := autostartTime.Add(ttl)
+
+	// Calculate the next autostart time after the one we just calculated. If
+	// it's before the new deadline, we should not bump the deadline.
+	//
+	// If we didn't have this check, we could end up in a situation where we
+	// would be bumping the deadline every day and keeping it alive permanently.
+	// E.g. ttl is 1 week but the autostart is daily. We would bump the deadline
+	// by 1 week every day, keeping the workspace alive forever.
+	//
+	// This essentially means we do nothing* if the TTL is longer than a day.
+	// *Depends on what days the autostart schedule is set to and the TTL
+	// duration
+	nextAutostartTime := autostartSchedule.Next(autostartTime)
+	if nextAutostartTime.Before(newDeadline) {
+		return time.Time{}
+	}
+
+	return newDeadline
+}

--- a/coderd/schedule/workspace_test.go
+++ b/coderd/schedule/workspace_test.go
@@ -1,0 +1,212 @@
+package schedule_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/schedule"
+	"github.com/coder/coder/v2/coderd/schedule/cron"
+)
+
+func TestGetWorkspaceAutostartSchedule(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                string
+		autostartEnabled    bool
+		autostartSchedule   string
+		expectedNotNil      bool
+		expectedErrContains string
+	}{
+		{
+			name:                "autostart disabled",
+			autostartEnabled:    false,
+			autostartSchedule:   "CRON_TZ=UTC 0 0 * * *",
+			expectedNotNil:      false,
+			expectedErrContains: "",
+		},
+		{
+			name:                "autostart enabled, no schedule",
+			autostartEnabled:    true,
+			autostartSchedule:   "",
+			expectedNotNil:      false,
+			expectedErrContains: "",
+		},
+		{
+			name:                "autostart enabled, invalid schedule",
+			autostartEnabled:    true,
+			autostartSchedule:   "dean was here",
+			expectedNotNil:      false,
+			expectedErrContains: "parse workspace autostart schedule",
+		},
+		{
+			name:                "autostart enabled, OK schedule",
+			autostartEnabled:    true,
+			autostartSchedule:   "CRON_TZ=UTC 0 0 * * *",
+			expectedNotNil:      true,
+			expectedErrContains: "",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			sched, err := schedule.GetWorkspaceAutostartSchedule(schedule.TemplateScheduleOptions{
+				UserAutostartEnabled: c.autostartEnabled,
+			}, database.Workspace{
+				AutostartSchedule: sql.NullString{
+					String: c.autostartSchedule,
+					Valid:  true,
+				},
+			})
+
+			if c.expectedErrContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.expectedErrContains)
+				return
+			}
+			require.NoError(t, err)
+			if c.expectedNotNil {
+				require.NotNil(t, sched)
+			} else {
+				require.Nil(t, sched)
+			}
+		})
+	}
+}
+
+func TestWorkspaceTTL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                string
+		wsTTL               time.Duration
+		userAutostopEnabled bool
+		templateDefaultTTL  time.Duration
+		expected            time.Duration
+	}{
+		{
+			name:                "Workspace",
+			wsTTL:               time.Hour,
+			userAutostopEnabled: true,
+			templateDefaultTTL:  time.Hour * 2,
+			expected:            time.Hour,
+		},
+		{
+			name:                "WorkspaceZero",
+			wsTTL:               0,
+			userAutostopEnabled: true,
+			templateDefaultTTL:  time.Hour * 2,
+			expected:            0,
+		},
+		{
+			name:                "Template",
+			wsTTL:               time.Hour,
+			userAutostopEnabled: false,
+			templateDefaultTTL:  time.Hour * 2,
+			expected:            time.Hour * 2,
+		},
+		{
+			name:                "TemplateZero",
+			wsTTL:               time.Hour,
+			userAutostopEnabled: false,
+			templateDefaultTTL:  0,
+			expected:            0,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := schedule.WorkspaceTTL(schedule.TemplateScheduleOptions{
+				UserAutostopEnabled: c.userAutostopEnabled,
+				DefaultTTL:          c.templateDefaultTTL,
+			}, database.Workspace{
+				Ttl: sql.NullInt64{
+					Int64: int64(c.wsTTL),
+					Valid: true,
+				},
+			})
+			require.Equal(t, c.expected, got)
+		})
+	}
+}
+
+func TestMaybeBumpDeadline(t *testing.T) {
+	t.Parallel()
+
+	midnight := time.Date(2023, 10, 4, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name              string
+		autostartSchedule string
+		deadline          time.Time
+		ttl               time.Duration
+		expected          time.Time
+	}{
+		{
+			name:              "not eligible",
+			autostartSchedule: "CRON_TZ=UTC 0 0 * * *",
+			deadline:          midnight.Add(time.Hour * -2),
+			ttl:               time.Hour * 10,
+			// not eligible because the deadline is over an hour before the next
+			// autostart time
+			expected: time.Time{},
+		},
+		{
+			name:              "autostart before deadline by 1h",
+			autostartSchedule: "CRON_TZ=UTC 0 0 * * *",
+			deadline:          midnight.Add(time.Hour),
+			ttl:               time.Hour * 10,
+			expected:          midnight.Add(time.Hour * 10),
+		},
+		{
+			name:              "autostart before deadline by 9h",
+			autostartSchedule: "CRON_TZ=UTC 0 0 * * *",
+			deadline:          midnight.Add(time.Hour * 9),
+			ttl:               time.Hour * 10,
+			// should still be bumped
+			expected: midnight.Add(time.Hour * 10),
+		},
+		{
+			name:              "eligible but exceeds next next autostart",
+			autostartSchedule: "CRON_TZ=UTC 0 0 * * *",
+			deadline:          midnight.Add(time.Hour * 1),
+			// ttl causes next autostart + 25h to exceed the next next autostart
+			ttl: time.Hour * 25,
+			// should not be bumped to avoid infinite bumping every day
+			expected: time.Time{},
+		},
+		{
+			name:              "deadline is 1h before autostart",
+			autostartSchedule: "CRON_TZ=UTC 0 0 * * *",
+			deadline:          midnight.Add(time.Hour * -1).Add(time.Minute),
+			ttl:               time.Hour * 10,
+			// should still be bumped
+			expected: midnight.Add(time.Hour * 10),
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			sched, err := cron.Weekly(c.autostartSchedule)
+			require.NoError(t, err)
+
+			got := schedule.MaybeBumpDeadline(sched, c.deadline, c.ttl)
+			require.WithinDuration(t, c.expected, got, time.Minute)
+		})
+	}
+}

--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	agpl "github.com/coder/coder/v2/coderd/schedule"
+	"github.com/coder/coder/v2/coderd/schedule/autostop"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -253,7 +254,7 @@ func (s *EnterpriseTemplateScheduleStore) updateWorkspaceBuild(ctx context.Conte
 		return nil
 	}
 
-	autostop, err := agpl.CalculateAutostop(ctx, agpl.CalculateAutostopParams{
+	autostop, err := autostop.CalculateAutostop(ctx, autostop.CalculateAutostopParams{
 		Database:                    db,
 		TemplateScheduleStore:       s,
 		UserQuietHoursScheduleStore: *s.UserQuietHoursScheduleStore.Load(),


### PR DESCRIPTION
If the autostop deadline passes the next autostart deadline, increase the autostop deadline to be `next_autostart + ttl` instead of `now + ttl`.

This applies both on workspace build and periodically via the lifecycle executor system. It cannot happen immediately on activity bump as there's no way to execute cron statements in the database.

Also fixes a bug where activity bump would always use the workspace's configured TTL even if the template forbade it.

Closes #2028