### PR TITLE
fix: parse username/workspace correctly on coder state push --build

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -103,7 +103,11 @@ func (r *RootCmd) statePush() *clibase.Cmd {
 			if buildNumber == 0 {
 				build = workspace.LatestBuild
 			} else {
-				build, err = client.WorkspaceBuildByUsernameAndWorkspaceNameAndBuildNumber(inv.Context(), codersdk.Me, inv.Args[0], strconv.FormatInt((buildNumber), 10))
+				owner, workspace, err := splitNamedWorkspace(inv.Args[0])
+				if err != nil {
+					return err
+				}
+				build, err = client.WorkspaceBuildByUsernameAndWorkspaceNameAndBuildNumber(inv.Context(), owner, workspace, strconv.FormatInt((buildNumber), 10))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes the same issue as #10884 but for state push
