### PR TITLE
feat: include server agent API version in buildinfo

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7827,6 +7827,10 @@ const docTemplate = `{
         "codersdk.BuildInfoResponse": {
             "type": "object",
             "properties": {
+                "agent_api_version": {
+                    "description": "AgentAPIVersion is the current version of the Agent API (back versions\nMAY still be supported).",
+                    "type": "string"
+                },
                 "dashboard_url": {
                     "description": "DashboardURL is the URL to hit the deployment's dashboard.\nFor external workspace proxies, this is the coderd they are connected\nto.",
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6970,6 +6970,10 @@
     "codersdk.BuildInfoResponse": {
       "type": "object",
       "properties": {
+        "agent_api_version": {
+          "description": "AgentAPIVersion is the current version of the Agent API (back versions\nMAY still be supported).",
+          "type": "string"
+        },
         "dashboard_url": {
           "description": "DashboardURL is the URL to hit the deployment's dashboard.\nFor external workspace proxies, this is the coderd they are connected\nto.",
           "type": "string"

--- a/coderd/deployment.go
+++ b/coderd/deployment.go
@@ -71,10 +71,11 @@ func (api *API) deploymentStats(rw http.ResponseWriter, r *http.Request) {
 func buildInfo(accessURL *url.URL) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.BuildInfoResponse{
-			ExternalURL:    buildinfo.ExternalURL(),
-			Version:        buildinfo.Version(),
-			DashboardURL:   accessURL.String(),
-			WorkspaceProxy: false,
+			ExternalURL:     buildinfo.ExternalURL(),
+			Version:         buildinfo.Version(),
+			AgentAPIVersion: AgentAPIVersionREST,
+			DashboardURL:    accessURL.String(),
+			WorkspaceProxy:  false,
 		})
 	}
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2003,6 +2003,10 @@ type BuildInfoResponse struct {
 	DashboardURL string `json:"dashboard_url"`
 
 	WorkspaceProxy bool `json:"workspace_proxy"`
+
+	// AgentAPIVersion is the current version of the Agent API (back versions
+	// MAY still be supported).
+	AgentAPIVersion string `json:"agent_api_version"`
 }
 
 type WorkspaceProxyBuildInfo struct {

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -53,6 +53,7 @@ curl -X GET http://coder-server:8080/api/v2/buildinfo \
 
 ```json
 {
+  "agent_api_version": "string",
   "dashboard_url": "string",
   "external_url": "string",
   "version": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1430,6 +1430,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
+  "agent_api_version": "string",
   "dashboard_url": "string",
   "external_url": "string",
   "version": "string",
@@ -1439,12 +1440,13 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name              | Type    | Required | Restrictions | Description                                                                                                                                                         |
-| ----------------- | ------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dashboard_url`   | string  | false    |              | Dashboard URL is the URL to hit the deployment's dashboard. For external workspace proxies, this is the coderd they are connected to.                               |
-| `external_url`    | string  | false    |              | External URL references the current Coder version. For production builds, this will link directly to a release. For development builds, this will link to a commit. |
-| `version`         | string  | false    |              | Version returns the semantic version of the build.                                                                                                                  |
-| `workspace_proxy` | boolean | false    |              |                                                                                                                                                                     |
+| Name                | Type    | Required | Restrictions | Description                                                                                                                                                         |
+| ------------------- | ------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_api_version` | string  | false    |              | Agent api version is the current version of the Agent API (back versions MAY still be supported).                                                                   |
+| `dashboard_url`     | string  | false    |              | Dashboard URL is the URL to hit the deployment's dashboard. For external workspace proxies, this is the coderd they are connected to.                               |
+| `external_url`      | string  | false    |              | External URL references the current Coder version. For production builds, this will link directly to a release. For development builds, this will link to a commit. |
+| `version`           | string  | false    |              | Version returns the semantic version of the build.                                                                                                                  |
+| `workspace_proxy`   | boolean | false    |              |                                                                                                                                                                     |
 
 ## codersdk.BuildReason
 

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -475,10 +475,11 @@ func (s *Server) DialCoordinator(ctx context.Context) (tailnet.MultiAgentConn, e
 
 func (s *Server) buildInfo(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.BuildInfoResponse{
-		ExternalURL:    buildinfo.ExternalURL(),
-		Version:        buildinfo.Version(),
-		DashboardURL:   s.DashboardURL.String(),
-		WorkspaceProxy: true,
+		ExternalURL:     buildinfo.ExternalURL(),
+		Version:         buildinfo.Version(),
+		AgentAPIVersion: coderd.AgentAPIVersionREST,
+		DashboardURL:    s.DashboardURL.String(),
+		WorkspaceProxy:  true,
 	})
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -162,6 +162,7 @@ export interface BuildInfoResponse {
   readonly version: string;
   readonly dashboard_url: string;
   readonly workspace_proxy: boolean;
+  readonly agent_api_version: string;
 }
 
 // From codersdk/insights.go

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -194,6 +194,7 @@ export const MockProxyLatencies: Record<string, ProxyLatencyReport> = {
 };
 
 export const MockBuildInfo: TypesGen.BuildInfoResponse = {
+  agent_api_version: "2.1",
   external_url: "file:///mock-url",
   version: "v99.999.9999+c9cdf14",
   dashboard_url: "https:///mock-url",


### PR DESCRIPTION
First part of #10340 -- we need this version to compare with agents to tell if they are on a deprecated Agent API version
