### PR TITLE
feat: fix 404 on the first app loads when unauthenticated

### DIFF
--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -26,10 +26,6 @@ export const LoginPage: FC = () => {
     // to trigger a HTTP request. This allows the BE to generate the auth
     // cookie required.
     // If no redirect is present, then ignore this branched logic.
-    //
-    // The downside to this logic is that it is not required if the user
-    // is already authenticated. It only matters if the user has to
-    // authenticate in this login flow.
     if (redirectTo !== "" && redirectTo !== "/") {
       try {
         // This catches any absolute redirects. Relative redirects

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -33,6 +33,7 @@ export const LoginPage: FC = () => {
         const redirectURL = new URL(redirectTo);
         if (redirectURL.host !== window.location.host) {
           window.location.href = redirectTo;
+          return;
         }
       } catch {
         // Do nothing
@@ -40,6 +41,7 @@ export const LoginPage: FC = () => {
       // Path based apps.
       if (redirectTo.includes("/apps/")) {
         window.location.href = redirectTo;
+        return;
       }
     }
     return <Navigate to={redirectTo} replace />;

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -21,26 +21,53 @@ export const LoginPage: FC = () => {
   const navigate = useNavigate();
 
   if (isSignedIn) {
+    // If the redirect is going to a workspace application, and we
+    // are missing authentication, then we need to change the href location
+    // to trigger a HTTP request. This allows the BE to generate the auth
+    // cookie required.
+    // If no redirect is present, then ignore this branched logic.
+    //
+    // The downside to this logic is that it is not required if the user
+    // is already authenticated. It only matters if the user has to
+    // authenticate in this login flow.
+    if (redirectTo !== "" && redirectTo !== "/") {
+      try {
+        // This catches any absolute redirects. Relative redirects
+        // will fail the try/catch. Subdomain apps are absolute redirects.
+        const redirectURL = new URL(redirectTo);
+        if (redirectURL.host !== window.location.host) {
+          window.location.href = redirectTo;
+        }
+      } catch {
+        // Do nothing
+      }
+      // Path based apps.
+      if (redirectTo.includes("/apps/")) {
+        window.location.href = redirectTo;
+      }
+    }
     return <Navigate to={redirectTo} replace />;
-  } else if (isConfiguringTheFirstUser) {
-    return <Navigate to="/setup" replace />;
   } else {
-    return (
-      <>
-        <Helmet>
-          <title>Sign in to {applicationName}</title>
-        </Helmet>
-        <LoginPageView
-          authMethods={authMethods}
-          error={signInError}
-          isSigningIn={isSigningIn}
-          onSignIn={async ({ email, password }) => {
-            await signIn(email, password);
-            navigate("/");
-          }}
-        />
-      </>
-    );
+    if (isConfiguringTheFirstUser) {
+      return <Navigate to="/setup" replace />;
+    } else {
+      return (
+        <>
+          <Helmet>
+            <title>Sign in to {applicationName}</title>
+          </Helmet>
+          <LoginPageView
+            authMethods={authMethods}
+            error={signInError}
+            isSigningIn={isSigningIn}
+            onSignIn={async ({ email, password }) => {
+              await signIn(email, password);
+              navigate("/");
+            }}
+          />
+        </>
+      );
+    }
   }
 };
 

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -43,27 +43,25 @@ export const LoginPage: FC = () => {
       }
     }
     return <Navigate to={redirectTo} replace />;
+  } else if (isConfiguringTheFirstUser) {
+    return <Navigate to="/setup" replace />;
   } else {
-    if (isConfiguringTheFirstUser) {
-      return <Navigate to="/setup" replace />;
-    } else {
-      return (
-        <>
-          <Helmet>
-            <title>Sign in to {applicationName}</title>
-          </Helmet>
-          <LoginPageView
-            authMethods={authMethods}
-            error={signInError}
-            isSigningIn={isSigningIn}
-            onSignIn={async ({ email, password }) => {
-              await signIn(email, password);
-              navigate("/");
-            }}
-          />
-        </>
-      );
-    }
+    return (
+      <>
+        <Helmet>
+          <title>Sign in to {applicationName}</title>
+        </Helmet>
+        <LoginPageView
+          authMethods={authMethods}
+          error={signInError}
+          isSigningIn={isSigningIn}
+          onSignIn={async ({ email, password }) => {
+            await signIn(email, password);
+            navigate("/");
+          }}
+        />
+      </>
+    );
   }
 };
 

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -33,7 +33,7 @@ export const LoginPage: FC = () => {
         const redirectURL = new URL(redirectTo);
         if (redirectURL.host !== window.location.host) {
           window.location.href = redirectTo;
-          return;
+          return <></>;
         }
       } catch {
         // Do nothing
@@ -41,7 +41,7 @@ export const LoginPage: FC = () => {
       // Path based apps.
       if (redirectTo.includes("/apps/")) {
         window.location.href = redirectTo;
-        return;
+        return <></>;
       }
     }
     return <Navigate to={redirectTo} replace />;


### PR DESCRIPTION
Closes: https://github.com/coder/coder/issues/9958

# What the issue was

1. Hit app page **without any cookies**
2. Get redirected with a 303 to `/login` with `redirect` query param set to the app url.
3. Hit the login page
4. Enter credentials
5. [This code](https://github.com/coder/coder/blob/stevenmasley%2Fautostart_schedule/site/src/pages/LoginPage/LoginPage.tsx#L24) navigates you to the redirect url
6. You hit a 404 page

The technical thing to note is that step 5 is doing a react navigation. We need to send this URL in an HTTP request to the Golang backend to generate the `coder_signed_app_token` cookie. The react `Navigate` does not send an HTTP request to the `redirectTo` url.

This is also an issue with subdomain based apps. The redirect fails.

# What changes

This changes all app based redirects to a window.location.href change. This triggers a new HTTP request to the redirect url which the Golang BE can return a `set-cookie` for the app authentication.