### PR TITLE
fix(dogfood): fix slackme module source

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -72,8 +72,7 @@ data "coder_git_auth" "github" {
 data "coder_workspace" "me" {}
 
 module "slackme" {
-  # Required while slackme is WIP.
-  source           = "https://registry.coder.com/modules/slackme?ref=slackme"
+  source           = "https://registry.coder.com/modules/slackme"
   agent_id         = coder_agent.dev.id
   auth_provider_id = "slack"
 }


### PR DESCRIPTION
This was pinned to the branch ref and is no more needed after the branch has been merged.