### PR TITLE
fix: set `ignore_changes` on EC2 example templates

### DIFF
--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -255,6 +255,9 @@ resource "aws_instance" "dev" {
     # Required if you are using our example policy, see template README
     Coder_Provisioned = "true"
   }
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "coder_metadata" "workspace_info" {

--- a/examples/templates/aws-windows/main.tf
+++ b/examples/templates/aws-windows/main.tf
@@ -191,6 +191,9 @@ resource "aws_instance" "dev" {
     # Required if you are using our example policy, see template README
     Coder_Provisioned = "true"
   }
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "coder_metadata" "workspace_info" {


### PR DESCRIPTION
this PR sets `ignore_changes` on our example EC2 templates. a customer's EC2 workspace was inadvertently deleted due to the AMI changing underneath, so a `Stop` ended up replacing the instance.

`ignore_changes` will prevent this from happening again.