### PR TITLE
fix(site): prevent overwriting of newest workspace data during optimistic updates

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -16,7 +16,7 @@ import {
   RichParameter,
 } from "./provisionerGenerated";
 import { prometheusPort, pprofPort } from "./constants";
-import { port, TEST_TIMEOUT } from "./playwright.config";
+import { port } from "./playwright.config";
 import * as ssh from "ssh2";
 import { Duplex } from "stream";
 import { WorkspaceBuildParameter } from "api/typesGenerated";
@@ -197,7 +197,6 @@ export const stopWorkspace = async (page: Page, workspaceName: string) => {
     "span[data-testid='build-status'] >> text=Stopped",
     {
       state: "visible",
-      timeout: TEST_TIMEOUT * 2,
     },
   );
 };

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -12,8 +12,6 @@ const coderMain = path.join(__dirname, "../../enterprise/cmd/coder");
 
 export const STORAGE_STATE = path.join(__dirname, ".auth.json");
 
-export const TEST_TIMEOUT = 60_000;
-
 const localURL = (port: number, path: string): string => {
   return `http://localhost:${port}${path}`;
 };
@@ -31,7 +29,7 @@ export default defineConfig({
       use: {
         storageState: STORAGE_STATE,
       },
-      timeout: TEST_TIMEOUT,
+      timeout: 60_000,
     },
   ],
   reporter: [["./reporter.ts"]],

--- a/site/src/api/queries/workspaces.ts
+++ b/site/src/api/queries/workspaces.ts
@@ -249,10 +249,18 @@ const updateWorkspaceBuild = async (
     build.workspace_name,
   );
   const previousData = queryClient.getQueryData(workspaceKey) as Workspace;
-  queryClient.setQueryData(workspaceKey, {
-    ...previousData,
-    latest_build: build,
-  });
+
+  // Check if the build returned is newer than the previous build that could be
+  // updated from web socket
+  const previousUpdate = new Date(previousData.latest_build.updated_at);
+  const newestUpdate = new Date(build.updated_at);
+  if (newestUpdate > previousUpdate) {
+    queryClient.setQueryData(workspaceKey, {
+      ...previousData,
+      latest_build: build,
+    });
+  }
+
   await queryClient.invalidateQueries({
     queryKey: workspaceBuildsKey(build.workspace_id),
   });


### PR DESCRIPTION
Fix https://github.com/coder/coder/issues/10747