### PR TITLE
test(agent/agentssh): fix flake in signal test

### DIFF
--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -216,7 +216,7 @@ func TestNewServer_Signal(t *testing.T) {
 		}
 		require.NoError(t, sc.Err())
 
-		err = sess.Signal(ssh.SIGINT)
+		err = sess.Signal(ssh.SIGKILL)
 		require.NoError(t, err)
 
 		// Assumption, signal propagates and the command exists, closing stdout.
@@ -289,7 +289,7 @@ func TestNewServer_Signal(t *testing.T) {
 		}
 		require.NoError(t, sc.Err())
 
-		err = sess.Signal(ssh.SIGINT)
+		err = sess.Signal(ssh.SIGKILL)
 		require.NoError(t, err)
 
 		// Assumption, signal propagates and the command exists, closing stdout.


### PR DESCRIPTION
I'm hoping this will fix the following flake:

https://github.com/coder/coder/actions/runs/6972992773/job/18976211275

I'm unable to reproduce the issue on my Mac, hence 🤞
