### PR TITLE
fix: stop metadata queries from short-circuiting

### DIFF
--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -1,21 +1,30 @@
-import { QueryClient } from "react-query";
+import { QueryClient, type QueryOptions } from "react-query";
 import * as API from "api/api";
-import { AppearanceConfig } from "api/typesGenerated";
+import { type AppearanceConfig } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
 
-export const appearance = () => {
+const initialAppearanceData = getMetadataAsJSON<AppearanceConfig>("appearance");
+const appearanceConfigKey = ["appearance"] as const;
+
+export const appearance = (queryClient: QueryClient) => {
   return {
-    queryKey: ["appearance"],
-    queryFn: async () =>
-      getMetadataAsJSON<AppearanceConfig>("appearance") ?? API.getAppearance(),
-  };
+    queryKey: appearanceConfigKey,
+    queryFn: async () => {
+      const cachedData = queryClient.getQueryData(appearanceConfigKey);
+      if (cachedData === undefined && initialAppearanceData !== undefined) {
+        return initialAppearanceData;
+      }
+
+      return API.getAppearance();
+    },
+  } satisfies QueryOptions<AppearanceConfig>;
 };
 
 export const updateAppearance = (queryClient: QueryClient) => {
   return {
     mutationFn: API.updateAppearance,
     onSuccess: (newConfig: AppearanceConfig) => {
-      queryClient.setQueryData(["appearance"], newConfig);
+      queryClient.setQueryData(appearanceConfigKey, newConfig);
     },
   };
 };

--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -1,4 +1,4 @@
-import { QueryClient, type QueryOptions } from "react-query";
+import { QueryClient, type UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import { type AppearanceConfig } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
@@ -17,7 +17,7 @@ export const appearance = (queryClient: QueryClient) => {
 
       return API.getAppearance();
     },
-  } satisfies QueryOptions<AppearanceConfig>;
+  } satisfies UseQueryOptions<AppearanceConfig>;
 };
 
 export const updateAppearance = (queryClient: QueryClient) => {

--- a/site/src/api/queries/buildInfo.ts
+++ b/site/src/api/queries/buildInfo.ts
@@ -1,11 +1,21 @@
+import { QueryClient, type UseQueryOptions } from "react-query";
+import { type BuildInfoResponse } from "api/typesGenerated";
 import * as API from "api/api";
-import { BuildInfoResponse } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
 
-export const buildInfo = () => {
+const initialBuildInfoData = getMetadataAsJSON<BuildInfoResponse>("build-info");
+const buildInfoKey = ["buildInfo"] as const;
+
+export const buildInfo = (queryClient: QueryClient) => {
   return {
-    queryKey: ["buildInfo"],
-    queryFn: async () =>
-      getMetadataAsJSON<BuildInfoResponse>("build-info") ?? API.getBuildInfo(),
-  };
+    queryKey: buildInfoKey,
+    queryFn: async () => {
+      const cachedData = queryClient.getQueryData(buildInfoKey);
+      if (cachedData === undefined && initialBuildInfoData !== undefined) {
+        return initialBuildInfoData;
+      }
+
+      return API.getBuildInfo();
+    },
+  } satisfies UseQueryOptions<BuildInfoResponse>;
 };

--- a/site/src/api/queries/experiments.ts
+++ b/site/src/api/queries/experiments.ts
@@ -1,7 +1,7 @@
 import * as API from "api/api";
 import { getMetadataAsJSON } from "utils/metadata";
 import { type Experiments } from "api/typesGenerated";
-import { QueryClient, type QueryOptions } from "react-query";
+import { QueryClient, type UseQueryOptions } from "react-query";
 
 const initialExperimentsData = getMetadataAsJSON<Experiments>("experiments");
 const experimentsKey = ["experiments"] as const;
@@ -17,5 +17,5 @@ export const experiments = (queryClient: QueryClient) => {
 
       return API.getExperiments();
     },
-  } satisfies QueryOptions<Experiments>;
+  } satisfies UseQueryOptions<Experiments>;
 };

--- a/site/src/api/queries/experiments.ts
+++ b/site/src/api/queries/experiments.ts
@@ -1,11 +1,21 @@
 import * as API from "api/api";
-import { Experiments } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
+import { type Experiments } from "api/typesGenerated";
+import { QueryClient, type QueryOptions } from "react-query";
 
-export const experiments = () => {
+const initialExperimentsData = getMetadataAsJSON<Experiments>("experiments");
+const experimentsKey = ["experiments"] as const;
+
+export const experiments = (queryClient: QueryClient) => {
   return {
-    queryKey: ["experiments"],
-    queryFn: async () =>
-      getMetadataAsJSON<Experiments>("experiments") ?? API.getExperiments(),
-  };
+    queryKey: experimentsKey,
+    queryFn: async () => {
+      const cachedData = queryClient.getQueryData(experimentsKey);
+      if (cachedData === undefined && initialExperimentsData !== undefined) {
+        return initialExperimentsData;
+      }
+
+      return API.getExperiments();
+    },
+  } satisfies QueryOptions<Experiments>;
 };

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryOptions } from "react-query";
+import { QueryClient, type UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import {
   AuthorizationRequest,
@@ -11,7 +11,7 @@ import {
 import { getMetadataAsJSON } from "utils/metadata";
 import { getAuthorizationKey } from "./authCheck";
 
-export const users = (req: UsersRequest): QueryOptions<GetUsersResponse> => {
+export const users = (req: UsersRequest): UseQueryOptions<GetUsersResponse> => {
   return {
     queryKey: ["users", req],
     queryFn: ({ signal }) => API.getUsers(req, signal),
@@ -103,7 +103,7 @@ export const me = (queryClient: QueryClient) => {
 
       return API.getAuthenticatedUser();
     },
-  } satisfies QueryOptions<User>;
+  } satisfies UseQueryOptions<User>;
 };
 
 export const hasFirstUser = () => {

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -89,12 +89,21 @@ export const authMethods = () => {
   };
 };
 
-export const me = () => {
+const initialMeData = getMetadataAsJSON<User>("user");
+const meKey = ["me"] as const;
+
+export const me = (queryClient: QueryClient) => {
   return {
-    queryKey: ["me"],
-    queryFn: async () =>
-      getMetadataAsJSON<User>("user") ?? API.getAuthenticatedUser(),
-  };
+    queryKey: meKey,
+    queryFn: async () => {
+      const cachedData = queryClient.getQueryData(meKey);
+      if (cachedData === undefined && initialMeData !== undefined) {
+        return initialMeData;
+      }
+
+      return API.getAuthenticatedUser();
+    },
+  } satisfies QueryOptions<User>;
 };
 
 export const hasFirstUser = () => {

--- a/site/src/components/AuthProvider/AuthProvider.tsx
+++ b/site/src/components/AuthProvider/AuthProvider.tsx
@@ -45,7 +45,9 @@ type AuthContextValue = {
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
-  const meOptions = me();
+  const queryClient = useQueryClient();
+  const meOptions = me(queryClient);
+
   const userQuery = useQuery(meOptions);
   const authMethodsQuery = useQuery(authMethods());
   const hasFirstUserQuery = useQuery(hasFirstUser());
@@ -54,7 +56,6 @@ export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
     enabled: userQuery.data !== undefined,
   });
 
-  const queryClient = useQueryClient();
   const loginMutation = useMutation(
     login({ checks: permissionsToCheck }, queryClient),
   );

--- a/site/src/components/Dashboard/DashboardProvider.tsx
+++ b/site/src/components/Dashboard/DashboardProvider.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { buildInfo } from "api/queries/buildInfo";
 import { experiments } from "api/queries/experiments";
 import { entitlements } from "api/queries/entitlements";
@@ -30,8 +30,8 @@ interface Appearance {
 interface DashboardProviderValue {
   buildInfo: BuildInfoResponse;
   entitlements: Entitlements;
-  appearance: Appearance;
   experiments: Experiments;
+  appearance: Appearance;
 }
 
 export const DashboardProviderContext = createContext<
@@ -39,10 +39,12 @@ export const DashboardProviderContext = createContext<
 >(undefined);
 
 export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
-  const buildInfoQuery = useQuery(buildInfo());
+  const queryClient = useQueryClient();
+  const buildInfoQuery = useQuery(buildInfo(queryClient));
   const entitlementsQuery = useQuery(entitlements());
-  const experimentsQuery = useQuery(experiments());
-  const appearanceQuery = useQuery(appearance());
+  const experimentsQuery = useQuery(experiments(queryClient));
+  const appearanceQuery = useQuery(appearance(queryClient));
+
   const isLoading =
     !buildInfoQuery.data ||
     !entitlementsQuery.data ||

--- a/site/src/theme/colors.ts
+++ b/site/src/theme/colors.ts
@@ -6,7 +6,8 @@ import { getMetadataAsJSON } from "utils/metadata";
 // so you can just set this to true.
 export const experimentalTheme =
   typeof document !== "undefined" &&
-  getMetadataAsJSON("experiments")?.includes("dashboard_theme");
+  (getMetadataAsJSON<string[]>("experiments")?.includes("dashboard_theme") ??
+    false);
 
 export const colors = {
   white: "hsl(0, 0%, 100%)",

--- a/site/src/utils/metadata.ts
+++ b/site/src/utils/metadata.ts
@@ -1,18 +1,24 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- It can be any
-export const getMetadataAsJSON = <T extends Record<string, any>>(
+export const getMetadataAsJSON = <T extends NonNullable<unknown>>(
   property: string,
 ): T | undefined => {
   const appearance = document.querySelector(`meta[property=${property}]`);
+
   if (appearance) {
     const rawContent = appearance.getAttribute("content");
-    try {
-      return JSON.parse(rawContent as string);
-    } catch (ex) {
-      // In development the metadata is always going to be empty throwing this
-      // error
-      if (process.env.NODE_ENV === "production") {
-        console.warn(`Failed to parse ${property} metadata`);
+
+    if (rawContent) {
+      try {
+        return JSON.parse(rawContent);
+      } catch (err) {
+        // In development, the metadata is always going to be empty; error is
+        // only a concern for production
+        if (process.env.NODE_ENV === "production") {
+          console.warn(`Failed to parse ${property} metadata. Error message:`);
+          console.warn(err);
+        }
       }
     }
   }
+
+  return undefined;
 };


### PR DESCRIPTION
Doesn't close any open issues, but does address some problems noticed from the company Slack yesterday.

## Changes made
1. Updates all the `useQueryOptions` factory functions that reference embedded HTML metadata, and makes sure that they can't short-circuit with stale data.
2. Updates some of the type definitions for `getMetadataAsJSON`

## Other notes
Going to be copy-pasting the thread from the company Slack, just for documentation:

```ts
export const appearance = () => {
  return {
    queryKey: ["appearance"],
    queryFn: async () =>
      getMetadataAsJSON<AppearanceConfig>("appearance") ?? API.getAppearance(),
  };
};

export const updateAppearance = (queryClient: QueryClient) => {
  return {
    mutationFn: API.updateAppearance,
    onSuccess: (newConfig: AppearanceConfig) => {
      queryClient.setQueryData(["appearance"], newConfig);
    },
  };
};
```
The only way for a server request to get made is if the metadata tags in the `index.html` file aren't set when the server delivers the initial response. Otherwise, the `getMetadataAsJSON` call will always short-circuit the expression with local data

Another potential bug I'm worried about is background refetches:
1. `updateAppearance` gets called, and the `onSuccess` callback mutates the query client cache with a value different from what was provided via the HTML's meta tag
2. The user goes to a different tab, and then comes back to Coder
3. React Query automatically kicks off a background refetch, and calls the query function again
4. But because the meta tag is still the same from the initial page load, React Query will evaluate the short-circuiting query function and grab the old value from the HTML
5. The client is stuck with stale data until another mutation gets made, and the stale data spreads to every component subscribed to the query
6. Even if another mutation does get made, any background refetch would make the data stale again

I'm wondering if it might better to leverage the `initialData` property to use the metadata tag only while the initial query is loading, but then when we get something back from the server, the initial data will be ignored for all other renders.  initialData is never put in the query cache itself, and the only time it could pop up again is if the query cache for that key gets completely vacated.

The `getMetadataAsJSON` function would need some more massaging to make things have the right types, but I was thinking something like this:

```ts
// Defined outside the function to keep renders pure
const initialData = getMetadataAsJSON<AppearanceConfig>("appearance");

export const appearance = () => {
  return {
    initialData,
    queryKey: ["appearance"],
    queryFn: async () => API.getAppearance(),
  } satisfies QueryOptions<AppearanceConfig>;
};
```

---

So, uh, famous last words – this is not simple

Basically, React Query has two properties that it lets you define on the query object:
- `placeholderData` – This is the property I was actually thinking of. It acts as initial data for the query, but it's never stored in the cache
- `initialData` – This works like placeholderData, but it is stored in the cache. By default, this data is always stale, so the query function still runs, even on the first render

Both of these can be actual data or functions that lazy-evaluate to data. 

The problem is that the `UseQueryOptions` type has four type parameter slots:
`TQueryFnData` – The data we get back from the query function. Defaults to `unknown`
`TError` – The error that gets thrown if a query function fails. Defaults to `unknown`
`TData` – Used to define the type of initialData (if it's different from `TQueryFnData`). Defaults to `TQueryFnData`
`TQueryKey` – The type of the query key. Defaults to an unknown array

`initialData` has flexibility – it's defined via `TData`, and it can default to `TQueryFnData` if it's not specified. `placeholderData` doesn't get that privilege, though. It always has to be of type `TQueryFnData`. And because `getMetadataAsJSON` can also return `undefined`, that extra possibility has a risk of "polluting" all the other types.

1. If we use `placeholderData`, then the our useQuery object has to be updated to return `Data | undefined`, meaning the query object's data property will always have an `undefined` case, even if the query has succeeded
2. If we use `initialData`, we have the ability to split hairs and say that the query function returns `Data`, while the initial data is `Data | undefined`. But because useQuery's data property is `TQueryFnData | TData`, we're still polluting the query object