### PR TITLE
feat(cli): add --parameter flag to exp scaletest command

### DIFF
--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -48,6 +48,8 @@ func TestScaleTestCreateWorkspaces(t *testing.T) {
 		"--cleanup-job-timeout", "15s",
 		"--output", "text",
 		"--output", "json:"+outputFile,
+		"--parameter", "foo=baz",
+		"--rich-parameter-file", "/path/to/some/parameter/file.ext",
 	)
 	clitest.SetupConfig(t, client, root)
 	pty := ptytest.New(t)

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -34,6 +34,19 @@ func Test_Runner(t *testing.T) {
 		t.Skip("Race detector enabled, skipping time-sensitive test.")
 	}
 
+	testParameters := []*proto.RichParameter{
+		{
+			Name:         "foo",
+			DefaultValue: "baz",
+		},
+	}
+	testParameterValues := []codersdk.WorkspaceBuildParameter{
+		{
+			Name:  "foo",
+			Value: "baz",
+		},
+	}
+
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
@@ -47,8 +60,16 @@ func Test_Runner(t *testing.T) {
 
 		authToken := uuid.NewString()
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
-			Parse:         echo.ParseComplete,
-			ProvisionPlan: echo.PlanComplete,
+			Parse: echo.ParseComplete,
+			ProvisionPlan: []*proto.Response{
+				{
+					Type: &proto.Response_Plan{
+						Plan: &proto.PlanComplete{
+							Parameters: testParameters,
+						},
+					},
+				},
+			},
 			ProvisionApply: []*proto.Response{
 				{
 					Type: &proto.Response_Log{
@@ -102,7 +123,8 @@ func Test_Runner(t *testing.T) {
 			Workspace: workspacebuild.Config{
 				OrganizationID: user.OrganizationID,
 				Request: codersdk.CreateWorkspaceRequest{
-					TemplateID: template.ID,
+					TemplateID:          template.ID,
+					RichParameterValues: testParameterValues,
 				},
 			},
 			ReconnectingPTY: &reconnectingpty.Config{
@@ -132,6 +154,13 @@ func Test_Runner(t *testing.T) {
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{})
 		require.NoError(t, err)
 		require.Len(t, workspaces.Workspaces, 1)
+
+		// Ensure the correct build parameters were used.
+		buildParams, err := client.WorkspaceBuildParameters(ctx, workspaces.Workspaces[0].LatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParams, 1)
+		require.Equal(t, testParameterValues[0].Name, buildParams[0].Name)
+		require.Equal(t, testParameterValues[0].Value, buildParams[0].Value)
 
 		// Look for strings in the logs.
 		require.Contains(t, logsStr, "Generating user password...")
@@ -173,8 +202,16 @@ func Test_Runner(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
-			Parse:         echo.ParseComplete,
-			ProvisionPlan: echo.PlanComplete,
+			Parse: echo.ParseComplete,
+			ProvisionPlan: []*proto.Response{
+				{
+					Type: &proto.Response_Plan{
+						Plan: &proto.PlanComplete{
+							Parameters: testParameters,
+						},
+					},
+				},
+			},
 			ProvisionApply: []*proto.Response{
 				{
 					Type: &proto.Response_Log{Log: &proto.Log{}},
@@ -200,7 +237,8 @@ func Test_Runner(t *testing.T) {
 			Workspace: workspacebuild.Config{
 				OrganizationID: user.OrganizationID,
 				Request: codersdk.CreateWorkspaceRequest{
-					TemplateID: template.ID,
+					TemplateID:          template.ID,
+					RichParameterValues: testParameterValues,
 				},
 			},
 		})
@@ -288,8 +326,16 @@ func Test_Runner(t *testing.T) {
 
 		authToken := uuid.NewString()
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
-			Parse:         echo.ParseComplete,
-			ProvisionPlan: echo.PlanComplete,
+			Parse: echo.ParseComplete,
+			ProvisionPlan: []*proto.Response{
+				{
+					Type: &proto.Response_Plan{
+						Plan: &proto.PlanComplete{
+							Parameters: testParameters,
+						},
+					},
+				},
+			},
 			ProvisionApply: []*proto.Response{
 				{
 					Type: &proto.Response_Log{
@@ -344,7 +390,8 @@ func Test_Runner(t *testing.T) {
 			Workspace: workspacebuild.Config{
 				OrganizationID: user.OrganizationID,
 				Request: codersdk.CreateWorkspaceRequest{
-					TemplateID: template.ID,
+					TemplateID:          template.ID,
+					RichParameterValues: testParameterValues,
 				},
 			},
 			ReconnectingPTY: &reconnectingpty.Config{
@@ -374,6 +421,13 @@ func Test_Runner(t *testing.T) {
 		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{})
 		require.NoError(t, err)
 		require.Len(t, workspaces.Workspaces, 1)
+
+		// Ensure the correct build parameters were used.
+		buildParams, err := client.WorkspaceBuildParameters(ctx, workspaces.Workspaces[0].LatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParams, 1)
+		require.Equal(t, testParameterValues[0].Name, buildParams[0].Name)
+		require.Equal(t, testParameterValues[0].Value, buildParams[0].Value)
 
 		// Look for strings in the logs.
 		require.Contains(t, logsStr, "Generating user password...")
@@ -413,8 +467,16 @@ func Test_Runner(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
-			Parse:         echo.ParseComplete,
-			ProvisionPlan: echo.PlanComplete,
+			Parse: echo.ParseComplete,
+			ProvisionPlan: []*proto.Response{
+				{
+					Type: &proto.Response_Plan{
+						Plan: &proto.PlanComplete{
+							Parameters: testParameters,
+						},
+					},
+				},
+			},
 			ProvisionApply: []*proto.Response{
 				{
 					Type: &proto.Response_Apply{
@@ -438,7 +500,8 @@ func Test_Runner(t *testing.T) {
 			Workspace: workspacebuild.Config{
 				OrganizationID: user.OrganizationID,
 				Request: codersdk.CreateWorkspaceRequest{
-					TemplateID: template.ID,
+					TemplateID:          template.ID,
+					RichParameterValues: testParameterValues,
 				},
 			},
 		})

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -17,6 +17,9 @@ fi
 if [[ ${1:-} == wsproxy ]] && [[ ${2:-} == server ]]; then
 	BINARY_TYPE=coder
 fi
+if [[ ${1:-} == exp ]] && [[ ${2:-} == scaletest ]]; then
+	BINARY_TYPE=coder
+fi
 RELATIVE_BINARY_PATH="build/${BINARY_TYPE}_${GOOS}_${GOARCH}"
 
 # To preserve the CWD when running the binary, we need to use pushd and popd to


### PR DESCRIPTION
This PR adds support for passing parameters to workspaces built by `exp scaletest`.