### PR TITLE
fix: prevent connIO from panicking in race between Close and Enqueue

### DIFF
--- a/enterprise/tailnet/connio.go
+++ b/enterprise/tailnet/connio.go
@@ -197,9 +197,8 @@ func (c *connIO) UniqueID() uuid.UUID {
 func (c *connIO) Enqueue(resp *proto.CoordinateResponse) error {
 	atomic.StoreInt64(&c.lastWrite, time.Now().Unix())
 	c.mu.Lock()
-	closed := c.closed
-	c.mu.Unlock()
-	if closed {
+	defer c.mu.Unlock()
+	if c.closed {
 		return xerrors.New("connIO closed")
 	}
 	select {


### PR DESCRIPTION
Spotted during a code read.  ConnIO unlocks the mutex before attempting to write to the response channel, which could allow another goroutine to call Close() and close the channel, causing a panic.

Fix is to hold the mutex.  This won't cause a deadlock because the `select{}` has a `default` case, so we won't block even if the receiver isn't keeping up.
