### PR TITLE
chore: validate queries using sqlc-vet in github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,6 +625,7 @@ jobs:
       - test-js
       - test-e2e
       - offlinedocs
+      - sqlc-vet
     # Allow this job to run even if the needed jobs fail, are skipped or
     # cancelled.
     if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -916,7 +916,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     needs: changes
     # TODO: We should do this on any migration or query changes.
-#    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    #    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -315,7 +315,7 @@ jobs:
 
   test-go-pg:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
-    needs: changes
+    needs: sqlc-vet
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
     # `make test-postgres` to ensure we receive a trace of running

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -908,3 +908,27 @@ jobs:
 
             echo "::endgroup::"
           done
+
+  # sqlc-vet runs a postgres docker container, runs Coder migrations, and then
+  # runs sqlc-vet to ensure all queries are valid. This catches any mistakes
+  # in migrations or sqlc queries that makes a query unable to be prepared.
+  sqlc-vet:
+    runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
+    needs: changes
+    # TODO: We should do this on any migration or query changes.
+#    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      # We need golang to run the migration main.go
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup sqlc
+        uses: ./.github/actions/setup-sqlc
+
+      - name: Setup and run sqlc vet
+        run: |
+          make sqlc-vet

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
       ts: ${{ steps.filter.outputs.ts }}
       k8s: ${{ steps.filter.outputs.k8s }}
       ci: ${{ steps.filter.outputs.ci }}
+      db: ${{ steps.filter.outputs.db }}
       offlinedocs-only: ${{ steps.filter.outputs.offlinedocs_count == steps.filter.outputs.all_count }}
       offlinedocs: ${{ steps.filter.outputs.offlinedocs }}
     steps:
@@ -57,6 +58,12 @@ jobs:
               - "examples/web-server/**"
               - "examples/monitoring/**"
               - "examples/lima/**"
+            db:
+              - "**.sql"
+              - "coderd/database/queries/**"
+              - "coderd/database/migrations"
+              - "coderd/database/sqlc.yaml"
+              - "coderd/database/dump.sql"
             go:
               - "**.sql"
               - "**.go"
@@ -315,7 +322,7 @@ jobs:
 
   test-go-pg:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
-    needs: sqlc-vet
+    needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
     # `make test-postgres` to ensure we receive a trace of running
@@ -915,8 +922,7 @@ jobs:
   sqlc-vet:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     needs: changes
-    # TODO: We should do this on any migration or query changes.
-    #    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    if: needs.changes.outputs.db == 'true' || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -711,7 +711,7 @@ test:
 sqlc-vet: test-postgres-docker
 	echo "--- sqlc vet"
 	SQLC_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/$(shell go run scripts/migrate-ci/main.go)" \
-	sqlc vet -f coderd/database/sqlc.yaml
+	sqlc vet -f coderd/database/sqlc.yaml && echo "Passed sqlc vet"
 
 # When updating -timeout for this test, keep in sync with
 # test-go-postgres (.github/workflows/coder.yaml).

--- a/Makefile
+++ b/Makefile
@@ -708,6 +708,11 @@ test:
 	gotestsum --format standard-quiet -- -v -short -count=1 ./...
 .PHONY: test
 
+sqlc-vet: test-postgres-docker
+	echo "--- sqlc vet"
+	SQLC_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/$(shell go run scripts/migrate-ci/main.go)" \
+	sqlc vet -f coderd/database/sqlc.yaml
+
 # When updating -timeout for this test, keep in sync with
 # test-go-postgres (.github/workflows/coder.yaml).
 # Do add coverage flags so that test caching works.

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -83,7 +83,7 @@ sql:
     queries: "./queries"
     engine: "postgresql"
     # This only works if you are running a local postgres database with the
-    # schema loaded and migrations run.
+    # schema loaded and migrations run. Run `make sqlc-vet` to run the linter.
     database:
       uri: "${SQLC_DATABASE_URL}"
     rules:

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -82,6 +82,12 @@ sql:
   - schema: "./dump.sql"
     queries: "./queries"
     engine: "postgresql"
+    # This only works if you are running a local postgres database with the
+    # schema loaded and migrations run.
+    database:
+      uri: "${SQLC_DATABASE_URL}"
+    rules:
+      - sqlc/db-prepare
     gen:
       go:
         package: "database"


### PR DESCRIPTION
# What this does

This runs [`sqlc vet`](https://docs.sqlc.dev/en/stable/howto/vet.html) using our queries and schema for a given commit. The only sql lint rule we currently have is that a query can be prepared against our schema.

This protects us from writing a migration that breaks an existing query, or writing a new query that will not execute.

We unit test _almost all of our queries_, so this failure will likely be caught in `test-go-pg`. However, the reported failure will correspond to some number of Go tests, and the output might not be straight forward. `sqlc vet` will have clearer reporting and easier debugging.

# Example

Found a query that does not work: (https://github.com/coder/coder/actions/runs/7186260845/job/19574288356)

```
--- sqlc vet
# package 
queries/tailnet.sql:101:8: column "tailnet_clients.id" must appear in the GROUP BY clause or be used in an aggregate function
```