### PR TITLE
feat(provisioner): expose template version to provisioner

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -198,6 +198,7 @@ func provisionEnv(
 		"CODER_WORKSPACE_OWNER_SESSION_TOKEN="+metadata.GetWorkspaceOwnerSessionToken(),
 		"CODER_WORKSPACE_TEMPLATE_ID="+metadata.GetTemplateId(),
 		"CODER_WORKSPACE_TEMPLATE_NAME="+metadata.GetTemplateName(),
+		"CODER_WORKSPACE_TEMPLATE_VERSION="+metadata.GetTemplateVersion(),
 	)
 	for key, value := range provisionersdk.AgentScriptEnv() {
 		env = append(env, key+"="+value)


### PR DESCRIPTION
This PR exposes the template version to the provisioner context also.

Having access to the template name _and_ version within the Coder template can be useful to support conditional workflows and\or introducing backwards-compatible changes into template.