### PR TITLE
fix: close ssh sessions gracefully

### DIFF
--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -1,8 +1,15 @@
 package cli
 
 import (
+	"context"
 	"net/url"
 	"testing"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,4 +62,78 @@ func TestBuildWorkspaceLink(t *testing.T) {
 	workspaceLink := buildWorkspaceLink(serverURL, workspace)
 
 	assert.Equal(t, workspaceLink.String(), fakeServerURL+"/@"+fakeOwnerName+"/"+fakeWorkspaceName)
+}
+
+func TestCloserStack_Mainline(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	uut := newCloserStack(ctx, logger)
+	closes := new([]*fakeCloser)
+	fc0 := &fakeCloser{closes: closes}
+	fc1 := &fakeCloser{closes: closes}
+
+	func() {
+		defer uut.close(nil)
+		err := uut.push("fc0", fc0)
+		require.NoError(t, err)
+		err = uut.push("fc1", fc1)
+		require.NoError(t, err)
+	}()
+	// order reversed
+	require.Equal(t, []*fakeCloser{fc1, fc0}, *closes)
+}
+
+func TestCloserStack_Context(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	uut := newCloserStack(ctx, logger)
+	closes := new([]*fakeCloser)
+	fc0 := &fakeCloser{closes: closes}
+	fc1 := &fakeCloser{closes: closes}
+
+	err := uut.push("fc0", fc0)
+	require.NoError(t, err)
+	err = uut.push("fc1", fc1)
+	require.NoError(t, err)
+	cancel()
+	require.Eventually(t, func() bool {
+		uut.Lock()
+		defer uut.Unlock()
+		return uut.closed
+	}, testutil.WaitShort, testutil.IntervalFast)
+}
+
+func TestCloserStack_PushAfterClose(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	uut := newCloserStack(ctx, logger)
+	closes := new([]*fakeCloser)
+	fc0 := &fakeCloser{closes: closes}
+	fc1 := &fakeCloser{closes: closes}
+
+	err := uut.push("fc0", fc0)
+	require.NoError(t, err)
+
+	exErr := xerrors.New("test")
+	uut.close(exErr)
+	require.Equal(t, []*fakeCloser{fc0}, *closes)
+
+	err = uut.push("fc1", fc1)
+	require.ErrorIs(t, err, exErr)
+	require.Equal(t, []*fakeCloser{fc1, fc0}, *closes, "should close fc1")
+}
+
+type fakeCloser struct {
+	closes *[]*fakeCloser
+	err    error
+}
+
+func (c *fakeCloser) Close() error {
+	*c.closes = append(*c.closes, c)
+	return c.err
 }

--- a/codersdk/workspaceagentconn.go
+++ b/codersdk/workspaceagentconn.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/xerrors"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/speedtest"
 
@@ -249,7 +250,7 @@ func (c *WorkspaceAgentConn) ReconnectingPTY(ctx context.Context, id uuid.UUID, 
 
 // SSH pipes the SSH protocol over the returned net.Conn.
 // This connects to the built-in SSH server in the workspace agent.
-func (c *WorkspaceAgentConn) SSH(ctx context.Context) (net.Conn, error) {
+func (c *WorkspaceAgentConn) SSH(ctx context.Context) (*gonet.TCPConn, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 


### PR DESCRIPTION
Re-enables TestSSH/RemoteForward_Unix_Signal and addresses the underlying race: we were not closing the remote forward on context expiry, only the session and connection.

However, there is still a more fundamental issue in that we don't have the ability to ensure that TCP sessions are properly terminated before tearing down the Tailnet conn.  This is due to the assumption in the sockets API, that the underlying IP interface is long 
lived compared with the TCP socket, and thus closing a socket returns immediately and does not wait for the TCP termination handshake --- that is handled async in the tcpip stack.  However, this assumption does not hold for us and tailnet, since on shutdown,
we also tear down the tailnet connection, and this can race with the TCP termination.

Closing the remote forward explicitly should prevent forward state from accumulating, since the Close() function waits for a reply from the remote SSH server.

I've also attempted to workaround the TCP/tailnet issue for `--stdio` by using `CloseWrite()` instead of `Close()`.  By closing the write side of the connection, half-close the TCP connection, and the server detects this and closes the other direction, which then
triggers our read loop to exit only after the server has had a chance to process the close.

TODO in a stacked PR is to implement this logic for `vscodessh` as well.
