### PR TITLE
fix(codersdk): keep workspace agent connection open after dial context

### DIFF
--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -317,10 +317,11 @@ func (c *Client) DialWorkspaceAgent(dialCtx context.Context, agentID uuid.UUID, 
 		return nil, xerrors.Errorf("parse url: %w", err)
 	}
 	closedCoordinator := make(chan struct{})
-	firstCoordinator := make(chan error)
+	// Must only ever be used once, send error OR close to avoid
+	// reassignment race. Buffered so we don't hang in goroutine.
+	firstCoordinator := make(chan error, 1)
 	go func() {
 		defer close(closedCoordinator)
-		firstCoordinator := firstCoordinator // Shadowed so it can be reassigned outside goroutine.
 		isFirst := true
 		for retrier := retry.New(50*time.Millisecond, 10*time.Second); retrier.Wait(ctx); {
 			options.Logger.Debug(ctx, "connecting")
@@ -370,10 +371,11 @@ func (c *Client) DialWorkspaceAgent(dialCtx context.Context, agentID uuid.UUID, 
 		return nil, xerrors.Errorf("parse url: %w", err)
 	}
 	closedDerpMap := make(chan struct{})
-	firstDerpMap := make(chan error)
+	// Must only ever be used once, send error OR close to avoid
+	// reassignment race. Buffered so we don't hang in goroutine.
+	firstDerpMap := make(chan error, 1)
 	go func() {
 		defer close(closedDerpMap)
-		firstDerpMap := firstDerpMap // Shadowed so it can be reassigned outside goroutine.
 		isFirst := true
 		for retrier := retry.New(50*time.Millisecond, 10*time.Second); retrier.Wait(ctx); {
 			options.Logger.Debug(ctx, "connecting to server for derp map updates")

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -430,15 +430,15 @@ func (c *Client) DialWorkspaceAgent(dialCtx context.Context, agentID uuid.UUID, 
 	for firstCoordinator != nil || firstDerpMap != nil {
 		select {
 		case <-dialCtx.Done():
-			return nil, dialCtx.Err()
+			return nil, xerrors.Errorf("timed out waiting for coordinator and derp map: %w", dialCtx.Err())
 		case err = <-firstCoordinator:
 			if err != nil {
-				return nil, err
+				return nil, xerrors.Errorf("start coordinator: %w", err)
 			}
 			firstCoordinator = nil
 		case err = <-firstDerpMap:
 			if err != nil {
-				return nil, err
+				return nil, xerrors.Errorf("receive derp map: %w", err)
 			}
 			firstDerpMap = nil
 		}
@@ -461,7 +461,7 @@ func (c *Client) DialWorkspaceAgent(dialCtx context.Context, agentID uuid.UUID, 
 
 	if !agentConn.AwaitReachable(dialCtx) {
 		_ = agentConn.Close()
-		return nil, xerrors.Errorf("timed out waiting for agent to become reachable: %w", ctx.Err())
+		return nil, xerrors.Errorf("timed out waiting for agent to become reachable: %w", dialCtx.Err())
 	}
 
 	return agentConn, nil


### PR DESCRIPTION
This PR fixes the issue where dial and lifetime contexts for agent connections returned by DialWorkspaceAgent were intertwined. This is unexpected behavior for a dial function and had the side-effect of closing both the coordinator and derp map updates whilst leaving the tailscale connection open. To close the connection, a user should call `.Close()`.

This PR simply separates the contexts, it takes no stance on whether or not exiting the coordinator or derp map routine should also close the tailscale connection.
