### PR TITLE
chore: path app IDEs

### DIFF
--- a/docs/admin/healthcheck.md
+++ b/docs/admin/healthcheck.md
@@ -114,7 +114,7 @@ Coder's current activity and usage. It may be necessary to increase the
 resources allocated to Coder's database. Alternatively, you can raise the
 configured threshold to a higher value (this will not address the root cause).
 
-> **Tip:**
+> [!TIP]
 >
 > - You can enable
 >   [detailed database metrics](../cli/server.md#--prometheus-collect-db-metrics)

--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -222,6 +222,16 @@ resource "coder_app" "jupyter" {
 }
 ```
 
+If you cannot enable a
+[wildcard subdomain](https://coder.com/docs/v2/latest/admin/configure#wildcard-access-url),
+you can configure the template to run Jupyter on a path. There is however
+[security risk](https://coder.com/docs/v2/latest/cli/server#--dangerous-allow-path-app-sharing)
+running an app on a path and the template code is more complicated with coder
+value substitution to recreate the path structure.
+
+[This](https://github.com/sharkymark/v2-templates/tree/main/pod-with-jupyter-path)
+is a community template example.
+
 ![JupyterLab in Coder](../images/jupyter.png)
 
 ## RStudio
@@ -258,6 +268,17 @@ resource "coder_app" "rstudio" {
   }
 }
 ```
+
+If you cannot enable a
+[wildcard subdomain](https://coder.com/docs/v2/latest/admin/configure#wildcard-access-url),
+you can configure the template to run RStudio on a path using an NGINX reverse
+proxy in the template. There is however
+[security risk](https://coder.com/docs/v2/latest/cli/server#--dangerous-allow-path-app-sharing)
+running an app on a path and the template code is more complicated with coder
+value substitution to recreate the path structure.
+
+[This](https://github.com/sempie/coder-templates/tree/main/rstudio) is a
+community template example.
 
 ![RStudio in Coder](../images/rstudio-port-forward.png)
 

--- a/examples/templates/community-templates.md
+++ b/examples/templates/community-templates.md
@@ -29,8 +29,8 @@ templates.
 - [atnomoverflow/coder-template](https://github.com/atnomoverflow/coder-template) -
   Kubernetes template that install VS code server Rstudio jupyter and also set
   ssh access to gitlab (Works also on self managed gitlab).
-- [sempie/coder-templates](https://github.com/sempie/coder-templates) -
-  RStudio template on a path using NGINX in the workspace 
+- [sempie/coder-templates](https://github.com/sempie/coder-templates) - RStudio
+  template on a path using NGINX in the workspace
 
 ## Automation
 

--- a/examples/templates/community-templates.md
+++ b/examples/templates/community-templates.md
@@ -29,6 +29,8 @@ templates.
 - [atnomoverflow/coder-template](https://github.com/atnomoverflow/coder-template) -
   Kubernetes template that install VS code server Rstudio jupyter and also set
   ssh access to gitlab (Works also on self managed gitlab).
+- [sempie/coder-templates](https://github.com/sempie/coder-templates) -
+  RStudio template on a path using NGINX in the workspace 
 
 ## Automation
 


### PR DESCRIPTION
This PR:

1. Updates the Web IDEs doc to give examples of using Jupyter and RStudio IDEs on a path if wildcard subdomains are not possible
2. Add `sempie` to community template examples for RStudio template