### PR TITLE
fix(site): use correct default insights time for day interval

### DIFF
--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -25,7 +25,14 @@ import {
   useId,
 } from "react";
 import chroma from "chroma-js";
-import { subDays, addWeeks, format, startOfDay } from "date-fns";
+import {
+  subDays,
+  addWeeks,
+  format,
+  startOfDay,
+  startOfHour,
+  addHours,
+} from "date-fns";
 import { useSearchParams } from "react-router-dom";
 import "react-date-range/dist/styles.css";
 import "react-date-range/dist/theme/default.css";
@@ -152,7 +159,8 @@ const getDateRange = (
     const today = new Date();
     return {
       startDate: startOfDay(subDays(today, 6)),
-      endDate: today,
+      // Add one hour to endDate to include real-time data for today.
+      endDate: addHours(startOfHour(today), 1),
     };
   }
 

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -25,7 +25,7 @@ import {
   useId,
 } from "react";
 import chroma from "chroma-js";
-import { subDays, addWeeks, format } from "date-fns";
+import { subDays, addWeeks, format, startOfDay } from "date-fns";
 import { useSearchParams } from "react-router-dom";
 import "react-date-range/dist/styles.css";
 import "react-date-range/dist/theme/default.css";
@@ -146,9 +146,13 @@ const getDateRange = (
   }
 
   if (interval === "day") {
+    // Only instantiate new Date once so that we don't get the wrong interval if
+    // start is 23:59:59.999 and the clock shifts to 00:00:00 before the second
+    // instantiation.
+    const today = new Date();
     return {
-      startDate: subDays(new Date(), 6),
-      endDate: new Date(),
+      startDate: startOfDay(subDays(today, 6)),
+      endDate: today,
     };
   }
 


### PR DESCRIPTION
API requests were being made without fixing the clock due to default values relying on `new Date` without truncating. E.g.

```
start_time: 2023-11-16T14:34:23+02:00
end_time: 2023-11-22T14:34:23+02:00
```

```
{
	"message": "Query parameter has invalid value.",
	"validations": [
		{
			"field": "start_time",
			"detail": "Query param \"start_time\" must have the clock set to 00:00:00"
		}
	]
}
```

This change fixes both start and end, and takes into account corner cases like day changing between two invocations of `new Date()`.