### PR TITLE
chore: refactor workspace conversion to accept ownerName

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -652,7 +652,7 @@ func New(options *Options) *API {
 					r.Get("/roles", api.assignableOrgRoles)
 					r.Route("/{user}", func(r chi.Router) {
 						r.Use(
-							httpmw.ExtractUserParam(options.Database, false),
+							httpmw.ExtractUserParam(options.Database),
 							httpmw.ExtractOrganizationMemberParam(options.Database),
 						)
 						r.Put("/roles", api.putMemberRoles)
@@ -741,7 +741,7 @@ func New(options *Options) *API {
 					r.Get("/", api.assignableSiteRoles)
 				})
 				r.Route("/{user}", func(r chi.Router) {
-					r.Use(httpmw.ExtractUserParam(options.Database, false))
+					r.Use(httpmw.ExtractUserParam(options.Database))
 					r.Post("/convert-login", api.postConvertLoginType)
 					r.Delete("/", api.deleteUser)
 					r.Get("/", api.userByName)

--- a/coderd/httpmw/organizationparam_test.go
+++ b/coderd/httpmw/organizationparam_test.go
@@ -125,7 +125,7 @@ func TestOrganizationParam(t *testing.T) {
 				DB:              db,
 				RedirectToLogin: false,
 			}),
-			httpmw.ExtractUserParam(db, false),
+			httpmw.ExtractUserParam(db),
 			httpmw.ExtractOrganizationParam(db),
 			httpmw.ExtractOrganizationMemberParam(db),
 		)
@@ -157,7 +157,7 @@ func TestOrganizationParam(t *testing.T) {
 				RedirectToLogin: false,
 			}),
 			httpmw.ExtractOrganizationParam(db),
-			httpmw.ExtractUserParam(db, false),
+			httpmw.ExtractUserParam(db),
 			httpmw.ExtractOrganizationMemberParam(db),
 		)
 		rtr.Get("/", func(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/httpmw/userparam_test.go
+++ b/coderd/httpmw/userparam_test.go
@@ -44,7 +44,7 @@ func TestUserParam(t *testing.T) {
 			r = returnedRequest
 		})).ServeHTTP(rw, r)
 
-		httpmw.ExtractUserParam(db, false)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		httpmw.ExtractUserParam(db)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			rw.WriteHeader(http.StatusOK)
 		})).ServeHTTP(rw, r)
 		res := rw.Result()
@@ -66,7 +66,7 @@ func TestUserParam(t *testing.T) {
 		routeContext := chi.NewRouteContext()
 		routeContext.URLParams.Add("user", "ben")
 		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routeContext))
-		httpmw.ExtractUserParam(db, false)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		httpmw.ExtractUserParam(db)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			rw.WriteHeader(http.StatusOK)
 		})).ServeHTTP(rw, r)
 		res := rw.Result()
@@ -88,7 +88,7 @@ func TestUserParam(t *testing.T) {
 		routeContext := chi.NewRouteContext()
 		routeContext.URLParams.Add("user", "me")
 		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routeContext))
-		httpmw.ExtractUserParam(db, false)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		httpmw.ExtractUserParam(db)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			_ = httpmw.UserParam(r)
 			rw.WriteHeader(http.StatusOK)
 		})).ServeHTTP(rw, r)

--- a/coderd/httpmw/workspaceparam_test.go
+++ b/coderd/httpmw/workspaceparam_test.go
@@ -315,7 +315,7 @@ func TestWorkspaceAgentByNameParam(t *testing.T) {
 					DB:              db,
 					RedirectToLogin: true,
 				}),
-				httpmw.ExtractUserParam(db, false),
+				httpmw.ExtractUserParam(db),
 				httpmw.ExtractWorkspaceAndAgentParam(db),
 			)
 			rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1177,13 +1177,13 @@ func userOrganizationIDs(ctx context.Context, api *API, user database.User) ([]u
 	return member.OrganizationIDs, nil
 }
 
-func findUser(id uuid.UUID, users []database.User) *database.User {
-	for _, u := range users {
-		if u.ID == id {
-			return &u
+func usernameWithID(id uuid.UUID, users []database.User) (string, bool) {
+	for _, user := range users {
+		if id == user.ID {
+			return user.Username, true
 		}
 	}
-	return nil
+	return "", false
 }
 
 func convertAPIKey(k database.APIKey) codersdk.APIKey {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -269,7 +269,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				apiKeyMiddleware,
 			)
 			r.Route("/{user}", func(r chi.Router) {
-				r.Use(httpmw.ExtractUserParam(options.Database, false))
+				r.Use(httpmw.ExtractUserParam(options.Database))
 				r.Get("/", api.workspaceQuota)
 			})
 		})
@@ -296,7 +296,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Use(
 				api.autostopRequirementEnabledMW,
 				apiKeyMiddleware,
-				httpmw.ExtractUserParam(options.Database, false),
+				httpmw.ExtractUserParam(options.Database),
 			)
 
 			r.Get("/", api.userQuietHoursSchedule)


### PR DESCRIPTION
Refactors workspace conversion to accept the ownerName, rather than a slice of users, since all it does is search the slice for the owner and use the username.

This is in preparation for a fix to `postWorkspacesByOrganization()` that will remove the need to pass the user object.

Also avoids panicing if the required user is not in the slice, since `findUser` could return nil in the old code, which would then get dereferenced for the username.
