### PR TITLE
ci: bump terraform version to 1.5.7 to match embedded terraform version

### DIFF
--- a/.github/actions/setup-tf/action.yaml
+++ b/.github/actions/setup-tf/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: 1.5.5
+        terraform_version: 1.5.7
         terraform_wrapper: false


### PR DESCRIPTION
We are using terraform version 1.5.7 in the Coder image. This PR updates ci to use the same version.