### PR TITLE
fix: allow auditors to query deployment stats and insights

### DIFF
--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -169,6 +169,9 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 			ResourceAuditLog.Type: {ActionRead},
 			ResourceUser.Type:     {ActionRead},
 			ResourceGroup.Type:    {ActionRead},
+			// Allow auditors to query deployment stats and insights.
+			ResourceDeploymentStats.Type:  {ActionRead},
+			ResourceDeploymentValues.Type: {ActionRead},
 			// Org roles are not really used yet, so grant the perm at the site level.
 			ResourceOrganizationMember.Type: {ActionRead},
 		}),


### PR DESCRIPTION
This is a customer request.