### PR TITLE
chore: add external auth providers to `oidctest`

### DIFF
--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -713,7 +713,7 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 		_ = json.NewEncoder(rw).Encode(claims)
 	}))
 
-	mux.Handle("/external-auth-validate/{provider-id}", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	mux.Mount("/external-auth-validate/{provider-id}", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		token, err := f.authenticateBearerTokenRequest(t, r)
 		f.logger.Info(r.Context(), "http call idp external auth validate",
 			slog.Error(err),
@@ -843,15 +843,62 @@ func (f *FakeIDP) SetCoderdCallbackHandler(handler http.HandlerFunc) {
 	})
 }
 
+type ExternalAuthConfigOptions struct {
+	// ValidatePayload is the payload that is used when the user calls the
+	// equivalent of "userinfo" for oauth2. This is not standardized, so is
+	// different for each provider type.
+	ValidatePayload func(email string) interface{}
+
+	// routes is more advanced usage. This allows the caller to
+	// completely customize the response. It captures all routes under the /external-auth-validate/{provider-id}/*
+	// so the caller can do whatever they want and even add routes.
+	routes map[string]func(email string, rw http.ResponseWriter, r *http.Request)
+}
+
+func (o *ExternalAuthConfigOptions) AddRoute(route string, handle func(email string, rw http.ResponseWriter, r *http.Request)) *ExternalAuthConfigOptions {
+	if route == "/" || route == "" || route == "/user" {
+		panic("cannot override the /user route. Use ValidatePayload instead")
+	}
+	if !strings.HasPrefix(route, "/") {
+		route = "/" + route
+	}
+	if o.routes == nil {
+		o.routes = make(map[string]func(email string, rw http.ResponseWriter, r *http.Request))
+	}
+	o.routes[route] = handle
+	return o
+}
+
 // ExternalAuthConfig takes a validatePayload, which should be the user data in a parseable format based
 // on the type. Or just omitted if the user info is not important.
-func (f *FakeIDP) ExternalAuthConfig(t testing.TB, id string, validatePayload func(email string) interface{}, opts ...func(cfg *externalauth.Config)) *externalauth.Config {
-	if validatePayload == nil {
-		validatePayload = func(_ string) interface{} { return "OK" }
+func (f *FakeIDP) ExternalAuthConfig(t testing.TB, id string, custom *ExternalAuthConfigOptions, opts ...func(cfg *externalauth.Config)) *externalauth.Config {
+	if custom == nil {
+		custom = &ExternalAuthConfigOptions{}
 	}
+
 	f.externalAuthValidate[id] = func(email string, rw http.ResponseWriter, r *http.Request) {
-		payload := validatePayload(email)
-		_ = json.NewEncoder(rw).Encode(payload)
+		newPath := strings.TrimPrefix(r.URL.Path, fmt.Sprintf("/external-auth-validate/%s", id))
+		switch newPath {
+		// /user is ALWAYS supported under the `/` path too.
+		case "/user", "/", "":
+			var payload interface{} = "OK"
+			if custom.ValidatePayload != nil {
+				payload = custom.ValidatePayload(email)
+
+			}
+			_ = json.NewEncoder(rw).Encode(payload)
+		default:
+			if custom.routes == nil {
+				custom.routes = make(map[string]func(email string, rw http.ResponseWriter, r *http.Request))
+			}
+			handle, ok := custom.routes[newPath]
+			if !ok {
+				t.Errorf("missing route handler for %s", newPath)
+				http.Error(rw, fmt.Sprintf("missing route handler for %s", newPath), http.StatusBadRequest)
+				return
+			}
+			handle(email, rw, r)
+		}
 	}
 	cfg := &externalauth.Config{
 		OAuth2Config: f.OIDCConfig(t, nil),
@@ -859,7 +906,9 @@ func (f *FakeIDP) ExternalAuthConfig(t testing.TB, id string, validatePayload fu
 		// No defaults for these fields by omitting the type
 		Type:        "",
 		DisplayIcon: f.WellknownConfig().UserInfoURL,
-		ValidateURL: f.issuerURL.ResolveReference(&url.URL{Path: "/external-auth-validate/" + id}).String(),
+		// Omit the /user for the validate so we can easily append to it when modifying
+		// the cfg for advanced tests.
+		ValidateURL: f.issuerURL.ResolveReference(&url.URL{Path: fmt.Sprintf("/external-auth-validate/%s", id)}).String(),
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -884,7 +884,6 @@ func (f *FakeIDP) ExternalAuthConfig(t testing.TB, id string, custom *ExternalAu
 			var payload interface{} = "OK"
 			if custom.ValidatePayload != nil {
 				payload = custom.ValidatePayload(email)
-
 			}
 			_ = json.NewEncoder(rw).Encode(payload)
 		default:

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -358,7 +358,7 @@ func (f *FakeIDP) LoginWithClient(t testing.TB, client *codersdk.Client, idToken
 
 // ExternalLogin does the oauth2 flow for external auth providers. This requires
 // an authenticated coder client.
-func (f *FakeIDP) ExternalLogin(t testing.TB, client *codersdk.Client, opts ...func(r *http.Request)) *http.Response {
+func (f *FakeIDP) ExternalLogin(t testing.TB, client *codersdk.Client, opts ...func(r *http.Request)) {
 	coderOauthURL, err := client.URL.Parse(fmt.Sprintf("/external-auth/%s/callback", f.externalProviderID))
 	require.NoError(t, err)
 	f.SetRedirect(t, coderOauthURL.String())
@@ -394,10 +394,7 @@ func (f *FakeIDP) ExternalLogin(t testing.TB, client *codersdk.Client, opts ...f
 	res, err := cli.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode, "client failed to login")
-	t.Cleanup(func() {
-		res.Body.Close()
-	})
-	return res
+	_ = res.Body.Close()
 }
 
 // OIDCCallback will emulate the IDP redirecting back to the Coder callback.

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -63,7 +63,7 @@ func TestExternalAuthByID(t *testing.T) {
 		})
 
 		coderdtest.CreateFirstUser(t, client)
-		fake.ExternalLogin(t, client, providerID)
+		fake.ExternalLogin(t, client)
 
 		auth, err := client.ExternalAuthByID(context.Background(), providerID)
 		require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestExternalAuthByID(t *testing.T) {
 
 		coderdtest.CreateFirstUser(t, client)
 		// Login to external auth provider
-		fake.ExternalLogin(t, client, providerID)
+		fake.ExternalLogin(t, client)
 
 		auth, err := client.ExternalAuthByID(context.Background(), providerID)
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestExternalAuthByID(t *testing.T) {
 		})
 
 		coderdtest.CreateFirstUser(t, client)
-		fake.ExternalLogin(t, client, providerID)
+		fake.ExternalLogin(t, client)
 
 		auth, err := client.ExternalAuthByID(context.Background(), providerID)
 		require.NoError(t, err)

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -50,7 +50,7 @@ func TestExternalAuthByID(t *testing.T) {
 		// Ensures that a provider that can't obtain a user can
 		// still return that the provider is authenticated.
 		t.Parallel()
-		const providerID = "fake-github"
+		const providerID = "fake-azure"
 		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
 
 		client := coderdtest.New(t, &coderdtest.Options{


### PR DESCRIPTION
# What this does

Enables external auth tests to use `oidctest` pkg with a fake oauth provider. This makes external auth flows actually test against a functioning fake idp. I had to add some custom settings to the IDP to support the custom route additions.

I did not touch the device flow because I do not 100% understand it.

# Why?

Firstly using an actual IDP is just overall good for our tests. I am working on a different external auth thing, and want to use this.