### PR TITLE
chore: disable test on save in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -205,8 +205,6 @@
   "files.insertFinalNewline": true,
   "go.lintTool": "golangci-lint",
   "go.lintFlags": ["--fast"],
-  "go.lintOnSave": "package",
-  "go.coverOnSave": true,
   "go.coverageDecorator": {
     "type": "gutter",
     "coveredGutterStyle": "blockgreen",


### PR DESCRIPTION
Running tests on save is really obnoxious when you just want to run one test or file of tests. Especially in large packages like coderd that take more than a few moments to finish running tests.

Kyle said I could remove this a few months ago and I never got around to it