### PR TITLE
chore: remove dbfake.WorkspaceBuild in favor of builder pattern

### DIFF
--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -69,7 +69,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -77,7 +77,7 @@ func TestWorkspaceAgent(t *testing.T) {
 					InstanceId: instanceID,
 				},
 			}},
-		})
+		}).Do()
 
 		inv, _ := clitest.New(t, "agent", "--auth", "azure-instance-identity", "--agent-url", client.URL.String())
 		inv = inv.WithContext(
@@ -112,7 +112,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -120,7 +120,7 @@ func TestWorkspaceAgent(t *testing.T) {
 					InstanceId: instanceID,
 				},
 			}},
-		})
+		}).Do()
 
 		inv, _ := clitest.New(t, "agent", "--auth", "aws-instance-identity", "--agent-url", client.URL.String())
 		inv = inv.WithContext(
@@ -156,7 +156,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        memberUser.ID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Name: "somename",
 			Type: "someinstance",
 			Agents: []*proto.Agent{{
@@ -164,7 +164,7 @@ func TestWorkspaceAgent(t *testing.T) {
 					InstanceId: instanceID,
 				},
 			}},
-		})
+		}).Do()
 		inv, cfg := clitest.New(t, "agent", "--auth", "google-instance-identity", "--agent-url", client.URL.String())
 		clitest.SetupConfig(t, member, cfg)
 

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -696,7 +696,7 @@ func TestConfigSSH_Hostnames(t *testing.T) {
 				OrganizationID: owner.OrganizationID,
 				OwnerID:        memberUser.ID,
 			})
-			dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, resources...)
+			dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(resources...).Do()
 			sshConfigFile := sshConfigFileName(t)
 
 			inv, root := clitest.New(t, "config-ssh", "--ssh-config-file", sshConfigFile)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -151,7 +151,7 @@ func TestSSH(t *testing.T) {
 		pty.WriteLine("echo hell'o'")
 		pty.ExpectMatchContext(ctx, "hello")
 
-		_ = dbfake.WorkspaceBuildBuilder(t, store, workspace).
+		_ = dbfake.NewWorkspaceBuildBuilder(t, store, workspace).
 			Seed(database.WorkspaceBuild{
 				Transition:  database.WorkspaceTransitionStop,
 				BuildNumber: 2,
@@ -520,7 +520,7 @@ func TestSSH(t *testing.T) {
 		err = session.Shell()
 		require.NoError(t, err)
 
-		_ = dbfake.WorkspaceBuildBuilder(t, store, workspace).
+		_ = dbfake.NewWorkspaceBuildBuilder(t, store, workspace).
 			Seed(database.WorkspaceBuild{
 				Transition:  database.WorkspaceTransitionStop,
 				BuildNumber: 2,

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -50,13 +50,13 @@ func TestWorkspaceAgent(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        anotherUser.ID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Name: "aws_instance",
 			Agents: []*proto.Agent{{
 				Id:        uuid.NewString(),
 				Directory: tmpDir,
 			}},
-		})
+		}).Do()
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 		workspace, err := anotherClient.Workspace(ctx, ws.ID)
@@ -75,13 +75,13 @@ func TestWorkspaceAgent(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Name: "aws_instance",
 			Agents: []*proto.Agent{{
 				Id:        uuid.NewString(),
 				Directory: tmpDir,
 			}},
-		})
+		}).Do()
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 		defer cancel()
@@ -107,7 +107,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			OwnerID:        user.UserID,
 			OrganizationID: user.OrganizationID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Name: "example",
 			Type: "aws_instance",
 			Agents: []*proto.Agent{{
@@ -119,7 +119,7 @@ func TestWorkspaceAgent(t *testing.T) {
 				ConnectionTimeoutSeconds: 1,
 				TroubleshootingUrl:       wantTroubleshootingURL,
 			}},
-		})
+		}).Do()
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 		defer cancel()
@@ -156,7 +156,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			PortForwardingHelper: true,
 			SshHelper:            true,
 		}
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Agents: []*proto.Agent{
 				{
 					Directory: tmpDir,
@@ -166,7 +166,7 @@ func TestWorkspaceAgent(t *testing.T) {
 					DisplayApps: apps,
 				},
 			},
-		})
+		}).Do()
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -196,7 +196,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		})
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Agents: []*proto.Agent{
 				{
 					Directory: tmpDir,
@@ -206,7 +206,7 @@ func TestWorkspaceAgent(t *testing.T) {
 					DisplayApps: apps,
 				},
 			},
-		})
+		}).Do()
 		workspace, err = client.Workspace(ctx, ws.ID)
 		require.NoError(t, err)
 
@@ -543,14 +543,14 @@ func TestWorkspaceAgentListeningPorts(t *testing.T) {
 			OwnerID:        user.UserID,
 		})
 		authToken := uuid.NewString()
-		dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+		dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 			Agents: []*proto.Agent{{
 				Apps: apps,
 				Auth: &proto.Agent_Token{
 					Token: authToken,
 				},
 			}},
-		})
+		}).Do()
 		_ = agenttest.New(t, client.URL, authToken)
 		resources := coderdtest.AwaitWorkspaceAgents(t, client, ws.ID)
 		return client, uint16(coderdPort), resources[0].Agents[0].ID
@@ -776,7 +776,7 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
-	dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+	dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 		Name: "example",
 		Type: "aws_instance",
 		Agents: []*proto.Agent{{
@@ -786,7 +786,7 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 			},
 			Apps: apps,
 		}},
-	})
+	}).Do()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
@@ -958,7 +958,7 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
-	dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+	dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 		Name: "example",
 		Type: "aws_instance",
 		Agents: []*proto.Agent{{
@@ -990,7 +990,7 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 				Token: authToken,
 			},
 		}},
-	})
+	}).Do()
 	workspace, err := client.Workspace(context.Background(), ws.ID)
 	require.NoError(t, err)
 	for _, res := range workspace.LatestBuild.Resources {
@@ -1141,7 +1141,7 @@ func TestWorkspaceAgent_Metadata_CatchMemoryLeak(t *testing.T) {
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	})
-	dbfake.WorkspaceBuild(t, db, ws, database.WorkspaceBuild{}, &proto.Resource{
+	dbfake.NewWorkspaceBuildBuilder(t, db, ws).Resource(&proto.Resource{
 		Name: "example",
 		Type: "aws_instance",
 		Agents: []*proto.Agent{{
@@ -1166,7 +1166,7 @@ func TestWorkspaceAgent_Metadata_CatchMemoryLeak(t *testing.T) {
 				Token: authToken,
 			},
 		}},
-	})
+	}).Do()
 	workspace, err := client.Workspace(context.Background(), ws.ID)
 	require.NoError(t, err)
 	for _, res := range workspace.LatestBuild.Resources {


### PR DESCRIPTION
I'd like to convert dbfake into a builder pattern to prevent a proliferation of XXXWithYYY methods.  This is one step of the way by removing the Non-builder function.
