### PR TITLE
fix(site): e2e: use click instead of check

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -646,14 +646,14 @@ export const fillParameters = async (
           buildParameter.value +
           "']",
       );
-      await parameterField.check();
+      await parameterField.click();
     } else if (richParameter.options.length > 0) {
       const parameterField = await parameterLabel.waitForSelector(
         "[data-testid='parameter-field-options'] .MuiRadio-root input[value='" +
           buildParameter.value +
           "']",
       );
-      await parameterField.check();
+      await parameterField.click();
     } else if (richParameter.type === "list(string)") {
       throw new Error("not implemented yet"); // FIXME
     } else {


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/10989

Following the advisory in https://github.com/microsoft/playwright/issues/10477, we may want to replace all `check()` calls with `click()`.