### PR TITLE
fix: increase default staleTime for paginated data

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -24,7 +24,7 @@ const defaultQueryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
-      cacheTime: shouldEnableCache ? undefined : 0,
+      staleTime: shouldEnableCache ? undefined : 0,
       networkMode: shouldEnableCache ? undefined : "offlineFirst",
     },
   },

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -24,7 +24,7 @@ const defaultQueryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
-      staleTime: shouldEnableCache ? undefined : 0,
+      cacheTime: shouldEnableCache ? undefined : 0,
       networkMode: shouldEnableCache ? undefined : "offlineFirst",
     },
   },

--- a/site/src/hooks/usePaginatedQuery.ts
+++ b/site/src/hooks/usePaginatedQuery.ts
@@ -141,7 +141,6 @@ export function usePaginatedQuery<
   const query = useQuery<TQueryFnData, TError, TData, TQueryKey>({
     ...extraOptions,
     ...getQueryOptionsFromPage(currentPage),
-    staleTime,
     keepPreviousData: true,
   });
 

--- a/site/src/hooks/usePaginatedQuery.ts
+++ b/site/src/hooks/usePaginatedQuery.ts
@@ -12,7 +12,7 @@ import {
   useQuery,
 } from "react-query";
 
-const DEFAULT_RECORDS_PER_PAGE = 25;
+const DEFAULT_RECORDS_PER_PAGE = 10;
 
 /**
  * The key to use for getting/setting the page number from the search params
@@ -105,6 +105,7 @@ export function usePaginatedQuery<
     searchParams: outerSearchParams,
     queryFn: outerQueryFn,
     prefetch = true,
+    staleTime = 60 * 1000, // One minute
     ...extraOptions
   } = options;
 
@@ -139,6 +140,7 @@ export function usePaginatedQuery<
   const query = useQuery<TQueryFnData, TError, TData, TQueryKey>({
     ...extraOptions,
     ...getQueryOptionsFromPage(currentPage),
+    staleTime,
     keepPreviousData: true,
   });
 
@@ -160,7 +162,6 @@ export function usePaginatedQuery<
     }
 
     const options = getQueryOptionsFromPage(newPage);
-
     return queryClient.prefetchQuery(options);
   });
 

--- a/site/src/hooks/usePaginatedQuery.ts
+++ b/site/src/hooks/usePaginatedQuery.ts
@@ -12,7 +12,7 @@ import {
   useQuery,
 } from "react-query";
 
-const DEFAULT_RECORDS_PER_PAGE = 10;
+const DEFAULT_RECORDS_PER_PAGE = 25;
 
 /**
  * The key to use for getting/setting the page number from the search params

--- a/site/src/hooks/usePaginatedQuery.ts
+++ b/site/src/hooks/usePaginatedQuery.ts
@@ -116,7 +116,8 @@ export function usePaginatedQuery<
   const currentPage = parsePage(searchParams);
   const currentPageOffset = (currentPage - 1) * limit;
 
-  const getQueryOptionsFromPage = (pageNumber: number) => {
+  type Options = UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>;
+  const getQueryOptionsFromPage = (pageNumber: number): Options => {
     const pageParams: QueryPageParams = {
       pageNumber,
       limit,
@@ -125,13 +126,13 @@ export function usePaginatedQuery<
     };
 
     const payload = queryPayload?.(pageParams) as RuntimePayload<TQueryPayload>;
-
     return {
+      staleTime,
       queryKey: queryKey({ ...pageParams, payload }),
       queryFn: (context: QueryFunctionContext<TQueryKey>) => {
         return outerQueryFn({ ...context, ...pageParams, payload });
       },
-    } as const;
+    };
   };
 
   // Not using infinite query right now because that requires a fair bit of list


### PR DESCRIPTION
Closes #11016 in tandem with #11040

## Changes made
- Increases the `staleTime` value for `usePaginatedQuery` so that data only gets auto-invalidated after 1 minute passes (instead of it happening immediately)
   - Could have applied this change to the entire app, but that would have required a lot more testing
   - We probably should increase the app's `staleTime` at some point, but making a more local change was the least aggressive way to wrangle the `usePaginatedQuery` hook for now
   - Data can still be invalidated manually when need be with no issue, though