### PR TITLE
chore(site): decrease refetch interval for deployment health

### DIFF
--- a/site/src/pages/HealthPage/HealthPage.tsx
+++ b/site/src/pages/HealthPage/HealthPage.tsx
@@ -32,7 +32,7 @@ export default function HealthPage() {
   const { data: healthStatus } = useQuery({
     queryKey: ["health"],
     queryFn: () => getHealth(),
-    refetchInterval: 10_000,
+    refetchInterval: 120_000,
   });
 
   return (


### PR DESCRIPTION
resolves #9799

We have decreased the refetch interval from 10ms to 2 min for `api.getHealth` such that there is less likelihood of seeing an error banner.

Down the road, we should consider checking unhealthy statuses on the BE a certain number of times before updating the `healthCheckCache`; however, after discussing with @sreya, this is the solution we're going with for now.