### PR TITLE
refactor: update logic for all metadata query factories

### DIFF
--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -6,18 +6,12 @@ import { getMetadataAsJSON } from "utils/metadata";
 const initialAppearanceData = getMetadataAsJSON<AppearanceConfig>("appearance");
 const appearanceConfigKey = ["appearance"] as const;
 
-export const appearance = (queryClient: QueryClient) => {
+export const appearance = (): UseQueryOptions<AppearanceConfig> => {
   return {
-    queryKey: appearanceConfigKey,
-    queryFn: async () => {
-      const cachedData = queryClient.getQueryData(appearanceConfigKey);
-      if (cachedData === undefined && initialAppearanceData !== undefined) {
-        return initialAppearanceData;
-      }
-
-      return API.getAppearance();
-    },
-  } satisfies UseQueryOptions<AppearanceConfig>;
+    queryKey: ["appearance"],
+    initialData: initialAppearanceData,
+    queryFn: () => API.getAppearance(),
+  };
 };
 
 export const updateAppearance = (queryClient: QueryClient) => {

--- a/site/src/api/queries/buildInfo.ts
+++ b/site/src/api/queries/buildInfo.ts
@@ -1,4 +1,4 @@
-import { QueryClient, type UseQueryOptions } from "react-query";
+import { type UseQueryOptions } from "react-query";
 import { type BuildInfoResponse } from "api/typesGenerated";
 import * as API from "api/api";
 import { getMetadataAsJSON } from "utils/metadata";
@@ -6,16 +6,10 @@ import { getMetadataAsJSON } from "utils/metadata";
 const initialBuildInfoData = getMetadataAsJSON<BuildInfoResponse>("build-info");
 const buildInfoKey = ["buildInfo"] as const;
 
-export const buildInfo = (queryClient: QueryClient) => {
+export const buildInfo = (): UseQueryOptions<BuildInfoResponse> => {
   return {
     queryKey: buildInfoKey,
-    queryFn: async () => {
-      const cachedData = queryClient.getQueryData(buildInfoKey);
-      if (cachedData === undefined && initialBuildInfoData !== undefined) {
-        return initialBuildInfoData;
-      }
-
-      return API.getBuildInfo();
-    },
-  } satisfies UseQueryOptions<BuildInfoResponse>;
+    initialData: initialBuildInfoData,
+    queryFn: () => API.getBuildInfo(),
+  };
 };

--- a/site/src/api/queries/entitlements.ts
+++ b/site/src/api/queries/entitlements.ts
@@ -1,15 +1,16 @@
-import { QueryClient } from "react-query";
+import { QueryClient, UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import { Entitlements } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
 
-const ENTITLEMENTS_QUERY_KEY = ["entitlements"];
+const initialEntitlementsData = getMetadataAsJSON<Entitlements>("entitlements");
+const ENTITLEMENTS_QUERY_KEY = ["entitlements"] as const;
 
-export const entitlements = () => {
+export const entitlements = (): UseQueryOptions<Entitlements> => {
   return {
     queryKey: ENTITLEMENTS_QUERY_KEY,
-    queryFn: async () =>
-      getMetadataAsJSON<Entitlements>("entitlements") ?? API.getEntitlements(),
+    queryFn: () => API.getEntitlements(),
+    initialData: initialEntitlementsData,
   };
 };
 

--- a/site/src/api/queries/experiments.ts
+++ b/site/src/api/queries/experiments.ts
@@ -1,22 +1,16 @@
 import * as API from "api/api";
 import { getMetadataAsJSON } from "utils/metadata";
 import { type Experiments } from "api/typesGenerated";
-import { QueryClient, type UseQueryOptions } from "react-query";
+import { type UseQueryOptions } from "react-query";
 
 const initialExperimentsData = getMetadataAsJSON<Experiments>("experiments");
 const experimentsKey = ["experiments"] as const;
 
-export const experiments = (queryClient: QueryClient) => {
+export const experiments = (): UseQueryOptions<Experiments> => {
   return {
     queryKey: experimentsKey,
-    queryFn: async () => {
-      const cachedData = queryClient.getQueryData(experimentsKey);
-      if (cachedData === undefined && initialExperimentsData !== undefined) {
-        return initialExperimentsData;
-      }
-
-      return API.getExperiments();
-    },
+    initialData: initialExperimentsData,
+    queryFn: () => API.getExperiments(),
   } satisfies UseQueryOptions<Experiments>;
 };
 

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -91,7 +91,7 @@ export const authMethods = () => {
 
 const initialUserData = getMetadataAsJSON<User>("user");
 
-export const me = () => {
+export const me = (): UseQueryOptions<User> => {
   return {
     queryKey: ["me"],
     initialData: initialUserData,

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -91,7 +91,9 @@ export const authMethods = () => {
 
 const initialUserData = getMetadataAsJSON<User>("user");
 
-export const me = (): UseQueryOptions<User> => {
+export const me = (): UseQueryOptions<User> & {
+  queryKey: NonNullable<UseQueryOptions<User>["queryKey"]>;
+} => {
   return {
     queryKey: ["me"],
     initialData: initialUserData,

--- a/site/src/components/Dashboard/DashboardProvider.tsx
+++ b/site/src/components/Dashboard/DashboardProvider.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "react-query";
+import { useQuery } from "react-query";
 import { buildInfo } from "api/queries/buildInfo";
 import { experiments } from "api/queries/experiments";
 import { entitlements } from "api/queries/entitlements";
@@ -39,11 +39,10 @@ export const DashboardProviderContext = createContext<
 >(undefined);
 
 export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
-  const queryClient = useQueryClient();
-  const buildInfoQuery = useQuery(buildInfo(queryClient));
+  const buildInfoQuery = useQuery(buildInfo());
   const entitlementsQuery = useQuery(entitlements());
-  const experimentsQuery = useQuery(experiments(queryClient));
-  const appearanceQuery = useQuery(appearance(queryClient));
+  const experimentsQuery = useQuery(experiments());
+  const appearanceQuery = useQuery(appearance());
 
   const isLoading =
     !buildInfoQuery.data ||


### PR DESCRIPTION
Connected to #10312

## Changes made 
- Simplifies the setup for all query factory functions related to the `getMetadataAsJSON` function

## Problems and future pitfalls
Unfortunately, while the runtime code is cleaner and no longer requires the query client, there's still a problem, which is that it's hard to make React Query and TypeScript happy.

*Every single* factory function must have an explicit return type, or else there is a risk of the `undefined` case from `getMetadataAsJSON` will pollute the query cache's types. It has to be an explicit return type (and not something like `satisfies` or no type annotations at all), because the return type needs to do some implicit type casting.

Let's say we have a component like this:
```tsx
function MyComponent () {
  const appearanceQuery = useQuery(appearance());
  if (appearanceQuery.isSuccess) {
    const data = appearanceQuery.data;
  }
}
```
This is the type that `data` will be with each approach for typing the `appearance` function:
- No type annotations whatsoever - Has type `AppearanceConfig | undefined` - The cache's types got polluted
- `satisfies` - Has type `AppearanceConfig | undefined` - The cache's types still got polluted, because the underlying type didn't change
- `as const satisfies` - Has type `AppearanceConfig | undefined` - Even with the object being treated as more of a type literal, the underlying type still doesn't change enough
- Explicit return type – Has type `AppearanceConfig` - No pollution. This is the only option that works, because the explicit return type is overriding the type that the object would normally be

It's a weird position to be in, where there's only one right way to set up the factory, or else we basically break React Query's internal type system

## Next steps
This PR is meant to be more of a stopgap until we figure out a way to avoid these type issues in a more permanent way