### PR TITLE
chore: add auditing to workspace dormancy

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -938,7 +938,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			autobuildTicker := time.NewTicker(vals.AutobuildPollInterval.Value())
 			defer autobuildTicker.Stop()
 			autobuildExecutor := autobuild.NewExecutor(
-				ctx, options.Database, options.Pubsub, coderAPI.TemplateScheduleStore, logger, autobuildTicker.C)
+				ctx, options.Database, options.Pubsub, coderAPI.TemplateScheduleStore, &coderAPI.Auditor, logger, autobuildTicker.C)
 			autobuildExecutor.Run()
 
 			hangDetectorTicker := time.NewTicker(vals.JobHangDetectorInterval.Value())

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2825,8 +2825,9 @@ func TestWorkspaceDormant(t *testing.T) {
 		t.Parallel()
 		var (
 			auditRecorder = audit.NewMock()
-			client        = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true,
-				Auditor: auditRecorder,
+			client        = coderdtest.New(t, &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+				Auditor:                  auditRecorder,
 			})
 			user                     = coderdtest.CreateFirstUser(t, client)
 			version                  = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2824,7 +2824,10 @@ func TestWorkspaceDormant(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 		var (
-			client                   = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			auditRecorder = audit.NewMock()
+			client        = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true,
+				Auditor: auditRecorder,
+			})
 			user                     = coderdtest.CreateFirstUser(t, client)
 			version                  = coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			_                        = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
@@ -2841,10 +2844,12 @@ func TestWorkspaceDormant(t *testing.T) {
 		defer cancel()
 
 		lastUsedAt := workspace.LastUsedAt
+		auditRecorder.ResetLogs()
 		err := client.UpdateWorkspaceDormancy(ctx, workspace.ID, codersdk.UpdateWorkspaceDormancy{
 			Dormant: true,
 		})
 		require.NoError(t, err)
+		require.Len(t, auditRecorder.AuditLogs(), 1)
 
 		workspace = coderdtest.MustWorkspace(t, client, workspace.ID)
 		require.NoError(t, err, "fetch provisioned workspace")

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -72,7 +72,6 @@ const (
 	AuditActionLogin    AuditAction = "login"
 	AuditActionLogout   AuditAction = "logout"
 	AuditActionRegister AuditAction = "register"
-	AuditActionDormant  AuditAction = "dormant"
 )
 
 func (a AuditAction) Friendly() string {
@@ -93,8 +92,6 @@ func (a AuditAction) Friendly() string {
 		return "logged out"
 	case AuditActionRegister:
 		return "registered"
-	case AuditActionDormant:
-		return "has gone dormant"
 	default:
 		return "unknown"
 	}

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -72,6 +72,7 @@ const (
 	AuditActionLogin    AuditAction = "login"
 	AuditActionLogout   AuditAction = "logout"
 	AuditActionRegister AuditAction = "register"
+	AuditActionDormant  AuditAction = "dormant"
 )
 
 func (a AuditAction) Friendly() string {
@@ -92,6 +93,8 @@ func (a AuditAction) Friendly() string {
 		return "logged out"
 	case AuditActionRegister:
 		return "registered"
+	case AuditActionDormant:
+		return "has gone dormant"
 	default:
 		return "unknown"
 	}

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -208,9 +208,9 @@ func TestTemplates(t *testing.T) {
 			require.EqualValues(t, 0, template.TimeTilDormantAutoDeleteMillis)
 
 			var (
-				failureTTL    time.Duration = 1 * time.Minute
-				inactivityTTL time.Duration = 2 * time.Minute
-				dormantTTL    time.Duration = 3 * time.Minute
+				failureTTL    = 1 * time.Minute
+				inactivityTTL = 2 * time.Minute
+				dormantTTL    = 3 * time.Minute
 			)
 
 			updated, err := client.UpdateTemplateMeta(ctx, template.ID, codersdk.UpdateTemplateMeta{

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -185,55 +185,123 @@ func TestTemplates(t *testing.T) {
 	})
 
 	t.Run("CleanupTTLs", func(t *testing.T) {
-		t.Parallel()
+		t.Run("OK", func(t *testing.T) {
+			t.Parallel()
 
-		ctx := testutil.Context(t, testutil.WaitMedium)
-		client, user := coderdenttest.New(t, &coderdenttest.Options{
-			Options: &coderdtest.Options{
-				IncludeProvisionerDaemon: true,
-			},
-			LicenseOptions: &coderdenttest.LicenseOptions{
-				Features: license.Features{
-					codersdk.FeatureAdvancedTemplateScheduling: 1,
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			client, user := coderdenttest.New(t, &coderdenttest.Options{
+				Options: &coderdtest.Options{
+					IncludeProvisionerDaemon: true,
 				},
-			},
+				LicenseOptions: &coderdenttest.LicenseOptions{
+					Features: license.Features{
+						codersdk.FeatureAdvancedTemplateScheduling: 1,
+					},
+				},
+			})
+
+			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+			template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+			require.EqualValues(t, 0, template.TimeTilDormantMillis)
+			require.EqualValues(t, 0, template.FailureTTLMillis)
+			require.EqualValues(t, 0, template.TimeTilDormantAutoDeleteMillis)
+
+			var (
+				failureTTL    time.Duration = 1 * time.Minute
+				inactivityTTL time.Duration = 2 * time.Minute
+				dormantTTL    time.Duration = 3 * time.Minute
+			)
+
+			updated, err := client.UpdateTemplateMeta(ctx, template.ID, codersdk.UpdateTemplateMeta{
+				Name:                           template.Name,
+				DisplayName:                    template.DisplayName,
+				Description:                    template.Description,
+				Icon:                           template.Icon,
+				AllowUserCancelWorkspaceJobs:   template.AllowUserCancelWorkspaceJobs,
+				TimeTilDormantMillis:           inactivityTTL.Milliseconds(),
+				FailureTTLMillis:               failureTTL.Milliseconds(),
+				TimeTilDormantAutoDeleteMillis: dormantTTL.Milliseconds(),
+			})
+			require.NoError(t, err)
+			require.Equal(t, failureTTL.Milliseconds(), updated.FailureTTLMillis)
+			require.Equal(t, inactivityTTL.Milliseconds(), updated.TimeTilDormantMillis)
+			require.Equal(t, dormantTTL.Milliseconds(), updated.TimeTilDormantAutoDeleteMillis)
+
+			// Validate fetching the template returns the same values as updating
+			// the template.
+			template, err = client.Template(ctx, template.ID)
+			require.NoError(t, err)
+			require.Equal(t, failureTTL.Milliseconds(), updated.FailureTTLMillis)
+			require.Equal(t, inactivityTTL.Milliseconds(), updated.TimeTilDormantMillis)
+			require.Equal(t, dormantTTL.Milliseconds(), updated.TimeTilDormantAutoDeleteMillis)
 		})
 
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		require.EqualValues(t, 0, template.TimeTilDormantMillis)
-		require.EqualValues(t, 0, template.FailureTTLMillis)
-		require.EqualValues(t, 0, template.TimeTilDormantAutoDeleteMillis)
+		t.Run("BadRequest", func(t *testing.T) {
+			t.Parallel()
 
-		var (
-			failureTTL    int64 = 1
-			inactivityTTL int64 = 2
-			dormantTTL    int64 = 3
-		)
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			client, user := coderdenttest.New(t, &coderdenttest.Options{
+				Options: &coderdtest.Options{
+					IncludeProvisionerDaemon: true,
+				},
+				LicenseOptions: &coderdenttest.LicenseOptions{
+					Features: license.Features{
+						codersdk.FeatureAdvancedTemplateScheduling: 1,
+					},
+				},
+			})
 
-		updated, err := client.UpdateTemplateMeta(ctx, template.ID, codersdk.UpdateTemplateMeta{
-			Name:                           template.Name,
-			DisplayName:                    template.DisplayName,
-			Description:                    template.Description,
-			Icon:                           template.Icon,
-			AllowUserCancelWorkspaceJobs:   template.AllowUserCancelWorkspaceJobs,
-			TimeTilDormantMillis:           inactivityTTL,
-			FailureTTLMillis:               failureTTL,
-			TimeTilDormantAutoDeleteMillis: dormantTTL,
+			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+			coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+			template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+
+			type testcase struct {
+				Name                string
+				TimeTilDormantMS    int64
+				FailureTTLMS        int64
+				DormantAutoDeleteMS int64
+			}
+
+			cases := []testcase{
+				{
+					Name:                "NegativeValue",
+					TimeTilDormantMS:    -1,
+					FailureTTLMS:        -2,
+					DormantAutoDeleteMS: -3,
+				},
+				{
+					Name:                "ValueTooSmall",
+					TimeTilDormantMS:    1,
+					FailureTTLMS:        999,
+					DormantAutoDeleteMS: 500,
+				},
+			}
+
+			for _, c := range cases {
+				c := c
+
+				t.Run(c.Name, func(t *testing.T) {
+					t.Parallel()
+
+					_, err := client.UpdateTemplateMeta(ctx, template.ID, codersdk.UpdateTemplateMeta{
+						Name:                           template.Name,
+						DisplayName:                    template.DisplayName,
+						Description:                    template.Description,
+						Icon:                           template.Icon,
+						AllowUserCancelWorkspaceJobs:   template.AllowUserCancelWorkspaceJobs,
+						TimeTilDormantMillis:           c.TimeTilDormantMS,
+						FailureTTLMillis:               c.FailureTTLMS,
+						TimeTilDormantAutoDeleteMillis: c.DormantAutoDeleteMS,
+					})
+					require.Error(t, err)
+					cerr, ok := codersdk.AsError(err)
+					require.True(t, ok)
+					require.Len(t, cerr.Validations, 3)
+					require.Equal(t, "Value must be at least one minute.", cerr.Validations[0].Detail)
+				})
+			}
 		})
-		require.NoError(t, err)
-		require.Equal(t, failureTTL, updated.FailureTTLMillis)
-		require.Equal(t, inactivityTTL, updated.TimeTilDormantMillis)
-		require.Equal(t, dormantTTL, updated.TimeTilDormantAutoDeleteMillis)
-
-		// Validate fetching the template returns the same values as updating
-		// the template.
-		template, err = client.Template(ctx, template.ID)
-		require.NoError(t, err)
-		require.Equal(t, failureTTL, updated.FailureTTLMillis)
-		require.Equal(t, inactivityTTL, updated.TimeTilDormantMillis)
-		require.Equal(t, dormantTTL, updated.TimeTilDormantAutoDeleteMillis)
 	})
 
 	t.Run("UpdateTimeTilDormantAutoDelete", func(t *testing.T) {

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -2,6 +2,7 @@ package coderd_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync/atomic"
@@ -12,6 +13,7 @@ import (
 
 	"cdr.dev/slog/sloggers/slogtest"
 
+	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/autobuild"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -237,10 +239,11 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		t.Parallel()
 
 		var (
-			ctx         = testutil.Context(t, testutil.WaitMedium)
-			ticker      = make(chan time.Time)
-			statCh      = make(chan autobuild.Stats)
-			inactiveTTL = time.Minute
+			ctx           = testutil.Context(t, testutil.WaitMedium)
+			ticker        = make(chan time.Time)
+			statCh        = make(chan autobuild.Stats)
+			inactiveTTL   = time.Minute
+			auditRecorder = audit.NewMock()
 		)
 
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
@@ -249,6 +252,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 				IncludeProvisionerDaemon: true,
 				AutobuildStats:           statCh,
 				TemplateScheduleStore:    schedule.NewEnterpriseTemplateScheduleStore(agplUserQuietHoursScheduleStore()),
+				Auditor:                  auditRecorder,
 			},
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{codersdk.FeatureAdvancedTemplateScheduling: 1},
@@ -268,6 +272,9 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		ws := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
 		build := coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
 		require.Equal(t, codersdk.WorkspaceStatusRunning, build.Status)
+
+		// Reset the audit log so we can verify a log is generated.
+		auditRecorder.ResetLogs()
 		// Simulate being inactive.
 		ticker <- ws.LastUsedAt.Add(inactiveTTL * 2)
 		stats := <-statCh
@@ -276,13 +283,23 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// failure TTL.
 		require.Len(t, stats.Transitions, 1)
 		require.Equal(t, stats.Transitions[ws.ID], database.WorkspaceTransitionStop)
+		require.Len(t, auditRecorder.AuditLogs(), 1)
+
+		auditLog := auditRecorder.AuditLogs()[0]
+		require.Equal(t, auditLog.Action, database.AuditActionWrite)
+
+		var fields audit.AdditionalFields
+		err := json.Unmarshal(auditLog.AdditionalFields, &fields)
+		require.NoError(t, err)
+		require.Equal(t, ws.Name, fields.WorkspaceName)
+		require.Equal(t, database.BuildReasonAutolock, fields.BuildReason)
 
 		// The workspace should be dormant.
 		ws = coderdtest.MustWorkspace(t, client, ws.ID)
 		require.NotNil(t, ws.DormantAt)
 		lastUsedAt := ws.LastUsedAt
 
-		err := client.UpdateWorkspaceDormancy(ctx, ws.ID, codersdk.UpdateWorkspaceDormancy{Dormant: false})
+		err = client.UpdateWorkspaceDormancy(ctx, ws.ID, codersdk.UpdateWorkspaceDormancy{Dormant: false})
 		require.NoError(t, err)
 
 		// Assert that we updated our last_used_at so that we don't immediately


### PR DESCRIPTION
- Adds an audit log for workspaces automatically transitioned to the dormant state.
- Imposes a mininum of 1 minute on cleanup-related fields. This is to prevent accidental API misuse from resulting in catastrophe.