### PR TITLE
chore: return context.Canceled when in Prepare for rbac

### DIFF
--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -395,6 +395,7 @@ func (a RegoAuthorizer) Prepare(ctx context.Context, subject Subject, action Act
 
 	prepared, err := a.newPartialAuthorizer(ctx, subject, action, objectType)
 	if err != nil {
+		err = correctCancelError(err)
 		return nil, xerrors.Errorf("new partial authorizer: %w", err)
 	}
 

--- a/coderd/rbac/authz_internal_test.go
+++ b/coderd/rbac/authz_internal_test.go
@@ -1023,24 +1023,6 @@ func TestAuthorizeScope(t *testing.T) {
 	)
 }
 
-func TestCanceledPrepare(t *testing.T) {
-	t.Parallel()
-
-	authorizer := NewAuthorizer(prometheus.NewRegistry())
-	// This context is canceled intentionally to test the prepare error.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// The error should be a `context.Canceled` error.
-	// By default Rego throws a custom cancelled error.
-	_, err := authorizer.Prepare(ctx, Subject{
-		ID:    "foo",
-		Roles: RoleNames{RoleOwner()},
-		Scope: ScopeAll,
-	}, ActionRead, ResourceWorkspace.Type)
-	require.ErrorIs(t, err, context.Canceled, "expected canceled context")
-}
-
 // cases applies a given function to all test cases. This makes generalities easier to create.
 func cases(opt func(c authTestCase) authTestCase, cases []authTestCase) []authTestCase {
 	if opt == nil {


### PR DESCRIPTION
Was returning a custom rego canceled error. This conforms with how Authorize handles this error.

Closes https://github.com/coder/coder/issues/9986