### PR TITLE
feat: add prometheus metrics to debug health

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,7 @@ linters-settings:
       # a database row. Ref: #9936
       - 'github.com/coder/coder/v2/coderd/database\.[^G][^e][^t]\w+Params'
   gocognit:
-    min-complexity: 300
+    min-complexity: 320
 
   goconst:
     min-len: 4 # Min length of string consts (def 3).

--- a/cli/server.go
+++ b/cli/server.go
@@ -745,6 +745,21 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					return xerrors.Errorf("oauth signing key in database is empty")
 				}
 
+				dhcKey, err := tx.GetDebugHealthConnectionKey(ctx)
+				if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+					return xerrors.Errorf("get debug health connection key: %w", err)
+				}
+				if dhcKey == "" {
+					dhcKey, err = cryptorand.String(22)
+					if err != nil {
+						return xerrors.Errorf("generate debug health connection key: %w", err)
+					}
+					err = tx.UpsertDebugHealthConnectionKey(ctx, dhcKey)
+					if err != nil {
+						return xerrors.Errorf("set deployment id: %w", err)
+					}
+				}
+
 				return nil
 			}, nil)
 			if err != nil {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -944,6 +944,10 @@ func (q *querier) GetDERPMeshKey(ctx context.Context) (string, error) {
 	return q.db.GetDERPMeshKey(ctx)
 }
 
+func (q *querier) GetDebugHealthConnectionKey(ctx context.Context) (string, error) {
+	return q.db.GetDebugHealthConnectionKey(ctx)
+}
+
 func (q *querier) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaultProxyConfigRow, error) {
 	// No authz checks
 	return q.db.GetDefaultProxyConfig(ctx)
@@ -3000,6 +3004,10 @@ func (q *querier) UpsertApplicationName(ctx context.Context, value string) error
 		return err
 	}
 	return q.db.UpsertApplicationName(ctx, value)
+}
+
+func (q *querier) UpsertDebugHealthConnectionKey(ctx context.Context, value string) error {
+	return q.db.UpsertDebugHealthConnectionKey(ctx, value)
 }
 
 func (q *querier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDefaultProxyParams) error {

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -154,19 +154,20 @@ type data struct {
 	workspaceProxies              []database.WorkspaceProxy
 	// Locks is a map of lock names. Any keys within the map are currently
 	// locked.
-	locks                   map[int64]struct{}
-	deploymentID            string
-	derpMeshKey             string
-	lastUpdateCheck         []byte
-	serviceBanner           []byte
-	healthSettings          []byte
-	applicationName         string
-	logoURL                 string
-	appSecurityKey          string
-	oauthSigningKey         string
-	lastLicenseID           int32
-	defaultProxyDisplayName string
-	defaultProxyIconURL     string
+	locks                    map[int64]struct{}
+	deploymentID             string
+	derpMeshKey              string
+	lastUpdateCheck          []byte
+	serviceBanner            []byte
+	healthSettings           []byte
+	applicationName          string
+	logoURL                  string
+	appSecurityKey           string
+	oauthSigningKey          string
+	lastLicenseID            int32
+	defaultProxyDisplayName  string
+	defaultProxyIconURL      string
+	debugHealthConnectionKey string
 }
 
 func validateDatabaseTypeWithValid(v reflect.Value) (handled bool, err error) {
@@ -1455,6 +1456,17 @@ func (q *FakeQuerier) GetDERPMeshKey(_ context.Context) (string, error) {
 	defer q.mutex.RUnlock()
 
 	return q.derpMeshKey, nil
+}
+
+func (q *FakeQuerier) GetDebugHealthConnectionKey(_ context.Context) (string, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	if q.debugHealthConnectionKey == "" {
+		return "", sql.ErrNoRows
+	}
+
+	return q.debugHealthConnectionKey, nil
 }
 
 func (q *FakeQuerier) GetDefaultProxyConfig(_ context.Context) (database.GetDefaultProxyConfigRow, error) {
@@ -6807,6 +6819,14 @@ func (q *FakeQuerier) UpsertApplicationName(_ context.Context, data string) erro
 	defer q.mutex.RUnlock()
 
 	q.applicationName = data
+	return nil
+}
+
+func (q *FakeQuerier) UpsertDebugHealthConnectionKey(_ context.Context, value string) error {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	q.debugHealthConnectionKey = value
 	return nil
 }
 

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -377,6 +377,13 @@ func (m metricsStore) GetDERPMeshKey(ctx context.Context) (string, error) {
 	return key, err
 }
 
+func (m metricsStore) GetDebugHealthConnectionKey(ctx context.Context) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetDebugHealthConnectionKey(ctx)
+	m.queryLatencies.WithLabelValues("GetDebugHealthConnectionKey").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m metricsStore) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaultProxyConfigRow, error) {
 	start := time.Now()
 	resp, err := m.s.GetDefaultProxyConfig(ctx)
@@ -1884,6 +1891,13 @@ func (m metricsStore) UpsertApplicationName(ctx context.Context, value string) e
 	start := time.Now()
 	r0 := m.s.UpsertApplicationName(ctx, value)
 	m.queryLatencies.WithLabelValues("UpsertApplicationName").Observe(time.Since(start).Seconds())
+	return r0
+}
+
+func (m metricsStore) UpsertDebugHealthConnectionKey(ctx context.Context, value string) error {
+	start := time.Now()
+	r0 := m.s.UpsertDebugHealthConnectionKey(ctx, value)
+	m.queryLatencies.WithLabelValues("UpsertDebugHealthConnectionKey").Observe(time.Since(start).Seconds())
 	return r0
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -712,6 +712,21 @@ func (mr *MockStoreMockRecorder) GetDERPMeshKey(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDERPMeshKey", reflect.TypeOf((*MockStore)(nil).GetDERPMeshKey), arg0)
 }
 
+// GetDebugHealthConnectionKey mocks base method.
+func (m *MockStore) GetDebugHealthConnectionKey(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDebugHealthConnectionKey", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDebugHealthConnectionKey indicates an expected call of GetDebugHealthConnectionKey.
+func (mr *MockStoreMockRecorder) GetDebugHealthConnectionKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDebugHealthConnectionKey", reflect.TypeOf((*MockStore)(nil).GetDebugHealthConnectionKey), arg0)
+}
+
 // GetDefaultProxyConfig mocks base method.
 func (m *MockStore) GetDefaultProxyConfig(arg0 context.Context) (database.GetDefaultProxyConfigRow, error) {
 	m.ctrl.T.Helper()
@@ -3961,6 +3976,20 @@ func (m *MockStore) UpsertApplicationName(arg0 context.Context, arg1 string) err
 func (mr *MockStoreMockRecorder) UpsertApplicationName(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertApplicationName", reflect.TypeOf((*MockStore)(nil).UpsertApplicationName), arg0, arg1)
+}
+
+// UpsertDebugHealthConnectionKey mocks base method.
+func (m *MockStore) UpsertDebugHealthConnectionKey(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertDebugHealthConnectionKey", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertDebugHealthConnectionKey indicates an expected call of UpsertDebugHealthConnectionKey.
+func (mr *MockStoreMockRecorder) UpsertDebugHealthConnectionKey(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDebugHealthConnectionKey", reflect.TypeOf((*MockStore)(nil).UpsertDebugHealthConnectionKey), arg0, arg1)
 }
 
 // UpsertDefaultProxy mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -88,6 +88,7 @@ type sqlcQuerier interface {
 	GetAuthorizationUserRoles(ctx context.Context, userID uuid.UUID) (GetAuthorizationUserRolesRow, error)
 	GetDBCryptKeys(ctx context.Context) ([]DBCryptKey, error)
 	GetDERPMeshKey(ctx context.Context) (string, error)
+	GetDebugHealthConnectionKey(ctx context.Context) (string, error)
 	GetDefaultProxyConfig(ctx context.Context) (GetDefaultProxyConfigRow, error)
 	GetDeploymentDAUs(ctx context.Context, tzOffset int32) ([]GetDeploymentDAUsRow, error)
 	GetDeploymentID(ctx context.Context) (string, error)
@@ -357,6 +358,7 @@ type sqlcQuerier interface {
 	UpdateWorkspacesDormantDeletingAtByTemplateID(ctx context.Context, arg UpdateWorkspacesDormantDeletingAtByTemplateIDParams) error
 	UpsertAppSecurityKey(ctx context.Context, value string) error
 	UpsertApplicationName(ctx context.Context, value string) error
+	UpsertDebugHealthConnectionKey(ctx context.Context, value string) error
 	// The default proxy is implied and not actually stored in the database.
 	// So we need to store it's configuration here for display purposes.
 	// The functional values are immutable and controlled implicitly.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4315,6 +4315,17 @@ func (q *sqlQuerier) GetDERPMeshKey(ctx context.Context) (string, error) {
 	return value, err
 }
 
+const getDebugHealthConnectionKey = `-- name: GetDebugHealthConnectionKey :one
+SELECT value FROM site_configs WHERE key = 'debug_health_key'
+`
+
+func (q *sqlQuerier) GetDebugHealthConnectionKey(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getDebugHealthConnectionKey)
+	var value string
+	err := row.Scan(&value)
+	return value, err
+}
+
 const getDefaultProxyConfig = `-- name: GetDefaultProxyConfig :one
 SELECT
 	COALESCE((SELECT value FROM site_configs WHERE key = 'default_proxy_display_name'), 'Default') :: text AS display_name,
@@ -4435,6 +4446,16 @@ ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'application
 
 func (q *sqlQuerier) UpsertApplicationName(ctx context.Context, value string) error {
 	_, err := q.db.ExecContext(ctx, upsertApplicationName, value)
+	return err
+}
+
+const upsertDebugHealthConnectionKey = `-- name: UpsertDebugHealthConnectionKey :exec
+INSERT INTO site_configs (key, value) VALUES ('debug_health_key', $1)
+ON CONFLICT (key) DO UPDATE set value = $1 WHERE site_configs.key = 'debug_health_key'
+`
+
+func (q *sqlQuerier) UpsertDebugHealthConnectionKey(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, upsertDebugHealthConnectionKey, value)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -79,3 +79,10 @@ SELECT
 -- name: UpsertHealthSettings :exec
 INSERT INTO site_configs (key, value) VALUES ('health_settings', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'health_settings';
+
+-- name: GetDebugHealthConnectionKey :one
+SELECT value FROM site_configs WHERE key = 'debug_health_key';
+
+-- name: UpsertDebugHealthConnectionKey :exec
+INSERT INTO site_configs (key, value) VALUES ('debug_health_key', $1)
+ON CONFLICT (key) DO UPDATE set value = $1 WHERE site_configs.key = 'debug_health_key';

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -136,15 +136,6 @@ func (api *API) debugDeploymentHealth(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// dhcKey, err := api.Database.GetDebugHealthConnectionKey(ctx)
-	// if err != nil {
-	// 	httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-	// 		Message: "Failed to fetch debug health connection key.",
-	// 		Detail:  err.Error(),
-	// 	})
-	// 	return
-	// }
-
 	resChan := api.healthCheckGroup.DoChan("", func() (*healthcheck.Report, error) {
 		// Create a new context not tied to the request.
 		ctx, cancel := context.WithTimeout(context.Background(), api.Options.HealthcheckTimeout)

--- a/coderd/healthcheck/websocket.go
+++ b/coderd/healthcheck/websocket.go
@@ -13,6 +13,7 @@ import (
 	"nhooyr.io/websocket"
 
 	"github.com/coder/coder/v2/coderd/healthcheck/health"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // @typescript-generate WebsocketReport
@@ -59,7 +60,7 @@ func (r *WebsocketReport) Run(ctx context.Context, opts *WebsocketReportOptions)
 	//nolint:bodyclose // websocket package closes this for you
 	c, res, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{
 		HTTPClient: opts.HTTPClient,
-		HTTPHeader: http.Header{"Coder-Session-Token": []string{opts.APIKey}},
+		HTTPHeader: http.Header{codersdk.SessionTokenHeader: []string{opts.APIKey}},
 	})
 	if res != nil {
 		var body string

--- a/coderd/httpmw/debug.go
+++ b/coderd/httpmw/debug.go
@@ -1,0 +1,41 @@
+package httpmw
+
+import (
+	"net/http"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func RequireConnectionKey(db database.Store) func(h http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			v := r.Header.Get(codersdk.SessionTokenHeader)
+			if v == "" {
+				httpapi.Write(r.Context(), w, http.StatusUnauthorized, codersdk.Response{
+					Message: "missing connection key",
+				})
+				return
+			}
+
+			key, err := db.GetDebugHealthConnectionKey(r.Context())
+			if err != nil {
+				httpapi.Write(r.Context(), w, http.StatusInternalServerError, codersdk.Response{
+					Message: "failed to get connection key",
+					Detail:  err.Error(),
+				})
+				return
+			}
+
+			if v != key {
+				httpapi.Write(r.Context(), w, http.StatusUnauthorized, codersdk.Response{
+					Message: "invalid connection key",
+				})
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
This ballooned into something much larger than just adding some prometheus metrics.

- Added a background loop to initialize and refresh the metrics on the refresh interval in order to always have valid prom metrics
- Added a new site_config key value for a token used to validate connections from ourself on the debug websocket endpoint
- Removed the usage of the requesting user's api key to use one that is generated once in site_config and use for the websocket endpoint
- Added middleware to websocket endpoint that validates the new system token we use

Closes https://github.com/coder/coder/issues/10678