### PR TITLE
refactor(site): change a few names related to workspace actions

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -3,7 +3,7 @@ import { Workspace, WorkspaceBuildParameter } from "api/typesGenerated";
 import { useWorkspaceDuplication } from "pages/CreateWorkspacePage/useWorkspaceDuplication";
 
 import { workspaceUpdatePolicy } from "utils/workspace";
-import { type ButtonType, actionsByWorkspaceStatus } from "./constants";
+import { type ActionType, abilitiesByWorkspaceStatus } from "./constants";
 
 import {
   ActionLoadingButton,
@@ -72,7 +72,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   const { duplicateWorkspace, isDuplicationReady } =
     useWorkspaceDuplication(workspace);
 
-  const { actions, canCancel, canAcceptJobs } = actionsByWorkspaceStatus(
+  const { actions, canCancel, canAcceptJobs } = abilitiesByWorkspaceStatus(
     workspace,
     canRetryDebug,
   );
@@ -85,7 +85,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   const canBeUpdated = workspace.outdated && canAcceptJobs;
 
   // A mapping of button type to the corresponding React component
-  const buttonMapping: Record<ButtonType, ReactNode> = {
+  const buttonMapping: Record<ActionType, ReactNode> = {
     update: <UpdateButton handleAction={handleUpdate} />,
     updating: <UpdateButton loading handleAction={handleUpdate} />,
     start: (

--- a/site/src/pages/WorkspacePage/WorkspaceActions/constants.ts
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/constants.ts
@@ -1,9 +1,9 @@
 import { type Workspace, type WorkspaceStatus } from "api/typesGenerated";
 
 /**
- * An iterable of all button types supported by the workspace actions UI
+ * An iterable of all action types supported by the workspace UI
  */
-export const buttonTypes = [
+export const actionTypes = [
   "start",
   "starting",
   "stop",
@@ -28,18 +28,15 @@ export const buttonTypes = [
   "pending",
 ] as const;
 
-/**
- * A button type supported by the workspace actions UI
- */
-export type ButtonType = (typeof buttonTypes)[number];
+export type ActionType = (typeof actionTypes)[number];
 
 type WorkspaceAbilities = {
-  actions: readonly ButtonType[];
+  actions: readonly ActionType[];
   canCancel: boolean;
   canAcceptJobs: boolean;
 };
 
-export const actionsByWorkspaceStatus = (
+export const abilitiesByWorkspaceStatus = (
   workspace: Workspace,
   canRetryDebug: boolean,
 ): WorkspaceAbilities => {

--- a/site/src/pages/WorkspacePage/WorkspaceActions/constants.ts
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/constants.ts
@@ -51,15 +51,15 @@ export const abilitiesByWorkspaceStatus = (
   const status = workspace.latest_build.status;
   if (status === "failed" && canRetryDebug) {
     return {
-      ...statusToActions.failed,
+      ...statusToAbility.failed,
       actions: ["retry", "retryDebug"],
     };
   }
 
-  return statusToActions[status];
+  return statusToAbility[status];
 };
 
-const statusToActions: Record<WorkspaceStatus, WorkspaceAbilities> = {
+const statusToAbility: Record<WorkspaceStatus, WorkspaceAbilities> = {
   starting: {
     actions: ["starting"],
     canCancel: true,


### PR DESCRIPTION
Motivation: I just found strange a method called getActions returning a type called abilities with actions inside of it with other name