### PR TITLE
chore: add Resources() to dbfake.WorkspaceBuilder

### DIFF
--- a/cli/configssh_test.go
+++ b/cli/configssh_test.go
@@ -695,11 +695,12 @@ func TestConfigSSH_Hostnames(t *testing.T) {
 			owner := coderdtest.CreateFirstUser(t, client)
 			member, memberUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 
-			r := dbfake.Workspace(t, db).Seed(database.Workspace{
-				OrganizationID: owner.OrganizationID,
-				OwnerID:        memberUser.ID,
-			}).Do()
-			dbfake.WorkspaceBuild(t, db, r.Workspace).Resource(resources...).Do()
+			r := dbfake.Workspace(t, db).
+				Seed(database.Workspace{
+					OrganizationID: owner.OrganizationID,
+					OwnerID:        memberUser.ID,
+				}).
+				Resource(resources...).Do()
 			sshConfigFile := sshConfigFileName(t)
 
 			inv, root := clitest.New(t, "config-ssh", "--ssh-config-file", sshConfigFile)

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -66,6 +66,12 @@ func (b WorkspaceBuilder) WithAgent(mutations ...func([]*sdkproto.Agent) []*sdkp
 	return b
 }
 
+func (b WorkspaceBuilder) Resource(resource ...*sdkproto.Resource) WorkspaceBuilder {
+	//nolint: revive // returns modified struct
+	b.resources = append(b.resources, resource...)
+	return b
+}
+
 func (b WorkspaceBuilder) Do() WorkspaceResponse {
 	var r WorkspaceResponse
 	// This intentionally fulfills the minimum requirements of the schema.
@@ -82,6 +88,8 @@ func (b WorkspaceBuilder) Do() WorkspaceResponse {
 	r.Workspace = dbgen.Workspace(b.t, b.db, b.seed)
 	if b.agentToken != "" {
 		r.AgentToken = b.agentToken
+	}
+	if len(b.resources) > 0 {
 		r.Build = WorkspaceBuild(b.t, b.db, r.Workspace).
 			Resource(b.resources...).
 			Do()


### PR DESCRIPTION
Refactor to allow directly adding resources to `WorkspaceBuilder`, which makes writing tests more brief.
