### PR TITLE
fix: revert: use CRC32 to shorten app subdomain

### DIFF
--- a/coderd/httpapi/url.go
+++ b/coderd/httpapi/url.go
@@ -2,7 +2,6 @@ package httpapi
 
 import (
 	"fmt"
-	"hash/crc32"
 	"net"
 	"regexp"
 	"strings"
@@ -19,8 +18,6 @@ var (
 		nameRegex))
 
 	validHostnameLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
-
-	crcTable = crc32.MakeTable(crc32.IEEE)
 )
 
 // ApplicationURL is a parsed application URL hostname.
@@ -42,12 +39,7 @@ func (a ApplicationURL) String() string {
 	_, _ = appURL.WriteString(a.WorkspaceName)
 	_, _ = appURL.WriteString("--")
 	_, _ = appURL.WriteString(a.Username)
-	hostname := appURL.String()
-
-	if len(hostname) < 64 { // max length for the subdomain level
-		return hostname
-	}
-	return fmt.Sprintf("app-%08x", crc32.Checksum([]byte(hostname), crcTable))
+	return appURL.String()
 }
 
 // ParseSubdomainAppURL parses an ApplicationURL from the given subdomain. If

--- a/coderd/httpapi/url_test.go
+++ b/coderd/httpapi/url_test.go
@@ -42,16 +42,6 @@ func TestApplicationURLString(t *testing.T) {
 			},
 			Expected: "8080--agent--workspace--user",
 		},
-		{
-			Name: "LongAppName",
-			URL: httpapi.ApplicationURL{
-				AppSlugOrPort: "0123456789012345678901234567890123456789",
-				AgentName:     "agent",
-				WorkspaceName: "workspace",
-				Username:      "user",
-			},
-			Expected: "app-90667f72",
-		},
 	}
 
 	for _, c := range testCases {

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -1353,7 +1353,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 		}, testutil.WaitLong, testutil.IntervalFast, "stats not reported")
 
 		assert.Equal(t, workspaceapps.AccessMethodPath, stats[0].AccessMethod)
-		assert.Equal(t, proxyTestAppNameOwner, stats[0].SlugOrPort)
+		assert.Equal(t, "test-app-owner", stats[0].SlugOrPort)
 		assert.Equal(t, 1, stats[0].Requests)
 	})
 }

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	proxyTestAgentName            = "agent-name"
-	proxyTestAppNameFake          = "taf"
-	proxyTestAppNameOwner         = "tao"
-	proxyTestAppNameAuthenticated = "taa"
-	proxyTestAppNamePublic        = "tap"
+	proxyTestAppNameFake          = "test-app-fake"
+	proxyTestAppNameOwner         = "test-app-owner"
+	proxyTestAppNameAuthenticated = "test-app-authenticated"
+	proxyTestAppNamePublic        = "test-app-public"
 	proxyTestAppQuery             = "query=true"
 	proxyTestAppBody              = "hello world from apps test"
 


### PR DESCRIPTION
Reopen: https://github.com/coder/coder/issues/8145

This reverts commit 0e28397c82afe478bee2131bf8ea605f3de8e553.

@deansheather spotted that there is still missing a corresponding implementation on the workspace proxy side, to map a URL with CRC32 hash to the application. Unfortunately, it requires a lot of wiring and does not align with my original assumption that all application URLs are stored in a database.