### PR TITLE
ci: install protoc for offlinedocs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -568,6 +568,16 @@ jobs:
         with:
           directory: offlinedocs
 
+      - name: Install Protoc
+        run: |
+          mkdir -p /tmp/proto
+          pushd /tmp/proto
+          curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-linux-x86_64.zip
+          unzip protoc.zip
+          cp -r ./bin/* /usr/local/bin
+          cp -r ./include /usr/local/bin/include
+          popd
+
       - name: Setup Go
         uses: ./.github/actions/setup-go
 


### PR DESCRIPTION
Seen here: https://github.com/coder/coder/actions/runs/7179522755/job/19549879090?pr=11108

It looks like protoc is a transitive dependency of `offlinedocs` (the `make build` step), which means we need to install it