### PR TITLE
fix: disable pagination nav buttons correctly

### DIFF
--- a/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
+++ b/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
@@ -15,9 +15,9 @@ export type PaginationWidgetBaseProps = {
 
 export const PaginationWidgetBase = ({
   count,
-  page,
   limit,
   onChange,
+  page: currentPage,
 }: PaginationWidgetBaseProps): JSX.Element | null => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -27,8 +27,8 @@ export const PaginationWidgetBase = ({
     return null;
   }
 
-  const isFirstPage = page <= 1;
-  const isLastPage = page >= numPages;
+  const isFirstPage = currentPage <= 1;
+  const isLastPage = currentPage >= numPages;
 
   return (
     <div
@@ -48,21 +48,25 @@ export const PaginationWidgetBase = ({
         disabled={isFirstPage}
         onClick={() => {
           if (!isFirstPage) {
-            onChange(page - 1);
+            onChange(currentPage - 1);
           }
         }}
       >
         <KeyboardArrowLeft />
       </Button>
       {isMobile ? (
-        <PageButton activePage={page} page={page} numPages={numPages} />
+        <PageButton
+          activePage={currentPage}
+          page={currentPage}
+          numPages={numPages}
+        />
       ) : (
-        buildPagedList(numPages, page).map((pageItem) => {
+        buildPagedList(numPages, currentPage).map((pageItem) => {
           if (pageItem === "left" || pageItem === "right") {
             return (
               <PageButton
                 key={pageItem}
-                activePage={page}
+                activePage={currentPage}
                 placeholder="..."
                 disabled
               />
@@ -73,7 +77,7 @@ export const PaginationWidgetBase = ({
             <PageButton
               key={pageItem}
               page={pageItem}
-              activePage={page}
+              activePage={currentPage}
               numPages={numPages}
               onPageClick={() => onChange(pageItem)}
             />
@@ -85,7 +89,7 @@ export const PaginationWidgetBase = ({
         disabled={isLastPage}
         onClick={() => {
           if (!isLastPage) {
-            onChange(page + 1);
+            onChange(currentPage + 1);
           }
         }}
       >

--- a/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
+++ b/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
@@ -80,7 +80,6 @@ export const PaginationWidgetBase = ({
           );
         })
       )}
-
       <Button
         aria-label="Next page"
         disabled={isLastPage}

--- a/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
+++ b/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
@@ -14,8 +14,8 @@ export type PaginationWidgetBaseProps = {
 };
 
 export const PaginationWidgetBase = ({
-  page,
   count,
+  page,
   limit,
   onChange,
 }: PaginationWidgetBaseProps): JSX.Element | null => {

--- a/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
+++ b/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
@@ -14,10 +14,10 @@ export type PaginationWidgetBaseProps = {
 };
 
 export const PaginationWidgetBase = ({
+  page,
   count,
   limit,
   onChange,
-  page: currentPage,
 }: PaginationWidgetBaseProps): JSX.Element | null => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -27,8 +27,8 @@ export const PaginationWidgetBase = ({
     return null;
   }
 
-  const isFirstPage = currentPage <= 1;
-  const isLastPage = currentPage >= numPages;
+  const isFirstPage = page <= 1;
+  const isLastPage = page >= numPages;
 
   return (
     <div
@@ -48,25 +48,21 @@ export const PaginationWidgetBase = ({
         disabled={isFirstPage}
         onClick={() => {
           if (!isFirstPage) {
-            onChange(currentPage - 1);
+            onChange(page - 1);
           }
         }}
       >
         <KeyboardArrowLeft />
       </Button>
       {isMobile ? (
-        <PageButton
-          activePage={currentPage}
-          page={currentPage}
-          numPages={numPages}
-        />
+        <PageButton activePage={page} page={page} numPages={numPages} />
       ) : (
-        buildPagedList(numPages, currentPage).map((pageItem) => {
+        buildPagedList(numPages, page).map((pageItem) => {
           if (pageItem === "left" || pageItem === "right") {
             return (
               <PageButton
                 key={pageItem}
-                activePage={currentPage}
+                activePage={page}
                 placeholder="..."
                 disabled
               />
@@ -77,7 +73,7 @@ export const PaginationWidgetBase = ({
             <PageButton
               key={pageItem}
               page={pageItem}
-              activePage={currentPage}
+              activePage={page}
               numPages={numPages}
               onPageClick={() => onChange(pageItem)}
             />
@@ -89,7 +85,7 @@ export const PaginationWidgetBase = ({
         disabled={isLastPage}
         onClick={() => {
           if (!isLastPage) {
-            onChange(currentPage + 1);
+            onChange(page + 1);
           }
         }}
       >

--- a/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
+++ b/site/src/components/PaginationWidget/PaginationWidgetBase.tsx
@@ -21,13 +21,14 @@ export const PaginationWidgetBase = ({
 }: PaginationWidgetBaseProps): JSX.Element | null => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const numPages = Math.ceil(count / limit);
-  const isFirstPage = page === 0;
-  const isLastPage = page === numPages - 1;
 
+  const numPages = Math.ceil(count / limit);
   if (numPages < 2) {
     return null;
   }
+
+  const isFirstPage = page <= 1;
+  const isLastPage = page >= numPages;
 
   return (
     <div
@@ -79,6 +80,7 @@ export const PaginationWidgetBase = ({
           );
         })
       )}
+
       <Button
         aria-label="Next page"
         disabled={isLastPage}


### PR DESCRIPTION
Stopgap solution for #10452 and #10549 

Basically, after looking at the pagination code, there are a few things I think should be updated (especially to address navigation URL edge cases), but there's enough of them that the scope is veering on becoming a feature

I don't want that to block the "easy fix", which is just updating the buttons to be disabled properly

## Changes made
All changes were made to `PaginationWidgetBase`
- Update the logic for the previous button so that it's disabled if on page 1 (or earlier, if the URL somehow gets malformed)
- Update the logic for the next button so that it's disabled on the last page or later (this isn't as fool-proof, because of how we're choosing to render content if you somehow shoot past the last page. I'd prefer to have more in place to catch issues like this, instead of hoping the button takes care of everything)