### PR TITLE
fix: update create workspace button to recognize template names+display names

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -37,7 +37,11 @@ function sortTemplatesByUsersDesc(
 
   const termMatcher = new RegExp(searchTerm.replaceAll(/[^\w]/g, "."), "i");
   return templates
-    .filter((template) => termMatcher.test(template.display_name))
+    .filter(
+      (template) =>
+        termMatcher.test(template.display_name) ||
+        termMatcher.test(template.name),
+    )
     .sort((t1, t2) => t2.active_user_count - t1.active_user_count)
     .slice(0, 10);
 }

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -84,7 +84,7 @@ function WorkspaceResultsRow({ template }: { template: Template }) {
             sx={{ marginY: 0, paddingBottom: 0.5, lineHeight: 1 }}
             noWrap
           >
-            {template.display_name || "[Unnamed]"}
+            {template.display_name || template.name || "[Unnamed]"}
           </Typography>
 
           <Box


### PR DESCRIPTION
Closes #10231

With this change, the "Create workspace" button goes through all templates available, listing them by display name, then if that's not available, the template name. The text "[Unnamed]" is only used in the event that neither has a usable value.