### PR TITLE
fix: implement fake DeleteOldWorkspaceAgentLogs

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1131,8 +1131,29 @@ func (q *FakeQuerier) DeleteOldProvisionerDaemons(_ context.Context) error {
 	return nil
 }
 
-func (*FakeQuerier) DeleteOldWorkspaceAgentLogs(_ context.Context) error {
-	// no-op
+func (q *FakeQuerier) DeleteOldWorkspaceAgentLogs(_ context.Context) error {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	now := dbtime.Now()
+	weekInterval := 7 * 24 * time.Hour
+	weekAgo := now.Add(-weekInterval)
+
+	var validLogs []database.WorkspaceAgentLog
+	for _, log := range q.workspaceAgentLogs {
+		var toBeDeleted bool
+		for _, agent := range q.workspaceAgents {
+			if agent.ID == log.AgentID && agent.LastConnectedAt.Valid && agent.LastConnectedAt.Time.Before(weekAgo) {
+				toBeDeleted = true
+				break
+			}
+		}
+
+		if !toBeDeleted {
+			validLogs = append(validLogs, log)
+		}
+	}
+	q.workspaceAgentLogs = validLogs
 	return nil
 }
 

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -93,7 +93,7 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 }
 
 func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Store, agentLastConnectedAt time.Time, output string) uuid.UUID {
-	agent := mustCreateAgent(ctx, t, db)
+	agent := mustCreateAgent(t, db)
 
 	err := db.UpdateWorkspaceAgentConnectionByID(ctx, database.UpdateWorkspaceAgentConnectionByIDParams{
 		ID:              agent.ID,
@@ -110,7 +110,7 @@ func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Stor
 	return agent.ID
 }
 
-func mustCreateAgent(ctx context.Context, t *testing.T, db database.Store) database.WorkspaceAgent {
+func mustCreateAgent(t *testing.T, db database.Store) database.WorkspaceAgent {
 	user := dbgen.User(t, db, database.User{})
 	workspace := dbgen.Workspace(t, db, database.Workspace{
 		OwnerID: user.ID,

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -118,17 +118,17 @@ func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Stor
 
 func mustCreateAgent(t *testing.T, db database.Store, user database.User, org database.Organization, tmpl database.Template, tv database.TemplateVersion) database.WorkspaceAgent {
 	workspace := dbgen.Workspace(t, db, database.Workspace{OwnerID: user.ID, OrganizationID: org.ID, TemplateID: tmpl.ID})
-	build := dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
-		WorkspaceID:       workspace.ID,
-		TemplateVersionID: tv.ID,
-		Transition:        database.WorkspaceTransitionStart,
-		Reason:            database.BuildReasonInitiator,
-	})
 	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
-		ID:            build.JobID,
 		Type:          database.ProvisionerJobTypeWorkspaceBuild,
 		Provisioner:   database.ProvisionerTypeEcho,
 		StorageMethod: database.ProvisionerStorageMethodFile,
+	})
+	_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+		WorkspaceID:       workspace.ID,
+		JobID:             job.ID,
+		TemplateVersionID: tv.ID,
+		Transition:        database.WorkspaceTransitionStart,
+		Reason:            database.BuildReasonInitiator,
 	})
 	resource := dbgen.WorkspaceResource(t, db, database.WorkspaceResource{
 		JobID:      job.ID,

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -42,7 +42,7 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 	user := dbgen.User(t, db, database.User{})
 	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
 	tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
-	_ = dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
+	tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	now := dbtime.Now()
@@ -54,7 +54,7 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 		defer cancel()
 
 		// given
-		agent := mustCreateAgentWithLogs(ctx, t, db, user, org, tv, now.Add(-8*24*time.Hour), t.Name())
+		agent := mustCreateAgentWithLogs(ctx, t, db, user, org, tmpl, tv, now.Add(-8*24*time.Hour), t.Name())
 
 		// when
 		closer := dbpurge.New(ctx, logger, db)
@@ -79,7 +79,7 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 		defer cancel()
 
 		// given
-		agent := mustCreateAgentWithLogs(ctx, t, db, user, org, tv, now.Add(-6*24*time.Hour), t.Name())
+		agent := mustCreateAgentWithLogs(ctx, t, db, user, org, tmpl, tv, now.Add(-6*24*time.Hour), t.Name())
 
 		// when
 		closer := dbpurge.New(ctx, logger, db)
@@ -98,8 +98,8 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 	})
 }
 
-func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Store, user database.User, org database.Organization, tv database.TemplateVersion, agentLastConnectedAt time.Time, output string) uuid.UUID {
-	agent := mustCreateAgent(t, db, user, org, tv)
+func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Store, user database.User, org database.Organization, tmpl database.Template, tv database.TemplateVersion, agentLastConnectedAt time.Time, output string) uuid.UUID {
+	agent := mustCreateAgent(t, db, user, org, tmpl, tv)
 
 	err := db.UpdateWorkspaceAgentConnectionByID(ctx, database.UpdateWorkspaceAgentConnectionByIDParams{
 		ID:              agent.ID,
@@ -116,8 +116,8 @@ func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Stor
 	return agent.ID
 }
 
-func mustCreateAgent(t *testing.T, db database.Store, user database.User, org database.Organization, tv database.TemplateVersion) database.WorkspaceAgent {
-	workspace := dbgen.Workspace(t, db, database.Workspace{OwnerID: user.ID, OrganizationID: org.ID})
+func mustCreateAgent(t *testing.T, db database.Store, user database.User, org database.Organization, tmpl database.Template, tv database.TemplateVersion) database.WorkspaceAgent {
+	workspace := dbgen.Workspace(t, db, database.Workspace{OwnerID: user.ID, OrganizationID: org.ID, TemplateID: tmpl.ID})
 	build := dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
 		WorkspaceID:       workspace.ID,
 		TemplateVersionID: tv.ID,

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -119,9 +119,10 @@ func mustCreateAgentWithLogs(ctx context.Context, t *testing.T, db database.Stor
 func mustCreateAgent(t *testing.T, db database.Store, user database.User, org database.Organization, tmpl database.Template, tv database.TemplateVersion) database.WorkspaceAgent {
 	workspace := dbgen.Workspace(t, db, database.Workspace{OwnerID: user.ID, OrganizationID: org.ID, TemplateID: tmpl.ID})
 	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
-		Type:          database.ProvisionerJobTypeWorkspaceBuild,
-		Provisioner:   database.ProvisionerTypeEcho,
-		StorageMethod: database.ProvisionerStorageMethodFile,
+		OrganizationID: org.ID,
+		Type:           database.ProvisionerJobTypeWorkspaceBuild,
+		Provisioner:    database.ProvisionerTypeEcho,
+		StorageMethod:  database.ProvisionerStorageMethodFile,
 	})
 	_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
 		WorkspaceID:       workspace.ID,


### PR DESCRIPTION
Partially fixes: https://github.com/coder/coder/pull/10955

This PR implements the `DeleteOldWorkspaceAgentLogs` function with basic test coverage.