### PR TITLE
fix: provide helpful error when no login url specified

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -147,6 +147,10 @@ func (r *RootCmd) login() *clibase.Cmd {
 				rawURL = inv.Args[0]
 			}
 
+			if rawURL == "" {
+				return xerrors.Errorf("no url argument provided")
+			}
+
 			if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
 				scheme := "https"
 				if strings.HasPrefix(rawURL, "localhost") {


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/11003

Example:
```
➜  coder git:(f0ssel/no-login-url) ✗ go run ./cmd/coder/main.go login                                      
Encountered an error running "coder login"
no url argument provided
exit status 1
```