### PR TITLE
fix(enterprise/coderd/proxyhealth): properly defer healthCheckDuration observe

### DIFF
--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -215,7 +215,7 @@ func (p *ProxyHealth) ProxyHosts() []string {
 // unreachable.
 func (p *ProxyHealth) runOnce(ctx context.Context, now time.Time) (map[uuid.UUID]ProxyStatus, error) {
 	// Record from the given time.
-	defer p.healthCheckDuration.Observe(time.Since(now).Seconds())
+	defer func() { p.healthCheckDuration.Observe(time.Since(now).Seconds()) }()
 
 	//nolint:gocritic // Proxy health is a system service.
 	proxies, err := p.db.GetWorkspaceProxies(dbauthz.AsSystemRestricted(ctx))


### PR DESCRIPTION
Drive-by linter fix. We weren't properly calling `time.Since()` in a `defer()`.