### PR TITLE
chore: update openssl in Dockerfile

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -11,6 +11,7 @@ RUN apk add --no-cache \
 		wget \
 		bash \
 		git \
+		openssl \
 		openssh-client && \
 	addgroup \
 		-g 1000 \


### PR DESCRIPTION
Includes a security fix for CVE-2023-5363 and CVE-2023-5678.