### PR TITLE
feat(coderd/healthcheck): add health check for proxy

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12448,7 +12448,7 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "workspaceProxies": {
+                "workspace_proxies": {
                     "$ref": "#/definitions/codersdk.RegionsResponse-codersdk_WorkspaceProxy"
                 }
             }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12388,6 +12388,9 @@ const docTemplate = `{
                 },
                 "websocket": {
                     "$ref": "#/definitions/healthcheck.WebsocketReport"
+                },
+                "workspace_proxy": {
+                    "$ref": "#/definitions/healthcheck.WorkspaceProxyReport"
                 }
             }
         },
@@ -12424,6 +12427,29 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "healthcheck.WorkspaceProxyReport": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "severity": {
+                    "$ref": "#/definitions/health.Severity"
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "workspaceProxies": {
+                    "$ref": "#/definitions/codersdk.RegionsResponse-codersdk_WorkspaceProxy"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -11277,6 +11277,9 @@
         },
         "websocket": {
           "$ref": "#/definitions/healthcheck.WebsocketReport"
+        },
+        "workspace_proxy": {
+          "$ref": "#/definitions/healthcheck.WorkspaceProxyReport"
         }
       }
     },
@@ -11309,6 +11312,29 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "healthcheck.WorkspaceProxyReport": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "healthy": {
+          "type": "boolean"
+        },
+        "severity": {
+          "$ref": "#/definitions/health.Severity"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workspaceProxies": {
+          "$ref": "#/definitions/codersdk.RegionsResponse-codersdk_WorkspaceProxy"
         }
       }
     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -11333,7 +11333,7 @@
             "type": "string"
           }
         },
-        "workspaceProxies": {
+        "workspace_proxies": {
           "$ref": "#/definitions/codersdk.RegionsResponse-codersdk_WorkspaceProxy"
         }
       }

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -430,8 +430,8 @@ func New(options *Options) *API {
 				},
 				WorkspaceProxy: healthcheck.WorkspaceProxyReportOptions{
 					CurrentVersion:        buildinfo.Version(),
-					FetchWorkspaceProxies: *options.FetchWorkspaceProxiesFunc.Load(),
-					UpdateProxyHealth:     *options.UpdateProxyHealthFunc.Load(),
+					FetchWorkspaceProxies: options.FetchWorkspaceProxiesFunc.Load(),
+					UpdateProxyHealth:     options.UpdateProxyHealthFunc.Load(),
 				},
 			})
 		}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -137,12 +137,10 @@ type Options struct {
 	// workspace applications. It consists of both a signing and encryption key.
 	AppSecurityKey workspaceapps.SecurityKey
 
-	FetchWorkspaceProxiesFunc *atomic.Pointer[func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)]
-	UpdateProxyHealthFunc     *atomic.Pointer[func(context.Context) error]
-
-	HealthcheckFunc    func(ctx context.Context, apiKey string) *healthcheck.Report
-	HealthcheckTimeout time.Duration
-	HealthcheckRefresh time.Duration
+	HealthcheckFunc              func(ctx context.Context, apiKey string) *healthcheck.Report
+	HealthcheckTimeout           time.Duration
+	HealthcheckRefresh           time.Duration
+	WorkspaceProxiesFetchUpdater *atomic.Pointer[healthcheck.WorkspaceProxiesFetchUpdater]
 
 	// OAuthSigningKey is the crypto key used to sign and encrypt state strings
 	// related to OAuth. This is a symmetric secret key using hmac to sign payloads.
@@ -401,14 +399,11 @@ func New(options *Options) *API {
 		)
 	}
 
-	// The following two functions are dependencies of HealthcheckFunc but are only implemented
-	// in enterprise. Stubbing them out here.
-	if options.FetchWorkspaceProxiesFunc == nil {
-		options.FetchWorkspaceProxiesFunc = &atomic.Pointer[func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)]{}
-	}
-
-	if options.UpdateProxyHealthFunc == nil {
-		options.UpdateProxyHealthFunc = &atomic.Pointer[func(context.Context) error]{}
+	if options.WorkspaceProxiesFetchUpdater == nil {
+		options.WorkspaceProxiesFetchUpdater = &atomic.Pointer[healthcheck.WorkspaceProxiesFetchUpdater]{}
+		var wpfu healthcheck.WorkspaceProxiesFetchUpdater //nolint:gosimple
+		wpfu = &healthcheck.AGPLWorkspaceProxiesFetchUpdater{}
+		options.WorkspaceProxiesFetchUpdater.Store(&wpfu)
 	}
 
 	if options.HealthcheckFunc == nil {
@@ -430,9 +425,8 @@ func New(options *Options) *API {
 					DERPMap: api.DERPMap(),
 				},
 				WorkspaceProxy: healthcheck.WorkspaceProxyReportOptions{
-					CurrentVersion:        buildinfo.Version(),
-					FetchWorkspaceProxies: options.FetchWorkspaceProxiesFunc.Load(),
-					UpdateProxyHealth:     options.UpdateProxyHealthFunc.Load(),
+					CurrentVersion:               buildinfo.Version(),
+					WorkspaceProxiesFetchUpdater: *(options.WorkspaceProxiesFetchUpdater).Load(),
 				},
 			})
 		}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -413,7 +413,8 @@ func New(options *Options) *API {
 
 	if options.HealthcheckFunc == nil {
 		options.HealthcheckFunc = func(ctx context.Context, apiKey string) *healthcheck.Report {
-			return healthcheck.Run(ctx, &healthcheck.ReportOptions{
+			authCtx := dbauthz.AsSystemRestricted(ctx) //nolint:gocritic // internal function
+			return healthcheck.Run(authCtx, &healthcheck.ReportOptions{
 				Database: healthcheck.DatabaseReportOptions{
 					DB:        options.Database,
 					Threshold: options.DeploymentValues.Healthcheck.ThresholdDatabase.Value(),

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -137,8 +137,6 @@ type Options struct {
 	// workspace applications. It consists of both a signing and encryption key.
 	AppSecurityKey workspaceapps.SecurityKey
 
-	// The following two functions are dependencies of HealthcheckFunc but are only implemented
-	// in enterprise. Stubbing them out here.
 	FetchWorkspaceProxiesFunc *atomic.Pointer[func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)]
 	UpdateProxyHealthFunc     *atomic.Pointer[func(context.Context) error]
 
@@ -403,6 +401,8 @@ func New(options *Options) *API {
 		)
 	}
 
+	// The following two functions are dependencies of HealthcheckFunc but are only implemented
+	// in enterprise. Stubbing them out here.
 	if options.FetchWorkspaceProxiesFunc == nil {
 		options.FetchWorkspaceProxiesFunc = &atomic.Pointer[func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)]{}
 	}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -401,8 +401,7 @@ func New(options *Options) *API {
 
 	if options.WorkspaceProxiesFetchUpdater == nil {
 		options.WorkspaceProxiesFetchUpdater = &atomic.Pointer[healthcheck.WorkspaceProxiesFetchUpdater]{}
-		var wpfu healthcheck.WorkspaceProxiesFetchUpdater //nolint:gosimple
-		wpfu = &healthcheck.AGPLWorkspaceProxiesFetchUpdater{}
+		var wpfu healthcheck.WorkspaceProxiesFetchUpdater = &healthcheck.AGPLWorkspaceProxiesFetchUpdater{}
 		options.WorkspaceProxiesFetchUpdater.Store(&wpfu)
 	}
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -408,8 +408,7 @@ func New(options *Options) *API {
 
 	if options.HealthcheckFunc == nil {
 		options.HealthcheckFunc = func(ctx context.Context, apiKey string) *healthcheck.Report {
-			authCtx := dbauthz.AsSystemRestricted(ctx) //nolint:gocritic // internal function
-			return healthcheck.Run(authCtx, &healthcheck.ReportOptions{
+			return healthcheck.Run(ctx, &healthcheck.ReportOptions{
 				Database: healthcheck.DatabaseReportOptions{
 					DB:        options.Database,
 					Threshold: options.DeploymentValues.Healthcheck.ThresholdDatabase.Value(),

--- a/coderd/healthcheck/healthcheck.go
+++ b/coderd/healthcheck/healthcheck.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	SectionDERP      string = "DERP"
-	SectionAccessURL string = "AccessURL"
-	SectionWebsocket string = "Websocket"
-	SectionDatabase  string = "Database"
+	SectionDERP           string = "DERP"
+	SectionAccessURL      string = "AccessURL"
+	SectionWebsocket      string = "Websocket"
+	SectionDatabase       string = "Database"
+	SectionWorkspaceProxy string = "WorkspaceProxy"
 )
 
 type Checker interface {
@@ -24,6 +25,7 @@ type Checker interface {
 	AccessURL(ctx context.Context, opts *AccessURLReportOptions) AccessURLReport
 	Websocket(ctx context.Context, opts *WebsocketReportOptions) WebsocketReport
 	Database(ctx context.Context, opts *DatabaseReportOptions) DatabaseReport
+	WorkspaceProxy(ctx context.Context, opts *WorkspaceProxyReportOptions) WorkspaceProxyReport
 }
 
 // @typescript-generate Report
@@ -38,20 +40,22 @@ type Report struct {
 	// FailingSections is a list of sections that have failed their healthcheck.
 	FailingSections []string `json:"failing_sections"`
 
-	DERP      derphealth.Report `json:"derp"`
-	AccessURL AccessURLReport   `json:"access_url"`
-	Websocket WebsocketReport   `json:"websocket"`
-	Database  DatabaseReport    `json:"database"`
+	DERP           derphealth.Report    `json:"derp"`
+	AccessURL      AccessURLReport      `json:"access_url"`
+	Websocket      WebsocketReport      `json:"websocket"`
+	Database       DatabaseReport       `json:"database"`
+	WorkspaceProxy WorkspaceProxyReport `json:"workspace_proxy"`
 
 	// The Coder version of the server that the report was generated on.
 	CoderVersion string `json:"coder_version"`
 }
 
 type ReportOptions struct {
-	AccessURL  AccessURLReportOptions
-	Database   DatabaseReportOptions
-	DerpHealth derphealth.ReportOptions
-	Websocket  WebsocketReportOptions
+	AccessURL      AccessURLReportOptions
+	Database       DatabaseReportOptions
+	DerpHealth     derphealth.ReportOptions
+	Websocket      WebsocketReportOptions
+	WorkspaceProxy WorkspaceProxyReportOptions
 
 	Checker Checker
 }
@@ -74,6 +78,11 @@ func (defaultChecker) Websocket(ctx context.Context, opts *WebsocketReportOption
 }
 
 func (defaultChecker) Database(ctx context.Context, opts *DatabaseReportOptions) (report DatabaseReport) {
+	report.Run(ctx, opts)
+	return report
+}
+
+func (defaultChecker) WorkspaceProxy(ctx context.Context, opts *WorkspaceProxyReportOptions) (report WorkspaceProxyReport) {
 	report.Run(ctx, opts)
 	return report
 }
@@ -136,6 +145,18 @@ func Run(ctx context.Context, opts *ReportOptions) *Report {
 		report.Database = opts.Checker.Database(ctx, &opts.Database)
 	}()
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if err := recover(); err != nil {
+				report.WorkspaceProxy.Error = ptr.Ref(fmt.Sprint(err))
+			}
+		}()
+
+		report.WorkspaceProxy = opts.Checker.WorkspaceProxy(ctx, &opts.WorkspaceProxy)
+	}()
+
 	report.CoderVersion = buildinfo.Version()
 	wg.Wait()
 
@@ -152,6 +173,9 @@ func Run(ctx context.Context, opts *ReportOptions) *Report {
 	}
 	if !report.Database.Healthy {
 		report.FailingSections = append(report.FailingSections, SectionDatabase)
+	}
+	if !report.WorkspaceProxy.Healthy {
+		report.FailingSections = append(report.FailingSections, SectionWorkspaceProxy)
 	}
 
 	report.Healthy = len(report.FailingSections) == 0

--- a/coderd/healthcheck/healthcheck.go
+++ b/coderd/healthcheck/healthcheck.go
@@ -195,6 +195,9 @@ func Run(ctx context.Context, opts *ReportOptions) *Report {
 	if report.Database.Severity.Value() > report.Severity.Value() {
 		report.Severity = report.Database.Severity
 	}
+	if report.WorkspaceProxy.Severity.Value() > report.Severity.Value() {
+		report.Severity = report.WorkspaceProxy.Severity
+	}
 	return &report
 }
 

--- a/coderd/healthcheck/healthcheck_test.go
+++ b/coderd/healthcheck/healthcheck_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 type testChecker struct {
-	DERPReport      derphealth.Report
-	AccessURLReport healthcheck.AccessURLReport
-	WebsocketReport healthcheck.WebsocketReport
-	DatabaseReport  healthcheck.DatabaseReport
+	DERPReport           derphealth.Report
+	AccessURLReport      healthcheck.AccessURLReport
+	WebsocketReport      healthcheck.WebsocketReport
+	DatabaseReport       healthcheck.DatabaseReport
+	WorkspaceProxyReport healthcheck.WorkspaceProxyReport
 }
 
 func (c *testChecker) DERP(context.Context, *derphealth.ReportOptions) derphealth.Report {
@@ -31,6 +32,10 @@ func (c *testChecker) Websocket(context.Context, *healthcheck.WebsocketReportOpt
 
 func (c *testChecker) Database(context.Context, *healthcheck.DatabaseReportOptions) healthcheck.DatabaseReport {
 	return c.DatabaseReport
+}
+
+func (c *testChecker) WorkspaceProxy(context.Context, *healthcheck.WorkspaceProxyReportOptions) healthcheck.WorkspaceProxyReport {
+	return c.WorkspaceProxyReport
 }
 
 func TestHealthcheck(t *testing.T) {
@@ -56,6 +61,9 @@ func TestHealthcheck(t *testing.T) {
 			DatabaseReport: healthcheck.DatabaseReport{
 				Healthy: true,
 			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
+				Healthy: true,
+			},
 		},
 		healthy:         true,
 		failingSections: []string{},
@@ -72,6 +80,9 @@ func TestHealthcheck(t *testing.T) {
 				Healthy: true,
 			},
 			DatabaseReport: healthcheck.DatabaseReport{
+				Healthy: true,
+			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
 				Healthy: true,
 			},
 		},
@@ -93,6 +104,9 @@ func TestHealthcheck(t *testing.T) {
 			DatabaseReport: healthcheck.DatabaseReport{
 				Healthy: true,
 			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
+				Healthy: true,
+			},
 		},
 		healthy:         true,
 		failingSections: []string{},
@@ -109,6 +123,9 @@ func TestHealthcheck(t *testing.T) {
 				Healthy: true,
 			},
 			DatabaseReport: healthcheck.DatabaseReport{
+				Healthy: true,
+			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
 				Healthy: true,
 			},
 		},
@@ -129,6 +146,9 @@ func TestHealthcheck(t *testing.T) {
 			DatabaseReport: healthcheck.DatabaseReport{
 				Healthy: true,
 			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
+				Healthy: true,
+			},
 		},
 		healthy:         false,
 		failingSections: []string{healthcheck.SectionWebsocket},
@@ -147,9 +167,33 @@ func TestHealthcheck(t *testing.T) {
 			DatabaseReport: healthcheck.DatabaseReport{
 				Healthy: false,
 			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
+				Healthy: true,
+			},
 		},
 		healthy:         false,
 		failingSections: []string{healthcheck.SectionDatabase},
+	}, {
+		name: "ProxyFail",
+		checker: &testChecker{
+			DERPReport: derphealth.Report{
+				Healthy: true,
+			},
+			AccessURLReport: healthcheck.AccessURLReport{
+				Healthy: true,
+			},
+			WebsocketReport: healthcheck.WebsocketReport{
+				Healthy: true,
+			},
+			DatabaseReport: healthcheck.DatabaseReport{
+				Healthy: true,
+			},
+			WorkspaceProxyReport: healthcheck.WorkspaceProxyReport{
+				Healthy: false,
+			},
+		},
+		healthy:         false,
+		failingSections: []string{healthcheck.SectionWorkspaceProxy},
 	}, {
 		name:    "AllFail",
 		checker: &testChecker{},
@@ -159,6 +203,7 @@ func TestHealthcheck(t *testing.T) {
 			healthcheck.SectionAccessURL,
 			healthcheck.SectionWebsocket,
 			healthcheck.SectionDatabase,
+			healthcheck.SectionWorkspaceProxy,
 		},
 	}} {
 		c := c
@@ -175,6 +220,8 @@ func TestHealthcheck(t *testing.T) {
 			assert.Equal(t, c.checker.DERPReport.Warnings, report.DERP.Warnings)
 			assert.Equal(t, c.checker.AccessURLReport.Healthy, report.AccessURL.Healthy)
 			assert.Equal(t, c.checker.WebsocketReport.Healthy, report.Websocket.Healthy)
+			assert.Equal(t, c.checker.WorkspaceProxyReport.Healthy, report.WorkspaceProxy.Healthy)
+			assert.Equal(t, c.checker.WorkspaceProxyReport.Warnings, report.WorkspaceProxy.Warnings)
 			assert.NotZero(t, report.Time)
 			assert.NotZero(t, report.CoderVersion)
 		})

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -90,7 +90,7 @@ func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyRepo
 	}
 
 	r.Severity = calculateSeverity(total, healthy)
-	r.Healthy = r.Severity != health.SeverityError
+	r.Healthy = r.Severity.Value() < health.SeverityError.Value()
 
 	// Versions _must_ match. Perform this check last. This will clobber any other severity.
 	for _, proxy := range r.WorkspaceProxies.Regions {

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -10,16 +10,16 @@ import (
 )
 
 type WorkspaceProxyReportOptions struct {
+	// CurrentVersion is the current server version.
+	// We pass this in to make it easier to test.
+	CurrentVersion string
+	// FetchWorkspaceProxies is a function that returns the available workspace proxies.
+	FetchWorkspaceProxies func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
 	// UpdateProxyHealth is a function called when healthcheck is run.
 	// This would normally be ProxyHealth.ForceUpdate().
 	// We do this because if someone mashes the healthcheck refresh button
 	// they would expect up-to-date data.
 	UpdateProxyHealth func(context.Context) error
-	// FetchWorkspaceProxies is a function that returns the available workspace proxies.
-	FetchWorkspaceProxies func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
-	// CurrentVersion is the current server version.
-	// We pass this in to make it easier to test.
-	CurrentVersion string
 }
 
 // @typescript-generate Report

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -34,7 +34,7 @@ type WorkspaceProxyReport struct {
 	Warnings []string        `json:"warnings"`
 	Error    *string         `json:"error"`
 
-	WorkspaceProxies codersdk.RegionsResponse[codersdk.WorkspaceProxy]
+	WorkspaceProxies codersdk.RegionsResponse[codersdk.WorkspaceProxy] `json:"workspace_proxies"`
 }
 
 func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyReportOptions) {

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -1,0 +1,87 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+
+	"cdr.dev/slog"
+	"github.com/coder/coder/v2/buildinfo"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type WorkspaceProxyReportOptions struct {
+	// UpdateProxyHealth is a function called when healthcheck is run.
+	// This would normally be ProxyHealth.ForceUpdate().
+	// We do this because if someone mashes the healthcheck refresh button
+	// they would expect up-to-date data.
+	UpdateProxyHealth func(context.Context) error
+	// FetchWorkspaceProxies is a function that returns the available workspace proxies.
+	FetchWorkspaceProxies func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
+	// CurrentVersion is the current server version.
+	// We pass this in to make it easier to test.
+	CurrentVersion string
+	Logger         slog.Logger
+}
+
+// @typescript-generate Report
+type WorkspaceProxyReport struct {
+	Healthy  bool     `json:"healthy"`
+	Warnings []string `json:"warnings"`
+	Error    *string  `json:"error"`
+
+	WorkspaceProxies codersdk.RegionsResponse[codersdk.WorkspaceProxy]
+}
+
+func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyReportOptions) {
+	r.Healthy = true
+	r.Warnings = []string{}
+
+	if opts.FetchWorkspaceProxies == nil {
+		opts.Logger.Debug(ctx, "no workspace proxies configured")
+		return
+	}
+
+	if opts.UpdateProxyHealth == nil {
+		err := "opts.UpdateProxyHealth must not be nil if opts.FetchWorkspaceProxies is not nil"
+		opts.Logger.Error(ctx, "developer error: "+err)
+		r.Error = ptr.Ref(err)
+		return
+	}
+
+	if err := opts.UpdateProxyHealth(ctx); err != nil {
+		opts.Logger.Error(ctx, "failed to update proxy health: %w", err)
+		r.Error = ptr.Ref(err.Error())
+		return
+	}
+
+	proxies, err := opts.FetchWorkspaceProxies(ctx)
+	if err != nil {
+		opts.Logger.Error(ctx, "failed to fetch workspace proxies", slog.Error(err))
+		r.Healthy = false
+		r.Error = ptr.Ref(err.Error())
+		return
+	}
+
+	r.WorkspaceProxies = proxies
+
+	var numProxies int
+	var healthyProxies int
+	for _, proxy := range r.WorkspaceProxies.Regions {
+		numProxies++
+		if proxy.Healthy {
+			healthyProxies++
+		}
+
+		// check versions
+		if !buildinfo.VersionsMatch(proxy.Version, opts.CurrentVersion) {
+			opts.Logger.Warn(ctx, "proxy version mismatch",
+				slog.F("version", opts.CurrentVersion),
+				slog.F("proxy_version", proxy.Version),
+				slog.F("proxy_name", proxy.Name),
+			)
+			r.Healthy = false
+			r.Warnings = append(r.Warnings, fmt.Sprintf("Proxy %q version %q does not match primary server version %q", proxy.Name, proxy.Version, opts.CurrentVersion))
+		}
+	}
+}

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -2,11 +2,15 @@ package healthcheck
 
 import (
 	"context"
-	"fmt"
+
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/buildinfo"
+	"github.com/coder/coder/v2/coderd/healthcheck/health"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 type WorkspaceProxyReportOptions struct {
@@ -14,63 +18,120 @@ type WorkspaceProxyReportOptions struct {
 	// We pass this in to make it easier to test.
 	CurrentVersion string
 	// FetchWorkspaceProxies is a function that returns the available workspace proxies.
-	FetchWorkspaceProxies func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
+	FetchWorkspaceProxies *func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
 	// UpdateProxyHealth is a function called when healthcheck is run.
 	// This would normally be ProxyHealth.ForceUpdate().
 	// We do this because if someone mashes the healthcheck refresh button
 	// they would expect up-to-date data.
-	UpdateProxyHealth func(context.Context) error
+	UpdateProxyHealth *func(context.Context) error
 }
 
 // @typescript-generate Report
 type WorkspaceProxyReport struct {
-	Healthy  bool     `json:"healthy"`
-	Warnings []string `json:"warnings"`
-	Error    *string  `json:"error"`
+	Healthy  bool            `json:"healthy"`
+	Severity health.Severity `json:"severity"`
+	Warnings []string        `json:"warnings"`
+	Error    *string         `json:"error"`
 
 	WorkspaceProxies codersdk.RegionsResponse[codersdk.WorkspaceProxy]
 }
 
 func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyReportOptions) {
 	r.Healthy = true
+	r.Severity = health.SeverityOK
 	r.Warnings = []string{}
 
 	if opts.FetchWorkspaceProxies == nil {
 		return
 	}
+	fetchWorkspaceProxiesFunc := *opts.FetchWorkspaceProxies
 
 	if opts.UpdateProxyHealth == nil {
 		err := "opts.UpdateProxyHealth must not be nil if opts.FetchWorkspaceProxies is not nil"
 		r.Error = ptr.Ref(err)
 		return
 	}
+	updateProxyHealthFunc := *opts.UpdateProxyHealth
 
-	if err := opts.UpdateProxyHealth(ctx); err != nil {
-		r.Error = ptr.Ref(err.Error())
+	// If this fails, just mark it as a warning. It is still updated in the background.
+	if err := updateProxyHealthFunc(ctx); err != nil {
+		r.Severity = health.SeverityWarning
+		r.Warnings = append(r.Warnings, xerrors.Errorf("update proxy health: %w", err).Error())
 		return
 	}
 
-	proxies, err := opts.FetchWorkspaceProxies(ctx)
+	proxies, err := fetchWorkspaceProxiesFunc(ctx)
 	if err != nil {
 		r.Healthy = false
+		r.Severity = health.SeverityError
 		r.Error = ptr.Ref(err.Error())
 		return
 	}
 
 	r.WorkspaceProxies = proxies
 
-	var numProxies int
-	var healthyProxies int
+	var total, healthy int
 	for _, proxy := range r.WorkspaceProxies.Regions {
-		numProxies++
+		total++
 		if proxy.Healthy {
-			healthyProxies++
+			healthy++
 		}
 
-		// check versions
-		if !buildinfo.VersionsMatch(proxy.Version, opts.CurrentVersion) {
-			r.Healthy = false
-			r.Warnings = append(r.Warnings, fmt.Sprintf("Proxy %q version %q does not match primary server version %q", proxy.Name, proxy.Version, opts.CurrentVersion))
+		if len(proxy.Status.Report.Errors) > 0 {
+			for _, err := range proxy.Status.Report.Errors {
+				r.appendError(xerrors.New(err))
+			}
 		}
 	}
+
+	r.Severity = calculateSeverity(total, healthy)
+	r.Healthy = r.Severity != health.SeverityError
+
+	// Versions _must_ match. Perform this check last. This will clobber any other severity.
+	for _, proxy := range r.WorkspaceProxies.Regions {
+		if vErr := checkVersion(proxy, opts.CurrentVersion); vErr != nil {
+			r.Healthy = false
+			r.Severity = health.SeverityError
+			r.appendError(vErr)
+		}
+	}
+}
+
+// appendError multierror-appends err onto r.Error.
+// We only have one error, so multiple errors need to be squashed in there.
+func (r *WorkspaceProxyReport) appendError(errs ...error) {
+	var prevErr error
+	if r.Error != nil {
+		prevErr = xerrors.New(*r.Error)
+	}
+	r.Error = ptr.Ref(multierror.Append(prevErr, errs...).Error())
+}
+
+func checkVersion(proxy codersdk.WorkspaceProxy, currentVersion string) error {
+	if proxy.Version == "" {
+		return nil // may have not connected yet, this is OK
+	}
+	if buildinfo.VersionsMatch(proxy.Version, currentVersion) {
+		return nil
+	}
+
+	return xerrors.Errorf("proxy %q version %q does not match primary server version %q",
+		proxy.Name,
+		proxy.Version,
+		currentVersion,
+	)
+}
+
+// calculateSeverity returns:
+// health.SeverityError if all proxies are unhealthy,
+// health.SeverityOK if all proxies are healthy,
+// health.SeverityWarning otherwise.
+func calculateSeverity(total, healthy int) health.Severity {
+	if total == 0 || total == healthy {
+		return health.SeverityOK
+	}
+	if total-healthy == total {
+		return health.SeverityError
+	}
+	return health.SeverityWarning
 }

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -26,7 +26,7 @@ type WorkspaceProxyReportOptions struct {
 	UpdateProxyHealth *func(context.Context) error
 }
 
-// @typescript-generate Report
+// @typescript-generate WorkspaceProxyReport
 type WorkspaceProxyReport struct {
 	Healthy  bool            `json:"healthy"`
 	Severity health.Severity `json:"severity"`

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"context"
+	"sort"
 
 	"golang.org/x/xerrors"
 
@@ -69,6 +70,10 @@ func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyRepo
 	}
 
 	r.WorkspaceProxies = proxies
+	// Stable sort based on create timestamp.
+	sort.Slice(r.WorkspaceProxies.Regions, func(i int, j int) bool {
+		return r.WorkspaceProxies.Regions[i].CreatedAt.Before(r.WorkspaceProxies.Regions[j].CreatedAt)
+	})
 
 	var total, healthy int
 	for _, proxy := range r.WorkspaceProxies.Regions {

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"cdr.dev/slog"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
@@ -21,7 +20,6 @@ type WorkspaceProxyReportOptions struct {
 	// CurrentVersion is the current server version.
 	// We pass this in to make it easier to test.
 	CurrentVersion string
-	Logger         slog.Logger
 }
 
 // @typescript-generate Report
@@ -38,26 +36,22 @@ func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyRepo
 	r.Warnings = []string{}
 
 	if opts.FetchWorkspaceProxies == nil {
-		opts.Logger.Debug(ctx, "no workspace proxies configured")
 		return
 	}
 
 	if opts.UpdateProxyHealth == nil {
 		err := "opts.UpdateProxyHealth must not be nil if opts.FetchWorkspaceProxies is not nil"
-		opts.Logger.Error(ctx, "developer error: "+err)
 		r.Error = ptr.Ref(err)
 		return
 	}
 
 	if err := opts.UpdateProxyHealth(ctx); err != nil {
-		opts.Logger.Error(ctx, "failed to update proxy health: %w", err)
 		r.Error = ptr.Ref(err.Error())
 		return
 	}
 
 	proxies, err := opts.FetchWorkspaceProxies(ctx)
 	if err != nil {
-		opts.Logger.Error(ctx, "failed to fetch workspace proxies", slog.Error(err))
 		r.Healthy = false
 		r.Error = ptr.Ref(err.Error())
 		return
@@ -75,11 +69,6 @@ func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyRepo
 
 		// check versions
 		if !buildinfo.VersionsMatch(proxy.Version, opts.CurrentVersion) {
-			opts.Logger.Warn(ctx, "proxy version mismatch",
-				slog.F("version", opts.CurrentVersion),
-				slog.F("proxy_version", proxy.Version),
-				slog.F("proxy_name", proxy.Name),
-			)
 			r.Healthy = false
 			r.Warnings = append(r.Warnings, fmt.Sprintf("Proxy %q version %q does not match primary server version %q", proxy.Name, proxy.Version, opts.CurrentVersion))
 		}

--- a/coderd/healthcheck/workspaceproxy_internal_test.go
+++ b/coderd/healthcheck/workspaceproxy_internal_test.go
@@ -1,0 +1,95 @@
+package healthcheck
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coder/coder/v2/coderd/healthcheck/health"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/xerrors"
+)
+
+func Test_WorkspaceProxyReport_appendErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		expected string
+		prevErr  string
+		errs     []error
+	}{
+		{
+			name: "nil",
+			errs: nil,
+		},
+		{
+			name:     "one error",
+			expected: assert.AnError.Error(),
+			errs:     []error{assert.AnError},
+		},
+		{
+			name:     "one error, one prev",
+			prevErr:  "previous error",
+			expected: "previous error\n" + assert.AnError.Error(),
+			errs:     []error{assert.AnError},
+		},
+		{
+			name:     "two errors",
+			expected: assert.AnError.Error() + "\nanother error",
+			errs:     []error{assert.AnError, xerrors.Errorf("another error")},
+		},
+		{
+			name:     "two errors, one prev",
+			prevErr:  "previous error",
+			expected: "previous error\n" + assert.AnError.Error() + "\nanother error",
+			errs:     []error{assert.AnError, xerrors.Errorf("another error")},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var rpt WorkspaceProxyReport
+			if tt.prevErr != "" {
+				rpt.Error = ptr.Ref(tt.prevErr)
+			}
+			rpt.appendError(tt.errs...)
+			if tt.expected == "" {
+				require.Nil(t, rpt.Error)
+			} else {
+				require.NotNil(t, rpt.Error)
+				require.Equal(t, tt.expected, *rpt.Error)
+			}
+		})
+	}
+}
+
+func Test_calculateSeverity(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		total    int
+		healthy  int
+		expected health.Severity
+	}{
+		{0, 0, health.SeverityOK},
+		{1, 1, health.SeverityOK},
+		{1, 0, health.SeverityError},
+		{2, 2, health.SeverityOK},
+		{2, 1, health.SeverityWarning},
+		{2, 0, health.SeverityError},
+	} {
+		tt := tt
+		name := fmt.Sprintf("%d total, %d healthy -> %s", tt.total, tt.healthy, tt.expected)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := calculateSeverity(tt.total, tt.healthy)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/coderd/healthcheck/workspaceproxy_test.go
+++ b/coderd/healthcheck/workspaceproxy_test.go
@@ -1,0 +1,142 @@
+package healthcheck_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/sloggers/slogtest"
+
+	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestWorkspaceProxies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NotEnabled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		log := slogtest.Make(t, nil)
+		rpt := healthcheck.WorkspaceProxyReport{}
+		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
+			Logger: log,
+		})
+
+		require.True(t, rpt.Healthy, "expected report to be healthy")
+		require.Empty(t, rpt.Warnings, "expected no warnings")
+		require.Empty(t, rpt.WorkspaceProxies, "expected no proxies")
+	})
+
+	t.Run("Enabled/None", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		log := slogtest.Make(t, nil)
+		rpt := healthcheck.WorkspaceProxyReport{}
+		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
+			CurrentVersion: "v2.34.5",
+			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{},
+				}, nil
+			},
+			UpdateProxyHealth: func(context.Context) error { return nil },
+			Logger:            log,
+		})
+
+		require.True(t, rpt.Healthy, "expected report to be healthy")
+		require.Empty(t, rpt.Warnings, "expected no warnings")
+		require.NotEmpty(t, rpt.WorkspaceProxies, "expected at least one proxy")
+	})
+
+	t.Run("Enabled/Match", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		log := slogtest.Make(t, nil)
+		rpt := healthcheck.WorkspaceProxyReport{}
+		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
+			CurrentVersion: "v2.34.5",
+			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy(true, "v2.34.5"),
+						fakeWorkspaceProxy(true, "v2.34.5"),
+					},
+				}, nil
+			},
+			UpdateProxyHealth: func(context.Context) error { return nil },
+			Logger:            log,
+		})
+
+		require.True(t, rpt.Healthy, "expected report to be healthy")
+		require.Empty(t, rpt.Warnings, "expected no warnings")
+		require.NotEmpty(t, rpt.WorkspaceProxies, "expected at least one proxy")
+	})
+
+	t.Run("Enabled/Mismatch/One", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		log := slogtest.Make(t, nil)
+		rpt := healthcheck.WorkspaceProxyReport{}
+		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
+			CurrentVersion: "v2.35.0",
+			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy(true, "v2.35.0"),
+						fakeWorkspaceProxy(true, "v2.34.5"),
+					},
+				}, nil
+			},
+			Logger:            log,
+			UpdateProxyHealth: func(context.Context) error { return nil },
+		})
+
+		require.False(t, rpt.Healthy, "expected report not to be healthy")
+		require.Len(t, rpt.Warnings, 1)
+		require.Contains(t, rpt.Warnings[0], "does not match primary server version")
+		require.NotEmpty(t, rpt.WorkspaceProxies)
+	})
+
+	t.Run("Enabled/Mismatch/Multiple", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		log := slogtest.Make(t, nil)
+		rpt := healthcheck.WorkspaceProxyReport{}
+		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
+			CurrentVersion: "v2.35.0",
+			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy(true, "v2.34.5"),
+						fakeWorkspaceProxy(true, "v2.34.5"),
+					},
+				}, nil
+			},
+			Logger:            log,
+			UpdateProxyHealth: func(context.Context) error { return nil },
+		})
+
+		require.False(t, rpt.Healthy, "expected report not to be healthy")
+		require.Len(t, rpt.Warnings, 2)
+		require.Contains(t, rpt.Warnings[0], "does not match primary server version")
+		require.Contains(t, rpt.Warnings[1], "does not match primary server version")
+		require.NotEmpty(t, rpt.WorkspaceProxies)
+	})
+}
+
+func fakeWorkspaceProxy(healthy bool, version string) codersdk.WorkspaceProxy {
+	return codersdk.WorkspaceProxy{
+		Region: codersdk.Region{
+			Healthy: healthy,
+		},
+		Version: version,
+	}
+}

--- a/coderd/healthcheck/workspaceproxy_test.go
+++ b/coderd/healthcheck/workspaceproxy_test.go
@@ -4,124 +4,258 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/coder/coder/v2/coderd/healthcheck"
+	"github.com/coder/coder/v2/coderd/healthcheck/health"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/testutil"
 )
 
 func TestWorkspaceProxies(t *testing.T) {
 	t.Parallel()
 
-	t.Run("NotEnabled", func(t *testing.T) {
-		t.Parallel()
+	var (
+		newerPatchVersion = "v2.34.6"
+		currentVersion    = "v2.34.5"
+		olderVersion      = "v2.33.0"
+	)
 
-		ctx := testutil.Context(t, testutil.WaitShort)
-		rpt := healthcheck.WorkspaceProxyReport{}
-		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{})
-
-		require.True(t, rpt.Healthy, "expected report to be healthy")
-		require.Empty(t, rpt.Warnings, "expected no warnings")
-		require.Empty(t, rpt.WorkspaceProxies, "expected no proxies")
-	})
-
-	t.Run("Enabled/None", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-		rpt := healthcheck.WorkspaceProxyReport{}
-		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
-			CurrentVersion: "v2.34.5",
-			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+	for _, tt := range []struct {
+		name                  string
+		fetchWorkspaceProxies *func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
+		updateProxyHealth     *func(context.Context) error
+		expectedHealthy       bool
+		expectedError         string
+		expectedSeverity      health.Severity
+	}{
+		{
+			name:             "NotEnabled",
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityOK,
+		},
+		{
+			name: "Enabled/NoProxies",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
 				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
 					Regions: []codersdk.WorkspaceProxy{},
 				}, nil
-			},
-			UpdateProxyHealth: func(context.Context) error { return nil },
-		})
-
-		require.True(t, rpt.Healthy, "expected report to be healthy")
-		require.Empty(t, rpt.Warnings, "expected no warnings")
-		require.NotEmpty(t, rpt.WorkspaceProxies, "expected at least one proxy")
-	})
-
-	t.Run("Enabled/Match", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-		rpt := healthcheck.WorkspaceProxyReport{}
-		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
-			CurrentVersion: "v2.34.5",
-			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityOK,
+		},
+		{
+			name: "Enabled/OneHealthy",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
 				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
 					Regions: []codersdk.WorkspaceProxy{
-						fakeWorkspaceProxy(true, "v2.34.5"),
-						fakeWorkspaceProxy(true, "v2.34.5"),
+						fakeWorkspaceProxy("alpha", true, currentVersion),
 					},
 				}, nil
-			},
-			UpdateProxyHealth: func(context.Context) error { return nil },
-		})
-
-		require.True(t, rpt.Healthy, "expected report to be healthy")
-		require.Empty(t, rpt.Warnings, "expected no warnings")
-		require.NotEmpty(t, rpt.WorkspaceProxies, "expected at least one proxy")
-	})
-
-	t.Run("Enabled/Mismatch/One", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-		rpt := healthcheck.WorkspaceProxyReport{}
-		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
-			CurrentVersion: "v2.35.0",
-			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityOK,
+		},
+		{
+			name: "Enabled/OneUnhealthy",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
 				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
 					Regions: []codersdk.WorkspaceProxy{
-						fakeWorkspaceProxy(true, "v2.35.0"),
-						fakeWorkspaceProxy(true, "v2.34.5"),
+						fakeWorkspaceProxy("alpha", false, currentVersion),
 					},
 				}, nil
-			},
-			UpdateProxyHealth: func(context.Context) error { return nil },
-		})
-
-		require.False(t, rpt.Healthy, "expected report not to be healthy")
-		require.Len(t, rpt.Warnings, 1)
-		require.Contains(t, rpt.Warnings[0], "does not match primary server version")
-		require.NotEmpty(t, rpt.WorkspaceProxies)
-	})
-
-	t.Run("Enabled/Mismatch/Multiple", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitShort)
-		rpt := healthcheck.WorkspaceProxyReport{}
-		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
-			CurrentVersion: "v2.35.0",
-			FetchWorkspaceProxies: func(_ context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  false,
+			expectedSeverity: health.SeverityError,
+		},
+		{
+			name: "Enabled/OneUnreachable",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
 				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
 					Regions: []codersdk.WorkspaceProxy{
-						fakeWorkspaceProxy(true, "v2.34.5"),
-						fakeWorkspaceProxy(true, "v2.34.5"),
+						{
+							Region: codersdk.Region{
+								Name:    "gone",
+								Healthy: false,
+							},
+							Version: currentVersion,
+							Status: codersdk.WorkspaceProxyStatus{
+								Status: codersdk.ProxyUnreachable,
+								Report: codersdk.ProxyHealthReport{
+									Errors: []string{
+										"request to proxy failed: Get \"http://127.0.0.1:3001/healthz-report\": dial tcp 127.0.0.1:3001: connect: connection refused",
+									},
+								},
+							},
+						},
 					},
 				}, nil
-			},
-			UpdateProxyHealth: func(context.Context) error { return nil },
-		})
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  false,
+			expectedSeverity: health.SeverityError,
+			expectedError:    "connect: connection refused",
+		},
+		{
+			name: "Enabled/AllHealthy",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy("alpha", true, currentVersion),
+						fakeWorkspaceProxy("beta", true, currentVersion),
+					},
+				}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityOK,
+		},
+		{
+			name: "Enabled/OneHealthyOneUnhealthy",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy("alpha", true, currentVersion),
+						fakeWorkspaceProxy("beta", false, currentVersion),
+					},
+				}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityWarning,
+		},
+		{
+			name: "Enabled/AllUnhealthy",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy("alpha", false, currentVersion),
+						fakeWorkspaceProxy("beta", false, currentVersion),
+					},
+				}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  false,
+			expectedSeverity: health.SeverityError,
+		},
+		{
+			name: "Enabled/OneOutOfDate",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy("alpha", true, currentVersion),
+						fakeWorkspaceProxy("beta", true, olderVersion),
+					},
+				}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  false,
+			expectedSeverity: health.SeverityError,
+			expectedError:    `proxy "beta" version "v2.33.0" does not match primary server version "v2.34.5"`,
+		},
+		{
+			name: "Enabled/OneSlightlyNewerButStillOK",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy("alpha", true, currentVersion),
+						fakeWorkspaceProxy("beta", true, newerPatchVersion),
+					},
+				}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityOK,
+		},
+		{
+			name: "Enabled/NotConnectedYet",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{
+					Regions: []codersdk.WorkspaceProxy{
+						fakeWorkspaceProxy("slowpoke", true, ""),
+					},
+				}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityOK,
+		},
+		{
+			name: "Enabled/ErrFetchWorkspaceProxy",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{}, assert.AnError
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return nil
+			}),
+			expectedHealthy:  false,
+			expectedSeverity: health.SeverityError,
+			expectedError:    assert.AnError.Error(),
+		},
+		{
+			name: "Enabled/ErrUpdateProxyHealth",
+			fetchWorkspaceProxies: ptr.Ref(func(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+				return codersdk.RegionsResponse[codersdk.WorkspaceProxy]{}, nil
+			}),
+			updateProxyHealth: ptr.Ref(func(ctx context.Context) error {
+				return assert.AnError
+			}),
+			expectedHealthy:  true,
+			expectedSeverity: health.SeverityWarning,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var rpt healthcheck.WorkspaceProxyReport
+			var opts healthcheck.WorkspaceProxyReportOptions
+			opts.CurrentVersion = currentVersion
+			opts.FetchWorkspaceProxies = tt.fetchWorkspaceProxies
+			opts.UpdateProxyHealth = tt.updateProxyHealth
 
-		require.False(t, rpt.Healthy, "expected report not to be healthy")
-		require.Len(t, rpt.Warnings, 2)
-		require.Contains(t, rpt.Warnings[0], "does not match primary server version")
-		require.Contains(t, rpt.Warnings[1], "does not match primary server version")
-		require.NotEmpty(t, rpt.WorkspaceProxies)
-	})
+			rpt.Run(context.Background(), &opts)
+
+			assert.Equal(t, tt.expectedHealthy, rpt.Healthy)
+			assert.Equal(t, tt.expectedSeverity, rpt.Severity)
+			if tt.expectedError != "" {
+				assert.NotNil(t, rpt.Error)
+				assert.Contains(t, *rpt.Error, tt.expectedError)
+			} else {
+				if !assert.Nil(t, rpt.Error) {
+					assert.Empty(t, *rpt.Error)
+				}
+			}
+		})
+	}
 }
 
-func fakeWorkspaceProxy(healthy bool, version string) codersdk.WorkspaceProxy {
+func fakeWorkspaceProxy(name string, healthy bool, version string) codersdk.WorkspaceProxy {
 	return codersdk.WorkspaceProxy{
 		Region: codersdk.Region{
+			Name:    name,
 			Healthy: healthy,
 		},
 		Version: version,

--- a/coderd/healthcheck/workspaceproxy_test.go
+++ b/coderd/healthcheck/workspaceproxy_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/sloggers/slogtest"
-
 	"github.com/coder/coder/v2/coderd/healthcheck"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -20,11 +18,8 @@ func TestWorkspaceProxies(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, nil)
 		rpt := healthcheck.WorkspaceProxyReport{}
-		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
-			Logger: log,
-		})
+		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{})
 
 		require.True(t, rpt.Healthy, "expected report to be healthy")
 		require.Empty(t, rpt.Warnings, "expected no warnings")
@@ -35,7 +30,6 @@ func TestWorkspaceProxies(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, nil)
 		rpt := healthcheck.WorkspaceProxyReport{}
 		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
 			CurrentVersion: "v2.34.5",
@@ -45,7 +39,6 @@ func TestWorkspaceProxies(t *testing.T) {
 				}, nil
 			},
 			UpdateProxyHealth: func(context.Context) error { return nil },
-			Logger:            log,
 		})
 
 		require.True(t, rpt.Healthy, "expected report to be healthy")
@@ -57,7 +50,6 @@ func TestWorkspaceProxies(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, nil)
 		rpt := healthcheck.WorkspaceProxyReport{}
 		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
 			CurrentVersion: "v2.34.5",
@@ -70,7 +62,6 @@ func TestWorkspaceProxies(t *testing.T) {
 				}, nil
 			},
 			UpdateProxyHealth: func(context.Context) error { return nil },
-			Logger:            log,
 		})
 
 		require.True(t, rpt.Healthy, "expected report to be healthy")
@@ -82,7 +73,6 @@ func TestWorkspaceProxies(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, nil)
 		rpt := healthcheck.WorkspaceProxyReport{}
 		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
 			CurrentVersion: "v2.35.0",
@@ -94,7 +84,6 @@ func TestWorkspaceProxies(t *testing.T) {
 					},
 				}, nil
 			},
-			Logger:            log,
 			UpdateProxyHealth: func(context.Context) error { return nil },
 		})
 
@@ -108,7 +97,6 @@ func TestWorkspaceProxies(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, nil)
 		rpt := healthcheck.WorkspaceProxyReport{}
 		rpt.Run(ctx, &healthcheck.WorkspaceProxyReportOptions{
 			CurrentVersion: "v2.35.0",
@@ -120,7 +108,6 @@ func TestWorkspaceProxies(t *testing.T) {
 					},
 				}, nil
 			},
-			Logger:            log,
 			UpdateProxyHealth: func(context.Context) error { return nil },
 		})
 

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -253,6 +253,39 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
     "healthy": true,
     "severity": "ok",
     "warnings": ["string"]
+  },
+  "workspace_proxy": {
+    "error": "string",
+    "healthy": true,
+    "severity": "ok",
+    "warnings": ["string"],
+    "workspaceProxies": {
+      "regions": [
+        {
+          "created_at": "2019-08-24T14:15:22Z",
+          "deleted": true,
+          "derp_enabled": true,
+          "derp_only": true,
+          "display_name": "string",
+          "healthy": true,
+          "icon_url": "string",
+          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "name": "string",
+          "path_app_url": "string",
+          "status": {
+            "checked_at": "2019-08-24T14:15:22Z",
+            "report": {
+              "errors": ["string"],
+              "warnings": ["string"]
+            },
+            "status": "ok"
+          },
+          "updated_at": "2019-08-24T14:15:22Z",
+          "version": "string",
+          "wildcard_hostname": "string"
+        }
+      ]
+    }
   }
 }
 ```

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -259,7 +259,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
     "healthy": true,
     "severity": "ok",
     "warnings": ["string"],
-    "workspaceProxies": {
+    "workspace_proxies": {
       "regions": [
         {
           "created_at": "2019-08-24T14:15:22Z",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7795,7 +7795,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
     "healthy": true,
     "severity": "ok",
     "warnings": ["string"],
-    "workspaceProxies": {
+    "workspace_proxies": {
       "regions": [
         {
           "created_at": "2019-08-24T14:15:22Z",
@@ -7889,7 +7889,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "healthy": true,
   "severity": "ok",
   "warnings": ["string"],
-  "workspaceProxies": {
+  "workspace_proxies": {
     "regions": [
       {
         "created_at": "2019-08-24T14:15:22Z",
@@ -7921,13 +7921,13 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name               | Type                                                                                                 | Required | Restrictions | Description |
-| ------------------ | ---------------------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `error`            | string                                                                                               | false    |              |             |
-| `healthy`          | boolean                                                                                              | false    |              |             |
-| `severity`         | [health.Severity](#healthseverity)                                                                   | false    |              |             |
-| `warnings`         | array of string                                                                                      | false    |              |             |
-| `workspaceProxies` | [codersdk.RegionsResponse-codersdk_WorkspaceProxy](#codersdkregionsresponse-codersdk_workspaceproxy) | false    |              |             |
+| Name                | Type                                                                                                 | Required | Restrictions | Description |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `error`             | string                                                                                               | false    |              |             |
+| `healthy`           | boolean                                                                                              | false    |              |             |
+| `severity`          | [health.Severity](#healthseverity)                                                                   | false    |              |             |
+| `warnings`          | array of string                                                                                      | false    |              |             |
+| `workspace_proxies` | [codersdk.RegionsResponse-codersdk_WorkspaceProxy](#codersdkregionsresponse-codersdk_workspaceproxy) | false    |              |             |
 
 ## netcheck.Report
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7789,23 +7789,57 @@ If the schedule is empty, the user will be updated to use the default schedule.|
     "healthy": true,
     "severity": "ok",
     "warnings": ["string"]
+  },
+  "workspace_proxy": {
+    "error": "string",
+    "healthy": true,
+    "severity": "ok",
+    "warnings": ["string"],
+    "workspaceProxies": {
+      "regions": [
+        {
+          "created_at": "2019-08-24T14:15:22Z",
+          "deleted": true,
+          "derp_enabled": true,
+          "derp_only": true,
+          "display_name": "string",
+          "healthy": true,
+          "icon_url": "string",
+          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "name": "string",
+          "path_app_url": "string",
+          "status": {
+            "checked_at": "2019-08-24T14:15:22Z",
+            "report": {
+              "errors": ["string"],
+              "warnings": ["string"]
+            },
+            "status": "ok"
+          },
+          "updated_at": "2019-08-24T14:15:22Z",
+          "version": "string",
+          "wildcard_hostname": "string"
+        }
+      ]
+    }
   }
 }
 ```
 
 ### Properties
 
-| Name               | Type                                                       | Required | Restrictions | Description                                                                         |
-| ------------------ | ---------------------------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------- |
-| `access_url`       | [healthcheck.AccessURLReport](#healthcheckaccessurlreport) | false    |              |                                                                                     |
-| `coder_version`    | string                                                     | false    |              | The Coder version of the server that the report was generated on.                   |
-| `database`         | [healthcheck.DatabaseReport](#healthcheckdatabasereport)   | false    |              |                                                                                     |
-| `derp`             | [derphealth.Report](#derphealthreport)                     | false    |              |                                                                                     |
-| `failing_sections` | array of string                                            | false    |              | Failing sections is a list of sections that have failed their healthcheck.          |
-| `healthy`          | boolean                                                    | false    |              | Healthy is true if the report returns no errors. Deprecated: use `Severity` instead |
-| `severity`         | [health.Severity](#healthseverity)                         | false    |              | Severity indicates the status of Coder health.                                      |
-| `time`             | string                                                     | false    |              | Time is the time the report was generated at.                                       |
-| `websocket`        | [healthcheck.WebsocketReport](#healthcheckwebsocketreport) | false    |              |                                                                                     |
+| Name               | Type                                                                 | Required | Restrictions | Description                                                                         |
+| ------------------ | -------------------------------------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------- |
+| `access_url`       | [healthcheck.AccessURLReport](#healthcheckaccessurlreport)           | false    |              |                                                                                     |
+| `coder_version`    | string                                                               | false    |              | The Coder version of the server that the report was generated on.                   |
+| `database`         | [healthcheck.DatabaseReport](#healthcheckdatabasereport)             | false    |              |                                                                                     |
+| `derp`             | [derphealth.Report](#derphealthreport)                               | false    |              |                                                                                     |
+| `failing_sections` | array of string                                                      | false    |              | Failing sections is a list of sections that have failed their healthcheck.          |
+| `healthy`          | boolean                                                              | false    |              | Healthy is true if the report returns no errors. Deprecated: use `Severity` instead |
+| `severity`         | [health.Severity](#healthseverity)                                   | false    |              | Severity indicates the status of Coder health.                                      |
+| `time`             | string                                                               | false    |              | Time is the time the report was generated at.                                       |
+| `websocket`        | [healthcheck.WebsocketReport](#healthcheckwebsocketreport)           | false    |              |                                                                                     |
+| `workspace_proxy`  | [healthcheck.WorkspaceProxyReport](#healthcheckworkspaceproxyreport) | false    |              |                                                                                     |
 
 #### Enumerated Values
 
@@ -7846,6 +7880,54 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `severity` | `ok`      |
 | `severity` | `warning` |
 | `severity` | `error`   |
+
+## healthcheck.WorkspaceProxyReport
+
+```json
+{
+  "error": "string",
+  "healthy": true,
+  "severity": "ok",
+  "warnings": ["string"],
+  "workspaceProxies": {
+    "regions": [
+      {
+        "created_at": "2019-08-24T14:15:22Z",
+        "deleted": true,
+        "derp_enabled": true,
+        "derp_only": true,
+        "display_name": "string",
+        "healthy": true,
+        "icon_url": "string",
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "name": "string",
+        "path_app_url": "string",
+        "status": {
+          "checked_at": "2019-08-24T14:15:22Z",
+          "report": {
+            "errors": ["string"],
+            "warnings": ["string"]
+          },
+          "status": "ok"
+        },
+        "updated_at": "2019-08-24T14:15:22Z",
+        "version": "string",
+        "wildcard_hostname": "string"
+      }
+    ]
+  }
+}
+```
+
+### Properties
+
+| Name               | Type                                                                                                 | Required | Restrictions | Description |
+| ------------------ | ---------------------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `error`            | string                                                                                               | false    |              |             |
+| `healthy`          | boolean                                                                                              | false    |              |             |
+| `severity`         | [health.Severity](#healthseverity)                                                                   | false    |              |             |
+| `warnings`         | array of string                                                                                      | false    |              |             |
+| `workspaceProxies` | [codersdk.RegionsResponse-codersdk_WorkspaceProxy](#codersdkregionsresponse-codersdk_workspaceproxy) | false    |              |             |
 
 ## netcheck.Report
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
 	agplschedule "github.com/coder/coder/v2/coderd/schedule"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/dbauthz"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
@@ -374,6 +375,10 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		// Use proxy health to return the healthy workspace proxy hostnames.
 		f := api.ProxyHealth.ProxyHosts
 		api.AGPL.WorkspaceProxyHostsFn.Store(&f)
+
+		// Wire this up to healthcheck.
+		api.AGPL.FetchWorkspaceProxiesFunc.Store(ptr.Ref(api.fetchWorkspaceProxies))
+		api.AGPL.UpdateProxyHealthFunc.Store(ptr.Ref(api.ProxyHealth.ForceUpdate))
 	}
 
 	err = api.PrometheusRegistry.Register(&api.licenseMetricsCollector)

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -557,8 +557,8 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 				Log:      api.Logger.Named("quota_committer"),
 				Database: api.Database,
 			}
-			ptr := proto.QuotaCommitter(&committer)
-			api.AGPL.QuotaCommitter.Store(&ptr)
+			qcPtr := proto.QuotaCommitter(&committer)
+			api.AGPL.QuotaCommitter.Store(&qcPtr)
 		} else {
 			api.AGPL.QuotaCommitter.Store(nil)
 		}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -377,8 +377,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		api.AGPL.WorkspaceProxyHostsFn.Store(&f)
 
 		// Wire this up to healthcheck.
-		var fetchUpdater healthcheck.WorkspaceProxiesFetchUpdater //nolint:gosimple
-		fetchUpdater = &workspaceProxiesFetchUpdater{
+		var fetchUpdater healthcheck.WorkspaceProxiesFetchUpdater = &workspaceProxiesFetchUpdater{
 			fetchFunc:  api.fetchWorkspaceProxies,
 			updateFunc: api.ProxyHealth.ForceUpdate,
 		}

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -960,3 +960,20 @@ func convertProxy(p database.WorkspaceProxy, status proxyhealth.ProxyStatus) cod
 		},
 	}
 }
+
+// workspaceProxiesFetchUpdater implements healthcheck.WorkspaceProxyFetchUpdater
+// in an actually useful and meaningful way.
+type workspaceProxiesFetchUpdater struct {
+	fetchFunc  func(context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error)
+	updateFunc func(context.Context) error
+}
+
+func (w *workspaceProxiesFetchUpdater) Fetch(ctx context.Context) (codersdk.RegionsResponse[codersdk.WorkspaceProxy], error) {
+	//nolint:gocritic // Need perms to read all workspace proxies.
+	authCtx := dbauthz.AsSystemRestricted(ctx)
+	return w.fetchFunc(authCtx)
+}
+
+func (w *workspaceProxiesFetchUpdater) Update(ctx context.Context) error {
+	return w.updateFunc(ctx)
+}

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -867,6 +867,10 @@ func (g *Generator) typescriptType(ty types.Type) (TypescriptType, error) {
 			return TypescriptType{ValueType: "Record<string, string>"}, nil
 		case "github.com/coder/coder/v2/cli/clibase.URL":
 			return TypescriptType{ValueType: "string"}, nil
+		// XXX: For some reason, the type generator generates this as `any`
+		//      so explicitly specifying the correct generic TS type.
+		case "github.com/coder/coder/v2/codersdk.RegionsResponse[github.com/coder/coder/v2/codersdk.WorkspaceProxy]":
+			return TypescriptType{ValueType: "RegionsResponse<WorkspaceProxy>"}, nil
 		}
 
 		// Some hard codes are a bit trickier.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2129,6 +2129,17 @@ export interface HealthcheckWebsocketReport {
   readonly error?: string;
 }
 
+// From healthcheck/workspaceproxy.go
+export interface HealthcheckWorkspaceProxyReport {
+  readonly healthy: boolean;
+  readonly severity: HealthSeverity;
+  readonly warnings: string[];
+  readonly error?: string;
+  // Named type "github.com/coder/coder/v2/codersdk.RegionsResponse[github.com/coder/coder/v2/codersdk.WorkspaceProxy]" unknown, using "any"
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
+  readonly WorkspaceProxies: any;
+}
+
 // The code below is generated from cli/clibase.
 
 // From clibase/clibase.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2135,9 +2135,7 @@ export interface HealthcheckWorkspaceProxyReport {
   readonly severity: HealthSeverity;
   readonly warnings: string[];
   readonly error?: string;
-  // Named type "github.com/coder/coder/v2/codersdk.RegionsResponse[github.com/coder/coder/v2/codersdk.WorkspaceProxy]" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly workspace_proxies: any;
+  readonly workspace_proxies: RegionsResponse<WorkspaceProxy>;
 }
 
 // The code below is generated from cli/clibase.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2137,7 +2137,7 @@ export interface HealthcheckWorkspaceProxyReport {
   readonly error?: string;
   // Named type "github.com/coder/coder/v2/codersdk.RegionsResponse[github.com/coder/coder/v2/codersdk.WorkspaceProxy]" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly WorkspaceProxies: any;
+  readonly workspace_proxies: any;
 }
 
 // The code below is generated from cli/clibase.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2115,6 +2115,7 @@ export interface HealthcheckReport {
   readonly access_url: HealthcheckAccessURLReport;
   readonly websocket: HealthcheckWebsocketReport;
   readonly database: HealthcheckDatabaseReport;
+  readonly workspace_proxy: HealthcheckWorkspaceProxyReport;
   readonly coder_version: string;
 }
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2827,6 +2827,14 @@ export const MockHealth: TypesGen.HealthcheckReport = {
     latency_ms: 92570,
     threshold_ms: 92570,
   },
+  workspace_proxy: {
+    healthy: true,
+    severity: "ok",
+    warnings: [],
+    workspace_proxies: {
+      regions: [],
+    },
+  },
   coder_version: "v0.27.1-devel+c575292",
 };
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2906,7 +2906,7 @@ export const DeploymentHealthUnhealthy: TypesGen.HealthcheckReport = {
             status: "unreachable",
             report: {
               errors: ["some error"],
-              warnings: null,
+              warnings: [],
             },
             checked_at: "2023-11-24T12:14:05.743303497Z",
           },

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2877,4 +2877,37 @@ export const DeploymentHealthUnhealthy: TypesGen.HealthcheckReport = {
     body: "",
     code: 0,
   },
+  workspace_proxy: {
+    healthy: false,
+    error: "some error",
+    severity: "error",
+    warnings: [],
+    workspace_proxies: {
+      regions: [
+        {
+          id: "df7e4b2b-2d40-47e5-a021-e5d08b219c77",
+          name: "unhealthy",
+          display_name: "unhealthy",
+          icon_url: "/emojis/1f5fa.png",
+          healthy: false,
+          path_app_url: "http://127.0.0.1:3001",
+          wildcard_hostname: "",
+          derp_enabled: true,
+          derp_only: false,
+          status: {
+            status: "unreachable",
+            report: {
+              errors: ["some error"],
+              warnings: null,
+            },
+            checked_at: "2023-11-24T12:14:05.743303497Z",
+          },
+          created_at: "2023-11-23T15:37:25.513213Z",
+          updated_at: "2023-11-23T18:09:19.734747Z",
+          deleted: false,
+          version: "v2.4.0-devel+89bae7eff",
+        },
+      ],
+    },
+  },
 };


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/9558

Adds a health check for workspace proxies:
- Healthy iff all proxies are healthy and the same version,
- Warning if some proxies are unhealthy,
- Error if all proxies are unhealthy, or do not all have the same version.