### PR TITLE
fix: insert replica when removed by cleanup

### DIFF
--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -171,7 +171,7 @@ func (m *Manager) loop(ctx context.Context) {
 		}
 		err := m.syncReplicas(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
-			m.logger.Error(ctx, "run replica update loop", slog.Error(err))
+			m.logger.Warn(ctx, "run replica update loop", slog.Error(err))
 		}
 	}
 }
@@ -192,7 +192,7 @@ func (m *Manager) subscribe(ctx context.Context) error {
 	update = func() {
 		err := m.syncReplicas(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
-			m.logger.Error(ctx, "run replica from subscribe", slog.Error(err))
+			m.logger.Warn(ctx, "run replica from subscribe", slog.Error(err))
 		}
 		updateMutex.Lock()
 		if needsUpdate {

--- a/enterprise/replicasync/replicasync.go
+++ b/enterprise/replicasync/replicasync.go
@@ -171,7 +171,7 @@ func (m *Manager) loop(ctx context.Context) {
 		}
 		err := m.syncReplicas(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
-			m.logger.Warn(ctx, "run replica update loop", slog.Error(err))
+			m.logger.Error(ctx, "run replica update loop", slog.Error(err))
 		}
 	}
 }
@@ -192,7 +192,7 @@ func (m *Manager) subscribe(ctx context.Context) error {
 	update = func() {
 		err := m.syncReplicas(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
-			m.logger.Warn(ctx, "run replica from subscribe", slog.Error(err))
+			m.logger.Error(ctx, "run replica from subscribe", slog.Error(err))
 		}
 		updateMutex.Lock()
 		if needsUpdate {


### PR DESCRIPTION
I didn't feel great about changing the database query because there's other things besides this loop that call it, and I don't feel those callers have the same authority about re-inserting on update. Let me know if that is not a correct assumption. 

Closes https://github.com/coder/coder/issues/8858