### PR TITLE
test: insights metrics: verify plugin usage

### DIFF
--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -95,9 +95,10 @@ func TestCollectInsights(t *testing.T) {
 		ConnectionsByProto: map[string]int64{"TCP": 1},
 		// ConnectionCount must be positive as database query ignores stats with no active connections at the time frame
 		ConnectionCount: 74,
-		// SessionCountJetBrains must be positive, but the exact value is ignored.
+		// SessionCountJetBrains, SessionCountVSCode must be positive, but the exact value is ignored.
 		// Database query approximates it to 60s of usage.
 		SessionCountJetBrains: 47,
+		SessionCountVSCode:    34,
 	})
 	require.NoError(t, err, "unable to post fake stats")
 

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -91,13 +91,15 @@ func TestCollectInsights(t *testing.T) {
 
 	// Fake app stats
 	_, err = agentClient.PostStats(context.Background(), &agentsdk.Stats{
-		ConnectionsByProto:        map[string]int64{"TCP": 1},
-		ConnectionCount:           74,
-		ConnectionMedianLatencyMS: 774,
-
+		// ConnectionsByProto can't be nil, otherwise stats get rejected
+		ConnectionsByProto: map[string]int64{"TCP": 1},
+		// ConnectionCount must be positive as database query ignores stats with no active connections at the time frame
+		ConnectionCount: 74,
+		// SessionCountJetBrains must be positive, but the exact value is ignored.
+		// Database query approximates it to 60s of usage.
 		SessionCountJetBrains: 47,
 	})
-	require.NoError(t, err, "unable to submit fake stats")
+	require.NoError(t, err, "unable to post fake stats")
 
 	// Fake app usage
 	reporter := workspaceapps.NewStatsDBReporter(db, workspaceapps.DefaultStatsDBReporterBatchSize)

--- a/coderd/prometheusmetrics/insights/testdata/insights-metrics.json
+++ b/coderd/prometheusmetrics/insights/testdata/insights-metrics.json
@@ -1,5 +1,5 @@
 {
-  "coderd_insights_applications_usage_seconds[application_name=JetBrains,slug=,template_name=golden-template]": 0,
+  "coderd_insights_applications_usage_seconds[application_name=JetBrains,slug=,template_name=golden-template]": 60,
   "coderd_insights_applications_usage_seconds[application_name=Visual Studio Code,slug=,template_name=golden-template]": 0,
   "coderd_insights_applications_usage_seconds[application_name=Web Terminal,slug=,template_name=golden-template]": 0,
   "coderd_insights_applications_usage_seconds[application_name=SSH,slug=,template_name=golden-template]": 60,

--- a/coderd/prometheusmetrics/insights/testdata/insights-metrics.json
+++ b/coderd/prometheusmetrics/insights/testdata/insights-metrics.json
@@ -1,6 +1,6 @@
 {
   "coderd_insights_applications_usage_seconds[application_name=JetBrains,slug=,template_name=golden-template]": 60,
-  "coderd_insights_applications_usage_seconds[application_name=Visual Studio Code,slug=,template_name=golden-template]": 0,
+  "coderd_insights_applications_usage_seconds[application_name=Visual Studio Code,slug=,template_name=golden-template]": 60,
   "coderd_insights_applications_usage_seconds[application_name=Web Terminal,slug=,template_name=golden-template]": 0,
   "coderd_insights_applications_usage_seconds[application_name=SSH,slug=,template_name=golden-template]": 60,
   "coderd_insights_applications_usage_seconds[application_name=Golden Slug,slug=golden-slug,template_name=golden-template]": 120,


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/11103

Make sure that `MetricsCollector` collects and exposes Prometheus metrics for JetBrains and VS Code plugins.