### PR TITLE
fix(coderd/provisionerdserver): pass through api ctx to provisionerdserver

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1108,7 +1108,7 @@ func (api *API) CreateInMemoryProvisionerDaemon(ctx context.Context) (client pro
 	logger := api.Logger.Named(fmt.Sprintf("inmem-provisionerd-%s", name))
 	logger.Info(ctx, "starting in-memory provisioner daemon")
 	srv, err := provisionerdserver.NewServer(
-		ctx,
+		api.ctx,
 		api.AccessURL,
 		uuid.New(),
 		logger,

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1108,6 +1108,7 @@ func (api *API) CreateInMemoryProvisionerDaemon(ctx context.Context) (client pro
 	logger := api.Logger.Named(fmt.Sprintf("inmem-provisionerd-%s", name))
 	logger.Info(ctx, "starting in-memory provisioner daemon")
 	srv, err := provisionerdserver.NewServer(
+		ctx,
 		api.AccessURL,
 		uuid.New(),
 		logger,

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1197,6 +1197,7 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 								slog.F("workspace_build_id", workspaceBuild.ID),
 								slog.Error(err),
 							)
+							return
 						case <-wait:
 							// Wait for the next potential timeout to occur. Note that we
 							// can't listen on the context here because we will hang around

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1196,18 +1196,14 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 						select {
 						case <-s.lifecycleCtx.Done():
 							// If the server is shutting down, we don't want to wait around.
-							s.Logger.Warn(context.Background(), "stopping notifications due to server shutdown",
+							s.Logger.Debug(ctx, "stopping notifications due to server shutdown",
 								slog.F("workspace_build_id", workspaceBuild.ID),
-								slog.Error(err),
 							)
 							return
 						case <-wait:
-							// Wait for the next potential timeout to occur. Note that we
-							// can't listen on the context here because we will hang around
-							// after this function has returned. The s also doesn't
-							// have a shutdown signal we can listen to.
+							// Wait for the next potential timeout to occur.
 							if err := s.Pubsub.Publish(codersdk.WorkspaceNotifyChannel(workspaceBuild.WorkspaceID), []byte{}); err != nil {
-								s.Logger.Error(context.Background(), "workspace notification after agent timeout failed",
+								s.Logger.Error(ctx, "workspace notification after agent timeout failed",
 									slog.F("workspace_build_id", workspaceBuild.ID),
 									slog.Error(err),
 								)

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1733,6 +1733,7 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 	}
 
 	srv, err := provisionerdserver.NewServer(
+		ctx,
 		&url.URL{},
 		srvID,
 		slogtest.Make(t, &slogtest.Options{IgnoreErrors: ignoreLogErrors}),

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -243,6 +243,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 	logger := api.Logger.Named(fmt.Sprintf("ext-provisionerd-%s", name))
 	logger.Info(ctx, "starting external provisioner daemon")
 	srv, err := provisionerdserver.NewServer(
+		api.ctx,
 		api.AccessURL,
 		uuid.New(),
 		logger,


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/10257

We just happened to be sending a notification when the test completed.

Passes through coderd API ctx to provisionerd server so we can cancel workspace updates when API is shutting down.