### PR TITLE
feat: add endpoint for resolving autostart status

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6487,9 +6487,6 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6480,7 +6480,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaces/{workspace}/resolve": {
+        "/workspaces/{workspace}/resolve-autostart": {
             "get": {
                 "security": [
                     {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6480,6 +6480,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{workspace}/resolve": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Determine whether a workspace is capable of autostarting.",
+                "operationId": "resolve-workspace-autostart-by-id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace ID",
+                        "name": "workspace",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ResolveAutostartResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{workspace}/ttl": {
             "put": {
                 "security": [
@@ -9717,6 +9752,14 @@ const docTemplate = `{
                 "relay_address": {
                     "description": "RelayAddress is the accessible address to relay DERP connections.",
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.ResolveAutostartResponse": {
+            "type": "object",
+            "properties": {
+                "parameter_mismatch": {
+                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6490,6 +6490,9 @@ const docTemplate = `{
                 "consumes": [
                     "application/json"
                 ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Workspaces"
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6493,7 +6493,7 @@ const docTemplate = `{
                 "tags": [
                     "Workspaces"
                 ],
-                "summary": "Determine whether a workspace is capable of autostarting.",
+                "summary": "Resolve workspace autostart by id.",
                 "operationId": "resolve-workspace-autostart-by-id",
                 "parameters": [
                     {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5718,7 +5718,7 @@
         }
       }
     },
-    "/workspaces/{workspace}/resolve": {
+    "/workspaces/{workspace}/resolve-autostart": {
       "get": {
         "security": [
           {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5718,6 +5718,37 @@
         }
       }
     },
+    "/workspaces/{workspace}/resolve": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "consumes": ["application/json"],
+        "tags": ["Workspaces"],
+        "summary": "Determine whether a workspace is capable of autostarting.",
+        "operationId": "resolve-workspace-autostart-by-id",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workspace ID",
+            "name": "workspace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/codersdk.ResolveAutostartResponse"
+            }
+          }
+        }
+      }
+    },
     "/workspaces/{workspace}/ttl": {
       "put": {
         "security": [
@@ -8753,6 +8784,14 @@
         "relay_address": {
           "description": "RelayAddress is the accessible address to relay DERP connections.",
           "type": "string"
+        }
+      }
+    },
+    "codersdk.ResolveAutostartResponse": {
+      "type": "object",
+      "properties": {
+        "parameter_mismatch": {
+          "type": "boolean"
         }
       }
     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5727,7 +5727,7 @@
         ],
         "produces": ["application/json"],
         "tags": ["Workspaces"],
-        "summary": "Determine whether a workspace is capable of autostarting.",
+        "summary": "Resolve workspace autostart by id.",
         "operationId": "resolve-workspace-autostart-by-id",
         "parameters": [
           {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5725,7 +5725,6 @@
             "CoderSessionToken": []
           }
         ],
-        "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["Workspaces"],
         "summary": "Determine whether a workspace is capable of autostarting.",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5726,6 +5726,7 @@
           }
         ],
         "consumes": ["application/json"],
+        "produces": ["application/json"],
         "tags": ["Workspaces"],
         "summary": "Determine whether a workspace is capable of autostarting.",
         "operationId": "resolve-workspace-autostart-by-id",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -885,7 +885,7 @@ func New(options *Options) *API {
 				r.Put("/extend", api.putExtendWorkspace)
 				r.Put("/dormant", api.putWorkspaceDormant)
 				r.Put("/autoupdates", api.putWorkspaceAutoupdates)
-				r.Get("/resolve", api.resolveAutostart)
+				r.Get("/resolve-autostart", api.resolveAutostart)
 			})
 		})
 		r.Route("/workspacebuilds/{workspacebuild}", func(r chi.Router) {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -885,6 +885,7 @@ func New(options *Options) *API {
 				r.Put("/extend", api.putExtendWorkspace)
 				r.Put("/dormant", api.putWorkspaceDormant)
 				r.Put("/autoupdates", api.putWorkspaceAutoupdates)
+				r.Get("/resolve", api.resolveAutostart)
 			})
 		})
 		r.Route("/workspacebuilds/{workspacebuild}", func(r chi.Router) {

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/exp/slices"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/parameter"
@@ -28,6 +29,19 @@ func WorkspaceBuildParameter(p database.WorkspaceBuildParameter) codersdk.Worksp
 		Name:  p.Name,
 		Value: p.Value,
 	}
+}
+
+func TemplateVersionParameters(params []database.TemplateVersionParameter) ([]codersdk.TemplateVersionParameter, error) {
+	out := make([]codersdk.TemplateVersionParameter, len(params))
+	var err error
+	for i, p := range params {
+		out[i], err = TemplateVersionParameter(p)
+		if err != nil {
+			return nil, xerrors.Errorf("convert template version parameter %q: %w", p.Name, err)
+		}
+	}
+
+	return out, nil
 }
 
 func TemplateVersionParameter(param database.TemplateVersionParameter) (codersdk.TemplateVersionParameter, error) {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1082,9 +1082,7 @@ func (api *API) resolveAutostart(rw http.ResponseWriter, r *http.Request) {
 
 	useActiveVersion := template.RequireActiveVersion || workspace.AutomaticUpdates == database.AutomaticUpdatesAlways
 	if !useActiveVersion {
-		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ResolveAutostartResponse{
-			ParameterMismatch: true,
-		})
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ResolveAutostartResponse{})
 		return
 	}
 
@@ -1098,28 +1096,14 @@ func (api *API) resolveAutostart(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if build.TemplateVersionID == template.ActiveVersionID {
-		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ResolveAutostartResponse{
-			ParameterMismatch: false,
-		})
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ResolveAutostartResponse{})
 		return
 	}
 
 	version, err := api.Database.GetTemplateVersionByID(ctx, template.ActiveVersionID)
-	if httpapi.Is404Error(err) {
-		httpapi.ResourceNotFound(rw)
-		return
-	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching template version.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-
-	if version.TemplateID.UUID != workspace.TemplateID {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Workspace cannot be resolved against unrelated template.",
 			Detail:  err.Error(),
 		})
 		return

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -17,6 +17,7 @@ import (
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/provisionerjobs"
@@ -1057,6 +1058,113 @@ func (api *API) putWorkspaceAutoupdates(rw http.ResponseWriter, r *http.Request)
 	aReq.New = newWorkspace
 
 	rw.WriteHeader(http.StatusNoContent)
+}
+
+// @Summary Determine whether a workspace is capable of autostarting.
+// @ID resolve-workspace-autostart-by-id
+// @Security CoderSessionToken
+// @Accept json
+// @Tags Workspaces
+// @Param workspace path string true "Workspace ID" format(uuid)
+// @Success 200 {object} codersdk.ResolveAutostartResponse
+// @Router /workspaces/{workspace}/resolve [get]
+func (api *API) resolveAutostart(rw http.ResponseWriter, r *http.Request) {
+	var (
+		ctx       = r.Context()
+		workspace = httpmw.WorkspaceParam(r)
+	)
+
+	template, err := api.Database.GetTemplateByID(ctx, workspace.TemplateID)
+	if err != nil {
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	useActiveVersion := template.RequireActiveVersion || workspace.AutomaticUpdates == database.AutomaticUpdatesAlways
+	if !useActiveVersion {
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ResolveAutostartResponse{
+			ParameterMismatch: true,
+		})
+		return
+	}
+
+	build, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching latest workspace build.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	if build.TemplateVersionID == template.ActiveVersionID {
+		httpapi.Write(ctx, rw, http.StatusOK, codersdk.ResolveAutostartResponse{
+			ParameterMismatch: false,
+		})
+		return
+	}
+
+	version, err := api.Database.GetTemplateVersionByID(ctx, template.ActiveVersionID)
+	if httpapi.Is404Error(err) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching template version.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	if version.TemplateID.UUID != workspace.TemplateID {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Workspace cannot be resolved against unrelated template.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	dbVersionParams, err := api.Database.GetTemplateVersionParameters(ctx, version.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Internal error fetching template version parameters.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	dbBuildParams, err := api.Database.GetWorkspaceBuildParameters(ctx, build.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching latest workspace build parameters.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	versionParams, err := db2sdk.TemplateVersionParameters(dbVersionParams)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error converting template version parameters.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	resolver := codersdk.ParameterResolver{
+		Rich: db2sdk.WorkspaceBuildParameters(dbBuildParams),
+	}
+
+	var response codersdk.ResolveAutostartResponse
+	for i := 0; i < len(versionParams) && !response.ParameterMismatch; i++ {
+		_, err := resolver.ValidateResolve(versionParams[i], nil)
+		// There's a parameter mismatch if we get an error back from the
+		// resolver.
+		response.ParameterMismatch = err != nil
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
 // @Summary Watch workspace by ID

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1067,7 +1067,7 @@ func (api *API) putWorkspaceAutoupdates(rw http.ResponseWriter, r *http.Request)
 // @Tags Workspaces
 // @Param workspace path string true "Workspace ID" format(uuid)
 // @Success 200 {object} codersdk.ResolveAutostartResponse
-// @Router /workspaces/{workspace}/resolve [get]
+// @Router /workspaces/{workspace}/resolve-autostart [get]
 func (api *API) resolveAutostart(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx       = r.Context()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1150,7 +1150,6 @@ func (api *API) resolveAutostart(rw http.ResponseWriter, r *http.Request) {
 		if response.ParameterMismatch {
 			break
 		}
-
 	}
 	httpapi.Write(ctx, rw, http.StatusOK, response)
 }

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1064,6 +1064,7 @@ func (api *API) putWorkspaceAutoupdates(rw http.ResponseWriter, r *http.Request)
 // @ID resolve-workspace-autostart-by-id
 // @Security CoderSessionToken
 // @Accept json
+// @Produce json
 // @Tags Workspaces
 // @Param workspace path string true "Workspace ID" format(uuid)
 // @Success 200 {object} codersdk.ResolveAutostartResponse

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1060,7 +1060,7 @@ func (api *API) putWorkspaceAutoupdates(rw http.ResponseWriter, r *http.Request)
 	rw.WriteHeader(http.StatusNoContent)
 }
 
-// @Summary Determine whether a workspace is capable of autostarting.
+// @Summary Resolve workspace autostart by id.
 // @ID resolve-workspace-autostart-by-id
 // @Security CoderSessionToken
 // @Produce json

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1063,7 +1063,6 @@ func (api *API) putWorkspaceAutoupdates(rw http.ResponseWriter, r *http.Request)
 // @Summary Determine whether a workspace is capable of autostarting.
 // @ID resolve-workspace-autostart-by-id
 // @Security CoderSessionToken
-// @Accept json
 // @Produce json
 // @Tags Workspaces
 // @Param workspace path string true "Workspace ID" format(uuid)

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -340,6 +340,99 @@ func TestWorkspace(t *testing.T) {
 	})
 }
 
+func TestResolveAutostart(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		ownerClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, ownerClient)
+		version1 := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version1.ID)
+		template := coderdtest.CreateTemplate(t, ownerClient, owner.OrganizationID, version1.ID)
+
+		params := &echo.Responses{
+			Parse: echo.ParseComplete,
+			ProvisionPlan: []*proto.Response{
+				{
+					Type: &proto.Response_Plan{
+						Plan: &proto.PlanComplete{
+							Parameters: []*proto.RichParameter{
+								{
+									Name:        "param",
+									Description: "param",
+									Required:    true,
+									Mutable:     true,
+								},
+							},
+						},
+					},
+				},
+			},
+			ProvisionApply: echo.ApplyComplete,
+		}
+		version2 := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, params, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.TemplateID = template.ID
+		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version2.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+		workspace := coderdtest.CreateWorkspace(t, client, owner.OrganizationID, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+			cwr.AutomaticUpdates = codersdk.AutomaticUpdatesAlways
+		})
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		err := ownerClient.UpdateActiveTemplateVersion(ctx, template.ID, codersdk.UpdateActiveTemplateVersion{
+			ID: version2.ID,
+		})
+		require.NoError(t, err)
+
+		// Autostart shouldn't be possible if parameters do not match.
+		resp, err := client.ResolveAutostart(ctx, workspace.ID.String())
+		require.NoError(t, err)
+		require.True(t, resp.ParameterMismatch)
+
+		update, err := client.CreateWorkspaceBuild(ctx, workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+			TemplateVersionID: version2.ID,
+			Transition:        codersdk.WorkspaceTransitionStart,
+			RichParameterValues: []codersdk.WorkspaceBuildParameter{
+				{
+					Name:  "param",
+					Value: "Hello",
+				},
+			},
+		})
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, update.ID)
+
+		// We should be able to autostart since parameters are updated.
+		resp, err = client.ResolveAutostart(ctx, workspace.ID.String())
+		require.NoError(t, err)
+		require.False(t, resp.ParameterMismatch)
+
+		// Create one last version where the parameters are the same as the previous
+		// version.
+		version3 := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, params, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.TemplateID = template.ID
+		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version3.ID)
+
+		err = ownerClient.UpdateActiveTemplateVersion(ctx, template.ID, codersdk.UpdateActiveTemplateVersion{
+			ID: version3.ID,
+		})
+		require.NoError(t, err)
+
+		// Even though we're out of date we should still be able to autostart
+		// since parameters resolve.
+		resp, err = client.ResolveAutostart(ctx, workspace.ID.String())
+		require.NoError(t, err)
+		require.False(t, resp.ParameterMismatch)
+	})
+}
+
 func TestAdminViewAllWorkspaces(t *testing.T) {
 	t.Parallel()
 	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -449,6 +449,23 @@ func (c *Client) WorkspaceQuota(ctx context.Context, userID string) (WorkspaceQu
 	return quota, json.NewDecoder(res.Body).Decode(&quota)
 }
 
+type ResolveAutostartResponse struct {
+	ParameterMismatch bool `json:"parameter_mismatch"`
+}
+
+func (c *Client) ResolveAutostart(ctx context.Context, workspaceID string) (ResolveAutostartResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/workspaces/%s/resolve", workspaceID), nil)
+	if err != nil {
+		return ResolveAutostartResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ResolveAutostartResponse{}, ReadBodyAsError(res)
+	}
+	var response ResolveAutostartResponse
+	return response, json.NewDecoder(res.Body).Decode(&response)
+}
+
 // WorkspaceNotifyChannel is the PostgreSQL NOTIFY
 // channel to listen for updates on. The payload is empty,
 // because the size of a workspace payload can be very large.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -454,7 +454,7 @@ type ResolveAutostartResponse struct {
 }
 
 func (c *Client) ResolveAutostart(ctx context.Context, workspaceID string) (ResolveAutostartResponse, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/workspaces/%s/resolve", workspaceID), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/workspaces/%s/resolve-autostart", workspaceID), nil)
 	if err != nil {
 		return ResolveAutostartResponse{}, err
 	}

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -4100,6 +4100,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `region_id`        | integer | false    |              | Region ID is the region of the replica.                            |
 | `relay_address`    | string  | false    |              | Relay address is the accessible address to relay DERP connections. |
 
+## codersdk.ResolveAutostartResponse
+
+```json
+{
+  "parameter_mismatch": true
+}
+```
+
+### Properties
+
+| Name                 | Type    | Required | Restrictions | Description |
+| -------------------- | ------- | -------- | ------------ | ----------- |
+| `parameter_mismatch` | boolean | false    |              |             |
+
 ## codersdk.ResourceType
 
 ```json

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -1246,12 +1246,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve \
+curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve-autostart \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/resolve`
+`GET /workspaces/{workspace}/resolve-autostart`
 
 ### Parameters
 

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -1240,6 +1240,37 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/extend \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Determine whether a workspace is capable of autostarting.
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve \
+  -H 'Accept: */*' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspaces/{workspace}/resolve`
+
+### Parameters
+
+| Name        | In   | Type         | Required | Description  |
+| ----------- | ---- | ------------ | -------- | ------------ |
+| `workspace` | path | string(uuid) | true     | Workspace ID |
+
+### Example responses
+
+> 200 Response
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                           |
+| ------ | ------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ResolveAutostartResponse](schemas.md#codersdkresolveautostartresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Update workspace TTL by ID
 
 ### Code samples

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -1247,7 +1247,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 ```shell
 # Example request using curl
 curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve \
-  -H 'Accept: */*' \
+  -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
@@ -1262,6 +1262,12 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve \
 ### Example responses
 
 > 200 Response
+
+```json
+{
+  "parameter_mismatch": true
+}
+```
 
 ### Responses
 

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -1240,7 +1240,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/extend \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Determine whether a workspace is capable of autostarting.
+## Resolve workspace autostart by id.
 
 ### Code samples
 

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -1115,6 +1115,7 @@ func TestResolveAutostart(t *testing.T) {
 	workspace := coderdtest.CreateWorkspace(t, client, owner.OrganizationID, template.ID)
 	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
 
+	//nolint:gocritic
 	err := ownerClient.UpdateActiveTemplateVersion(ctx, template.ID, codersdk.UpdateActiveTemplateVersion{
 		ID: version2.ID,
 	})

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/enterprise/coderd/schedule"
 	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -1059,6 +1060,71 @@ func TestWorkspaceLock(t *testing.T) {
 		// The last_used_at should get updated when we unlock the workspace.
 		require.True(t, workspace.LastUsedAt.After(lastUsedAt))
 	})
+}
+
+func TestResolveAutostart(t *testing.T) {
+	t.Parallel()
+
+	ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+		Options: &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			TemplateScheduleStore:    &schedule.EnterpriseTemplateScheduleStore{},
+		},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureAccessControl: 1,
+			},
+		},
+	})
+
+	version1 := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, nil)
+	coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version1.ID)
+	template := coderdtest.CreateTemplate(t, ownerClient, owner.OrganizationID, version1.ID, func(ctr *codersdk.CreateTemplateRequest) {
+		ctr.RequireActiveVersion = true
+	})
+
+	params := &echo.Responses{
+		Parse: echo.ParseComplete,
+		ProvisionPlan: []*proto.Response{
+			{
+				Type: &proto.Response_Plan{
+					Plan: &proto.PlanComplete{
+						Parameters: []*proto.RichParameter{
+							{
+								Name:        "param",
+								Description: "param",
+								Required:    true,
+								Mutable:     true,
+							},
+						},
+					},
+				},
+			},
+		},
+		ProvisionApply: echo.ApplyComplete,
+	}
+	version2 := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, params, func(ctvr *codersdk.CreateTemplateVersionRequest) {
+		ctvr.TemplateID = template.ID
+	})
+	coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version2.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	client, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+	workspace := coderdtest.CreateWorkspace(t, client, owner.OrganizationID, template.ID)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+	err := ownerClient.UpdateActiveTemplateVersion(ctx, template.ID, codersdk.UpdateActiveTemplateVersion{
+		ID: version2.ID,
+	})
+	require.NoError(t, err)
+
+	// Autostart shouldn't be possible since the template requires automatic
+	// updates.
+	resp, err := client.ResolveAutostart(ctx, workspace.ID.String())
+	require.NoError(t, err)
+	require.True(t, resp.ParameterMismatch)
 }
 
 func must[T any](value T, err error) T {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -812,6 +812,11 @@ export interface Replica {
   readonly database_latency: number;
 }
 
+// From codersdk/workspaces.go
+export interface ResolveAutostartResponse {
+  readonly parameter_mismatch: boolean;
+}
+
 // From codersdk/client.go
 export interface Response {
   readonly message: string;


### PR DESCRIPTION
This PR adds an endpoint for determining whether autostart is possible for a workspace. It takes into account whether the template mandates automatic updates or if workspace has opted in to automatic updates. This provides the backend plumbing necessary for https://github.com/coder/coder/issues/10098. 

A separate PR will be opened to handle the frontend implementation. 