### PR TITLE
fix: accept legacy redirect HTTP environment variables

### DIFF
--- a/cli/clibase/cmd.go
+++ b/cli/clibase/cmd.go
@@ -226,6 +226,15 @@ func (inv *Invocation) SignalNotifyContext(parent context.Context, signals ...os
 	return inv.signalNotifyContext(parent, signals...)
 }
 
+func (inv *Invocation) WithTestParsedFlags(
+	_ testing.TB, // ensure we only call this from tests
+	parsedFlags *pflag.FlagSet,
+) *Invocation {
+	return inv.with(func(i *Invocation) {
+		i.parsedFlags = parsedFlags
+	})
+}
+
 func (inv *Invocation) Context() context.Context {
 	if inv.ctx == nil {
 		return context.Background()

--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -5,16 +5,15 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
-	"github.com/coder/coder/v2/testutil"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 const (

--- a/docs/admin/configure.md
+++ b/docs/admin/configure.md
@@ -29,7 +29,7 @@ export CODER_TLS_ENABLE=true
 export CODER_TLS_ADDRESS=0.0.0.0:443
 
 ## Redirect from HTTP to HTTPS
-export CODER_TLS_REDIRECT_HTTP=true
+export CODER_REDIRECT_TO_ACCESS_URL=true
 
 # Start the Coder server
 coder server


### PR DESCRIPTION
> Can someone help me understand the differences between these env variables:
>
>    CODER_REDIRECT_TO_ACCESS_URL
>    CODER_TLS_REDIRECT_HTTP_TO_HTTPS
>    CODER_TLS_REDIRECT_HTTP

Oh man, what a mess. It looks like `CODER_TLS_REDIRECT_HTTP ` appears in our config docs. Maybe that was the initial name for the environment variable?

At some point, both the flag and the environment variable were `--tls-redirect-http-to-https` and `CODER_TLS_REDIRECT_HTTP_TO_HTTPS`.  `CODER_TLS_REDIRECT_HTTP` did nothing.

However, then we introduced `CODER_REDIRECT_TO_ACCESS_URL`, we put in some deprecation code that was maybe fat-fingered such that we accept the environment variable `CODER_TLS_REDIRECT_HTTP` but the flag `--tls-redirect-http-to-https`.  Our docs still refer to `CODER_TLS_REDIRECT_HTTP` at https://coder.com/docs/v2/latest/admin/configure#address

So, I think what we gotta do is still accept `CODER_TLS_REDIRECT_HTTP` since it was working and in an example doc, but also fix the deprecation code to accept `CODER_TLS_REDIRECT_HTTP_TO_HTTPS` environment variable.
