### PR TITLE
fix: initialize healthcheck warnings with empty array

### DIFF
--- a/coderd/healthcheck/derphealth/derp.go
+++ b/coderd/healthcheck/derphealth/derp.go
@@ -166,6 +166,7 @@ func (r *RegionReport) Run(ctx context.Context) {
 	r.Healthy = true
 	r.Severity = health.SeverityOK
 	r.NodeReports = []*NodeReport{}
+	r.Warnings = []string{}
 
 	wg := &sync.WaitGroup{}
 	var unhealthyNodes int // atomic.Int64 is not mandatory as we depend on RegionReport mutex.
@@ -262,6 +263,7 @@ func (r *NodeReport) Run(ctx context.Context) {
 	r.Severity = health.SeverityOK
 	r.ClientLogs = [][]string{}
 	r.ClientErrs = [][]string{}
+	r.Warnings = []string{}
 
 	wg := &sync.WaitGroup{}
 

--- a/coderd/healthcheck/derphealth/derp_test.go
+++ b/coderd/healthcheck/derphealth/derp_test.go
@@ -68,6 +68,8 @@ func TestDERP(t *testing.T) {
 			for _, node := range region.NodeReports {
 				assert.True(t, node.Healthy)
 				assert.True(t, node.CanExchangeMessages)
+				assert.Empty(t, node.Warnings)
+				assert.NotNil(t, node.Warnings)
 				assert.NotEmpty(t, node.RoundTripPing)
 				assert.Len(t, node.ClientLogs, 2)
 				assert.Len(t, node.ClientLogs[0], 3)
@@ -128,6 +130,8 @@ func TestDERP(t *testing.T) {
 		for _, region := range report.Regions {
 			assert.True(t, region.Healthy)
 			assert.True(t, region.NodeReports[0].Healthy)
+			assert.Empty(t, region.NodeReports[0].Warnings)
+			assert.NotNil(t, region.NodeReports[0].Warnings)
 			assert.Equal(t, health.SeverityOK, region.NodeReports[0].Severity)
 			assert.False(t, region.NodeReports[1].Healthy)
 			assert.Equal(t, health.SeverityError, region.NodeReports[1].Severity)


### PR DESCRIPTION
Spotted while working on https://github.com/coder/coder/issues/10712

DERP healthcheck has `warnings: null` when it is healthy. For consistency reasons, it should be an empty array.