### PR TITLE
fix(docs): remove anchor links from headings in admin/healthcheck.md

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs-only: ${{ steps.filter.outputs.docs_count == steps.filter.outputs.all_count }}
+      docs: ${{ steps.filter.outputs.docs }}
       go: ${{ steps.filter.outputs.go }}
       ts: ${{ steps.filter.outputs.ts }}
       k8s: ${{ steps.filter.outputs.k8s }}
@@ -647,7 +648,8 @@ jobs:
     name: offlinedocs
     needs: changes
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
-    if: needs.changes.outputs.offlinedocs == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.offlinedocs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.docs == 'true'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/admin/healthcheck.md
+++ b/docs/admin/healthcheck.md
@@ -21,7 +21,7 @@ If there is an issue, you may see one of the following errors reported:
 
 ### EACS01
 
-*Access URL not set*
+_Access URL not set_
 
 **Problem:** no access URL has been configured.
 
@@ -29,7 +29,7 @@ If there is an issue, you may see one of the following errors reported:
 
 ### EACS02
 
-*Access URL invalid*
+_Access URL invalid_
 
 **Problem:** `${CODER_ACCESS_URL}/healthz` is not a valid URL.
 
@@ -41,7 +41,7 @@ If there is an issue, you may see one of the following errors reported:
 
 ### EACS03
 
-*Failed to fetch `/healthz`*
+_Failed to fetch `/healthz`_
 
 **Problem:** Coder was unable to execute a GET request to
 `${CODER_ACCESS_URL}/healthz`.
@@ -71,7 +71,7 @@ The output of this command should aid further diagnosis.
 
 ### EACS04
 
-*/healthz did not return 200 OK*
+_/healthz did not return 200 OK_
 
 **Problem:** Coder was able to execute a GET request to
 `${CODER_ACCESS_URL}/healthz`, but the response code was not `200 OK` as
@@ -94,7 +94,7 @@ its configured database, and also measures the median latency over 5 attempts.
 
 ### EDB01
 
-*Database Ping Failed*
+_Database Ping Failed_
 
 **Problem:** This error code is returned if any attempt to execute this database
 query fails.
@@ -103,7 +103,7 @@ query fails.
 
 ### EDB02
 
-*Database Latency High*
+_Database Latency High_
 
 **Problem:** This code is returned if the median latency is higher than the
 [configured threshold](../cli/server.md#--health-check-threshold-database). This
@@ -134,7 +134,7 @@ following:
 
 ### EDERP01
 
-*DERP Node Uses Websocket*
+_DERP Node Uses Websocket_
 
 **Problem:** When Coder attempts to establish a connection to one or more DERP
 servers, it sends a specific `Upgrade: derp` HTTP header. Some load balancers
@@ -153,7 +153,7 @@ still be able to reach their workspaces, connection performance may be degraded.
 
 ### EDERP02
 
-*One or more DERP nodes are unhealthy*
+_One or more DERP nodes are unhealthy_
 
 **Problem:** This is shown if Coder is unable to reach one or more configured
 DERP servers. Clients will fall back to use the remaining DERP servers, but
@@ -188,7 +188,7 @@ message over the connection, and attempt to read back that same message.
 
 ### EWS01
 
-*Failed to establish a WebSocket connection*
+_Failed to establish a WebSocket connection_
 
 **Problem:** Coder was unable to establish a WebSocket connection over its own
 Access URL.
@@ -207,7 +207,7 @@ Access URL.
 
 ### EWS02
 
-*Failed to echo a WebSocket message*
+_Failed to echo a WebSocket message_
 
 **Problem:** Coder was able to establish a WebSocket connection, but was unable
 to write a message.
@@ -228,7 +228,7 @@ will periodically query their availability and show their status here.
 
 ### EWP01
 
-*Error Updating Workspace Proxy Health*
+_Error Updating Workspace Proxy Health_
 
 **Problem:** Coder was unable to query the connected workspace proxies for their
 health status.
@@ -238,7 +238,7 @@ connectivity issue.
 
 ### EWP02
 
-*Error Fetching Workspace Proxies*
+_Error Fetching Workspace Proxies_
 
 **Problem:** Coder was unable to fetch the stored workspace proxy health data
 from the database.
@@ -248,7 +248,7 @@ issue with Coder's configured database.
 
 ### EWP03
 
-*Workspace Proxy Version Mismatch*
+_Workspace Proxy Version Mismatch_
 
 **Problem:** One or more workspace proxies are more than one major or minor
 version out of date with the main deployment. It is important that workspace
@@ -260,7 +260,7 @@ of Coder.
 
 ### EWP04
 
-*One or more Workspace Proxies Unhealthy*
+_One or more Workspace Proxies Unhealthy_
 
 **Problem:** One or more workspace proxies are not reachable.
 
@@ -269,7 +269,7 @@ workspace proxies on port 443.
 
 ## EUNKNOWN
 
-*Unknown Error*
+_Unknown Error_
 
 **Problem:** This error is shown when an unexpected error occurred evaluating
 deployment health. It may resolve on its own.

--- a/docs/admin/healthcheck.md
+++ b/docs/admin/healthcheck.md
@@ -19,13 +19,17 @@ string `OK`.
 
 If there is an issue, you may see one of the following errors reported:
 
-### <a name="EACS01">EACS01: Access URL not set</a>
+### EACS01
+
+*Access URL not set*
 
 **Problem:** no access URL has been configured.
 
 **Solution:** configure an [access URL](./configure.md#access-url) for Coder.
 
-### <a name="EACS02">EACS02: Access URL invalid</a>
+### EACS02
+
+*Access URL invalid*
 
 **Problem:** `${CODER_ACCESS_URL}/healthz` is not a valid URL.
 
@@ -35,7 +39,9 @@ If there is an issue, you may see one of the following errors reported:
 
 > **Tip:** You can check this [here](https://go.dev/play/p/CabcJZyTwt9).
 
-### <a name="EACS03">EACS03: Failed to fetch `/healthz`</a>
+### EACS03
+
+*Failed to fetch `/healthz`*
 
 **Problem:** Coder was unable to execute a GET request to
 `${CODER_ACCESS_URL}/healthz`.
@@ -63,7 +69,9 @@ curl -v ${CODER_ACCESS_URL}/healthz
 
 The output of this command should aid further diagnosis.
 
-### <a name="EACS04">EACS04: /healthz did not return 200 OK</a>
+### EACS04
+
+*/healthz did not return 200 OK*
 
 **Problem:** Coder was able to execute a GET request to
 `${CODER_ACCESS_URL}/healthz`, but the response code was not `200 OK` as
@@ -84,14 +92,18 @@ should give you a good indication of the root cause.
 Coder continuously executes a short database query to validate that it can reach
 its configured database, and also measures the median latency over 5 attempts.
 
-### <a name="EDB01">EDB01: Database Ping Failed</a>
+### EDB01
+
+*Database Ping Failed*
 
 **Problem:** This error code is returned if any attempt to execute this database
 query fails.
 
 **Solution:** Investigate the health of the database.
 
-### <a name="EDB02">EDB02: Database Latency High</a>
+### EDB02
+
+*Database Latency High*
 
 **Problem:** This code is returned if the median latency is higher than the
 [configured threshold](../cli/server.md#--health-check-threshold-database). This
@@ -120,7 +132,9 @@ traffic between Coder and workspace agents. Coder periodically queries the
 health of its configured DERP servers and may return one or more of the
 following:
 
-### <a name="EDERP01">EDERP01: DERP Node Uses Websocket</a>
+### EDERP01
+
+*DERP Node Uses Websocket*
 
 **Problem:** When Coder attempts to establish a connection to one or more DERP
 servers, it sends a specific `Upgrade: derp` HTTP header. Some load balancers
@@ -137,7 +151,9 @@ still be able to reach their workspaces, connection performance may be degraded.
 **Solution:** ensure that any configured reverse proxy does not strip the
 `Upgrade: derp` header.
 
-### <a name="EDERP02">EDERP02: One or more DERP nodes are unhealthy</a>
+### EDERP02
+
+*One or more DERP nodes are unhealthy*
 
 **Problem:** This is shown if Coder is unable to reach one or more configured
 DERP servers. Clients will fall back to use the remaining DERP servers, but
@@ -170,7 +186,9 @@ functionality, Coder will periodically attempt to establish a WebSocket
 connection with itself using the configured [Access URL](#access-url), send a
 message over the connection, and attempt to read back that same message.
 
-### <a name="EWS01">EWS01: Failed to establish a WebSocket connection</a>
+### EWS01
+
+*Failed to establish a WebSocket connection*
 
 **Problem:** Coder was unable to establish a WebSocket connection over its own
 Access URL.
@@ -187,7 +205,9 @@ Access URL.
 2. Ensure that any reverse proxy that is sitting in front of Coder's configured
    access URL is not stripping the HTTP header `Upgrade: websocket`.
 
-### <a name="EWS02">EWS02: Failed to echo a WebSocket message</a>
+### EWS02
+
+*Failed to echo a WebSocket message*
 
 **Problem:** Coder was able to establish a WebSocket connection, but was unable
 to write a message.
@@ -206,7 +226,9 @@ to write a message.
 If you have configured [Workspace Proxies](../admin/workspace-proxies.md), Coder
 will periodically query their availability and show their status here.
 
-### <a name="EWP01">EWP01: Error Updating Workspace Proxy Health</a>
+### EWP01
+
+*Error Updating Workspace Proxy Health*
 
 **Problem:** Coder was unable to query the connected workspace proxies for their
 health status.
@@ -214,7 +236,9 @@ health status.
 **Solution:** This may be a transient issue. If it persists, it could signify a
 connectivity issue.
 
-### <a name="EWP02">EWP02: Error Fetching Workspace Proxies</a>
+### EWP02
+
+*Error Fetching Workspace Proxies*
 
 **Problem:** Coder was unable to fetch the stored workspace proxy health data
 from the database.
@@ -222,7 +246,9 @@ from the database.
 **Solution:** This may be a transient issue. If it persists, it could signify an
 issue with Coder's configured database.
 
-### <a name="EWP03">EWP03: Workspace Proxy Version Mismatch</a>
+### EWP03
+
+*Workspace Proxy Version Mismatch*
 
 **Problem:** One or more workspace proxies are more than one major or minor
 version out of date with the main deployment. It is important that workspace
@@ -232,14 +258,18 @@ of API incompatibility.
 **Solution:** Update the workspace proxy to match the currently running version
 of Coder.
 
-### <a name="EWP04">EWP04: One or more Workspace Proxies Unhealthy</a>
+### EWP04
+
+*One or more Workspace Proxies Unhealthy*
 
 **Problem:** One or more workspace proxies are not reachable.
 
 **Solution:** Ensure that Coder can establish a connection to the configured
 workspace proxies on port 443.
 
-## <a name="EUNKNOWN">Unknown Error</a>
+## EUNKNOWN
+
+*Unknown Error*
 
 **Problem:** This error is shown when an unexpected error occurred evaluating
 deployment health. It may resolve on its own.


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/8965

- Fixes offlinedocs that broke from change in https://github.com/coder/coder/pull/10915 by removing the offending anchor links from the page subheadings.
- Makes offlinedocs also conditional on changes to docs