### PR TITLE
fix: update autostart context to include querying users

### DIFF
--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -172,13 +172,14 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 			}()
 
 			stats := <-statsCh
-			assert.Len(t, stats.Errors, 0)
 			if !tc.expectStart {
 				// Then: the workspace should not be started
 				assert.Len(t, stats.Transitions, 0)
+				assert.Len(t, stats.Errors, 1)
 				return
 			}
 
+			assert.Len(t, stats.Errors, 0)
 			// Then: the workspace should be started
 			assert.Len(t, stats.Transitions, 1)
 			assert.Contains(t, stats.Transitions, workspace.ID)

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -54,7 +54,7 @@ func TestExecutorAutostartOK(t *testing.T) {
 
 	// Then: the workspace should eventually be started
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[workspace.ID])
@@ -172,7 +172,7 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 			}()
 
 			stats := <-statsCh
-			assert.NoError(t, stats.Error)
+			assert.Len(t, stats.Errors, 0)
 			if !tc.expectStart {
 				// Then: the workspace should not be started
 				assert.Len(t, stats.Transitions, 0)
@@ -226,7 +226,7 @@ func TestExecutorAutostartAlreadyRunning(t *testing.T) {
 
 	// Then: the workspace should not be started.
 	stats := <-statsCh
-	require.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	require.Len(t, stats.Transitions, 0)
 }
 
@@ -261,7 +261,7 @@ func TestExecutorAutostartNotEnabled(t *testing.T) {
 
 	// Then: the workspace should not be started.
 	stats := <-statsCh
-	require.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	require.Len(t, stats.Transitions, 0)
 }
 
@@ -305,7 +305,7 @@ func TestExecutorAutostartUserSuspended(t *testing.T) {
 
 	// Then: nothing should happen
 	stats := testutil.RequireRecvCtx(ctx, t, statsCh)
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -335,7 +335,7 @@ func TestExecutorAutostopOK(t *testing.T) {
 
 	// Then: the workspace should be stopped
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStop, stats.Transitions[workspace.ID])
@@ -378,7 +378,7 @@ func TestExecutorAutostopExtend(t *testing.T) {
 
 	// Then: nothing should happen and the workspace should stay running
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 
 	// When: the autobuild executor ticks after the *new* deadline:
@@ -389,7 +389,7 @@ func TestExecutorAutostopExtend(t *testing.T) {
 
 	// Then: the workspace should be stopped
 	stats = <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStop, stats.Transitions[workspace.ID])
@@ -423,7 +423,7 @@ func TestExecutorAutostopAlreadyStopped(t *testing.T) {
 
 	// Then: the workspace should remain stopped and no build should happen.
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -461,7 +461,7 @@ func TestExecutorAutostopNotEnabled(t *testing.T) {
 
 	// Then: the workspace should not be stopped.
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -494,7 +494,7 @@ func TestExecutorWorkspaceDeleted(t *testing.T) {
 
 	// Then: nothing should happen
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -526,7 +526,7 @@ func TestExecutorWorkspaceAutostartTooEarly(t *testing.T) {
 
 	// Then: nothing should happen
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -557,7 +557,7 @@ func TestExecutorWorkspaceAutostopBeforeDeadline(t *testing.T) {
 
 	// Then: nothing should happen
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -592,7 +592,7 @@ func TestExecutorWorkspaceAutostopNoWaitChangedMyMind(t *testing.T) {
 
 	// Then: the workspace should stop
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Equal(t, stats.Transitions[workspace.ID], database.WorkspaceTransitionStop)
 
@@ -620,7 +620,7 @@ func TestExecutorWorkspaceAutostopNoWaitChangedMyMind(t *testing.T) {
 
 	// Then: the workspace should not stop
 	stats = <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -665,14 +665,14 @@ func TestExecutorAutostartMultipleOK(t *testing.T) {
 
 	// Then: the workspace should eventually be started
 	stats1 := <-statsCh1
-	assert.NoError(t, stats1.Error)
+	assert.Len(t, stats1.Errors, 0)
 	assert.Len(t, stats1.Transitions, 1)
 	assert.Contains(t, stats1.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStart, stats1.Transitions[workspace.ID])
 
 	// Then: the other executor should not have done anything
 	stats2 := <-statsCh2
-	assert.NoError(t, stats2.Error)
+	assert.Len(t, stats2.Errors, 0)
 	assert.Len(t, stats2.Transitions, 0)
 }
 
@@ -728,7 +728,7 @@ func TestExecutorAutostartWithParameters(t *testing.T) {
 
 	// Then: the workspace with parameters should eventually be started
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[workspace.ID])
@@ -778,7 +778,7 @@ func TestExecutorAutostartTemplateDisabled(t *testing.T) {
 
 	// Then: nothing should happen
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 }
 
@@ -821,7 +821,7 @@ func TestExecutorAutostopTemplateDisabled(t *testing.T) {
 
 	// Then: nothing should happen
 	stats := <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 0)
 
 	// When: the autobuild executor ticks after the template setting:
@@ -832,7 +832,7 @@ func TestExecutorAutostopTemplateDisabled(t *testing.T) {
 
 	// Then: the workspace should be stopped
 	stats = <-statsCh
-	assert.NoError(t, stats.Error)
+	assert.Len(t, stats.Errors, 0)
 	assert.Len(t, stats.Transitions, 1)
 	assert.Contains(t, stats.Transitions, workspace.ID)
 	assert.Equal(t, database.WorkspaceTransitionStop, stats.Transitions[workspace.ID])

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -183,6 +183,7 @@ var (
 					rbac.ResourceTemplate.Type:       {rbac.ActionRead, rbac.ActionUpdate},
 					rbac.ResourceWorkspace.Type:      {rbac.ActionRead, rbac.ActionUpdate},
 					rbac.ResourceWorkspaceBuild.Type: {rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
+					// rbac.ResourceUser.Type: {rbac.ActionRead},
 				}),
 				Org:  map[string][]rbac.Permission{},
 				User: []rbac.Permission{},

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -183,7 +183,7 @@ var (
 					rbac.ResourceTemplate.Type:       {rbac.ActionRead, rbac.ActionUpdate},
 					rbac.ResourceWorkspace.Type:      {rbac.ActionRead, rbac.ActionUpdate},
 					rbac.ResourceWorkspaceBuild.Type: {rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
-					// rbac.ResourceUser.Type: {rbac.ActionRead},
+					rbac.ResourceUser.Type:           {rbac.ActionRead},
 				}),
 				Org:  map[string][]rbac.Permission{},
 				User: []rbac.Permission{},

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -702,7 +702,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// Assert that autostart works when the workspace isn't dormant..
 		tickCh <- sched.Next(ws.LatestBuild.CreatedAt)
 		stats := <-statsCh
-		require.NoError(t, stats.Error)
+		require.Len(t, stats.Errors, 0)
 		require.Len(t, stats.Transitions, 1)
 		require.Contains(t, stats.Transitions, ws.ID)
 		require.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[ws.ID])
@@ -720,7 +720,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// We should see the workspace get stopped now.
 		tickCh <- ws.LastUsedAt.Add(inactiveTTL * 2)
 		stats = <-statsCh
-		require.NoError(t, stats.Error)
+		require.Len(t, stats.Errors, 0)
 		require.Len(t, stats.Transitions, 1)
 		require.Contains(t, stats.Transitions, ws.ID)
 		require.Equal(t, database.WorkspaceTransitionStop, stats.Transitions[ws.ID])
@@ -878,7 +878,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// Kick of an autostart build.
 		tickCh <- sched.Next(ws.LatestBuild.CreatedAt)
 		stats := <-statsCh
-		require.NoError(t, stats.Error)
+		require.Len(t, stats.Errors, 0)
 		require.Len(t, stats.Transitions, 1)
 		require.Contains(t, stats.Transitions, ws.ID)
 		require.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[ws.ID])
@@ -904,7 +904,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// Force an autostart transition again.
 		tickCh <- sched.Next(firstBuild.CreatedAt)
 		stats = <-statsCh
-		require.NoError(t, stats.Error)
+		require.Len(t, stats.Errors, 0)
 		require.Len(t, stats.Transitions, 1)
 		require.Contains(t, stats.Transitions, ws.ID)
 		require.Equal(t, database.WorkspaceTransitionStart, stats.Transitions[ws.ID])
@@ -970,7 +970,7 @@ func TestExecutorAutostartBlocked(t *testing.T) {
 
 	// Then: the workspace should not be started.
 	stats := <-statsCh
-	require.NoError(t, stats.Error)
+	require.Len(t, stats.Errors, 0)
 	require.Len(t, stats.Transitions, 0)
 }
 


### PR DESCRIPTION
- Fixes an issue where autobuild becomes effectively disabled due to its context not having all the privileges it requires to make scheduling decisions.
- Updates the `Error` field to `Errors` and records all errors that occur over an evaluation iteration.

This bug surfaces some deviations we've made between our testing harness and our production path: 
- `coderdtest.NewOptions` does more than just instantiate sensible defaults for `coderd.API` fields. It's also starting background processes like `autobuild` and the `unhanger.Detector` prior to instantiating a `coderd.API` which is surprising. 
-  This deviates from how `cli/server.go` functions...it first instantiates a `coderd.API` and then starts some background based on the options
- `coderd.New` is not only instantiating a `coderd.API` it's also overwriting options on fields like `Database` to wrap it in `dbauthz`. This means we're "getting lucky" when we start `autobuild` in production, when instantiating that background process you need to be aware that `coderd.API` is responsible for taking whatever type you passed for a `Database` and wrapping it in a `dbauthz.Store` which seems unnecessarily brittle.

The result of this is that we would never catch auth-related errors in `autobuild` in our tests.

There's a non-trivial amount of code to refactor to make this less fragile so this only fixes the autobuild issues.