### PR TITLE
feat(cli): create workspace using parameters from existing workspace

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -86,7 +86,7 @@ func (r *RootCmd) create() *clibase.Cmd {
 
 				sourceWorkspace, err = client.WorkspaceByOwnerAndName(inv.Context(), sourceWorkspaceOwner, sourceWorkspaceName, codersdk.WorkspaceOptions{})
 				if err != nil {
-					return err
+					return xerrors.Errorf("get source workspace: %w", err)
 				}
 
 				_, _ = fmt.Fprintf(inv.Stdout, "Coder will use the same template %q as the source workspace.\n", sourceWorkspace.TemplateName)
@@ -158,9 +158,9 @@ func (r *RootCmd) create() *clibase.Cmd {
 
 			var sourceWorkspaceParameters []codersdk.WorkspaceBuildParameter
 			if copyParameters != "" {
-				sourceWorkspaceParameters, err = client.WorkspaceBuildParameters(inv.Context(), sourceWorkspace.ID)
+				sourceWorkspaceParameters, err = client.WorkspaceBuildParameters(inv.Context(), sourceWorkspace.LatestBuild.ID)
 				if err != nil {
-					return err
+					return xerrors.Errorf("get source workspace build parameters: %w", err)
 				}
 			}
 

--- a/cli/create.go
+++ b/cli/create.go
@@ -248,7 +248,6 @@ func (r *RootCmd) create() *clibase.Cmd {
 			Flag:        "copy-parameters",
 			Env:         "CODER_WORKSPACE_COPY_PARAMETERS",
 			Description: "Specify the source workspace name to copy parameters from.",
-			Default:     string(codersdk.AutomaticUpdatesNever),
 			Value:       clibase.StringOf(&copyParameters),
 		},
 		cliui.SkipPromptOption(),

--- a/cli/create.go
+++ b/cli/create.go
@@ -26,9 +26,9 @@ func (r *RootCmd) create() *clibase.Cmd {
 		stopAfter     time.Duration
 		workspaceName string
 
-		parameterFlags workspaceParameterFlags
-		autoUpdates    string
-		copyParameters string
+		parameterFlags     workspaceParameterFlags
+		autoUpdates        string
+		copyParametersFrom string
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -78,8 +78,8 @@ func (r *RootCmd) create() *clibase.Cmd {
 			}
 
 			var sourceWorkspace codersdk.Workspace
-			if copyParameters != "" {
-				sourceWorkspaceOwner, sourceWorkspaceName, err := splitNamedWorkspace(copyParameters)
+			if copyParametersFrom != "" {
+				sourceWorkspaceOwner, sourceWorkspaceName, err := splitNamedWorkspace(copyParametersFrom)
 				if err != nil {
 					return err
 				}
@@ -157,7 +157,7 @@ func (r *RootCmd) create() *clibase.Cmd {
 			}
 
 			var sourceWorkspaceParameters []codersdk.WorkspaceBuildParameter
-			if copyParameters != "" {
+			if copyParametersFrom != "" {
 				sourceWorkspaceParameters, err = client.WorkspaceBuildParameters(inv.Context(), sourceWorkspace.LatestBuild.ID)
 				if err != nil {
 					return xerrors.Errorf("get source workspace build parameters: %w", err)
@@ -245,10 +245,10 @@ func (r *RootCmd) create() *clibase.Cmd {
 			Value:       clibase.StringOf(&autoUpdates),
 		},
 		clibase.Option{
-			Flag:        "copy-parameters",
-			Env:         "CODER_WORKSPACE_COPY_PARAMETERS",
+			Flag:        "copy-parameters-from",
+			Env:         "CODER_WORKSPACE_COPY_PARAMETERS_FROM",
 			Description: "Specify the source workspace name to copy parameters from.",
-			Value:       clibase.StringOf(&copyParameters),
+			Value:       clibase.StringOf(&copyParametersFrom),
 		},
 		cliui.SkipPromptOption(),
 	)

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -443,7 +443,7 @@ func TestCreateWithRichParameters(t *testing.T) {
 		// Secondly, create a new workspace using parameters from the previous workspace.
 		const otherWorkspace = "other-workspace"
 
-		inv, root = clitest.New(t, "create", "--copy-parameters", "my-workspace", otherWorkspace, "-y")
+		inv, root = clitest.New(t, "create", "--copy-parameters-from", "my-workspace", otherWorkspace, "-y")
 		clitest.SetupConfig(t, member, root)
 		pty = ptytest.New(t).Attach(inv)
 		inv.Stdout = pty.Output()

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -470,6 +470,70 @@ func TestCreateWithRichParameters(t *testing.T) {
 		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: secondParameterName, Value: secondParameterValue})
 		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: immutableParameterName, Value: immutableParameterValue})
 	})
+
+	t.Run("CopyParametersFromNotUpdatedWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		owner := coderdtest.CreateFirstUser(t, client)
+		member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, echoResponses)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+
+		template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+		// Firstly, create a regular workspace using template with parameters.
+		inv, root := clitest.New(t, "create", "my-workspace", "--template", template.Name, "-y",
+			"--parameter", fmt.Sprintf("%s=%s", firstParameterName, firstParameterValue),
+			"--parameter", fmt.Sprintf("%s=%s", secondParameterName, secondParameterValue),
+			"--parameter", fmt.Sprintf("%s=%s", immutableParameterName, immutableParameterValue))
+		clitest.SetupConfig(t, member, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err := inv.Run()
+		require.NoError(t, err, "can't create first workspace")
+
+		// Secondly, update the template to the newer version.
+		version2 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, prepareEchoResponses([]*proto.RichParameter{
+			{Name: "third_parameter", Type: "string", DefaultValue: "not-relevant"},
+		}), func(ctvr *codersdk.CreateTemplateVersionRequest) {
+			ctvr.TemplateID = template.ID
+		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version2.ID)
+		coderdtest.UpdateActiveTemplateVersion(t, client, template.ID, version2.ID)
+
+		// Thirdly, create a new workspace using parameters from the previous workspace.
+		const otherWorkspace = "other-workspace"
+
+		inv, root = clitest.New(t, "create", "--copy-parameters-from", "my-workspace", otherWorkspace, "-y")
+		clitest.SetupConfig(t, member, root)
+		pty = ptytest.New(t).Attach(inv)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+		err = inv.Run()
+		require.NoError(t, err, "can't create a workspace based on the source workspace")
+
+		// Verify if the new workspace uses expected parameters.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		workspaces, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Name: otherWorkspace,
+		})
+		require.NoError(t, err, "can't list available workspaces")
+		require.Len(t, workspaces.Workspaces, 1)
+
+		otherWorkspaceLatestBuild := workspaces.Workspaces[0].LatestBuild
+		require.Equal(t, version.ID, otherWorkspaceLatestBuild.TemplateVersionID)
+
+		buildParameters, err := client.WorkspaceBuildParameters(ctx, otherWorkspaceLatestBuild.ID)
+		require.NoError(t, err)
+		require.Len(t, buildParameters, 3)
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: firstParameterName, Value: firstParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: secondParameterName, Value: secondParameterValue})
+		require.Contains(t, buildParameters, codersdk.WorkspaceBuildParameter{Name: immutableParameterName, Value: immutableParameterValue})
+	})
 }
 
 func TestCreateValidateRichParameters(t *testing.T) {

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -14,6 +14,9 @@ OPTIONS:
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
+      --copy-parameters string, $CODER_WORKSPACE_COPY_PARAMETERS (default: never)
+          Specify the source workspace name to copy parameters from.
+
       --parameter string-array, $CODER_RICH_PARAMETER
           Rich parameter value in the format "name=value".
 

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -14,7 +14,7 @@ OPTIONS:
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
-      --copy-parameters string, $CODER_WORKSPACE_COPY_PARAMETERS
+      --copy-parameters-from string, $CODER_WORKSPACE_COPY_PARAMETERS_FROM
           Specify the source workspace name to copy parameters from.
 
       --parameter string-array, $CODER_RICH_PARAMETER

--- a/cli/testdata/coder_create_--help.golden
+++ b/cli/testdata/coder_create_--help.golden
@@ -14,7 +14,7 @@ OPTIONS:
           Specify automatic updates setting for the workspace (accepts 'always'
           or 'never').
 
-      --copy-parameters string, $CODER_WORKSPACE_COPY_PARAMETERS (default: never)
+      --copy-parameters string, $CODER_WORKSPACE_COPY_PARAMETERS
           Specify the source workspace name to copy parameters from.
 
       --parameter string-array, $CODER_RICH_PARAMETER

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -30,12 +30,12 @@ coder create [flags] [name]
 
 Specify automatic updates setting for the workspace (accepts 'always' or 'never').
 
-### --copy-parameters
+### --copy-parameters-from
 
-|             |                                               |
-| ----------- | --------------------------------------------- |
-| Type        | <code>string</code>                           |
-| Environment | <code>$CODER_WORKSPACE_COPY_PARAMETERS</code> |
+|             |                                                    |
+| ----------- | -------------------------------------------------- |
+| Type        | <code>string</code>                                |
+| Environment | <code>$CODER_WORKSPACE_COPY_PARAMETERS_FROM</code> |
 
 Specify the source workspace name to copy parameters from.
 

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -36,7 +36,6 @@ Specify automatic updates setting for the workspace (accepts 'always' or 'never'
 | ----------- | --------------------------------------------- |
 | Type        | <code>string</code>                           |
 | Environment | <code>$CODER_WORKSPACE_COPY_PARAMETERS</code> |
-| Default     | <code>never</code>                            |
 
 Specify the source workspace name to copy parameters from.
 

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -30,6 +30,16 @@ coder create [flags] [name]
 
 Specify automatic updates setting for the workspace (accepts 'always' or 'never').
 
+### --copy-parameters
+
+|             |                                               |
+| ----------- | --------------------------------------------- |
+| Type        | <code>string</code>                           |
+| Environment | <code>$CODER_WORKSPACE_COPY_PARAMETERS</code> |
+| Default     | <code>never</code>                            |
+
+Specify the source workspace name to copy parameters from.
+
 ### --parameter
 
 |             |                                    |


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/9923

This PR adds support for duplicating workspace using CLI. It is implemented as part of the `coder create` command according to this [design](https://github.com/coder/coder/issues/9923#issuecomment-1759551552) (thanks @Parkreiner!).

```bash
./scripts/coder-dev.sh create --copy-parameters-from=workspace-5 workspace-6-copy
```