### PR TITLE
refactor(cli): extract workspace list parameters

### DIFF
--- a/cli/cliui/filter.go
+++ b/cli/cliui/filter.go
@@ -1,0 +1,63 @@
+package cliui
+
+import (
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+var defaultQuery = "owner:me"
+
+// WorkspaceFilter wraps codersdk.WorkspaceFilter
+// and allows easy integration to a CLI command.
+// Example usage:
+//
+//	func (r *RootCmd) MyCmd() *clibase.Cmd {
+//	  var (
+//	    filter cliui.WorkspaceFilter
+//	    ...
+//	  )
+//	  cmd := &clibase.Cmd{
+//	    ...
+//	  }
+//	  filter.AttachOptions(&cmd.Options)
+//	  ...
+//	  return cmd
+//	}
+//
+// The above will add the following flags to the command:
+// --all
+// --search
+type WorkspaceFilter struct {
+	searchQuery string
+	all         bool
+}
+
+func (w *WorkspaceFilter) Filter() codersdk.WorkspaceFilter {
+	var f codersdk.WorkspaceFilter
+	if w.all {
+		return f
+	}
+	f.FilterQuery = w.searchQuery
+	if f.FilterQuery == "" {
+		f.FilterQuery = defaultQuery
+	}
+	return f
+}
+
+func (w *WorkspaceFilter) AttachOptions(opts *clibase.OptionSet) {
+	*opts = append(*opts,
+		clibase.Option{
+			Flag:          "all",
+			FlagShorthand: "a",
+			Description:   "Specifies whether all workspaces will be listed or not.",
+
+			Value: clibase.BoolOf(&w.all),
+		},
+		clibase.Option{
+			Flag:        "search",
+			Description: "Search for a workspace with a query.",
+			Default:     defaultQuery,
+			Value:       clibase.StringOf(&w.searchQuery),
+		},
+	)
+}

--- a/cli/list.go
+++ b/cli/list.go
@@ -77,9 +77,7 @@ func workspaceListRowFromWorkspace(now time.Time, usersByID map[uuid.UUID]coders
 
 func (r *RootCmd) list() *clibase.Cmd {
 	var (
-		all               bool
-		defaultQuery      = "owner:me"
-		searchQuery       string
+		filter            cliui.WorkspaceFilter
 		displayWorkspaces []workspaceListRow
 		formatter         = cliui.NewOutputFormatter(
 			cliui.TableFormat(
@@ -109,14 +107,7 @@ func (r *RootCmd) list() *clibase.Cmd {
 			r.InitClient(client),
 		),
 		Handler: func(inv *clibase.Invocation) error {
-			filter := codersdk.WorkspaceFilter{
-				FilterQuery: searchQuery,
-			}
-			if all && searchQuery == defaultQuery {
-				filter.FilterQuery = ""
-			}
-
-			res, err := client.Workspaces(inv.Context(), filter)
+			res, err := client.Workspaces(inv.Context(), filter.Filter())
 			if err != nil {
 				return err
 			}
@@ -153,22 +144,7 @@ func (r *RootCmd) list() *clibase.Cmd {
 			return err
 		},
 	}
-	cmd.Options = clibase.OptionSet{
-		{
-			Flag:          "all",
-			FlagShorthand: "a",
-			Description:   "Specifies whether all workspaces will be listed or not.",
-
-			Value: clibase.BoolOf(&all),
-		},
-		{
-			Flag:        "search",
-			Description: "Search for a workspace with a query.",
-			Default:     defaultQuery,
-			Value:       clibase.StringOf(&searchQuery),
-		},
-	}
-
+	filter.AttachOptions(&cmd.Options)
 	formatter.AttachOptions(&cmd.Options)
 	return cmd
 }


### PR DESCRIPTION
In support of https://github.com/coder/coder/issues/10428: extracts the --search and --all parameters to a separate struct in `cliui`.