### PR TITLE
fix: add support for custom auth header with client secret

### DIFF
--- a/codersdk/externalauth.go
+++ b/codersdk/externalauth.go
@@ -35,6 +35,7 @@ const (
 	EnhancedExternalAuthProviderGitLab      EnhancedExternalAuthProvider = "gitlab"
 	EnhancedExternalAuthProviderBitBucket   EnhancedExternalAuthProvider = "bitbucket"
 	EnhancedExternalAuthProviderSlack       EnhancedExternalAuthProvider = "slack"
+	EnhancedExternalAuthProviderJFrog       EnhancedExternalAuthProvider = "jfrog"
 )
 
 type ExternalAuth struct {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1684,12 +1684,14 @@ export type EnhancedExternalAuthProvider =
   | "bitbucket"
   | "github"
   | "gitlab"
+  | "jfrog"
   | "slack";
 export const EnhancedExternalAuthProviders: EnhancedExternalAuthProvider[] = [
   "azure-devops",
   "bitbucket",
   "github",
   "gitlab",
+  "jfrog",
   "slack",
 ];
 


### PR DESCRIPTION
This fixes OAuth2 with JFrog Artifactory.
