### PR TITLE
chore(site): remove paperLight background value

### DIFF
--- a/site/src/@types/mui.d.ts
+++ b/site/src/@types/mui.d.ts
@@ -14,10 +14,6 @@ declare module "@mui/material/styles" {
     experimental: NewTheme;
   }
 
-  interface TypeBackground {
-    paperLight: string;
-  }
-
   interface Palette {
     neutral: PaletteColor;
   }

--- a/site/src/components/Dashboard/Navbar/NavbarView.tsx
+++ b/site/src/components/Dashboard/Navbar/NavbarView.tsx
@@ -187,7 +187,6 @@ export const NavbarView: FC<NavbarViewProps> = ({
     <nav
       css={(theme) => ({
         height: navHeight,
-        background: theme.palette.background.paper,
         borderBottom: `1px solid ${theme.palette.divider}`,
       })}
     >

--- a/site/src/components/Dashboard/Navbar/NavbarView.tsx
+++ b/site/src/components/Dashboard/Navbar/NavbarView.tsx
@@ -188,6 +188,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
       css={(theme) => ({
         height: navHeight,
         borderBottom: `1px solid ${theme.palette.divider}`,
+        backgroundColor: theme.palette.background.paper,
       })}
     >
       <div css={styles.wrapper}>

--- a/site/src/components/DeploySettingsLayout/Fieldset.tsx
+++ b/site/src/components/DeploySettingsLayout/Fieldset.tsx
@@ -29,7 +29,6 @@ export const Fieldset: FC<FieldsetProps> = (props) => {
       css={{
         borderRadius: 8,
         border: `1px solid ${theme.palette.divider}`,
-        background: theme.palette.background.paper,
         marginTop: 32,
       }}
       onSubmit={onSubmit}
@@ -63,7 +62,7 @@ export const Fieldset: FC<FieldsetProps> = (props) => {
         css={[
           theme.typography.body2 as CSSObject,
           {
-            background: theme.palette.background.paperLight,
+            background: theme.palette.background.paper,
             padding: "16px 24px",
             display: "flex",
             alignItems: "center",

--- a/site/src/components/DeploySettingsLayout/Option.tsx
+++ b/site/src/components/DeploySettingsLayout/Option.tsx
@@ -127,9 +127,7 @@ interface OptionConfigProps extends BoxProps {
 export const OptionConfig = (props: OptionConfigProps) => {
   const { source, sx, ...attrs } = props;
   const theme = useTheme();
-  const borderColor = source
-    ? theme.palette.primary.main
-    : theme.palette.divider;
+  const borderColor = source ? undefined : theme.palette.divider;
 
   return (
     <Box
@@ -139,9 +137,7 @@ export const OptionConfig = (props: OptionConfigProps) => {
         fontFamily: MONOSPACE_FONT_FAMILY,
         fontWeight: 600,
         backgroundColor: (theme) =>
-          source
-            ? theme.palette.primary.dark
-            : theme.palette.background.paperLight,
+          source ? theme.palette.primary.dark : theme.palette.background.paper,
         display: "inline-flex",
         alignItems: "center",
         borderRadius: 0.25,

--- a/site/src/components/ErrorBoundary/RuntimeErrorState.tsx
+++ b/site/src/components/ErrorBoundary/RuntimeErrorState.tsx
@@ -160,7 +160,6 @@ const styles = {
   }),
 
   stack: (theme) => ({
-    backgroundColor: theme.palette.background.paper,
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: 4,
     marginTop: 64,
@@ -174,7 +173,7 @@ const styles = {
     fontWeight: 600,
     letterSpacing: 1,
     padding: "8px 8px 8px 16px",
-    backgroundColor: theme.palette.background.paperLight,
+    backgroundColor: theme.palette.background.paper,
     borderBottom: `1px solid ${theme.palette.divider}`,
     color: theme.palette.text.secondary,
     display: "flex",

--- a/site/src/components/Filter/filter.tsx
+++ b/site/src/components/Filter/filter.tsx
@@ -125,7 +125,7 @@ const BaseSkeleton = (props: SkeletonProps) => {
       height={36}
       {...props}
       sx={{
-        bgcolor: (theme) => theme.palette.background.paperLight,
+        bgcolor: (theme) => theme.palette.background.paper,
         borderRadius: "6px",
         ...props.sx,
       }}

--- a/site/src/components/Markdown/Markdown.tsx
+++ b/site/src/components/Markdown/Markdown.tsx
@@ -217,7 +217,7 @@ const markdownStyles: Interpolation<Theme> = (theme: Theme) => ({
   },
 
   "& .prismjs": {
-    background: theme.palette.background.paperLight,
+    background: theme.palette.background.paper,
     borderRadius: 8,
     padding: "16px 24px",
     overflowX: "auto",

--- a/site/src/components/PageHeader/FullWidthPageHeader.tsx
+++ b/site/src/components/PageHeader/FullWidthPageHeader.tsx
@@ -12,7 +12,7 @@ export const FullWidthPageHeader: FC<
         {
           ...(theme.typography.body2 as CSSObject),
           padding: 24,
-          background: theme.palette.background.paper,
+          background: theme.palette.background.default,
           borderBottom: `1px solid ${theme.palette.divider}`,
           display: "flex",
           alignItems: "center",

--- a/site/src/components/Resources/AgentButton.tsx
+++ b/site/src/components/Resources/AgentButton.tsx
@@ -1,34 +1,28 @@
 import Button, { ButtonProps } from "@mui/material/Button";
-import { FC, forwardRef } from "react";
-
-export const PrimaryAgentButton: FC<ButtonProps> = ({
-  className,
-  ...props
-}) => {
-  return (
-    <Button
-      color="neutral"
-      {...props}
-      sx={{
-        backgroundColor: (theme) => theme.palette.background.default,
-        "&:hover": {
-          backgroundColor: (theme) => theme.palette.background.paper,
-        },
-        // Making them smaller since those icons don't have a padding around them
-        "& .MuiButton-startIcon": {
-          width: 12,
-          height: 12,
-          "& svg": { width: "100%", height: "100%" },
-        },
-        ...props.sx,
-      }}
-    />
-  );
-};
+import { forwardRef } from "react";
 
 // eslint-disable-next-line react/display-name -- Name is inferred from variable name
-export const SecondaryAgentButton = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, ...props }, ref) => {
-    return <Button ref={ref} className={className} {...props} />;
+export const AgentButton = forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => {
+    return (
+      <Button
+        color="neutral"
+        {...props}
+        ref={ref}
+        sx={{
+          backgroundColor: (theme) => theme.palette.background.default,
+          "&:hover": {
+            backgroundColor: (theme) => theme.palette.background.paper,
+          },
+          // Making them smaller since those icons don't have a padding around them
+          "& .MuiButton-startIcon": {
+            width: 12,
+            height: 12,
+            "& svg": { width: "100%", height: "100%" },
+          },
+          ...props.sx,
+        }}
+      />
+    );
   },
 );

--- a/site/src/components/Resources/AgentMetadata.tsx
+++ b/site/src/components/Resources/AgentMetadata.tsx
@@ -207,7 +207,6 @@ const styles = {
   root: (theme) => ({
     padding: "20px 32px",
     borderTop: `1px solid ${theme.palette.divider}`,
-    background: theme.palette.background.paper,
     overflowX: "auto",
     scrollPadding: "0 32px",
   }),

--- a/site/src/components/Resources/AgentRow.tsx
+++ b/site/src/components/Resources/AgentRow.tsx
@@ -513,7 +513,6 @@ const useAgentLogs = (
 
 const styles = {
   agentRow: (theme) => ({
-    backgroundColor: theme.palette.background.paper,
     fontSize: 16,
     borderLeft: `2px solid ${theme.palette.text.secondary}`,
 
@@ -578,6 +577,7 @@ const styles = {
     alignItems: "center",
     gap: 48,
     flexWrap: "wrap",
+    backgroundColor: theme.palette.background.paper,
 
     [theme.breakpoints.down("md")]: {
       gap: 16,

--- a/site/src/components/Resources/AgentRow.tsx
+++ b/site/src/components/Resources/AgentRow.tsx
@@ -513,7 +513,7 @@ const useAgentLogs = (
 
 const styles = {
   agentRow: (theme) => ({
-    backgroundColor: theme.palette.background.paperLight,
+    backgroundColor: theme.palette.background.paper,
     fontSize: 16,
     borderLeft: `2px solid ${theme.palette.text.secondary}`,
 

--- a/site/src/components/Resources/AgentRowPreview.tsx
+++ b/site/src/components/Resources/AgentRowPreview.tsx
@@ -103,7 +103,7 @@ export const AgentRowPreview: FC<AgentRowPreviewProps> = ({
 const styles = {
   agentRow: (theme) => ({
     padding: "16px 32px",
-    backgroundColor: theme.palette.background.paperLight,
+    backgroundColor: theme.palette.background.paper,
     fontSize: 16,
     position: "relative",
 

--- a/site/src/components/Resources/AppLink/AppLink.tsx
+++ b/site/src/components/Resources/AppLink/AppLink.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@emotion/react";
 import { getApiKey } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import { useProxy } from "contexts/ProxyContext";
-import { PrimaryAgentButton } from "components/Resources/AgentButton";
+import { AgentButton } from "components/Resources/AgentButton";
 import { createAppLinkHref } from "utils/apps";
 import { generateRandomString } from "utils/random";
 import { BaseIcon } from "./BaseIcon";
@@ -86,7 +86,7 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
   const isPrivateApp = app.sharing_level === "owner";
 
   const button = (
-    <PrimaryAgentButton
+    <AgentButton
       startIcon={icon}
       endIcon={isPrivateApp ? undefined : <ShareIcon app={app} />}
       disabled={!canClick}
@@ -100,7 +100,7 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
       >
         {appDisplayName}
       </span>
-    </PrimaryAgentButton>
+    </AgentButton>
   );
 
   return (

--- a/site/src/components/Resources/PortForwardButton.tsx
+++ b/site/src/components/Resources/PortForwardButton.tsx
@@ -20,7 +20,7 @@ import {
   HelpTooltipText,
   HelpTooltipTitle,
 } from "components/HelpTooltip/HelpTooltip";
-import { SecondaryAgentButton } from "components/Resources/AgentButton";
+import { AgentButton } from "components/Resources/AgentButton";
 import {
   Popover,
   PopoverContent,
@@ -49,14 +49,14 @@ export const PortForwardButton: FC<PortForwardButtonProps> = (props) => {
   return (
     <Popover>
       <PopoverTrigger>
-        <SecondaryAgentButton disabled={!portsQuery.data}>
+        <AgentButton disabled={!portsQuery.data}>
           Ports
           {portsQuery.data ? (
             <div css={styles.portCount}>{portsQuery.data.ports.length}</div>
           ) : (
             <CircularProgress size={10} css={{ marginLeft: 8 }} />
           )}
-        </SecondaryAgentButton>
+        </AgentButton>
       </PopoverTrigger>
       <PopoverContent horizontal="right" classes={{ paper }}>
         <PortForwardPopoverView {...props} ports={portsQuery.data?.ports} />

--- a/site/src/components/Resources/ResourceCard.tsx
+++ b/site/src/components/Resources/ResourceCard.tsx
@@ -13,7 +13,6 @@ import { SensitiveValue } from "./SensitiveValue";
 
 const styles = {
   resourceCard: (theme) => ({
-    background: theme.palette.background.paper,
     borderRadius: 8,
     border: `1px solid ${theme.palette.divider}`,
 

--- a/site/src/components/Resources/SSHButton/SSHButton.tsx
+++ b/site/src/components/Resources/SSHButton/SSHButton.tsx
@@ -14,7 +14,7 @@ import {
   PopoverTrigger,
 } from "components/Popover/Popover";
 import { Stack } from "components/Stack/Stack";
-import { SecondaryAgentButton } from "../AgentButton";
+import { AgentButton } from "../AgentButton";
 
 export interface SSHButtonProps {
   workspaceName: string;
@@ -34,7 +34,7 @@ export const SSHButton: FC<PropsWithChildren<SSHButtonProps>> = ({
   return (
     <Popover isDefaultOpen={isDefaultOpen}>
       <PopoverTrigger>
-        <SecondaryAgentButton>SSH</SecondaryAgentButton>
+        <AgentButton>SSH</AgentButton>
       </PopoverTrigger>
 
       <PopoverContent horizontal="right" classes={{ paper }}>

--- a/site/src/components/Resources/TerminalLink/TerminalLink.tsx
+++ b/site/src/components/Resources/TerminalLink/TerminalLink.tsx
@@ -1,5 +1,5 @@
 import Link from "@mui/material/Link";
-import { SecondaryAgentButton } from "components/Resources/AgentButton";
+import { AgentButton } from "components/Resources/AgentButton";
 import { FC } from "react";
 import * as TypesGen from "api/typesGenerated";
 import { generateRandomString } from "utils/random";
@@ -46,7 +46,7 @@ export const TerminalLink: FC<React.PropsWithChildren<TerminalLinkProps>> = ({
       }}
       data-testid="terminal"
     >
-      <SecondaryAgentButton>{Language.linkText}</SecondaryAgentButton>
+      <AgentButton>{Language.linkText}</AgentButton>
     </Link>
   );
 };

--- a/site/src/components/Resources/VSCodeDesktopButton/VSCodeDesktopButton.tsx
+++ b/site/src/components/Resources/VSCodeDesktopButton/VSCodeDesktopButton.tsx
@@ -2,7 +2,7 @@ import { FC, PropsWithChildren, useState, useRef } from "react";
 import { getApiKey } from "api/api";
 import { VSCodeIcon } from "components/Icons/VSCodeIcon";
 import { VSCodeInsidersIcon } from "components/Icons/VSCodeInsidersIcon";
-import { PrimaryAgentButton } from "components/Resources/AgentButton";
+import { AgentButton } from "components/Resources/AgentButton";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import { useLocalStorage } from "hooks";
@@ -63,7 +63,7 @@ export const VSCodeDesktopButton: FC<
           <VSCodeInsidersButton {...props} />
         )}
 
-        <PrimaryAgentButton
+        <AgentButton
           aria-controls={
             isVariantMenuOpen ? "vscode-variant-button-menu" : undefined
           }
@@ -77,7 +77,7 @@ export const VSCodeDesktopButton: FC<
           sx={{ px: 0 }}
         >
           <KeyboardArrowDownIcon sx={{ fontSize: 16 }} />
-        </PrimaryAgentButton>
+        </AgentButton>
       </ButtonGroup>
 
       <Menu
@@ -126,7 +126,7 @@ const VSCodeButton = ({
   const [loading, setLoading] = useState(false);
 
   return (
-    <PrimaryAgentButton
+    <AgentButton
       startIcon={<VSCodeIcon />}
       disabled={loading}
       onClick={() => {
@@ -157,7 +157,7 @@ const VSCodeButton = ({
       }}
     >
       VS Code Desktop
-    </PrimaryAgentButton>
+    </AgentButton>
   );
 };
 
@@ -170,7 +170,7 @@ const VSCodeInsidersButton = ({
   const [loading, setLoading] = useState(false);
 
   return (
-    <PrimaryAgentButton
+    <AgentButton
       startIcon={<VSCodeInsidersIcon />}
       disabled={loading}
       onClick={() => {
@@ -201,6 +201,6 @@ const VSCodeInsidersButton = ({
       }}
     >
       VS Code Insiders
-    </PrimaryAgentButton>
+    </AgentButton>
   );
 };

--- a/site/src/components/SyntaxHighlighter/coderTheme.ts
+++ b/site/src/components/SyntaxHighlighter/coderTheme.ts
@@ -207,9 +207,9 @@ export const coderTheme = (theme: Theme): editor.IStandaloneThemeData => ({
   ],
   colors: {
     "editor.foreground": theme.palette.text.primary,
-    "editor.background": theme.palette.background.paper,
+    "editor.background": theme.palette.background.default,
     "editor.selectionBackground": theme.palette.action.hover,
-    "editor.lineHighlightBackground": theme.palette.background.paperLight,
+    "editor.lineHighlightBackground": theme.palette.background.paper,
 
     "editorCursor.foreground": "#f8f8f0",
     "editorWhitespace.foreground": "#3B3A32",

--- a/site/src/components/TemplateFiles/TemplateFiles.tsx
+++ b/site/src/components/TemplateFiles/TemplateFiles.tsx
@@ -146,7 +146,7 @@ const styles = {
   }),
 
   codeWrapper: (theme) => ({
-    background: theme.palette.background.paperLight,
+    background: theme.palette.background.paper,
   }),
 
   files: (theme) => ({

--- a/site/src/components/Timeline/TimelineDateRow.tsx
+++ b/site/src/components/Timeline/TimelineDateRow.tsx
@@ -14,8 +14,6 @@ export const TimelineDateRow: FC<TimelineDateRow> = ({ date }) => {
   return (
     <TableRow
       css={css`
-        background: ${theme.palette.background.paper};
-
         &:not(:first-of-type) td {
           border-top: 1px solid ${theme.palette.divider};
         }
@@ -24,7 +22,7 @@ export const TimelineDateRow: FC<TimelineDateRow> = ({ date }) => {
       <TableCell
         css={{
           padding: `8px 32px !important`,
-          background: `${theme.palette.background.paperLight} !important`,
+          background: `${theme.palette.background.paper} !important`,
           fontSize: 12,
           position: "relative",
           color: theme.palette.text.secondary,

--- a/site/src/components/WorkspaceBuildLogs/Logs.tsx
+++ b/site/src/components/WorkspaceBuildLogs/Logs.tsx
@@ -120,7 +120,7 @@ const styles = {
     },
 
     "&.debug": {
-      backgroundColor: theme.palette.background.paperLight,
+      backgroundColor: theme.palette.background.paper,
     },
 
     "&.warn": {

--- a/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
+++ b/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
@@ -92,7 +92,7 @@ const FailureTooltip: FC<TooltipProps> = ({ children, ...tooltipProps }) => {
   const popper = useClassName(
     (css, theme) => css`
       & .${tooltipClasses.tooltip} {
-        background-color: ${theme.palette.background.paperLight};
+        background-color: ${theme.palette.background.paper};
         border: 1px solid ${theme.palette.divider};
         font-size: 12px;
         padding: 8px 10px;

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/DateRange.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/DateRange.tsx
@@ -157,7 +157,7 @@ const styles = {
       color: theme.palette.text.secondary,
 
       "&:hover .rdrStaticRangeLabel": {
-        background: theme.palette.background.paperLight,
+        background: theme.palette.background.paper,
         color: theme.palette.text.primary,
       },
 
@@ -175,7 +175,7 @@ const styles = {
     },
 
     "& .rdrCalendarWrapper": {
-      backgroundColor: theme.palette.background.paperLight,
+      backgroundColor: theme.palette.background.paper,
     },
 
     "& .rdrDateDisplayItem": {
@@ -188,7 +188,7 @@ const styles = {
 
       "&.rdrDateDisplayItemActive": {
         borderColor: theme.palette.text.primary,
-        backgroundColor: theme.palette.background.paperLight,
+        backgroundColor: theme.palette.background.paper,
 
         "& input": {
           color: theme.palette.text.primary,

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
@@ -147,7 +147,7 @@ const styles = {
   },
 
   active: (theme) => ({
-    backgroundColor: theme.palette.background.paperLight,
+    backgroundColor: theme.palette.background.paper,
   }),
 
   versionCell: {

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -471,7 +471,6 @@ const styles = {
     alignItems: "center",
     justifyContent: "space-between",
     height: topbarHeight,
-    background: theme.palette.background.paper,
   }),
   topbarSides: {
     display: "flex",
@@ -486,7 +485,6 @@ const styles = {
   },
   sidebar: (theme) => ({
     minWidth: 256,
-    backgroundColor: theme.palette.background.paper,
     borderRight: `1px solid ${theme.palette.divider}`,
   }),
   sidebarTitle: (theme) => ({

--- a/site/src/pages/TerminalPage/TerminalAlerts.tsx
+++ b/site/src/pages/TerminalPage/TerminalAlerts.tsx
@@ -96,7 +96,7 @@ const TerminalAlert = (props: AlertProps) => {
         borderWidth: 0,
         borderBottomWidth: 1,
         borderBottomColor: (theme) => theme.palette.divider,
-        backgroundColor: (theme) => theme.palette.background.paperLight,
+        backgroundColor: (theme) => theme.palette.background.paper,
         borderLeft: (theme) =>
           `3px solid ${theme.palette[props.severity!].light}`,
         marginBottom: 1,

--- a/site/src/pages/TerminalPage/TerminalPageAlert.tsx
+++ b/site/src/pages/TerminalPage/TerminalPageAlert.tsx
@@ -112,7 +112,7 @@ export default ({
         borderWidth: 0,
         borderBottomWidth: 1,
         borderBottomColor: (theme) => theme.palette.divider,
-        backgroundColor: (theme) => theme.palette.background.paperLight,
+        backgroundColor: (theme) => theme.palette.background.paper,
         borderLeft: (theme) => `3px solid ${theme.palette[severity].light}`,
         marginBottom: 1,
       }}

--- a/site/src/pages/UsersPage/UsersTable/EditRolesButton.tsx
+++ b/site/src/pages/UsersPage/UsersTable/EditRolesButton.tsx
@@ -161,7 +161,7 @@ const classNames = {
   paper: (css, theme) => css`
     width: 360px;
     margin-top: 8px;
-    background: ${theme.palette.background.paperLight};
+    background: ${theme.palette.background.paper};
   `,
 } satisfies Record<string, ClassName>;
 

--- a/site/src/pages/UsersPage/UsersTable/UserRoleCell.tsx
+++ b/site/src/pages/UsersPage/UsersTable/UserRoleCell.tsx
@@ -76,7 +76,7 @@ export function UserRoleCell({
           css={{
             backgroundColor: hasOwnerRole
               ? theme.palette.info.dark
-              : theme.palette.background.paperLight,
+              : theme.palette.background.paper,
             borderColor: hasOwnerRole
               ? theme.palette.info.light
               : theme.palette.divider,
@@ -102,7 +102,7 @@ function OverflowRolePill({ roles }: OverflowRolePillProps) {
         <Pill
           text={`+${roles.length} more`}
           css={{
-            backgroundColor: theme.palette.background.paperLight,
+            backgroundColor: theme.palette.background.paper,
             borderColor: theme.palette.divider,
           }}
         />
@@ -136,7 +136,7 @@ function OverflowRolePill({ roles }: OverflowRolePillProps) {
             key={role.name}
             text={role.display_name || role.name}
             css={{
-              backgroundColor: theme.palette.background.paperLight,
+              backgroundColor: theme.palette.background.paper,
               borderColor: theme.palette.divider,
             }}
           />

--- a/site/src/pages/WorkspacePage/WorkspaceDeleteDialog/WorkspaceDeleteDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceDeleteDialog/WorkspaceDeleteDialog.tsx
@@ -12,11 +12,11 @@ const styles = {
   workspaceInfo: (theme) => ({
     display: "flex",
     justifyContent: "space-between",
-    backgroundColor: theme.palette.divider,
     borderRadius: 6,
     padding: 16,
     marginBottom: 20,
     lineHeight: "1.3em",
+    border: `1px solid ${theme.palette.divider}`,
 
     "& .name": {
       fontSize: 16,

--- a/site/src/pages/WorkspacePage/WorkspaceDeleteDialog/WorkspaceDeleteDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceDeleteDialog/WorkspaceDeleteDialog.tsx
@@ -12,8 +12,7 @@ const styles = {
   workspaceInfo: (theme) => ({
     display: "flex",
     justifyContent: "space-between",
-    backgroundColor: theme.palette.background.paperLight,
-    border: `1px solid ${theme.palette.divider}`,
+    backgroundColor: theme.palette.divider,
     borderRadius: 6,
     padding: 16,
     marginBottom: 20,

--- a/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
@@ -106,7 +106,7 @@ export const WorkspacesEmpty = (props: {
                   color: "inherit",
 
                   "&:hover": {
-                    backgroundColor: theme.palette.background.paperLight,
+                    backgroundColor: theme.palette.background.paper,
                   },
                 })}
               >

--- a/site/src/theme/mui.ts
+++ b/site/src/theme/mui.ts
@@ -40,7 +40,6 @@ export let dark = createTheme({
     background: {
       default: colors.gray[17],
       paper: colors.gray[16],
-      paperLight: colors.gray[14],
     },
     text: {
       primary: colors.gray[1],

--- a/site/src/theme/mui.ts
+++ b/site/src/theme/mui.ts
@@ -244,7 +244,6 @@ dark = createTheme(dark, {
         root: ({ theme }) => ({
           borderCollapse: "unset",
           border: "none",
-          background: dark.palette.background.paper,
           boxShadow: `0 0 0 1px ${dark.palette.background.default} inset`,
           overflow: "hidden",
 
@@ -266,7 +265,7 @@ dark = createTheme(dark, {
           fontSize: 14,
           color: dark.palette.text.secondary,
           fontWeight: 600,
-          background: dark.palette.background.paperLight,
+          background: dark.palette.background.paper,
         },
         root: {
           fontSize: 16,


### PR DESCRIPTION
I noticed we have been overusing colors in the UI, so simplifying is better for the "look and feel" and maintaining the styles over time. 

![image](https://github.com/coder/coder/assets/3165839/f70c831d-eba8-4521-820a-6257ae0bedf1)

If you want to have a better sense of what it looks like, I recommend you go to the Chromatic snapshot.