### PR TITLE
fix: fix TestWorkspaceAutobuild/InactiveTTLOK flake

### DIFF
--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -316,6 +316,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		}
 
 		dormantLastUsedAt := ws.LastUsedAt
+		// nolint:gocritic // this test is not testing RBAC.
 		err := client.UpdateWorkspaceDormancy(ctx, ws.ID, codersdk.UpdateWorkspaceDormancy{Dormant: false})
 		require.NoError(t, err)
 


### PR DESCRIPTION
The workspace is in a started state. We try to stop any started workspaces when transitioning them to dormant. There's a race with the provisioner who will also generate an audit log for the workspace build associated with the stop.

fixes https://github.com/coder/coder/issues/10957