### PR TITLE
feat(scaletest): annotate scaletest pod when scaletest is in progress

### DIFF
--- a/scaletest/templates/scaletest-runner/scripts/lib.sh
+++ b/scaletest/templates/scaletest-runner/scripts/lib.sh
@@ -295,3 +295,14 @@ fetch_coder_full() {
 	maybedryrun "${DRY_RUN}" chmod +x "${SCALETEST_CODER_BINARY}"
 	log "Full Coder binary downloaded to ${SCALETEST_CODER_BINARY}"
 }
+
+# set_status_annotation annotates the currently running pod with the key
+# com.coder.scaletest.status. It will overwrite the previous status.
+set_status_annotation() {
+	if [[ $# -ne 1 ]]; then
+		log "must specify an annotation value"
+		exit 1
+	else
+		maybedryrun "${DRY_RUN}" kubectl --namespace "$(namespace)" annotate pod "$(hostname)" "com.coder.scaletest.status=$2" --overwrite
+	fi
+}

--- a/scaletest/templates/scaletest-runner/scripts/lib.sh
+++ b/scaletest/templates/scaletest-runner/scripts/lib.sh
@@ -302,6 +302,6 @@ set_pod_status_annotation() {
 		log "must specify an annotation value"
 		return
 	else
-		maybedryrun "${DRY_RUN}" kubectl --namespace "$(namespace)" annotate pod "$(hostname)" "com.coder.scaletest.status=$2" --overwrite
+		maybedryrun "${DRY_RUN}" kubectl --namespace "$(namespace)" annotate pod "$(hostname)" "com.coder.scaletest.status=$1" --overwrite
 	fi
 }

--- a/scaletest/templates/scaletest-runner/scripts/lib.sh
+++ b/scaletest/templates/scaletest-runner/scripts/lib.sh
@@ -270,7 +270,7 @@ fetch_coder_full() {
 	ns=$(namespace)
 	if [[ -z "${ns}" ]]; then
 		log "Could not determine namespace!"
-		return
+		return 1
 	fi
 	log "Namespace from serviceaccount token is ${ns}"
 	pods=$(coder_pods)

--- a/scaletest/templates/scaletest-runner/scripts/prepare.sh
+++ b/scaletest/templates/scaletest-runner/scripts/prepare.sh
@@ -11,6 +11,7 @@ mkdir -p "${SCALETEST_RESULTS_DIR}"
 
 log "Preparing scaletest workspace environment..."
 set_status Preparing
+set_status_annotation preparing
 
 log "Compressing previous run logs (if applicable)..."
 mkdir -p "${HOME}/archive"

--- a/scaletest/templates/scaletest-runner/scripts/prepare.sh
+++ b/scaletest/templates/scaletest-runner/scripts/prepare.sh
@@ -11,7 +11,6 @@ mkdir -p "${SCALETEST_RESULTS_DIR}"
 
 log "Preparing scaletest workspace environment..."
 set_status Preparing
-set_status_annotation preparing
 
 log "Compressing previous run logs (if applicable)..."
 mkdir -p "${HOME}/archive"

--- a/scaletest/templates/scaletest-runner/scripts/run.sh
+++ b/scaletest/templates/scaletest-runner/scripts/run.sh
@@ -17,6 +17,7 @@ coder exp scaletest create-workspaces \
 	--count "${SCALETEST_PARAM_NUM_WORKSPACES}" \
 	--template "${SCALETEST_PARAM_TEMPLATE}" \
 	--concurrency "${SCALETEST_PARAM_CREATE_CONCURRENCY}" \
+	--timeout 5h \
 	--job-timeout 5h \
 	--no-cleanup \
 	--output json:"${SCALETEST_RESULTS_DIR}/create-workspaces.json"

--- a/scaletest/templates/scaletest-runner/scripts/run.sh
+++ b/scaletest/templates/scaletest-runner/scripts/run.sh
@@ -64,4 +64,4 @@ done
 
 log "Scaletest complete!"
 set_status Complete
-set_status_annotation complete
+set_status_annotation completed

--- a/scaletest/templates/scaletest-runner/scripts/run.sh
+++ b/scaletest/templates/scaletest-runner/scripts/run.sh
@@ -11,6 +11,7 @@ export SCALETEST_PARAM_LOAD_SCENARIOS=("${scaletest_load_scenarios[@]}")
 
 log "Running scaletest..."
 set_status Running
+set_status_annotation running
 
 start_phase "Creating workspaces"
 coder exp scaletest create-workspaces \
@@ -63,3 +64,4 @@ done
 
 log "Scaletest complete!"
 set_status Complete
+set_status_annotation complete

--- a/scaletest/templates/scaletest-runner/scripts/run.sh
+++ b/scaletest/templates/scaletest-runner/scripts/run.sh
@@ -11,7 +11,6 @@ export SCALETEST_PARAM_LOAD_SCENARIOS=("${scaletest_load_scenarios[@]}")
 
 log "Running scaletest..."
 set_status Running
-set_status_annotation running
 
 start_phase "Creating workspaces"
 coder exp scaletest create-workspaces \
@@ -64,4 +63,3 @@ done
 
 log "Scaletest complete!"
 set_status Complete
-set_status_annotation completed


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/7777

This PR modifies the scaletest-runner template to add a pod annotation to the scaletest runner pod. 

The annotation key is set to `com.coder.scaletest.phase` and the annotation value is one of `preparing`, `running`, or `completed`.

This will allow checking if a scaletest is in progress, and preventing any operations that would interrupt a running scaletest.