### PR TITLE
fix: return 403 when rebuilding workspace with require_active_version

### DIFF
--- a/cli/restart.go
+++ b/cli/restart.go
@@ -63,7 +63,7 @@ func (r *RootCmd) restart() *clibase.Cmd {
 			build, err = client.CreateWorkspaceBuild(ctx, workspace.ID, startReq)
 			// It's possible for a workspace build to fail due to the template requiring starting
 			// workspaces with the active version.
-			if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusUnauthorized {
+			if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusForbidden {
 				_, _ = fmt.Fprintln(inv.Stdout, "Failed to restart with the template version from your last build. Policy may require you to restart with the current active template version.")
 				build, err = startWorkspace(inv, client, workspace, parameterFlags, WorkspaceUpdate)
 				if err != nil {

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coder/retry"
 	"github.com/gen2brain/beeep"
 	"github.com/gofrs/flock"
 	"github.com/google/uuid"
@@ -24,6 +23,8 @@ import (
 	"golang.org/x/term"
 	"golang.org/x/xerrors"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+
+	"github.com/coder/retry"
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"

--- a/cli/start.go
+++ b/cli/start.go
@@ -34,7 +34,7 @@ func (r *RootCmd) start() *clibase.Cmd {
 			build, err := startWorkspace(inv, client, workspace, parameterFlags, WorkspaceStart)
 			// It's possible for a workspace build to fail due to the template requiring starting
 			// workspaces with the active version.
-			if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusUnauthorized {
+			if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusForbidden {
 				_, _ = fmt.Fprintln(inv.Stdout, "Failed to restart with the template version from your last build. Policy may require you to restart with the current active template version.")
 				build, err = startWorkspace(inv, client, workspace, parameterFlags, WorkspaceUpdate)
 				if err != nil {

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -379,7 +379,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	if xerrors.As(err, &buildErr) {
 		var authErr dbauthz.NotAuthorizedError
 		if xerrors.As(err, &authErr) {
-			buildErr.Status = http.StatusUnauthorized
+			buildErr.Status = http.StatusForbidden
 		}
 
 		if buildErr.Status == http.StatusInternalServerError {

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -353,7 +353,7 @@ func (b *Builder) buildTx(authFunc func(action rbac.Action, object rbac.Objecter
 		if err != nil {
 			code := http.StatusInternalServerError
 			if rbac.IsUnauthorizedError(err) {
-				code = http.StatusUnauthorized
+				code = http.StatusForbidden
 			}
 			return BuildError{code, "insert workspace build", err}
 		}

--- a/enterprise/coderd/workspacebuilds_test.go
+++ b/enterprise/coderd/workspacebuilds_test.go
@@ -103,7 +103,7 @@ func TestWorkspaceBuild(t *testing.T) {
 			{
 				Name:               "MemberFails",
 				Client:             memberClient,
-				ExpectedStatusCode: http.StatusUnauthorized,
+				ExpectedStatusCode: http.StatusForbidden,
 			},
 		}
 


### PR DESCRIPTION
- Trying to rebuild from the dashboard when your workspace is out of date could inadvertently sign you out.