### PR TITLE
ci: bump go to version 1.20.11

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.20.10"
+    default: "1.20.11"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
         with:
           # This doesn't need caching. It's super fast anyways!
           cache: false
-          go-version: 1.20.10
+          go-version: 1.20.11
 
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY
We may also move to [1.21](https://github.com/coder/coder/issues/9110)