### PR TITLE
fix(scripts/apitypings): force health.Message and health.Severity to correct types

### DIFF
--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -54,7 +54,7 @@ func (*AGPLWorkspaceProxiesFetchUpdater) Update(context.Context) error {
 func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyReportOptions) {
 	r.Healthy = true
 	r.Severity = health.SeverityOK
-	r.Warnings = []health.Message{}
+	r.Warnings = make([]health.Message, 0)
 	r.Dismissed = opts.Dismissed
 
 	if opts.WorkspaceProxiesFetchUpdater == nil {

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -945,6 +945,12 @@ func convertProxy(p database.WorkspaceProxy, status proxyhealth.ProxyStatus) cod
 	if status.Status == "" {
 		status.Status = proxyhealth.Unknown
 	}
+	if status.Report.Errors == nil {
+		status.Report.Errors = make([]string, 0)
+	}
+	if status.Report.Warnings == nil {
+		status.Report.Warnings = make([]string, 0)
+	}
 	return codersdk.WorkspaceProxy{
 		Region:      convertRegion(p, status),
 		DerpEnabled: p.DerpEnabled,

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -867,10 +867,14 @@ func (g *Generator) typescriptType(ty types.Type) (TypescriptType, error) {
 			return TypescriptType{ValueType: "Record<string, string>"}, nil
 		case "github.com/coder/coder/v2/cli/clibase.URL":
 			return TypescriptType{ValueType: "string"}, nil
-		// XXX: For some reason, the type generator generates this as `any`
+		// XXX: For some reason, the type generator generates these as `any`
 		//      so explicitly specifying the correct generic TS type.
 		case "github.com/coder/coder/v2/codersdk.RegionsResponse[github.com/coder/coder/v2/codersdk.WorkspaceProxy]":
 			return TypescriptType{ValueType: "RegionsResponse<WorkspaceProxy>"}, nil
+		case "github.com/coder/coder/v2/coderd/healthcheck/health.Message":
+			return TypescriptType{ValueType: "HealthMessage"}, nil
+		case "github.com/coder/coder/v2/coderd/healthcheck/health.Severity":
+			return TypescriptType{ValueType: "HealthSeverity"}, nil
 		}
 
 		// Some hard codes are a bit trickier.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2257,11 +2257,8 @@ export const HealthSeveritys: HealthSeverity[] = ["error", "ok", "warning"];
 // From derphealth/derp.go
 export interface DerphealthNodeReport {
   readonly healthy: boolean;
-  // This is likely an enum in an external package ("github.com/coder/coder/v2/coderd/healthcheck/health.Severity")
-  readonly severity: string;
-  // Named type "github.com/coder/coder/v2/coderd/healthcheck/health.Message" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly warnings: any[];
+  readonly severity: HealthSeverity;
+  readonly warnings: HealthMessage[];
   // Named type "tailscale.com/tailcfg.DERPNode" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly node?: any;
@@ -2281,11 +2278,8 @@ export interface DerphealthNodeReport {
 // From derphealth/derp.go
 export interface DerphealthRegionReport {
   readonly healthy: boolean;
-  // This is likely an enum in an external package ("github.com/coder/coder/v2/coderd/healthcheck/health.Severity")
-  readonly severity: string;
-  // Named type "github.com/coder/coder/v2/coderd/healthcheck/health.Message" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly warnings: any[];
+  readonly severity: HealthSeverity;
+  readonly warnings: HealthMessage[];
   // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly region?: any;
@@ -2296,11 +2290,8 @@ export interface DerphealthRegionReport {
 // From derphealth/derp.go
 export interface DerphealthReport {
   readonly healthy: boolean;
-  // This is likely an enum in an external package ("github.com/coder/coder/v2/coderd/healthcheck/health.Severity")
-  readonly severity: string;
-  // Named type "github.com/coder/coder/v2/coderd/healthcheck/health.Message" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly warnings: any[];
+  readonly severity: HealthSeverity;
+  readonly warnings: HealthMessage[];
   readonly dismissed: boolean;
   readonly regions: Record<number, DerphealthRegionReport>;
   // Named type "tailscale.com/net/netcheck.Report" unknown, using "any"

--- a/site/src/pages/HealthPage/HealthPage.stories.tsx
+++ b/site/src/pages/HealthPage/HealthPage.stories.tsx
@@ -134,7 +134,7 @@ export const DERPWarnings: Story = {
         warnings: [
           {
             message: "derp derp derp",
-            code: "EDERP01"
+            code: "EDERP01",
           },
         ],
       },

--- a/site/src/pages/HealthPage/HealthPage.stories.tsx
+++ b/site/src/pages/HealthPage/HealthPage.stories.tsx
@@ -131,7 +131,12 @@ export const DERPWarnings: Story = {
       severity: "warning",
       derp: {
         ...MockHealth.derp,
-        warnings: ["foobar"],
+        warnings: [
+          {
+            message: "derp derp derp",
+            code: "EDERP01"
+          },
+        ],
       },
     },
   },


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/8971

- Force typegen types for some fields of derp health report
- Explicitly allocate slices for RegionReport.{Errors,Warnings} to avoid `null`s in API response