### PR TITLE
chore: fix flake in TestExecutorAutostopTemplateDisabled

### DIFF
--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -817,7 +817,7 @@ func TestExecutorAutostopTemplateDisabled(t *testing.T) {
 
 	// When: the autobuild executor ticks after the workspace setting, but before the template setting:
 	go func() {
-		tickCh <- workspace.LatestBuild.CreatedAt.Add(45 * time.Minute)
+		tickCh <- workspace.LatestBuild.Job.CompletedAt.Add(45 * time.Minute)
 	}()
 
 	// Then: nothing should happen
@@ -827,7 +827,7 @@ func TestExecutorAutostopTemplateDisabled(t *testing.T) {
 
 	// When: the autobuild executor ticks after the template setting:
 	go func() {
-		tickCh <- workspace.LatestBuild.CreatedAt.Add(61 * time.Minute)
+		tickCh <- workspace.LatestBuild.Job.CompletedAt.Add(61 * time.Minute)
 		close(tickCh)
 	}()
 

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1131,9 +1131,9 @@ func (s *server) CompleteJob(ctx context.Context, completed *proto.CompletedJob)
 
 			err = db.UpdateProvisionerJobWithCompleteByID(ctx, database.UpdateProvisionerJobWithCompleteByIDParams{
 				ID:        jobID,
-				UpdatedAt: dbtime.Now(),
+				UpdatedAt: now,
 				CompletedAt: sql.NullTime{
-					Time:  dbtime.Now(),
+					Time:  now,
 					Valid: true,
 				},
 				Error:     sql.NullString{},


### PR DESCRIPTION
Fixes a flake where the following can happen:
- A build _starts_ at `23:34:59.981` but ends at `23:35:00.205`
- When calculating the deadline of 1 hour we set on the build we get `00:35:00.205`.
- We pass a tick that adds 61 minutes but it's based off the `created_at` instead of the `completed_at` of the build so we get `00:35:59.981` which truncates down to `00:35:00` which is less than the deadline.

I've gone ahead and fixed it but we should maybe reconsider whether this test should exist in `autobuild` since it's really testing that the deadline is set correctly in `provisionerdserver`. We can't really refactor this test with `dbfake` without completely obviating what it's trying to test.

fixes https://github.com/coder/coder/issues/10359