### PR TITLE
fix: disable prefetches for audits table

### DIFF
--- a/site/src/api/queries/audits.ts
+++ b/site/src/api/queries/audits.ts
@@ -19,5 +19,6 @@ export function paginatedAudits(
         q: payload,
       });
     },
+    prefetch: false,
   };
 }

--- a/site/src/hooks/usePaginatedQuery.ts
+++ b/site/src/hooks/usePaginatedQuery.ts
@@ -66,6 +66,12 @@ export type UsePaginatedQueryOptions<
      * closest valid page.
      */
     onInvalidPageChange?: (params: InvalidPageParams) => void;
+
+    /**
+     * Defaults to true. Allows you to disable prefetches for pages where making
+     * a request is very expensive.
+     */
+    prefetch?: boolean;
   };
 
 /**
@@ -98,6 +104,7 @@ export function usePaginatedQuery<
     onInvalidPageChange,
     searchParams: outerSearchParams,
     queryFn: outerQueryFn,
+    prefetch = true,
     ...extraOptions
   } = options;
 
@@ -148,7 +155,12 @@ export function usePaginatedQuery<
 
   const queryClient = useQueryClient();
   const prefetchPage = useEffectEvent((newPage: number) => {
+    if (!prefetch) {
+      return;
+    }
+
     const options = getQueryOptionsFromPage(newPage);
+
     return queryClient.prefetchQuery(options);
   });
 


### PR DESCRIPTION
Helps close #11016

## Changes made
- Updates `usePaginatedQuery` to let you turn prefetching off
- Turns off prefetching for audits table

## Issues not resolved just yet
- No updates to the logic for checking the staleness of data just yet – at least according to [the RQ docs](https://tanstack.com/query/v4/docs/react/reference/QueryClient), our code should already be doing that. Need to look into whether:
   - There's a bug in RQ (unlikely)
   - We need to change how we have our app query client configured