### PR TITLE
feat(helm/provisioner): add extraTemplates

### DIFF
--- a/helm/coder/tests/chart_test.go
+++ b/helm/coder/tests/chart_test.go
@@ -76,6 +76,10 @@ var testCases = []testCase{
 		name:          "env_from",
 		expectedError: "",
 	},
+	{
+		name:          "extra_templates",
+		expectedError: "",
+	},
 }
 
 type testCase struct {

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: some-config
+  namespace: default
 data:
   key: some-value
 ---

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -1,0 +1,198 @@
+---
+# Source: coder/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-0.1.0
+  name: coder
+---
+# Source: coder/templates/extra-templates.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: some-config
+data:
+  key: some-value
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder"
+subjects:
+  - kind: ServiceAccount
+    name: "coder"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-workspace-perms
+---
+# Source: coder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder
+  labels:
+    helm.sh/chart: coder-0.1.0
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  sessionAffinity: None
+  ports:
+    - name: "http"
+      port: 80
+      targetPort: "http"
+      protocol: TCP
+      
+  externalTrafficPolicy: "Cluster"
+  selector:
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/instance: release-name
+---
+# Source: coder/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/part-of: coder
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-0.1.0
+  name: coder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: coder
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: coder
+        app.kubernetes.io/part-of: coder
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-0.1.0
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - coder
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+      - args:
+        - server
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_HTTP_ADDRESS
+          value: 0.0.0.0:8080
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_ACCESS_URL
+          value: http://coder.default.svc.cluster.local
+        - name: KUBE_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: CODER_DERP_SERVER_RELAY_URL
+          value: http://$(KUBE_POD_IP):8080
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+        name: coder
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: coder
+      terminationGracePeriodSeconds: 60
+      volumes: []

--- a/helm/coder/tests/testdata/extra_templates.yaml
+++ b/helm/coder/tests/testdata/extra_templates.yaml
@@ -7,5 +7,6 @@ extraTemplates:
     kind: ConfigMap
     metadata:
       name: some-config
+      namespace: {{ .Release.Namespace }}
     data:
       key: some-value

--- a/helm/coder/tests/testdata/extra_templates.yaml
+++ b/helm/coder/tests/testdata/extra_templates.yaml
@@ -1,0 +1,11 @@
+coder:
+  image:
+    tag: latest
+extraTemplates:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: some-config
+    data:
+      key: some-value

--- a/helm/provisioner/templates/extra-templates.yaml
+++ b/helm/provisioner/templates/extra-templates.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraTemplates }}
+---
+{{ include "coder.renderTemplate" (dict "value" . "context" $) }}
+{{- end }}

--- a/helm/provisioner/tests/chart_test.go
+++ b/helm/provisioner/tests/chart_test.go
@@ -52,6 +52,10 @@ var testCases = []testCase{
 		name:          "provisionerd_psk",
 		expectedError: "",
 	},
+	{
+		name:          "extra_templates",
+		expectedError: "",
+	},
 }
 
 type testCase struct {

--- a/helm/provisioner/tests/testdata/extra_templates.golden
+++ b/helm/provisioner/tests/testdata/extra_templates.golden
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: some-config
+  namespace: default
 data:
   key: some-value
 ---

--- a/helm/provisioner/tests/testdata/extra_templates.golden
+++ b/helm/provisioner/tests/testdata/extra_templates.golden
@@ -1,0 +1,143 @@
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+---
+# Source: coder-provisioner/templates/extra-templates.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: some-config
+data:
+  key: some-value
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-provisioner-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder-provisioner"
+subjects:
+  - kind: ServiceAccount
+    name: "coder-provisioner"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-provisioner-workspace-perms
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: coder-provisioner
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: coder-provisioner
+        app.kubernetes.io/part-of: coder-provisioner
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-provisioner-0.1.0
+    spec:
+      containers:
+      - args:
+        - provisionerd
+        - start
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_PROVISIONER_DAEMON_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: coder-provisioner-psk
+        - name: CODER_URL
+          value: http://coder.default.svc.cluster.local
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        name: coder
+        ports: null
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: coder-provisioner
+      terminationGracePeriodSeconds: 600
+      volumes: []

--- a/helm/provisioner/tests/testdata/extra_templates.yaml
+++ b/helm/provisioner/tests/testdata/extra_templates.yaml
@@ -7,5 +7,6 @@ extraTemplates:
     kind: ConfigMap
     metadata:
       name: some-config
+      namespace: {{ .Release.Namespace }}
     data:
       key: some-value

--- a/helm/provisioner/tests/testdata/extra_templates.yaml
+++ b/helm/provisioner/tests/testdata/extra_templates.yaml
@@ -1,0 +1,11 @@
+coder:
+  image:
+    tag: latest
+extraTemplates:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: some-config
+    data:
+      key: some-value

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -207,3 +207,15 @@ provisionerDaemon:
   # terminating the provisioner daemon.  You should set this to be longer than your longest expected build time so that
   # redeployments do not interrupt builds in progress.
   terminationGracePeriodSeconds: 600
+
+# extraTemplates -- Array of extra objects to deploy with the release. Strings
+# are evaluated as a template and can use template expansions and functions. All
+# other objects are used as yaml.
+extraTemplates:
+  #- |
+  #    apiVersion: v1
+  #    kind: ConfigMap
+  #    metadata:
+  #      name: my-configmap
+  #    data:
+  #      key: {{ .Values.myCustomValue | quote }}


### PR DESCRIPTION
This PR adds support for `extraTemplates` to the `coder-provisioner` chart to bring it in line with the `coder` chart.