### PR TITLE
fix: fix TestWorkspaceAutobuild/DormantNoAutostart flake

### DIFF
--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -697,7 +697,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			cwr.AutostartSchedule = ptr.Ref(sched.String())
 		})
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws.LatestBuild.ID)
-		coderdtest.MustTransitionWorkspace(t, client, ws.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+		ws = coderdtest.MustTransitionWorkspace(t, client, ws.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
 
 		// Assert that autostart works when the workspace isn't dormant..
 		tickCh <- sched.Next(ws.LatestBuild.CreatedAt)


### PR DESCRIPTION
fixes https://github.com/coder/coder/issues/10947

The test forgets to reassign the updated workspace object after stopping the workspace so the build time that we use to pass to the autobuilder ticker is the one from initially starting the workspace. You would frequently get lucky because both builds would occur within the same hour. In this case the start build happened on (e.g.) `01:59` and the stop build happened on `02:00` so when we're calculating the next occurrence we're off by one hour.   
