### PR TITLE
chore(dogfood): use go 1.20.11 to match CI

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:jammy AS go
 
 RUN apt-get update && apt-get install --yes curl gcc
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.21.4
+ARG GO_VERSION=1.20.11
 RUN mkdir --parents /usr/local/go
 
 # Boring Go is needed to build FIPS-compliant binaries.


### PR DESCRIPTION
I guess it accidently got bumped to the latest stable version in #11022