### PR TITLE
feat(coderd/coderdtest): deprecate coderdtest.CreateFirstUser

### DIFF
--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -21,7 +21,7 @@ func TestLogin(t *testing.T) {
 	t.Parallel()
 	t.Run("InitialUserNoTTY", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		root, _ := clitest.New(t, "login", client.URL.String())
 		err := root.Run()
 		require.Error(t, err)
@@ -38,7 +38,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("InitialUserTTY", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		// The --force-tty flag is required on Windows, because the `isatty` library does not
 		// accurately detect Windows ptys when they are not attached to a process:
 		// https://github.com/mattn/go-isatty/issues/59
@@ -71,7 +71,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("InitialUserTTYFlag", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		// The --force-tty flag is required on Windows, because the `isatty` library does not
 		// accurately detect Windows ptys when they are not attached to a process:
 		// https://github.com/mattn/go-isatty/issues/59
@@ -99,7 +99,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("InitialUserFlags", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		inv, _ := clitest.New(
 			t, "login", client.URL.String(),
 			"--first-user-username", "testuser", "--first-user-email", "user@coder.com",
@@ -115,7 +115,7 @@ func TestLogin(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		// The --force-tty flag is required on Windows, because the `isatty` library does not
 		// accurately detect Windows ptys when they are not attached to a process:
 		// https://github.com/mattn/go-isatty/issues/59
@@ -157,7 +157,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("ExistingUserValidTokenTTY", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		coderdtest.CreateFirstUser(t, client)
 
 		doneChan := make(chan struct{})
@@ -181,7 +181,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("ExistingUserInvalidTokenTTY", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancelFunc := context.WithCancel(context.Background())
@@ -210,7 +210,7 @@ func TestLogin(t *testing.T) {
 	// TokenFlag should generate a new session token and store it in the session file.
 	t.Run("TokenFlag", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
+		client := coderdtest.New(t, &coderdtest.Options{SkipAutoCreateFirstUser: true})
 		coderdtest.CreateFirstUser(t, client)
 		root, cfg := clitest.New(t, "login", client.URL.String(), "--token", client.SessionToken())
 		err := root.Run()

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -456,7 +456,7 @@ func NewWithAPI(t testing.TB, options *Options) (*codersdk.Client, io.Closer, *c
 	}
 	client := codersdk.New(serverURL)
 	if !options.SkipAutoCreateFirstUser {
-		createFirstUser(t, client)
+		_createFirstUser(t, client)
 	}
 	t.Cleanup(func() {
 		cancelFunc()
@@ -591,7 +591,7 @@ var FirstUserParams = codersdk.CreateFirstUserRequest{
 // Instead, create additional users as required using CreateOwner, CreateTemplateAdmin, and so on.
 // Alternatively, use AsFirstUser to run a function as the first user.
 func CreateFirstUser(t testing.TB, client *codersdk.Client) codersdk.CreateFirstUserResponse {
-	createFirstUser(t, client)
+	_createFirstUser(t, client)
 	loginAsFirstUser(t, client)
 	user, err := client.User(context.Background(), codersdk.Me)
 	require.NoError(t, err)
@@ -601,7 +601,7 @@ func CreateFirstUser(t testing.TB, client *codersdk.Client) codersdk.CreateFirst
 	}
 }
 
-func createFirstUser(t testing.TB, client *codersdk.Client) {
+func _createFirstUser(t testing.TB, client *codersdk.Client) {
 	t.Helper()
 	_, err := client.CreateFirstUser(context.Background(), FirstUserParams)
 	if err == nil {

--- a/coderd/coderdtest/coderdtest_test.go
+++ b/coderd/coderdtest/coderdtest_test.go
@@ -17,11 +17,11 @@ func TestNew(t *testing.T) {
 	client := coderdtest.New(t, &coderdtest.Options{
 		IncludeProvisionerDaemon: true,
 	})
-	user := coderdtest.CreateFirstUser(t, client)
-	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+	client, user := coderdtest.CreateTemplateAdmin(t, client)
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationIDs[0], nil)
 	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationIDs[0], version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, user.OrganizationIDs[0], template.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 	coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 	_, _ = coderdtest.NewGoogleInstanceIdentity(t, "example", false)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -294,7 +294,6 @@ func TestPostLogin(t *testing.T) {
 			require.True(t, apiKey.ExpiresAt.Before(time.Now().Add(time.Hour*24*31)), "default tokens lasts less than 31 days")
 			require.Greater(t, apiKey.LifetimeSeconds, key.LifetimeSeconds, "token should have longer lifetime")
 		})
-
 	})
 }
 


### PR DESCRIPTION
This PR:
- Deprecates `coderdtest.CreateFirstUser`
- Automatically creates the first user unless `SkipAutoCreateFirstUser` is set.
- Adds helper methods for creating additional test users with pre-defined roles.
- Adds a helper method `RunAsFirstUser` as an escape hatch where required.

Rationale: a lot of unit tests were simply calling `client = coderdtest.CreateFirstUser()` and performing all testing with that client. As that client has unrestricted permissions, there is a high possibility of unintentionally missing auth-related bugs.

I have not run through all of the existing unit tests, as that would be a prohibitively large diff. We can instead update as we modify existing tests.