### PR TITLE
feat: add observability configuration values to deployment page 

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -122,6 +122,12 @@ const NetworkSettingsPage = lazy(
       "./pages/DeploySettingsPage/NetworkSettingsPage/NetworkSettingsPage"
     ),
 );
+const ObservabilitySettingsPage = lazy(
+  () =>
+    import(
+      "./pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPage"
+    ),
+);
 const ExternalAuthPage = lazy(
   () => import("./pages/ExternalAuthPage/ExternalAuthPage"),
 );
@@ -290,6 +296,10 @@ export const AppRouter: FC = () => {
                 <Route path="licenses" element={<LicensesSettingsPage />} />
                 <Route path="licenses/add" element={<AddNewLicensePage />} />
                 <Route path="security" element={<SecuritySettingsPage />} />
+                <Route
+                  path="observability"
+                  element={<ObservabilitySettingsPage />}
+                />
                 <Route path="appearance" element={<AppearanceSettingsPage />} />
                 <Route path="network" element={<NetworkSettingsPage />} />
                 <Route path="userauth" element={<UserAuthSettingsPage />} />

--- a/site/src/components/DeploySettingsLayout/Sidebar.tsx
+++ b/site/src/components/DeploySettingsLayout/Sidebar.tsx
@@ -2,7 +2,7 @@ import Brush from "@mui/icons-material/Brush";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import ApprovalIcon from "@mui/icons-material/VerifiedUserOutlined";
 import LockRounded from "@mui/icons-material/LockOutlined";
-import AnalyticsIcon from "@mui/icons-material/Analytics";
+import InsertChartIcon from "@mui/icons-material/InsertChart";
 import Globe from "@mui/icons-material/PublicOutlined";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import VpnKeyOutlined from "@mui/icons-material/VpnKeyOutlined";
@@ -136,7 +136,7 @@ export const Sidebar: React.FC = () => {
       </SidebarNavItem>
       <SidebarNavItem
         href="observability"
-        icon={<SidebarNavItemIcon icon={AnalyticsIcon} />}
+        icon={<SidebarNavItemIcon icon={InsertChartIcon} />}
       >
         Observability
       </SidebarNavItem>

--- a/site/src/components/DeploySettingsLayout/Sidebar.tsx
+++ b/site/src/components/DeploySettingsLayout/Sidebar.tsx
@@ -2,6 +2,7 @@ import Brush from "@mui/icons-material/Brush";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import ApprovalIcon from "@mui/icons-material/VerifiedUserOutlined";
 import LockRounded from "@mui/icons-material/LockOutlined";
+import AnalyticsIcon from "@mui/icons-material/Analytics";
 import Globe from "@mui/icons-material/PublicOutlined";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import VpnKeyOutlined from "@mui/icons-material/VpnKeyOutlined";
@@ -132,6 +133,12 @@ export const Sidebar: React.FC = () => {
         icon={<SidebarNavItemIcon icon={LockRounded} />}
       >
         Security
+      </SidebarNavItem>
+      <SidebarNavItem
+        href="observability"
+        icon={<SidebarNavItemIcon icon={AnalyticsIcon} />}
+      >
+        Observability
       </SidebarNavItem>
       {dashboard.experiments.includes("deployment_health_page") && (
         <SidebarNavItem

--- a/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPage.tsx
+++ b/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPage.tsx
@@ -3,26 +3,24 @@ import { useDeploySettings } from "components/DeploySettingsLayout/DeploySetting
 import { FC } from "react";
 import { Helmet } from "react-helmet-async";
 import { pageTitle } from "utils/page";
-import { SecuritySettingsPageView } from "./SecuritySettingsPageView";
+import { ObservabilitySettingsPageView } from "./ObservabilitySettingsPageView";
 
-const SecuritySettingsPage: FC = () => {
+const ObservabilitySettingsPage: FC = () => {
   const { deploymentValues: deploymentValues } = useDeploySettings();
   const { entitlements } = useDashboard();
 
   return (
     <>
       <Helmet>
-        <title>{pageTitle("Security Settings")}</title>
+        <title>{pageTitle("Observability Settings")}</title>
       </Helmet>
 
-      <SecuritySettingsPageView
+      <ObservabilitySettingsPageView
         options={deploymentValues.options}
-        featureBrowserOnlyEnabled={
-          entitlements.features["browser_only"].enabled
-        }
+        featureAuditLogEnabled={entitlements.features["audit_log"].enabled}
       />
     </>
   );
 };
 
-export default SecuritySettingsPage;
+export default ObservabilitySettingsPage;

--- a/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.stories.tsx
@@ -1,0 +1,54 @@
+import { ObservabilitySettingsPageView } from "./ObservabilitySettingsPageView";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ClibaseGroup } from "api/typesGenerated";
+
+const group: ClibaseGroup = {
+  name: "Introspection",
+  description: "",
+};
+
+const meta: Meta<typeof ObservabilitySettingsPageView> = {
+  title: "pages/DeploySettingsPage/ObservabilitySettingsPageView",
+  component: ObservabilitySettingsPageView,
+  args: {
+    options: [
+      {
+        name: "Verbose",
+        value: true,
+        group,
+        flag: "verbose",
+        flag_shorthand: "v",
+        hidden: false,
+      },
+      {
+        name: "Human Log Location",
+        description: "Output human-readable logs to a given file.",
+        value: "/dev/stderr",
+        flag: "log-human",
+        hidden: false,
+      },
+      {
+        name: "Stackdriver Log Location",
+        description: "Output Stackdriver compatible logs to a given file.",
+        value: "",
+        flag: "log-stackdriver",
+        hidden: false,
+      },
+      {
+        name: "Prometheus Enable",
+        description:
+          "Serve prometheus metrics on the address defined by prometheus address.",
+        value: true,
+        group: { ...group },
+        flag: "prometheus-enable",
+        hidden: false,
+      },
+    ],
+    featureAuditLogEnabled: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ObservabilitySettingsPageView>;
+
+export const Page: Story = {};

--- a/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -22,12 +22,8 @@ export const ObservabilitySettingsPageView = ({
   return (
     <>
       <Stack direction="column" spacing={6}>
-        <Header
-          title="Observability"
-          description="Coder application observability."
-        />
-
         <div>
+          <Header title="Observability" />
           <Header
             title="Audit Logging"
             secondary

--- a/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -1,0 +1,60 @@
+import { ClibaseOption } from "api/typesGenerated";
+import {
+  Badges,
+  DisabledBadge,
+  EnabledBadge,
+  EnterpriseBadge,
+} from "components/DeploySettingsLayout/Badges";
+import { Header } from "components/DeploySettingsLayout/Header";
+import OptionsTable from "components/DeploySettingsLayout/OptionsTable";
+import { Stack } from "components/Stack/Stack";
+import { deploymentGroupHasParent } from "utils/deployOptions";
+import { docs } from "utils/docs";
+
+export type ObservabilitySettingsPageViewProps = {
+  options: ClibaseOption[];
+  featureAuditLogEnabled: boolean;
+};
+export const ObservabilitySettingsPageView = ({
+  options: options,
+  featureAuditLogEnabled,
+}: ObservabilitySettingsPageViewProps): JSX.Element => {
+  return (
+    <>
+      <Stack direction="column" spacing={6}>
+        <Header
+          title="Observability"
+          description="Coder application observability."
+        />
+
+        <div>
+          <Header
+            title="Audit Logging"
+            secondary
+            description="Allow auditors to monitor user operations in your deployment."
+            docsHref={docs("/admin/audit-logs")}
+          />
+
+          <Badges>
+            {featureAuditLogEnabled ? <EnabledBadge /> : <DisabledBadge />}
+            <EnterpriseBadge />
+          </Badges>
+        </div>
+
+        <div>
+          <Header
+            title="Monitoring"
+            secondary
+            description="Monitoring your Coder application with logs and metrics."
+          />
+
+          <OptionsTable
+            options={options.filter((o) =>
+              deploymentGroupHasParent(o.group, "Introspection"),
+            )}
+          />
+        </div>
+      </Stack>
+    </>
+  );
+};

--- a/site/src/pages/DeploySettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
+++ b/site/src/pages/DeploySettingsPage/SecuritySettingsPage/SecuritySettingsPageView.stories.tsx
@@ -47,7 +47,6 @@ const meta: Meta<typeof SecuritySettingsPageView> = {
         hidden: false,
       },
     ],
-    featureAuditLogEnabled: true,
     featureBrowserOnlyEnabled: true,
   },
 };

--- a/site/src/pages/DeploySettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -16,12 +16,10 @@ import { docs } from "utils/docs";
 
 export type SecuritySettingsPageViewProps = {
   options: ClibaseOption[];
-  featureAuditLogEnabled: boolean;
   featureBrowserOnlyEnabled: boolean;
 };
 export const SecuritySettingsPageView = ({
   options: options,
-  featureAuditLogEnabled,
   featureBrowserOnlyEnabled,
 }: SecuritySettingsPageViewProps): JSX.Element => {
   const tlsOptions = options.filter((o) =>
@@ -45,20 +43,6 @@ export const SecuritySettingsPageView = ({
               "Disable Owner Workspace Access",
             )}
           />
-        </div>
-
-        <div>
-          <Header
-            title="Audit Logging"
-            secondary
-            description="Allow auditors to monitor user operations in your deployment."
-            docsHref={docs("/admin/audit-logs")}
-          />
-
-          <Badges>
-            {featureAuditLogEnabled ? <EnabledBadge /> : <DisabledBadge />}
-            <EnterpriseBadge />
-          </Badges>
         </div>
 
         <div>


### PR DESCRIPTION
# What this does

Adds a new "Observability" deployment settings page for logging, prometheus, tracing, and pprof settings.

Moves the "Audit Logging" feature to this page.

![Screenshot from 2023-11-01 09-37-59](https://github.com/coder/coder/assets/5446298/b458f8db-43aa-4326-af5c-84ba5f4e811a)

Closes https://github.com/coder/coder/issues/10301