### PR TITLE
fix(coderd): fix memory leak in `watchWorkspaceAgentMetadata`

### DIFF
--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -492,6 +492,11 @@ func (c *Client) WatchWorkspaceAgentMetadata(ctx context.Context, id uuid.UUID) 
 				firstEvent = false
 			}
 
+			// Ignore pings.
+			if sse.Type == ServerSentEventTypePing {
+				continue
+			}
+
 			b, ok := sse.Data.([]byte)
 			if !ok {
 				return xerrors.Errorf("unexpected data type: %T", sse.Data)

--- a/testutil/go.go
+++ b/testutil/go.go
@@ -1,0 +1,45 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+)
+
+// Go runs fn in a goroutine and waits until fn has completed before
+// test completion. Done is returned for optionally waiting for fn to
+// exit.
+func Go(t *testing.T, fn func()) (done <-chan struct{}) {
+	t.Helper()
+
+	doneC := make(chan struct{})
+	t.Cleanup(func() {
+		<-doneC
+	})
+	go func() {
+		fn()
+		close(doneC)
+	}()
+
+	return doneC
+}
+
+// GoContext runs fn in a goroutine passing a context that will be
+// canceled on test completion and wait until fn has finished executing.
+// Done and cancel are returned for optionally waiting until completion
+// or early cancellation.
+func GoContext(t *testing.T, fn func(context.Context)) (done <-chan struct{}, cancel context.CancelFunc) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneC := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	go func() {
+		fn(ctx)
+		close(doneC)
+	}()
+
+	return doneC, cancel
+}

--- a/testutil/go.go
+++ b/testutil/go.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"context"
 	"testing"
 )
 
@@ -21,25 +20,4 @@ func Go(t *testing.T, fn func()) (done <-chan struct{}) {
 	}()
 
 	return doneC
-}
-
-// GoContext runs fn in a goroutine passing a context that will be
-// canceled on test completion and wait until fn has finished executing.
-// Done and cancel are returned for optionally waiting until completion
-// or early cancellation.
-func GoContext(t *testing.T, fn func(context.Context)) (done <-chan struct{}, cancel context.CancelFunc) {
-	t.Helper()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	doneC := make(chan struct{})
-	t.Cleanup(func() {
-		cancel()
-		<-done
-	})
-	go func() {
-		fn(ctx)
-		close(doneC)
-	}()
-
-	return doneC, cancel
 }


### PR DESCRIPTION
A change to agent metadata processing was introduced in https://github.com/coder/coder/releases/tag/v2.3.1 which introduced a logic bug leading to a memory leak. However, it's not entirely clear how this can be triggered. I managed to trigger it twice, but the exact steps elude me. One time `coderd` was left with a permanent memory consumption of 1.7 GB and the other time, it was OOM killed (ironically, after I had given up reproducing the issue).

To trigger the memory leak that was fixed here, the `coderd` watch metadata handler has to 1) subscribe to metadata updates via pubsub and 2) somewhere along the way, begin teardown of the handler or exit the consumer running in a goroutine _without_ getting so far as to unsubscribing from the pubsub.

Potential triggers for the bug:
1. Slow/hung database read
2. Slow/hung write on the HTTP connection (SSE)
3. Unsubscribe from pubsub failing -- seems unlikely

~~This is not guaranteed to fix #10550, but it's a good candidate.~~

Fixes #10550
Closes https://github.com/coder/customers/issues/334
