### PR TITLE
fix: handle 404 on unknown top level routes

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -320,25 +320,25 @@ export const AppRouter: FC = () => {
                 </Route>
               </Route>
 
-              <Route path="/:username">
-                <Route path=":workspace">
-                  <Route index element={<WorkspacePage />} />
-                  <Route
-                    path="builds/:buildNumber"
-                    element={<WorkspaceBuildPage />}
-                  />
-                  <Route path="settings" element={<WorkspaceSettingsLayout />}>
-                    <Route index element={<WorkspaceSettingsPage />} />
-                    <Route
-                      path="parameters"
-                      element={<WorkspaceParametersPage />}
-                    />
-                    <Route
-                      path="schedule"
-                      element={<WorkspaceSchedulePage />}
-                    />
-                  </Route>
-                </Route>
+
+              <Route
+                path="/:username/:workspace"
+                element={<WorkspacePage />}
+              />
+              <Route
+                path="/:username/:workspace/builds/:buildNumber"
+                element={<WorkspaceBuildPage />}
+              />
+              <Route path="/:username/:workspace/settings" element={<WorkspaceSettingsLayout />}>
+                <Route index element={<WorkspaceSettingsPage />} />
+                <Route
+                  path="parameters"
+                  element={<WorkspaceParametersPage />}
+                />
+                <Route
+                  path="schedule"
+                  element={<WorkspaceSchedulePage />}
+                />
               </Route>
             </Route>
 

--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -321,6 +321,8 @@ export const AppRouter: FC = () => {
               </Route>
 
 
+              {/* In order for the 404 page to work properly the routes that start with
+              top level parameter must be fully qualified. */}
               <Route
                 path="/:username/:workspace"
                 element={<WorkspacePage />}

--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -320,27 +320,23 @@ export const AppRouter: FC = () => {
                 </Route>
               </Route>
 
-
               {/* In order for the 404 page to work properly the routes that start with
               top level parameter must be fully qualified. */}
-              <Route
-                path="/:username/:workspace"
-                element={<WorkspacePage />}
-              />
+              <Route path="/:username/:workspace" element={<WorkspacePage />} />
               <Route
                 path="/:username/:workspace/builds/:buildNumber"
                 element={<WorkspaceBuildPage />}
               />
-              <Route path="/:username/:workspace/settings" element={<WorkspaceSettingsLayout />}>
+              <Route
+                path="/:username/:workspace/settings"
+                element={<WorkspaceSettingsLayout />}
+              >
                 <Route index element={<WorkspaceSettingsPage />} />
                 <Route
                   path="parameters"
                   element={<WorkspaceParametersPage />}
                 />
-                <Route
-                  path="schedule"
-                  element={<WorkspaceSchedulePage />}
-                />
+                <Route path="schedule" element={<WorkspaceSchedulePage />} />
               </Route>
 
               {/* Using path="*"" means "match anything", so this route

--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -342,6 +342,11 @@ export const AppRouter: FC = () => {
                   element={<WorkspaceSchedulePage />}
                 />
               </Route>
+
+              {/* Using path="*"" means "match anything", so this route
+              acts like a catch-all for URLs that we don't have explicit
+              routes for. */}
+              <Route path="*" element={<NotFoundPage />} />
             </Route>
 
             {/* Pages that don't have the dashboard layout */}
@@ -356,11 +361,6 @@ export const AppRouter: FC = () => {
               element={<TemplateVersionEditorPage />}
             />
           </Route>
-
-          {/* Using path="*"" means "match anything", so this route
-        acts like a catch-all for URLs that we don't have explicit
-        routes for. */}
-          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Router>
     </Suspense>


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/10901

Currently if you put garbage into the top level route you get an empty dashboard layout page:
<img width="1380" alt="image" src="https://github.com/coder/coder/assets/19379394/1337143c-5d46-43ad-8597-869b032e28f7">

This is due to some odd behavior with the top level parameter block `/:username` and the `*` path. I trialed and errored a few different places I could add an additional 404 page route with no luck. 

Specifying the fully qualified routes and moving the 404 page worked and I think this is a reasonable tradeoff. Please be vocal if you feel otherwise. 

Now what happens when you type a garbage top level route:
<img width="1379" alt="image" src="https://github.com/coder/coder/assets/19379394/466d819f-4456-42fc-acc9-dc31e12860bf">
