### PR TITLE
fix: disable t.Parallel on TestPortForward

### DIFF
--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -140,9 +140,10 @@ func TestPortForward(t *testing.T) {
 
 	for _, c := range cases {
 		c := c
-		// Delay parallel tests here because setupLocal reserves
+		// No parallel tests here because setupLocal reserves
 		// a free open port which is not guaranteed to be free
 		// between the listener closing and port-forward ready.
+		//nolint:tparallel,paralleltest
 		t.Run(c.name+"_OnePort", func(t *testing.T) {
 			p1 := setupTestListener(t, c.setupRemote(t))
 
@@ -166,8 +167,6 @@ func TestPortForward(t *testing.T) {
 			}()
 			pty.ExpectMatchContext(ctx, "Ready!")
 
-			t.Parallel() // Port is reserved, enable parallel execution.
-
 			// Open two connections simultaneously and test them out of
 			// sync.
 			d := net.Dialer{Timeout: testutil.WaitShort}
@@ -185,6 +184,10 @@ func TestPortForward(t *testing.T) {
 			require.ErrorIs(t, err, context.Canceled)
 		})
 
+		// No parallel tests here because setupLocal reserves
+		// a free open port which is not guaranteed to be free
+		// between the listener closing and port-forward ready.
+		//nolint:tparallel,paralleltest
 		t.Run(c.name+"_TwoPorts", func(t *testing.T) {
 			var (
 				p1 = setupTestListener(t, c.setupRemote(t))
@@ -213,8 +216,6 @@ func TestPortForward(t *testing.T) {
 			}()
 			pty.ExpectMatchContext(ctx, "Ready!")
 
-			t.Parallel() // Port is reserved, enable parallel execution.
-
 			// Open a connection to both listener 1 and 2 simultaneously and
 			// then test them out of order.
 			d := net.Dialer{Timeout: testutil.WaitShort}
@@ -234,6 +235,10 @@ func TestPortForward(t *testing.T) {
 	}
 
 	// Test doing TCP and UDP at the same time.
+	// No parallel tests here because setupLocal reserves
+	// a free open port which is not guaranteed to be free
+	// between the listener closing and port-forward ready.
+	//nolint:tparallel,paralleltest
 	t.Run("All", func(t *testing.T) {
 		var (
 			dials = []addr{}
@@ -265,8 +270,6 @@ func TestPortForward(t *testing.T) {
 			errC <- inv.WithContext(ctx).Run()
 		}()
 		pty.ExpectMatchContext(ctx, "Ready!")
-
-		t.Parallel() // Port is reserved, enable parallel execution.
 
 		// Open connections to all items in the "dial" array.
 		var (

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -941,7 +941,7 @@ func (c *Conn) DialContextTCP(ctx context.Context, ipp netip.AddrPort) (*gonet.T
 }
 
 func (c *Conn) DialContextUDP(ctx context.Context, ipp netip.AddrPort) (*gonet.UDPConn, error) {
-	c.logger.Debug(ctx, "dial tcp", slog.F("addr_port", ipp))
+	c.logger.Debug(ctx, "dial udp", slog.F("addr_port", ipp))
 	return c.netStack.DialContextUDP(ctx, ipp)
 }
 

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -936,10 +936,12 @@ func (c *Conn) Listen(network, addr string) (net.Listener, error) {
 }
 
 func (c *Conn) DialContextTCP(ctx context.Context, ipp netip.AddrPort) (*gonet.TCPConn, error) {
+	c.logger.Debug(ctx, "dial tcp", slog.F("addr_port", ipp))
 	return c.netStack.DialContextTCP(ctx, ipp)
 }
 
 func (c *Conn) DialContextUDP(ctx context.Context, ipp netip.AddrPort) (*gonet.UDPConn, error) {
+	c.logger.Debug(ctx, "dial tcp", slog.F("addr_port", ipp))
 	return c.netStack.DialContextUDP(ctx, ipp)
 }
 


### PR DESCRIPTION
I've said it before, I'll say it again: you can't create a timed context before calling `t.Parallel()` and then use it after.

Fixes flakes like https://github.com/coder/coder/actions/runs/6716682414/job/18253279157

I've chosen just to drop `t.Parallel()` entirely rather than create a second context after the parallel call, since the vast majority of the test time happens before where the parallel call was.  It does all the tailnet setup before `t.Parallel()`.
Leaving a call to `t.Parallel()` is a bug risk for future maintainers to come in and use the wrong context in the latter part of the test by accident.
