### PR TITLE
fix: wait for dial goroutine to complete

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -409,7 +409,9 @@ func TestSSH(t *testing.T) {
 			//
 			// To work around this, we attempt to send messages in a loop until one succeeds
 			success := make(chan struct{})
+			done := make(chan struct{})
 			go func() {
+				defer close(done)
 				var (
 					conn net.Conn
 					err  error
@@ -447,6 +449,8 @@ func TestSSH(t *testing.T) {
 			fsn.Notify()
 			<-cmdDone
 			fsn.AssertStopped()
+			// wait for dial goroutine to complete
+			_ = testutil.RequireRecvCtx(ctx, t, done)
 
 			// wait for the remote socket to get cleaned up before retrying,
 			// because cleaning up the socket happens asynchronously, and we


### PR DESCRIPTION
Fixes flake seen here: https://github.com/coder/coder/runs/19170327767

The goroutine that attempts to dial the socket didn't complete before the test did.  Here we add an explicit wait for it to complete in each run of the loop.
