### PR TITLE
fix(cli): remove invalid character for kubernetes provider in implicit non-obvious plan

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -503,7 +503,6 @@ func (r *RootCmd) scaletestCreateWorkspaces() *clibase.Cmd {
 		count    int64
 		template string
 
-		noPlan    bool
 		noCleanup bool
 		// TODO: implement this flag
 		// noCleanupFailures bool
@@ -594,10 +593,6 @@ func (r *RootCmd) scaletestCreateWorkspaces() *clibase.Cmd {
 			if tpl.ID == uuid.Nil {
 				return xerrors.Errorf("could not find template %q in any organization", template)
 			}
-			templateVersion, err := client.TemplateVersion(ctx, tpl.ActiveVersionID)
-			if err != nil {
-				return xerrors.Errorf("get template version %q: %w", tpl.ActiveVersionID, err)
-			}
 
 			cliRichParameters, err := asWorkspaceBuildParameters(parameterFlags.richParameters)
 			if err != nil {
@@ -607,42 +602,13 @@ func (r *RootCmd) scaletestCreateWorkspaces() *clibase.Cmd {
 			richParameters, err := prepWorkspaceBuild(inv, client, prepWorkspaceBuildArgs{
 				Action:           WorkspaceCreate,
 				Template:         tpl,
-				NewWorkspaceName: "scaletest-%", // TODO: the scaletest runner will pass in a different name here. Does this matter?
+				NewWorkspaceName: "scaletest-N", // TODO: the scaletest runner will pass in a different name here. Does this matter?
 
 				RichParameterFile: parameterFlags.richParameterFile,
 				RichParameters:    cliRichParameters,
 			})
 			if err != nil {
 				return xerrors.Errorf("prepare build: %w", err)
-			}
-
-			// Do a dry-run to ensure the template and parameters are valid
-			// before we start creating users and workspaces.
-			if !noPlan {
-				dryRun, err := client.CreateTemplateVersionDryRun(ctx, templateVersion.ID, codersdk.CreateTemplateVersionDryRunRequest{
-					WorkspaceName:       "scaletest",
-					RichParameterValues: richParameters,
-				})
-				if err != nil {
-					return xerrors.Errorf("start dry run workspace creation: %w", err)
-				}
-				_, _ = fmt.Fprintln(inv.Stdout, "Planning workspace...")
-				err = cliui.ProvisionerJob(inv.Context(), inv.Stdout, cliui.ProvisionerJobOptions{
-					Fetch: func() (codersdk.ProvisionerJob, error) {
-						return client.TemplateVersionDryRun(inv.Context(), templateVersion.ID, dryRun.ID)
-					},
-					Cancel: func() error {
-						return client.CancelTemplateVersionDryRun(inv.Context(), templateVersion.ID, dryRun.ID)
-					},
-					Logs: func() (<-chan codersdk.ProvisionerJobLog, io.Closer, error) {
-						return client.TemplateVersionDryRunLogsAfter(inv.Context(), templateVersion.ID, dryRun.ID, 0)
-					},
-					// Don't show log output for the dry-run unless there's an error.
-					Silent: true,
-				})
-				if err != nil {
-					return xerrors.Errorf("dry-run workspace: %w", err)
-				}
 			}
 
 			tracerProvider, closeTracing, tracingEnabled, err := tracingFlags.provider(ctx)
@@ -792,12 +758,6 @@ func (r *RootCmd) scaletestCreateWorkspaces() *clibase.Cmd {
 			Env:           "CODER_SCALETEST_TEMPLATE",
 			Description:   "Required: Name or ID of the template to use for workspaces.",
 			Value:         clibase.StringOf(&template),
-		},
-		{
-			Flag:        "no-plan",
-			Env:         "CODER_SCALETEST_NO_PLAN",
-			Description: `Skip the dry-run step to plan the workspace creation. This step ensures that the given parameters are valid for the given template.`,
-			Value:       clibase.BoolOf(&noPlan),
 		},
 		{
 			Flag:        "no-cleanup",


### PR DESCRIPTION
Introduced by https://github.com/coder/coder/pull/10132.

When running `exp scaletest create-workspaces` against a kubernetes cluster:

```
Planning workspace...
==> ⧗ Queued
=== ✔ Queued [0ms]
==> ⧗ Running
=== ✔ Running [22ms]
==> ⧗ Setting up
=== ✔ Setting up [43ms]
==> ⧗ Detecting persistent resources
=== ✔ Detecting persistent resources [4483ms]
==> ⧗ Cleaning Up
=== ✘ Cleaning Up [27ms]
=== ✘ Cleaning Up [48ms]
Encountered an error running "coder exp scaletest create-workspaces"
prepare build:
    github.com/coder/coder/v2/cli.(*RootCmd).scaletestCreateWorkspaces.func1
        /home/runner/actions-runner/_work/coder/coder/cli/exp_scaletest.go:616
  - dry-run workspace:
    github.com/coder/coder/v2/cli.prepWorkspaceBuild
        /home/runner/actions-runner/_work/coder/coder/cli/create.go:311
  - run dry-run provision job: terraform plan: exit status 1
```

The function `prepWorkspaceBuild` actually does a `terraform plan` under the hood.
So in effect I was passing `scaletest-%` to `kubectl create pod`, which the Kuberentes terraform provider really hates, but apparently the kreuzwerker  Docker provider is cool with.

However, if we need to do a plan to get rich parameters, then the `--no-plan` parameter for `exp scaletest create-workspaces` isn't really an option. Or am I misunderstanding?