### PR TITLE
feat(site): disable rich parameters when using open in coder

### DIFF
--- a/docs/templates/open-in-coder.md
+++ b/docs/templates/open-in-coder.md
@@ -106,6 +106,13 @@ approach for "Open in Coder" flows.
 
    ![Pre-filled parameters](../images/templates/pre-filled-parameters.png)
 
+1. Optional: disable specific parameter fields by including their names as
+   specified in your template in the `disable_params` search params list
+
+   ```md
+   [![Open in Coder](https://YOUR_ACCESS_URL/open-in-coder.svg)](https://YOUR_ACCESS_URL/templates/YOUR_TEMPLATE/workspace?disable_params=first_parameter,second_parameter)
+   ```
+
 ## Example: Kubernetes
 
 For a full example of the Open in Coder flow in Kubernetes, check out

--- a/site/e2e/tests/createWorkspace.spec.ts
+++ b/site/e2e/tests/createWorkspace.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import {
   createTemplate,
   createWorkspace,
@@ -118,4 +118,26 @@ test("create workspace and overwrite default parameters", async ({ page }) => {
     buildParameters,
   );
   await verifyParameters(page, workspaceName, richParameters, buildParameters);
+});
+
+test("create workspace with disable_param search params", async ({ page }) => {
+  const richParameters: RichParameter[] = [
+    firstParameter, // mutable
+    secondParameter, //immutable
+  ];
+
+  const templateName = await createTemplate(
+    page,
+    echoResponsesWithParameters(richParameters),
+  );
+
+  await page.goto(
+    `/templates/${templateName}/workspace?disable_params=first_parameter,second_parameter`,
+    {
+      waitUntil: "domcontentloaded",
+    },
+  );
+
+  await expect(page.getByLabel(/First parameter/i)).toBeDisabled();
+  await expect(page.getByLabel(/Second parameter/i)).toBeDisabled();
 });

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -31,6 +31,7 @@ import { ExternalAuth } from "./ExternalAuth";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { Stack } from "components/Stack/Stack";
 import { type ExternalAuthPollingState } from "./CreateWorkspacePage";
+import { useSearchParams } from "react-router-dom";
 
 export interface CreateWorkspacePageViewProps {
   error: unknown;
@@ -72,6 +73,9 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
   const [owner, setOwner] = useState(defaultOwner);
   const { verifyExternalAuth, externalAuthErrors } =
     useExternalAuthVerification(externalAuth);
+  const [searchParams] = useSearchParams();
+  const disabledParamsList = searchParams?.get("disable_params")?.split(",");
+
   const form: FormikContextType<TypesGen.CreateWorkspaceRequest> =
     useFormik<TypesGen.CreateWorkspaceRequest>({
       initialValues: {
@@ -198,7 +202,10 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
                       value: value,
                     });
                   },
-                  disabled: form.isSubmitting,
+                  disabled:
+                    disabledParamsList?.includes(
+                      parameter.name.toLowerCase().replace(/ /g, "_"),
+                    ) || form.isSubmitting,
                 };
               }}
             />
@@ -216,7 +223,10 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
                       value: value,
                     });
                   },
-                  disabled: form.isSubmitting,
+                  disabled:
+                    disabledParamsList?.includes(
+                      parameter.name.toLowerCase().replace(/ /g, "_"),
+                    ) || form.isSubmitting,
                 };
               }}
             />

--- a/site/src/pages/HealthPage/HealthPage.tsx
+++ b/site/src/pages/HealthPage/HealthPage.tsx
@@ -32,7 +32,7 @@ export default function HealthPage() {
   const { data: healthStatus } = useQuery({
     queryKey: ["health"],
     queryFn: () => getHealth(),
-    refetchInterval: 10_000,
+    refetchInterval: 120_000,
   });
 
   return (

--- a/site/src/pages/HealthPage/HealthPage.tsx
+++ b/site/src/pages/HealthPage/HealthPage.tsx
@@ -32,7 +32,7 @@ export default function HealthPage() {
   const { data: healthStatus } = useQuery({
     queryKey: ["health"],
     queryFn: () => getHealth(),
-    refetchInterval: 120_000,
+    refetchInterval: 10_000,
   });
 
   return (


### PR DESCRIPTION
resolves #7505

The _Open in Coder_ button now supports markdown which disables specified parameter fields.
![Screenshot 2023-10-06 at 3 25 12 PM](https://github.com/coder/coder/assets/19142439/586f8908-2833-49a5-8318-e9154bdeb1a0)
