### PR TITLE
feat: only display license warnings to privileged users

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -835,10 +835,18 @@ func (r *RootCmd) checkWarnings(i *clibase.Invocation, client *codersdk.Client) 
 	ctx, cancel := context.WithTimeout(i.Context(), 10*time.Second)
 	defer cancel()
 
+	user, err := client.User(ctx, codersdk.Me)
+	if err != nil {
+		return xerrors.Errorf("get user me: %w", err)
+	}
+
 	entitlements, err := client.Entitlements(ctx)
 	if err == nil {
-		for _, w := range entitlements.Warnings {
-			_, _ = fmt.Fprintln(i.Stderr, pretty.Sprint(cliui.DefaultStyles.Warn, w))
+		// Don't show warning to regular users.
+		if len(user.Roles) > 0 {
+			for _, w := range entitlements.Warnings {
+				_, _ = fmt.Fprintln(i.Stderr, pretty.Sprint(cliui.DefaultStyles.Warn, w))
+			}
 		}
 	}
 	return nil

--- a/enterprise/cli/licenses_test.go
+++ b/enterprise/cli/licenses_test.go
@@ -254,6 +254,7 @@ func newFakeLicenseAPI(t *testing.T) http.Handler {
 	r.Post("/api/v2/licenses", a.postLicense)
 	r.Get("/api/v2/licenses", a.licenses)
 	r.Get("/api/v2/buildinfo", a.noop)
+	r.Get("/api/v2/users/me", a.noop)
 	r.Delete("/api/v2/licenses/{id}", a.deleteLicense)
 	r.Get("/api/v2/entitlements", a.entitlements)
 	return r

--- a/enterprise/cli/root_test.go
+++ b/enterprise/cli/root_test.go
@@ -33,7 +33,10 @@ func TestEnterpriseHandlersOK(t *testing.T) {
 }
 
 func TestCheckWarnings(t *testing.T) {
+	t.Parallel()
+
 	t.Run("LicenseWarningForPrivilegedRoles", func(t *testing.T) {
+		t.Parallel()
 		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				ExpiresAt: time.Now().Add(time.Hour * 24),
@@ -53,6 +56,7 @@ func TestCheckWarnings(t *testing.T) {
 	})
 
 	t.Run("NoLicenseWarningForRegularUser", func(t *testing.T) {
+		t.Parallel()
 		adminClient, admin := coderdenttest.New(t, &coderdenttest.Options{
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				ExpiresAt: time.Now().Add(time.Hour * 24),

--- a/enterprise/cli/root_test.go
+++ b/enterprise/cli/root_test.go
@@ -1,14 +1,18 @@
 package cli_test
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/cli/config"
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/enterprise/cli"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 )
 
 func newCLI(t *testing.T, args ...string) (*clibase.Invocation, config.Root) {
@@ -26,4 +30,46 @@ func TestEnterpriseHandlersOK(t *testing.T) {
 	require.NoError(t, err)
 
 	clitest.HandlersOK(t, cmd)
+}
+
+func TestCheckWarnings(t *testing.T) {
+	t.Run("LicenseWarningForPrivilegedRoles", func(t *testing.T) {
+		client, _ := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				ExpiresAt: time.Now().Add(time.Hour * 24),
+			},
+		})
+
+		inv, conf := newCLI(t, "list")
+
+		var buf bytes.Buffer
+		inv.Stderr = &buf
+		clitest.SetupConfig(t, client, conf)
+
+		err := inv.Run()
+		require.NoError(t, err)
+
+		require.Contains(t, buf.String(), "Your license expires in 1 day.")
+	})
+
+	t.Run("NoLicenseWarningForRegularUser", func(t *testing.T) {
+		adminClient, admin := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				ExpiresAt: time.Now().Add(time.Hour * 24),
+			},
+		})
+
+		client, _ := coderdtest.CreateAnotherUser(t, adminClient, admin.OrganizationID)
+
+		inv, conf := newCLI(t, "list")
+
+		var buf bytes.Buffer
+		inv.Stderr = &buf
+		clitest.SetupConfig(t, client, conf)
+
+		err := inv.Run()
+		require.NoError(t, err)
+
+		require.NotContains(t, buf.String(), "Your license expires")
+	})
 }


### PR DESCRIPTION
fixes #9350

This does not address entitlement _errors_ as it appears we aren't currently displaying those anyway and it's unclear if we've come to a consensus on whether we are displaying those to all users or not. 