### PR TITLE
feat(cli): make the dotfiles repository directory configurable

### DIFF
--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -22,6 +22,7 @@ import (
 func (r *RootCmd) dotfiles() *clibase.Cmd {
 	var symlinkDir string
 	var gitbranch string
+	var dotfilesRepoDir string
 
 	cmd := &clibase.Cmd{
 		Use:        "dotfiles <git_repo_url>",
@@ -35,11 +36,10 @@ func (r *RootCmd) dotfiles() *clibase.Cmd {
 		),
 		Handler: func(inv *clibase.Invocation) error {
 			var (
-				dotfilesRepoDir = "dotfiles"
-				gitRepo         = inv.Args[0]
-				cfg             = r.createConfig()
-				cfgDir          = string(cfg)
-				dotfilesDir     = filepath.Join(cfgDir, dotfilesRepoDir)
+				gitRepo     = inv.Args[0]
+				cfg         = r.createConfig()
+				cfgDir      = string(cfg)
+				dotfilesDir = filepath.Join(cfgDir, dotfilesRepoDir)
 				// This follows the same pattern outlined by others in the market:
 				// https://github.com/coder/coder/pull/1696#issue-1245742312
 				installScriptSet = []string{
@@ -289,6 +289,13 @@ func (r *RootCmd) dotfiles() *clibase.Cmd {
 			Description: "Specifies which branch to clone. " +
 				"If empty, will default to cloning the default branch or using the existing branch in the cloned repo on disk.",
 			Value: clibase.StringOf(&gitbranch),
+		},
+		{
+			Flag:        "repo-dir",
+			Default:     "dotfiles",
+			Env:         "CODER_DOTFILES_REPO_DIR",
+			Description: "Specifies the directory for the dotfiles repository, relative to global config directory.",
+			Value:       clibase.StringOf(&dotfilesRepoDir),
 		},
 		cliui.SkipPromptOption(),
 	}

--- a/cli/testdata/coder_dotfiles_--help.golden
+++ b/cli/testdata/coder_dotfiles_--help.golden
@@ -15,6 +15,10 @@ OPTIONS:
           default branch or using the existing branch in the cloned repo on
           disk.
 
+      --repo-dir string, $CODER_DOTFILES_REPO_DIR (default: dotfiles)
+          Specifies the directory for the dotfiles repository, relative to
+          global config directory.
+
       --symlink-dir string, $CODER_SYMLINK_DIR
           Specifies the directory for the dotfiles symlink destinations. If
           empty, will use $HOME.

--- a/docs/cli/dotfiles.md
+++ b/docs/cli/dotfiles.md
@@ -28,6 +28,16 @@ coder dotfiles [flags] <git_repo_url>
 
 Specifies which branch to clone. If empty, will default to cloning the default branch or using the existing branch in the cloned repo on disk.
 
+### --repo-dir
+
+|             |                                       |
+| ----------- | ------------------------------------- |
+| Type        | <code>string</code>                   |
+| Environment | <code>$CODER_DOTFILES_REPO_DIR</code> |
+| Default     | <code>dotfiles</code>                 |
+
+Specifies the directory for the dotfiles repository, relative to global config directory.
+
 ### --symlink-dir
 
 |             |                                 |


### PR DESCRIPTION
# Context

When running `coder dotfiles`, it defaults to cloning the repository to `$CODER_CONFIG_DIR/dotfiles`.

# Intent

This PR adds a `--repo-dir` \ `$CODER_DOTFILES_REPO_DIR` option for the `coder dotfiles` command.

This option makes the repository directory configurable, relative to `$CODER_CONFIG_DIR`.

This is particularly useful if the user wants to utilise multiple dotfiles repositories and have them both checked out at the same time.

**For example:**
```
coder dotfiles --repo-dir dotfiles.base    https://github.com/JoshVee/foobar1
coder dotfiles --repo-dir dotfiles.default https://github.com/JoshVee/foobar2
```