### PR TITLE
feat(coderd): add parameter to force health check in /debug/health

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -412,6 +412,14 @@ const docTemplate = `{
                 ],
                 "summary": "Debug Info Deployment Health",
                 "operationId": "debug-info-deployment-health",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Force a healthcheck to run",
+                        "name": "force",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -348,6 +348,14 @@
         "tags": ["Debug"],
         "summary": "Debug Info Deployment Health",
         "operationId": "debug-info-deployment-health",
+        "parameters": [
+          {
+            "type": "boolean",
+            "description": "Force a healthcheck to run",
+            "name": "force",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -33,6 +33,12 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
 
 `GET /debug/health`
 
+### Parameters
+
+| Name    | In    | Type    | Required | Description                |
+| ------- | ----- | ------- | -------- | -------------------------- |
+| `force` | query | boolean | false    | Force a healthcheck to run |
+
 ### Example responses
 
 > 200 Response


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/8969
Modifies the `/debug/health` endpoint to accept a `force=(true|_)` parameter.
Iff set to `true`, will re-run the healthcheck immediately.
UI changes will come in a separate PR.