### PR TITLE
fix: handle SIGHUP from OpenSSH

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -8,7 +8,6 @@ import (
 	"net/http/pprof"
 	"net/url"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -144,7 +143,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 			// Note that we don't want to handle these signals in the
 			// process that runs as PID 1, that's why we do this after
 			// the reaper forked.
-			ctx, stopNotify := signal.NotifyContext(ctx, InterruptSignals...)
+			ctx, stopNotify := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer stopNotify()
 
 			// DumpHandler does signal handling, so we call it after the

--- a/cli/clitest/signal.go
+++ b/cli/clitest/signal.go
@@ -1,0 +1,59 @@
+package clitest
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeSignalNotifier struct {
+	sync.Mutex
+	t       *testing.T
+	ctx     context.Context
+	cancel  context.CancelFunc
+	signals []os.Signal
+	stopped bool
+}
+
+func NewFakeSignalNotifier(t *testing.T) *FakeSignalNotifier {
+	fsn := &FakeSignalNotifier{t: t}
+	return fsn
+}
+
+func (f *FakeSignalNotifier) Stop() {
+	f.Lock()
+	defer f.Unlock()
+	f.stopped = true
+	if f.cancel == nil {
+		f.t.Error("stopped before started")
+		return
+	}
+	f.cancel()
+}
+
+func (f *FakeSignalNotifier) NotifyContext(parent context.Context, signals ...os.Signal) (ctx context.Context, stop context.CancelFunc) {
+	f.Lock()
+	defer f.Unlock()
+	f.signals = signals
+	f.ctx, f.cancel = context.WithCancel(parent)
+	return f.ctx, f.Stop
+}
+
+func (f *FakeSignalNotifier) Notify() {
+	f.Lock()
+	defer f.Unlock()
+	if f.cancel == nil {
+		f.t.Error("notified before started")
+		return
+	}
+	f.cancel()
+}
+
+func (f *FakeSignalNotifier) AssertStopped() {
+	f.Lock()
+	defer f.Unlock()
+	assert.True(f.t, f.stopped)
+}

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-	"os/signal"
 
 	"golang.org/x/xerrors"
 
@@ -63,7 +62,7 @@ fi
 		Handler: func(inv *clibase.Invocation) error {
 			ctx := inv.Context()
 
-			ctx, stop := signal.NotifyContext(ctx, InterruptSignals...)
+			ctx, stop := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer stop()
 
 			client, err := r.createAgentClient()

--- a/cli/gitaskpass.go
+++ b/cli/gitaskpass.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os/signal"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -26,7 +25,7 @@ func (r *RootCmd) gitAskpass() *clibase.Cmd {
 		Handler: func(inv *clibase.Invocation) error {
 			ctx := inv.Context()
 
-			ctx, stop := signal.NotifyContext(ctx, InterruptSignals...)
+			ctx, stop := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer stop()
 
 			user, host, err := gitauth.ParseAskpass(inv.Args[0])

--- a/cli/gitssh.go
+++ b/cli/gitssh.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
 
@@ -30,7 +29,7 @@ func (r *RootCmd) gitssh() *clibase.Cmd {
 
 			// Catch interrupt signals to ensure the temporary private
 			// key file is cleaned up on most cases.
-			ctx, stop := signal.NotifyContext(ctx, InterruptSignals...)
+			ctx, stop := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer stop()
 
 			// Early check so errors are reported immediately.

--- a/cli/server.go
+++ b/cli/server.go
@@ -22,7 +22,6 @@ import (
 	"net/http/pprof"
 	"net/url"
 	"os"
-	"os/signal"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -333,7 +332,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			//
 			// To get out of a graceful shutdown, the user can send
 			// SIGQUIT with ctrl+\ or SIGKILL with `kill -9`.
-			notifyCtx, notifyStop := signal.NotifyContext(ctx, InterruptSignals...)
+			notifyCtx, notifyStop := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer notifyStop()
 
 			cacheDir := vals.CacheDir.String()
@@ -1098,7 +1097,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				logger = logger.Leveled(slog.LevelDebug)
 			}
 
-			ctx, cancel := signal.NotifyContext(ctx, InterruptSignals...)
+			ctx, cancel := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer cancel()
 
 			url, closePg, err := startBuiltinPostgres(ctx, cfg, logger)

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"fmt"
-	"os/signal"
 	"sort"
 
 	"github.com/google/uuid"
@@ -48,7 +47,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *clibase.Cmd {
 				logger = logger.Leveled(slog.LevelDebug)
 			}
 
-			ctx, cancel := signal.NotifyContext(ctx, InterruptSignals...)
+			ctx, cancel := inv.SignalNotifyContext(ctx, InterruptSignals...)
 			defer cancel()
 
 			if newUserDBURL == "" {

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -290,7 +290,7 @@ func TestSSH(t *testing.T) {
 			})
 
 			// accept a single connection
-			msgs := make(chan string)
+			msgs := make(chan string, 1)
 			go func() {
 				conn, err := l.Accept()
 				if !assert.NoError(t, err) {

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -14,11 +14,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/xerrors"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -243,6 +246,119 @@ func TestSSH(t *testing.T) {
 		_ = clientOutput.Close()
 
 		<-cmdDone
+	})
+
+	// Test that we handle OS signals properly while remote forwarding, and don't just leave the TCP
+	// socket hanging.
+	t.Run("RemoteForward_Unix_Signal", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("No unix sockets on windows")
+		}
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitSuperLong)
+		client, workspace, agentToken := setupWorkspaceForAgent(t, nil)
+		_, _ = tGoContext(t, func(ctx context.Context) {
+			// Run this async so the SSH command has to wait for
+			// the build and agent to connect!
+			_ = agenttest.New(t, client.URL, agentToken)
+			<-ctx.Done()
+		})
+
+		tmpdir := tempDirUnixSocket(t)
+		localSock := filepath.Join(tmpdir, "local.sock")
+		l, err := net.Listen("unix", localSock)
+		require.NoError(t, err)
+		defer l.Close()
+		remoteSock := path.Join(tmpdir, "remote.sock")
+		for i := 0; i < 2; i++ {
+			t.Logf("connect %d of 2", i+1)
+			inv, root := clitest.New(t,
+				"ssh",
+				workspace.Name,
+				"--remote-forward",
+				remoteSock+":"+localSock,
+			)
+			fsn := clitest.NewFakeSignalNotifier(t)
+			inv = inv.WithTestSignalNotifyContext(t, fsn.NotifyContext)
+			inv.Stdout = io.Discard
+			inv.Stderr = io.Discard
+
+			clitest.SetupConfig(t, client, root)
+			cmdDone := tGo(t, func() {
+				err := inv.WithContext(ctx).Run()
+				assert.Error(t, err)
+			})
+
+			// accept a single connection
+			msgs := make(chan string)
+			go func() {
+				conn, err := l.Accept()
+				if !assert.NoError(t, err) {
+					return
+				}
+				msg, err := io.ReadAll(conn)
+				if !assert.NoError(t, err) {
+					return
+				}
+				msgs <- string(msg)
+			}()
+
+			// Unfortunately, there is a race in crypto/ssh where it sends the request to forward
+			// unix sockets before it is prepared to receive the response, meaning that even after
+			// the socket exists on the file system, the client might not be ready to accept the
+			// channel.
+			//
+			// https://cs.opensource.google/go/x/crypto/+/master:ssh/streamlocal.go;drc=2fc4c88bf43f0ea5ea305eae2b7af24b2cc93287;l=33
+			//
+			// To work around this, we attempt to send messages in a loop until one succeeds
+			success := make(chan struct{})
+			go func() {
+				var (
+					conn net.Conn
+					err  error
+				)
+				for {
+					time.Sleep(testutil.IntervalMedium)
+					select {
+					case <-ctx.Done():
+						t.Error("timeout")
+						return
+					case <-success:
+						return
+					default:
+						// Ok
+					}
+					conn, err = net.Dial("unix", remoteSock)
+					if err != nil {
+						t.Logf("dial error: %s", err)
+						continue
+					}
+					_, err = conn.Write([]byte("test"))
+					if err != nil {
+						t.Logf("write error: %s", err)
+					}
+					err = conn.Close()
+					if err != nil {
+						t.Logf("close error: %s", err)
+					}
+				}
+			}()
+
+			msg := testutil.RequireRecvCtx(ctx, t, msgs)
+			require.Equal(t, "test", msg)
+			close(success)
+			fsn.Notify()
+			<-cmdDone
+			fsn.AssertStopped()
+
+			// wait for the remote socket to get cleaned up before retrying,
+			// because cleaning up the socket happens asynchronously, and we
+			// might connect to an old listener on the agent side.
+			require.Eventually(t, func() bool {
+				_, err = os.Stat(remoteSock)
+				return xerrors.Is(err, os.ErrNotExist)
+			}, testutil.WaitShort, testutil.IntervalFast)
+		}
 	})
 
 	t.Run("StdioExitOnStop", func(t *testing.T) {

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,7 +60,7 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 			ctx, cancel := context.WithCancel(inv.Context())
 			defer cancel()
 
-			notifyCtx, notifyStop := signal.NotifyContext(ctx, agpl.InterruptSignals...)
+			notifyCtx, notifyStop := inv.SignalNotifyContext(ctx, agpl.InterruptSignals...)
 			defer notifyStop()
 
 			tags, err := agpl.ParseProvisionerTags(rawTags)

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
-	"os/signal"
 	"regexp"
 	rpprof "runtime/pprof"
 	"time"
@@ -142,7 +141,7 @@ func (*RootCmd) proxyServer() *clibase.Cmd {
 			//
 			// To get out of a graceful shutdown, the user can send
 			// SIGQUIT with ctrl+\ or SIGKILL with `kill -9`.
-			notifyCtx, notifyStop := signal.NotifyContext(ctx, cli.InterruptSignals...)
+			notifyCtx, notifyStop := inv.SignalNotifyContext(ctx, cli.InterruptSignals...)
 			defer notifyStop()
 
 			// Clean up idle connections at the end, e.g.

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -788,6 +788,7 @@ func (c *Conn) Close() error {
 	}
 
 	_ = c.netStack.Close()
+	c.logger.Debug(context.Background(), "closed netstack")
 	c.dialCancel()
 	_ = c.wireguardMonitor.Close()
 	_ = c.dialer.Close()

--- a/testutil/ctx.go
+++ b/testutil/ctx.go
@@ -11,3 +11,14 @@ func Context(t *testing.T, dur time.Duration) context.Context {
 	t.Cleanup(cancel)
 	return ctx
 }
+
+func RequireRecvCtx[A any](ctx context.Context, t testing.TB, c <-chan A) (a A) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+		t.Fatal("timeout")
+		return a
+	case a = <-c:
+		return a
+	}
+}


### PR DESCRIPTION
Fixes an issue where remote forwards are not correctly torn down when using OpenSSH with `coder ssh --stdio`.  OpenSSH sends a disconnect signal, but then also sends SIGHUP to `coder`.  Previously, we just exited when we got SIGHUP, and this raced against properly disconnecting.

Fixes https://github.com/coder/customers/issues/327
