### PR TITLE
chore: remove New----Builder from dbfake function names

### DIFF
--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -31,7 +31,7 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).
+		r := dbfake.Workspace(t, db).
 			Seed(database.Workspace{
 				OrganizationID: user.OrganizationID,
 				OwnerID:        user.UserID,
@@ -68,7 +68,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			AzureCertificates: certificates,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -105,7 +105,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			AWSCertificates: certificates,
 		})
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -143,7 +143,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		})
 		owner := coderdtest.CreateFirstUser(t, client)
 		member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        memberUser.ID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -195,7 +195,7 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).
+		r := dbfake.Workspace(t, db).
 			Seed(database.Workspace{
 				OrganizationID: user.OrganizationID,
 				OwnerID:        user.UserID,

--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -77,7 +77,7 @@ func TestConfigSSH(t *testing.T) {
 	})
 	owner := coderdtest.CreateFirstUser(t, client)
 	member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-	r := dbfake.NewWorkspaceBuilder(t, db).
+	r := dbfake.Workspace(t, db).
 		Seed(database.Workspace{
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        memberUser.ID,
@@ -575,7 +575,7 @@ func TestConfigSSH_FileWriteAndOptionsFlow(t *testing.T) {
 			client, db := coderdtest.NewWithDatabase(t, nil)
 			user := coderdtest.CreateFirstUser(t, client)
 			if tt.hasAgent {
-				_ = dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+				_ = dbfake.Workspace(t, db).Seed(database.Workspace{
 					OrganizationID: user.OrganizationID,
 					OwnerID:        user.UserID,
 				}).WithAgent().Do()
@@ -695,11 +695,11 @@ func TestConfigSSH_Hostnames(t *testing.T) {
 			owner := coderdtest.CreateFirstUser(t, client)
 			member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 
-			r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+			r := dbfake.Workspace(t, db).Seed(database.Workspace{
 				OrganizationID: owner.OrganizationID,
 				OwnerID:        memberUser.ID,
 			}).Do()
-			dbfake.NewWorkspaceBuildBuilder(t, db, r.Workspace).Resource(resources...).Do()
+			dbfake.WorkspaceBuild(t, db, r.Workspace).Resource(resources...).Do()
 			sshConfigFile := sshConfigFileName(t)
 
 			inv, root := clitest.New(t, "config-ssh", "--ssh-config-file", sshConfigFile)

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -48,7 +48,7 @@ func prepareTestGitSSH(ctx context.Context, t *testing.T) (*agentsdk.Client, str
 	require.NoError(t, err)
 
 	// setup template
-	r := dbfake.NewWorkspaceBuilder(t, db).
+	r := dbfake.Workspace(t, db).
 		Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -25,7 +25,7 @@ func TestList(t *testing.T) {
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		owner := coderdtest.CreateFirstUser(t, client)
 		member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        memberUser.ID,
 		}).WithAgent().Do()
@@ -52,7 +52,7 @@ func TestList(t *testing.T) {
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		owner := coderdtest.CreateFirstUser(t, client)
 		member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-		dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: owner.OrganizationID,
 			OwnerID:        memberUser.ID,
 		}).WithAgent().Do()

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -305,7 +305,7 @@ func runAgent(t *testing.T, client *codersdk.Client, owner uuid.UUID, db databas
 	require.NoError(t, err, "specified user does not exist")
 	require.Greater(t, len(user.OrganizationIDs), 0, "user has no organizations")
 	orgID := user.OrganizationIDs[0]
-	r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	r := dbfake.Workspace(t, db).Seed(database.Workspace{
 		OrganizationID: orgID,
 		OwnerID:        owner,
 	}).WithAgent().Do()

--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -38,26 +38,26 @@ func setupTestSchedule(t *testing.T, sched *cron.Schedule) (ownerClient, memberC
 	memberClient, memberUser := coderdtest.CreateAnotherUserMutators(t, ownerClient, owner.OrganizationID, nil, func(r *codersdk.CreateUserRequest) {
 		r.Username = "testuser2" // ensure deterministic ordering
 	})
-	_ = dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	_ = dbfake.Workspace(t, db).Seed(database.Workspace{
 		Name:              "a-owner",
 		OwnerID:           owner.UserID,
 		OrganizationID:    owner.OrganizationID,
 		AutostartSchedule: sql.NullString{String: sched.String(), Valid: true},
 		Ttl:               sql.NullInt64{Int64: 8 * time.Hour.Nanoseconds(), Valid: true},
 	}).WithAgent().Do()
-	_ = dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	_ = dbfake.Workspace(t, db).Seed(database.Workspace{
 		Name:              "b-owner",
 		OwnerID:           owner.UserID,
 		OrganizationID:    owner.OrganizationID,
 		AutostartSchedule: sql.NullString{String: sched.String(), Valid: true},
 	}).WithAgent().Do()
-	_ = dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	_ = dbfake.Workspace(t, db).Seed(database.Workspace{
 		Name:           "c-member",
 		OwnerID:        memberUser.ID,
 		OrganizationID: owner.OrganizationID,
 		Ttl:            sql.NullInt64{Int64: 8 * time.Hour.Nanoseconds(), Valid: true},
 	}).WithAgent().Do()
-	_ = dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	_ = dbfake.Workspace(t, db).Seed(database.Workspace{
 		Name:           "d-member",
 		OwnerID:        memberUser.ID,
 		OrganizationID: owner.OrganizationID,

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -52,7 +52,7 @@ func setupWorkspaceForAgent(t *testing.T, mutations ...func([]*proto.Agent) []*p
 	client.SetLogger(slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug))
 	first := coderdtest.CreateFirstUser(t, client)
 	userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
-	r := dbfake.NewWorkspaceBuilder(t, store).
+	r := dbfake.Workspace(t, store).
 		Seed(database.Workspace{
 			OrganizationID: first.OrganizationID,
 			OwnerID:        user.ID,
@@ -130,7 +130,7 @@ func TestSSH(t *testing.T) {
 		client.SetLogger(slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug))
 		first := coderdtest.CreateFirstUser(t, client)
 		userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
-		r := dbfake.NewWorkspaceBuilder(t, store).Seed(database.Workspace{
+		r := dbfake.Workspace(t, store).Seed(database.Workspace{
 			OrganizationID: first.OrganizationID,
 			OwnerID:        user.ID,
 		}).WithAgent().Do()
@@ -154,7 +154,7 @@ func TestSSH(t *testing.T) {
 		pty.WriteLine("echo hell'o'")
 		pty.ExpectMatchContext(ctx, "hello")
 
-		_ = dbfake.NewWorkspaceBuildBuilder(t, store, r.Workspace).
+		_ = dbfake.WorkspaceBuild(t, store, r.Workspace).
 			Seed(database.WorkspaceBuild{
 				Transition:  database.WorkspaceTransitionStop,
 				BuildNumber: 2,
@@ -469,7 +469,7 @@ func TestSSH(t *testing.T) {
 		client.SetLogger(slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug))
 		first := coderdtest.CreateFirstUser(t, client)
 		userClient, user := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
-		r := dbfake.NewWorkspaceBuilder(t, store).Seed(database.Workspace{
+		r := dbfake.Workspace(t, store).Seed(database.Workspace{
 			OrganizationID: first.OrganizationID,
 			OwnerID:        user.ID,
 		}).WithAgent().Do()
@@ -523,7 +523,7 @@ func TestSSH(t *testing.T) {
 		err = session.Shell()
 		require.NoError(t, err)
 
-		_ = dbfake.NewWorkspaceBuildBuilder(t, store, r.Workspace).
+		_ = dbfake.WorkspaceBuild(t, store, r.Workspace).
 			Seed(database.WorkspaceBuild{
 				Transition:  database.WorkspaceTransitionStop,
 				BuildNumber: 2,

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -36,7 +36,7 @@ type WorkspaceResponse struct {
 	AgentToken string
 }
 
-func NewWorkspaceBuilder(t testing.TB, db database.Store) WorkspaceBuilder {
+func Workspace(t testing.TB, db database.Store) WorkspaceBuilder {
 	return WorkspaceBuilder{t: t, db: db}
 }
 
@@ -82,7 +82,7 @@ func (b WorkspaceBuilder) Do() WorkspaceResponse {
 	r.Workspace = dbgen.Workspace(b.t, b.db, b.seed)
 	if b.agentToken != "" {
 		r.AgentToken = b.agentToken
-		r.Build = NewWorkspaceBuildBuilder(b.t, b.db, r.Workspace).
+		r.Build = WorkspaceBuild(b.t, b.db, r.Workspace).
 			Resource(b.resources...).
 			Do()
 	}
@@ -98,7 +98,7 @@ type WorkspaceBuildBuilder struct {
 	resources []*sdkproto.Resource
 }
 
-func NewWorkspaceBuildBuilder(t testing.TB, db database.Store, ws database.Workspace) WorkspaceBuildBuilder {
+func WorkspaceBuild(t testing.TB, db database.Store, ws database.Workspace) WorkspaceBuildBuilder {
 	return WorkspaceBuildBuilder{t: t, db: db, ws: ws}
 }
 
@@ -187,11 +187,11 @@ func (b WorkspaceBuildBuilder) Do() database.WorkspaceBuild {
 				Valid: true,
 			},
 		})
-		NewProvisionerJobResourcesBuilder(b.t, b.db, jobID, b.seed.Transition, b.resources...).Do()
+		ProvisionerJobResources(b.t, b.db, jobID, b.seed.Transition, b.resources...).Do()
 		b.seed.TemplateVersionID = templateVersion.ID
 	}
 	build := dbgen.WorkspaceBuild(b.t, b.db, b.seed)
-	NewProvisionerJobResourcesBuilder(b.t, b.db, job.ID, b.seed.Transition, b.resources...).Do()
+	ProvisionerJobResources(b.t, b.db, job.ID, b.seed.Transition, b.resources...).Do()
 	if b.ps != nil {
 		err = b.ps.Publish(codersdk.WorkspaceNotifyChannel(build.WorkspaceID), []byte{})
 		require.NoError(b.t, err)
@@ -207,8 +207,8 @@ type ProvisionerJobResourcesBuilder struct {
 	resources  []*sdkproto.Resource
 }
 
-// NewProvisionerJobResourcesBuilder inserts a series of resources into a provisioner job.
-func NewProvisionerJobResourcesBuilder(
+// ProvisionerJobResources inserts a series of resources into a provisioner job.
+func ProvisionerJobResources(
 	t testing.TB, db database.Store, jobID uuid.UUID, transition database.WorkspaceTransition, resources ...*sdkproto.Resource,
 ) ProvisionerJobResourcesBuilder {
 	return ProvisionerJobResourcesBuilder{

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -47,7 +47,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		tmpDir := t.TempDir()
 		anotherClient, anotherUser := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
 
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        anotherUser.ID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -69,7 +69,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
 		tmpDir := t.TempDir()
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -97,7 +97,7 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		wantTroubleshootingURL := "https://example.com/troubleshoot"
 
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -138,7 +138,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			PortForwardingHelper: true,
 			SshHelper:            true,
 		}
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -171,7 +171,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		apps.WebTerminal = false
 
 		// Creating another workspace is easier
-		r = dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r = dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -195,7 +195,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -237,7 +237,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -279,7 +279,7 @@ func TestWorkspaceAgentLogs(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -322,7 +322,7 @@ func TestWorkspaceAgentListen(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -408,7 +408,7 @@ func TestWorkspaceAgentTailnet(t *testing.T) {
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	user := coderdtest.CreateFirstUser(t, client)
 
-	r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	r := dbfake.Workspace(t, db).Seed(database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	}).WithAgent().Do()
@@ -454,7 +454,7 @@ func TestWorkspaceAgentTailnetDirectDisabled(t *testing.T) {
 		DeploymentValues: dv,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
-	r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	r := dbfake.Workspace(t, db).Seed(database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	}).WithAgent().Do()
@@ -517,7 +517,7 @@ func TestWorkspaceAgentListeningPorts(t *testing.T) {
 		require.NoError(t, err)
 
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -752,7 +752,7 @@ func TestWorkspaceAgentAppHealth(t *testing.T) {
 			},
 		},
 	}
-	r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	r := dbfake.Workspace(t, db).Seed(database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -819,7 +819,7 @@ func TestWorkspaceAgentReportStats(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -886,7 +886,7 @@ func TestWorkspaceAgent_LifecycleState(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -951,7 +951,7 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	user := coderdtest.CreateFirstUser(t, client)
-	r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	r := dbfake.Workspace(t, db).Seed(database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -1129,7 +1129,7 @@ func TestWorkspaceAgent_Metadata_CatchMemoryLeak(t *testing.T) {
 		Logger:                   &logger,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
-	r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+	r := dbfake.Workspace(t, db).Seed(database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
@@ -1258,7 +1258,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -1304,7 +1304,7 @@ func TestWorkspaceAgent_Startup(t *testing.T) {
 
 		client, db := coderdtest.NewWithDatabase(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		r := dbfake.NewWorkspaceBuilder(t, db).Seed(database.Workspace{
+		r := dbfake.Workspace(t, db).Seed(database.Workspace{
 			OrganizationID: user.OrganizationID,
 			OwnerID:        user.UserID,
 		}).WithAgent().Do()
@@ -1352,7 +1352,7 @@ func TestWorkspaceAgent_UpdatedDERP(t *testing.T) {
 	api.DERPMapper.Store(&derpMapFn)
 
 	// Start workspace a workspace agent.
-	r := dbfake.NewWorkspaceBuilder(t, api.Database).Seed(database.Workspace{
+	r := dbfake.Workspace(t, api.Database).Seed(database.Workspace{
 		OrganizationID: user.OrganizationID,
 		OwnerID:        user.UserID,
 	}).WithAgent().Do()


### PR DESCRIPTION
Drop "New" and "Builder" from the function names, in favor of the top-level resource created.  This shortens tests and gives a nice syntax.  Since everything is a builder, the prefix and suffix don't add much value and just make things harder to read.

I've also chosen to leave `Do()` as the function to insert into the database.  Even though it's a builder pattern, I fear `.Build()` might be confusing with Workspace Builds.  One other idea is `Insert()` but if we later add dbfake functions that update, this might be inconsistent.

