### PR TITLE
docs: add text to docs mentioning appearance settings for oidc sign-on page

### DIFF
--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -215,7 +215,8 @@ CODER_OIDC_SIGN_IN_TEXT="Sign in with Gitea"
 CODER_OIDC_ICON_URL=https://gitea.io/images/gitea.png
 ```
 
-To change the icon and text above the OpenID Connect button, see application name and logo url in [appearance](./appearance.md) settings.
+To change the icon and text above the OpenID Connect button, see application 
+name and logo url in [appearance](./appearance.md) settings.
 
 ## Disable Built-in Authentication
 

--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -215,6 +215,8 @@ CODER_OIDC_SIGN_IN_TEXT="Sign in with Gitea"
 CODER_OIDC_ICON_URL=https://gitea.io/images/gitea.png
 ```
 
+To change the icon and text above the OpenID Connect button, see application name and logo url in [appearance](./appearance.md) settings.
+
 ## Disable Built-in Authentication
 
 To remove email and password login, set the following environment variable on

--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -215,7 +215,7 @@ CODER_OIDC_SIGN_IN_TEXT="Sign in with Gitea"
 CODER_OIDC_ICON_URL=https://gitea.io/images/gitea.png
 ```
 
-To change the icon and text above the OpenID Connect button, see application 
+To change the icon and text above the OpenID Connect button, see application
 name and logo url in [appearance](./appearance.md) settings.
 
 ## Disable Built-in Authentication


### PR DESCRIPTION
Added mention of appearance settings for oidc sign-on page customization.  Previous customization instructions were not clear, only mentioning the sign-on button.