### PR TITLE
fix: prevent alt text from appearing if OIDC icon fail to load

### DIFF
--- a/site/src/pages/LoginPage/OAuthSignInForm.tsx
+++ b/site/src/pages/LoginPage/OAuthSignInForm.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import KeyIcon from "@mui/icons-material/VpnKey";
 import Box from "@mui/material/Box";
-import { type FC } from "react";
+import { useId, type FC } from "react";
 import { Language } from "./SignInForm";
 import { type AuthMethods } from "api/typesGenerated";
 
@@ -12,16 +12,16 @@ type OAuthSignInFormProps = {
   authMethods?: AuthMethods;
 };
 
+const iconStyles = {
+  width: 16,
+  height: 16,
+};
+
 export const OAuthSignInForm: FC<OAuthSignInFormProps> = ({
   isSigningIn,
   redirectTo,
   authMethods,
 }) => {
-  const iconStyles = {
-    width: 16,
-    height: 16,
-  };
-
   return (
     <Box display="grid" gap="16px">
       {authMethods?.github.enabled && (
@@ -51,11 +51,7 @@ export const OAuthSignInForm: FC<OAuthSignInFormProps> = ({
           size="xlarge"
           startIcon={
             authMethods.oidc.iconUrl ? (
-              <img
-                alt="Open ID Connect icon"
-                src={authMethods.oidc.iconUrl}
-                css={iconStyles}
-              />
+              <OidcIcon iconUrl={authMethods.oidc.iconUrl} />
             ) : (
               <KeyIcon css={iconStyles} />
             )
@@ -70,3 +66,22 @@ export const OAuthSignInForm: FC<OAuthSignInFormProps> = ({
     </Box>
   );
 };
+
+type OidcIconProps = {
+  iconUrl: string;
+};
+
+function OidcIcon({ iconUrl }: OidcIconProps) {
+  const hookId = useId();
+  const oidcId = `${hookId}-oidc`;
+
+  // Even if the URL is defined, there is a chance that the request for the
+  // image fails. Have to use blank alt text to avoid button from getting ugly
+  // if that happens, but also still need a way to inject accessible text
+  return (
+    <>
+      <img alt="" src={iconUrl} css={iconStyles} aria-labelledby={oidcId} />
+      <div id={oidcId}>Open ID Connect</div>
+    </>
+  );
+}

--- a/site/src/pages/LoginPage/OAuthSignInForm.tsx
+++ b/site/src/pages/LoginPage/OAuthSignInForm.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import KeyIcon from "@mui/icons-material/VpnKey";
 import Box from "@mui/material/Box";
-import { useId, type FC, CSSProperties } from "react";
+import { useId, type FC } from "react";
 import { Language } from "./SignInForm";
 import { type AuthMethods } from "api/typesGenerated";
 import { visuallyHidden } from "@mui/utils";

--- a/site/src/pages/LoginPage/OAuthSignInForm.tsx
+++ b/site/src/pages/LoginPage/OAuthSignInForm.tsx
@@ -2,9 +2,10 @@ import Button from "@mui/material/Button";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import KeyIcon from "@mui/icons-material/VpnKey";
 import Box from "@mui/material/Box";
-import { useId, type FC } from "react";
+import { useId, type FC, CSSProperties } from "react";
 import { Language } from "./SignInForm";
 import { type AuthMethods } from "api/typesGenerated";
+import { visuallyHidden } from "@mui/utils";
 
 type OAuthSignInFormProps = {
   isSigningIn: boolean;
@@ -81,7 +82,9 @@ function OidcIcon({ iconUrl }: OidcIconProps) {
   return (
     <>
       <img alt="" src={iconUrl} css={iconStyles} aria-labelledby={oidcId} />
-      <div id={oidcId}>Open ID Connect</div>
+      <div id={oidcId} css={{ ...visuallyHidden }}>
+        Open ID Connect
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Changes made
- Makes it so that if an OIDC icon fails to load on the login page, the alt text will not appear in the UI (but the text will still be available to screen readers)

## Next steps
- Just because we're using this special alt-text workaround in a few places, I feel like we should extract things out into a reusable component pretty soon