### PR TITLE
fix: remove AwaitWorkspaceAgents in goroutines

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -183,7 +183,6 @@ func TestSSH(t *testing.T) {
 			// Run this async so the SSH command has to wait for
 			// the build and agent to connect!
 			_ = agenttest.New(t, client.URL, agentToken)
-			coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 			<-ctx.Done()
 		})
 
@@ -246,7 +245,6 @@ func TestSSH(t *testing.T) {
 			// Run this async so the SSH command has to wait for
 			// the build and agent to connect.
 			_ = agenttest.New(t, client.URL, agentToken)
-			coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 			<-ctx.Done()
 		})
 


### PR DESCRIPTION
AwaitWorkspaceAgent calls testify.require which isn't allowed from a goroutine and causes cascading failures in the test suite such as: https://github.com/coder/coder/actions/runs/6458768855/job/17533163316

I don't believe these functions serve a direct purpose since nothing else is "waiting" for the functions to return before doing other things.
