### PR TITLE
fix(agent/agentscripts): display informative error for ErrWaitDelay

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -743,7 +743,7 @@ func (a *agent) run(ctx context.Context) error {
 				return script.RunOnStart
 			})
 			if err != nil {
-				a.logger.Warn(ctx, "startup script failed", slog.Error(err))
+				a.logger.Warn(ctx, "startup script(s) failed", slog.Error(err))
 				if errors.Is(err, agentscripts.ErrTimeout) {
 					a.setLifecycle(ctx, codersdk.WorkspaceAgentLifecycleStartTimeout)
 				} else {
@@ -1465,6 +1465,7 @@ func (a *agent) Close() error {
 		return script.RunOnStop
 	})
 	if err != nil {
+		a.logger.Warn(ctx, "shutdown script(s) failed", slog.Error(err))
 		if errors.Is(err, agentscripts.ErrTimeout) {
 			lifecycleState = codersdk.WorkspaceAgentLifecycleShutdownTimeout
 		} else {

--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -27,7 +27,13 @@ import (
 var (
 	// ErrTimeout is returned when a script times out.
 	ErrTimeout = xerrors.New("script timed out")
-	// ErrTimeout is returned when a script times out.
+	// ErrOutputPipesOpen is returned when a script exits leaving the output
+	// pipe(s) (stdout, stderr) open. This happens because we set WaitDelay on
+	// the command, which gives us two things:
+	//
+	// 1. The ability to ensure that a script exits (this is important for e.g.
+	//    blocking login, and avoiding doing so indefinitely)
+	// 2. Improved command cancellation on timeout
 	ErrOutputPipesOpen = xerrors.New("script exited without closing output pipes")
 
 	parser = cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional)

--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -262,8 +262,9 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript) 
 		message := fmt.Sprintf("script exited successfully, but output pipes were not closed after %s", cmd.WaitDelay)
 		details := fmt.Sprint(
 			"This usually means a child process was started with references to stdout or stderr. As a result, this " +
-				"process may now have been terminated. Consider using a separate \"coder_script\" for the service, " +
-				"see https://coder.com/docs/v2/latest/templates/troubleshooting#startup-script-issues for more information.",
+				"process may now have been terminated. Consider redirecting the output or using a separate " +
+				"\"coder_script\" for the process, see " +
+				"https://coder.com/docs/v2/latest/templates/troubleshooting#startup-script-issues for more information.",
 		)
 		// Inform the user by propagating the message via log writers.
 		_, _ = fmt.Fprintf(cmd.Stderr, "WARNING: %s. %s\n", message, details)

--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -27,6 +27,8 @@ import (
 var (
 	// ErrTimeout is returned when a script times out.
 	ErrTimeout = xerrors.New("script timed out")
+	// ErrTimeout is returned when a script times out.
+	ErrOutputPipesOpen = xerrors.New("script exited without closing output pipes")
 
 	parser = cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.DowOptional)
 )
@@ -248,7 +250,21 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript) 
 		err = cmdCtx.Err()
 	case err = <-cmdDone:
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	switch {
+	case errors.Is(err, exec.ErrWaitDelay):
+		err = ErrOutputPipesOpen
+		message := fmt.Sprintf("script exited successfully, but output pipes were not closed after %s", cmd.WaitDelay)
+		details := fmt.Sprint(
+			"This usually means a child process was started with references to stdout or stderr. As a result, this " +
+				"process may now have been terminated. Consider using a separate \"coder_script\" for the service, " +
+				"see https://coder.com/docs/v2/latest/templates/troubleshooting#startup-script-issues for more information.",
+		)
+		// Inform the user by propagating the message via log writers.
+		_, _ = fmt.Fprintf(cmd.Stderr, "WARNING: %s. %s\n", message, details)
+		// Also log to agent logs for ease of debugging.
+		r.Logger.Warn(ctx, message, slog.F("details", details), slog.Error(err))
+
+	case errors.Is(err, context.DeadlineExceeded):
 		err = ErrTimeout
 	}
 	return err


### PR DESCRIPTION
This PR makes it so that Coder shows an informative error instead of `exec.ErrWaitDelay` to users. To ease with discovery, and informing the user that something is wrong, the message is printed to both the script log (db/file) and to the agent log.

Fixes #10400

Web UI example:
<img width="1236" alt="image" src="https://github.com/coder/coder/assets/147409/7872326f-077b-409f-a3c2-36035d016f64">

Agent log example:

```
2023-10-27 11:53:35.129 [debu]  sdk response  method=POST  url=http://host.docker.internal:3000/api/v2/workspaceagents/me/metadata  status=204  body=""  trace_id=""  span_id=""
2023-10-27 11:53:35.817 [warn]  script exited successfully, but output pipes were not closed after 10s  details="This usually means a child process was started with references to stdout or stderr. As a result, this
 process may now have been terminated. Consider redirecting the output or using a separate \"coder_script\" for the process, see https://coder.com/docs/v2/latest/templates/troubleshooting#startup-script-issues for more information." ...
    error= script exited without closing output pipes:
               github.com/coder/coder/v2/agent/agentscripts.init
                   /home/coder/src/coder/coder/agent/agentscripts/agentscripts.go:31
2023-10-27 11:53:35.817 [warn]  /tmp/coder-startup-script.log script failed  log_path=/tmp/coder-startup-script.log  execution_time=13.665894534s  exit_code=255 ...
    error= script exited without closing output pipes:
               github.com/coder/coder/v2/agent/agentscripts.init
                   /home/coder/src/coder/coder/agent/agentscripts/agentscripts.go:31
2023-10-27 11:53:35.817 [debu]  sdk request  method=PATCH  url=http://host.docker.internal:3000/api/v2/workspaceagents/me/logs  body=""
2023-10-27 11:53:35.826 [debu]  sdk response  method=PATCH  url=http://host.docker.internal:3000/api/v2/workspaceagents/me/logs  status=200  body=""  trace_id=""  span_id=""
2023-10-27 11:53:35.826 [debu]  startup logs sender exited  log_path=/tmp/coder-startup-script.log
2023-10-27 11:53:35.826 [warn]  startup script(s) failed ...
    error= run agent script "5d6eb345-a901-4c07-8ca2-79331a0c3699":
               github.com/coder/coder/v2/agent/agentscripts.(*Runner).Execute.func2
                   /home/coder/src/coder/coder/agent/agentscripts/agentscripts.go:130
             - script exited without closing output pipes:
               github.com/coder/coder/v2/agent/agentscripts.init
                   /home/coder/src/coder/coder/agent/agentscripts/agentscripts.go:31
2023-10-27 11:53:35.826 [debu]  set lifecycle state  current={"state":"start_error","changed_at":"2023-10-27T11:53:35.826803Z"}  last={"state":"starting","changed_at":"2023-10-27T11:53:22.150913Z"}
2023-10-27 11:53:35.826 [debu]  reporting lifecycle state  payload={"state":"start_error","changed_at":"2023-10-27T11:53:35.826803Z"}
```
