### PR TITLE
ci: set flux version to 2.1.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -765,6 +765,9 @@ jobs:
 
       - name: Set up Flux CLI
         uses: fluxcd/flux2/action@main
+        with:
+          # Keep this up to date with the version of flux installed in dogfood cluster
+          version: '2.1.2'
 
       - name: Get Cluster Credentials
         uses: "google-github-actions/get-gke-credentials@v2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -767,7 +767,7 @@ jobs:
         uses: fluxcd/flux2/action@main
         with:
           # Keep this up to date with the version of flux installed in dogfood cluster
-          version: '2.1.2'
+          version: "2.1.2"
 
       - name: Get Cluster Credentials
         uses: "google-github-actions/get-gke-credentials@v2"


### PR DESCRIPTION
cc @deansheather 

Looks like breaking change was made in 2.1.2 -> 2.2.0

```
Downloading flux 2.2.0 for linux/amd64
Verifying checksum
Installing flux to /opt/hostedtoolcache/flux2/2.2.0/linux/amd64
Adding flux to path
Run flux -v
flux version 2.2.0
[...]
+ flux --namespace coder reconcile helmrelease coder
✗ failed to get API group resources: unable to retrieve the complete list of server APIs: helm.toolkit.fluxcd.io/v2beta2: the server could not find the requested resource
```

From https://github.com/fluxcd/flux2/releases/tag/v2.2.0:

> Set apiVersion: helm.toolkit.fluxcd.io/v2beta2 in the YAML files that contain HelmRelease definitions.