### PR TITLE
ci: ungroup Dockerfile dependabot changes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -62,10 +62,6 @@ updates:
       # We need to coordinate terraform updates with the version hardcoded in
       # our Go code.
       - dependency-name: "terraform"
-    groups:
-      scripts-docker:
-        patterns:
-          - "*"
 
   - package-ecosystem: "npm"
     directory: "/site/"


### PR DESCRIPTION
This will give better visibility into what is changing in our `base.Dockerfoile` instead of PRs with title: [chore: bump the scripts-docker group in /scripts with 1 update](https://github.com/coder/coder/pull/11122)