### PR TITLE
chore: update build_reason 'autolock' -> 'dormancy'

### DIFF
--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -47,12 +47,12 @@ type Request[T Auditable] struct {
 	Action database.AuditAction
 }
 
-type BuildAuditParams[T Auditable] struct {
+type BackgroundAuditParams[T Auditable] struct {
 	Audit Auditor
 	Log   slog.Logger
 
 	UserID           uuid.UUID
-	JobID            uuid.UUID
+	RequestID        uuid.UUID
 	Status           int
 	Action           database.AuditAction
 	OrganizationID   uuid.UUID
@@ -255,9 +255,9 @@ func InitRequest[T Auditable](w http.ResponseWriter, p *RequestParams) (*Request
 	}
 }
 
-// WorkspaceBuildAudit creates an audit log for a workspace build.
+// BackgroundAudit creates an audit log for a background event.
 // The audit log is committed upon invocation.
-func WorkspaceBuildAudit[T Auditable](ctx context.Context, p *BuildAuditParams[T]) {
+func BackgroundAudit[T Auditable](ctx context.Context, p *BackgroundAuditParams[T]) {
 	ip := parseIP(p.IP)
 
 	diff := Diff(p.Audit, p.Old, p.New)
@@ -285,7 +285,7 @@ func WorkspaceBuildAudit[T Auditable](ctx context.Context, p *BuildAuditParams[T
 		Action:           p.Action,
 		Diff:             diffRaw,
 		StatusCode:       int32(p.Status),
-		RequestID:        p.JobID,
+		RequestID:        p.RequestID,
 		AdditionalFields: p.AdditionalFields,
 	}
 	err = p.Audit.Export(ctx, auditLog)

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -31,7 +31,7 @@ CREATE TYPE build_reason AS ENUM (
     'initiator',
     'autostart',
     'autostop',
-    'autolock',
+    'dormancy',
     'failedstop',
     'autodelete'
 );

--- a/coderd/database/migrations/000174_rename_autolock.down.sql
+++ b/coderd/database/migrations/000174_rename_autolock.down.sql
@@ -1,0 +1,1 @@
+ALTER TYPE build_reason RENAME VALUE 'dormancy' TO 'autolock';

--- a/coderd/database/migrations/000174_rename_autolock.up.sql
+++ b/coderd/database/migrations/000174_rename_autolock.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE build_reason RENAME VALUE 'autolock' TO 'dormancy';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -275,7 +275,7 @@ const (
 	BuildReasonInitiator  BuildReason = "initiator"
 	BuildReasonAutostart  BuildReason = "autostart"
 	BuildReasonAutostop   BuildReason = "autostop"
-	BuildReasonAutolock   BuildReason = "autolock"
+	BuildReasonDormancy   BuildReason = "dormancy"
 	BuildReasonFailedstop BuildReason = "failedstop"
 	BuildReasonAutodelete BuildReason = "autodelete"
 )
@@ -320,7 +320,7 @@ func (e BuildReason) Valid() bool {
 	case BuildReasonInitiator,
 		BuildReasonAutostart,
 		BuildReasonAutostop,
-		BuildReasonAutolock,
+		BuildReasonDormancy,
 		BuildReasonFailedstop,
 		BuildReasonAutodelete:
 		return true
@@ -333,7 +333,7 @@ func AllBuildReasonValues() []BuildReason {
 		BuildReasonInitiator,
 		BuildReasonAutostart,
 		BuildReasonAutostop,
-		BuildReasonAutolock,
+		BuildReasonDormancy,
 		BuildReasonFailedstop,
 		BuildReasonAutodelete,
 	}

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -914,12 +914,12 @@ func (s *server) FailJob(ctx context.Context, failJob *proto.FailedJob) (*proto.
 
 				bag := audit.BaggageFromContext(ctx)
 
-				audit.WorkspaceBuildAudit(ctx, &audit.BuildAuditParams[database.WorkspaceBuild]{
+				audit.BackgroundAudit(ctx, &audit.BackgroundAuditParams[database.WorkspaceBuild]{
 					Audit:            *auditor,
 					Log:              s.Logger,
 					UserID:           job.InitiatorID,
 					OrganizationID:   workspace.OrganizationID,
-					JobID:            job.ID,
+					RequestID:        job.ID,
 					IP:               bag.IP,
 					Action:           auditAction,
 					Old:              previousBuild,
@@ -1271,12 +1271,12 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 
 			bag := audit.BaggageFromContext(ctx)
 
-			audit.WorkspaceBuildAudit(ctx, &audit.BuildAuditParams[database.WorkspaceBuild]{
+			audit.BackgroundAudit(ctx, &audit.BackgroundAuditParams[database.WorkspaceBuild]{
 				Audit:            *auditor,
 				Log:              s.Logger,
 				UserID:           job.InitiatorID,
 				OrganizationID:   workspace.OrganizationID,
-				JobID:            job.ID,
+				RequestID:        job.ID,
 				IP:               bag.IP,
 				Action:           auditAction,
 				Old:              previousBuild,

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -308,7 +308,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 				err := json.Unmarshal(alog.AdditionalFields, &fields)
 				require.NoError(t, err)
 				require.Equal(t, ws.Name, fields.WorkspaceName)
-				require.Equal(t, database.BuildReasonAutolock, fields.BuildReason)
+				require.Equal(t, database.BuildReasonDormancy, fields.BuildReason)
 
 			default:
 				t.Fatalf("unexpected audit log (%+v)", alog)


### PR DESCRIPTION
Updates the `build_reason` enum to reflect update in terminology.

Support for renaming types was introduces in Postgres 12 so we should be ok since our min is 13.