### PR TITLE
fix(coderd/database): remove column updated_at from provisioner_daemons table

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9669,10 +9669,6 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "updated_at": {
-                    "type": "string",
-                    "format": "date-time"
-                },
                 "version": {
                     "type": "string"
                 }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8696,10 +8696,6 @@
             "type": "string"
           }
         },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
         "version": {
           "type": "string"
         }

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1145,7 +1145,7 @@ func (q *FakeQuerier) DeleteOldProvisionerDaemons(_ context.Context) error {
 
 	var validDaemons []database.ProvisionerDaemon
 	for _, p := range q.provisionerDaemons {
-		if (p.CreatedAt.Before(weekAgo) && !p.UpdatedAt.Valid) || (p.UpdatedAt.Valid && p.UpdatedAt.Time.Before(weekAgo)) {
+		if (p.CreatedAt.Before(weekAgo) && !p.LastSeenAt.Valid) || (p.LastSeenAt.Valid && p.LastSeenAt.Time.Before(weekAgo)) {
 			continue
 		}
 		validDaemons = append(validDaemons, p)
@@ -4951,11 +4951,10 @@ func (q *FakeQuerier) InsertProvisionerDaemon(_ context.Context, arg database.In
 
 	daemon := database.ProvisionerDaemon{
 		ID:           arg.ID,
-		CreatedAt:    arg.CreatedAt,
 		Name:         arg.Name,
 		Provisioners: arg.Provisioners,
 		Tags:         arg.Tags,
-		UpdatedAt:    arg.UpdatedAt,
+		LastSeenAt:   arg.LastSeenAt,
 	}
 	q.provisionerDaemons = append(q.provisionerDaemons, daemon)
 	return daemon, nil

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -215,7 +215,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Name:         "external-0",
 		Provisioners: []database.ProvisionerType{"echo"},
 		CreatedAt:    now.Add(-14 * 24 * time.Hour),
-		UpdatedAt:    sql.NullTime{Valid: true, Time: now.Add(-7 * 24 * time.Hour).Add(time.Minute)},
+		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-7 * 24 * time.Hour).Add(time.Minute)},
 	})
 	require.NoError(t, err)
 	_, err = db.InsertProvisionerDaemon(ctx, database.InsertProvisionerDaemonParams{
@@ -224,7 +224,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Name:         "external-1",
 		Provisioners: []database.ProvisionerType{"echo"},
 		CreatedAt:    now.Add(-8 * 24 * time.Hour),
-		UpdatedAt:    sql.NullTime{Valid: true, Time: now.Add(-8 * 24 * time.Hour).Add(time.Hour)},
+		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-8 * 24 * time.Hour).Add(time.Hour)},
 	})
 	require.NoError(t, err)
 	_, err = db.InsertProvisionerDaemon(ctx, database.InsertProvisionerDaemonParams{
@@ -241,7 +241,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Name:         "external-3",
 		Provisioners: []database.ProvisionerType{"echo"},
 		CreatedAt:    now.Add(-6 * 24 * time.Hour),
-		UpdatedAt:    sql.NullTime{Valid: true, Time: now.Add(-6 * 24 * time.Hour)},
+		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-6 * 24 * time.Hour)},
 	})
 	require.NoError(t, err)
 

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -509,7 +509,6 @@ CREATE TABLE parameter_values (
 CREATE TABLE provisioner_daemons (
     id uuid NOT NULL,
     created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone,
     name character varying(64) NOT NULL,
     provisioners provisioner_type[] NOT NULL,
     replica_id uuid,

--- a/coderd/database/migrations/000177_drop_provisioner_updated_at.down.sql
+++ b/coderd/database/migrations/000177_drop_provisioner_updated_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE provisioner_daemons
+ADD COLUMN updated_at timestamp with time zone;

--- a/coderd/database/migrations/000177_drop_provisioner_updated_at.up.sql
+++ b/coderd/database/migrations/000177_drop_provisioner_updated_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE provisioner_daemons DROP COLUMN updated_at;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1839,7 +1839,6 @@ type ParameterValue struct {
 type ProvisionerDaemon struct {
 	ID           uuid.UUID         `db:"id" json:"id"`
 	CreatedAt    time.Time         `db:"created_at" json:"created_at"`
-	UpdatedAt    sql.NullTime      `db:"updated_at" json:"updated_at"`
 	Name         string            `db:"name" json:"name"`
 	Provisioners []ProvisionerType `db:"provisioners" json:"provisioners"`
 	ReplicaID    uuid.NullUUID     `db:"replica_id" json:"replica_id"`

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -59,7 +59,7 @@ type sqlcQuerier interface {
 	DeleteLicense(ctx context.Context, id int32) (int32, error)
 	// Delete provisioner daemons that have been created at least a week ago
 	// and have not connected to coderd since a week.
-	// A provisioner daemon with "zeroed" updated_at column indicates possible
+	// A provisioner daemon with "zeroed" last_seen_at column indicates possible
 	// connectivity issues (no provisioner daemon activity since registration).
 	DeleteOldProvisionerDaemons(ctx context.Context) error
 	// If an agent hasn't connected in the last 7 days, we purge it's logs.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3010,7 +3010,7 @@ DELETE FROM provisioner_daemons WHERE (
 
 // Delete provisioner daemons that have been created at least a week ago
 // and have not connected to coderd since a week.
-// A provisioner daemon with "zeroed" updated_at column indicates possible
+// A provisioner daemon with "zeroed" last_seen_at column indicates possible
 // connectivity issues (no provisioner daemon activity since registration).
 func (q *sqlQuerier) DeleteOldProvisionerDaemons(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, deleteOldProvisionerDaemons)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3003,8 +3003,8 @@ func (q *sqlQuerier) GetParameterSchemasByJobID(ctx context.Context, jobID uuid.
 
 const deleteOldProvisionerDaemons = `-- name: DeleteOldProvisionerDaemons :exec
 DELETE FROM provisioner_daemons WHERE (
-	(created_at < (NOW() - INTERVAL '7 days') AND updated_at IS NULL) OR
-	(updated_at IS NOT NULL AND updated_at < (NOW() - INTERVAL '7 days'))
+	(created_at < (NOW() - INTERVAL '7 days') AND last_seen_at IS NULL) OR
+	(last_seen_at IS NOT NULL AND last_seen_at < (NOW() - INTERVAL '7 days'))
 )
 `
 
@@ -3019,7 +3019,7 @@ func (q *sqlQuerier) DeleteOldProvisionerDaemons(ctx context.Context) error {
 
 const getProvisionerDaemons = `-- name: GetProvisionerDaemons :many
 SELECT
-	id, created_at, updated_at, name, provisioners, replica_id, tags, last_seen_at, version
+	id, created_at, name, provisioners, replica_id, tags, last_seen_at, version
 FROM
 	provisioner_daemons
 `
@@ -3036,7 +3036,6 @@ func (q *sqlQuerier) GetProvisionerDaemons(ctx context.Context) ([]ProvisionerDa
 		if err := rows.Scan(
 			&i.ID,
 			&i.CreatedAt,
-			&i.UpdatedAt,
 			&i.Name,
 			pq.Array(&i.Provisioners),
 			&i.ReplicaID,
@@ -3065,10 +3064,10 @@ INSERT INTO
 		"name",
 		provisioners,
 		tags,
-		updated_at
+		last_seen_at
 	)
 VALUES
-	($1, $2, $3, $4, $5, $6) RETURNING id, created_at, updated_at, name, provisioners, replica_id, tags, last_seen_at, version
+	($1, $2, $3, $4, $5, $6) RETURNING id, created_at, name, provisioners, replica_id, tags, last_seen_at, version
 `
 
 type InsertProvisionerDaemonParams struct {
@@ -3077,7 +3076,7 @@ type InsertProvisionerDaemonParams struct {
 	Name         string            `db:"name" json:"name"`
 	Provisioners []ProvisionerType `db:"provisioners" json:"provisioners"`
 	Tags         StringMap         `db:"tags" json:"tags"`
-	UpdatedAt    sql.NullTime      `db:"updated_at" json:"updated_at"`
+	LastSeenAt   sql.NullTime      `db:"last_seen_at" json:"last_seen_at"`
 }
 
 func (q *sqlQuerier) InsertProvisionerDaemon(ctx context.Context, arg InsertProvisionerDaemonParams) (ProvisionerDaemon, error) {
@@ -3087,13 +3086,12 @@ func (q *sqlQuerier) InsertProvisionerDaemon(ctx context.Context, arg InsertProv
 		arg.Name,
 		pq.Array(arg.Provisioners),
 		arg.Tags,
-		arg.UpdatedAt,
+		arg.LastSeenAt,
 	)
 	var i ProvisionerDaemon
 	err := row.Scan(
 		&i.ID,
 		&i.CreatedAt,
-		&i.UpdatedAt,
 		&i.Name,
 		pq.Array(&i.Provisioners),
 		&i.ReplicaID,

--- a/coderd/database/queries/provisionerdaemons.sql
+++ b/coderd/database/queries/provisionerdaemons.sql
@@ -12,7 +12,7 @@ INSERT INTO
 		"name",
 		provisioners,
 		tags,
-		updated_at
+		last_seen_at
 	)
 VALUES
 	($1, $2, $3, $4, $5, $6) RETURNING *;
@@ -20,9 +20,9 @@ VALUES
 -- name: DeleteOldProvisionerDaemons :exec
 -- Delete provisioner daemons that have been created at least a week ago
 -- and have not connected to coderd since a week.
--- A provisioner daemon with "zeroed" updated_at column indicates possible
+-- A provisioner daemon with "zeroed" last_seen_at column indicates possible
 -- connectivity issues (no provisioner daemon activity since registration).
 DELETE FROM provisioner_daemons WHERE (
-	(created_at < (NOW() - INTERVAL '7 days') AND updated_at IS NULL) OR
-	(updated_at IS NOT NULL AND updated_at < (NOW() - INTERVAL '7 days'))
+	(created_at < (NOW() - INTERVAL '7 days') AND last_seen_at IS NULL) OR
+	(last_seen_at IS NOT NULL AND last_seen_at < (NOW() - INTERVAL '7 days'))
 );

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -38,7 +38,6 @@ const (
 type ProvisionerDaemon struct {
 	ID           uuid.UUID         `json:"id" format:"uuid"`
 	CreatedAt    time.Time         `json:"created_at" format:"date-time"`
-	UpdatedAt    NullTime          `json:"updated_at,omitempty" format:"date-time"`
 	LastSeenAt   NullTime          `json:"last_seen_at,omitempty" format:"date-time"`
 	Name         string            `json:"name"`
 	Version      string            `json:"version"`

--- a/docs/api/enterprise.md
+++ b/docs/api/enterprise.md
@@ -707,7 +707,6 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
       "property1": "string",
       "property2": "string"
     },
-    "updated_at": "2019-08-24T14:15:22Z",
     "version": "string"
   }
 ]
@@ -733,7 +732,6 @@ Status Code **200**
 | `» provisioners`    | array             | false    |              |             |
 | `» tags`            | object            | false    |              |             |
 | `»» [any property]` | string            | false    |              |             |
-| `» updated_at`      | string(date-time) | false    |              |             |
 | `» version`         | string            | false    |              |             |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3827,7 +3827,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "property1": "string",
     "property2": "string"
   },
-  "updated_at": "2019-08-24T14:15:22Z",
   "version": "string"
 }
 ```
@@ -3843,7 +3842,6 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `provisioners`     | array of string | false    |              |             |
 | `tags`             | object          | false    |              |             |
 | » `[any property]` | string          | false    |              |             |
-| `updated_at`       | string          | false    |              |             |
 | `version`          | string          | false    |              |             |
 
 ## codersdk.ProvisionerJob

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -320,7 +320,6 @@ func convertProvisionerDaemon(daemon database.ProvisionerDaemon) codersdk.Provis
 	result := codersdk.ProvisionerDaemon{
 		ID:         daemon.ID,
 		CreatedAt:  daemon.CreatedAt,
-		UpdatedAt:  codersdk.NullTime{NullTime: daemon.UpdatedAt},
 		LastSeenAt: codersdk.NullTime{NullTime: daemon.LastSeenAt},
 		Name:       daemon.Name,
 		Tags:       daemon.Tags,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -777,7 +777,6 @@ export interface ProvisionerConfig {
 export interface ProvisionerDaemon {
   readonly id: string;
   readonly created_at: string;
-  readonly updated_at?: string;
   readonly last_seen_at?: string;
   readonly name: string;
   readonly version: string;

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -327,7 +327,6 @@ export const SuspendedMockUser: TypesGen.User = {
 
 export const MockProvisioner: TypesGen.ProvisionerDaemon = {
   created_at: "2022-05-17T17:39:01.382927298Z",
-  updated_at: "2022-05-17T17:39:01.382927298Z",
   id: "test-provisioner",
   name: "Test Provisioner",
   provisioners: ["echo"],


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/10676

Drops updated_at in favour of last_seen_at.

Should have been part of https://github.com/coder/coder/pull/11033

We're not inserting provisioner daemons into the database right now anyway so this is pretty safe.
