### PR TITLE
fix: resolve User is not unauthenticated error seen on logout

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,6 +17,7 @@
   <meta property="og:type" content="website" />
   <meta property="csrf-token" content="{{ .CSRF.Token }}" />
   <meta property="build-info" content="{{ .BuildInfo }}" />
+  <meta property="user" content="{{ .User }}" />
   <meta property="entitlements" content="{{ .Entitlements }}" />
   <meta property="appearance" content="{{ .Appearance }}" />
   <meta property="experiments" content="{{ .Experiments }}" />

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,6 @@
   <meta property="og:type" content="website" />
   <meta property="csrf-token" content="{{ .CSRF.Token }}" />
   <meta property="build-info" content="{{ .BuildInfo }}" />
-  <meta property="user" content="{{ .User }}" />
   <meta property="entitlements" content="{{ .Entitlements }}" />
   <meta property="appearance" content="{{ .Appearance }}" />
   <meta property="experiments" content="{{ .Experiments }}" />

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -5,10 +5,8 @@ import {
   GetUsersResponse,
   UpdateUserPasswordRequest,
   UpdateUserProfileRequest,
-  User,
   UsersRequest,
 } from "api/typesGenerated";
-import { getMetadataAsJSON } from "utils/metadata";
 import { getAuthorizationKey } from "./authCheck";
 
 export const users = (req: UsersRequest): UseQueryOptions<GetUsersResponse> => {
@@ -89,21 +87,11 @@ export const authMethods = () => {
   };
 };
 
-const initialMeData = getMetadataAsJSON<User>("user");
-const meKey = ["me"] as const;
-
-export const me = (queryClient: QueryClient) => {
+export const me = () => {
   return {
-    queryKey: meKey,
-    queryFn: async () => {
-      const cachedData = queryClient.getQueryData(meKey);
-      if (cachedData === undefined && initialMeData !== undefined) {
-        return initialMeData;
-      }
-
-      return API.getAuthenticatedUser();
-    },
-  } satisfies UseQueryOptions<User>;
+    queryKey: ["me"],
+    queryFn: async () => API.getAuthenticatedUser(),
+  };
 };
 
 export const hasFirstUser = () => {

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -89,10 +89,12 @@ export const authMethods = () => {
   };
 };
 
+const initialUserData = getMetadataAsJSON<User>("user");
+
 export const me = () => {
   return {
     queryKey: ["me"],
-    initialData: getMetadataAsJSON<User>("user"),
+    initialData: initialUserData,
     queryFn: API.getAuthenticatedUser,
   };
 };

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -6,8 +6,10 @@ import {
   UpdateUserPasswordRequest,
   UpdateUserProfileRequest,
   UsersRequest,
+  User,
 } from "api/typesGenerated";
 import { getAuthorizationKey } from "./authCheck";
+import { getMetadataAsJSON } from "utils/metadata";
 
 export const users = (req: UsersRequest): UseQueryOptions<GetUsersResponse> => {
   return {
@@ -90,7 +92,8 @@ export const authMethods = () => {
 export const me = () => {
   return {
     queryKey: ["me"],
-    queryFn: async () => API.getAuthenticatedUser(),
+    initialData: getMetadataAsJSON<User>("user"),
+    queryFn: API.getAuthenticatedUser,
   };
 };
 

--- a/site/src/components/AuthProvider/AuthProvider.tsx
+++ b/site/src/components/AuthProvider/AuthProvider.tsx
@@ -46,7 +46,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
   const queryClient = useQueryClient();
-  const meOptions = me(queryClient);
+  const meOptions = me();
 
   const userQuery = useQuery(meOptions);
   const authMethodsQuery = useQuery(authMethods());


### PR DESCRIPTION
Resolves the below error seen when logging out which was [flagged in Slack](https://codercom.slack.com/archives/CJURPL8DN/p1697645702559489):
![image](https://github.com/coder/coder/assets/19142439/a6d8c125-d065-4890-a470-2333051f0269)

~I believe this issue stemmed from https://github.com/coder/coder/commit/0f2d4fdb6dc98735cfe894beb24c0ebff1244d41, which we could revert in its entirety~ _no seems broken before_, although I'm not sure why were were caching the response from `/api/v2/users/me` in the first place. For now, I've just ensured we always have fresh data when retrieving that endpoint. It appears we only call the `me()` handler in our `AuthProvider` anyway.

 