### PR TITLE
feat: add dbfake for workspace builds and resources

### DIFF
--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbfakedata"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/provisionersdk/proto"
@@ -74,11 +74,11 @@ func TestWorkspaceAgent(t *testing.T) {
 			AzureCertificates: certificates,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
-		ws := dbfakedata.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfakedata.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -116,11 +116,11 @@ func TestWorkspaceAgent(t *testing.T) {
 			AWSCertificates: certificates,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
-		ws := dbfakedata.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfakedata.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -31,7 +31,7 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -65,11 +65,11 @@ func TestWorkspaceAgent(t *testing.T) {
 			AzureCertificates: certificates,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -107,11 +107,11 @@ func TestWorkspaceAgent(t *testing.T) {
 			AWSCertificates: certificates,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -150,11 +150,11 @@ func TestWorkspaceAgent(t *testing.T) {
 		})
 		owner := coderdtest.CreateFirstUser(t, client)
 		member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        memberUser.ID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -207,7 +207,7 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -151,6 +151,13 @@ func New(t testing.TB, options *Options) *codersdk.Client {
 	return client
 }
 
+// NewWithDatabase constructs a codersdk client connected to an in-memory API instance.
+// The database is returned to provide direct data manipulation for tests.
+func NewWithDatabase(t testing.TB, options *Options) (*codersdk.Client, database.Store) {
+	client, _, api := NewWithAPI(t, options)
+	return client, api.Database
+}
+
 // NewWithProvisionerCloser returns a client as well as a handle to close
 // the provisioner. This is a temporary function while work is done to
 // standardize how provisioners are registered with coderd. The option

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -19,8 +19,8 @@ import (
 	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
 )
 
-// CreateWorkspace inserts a workspace into the database.
-func CreateWorkspace(t testing.TB, db database.Store, seed database.Workspace) database.Workspace {
+// Workspace inserts a workspace into the database.
+func Workspace(t testing.TB, db database.Store, seed database.Workspace) database.Workspace {
 	t.Helper()
 
 	// This intentionally fulfills the minimum requirements of the schema.
@@ -37,13 +37,13 @@ func CreateWorkspace(t testing.TB, db database.Store, seed database.Workspace) d
 	return dbgen.Workspace(t, db, seed)
 }
 
-// CreateWorkspaceWithAgent is a helper that generates a workspace with a single resource
+// WorkspaceWithAgent is a helper that generates a workspace with a single resource
 // that has an agent attached to it. The agent token is returned.
-func CreateWorkspaceWithAgent(t testing.TB, db database.Store, seed database.Workspace) (database.Workspace, string) {
+func WorkspaceWithAgent(t testing.TB, db database.Store, seed database.Workspace) (database.Workspace, string) {
 	t.Helper()
 	authToken := uuid.NewString()
-	ws := CreateWorkspace(t, db, seed)
-	CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+	ws := Workspace(t, db, seed)
+	WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 		Name: "example",
 		Type: "aws_instance",
 		Agents: []*proto.Agent{{
@@ -56,8 +56,8 @@ func CreateWorkspaceWithAgent(t testing.TB, db database.Store, seed database.Wor
 	return ws, authToken
 }
 
-// CreateWorkspaceBuild inserts a build and a successful job into the database.
-func CreateWorkspaceBuild(t testing.TB, db database.Store, ws database.Workspace, seed database.WorkspaceBuild, resources ...*sdkproto.Resource) database.WorkspaceBuild {
+// WorkspaceBuild inserts a build and a successful job into the database.
+func WorkspaceBuild(t testing.TB, db database.Store, ws database.Workspace, seed database.WorkspaceBuild, resources ...*sdkproto.Resource) database.WorkspaceBuild {
 	t.Helper()
 	jobID := uuid.New()
 	seed.JobID = jobID
@@ -105,12 +105,12 @@ func CreateWorkspaceBuild(t testing.TB, db database.Store, ws database.Workspace
 			Valid: true,
 		},
 	})
-	CreateProvisionerJobResources(t, db, job.ID, seed.Transition, resources...)
+	ProvisionerJobResources(t, db, job.ID, seed.Transition, resources...)
 	return build
 }
 
-// CreateProvisionerJobResources inserts a series of resources into a provisioner job.
-func CreateProvisionerJobResources(t testing.TB, db database.Store, job uuid.UUID, transition database.WorkspaceTransition, resources ...*sdkproto.Resource) {
+// ProvisionerJobResources inserts a series of resources into a provisioner job.
+func ProvisionerJobResources(t testing.TB, db database.Store, job uuid.UUID, transition database.WorkspaceTransition, resources ...*sdkproto.Resource) {
 	t.Helper()
 	if transition == "" {
 		// Default to start!

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -1,4 +1,4 @@
-package dbfakedata
+package dbfake
 
 import (
 	"context"

--- a/coderd/database/dbfakedata/dbfakedata.go
+++ b/coderd/database/dbfakedata/dbfakedata.go
@@ -1,0 +1,83 @@
+package dbfakedata
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/provisionerdserver"
+	"github.com/coder/coder/v2/coderd/telemetry"
+	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
+)
+
+// CreateWorkspace inserts a workspace into the database.
+func CreateWorkspace(t testing.TB, db database.Store, seed database.Workspace) database.Workspace {
+	t.Helper()
+
+	// This intentionally fulfills the minimum requirements of the schema.
+	// Tests can provide a custom template ID if necessary.
+	if seed.TemplateID == uuid.Nil {
+		template := dbgen.Template(t, db, database.Template{
+			OrganizationID: seed.OrganizationID,
+			CreatedBy:      seed.OwnerID,
+		})
+		seed.TemplateID = template.ID
+	}
+	return dbgen.Workspace(t, db, seed)
+}
+
+// CreateWorkspaceBuild inserts a build and a successful job into the database.
+func CreateWorkspaceBuild(t testing.TB, db database.Store, ws database.Workspace, seed database.WorkspaceBuild, resources ...*sdkproto.Resource) database.WorkspaceBuild {
+	t.Helper()
+	jobID := uuid.New()
+	seed.JobID = jobID
+	seed.WorkspaceID = ws.ID
+	// This intentionally fulfills the minimum requirements of the schema.
+	// Tests can provide a custom version ID if necessary.
+	if seed.TemplateVersionID == uuid.Nil {
+		templateVersion := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+			OrganizationID: ws.OrganizationID,
+			CreatedBy:      ws.OwnerID,
+		})
+		seed.TemplateVersionID = templateVersion.ID
+	}
+	build := dbgen.WorkspaceBuild(t, db, seed)
+
+	payload, err := json.Marshal(provisionerdserver.WorkspaceProvisionJob{
+		WorkspaceBuildID: build.ID,
+	})
+	require.NoError(t, err)
+	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		ID:             jobID,
+		Input:          payload,
+		OrganizationID: ws.OrganizationID,
+		CompletedAt: sql.NullTime{
+			Time:  dbtime.Now(),
+			Valid: true,
+		},
+	})
+	CreateProvisionerJobResources(t, db, job.ID, seed.Transition, resources...)
+	return build
+}
+
+// CreateProvisionerJobResources inserts a series of resources into a provisioner job.
+func CreateProvisionerJobResources(t testing.TB, db database.Store, job uuid.UUID, transition database.WorkspaceTransition, resources ...*sdkproto.Resource) {
+	t.Helper()
+	if transition == "" {
+		// Default to start!
+		transition = database.WorkspaceTransitionStart
+	}
+	for _, resource := range resources {
+		//nolint:gocritic // This is only used by tests.
+		err := provisionerdserver.InsertWorkspaceResource(dbauthz.AsSystemRestricted(context.Background()), db, job, transition, resource, &telemetry.Snapshot{})
+		require.NoError(t, err)
+	}
+}

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -66,6 +66,12 @@ func AuditLog(t testing.TB, db database.Store, seed database.AuditLog) database.
 
 func Template(t testing.TB, db database.Store, seed database.Template) database.Template {
 	id := takeFirst(seed.ID, uuid.New())
+	if seed.GroupACL == nil {
+		// By default, all users in the organization can read the template.
+		seed.GroupACL = database.TemplateACL{
+			seed.OrganizationID.String(): []rbac.Action{rbac.ActionRead},
+		}
+	}
 	err := db.InsertTemplate(genCtx, database.InsertTemplateParams{
 		ID:                           id,
 		CreatedAt:                    takeFirst(seed.CreatedAt, dbtime.Now()),
@@ -84,7 +90,7 @@ func Template(t testing.TB, db database.Store, seed database.Template) database.
 	})
 	require.NoError(t, err, "insert template")
 
-	template, err := db.GetTemplateByID(context.Background(), id)
+	template, err := db.GetTemplateByID(genCtx, id)
 	require.NoError(t, err, "get template")
 	return template
 }

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -395,9 +395,6 @@ func ProvisionerJob(t testing.TB, db database.Store, ps pubsub.Pubsub, orig data
 		require.NoError(t, err)
 	}
 
-	job, err = db.GetProvisionerJobByID(genCtx, jobID)
-	require.NoError(t, err)
-
 	return job
 }
 

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -395,6 +395,9 @@ func ProvisionerJob(t testing.TB, db database.Store, ps pubsub.Pubsub, orig data
 		require.NoError(t, err)
 	}
 
+	job, err = db.GetProvisionerJobByID(genCtx, jobID)
+	require.NoError(t, err)
+
 	return job
 }
 

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -153,11 +153,8 @@ func TestWorkspaceAgent(t *testing.T) {
 			SshHelper:            true,
 		}
 		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
-			Name: "example",
-			Type: "aws_instance",
 			Agents: []*proto.Agent{
 				{
-					Id:        uuid.NewString(),
 					Directory: tmpDir,
 					Auth: &proto.Agent_Token{
 						Token: authToken,
@@ -196,11 +193,8 @@ func TestWorkspaceAgent(t *testing.T) {
 			OwnerID:        user.UserID,
 		})
 		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
-			Name: "example",
-			Type: "aws_instance",
 			Agents: []*proto.Agent{
 				{
-					Id:        uuid.NewString(),
 					Directory: tmpDir,
 					Auth: &proto.Agent_Token{
 						Token: authToken,

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -42,11 +42,11 @@ func TestWorkspaceAgent(t *testing.T) {
 		tmpDir := t.TempDir()
 		anotherClient, anotherUser := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
 
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        anotherUser.ID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "aws_instance",
 			Agents: []*proto.Agent{{
 				Id:        uuid.NewString(),
@@ -67,11 +67,11 @@ func TestWorkspaceAgent(t *testing.T) {
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
 		tmpDir := t.TempDir()
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "aws_instance",
 			Agents: []*proto.Agent{{
 				Id:        uuid.NewString(),
@@ -99,11 +99,11 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		wantTroubleshootingURL := "https://example.com/troubleshoot"
 
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OwnerID:        user.UserID,
 			OrganizationID: user.OrganizationID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "example",
 			Type: "aws_instance",
 			Agents: []*proto.Agent{{
@@ -139,7 +139,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		t.Parallel()
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -152,7 +152,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			PortForwardingHelper: true,
 			SshHelper:            true,
 		}
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "example",
 			Type: "aws_instance",
 			Agents: []*proto.Agent{
@@ -191,11 +191,11 @@ func TestWorkspaceAgent(t *testing.T) {
 		apps.WebTerminal = false
 
 		// Creating another workspace is easier
-		ws = dbfake.CreateWorkspace(t, db, database.Workspace{
+		ws = dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "example",
 			Type: "aws_instance",
 			Agents: []*proto.Agent{
@@ -225,7 +225,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -267,7 +267,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -309,7 +309,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -352,7 +352,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -438,7 +438,7 @@ func TestWorkspaceAgentTailnet(t *testing.T) {
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	user := coderdtest.CreateFirstUser(t, client)
 
-	ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+	ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
@@ -477,7 +477,7 @@ func TestWorkspaceAgentTailnetDirectDisabled(t *testing.T) {
 		DeploymentValues: dv,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
-	ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+	ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
@@ -540,7 +540,7 @@ func TestWorkspaceAgentListeningPorts(t *testing.T) {
 		require.NoError(t, err)
 
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -765,11 +765,11 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 			},
 		},
 	}
-	ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+	ws := dbfake.Workspace(t, db, database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
-	dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+	dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 		Name: "example",
 		Type: "aws_instance",
 		Agents: []*proto.Agent{{
@@ -840,7 +840,7 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -881,7 +881,7 @@ func TestWorkspaceAgent_LifecycleState(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -947,11 +947,11 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()
-	ws := dbfake.CreateWorkspace(t, db, database.Workspace{
+	ws := dbfake.Workspace(t, db, database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
-	dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+	dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 		Name: "example",
 		Type: "aws_instance",
 		Agents: []*proto.Agent{{
@@ -1111,7 +1111,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -1156,7 +1156,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		_, authToken := dbfake.CreateWorkspaceWithAgent(t, db, database.Workspace{
+		_, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
@@ -1204,7 +1204,7 @@ func TestWorkspaceAgent_UpdatedDERP(t *testing.T) {
 	api.DERPMapper.Store(&derpMapFn)
 
 	// Start workspace a workspace agent.
-	ws, agentToken := dbfake.CreateWorkspaceWithAgent(t, api.Database, database.Workspace{
+	ws, agentToken := dbfake.WorkspaceWithAgent(t, api.Database, database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbfakedata"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -45,11 +45,11 @@ func TestWorkspaceAgent(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		ws := dbfakedata.CreateWorkspace(t, db, database.Workspace{
+		ws := dbfake.CreateWorkspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        anotherUser.ID,
 		})
-		dbfakedata.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.CreateWorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
 			Name: "aws_instance",
 			Agents: []*proto.Agent{{
 				Id:        uuid.NewString(),

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -534,9 +534,18 @@ func TestWorkspaceAgentListeningPorts(t *testing.T) {
 		require.NoError(t, err)
 
 		user := coderdtest.CreateFirstUser(t, client)
-		ws, authToken := dbfake.WorkspaceWithAgent(t, db, database.Workspace{
+		ws := dbfake.Workspace(t, db, database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
+		})
+		authToken := uuid.NewString()
+		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+			Agents: []*proto.Agent{{
+				Apps: apps,
+				Auth: &proto.Agent_Token{
+					Token: authToken,
+				},
+			}},
 		})
 		_ = agenttest.New(t, client.URL, authToken)
 		resources := coderdtest.AwaitWorkspaceAgents(t, client, ws.ID)


### PR DESCRIPTION
This creates `coderdtest.NewWithDatabase` and adds a series of helper functions to `dbfake` that insert structured fake data for resources into the database.

It allows us to remove provisionerd from many tests, which should speed them up and reduce flakes.

Ideally, we merge this then I convert all tests to use this new structure. It's intentionally abstract right now because I assume more patterns will emerge as I work through cases.