### PR TITLE
feat: support graceful disconnect in PGCoordinator

### DIFF
--- a/enterprise/tailnet/connio.go
+++ b/enterprise/tailnet/connio.go
@@ -24,16 +24,17 @@ type connIO struct {
 	// coordCtx is the parent context, that is, the context of the Coordinator
 	coordCtx context.Context
 	// peerCtx is the context of the connection to our peer
-	peerCtx   context.Context
-	cancel    context.CancelFunc
-	logger    slog.Logger
-	requests  <-chan *proto.CoordinateRequest
-	responses chan<- *proto.CoordinateResponse
-	bindings  chan<- binding
-	tunnels   chan<- tunnel
-	auth      agpl.TunnelAuth
-	mu        sync.Mutex
-	closed    bool
+	peerCtx      context.Context
+	cancel       context.CancelFunc
+	logger       slog.Logger
+	requests     <-chan *proto.CoordinateRequest
+	responses    chan<- *proto.CoordinateResponse
+	bindings     chan<- binding
+	tunnels      chan<- tunnel
+	auth         agpl.TunnelAuth
+	mu           sync.Mutex
+	closed       bool
+	disconnected bool
 
 	name       string
 	start      int64
@@ -76,20 +77,29 @@ func newConnIO(coordContext context.Context,
 
 func (c *connIO) recvLoop() {
 	defer func() {
-		// withdraw bindings & tunnels when we exit.  We need to use the parent context here, since
+		// withdraw bindings & tunnels when we exit.  We need to use the coordinator context here, since
 		// our own context might be canceled, but we still need to withdraw.
 		b := binding{
 			bKey: bKey(c.UniqueID()),
+			kind: proto.CoordinateResponse_PeerUpdate_LOST,
+		}
+		if c.disconnected {
+			b.kind = proto.CoordinateResponse_PeerUpdate_DISCONNECTED
 		}
 		if err := sendCtx(c.coordCtx, c.bindings, b); err != nil {
 			c.logger.Debug(c.coordCtx, "parent context expired while withdrawing bindings", slog.Error(err))
 		}
-		t := tunnel{
-			tKey:   tKey{src: c.UniqueID()},
-			active: false,
-		}
-		if err := sendCtx(c.coordCtx, c.tunnels, t); err != nil {
-			c.logger.Debug(c.coordCtx, "parent context expired while withdrawing tunnels", slog.Error(err))
+		// only remove tunnels on graceful disconnect.  If we remove tunnels for lost peers, then
+		// this will look like a disconnect from the peer perspective, since we query for active peers
+		// by using the tunnel as a join in the database
+		if c.disconnected {
+			t := tunnel{
+				tKey:   tKey{src: c.UniqueID()},
+				active: false,
+			}
+			if err := sendCtx(c.coordCtx, c.tunnels, t); err != nil {
+				c.logger.Debug(c.coordCtx, "parent context expired while withdrawing tunnels", slog.Error(err))
+			}
 		}
 	}()
 	defer c.Close()
@@ -111,6 +121,8 @@ func (c *connIO) recvLoop() {
 	}
 }
 
+var errDisconnect = xerrors.New("graceful disconnect")
+
 func (c *connIO) handleRequest(req *proto.CoordinateRequest) error {
 	c.logger.Debug(c.peerCtx, "got request")
 	if req.UpdateSelf != nil {
@@ -118,6 +130,7 @@ func (c *connIO) handleRequest(req *proto.CoordinateRequest) error {
 		b := binding{
 			bKey: bKey(c.UniqueID()),
 			node: req.UpdateSelf.Node,
+			kind: proto.CoordinateResponse_PeerUpdate_NODE,
 		}
 		if err := sendCtx(c.coordCtx, c.bindings, b); err != nil {
 			c.logger.Debug(c.peerCtx, "failed to send binding", slog.Error(err))
@@ -169,7 +182,11 @@ func (c *connIO) handleRequest(req *proto.CoordinateRequest) error {
 			return err
 		}
 	}
-	// TODO: (spikecurtis) support Disconnect
+	if req.Disconnect != nil {
+		c.logger.Debug(c.peerCtx, "graceful disconnect")
+		c.disconnected = true
+		return errDisconnect
+	}
 	return nil
 }
 

--- a/enterprise/tailnet/multiagent_test.go
+++ b/enterprise/tailnet/multiagent_test.go
@@ -58,7 +58,7 @@ func TestPGCoordinator_MultiAgent(t *testing.T) {
 	require.NoError(t, agent1.close())
 
 	assertEventuallyNoClientsForAgent(ctx, t, store, agent1.id)
-	assertEventuallyNoAgents(ctx, t, store, agent1.id)
+	assertEventuallyLost(ctx, t, store, agent1.id)
 }
 
 // TestPGCoordinator_MultiAgent_UnsubscribeRace tests a single coordinator with
@@ -106,7 +106,7 @@ func TestPGCoordinator_MultiAgent_UnsubscribeRace(t *testing.T) {
 	require.NoError(t, agent1.close())
 
 	assertEventuallyNoClientsForAgent(ctx, t, store, agent1.id)
-	assertEventuallyNoAgents(ctx, t, store, agent1.id)
+	assertEventuallyLost(ctx, t, store, agent1.id)
 }
 
 // TestPGCoordinator_MultiAgent_Unsubscribe tests a single coordinator with a
@@ -168,7 +168,7 @@ func TestPGCoordinator_MultiAgent_Unsubscribe(t *testing.T) {
 	require.NoError(t, agent1.close())
 
 	assertEventuallyNoClientsForAgent(ctx, t, store, agent1.id)
-	assertEventuallyNoAgents(ctx, t, store, agent1.id)
+	assertEventuallyLost(ctx, t, store, agent1.id)
 }
 
 // TestPGCoordinator_MultiAgent_MultiCoordinator tests two coordinators with a
@@ -220,7 +220,7 @@ func TestPGCoordinator_MultiAgent_MultiCoordinator(t *testing.T) {
 	require.NoError(t, agent1.close())
 
 	assertEventuallyNoClientsForAgent(ctx, t, store, agent1.id)
-	assertEventuallyNoAgents(ctx, t, store, agent1.id)
+	assertEventuallyLost(ctx, t, store, agent1.id)
 }
 
 // TestPGCoordinator_MultiAgent_MultiCoordinator_UpdateBeforeSubscribe tests two
@@ -273,7 +273,7 @@ func TestPGCoordinator_MultiAgent_MultiCoordinator_UpdateBeforeSubscribe(t *test
 	require.NoError(t, agent1.close())
 
 	assertEventuallyNoClientsForAgent(ctx, t, store, agent1.id)
-	assertEventuallyNoAgents(ctx, t, store, agent1.id)
+	assertEventuallyLost(ctx, t, store, agent1.id)
 }
 
 // TestPGCoordinator_MultiAgent_TwoAgents tests three coordinators with a
@@ -344,5 +344,5 @@ func TestPGCoordinator_MultiAgent_TwoAgents(t *testing.T) {
 	require.NoError(t, agent2.close())
 
 	assertEventuallyNoClientsForAgent(ctx, t, store, agent1.id)
-	assertEventuallyNoAgents(ctx, t, store, agent1.id)
+	assertEventuallyLost(ctx, t, store, agent1.id)
 }


### PR DESCRIPTION
Adds support for graceful disconnect to PGCoordinator.  When peers gracefully disconnect, they send a disconnect message.  This triggers the peer to be disconnected from all tunneled peers.

The Multi-Agent Client supports graceful disconnect, since it is in memory and we know that when it is closed, we really mean to disconnect.

The v1 agent and client Websocket connections do not support graceful disconnect, since the v1 protocol doesn't have this feature.  That means that if a v1 peer connects to a v2 peer, when the v1 peer's coordinator connection is closed, the v2 peer will
see it as "lost" since we don't know whether the v1 peer meant to disconnect, or it just lost connectivity to the coordinator.
