### PR TITLE
feat: add more logging around echo tar

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -709,7 +709,7 @@ func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationI
 // with testing.
 func CreateTemplateVersion(t testing.TB, client *codersdk.Client, organizationID uuid.UUID, res *echo.Responses, mutators ...func(*codersdk.CreateTemplateVersionRequest)) codersdk.TemplateVersion {
 	t.Helper()
-	data, err := echo.Tar(res)
+	data, err := echo.TarWithOptions(context.Background(), client.Logger(), res)
 	require.NoError(t, err)
 	file, err := client.Upload(context.Background(), codersdk.ContentTypeTar, bytes.NewReader(data))
 	require.NoError(t, err)

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -41,6 +42,7 @@ func TestCollectInsights(t *testing.T) {
 		Pubsub:                    ps,
 	}
 	client := coderdtest.New(t, options)
+	client.SetLogger(logger.Named("client").Leveled(slog.LevelDebug))
 
 	// Given
 	// Initialize metrics collector

--- a/provisionersdk/session.go
+++ b/provisionersdk/session.go
@@ -4,8 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"os"
 	"path/filepath"
@@ -260,7 +260,7 @@ func (s *Session) extractArchive() error {
 				return xerrors.Errorf("create file %q (mode %s): %w", headerPath, mode, err)
 			}
 
-			hash := sha256.New()
+			hash := crc32.NewIEEE()
 			hashReader := io.TeeReader(reader, hash)
 			// Max file size of 10MiB.
 			size, err := io.CopyN(file, hashReader, 10<<20)

--- a/provisionersdk/session.go
+++ b/provisionersdk/session.go
@@ -4,7 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -260,8 +260,7 @@ func (s *Session) extractArchive() error {
 				return xerrors.Errorf("create file %q (mode %s): %w", headerPath, mode, err)
 			}
 
-			//nolint:gosec // Calculate the file checksum for debugging purposes if the file is corrupted
-			hash := md5.New()
+			hash := sha256.New()
 			hashReader := io.TeeReader(reader, hash)
 			// Max file size of 10MiB.
 			size, err := io.CopyN(file, hashReader, 10<<20)


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/10599
Spotted in: https://github.com/coder/coder/actions/runs/6804539935/job/18502315372?pr=10598

I wasn't able to reproduce it locally, so I'm adding more logging. It looks like Coder [lost part of the "echo responses"](https://github.com/coder/coder/issues/10599#issuecomment-1814223905), unfortunately `plan` with rich parameters, so the whole test failed as it expected a workspace with build parameters. Without extra debug information we can't determine whether the client sent incomplete "echo responses" or the provisioner lost them while unpacking the template.

Changes:
* first logging in `echo.Tar`. I enabled it only for `coderdtest.CreateTemplateVersion`, but can add it to more places if it isn't too noisy
* in debug mode provisioner reports ~~MD5~~ CRC32 checksum for files in the archive

Once this PR is merged:

```
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.219 [debu]  client.echo_tar: write proto  name=0.parse.protobuf  message="\x12\x00"
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.219 [debu]  client.echo_tar: proto written  name=0.parse.protobuf  size=2
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.219 [debu]  client.echo_tar: write proto  name=0.apply.protobuf ...
        message= "��
                 exampleaws_instance�
                 $da51a24a-9914-41b6-992f-967b1fd6e6dfexampleB1
                 golden-slugGolden Slug"http://localhost:1234J$a27f678f-a02e-422f-971a-38bc138ec68b
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.219 [debu]  client.echo_tar: proto written  name=0.apply.protobuf  size=168
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.219 [debu]  client.echo_tar: write proto  name=0.plan.protobuf ...
        message= V
                 first_parameterstring 
                 second_parameterbool 
                 third_parameternumber 
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.219 [debu]  client.echo_tar: proto written  name=0.plan.protobuf  size=88
```

```
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.223 [debu]  echo: read archive entry  session_id=56462801-0ae8-416f-924b-a1dca686fc0c  name=0.apply.protobuf  mod_time="1970-01-01T01:00:00+01:00"  size=168
    /Users/mtojek/code/coder/coderd/prometheusmetrics/insights/t.go:84: 2023-11-16 12:39:02.224 [debu]  echo: extracted file  session_id=56462801-0ae8-416f-924b-a1dca686fc0c  size_bytes=168  path=/var/folders/82/7tbcycl16pz_7rxv981qdqsh0000gn/T/TestCollectInsights4220252943/002/Session56462801-0ae8-416f-924b-a1dca686fc0c/0.apply.protobuf  mode=-rw-r--r--  checksum=7f74c7cc7f83c4940db761ed029f7da7
```