### PR TITLE
refactor(coderd): move provisionerd tags to provisionersdk

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1160,7 +1160,7 @@ func (api *API) CreateInMemoryProvisionerDaemon(ctx context.Context, name string
 	}()
 
 	tags := provisionerdserver.Tags{
-		provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+		provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 	}
 
 	mux := drpcmux.New()

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/examples"
+	"github.com/coder/coder/v2/provisionersdk"
 	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
 )
 
@@ -1331,7 +1332,7 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 	}
 
 	// Ensures the "owner" is properly applied.
-	tags := provisionerdserver.MutateTags(apiKey.UserID, req.ProvisionerTags)
+	tags := provisionersdk.MutateTags(apiKey.UserID, req.ProvisionerTags)
 
 	if req.ExampleID != "" && req.FileID != uuid.Nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/externalauth"
-	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/examples"
 	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -154,7 +154,7 @@ func TestPostTemplateVersionsByOrganization(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, "bananas", version.Name)
-		require.Equal(t, provisionerdserver.ScopeOrganization, version.Job.Tags[provisionerdserver.TagScope])
+		require.Equal(t, provisionersdk.ScopeOrganization, version.Job.Tags[provisionersdk.TagScope])
 
 		require.Len(t, auditor.AuditLogs(), 2)
 		assert.Equal(t, database.AuditActionCreate, auditor.AuditLogs()[1].Action)

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/coder/coder/v2/provisionersdk"
+
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
@@ -294,7 +296,7 @@ func (b *Builder) buildTx(authFunc func(action rbac.Action, object rbac.Objecter
 	if err != nil {
 		return nil, nil, BuildError{http.StatusInternalServerError, "marshal metadata", err}
 	}
-	tags := provisionerdserver.MutateTags(b.workspace.OwnerID, templateVersionJob.Tags)
+	tags := provisionersdk.MutateTags(b.workspace.OwnerID, templateVersionJob.Tags)
 
 	now := dbtime.Now()
 	provisionerJob, err := b.store.InsertProvisionerJob(b.ctx, database.InsertProvisionerJobParams{

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/coder/v2/provisionersdk"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -690,8 +692,8 @@ func withActiveVersion(params []database.TemplateVersionParameter) func(mTx *dbm
 			Type:           database.ProvisionerJobTypeTemplateVersionImport,
 			Input:          nil,
 			Tags: database.StringMap{
-				"version":                   "active",
-				provisionerdserver.TagScope: provisionerdserver.ScopeUser,
+				"version":               "active",
+				provisionersdk.TagScope: provisionersdk.ScopeUser,
 			},
 			FileID:      activeFileID,
 			StartedAt:   sql.NullTime{Time: dbtime.Now(), Valid: true},
@@ -730,8 +732,8 @@ func withInactiveVersion(params []database.TemplateVersionParameter) func(mTx *d
 			Type:           database.ProvisionerJobTypeTemplateVersionImport,
 			Input:          nil,
 			Tags: database.StringMap{
-				"version":                   "inactive",
-				provisionerdserver.TagScope: provisionerdserver.ScopeUser,
+				"version":               "inactive",
+				provisionersdk.TagScope: provisionersdk.ScopeUser,
 			},
 			FileID:      inactiveFileID,
 			StartedAt:   sql.NullTime{Time: dbtime.Now(), Valid: true},

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -19,7 +19,6 @@ import (
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/cliutil"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/terraform"
 	"github.com/coder/coder/v2/provisionerd"
@@ -102,8 +101,8 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 			// When authorizing with a PSK, we automatically scope the provisionerd
 			// to organization. Scoping to user with PSK auth is not a valid configuration.
 			if preSharedKey != "" {
-				logger.Info(ctx, "psk auth automatically sets tag "+provisionerdserver.TagScope+"="+provisionerdserver.ScopeOrganization)
-				tags[provisionerdserver.TagScope] = provisionerdserver.ScopeOrganization
+				logger.Info(ctx, "psk auth automatically sets tag "+provisionersdk.TagScope+"="+provisionersdk.ScopeOrganization)
+				tags[provisionersdk.TagScope] = provisionersdk.ScopeOrganization
 			}
 
 			err = os.MkdirAll(cacheDir, 0o700)

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coder/coder/v2/provisionersdk"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/yamux"
 	"github.com/moby/moby/pkg/namesgenerator"
@@ -101,8 +103,8 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, tags map[string]strin
 	ctx := r.Context()
 	apiKey, ok := httpmw.APIKeyOptional(r)
 	if ok {
-		tags = provisionerdserver.MutateTags(apiKey.UserID, tags)
-		if tags[provisionerdserver.TagScope] == provisionerdserver.ScopeUser {
+		tags = provisionersdk.MutateTags(apiKey.UserID, tags)
+		if tags[provisionersdk.TagScope] == provisionersdk.ScopeUser {
 			// Any authenticated user can create provisioner daemons scoped
 			// for jobs that they own,
 			return tags, true
@@ -119,7 +121,7 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, tags map[string]strin
 		psk := r.Header.Get(codersdk.ProvisionerDaemonPSK)
 		if subtle.ConstantTimeCompare([]byte(p.psk), []byte(psk)) == 1 {
 			// If using PSK auth, the daemon is, by definition, scoped to the organization.
-			tags[provisionerdserver.TagScope] = provisionerdserver.ScopeOrganization
+			tags[provisionersdk.TagScope] = provisionersdk.ScopeOrganization
 			return tags, true
 		}
 	}

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -13,7 +13,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
@@ -91,7 +90,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				codersdk.ProvisionerTypeEcho,
 			},
 			Tags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		})
 		require.Error(t, err)
@@ -118,7 +117,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				codersdk.ProvisionerTypeEcho,
 			},
 			Tags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		})
 		require.Error(t, err)
@@ -135,7 +134,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 			},
 		}})
 		closer := coderdtest.NewExternalProvisionerDaemon(t, client, user.OrganizationID, map[string]string{
-			provisionerdserver.TagScope: provisionerdserver.ScopeUser,
+			provisionersdk.TagScope: provisionersdk.ScopeUser,
 		})
 		defer closer.Close()
 
@@ -169,7 +168,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 			FileID:        file.ID,
 			Provisioner:   codersdk.ProvisionerTypeEcho,
 			ProvisionerTags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeUser,
+				provisionersdk.TagScope: provisionersdk.ScopeUser,
 			},
 		})
 		require.NoError(t, err)
@@ -178,7 +177,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 		another, _ := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
 		_ = closer.Close()
 		closer = coderdtest.NewExternalProvisionerDaemon(t, another, user.OrganizationID, map[string]string{
-			provisionerdserver.TagScope: provisionerdserver.ScopeUser,
+			provisionersdk.TagScope: provisionersdk.ScopeUser,
 		})
 		defer closer.Close()
 		workspace := coderdtest.CreateWorkspace(t, another, user.OrganizationID, template.ID)
@@ -204,7 +203,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				codersdk.ProvisionerTypeEcho,
 			},
 			Tags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 			PreSharedKey: "provisionersftw",
 		})
@@ -260,7 +259,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 					codersdk.ProvisionerTypeEcho,
 				},
 				Tags: map[string]string{
-					provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+					provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 				},
 				PreSharedKey: "provisionersftw",
 			})
@@ -338,7 +337,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				codersdk.ProvisionerTypeEcho,
 			},
 			Tags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 			PreSharedKey: "the wrong key",
 		})
@@ -369,7 +368,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				codersdk.ProvisionerTypeEcho,
 			},
 			Tags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		})
 		require.Error(t, err)
@@ -398,7 +397,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				codersdk.ProvisionerTypeEcho,
 			},
 			Tags: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 			PreSharedKey: "provisionersftw",
 		})

--- a/provisionersdk/provisionertags.go
+++ b/provisionersdk/provisionertags.go
@@ -1,4 +1,4 @@
-package provisionerdserver
+package provisionersdk
 
 import "github.com/google/uuid"
 

--- a/provisionersdk/provisionertags_test.go
+++ b/provisionersdk/provisionertags_test.go
@@ -1,13 +1,13 @@
-package provisionerdserver_test
+package provisionersdk_test
 
 import (
 	"encoding/json"
 	"testing"
 
+	"github.com/coder/coder/v2/provisionersdk"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-
-	"github.com/coder/coder/v2/coderd/provisionerdserver"
 )
 
 func TestMutateTags(t *testing.T) {
@@ -26,7 +26,7 @@ func TestMutateTags(t *testing.T) {
 			userID: uuid.Nil,
 			tags:   nil,
 			want: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		},
 		{
@@ -34,32 +34,32 @@ func TestMutateTags(t *testing.T) {
 			userID: uuid.Nil,
 			tags:   map[string]string{},
 			want: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		},
 		{
 			name:   "user scope",
-			tags:   map[string]string{provisionerdserver.TagScope: provisionerdserver.ScopeUser},
+			tags:   map[string]string{provisionersdk.TagScope: provisionersdk.ScopeUser},
 			userID: testUserID,
 			want: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeUser,
-				provisionerdserver.TagOwner: testUserID.String(),
+				provisionersdk.TagScope: provisionersdk.ScopeUser,
+				provisionersdk.TagOwner: testUserID.String(),
 			},
 		},
 		{
 			name:   "organization scope",
-			tags:   map[string]string{provisionerdserver.TagScope: provisionerdserver.ScopeOrganization},
+			tags:   map[string]string{provisionersdk.TagScope: provisionersdk.ScopeOrganization},
 			userID: testUserID,
 			want: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		},
 		{
 			name:   "invalid scope",
-			tags:   map[string]string{provisionerdserver.TagScope: "360noscope"},
+			tags:   map[string]string{provisionersdk.TagScope: "360noscope"},
 			userID: testUserID,
 			want: map[string]string{
-				provisionerdserver.TagScope: provisionerdserver.ScopeOrganization,
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 			},
 		},
 	} {
@@ -73,7 +73,7 @@ func TestMutateTags(t *testing.T) {
 			var tags map[string]string
 			err = json.Unmarshal(bytes, &tags)
 			require.NoError(t, err)
-			got := provisionerdserver.MutateTags(tt.userID, tags)
+			got := provisionersdk.MutateTags(tt.userID, tags)
 			require.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
Required by https://github.com/coder/coder/pull/11086 to avoid an import cycle