### PR TITLE
ci: add `arm64` and `amd64` portable binaries to `winget`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -434,15 +434,13 @@ jobs:
 
           $release_assets = gh release view --repo coder/coder "v${version}" --json assets | `
             ConvertFrom-Json
-          # Get the amd64 installer URL from the release assets.
+          # Get the installer URLs from the release assets.
           $amd64_installer_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_amd64_installer.exe$" | `
             Select -ExpandProperty url
-          # Get amd64 zip URL
           $amd64_zip_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_amd64.zip$" | `
             Select -ExpandProperty url
-          # Get arm64 zip URL
           $arm64_zip_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_arm64.zip$" | `
             Select -ExpandProperty url

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -447,24 +447,15 @@ jobs:
             Where-Object name -Match ".*_windows_arm64.zip$" | `
             Select -ExpandProperty url
 
-          echo "x64 Installer URL: ${x64_installer_url}"
-          echo "x64 zip URL: ${x64_zip_url}"
+          echo "amd64 Installer URL: ${amd64_installer_url}"
+          echo "amd64 zip URL: ${amd64_zip_url}"
           echo "arm64 zip URL: ${arm64_zip_url}"
           echo "Package version: ${version}"
 
-          # The URL "|X64" suffix forces the architecture as it cannot be
-          # sniffed properly from the URL. wingetcreate checks both the URL and
-          # binary magic bytes for the architecture and they need to both match,
-          # but they only check for `x64`, `win64` and `_64` in the URL. Our URL
-          # contains `amd64` which doesn't match sadly.
-          #
-          # wingetcreate will still do the binary magic bytes check, so if we
-          # accidentally change the architecture of the installer, it will fail
-          # submission.
           .\wingetcreate.exe update Coder.Coder `
             --submit `
             --version "${version}" `
-            --urls "${x64_installer_url}|X64" "${x64_zip_url}|X64" "${arm64_zip_url}" `
+            --urls "${amd64_installer_url}" "${amd64_zip_url}" "${arm64_zip_url}" `
             --token "$env:WINGET_GH_TOKEN"
 
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -434,12 +434,22 @@ jobs:
 
           $release_assets = gh release view --repo coder/coder "v${version}" --json assets | `
             ConvertFrom-Json
-          # Get the installer URL from the release assets.
-          $installer_url = $release_assets.assets | `
+          # Get the x64 installer URL from the release assets.
+          $x64_installer_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_amd64_installer.exe$" | `
             Select -ExpandProperty url
+          # Get amd64 zip URL
+          $x64_zip_url = $release_assets.assets | `
+            Where-Object name -Match ".*_windows_amd64.zip$" | `
+            Select -ExpandProperty url
+          # Get arm64 zip URL
+          $arm64_zip_url = $release_assets.assets | `
+            Where-Object name -Match ".*_windows_arm64.zip$" | `
+            Select -ExpandProperty url
 
-          echo "Installer URL: ${installer_url}"
+          echo "x64 Installer URL: ${x64_installer_url}"
+          echo "x64 zip URL: ${x64_zip_url}"
+          echo "arm64 zip URL: ${arm64_zip_url}"
           echo "Package version: ${version}"
 
           # The URL "|X64" suffix forces the architecture as it cannot be
@@ -455,6 +465,8 @@ jobs:
             --submit `
             --version "${version}" `
             --urls "${installer_url}|X64" `
+            --urls "${x64_zip_url}|X64" `
+            --urls "${arm64_zip_url}" `
             --token "$env:WINGET_GH_TOKEN"
 
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -464,7 +464,7 @@ jobs:
           .\wingetcreate.exe update Coder.Coder `
             --submit `
             --version "${version}" `
-            --urls "${installer_url}|X64" `
+            --urls "${x64_installer_url}|X64" `
             --urls "${x64_zip_url}|X64" `
             --urls "${arm64_zip_url}" `
             --token "$env:WINGET_GH_TOKEN"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -464,9 +464,7 @@ jobs:
           .\wingetcreate.exe update Coder.Coder `
             --submit `
             --version "${version}" `
-            --urls "${x64_installer_url}|X64" `
-            --urls "${x64_zip_url}|X64" `
-            --urls "${arm64_zip_url}" `
+            --urls "${x64_installer_url}|X64" "${x64_zip_url}|X64" "${arm64_zip_url}" `
             --token "$env:WINGET_GH_TOKEN"
 
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -434,12 +434,12 @@ jobs:
 
           $release_assets = gh release view --repo coder/coder "v${version}" --json assets | `
             ConvertFrom-Json
-          # Get the x64 installer URL from the release assets.
-          $x64_installer_url = $release_assets.assets | `
+          # Get the amd64 installer URL from the release assets.
+          $amd64_installer_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_amd64_installer.exe$" | `
             Select -ExpandProperty url
           # Get amd64 zip URL
-          $x64_zip_url = $release_assets.assets | `
+          $amd64_zip_url = $release_assets.assets | `
             Where-Object name -Match ".*_windows_amd64.zip$" | `
             Select -ExpandProperty url
           # Get arm64 zip URL


### PR DESCRIPTION
This PR updates the `release.yaml` workflow to automate updates for `arm64` and `x64` zip installers to winget. This has recently been merged into [winget](https://github.com/microsoft/winget-pkgs/pull/129175).

Thanks to @mdanish-kh for the upstream PR.