### PR TITLE
fix: check for nil pointer in AwaitWorkspaceAgents

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -857,6 +857,9 @@ func AwaitWorkspaceAgents(t testing.TB, client *codersdk.Client, workspaceID uui
 		if !assert.NoError(t, err) {
 			return false
 		}
+		if workspace.LatestBuild.Job.CompletedAt == nil {
+			return false
+		}
 		if workspace.LatestBuild.Job.CompletedAt.IsZero() {
 			return false
 		}


### PR DESCRIPTION
CompletedAt is a pointer and can be nil, need to check before calling IsZero() on it

c.f. https://github.com/coder/coder/runs/17534657301
