### PR TITLE
feat: add list of user's groups to Accounts page

### DIFF
--- a/site/src/api/queries/groups.ts
+++ b/site/src/api/queries/groups.ts
@@ -8,6 +8,7 @@ import {
 } from "api/typesGenerated";
 
 const GROUPS_QUERY_KEY = ["groups"];
+type GroupSortOrder = "asc" | "desc";
 
 const getGroupQueryKey = (groupId: string) => ["group", groupId];
 
@@ -15,7 +16,7 @@ export const groups = (organizationId: string) => {
   return {
     queryKey: GROUPS_QUERY_KEY,
     queryFn: () => API.getGroups(organizationId),
-  };
+  } satisfies UseQueryOptions<Group[]>;
 };
 
 export const group = (groupId: string) => {
@@ -33,18 +34,9 @@ export function groupsByUserId(organizationId: string) {
     select: (allGroups) => {
       // Sorting here means that nothing has to be sorted for the individual
       // user arrays later
-      const sorted = [...allGroups].sort((g1, g2) => {
-        const key =
-          g1.display_name && g2.display_name ? "display_name" : "name";
-
-        if (g1[key] === g2[key]) {
-          return 0;
-        }
-
-        return g1[key] < g2[key] ? -1 : 1;
-      });
-
+      const sorted = sortGroupsByName(allGroups, "asc");
       const userIdMapper = new Map<string, Group[]>();
+
       for (const group of sorted) {
         for (const user of group.members) {
           let groupsForUser = userIdMapper.get(user.id);
@@ -60,6 +52,20 @@ export function groupsByUserId(organizationId: string) {
       return userIdMapper as GroupsByUserId;
     },
   } satisfies UseQueryOptions<Group[], unknown, GroupsByUserId>;
+}
+
+export function groupsForUser(organizationId: string, userId: string) {
+  return {
+    ...groups(organizationId),
+    select: (allGroups) => {
+      const groupsForUser = allGroups.filter((group) => {
+        const groupMemberIds = group.members.map((member) => member.id);
+        return groupMemberIds.includes(userId);
+      });
+
+      return sortGroupsByName(groupsForUser, "asc");
+    },
+  } satisfies UseQueryOptions<Group[]>;
 }
 
 export const groupPermissions = (groupId: string) => {
@@ -136,3 +142,22 @@ export const invalidateGroup = (queryClient: QueryClient, groupId: string) =>
     queryClient.invalidateQueries(GROUPS_QUERY_KEY),
     queryClient.invalidateQueries(getGroupQueryKey(groupId)),
   ]);
+
+export function sortGroupsByName(
+  groups: readonly Group[],
+  order: GroupSortOrder,
+) {
+  return [...groups].sort((g1, g2) => {
+    const key = g1.display_name && g2.display_name ? "display_name" : "name";
+
+    if (g1[key] === g2[key]) {
+      return 0;
+    }
+
+    if (order === "asc") {
+      return g1[key] < g2[key] ? -1 : 1;
+    } else {
+      return g1[key] < g2[key] ? 1 : -1;
+    }
+  });
+}

--- a/site/src/api/queries/groups.ts
+++ b/site/src/api/queries/groups.ts
@@ -65,7 +65,7 @@ export function groupsForUser(organizationId: string, userId: string) {
 
       return sortGroupsByName(groupsForUser, "asc");
     },
-  } satisfies UseQueryOptions<Group[]>;
+  } as const satisfies UseQueryOptions<Group[], unknown, readonly Group[]>;
 }
 
 export const groupPermissions = (groupId: string) => {

--- a/site/src/components/Avatar/Avatar.stories.tsx
+++ b/site/src/components/Avatar/Avatar.stories.tsx
@@ -65,7 +65,7 @@ export const MuiIconXL = {
 
 export const AvatarIconDarken = {
   args: {
-    children: <AvatarIcon src="/icon/database.svg" />,
+    children: <AvatarIcon src="/icon/database.svg" alt="Database" />,
     colorScheme: "darken",
   },
 };

--- a/site/src/components/Avatar/Avatar.tsx
+++ b/site/src/components/Avatar/Avatar.tsx
@@ -1,8 +1,10 @@
 // This is the only place MuiAvatar can be used
 // eslint-disable-next-line no-restricted-imports -- Read above
 import MuiAvatar, { AvatarProps as MuiAvatarProps } from "@mui/material/Avatar";
-import { FC } from "react";
+import { FC, useId } from "react";
 import { css, type Interpolation, type Theme } from "@emotion/react";
+import { Box } from "@mui/system";
+import { visuallyHidden } from "@mui/utils";
 
 export type AvatarProps = MuiAvatarProps & {
   size?: "xs" | "sm" | "md" | "xl";
@@ -66,18 +68,30 @@ export const Avatar: FC<AvatarProps> = ({
   );
 };
 
+type AvatarIconProps = {
+  src: string;
+  alt: string;
+};
+
 /**
  * Use it to make an img element behaves like a MaterialUI Icon component
  */
-export const AvatarIcon: FC<{ src: string }> = ({ src }) => {
+export const AvatarIcon: FC<AvatarIconProps> = ({ src, alt }) => {
+  const hookId = useId();
+  const avatarId = `${hookId}-avatar`;
+
   return (
-    <img
-      src={src}
-      alt=""
-      css={{
-        maxWidth: "50%",
-      }}
-    />
+    <>
+      <img
+        src={src}
+        alt=""
+        css={{ maxWidth: "50%" }}
+        aria-labelledby={avatarId}
+      />
+      <Box id={avatarId} sx={visuallyHidden}>
+        {alt}
+      </Box>
+    </>
   );
 };
 

--- a/site/src/components/AvatarCard/AvatarCard.stories.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.stories.tsx
@@ -1,0 +1,32 @@
+import { type Meta, type StoryObj } from "@storybook/react";
+import { AvatarCard } from "./AvatarCard";
+
+const meta: Meta<typeof AvatarCard> = {
+  title: "components/AvatarCard",
+  component: AvatarCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarCard>;
+
+export const WithImage: Story = {
+  args: {
+    header: "Coder",
+    imgUrl: "https://avatars.githubusercontent.com/u/95932066?s=200&v=4",
+    altText: "Coder",
+    subtitle: "56 members",
+  },
+};
+
+export const WithoutImage: Story = {
+  args: {
+    header: "Patrick Star",
+    subtitle: "Friends with 723 people",
+  },
+};
+
+export const WithoutSubtitleOrImage: Story = {
+  args: {
+    header: "Sandy Cheeks",
+  },
+};

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -43,6 +43,7 @@ export function AvatarCard({
        */}
       <div css={{ marginRight: "auto", minWidth: 0 }}>
         <h3
+          // Lets users hover over truncated text to see whole thing
           title={header}
           css={[
             theme.typography.body1 as CSSObject,

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -1,13 +1,6 @@
 import { type ReactNode } from "react";
 import { Avatar, AvatarIcon } from "components/Avatar/Avatar";
-import {
-  type CSSObject,
-  type Interpolation,
-  type Theme,
-  useTheme,
-} from "@emotion/react";
-
-type Width = "sm" | "md" | "lg" | "full";
+import { type CSSObject, useTheme } from "@emotion/react";
 
 type AvatarCardProps = {
   header: ReactNode;
@@ -15,40 +8,29 @@ type AvatarCardProps = {
   altText: string;
 
   subtitle?: ReactNode;
-  width?: Width;
 };
-
-const renderedWidths = {
-  sm: (theme) => theme.spacing(2),
-  md: (theme) => theme.spacing(3),
-  lg: (theme) => theme.spacing(6),
-  full: { width: "100%" },
-} as const satisfies Record<Width, Interpolation<Theme>>;
 
 export function AvatarCard({
   header,
   imgUrl,
   altText,
   subtitle,
-  width = "full",
 }: AvatarCardProps) {
   const theme = useTheme();
 
   return (
-    <div
-      css={[
-        renderedWidths[width],
-        {
-          display: "flex",
-          flexFlow: "row nowrap",
-          alignItems: "center",
-          border: `1px solid ${theme.palette.divider}`,
-          gap: theme.spacing(2),
-          padding: theme.spacing(2),
-          borderRadius: theme.shape.borderRadius,
-          cursor: "default",
-        },
-      ]}
+    <article
+      css={{
+        width: "100%",
+        display: "flex",
+        flexFlow: "row nowrap",
+        alignItems: "center",
+        border: `1px solid ${theme.palette.divider}`,
+        gap: "16px",
+        padding: "16px",
+        borderRadius: "8px",
+        cursor: "default",
+      }}
     >
       <div css={{ marginRight: "auto" }}>
         <div css={theme.typography.body1 as CSSObject}>{header}</div>
@@ -70,6 +52,6 @@ export function AvatarCard({
           <AvatarIcon src={imgUrl} alt={altText} />
         </Avatar>
       </div>
-    </div>
+    </article>
   );
 }

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -9,6 +9,7 @@ type AvatarCardProps = {
   altText: string;
 
   subtitle?: ReactNode;
+  maxWidth?: number | "none";
 };
 
 export function AvatarCard({
@@ -16,13 +17,14 @@ export function AvatarCard({
   imgUrl,
   altText,
   subtitle,
+  maxWidth = 420,
 }: AvatarCardProps) {
   const theme = useTheme();
 
   return (
     <article
       css={{
-        width: "100%",
+        maxWidth: maxWidth === undefined ? undefined : `${maxWidth}px`,
         display: "flex",
         flexFlow: "row nowrap",
         alignItems: "center",

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -17,14 +17,14 @@ export function AvatarCard({
   imgUrl,
   altText,
   subtitle,
-  maxWidth = 420,
+  maxWidth = "none",
 }: AvatarCardProps) {
   const theme = useTheme();
 
   return (
     <article
       css={{
-        maxWidth: maxWidth === undefined ? undefined : `${maxWidth}px`,
+        maxWidth: maxWidth === "none" ? undefined : `${maxWidth}px`,
         display: "flex",
         flexFlow: "row nowrap",
         alignItems: "center",

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode } from "react";
-import { Avatar, AvatarIcon } from "components/Avatar/Avatar";
+import { Avatar } from "components/Avatar/Avatar";
 import { type CSSObject, useTheme } from "@emotion/react";
 
 type AvatarCardProps = {
-  header: ReactNode;
+  header: string;
   imgUrl: string;
   altText: string;
 
@@ -32,8 +32,22 @@ export function AvatarCard({
         cursor: "default",
       }}
     >
-      <div css={{ marginRight: "auto" }}>
-        <div css={theme.typography.body1 as CSSObject}>{header}</div>
+      <div css={{ marginRight: "auto", minWidth: 0 }}>
+        <h3
+          title={header}
+          css={[
+            theme.typography.body1 as CSSObject,
+            {
+              lineHeight: 1.5,
+              margin: 0,
+              overflow: "hidden",
+              whiteSpace: "nowrap",
+              textOverflow: "ellipsis",
+            },
+          ]}
+        >
+          {header}
+        </h3>
 
         {subtitle && (
           <div
@@ -47,11 +61,9 @@ export function AvatarCard({
         )}
       </div>
 
-      <div>
-        <Avatar>
-          <AvatarIcon src={imgUrl} alt={altText} />
-        </Avatar>
-      </div>
+      <Avatar src={imgUrl} alt={altText} colorScheme="darken">
+        {header}
+      </Avatar>
     </article>
   );
 }

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -4,23 +4,31 @@ import { useTheme } from "@emotion/react";
 type AvatarCardProps = {
   header: ReactNode;
   imgUrl: string;
+  altText: string;
 
-  subtitle?: string;
-  maxWidth?: number;
+  subtitle?: ReactNode;
+  width?: "sm" | "md" | "lg" | "full";
 };
 
 export function AvatarCard({
   header,
   imgUrl,
+  altText,
   subtitle,
-  maxWidth,
+  width = "full",
 }: AvatarCardProps) {
   const theme = useTheme();
 
   return (
     <div css={{ backgroundColor: "blue" }}>
-      <span>{header}</span>
-      {subtitle && <span>{subtitle}</span>}
+      <div>
+        <span>{header}</span>
+        {subtitle && <span>{subtitle}</span>}
+      </div>
+
+      <div>
+        <img src={imgUrl} alt={altText} />
+      </div>
     </div>
   );
 }

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -1,5 +1,13 @@
 import { type ReactNode } from "react";
-import { useTheme } from "@emotion/react";
+import { Avatar, AvatarIcon } from "components/Avatar/Avatar";
+import {
+  type CSSObject,
+  type Interpolation,
+  type Theme,
+  useTheme,
+} from "@emotion/react";
+
+type Width = "sm" | "md" | "lg" | "full";
 
 type AvatarCardProps = {
   header: ReactNode;
@@ -7,8 +15,15 @@ type AvatarCardProps = {
   altText: string;
 
   subtitle?: ReactNode;
-  width?: "sm" | "md" | "lg" | "full";
+  width?: Width;
 };
+
+const renderedWidths = {
+  sm: (theme) => theme.spacing(2),
+  md: (theme) => theme.spacing(3),
+  lg: (theme) => theme.spacing(6),
+  full: { width: "100%" },
+} as const satisfies Record<Width, Interpolation<Theme>>;
 
 export function AvatarCard({
   header,
@@ -20,14 +35,40 @@ export function AvatarCard({
   const theme = useTheme();
 
   return (
-    <div css={{ backgroundColor: "blue" }}>
-      <div>
-        <span>{header}</span>
-        {subtitle && <span>{subtitle}</span>}
+    <div
+      css={[
+        renderedWidths[width],
+        {
+          display: "flex",
+          flexFlow: "row nowrap",
+          alignItems: "center",
+          border: `1px solid ${theme.palette.divider}`,
+          gap: theme.spacing(2),
+          padding: theme.spacing(2),
+          borderRadius: theme.shape.borderRadius,
+          cursor: "default",
+        },
+      ]}
+    >
+      <div css={{ marginRight: "auto" }}>
+        <div css={theme.typography.body1 as CSSObject}>{header}</div>
+
+        {subtitle && (
+          <div
+            css={[
+              theme.typography.body2 as CSSObject,
+              { color: theme.palette.text.secondary },
+            ]}
+          >
+            {subtitle}
+          </div>
+        )}
       </div>
 
       <div>
-        <img src={imgUrl} alt={altText} />
+        <Avatar>
+          <AvatarIcon src={imgUrl} alt={altText} />
+        </Avatar>
       </div>
     </div>
   );

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -35,6 +35,12 @@ export function AvatarCard({
         cursor: "default",
       }}
     >
+      {/**
+       * minWidth is necessary to ensure that the text truncation works properly
+       * with flex containers that don't have fixed width
+       *
+       * @see {@link https://css-tricks.com/flexbox-truncated-text/}
+       */}
       <div css={{ marginRight: "auto", minWidth: 0 }}>
         <h3
           title={header}

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+import { useTheme } from "@emotion/react";
+
+type AvatarCardProps = {
+  header: ReactNode;
+  imgUrl: string;
+
+  subtitle?: string;
+  maxWidth?: number;
+};
+
+export function AvatarCard({
+  header,
+  imgUrl,
+  subtitle,
+  maxWidth,
+}: AvatarCardProps) {
+  const theme = useTheme();
+
+  return (
+    <div css={{ backgroundColor: "blue" }}>
+      <span>{header}</span>
+      {subtitle && <span>{subtitle}</span>}
+    </div>
+  );
+}

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from "react";
 import { Avatar } from "components/Avatar/Avatar";
 import { type CSSObject, useTheme } from "@emotion/react";
+import { colors } from "theme/colors";
 
 type AvatarCardProps = {
   header: string;
@@ -38,7 +39,7 @@ export function AvatarCard({
           css={[
             theme.typography.body1 as CSSObject,
             {
-              lineHeight: 1.5,
+              lineHeight: 1.4,
               margin: 0,
               overflow: "hidden",
               whiteSpace: "nowrap",
@@ -61,7 +62,12 @@ export function AvatarCard({
         )}
       </div>
 
-      <Avatar src={imgUrl} alt={altText} colorScheme="darken">
+      <Avatar
+        src={imgUrl}
+        alt={altText}
+        size="md"
+        css={{ backgroundColor: colors.gray[7] }}
+      >
         {header}
       </Avatar>
     </article>

--- a/site/src/components/AvatarCard/AvatarCard.tsx
+++ b/site/src/components/AvatarCard/AvatarCard.tsx
@@ -22,7 +22,7 @@ export function AvatarCard({
   const theme = useTheme();
 
   return (
-    <article
+    <div
       css={{
         maxWidth: maxWidth === "none" ? undefined : `${maxWidth}px`,
         display: "flex",
@@ -72,6 +72,6 @@ export function AvatarCard({
       >
         {header}
       </Avatar>
-    </article>
+    </div>
   );
 }

--- a/site/src/components/Resources/ResourceAvatar.tsx
+++ b/site/src/components/Resources/ResourceAvatar.tsx
@@ -40,7 +40,7 @@ export const ResourceAvatar: FC<ResourceAvatarProps> = ({ resource }) => {
 
   return (
     <Avatar colorScheme="darken">
-      <AvatarIcon src={avatarSrc} />
+      <AvatarIcon src={avatarSrc} alt={resource.name} />
     </Avatar>
   );
 };

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -57,13 +57,18 @@ export const AccountPage: FC = () => {
       >
         {groupsQuery.isSuccess ? (
           <>
-            {groupsQuery.data.map((group) => (
-              <AvatarCard
-                key={group.id}
-                header={group.display_name || group.name}
-                imgUrl={group.avatar_url}
-              />
-            ))}
+            {groupsQuery.data.map((group) => {
+              const groupName = group.display_name || group.name;
+
+              return (
+                <AvatarCard
+                  key={group.id}
+                  header={groupName}
+                  imgUrl={group.avatar_url}
+                  altText={groupName}
+                />
+              );
+            })}
           </>
         ) : (
           <Loader />

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -58,26 +58,31 @@ export const AccountPage: FC = () => {
           )
         }
       >
-        {groupsQuery.isLoading && <Loader />}
-        {groupsQuery.isError && <ErrorAlert error={groupsQuery.error} />}
+        <div
+          css={{ display: "flex", flexFlow: "column nowrap", rowGap: "24px" }}
+        >
+          {<ErrorAlert error={groupsQuery.error} />}
 
-        <Grid container columns={{ xs: 1, md: 2 }} spacing="16px">
-          {groupsQuery.data?.map((group) => (
-            <Grid item key={group.id} xs={1}>
-              <AvatarCard
-                imgUrl={group.avatar_url}
-                altText={group.display_name || group.name}
-                header={group.display_name || group.name}
-                subtitle={
-                  <>
-                    {group.members.length} member
-                    {group.members.length !== 1 && "s"}
-                  </>
-                }
-              />
-            </Grid>
-          ))}
-        </Grid>
+          <Grid container columns={{ xs: 1, md: 2 }} spacing="16px">
+            {groupsQuery.data?.map((group) => (
+              <Grid item key={group.id} xs={1}>
+                <AvatarCard
+                  imgUrl={group.avatar_url}
+                  altText={group.display_name || group.name}
+                  header={group.display_name || group.name}
+                  subtitle={
+                    <>
+                      {group.members.length} member
+                      {group.members.length !== 1 && "s"}
+                    </>
+                  }
+                />
+              </Grid>
+            ))}
+          </Grid>
+
+          {groupsQuery.isLoading && <Loader />}
+        </div>
       </Section>
     </Stack>
   );

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -4,20 +4,14 @@ import { usePermissions } from "hooks/usePermissions";
 import { useQuery } from "react-query";
 import { groupsForUser } from "api/queries/groups";
 import { useOrganizationId } from "hooks";
-import { useTheme } from "@emotion/react";
+import { useAuth } from "components/AuthProvider/AuthProvider";
 
 import { Stack } from "@mui/system";
-import Grid from "@mui/material/Grid";
-
+import { AccountUserGroups } from "./AccountUserGroups";
 import { AccountForm } from "./AccountForm";
-import { useAuth } from "components/AuthProvider/AuthProvider";
 import { Section } from "components/SettingsLayout/Section";
-import { Loader } from "components/Loader/Loader";
-import { AvatarCard } from "components/AvatarCard/AvatarCard";
-import { ErrorAlert } from "components/Alert/ErrorAlert";
 
 export const AccountPage: FC = () => {
-  const theme = useTheme();
   const { updateProfile, updateProfileError, isUpdatingProfile } = useAuth();
   const permissions = usePermissions();
 
@@ -38,53 +32,12 @@ export const AccountPage: FC = () => {
         />
       </Section>
 
-      <Section
-        title="Your groups"
-        layout="fluid"
-        description={
-          groupsQuery.isSuccess && (
-            <span>
-              You are in{" "}
-              <em
-                css={{
-                  fontStyle: "normal",
-                  color: theme.palette.text.primary,
-                  fontWeight: 600,
-                }}
-              >
-                {groupsQuery.data.length} group
-                {groupsQuery.data.length !== 1 && "s"}
-              </em>
-            </span>
-          )
-        }
-      >
-        <div
-          css={{ display: "flex", flexFlow: "column nowrap", rowGap: "24px" }}
-        >
-          {groupsQuery.isError && <ErrorAlert error={groupsQuery.error} />}
-
-          <Grid container columns={{ xs: 1, md: 2 }} spacing="16px">
-            {groupsQuery.data?.map((group) => (
-              <Grid item key={group.id} xs={1}>
-                <AvatarCard
-                  imgUrl={group.avatar_url}
-                  altText={group.display_name || group.name}
-                  header={group.display_name || group.name}
-                  subtitle={
-                    <>
-                      {group.members.length} member
-                      {group.members.length !== 1 && "s"}
-                    </>
-                  }
-                />
-              </Grid>
-            ))}
-          </Grid>
-
-          {groupsQuery.isLoading && <Loader />}
-        </div>
-      </Section>
+      {/* Has <Section> embedded inside because its description is dynamic */}
+      <AccountUserGroups
+        groups={groupsQuery.data}
+        loading={groupsQuery.isLoading}
+        error={groupsQuery.error}
+      />
     </Stack>
   );
 };

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -9,8 +9,9 @@ import { useQuery } from "react-query";
 import { groupsForUser } from "api/queries/groups";
 import { useOrganizationId } from "hooks";
 import { useTheme } from "@emotion/react";
+
 import { Loader } from "components/Loader/Loader";
-import { Group } from "api/typesGenerated";
+import { AvatarCard } from "components/AvatarCard/AvatarCard";
 
 export const AccountPage: FC = () => {
   const theme = useTheme();
@@ -55,7 +56,15 @@ export const AccountPage: FC = () => {
         }
       >
         {groupsQuery.isSuccess ? (
-          <GroupList groups={groupsQuery.data} />
+          <>
+            {groupsQuery.data.map((group) => (
+              <AvatarCard
+                key={group.id}
+                header={group.display_name || group.name}
+                imgUrl={group.avatar_url}
+              />
+            ))}
+          </>
         ) : (
           <Loader />
         )}
@@ -63,24 +72,5 @@ export const AccountPage: FC = () => {
     </Stack>
   );
 };
-
-type GroupListProps = {
-  groups: readonly Group[];
-};
-
-function GroupList({ groups }: GroupListProps) {
-  const theme = useTheme();
-
-  return (
-    <>
-      {groups.map((group) => (
-        <div key={group.id} css={{ backgroundColor: "blue" }}>
-          <span>{group.display_name || group.name}</span>
-          <span>{group.members.length} members</span>
-        </div>
-      ))}
-    </>
-  );
-}
 
 export default AccountPage;

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -1,15 +1,17 @@
 import { type FC } from "react";
-import { Section } from "components/SettingsLayout/Section";
-import { AccountForm } from "./AccountForm";
-import { useAuth } from "components/AuthProvider/AuthProvider";
 import { useMe } from "hooks/useMe";
 import { usePermissions } from "hooks/usePermissions";
-import { Stack } from "@mui/system";
 import { useQuery } from "react-query";
 import { groupsForUser } from "api/queries/groups";
 import { useOrganizationId } from "hooks";
 import { useTheme } from "@emotion/react";
 
+import { Stack } from "@mui/system";
+import Grid from "@mui/material/Grid";
+
+import { AccountForm } from "./AccountForm";
+import { useAuth } from "components/AuthProvider/AuthProvider";
+import { Section } from "components/SettingsLayout/Section";
 import { Loader } from "components/Loader/Loader";
 import { AvatarCard } from "components/AvatarCard/AvatarCard";
 
@@ -56,20 +58,27 @@ export const AccountPage: FC = () => {
         }
       >
         {groupsQuery.isSuccess ? (
-          <>
-            {groupsQuery.data.map((group) => {
-              const groupName = group.display_name || group.name;
-
-              return (
+          <Grid
+            container
+            columns={{ xs: 1, sm: 1, md: 2 }}
+            spacing={theme.spacing(3)}
+          >
+            {groupsQuery.data.map((group) => (
+              <Grid item key={group.id} xs={1}>
                 <AvatarCard
-                  key={group.id}
-                  header={groupName}
                   imgUrl={group.avatar_url}
-                  altText={groupName}
+                  altText={group.display_name || group.name}
+                  header={group.display_name || group.name}
+                  subtitle={
+                    <>
+                      {group.members.length} member
+                      {group.members.length !== 1 && "s"}
+                    </>
+                  }
                 />
-              );
-            })}
-          </>
+              </Grid>
+            ))}
+          </Grid>
         ) : (
           <Loader />
         )}

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -52,7 +52,8 @@ export const AccountPage: FC = () => {
                   fontWeight: 600,
                 }}
               >
-                {groupsQuery.data.length} groups
+                {groupsQuery.data.length} group
+                {groupsQuery.data.length !== 1 && "s"}
               </em>
             </span>
           )

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "components/AuthProvider/AuthProvider";
 import { Section } from "components/SettingsLayout/Section";
 import { Loader } from "components/Loader/Loader";
 import { AvatarCard } from "components/AvatarCard/AvatarCard";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
 
 export const AccountPage: FC = () => {
   const theme = useTheme();
@@ -57,31 +58,26 @@ export const AccountPage: FC = () => {
           )
         }
       >
-        {groupsQuery.isSuccess ? (
-          <Grid
-            container
-            columns={{ xs: 1, sm: 1, md: 2 }}
-            spacing={theme.spacing(3)}
-          >
-            {groupsQuery.data.map((group) => (
-              <Grid item key={group.id} xs={1}>
-                <AvatarCard
-                  imgUrl={group.avatar_url}
-                  altText={group.display_name || group.name}
-                  header={group.display_name || group.name}
-                  subtitle={
-                    <>
-                      {group.members.length} member
-                      {group.members.length !== 1 && "s"}
-                    </>
-                  }
-                />
-              </Grid>
-            ))}
-          </Grid>
-        ) : (
-          <Loader />
-        )}
+        {groupsQuery.isLoading && <Loader />}
+        {groupsQuery.isError && <ErrorAlert error={groupsQuery.error} />}
+
+        <Grid container columns={{ xs: 1, md: 2 }} spacing="16px">
+          {groupsQuery.data?.map((group) => (
+            <Grid item key={group.id} xs={1}>
+              <AvatarCard
+                imgUrl={group.avatar_url}
+                altText={group.display_name || group.name}
+                header={group.display_name || group.name}
+                subtitle={
+                  <>
+                    {group.members.length} member
+                    {group.members.length !== 1 && "s"}
+                  </>
+                }
+              />
+            </Grid>
+          ))}
+        </Grid>
       </Section>
     </Stack>
   );

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -1,30 +1,86 @@
-import { FC } from "react";
+import { type FC } from "react";
 import { Section } from "components/SettingsLayout/Section";
 import { AccountForm } from "./AccountForm";
 import { useAuth } from "components/AuthProvider/AuthProvider";
 import { useMe } from "hooks/useMe";
 import { usePermissions } from "hooks/usePermissions";
+import { Stack } from "@mui/system";
+import { useQuery } from "react-query";
+import { groupsForUser } from "api/queries/groups";
+import { useOrganizationId } from "hooks";
+import { useTheme } from "@emotion/react";
+import { Loader } from "components/Loader/Loader";
+import { Group } from "api/typesGenerated";
 
 export const AccountPage: FC = () => {
+  const theme = useTheme();
   const { updateProfile, updateProfileError, isUpdatingProfile } = useAuth();
-  const me = useMe();
   const permissions = usePermissions();
-  const canEditUsers = permissions && permissions.updateUsers;
+
+  const me = useMe();
+  const organizationId = useOrganizationId();
+  const groupsQuery = useQuery(groupsForUser(organizationId, me.id));
 
   return (
-    <Section title="Account" description="Update your account info">
-      <AccountForm
-        editable={Boolean(canEditUsers)}
-        email={me.email}
-        updateProfileError={updateProfileError}
-        isLoading={isUpdatingProfile}
-        initialValues={{
-          username: me.username,
-        }}
-        onSubmit={updateProfile}
-      />
-    </Section>
+    <Stack spacing={6}>
+      <Section title="Account" description="Update your account info">
+        <AccountForm
+          editable={permissions?.updateUsers ?? false}
+          email={me.email}
+          updateProfileError={updateProfileError}
+          isLoading={isUpdatingProfile}
+          initialValues={{ username: me.username }}
+          onSubmit={updateProfile}
+        />
+      </Section>
+
+      <Section
+        title="Your groups"
+        layout="fluid"
+        description={
+          groupsQuery.isSuccess && (
+            <span>
+              You are in{" "}
+              <em
+                css={{
+                  fontStyle: "normal",
+                  color: theme.palette.text.primary,
+                  fontWeight: 600,
+                }}
+              >
+                {groupsQuery.data.length} groups
+              </em>
+            </span>
+          )
+        }
+      >
+        {groupsQuery.isSuccess ? (
+          <GroupList groups={groupsQuery.data} />
+        ) : (
+          <Loader />
+        )}
+      </Section>
+    </Stack>
   );
 };
+
+type GroupListProps = {
+  groups: readonly Group[];
+};
+
+function GroupList({ groups }: GroupListProps) {
+  const theme = useTheme();
+
+  return (
+    <>
+      {groups.map((group) => (
+        <div key={group.id} css={{ backgroundColor: "blue" }}>
+          <span>{group.display_name || group.name}</span>
+          <span>{group.members.length} members</span>
+        </div>
+      ))}
+    </>
+  );
+}
 
 export default AccountPage;

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -61,7 +61,7 @@ export const AccountPage: FC = () => {
         <div
           css={{ display: "flex", flexFlow: "column nowrap", rowGap: "24px" }}
         >
-          {<ErrorAlert error={groupsQuery.error} />}
+          {groupsQuery.isError && <ErrorAlert error={groupsQuery.error} />}
 
           <Grid container columns={{ xs: 1, md: 2 }} spacing="16px">
             {groupsQuery.data?.map((group) => (

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountUserGroups.stories.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountUserGroups.stories.tsx
@@ -2,12 +2,17 @@ import { type Group } from "api/typesGenerated";
 import { type Meta, type StoryObj } from "@storybook/react";
 
 import { AccountUserGroups } from "./AccountUserGroups";
-import { MockGroup as MockGroup1, mockApiError } from "testHelpers/entities";
+import {
+  MockGroup as MockGroup1,
+  MockUser,
+  mockApiError,
+} from "testHelpers/entities";
 
 const MockGroup2: Group = {
   ...MockGroup1,
   avatar_url: "",
   display_name: "Goofy Goobers",
+  members: [MockUser],
 };
 
 const mockError = mockApiError({

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountUserGroups.stories.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountUserGroups.stories.tsx
@@ -1,0 +1,64 @@
+import { type Group } from "api/typesGenerated";
+import { type Meta, type StoryObj } from "@storybook/react";
+
+import { AccountUserGroups } from "./AccountUserGroups";
+import { MockGroup as MockGroup1, mockApiError } from "testHelpers/entities";
+
+const MockGroup2: Group = {
+  ...MockGroup1,
+  avatar_url: "",
+  display_name: "Goofy Goobers",
+};
+
+const mockError = mockApiError({
+  message: "Failed to retrieve your groups",
+});
+
+const meta: Meta<typeof AccountUserGroups> = {
+  title: "pages/UserSettingsPage/AccountUserGroups",
+  component: AccountUserGroups,
+  args: {
+    groups: [MockGroup1, MockGroup2],
+    loading: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountUserGroups>;
+
+export const Example: Story = {};
+
+export const NoGroups: Story = {
+  args: {
+    groups: [],
+  },
+};
+
+export const OneGroup: Story = {
+  args: {
+    groups: [MockGroup1],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    groups: undefined,
+    loading: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    groups: undefined,
+    error: mockError,
+    loading: false,
+  },
+};
+
+export const ErrorWithPreviousData: Story = {
+  args: {
+    groups: [MockGroup1, MockGroup2],
+    error: mockError,
+    loading: false,
+  },
+};

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountUserGroups.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountUserGroups.tsx
@@ -1,0 +1,73 @@
+import { useTheme } from "@emotion/react";
+import { isApiError } from "api/errors";
+import { type Group } from "api/typesGenerated";
+
+import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { AvatarCard } from "components/AvatarCard/AvatarCard";
+import { Loader } from "components/Loader/Loader";
+import { Section } from "components/SettingsLayout/Section";
+import Grid from "@mui/material/Grid";
+
+type AccountGroupsProps = {
+  groups: readonly Group[] | undefined;
+  error: unknown;
+  loading: boolean;
+};
+
+export function AccountUserGroups({
+  groups,
+  error,
+  loading,
+}: AccountGroupsProps) {
+  const theme = useTheme();
+
+  return (
+    <Section
+      title="Your groups"
+      layout="fluid"
+      description={
+        groups && (
+          <span>
+            You are in{" "}
+            <em
+              css={{
+                fontStyle: "normal",
+                color: theme.palette.text.primary,
+                fontWeight: 600,
+              }}
+            >
+              {groups.length} group
+              {groups.length !== 1 && "s"}
+            </em>
+          </span>
+        )
+      }
+    >
+      <div css={{ display: "flex", flexFlow: "column nowrap", rowGap: "24px" }}>
+        {isApiError(error) && <ErrorAlert error={error} />}
+
+        {groups && (
+          <Grid container columns={{ xs: 1, md: 2 }} spacing="16px">
+            {groups.map((group) => (
+              <Grid item key={group.id} xs={1}>
+                <AvatarCard
+                  imgUrl={group.avatar_url}
+                  altText={group.display_name || group.name}
+                  header={group.display_name || group.name}
+                  subtitle={
+                    <>
+                      {group.members.length} member
+                      {group.members.length !== 1 && "s"}
+                    </>
+                  }
+                />
+              </Grid>
+            ))}
+          </Grid>
+        )}
+
+        {loading && <Loader />}
+      </div>
+    </Section>
+  );
+}


### PR DESCRIPTION
Closes #10425

## Changes made
- Adds `AvatarCard` component
- Adds ability to query all groups for a specific user
- Fixes up some of the accessibility issues around how we've been using image alt text
- Renders a user's groups to the Accounts page via `AvatarCard`

## Other notes
- One thing I've noticed is that the base `<MUIAvatar>` component doesn't work super well with the emoji icons, funnily enough because they're "too" perfectly square. MUI takes the images and sands off the corners via `borderRadius`, making the icons always look funny
   - Ideally, there'd be a way to detect when we have an emoji icon, and shrink it down so that the image isn't cut up
   - Need to ask if the emoji have a common URL that we could maybe use. Maybe there's a way to sneak that logic into this PR?
   - This issue also affects every single component already using `<MUIAvatar>`, sadly