### PR TITLE
docs: add faqs from sharkymark

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -88,7 +88,7 @@ This example will hide all built-in coder_app icons except the web terminal.
 > It is **not** recommended to share a web IDE, but if required, the following
 > deployment environment variable settings are required.
 
-1. Set deployment (Kubernetes) to allow path app sharing
+Set deployment (Kubernetes) to allow path app sharing
 
 ```yaml
 # allow authenticated users to access path-based workspace apps
@@ -99,11 +99,11 @@ This example will hide all built-in coder_app icons except the web terminal.
   value: "true"
 ```
 
-2. In the template, set
-   [`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
-   [`share`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share)
-   option to `authenticated` and when a workspace is built with this template,
-   the pretty globe shows up next to path-based `code-server`:
+In the template, set
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+[`share`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share)
+option to `authenticated` and when a workspace is built with this template, the
+pretty globe shows up next to path-based `code-server`:
 
 ```hcl
 resource "coder_app" "code-server" {
@@ -177,8 +177,8 @@ sudo systemctl restart coder.service
 1. Run the `coder server` command below to retrieve the `psql` connection URL
    which includes the database user and password.
 2. `psql` into Postgres, and do a select query on the `users` table.
-3. Restart the `coder server`, pull up the Coder UI and log in (hope you
-   remembered your password)
+3. Restart the `coder server`, pull up the Coder UI and log in (you will still
+   need your password)
 
 ```sh
 coder server postgres-builtin-url
@@ -315,9 +315,9 @@ This code produces a hashed value that will be difficult to replicate.
 
 ```hcl
 locals {
-concatenated_string = "${data.coder_workspace.me.name}+${data.coder_workspace.me.owner}"
-hashed_string = md5(local.concatenated_string)
-truncated_hash = substr(local.hashed_string, 0, 16)
+  concatenated_string = "${data.coder_workspace.me.name}+${data.coder_workspace.me.owner}"
+  hashed_string = md5(local.concatenated_string)
+  truncated_hash = substr(local.hashed_string, 0, 16)
 }
 ```
 
@@ -345,8 +345,10 @@ open the IDE.
 
 ## What options do I have for adding VS Code extensions into code-server, VS Code Desktop or Microsoft's Code Server?
 
-Coder has an open-source project called `code-marketplace` which is a private VS
-Code extension marketplace. There is even integration with JFrog Artifactory.
+Coder has an open-source project called
+[`code-marketplace`](https://github.com/coder/code-marketplace) which is a
+private VS Code extension marketplace. There is even integration with JFrog
+Artifactory.
 
 - [Blog post](https://coder.com/blog/running-a-private-vs-code-extension-marketplace)
 - [OSS project](https://github.com/coder/code-marketplace)

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -36,29 +36,27 @@ coder licenses add -f <path/filename>
 The primary developer use case is a local IDE connecting over SSH to a Coder
 workspace.
 
-Coder's networking stack has intelligence to attempt a peer-to-peer or [Direct
-connection](https://coder.com/docs/v2/latest/networking#direct-connections) between the local IDE and the workspace.
-
-However, this requires some additional protocols like UDP and being able to
-reach a STUN server to echo the IP addresses of the local IDE machine and
-workspace, for sharing using a Wireguard Coordination Server.
-
-By default, Coder assumes Internet and attempts to reach Google's STUN servers
-to perform this IP echo.
+Coder's networking stack has intelligence to attempt a peer-to-peer or
+[Direct connection](https://coder.com/docs/v2/latest/networking#direct-connections)
+between the local IDE and the workspace. However, this requires some additional
+protocols like UDP and being able to reach a STUN server to echo the IP
+addresses of the local IDE machine and workspace, for sharing using a Wireguard
+Coordination Server. By default, Coder assumes Internet and attempts to reach
+Google's STUN servers to perform this IP echo.
 
 Operators experimenting with Coder may run into networking issues if UDP (which
 STUN requires) or the STUN servers are unavailable, potentially resulting in
 lengthy local IDE and SSH connection times as the Coder control plane attempts
 to establish these direct connections.
 
-Setting the following flags as shown disables this logic to simplify troubleshooting.
+Setting the following flags as shown disables this logic to simplify
+troubleshooting.
 
-
-Flag | Value | Meaning
----- | ----- | -------
-[`CODER_BLOCK_DIRECT`](https://coder.com/docs/v2/latest/cli/server#--block-direct-connections) | `true` | Blocks direct connections
-[`CODER_DERP_SERVER_STUN_ADDRESSES`](https://coder.com/docs/v2/latest/cli/server#--derp-server-stun-addresses) | `"disable"` | Disables STUN
-[`CODER_DERP_FORCE_WEBSOCKETS`](https://coder.com/docs/v2/latest/cli/server#--derp-force-websockets) | `true` | Forces websockets over Tailscale DERP
+| Flag                                                                                                           | Value       | Meaning                               |
+| -------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------- |
+| [`CODER_BLOCK_DIRECT`](https://coder.com/docs/v2/latest/cli/server#--block-direct-connections)                 | `true`      | Blocks direct connections             |
+| [`CODER_DERP_SERVER_STUN_ADDRESSES`](https://coder.com/docs/v2/latest/cli/server#--derp-server-stun-addresses) | `"disable"` | Disables STUN                         |
+| [`CODER_DERP_FORCE_WEBSOCKETS`](https://coder.com/docs/v2/latest/cli/server#--derp-force-websockets)           | `true`      | Forces websockets over Tailscale DERP |
 
 ## How do I configure NGINX as the reverse proxy in front of Coder?
 
@@ -100,9 +98,11 @@ This example will hide all built-in coder_app icons except the web terminal.
   value: "true"
 ```
 
-2. In the template, set [`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app) [`share`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share) option to `authenticated` and when a workspace
-   is built with this template, the pretty globe shows up next to path-based
-   `code-server`:
+2. In the template, set
+   [`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+   [`share`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share)
+   option to `authenticated` and when a workspace is built with this template,
+   the pretty globe shows up next to path-based `code-server`:
 
 ```hcl
 resource "coder_app" "code-server" {
@@ -146,9 +146,10 @@ example, if a template prompts users to choose options like a
 of these values can lead to existing workspaces failing to start. This issue
 occurs because the Terraform state will not be in sync with the new template.
 
-However, a lesser-known CLI sub-command, [`coder update`](https://coder.com/docs/v2/latest/cli/update), can resolve this issue. This
-command re-prompts users to re-enter the input variables, potentially saving the
-workspace from a failed status.
+However, a lesser-known CLI sub-command,
+[`coder update`](https://coder.com/docs/v2/latest/cli/update), can resolve this
+issue. This command re-prompts users to re-enter the input variables,
+potentially saving the workspace from a failed status.
 
 ```sh
 coder update --always-prompt <workspace name>

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,0 +1,349 @@
+# FAQs
+
+Frequently asked questions on Coder OSS and Enterprise deployments. These FAQs come from our community and enterprise customers, feel free to [contribute to this page](https://github.com/coder/coder/edit/main/docs/faqs.md).
+
+## How do I add an enterprise license?
+
+Visit https://coder.com/trial or contact [sales@coder.com](mailto:sales@coder.com?subject=License) to get a v2 enterprise trial key.
+
+You can add a license through the UI or CLI.
+
+In the UI, click the Deployment tab -> Licenses and upload the `jwt` license file.
+
+> To add the license with the CLI, first [install the Coder CLI](https://coder.com/docs/v2/latest/install/install.sh) and server to the latest release.
+
+If the license is a text string:
+
+```sh
+coder licenses add -l 1f5...765
+```
+
+If the license is in a file:
+
+```sh
+coder licenses add -f <path/filename>
+```
+
+
+## I'm experiencing networking issues, so want to disable Tailscale, STUN, Direct connections and force use of websockets
+
+The primary developer IDE use case is a local IDE connecting over SSH to a Coder workspace.
+
+Coder's networking stack has intelligence to attempt a peer-to-peer or `Direct` connection between the local IDE and the workspace, skipping routing traffic through the Coder control plane, thus reducing latency and a better developer experience.
+
+However, this requires some additional protocols like UDP and being able to reach a STUN server to echo the IP addresses of the local IDE machine and workspace, for sharing using a Wireguard Coordination Server.
+
+By default, Coder assumes Internet and attempts to reach Google's STUN servers to perform this IP echo.
+
+Operators experimenting with Coder make run into networking issues if UDP (which STUN requires) or the STUN servers are unavailable, potentially resulting in lengthy local IDE and SSH connection times as the Coder control plane attempts to establish these direct connections.
+
+A good troubleshooting tip is to just disable STUN, Direct connections, and even forcing websockets versus the embedded Tailscale DERP relay server.
+
+If using a `systemd` configuration of Coder's control plane, add these values to `/etc/coder.d/coder.env`:
+
+```sh
+# disable peer-to-peer, force web sockets
+CODER_BLOCK_DIRECT=true
+CODER_DERP_SERVER_STUN_ADDRESSES="disable"
+CODER_DERP_FORCE_WEBSOCKETS=true
+```
+
+If using a Kubernetes deployment, add these values to your `values.yaml` then `helm upgrade`:
+
+```yaml
+# disable Peer-to-Peer connections (e.g., local computer with SSH, local VS Code, local JetBrains Gateway)
+- name: CODER_BLOCK_DIRECT
+  value: "false"
+# unset Google STUN servers that are hardcoded into Coder
+- name: CODER_DERP_SERVER_STUN_ADDRESSES
+  value: "disable"
+# force websockets
+- name: CODER_DERP_FORCE_WEBSOCKETS
+  value: "true"
+```
+
+If starting the `coder server`from the command line, set these environment variables
+
+```sh
+coder server --block-direct-connections=true --derp-server-stun-addresses=disable --derp-force-websockets=true
+```
+
+
+## How do I configure NGINX as the reverse proxy in front of Coder?
+
+[This doc](https://github.com/coder/coder/tree/main/examples/web-server/nginx#configure-nginx) in our repo explains in detail how to configure NGINX with Coder so that our Tailscale Wireguard networking functions properly.
+
+## How do I hide some of the default icons in a workspace like VS Code Desktop, Terminal, SSH, Ports?
+
+The visibility of Coder apps is configurable in the template. To change the default (shows all), add this block inside the `coder_agent` of a template and configure as needed:
+
+```hcl
+  display_apps {
+    vscode = false
+    vscode_insiders = false
+    ssh_helper = false
+    port_forwarding_helper = false
+    web_terminal = true
+  }
+```
+
+This is example will shown any other `coder_app` entries in the template, and the web terminal only.
+
+## I want to allow code-server to be accessible by other users in my deployment.
+
+> It is **not** recommended to share a web IDE, but if required, the following deployment environment variable settings are required.
+
+1. Set deployment (Kubernetes) to allow path app sharing
+
+```yaml
+# allow authenticated users to access path-based workspace apps
+- name: CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
+  value: "true"
+# allow Coder owner roles to access path-based workspace apps
+- name: CODER_DANGEROUS_ALLOW_PATH_APP_SITE_OWNER_ACCESS
+  value: "true"
+```
+
+2. In the template, set `coder_app` `share=authenticated` and when a workspace is built with this template, the pretty globe shows up next to path-based `code-server`
+
+> KNOWN ISSUE: The first time another user authenticates to Coder with the code-server link, it gives a `404` but if you refresh, it works.
+
+## I installed Coder and created a workspace but the icons do not load.
+
+An important concept to understand is that Coder creates workspaces which have
+an agent that must be able to reach the `coder server`.
+
+If the `CODER_ACCESS_URL` is not accessible from a workspace, the workspace may
+build, but the agent cannot reach Coder, and thus the missing icons. e.g.,
+Terminal, IDEs, Apps.
+
+
+> By default, `coder server` automatically creates an Internet-accessible
+> reverse proxy so that workspaces you create can reach the server.
+
+If you are doing a standalone install, e.g., on a Macbook and want to build
+workspaces in Docker Desktop, everything is self-contained and workspaces
+(containers in Docker Desktop) can reach the Coder server.
+
+```sh
+coder server --access-url http://localhost:3000 --address 0.0.0.0:3000
+```
+
+> Even `coder server` which creates a reverse proxy, will let you use
+> http://localhost to access Coder from a browser.
+
+## I updated a template, and an existing workspace based on that template fails to start.
+
+When updating a template, be aware of potential issues with input variables. For example, if a template prompts users to choose options like a [code-server](https://github.com/coder/code-server) [VS
+Code](https://code.visualstudio.com/) IDE release, a [container
+image](https://hub.docker.com/u/codercom), or a [VS Code
+extension](https://marketplace.visualstudio.com/vscode), removing any of these values can lead to existing workspaces failing to start. This issue occurs because the Terraform state will not be in sync with the new template.
+
+However, a lesser-known CLI sub-command, `update`, can resolve this issue. This command re-prompts users to re-enter the input variables, potentially saving the workspace from a failed status.
+
+```sh
+coder update --always-prompt <workspace name>
+```
+
+## I'm running coder on a VM with systemd but latest release installed isn't showing up.
+
+Take, for example, a Coder deployment on a VM with a 2 shared vCPU systemd service. In this scenario, it's necessary to reload the daemon and then restart the Coder service. This prevents the `systemd` daemon from trying to reference the previous Coder release service since the unit file has changed.
+
+The following commands can be used to update Coder and refresh the service:
+
+```sh
+curl -fsSL https://coder.com/install.sh | sh
+sudo systemctl daemon-reload
+sudo systemctl restart coder.service
+```
+
+## I'm using the built-in Postgres database and forgot admin email I set up.
+
+1. Run the `coder server` command below to retrieve the `psql` connection URL which
+   includes the database user and password.
+2. `psql` into Postgres, and do a select query on the `users` table.
+3. Restart the `coder server`, pull up the Coder UI and log in (hope you
+   remembered your password)
+
+```sh
+coder server postgres-builtin-url
+psql "postgres://coder@localhost:53737/coder?sslmode=disable&password=I2S...pTk"
+```
+
+## How to find out Coder's latest Terraform provider version?
+
+[Coder is on the HashiCorp's Terraform
+registry](https://registry.terraform.io/providers/coder/coder/latest). Check
+this frequently to make sure you are on the latest version.
+
+Sometimes, the version may change and `resource` configurations
+will either become deprecated or new ones will be added when you get warnings or errors
+creating and pushing templates.
+
+## How can I set up TLS for my deployment and not create a signed certificate?
+
+Caddy is an easy-to-configure reverse proxy that also automatically creates certificates from Let's Encrypt. [Install docs here](https://caddyserver.com/docs/quick-starts/reverse-proxy) You can start Caddy as a `systemd` service.
+
+The Caddyfile configuration will appear like this where `127.0.0.1:3000` is your `CODER_ACCESS_URL`:
+
+```sh
+coder.example.com {
+
+	reverse_proxy 127.0.0.1:3000
+
+	tls {
+		issuer acme {
+			email mark@example.com
+		}
+	}
+
+}
+```
+
+## I'm using Caddy as my reverse proxy in front of Coder. How do I set up a wildcard domain for port forwarding?
+
+Caddy requires your DNS provider's credentials to create wildcard certificates. This involves building the Caddy binary [from source](https://github.com/caddyserver/caddy) with the DNS provider plugin added. e.g., [Google Cloud DNS provider here](https://github.com/caddy-dns/googleclouddns)
+
+
+To compile Caddy, the host running Coder requires Go. Once installed, replace the existing Caddy binary in `usr/bin` and restart the Caddy service.
+
+The updated Caddyfile configuration will look like this:
+
+```sh
+*.coder.example.com, coder.example.com {
+
+	reverse_proxy 127.0.0.1:3000
+
+	tls {
+		issuer acme {
+			email mark@example.com
+			dns googleclouddns {
+				gcp_project my-gcp-project
+			}
+		}
+	}
+
+}
+```
+
+## Can I use local or remote Terraform Modules in Coder templates?
+
+One way is to reference a Terraform module from a GitHub repo to avoid duplication and then just extend it or pass template-specific parameters/resources:
+
+```hcl
+# template1/main.tf
+module "central-coder-module" {
+  source = "github.com/yourorg/central-coder-module"
+  myparam = "custom-for-template1"
+}
+
+resource "ebs_volume` `custom_template1_only_resource ` {
+}
+```
+
+```hcl
+# template2/main.tf
+module "central-coder-module" {
+  source = "github.com/yourorg/central-coder-module"
+  myparam = "custom-for-template2"
+  myparam2 = "bar"
+}
+
+resource "aws_instance` `custom_template2_only_resource ` {
+}
+```
+
+Another way using local modules is to symlink the module directory inside the template directory and then `tar` the template.
+
+```sh
+ln -s modules template_1/modules
+tar -cvh -C ./template_1 | coder templates <push|create> -d - <name>
+```
+
+References:
+- [Public Github Issue 6117](https://github.com/coder/coder/issues/6117)
+- [Public Github Issue 5677](https://github.com/coder/coder/issues/5677)
+- [Coder docs: Templates/Change Management](https://coder.com/docs/v2/latest/templates/change-management)
+
+## Can I run Coder in an air-gapped or offline mode? (no Internet)?
+
+Yes, Coder can be deployed in air-gapped or offline mode.
+https://coder.com/docs/v2/latest/install/offline
+
+Our product bundles with the Terraform binary so assume access to terraform.io during installation. The docs outline rebuilding the Coder container with Terraform built-in as well as any required Terraform providers.
+
+Direct networking from local SSH to a Coder workspace needs a STUN server. Coder defaults to Google's STUN servers, so you can either create your STUN server in your network or disable and force all traffic through the control plane's DERP proxy.
+
+## Create a randomized computer_name for an Azure VM
+
+Azure VMs have a 15 character limit for the `computer_name` which can lead to duplicate name errors.
+
+This code produces a hashed value that will be difficult to replicate.
+
+```hcl
+locals {
+concatenated_string = "${data.coder_workspace.me.name}+${data.coder_workspace.me.owner}"
+hashed_string = md5(local.concatenated_string)
+truncated_hash = substr(local.hashed_string, 0, 16)
+}
+```
+
+## Do you have example JetBrains Gateway templates?
+
+In August 2023, JetBrains certified the Coder plugin signifying enhanced stability and reliability.
+
+The Coder plugin will appear in the Gateway UI when opened.
+
+Selecting the most suitable template depends on how the deployment manages Jetbrains IDE versions. If downloading from [jetbrains.com](https://www.jetbrains.com/remote-development/gateway/) is acceptable, see the example templates below which specifies the product code, IDE version and build number in the `coder_app` resource. This will present an icon in the workspace dashboard which when clicked, will look for a locally installed Gateway, and open it. Alternatively, the IDE can be baked into the container image and manually open Gateway (or IntelliJ which has Gateway built-in), using a session token to Coder and then open the IDE.
+
+- [IntelliJ IDEA](https://github.com/sharkymark/v2-templates/tree/main/pod-idea)
+- [IntelliJ IDEA with Icon](https://github.com/sharkymark/v2-templates/tree/main/pod-idea-icon)
+
+## What options do I have for adding VS Code extensions into code-server, VS Code Desktop or Microsoft's Code Server?
+
+Coder has an open-source project called `code-marketplace` which is a private VS Code extension marketplace. There is even integration with JFrog Artifactory.
+
+- [Blog post](https://coder.com/blog/running-a-private-vs-code-extension-marketplace)
+- [OSS project](https://github.com/coder/code-marketplace)
+
+[See this example template](https://github.com/sharkymark/v2-templates/blob/main/code-marketplace/main.tf#L229C1-L232C12) where the agent specifies the URL and config environment variables which code-server picks up and points the developer to.
+
+Another option is to use Microsoft's code-server - which is like Coder's, but it can connect to Microsoft's extension marketplace so Copilot and chat can be retrieved there. [See a sample template here](https://github.com/sharkymark/v2-templates/blob/main/vs-code-server/main.tf).
+
+Another option is to use VS Code Desktop (local) and that connects to Microsoft's marketplace.
+https://github.com/sharkymark/v2-templates/blob/main/vs-code-server/main.tf
+
+> Note: these are example templates with no SLAs on them and are not guaranteed long-term support.
+
+## I want to run Docker for my workspaces but not install Docker Desktop.
+
+[Colima](https://github.com/abiosoft/colima) is a Docker Desktop alternative.
+
+This example is meant for a users who want to try out Coder on a MacOS device.
+
+Install Colima and docker with:
+
+```sh
+brew install colima
+brew install docker
+```
+
+Start Colima:
+
+```sh
+colima start
+```
+
+Start Colima with specific compute options:
+
+```sh
+colima start --cpu 4 --memory 8
+```
+
+Starting Colima on a M3 Macbook Pro:
+
+```sh
+colima start --arch x86_64  --cpu 4 --memory 8 --disk 10
+```
+
+Colima will show the path to the docker socket so I have a [Coder template](./docker-code-server/main.tf) that prompts the Coder admin to enter the docker socket as a Terraform variable.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -349,7 +349,7 @@ stability and reliability.
 The Coder plugin will appear in the Gateway UI when opened.
 
 Selecting the most suitable template depends on how the deployment manages
-Jetbrains IDE versions. If downloading from
+JetBrains IDE versions. If downloading from
 [jetbrains.com](https://www.jetbrains.com/remote-development/gateway/) is
 acceptable, see the example templates below which specifies the product code,
 IDE version and build number in the `coder_app` resource. This will present an
@@ -389,7 +389,7 @@ https://github.com/sharkymark/v2-templates/blob/main/vs-code-server/main.tf
 
 [Colima](https://github.com/abiosoft/colima) is a Docker Desktop alternative.
 
-This example is meant for a users who want to try out Coder on a MacOS device.
+This example is meant for a users who want to try out Coder on a macOS device.
 
 Install Colima and docker with:
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,16 +1,23 @@
 # FAQs
 
-Frequently asked questions on Coder OSS and Enterprise deployments. These FAQs come from our community and enterprise customers, feel free to [contribute to this page](https://github.com/coder/coder/edit/main/docs/faqs.md).
+Frequently asked questions on Coder OSS and Enterprise deployments. These FAQs
+come from our community and enterprise customers, feel free to
+[contribute to this page](https://github.com/coder/coder/edit/main/docs/faqs.md).
 
 ## How do I add an enterprise license?
 
-Visit https://coder.com/trial or contact [sales@coder.com](mailto:sales@coder.com?subject=License) to get a v2 enterprise trial key.
+Visit https://coder.com/trial or contact
+[sales@coder.com](mailto:sales@coder.com?subject=License) to get a v2 enterprise
+trial key.
 
 You can add a license through the UI or CLI.
 
-In the UI, click the Deployment tab -> Licenses and upload the `jwt` license file.
+In the UI, click the Deployment tab -> Licenses and upload the `jwt` license
+file.
 
-> To add the license with the CLI, first [install the Coder CLI](https://coder.com/docs/v2/latest/install/install.sh) and server to the latest release.
+> To add the license with the CLI, first
+> [install the Coder CLI](https://coder.com/docs/v2/latest/install/install.sh)
+> and server to the latest release.
 
 If the license is a text string:
 
@@ -24,22 +31,33 @@ If the license is in a file:
 coder licenses add -f <path/filename>
 ```
 
-
 ## I'm experiencing networking issues, so want to disable Tailscale, STUN, Direct connections and force use of websockets
 
-The primary developer IDE use case is a local IDE connecting over SSH to a Coder workspace.
+The primary developer IDE use case is a local IDE connecting over SSH to a Coder
+workspace.
 
-Coder's networking stack has intelligence to attempt a peer-to-peer or `Direct` connection between the local IDE and the workspace, skipping routing traffic through the Coder control plane, thus reducing latency and a better developer experience.
+Coder's networking stack has intelligence to attempt a peer-to-peer or `Direct`
+connection between the local IDE and the workspace, skipping routing traffic
+through the Coder control plane, thus reducing latency and a better developer
+experience.
 
-However, this requires some additional protocols like UDP and being able to reach a STUN server to echo the IP addresses of the local IDE machine and workspace, for sharing using a Wireguard Coordination Server.
+However, this requires some additional protocols like UDP and being able to
+reach a STUN server to echo the IP addresses of the local IDE machine and
+workspace, for sharing using a Wireguard Coordination Server.
 
-By default, Coder assumes Internet and attempts to reach Google's STUN servers to perform this IP echo.
+By default, Coder assumes Internet and attempts to reach Google's STUN servers
+to perform this IP echo.
 
-Operators experimenting with Coder make run into networking issues if UDP (which STUN requires) or the STUN servers are unavailable, potentially resulting in lengthy local IDE and SSH connection times as the Coder control plane attempts to establish these direct connections.
+Operators experimenting with Coder make run into networking issues if UDP (which
+STUN requires) or the STUN servers are unavailable, potentially resulting in
+lengthy local IDE and SSH connection times as the Coder control plane attempts
+to establish these direct connections.
 
-A good troubleshooting tip is to just disable STUN, Direct connections, and even forcing websockets versus the embedded Tailscale DERP relay server.
+A good troubleshooting tip is to just disable STUN, Direct connections, and even
+forcing websockets versus the embedded Tailscale DERP relay server.
 
-If using a `systemd` configuration of Coder's control plane, add these values to `/etc/coder.d/coder.env`:
+If using a `systemd` configuration of Coder's control plane, add these values to
+`/etc/coder.d/coder.env`:
 
 ```sh
 # disable peer-to-peer, force web sockets
@@ -48,7 +66,8 @@ CODER_DERP_SERVER_STUN_ADDRESSES="disable"
 CODER_DERP_FORCE_WEBSOCKETS=true
 ```
 
-If using a Kubernetes deployment, add these values to your `values.yaml` then `helm upgrade`:
+If using a Kubernetes deployment, add these values to your `values.yaml` then
+`helm upgrade`:
 
 ```yaml
 # disable Peer-to-Peer connections (e.g., local computer with SSH, local VS Code, local JetBrains Gateway)
@@ -62,20 +81,24 @@ If using a Kubernetes deployment, add these values to your `values.yaml` then `h
   value: "true"
 ```
 
-If starting the `coder server`from the command line, set these environment variables
+If starting the `coder server`from the command line, set these environment
+variables
 
 ```sh
 coder server --block-direct-connections=true --derp-server-stun-addresses=disable --derp-force-websockets=true
 ```
 
-
 ## How do I configure NGINX as the reverse proxy in front of Coder?
 
-[This doc](https://github.com/coder/coder/tree/main/examples/web-server/nginx#configure-nginx) in our repo explains in detail how to configure NGINX with Coder so that our Tailscale Wireguard networking functions properly.
+[This doc](https://github.com/coder/coder/tree/main/examples/web-server/nginx#configure-nginx)
+in our repo explains in detail how to configure NGINX with Coder so that our
+Tailscale Wireguard networking functions properly.
 
 ## How do I hide some of the default icons in a workspace like VS Code Desktop, Terminal, SSH, Ports?
 
-The visibility of Coder apps is configurable in the template. To change the default (shows all), add this block inside the `coder_agent` of a template and configure as needed:
+The visibility of Coder apps is configurable in the template. To change the
+default (shows all), add this block inside the `coder_agent` of a template and
+configure as needed:
 
 ```hcl
   display_apps {
@@ -87,11 +110,13 @@ The visibility of Coder apps is configurable in the template. To change the defa
   }
 ```
 
-This is example will shown any other `coder_app` entries in the template, and the web terminal only.
+This is example will shown any other `coder_app` entries in the template, and
+the web terminal only.
 
 ## I want to allow code-server to be accessible by other users in my deployment.
 
-> It is **not** recommended to share a web IDE, but if required, the following deployment environment variable settings are required.
+> It is **not** recommended to share a web IDE, but if required, the following
+> deployment environment variable settings are required.
 
 1. Set deployment (Kubernetes) to allow path app sharing
 
@@ -104,9 +129,12 @@ This is example will shown any other `coder_app` entries in the template, and th
   value: "true"
 ```
 
-2. In the template, set `coder_app` `share=authenticated` and when a workspace is built with this template, the pretty globe shows up next to path-based `code-server`
+2. In the template, set `coder_app` `share=authenticated` and when a workspace
+   is built with this template, the pretty globe shows up next to path-based
+   `code-server`
 
-> KNOWN ISSUE: The first time another user authenticates to Coder with the code-server link, it gives a `404` but if you refresh, it works.
+> KNOWN ISSUE: The first time another user authenticates to Coder with the
+> code-server link, it gives a `404` but if you refresh, it works.
 
 ## I installed Coder and created a workspace but the icons do not load.
 
@@ -116,7 +144,6 @@ an agent that must be able to reach the `coder server`.
 If the `CODER_ACCESS_URL` is not accessible from a workspace, the workspace may
 build, but the agent cannot reach Coder, and thus the missing icons. e.g.,
 Terminal, IDEs, Apps.
-
 
 > By default, `coder server` automatically creates an Internet-accessible
 > reverse proxy so that workspaces you create can reach the server.
@@ -134,12 +161,18 @@ coder server --access-url http://localhost:3000 --address 0.0.0.0:3000
 
 ## I updated a template, and an existing workspace based on that template fails to start.
 
-When updating a template, be aware of potential issues with input variables. For example, if a template prompts users to choose options like a [code-server](https://github.com/coder/code-server) [VS
-Code](https://code.visualstudio.com/) IDE release, a [container
-image](https://hub.docker.com/u/codercom), or a [VS Code
-extension](https://marketplace.visualstudio.com/vscode), removing any of these values can lead to existing workspaces failing to start. This issue occurs because the Terraform state will not be in sync with the new template.
+When updating a template, be aware of potential issues with input variables. For
+example, if a template prompts users to choose options like a
+[code-server](https://github.com/coder/code-server)
+[VS Code](https://code.visualstudio.com/) IDE release, a
+[container image](https://hub.docker.com/u/codercom), or a
+[VS Code extension](https://marketplace.visualstudio.com/vscode), removing any
+of these values can lead to existing workspaces failing to start. This issue
+occurs because the Terraform state will not be in sync with the new template.
 
-However, a lesser-known CLI sub-command, `update`, can resolve this issue. This command re-prompts users to re-enter the input variables, potentially saving the workspace from a failed status.
+However, a lesser-known CLI sub-command, `update`, can resolve this issue. This
+command re-prompts users to re-enter the input variables, potentially saving the
+workspace from a failed status.
 
 ```sh
 coder update --always-prompt <workspace name>
@@ -147,7 +180,10 @@ coder update --always-prompt <workspace name>
 
 ## I'm running coder on a VM with systemd but latest release installed isn't showing up.
 
-Take, for example, a Coder deployment on a VM with a 2 shared vCPU systemd service. In this scenario, it's necessary to reload the daemon and then restart the Coder service. This prevents the `systemd` daemon from trying to reference the previous Coder release service since the unit file has changed.
+Take, for example, a Coder deployment on a VM with a 2 shared vCPU systemd
+service. In this scenario, it's necessary to reload the daemon and then restart
+the Coder service. This prevents the `systemd` daemon from trying to reference
+the previous Coder release service since the unit file has changed.
 
 The following commands can be used to update Coder and refresh the service:
 
@@ -159,8 +195,8 @@ sudo systemctl restart coder.service
 
 ## I'm using the built-in Postgres database and forgot admin email I set up.
 
-1. Run the `coder server` command below to retrieve the `psql` connection URL which
-   includes the database user and password.
+1. Run the `coder server` command below to retrieve the `psql` connection URL
+   which includes the database user and password.
 2. `psql` into Postgres, and do a select query on the `users` table.
 3. Restart the `coder server`, pull up the Coder UI and log in (hope you
    remembered your password)
@@ -172,19 +208,22 @@ psql "postgres://coder@localhost:53737/coder?sslmode=disable&password=I2S...pTk"
 
 ## How to find out Coder's latest Terraform provider version?
 
-[Coder is on the HashiCorp's Terraform
-registry](https://registry.terraform.io/providers/coder/coder/latest). Check
-this frequently to make sure you are on the latest version.
+[Coder is on the HashiCorp's Terraform registry](https://registry.terraform.io/providers/coder/coder/latest).
+Check this frequently to make sure you are on the latest version.
 
-Sometimes, the version may change and `resource` configurations
-will either become deprecated or new ones will be added when you get warnings or errors
+Sometimes, the version may change and `resource` configurations will either
+become deprecated or new ones will be added when you get warnings or errors
 creating and pushing templates.
 
 ## How can I set up TLS for my deployment and not create a signed certificate?
 
-Caddy is an easy-to-configure reverse proxy that also automatically creates certificates from Let's Encrypt. [Install docs here](https://caddyserver.com/docs/quick-starts/reverse-proxy) You can start Caddy as a `systemd` service.
+Caddy is an easy-to-configure reverse proxy that also automatically creates
+certificates from Let's Encrypt.
+[Install docs here](https://caddyserver.com/docs/quick-starts/reverse-proxy) You
+can start Caddy as a `systemd` service.
 
-The Caddyfile configuration will appear like this where `127.0.0.1:3000` is your `CODER_ACCESS_URL`:
+The Caddyfile configuration will appear like this where `127.0.0.1:3000` is your
+`CODER_ACCESS_URL`:
 
 ```sh
 coder.example.com {
@@ -202,10 +241,14 @@ coder.example.com {
 
 ## I'm using Caddy as my reverse proxy in front of Coder. How do I set up a wildcard domain for port forwarding?
 
-Caddy requires your DNS provider's credentials to create wildcard certificates. This involves building the Caddy binary [from source](https://github.com/caddyserver/caddy) with the DNS provider plugin added. e.g., [Google Cloud DNS provider here](https://github.com/caddy-dns/googleclouddns)
+Caddy requires your DNS provider's credentials to create wildcard certificates.
+This involves building the Caddy binary
+[from source](https://github.com/caddyserver/caddy) with the DNS provider plugin
+added. e.g.,
+[Google Cloud DNS provider here](https://github.com/caddy-dns/googleclouddns)
 
-
-To compile Caddy, the host running Coder requires Go. Once installed, replace the existing Caddy binary in `usr/bin` and restart the Caddy service.
+To compile Caddy, the host running Coder requires Go. Once installed, replace
+the existing Caddy binary in `usr/bin` and restart the Caddy service.
 
 The updated Caddyfile configuration will look like this:
 
@@ -228,7 +271,9 @@ The updated Caddyfile configuration will look like this:
 
 ## Can I use local or remote Terraform Modules in Coder templates?
 
-One way is to reference a Terraform module from a GitHub repo to avoid duplication and then just extend it or pass template-specific parameters/resources:
+One way is to reference a Terraform module from a GitHub repo to avoid
+duplication and then just extend it or pass template-specific
+parameters/resources:
 
 ```hcl
 # template1/main.tf
@@ -253,7 +298,8 @@ resource "aws_instance` `custom_template2_only_resource ` {
 }
 ```
 
-Another way using local modules is to symlink the module directory inside the template directory and then `tar` the template.
+Another way using local modules is to symlink the module directory inside the
+template directory and then `tar` the template.
 
 ```sh
 ln -s modules template_1/modules
@@ -261,6 +307,7 @@ tar -cvh -C ./template_1 | coder templates <push|create> -d - <name>
 ```
 
 References:
+
 - [Public Github Issue 6117](https://github.com/coder/coder/issues/6117)
 - [Public Github Issue 5677](https://github.com/coder/coder/issues/5677)
 - [Coder docs: Templates/Change Management](https://coder.com/docs/v2/latest/templates/change-management)
@@ -270,13 +317,19 @@ References:
 Yes, Coder can be deployed in air-gapped or offline mode.
 https://coder.com/docs/v2/latest/install/offline
 
-Our product bundles with the Terraform binary so assume access to terraform.io during installation. The docs outline rebuilding the Coder container with Terraform built-in as well as any required Terraform providers.
+Our product bundles with the Terraform binary so assume access to terraform.io
+during installation. The docs outline rebuilding the Coder container with
+Terraform built-in as well as any required Terraform providers.
 
-Direct networking from local SSH to a Coder workspace needs a STUN server. Coder defaults to Google's STUN servers, so you can either create your STUN server in your network or disable and force all traffic through the control plane's DERP proxy.
+Direct networking from local SSH to a Coder workspace needs a STUN server. Coder
+defaults to Google's STUN servers, so you can either create your STUN server in
+your network or disable and force all traffic through the control plane's DERP
+proxy.
 
 ## Create a randomized computer_name for an Azure VM
 
-Azure VMs have a 15 character limit for the `computer_name` which can lead to duplicate name errors.
+Azure VMs have a 15 character limit for the `computer_name` which can lead to
+duplicate name errors.
 
 This code produces a hashed value that will be difficult to replicate.
 
@@ -290,30 +343,47 @@ truncated_hash = substr(local.hashed_string, 0, 16)
 
 ## Do you have example JetBrains Gateway templates?
 
-In August 2023, JetBrains certified the Coder plugin signifying enhanced stability and reliability.
+In August 2023, JetBrains certified the Coder plugin signifying enhanced
+stability and reliability.
 
 The Coder plugin will appear in the Gateway UI when opened.
 
-Selecting the most suitable template depends on how the deployment manages Jetbrains IDE versions. If downloading from [jetbrains.com](https://www.jetbrains.com/remote-development/gateway/) is acceptable, see the example templates below which specifies the product code, IDE version and build number in the `coder_app` resource. This will present an icon in the workspace dashboard which when clicked, will look for a locally installed Gateway, and open it. Alternatively, the IDE can be baked into the container image and manually open Gateway (or IntelliJ which has Gateway built-in), using a session token to Coder and then open the IDE.
+Selecting the most suitable template depends on how the deployment manages
+Jetbrains IDE versions. If downloading from
+[jetbrains.com](https://www.jetbrains.com/remote-development/gateway/) is
+acceptable, see the example templates below which specifies the product code,
+IDE version and build number in the `coder_app` resource. This will present an
+icon in the workspace dashboard which when clicked, will look for a locally
+installed Gateway, and open it. Alternatively, the IDE can be baked into the
+container image and manually open Gateway (or IntelliJ which has Gateway
+built-in), using a session token to Coder and then open the IDE.
 
 - [IntelliJ IDEA](https://github.com/sharkymark/v2-templates/tree/main/pod-idea)
 - [IntelliJ IDEA with Icon](https://github.com/sharkymark/v2-templates/tree/main/pod-idea-icon)
 
 ## What options do I have for adding VS Code extensions into code-server, VS Code Desktop or Microsoft's Code Server?
 
-Coder has an open-source project called `code-marketplace` which is a private VS Code extension marketplace. There is even integration with JFrog Artifactory.
+Coder has an open-source project called `code-marketplace` which is a private VS
+Code extension marketplace. There is even integration with JFrog Artifactory.
 
 - [Blog post](https://coder.com/blog/running-a-private-vs-code-extension-marketplace)
 - [OSS project](https://github.com/coder/code-marketplace)
 
-[See this example template](https://github.com/sharkymark/v2-templates/blob/main/code-marketplace/main.tf#L229C1-L232C12) where the agent specifies the URL and config environment variables which code-server picks up and points the developer to.
+[See this example template](https://github.com/sharkymark/v2-templates/blob/main/code-marketplace/main.tf#L229C1-L232C12)
+where the agent specifies the URL and config environment variables which
+code-server picks up and points the developer to.
 
-Another option is to use Microsoft's code-server - which is like Coder's, but it can connect to Microsoft's extension marketplace so Copilot and chat can be retrieved there. [See a sample template here](https://github.com/sharkymark/v2-templates/blob/main/vs-code-server/main.tf).
+Another option is to use Microsoft's code-server - which is like Coder's, but it
+can connect to Microsoft's extension marketplace so Copilot and chat can be
+retrieved there.
+[See a sample template here](https://github.com/sharkymark/v2-templates/blob/main/vs-code-server/main.tf).
 
-Another option is to use VS Code Desktop (local) and that connects to Microsoft's marketplace.
+Another option is to use VS Code Desktop (local) and that connects to
+Microsoft's marketplace.
 https://github.com/sharkymark/v2-templates/blob/main/vs-code-server/main.tf
 
-> Note: these are example templates with no SLAs on them and are not guaranteed long-term support.
+> Note: these are example templates with no SLAs on them and are not guaranteed
+> long-term support.
 
 ## I want to run Docker for my workspaces but not install Docker Desktop.
 
@@ -346,4 +416,6 @@ Starting Colima on a M3 Macbook Pro:
 colima start --arch x86_64  --cpu 4 --memory 8 --disk 10
 ```
 
-Colima will show the path to the docker socket so I have a [Coder template](./docker-code-server/main.tf) that prompts the Coder admin to enter the docker socket as a Terraform variable.
+Colima will show the path to the docker socket so I have a
+[Coder template](./docker-code-server/main.tf) that prompts the Coder admin to
+enter the docker socket as a Terraform variable.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -207,14 +207,15 @@ The Caddyfile configuration will appear like this where `127.0.0.1:3000` is your
 ```sh
 coder.example.com {
 
-	reverse_proxy 127.0.0.1:3000
+  reverse_proxy 127.0.0.1:3000
 
 	tls {
-		issuer acme {
-			email mark@example.com
-		}
-	}
 
+		issuer acme {
+			email user@example.com
+		}
+
+	}
 }
 ```
 
@@ -238,7 +239,7 @@ The updated Caddyfile configuration will look like this:
 
 	tls {
 		issuer acme {
-			email mark@example.com
+			email user@example.com
 			dns googleclouddns {
 				gcp_project my-gcp-project
 			}

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -67,8 +67,9 @@ Tailscale Wireguard networking functions properly.
 ## How do I hide some of the default icons in a workspace like VS Code Desktop, Terminal, SSH, Ports?
 
 The visibility of Coder apps is configurable in the template. To change the
-default (shows all), add this block inside the `coder_agent` of a template and
-configure as needed:
+default (shows all), add this block inside the
+[`coder_agent`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+of a template and configure as needed:
 
 ```hcl
   display_apps {
@@ -117,9 +118,10 @@ resource "coder_app" "code-server" {
 An important concept to understand is that Coder creates workspaces which have
 an agent that must be able to reach the `coder server`.
 
-If the `CODER_ACCESS_URL` is not accessible from a workspace, the workspace may
-build, but the agent cannot reach Coder, and thus the missing icons. e.g.,
-Terminal, IDEs, Apps.
+If the
+[`CODER_ACCESS_URL`](https://coder.com/docs/v2/latest/admin/configure#access-url)
+is not accessible from a workspace, the workspace may build, but the agent
+cannot reach Coder, and thus the missing icons. e.g., Terminal, IDEs, Apps.
 
 > By default, `coder server` automatically creates an Internet-accessible
 > reverse proxy so that workspaces you create can reach the server.
@@ -329,11 +331,13 @@ Selecting the most suitable template depends on how the deployment manages
 JetBrains IDE versions. If downloading from
 [jetbrains.com](https://www.jetbrains.com/remote-development/gateway/) is
 acceptable, see the example templates below which specifies the product code,
-IDE version and build number in the `coder_app` resource. This will present an
-icon in the workspace dashboard which when clicked, will look for a locally
-installed Gateway, and open it. Alternatively, the IDE can be baked into the
-container image and manually open Gateway (or IntelliJ which has Gateway
-built-in), using a session token to Coder and then open the IDE.
+IDE version and build number in the
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app#share)
+resource. This will present an icon in the workspace dashboard which when
+clicked, will look for a locally installed Gateway, and open it. Alternatively,
+the IDE can be baked into the container image and manually open Gateway (or
+IntelliJ which has Gateway built-in), using a session token to Coder and then
+open the IDE.
 
 - [IntelliJ IDEA](https://github.com/sharkymark/v2-templates/tree/main/pod-idea)
 - [IntelliJ IDEA with Icon](https://github.com/sharkymark/v2-templates/tree/main/pod-idea-icon)

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -204,7 +204,7 @@ can start Caddy as a `systemd` service.
 The Caddyfile configuration will appear like this where `127.0.0.1:3000` is your
 `CODER_ACCESS_URL`:
 
-```sh
+```text
 coder.example.com {
 
   reverse_proxy 127.0.0.1:3000
@@ -232,7 +232,7 @@ the existing Caddy binary in `usr/bin` and restart the Caddy service.
 
 The updated Caddyfile configuration will look like this:
 
-```sh
+```text
 *.coder.example.com, coder.example.com {
 
 	reverse_proxy 127.0.0.1:3000
@@ -262,7 +262,7 @@ module "central-coder-module" {
   myparam = "custom-for-template1"
 }
 
-resource "ebs_volume` `custom_template1_only_resource ` {
+resource "ebs_volume" "custom_template1_only_resource" {
 }
 ```
 
@@ -274,7 +274,7 @@ module "central-coder-module" {
   myparam2 = "bar"
 }
 
-resource "aws_instance` `custom_template2_only_resource ` {
+resource "aws_instance" "custom_template2_only_resource" {
 }
 ```
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -995,6 +995,12 @@
           "path": "./security/0001_user_apikeys_invalidation.md"
         }
       ]
+    },
+    {
+      "title": "FAQs",
+      "description": "Frequently asked questions",
+      "path": "./faqs.md",
+      "icon_path": "./images/icons/home.svg"
     }
   ]
 }

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1000,7 +1000,7 @@
       "title": "FAQs",
       "description": "Frequently asked questions",
       "path": "./faqs.md",
-      "icon_path": "./images/icons/home.svg"
+      "icon_path": "./images/icons/info.svg"
     }
   ]
 }


### PR DESCRIPTION
## Overview
We need a top-level page in our docs to add common FAQs from customers and community members. These previously existed in @sharkymark's [v2-templates repository](https://github.com/sharkymark/v2-templates/blob/main/faq.md). This PR migrates them to our official docs under a new "FAQs" tab.

I cleaned up some of the informal text to match the tone of our docs. 

The formatting and content changes are minimal, open to feedback. 