### PR TITLE
fix: remove accidental scrollbar from deployment banner

### DIFF
--- a/site/src/components/Dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/components/Dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -131,7 +131,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
     justify-content: center;
     background-color: ${unhealthy ? colors.red[10] : undefined};
     padding: 0 12px;
-    height: calc(${bannerHeight}px - 1px);
+    height: 100%;
     color: #fff;
 
     & svg {

--- a/site/src/components/Dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/components/Dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -131,7 +131,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
     justify-content: center;
     background-color: ${unhealthy ? colors.red[10] : undefined};
     padding: 0 12px;
-    height: ${bannerHeight}px;
+    height: calc(${bannerHeight}px - 1px);
     color: #fff;
 
     & svg {
@@ -158,6 +158,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
     <div
       css={{
         position: "sticky",
+        lineHeight: 1,
         height: bannerHeight,
         bottom: 0,
         zIndex: 1,

--- a/site/src/components/Dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/components/Dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -75,13 +75,14 @@ export interface DeploymentBannerViewProps {
 export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
   const { health, stats, fetchStats } = props;
   const theme = useTheme();
+
   const aggregatedMinutes = useMemo(() => {
     if (!stats) {
       return;
     }
     return dayjs(stats.collected_at).diff(stats.aggregated_from, "minutes");
   }, [stats]);
-  const displayLatency = stats?.workspaces.connection_latency_ms.P50 || -1;
+
   const [timeUntilRefresh, setTimeUntilRefresh] = useState(0);
   useEffect(() => {
     if (!stats || !fetchStats) {
@@ -151,6 +152,8 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
     pointer-events: none;
   `;
 
+  const displayLatency = stats?.workspaces.connection_latency_ms.P50 || -1;
+
   return (
     <div
       css={{
@@ -216,6 +219,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
           </div>
         )}
       </Tooltip>
+
       <div css={styles.group}>
         <div css={styles.category}>Workspaces</div>
         <div css={styles.values}>
@@ -245,6 +249,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
           />
         </div>
       </div>
+
       <div css={styles.group}>
         <Tooltip title={`Activity in the last ~${aggregatedMinutes} minutes`}>
           <div css={styles.category}>Transmission</div>
@@ -279,6 +284,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
           </Tooltip>
         </div>
       </div>
+
       <div css={styles.group}>
         <div css={styles.category}>Active Connections</div>
 
@@ -317,6 +323,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = (props) => {
           </Tooltip>
         </div>
       </div>
+
       <div
         css={{
           color: theme.palette.text.primary,


### PR DESCRIPTION
No issue to link. At some point in the last month, we accidentally introduced a mini scrollbar on the deployment banner. This PR removes that.

![Screenshot 2023-11-09 at 3 36 35 PM](https://github.com/coder/coder/assets/28937484/66b659a9-4ada-476c-a0c3-1bd27a205fb2)