### PR TITLE
fix: prevent editing build parameters if template requires active version

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -71,7 +71,9 @@ export const WorkspaceParametersForm: FC<{
   );
 
   const disabled =
-    workspace.template_require_active_version && !canChangeVersions;
+    workspace.outdated &&
+    workspace.template_require_active_version &&
+    !canChangeVersions;
 
   return (
     <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -1,3 +1,7 @@
+import { useFormik } from "formik";
+import { type FC } from "react";
+import * as Yup from "yup";
+import { Alert } from "components/Alert/Alert";
 import {
   FormFields,
   FormFooter,
@@ -5,15 +9,12 @@ import {
   HorizontalForm,
 } from "components/Form/Form";
 import { RichParameterInput } from "components/RichParameterInput/RichParameterInput";
-import { useFormik } from "formik";
-import { FC } from "react";
 import {
   getInitialRichParameterValues,
   useValidationSchemaForRichParameters,
 } from "utils/richParameters";
-import * as Yup from "yup";
 import { getFormHelpers } from "utils/formUtils";
-import {
+import type {
   TemplateVersionParameter,
   Workspace,
   WorkspaceBuildParameter,
@@ -23,7 +24,7 @@ export type WorkspaceParametersFormValues = {
   rich_parameter_values: WorkspaceBuildParameter[];
 };
 
-export const WorkspaceParametersForm: FC<{
+interface WorkspaceParameterFormProps {
   workspace: Workspace;
   templateVersionRichParameters: TemplateVersionParameter[];
   buildParameters: WorkspaceBuildParameter[];
@@ -32,7 +33,9 @@ export const WorkspaceParametersForm: FC<{
   error: unknown;
   onCancel: () => void;
   onSubmit: (values: WorkspaceParametersFormValues) => void;
-}> = ({
+}
+
+export const WorkspaceParametersForm: FC<WorkspaceParameterFormProps> = ({
   workspace,
   onCancel,
   onSubmit,
@@ -76,100 +79,115 @@ export const WorkspaceParametersForm: FC<{
     !canChangeVersions;
 
   return (
-    <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
-      {hasNonEphemeralParameters && (
-        <FormSection
-          title="Parameters"
-          description="Settings used by your template"
-        >
-          <FormFields>
-            {templateVersionRichParameters.map((parameter, index) =>
-              // Since we are adding the values to the form based on the index
-              // we can't filter them to not loose the right index position
-              parameter.mutable && !parameter.ephemeral ? (
-                <RichParameterInput
-                  {...getFieldHelpers(
-                    "rich_parameter_values[" + index + "].value",
-                  )}
-                  disabled={isSubmitting || disabled}
-                  key={parameter.name}
-                  onChange={async (value) => {
-                    await form.setFieldValue("rich_parameter_values." + index, {
-                      name: parameter.name,
-                      value: value,
-                    });
-                  }}
-                  parameter={parameter}
-                />
-              ) : null,
-            )}
-          </FormFields>
-        </FormSection>
+    <>
+      {disabled && (
+        <Alert severity="warning" css={{ marginBottom: 48 }}>
+          The template for this workspace requires automatic updates. Update the
+          workspace to edit parameters.
+        </Alert>
       )}
-      {hasEphemeralParameters && (
-        <FormSection
-          title="Ephemeral Parameters"
-          description="These parameters only apply for a single workspace start."
-        >
-          <FormFields>
-            {templateVersionRichParameters.map((parameter, index) =>
-              // Since we are adding the values to the form based on the index
-              // we can't filter them to not loose the right index position
-              parameter.mutable && parameter.ephemeral ? (
-                <RichParameterInput
-                  {...getFieldHelpers(
-                    "rich_parameter_values[" + index + "].value",
-                  )}
-                  disabled={isSubmitting || disabled}
-                  key={parameter.name}
-                  onChange={async (value) => {
-                    await form.setFieldValue("rich_parameter_values." + index, {
-                      name: parameter.name,
-                      value: value,
-                    });
-                  }}
-                  parameter={parameter}
-                />
-              ) : null,
-            )}
-          </FormFields>
-        </FormSection>
-      )}
-      {/* They are displayed here only for visibility purposes */}
-      {hasImmutableParameters && (
-        <FormSection
-          title="Immutable parameters"
-          description={
-            <>
-              These settings <strong>cannot be changed</strong> after creating
-              the workspace.
-            </>
-          }
-        >
-          <FormFields>
-            {templateVersionRichParameters.map((parameter, index) =>
-              !parameter.mutable ? (
-                <RichParameterInput
-                  disabled
-                  {...getFieldHelpers(
-                    "rich_parameter_values[" + index + "].value",
-                  )}
-                  key={parameter.name}
-                  parameter={parameter}
-                  onChange={() => {
-                    throw new Error("Immutable parameters cannot be changed");
-                  }}
-                />
-              ) : null,
-            )}
-          </FormFields>
-        </FormSection>
-      )}
-      <FormFooter
-        onCancel={onCancel}
-        isLoading={isSubmitting}
-        submitDisabled={disabled}
-      />
-    </HorizontalForm>
+
+      <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
+        {hasNonEphemeralParameters && (
+          <FormSection
+            title="Parameters"
+            description="Settings used by your template"
+          >
+            <FormFields>
+              {templateVersionRichParameters.map((parameter, index) =>
+                // Since we are adding the values to the form based on the index
+                // we can't filter them to not loose the right index position
+                parameter.mutable && !parameter.ephemeral ? (
+                  <RichParameterInput
+                    {...getFieldHelpers(
+                      "rich_parameter_values[" + index + "].value",
+                    )}
+                    disabled={isSubmitting || disabled}
+                    key={parameter.name}
+                    onChange={async (value) => {
+                      await form.setFieldValue(
+                        "rich_parameter_values." + index,
+                        {
+                          name: parameter.name,
+                          value: value,
+                        },
+                      );
+                    }}
+                    parameter={parameter}
+                  />
+                ) : null,
+              )}
+            </FormFields>
+          </FormSection>
+        )}
+        {hasEphemeralParameters && (
+          <FormSection
+            title="Ephemeral Parameters"
+            description="These parameters only apply for a single workspace start."
+          >
+            <FormFields>
+              {templateVersionRichParameters.map((parameter, index) =>
+                // Since we are adding the values to the form based on the index
+                // we can't filter them to not loose the right index position
+                parameter.mutable && parameter.ephemeral ? (
+                  <RichParameterInput
+                    {...getFieldHelpers(
+                      "rich_parameter_values[" + index + "].value",
+                    )}
+                    disabled={isSubmitting || disabled}
+                    key={parameter.name}
+                    onChange={async (value) => {
+                      await form.setFieldValue(
+                        "rich_parameter_values." + index,
+                        {
+                          name: parameter.name,
+                          value: value,
+                        },
+                      );
+                    }}
+                    parameter={parameter}
+                  />
+                ) : null,
+              )}
+            </FormFields>
+          </FormSection>
+        )}
+        {/* They are displayed here only for visibility purposes */}
+        {hasImmutableParameters && (
+          <FormSection
+            title="Immutable parameters"
+            description={
+              <>
+                These settings <strong>cannot be changed</strong> after creating
+                the workspace.
+              </>
+            }
+          >
+            <FormFields>
+              {templateVersionRichParameters.map((parameter, index) =>
+                !parameter.mutable ? (
+                  <RichParameterInput
+                    disabled
+                    {...getFieldHelpers(
+                      "rich_parameter_values[" + index + "].value",
+                    )}
+                    key={parameter.name}
+                    parameter={parameter}
+                    onChange={() => {
+                      throw new Error("Immutable parameters cannot be changed");
+                    }}
+                  />
+                ) : null,
+              )}
+            </FormFields>
+          </FormSection>
+        )}
+        <FormFooter
+          onCancel={onCancel}
+          isLoading={isSubmitting}
+          submitDisabled={disabled}
+        />
+      </HorizontalForm>
+    </>
   );
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -15,6 +15,7 @@ import * as Yup from "yup";
 import { getFormHelpers } from "utils/formUtils";
 import {
   TemplateVersionParameter,
+  Workspace,
   WorkspaceBuildParameter,
 } from "api/typesGenerated";
 
@@ -23,18 +24,22 @@ export type WorkspaceParametersFormValues = {
 };
 
 export const WorkspaceParametersForm: FC<{
-  isSubmitting: boolean;
+  workspace: Workspace;
   templateVersionRichParameters: TemplateVersionParameter[];
   buildParameters: WorkspaceBuildParameter[];
+  isSubmitting: boolean;
+  canChangeVersions: boolean;
   error: unknown;
   onCancel: () => void;
   onSubmit: (values: WorkspaceParametersFormValues) => void;
 }> = ({
+  workspace,
   onCancel,
   onSubmit,
   templateVersionRichParameters,
   buildParameters,
   error,
+  canChangeVersions,
   isSubmitting,
 }) => {
   const form = useFormik<WorkspaceParametersFormValues>({
@@ -65,6 +70,9 @@ export const WorkspaceParametersForm: FC<{
     (parameter) => !parameter.mutable,
   );
 
+  const disabled =
+    workspace.template_require_active_version && !canChangeVersions;
+
   return (
     <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
       {hasNonEphemeralParameters && (
@@ -81,7 +89,7 @@ export const WorkspaceParametersForm: FC<{
                   {...getFieldHelpers(
                     "rich_parameter_values[" + index + "].value",
                   )}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || disabled}
                   key={parameter.name}
                   onChange={async (value) => {
                     await form.setFieldValue("rich_parameter_values." + index, {
@@ -110,7 +118,7 @@ export const WorkspaceParametersForm: FC<{
                   {...getFieldHelpers(
                     "rich_parameter_values[" + index + "].value",
                   )}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || disabled}
                   key={parameter.name}
                   onChange={async (value) => {
                     await form.setFieldValue("rich_parameter_values." + index, {
@@ -155,7 +163,11 @@ export const WorkspaceParametersForm: FC<{
           </FormFields>
         </FormSection>
       )}
-      <FormFooter onCancel={onCancel} isLoading={isSubmitting} />
+      <FormFooter
+        onCancel={onCancel}
+        isLoading={isSubmitting}
+        submitDisabled={disabled}
+      />
     </HorizontalForm>
   );
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.stories.tsx
@@ -7,6 +7,8 @@ import {
   MockTemplateVersionParameter2,
   MockTemplateVersionParameter3,
   MockWorkspaceBuildParameter3,
+  MockWorkspace,
+  MockOutdatedStoppedWorkspaceRequireActiveVersion,
 } from "testHelpers/entities";
 
 const meta: Meta<typeof WorkspaceParametersPageView> = {
@@ -15,6 +17,8 @@ const meta: Meta<typeof WorkspaceParametersPageView> = {
   args: {
     submitError: undefined,
     isSubmitting: false,
+    workspace: MockWorkspace,
+    canChangeVersions: true,
 
     data: {
       buildParameters: [
@@ -44,6 +48,50 @@ export const Empty: Story = {
     data: {
       buildParameters: [],
       templateVersionRichParameters: [],
+    },
+  },
+};
+
+export const RequireActiveVersionNoChangeVersion: Story = {
+  args: {
+    workspace: MockOutdatedStoppedWorkspaceRequireActiveVersion,
+    canChangeVersions: false,
+    data: {
+      buildParameters: [
+        MockWorkspaceBuildParameter1,
+        MockWorkspaceBuildParameter2,
+        MockWorkspaceBuildParameter3,
+      ],
+      templateVersionRichParameters: [
+        MockTemplateVersionParameter1,
+        MockTemplateVersionParameter2,
+        {
+          ...MockTemplateVersionParameter3,
+          mutable: false,
+        },
+      ],
+    },
+  },
+};
+
+export const RequireActiveVersionCanChangeVersion: Story = {
+  args: {
+    workspace: MockOutdatedStoppedWorkspaceRequireActiveVersion,
+    canChangeVersions: true,
+    data: {
+      buildParameters: [
+        MockWorkspaceBuildParameter1,
+        MockWorkspaceBuildParameter2,
+        MockWorkspaceBuildParameter3,
+      ],
+      templateVersionRichParameters: [
+        MockTemplateVersionParameter1,
+        MockTemplateVersionParameter2,
+        {
+          ...MockTemplateVersionParameter3,
+          mutable: false,
+        },
+      ],
     },
   },
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -24,7 +24,7 @@ import { EmptyState } from "components/EmptyState/EmptyState";
 import Button from "@mui/material/Button";
 import OpenInNewOutlined from "@mui/icons-material/OpenInNewOutlined";
 import { docs } from "utils/docs";
-import { Alert } from "@mui/material";
+import { Alert } from "components/Alert/Alert";
 
 const WorkspaceParametersPage: FC = () => {
   const workspace = useWorkspaceSettings();

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -124,8 +124,8 @@ export const WorkspaceParametersPageView: FC<
 
       {workspace.template_require_active_version && !canChangeVersions && (
         <Alert severity="warning" css={{ marginBottom: 48 }}>
-          The template for this workspace requires automatic updates. This
-          workspace must be on the latest version to edit paremeters.
+          The template for this workspace requires automatic updates. Update the
+          workspace to edit parameters.
         </Alert>
       )}
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -1,7 +1,13 @@
 import { getWorkspaceParameters, postWorkspaceBuild } from "api/api";
 import { Helmet } from "react-helmet-async";
 import { pageTitle } from "utils/page";
+import {
+  WorkspacePermissions,
+  workspaceChecks,
+} from "../../WorkspacePage/permissions";
+import { checkAuthorization } from "api/queries/authCheck";
 import { useWorkspaceSettings } from "../WorkspaceSettingsLayout";
+import { templateByName } from "api/queries/templates";
 import { useMutation, useQuery } from "react-query";
 import { Loader } from "components/Loader/Loader";
 import {
@@ -13,11 +19,12 @@ import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { type FC } from "react";
 import { isApiValidationError } from "api/errors";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
-import { WorkspaceBuildParameter } from "api/typesGenerated";
+import { Workspace, WorkspaceBuildParameter } from "api/typesGenerated";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import Button from "@mui/material/Button";
 import OpenInNewOutlined from "@mui/icons-material/OpenInNewOutlined";
 import { docs } from "utils/docs";
+import { Alert } from "@mui/material";
 
 const WorkspaceParametersPage: FC = () => {
   const workspace = useWorkspaceSettings();
@@ -37,6 +44,22 @@ const WorkspaceParametersPage: FC = () => {
     },
   });
 
+  const templateQuery = useQuery({
+    ...templateByName(workspace.organization_id, workspace.template_name ?? ""),
+    enabled: workspace !== undefined,
+  });
+  const template = templateQuery.data;
+
+  // Permissions
+  const checks =
+    workspace && template ? workspaceChecks(workspace, template) : {};
+  const permissionsQuery = useQuery({
+    ...checkAuthorization({ checks }),
+    enabled: workspace !== undefined && template !== undefined,
+  });
+  const permissions = permissionsQuery.data as WorkspacePermissions | undefined;
+  const canChangeVersions = Boolean(permissions?.updateTemplate);
+
   return (
     <>
       <Helmet>
@@ -44,6 +67,8 @@ const WorkspaceParametersPage: FC = () => {
       </Helmet>
 
       <WorkspaceParametersPageView
+        workspace={workspace}
+        canChangeVersions={canChangeVersions}
         data={parameters.data}
         submitError={updateParameters.error}
         isSubmitting={updateParameters.isLoading}
@@ -67,6 +92,8 @@ const WorkspaceParametersPage: FC = () => {
 };
 
 export type WorkspaceParametersPageViewProps = {
+  workspace: Workspace;
+  canChangeVersions: boolean;
   data: Awaited<ReturnType<typeof getWorkspaceParameters>> | undefined;
   submitError: unknown;
   isSubmitting: boolean;
@@ -76,7 +103,15 @@ export type WorkspaceParametersPageViewProps = {
 
 export const WorkspaceParametersPageView: FC<
   WorkspaceParametersPageViewProps
-> = ({ data, submitError, isSubmitting, onSubmit, onCancel }) => {
+> = ({
+  workspace,
+  canChangeVersions,
+  data,
+  submitError,
+  onSubmit,
+  isSubmitting,
+  onCancel,
+}) => {
   return (
     <>
       <PageHeader css={{ paddingTop: 0 }}>
@@ -87,9 +122,18 @@ export const WorkspaceParametersPageView: FC<
         <ErrorAlert error={submitError} css={{ marginBottom: 48 }} />
       )}
 
+      {workspace.template_require_active_version && !canChangeVersions && (
+        <Alert severity="warning" css={{ marginBottom: 48 }}>
+          The template for this workspace requires automatic updates. This
+          workspace must be on the latest version to edit paremeters.
+        </Alert>
+      )}
+
       {data ? (
         data.templateVersionRichParameters.length > 0 ? (
           <WorkspaceParametersForm
+            workspace={workspace}
+            canChangeVersions={canChangeVersions}
             buildParameters={data.buildParameters}
             templateVersionRichParameters={data.templateVersionRichParameters}
             error={submitError}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -24,7 +24,6 @@ import { EmptyState } from "components/EmptyState/EmptyState";
 import Button from "@mui/material/Button";
 import OpenInNewOutlined from "@mui/icons-material/OpenInNewOutlined";
 import { docs } from "utils/docs";
-import { Alert } from "components/Alert/Alert";
 
 const WorkspaceParametersPage: FC = () => {
   const workspace = useWorkspaceSettings();
@@ -121,15 +120,6 @@ export const WorkspaceParametersPageView: FC<
       {submitError && !isApiValidationError(submitError) && (
         <ErrorAlert error={submitError} css={{ marginBottom: 48 }} />
       )}
-
-      {workspace.outdated &&
-        workspace.template_require_active_version &&
-        !canChangeVersions && (
-          <Alert severity="warning" css={{ marginBottom: 48 }}>
-            The template for this workspace requires automatic updates. Update
-            the workspace to edit parameters.
-          </Alert>
-        )}
 
       {data ? (
         data.templateVersionRichParameters.length > 0 ? (

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.tsx
@@ -122,12 +122,14 @@ export const WorkspaceParametersPageView: FC<
         <ErrorAlert error={submitError} css={{ marginBottom: 48 }} />
       )}
 
-      {workspace.template_require_active_version && !canChangeVersions && (
-        <Alert severity="warning" css={{ marginBottom: 48 }}>
-          The template for this workspace requires automatic updates. Update the
-          workspace to edit parameters.
-        </Alert>
-      )}
+      {workspace.outdated &&
+        workspace.template_require_active_version &&
+        !canChangeVersions && (
+          <Alert severity="warning" css={{ marginBottom: 48 }}>
+            The template for this workspace requires automatic updates. Update
+            the workspace to edit parameters.
+          </Alert>
+        )}
 
       {data ? (
         data.templateVersionRichParameters.length > 0 ? (


### PR DESCRIPTION
This PR disables the build parameters form when editing a workspace if the workspace is outdated and its template requires being on the active version. This isn't ideal because a user has to update and then edit the parameters which incurs another workspace build; however, right now the user experiences an error since they aren't allowed to "restart" a workspace when the template setting is enabled. 

In order to make this a better experience we need to either support supplying first-time values to template parameters (since we have to update) or we allow editing existing parameters from the update button. I'd like to do the former but it'll require a little design work.

This is more of a stopgap in the meantime. 


![image](https://github.com/coder/coder/assets/4856196/c6eb0758-c248-4893-b6cc-28eab5b3c230)
