### PR TITLE
fix: remove Parallel() call after timeout context

### DIFF
--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -281,9 +281,8 @@ func TestTemplates(t *testing.T) {
 			for _, c := range cases {
 				c := c
 
+				// nolint: paralleltest // context is from parent t.Run
 				t.Run(c.Name, func(t *testing.T) {
-					t.Parallel()
-
 					_, err := client.UpdateTemplateMeta(ctx, template.ID, codersdk.UpdateTemplateMeta{
 						Name:                           template.Name,
 						DisplayName:                    template.DisplayName,


### PR DESCRIPTION
Fixes test flake seen here: https://github.com/coder/coder/runs/17562370632

It's inherently flaky to create a context with a timeout and then later call `t.Parallel()` since it causes the test to wait until all non-parallel tests have completed before resuming execution.  By the time execution has resumed, the context may 
have expired.  The amount of time before resuming is dependent on machine resources and number of test cases, which are inherently variable.
