### PR TITLE
fix: add missing focus state styling to buttons and checkboxes

### DIFF
--- a/site/src/theme/theme.ts
+++ b/site/src/theme/theme.ts
@@ -516,5 +516,15 @@ dark = createTheme(dark, {
         },
       },
     },
+
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          "&.Mui-focusVisible": {
+            outline: `10px auto ${colors.blue[7]}`,
+          },
+        },
+      },
+    },
   },
 } as ThemeOptions);

--- a/site/src/theme/theme.ts
+++ b/site/src/theme/theme.ts
@@ -444,7 +444,7 @@ dark = createTheme(dark, {
            * customization).
            */
           "&.Mui-focusVisible": {
-            outline: `10px auto ${colors.blue[7]}`,
+            boxShadow: `0 0 0 2px ${colors.blue[7]}`,
           },
 
           "&.Mui-disabled": {
@@ -458,7 +458,9 @@ dark = createTheme(dark, {
       styleOverrides: {
         root: {
           ".Mui-focusVisible .MuiSwitch-thumb": {
-            outline: `10px auto ${colors.blue[7]}`,
+            // Had to thicken outline to make sure that the focus color didn't
+            // bleed into the thumb and was still easily-visible
+            boxShadow: `0 0 0 3px ${colors.blue[7]}`,
           },
         },
       },
@@ -526,7 +528,7 @@ dark = createTheme(dark, {
       styleOverrides: {
         root: {
           "&.Mui-focusVisible": {
-            outline: `10px auto ${colors.blue[7]}`,
+            boxShadow: `0 0 0 2px ${colors.blue[7]}`,
           },
         },
       },

--- a/site/src/theme/theme.ts
+++ b/site/src/theme/theme.ts
@@ -427,6 +427,26 @@ dark = createTheme(dark, {
     MuiCheckbox: {
       styleOverrides: {
         root: {
+          /**
+           * Adds focus styling to checkboxes (which doesn't exist normally, for
+           * some reason?).
+           *
+           * The checkbox component is a root span with a checkbox input inside
+           * it. MUI does not allow you to use selectors like (& input) to
+           * target the inner checkbox (even though you can use & td to style
+           * tables). Tried every combination of selector possible (including
+           * lots of !important), and the main issue seems to be that the
+           * styling just never gets processed for it to get injected into the
+           * CSSOM.
+           *
+           * Had to settle for adding styling to the span itself (which does
+           * make the styling more obvious, even if there's not much room for
+           * customization).
+           */
+          "&.Mui-focusVisible": {
+            outline: `10px auto ${colors.blue[7]}`,
+          },
+
           "&.Mui-disabled": {
             color: colors.gray[11],
           },

--- a/site/src/theme/theme.ts
+++ b/site/src/theme/theme.ts
@@ -454,8 +454,13 @@ dark = createTheme(dark, {
       },
     },
     MuiSwitch: {
-      defaultProps: {
-        color: "primary",
+      defaultProps: { color: "primary" },
+      styleOverrides: {
+        root: {
+          ".Mui-focusVisible .MuiSwitch-thumb": {
+            outline: `10px auto ${colors.blue[7]}`,
+          },
+        },
       },
     },
     MuiAutocomplete: {


### PR DESCRIPTION
Closes #9855 and adds a couple of other changes, too.

## Changes made
- Adds visual focus state to all checkboxes
-  Adds visual focus state to all switches
- Adds visual focus state to all icon buttons

<img width="179" alt="Screenshot 2023-11-09 at 2 58 28 PM" src="https://github.com/coder/coder/assets/28937484/7f1c5b9f-6567-4942-b07b-5c7cb9b2ee9f">
<img width="148" alt="Screenshot 2023-11-09 at 2 58 46 PM" src="https://github.com/coder/coder/assets/28937484/d86755a8-1fe7-4503-96bc-c10aeee9144d">
<img width="96" alt="Screenshot 2023-11-09 at 2 58 16 PM" src="https://github.com/coder/coder/assets/28937484/ae0cefa0-e97c-4050-b505-91844f634f77">

There might be some other components that need similar updates, but this should help keyboard navigation in the site a lot.