### PR TITLE
ci: do not rebuild but use artifacts from the `build` job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -835,21 +835,16 @@ jobs:
           TOKEN_SAO_PAULO: ${{ secrets.FLY_SAO_PAULO_CODER_PROXY_SESSION_TOKEN }}
 
   deploy-legacy-proxies:
-    name: "deploy-legacy-proxies"
-    runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-16vcpu-ubuntu-2204' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: changes
-    if: |
-      github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
-      && needs.changes.outputs.docs-only == 'false'
+    needs: build
+    if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -860,30 +855,11 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
-      - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.16.0
-
-      - name: Install zstd
-        run: sudo apt-get install -y zstd
-
-      - name: Build Release
-        run: |
-          set -euo pipefail
-          go mod download
-
-          version="$(./scripts/version.sh)"
-          make gen/mark-fresh
-          make -j \
-            build/coder_"$version"_windows_amd64.zip \
-            build/coder_"$version"_linux_amd64.{tar.gz,deb}
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: coder
+          path: ./build
 
       - name: Install Release
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -657,7 +657,8 @@ jobs:
     # to main branch. We are only building this for amd64 platform. (>95% pulls
     # are for amd64)
     needs: changes
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
+    # uncomment after testing
+    # if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -838,7 +839,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build
-    if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+    # uncomment after testing
+    # if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
     permissions:
       contents: read
       id-token: write
@@ -884,7 +886,8 @@ jobs:
             set -x
             gcloud config set compute/zone "$1"
             gcloud compute scp "$deb_pkg" "${2}:/tmp/coder.deb"
-            gcloud compute ssh "$2" -- /bin/sh -c "set -eux; sudo dpkg -i --force-confdef /tmp/coder.deb; sudo systemctl daemon-reload; sudo service '$3' restart"
+            # uncomment after testing
+            # gcloud compute ssh "$2" -- /bin/sh -c "set -eux; sudo dpkg -i --force-confdef /tmp/coder.deb; sudo systemctl daemon-reload; sudo service '$3' restart"
             set +x
 
             echo "::endgroup::"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -856,7 +856,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/download-artifact@v3
         with:
           name: coder
           path: ./build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -657,8 +657,7 @@ jobs:
     # to main branch. We are only building this for amd64 platform. (>95% pulls
     # are for amd64)
     needs: changes
-    # uncomment after testing
-    # if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs-only == 'false'
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -839,8 +838,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build
-    # uncomment after testing
-    # if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
+    if: github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork
     permissions:
       contents: read
       id-token: write
@@ -886,8 +884,7 @@ jobs:
             set -x
             gcloud config set compute/zone "$1"
             gcloud compute scp "$deb_pkg" "${2}:/tmp/coder.deb"
-            # uncomment after testing
-            # gcloud compute ssh "$2" -- /bin/sh -c "set -eux; sudo dpkg -i --force-confdef /tmp/coder.deb; sudo systemctl daemon-reload; sudo service '$3' restart"
+            gcloud compute ssh "$2" -- /bin/sh -c "set -eux; sudo dpkg -i --force-confdef /tmp/coder.deb; sudo systemctl daemon-reload; sudo service '$3' restart"
             set +x
 
             echo "::endgroup::"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -843,9 +843,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -871,7 +871,7 @@ jobs:
             "southamerica-east1-b coder-brazil coder-workspace-proxy"
           )
 
-          deb_pkg="./build/coder_$(./scripts/version.sh)_linux_amd64.deb"
+          deb_pkg="./build/coder_*_linux_amd64.deb"
           if [ ! -f "$deb_pkg" ]; then
             echo "deb package not found: $deb_pkg"
             ls -l ./build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -855,7 +855,7 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Upload build artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
           name: coder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -871,11 +871,11 @@ jobs:
             "southamerica-east1-b coder-brazil coder-workspace-proxy"
           )
 
-          deb_pkg="./build/coder_*_linux_amd64.deb"
-          if [ ! -f "$deb_pkg" ]; then
-            echo "deb package not found: $deb_pkg"
-            ls -l ./build
-            exit 1
+          deb_pkg=$(find ./build -name "coder_*_linux_amd64.deb" -print -quit)
+          if [ -z "$deb_pkg" ]; then
+              echo "deb package $deb_pkg not found"
+              ls -l ./build
+              exit 1
           fi
 
           gcloud config set project coder-dogfood


### PR DESCRIPTION
This will make this job faster. Also, we do not need to use the buildjet runner as we are not building anything.