### PR TITLE
fix(coderd): make activitybump aware of default template ttl 

### DIFF
--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -731,6 +731,51 @@ func TestExecutorAutostartTemplateDisabled(t *testing.T) {
 	assert.Len(t, stats.Transitions, 0)
 }
 
+func TestExecutorAutostopTemplateDisabled(t *testing.T) {
+	t.Parallel()
+
+	// Given: we have a workspace built from a template that disallows user autostop
+	var (
+		sched   = mustSchedule(t, "CRON_TZ=UTC 0 * * * *")
+		tickCh  = make(chan time.Time)
+		statsCh = make(chan autobuild.Stats)
+
+		client = coderdtest.New(t, &coderdtest.Options{
+			AutobuildTicker:          tickCh,
+			IncludeProvisionerDaemon: true,
+			AutobuildStats:           statsCh,
+			// We are using a mock store here as the AGPL store does not implement this.
+			TemplateScheduleStore: schedule.MockTemplateScheduleStore{
+				GetFn: func(_ context.Context, _ database.Store, _ uuid.UUID) (schedule.TemplateScheduleOptions, error) {
+					return schedule.TemplateScheduleOptions{
+						UserAutostopEnabled: false,
+						DefaultTTL:          time.Hour,
+					}, nil
+				},
+			},
+		})
+		// Given: we have a user with a workspace configured to autostart some time in the future
+		workspace = mustProvisionWorkspace(t, client, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.TTLMillis = ptr.Ref(8 * time.Hour.Milliseconds())
+		})
+	)
+
+	// When: we create the workspace
+	// Then: the deadline should be set to the template default TTL
+	assert.WithinDuration(t, workspace.LatestBuild.CreatedAt.Add(time.Hour), workspace.LatestBuild.Deadline.Time, time.Minute)
+
+	// When: the autobuild executor ticks before the next scheduled time
+	go func() {
+		tickCh <- sched.Next(workspace.LatestBuild.CreatedAt).Add(time.Minute)
+		close(tickCh)
+	}()
+
+	// Then: nothing should happen
+	stats := <-statsCh
+	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Transitions, 0)
+}
+
 // TestExecutorFailedWorkspace test AGPL functionality which mainly
 // ensures that autostop actions as a result of a failed workspace
 // build do not trigger.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -28,6 +28,7 @@ type sqlcQuerier interface {
 	// as the TTL wraps. For example, if I set the TTL to 12 hours, sign off
 	// work at midnight, come back at 10am, I would want another full day
 	// of uptime.
+	// We only bump if the raw interval is positive and non-zero.
 	// We only bump if workspace shutdown is manual.
 	// We only bump when 5% of the deadline has elapsed.
 	ActivityBumpWorkspace(ctx context.Context, workspaceID uuid.UUID) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -23,12 +23,20 @@ WITH latest AS (
 		workspace_builds.max_deadline::timestamp with time zone AS build_max_deadline,
 		workspace_builds.transition AS build_transition,
 		provisioner_jobs.completed_at::timestamp with time zone AS job_completed_at,
-		(workspaces.ttl / 1000 / 1000 / 1000 || ' seconds')::interval AS ttl_interval
+		(
+			CASE
+				WHEN templates.allow_user_autostop
+				THEN (workspaces.ttl / 1000 / 1000 / 1000 || ' seconds')::interval
+				ELSE (templates.default_ttl / 1000 / 1000 / 1000 || ' seconds')::interval
+			END
+		) AS ttl_interval
 	FROM workspace_builds
 	JOIN provisioner_jobs
 		ON provisioner_jobs.id = workspace_builds.job_id
 	JOIN workspaces
 		ON workspaces.id = workspace_builds.workspace_id
+	JOIN templates
+		ON templates.id = workspaces.template_id
 	WHERE workspace_builds.workspace_id = $1::uuid
 	ORDER BY workspace_builds.build_number DESC
 	LIMIT 1
@@ -46,6 +54,7 @@ FROM latest l
 WHERE wb.id = l.build_id
 AND l.job_completed_at IS NOT NULL
 AND l.build_transition = 'start'
+AND l.ttl_interval > '0 seconds'::interval
 AND l.build_deadline != '0001-01-01 00:00:00+00'
 AND l.build_deadline - (l.ttl_interval * 0.95) < NOW()
 `
@@ -54,6 +63,7 @@ AND l.build_deadline - (l.ttl_interval * 0.95) < NOW()
 // as the TTL wraps. For example, if I set the TTL to 12 hours, sign off
 // work at midnight, come back at 10am, I would want another full day
 // of uptime.
+// We only bump if the raw interval is positive and non-zero.
 // We only bump if workspace shutdown is manual.
 // We only bump when 5% of the deadline has elapsed.
 func (q *sqlQuerier) ActivityBumpWorkspace(ctx context.Context, workspaceID uuid.UUID) error {

--- a/coderd/database/queries/activitybump.sql
+++ b/coderd/database/queries/activitybump.sql
@@ -10,12 +10,20 @@ WITH latest AS (
 		workspace_builds.max_deadline::timestamp with time zone AS build_max_deadline,
 		workspace_builds.transition AS build_transition,
 		provisioner_jobs.completed_at::timestamp with time zone AS job_completed_at,
-		(workspaces.ttl / 1000 / 1000 / 1000 || ' seconds')::interval AS ttl_interval
+		(
+			CASE
+				WHEN templates.allow_user_autostop
+				THEN (workspaces.ttl / 1000 / 1000 / 1000 || ' seconds')::interval
+				ELSE (templates.default_ttl / 1000 / 1000 / 1000 || ' seconds')::interval
+			END
+		) AS ttl_interval
 	FROM workspace_builds
 	JOIN provisioner_jobs
 		ON provisioner_jobs.id = workspace_builds.job_id
 	JOIN workspaces
 		ON workspaces.id = workspace_builds.workspace_id
+	JOIN templates
+		ON templates.id = workspaces.template_id
 	WHERE workspace_builds.workspace_id = @workspace_id::uuid
 	ORDER BY workspace_builds.build_number DESC
 	LIMIT 1
@@ -33,6 +41,8 @@ FROM latest l
 WHERE wb.id = l.build_id
 AND l.job_completed_at IS NOT NULL
 AND l.build_transition = 'start'
+-- We only bump if the raw interval is positive and non-zero.
+AND l.ttl_interval > '0 seconds'::interval
 -- We only bump if workspace shutdown is manual.
 AND l.build_deadline != '0001-01-01 00:00:00+00'
 -- We only bump when 5% of the deadline has elapsed.


### PR DESCRIPTION
The refactored ActivityBump query did not take into account the
template-level TTL, resulting in potentially incorrect bump
amounts for workspaces that have both a user-defined and template-
defined TTL that differ.

This change is ported over from [PR#10035](https://github.com/coder/coder/pull/10035) to reduce the overall
size of that PR.

Also includes a drive-by unit test in autobuild for checking template autostop/TTL.