### PR TITLE
chore(docs): fix syntax highlighting

### DIFF
--- a/docs/templates/icons.md
+++ b/docs/templates/icons.md
@@ -23,7 +23,7 @@ come bundled with your Coder deployment.
 
   These can all be configured to use an icon by setting the `icon` field.
 
-  ```terraform
+  ```hcl
   data "coder_parameter" "my_parameter" {
     icon = "/icon/coder.svg"
 


### PR DESCRIPTION
Due to some reason, our docs are not rendering syntax highlighting when the code block type is 'terraform'. Changing the type to `hcl` fixes this.