### PR TITLE
chore(site): clarify autostop description

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -374,8 +374,8 @@ export const WorkspaceScheduleForm: FC<
         description={
           <>
             <div css={{ marginBottom: 16 }}>
-            Set how many hours should elapse after you log off before the
-            workspace automatically shuts down.
+              Set how many hours should elapse after you log off before the
+              workspace automatically shuts down.
             </div>
             {!enableAutoStop && (
               <Tooltip title="This option can be enabled in the template settings">

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -374,8 +374,8 @@ export const WorkspaceScheduleForm: FC<
         description={
           <>
             <div css={{ marginBottom: 16 }}>
-            Set how many hours should elapse after you log off before it
-            automatically shuts down.
+            Set how many hours should elapse after you log off before the
+            workspace automatically shuts down.
             </div>
             {!enableAutoStop && (
               <Tooltip title="This option can be enabled in the template settings">

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -374,10 +374,8 @@ export const WorkspaceScheduleForm: FC<
         description={
           <>
             <div css={{ marginBottom: 16 }}>
-              Set how many hours should elapse after a workspace is started
-              before it automatically shuts down. If workspace connection
-              activity is detected, the autostop timer will be bumped by this
-              value.
+            Set how many hours should elapse after you log off before it
+            automatically shuts down.
             </div>
             {!enableAutoStop && (
               <Tooltip title="This option can be enabled in the template settings">


### PR DESCRIPTION
An enterprise customer pointed out that the Autstop description in workspaces is a bit verbose and unclear. They recommended the following change:

Old
```console
Set how many hours should elapse after a workspace is started before it automatically shuts down. 
If workspace connection activity is detected, the autostop timer will be bumped by this value.
```

New
```console
Set how many hours should elapse after you log off before the workspace automatically shuts down.
```