### PR TITLE
fix: stop redirecting DERP and replicasync http requests

### DIFF
--- a/cli/server_internal_test.go
+++ b/cli/server_internal_test.go
@@ -243,3 +243,56 @@ func TestRedirectHTTPToHTTPSDeprecation(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDERPPath(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		path     string
+		expected bool
+	}{
+		//{
+		//	path:     "/derp",
+		//	expected: true,
+		//},
+		{
+			path:     "/derp/",
+			expected: true,
+		},
+		{
+			path:     "/derp/latency-check",
+			expected: true,
+		},
+		{
+			path:     "/derp/latency-check/",
+			expected: true,
+		},
+		{
+			path:     "",
+			expected: false,
+		},
+		{
+			path:     "/",
+			expected: false,
+		},
+		{
+			path:     "/derptastic",
+			expected: false,
+		},
+		{
+			path:     "/api/v2/derp",
+			expected: false,
+		},
+		{
+			path:     "//",
+			expected: false,
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, isDERPPath(tc.path))
+		})
+	}
+}

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -683,6 +683,12 @@ func TestServer(t *testing.T) {
 						require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 						require.Equal(t, c.expectRedirect, resp.Header.Get("Location"))
 					}
+
+					// We should never redirect DERP
+					respDERP, err := client.Request(ctx, http.MethodGet, "/derp", nil)
+					require.NoError(t, err)
+					defer respDERP.Body.Close()
+					require.Equal(t, http.StatusUpgradeRequired, respDERP.StatusCode)
 				}
 
 				// Verify TLS


### PR DESCRIPTION
Fixes an issue where setting CODER_REDIRECT_TO_ACCESS_URL breaks use of multiple Coder server replicas for DERP traffic.

