### PR TITLE
feat: allow reading the agent token from a file

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -199,9 +199,19 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 			var exchangeToken func(context.Context) (agentsdk.AuthenticateResponse, error)
 			switch auth {
 			case "token":
-				token, err := inv.ParsedFlags().GetString(varAgentToken)
-				if err != nil {
-					return xerrors.Errorf("CODER_AGENT_TOKEN must be set for token auth: %w", err)
+				token, _ := inv.ParsedFlags().GetString(varAgentToken)
+				if token == "" {
+					tokenFile, _ := inv.ParsedFlags().GetString(varAgentTokenFile)
+					if tokenFile != "" {
+						tokenBytes, err := os.ReadFile(tokenFile)
+						if err != nil {
+							return xerrors.Errorf("read token file %q: %w", tokenFile, err)
+						}
+						token = strings.TrimSpace(string(tokenBytes))
+					}
+				}
+				if token == "" {
+					return xerrors.Errorf("CODER_AGENT_TOKEN or CODER_AGENT_TOKEN_FILE must be set for token auth")
 				}
 				client.SetSessionToken(token)
 			case "google-instance-identity":

--- a/cli/root.go
+++ b/cli/root.go
@@ -55,6 +55,7 @@ const (
 	varURL              = "url"
 	varToken            = "token"
 	varAgentToken       = "agent-token"
+	varAgentTokenFile   = "agent-token-file"
 	varAgentURL         = "agent-url"
 	varHeader           = "header"
 	varHeaderCommand    = "header-command"
@@ -71,7 +72,9 @@ const (
 	envSessionToken     = "CODER_SESSION_TOKEN"
 	//nolint:gosec
 	envAgentToken = "CODER_AGENT_TOKEN"
-	envURL        = "CODER_URL"
+	//nolint:gosec
+	envAgentTokenFile = "CODER_AGENT_TOKEN_FILE"
+	envURL            = "CODER_URL"
 )
 
 var errUnauthenticated = xerrors.New(notLoggedInMessage)
@@ -329,6 +332,14 @@ func (r *RootCmd) Command(subcommands []*clibase.Cmd) (*clibase.Cmd, error) {
 			Group:       globalGroup,
 		},
 		{
+			Flag:        varAgentTokenFile,
+			Env:         envAgentTokenFile,
+			Description: "A file containing an agent authentication token.",
+			Value:       clibase.StringOf(&r.agentTokenFile),
+			Hidden:      true,
+			Group:       globalGroup,
+		},
+		{
 			Flag:        varAgentURL,
 			Env:         "CODER_AGENT_URL",
 			Description: "URL for an agent to access your deployment.",
@@ -446,19 +457,20 @@ func LoggerFromContext(ctx context.Context) (slog.Logger, bool) {
 
 // RootCmd contains parameters and helpers useful to all commands.
 type RootCmd struct {
-	clientURL     *url.URL
-	token         string
-	globalConfig  string
-	header        []string
-	headerCommand string
-	agentToken    string
-	agentURL      *url.URL
-	forceTTY      bool
-	noOpen        bool
-	verbose       bool
-	versionFlag   bool
-	disableDirect bool
-	debugHTTP     bool
+	clientURL      *url.URL
+	token          string
+	globalConfig   string
+	header         []string
+	headerCommand  string
+	agentToken     string
+	agentTokenFile string
+	agentURL       *url.URL
+	forceTTY       bool
+	noOpen         bool
+	verbose        bool
+	versionFlag    bool
+	disableDirect  bool
+	debugHTTP      bool
 
 	noVersionCheck   bool
 	noFeatureWarning bool


### PR DESCRIPTION
Adds `CODER_AGENT_TOKEN_FILE` which will read the agent token from a file if `CODER_AGENT_TOKEN` is not provided. Using a Kubernetes Secret with a volume-mounted file is a more secure way to provide the agent token instead of an environment variable.