### PR TITLE
feat: add database support for dismissed healthchecks

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -948,6 +948,10 @@ func (q *querier) GetDeploymentWorkspaceStats(ctx context.Context) (database.Get
 	return q.db.GetDeploymentWorkspaceStats(ctx)
 }
 
+func (q *querier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
+	panic("not implemented")
+}
+
 func (q *querier) GetExternalAuthLink(ctx context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	return fetch(q.log, q.auth, q.db.GetExternalAuthLink)(ctx, arg)
 }
@@ -2956,6 +2960,10 @@ func (q *querier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDef
 		return err
 	}
 	return q.db.UpsertDefaultProxy(ctx, arg)
+}
+
+func (q *querier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
+	panic("not implemented")
 }
 
 func (q *querier) UpsertLastUpdateCheck(ctx context.Context, value string) error {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -948,11 +948,6 @@ func (q *querier) GetDeploymentWorkspaceStats(ctx context.Context) (database.Get
 	return q.db.GetDeploymentWorkspaceStats(ctx)
 }
 
-func (q *querier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
-	// No authz checks
-	return q.db.GetDismissedHealthchecks(ctx)
-}
-
 func (q *querier) GetExternalAuthLink(ctx context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	return fetch(q.log, q.auth, q.db.GetExternalAuthLink)(ctx, arg)
 }
@@ -1024,6 +1019,11 @@ func (q *querier) GetGroupMembers(ctx context.Context, id uuid.UUID) ([]database
 
 func (q *querier) GetGroupsByOrganizationID(ctx context.Context, organizationID uuid.UUID) ([]database.Group, error) {
 	return fetchWithPostFilter(q.auth, q.db.GetGroupsByOrganizationID)(ctx, organizationID)
+}
+
+func (q *querier) GetHealthSettings(ctx context.Context) (string, error) {
+	// No authz checks
+	return q.db.GetHealthSettings(ctx)
 }
 
 // TODO: We need to create a ProvisionerJob resource type
@@ -2963,11 +2963,11 @@ func (q *querier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDef
 	return q.db.UpsertDefaultProxy(ctx, arg)
 }
 
-func (q *querier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
+func (q *querier) UpsertHealthSettings(ctx context.Context, value string) error {
 	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
-	return q.db.UpsertDismissedHealthchecks(ctx, value)
+	return q.db.UpsertHealthSettings(ctx, value)
 }
 
 func (q *querier) UpsertLastUpdateCheck(ctx context.Context, value string) error {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -949,7 +949,8 @@ func (q *querier) GetDeploymentWorkspaceStats(ctx context.Context) (database.Get
 }
 
 func (q *querier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
-	panic("not implemented")
+	// No authz checks
+	return q.db.GetDismissedHealthchecks(ctx)
 }
 
 func (q *querier) GetExternalAuthLink(ctx context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
@@ -2963,7 +2964,10 @@ func (q *querier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDef
 }
 
 func (q *querier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
-	panic("not implemented")
+	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
+		return err
+	}
+	return q.db.UpsertDismissedHealthchecks(ctx, value)
 }
 
 func (q *querier) UpsertLastUpdateCheck(ctx context.Context, value string) error {

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1777,7 +1777,7 @@ func (q *FakeQuerier) GetHealthSettings(_ context.Context) (string, error) {
 	defer q.mutex.RUnlock()
 
 	if q.healthSettings == nil {
-		return "", sql.ErrNoRows
+		return "{}", nil
 	}
 
 	return string(q.healthSettings), nil

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1591,6 +1591,10 @@ func (q *FakeQuerier) GetDeploymentWorkspaceStats(ctx context.Context) (database
 	return stat, nil
 }
 
+func (q *FakeQuerier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
+	panic("not implemented")
+}
+
 func (q *FakeQuerier) GetExternalAuthLink(_ context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	if err := validateDatabaseType(arg); err != nil {
 		return database.ExternalAuthLink{}, err
@@ -6788,6 +6792,10 @@ func (q *FakeQuerier) UpsertDefaultProxy(_ context.Context, arg database.UpsertD
 	q.defaultProxyDisplayName = arg.DisplayName
 	q.defaultProxyIconURL = arg.IconUrl
 	return nil
+}
+
+func (q *FakeQuerier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
+	panic("not implemented")
 }
 
 func (q *FakeQuerier) UpsertLastUpdateCheck(_ context.Context, data string) error {

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -6802,7 +6802,7 @@ func (q *FakeQuerier) UpsertDefaultProxy(_ context.Context, arg database.UpsertD
 	return nil
 }
 
-func (q *FakeQuerier) UpsertDismissedHealthchecks(ctx context.Context, data string) error {
+func (q *FakeQuerier) UpsertDismissedHealthchecks(_ context.Context, data string) error {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1592,7 +1592,7 @@ func (q *FakeQuerier) GetDeploymentWorkspaceStats(ctx context.Context) (database
 	return stat, nil
 }
 
-func (q *FakeQuerier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
+func (q *FakeQuerier) GetDismissedHealthchecks(_ context.Context) (string, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -159,6 +159,7 @@ type data struct {
 	derpMeshKey             string
 	lastUpdateCheck         []byte
 	serviceBanner           []byte
+	dismissedHealthchecks   []byte
 	applicationName         string
 	logoURL                 string
 	appSecurityKey          string
@@ -1592,7 +1593,14 @@ func (q *FakeQuerier) GetDeploymentWorkspaceStats(ctx context.Context) (database
 }
 
 func (q *FakeQuerier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
-	panic("not implemented")
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	if q.dismissedHealthchecks == nil {
+		return "", sql.ErrNoRows
+	}
+
+	return string(q.dismissedHealthchecks), nil
 }
 
 func (q *FakeQuerier) GetExternalAuthLink(_ context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
@@ -6794,8 +6802,12 @@ func (q *FakeQuerier) UpsertDefaultProxy(_ context.Context, arg database.UpsertD
 	return nil
 }
 
-func (q *FakeQuerier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
-	panic("not implemented")
+func (q *FakeQuerier) UpsertDismissedHealthchecks(ctx context.Context, data string) error {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	q.dismissedHealthchecks = []byte(data)
+	return nil
 }
 
 func (q *FakeQuerier) UpsertLastUpdateCheck(_ context.Context, data string) error {

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -159,7 +159,7 @@ type data struct {
 	derpMeshKey             string
 	lastUpdateCheck         []byte
 	serviceBanner           []byte
-	dismissedHealthchecks   []byte
+	healthSettings          []byte
 	applicationName         string
 	logoURL                 string
 	appSecurityKey          string
@@ -1592,17 +1592,6 @@ func (q *FakeQuerier) GetDeploymentWorkspaceStats(ctx context.Context) (database
 	return stat, nil
 }
 
-func (q *FakeQuerier) GetDismissedHealthchecks(_ context.Context) (string, error) {
-	q.mutex.RLock()
-	defer q.mutex.RUnlock()
-
-	if q.dismissedHealthchecks == nil {
-		return "", sql.ErrNoRows
-	}
-
-	return string(q.dismissedHealthchecks), nil
-}
-
 func (q *FakeQuerier) GetExternalAuthLink(_ context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	if err := validateDatabaseType(arg); err != nil {
 		return database.ExternalAuthLink{}, err
@@ -1781,6 +1770,17 @@ func (q *FakeQuerier) GetGroupsByOrganizationID(_ context.Context, id uuid.UUID)
 	}
 
 	return groups, nil
+}
+
+func (q *FakeQuerier) GetHealthSettings(_ context.Context) (string, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	if q.healthSettings == nil {
+		return "", sql.ErrNoRows
+	}
+
+	return string(q.healthSettings), nil
 }
 
 func (q *FakeQuerier) GetHungProvisionerJobs(_ context.Context, hungSince time.Time) ([]database.ProvisionerJob, error) {
@@ -6802,11 +6802,11 @@ func (q *FakeQuerier) UpsertDefaultProxy(_ context.Context, arg database.UpsertD
 	return nil
 }
 
-func (q *FakeQuerier) UpsertDismissedHealthchecks(_ context.Context, data string) error {
+func (q *FakeQuerier) UpsertHealthSettings(_ context.Context, data string) error {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
-	q.dismissedHealthchecks = []byte(data)
+	q.healthSettings = []byte(data)
 	return nil
 }
 

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -391,13 +391,6 @@ func (m metricsStore) GetDeploymentWorkspaceStats(ctx context.Context) (database
 	return row, err
 }
 
-func (m metricsStore) GetDismissedHealthchecks(ctx context.Context) (string, error) {
-	start := time.Now()
-	r0, r1 := m.s.GetDismissedHealthchecks(ctx)
-	m.queryLatencies.WithLabelValues("GetDismissedHealthchecks").Observe(time.Since(start).Seconds())
-	return r0, r1
-}
-
 func (m metricsStore) GetExternalAuthLink(ctx context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	start := time.Now()
 	link, err := m.s.GetExternalAuthLink(ctx, arg)
@@ -466,6 +459,13 @@ func (m metricsStore) GetGroupsByOrganizationID(ctx context.Context, organizatio
 	groups, err := m.s.GetGroupsByOrganizationID(ctx, organizationID)
 	m.queryLatencies.WithLabelValues("GetGroupsByOrganizationID").Observe(time.Since(start).Seconds())
 	return groups, err
+}
+
+func (m metricsStore) GetHealthSettings(ctx context.Context) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetHealthSettings(ctx)
+	m.queryLatencies.WithLabelValues("GetHealthSettings").Observe(time.Since(start).Seconds())
+	return r0, r1
 }
 
 func (m metricsStore) GetHungProvisionerJobs(ctx context.Context, hungSince time.Time) ([]database.ProvisionerJob, error) {
@@ -1873,10 +1873,10 @@ func (m metricsStore) UpsertDefaultProxy(ctx context.Context, arg database.Upser
 	return r0
 }
 
-func (m metricsStore) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
+func (m metricsStore) UpsertHealthSettings(ctx context.Context, value string) error {
 	start := time.Now()
-	r0 := m.s.UpsertDismissedHealthchecks(ctx, value)
-	m.queryLatencies.WithLabelValues("UpsertDismissedHealthchecks").Observe(time.Since(start).Seconds())
+	r0 := m.s.UpsertHealthSettings(ctx, value)
+	m.queryLatencies.WithLabelValues("UpsertHealthSettings").Observe(time.Since(start).Seconds())
 	return r0
 }
 

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -391,6 +391,13 @@ func (m metricsStore) GetDeploymentWorkspaceStats(ctx context.Context) (database
 	return row, err
 }
 
+func (m metricsStore) GetDismissedHealthchecks(ctx context.Context) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetDismissedHealthchecks(ctx)
+	m.queryLatencies.WithLabelValues("GetDismissedHealthchecks").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m metricsStore) GetExternalAuthLink(ctx context.Context, arg database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	start := time.Now()
 	link, err := m.s.GetExternalAuthLink(ctx, arg)
@@ -1863,6 +1870,13 @@ func (m metricsStore) UpsertDefaultProxy(ctx context.Context, arg database.Upser
 	start := time.Now()
 	r0 := m.s.UpsertDefaultProxy(ctx, arg)
 	m.queryLatencies.WithLabelValues("UpsertDefaultProxy").Observe(time.Since(start).Seconds())
+	return r0
+}
+
+func (m metricsStore) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
+	start := time.Now()
+	r0 := m.s.UpsertDismissedHealthchecks(ctx, value)
+	m.queryLatencies.WithLabelValues("UpsertDismissedHealthchecks").Observe(time.Since(start).Seconds())
 	return r0
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -742,6 +742,21 @@ func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceStats(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceStats), arg0)
 }
 
+// GetDismissedHealthchecks mocks base method.
+func (m *MockStore) GetDismissedHealthchecks(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDismissedHealthchecks", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDismissedHealthchecks indicates an expected call of GetDismissedHealthchecks.
+func (mr *MockStoreMockRecorder) GetDismissedHealthchecks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDismissedHealthchecks", reflect.TypeOf((*MockStore)(nil).GetDismissedHealthchecks), arg0)
+}
+
 // GetExternalAuthLink mocks base method.
 func (m *MockStore) GetExternalAuthLink(arg0 context.Context, arg1 database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	m.ctrl.T.Helper()
@@ -3915,6 +3930,20 @@ func (m *MockStore) UpsertDefaultProxy(arg0 context.Context, arg1 database.Upser
 func (mr *MockStoreMockRecorder) UpsertDefaultProxy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDefaultProxy", reflect.TypeOf((*MockStore)(nil).UpsertDefaultProxy), arg0, arg1)
+}
+
+// UpsertDismissedHealthchecks mocks base method.
+func (m *MockStore) UpsertDismissedHealthchecks(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertDismissedHealthchecks", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertDismissedHealthchecks indicates an expected call of UpsertDismissedHealthchecks.
+func (mr *MockStoreMockRecorder) UpsertDismissedHealthchecks(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDismissedHealthchecks", reflect.TypeOf((*MockStore)(nil).UpsertDismissedHealthchecks), arg0, arg1)
 }
 
 // UpsertLastUpdateCheck mocks base method.

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -742,21 +742,6 @@ func (mr *MockStoreMockRecorder) GetDeploymentWorkspaceStats(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentWorkspaceStats", reflect.TypeOf((*MockStore)(nil).GetDeploymentWorkspaceStats), arg0)
 }
 
-// GetDismissedHealthchecks mocks base method.
-func (m *MockStore) GetDismissedHealthchecks(arg0 context.Context) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDismissedHealthchecks", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDismissedHealthchecks indicates an expected call of GetDismissedHealthchecks.
-func (mr *MockStoreMockRecorder) GetDismissedHealthchecks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDismissedHealthchecks", reflect.TypeOf((*MockStore)(nil).GetDismissedHealthchecks), arg0)
-}
-
 // GetExternalAuthLink mocks base method.
 func (m *MockStore) GetExternalAuthLink(arg0 context.Context, arg1 database.GetExternalAuthLinkParams) (database.ExternalAuthLink, error) {
 	m.ctrl.T.Helper()
@@ -905,6 +890,21 @@ func (m *MockStore) GetGroupsByOrganizationID(arg0 context.Context, arg1 uuid.UU
 func (mr *MockStoreMockRecorder) GetGroupsByOrganizationID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupsByOrganizationID", reflect.TypeOf((*MockStore)(nil).GetGroupsByOrganizationID), arg0, arg1)
+}
+
+// GetHealthSettings mocks base method.
+func (m *MockStore) GetHealthSettings(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHealthSettings", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHealthSettings indicates an expected call of GetHealthSettings.
+func (mr *MockStoreMockRecorder) GetHealthSettings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHealthSettings", reflect.TypeOf((*MockStore)(nil).GetHealthSettings), arg0)
 }
 
 // GetHungProvisionerJobs mocks base method.
@@ -3932,18 +3932,18 @@ func (mr *MockStoreMockRecorder) UpsertDefaultProxy(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDefaultProxy", reflect.TypeOf((*MockStore)(nil).UpsertDefaultProxy), arg0, arg1)
 }
 
-// UpsertDismissedHealthchecks mocks base method.
-func (m *MockStore) UpsertDismissedHealthchecks(arg0 context.Context, arg1 string) error {
+// UpsertHealthSettings mocks base method.
+func (m *MockStore) UpsertHealthSettings(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertDismissedHealthchecks", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpsertHealthSettings", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpsertDismissedHealthchecks indicates an expected call of UpsertDismissedHealthchecks.
-func (mr *MockStoreMockRecorder) UpsertDismissedHealthchecks(arg0, arg1 interface{}) *gomock.Call {
+// UpsertHealthSettings indicates an expected call of UpsertHealthSettings.
+func (mr *MockStoreMockRecorder) UpsertHealthSettings(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDismissedHealthchecks", reflect.TypeOf((*MockStore)(nil).UpsertDismissedHealthchecks), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertHealthSettings", reflect.TypeOf((*MockStore)(nil).UpsertHealthSettings), arg0, arg1)
 }
 
 // UpsertLastUpdateCheck mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -89,6 +89,7 @@ type sqlcQuerier interface {
 	GetDeploymentID(ctx context.Context) (string, error)
 	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
 	GetDeploymentWorkspaceStats(ctx context.Context) (GetDeploymentWorkspaceStatsRow, error)
+	GetDismissedHealthchecks(ctx context.Context) (string, error)
 	GetExternalAuthLink(ctx context.Context, arg GetExternalAuthLinkParams) (ExternalAuthLink, error)
 	GetExternalAuthLinksByUserID(ctx context.Context, userID uuid.UUID) ([]ExternalAuthLink, error)
 	GetFileByHashAndCreator(ctx context.Context, arg GetFileByHashAndCreatorParams) (File, error)
@@ -356,6 +357,7 @@ type sqlcQuerier interface {
 	// So we need to store it's configuration here for display purposes.
 	// The functional values are immutable and controlled implicitly.
 	UpsertDefaultProxy(ctx context.Context, arg UpsertDefaultProxyParams) error
+	UpsertDismissedHealthchecks(ctx context.Context, value string) error
 	UpsertLastUpdateCheck(ctx context.Context, value string) error
 	UpsertLogoURL(ctx context.Context, value string) error
 	UpsertOAuthSigningKey(ctx context.Context, value string) error

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -89,7 +89,6 @@ type sqlcQuerier interface {
 	GetDeploymentID(ctx context.Context) (string, error)
 	GetDeploymentWorkspaceAgentStats(ctx context.Context, createdAt time.Time) (GetDeploymentWorkspaceAgentStatsRow, error)
 	GetDeploymentWorkspaceStats(ctx context.Context) (GetDeploymentWorkspaceStatsRow, error)
-	GetDismissedHealthchecks(ctx context.Context) (string, error)
 	GetExternalAuthLink(ctx context.Context, arg GetExternalAuthLinkParams) (ExternalAuthLink, error)
 	GetExternalAuthLinksByUserID(ctx context.Context, userID uuid.UUID) ([]ExternalAuthLink, error)
 	GetFileByHashAndCreator(ctx context.Context, arg GetFileByHashAndCreatorParams) (File, error)
@@ -103,6 +102,7 @@ type sqlcQuerier interface {
 	// If it is the "Everyone" group, then we need to check the organization_members table.
 	GetGroupMembers(ctx context.Context, groupID uuid.UUID) ([]User, error)
 	GetGroupsByOrganizationID(ctx context.Context, organizationID uuid.UUID) ([]Group, error)
+	GetHealthSettings(ctx context.Context) (string, error)
 	GetHungProvisionerJobs(ctx context.Context, updatedAt time.Time) ([]ProvisionerJob, error)
 	GetLastUpdateCheck(ctx context.Context) (string, error)
 	GetLatestWorkspaceBuildByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (WorkspaceBuild, error)
@@ -357,7 +357,7 @@ type sqlcQuerier interface {
 	// So we need to store it's configuration here for display purposes.
 	// The functional values are immutable and controlled implicitly.
 	UpsertDefaultProxy(ctx context.Context, arg UpsertDefaultProxyParams) error
-	UpsertDismissedHealthchecks(ctx context.Context, value string) error
+	UpsertHealthSettings(ctx context.Context, value string) error
 	UpsertLastUpdateCheck(ctx context.Context, value string) error
 	UpsertLogoURL(ctx context.Context, value string) error
 	UpsertOAuthSigningKey(ctx context.Context, value string) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4344,12 +4344,12 @@ func (q *sqlQuerier) GetDeploymentID(ctx context.Context) (string, error) {
 	return value, err
 }
 
-const getDismissedHealthchecks = `-- name: GetDismissedHealthchecks :one
-SELECT value FROM site_configs WHERE key = 'dismissed_healthchecks'
+const getHealthSettings = `-- name: GetHealthSettings :one
+SELECT COALESCE(value, '{}') FROM site_configs WHERE key = 'health_settings'
 `
 
-func (q *sqlQuerier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getDismissedHealthchecks)
+func (q *sqlQuerier) GetHealthSettings(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getHealthSettings)
 	var value string
 	err := row.Scan(&value)
 	return value, err
@@ -4460,13 +4460,13 @@ func (q *sqlQuerier) UpsertDefaultProxy(ctx context.Context, arg UpsertDefaultPr
 	return err
 }
 
-const upsertDismissedHealthchecks = `-- name: UpsertDismissedHealthchecks :exec
-INSERT INTO site_configs (key, value) VALUES ('dismissed_healthchecks', $1)
-ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'dismissed_healthchecks'
+const upsertHealthSettings = `-- name: UpsertHealthSettings :exec
+INSERT INTO site_configs (key, value) VALUES ('health_settings', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'health_settings'
 `
 
-func (q *sqlQuerier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, upsertDismissedHealthchecks, value)
+func (q *sqlQuerier) UpsertHealthSettings(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, upsertHealthSettings, value)
 	return err
 }
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4345,14 +4345,15 @@ func (q *sqlQuerier) GetDeploymentID(ctx context.Context) (string, error) {
 }
 
 const getHealthSettings = `-- name: GetHealthSettings :one
-SELECT COALESCE(value, '{}') FROM site_configs WHERE key = 'health_settings'
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'health_settings'), '{}') :: text AS health_settings
 `
 
 func (q *sqlQuerier) GetHealthSettings(ctx context.Context) (string, error) {
 	row := q.db.QueryRowContext(ctx, getHealthSettings)
-	var value string
-	err := row.Scan(&value)
-	return value, err
+	var health_settings string
+	err := row.Scan(&health_settings)
+	return health_settings, err
 }
 
 const getLastUpdateCheck = `-- name: GetLastUpdateCheck :one

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4344,6 +4344,17 @@ func (q *sqlQuerier) GetDeploymentID(ctx context.Context) (string, error) {
 	return value, err
 }
 
+const getDismissedHealthchecks = `-- name: GetDismissedHealthchecks :one
+SELECT value FROM site_configs WHERE key = 'dismissed_healthchecks'
+`
+
+func (q *sqlQuerier) GetDismissedHealthchecks(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getDismissedHealthchecks)
+	var value string
+	err := row.Scan(&value)
+	return value, err
+}
+
 const getLastUpdateCheck = `-- name: GetLastUpdateCheck :one
 SELECT value FROM site_configs WHERE key = 'last_update_check'
 `
@@ -4446,6 +4457,16 @@ type UpsertDefaultProxyParams struct {
 // The functional values are immutable and controlled implicitly.
 func (q *sqlQuerier) UpsertDefaultProxy(ctx context.Context, arg UpsertDefaultProxyParams) error {
 	_, err := q.db.ExecContext(ctx, upsertDefaultProxy, arg.DisplayName, arg.IconUrl)
+	return err
+}
+
+const upsertDismissedHealthchecks = `-- name: UpsertDismissedHealthchecks :exec
+INSERT INTO site_configs (key, value) VALUES ('dismissed_healthchecks', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'dismissed_healthchecks'
+`
+
+func (q *sqlQuerier) UpsertDismissedHealthchecks(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, upsertDismissedHealthchecks, value)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -71,9 +71,9 @@ SELECT value FROM site_configs WHERE key = 'oauth_signing_key';
 INSERT INTO site_configs (key, value) VALUES ('oauth_signing_key', $1)
 ON CONFLICT (key) DO UPDATE set value = $1 WHERE site_configs.key = 'oauth_signing_key';
 
--- name: GetDismissedHealthchecks :one
-SELECT value FROM site_configs WHERE key = 'dismissed_healthchecks';
+-- name: GetHealthSettings :one
+SELECT COALESCE(value, '{}') FROM site_configs WHERE key = 'health_settings';
 
--- name: UpsertDismissedHealthchecks :exec
-INSERT INTO site_configs (key, value) VALUES ('dismissed_healthchecks', $1)
-ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'dismissed_healthchecks';
+-- name: UpsertHealthSettings :exec
+INSERT INTO site_configs (key, value) VALUES ('health_settings', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'health_settings';

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -70,3 +70,10 @@ SELECT value FROM site_configs WHERE key = 'oauth_signing_key';
 -- name: UpsertOAuthSigningKey :exec
 INSERT INTO site_configs (key, value) VALUES ('oauth_signing_key', $1)
 ON CONFLICT (key) DO UPDATE set value = $1 WHERE site_configs.key = 'oauth_signing_key';
+
+-- name: GetDismissedHealthchecks :one
+SELECT value FROM site_configs WHERE key = 'dismissed_healthchecks';
+
+-- name: UpsertDismissedHealthchecks :exec
+INSERT INTO site_configs (key, value) VALUES ('dismissed_healthchecks', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'dismissed_healthchecks';

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -72,7 +72,9 @@ INSERT INTO site_configs (key, value) VALUES ('oauth_signing_key', $1)
 ON CONFLICT (key) DO UPDATE set value = $1 WHERE site_configs.key = 'oauth_signing_key';
 
 -- name: GetHealthSettings :one
-SELECT COALESCE(value, '{}') FROM site_configs WHERE key = 'health_settings';
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'health_settings'), '{}') :: text AS health_settings
+;
 
 -- name: UpsertHealthSettings :exec
 INSERT INTO site_configs (key, value) VALUES ('health_settings', $1)


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/10712

This PR adds database support for dismissed healthchecks. The idea is to store healthcheck settings in JSON format in `site_configs`.