### PR TITLE
fix: remove URL desyncs when trying to search users table

### DIFF
--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -17,11 +17,11 @@ export function usersKey(req: UsersRequest) {
   return ["users", req] as const;
 }
 
-export function paginatedUsers(): UsePaginatedQueryOptions<
-  GetUsersResponse,
-  UsersRequest
-> {
+export function paginatedUsers(
+  searchParams: URLSearchParams,
+): UsePaginatedQueryOptions<GetUsersResponse, UsersRequest> {
   return {
+    searchParams,
     queryPayload: ({ limit, offset, searchParams }) => {
       return {
         limit,

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -22,7 +22,7 @@ export function paginatedUsers(
 ): UsePaginatedQueryOptions<GetUsersResponse, UsersRequest> {
   return {
     searchParams,
-    queryPayload: ({ limit, offset, searchParams }) => {
+    queryPayload: ({ limit, offset }) => {
       return {
         limit,
         offset,

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -55,7 +55,7 @@ export const UsersPage: FC<{ children?: ReactNode }> = () => {
     enabled: viewDeploymentValues,
   });
 
-  const usersQuery = usePaginatedQuery(paginatedUsers());
+  const usersQuery = usePaginatedQuery(paginatedUsers(searchParamsResult[0]));
   const useFilterResult = useFilter({
     searchParamsResult,
     onUpdate: usersQuery.goToFirstPage,


### PR DESCRIPTION
## Changes made
- Made sure that the same URL search params object from React Router is being used all throughout the users page