### PR TITLE
fix: silence bash deprecation warning on macOS runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,6 +282,11 @@ jobs:
           # is a fine default.
           PARALLEL_FLAG=""
 
+          # macOS will output "The default interactive shell is now zsh"
+          # intermittently in CI...
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            touch ~/.bash_profile && echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bash_profile
+          fi
           export TS_DEBUG_DISCO=true
           gotestsum --junitfile="gotests.xml" --jsonfile="gotests.json" \
             --packages="./..." -- $PARALLEL_FLAG -short -failfast $COVERAGE_FLAGS


### PR DESCRIPTION
See https://github.com/coder/coder/actions/runs/6407839577/job/17395535790?pr=10050
