### PR TITLE
fix: handle no memory limit in coder stat mem

### DIFF
--- a/cli/clistat/stat_internal_test.go
+++ b/cli/clistat/stat_internal_test.go
@@ -48,9 +48,6 @@ func TestResultString(t *testing.T) {
 			Expected: "0.5/8 cores (6%)",
 			Result:   Result{Used: 0.5, Total: ptr.To(8.0), Unit: "cores"},
 		},
-		{
-			Result: Result{Used: 1, Total: ptr.To(8.0), Unit: "Gb"},
-		},
 	} {
 		assert.Equal(t, tt.Expected, tt.Result.String())
 	}


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/10952

When running `./scripts/develop.sh` in dogfood I noticed this unreasonably high number for memory limit. After some digging (https://unix.stackexchange.com/questions/420906/what-is-the-value-for-the-cgroups-limit-in-bytes-if-the-memory-is-not-restricte) I found out that this number is used by docker to effectively use unlimited memory for the container. 