### PR TITLE
ci: add missing go tools to offlinedocs build step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -573,6 +573,10 @@ jobs:
 
       - name: Install go tools
         run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30
+          go install storj.io/drpc/cmd/protoc-gen-go-drpc@v0.0.33
+          go install golang.org/x/tools/cmd/goimports@latest
+          go install github.com/mikefarah/yq/v4@v4.30.6
           go install github.com/golang/mock/mockgen@v1.6.0
 
       - name: Setup sqlc


### PR DESCRIPTION
Seen here: https://github.com/coder/coder/actions/runs/7100127052/job/19325559713?pr=11033

```
Run make -j build/coder_docs_"$(./scripts/version.sh)".tgz
bash: line 2: protoc: command not found
```