### PR TITLE
chore: pin devcontainer.json to pre-nix image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,10 @@
 
   "features": {
     // See all possible options here https://github.com/devcontainers/features/tree/main/src/docker-in-docker
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": "false"
+    }
   },
   // SYS_PTRACE to enable go debugging
-  // without --priviliged the Github Codespace build fails (not required otherwise)
-  "runArgs": ["--cap-add=SYS_PTRACE", "--privileged"]
+  "runArgs": ["--cap-add=SYS_PTRACE"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Development environments on your infrastructure",
-  "image": "codercom/oss-dogfood:latest",
+  "image": "codercom/oss-dogfood:pre-nix",
 
   "features": {
     // See all possible options here https://github.com/devcontainers/features/tree/main/src/docker-in-docker

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,6 @@
       "moby": "false"
     }
   },
-  // SYS_PTRACE to enable go debugging
-  "runArgs": ["--cap-add=SYS_PTRACE"]
+   // without --priviliged the Github Codespace build fails (not required otherwise)
+  "runArgs": ["--cap-add=SYS_PTRACE", "--privileged"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,6 @@
       "moby": "false"
     }
   },
-   // without --priviliged the Github Codespace build fails (not required otherwise)
-  "runArgs": ["--cap-add=SYS_PTRACE", "--privileged"]
+  // SYS_PTRACE to enable go debugging
+  "runArgs": ["--cap-add=SYS_PTRACE"]
 }


### PR DESCRIPTION
fixes #10416
this is a workaround, and it is tagged to an old version of an image. 
While testing, it seems like `--privileged` is no longer required. 