### PR TITLE
fix: improve exit codes for agent/agentssh and cli/ssh

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -237,8 +237,28 @@ func (s *Server) sessionHandler(session ssh.Session) {
 	err := s.sessionStart(logger, session, extraEnv)
 	var exitError *exec.ExitError
 	if xerrors.As(err, &exitError) {
-		logger.Info(ctx, "ssh session returned", slog.Error(exitError))
-		_ = session.Exit(exitError.ExitCode())
+		code := exitError.ExitCode()
+		if code == -1 {
+			// If we return -1 here, it will be transmitted as an
+			// uint32(4294967295). This exit code is nonsense, so
+			// instead we return 255 (same as OpenSSH). This is
+			// also the same exit code that the shell returns for
+			// -1.
+			//
+			// For signals, we could consider sending 128+signal
+			// instead (however, OpenSSH doesn't seem to do this).
+			code = 255
+		}
+		logger.Info(ctx, "ssh session returned",
+			slog.Error(exitError),
+			slog.F("process_exit_code", exitError.ExitCode()),
+			slog.F("exit_code", code),
+		)
+
+		// TODO(mafredri): For signal exit, there's also an "exit-signal"
+		// request (session.Exit sends "exit-status"), however, the
+		// implementation seems incomplete.
+		_ = session.Exit(code)
 		return
 	}
 	if err != nil {

--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -256,8 +256,9 @@ func (s *Server) sessionHandler(session ssh.Session) {
 		)
 
 		// TODO(mafredri): For signal exit, there's also an "exit-signal"
-		// request (session.Exit sends "exit-status"), however, the
-		// implementation seems incomplete.
+		// request (session.Exit sends "exit-status"), however, since it's
+		// not implemented on the session interface and not used by
+		// OpenSSH, we'll leave it for now.
 		_ = session.Exit(code)
 		return
 	}

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -227,7 +227,9 @@ func TestNewServer_Signal(t *testing.T) {
 		require.NoError(t, sc.Err())
 
 		err = sess.Wait()
-		require.Error(t, err)
+		exitErr := &ssh.ExitError{}
+		require.ErrorAs(t, err, &exitErr)
+		require.Equal(t, 255, exitErr.ExitStatus())
 	})
 	t.Run("PTY", func(t *testing.T) {
 		t.Parallel()
@@ -300,7 +302,9 @@ func TestNewServer_Signal(t *testing.T) {
 		require.NoError(t, sc.Err())
 
 		err = sess.Wait()
-		require.Error(t, err)
+		exitErr := &ssh.ExitError{}
+		require.ErrorAs(t, err, &exitErr)
+		require.Equal(t, 255, exitErr.ExitStatus())
 	})
 }
 

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -229,7 +229,11 @@ func TestNewServer_Signal(t *testing.T) {
 		err = sess.Wait()
 		exitErr := &ssh.ExitError{}
 		require.ErrorAs(t, err, &exitErr)
-		require.Equal(t, 255, exitErr.ExitStatus())
+		wantCode := 255
+		if runtime.GOOS == "windows" {
+			wantCode = 1
+		}
+		require.Equal(t, wantCode, exitErr.ExitStatus())
 	})
 	t.Run("PTY", func(t *testing.T) {
 		t.Parallel()
@@ -304,7 +308,11 @@ func TestNewServer_Signal(t *testing.T) {
 		err = sess.Wait()
 		exitErr := &ssh.ExitError{}
 		require.ErrorAs(t, err, &exitErr)
-		require.Equal(t, 255, exitErr.ExitStatus())
+		wantCode := 255
+		if runtime.GOOS == "windows" {
+			wantCode = 1
+		}
+		require.Equal(t, wantCode, exitErr.ExitStatus())
 	})
 }
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -136,14 +136,22 @@ func (r *RootCmd) RunMain(subcommands []*clibase.Cmd) {
 	}
 	err = cmd.Invoke().WithOS().Run()
 	if err != nil {
+		code := 1
+		var exitErr *exitError
+		if errors.As(err, &exitErr) {
+			code = exitErr.code
+			err = exitErr.err
+		}
 		if errors.Is(err, cliui.Canceled) {
 			//nolint:revive
-			os.Exit(1)
+			os.Exit(code)
 		}
 		f := prettyErrorFormatter{w: os.Stderr, verbose: r.verbose}
-		f.format(err)
+		if err != nil {
+			f.format(err)
+		}
 		//nolint:revive
-		os.Exit(1)
+		os.Exit(code)
 	}
 }
 
@@ -951,6 +959,30 @@ func DumpHandler(ctx context.Context) {
 			os.Exit(1)
 		}
 	}
+}
+
+type exitError struct {
+	code int
+	err  error
+}
+
+var _ error = (*exitError)(nil)
+
+func (e *exitError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("exit code %d: %v", e.code, e.err)
+	}
+	return fmt.Sprintf("exit code %d", e.code)
+}
+
+func (e *exitError) Unwrap() error {
+	return e.err
+}
+
+// ExitError returns an error that will cause the CLI to exit with the given
+// exit code. If err is non-nil, it will be wrapped by the returned error.
+func ExitError(code int, err error) error {
+	return &exitError{code: code, err: err}
 }
 
 // IiConnectionErr is a convenience function for checking if the source of an

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -379,11 +379,16 @@ func (r *RootCmd) ssh() *clibase.Cmd {
 
 			err = sshSession.Wait()
 			if err != nil {
+				if exitErr := &gossh.ExitError{}; errors.As(err, &exitErr) {
+					// Clear the error since it's not useful beyond
+					// reporting status.
+					return ExitError(exitErr.ExitStatus(), nil)
+				}
 				// If the connection drops unexpectedly, we get an
 				// ExitMissingError but no other error details, so try to at
 				// least give the user a better message
 				if errors.Is(err, &gossh.ExitMissingError{}) {
-					return xerrors.New("SSH connection ended unexpectedly")
+					return ExitError(255, xerrors.New("SSH connection ended unexpectedly"))
 				}
 				return xerrors.Errorf("session ended: %w", err)
 			}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -379,7 +379,7 @@ func (r *RootCmd) ssh() *clibase.Cmd {
 
 			err = sshSession.Wait()
 			if err != nil {
-				if exitErr := &gossh.ExitError{}; errors.As(err, &exitErr) {
+				if exitErr := (&gossh.ExitError{}); errors.As(err, &exitErr) {
 					// Clear the error since it's not useful beyond
 					// reporting status.
 					return ExitError(exitErr.ExitStatus(), nil)


### PR DESCRIPTION
This PR improves the exit codes of agent/agentssh and cli/ssh (non-stdio).

In cases where the process is killed via signal, agentssh returned -1 which was translated into a 32-bit uint max (4294967295) over the wire. What this logically translates to is 255 (uint8(-1)).

Consequently, cli/ssh was also returning nonsense exit codes of 0/1 only and masking the true exit code. This is now fixed.

```
~/Work/Code/coder mafredri/fix-ssh-exit*
❯ coder ssh work; echo $?

mafredri@work ~
❯ exit 2
Encountered an error running "coder ssh"
session ended:
    github.com/coder/coder/v2/cli.(*RootCmd).ssh.func1
        /home/runner/actions-runner/_work/coder/coder/cli/ssh.go:388
  - Process exited with status 2
1
```

Compared to:

```
~/Work/Code/coder mafredri/fix-ssh-exit*
❯ ./coder ssh work; echo $?

mafredri@work ~
❯ exit 2
2
```
