### PR TITLE
fix: fail server startup on invalid DERP map

### DIFF
--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1755,3 +1755,22 @@ func TestConnectToPostgres(t *testing.T) {
 	})
 	require.NoError(t, sqlDB.PingContext(ctx))
 }
+
+func TestServer_InvalidDERP(t *testing.T) {
+	t.Parallel()
+
+	// Try to start a server with the built-in DERP server disabled and no
+	// external DERP map.
+	inv, _ := clitest.New(t,
+		"server",
+		"--in-memory",
+		"--http-address", ":0",
+		"--access-url", "http://example.com",
+		"--derp-server-enable=false",
+		"--derp-server-stun-addresses", "disable",
+		"--block-direct-connections",
+	)
+	err := inv.Run()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "A valid DERP map is required for networking to work")
+}

--- a/tailnet/derpmap.go
+++ b/tailnet/derpmap.go
@@ -130,6 +130,25 @@ func NewDERPMap(ctx context.Context, region *tailcfg.DERPRegion, stunAddrs []str
 		}
 	}
 
+	// Fail if the DERP map has no regions or no DERP nodes.
+	badDerpMapMsg := "A valid DERP map is required for networking to work. You must either supply your own DERP map or use the built-in DERP server"
+	if len(derpMap.Regions) == 0 {
+		return nil, xerrors.New("DERP map has no regions. " + badDerpMapMsg)
+	}
+	foundValidNode := false
+regionLoop:
+	for _, region := range derpMap.Regions {
+		for _, node := range region.Nodes {
+			if !node.STUNOnly {
+				foundValidNode = true
+				break regionLoop
+			}
+		}
+	}
+	if !foundValidNode {
+		return nil, xerrors.New("DERP map has no DERP nodes. " + badDerpMapMsg)
+	}
+
 	return derpMap, nil
 }
 


### PR DESCRIPTION
Prevents users from trying to start with an invalid configuration and being unable to connect to any workspaces due to an empty DERP map. If you disable the built-in server and don't specify a custom DERP map, workspaces are completely inaccessible once started.

Closes #7173