### PR TITLE
fix: prevent db deadlock when workspaces go dormant

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10813,8 +10813,6 @@ SET
 FROM
 	templates
 WHERE
-	workspaces.template_id = templates.id
-AND
 	workspaces.id = $1
 RETURNING workspaces.id, workspaces.created_at, workspaces.updated_at, workspaces.owner_id, workspaces.organization_id, workspaces.template_id, workspaces.deleted, workspaces.name, workspaces.autostart_schedule, workspaces.ttl, workspaces.last_used_at, workspaces.dormant_at, workspaces.deleting_at, workspaces.automatic_updates
 `

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -488,8 +488,6 @@ SET
 FROM
 	templates
 WHERE
-	workspaces.template_id = templates.id
-AND
 	workspaces.id = $1
 RETURNING workspaces.*;
 


### PR DESCRIPTION
- Fixes an issue where during the evaluation of workspaces for dormancy, an attempt was made to insert an audit log in the midst of a transaction. If a sufficiently large number of workspaces were found eligible for dormancy a deadlock could occur where each transaction would attempt to write an audit log _outside_ the transaction, consuming a DB connection. We limit the number of concurrent transactions in `autobuild` to 10 so 10 connections could potentially be consumed leaving none free to handle the audit logging, effectively deadlocking the DB.
- We also now return errors from the transaction where it makes sense. I can't tell if it was a conscious decision to always return nil or not. Perhaps because it's mostly a read transaction it's less expensive to commit instead of rollback?
- The feature has not been released so this does not effect production deployments.

The solution is obviously to not do non-transaction DB operations from within a transaction. This was not an intentional implementation decision.

We could potentially add a timeout to the context we use in the transactions we open in `autobuild` but if a similar bug were to occur it would just provide temporary relief.

I'm a bit hesitant on adding the test for this since it's sort of easy for it to produce a false-positive. If we want to retain it I'll rewrite it to use our new `dbfake` implementation.

fixes https://github.com/coder/customers/issues/314