### PR TITLE
fix(site/src/api): getDeploymentDAUs: truncate tz_offset to whole number

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -933,8 +933,10 @@ export const getTemplateDAUs = async (
 };
 
 export const getDeploymentDAUs = async (
-  // Default to user's local timezone
-  offset = new Date().getTimezoneOffset() / 60,
+  // Default to user's local timezone.
+  // As /api/v2/insights/daus only accepts whole-number values for tz_offset
+  // we truncate the tz offset down to the closest hour.
+  offset = Math.trunc(new Date().getTimezoneOffset() / 60),
 ): Promise<TypesGen.DAUsResponse> => {
   const response = await axios.get(`/api/v2/insights/daus?tz_offset=${offset}`);
   return response.data;


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/10562

Per https://github.com/coder/coder/pull/7647#discussion_r1210499372 it appears that this was the intended behaviour.