### PR TITLE
chore: add sqlc push action on releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -501,5 +501,7 @@ jobs:
         uses: ./.github/actions/setup-sqlc
 
       - name: Push schema to sqlc cloud
+        # Don't block a release on this
+        continue-on-error: true
         run: |
           make sqlc-push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -484,7 +484,7 @@ jobs:
   # At present these pushes cannot be tagged, so the last push is always the latest.
   publish-sqlc:
     name: "Publish to schema sqlc cloud"
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     needs: release
     if: ${{ !inputs.dry_run }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -479,3 +479,27 @@ jobs:
           # For gh CLI. We need a real token since we're commenting on a PR in a
           # different repo.
           GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
+
+  # publish-sqlc pushes the latest schema to sqlc cloud.
+  # At present these pushes cannot be tagged, so the last push is always the latest.
+  publish-sqlc:
+    name: "Publish to schema sqlc cloud"
+    runs-on: 'ubuntu-latest'
+    needs: release
+    if: ${{ !inputs.dry_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # We need golang to run the migration main.go
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup sqlc
+        uses: ./.github/actions/setup-sqlc
+
+      - name: Push schema to sqlc cloud
+        run: |
+          make sqlc-push

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -2,6 +2,9 @@
 # It was chosen to ensure type-safety when interacting with
 # the database.
 version: "2"
+cloud:
+  # This is the static ID for the coder project.
+  project: '01HEP08N3WKWRFZT3ZZ9Q37J8X'
 # Ideally renames & overrides would go under the sql section, but there is a
 # bug in sqlc that only global renames & overrides are currently being applied.
 overrides:

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -4,7 +4,7 @@
 version: "2"
 cloud:
   # This is the static ID for the coder project.
-  project: '01HEP08N3WKWRFZT3ZZ9Q37J8X'
+  project: "01HEP08N3WKWRFZT3ZZ9Q37J8X"
 # Ideally renames & overrides would go under the sql section, but there is a
 # bug in sqlc that only global renames & overrides are currently being applied.
 overrides:


### PR DESCRIPTION
Begin pushing our schemas to sqlc cloud on all releases.

This will allow us to run `sqlc verify` when creating a new release or on regular commits.

**Warns**
- Indicate queries that are do seq scans (this will warn not fail)
- Nullable columns
- Tables without primary keys

It can also detect if previous queries are not forward compatible, meaning a blue/green deployment will fail.

**I am not going to run sqlc verify at this time in CI.**
