### PR TITLE
fix(site): change `utils/delay` import path

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import dayjs from "dayjs";
 import * as TypesGen from "./typesGenerated";
-import { delay } from "utils/delay";
+import { delay } from "../utils/delay";
 import userAgentParser from "ua-parser-js";
 
 // Adds 304 for the default axios validateStatus function

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import dayjs from "dayjs";
 import * as TypesGen from "./typesGenerated";
+// This needs to include the `../`, otherwise it breaks when importing into
+// vscode-coder.
 import { delay } from "../utils/delay";
 import userAgentParser from "ua-parser-js";
 


### PR DESCRIPTION
For some reason this fails when imported into `vscode-coder`.

```
ERROR in /home/coder/vscode-coder/node_modules/coder/site/src/api/api.ts
./node_modules/coder/site/src/api/api.ts 6:22-35
[tsl] ERROR in /home/coder/vscode-coder/node_modules/coder/site/src/api/api.ts(6,23)
      TS2307: Cannot find module 'utils/delay' or its corresponding type declarations.
```

After changing the import to add `../xxx` the error went away. I don't
really understand why.
