### PR TITLE
fix(coderd/rbac): allow user admin all perms on ResourceUserData

### DIFF
--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -206,6 +206,7 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 		Site: Permissions(map[string][]Action{
 			ResourceRoleAssignment.Type: {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
 			ResourceUser.Type:           {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
+			ResourceUserData.Type:       {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
 			// Full perms to manage org members
 			ResourceOrganizationMember.Type: {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
 			ResourceGroup.Type:              {ActionCreate, ActionRead, ActionUpdate, ActionDelete},

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -274,8 +274,8 @@ func TestRolePermissions(t *testing.T) {
 			Actions:  []rbac.Action{rbac.ActionCreate, rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
 			Resource: rbac.ResourceUserData.WithID(currentUser).WithOwner(currentUser.String()),
 			AuthorizeMap: map[bool][]authSubject{
-				true:  {owner, orgMemberMe, memberMe},
-				false: {orgAdmin, otherOrgAdmin, otherOrgMember, templateAdmin, userAdmin},
+				true:  {owner, orgMemberMe, memberMe, userAdmin},
+				false: {orgAdmin, otherOrgAdmin, otherOrgMember, templateAdmin},
 			},
 		},
 		{


### PR DESCRIPTION
While working on https://github.com/coder/coder/pull/10548 I noticed that a user with role user admin creating another user was failing due to an RBAC error. 

https://github.com/coder/coder/pull/10548/files#diff-1bb2eefb31fce70cfc8323c6ea0029250524fa4f8dc3d544079777ed6f12c973R715

