### PR TITLE
test(coderd/database/dbtestutil): allow access to `*sql.DB`

### DIFF
--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -63,6 +63,9 @@ func NewDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub) {
 	for _, opt := range opts {
 		opt(&o)
 	}
+	if o.returnSQLDB && !WillUsePostgres() {
+		t.Fatalf("cannot use WithReturnSQLDB without PostgreSQL, consider adding `if !dbtestutil.WillUsePostgres() { t.Skip() }` to this test")
+	}
 
 	db := dbfake.New()
 	ps := pubsub.NewInMemory()


### PR DESCRIPTION
This change may be controversial, but on occasion I find it useful. I needed this whilst benchmarking a database change.

Sample usage:

```
db, pubsub, sqlDB := dbtestutil.NewDBWithSQLDB(b)
client := coderdtest.New(b, &coderdtest.Options{
	IncludeProvisionerDaemon: true,
	Database:                 db,
	Pubsub:                   pubsub,
})

_, _ = sqlDB.Exec("...")
```

