### PR TITLE
fix(codersdk): make codersdk.ProvisionerDaemon.UpdatedAt a codersdk.NullTime

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9558,12 +9558,8 @@ const docTemplate = `{
                     }
                 },
                 "updated_at": {
-                    "format": "date-time",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/sql.NullTime"
-                        }
-                    ]
+                    "type": "string",
+                    "format": "date-time"
                 }
             }
         },
@@ -12731,18 +12727,6 @@ const docTemplate = `{
                 "upnP": {
                     "description": "UPnP is whether UPnP appears present on the LAN.\nEmpty means not checked.",
                     "type": "string"
-                }
-            }
-        },
-        "sql.NullTime": {
-            "type": "object",
-            "properties": {
-                "time": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if Time is not NULL",
-                    "type": "boolean"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8597,12 +8597,8 @@
           }
         },
         "updated_at": {
-          "format": "date-time",
-          "allOf": [
-            {
-              "$ref": "#/definitions/sql.NullTime"
-            }
-          ]
+          "type": "string",
+          "format": "date-time"
         }
       }
     },
@@ -11604,18 +11600,6 @@
         "upnP": {
           "description": "UPnP is whether UPnP appears present on the LAN.\nEmpty means not checked.",
           "type": "string"
-        }
-      }
-    },
-    "sql.NullTime": {
-      "type": "object",
-      "properties": {
-        "time": {
-          "type": "string"
-        },
-        "valid": {
-          "description": "Valid is true if Time is not NULL",
-          "type": "boolean"
         }
       }
     },

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -2,7 +2,6 @@ package codersdk
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,7 +38,7 @@ const (
 type ProvisionerDaemon struct {
 	ID           uuid.UUID         `json:"id" format:"uuid"`
 	CreatedAt    time.Time         `json:"created_at" format:"date-time"`
-	UpdatedAt    sql.NullTime      `json:"updated_at" format:"date-time"`
+	UpdatedAt    NullTime          `json:"updated_at" format:"date-time"`
 	Name         string            `json:"name"`
 	Provisioners []ProvisionerType `json:"provisioners"`
 	Tags         map[string]string `json:"tags"`

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -38,7 +38,7 @@ const (
 type ProvisionerDaemon struct {
 	ID           uuid.UUID         `json:"id" format:"uuid"`
 	CreatedAt    time.Time         `json:"created_at" format:"date-time"`
-	UpdatedAt    NullTime          `json:"updated_at" format:"date-time"`
+	UpdatedAt    NullTime          `json:"updated_at,omitempty" format:"date-time"`
 	Name         string            `json:"name"`
 	Provisioners []ProvisionerType `json:"provisioners"`
 	Tags         map[string]string `json:"tags"`

--- a/docs/api/enterprise.md
+++ b/docs/api/enterprise.md
@@ -706,10 +706,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
       "property1": "string",
       "property2": "string"
     },
-    "updated_at": {
-      "time": "string",
-      "valid": true
-    }
+    "updated_at": "2019-08-24T14:15:22Z"
   }
 ]
 ```
@@ -724,18 +721,16 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 
 Status Code **200**
 
-| Name                | Type                                   | Required | Restrictions | Description                       |
-| ------------------- | -------------------------------------- | -------- | ------------ | --------------------------------- |
-| `[array item]`      | array                                  | false    |              |                                   |
-| `» created_at`      | string(date-time)                      | false    |              |                                   |
-| `» id`              | string(uuid)                           | false    |              |                                   |
-| `» name`            | string                                 | false    |              |                                   |
-| `» provisioners`    | array                                  | false    |              |                                   |
-| `» tags`            | object                                 | false    |              |                                   |
-| `»» [any property]` | string                                 | false    |              |                                   |
-| `» updated_at`      | [sql.NullTime](schemas.md#sqlnulltime) | false    |              |                                   |
-| `»» time`           | string                                 | false    |              |                                   |
-| `»» valid`          | boolean                                | false    |              | Valid is true if Time is not NULL |
+| Name                | Type              | Required | Restrictions | Description |
+| ------------------- | ----------------- | -------- | ------------ | ----------- |
+| `[array item]`      | array             | false    |              |             |
+| `» created_at`      | string(date-time) | false    |              |             |
+| `» id`              | string(uuid)      | false    |              |             |
+| `» name`            | string            | false    |              |             |
+| `» provisioners`    | array             | false    |              |             |
+| `» tags`            | object            | false    |              |             |
+| `»» [any property]` | string            | false    |              |             |
+| `» updated_at`      | string(date-time) | false    |              |             |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3776,24 +3776,21 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "property1": "string",
     "property2": "string"
   },
-  "updated_at": {
-    "time": "string",
-    "valid": true
-  }
+  "updated_at": "2019-08-24T14:15:22Z"
 }
 ```
 
 ### Properties
 
-| Name               | Type                         | Required | Restrictions | Description |
-| ------------------ | ---------------------------- | -------- | ------------ | ----------- |
-| `created_at`       | string                       | false    |              |             |
-| `id`               | string                       | false    |              |             |
-| `name`             | string                       | false    |              |             |
-| `provisioners`     | array of string              | false    |              |             |
-| `tags`             | object                       | false    |              |             |
-| » `[any property]` | string                       | false    |              |             |
-| `updated_at`       | [sql.NullTime](#sqlnulltime) | false    |              |             |
+| Name               | Type            | Required | Restrictions | Description |
+| ------------------ | --------------- | -------- | ------------ | ----------- |
+| `created_at`       | string          | false    |              |             |
+| `id`               | string          | false    |              |             |
+| `name`             | string          | false    |              |             |
+| `provisioners`     | array of string | false    |              |             |
+| `tags`             | object          | false    |              |             |
+| » `[any property]` | string          | false    |              |             |
+| `updated_at`       | string          | false    |              |             |
 
 ## codersdk.ProvisionerJob
 
@@ -8179,22 +8176,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | » `[any property]`      | integer | false    |              |                                                                                                                                    |
 | `udp`                   | boolean | false    |              | a UDP STUN round trip completed                                                                                                    |
 | `upnP`                  | string  | false    |              | Upnp is whether UPnP appears present on the LAN. Empty means not checked.                                                          |
-
-## sql.NullTime
-
-```json
-{
-  "time": "string",
-  "valid": true
-}
-```
-
-### Properties
-
-| Name    | Type    | Required | Restrictions | Description                       |
-| ------- | ------- | -------- | ------------ | --------------------------------- |
-| `time`  | string  | false    |              |                                   |
-| `valid` | boolean | false    |              | Valid is true if Time is not NULL |
 
 ## tailcfg.DERPHomeParams
 

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -312,7 +312,7 @@ func convertProvisionerDaemon(daemon database.ProvisionerDaemon) codersdk.Provis
 	result := codersdk.ProvisionerDaemon{
 		ID:        daemon.ID,
 		CreatedAt: daemon.CreatedAt,
-		UpdatedAt: daemon.UpdatedAt,
+		UpdatedAt: codersdk.NullTime{NullTime: daemon.UpdatedAt},
 		Name:      daemon.Name,
 		Tags:      daemon.Tags,
 	}


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/10676

See discussion in https://github.com/coder/coder/pull/11033#discussion_r1415491768:

Migrating this to the proper type so it gets marshalled as a string and not a struct in the API.