### PR TITLE
fix: preserve order of node reports in healthcheck

### DIFF
--- a/coderd/healthcheck/derphealth/derp.go
+++ b/coderd/healthcheck/derphealth/derp.go
@@ -188,7 +188,7 @@ func (r *RegionReport) Run(ctx context.Context) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.NodeReports = sortedNodeReports(r.NodeReports)
+	sortNodeReports(r.NodeReports)
 
 	// Coder allows for 1 unhealthy node in the region, unless there is only 1 node.
 	if len(r.Region.Nodes) == 1 {
@@ -500,12 +500,8 @@ func convertError(err error) *string {
 	return nil
 }
 
-func sortedNodeReports(reports []*NodeReport) []*NodeReport {
-	sorted := make([]*NodeReport, len(reports))
-	copy(sorted, reports)
-
-	slices.SortFunc(sorted, func(a, b *NodeReport) int {
+func sortNodeReports(reports []*NodeReport) {
+	slices.SortFunc(reports, func(a, b *NodeReport) int {
 		return slice.Ascending(a.Node.Name, b.Node.Name)
 	})
-	return sorted
 }

--- a/coderd/healthcheck/derphealth/derp_test.go
+++ b/coderd/healthcheck/derphealth/derp_test.go
@@ -83,7 +83,6 @@ func TestDERP(t *testing.T) {
 
 	t.Run("HealthyWithNodeDegraded", func(t *testing.T) {
 		t.Parallel()
-		t.Skip("https://github.com/coder/coder/issues/10824")
 
 		healthyDerpSrv := derp.NewServer(key.NewNode(), func(format string, args ...any) { t.Logf(format, args...) })
 		defer healthyDerpSrv.Close()


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/10824

The current `HealthyWithNodeDegraded` test implementation assumes that the order of node reports is stable and sorted by node name. Unfortunately, that assumption was wrong, so this PR modifies the healthcheck logic to preserve the order.