### PR TITLE
fix(scaletest): fix flake in Test_Runner/Cleanup

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1241,7 +1241,7 @@ func (r *runnableTraceWrapper) Run(ctx context.Context, id string, logs io.Write
 	return r.runner.Run(ctx2, id, logs)
 }
 
-func (r *runnableTraceWrapper) Cleanup(ctx context.Context, id string) error {
+func (r *runnableTraceWrapper) Cleanup(ctx context.Context, id string, logs io.Writer) error {
 	c, ok := r.runner.(harness.Cleanable)
 	if !ok {
 		return nil
@@ -1253,7 +1253,7 @@ func (r *runnableTraceWrapper) Cleanup(ctx context.Context, id string) error {
 	ctx, span := r.tracer.Start(ctx, r.spanName+" cleanup")
 	defer span.End()
 
-	return c.Cleanup(ctx, id)
+	return c.Cleanup(ctx, id, logs)
 }
 
 // newScaleTestUser returns a random username and email address that can be used

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -176,13 +176,13 @@ resourceLoop:
 }
 
 // Cleanup implements Cleanable.
-func (r *Runner) Cleanup(ctx context.Context, id string) error {
+func (r *Runner) Cleanup(ctx context.Context, id string, w io.Writer) error {
 	if r.cfg.NoCleanup {
 		return nil
 	}
 
 	if r.workspacebuildRunner != nil {
-		err := r.workspacebuildRunner.Cleanup(ctx, id)
+		err := r.workspacebuildRunner.Cleanup(ctx, id, w)
 		if err != nil {
 			return xerrors.Errorf("cleanup workspace: %w", err)
 		}
@@ -191,6 +191,7 @@ func (r *Runner) Cleanup(ctx context.Context, id string) error {
 	if r.userID != uuid.Nil {
 		err := r.client.DeleteUser(ctx, r.userID)
 		if err != nil {
+			_, _ = fmt.Fprintf(w, "failed to delete user %q: %v\n", r.userID.String(), err)
 			return xerrors.Errorf("delete user: %w", err)
 		}
 	}

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -176,14 +176,14 @@ resourceLoop:
 }
 
 // Cleanup implements Cleanable.
-func (r *Runner) Cleanup(ctx context.Context, id string, w io.Writer) error {
+func (r *Runner) Cleanup(ctx context.Context, id string, logs io.Writer) error {
 	if r.cfg.NoCleanup {
-		_, _ = fmt.Fprintln(w, "skipping cleanup")
+		_, _ = fmt.Fprintln(logs, "skipping cleanup")
 		return nil
 	}
 
 	if r.workspacebuildRunner != nil {
-		err := r.workspacebuildRunner.Cleanup(ctx, id, w)
+		err := r.workspacebuildRunner.Cleanup(ctx, id, logs)
 		if err != nil {
 			return xerrors.Errorf("cleanup workspace: %w", err)
 		}
@@ -192,7 +192,7 @@ func (r *Runner) Cleanup(ctx context.Context, id string, w io.Writer) error {
 	if r.userID != uuid.Nil {
 		err := r.client.DeleteUser(ctx, r.userID)
 		if err != nil {
-			_, _ = fmt.Fprintf(w, "failed to delete user %q: %v\n", r.userID.String(), err)
+			_, _ = fmt.Fprintf(logs, "failed to delete user %q: %v\n", r.userID.String(), err)
 			return xerrors.Errorf("delete user: %w", err)
 		}
 	}

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -178,6 +178,7 @@ resourceLoop:
 // Cleanup implements Cleanable.
 func (r *Runner) Cleanup(ctx context.Context, id string, w io.Writer) error {
 	if r.cfg.NoCleanup {
+		_, _ = fmt.Fprintln(w, "skipping cleanup")
 		return nil
 	}
 

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -279,7 +279,6 @@ func Test_Runner(t *testing.T) {
 				t.Fatalf("expected build transition %s, got %s", codersdk.WorkspaceTransitionStart, ws.LatestBuild.Transition)
 			}
 			return ws.LatestBuild.Job.Status == codersdk.ProvisionerJobRunning
-
 		}, testutil.WaitShort, testutil.IntervalMedium)
 
 		cancelFunc()

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -181,7 +181,7 @@ func Test_Runner(t *testing.T) {
 		err = runner.Cleanup(ctx, "1", cleanupLogs)
 		require.NoError(t, err)
 		cleanupLogsStr := cleanupLogs.String()
-		require.Contains(t, cleanupLogsStr, "Deleting workspace: "+workspaces.Workspaces[0].ID.String())
+		require.Contains(t, cleanupLogsStr, "deleting workspace")
 		require.NotContains(t, cleanupLogsStr, "canceling workspace build") // The build should have already completed.
 		require.Contains(t, cleanupLogsStr, "Build succeeded!")
 
@@ -276,7 +276,8 @@ func Test_Runner(t *testing.T) {
 			t.Logf("checking build: %s | %s", ws.LatestBuild.Transition, ws.LatestBuild.Job.Status)
 			// There should be only one build at present.
 			if ws.LatestBuild.Transition != codersdk.WorkspaceTransitionStart {
-				t.Fatalf("expected build transition %s, got %s", codersdk.WorkspaceTransitionStart, ws.LatestBuild.Transition)
+				t.Errorf("expected build transition %s, got %s", codersdk.WorkspaceTransitionStart, ws.LatestBuild.Transition)
+				return false
 			}
 			return ws.LatestBuild.Job.Status == codersdk.ProvisionerJobRunning
 		}, testutil.WaitShort, testutil.IntervalMedium)

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 	"testing"
 	"time"
 
@@ -298,11 +297,6 @@ func Test_Runner(t *testing.T) {
 
 		// Ensure the job has been marked as deleted
 		require.Eventually(t, func() bool {
-			cleanupLogsStr := cleanupLogs.String()
-			if !strings.Contains(cleanupLogsStr, "canceling workspace build") {
-				t.Logf("workspace build has not canceled yet")
-				return false
-			}
 			workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{})
 			if err != nil {
 				return false
@@ -337,6 +331,8 @@ func Test_Runner(t *testing.T) {
 		}, testutil.WaitShort, testutil.IntervalMedium)
 		cancelFunc()
 		<-done
+		cleanupLogsStr := cleanupLogs.String()
+		require.Contains(t, cleanupLogsStr, "canceling workspace build")
 	})
 
 	t.Run("NoCleanup", func(t *testing.T) {

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -177,7 +177,8 @@ func Test_Runner(t *testing.T) {
 		require.Contains(t, logsStr, "Opening reconnecting PTY connection to agent")
 		require.Contains(t, logsStr, "Opening connection to workspace agent")
 
-		err = runner.Cleanup(ctx, "1")
+		cleanupLogs := bytes.NewBuffer(nil)
+		err = runner.Cleanup(ctx, "1", cleanupLogs)
 		require.NoError(t, err)
 
 		// Ensure the user and workspace were deleted.
@@ -281,11 +282,12 @@ func Test_Runner(t *testing.T) {
 		<-done
 
 		// When we run the cleanup, it should be canceled
+		cleanupLogs := bytes.NewBuffer(nil)
 		cancelCtx, cancelFunc = context.WithCancel(ctx)
 		done = make(chan struct{})
 		go func() {
 			// This will return an error as the "delete" operation will never complete.
-			_ = runner.Cleanup(cancelCtx, "1")
+			_ = runner.Cleanup(cancelCtx, "1", cleanupLogs)
 			close(done)
 		}()
 
@@ -458,7 +460,8 @@ func Test_Runner(t *testing.T) {
 		require.Contains(t, logsStr, "Opening reconnecting PTY connection to agent")
 		require.Contains(t, logsStr, "Opening connection to workspace agent")
 
-		err = runner.Cleanup(ctx, "1")
+		cleanupLogs := bytes.NewBuffer(nil)
+		err = runner.Cleanup(ctx, "1", cleanupLogs)
 		require.NoError(t, err)
 
 		// Ensure the user and workspace were not deleted.

--- a/scaletest/dashboard/run.go
+++ b/scaletest/dashboard/run.go
@@ -125,6 +125,6 @@ func (r *Runner) runUntilDeadlineExceeded(ctx context.Context) error {
 	}
 }
 
-func (*Runner) Cleanup(_ context.Context, _ string) error {
+func (*Runner) Cleanup(_ context.Context, _ string, _ io.Writer) error {
 	return nil
 }

--- a/scaletest/harness/harness_test.go
+++ b/scaletest/harness/harness_test.go
@@ -112,7 +112,7 @@ func Test_TestHarness(t *testing.T) {
 				RunFn: func(_ context.Context, _ string, _ io.Writer) error {
 					return nil
 				},
-				CleanupFn: func(_ context.Context, _ string) error {
+				CleanupFn: func(_ context.Context, _ string, _ io.Writer) error {
 					panic(testPanicMessage)
 				},
 			})
@@ -150,7 +150,7 @@ func Test_TestHarness(t *testing.T) {
 				RunFn: func(_ context.Context, _ string, _ io.Writer) error {
 					return nil
 				},
-				CleanupFn: func(_ context.Context, _ string) error {
+				CleanupFn: func(_ context.Context, _ string, _ io.Writer) error {
 					return nil
 				},
 			})
@@ -295,7 +295,7 @@ func fakeTestFns(err, cleanupErr error) testFns {
 		RunFn: func(_ context.Context, _ string, _ io.Writer) error {
 			return err
 		},
-		CleanupFn: func(_ context.Context, _ string) error {
+		CleanupFn: func(_ context.Context, _ string, _ io.Writer) error {
 			return cleanupErr
 		},
 	}

--- a/scaletest/harness/run.go
+++ b/scaletest/harness/run.go
@@ -28,7 +28,7 @@ type Runnable interface {
 type Cleanable interface {
 	Runnable
 	// Cleanup should clean up any lingering resources from the test.
-	Cleanup(ctx context.Context, id string) error
+	Cleanup(ctx context.Context, id string, logs io.Writer) error
 }
 
 // AddRun creates a new *TestRun with the given name, ID and Runnable, adds it
@@ -131,7 +131,7 @@ func (r *TestRun) Cleanup(ctx context.Context) (err error) {
 		}
 	}()
 
-	err = c.Cleanup(ctx, r.id)
+	err = c.Cleanup(ctx, r.id, r.logs)
 	//nolint:revive // we use named returns because we mutate it in a defer
 	return
 }

--- a/scaletest/harness/run_test.go
+++ b/scaletest/harness/run_test.go
@@ -16,7 +16,7 @@ import (
 type testFns struct {
 	RunFn func(ctx context.Context, id string, logs io.Writer) error
 	// CleanupFn is optional if no cleanup is required.
-	CleanupFn func(ctx context.Context, id string) error
+	CleanupFn func(ctx context.Context, id string, logs io.Writer) error
 }
 
 // Run implements Runnable.
@@ -25,12 +25,12 @@ func (fns testFns) Run(ctx context.Context, id string, logs io.Writer) error {
 }
 
 // Cleanup implements Cleanable.
-func (fns testFns) Cleanup(ctx context.Context, id string) error {
+func (fns testFns) Cleanup(ctx context.Context, id string, logs io.Writer) error {
 	if fns.CleanupFn == nil {
 		return nil
 	}
 
-	return fns.CleanupFn(ctx, id)
+	return fns.CleanupFn(ctx, id, logs)
 }
 
 func Test_TestRun(t *testing.T) {
@@ -49,7 +49,7 @@ func Test_TestRun(t *testing.T) {
 					atomic.AddInt64(&runCalled, 1)
 					return nil
 				},
-				CleanupFn: func(ctx context.Context, id string) error {
+				CleanupFn: func(ctx context.Context, id string, logs io.Writer) error {
 					atomic.AddInt64(&cleanupCalled, 1)
 					return nil
 				},
@@ -93,7 +93,7 @@ func Test_TestRun(t *testing.T) {
 				RunFn: func(ctx context.Context, id string, logs io.Writer) error {
 					return nil
 				},
-				CleanupFn: func(ctx context.Context, id string) error {
+				CleanupFn: func(ctx context.Context, id string, logs io.Writer) error {
 					atomic.AddInt64(&cleanupCalled, 1)
 					return nil
 				},

--- a/scaletest/workspacebuild/run.go
+++ b/scaletest/workspacebuild/run.go
@@ -151,12 +151,11 @@ func (r *CleanupRunner) Run(ctx context.Context, _ string, logs io.Writer) error
 }
 
 // Cleanup implements Cleanable by wrapping CleanupRunner.
-func (r *Runner) Cleanup(ctx context.Context, id string) error {
-	// TODO: capture these logs
+func (r *Runner) Cleanup(ctx context.Context, id string, w io.Writer) error {
 	return (&CleanupRunner{
 		client:      r.client,
 		workspaceID: r.workspaceID,
-	}).Run(ctx, id, io.Discard)
+	}).Run(ctx, id, w)
 }
 
 func waitForBuild(ctx context.Context, w io.Writer, client *codersdk.Client, buildID uuid.UUID) error {

--- a/scaletest/workspacebuild/run_test.go
+++ b/scaletest/workspacebuild/run_test.go
@@ -180,7 +180,8 @@ func Test_Runner(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspaces[0].LatestBuild.ID)
 		coderdtest.AwaitWorkspaceAgents(t, client, workspaces[0].ID)
 
-		err = runner.Cleanup(ctx, "1")
+		cleanupLogs := bytes.NewBuffer(nil)
+		err = runner.Cleanup(ctx, "1", cleanupLogs)
 		require.NoError(t, err)
 	})
 

--- a/scaletest/workspacetraffic/run.go
+++ b/scaletest/workspacetraffic/run.go
@@ -169,7 +169,7 @@ func (r *Runner) Run(ctx context.Context, _ string, logs io.Writer) error {
 }
 
 // Cleanup does nothing, successfully.
-func (*Runner) Cleanup(context.Context, string) error {
+func (*Runner) Cleanup(context.Context, string, io.Writer) error {
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/10240

From the linked issue:

- We get to the `require.Eventually` that asserts that the build was canceled
- This times out after 10 seconds
- It appears that the build job never got canceled after 10 seconds
- It also appears that a second build never got created
- We unfortunately appear to be missing cleanup logs in the output, so hard to troubleshoot further.

Based on the above, it looks like a race between `runner.Cleanup` doing its thing and the `require.Eventually` asserting that cleanup happened. I don't see a simple way to synchronize between these two actions, so to reduce the likelihood of this happening in future and hoepfully aid future troubleshooting:

- Added a check that the build is running before we cancel it
- Added cleanup output to logs (TODO done)
- Added some checks to the test cleanup logs

I wasn't able to recrate the original failure after running the test 100 times with `DB=ci` and `-race`, so while not 100% confident this completely fixes the flake, I'm hopeful at least.