### PR TITLE
fix(scaletest/dashboard): increase viewport size and handle deadlines

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1151,13 +1151,12 @@ func (r *RootCmd) scaletestDashboard() *clibase.Cmd {
 				userClient.SetSessionToken(userTokResp.Key)
 
 				config := dashboard.Config{
-					Interval:   interval,
-					Jitter:     jitter,
-					Trace:      tracingEnabled,
-					Logger:     logger.Named(name),
-					Headless:   headless,
-					ActionFunc: dashboard.ClickRandomElement,
-					RandIntn:   rndGen.Intn,
+					Interval: interval,
+					Jitter:   jitter,
+					Trace:    tracingEnabled,
+					Logger:   logger.Named(name),
+					Headless: headless,
+					RandIntn: rndGen.Intn,
 				}
 				//nolint:gocritic
 				logger.Info(ctx, "runner config", slog.F("interval", interval), slog.F("jitter", jitter), slog.F("headless", headless), slog.F("trace", tracingEnabled))

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1158,6 +1158,11 @@ func (r *RootCmd) scaletestDashboard() *clibase.Cmd {
 					Headless: headless,
 					RandIntn: rndGen.Intn,
 				}
+				// Only take a screenshot if we're in verbose mode.
+				// This could be useful for debugging, but it will blow up the disk.
+				if r.verbose {
+					config.Screenshot = dashboard.Screenshot
+				}
 				//nolint:gocritic
 				logger.Info(ctx, "runner config", slog.F("interval", interval), slog.F("jitter", jitter), slog.F("headless", headless), slog.F("trace", tracingEnabled))
 				if err := config.Validate(); err != nil {

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1099,6 +1099,9 @@ func (r *RootCmd) scaletestDashboard() *clibase.Cmd {
 			}
 			ctx := inv.Context()
 			logger := slog.Make(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelInfo)
+			if r.verbose {
+				logger = logger.Leveled(slog.LevelDebug)
+			}
 			tracerProvider, closeTracing, tracingEnabled, err := tracingFlags.provider(ctx)
 			if err != nil {
 				return xerrors.Errorf("create tracer provider: %w", err)
@@ -1200,14 +1203,14 @@ func (r *RootCmd) scaletestDashboard() *clibase.Cmd {
 		{
 			Flag:        "interval",
 			Env:         "CODER_SCALETEST_DASHBOARD_INTERVAL",
-			Default:     "3s",
+			Default:     "10s",
 			Description: "Interval between actions.",
 			Value:       clibase.DurationOf(&interval),
 		},
 		{
 			Flag:        "jitter",
 			Env:         "CODER_SCALETEST_DASHBOARD_JITTER",
-			Default:     "2s",
+			Default:     "5s",
 			Description: "Jitter between actions.",
 			Value:       clibase.DurationOf(&jitter),
 		},

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1160,7 +1160,7 @@ func (r *RootCmd) scaletestDashboard() *clibase.Cmd {
 					RandIntn:   rndGen.Intn,
 				}
 				//nolint:gocritic
-				logger.Info(ctx, "runner config", slog.F("min_wait", interval), slog.F("max_wait", jitter), slog.F("headless", headless), slog.F("trace", tracingEnabled))
+				logger.Info(ctx, "runner config", slog.F("interval", interval), slog.F("jitter", jitter), slog.F("headless", headless), slog.F("trace", tracingEnabled))
 				if err := config.Validate(); err != nil {
 					return err
 				}

--- a/scaletest/dashboard/chromedp.go
+++ b/scaletest/dashboard/chromedp.go
@@ -238,7 +238,7 @@ func Screenshot(ctx context.Context, name string) (string, error) {
 	fname := fmt.Sprintf("scaletest-dashboard-%s-%s.png", name, time.Now().Format("20060102-150405"))
 	pwd := os.Getenv("PWD")
 	fpath := filepath.Join(pwd, fname)
-	f, err := os.OpenFile(fpath, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(fpath, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return "", xerrors.Errorf("open file: %w", err)
 	}

--- a/scaletest/dashboard/chromedp.go
+++ b/scaletest/dashboard/chromedp.go
@@ -243,7 +243,10 @@ func Screenshot(ctx context.Context, name string) (string, error) {
 		return "", xerrors.Errorf("generate random string: %w", err)
 	}
 	fname := fmt.Sprintf("scaletest-dashboard-%s-%s-%s.png", name, time.Now().Format("20060102-150405"), randExt)
-	pwd := os.Getenv("PWD")
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", xerrors.Errorf("get working directory: %w", err)
+	}
 	fpath := filepath.Join(pwd, fname)
 	f, err := os.OpenFile(fpath, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {

--- a/scaletest/dashboard/chromedp.go
+++ b/scaletest/dashboard/chromedp.go
@@ -13,6 +13,8 @@ import (
 	"github.com/chromedp/chromedp"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/cryptorand"
+
 	"cdr.dev/slog"
 )
 
@@ -235,7 +237,12 @@ func Screenshot(ctx context.Context, name string) (string, error) {
 	if err := chromedp.Run(ctx, chromedp.CaptureScreenshot(&buf)); err != nil {
 		return "", xerrors.Errorf("capture screenshot: %w", err)
 	}
-	fname := fmt.Sprintf("scaletest-dashboard-%s-%s.png", name, time.Now().Format("20060102-150405"))
+	randExt, err := cryptorand.String(4)
+	if err != nil {
+		// this should never happen
+		return "", xerrors.Errorf("generate random string: %w", err)
+	}
+	fname := fmt.Sprintf("scaletest-dashboard-%s-%s-%s.png", name, time.Now().Format("20060102-150405"), randExt)
 	pwd := os.Getenv("PWD")
 	fpath := filepath.Join(pwd, fname)
 	f, err := os.OpenFile(fpath, os.O_CREATE|os.O_WRONLY, 0o644)

--- a/scaletest/dashboard/chromedp.go
+++ b/scaletest/dashboard/chromedp.go
@@ -192,6 +192,13 @@ func initChromeDPCtx(ctx context.Context, log slog.Logger, u *url.URL, sessionTo
 		}
 	}
 
+	// force a viewport size of 1024x768 so we don't go into mobile mode
+	if err := chromedp.Run(cdpCtx, chromedp.EmulateViewport(1024, 768)); err != nil {
+		cancelFunc()
+		allocCtxCancel()
+		return nil, nil, xerrors.Errorf("set viewport size: %w", err)
+	}
+
 	// set cookies
 	if err := setSessionTokenCookie(cdpCtx, sessionToken, u.Host); err != nil {
 		cancelFunc()

--- a/scaletest/dashboard/chromedp.go
+++ b/scaletest/dashboard/chromedp.go
@@ -230,7 +230,7 @@ func visitMainPage(ctx context.Context, u *url.URL) error {
 	return chromedp.Run(ctx, chromedp.Navigate(u.String()))
 }
 
-func screenshot(ctx context.Context, name string) (string, error) {
+func Screenshot(ctx context.Context, name string) (string, error) {
 	var buf []byte
 	if err := chromedp.Run(ctx, chromedp.CaptureScreenshot(&buf)); err != nil {
 		return "", xerrors.Errorf("capture screenshot: %w", err)

--- a/scaletest/dashboard/chromedp.go
+++ b/scaletest/dashboard/chromedp.go
@@ -88,11 +88,11 @@ var defaultTargets = []Target{
 	},
 }
 
-// ClickRandomElement returns an action that will click an element from defaultTargets.
+// clickRandomElement returns an action that will click an element from defaultTargets.
 // If no elements are found, an error is returned.
 // If more than one element is found, one is chosen at random.
 // The label of the clicked element is returned.
-func ClickRandomElement(ctx context.Context, log slog.Logger, randIntn func(int) int, deadline time.Time) (Label, Action, error) {
+func clickRandomElement(ctx context.Context, log slog.Logger, randIntn func(int) int, deadline time.Time) (Label, Action, error) {
 	var xpath Selector
 	var found bool
 	var err error

--- a/scaletest/dashboard/config.go
+++ b/scaletest/dashboard/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	Headless bool `json:"headless"`
 	// ActionFunc is a function that returns an action to run.
 	ActionFunc func(ctx context.Context, log slog.Logger, randIntn func(int) int, deadline time.Time) (Label, Action, error) `json:"-"`
+	// WaitLoaded is a function that waits for the page to be loaded.
+	WaitLoaded func(ctx context.Context, deadline time.Time) error
+	// Screenshot is a function that takes a screenshot.
+	Screenshot func(ctx context.Context, filename string) (string, error)
 	// RandIntn is a function that returns a random number between 0 and n-1.
 	RandIntn func(int) int `json:"-"`
 }

--- a/scaletest/dashboard/config.go
+++ b/scaletest/dashboard/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	// Headless controls headless mode for chromedp.
 	Headless bool `json:"headless"`
 	// ActionFunc is a function that returns an action to run.
-	ActionFunc func(ctx context.Context, randIntn func(int) int) (Label, Action, error) `json:"-"`
+	ActionFunc func(ctx context.Context, log slog.Logger, randIntn func(int) int, deadline time.Time) (Label, Action, error) `json:"-"`
 	// RandIntn is a function that returns a random number between 0 and n-1.
 	RandIntn func(int) int `json:"-"`
 }

--- a/scaletest/dashboard/run.go
+++ b/scaletest/dashboard/run.go
@@ -43,7 +43,7 @@ func NewRunner(client *codersdk.Client, metrics Metrics, cfg Config) *Runner {
 }
 
 func (r *Runner) Run(ctx context.Context, _ string, _ io.Writer) error {
-	err := r._run(ctx)
+	err := r.runUntilDeadlineExceeded(ctx)
 	// If the context deadline exceeded, don't return an error.
 	// This just means the test finished.
 	if err == nil || errors.Is(err, context.DeadlineExceeded) {
@@ -52,7 +52,7 @@ func (r *Runner) Run(ctx context.Context, _ string, _ io.Writer) error {
 	return err
 }
 
-func (r *Runner) _run(ctx context.Context) error {
+func (r *Runner) runUntilDeadlineExceeded(ctx context.Context) error {
 	if r.client == nil {
 		return xerrors.Errorf("client is nil")
 	}

--- a/scaletest/dashboard/run.go
+++ b/scaletest/dashboard/run.go
@@ -73,6 +73,11 @@ func (r *Runner) Run(ctx context.Context, _ string, _ io.Writer) error {
 			l, act, err := r.cfg.ActionFunc(cdpCtx, r.cfg.Logger, r.cfg.RandIntn, actionCompleteByDeadline)
 			if err != nil {
 				r.cfg.Logger.Error(ctx, "calling ActionFunc", slog.Error(err))
+				sPath, sErr := screenshot(cdpCtx, me.Username)
+				if sErr != nil {
+					r.cfg.Logger.Error(ctx, "screenshot failed", slog.Error(sErr))
+				}
+				r.cfg.Logger.Info(ctx, "screenshot saved", slog.F("path", sPath))
 				continue
 			}
 			start := time.Now()
@@ -83,6 +88,11 @@ func (r *Runner) Run(ctx context.Context, _ string, _ io.Writer) error {
 				r.metrics.IncErrors(string(l))
 				//nolint:gocritic
 				r.cfg.Logger.Error(ctx, "action failed", slog.F("label", l), slog.Error(err))
+				sPath, sErr := screenshot(cdpCtx, me.Username+"-"+string(l))
+				if sErr != nil {
+					r.cfg.Logger.Error(ctx, "screenshot failed", slog.Error(sErr))
+				}
+				r.cfg.Logger.Info(ctx, "screenshot saved", slog.F("path", sPath))
 			} else {
 				//nolint:gocritic
 				r.cfg.Logger.Info(ctx, "action success", slog.F("label", l))

--- a/scaletest/dashboard/run.go
+++ b/scaletest/dashboard/run.go
@@ -33,7 +33,7 @@ func NewRunner(client *codersdk.Client, metrics Metrics, cfg Config) *Runner {
 		cfg.ActionFunc = clickRandomElement
 	}
 	if cfg.Screenshot == nil {
-		cfg.Screenshot = screenshot
+		cfg.Screenshot = Screenshot
 	}
 	return &Runner{
 		client:  client,

--- a/scaletest/dashboard/run_test.go
+++ b/scaletest/dashboard/run_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/scaletest/dashboard"
@@ -51,7 +52,7 @@ func Test_Run(t *testing.T) {
 		Jitter:   100 * time.Millisecond,
 		Logger:   log,
 		Headless: true,
-		ActionFunc: func(_ context.Context, rnd func(int) int) (dashboard.Label, dashboard.Action, error) {
+		ActionFunc: func(_ context.Context, _ slog.Logger, rnd func(int) int, _ time.Time) (dashboard.Label, dashboard.Action, error) {
 			if rnd(2) == 0 {
 				return "fails", failAction, nil
 			}

--- a/scaletest/dashboard/run_test.go
+++ b/scaletest/dashboard/run_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,16 +48,28 @@ func Test_Run(t *testing.T) {
 		IgnoreErrors: true,
 	})
 	m := &testMetrics{}
+	var (
+		waitLoadedCalled atomic.Bool
+		screenshotCalled atomic.Bool
+	)
 	cfg := dashboard.Config{
 		Interval: 500 * time.Millisecond,
 		Jitter:   100 * time.Millisecond,
 		Logger:   log,
 		Headless: true,
+		WaitLoaded: func(_ context.Context, _ time.Time) error {
+			waitLoadedCalled.Store(true)
+			return nil
+		},
 		ActionFunc: func(_ context.Context, _ slog.Logger, rnd func(int) int, _ time.Time) (dashboard.Label, dashboard.Action, error) {
 			if rnd(2) == 0 {
 				return "fails", failAction, nil
 			}
 			return "succeeds", successAction, nil
+		},
+		Screenshot: func(_ context.Context, name string) (string, error) {
+			screenshotCalled.Store(true)
+			return "/fake/path/to/" + name + ".png", nil
 		},
 		RandIntn: rg.Intn,
 	}


### PR DESCRIPTION
So, turns out that headless chrome has a _tiiny_ viewport by default. Like, 640x480 or something. Small enough to trigger our responsive mobile view. So, I just made the viewport bigger and it fixed things.

- Added way more debug logging
- We now write a screenshot on error in verbose mode (I'm open to making this a separate flag, but screenshots are an easy way to introspect headless browsers).
- Added a deadline for each iteraction of clicking on and waiting for a thing. 