### PR TITLE
chore: update dependabot to use single groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,13 +44,6 @@ updates:
         update-types:
           - version-update:semver-patch
     groups:
-      otel:
-        patterns:
-          - "go.nhat.io/otelsql"
-          - "go.opentelemetry.io/otel*"
-      golang-x:
-        patterns:
-          - "golang.org/x/*"
       go:
         patterns:
           - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -51,6 +51,9 @@ updates:
       golang-x:
         patterns:
           - "golang.org/x/*"
+      go:
+        patterns:
+          - "*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"
@@ -94,26 +97,9 @@ updates:
           - version-update:semver-major
     open-pull-requests-limit: 15
     groups:
-      react:
+      site:
         patterns:
-          - "react*"
-          - "@types/react*"
-      xterm:
-        patterns:
-          - "xterm*"
-      mui:
-        patterns:
-          - "@mui*"
-      storybook:
-        patterns:
-          - "@storybook*"
-          - "storybook*"
-      eslint:
-        patterns:
-          - "eslint*"
-          - "@eslint*"
-          - "@typescript-eslint/eslint-plugin"
-          - "@typescript-eslint/parser"
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/offlinedocs/"
@@ -136,6 +122,10 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - version-update:semver-major
+    groups:
+      offlinedocs:
+        patterns:
+          - "*"
 
   # Update dogfood.
   - package-ecosystem: "terraform"


### PR DESCRIPTION
This will hopefully reduce @dependabot spamming PRs.

The downside is that it can make it harder to identify the dependency causing breaking behaviors. 