### PR TITLE
chore: add additional fields to license telemetry

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -788,6 +788,17 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					Prometheus:         vals.Prometheus.Enable.Value(),
 					STUN:               len(vals.DERP.Server.STUNAddresses) != 0,
 					Tunnel:             tunnel != nil,
+					ParseLicenseJWT: func(lic *telemetry.License) error {
+						email, trial, err := options.ParseLicenseClaims(lic.JWT)
+						if err != nil {
+							return err
+						}
+						if email != "" {
+							lic.Email = &email
+						}
+						lic.Trial = &trial
+						return nil
+					},
 				})
 				if err != nil {
 					return xerrors.Errorf("create telemetry reporter: %w", err)

--- a/cli/server.go
+++ b/cli/server.go
@@ -789,6 +789,11 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					STUN:               len(vals.DERP.Server.STUNAddresses) != 0,
 					Tunnel:             tunnel != nil,
 					ParseLicenseJWT: func(lic *telemetry.License) error {
+						// This will be nil when running in AGPL-only mode.
+						if options.ParseLicenseClaims == nil {
+							return nil
+						}
+
 						email, trial, err := options.ParseLicenseClaims(lic.JWT)
 						if err != nil {
 							return err

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -172,6 +172,8 @@ type Options struct {
 	StatsBatcher       *batchstats.Batcher
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
+
+	ParseLicenseClaims func(rawJWT string) (email string, trial bool, err error)
 }
 
 // @title Coder API

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -173,6 +173,9 @@ type Options struct {
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
 
+	// This janky function is used in telemetry to parse fields out of the raw
+	// JWT. It needs to be passed through like this because license parsing is
+	// under the enterprise license, and can't be imported into AGPL.
 	ParseLicenseClaims func(rawJWT string) (email string, trial bool, err error)
 }
 

--- a/coderd/httpmw/workspaceagentparam_test.go
+++ b/coderd/httpmw/workspaceagentparam_test.go
@@ -6,12 +6,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"cdr.dev/slog"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -109,6 +109,13 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		}
 	}()
 
+	api.AGPL.Options.ParseLicenseClaims = func(rawJWT string) (email string, trial bool, err error) {
+		c, err := license.ParseClaims(rawJWT, Keys)
+		if err != nil {
+			return "", false, err
+		}
+		return c.Subject, c.Trial, nil
+	}
 	api.AGPL.Options.SetUserGroups = api.setUserGroups
 	api.AGPL.Options.SetUserSiteRoles = api.setUserSiteRoles
 	api.AGPL.SiteHandler.AppearanceFetcher = api.fetchAppearanceConfig

--- a/enterprise/trialer/trialer.go
+++ b/enterprise/trialer/trialer.go
@@ -9,9 +9,8 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/xerrors"
-
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"


### PR DESCRIPTION
This sends the email the license was issued to, and whether or not it's a trial in the telemetry payload. It's a bit janky since the license parsing is all enterprise licensed.