### PR TITLE
fix: ignore logged errors in TestWorkspaceAgent/Timeout

### DIFF
--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -124,8 +124,11 @@ func TestWorkspaceAgent(t *testing.T) {
 	})
 	t.Run("Timeout", func(t *testing.T) {
 		t.Parallel()
+		// timeouts can cause error logs to be dropped on shutdown
+		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
+			Logger:                   &logger,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
 		authToken := uuid.NewString()


### PR DESCRIPTION
fixes #10167

Annoyingly, there isn't a good way to stop the publish from being sent on shutdown, and subscribing to them in the test is too fragile because empty messages are sent in a bunch of places, so we can't reliably tell it's regarding timeouts.
