### PR TITLE
chore: fix flake.nix to run on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           shfmt
           sqlc
           # strace is not available on OSX
-          (if system == "aarch64-darwin" then null else strace)
+          (if pkgs.stdenv.hostPlatform.isDarwin then null else strace)
           terraform
           typos
           vim


### PR DESCRIPTION
strace is unavailable on macos. flake.nix is updated to handle this scenario.