### PR TITLE
chore: limit history to the last 30 runs/days for PR deploy and cleanup workflows

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -52,8 +52,8 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
-          retain_days: 1
-          keep_minimum_runs: 1
+          retain_days: 30
+          keep_minimum_runs: 30
           delete_workflow_pattern: pr-cleanup.yaml
 
       - name: Delete PR Deploy workflow skipped runs
@@ -61,7 +61,6 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}
-          retain_days: 0
-          keep_minimum_runs: 0
-          delete_run_by_conclusion_pattern: skipped
+          retain_days: 30
+          keep_minimum_runs: 30
           delete_workflow_pattern: pr-deploy.yaml


### PR DESCRIPTION
keep last 30 runs and 30 days history for PR deploy and cleanup workflows