### PR TITLE
chore: add timezone to quiet hours display message in UI

### DIFF
--- a/site/src/utils/schedule.test.ts
+++ b/site/src/utils/schedule.test.ts
@@ -84,6 +84,6 @@ describe("util/schedule", () => {
       new Date("2023-09-06T15:00:00.000+10:00"),
     );
 
-    expect(quietHoursStart).toBe("12:00AM tomorrow (in 9 hours)");
+    expect(quietHoursStart).toBe("12:00AM tomorrow (in 9 hours) in Australia/Sydney");
   });
 });

--- a/site/src/utils/schedule.test.ts
+++ b/site/src/utils/schedule.test.ts
@@ -84,6 +84,8 @@ describe("util/schedule", () => {
       new Date("2023-09-06T15:00:00.000+10:00"),
     );
 
-    expect(quietHoursStart).toBe("12:00AM tomorrow (in 9 hours) in Australia/Sydney");
+    expect(quietHoursStart).toBe(
+      "12:00AM tomorrow (in 9 hours) in Australia/Sydney",
+    );
   });
 });

--- a/site/src/utils/schedule.ts
+++ b/site/src/utils/schedule.ts
@@ -206,7 +206,7 @@ export const quietHoursDisplay = (
     display += ` on ${day.format("dddd, MMMM D")}`;
   }
 
-  display += ` (${day.from(today)})`;
+  display += ` (${day.from(today)}) in ${tz}`;
 
   return display;
 };


### PR DESCRIPTION
Adds `in $TZ` to the end of the quiet hours message. A customer was unsure whether this was live or calculated by the server based on the currently saved value, so this makes it clear that it matches the form and is calculated client side.
 
Closes #10503