### PR TITLE
fix: numerical validation grammer

### DIFF
--- a/coderd/activitybump_internal_test.go
+++ b/coderd/activitybump_internal_test.go
@@ -258,7 +258,7 @@ func Test_ActivityBumpWorkspace(t *testing.T) {
 				expectedDeadlineStart := start.Add(tt.expectedBump).Add(time.Minute * -1)
 				expectedDeadlineEnd := end.Add(tt.expectedBump).Add(time.Minute)
 				require.GreaterOrEqual(t, updatedBuild.Deadline, expectedDeadlineStart, "new deadline should be greater than or equal to start")
-				require.LessOrEqual(t, updatedBuild.Deadline, expectedDeadlineEnd, "new deadline should be lesser than or equal to end")
+				require.LessOrEqual(t, updatedBuild.Deadline, expectedDeadlineEnd, "new deadline should be less than or equal to end")
 			})
 		}
 	}

--- a/site/src/utils/richParameters.ts
+++ b/site/src/utils/richParameters.ts
@@ -75,7 +75,7 @@ export const useValidationSchemaForRichParameters = (
                   if (templateParameter.validation_max < Number(val)) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: `Value must be lesser than ${templateParameter.validation_max}.`,
+                      message: `Value must be less than ${templateParameter.validation_max}.`,
                     });
                   }
                 } else if (


### PR DESCRIPTION
this PR corrects our use of `lesser than` to the `less than` phrase. a customer gave feedback on this.