### PR TITLE
fix(coderd): prevent logging error for query cancellation in `watchWorkspaceAgentMetadata`

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1979,7 +1979,7 @@ func (api *API) watchWorkspaceAgentMetadata(rw http.ResponseWriter, r *http.Requ
 					Keys:             payload.Keys,
 				})
 				if err != nil {
-					if !errors.Is(err, context.Canceled) {
+					if !database.IsQueryCanceledError(err) {
 						log.Error(ctx, "failed to get metadata", slog.Error(err))
 						_ = sseSendEvent(ctx, codersdk.ServerSentEvent{
 							Type: codersdk.ServerSentEventTypeError,


### PR DESCRIPTION
Fixes logging and (hopefully) flake seen in:

https://github.com/coder/coder/actions/runs/6959190289/job/18935916080?pr=10842
