### PR TITLE
fix: set K8s deployment strategy to `Recreate`

### DIFF
--- a/.github/pr-deployments/template/main.tf
+++ b/.github/pr-deployments/template/main.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     coder = {
-      source  = "coder/coder"
+      source = "coder/coder"
     }
     kubernetes = {
-      source  = "hashicorp/kubernetes"
+      source = "hashicorp/kubernetes"
     }
   }
 }
@@ -234,6 +234,9 @@ resource "kubernetes_deployment" "main" {
       match_labels = {
         "app.kubernetes.io/name" = "coder-workspace"
       }
+    }
+    strategy {
+      type = "Recreate"
     }
 
     template {

--- a/examples/templates/devcontainer-kubernetes/main.tf
+++ b/examples/templates/devcontainer-kubernetes/main.tf
@@ -177,6 +177,9 @@ resource "kubernetes_deployment" "workspace" {
         "coder.workspace_id" = data.coder_workspace.me.id
       }
     }
+    strategy {
+      type = "Recreate"
+    }
     template {
       metadata {
         labels = {

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -250,6 +250,9 @@ resource "kubernetes_deployment" "main" {
         "app.kubernetes.io/name" = "coder-workspace"
       }
     }
+    strategy {
+      type = "Recreate"
+    }
 
     template {
       metadata {


### PR DESCRIPTION
this PR sets `spec.strategy.type` to `Recreate` on the K8s deployments templates. this change means all existing pods in the deployment are killed before new ones are created, preventing any `MultiAttach` errors on the PVC during a workspace rebuild.

a large customer experienced the error due to the K8s default strategy of `RollingUpdate`, which waits for new deployment pods to be `Running` prior to taking down the old pods.