### PR TITLE
chore(dogfood): use `coder_extrenal_auth` over now deprecated `coder_git_auth`

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -65,7 +65,7 @@ provider "docker" {
 
 provider "coder" {}
 
-data "coder_git_auth" "github" {
+data "coder_external_auth" "github" {
   id = "github"
 }
 
@@ -130,7 +130,7 @@ resource "coder_agent" "dev" {
   os   = "linux"
   dir  = data.coder_parameter.repo_dir.value
   env = {
-    GITHUB_TOKEN : data.coder_git_auth.github.access_token,
+    GITHUB_TOKEN : data.coder_external_auth.github.access_token,
     OIDC_TOKEN : data.coder_workspace.me.owner_oidc_access_token,
   }
   startup_script_behavior = "blocking"


### PR DESCRIPTION
@kylecarbs does this need any changes on the Coder server? For example adopting to the new `CODER_EXTERNAL_AUTH_X` variables?