### PR TITLE
feat(cli): prompt for misspelled parameter names

### DIFF
--- a/cli/cliutil/levenshtein/levenshtein.go
+++ b/cli/cliutil/levenshtein/levenshtein.go
@@ -1,0 +1,88 @@
+package levenshtein
+
+import (
+	"golang.org/x/exp/constraints"
+	"golang.org/x/xerrors"
+)
+
+// Matches returns the closest matches to the needle from the haystack.
+// The maxDistance parameter is the maximum Matches distance to consider.
+// If no matches are found, an empty slice is returned.
+func Matches(needle string, maxDistance int, haystack ...string) (matches []string) {
+	for _, hay := range haystack {
+		if Distance(needle, hay) <= maxDistance {
+			matches = append(matches, hay)
+		}
+	}
+
+	return matches
+}
+
+// Distance returns the edit distance between a and b using the
+// Wagner-Fischer algorithm.
+// A and B must be less than 255 characters long.
+func Distance(a, b string) int {
+	if len(a) > 255 || len(b) > 255 {
+		panic(xerrors.Errorf("levenshtein: strings too long: %q, %q", a, b))
+	}
+	m := uint8(len(a))
+	n := uint8(len(b))
+
+	// Special cases for empty strings
+	if m == 0 {
+		return int(n)
+	}
+	if n == 0 {
+		return int(m)
+	}
+
+	// Allocate a matrix of size m+1 * n+1
+	d := make([][]uint8, 0)
+	var i, j uint8
+	for i = 0; i < m+1; i++ {
+		di := make([]uint8, n+1)
+		d = append(d, di)
+	}
+
+	// Source prefixes
+	for i = 1; i < m+1; i++ {
+		d[i][0] = i
+	}
+
+	// Target prefixes
+	for j = 1; j < n; j++ {
+		d[0][j] = j
+	}
+
+	// Compute the distance
+	for j = 0; j < n; j++ {
+		for i = 0; i < m; i++ {
+			var subCost uint8
+			// Equal
+			if a[i] != b[j] {
+				subCost = 1
+			}
+			// Don't forget: matrix is +1 size
+			d[i+1][j+1] = min(
+				d[i][j+1]+1,     // deletion
+				d[i+1][j]+1,     // insertion
+				d[i][j]+subCost, // substitution
+			)
+		}
+	}
+
+	return int(d[m][n])
+}
+
+func min[T constraints.Ordered](ts ...T) T {
+	if len(ts) == 0 {
+		panic("min: no arguments")
+	}
+	m := ts[0]
+	for _, t := range ts[1:] {
+		if t < m {
+			m = t
+		}
+	}
+	return m
+}

--- a/cli/cliutil/levenshtein/levenshtein.go
+++ b/cli/cliutil/levenshtein/levenshtein.go
@@ -10,7 +10,7 @@ import (
 // If no matches are found, an empty slice is returned.
 func Matches(needle string, maxDistance int, haystack ...string) (matches []string) {
 	for _, hay := range haystack {
-		if Distance(needle, hay) <= maxDistance {
+		if d, err := Distance(needle, hay); err == nil && d <= maxDistance {
 			matches = append(matches, hay)
 		}
 	}
@@ -21,19 +21,22 @@ func Matches(needle string, maxDistance int, haystack ...string) (matches []stri
 // Distance returns the edit distance between a and b using the
 // Wagner-Fischer algorithm.
 // A and B must be less than 255 characters long.
-func Distance(a, b string) int {
-	if len(a) > 255 || len(b) > 255 {
-		panic(xerrors.Errorf("levenshtein: strings too long: %q, %q", a, b))
+func Distance(a, b string) (int, error) {
+	if len(a) > 255 {
+		return 0, xerrors.Errorf("levenshtein: a must be less than 255 characters long")
+	}
+	if len(b) > 255 {
+		return 0, xerrors.Errorf("levenshtein: b must be less than 255 characters long")
 	}
 	m := uint8(len(a))
 	n := uint8(len(b))
 
 	// Special cases for empty strings
 	if m == 0 {
-		return int(n)
+		return int(n), nil
 	}
 	if n == 0 {
-		return int(m)
+		return int(m), nil
 	}
 
 	// Allocate a matrix of size m+1 * n+1
@@ -71,7 +74,7 @@ func Distance(a, b string) int {
 		}
 	}
 
-	return int(d[m][n])
+	return int(d[m][n]), nil
 }
 
 func min[T constraints.Ordered](ts ...T) T {

--- a/cli/cliutil/levenshtein/levenshtein.go
+++ b/cli/cliutil/levenshtein/levenshtein.go
@@ -18,7 +18,7 @@ func Matches(needle string, maxDistance int, haystack ...string) (matches []stri
 	return matches
 }
 
-var ErrMaxDist error = xerrors.New("levenshtein: maxDist exceeded")
+var ErrMaxDist = xerrors.New("levenshtein: maxDist exceeded")
 
 // Distance returns the edit distance between a and b using the
 // Wagner-Fischer algorithm.
@@ -84,6 +84,7 @@ func Distance(a, b string, maxDist int) (int, error) {
 
 	return int(d[m][n]), nil
 }
+
 func min[T constraints.Ordered](ts ...T) T {
 	if len(ts) == 0 {
 		panic("min: no arguments")

--- a/cli/cliutil/levenshtein/levenshtein_test.go
+++ b/cli/cliutil/levenshtein/levenshtein_test.go
@@ -104,63 +104,84 @@ func Test_Levenshtein_Distance(t *testing.T) {
 		Name     string
 		A        string
 		B        string
+		MaxDist  int
 		Expected int
+		Error    string
 	}{
 		{
 			Name:     "empty",
 			A:        "",
 			B:        "",
+			MaxDist:  -1,
 			Expected: 0,
 		},
 		{
 			Name:     "a empty",
 			A:        "",
 			B:        "foo",
+			MaxDist:  -1,
 			Expected: 3,
 		},
 		{
 			Name:     "b empty",
 			A:        "foo",
 			B:        "",
+			MaxDist:  -1,
 			Expected: 3,
 		},
 		{
 			Name:     "a is b",
 			A:        "foo",
 			B:        "foo",
+			MaxDist:  -1,
 			Expected: 0,
 		},
 		{
 			Name:     "one addition",
 			A:        "foo",
 			B:        "fooo",
+			MaxDist:  -1,
 			Expected: 1,
 		},
 		{
 			Name:     "one deletion",
 			A:        "fooo",
 			B:        "foo",
+			MaxDist:  -1,
 			Expected: 1,
 		},
 		{
 			Name:     "one substitution",
 			A:        "foo",
 			B:        "fou",
+			MaxDist:  -1,
 			Expected: 1,
 		},
 		{
 			Name:     "different strings entirely",
 			A:        "foo",
 			B:        "bar",
+			MaxDist:  -1,
 			Expected: 3,
+		},
+		{
+			Name:    "different strings, max distance 2",
+			A:       "foo",
+			B:       "bar",
+			MaxDist: 2,
+			Error:   levenshtein.ErrMaxDist.Error(),
 		},
 	} {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			actual, err := levenshtein.Distance(tt.A, tt.B)
-			require.NoError(t, err)
-			require.Equal(t, tt.Expected, actual)
+			actual, err := levenshtein.Distance(tt.A, tt.B, tt.MaxDist)
+			if tt.Error == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.Expected, actual)
+			} else {
+				require.EqualError(t, err, tt.Error)
+			}
 		})
 	}
 }

--- a/cli/cliutil/levenshtein/levenshtein_test.go
+++ b/cli/cliutil/levenshtein/levenshtein_test.go
@@ -158,7 +158,8 @@ func Test_Levenshtein_Distance(t *testing.T) {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			actual := levenshtein.Distance(tt.A, tt.B)
+			actual, err := levenshtein.Distance(tt.A, tt.B)
+			require.NoError(t, err)
 			require.Equal(t, tt.Expected, actual)
 		})
 	}

--- a/cli/cliutil/levenshtein/levenshtein_test.go
+++ b/cli/cliutil/levenshtein/levenshtein_test.go
@@ -1,0 +1,165 @@
+package levenshtein_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/cliutil/levenshtein"
+)
+
+func Test_Levenshtein_Matches(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		Name        string
+		Needle      string
+		MaxDistance int
+		Haystack    []string
+		Expected    []string
+	}{
+		{
+			Name:        "empty",
+			Needle:      "",
+			MaxDistance: 0,
+			Haystack:    []string{},
+			Expected:    []string{},
+		},
+		{
+			Name:        "empty haystack",
+			Needle:      "foo",
+			MaxDistance: 0,
+			Haystack:    []string{},
+			Expected:    []string{},
+		},
+		{
+			Name:        "empty needle",
+			Needle:      "",
+			MaxDistance: 0,
+			Haystack:    []string{"foo"},
+			Expected:    []string{},
+		},
+		{
+			Name:        "exact match distance 0",
+			Needle:      "foo",
+			MaxDistance: 0,
+			Haystack:    []string{"foo", "fob"},
+			Expected:    []string{"foo"},
+		},
+		{
+			Name:        "exact match distance 1",
+			Needle:      "foo",
+			MaxDistance: 1,
+			Haystack:    []string{"foo", "bar"},
+			Expected:    []string{"foo"},
+		},
+		{
+			Name:        "not found",
+			Needle:      "foo",
+			MaxDistance: 1,
+			Haystack:    []string{"bar"},
+			Expected:    []string{},
+		},
+		{
+			Name:        "1 deletion",
+			Needle:      "foo",
+			MaxDistance: 1,
+			Haystack:    []string{"bar", "fo"},
+			Expected:    []string{"fo"},
+		},
+		{
+			Name:        "one deletion, two matches",
+			Needle:      "foo",
+			MaxDistance: 1,
+			Haystack:    []string{"bar", "fo", "fou"},
+			Expected:    []string{"fo", "fou"},
+		},
+		{
+			Name:        "one deletion, one addition",
+			Needle:      "foo",
+			MaxDistance: 1,
+			Haystack:    []string{"bar", "fo", "fou", "f"},
+			Expected:    []string{"fo", "fou"},
+		},
+		{
+			Name:        "distance 2",
+			Needle:      "foo",
+			MaxDistance: 2,
+			Haystack:    []string{"bar", "boo", "boof"},
+			Expected:    []string{"boo", "boof"},
+		},
+	} {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			actual := levenshtein.Matches(tt.Needle, tt.MaxDistance, tt.Haystack...)
+			require.ElementsMatch(t, tt.Expected, actual)
+		})
+	}
+}
+
+func Test_Levenshtein_Distance(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		Name     string
+		A        string
+		B        string
+		Expected int
+	}{
+		{
+			Name:     "empty",
+			A:        "",
+			B:        "",
+			Expected: 0,
+		},
+		{
+			Name:     "a empty",
+			A:        "",
+			B:        "foo",
+			Expected: 3,
+		},
+		{
+			Name:     "b empty",
+			A:        "foo",
+			B:        "",
+			Expected: 3,
+		},
+		{
+			Name:     "a is b",
+			A:        "foo",
+			B:        "foo",
+			Expected: 0,
+		},
+		{
+			Name:     "one addition",
+			A:        "foo",
+			B:        "fooo",
+			Expected: 1,
+		},
+		{
+			Name:     "one deletion",
+			A:        "fooo",
+			B:        "foo",
+			Expected: 1,
+		},
+		{
+			Name:     "one substitution",
+			A:        "foo",
+			B:        "fou",
+			Expected: 1,
+		},
+		{
+			Name:     "different strings entirely",
+			A:        "foo",
+			B:        "bar",
+			Expected: 3,
+		},
+	} {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			actual := levenshtein.Distance(tt.A, tt.B)
+			require.Equal(t, tt.Expected, actual)
+		})
+	}
+}

--- a/cli/cliutil/levenshtein/levenshtein_test.go
+++ b/cli/cliutil/levenshtein/levenshtein_test.go
@@ -87,6 +87,13 @@ func Test_Levenshtein_Matches(t *testing.T) {
 			Haystack:    []string{"bar", "boo", "boof"},
 			Expected:    []string{"boo", "boof"},
 		},
+		{
+			Name:        "longer input",
+			Needle:      "kuberenetes",
+			MaxDistance: 5,
+			Haystack:    []string{"kubernetes", "kubeconfig", "kubectl", "kube"},
+			Expected:    []string{"kubernetes"},
+		},
 	} {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/10292

Performs a fuzzy-matching based on Levenshtein edit distance when an unknown parameter name is encountered.
Edit distance defaults to `len(parameter)/2`.
Should result in less guessing about what that parameter was named exactly.

<img width="571" alt="image" src="https://github.com/coder/coder/assets/4949514/acbce45d-7922-4759-aea0-2affa307a2a1">
