### PR TITLE
fix: only update last_used_at when connection count > 0

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1703,12 +1703,14 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 		return nil
 	})
 	errGroup.Go(func() error {
-		err := api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
-			ID:         workspace.ID,
-			LastUsedAt: now,
-		})
-		if err != nil {
-			return xerrors.Errorf("can't update workspace LastUsedAt: %w", err)
+		if req.ConnectionCount > 0 {
+			err := api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
+				ID:         workspace.ID,
+				LastUsedAt: now,
+			})
+			if err != nil {
+				return xerrors.Errorf("can't update workspace LastUsedAt: %w", err)
+			}
 		}
 		return nil
 	})

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1702,8 +1702,8 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 		}
 		return nil
 	})
-	errGroup.Go(func() error {
-		if req.ConnectionCount > 0 {
+	if req.SessionCount() > 0 {
+		errGroup.Go(func() error {
 			err := api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
 				ID:         workspace.ID,
 				LastUsedAt: now,
@@ -1711,9 +1711,9 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 			if err != nil {
 				return xerrors.Errorf("can't update workspace LastUsedAt: %w", err)
 			}
-		}
-		return nil
-	})
+			return nil
+		})
+	}
 	if api.Options.UpdateAgentMetrics != nil {
 		errGroup.Go(func() error {
 			user, err := api.Database.GetUserByID(ctx, workspace.OwnerID)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -857,17 +857,18 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 
 		_, err := agentClient.PostStats(context.Background(), &agentsdk.Stats{
 			ConnectionsByProto: map[string]int64{"TCP": 1},
-			// Set connection count to 0 to assert we aren't updating
-			// last_used_at.
-			ConnectionCount:             0,
+			// Set connection count to 1 but all session counts to zero to
+			// assert we aren't updating last_used_at for a connections that may
+			// be spawned passively by the dashboard.
+			ConnectionCount:             1,
 			RxPackets:                   1,
 			RxBytes:                     1,
 			TxPackets:                   1,
 			TxBytes:                     1,
-			SessionCountVSCode:          1,
-			SessionCountJetBrains:       1,
-			SessionCountReconnectingPTY: 1,
-			SessionCountSSH:             1,
+			SessionCountVSCode:          0,
+			SessionCountJetBrains:       0,
+			SessionCountReconnectingPTY: 0,
+			SessionCountSSH:             0,
 			ConnectionMedianLatencyMS:   10,
 		})
 		require.NoError(t, err)
@@ -888,9 +889,9 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 			TxPackets:                   1,
 			TxBytes:                     1,
 			SessionCountVSCode:          1,
-			SessionCountJetBrains:       1,
-			SessionCountReconnectingPTY: 1,
-			SessionCountSSH:             1,
+			SessionCountJetBrains:       0,
+			SessionCountReconnectingPTY: 0,
+			SessionCountSSH:             0,
 			ConnectionMedianLatencyMS:   10,
 		})
 		require.NoError(t, err)

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -573,6 +573,10 @@ type Stats struct {
 	Metrics []AgentMetric `json:"metrics"`
 }
 
+func (s Stats) SessionCount() int64 {
+	return s.SessionCountVSCode + s.SessionCountJetBrains + s.SessionCountReconnectingPTY + s.SessionCountSSH
+}
+
 type AgentMetricType string
 
 const (


### PR DESCRIPTION
Fixes stats reporting to only update `last_used_at` when the connection count is > 0.