### PR TITLE
fix: allow all environment variables to fallback prefix to `HOMEBREW_`

### DIFF
--- a/cli/clibase/option.go
+++ b/cli/clibase/option.go
@@ -262,6 +262,15 @@ func (optSet *OptionSet) ParseEnv(vs []EnvVar) error {
 		}
 
 		envVal, ok := envs[opt.Env]
+		if !ok {
+			// Homebrew strips all environment variables that do not start with `HOMEBREW_`.
+			// This prevented using brew to invoke the Coder agent, because the environment
+			// variables to not get passed down.
+			//
+			// A customer wanted to use their custom tap inside a workspace, which was failing
+			// because the agent lacked the environment variables to authenticate with Git.
+			envVal, ok = envs[`HOMEBREW_`+opt.Env]
+		}
 		// Currently, empty values are treated as if the environment variable is
 		// unset. This behavior is technically not correct as there is now no
 		// way for a user to change a Default value to an empty string from

--- a/cli/clibase/option_test.go
+++ b/cli/clibase/option_test.go
@@ -206,6 +206,26 @@ func TestOptionSet_ParseEnv(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, expected, actual.Value)
 	})
+
+	t.Run("Homebrew", func(t *testing.T) {
+		t.Parallel()
+
+		var agentToken clibase.String
+
+		os := clibase.OptionSet{
+			clibase.Option{
+				Name:  "Agent Token",
+				Value: &agentToken,
+				Env:   "AGENT_TOKEN",
+			},
+		}
+
+		err := os.ParseEnv([]clibase.EnvVar{
+			{Name: "HOMEBREW_AGENT_TOKEN", Value: "foo"},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, "foo", agentToken)
+	})
 }
 
 func TestOptionSet_JsonMarshal(t *testing.T) {


### PR DESCRIPTION
See the customer use-case in the code docs.