### PR TITLE
docs: add warning about Sysbox before installation

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,3 +1,10 @@
+<blockquote class="warning">
+**Before you install**
+If you would like your workspaces to be able to run Docker, we recommend that you <a href="https://github.com/nestybox/sysbox#installation" target="_blank">install Sysbox</a> before proceeding. 
+
+As part of the Sysbox installation you will be required to remove all existing Docker containers including containers used by Coder workspaces. Installing Sysbox ahead of time will reduce disruption to your Coder instance.
+</blockquote>
+
 There are a number of different methods to install and run Coder:
 
 <children>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,8 +1,11 @@
 <blockquote class="warning">
 **Before you install**
-If you would like your workspaces to be able to run Docker, we recommend that you <a href="https://github.com/nestybox/sysbox#installation" target="_blank">install Sysbox</a> before proceeding. 
+If you would like your workspaces to be able to run Docker, we recommend that you <a href="https://github.com/nestybox/sysbox#installation" target="_blank">install Sysbox</a> before proceeding.
 
-As part of the Sysbox installation you will be required to remove all existing Docker containers including containers used by Coder workspaces. Installing Sysbox ahead of time will reduce disruption to your Coder instance.
+As part of the Sysbox installation you will be required to remove all existing
+Docker containers including containers used by Coder workspaces. Installing
+Sysbox ahead of time will reduce disruption to your Coder instance.
+
 </blockquote>
 
 There are a number of different methods to install and run Coder:


### PR DESCRIPTION
As per #10602, add a warning to the install instructions to advise users to install Sysbox as early as possible to reduce disruptions.