### PR TITLE
fix: update ErrorDialog logic and tests

### DIFF
--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.test.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.test.tsx
@@ -8,11 +8,13 @@ const inputTestId = "delete-dialog-name-confirmation";
 
 async function fillInputField(inputElement: HTMLElement, text: string) {
   // 2023-10-06 - There's something wonky with MUI's ConfirmDialog that causes
-  // its state to update after a typing event being fired, and React Testing
+  // its state to update after a typing event gets  fired, and React Testing
   // Library isn't able to catch it, making React DOM freak out because an
-  // "unexpected" state change happened. Tried everything under the sun to catch
-  // the state changes the proper way, but the only way to get around it for now
-  // might be to manually make React aware of the changes
+  // "unexpected" state change happened. It won't fail the test, but it makes
+  // the console look really scary because it'll spit out a big warning message.
+  // Tried everything under the sun to catch the state changes the proper way,
+  // but the only way to get around it for now might be to manually make React
+  // DOM aware of the changes
 
   // eslint-disable-next-line testing-library/no-unnecessary-act -- have to make sure state updates don't slip through cracks
   return act(() => userEvent.type(inputElement, text));

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.test.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.test.tsx
@@ -2,6 +2,21 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "testHelpers/renderHelpers";
 import { DeleteDialog } from "./DeleteDialog";
+import { act } from "react-dom/test-utils";
+
+const inputTestId = "delete-dialog-name-confirmation";
+
+async function fillInputField(inputElement: HTMLElement, text: string) {
+  // 2023-10-06 - There's something wonky with MUI's ConfirmDialog that causes
+  // its state to update after a typing event being fired, and React Testing
+  // Library isn't able to catch it, making React DOM freak out because an
+  // "unexpected" state change happened. Tried everything under the sun to catch
+  // the state changes the proper way, but the only way to get around it for now
+  // might be to manually make React aware of the changes
+
+  // eslint-disable-next-line testing-library/no-unnecessary-act -- have to make sure state updates don't slip through cracks
+  return act(() => userEvent.type(inputElement, text));
+}
 
 describe("DeleteDialog", () => {
   it("disables confirm button when the text field is empty", () => {
@@ -14,6 +29,7 @@ describe("DeleteDialog", () => {
         name="MyTemplate"
       />,
     );
+
     const confirmButton = screen.getByRole("button", { name: "Delete" });
     expect(confirmButton).toBeDisabled();
   });
@@ -28,8 +44,10 @@ describe("DeleteDialog", () => {
         name="MyTemplate"
       />,
     );
-    const textField = screen.getByTestId("delete-dialog-name-confirmation");
-    await userEvent.type(textField, "MyTemplateWrong");
+
+    const textField = screen.getByTestId(inputTestId);
+    await fillInputField(textField, "MyTemplateButWrong");
+
     const confirmButton = screen.getByRole("button", { name: "Delete" });
     expect(confirmButton).toBeDisabled();
   });
@@ -44,8 +62,10 @@ describe("DeleteDialog", () => {
         name="MyTemplate"
       />,
     );
-    const textField = screen.getByTestId("delete-dialog-name-confirmation");
-    await userEvent.type(textField, "MyTemplate");
+
+    const textField = screen.getByTestId(inputTestId);
+    await fillInputField(textField, "MyTemplate");
+
     const confirmButton = screen.getByRole("button", { name: "Delete" });
     expect(confirmButton).not.toBeDisabled();
   });

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -43,7 +43,7 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
     }
   };
 
-  const confirmationId = `${hookId}-${DeleteDialog.name}-confirm`;
+  const confirmationId = `${hookId}-confirm`;
   const hasError = !deletionConfirmed && confirmationText.length > 0;
   const displayErrorMessage = hasError && !isFocused;
   const inputColor = hasError ? "error" : "primary";

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -46,7 +46,7 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
   const confirmationId = `${hookId}-${DeleteDialog.name}-confirm`;
   const hasError = !deletionConfirmed && confirmationText.length > 0;
   const displayErrorMessage = hasError && !isFocused;
-  const color = hasError ? "error" : "primary";
+  const inputColor = hasError ? "error" : "primary";
 
   return (
     <ConfirmDialog
@@ -86,13 +86,13 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               label={`Name of the ${entity} to delete`}
-              color={color}
+              color={inputColor}
               error={displayErrorMessage}
               helperText={
                 displayErrorMessage &&
                 `${confirmationText} does not match the name of this ${entity}`
               }
-              InputProps={{ color }}
+              InputProps={{ color: inputColor }}
               inputProps={{
                 ["data-testid"]: "delete-dialog-name-confirmation",
               }}

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -94,7 +94,7 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
               }
               InputProps={{ color: inputColor }}
               inputProps={{
-                ["data-testid"]: "delete-dialog-name-confirmation",
+                "data-testid": "delete-dialog-name-confirmation",
               }}
             />
           </form>

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -32,10 +32,10 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
   const hookId = useId();
   const theme = useTheme();
 
-  const [confirmationText, setConfirmationText] = useState("");
+  const [userConfirmationText, setUserConfirmationText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
-  const deletionConfirmed = name === confirmationText;
+  const deletionConfirmed = name === userConfirmationText;
   const onSubmit = (event: FormEvent) => {
     event.preventDefault();
     if (deletionConfirmed) {
@@ -43,8 +43,7 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
     }
   };
 
-  const confirmationId = `${hookId}-confirm`;
-  const hasError = !deletionConfirmed && confirmationText.length > 0;
+  const hasError = !deletionConfirmed && userConfirmationText.length > 0;
   const displayErrorMessage = hasError && !isFocused;
   const inputColor = hasError ? "error" : "primary";
 
@@ -79,10 +78,10 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
               sx={{ marginTop: theme.spacing(3) }}
               name="confirmation"
               autoComplete="off"
-              id={confirmationId}
+              id={`${hookId}-confirm`}
               placeholder={name}
-              value={confirmationText}
-              onChange={(event) => setConfirmationText(event.target.value)}
+              value={userConfirmationText}
+              onChange={(event) => setUserConfirmationText(event.target.value)}
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               label={`Name of the ${entity} to delete`}
@@ -90,7 +89,7 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
               error={displayErrorMessage}
               helperText={
                 displayErrorMessage &&
-                `${confirmationText} does not match the name of this ${entity}`
+                `${userConfirmationText} does not match the name of this ${entity}`
               }
               InputProps={{ color: inputColor }}
               inputProps={{

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -1,6 +1,13 @@
-import makeStyles from "@mui/styles/makeStyles";
+import {
+  type FC,
+  type FormEvent,
+  type PropsWithChildren,
+  useId,
+  useState,
+} from "react";
+
+import { useTheme } from "@emotion/react";
 import TextField from "@mui/material/TextField";
-import { ChangeEvent, useState, PropsWithChildren, FC } from "react";
 import { ConfirmDialog } from "../ConfirmDialog/ConfirmDialog";
 
 export interface DeleteDialogProps {
@@ -22,51 +29,23 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
   name,
   confirmLoading,
 }) => {
-  const styles = useStyles();
-  const [nameValue, setNameValue] = useState("");
-  const confirmed = name === nameValue;
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setNameValue(event.target.value);
+  const hookId = useId();
+  const theme = useTheme();
+
+  const [confirmationText, setConfirmationText] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (deletionConfirmed) {
+      onConfirm();
+    }
   };
-  const hasError = nameValue.length > 0 && !confirmed;
 
-  const content = (
-    <>
-      <p>Deleting this {entity} is irreversible!</p>
-      {Boolean(info) && <p className={styles.warning}>{info}</p>}
-      <p>Are you sure you want to proceed?</p>
-      <p>
-        Type &ldquo;<strong>{name}</strong>&rdquo; below to confirm.
-      </p>
-
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (confirmed) {
-            onConfirm();
-          }
-        }}
-      >
-        <TextField
-          fullWidth
-          autoFocus
-          className={styles.textField}
-          name="confirmation"
-          autoComplete="off"
-          id="confirmation"
-          placeholder={name}
-          value={nameValue}
-          onChange={handleChange}
-          label={`Name of the ${entity} to delete`}
-          error={hasError}
-          helperText={
-            hasError && `${nameValue} does not match the name of this ${entity}`
-          }
-          inputProps={{ ["data-testid"]: "delete-dialog-name-confirmation" }}
-        />
-      </form>
-    </>
-  );
+  const confirmationId = `${hookId}-${DeleteDialog.name}-confirm`;
+  const deletionConfirmed = name === confirmationText;
+  const hasError =
+    !isFocused && !deletionConfirmed && confirmationText.length > 0;
 
   return (
     <ConfirmDialog
@@ -76,19 +55,48 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
       title={`Delete ${entity}`}
       onConfirm={onConfirm}
       onClose={onCancel}
-      description={content}
       confirmLoading={confirmLoading}
-      disabled={!confirmed}
+      disabled={!deletionConfirmed}
+      description={
+        <>
+          <p>Deleting this {entity} is irreversible!</p>
+
+          {Boolean(info) && (
+            <p css={{ color: theme.palette.warning.light }}>{info}</p>
+          )}
+
+          <p>Are you sure you want to proceed?</p>
+
+          <p>
+            Type &ldquo;<strong>{name}</strong>&rdquo; below to confirm.
+          </p>
+
+          <form onSubmit={onSubmit}>
+            <TextField
+              fullWidth
+              autoFocus
+              sx={{ marginTop: theme.spacing(3) }}
+              name="confirmation"
+              autoComplete="off"
+              id={confirmationId}
+              placeholder={name}
+              value={confirmationText}
+              onChange={(event) => setConfirmationText(event.target.value)}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              label={`Name of the ${entity} to delete`}
+              error={hasError}
+              helperText={
+                hasError &&
+                `${confirmationText} does not match the name of this ${entity}`
+              }
+              inputProps={{
+                ["data-testid"]: "delete-dialog-name-confirmation",
+              }}
+            />
+          </form>
+        </>
+      }
     />
   );
 };
-
-const useStyles = makeStyles((theme) => ({
-  warning: {
-    color: theme.palette.warning.light,
-  },
-
-  textField: {
-    marginTop: theme.spacing(3),
-  },
-}));

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -35,17 +35,18 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
   const [confirmationText, setConfirmationText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
-  const onSubmit = (e: FormEvent) => {
-    e.preventDefault();
+  const deletionConfirmed = name === confirmationText;
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
     if (deletionConfirmed) {
       onConfirm();
     }
   };
 
   const confirmationId = `${hookId}-${DeleteDialog.name}-confirm`;
-  const deletionConfirmed = name === confirmationText;
-  const hasError =
-    !isFocused && !deletionConfirmed && confirmationText.length > 0;
+  const hasError = !deletionConfirmed && confirmationText.length > 0;
+  const displayErrorMessage = hasError && !isFocused;
+  const color = hasError ? "error" : "primary";
 
   return (
     <ConfirmDialog
@@ -85,11 +86,13 @@ export const DeleteDialog: FC<PropsWithChildren<DeleteDialogProps>> = ({
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               label={`Name of the ${entity} to delete`}
-              error={hasError}
+              color={color}
+              error={displayErrorMessage}
               helperText={
-                hasError &&
+                displayErrorMessage &&
                 `${confirmationText} does not match the name of this ${entity}`
               }
+              InputProps={{ color }}
               inputProps={{
                 ["data-testid"]: "delete-dialog-name-confirmation",
               }}


### PR DESCRIPTION
References #9348. Basically, some prep work for the actual feature. I just figured I'd just get these changes out today.

Had to spend a lot of the day debugging an issue with MUI in React Testing Library. Not sure when it was introduced

## Changes
- Updates the tests for `ErrorDialog` so that it no longer spits out cryptic messages about unexpected state changes
- Updates `ErrorDialog` so that the textbox doesn't start nagging you until the textbox loses focus

https://github.com/coder/coder/assets/28937484/9dd6ef07-2733-4f5a-ae92-ba2b956fdb88

