### PR TITLE
fix: pass in time parameter to prevent flakes

### DIFF
--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -550,9 +550,6 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 		{"end_time", endTimeString, &endTime},
 	} {
 		t, err := time.Parse(insightsTimeLayout, qp.value)
-		// strip monotonic clock reading
-		// so presentation time and arithmetic operations are consistent
-		t = t.Round(0)
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Query parameter has invalid value.",
@@ -565,6 +562,9 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 			})
 			return time.Time{}, time.Time{}, false
 		}
+		// strip monotonic clock reading
+		// so presentation time and arithmetic operations are consistent
+		t = t.Round(0)
 
 		if t.IsZero() {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -550,6 +550,9 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 		{"end_time", endTimeString, &endTime},
 	} {
 		t, err := time.Parse(insightsTimeLayout, qp.value)
+		// strip monotonic clock reading
+		// so presentation time and arithmetic operations are consistent
+		t = t.Round(0)
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Query parameter has invalid value.",

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -604,7 +604,7 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 				Validations: []codersdk.ValidationError{
 					{
 						Field:  qp.name,
-						Detail: fmt.Sprintf("Query param %q must have the clock set to 00:00:00", qp.name),
+						Detail: fmt.Sprintf("Query param %q must have the clock set to 00:00:00, got %s", qp.name, qp.value),
 					},
 				},
 			})
@@ -615,7 +615,7 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 				Validations: []codersdk.ValidationError{
 					{
 						Field:  qp.name,
-						Detail: fmt.Sprintf("Query param %q must have the clock set to %02d:00:00", qp.name, h),
+						Detail: fmt.Sprintf("Query param %q must have the clock set to %02d:00:00, got %s", qp.name, h, qp.value),
 					},
 				},
 			})

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -563,6 +563,9 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 			return time.Time{}, time.Time{}, false
 		}
 
+		// Change now to the same timezone as the parsed time.
+		now := now.In(t.Location())
+
 		if t.IsZero() {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Query parameter has invalid value.",

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -562,9 +562,6 @@ func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, s
 			})
 			return time.Time{}, time.Time{}, false
 		}
-		// strip monotonic clock reading
-		// so presentation time and arithmetic operations are consistent
-		t = t.Round(0)
 
 		if t.IsZero() {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -89,7 +89,7 @@ func (api *API) insightsUserActivity(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	startTime, endTime, ok := parseInsightsStartAndEndTime(ctx, rw, startTimeString, endTimeString)
+	startTime, endTime, ok := parseInsightsStartAndEndTime(ctx, rw, time.Now(), startTimeString, endTimeString)
 	if !ok {
 		return
 	}
@@ -176,7 +176,7 @@ func (api *API) insightsUserLatency(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	startTime, endTime, ok := parseInsightsStartAndEndTime(ctx, rw, startTimeString, endTimeString)
+	startTime, endTime, ok := parseInsightsStartAndEndTime(ctx, rw, time.Now(), startTimeString, endTimeString)
 	if !ok {
 		return
 	}
@@ -268,7 +268,7 @@ func (api *API) insightsTemplates(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	startTime, endTime, ok := parseInsightsStartAndEndTime(ctx, rw, startTimeString, endTimeString)
+	startTime, endTime, ok := parseInsightsStartAndEndTime(ctx, rw, time.Now(), startTimeString, endTimeString)
 	if !ok {
 		return
 	}
@@ -539,9 +539,7 @@ func convertTemplateInsightsApps(usage database.GetTemplateInsightsRow, appUsage
 // time are not zero and that the end time is not before the start time. The
 // clock must be set to 00:00:00, except for "today", where end time is allowed
 // to provide the hour of the day (e.g. 14:00:00).
-func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, startTimeString, endTimeString string) (startTime, endTime time.Time, ok bool) {
-	now := time.Now()
-
+func parseInsightsStartAndEndTime(ctx context.Context, rw http.ResponseWriter, now time.Time, startTimeString, endTimeString string) (startTime, endTime time.Time, ok bool) {
 	for _, qp := range []struct {
 		name, value string
 		dest        *time.Time

--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -156,7 +156,7 @@ func Test_parseInsightsStartAndEndTime(t *testing.T) {
 			}
 
 			rw := httptest.NewRecorder()
-			gotStartTime, gotEndTime, gotOk := parseInsightsStartAndEndTime(context.Background(), rw, tt.args.startTime, tt.args.endTime)
+			gotStartTime, gotEndTime, gotOk := parseInsightsStartAndEndTime(context.Background(), rw, now, tt.args.startTime, tt.args.endTime)
 
 			if !assert.Equal(t, tt.wantOk, gotOk) {
 				//nolint:bodyclose
@@ -261,7 +261,7 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 			t.Log("endTime: ", tt.args.endTime)
 
 			rw := httptest.NewRecorder()
-			startTime, endTime, ok := parseInsightsStartAndEndTime(context.Background(), rw, tt.args.startTime, tt.args.endTime)
+			startTime, endTime, ok := parseInsightsStartAndEndTime(context.Background(), rw, now, tt.args.startTime, tt.args.endTime)
 			if !ok {
 				//nolint:bodyclose
 				t.Log("Status: ", rw.Result().StatusCode)

--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -43,6 +43,16 @@ func Test_parseInsightsStartAndEndTime(t *testing.T) {
 		wantOk        bool
 	}{
 		{
+			name: "Same",
+			args: args{
+				startTime: "2023-07-10T00:00:00Z",
+				endTime:   "2023-07-10T00:00:00Z",
+			},
+			wantStartTime: time.Date(2023, 7, 10, 0, 0, 0, 0, time.UTC),
+			wantEndTime:   time.Date(2023, 7, 10, 0, 0, 0, 0, time.UTC),
+			wantOk:        true,
+		},
+		{
 			name: "Week",
 			args: args{
 				startTime: "2023-07-10T00:00:00Z",
@@ -138,6 +148,13 @@ func Test_parseInsightsStartAndEndTime(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			t.Log("startTime: ", tt.args.startTime)
+			t.Log("endTime: ", tt.args.endTime)
+			if tt.wantOk {
+				t.Log("wantStartTime: ", tt.wantStartTime)
+				t.Log("wantEndTime: ", tt.wantEndTime)
+			}
+
 			rw := httptest.NewRecorder()
 			gotStartTime, gotEndTime, gotOk := parseInsightsStartAndEndTime(context.Background(), rw, tt.args.startTime, tt.args.endTime)
 
@@ -145,6 +162,7 @@ func Test_parseInsightsStartAndEndTime(t *testing.T) {
 				//nolint:bodyclose
 				t.Log("Status: ", rw.Result().StatusCode)
 				t.Log("Body: ", rw.Body.String())
+				return
 			}
 			// assert.Equal is unable to test time equality with different
 			// (but same) locations because the *time.Location names differ
@@ -164,7 +182,7 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 	sydneyLoc, err := time.LoadLocation("Australia/Sydney") // Random location
 	require.NoError(t, err)
 
-	now := time.Now()
+	now := time.Now().In(sydneyLoc)
 	t.Logf("now: %s", now)
 
 	y, m, d := now.Date()
@@ -212,7 +230,7 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 			name: "6 days are acceptable",
 			args: args{
 				startTime: sixDaysAgo.Format(layout),
-				endTime:   thisHour.Format(layout),
+				endTime:   stripTime(thisHour).Format(layout),
 			},
 			wantOk: true,
 		},
@@ -228,15 +246,19 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 			name: "9 days (7 + 2) are not acceptable",
 			args: args{
 				startTime: nineDaysAgo.Format(layout),
-				endTime:   thisHour.Format(layout),
+				endTime:   stripTime(thisHour).Format(layout),
 			},
 			wantOk: false,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			t.Log("startTime: ", tt.args.startTime)
+			t.Log("endTime: ", tt.args.endTime)
 
 			rw := httptest.NewRecorder()
 			startTime, endTime, ok := parseInsightsStartAndEndTime(context.Background(), rw, tt.args.startTime, tt.args.endTime)
@@ -252,6 +274,7 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 				//nolint:bodyclose
 				t.Log("Status: ", rw.Result().StatusCode)
 				t.Log("Body: ", rw.Body.String())
+				return
 			}
 			if tt.wantOk {
 				assert.Equal(t, codersdk.InsightsReportIntervalWeek, parsedInterval)
@@ -302,10 +325,20 @@ func TestLastReportIntervalHasAtLeastSixDays(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			t.Log("startTime: ", tc.startTime)
+			t.Log("endTime: ", tc.endTime)
+
 			result := lastReportIntervalHasAtLeastSixDays(tc.startTime, tc.endTime)
 			if result != tc.expected {
 				t.Errorf("Expected %v, but got %v for start time %v and end time %v", tc.expected, result, tc.startTime, tc.endTime)
 			}
 		})
 	}
+}
+
+// stripTime strips the time from a time.Time value, but keeps the date and TZ.
+func stripTime(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
 }

--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -15,12 +15,18 @@ import (
 func Test_parseInsightsStartAndEndTime(t *testing.T) {
 	t.Parallel()
 
+	t.Logf("local: %s", time.Local)
 	layout := insightsTimeLayout
 	now := time.Now().UTC()
+	t.Logf("now: %s", now)
+	t.Logf("location: %s", now.Location())
 	y, m, d := now.Date()
 	today := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	t.Logf("today: %s", now)
 	thisHour := time.Date(y, m, d, now.Hour(), 0, 0, 0, time.UTC)
+	t.Logf("thisHour: %s", now)
 	thisHourRoundUp := thisHour.Add(time.Hour)
+	t.Logf("thisHourRoundUp: %s", now)
 
 	helsinki, err := time.LoadLocation("Europe/Helsinki")
 	require.NoError(t, err)

--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -15,18 +15,18 @@ import (
 func Test_parseInsightsStartAndEndTime(t *testing.T) {
 	t.Parallel()
 
-	t.Logf("local: %s", time.Local)
+	t.Logf("machine location: %s", time.Now().Location())
 	layout := insightsTimeLayout
 	now := time.Now().UTC()
 	t.Logf("now: %s", now)
-	t.Logf("location: %s", now.Location())
+	t.Logf("now location: %s", now.Location())
 	y, m, d := now.Date()
 	today := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
-	t.Logf("today: %s", now)
+	t.Logf("today: %s", today)
 	thisHour := time.Date(y, m, d, now.Hour(), 0, 0, 0, time.UTC)
-	t.Logf("thisHour: %s", now)
+	t.Logf("thisHour: %s", thisHour)
 	thisHourRoundUp := thisHour.Add(time.Hour)
-	t.Logf("thisHourRoundUp: %s", now)
+	t.Logf("thisHourRoundUp: %s", thisHourRoundUp)
 
 	helsinki, err := time.LoadLocation("Europe/Helsinki")
 	require.NoError(t, err)


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/10600

I'm trying to understand why these tests flake sometimes, like here: https://github.com/coder/coder/actions/runs/6805426561/job/18504925666#step:5:428

Here's what I have so far:
- The tests failed very close to midnight: `insights_internal_test.go:162: now: 2023-11-08 23:59:56.781794 +0000 UTC m=+7.293516543`
  - I noticed the monotonic clock reading, ~~and upon further reading about it I think it's reasonable to strip this when dealing with parsed times since we want our operations to match the presentation time.~~ Nvm, time.Parse already has this stripped so that won't do anything...
  - ~~Some tests fail with time not being an even hour, which I believe could be caused by a difference in wall vs monotonic clock.~~ We now think this is because we create a new `time.Now()` inside the function, and with processing lag this can be significant enough to change the time returned.  
- I've added more logging around `Location` and other times in the tests, as well as more verbose error responses so we know what times it thinks it got. My hunch is that all of these tests fail when it runs on a CI machine that has different time settings than we are used to running in. 

With the logs we hopefully have a better shot next time this happens. 

Update:
- After speaking with @mafredri we now pass the `now` time into the function. This is so if we are processing the test very slowly (like in CI) the drift can cause flakes when on a time barrier (end of hour, end of day, etc). 
