### PR TITLE
fix: disable autoupdate workspace setting when template setting enabled

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -187,7 +187,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
                     spacing={0.5}
                     css={styles.optionText}
                   >
-                    Require the active template version for workspace builds.
+                    Require workspaces automatically update when started.
                     <HelpTooltip>
                       <HelpTooltipText>
                         This setting is not enforced for template admins.
@@ -196,7 +196,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
                   </Stack>
                   <span css={styles.optionHelperText}>
                     Workspaces that are manually started or auto-started will
-                    use the promoted template version.
+                    use the active template version.
                   </span>
                 </Stack>
               </Stack>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -85,7 +85,13 @@ export const WorkspaceSettingsForm: FC<{
               label="Update Policy"
               value={form.values.automatic_updates}
               select
-              disabled={form.isSubmitting}
+              disabled={
+                form.isSubmitting || workspace.template_require_active_version
+              }
+              helperText={
+                workspace.template_require_active_version &&
+                "The template for this workspace requires automatic updates."
+              }
             >
               {AutomaticUpdateses.map((value) => (
                 <MenuItem value={value} key={value}>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -83,7 +83,11 @@ export const WorkspaceSettingsForm: FC<{
               {...getFieldHelpers("automatic_updates")}
               id="automatic_updates"
               label="Update Policy"
-              value={form.values.automatic_updates}
+              value={
+                workspace.template_require_active_version
+                  ? "always"
+                  : form.values.automatic_updates
+              }
               select
               disabled={
                 form.isSubmitting || workspace.template_require_active_version


### PR DESCRIPTION
- The setting defaults to `Always` when the template setting is enabled.
- Updates the wording for both settings to be consistent.

![image](https://github.com/coder/coder/assets/4856196/332bd0ab-d589-4a6d-9a03-d788a8deb537)
