### PR TITLE
feat: restart stopped workspaces on ssh command

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -40,6 +40,7 @@ func (r *RootCmd) ping() *clibase.Cmd {
 			workspaceName := inv.Args[0]
 			_, workspaceAgent, err := getWorkspaceAndAgent(
 				ctx, inv, client,
+				false, // Do not autostart for a ping.
 				codersdk.Me, workspaceName,
 			)
 			if err != nil {

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -181,13 +181,7 @@ func (r *RootCmd) portForward() *clibase.Cmd {
 			Description: "Forward UDP port(s) from the workspace to the local machine. The UDP connection has TCP-like semantics to support stateful UDP protocols.",
 			Value:       clibase.StringArrayOf(&udpForwards),
 		},
-		{
-			Flag:        "disable-autostart",
-			Description: "Disable starting the workspace automatically when connecting via port forward.",
-			Env:         "CODER_PORT_FORWARD_DISABLE_AUTOSTART",
-			Value:       clibase.BoolOf(&disableAutostart),
-			Default:     "false",
-		},
+		sshDisableAutostartOption(clibase.BoolOf(&disableAutostart)),
 	}
 
 	return cmd

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -26,8 +26,9 @@ import (
 
 func (r *RootCmd) portForward() *clibase.Cmd {
 	var (
-		tcpForwards []string // <port>:<port>
-		udpForwards []string // <port>:<port>
+		tcpForwards      []string // <port>:<port>
+		udpForwards      []string // <port>:<port>
+		disableAutostart bool
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -76,7 +77,7 @@ func (r *RootCmd) portForward() *clibase.Cmd {
 				return xerrors.New("no port-forwards requested")
 			}
 
-			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, codersdk.Me, inv.Args[0])
+			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, codersdk.Me, inv.Args[0])
 			if err != nil {
 				return err
 			}
@@ -179,6 +180,13 @@ func (r *RootCmd) portForward() *clibase.Cmd {
 			Env:         "CODER_PORT_FORWARD_UDP",
 			Description: "Forward UDP port(s) from the workspace to the local machine. The UDP connection has TCP-like semantics to support stateful UDP protocols.",
 			Value:       clibase.StringArrayOf(&udpForwards),
+		},
+		{
+			Flag:        "disable-autostart",
+			Description: "Disable starting the workspace automatically when connecting via port forward.",
+			Env:         "CODER_PORT_FORWARD_DISABLE_AUTOSTART",
+			Value:       clibase.BoolOf(&disableAutostart),
+			Default:     "false",
 		},
 	}
 

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -35,7 +35,7 @@ func (r *RootCmd) speedtest() *clibase.Cmd {
 			ctx, cancel := context.WithCancel(inv.Context())
 			defer cancel()
 
-			_, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, codersdk.Me, inv.Args[0])
+			_, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, false, codersdk.Me, inv.Args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -44,15 +44,16 @@ var (
 
 func (r *RootCmd) ssh() *clibase.Cmd {
 	var (
-		stdio          bool
-		forwardAgent   bool
-		forwardGPG     bool
-		identityAgent  string
-		wsPollInterval time.Duration
-		waitEnum       string
-		noWait         bool
-		logDirPath     string
-		remoteForward  string
+		stdio            bool
+		forwardAgent     bool
+		forwardGPG       bool
+		identityAgent    string
+		wsPollInterval   time.Duration
+		waitEnum         string
+		noWait           bool
+		logDirPath       string
+		remoteForward    string
+		disableAutostart bool
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -458,6 +459,13 @@ func (r *RootCmd) ssh() *clibase.Cmd {
 			Env:           "CODER_SSH_REMOTE_FORWARD",
 			FlagShorthand: "R",
 			Value:         clibase.StringOf(&remoteForward),
+		},
+		{
+			Flag:        "disable-autostart",
+			Description: "Disable starting the workspace automatically when connecting via SSH.",
+			Env:         "CODER_SSH_DISABLE_AUTOSTART",
+			Value:       clibase.BoolOf(&disableAutostart),
+			Default:     "false",
 		},
 	}
 	return cmd

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -570,10 +570,10 @@ func getWorkspaceAndAgent(ctx context.Context, inv *clibase.Invocation, client *
 				)
 		}
 		// startWorkspace based on the last build parameters.
-		_, _ = fmt.Fprintf(inv.Stderr, "Workspace was stopped, starting workspace to allow connection %q...\n", workspace.Name)
+		_, _ = fmt.Fprintf(inv.Stderr, "Workspace was stopped, starting workspace to allow connecting to %q...\n", workspace.Name)
 		build, err := startWorkspace(inv, client, workspace, workspaceParameterFlags{}, WorkspaceStart)
 		if err != nil {
-			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.Errorf("workspace is stopped, failed to start: %w", err)
+			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.Errorf("unable to start workspace: %w", err)
 		}
 		workspace.LatestBuild = build
 	}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/retry"
 	"github.com/gen2brain/beeep"
 	"github.com/gofrs/flock"
 	"github.com/google/uuid"
@@ -34,7 +35,6 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
-	"github.com/coder/retry"
 )
 
 var (
@@ -460,13 +460,7 @@ func (r *RootCmd) ssh() *clibase.Cmd {
 			FlagShorthand: "R",
 			Value:         clibase.StringOf(&remoteForward),
 		},
-		{
-			Flag:        "disable-autostart",
-			Description: "Disable starting the workspace automatically when connecting via SSH.",
-			Env:         "CODER_SSH_DISABLE_AUTOSTART",
-			Value:       clibase.BoolOf(&disableAutostart),
-			Default:     "false",
-		},
+		sshDisableAutostartOption(clibase.BoolOf(&disableAutostart)),
 	}
 	return cmd
 }
@@ -950,4 +944,14 @@ func (c *rawSSHCopier) Close() error {
 	case <-t.C:
 	}
 	return err
+}
+
+func sshDisableAutostartOption(src *clibase.Bool) clibase.Option {
+	return clibase.Option{
+		Flag:        "disable-autostart",
+		Description: "Disable starting the workspace automatically when connecting via SSH.",
+		Env:         "CODER_SSH_DISABLE_AUTOSTART",
+		Value:       src,
+		Default:     "false",
+	}
 }

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -21,11 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/google/uuid"
-
-	"github.com/coder/coder/v2/coderd/rbac"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -43,7 +39,9 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/pty"
 	"github.com/coder/coder/v2/pty/ptytest"

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -94,21 +94,6 @@ func TestSSH(t *testing.T) {
 	t.Run("StartStoppedWorkspace", func(t *testing.T) {
 		t.Parallel()
 
-		//store, ps := dbtestutil.NewDB(t)
-		//ownerClient := coderdtest.New(t, &coderdtest.Options{Pubsub: ps, Database: store, IncludeProvisionerDaemon: true})
-		//ownerClient.SetLogger(slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug))
-		//first := coderdtest.CreateFirstUser(t, ownerClient)
-		//client, user := coderdtest.CreateAnotherUser(t, ownerClient, first.OrganizationID)
-		//
-		//// Create a stopped workspace.
-		//workspaceData := dbfake.WorkspaceBuild(t, store, database.Workspace{
-		//	OrganizationID: first.OrganizationID,
-		//	OwnerID:        user.ID,
-		//}).Seed(database.WorkspaceBuild{
-		//	Transition: database.WorkspaceTransitionStop,
-		//}).WithAgent().Do()
-		//workspace := workspaceData.Workspace
-		//
 		authToken := uuid.NewString()
 		ownerClient := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		owner := coderdtest.CreateFirstUser(t, ownerClient)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -109,7 +109,7 @@ func TestSSH(t *testing.T) {
 		workspaceBuild := coderdtest.CreateWorkspaceBuild(t, client, workspace, database.WorkspaceTransitionStop)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspaceBuild.ID)
 
-		//
+		// SSH to the workspace which should autostart it
 		inv, root := clitest.New(t, "ssh", workspace.Name)
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
@@ -121,8 +121,9 @@ func TestSSH(t *testing.T) {
 			err := inv.WithContext(ctx).Run()
 			assert.NoError(t, err)
 		})
-		pty.ExpectMatch("⧗ Running")
 
+		// When the agent connects, the workspace was started, and we should
+		// have access to the shell.
 		_ = agenttest.New(t, client.URL, authToken)
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 

--- a/cli/testdata/coder_config-ssh_--help.golden
+++ b/cli/testdata/coder_config-ssh_--help.golden
@@ -21,6 +21,9 @@ OPTIONS:
           ProxyCommand. By default, the binary invoking this command ('config
           ssh') is used.
 
+      --disable-autostart bool, $CODER_CONFIGSSH_DISABLE_AUTOSTART (default: false)
+          Disable starting the workspace automatically when connecting via SSH.
+
   -n, --dry-run bool, $CODER_SSH_DRY_RUN
           Perform a trial run with no changes made, showing a diff at the end.
 

--- a/cli/testdata/coder_port-forward_--help.golden
+++ b/cli/testdata/coder_port-forward_--help.golden
@@ -34,6 +34,10 @@ USAGE:
        $ coder port-forward <workspace> --tcp 1.2.3.4:8080:8080
 
 OPTIONS:
+      --disable-autostart bool, $CODER_PORT_FORWARD_DISABLE_AUTOSTART (default: false)
+          Disable starting the workspace automatically when connecting via port
+          forward.
+
   -p, --tcp string-array, $CODER_PORT_FORWARD_TCP
           Forward TCP port(s) from the workspace to the local machine.
 

--- a/cli/testdata/coder_port-forward_--help.golden
+++ b/cli/testdata/coder_port-forward_--help.golden
@@ -34,9 +34,8 @@ USAGE:
        $ coder port-forward <workspace> --tcp 1.2.3.4:8080:8080
 
 OPTIONS:
-      --disable-autostart bool, $CODER_PORT_FORWARD_DISABLE_AUTOSTART (default: false)
-          Disable starting the workspace automatically when connecting via port
-          forward.
+      --disable-autostart bool, $CODER_SSH_DISABLE_AUTOSTART (default: false)
+          Disable starting the workspace automatically when connecting via SSH.
 
   -p, --tcp string-array, $CODER_PORT_FORWARD_TCP
           Forward TCP port(s) from the workspace to the local machine.

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -6,6 +6,9 @@ USAGE:
   Start a shell into a workspace
 
 OPTIONS:
+      --disable-autostart bool, $CODER_SSH_DISABLE_AUTOSTART (default: false)
+          Disable starting the workspace automatically when connecting via SSH.
+
   -A, --forward-agent bool, $CODER_SSH_FORWARD_AGENT
           Specifies whether to forward the SSH agent specified in
           $SSH_AUTH_SOCK.

--- a/docs/cli/config-ssh.md
+++ b/docs/cli/config-ssh.md
@@ -34,6 +34,16 @@ workspaces:
 
 Optionally specify the absolute path to the coder binary used in ProxyCommand. By default, the binary invoking this command ('config ssh') is used.
 
+### --disable-autostart
+
+|             |                                                 |
+| ----------- | ----------------------------------------------- |
+| Type        | <code>bool</code>                               |
+| Environment | <code>$CODER_CONFIGSSH_DISABLE_AUTOSTART</code> |
+| Default     | <code>false</code>                              |
+
+Disable starting the workspace automatically when connecting via SSH.
+
 ### -n, --dry-run
 
 |             |                                 |

--- a/docs/cli/port-forward.md
+++ b/docs/cli/port-forward.md
@@ -44,13 +44,13 @@ machine:
 
 ### --disable-autostart
 
-|             |                                                    |
-| ----------- | -------------------------------------------------- |
-| Type        | <code>bool</code>                                  |
-| Environment | <code>$CODER_PORT_FORWARD_DISABLE_AUTOSTART</code> |
-| Default     | <code>false</code>                                 |
+|             |                                           |
+| ----------- | ----------------------------------------- |
+| Type        | <code>bool</code>                         |
+| Environment | <code>$CODER_SSH_DISABLE_AUTOSTART</code> |
+| Default     | <code>false</code>                        |
 
-Disable starting the workspace automatically when connecting via port forward.
+Disable starting the workspace automatically when connecting via SSH.
 
 ### -p, --tcp
 

--- a/docs/cli/port-forward.md
+++ b/docs/cli/port-forward.md
@@ -42,6 +42,16 @@ machine:
 
 ## Options
 
+### --disable-autostart
+
+|             |                                                    |
+| ----------- | -------------------------------------------------- |
+| Type        | <code>bool</code>                                  |
+| Environment | <code>$CODER_PORT_FORWARD_DISABLE_AUTOSTART</code> |
+| Default     | <code>false</code>                                 |
+
+Disable starting the workspace automatically when connecting via port forward.
+
 ### -p, --tcp
 
 |             |                                      |

--- a/docs/cli/ssh.md
+++ b/docs/cli/ssh.md
@@ -12,6 +12,16 @@ coder ssh [flags] <workspace>
 
 ## Options
 
+### --disable-autostart
+
+|             |                                           |
+| ----------- | ----------------------------------------- |
+| Type        | <code>bool</code>                         |
+| Environment | <code>$CODER_SSH_DISABLE_AUTOSTART</code> |
+| Default     | <code>false</code>                        |
+
+Disable starting the workspace automatically when connecting via SSH.
+
 ### -A, --forward-agent
 
 |             |                                       |


### PR DESCRIPTION
# What this does

On `coder ssh` or `ssh` if the target workspace is off, the workspace will be started.

```
ssh coder.local-docker                                                                                                                           02:08:08 PM
Workspace was stopped, starting workspace to allow connection "local-docker"...
==> ⧗ Queued
=== ✔ Queued [0ms]
==> ⧗ Running
=== ✔ Running [4ms]
==> ⧗ Setting up
=== ✔ Setting up [29ms]
==> ⧗ Planning infrastructure
... rest of logs ...
```

Feature can be **opt out**, so by default this is on. To opt out:

```shell
$ coder ssh --disable-autostart local-docker
# Or
$ coder config-ssh --disable-autostart
```

Closes: https://github.com/coder/coder/issues/4973


# VScode extension?

Vscode uses `coder vscodessh` and is unaffected: https://github.com/coder/coder/blob/f422f471f6f7b8ca33e1b376e738d9ff1f5262c5/cli/vscodessh.go#L34-L34