### PR TITLE
fix: prevent duplicated creation of terminal

### DIFF
--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -154,7 +154,7 @@ const TerminalPage: FC = () => {
 
   // Create the terminal!
   useEffect(() => {
-    if (!xtermRef.current) {
+    if (!xtermRef.current || config.isLoading) {
       return;
     }
     const terminal = new XTerm.Terminal({
@@ -210,7 +210,7 @@ const TerminalPage: FC = () => {
       window.removeEventListener("resize", listener);
       terminal.dispose();
     };
-  }, [config.data, sendEvent, xtermRef, handleWebLink]);
+  }, [config.data, config.isLoading, sendEvent, xtermRef, handleWebLink]);
 
   // Triggers the initial terminal connection using
   // the reconnection token and workspace name found


### PR DESCRIPTION
xterm instance is created twice due to config load (my bad, I missed this in code review @sreya just fyi).  Does not seem to really harm anything though.

Was going to throw some other fixes in here but decided to keep it focused (for anyone looking at the history).