### PR TITLE
fix: use UTF-8 encoding with screen

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1544,11 +1544,13 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 	_, err := exec.LookPath("screen")
 	hasScreen := err == nil
 
+	// Make sure UTF-8 works even with LANG set to something like C.
+	t.Setenv("LANG", "C")
+
 	for _, backendType := range backends {
 		backendType := backendType
 		t.Run(backendType, func(t *testing.T) {
 			if backendType == "Screen" {
-				t.Parallel()
 				if runtime.GOOS != "linux" {
 					t.Skipf("`screen` is not supported on %s", runtime.GOOS)
 				} else if !hasScreen {
@@ -1563,8 +1565,6 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 				err = os.Symlink(bashPath, filepath.Join(dir, "bash"))
 				require.NoError(t, err, "symlink bash into reconnecting pty PATH")
 				t.Setenv("PATH", dir)
-			} else {
-				t.Parallel()
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -1656,6 +1656,17 @@ func TestAgent_ReconnectingPTY(t *testing.T) {
 			tr4 := testutil.NewTerminalReader(t, netConn4)
 			require.NoError(t, tr4.ReadUntil(ctx, matchEchoOutput), "find echo output")
 			require.ErrorIs(t, tr4.ReadUntil(ctx, nil), io.EOF)
+
+			// Ensure that UTF-8 is supported.  Avoid the terminal emulator because it
+			// does not appear to support UTF-8, just make sure the bytes that come
+			// back have the character in it.
+			netConn5, err := conn.ReconnectingPTY(ctx, uuid.New(), 80, 80, "echo ❯")
+			require.NoError(t, err)
+			defer netConn5.Close()
+
+			bytes, err := io.ReadAll(netConn5)
+			require.NoError(t, err)
+			require.Contains(t, string(bytes), "❯")
 		})
 	}
 }

--- a/agent/reconnectingpty/screen.go
+++ b/agent/reconnectingpty/screen.go
@@ -206,12 +206,13 @@ func (rpty *screenReconnectingPTY) doAttach(ctx context.Context, conn net.Conn, 
 	cmd := pty.CommandContext(ctx, "screen", append([]string{
 		// -S is for setting the session's name.
 		"-S", rpty.id,
+		// -U tells screen to use UTF-8 encoding.
 		// -x allows attaching to an already attached session.
 		// -RR reattaches to the daemon or creates the session daemon if missing.
 		// -q disables the "New screen..." message that appears for five seconds
 		//    when creating a new session with -RR.
 		// -c is the flag for the config file.
-		"-xRRqc", rpty.configFile,
+		"-UxRRqc", rpty.configFile,
 		rpty.command.Path,
 		// pty.Cmd duplicates Path as the first argument so remove it.
 	}, rpty.command.Args[1:]...)...)


### PR DESCRIPTION
This will make characters like ❯ and ⇣ work, for example.

Honestly I am not 100% sure of the consequences but defaulting to UTF-8 seems reasonable?

I experimented with adding a test but without success (for either backend); maybe the vt10x emulator we use in the tests does not support UTF-8.  I did confirm it works manually though.

Fixes #9343