### PR TITLE
feat!: move workspace renames behind flag, disable by default

### DIFF
--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -15,7 +15,7 @@ import (
 func TestRename(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, AllowWorkspaceRenames: true})
 	owner := coderdtest.CreateFirstUser(t, client)
 	member, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 	version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)

--- a/cli/server.go
+++ b/cli/server.go
@@ -585,8 +585,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				},
 				// we are experimenting with self destructing flags that stop working after a certain date.
 				// This flag should be removed after the date specified below.
-				AllowWorkspaceRenames:          shouldAllowWorkspaceRenames(vals.AllowWorkspaceRenames.Value()),
-				AllowWorkspaceRenamesExpiresAt: workspaceRenamesExpiresAt(),
+				AllowWorkspaceRenames: allowWorkspaceRenames(vals.AllowWorkspaceRenames.Value()),
 			}
 			if httpServers.TLSConfig != nil {
 				options.TLSCertificates = httpServers.TLSConfig.Certificates
@@ -2553,19 +2552,6 @@ func parseExternalAuthProvidersFromEnv(prefix string, environ []string) ([]coder
 	return providers, nil
 }
 
-const (
-	workspaceRenamesExpiresAtTime = "2024-04-01T00:00:00Z"
-)
-
-func workspaceRenamesExpiresAt() time.Time {
-	t, err := time.Parse(time.RFC3339, workspaceRenamesExpiresAtTime)
-	if err != nil {
-		panic(err)
-	}
-
-	return t
-}
-
-func shouldAllowWorkspaceRenames(value bool) bool {
-	return value && time.Now().Before(workspaceRenamesExpiresAt())
+func allowWorkspaceRenames(flagValue bool) bool {
+	return flagValue && time.Now().Before(codersdk.WorkspaceRenameDeadline)
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -583,9 +583,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					HostnamePrefix:   vals.SSHConfig.DeploymentName.String(),
 					SSHConfigOptions: configSSHOptions,
 				},
-				// we are experimenting with self destructing flags that stop working after a certain date.
-				// This flag should be removed after the date specified below.
-				AllowWorkspaceRenames: allowWorkspaceRenames(vals.AllowWorkspaceRenames.Value()),
+				AllowWorkspaceRenames: vals.AllowWorkspaceRenames.Value(),
 			}
 			if httpServers.TLSConfig != nil {
 				options.TLSCertificates = httpServers.TLSConfig.Certificates
@@ -2550,8 +2548,4 @@ func parseExternalAuthProvidersFromEnv(prefix string, environ []string) ([]coder
 		providers[providerNum] = provider
 	}
 	return providers, nil
-}
-
-func allowWorkspaceRenames(flagValue bool) bool {
-	return flagValue && time.Now().Before(codersdk.WorkspaceRenameDeadline)
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -583,6 +583,10 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					HostnamePrefix:   vals.SSHConfig.DeploymentName.String(),
 					SSHConfigOptions: configSSHOptions,
 				},
+				AllowWorkspaceRenames: vals.AllowWorkspaceRenames.Value(),
+				// we are experimenting with self destructing flags that stop working after a certain date.
+				// This flag should be removed after the date specified below.
+				AllowWorkspaceRenamesExpiresAt: mustParseTime(time.RFC3339, "2024-04-01T00:00:00Z00:00"),
 			}
 			if httpServers.TLSConfig != nil {
 				options.TLSCertificates = httpServers.TLSConfig.Certificates
@@ -2547,4 +2551,13 @@ func parseExternalAuthProvidersFromEnv(prefix string, environ []string) ([]coder
 		providers[providerNum] = provider
 	}
 	return providers, nil
+}
+
+func mustParseTime(layout string, timeString string) time.Time {
+	t, err := time.Parse(layout, timeString)
+	if err != nil {
+		panic(err)
+	}
+
+	return t
 }

--- a/cli/testdata/coder_list_--output_json.golden
+++ b/cli/testdata/coder_list_--output_json.golden
@@ -59,6 +59,7 @@
       "healthy": true,
       "failing_agents": []
     },
-    "automatic_updates": "never"
+    "automatic_updates": "never",
+    "allow_renames": false
   }
 ]

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -14,6 +14,11 @@ SUBCOMMANDS:
                               PostgreSQL deployment.
 
 OPTIONS:
+      --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
+          DEPRECATED: Allow users to rename their workspaces. Use only for
+          temporary compatibility reasons, this flag will no longer function
+          after 2024-04-01.
+
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and
           $CACHE_DIRECTORY is set, it will be used for compatibility with

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -16,8 +16,7 @@ SUBCOMMANDS:
 OPTIONS:
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
           DEPRECATED: Allow users to rename their workspaces. Use only for
-          temporary compatibility reasons, this flag will no longer function
-          after 2024-04-01.
+          temporary compatibility reasons.
 
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -16,7 +16,8 @@ SUBCOMMANDS:
 OPTIONS:
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
           DEPRECATED: Allow users to rename their workspaces. Use only for
-          temporary compatibility reasons.
+          temporary compatibility reasons, this will be removed in a future
+          release.
 
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -450,6 +450,7 @@ wgtunnelHost: ""
 userQuietHoursSchedule:
   # The default daily cron schedule applied to users that haven't set a custom quiet
   # hours schedule themselves. The quiet hours schedule determines when workspaces
+<<<<<<< HEAD
   # will be force stopped due to the template's autostop requirement, and will round
   # the max deadline up to be within the user's quiet hours window (or default). The
   # format is the same as the standard cron format, but the day-of-month, month and
@@ -462,3 +463,16 @@ userQuietHoursSchedule:
   # change their quiet hours schedule and the site default is always used.
   # (default: true, type: bool)
   allowCustomQuietHours: true
+=======
+  # will be force stopped due to the template's max TTL, and will round the max TTL
+  # up to be within the user's quiet hours window (or default). The format is the
+  # same as the standard cron format, but the day-of-month, month and day-of-week
+  # must be *. Only one hour and minute can be specified (ranges or comma separated
+  # values are not supported).
+  # (default: <unset>, type: string)
+  defaultQuietHoursSchedule: ""
+# DEPRECATED: Allow users to rename their workspaces. Use only for temporary
+# compatibility reasons, this flag will no longer function after 2024-04-01.
+# (default: false, type: bool)
+allowWorkspaceRenames: false
+>>>>>>> 899e802d6 (update golden)

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -463,6 +463,6 @@ userQuietHoursSchedule:
   # (default: true, type: bool)
   allowCustomQuietHours: true
 # DEPRECATED: Allow users to rename their workspaces. Use only for temporary
-# compatibility reasons.
+# compatibility reasons, this will be removed in a future release.
 # (default: false, type: bool)
 allowWorkspaceRenames: false

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -450,7 +450,6 @@ wgtunnelHost: ""
 userQuietHoursSchedule:
   # The default daily cron schedule applied to users that haven't set a custom quiet
   # hours schedule themselves. The quiet hours schedule determines when workspaces
-<<<<<<< HEAD
   # will be force stopped due to the template's autostop requirement, and will round
   # the max deadline up to be within the user's quiet hours window (or default). The
   # format is the same as the standard cron format, but the day-of-month, month and
@@ -463,16 +462,7 @@ userQuietHoursSchedule:
   # change their quiet hours schedule and the site default is always used.
   # (default: true, type: bool)
   allowCustomQuietHours: true
-=======
-  # will be force stopped due to the template's max TTL, and will round the max TTL
-  # up to be within the user's quiet hours window (or default). The format is the
-  # same as the standard cron format, but the day-of-month, month and day-of-week
-  # must be *. Only one hour and minute can be specified (ranges or comma separated
-  # values are not supported).
-  # (default: <unset>, type: string)
-  defaultQuietHoursSchedule: ""
 # DEPRECATED: Allow users to rename their workspaces. Use only for temporary
-# compatibility reasons, this flag will no longer function after 2024-04-01.
+# compatibility reasons.
 # (default: false, type: bool)
 allowWorkspaceRenames: false
->>>>>>> 899e802d6 (update golden)

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8558,6 +8558,9 @@ const docTemplate = `{
                 "agent_stat_refresh_interval": {
                     "type": "integer"
                 },
+                "allow_workspace_renames": {
+                    "type": "boolean"
+                },
                 "autobuild_poll_interval": {
                     "type": "integer"
                 },
@@ -11443,6 +11446,9 @@ const docTemplate = `{
         "codersdk.Workspace": {
             "type": "object",
             "properties": {
+                "allow_renames": {
+                    "type": "boolean"
+                },
                 "automatic_updates": {
                     "enum": [
                         "always",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7642,6 +7642,9 @@
         "agent_stat_refresh_interval": {
           "type": "integer"
         },
+        "allow_workspace_renames": {
+          "type": "boolean"
+        },
         "autobuild_poll_interval": {
           "type": "integer"
         },
@@ -10372,6 +10375,9 @@
     "codersdk.Workspace": {
       "type": "object",
       "properties": {
+        "allow_renames": {
+          "type": "boolean"
+        },
         "automatic_updates": {
           "enum": ["always", "never"],
           "allOf": [

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -179,7 +179,8 @@ type Options struct {
 	// This janky function is used in telemetry to parse fields out of the raw
 	// JWT. It needs to be passed through like this because license parsing is
 	// under the enterprise license, and can't be imported into AGPL.
-	ParseLicenseClaims func(rawJWT string) (email string, trial bool, err error)
+	ParseLicenseClaims    func(rawJWT string) (email string, trial bool, err error)
+	AllowWorkspaceRenames bool
 }
 
 // @title Coder API

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -145,7 +145,6 @@ type Options struct {
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
 	AllowWorkspaceRenames              bool
-	AllowWorkspaceRenamesExpiresAt     time.Time
 }
 
 // New constructs a codersdk client connected to an in-memory API instance.
@@ -399,10 +398,6 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	derpMap, err := tailnet.NewDERPMap(ctx, region, stunAddresses, "", "", options.DeploymentValues.DERP.Config.BlockDirect.Value())
 	require.NoError(t, err)
 
-	if options.AllowWorkspaceRenamesExpiresAt.IsZero() {
-		options.AllowWorkspaceRenamesExpiresAt = time.Now().Add(time.Hour)
-	}
-
 	return func(h http.Handler) {
 			mutex.Lock()
 			defer mutex.Unlock()
@@ -456,7 +451,6 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			StatsBatcher:                       options.StatsBatcher,
 			WorkspaceAppsStatsCollectorOptions: options.WorkspaceAppsStatsCollectorOptions,
 			AllowWorkspaceRenames:              options.AllowWorkspaceRenames,
-			AllowWorkspaceRenamesExpiresAt:     options.AllowWorkspaceRenamesExpiresAt,
 		}
 }
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -144,6 +144,8 @@ type Options struct {
 	StatsBatcher *batchstats.Batcher
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
+	AllowWorkspaceRenames              bool
+	AllowWorkspaceRenamesExpiresAt     time.Time
 }
 
 // New constructs a codersdk client connected to an in-memory API instance.
@@ -397,6 +399,10 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	derpMap, err := tailnet.NewDERPMap(ctx, region, stunAddresses, "", "", options.DeploymentValues.DERP.Config.BlockDirect.Value())
 	require.NoError(t, err)
 
+	if options.AllowWorkspaceRenamesExpiresAt.IsZero() {
+		options.AllowWorkspaceRenamesExpiresAt = time.Now().Add(time.Hour)
+	}
+
 	return func(h http.Handler) {
 			mutex.Lock()
 			defer mutex.Unlock()
@@ -449,6 +455,8 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			HealthcheckRefresh:                 options.HealthcheckRefresh,
 			StatsBatcher:                       options.StatsBatcher,
 			WorkspaceAppsStatsCollectorOptions: options.WorkspaceAppsStatsCollectorOptions,
+			AllowWorkspaceRenames:              options.AllowWorkspaceRenames,
+			AllowWorkspaceRenamesExpiresAt:     options.AllowWorkspaceRenamesExpiresAt,
 		}
 }
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -632,13 +632,13 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 	name := workspace.Name
 	if req.Name != "" || req.Name != workspace.Name {
 		if !api.Options.AllowWorkspaceRenames {
-			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Workspace renames are not allowed.",
 			})
 			return
 		}
 		if api.Options.AllowWorkspaceRenamesExpiresAt.Before(time.Now()) {
-			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Workspace renames are no longer allowed. Flag expired at " + api.Options.AllowWorkspaceRenamesExpiresAt.String(),
 			})
 			return

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -637,12 +637,6 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		if api.Options.AllowWorkspaceRenamesExpiresAt.Before(time.Now()) {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Workspace renames are no longer allowed. Flag expired at " + api.Options.AllowWorkspaceRenamesExpiresAt.String(),
-			})
-			return
-		}
 		name = req.Name
 	}
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -106,6 +106,7 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 		data.builds[0],
 		data.templates[0],
 		ownerName,
+		api.DeploymentValues.AllowWorkspaceRenames.Value(),
 	))
 }
 
@@ -277,6 +278,7 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 		data.builds[0],
 		data.templates[0],
 		ownerName,
+		api.DeploymentValues.AllowWorkspaceRenames.Value(),
 	))
 }
 
@@ -585,6 +587,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		apiBuild,
 		template,
 		member.Username,
+		api.DeploymentValues.AllowWorkspaceRenames.Value(),
 	))
 }
 
@@ -628,6 +631,12 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 	// patched in the future, it's enough if one changes.
 	name := workspace.Name
 	if req.Name != "" || req.Name != workspace.Name {
+		if !api.DeploymentValues.AllowWorkspaceRenames.Value() {
+			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+				Message: "Workspace renames are not allowed.",
+			})
+			return
+		}
 		name = req.Name
 	}
 
@@ -917,6 +926,7 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 		data.builds[0],
 		data.templates[0],
 		ownerName,
+		api.DeploymentValues.AllowWorkspaceRenames.Value(),
 	))
 }
 
@@ -1242,6 +1252,7 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 				data.builds[0],
 				data.templates[0],
 				ownerName,
+				api.DeploymentValues.AllowWorkspaceRenames.Value(),
 			),
 		})
 	}
@@ -1293,9 +1304,10 @@ func (api *API) watchWorkspace(rw http.ResponseWriter, r *http.Request) {
 }
 
 type workspaceData struct {
-	templates []database.Template
-	builds    []codersdk.WorkspaceBuild
-	users     []database.User
+	templates    []database.Template
+	builds       []codersdk.WorkspaceBuild
+	users        []database.User
+	allowRenames bool
 }
 
 // workspacesData only returns the data the caller can access. If the caller
@@ -1347,9 +1359,10 @@ func (api *API) workspaceData(ctx context.Context, workspaces []database.Workspa
 	}
 
 	return workspaceData{
-		templates: templates,
-		builds:    apiBuilds,
-		users:     data.users,
+		templates:    templates,
+		builds:       apiBuilds,
+		users:        data.users,
+		allowRenames: api.DeploymentValues.AllowWorkspaceRenames.Value(),
 	}, nil
 }
 
@@ -1392,6 +1405,7 @@ func convertWorkspaces(workspaces []database.Workspace, data workspaceData) ([]c
 			build,
 			template,
 			owner.Username,
+			data.allowRenames,
 		))
 	}
 	return apiWorkspaces, nil
@@ -1402,6 +1416,7 @@ func convertWorkspace(
 	workspaceBuild codersdk.WorkspaceBuild,
 	template database.Template,
 	ownerName string,
+	allowRenames bool,
 ) codersdk.Workspace {
 	var autostartSchedule *string
 	if workspace.AutostartSchedule.Valid {
@@ -1456,6 +1471,7 @@ func convertWorkspace(
 			FailingAgents: failingAgents,
 		},
 		AutomaticUpdates: codersdk.AutomaticUpdates(workspace.AutomaticUpdates),
+		AllowRenames:     allowRenames,
 	}
 }
 

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2202,7 +2202,10 @@ func TestUpdateWorkspaceAutomaticUpdates_NotFound(t *testing.T) {
 
 func TestWorkspaceWatcher(t *testing.T) {
 	t.Parallel()
-	client, closeFunc := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	client, closeFunc := coderdtest.NewWithProvisionerCloser(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: true,
+		AllowWorkspaceRenames:    true,
+	})
 	defer closeFunc.Close()
 	user := coderdtest.CreateFirstUser(t, client)
 	authToken := uuid.NewString()

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -160,30 +160,6 @@ func TestWorkspace(t *testing.T) {
 		require.ErrorContains(t, err, "Workspace renames are not allowed")
 	})
 
-	t.Run("RenameExpired", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{
-			IncludeProvisionerDaemon:       true,
-			AllowWorkspaceRenames:          true,
-			AllowWorkspaceRenamesExpiresAt: time.Now().Add(-1 * time.Hour),
-		})
-		user := coderdtest.CreateFirstUser(t, client)
-		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
-		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		ws1 := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
-		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws1.LatestBuild.ID)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
-		defer cancel()
-
-		want := "new-name"
-		err := client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
-			Name: want,
-		})
-		require.ErrorContains(t, err, "Workspace renames are no longer allowed")
-	})
-
 	t.Run("TemplateProperties", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -100,7 +100,10 @@ func TestWorkspace(t *testing.T) {
 
 	t.Run("Rename", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		client := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			AllowWorkspaceRenames:    true,
+		})
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
@@ -132,6 +135,53 @@ func TestWorkspace(t *testing.T) {
 			Name: ws2.Name,
 		})
 		require.Error(t, err, "workspace rename should have failed")
+	})
+
+	t.Run("RenameDisabled", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+			AllowWorkspaceRenames:    false,
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		ws1 := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws1.LatestBuild.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+		defer cancel()
+
+		want := "new-name"
+		err := client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
+			Name: want,
+		})
+		require.ErrorContains(t, err, "Workspace renames are not allowed")
+	})
+
+	t.Run("RenameExpired", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon:       true,
+			AllowWorkspaceRenames:          true,
+			AllowWorkspaceRenamesExpiresAt: time.Now().Add(-1 * time.Hour),
+		})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		ws1 := coderdtest.CreateWorkspace(t, client, user.OrganizationID, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, ws1.LatestBuild.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+		defer cancel()
+
+		want := "new-name"
+		err := client.UpdateWorkspace(ctx, ws1.ID, codersdk.UpdateWorkspaceRequest{
+			Name: want,
+		})
+		require.ErrorContains(t, err, "Workspace renames are no longer allowed")
 	})
 
 	t.Run("TemplateProperties", func(t *testing.T) {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1845,12 +1845,11 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Allow Workspace Renames",
-			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01T00:00:00Z00:00.",
+			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01.",
 			Flag:        "allow-workspace-renames",
 			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
 			Default:     "false",
 			Value:       &c.AllowWorkspaceRenames,
-			Group:       &deploymentGroupConfig,
 			YAML:        "allowWorkspaceRenames",
 		},
 		// Healthcheck Options

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1846,7 +1845,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Allow Workspace Renames",
-			Description: fmt.Sprintf("DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after %s.", WorkspaceRenameDeadline.Format("2006-01-02")),
+			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons.",
 			Flag:        "allow-workspace-renames",
 			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
 			Default:     "false",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1845,7 +1845,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Allow Workspace Renames",
-			Description: "Allow users to rename their workspaces. This is not recommended for production deployments as it can cause issues with the workspace's internal state. Use only for compatibility reasons.",
+			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01T00:00:00Z00:00.",
 			Flag:        "allow-workspace-renames",
 			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
 			Default:     "false",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1845,7 +1845,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Allow Workspace Renames",
-			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons.",
+			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this will be removed in a future release.",
 			Flag:        "allow-workspace-renames",
 			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
 			Default:     "false",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -181,6 +181,7 @@ type DeploymentValues struct {
 	EnableTerraformDebugMode        clibase.Bool                         `json:"enable_terraform_debug_mode,omitempty" typescript:",notnull"`
 	UserQuietHoursSchedule          UserQuietHoursScheduleConfig         `json:"user_quiet_hours_schedule,omitempty" typescript:",notnull"`
 	WebTerminalRenderer             clibase.String                       `json:"web_terminal_renderer,omitempty" typescript:",notnull"`
+	AllowWorkspaceRenames           clibase.Bool                         `json:"allow_workspace_renames,omitempty" typescript:",notnull"`
 	Healthcheck                     HealthcheckConfig                    `json:"healthcheck,omitempty" typescript:",notnull"`
 
 	Config      clibase.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
@@ -1841,6 +1842,16 @@ Write out the current server config as YAML to stdout.`,
 			Value:       &c.WebTerminalRenderer,
 			Group:       &deploymentGroupClient,
 			YAML:        "webTerminalRenderer",
+		},
+		{
+			Name:        "Allow Workspace Renames",
+			Description: "Allow users to rename their workspaces. This is not recommended for production deployments as it can cause issues with the workspace's internal state. Use only for compatibility reasons.",
+			Flag:        "allow-workspace-renames",
+			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
+			Default:     "false",
+			Value:       &c.AllowWorkspaceRenames,
+			Group:       &deploymentGroupConfig,
+			YAML:        "allowWorkspaceRenames",
 		},
 		// Healthcheck Options
 		{

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1845,7 +1846,7 @@ Write out the current server config as YAML to stdout.`,
 		},
 		{
 			Name:        "Allow Workspace Renames",
-			Description: "DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01.",
+			Description: fmt.Sprintf("DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after %s.", WorkspaceRenameDeadline.Format("2006-01-02")),
 			Flag:        "allow-workspace-renames",
 			Env:         "CODER_ALLOW_WORKSPACE_RENAMES",
 			Default:     "false",

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -57,6 +57,7 @@ type Workspace struct {
 	// what is causing an unhealthy status.
 	Health           WorkspaceHealth  `json:"health"`
 	AutomaticUpdates AutomaticUpdates `json:"automatic_updates" enums:"always,never"`
+	AllowRenames     bool             `json:"allow_renames"`
 }
 
 func (w Workspace) FullName() string {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -21,6 +21,8 @@ const (
 	AutomaticUpdatesNever  AutomaticUpdates = "never"
 )
 
+var WorkspaceRenameDeadline = time.Date(2024, 04, 01, 0, 0, 0, 0, time.UTC)
+
 // Workspace is a deployment of a template. It references a specific
 // version and can be updated.
 type Workspace struct {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -21,8 +21,6 @@ const (
 	AutomaticUpdatesNever  AutomaticUpdates = "never"
 )
 
-var WorkspaceRenameDeadline = time.Date(2024, 04, 01, 0, 0, 0, 0, time.UTC)
-
 // Workspace is a deployment of a template. It references a specific
 // version and can be updated.
 type Workspace struct {

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -153,6 +153,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "user": {}
     },
     "agent_stat_refresh_interval": 0,
+    "allow_workspace_renames": true,
     "autobuild_poll_interval": 0,
     "browser_only": true,
     "cache_directory": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2083,6 +2083,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "user": {}
     },
     "agent_stat_refresh_interval": 0,
+    "allow_workspace_renames": true,
     "autobuild_poll_interval": 0,
     "browser_only": true,
     "cache_directory": "string",
@@ -2460,6 +2461,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "user": {}
   },
   "agent_stat_refresh_interval": 0,
+  "allow_workspace_renames": true,
   "autobuild_poll_interval": 0,
   "browser_only": true,
   "cache_directory": "string",
@@ -2732,6 +2734,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `address`                            | [clibase.HostPort](#clibasehostport)                                                                 | false    |              | Address Use HTTPAddress or TLS.Address instead.                    |
 | `agent_fallback_troubleshooting_url` | [clibase.URL](#clibaseurl)                                                                           | false    |              |                                                                    |
 | `agent_stat_refresh_interval`        | integer                                                                                              | false    |              |                                                                    |
+| `allow_workspace_renames`            | boolean                                                                                              | false    |              |                                                                    |
 | `autobuild_poll_interval`            | integer                                                                                              | false    |              |                                                                    |
 | `browser_only`                       | boolean                                                                                              | false    |              |                                                                    |
 | `cache_directory`                    | string                                                                                               | false    |              |                                                                    |
@@ -5764,6 +5767,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ```json
 {
+  "allow_renames": true,
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
@@ -5943,6 +5947,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 | Name                                        | Type                                                   | Required | Restrictions | Description                                                                                                                                                                                                                                           |
 | ------------------------------------------- | ------------------------------------------------------ | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow_renames`                             | boolean                                                | false    |              |                                                                                                                                                                                                                                                       |
 | `automatic_updates`                         | [codersdk.AutomaticUpdates](#codersdkautomaticupdates) | false    |              |                                                                                                                                                                                                                                                       |
 | `autostart_schedule`                        | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
 | `created_at`                                | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
@@ -7025,6 +7030,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "count": 0,
   "workspaces": [
     {
+      "allow_renames": true,
       "automatic_updates": "always",
       "autostart_schedule": "string",
       "created_at": "2019-08-24T14:15:22Z",

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -47,6 +47,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
 
 ```json
 {
+  "allow_renames": true,
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
@@ -257,6 +258,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
 
 ```json
 {
+  "allow_renames": true,
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
@@ -470,6 +472,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
   "count": 0,
   "workspaces": [
     {
+      "allow_renames": true,
       "automatic_updates": "always",
       "autostart_schedule": "string",
       "created_at": "2019-08-24T14:15:22Z",
@@ -677,6 +680,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
 
 ```json
 {
+  "allow_renames": true,
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",
@@ -1003,6 +1007,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/dormant \
 
 ```json
 {
+  "allow_renames": true,
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "created_at": "2019-08-24T14:15:22Z",

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -49,15 +49,14 @@ Allow users to set their own quiet hours schedule for workspaces to stop in (dep
 | ----------- | ------------------------------------------- |
 | Type        | <code>bool</code>                           |
 | Environment | <code>$CODER_ALLOW_WORKSPACE_RENAMES</code> |
-| YAML        | <code>.allowWorkspaceRenames</code>         |
+| YAML        | <code>allowWorkspaceRenames</code>          |
 | Default     | <code>false</code>                          |
 
-<<<<<<< HEAD
+
 Allow users to rename their workspaces. This is not recommended for production deployments as it can cause issues with the workspace's internal state. Use only for compatibility reasons.
->>>>>>> 2a4d16f2d (make gen)
-=======
+
 DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01T00:00:00Z00:00.
->>>>>>> a05de9cdc (make gen)
+
 
 ### --block-direct-connections
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -52,8 +52,12 @@ Allow users to set their own quiet hours schedule for workspaces to stop in (dep
 | YAML        | <code>.allowWorkspaceRenames</code>         |
 | Default     | <code>false</code>                          |
 
+<<<<<<< HEAD
 Allow users to rename their workspaces. This is not recommended for production deployments as it can cause issues with the workspace's internal state. Use only for compatibility reasons.
 >>>>>>> 2a4d16f2d (make gen)
+=======
+DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01T00:00:00Z00:00.
+>>>>>>> a05de9cdc (make gen)
 
 ### --block-direct-connections
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -31,6 +31,7 @@ coder server [flags]
 
 The URL that users will use to access the Coder deployment.
 
+<<<<<<< HEAD
 ### --allow-custom-quiet-hours
 
 |             |                                                           |
@@ -41,6 +42,18 @@ The URL that users will use to access the Coder deployment.
 | Default     | <code>true</code>                                         |
 
 Allow users to set their own quiet hours schedule for workspaces to stop in (depending on template autostop requirement settings). If false, users can't change their quiet hours schedule and the site default is always used.
+=======
+### --allow-workspace-renames
+
+|             |                                             |
+| ----------- | ------------------------------------------- |
+| Type        | <code>bool</code>                           |
+| Environment | <code>$CODER_ALLOW_WORKSPACE_RENAMES</code> |
+| YAML        | <code>.allowWorkspaceRenames</code>         |
+| Default     | <code>false</code>                          |
+
+Allow users to rename their workspaces. This is not recommended for production deployments as it can cause issues with the workspace's internal state. Use only for compatibility reasons.
+>>>>>>> 2a4d16f2d (make gen)
 
 ### --block-direct-connections
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -31,7 +31,6 @@ coder server [flags]
 
 The URL that users will use to access the Coder deployment.
 
-<<<<<<< HEAD
 ### --allow-custom-quiet-hours
 
 |             |                                                           |
@@ -42,7 +41,7 @@ The URL that users will use to access the Coder deployment.
 | Default     | <code>true</code>                                         |
 
 Allow users to set their own quiet hours schedule for workspaces to stop in (depending on template autostop requirement settings). If false, users can't change their quiet hours schedule and the site default is always used.
-=======
+
 ### --allow-workspace-renames
 
 |             |                                             |
@@ -52,11 +51,7 @@ Allow users to set their own quiet hours schedule for workspaces to stop in (dep
 | YAML        | <code>allowWorkspaceRenames</code>          |
 | Default     | <code>false</code>                          |
 
-
-Allow users to rename their workspaces. This is not recommended for production deployments as it can cause issues with the workspace's internal state. Use only for compatibility reasons.
-
-DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this flag will no longer function after 2024-04-01T00:00:00Z00:00.
-
+DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons.
 
 ### --block-direct-connections
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -51,7 +51,7 @@ Allow users to set their own quiet hours schedule for workspaces to stop in (dep
 | YAML        | <code>allowWorkspaceRenames</code>          |
 | Default     | <code>false</code>                          |
 
-DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons.
+DEPRECATED: Allow users to rename their workspaces. Use only for temporary compatibility reasons, this will be removed in a future release.
 
 ### --block-direct-connections
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -15,6 +15,11 @@ SUBCOMMANDS:
                               PostgreSQL deployment.
 
 OPTIONS:
+      --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
+          DEPRECATED: Allow users to rename their workspaces. Use only for
+          temporary compatibility reasons, this flag will no longer function
+          after 2024-04-01.
+
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and
           $CACHE_DIRECTORY is set, it will be used for compatibility with

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -17,8 +17,7 @@ SUBCOMMANDS:
 OPTIONS:
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
           DEPRECATED: Allow users to rename their workspaces. Use only for
-          temporary compatibility reasons, this flag will no longer function
-          after 2024-04-01.
+          temporary compatibility reasons.
 
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -17,7 +17,8 @@ SUBCOMMANDS:
 OPTIONS:
       --allow-workspace-renames bool, $CODER_ALLOW_WORKSPACE_RENAMES (default: false)
           DEPRECATED: Allow users to rename their workspaces. Use only for
-          temporary compatibility reasons.
+          temporary compatibility reasons, this will be removed in a future
+          release.
 
       --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           The directory to cache temporary files. If unspecified and

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -424,6 +424,7 @@ export interface DeploymentValues {
   readonly enable_terraform_debug_mode?: boolean;
   readonly user_quiet_hours_schedule?: UserQuietHoursScheduleConfig;
   readonly web_terminal_renderer?: string;
+  readonly allow_workspace_renames?: boolean;
   readonly healthcheck?: HealthcheckConfig;
   readonly config?: string;
   readonly write_config?: boolean;
@@ -1429,6 +1430,7 @@ export interface Workspace {
   readonly dormant_at?: string;
   readonly health: WorkspaceHealth;
   readonly automatic_updates: AutomaticUpdates;
+  readonly allow_renames: boolean;
 }
 
 // From codersdk/workspaceagents.go

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -59,7 +59,7 @@ export const WorkspaceSettingsForm: FC<{
         <FormFields>
           <TextField
             {...getFieldHelpers("name")}
-            disabled={form.isSubmitting}
+            disabled={!workspace.allow_renames || form.isSubmitting}
             onChange={onChangeTrimmed(form)}
             autoFocus
             fullWidth
@@ -106,7 +106,7 @@ export const WorkspaceSettingsForm: FC<{
           </FormFields>
         </FormSection>
       )}
-      <FormFooter onCancel={onCancel} isLoading={form.isSubmitting} />
+      <FormFooter onCancel={onCancel} isLoading={form.isSubmitting} submitDisabled={!templatePoliciesEnabled && !workspace.allow_renames}/>
     </HorizontalForm>
   );
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -106,7 +106,11 @@ export const WorkspaceSettingsForm: FC<{
           </FormFields>
         </FormSection>
       )}
-      <FormFooter onCancel={onCancel} isLoading={form.isSubmitting} submitDisabled={!templatePoliciesEnabled && !workspace.allow_renames}/>
+      <FormFooter
+        onCancel={onCancel}
+        isLoading={form.isSubmitting}
+        submitDisabled={!templatePoliciesEnabled && !workspace.allow_renames}
+      />
     </HorizontalForm>
   );
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -70,9 +70,10 @@ export const WorkspaceSettingsForm: FC<{
             label="Name"
             css={workspace.allow_renames && styles.nameWarning}
             helperText={
-              workspace.allow_renames ?
-              form.values.name !== form.initialValues.name && "Depending on the template, renaming your workspace may be destructive" :
-              "Renaming your workspace can be destructive and has not been enabled for this deployment."
+              workspace.allow_renames
+                ? form.values.name !== form.initialValues.name &&
+                  "Depending on the template, renaming your workspace may be destructive"
+                : "Renaming your workspace can be destructive and has not been enabled for this deployment."
             }
           />
         </FormFields>
@@ -120,7 +121,7 @@ export const WorkspaceSettingsForm: FC<{
 const styles = {
   nameWarning: (theme: Theme) => ({
     "& .MuiFormHelperText-root": {
-      color: theme.palette.warning.light
+      color: theme.palette.warning.light,
     },
-  })
-}
+  }),
+};

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -34,6 +34,9 @@ export const WorkspaceSettingsForm: FC<{
   onCancel: () => void;
   onSubmit: (values: WorkspaceSettingsFormValues) => Promise<void>;
 }> = ({ onCancel, onSubmit, workspace, error, templatePoliciesEnabled }) => {
+  const formEnabled = (templatePoliciesEnabled && !workspace.template_require_active_version)
+    || workspace.allow_renames
+
   const form = useFormik<WorkspaceSettingsFormValues>({
     onSubmit,
     initialValues: {
@@ -54,7 +57,7 @@ export const WorkspaceSettingsForm: FC<{
     <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
       <FormSection
         title="Workspace Name"
-        description="Update the name of your workspace."
+        description="The name of your workspace."
       >
         <FormFields>
           <TextField
@@ -106,11 +109,13 @@ export const WorkspaceSettingsForm: FC<{
           </FormFields>
         </FormSection>
       )}
-      <FormFooter
-        onCancel={onCancel}
-        isLoading={form.isSubmitting}
-        submitDisabled={!templatePoliciesEnabled && !workspace.allow_renames}
-      />
+      {formEnabled && (
+        <FormFooter
+          onCancel={onCancel}
+          isLoading={form.isSubmitting}
+          submitDisabled={!templatePoliciesEnabled && !workspace.allow_renames}
+        />
+      )}
     </HorizontalForm>
   );
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -34,8 +34,9 @@ export const WorkspaceSettingsForm: FC<{
   onCancel: () => void;
   onSubmit: (values: WorkspaceSettingsFormValues) => Promise<void>;
 }> = ({ onCancel, onSubmit, workspace, error, templatePoliciesEnabled }) => {
-  const formEnabled = (templatePoliciesEnabled && !workspace.template_require_active_version)
-    || workspace.allow_renames
+  const formEnabled =
+    (templatePoliciesEnabled && !workspace.template_require_active_version) ||
+    workspace.allow_renames;
 
   const form = useFormik<WorkspaceSettingsFormValues>({
     onSubmit,

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -35,7 +35,7 @@ export const WorkspaceSettingsForm: FC<{
   onSubmit: (values: WorkspaceSettingsFormValues) => Promise<void>;
 }> = ({ onCancel, onSubmit, workspace, error, templatePoliciesEnabled }) => {
   const formEnabled =
-    (templatePoliciesEnabled && !workspace.template_require_active_version) ||
+    (!templatePoliciesEnabled && !workspace.template_require_active_version) ||
     workspace.allow_renames;
 
   const form = useFormik<WorkspaceSettingsFormValues>({
@@ -81,7 +81,7 @@ export const WorkspaceSettingsForm: FC<{
           )}
         </FormFields>
       </FormSection>
-      {templatePoliciesEnabled && (
+      {!templatePoliciesEnabled && (
         <FormSection
           title="Automatic Updates"
           description="Configure your workspace to automatically update when started."
@@ -115,11 +115,7 @@ export const WorkspaceSettingsForm: FC<{
         </FormSection>
       )}
       {formEnabled && (
-        <FormFooter
-          onCancel={onCancel}
-          isLoading={form.isSubmitting}
-          submitDisabled={!templatePoliciesEnabled && !workspace.allow_renames}
-        />
+        <FormFooter onCancel={onCancel} isLoading={form.isSubmitting} />
       )}
     </HorizontalForm>
   );

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -67,6 +67,10 @@ export const WorkspaceSettingsForm: FC<{
             autoFocus
             fullWidth
             label="Name"
+            helperText={
+              !workspace.allow_renames &&
+              "Renaming your workspace can be destructive and are not allowed."
+            }
           />
           {form.values.name !== form.initialValues.name && (
             <Alert severity="warning">

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -18,9 +18,9 @@ import {
   AutomaticUpdateses,
   Workspace,
 } from "api/typesGenerated";
-import { Alert } from "components/Alert/Alert";
 import MenuItem from "@mui/material/MenuItem";
 import upperFirst from "lodash/upperFirst";
+import { type Theme } from "@emotion/react";
 
 export type WorkspaceSettingsFormValues = {
   name: string;
@@ -58,7 +58,7 @@ export const WorkspaceSettingsForm: FC<{
     <HorizontalForm onSubmit={form.handleSubmit} data-testid="form">
       <FormSection
         title="Workspace Name"
-        description="The name of your workspace."
+        description="Update the name of your workspace."
       >
         <FormFields>
           <TextField
@@ -68,17 +68,13 @@ export const WorkspaceSettingsForm: FC<{
             autoFocus
             fullWidth
             label="Name"
+            css={workspace.allow_renames && styles.nameWarning}
             helperText={
-              !workspace.allow_renames &&
+              workspace.allow_renames ?
+              form.values.name !== form.initialValues.name && "Depending on the template, renaming your workspace may be destructive" :
               "Renaming your workspace can be destructive and has not been enabled for this deployment."
             }
           />
-          {form.values.name !== form.initialValues.name && (
-            <Alert severity="warning">
-              Depending on the template, renaming your workspace may be
-              destructive
-            </Alert>
-          )}
         </FormFields>
       </FormSection>
       {templatePoliciesEnabled && (
@@ -120,3 +116,11 @@ export const WorkspaceSettingsForm: FC<{
     </HorizontalForm>
   );
 };
+
+const styles = {
+  nameWarning: (theme: Theme) => ({
+    "& .MuiFormHelperText-root": {
+      color: theme.palette.warning.light
+    },
+  })
+}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -35,7 +35,7 @@ export const WorkspaceSettingsForm: FC<{
   onSubmit: (values: WorkspaceSettingsFormValues) => Promise<void>;
 }> = ({ onCancel, onSubmit, workspace, error, templatePoliciesEnabled }) => {
   const formEnabled =
-    (!templatePoliciesEnabled && !workspace.template_require_active_version) ||
+    (templatePoliciesEnabled && !workspace.template_require_active_version) ||
     workspace.allow_renames;
 
   const form = useFormik<WorkspaceSettingsFormValues>({
@@ -81,7 +81,7 @@ export const WorkspaceSettingsForm: FC<{
           )}
         </FormFields>
       </FormSection>
-      {!templatePoliciesEnabled && (
+      {templatePoliciesEnabled && (
         <FormSection
           title="Automatic Updates"
           description="Configure your workspace to automatically update when started."

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsForm.tsx
@@ -70,7 +70,7 @@ export const WorkspaceSettingsForm: FC<{
             label="Name"
             helperText={
               !workspace.allow_renames &&
-              "Renaming your workspace can be destructive and are not allowed."
+              "Renaming your workspace can be destructive and has not been enabled for this deployment."
             }
           />
           {form.values.name !== form.initialValues.name && (

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPage.test.tsx
@@ -12,7 +12,7 @@ test("Submit the workspace settings page successfully", async () => {
   // Mock the API calls that loads data
   jest
     .spyOn(api, "getWorkspaceByOwnerAndName")
-    .mockResolvedValueOnce(MockWorkspace);
+    .mockResolvedValueOnce({...MockWorkspace,});
   // Mock the API calls that submit data
   const patchWorkspaceSpy = jest
     .spyOn(api, "patchWorkspace")
@@ -38,4 +38,22 @@ test("Submit the workspace settings page successfully", async () => {
       name: "new-name",
     });
   });
+});
+
+test("Name field is disabled if renames are disabled", async () => {
+  // Mock the API calls that loads data
+  jest
+    .spyOn(api, "getWorkspaceByOwnerAndName")
+    .mockResolvedValueOnce({...MockWorkspace, allow_renames: false});
+  renderWithWorkspaceSettingsLayout(<WorkspaceSettingsPage />, {
+    route: "/@test-user/test-workspace/settings",
+    path: "/:username/:workspace/settings",
+    // Need this because after submit the user is redirected
+    extraRoutes: [{ path: "/:username/:workspace", element: <div /> }],
+  });
+  await waitForLoaderToBeRemoved();
+  // Fill the form and submit
+  const form = screen.getByTestId("form");
+  const name = within(form).getByLabelText("Name");
+  expect(name).toBeDisabled();
 });

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPage.test.tsx
@@ -12,7 +12,7 @@ test("Submit the workspace settings page successfully", async () => {
   // Mock the API calls that loads data
   jest
     .spyOn(api, "getWorkspaceByOwnerAndName")
-    .mockResolvedValueOnce({...MockWorkspace,});
+    .mockResolvedValueOnce({ ...MockWorkspace });
   // Mock the API calls that submit data
   const patchWorkspaceSpy = jest
     .spyOn(api, "patchWorkspace")
@@ -44,7 +44,7 @@ test("Name field is disabled if renames are disabled", async () => {
   // Mock the API calls that loads data
   jest
     .spyOn(api, "getWorkspaceByOwnerAndName")
-    .mockResolvedValueOnce({...MockWorkspace, allow_renames: false});
+    .mockResolvedValueOnce({ ...MockWorkspace, allow_renames: false });
   renderWithWorkspaceSettingsLayout(<WorkspaceSettingsPage />, {
     route: "/@test-user/test-workspace/settings",
     path: "/:username/:workspace/settings",

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
@@ -24,6 +24,6 @@ export const AutoUpdates: Story = {
 
 export const RenamesDisabled: Story = {
   args: {
-    workspace: {...MockWorkspace, allow_renames: false}
+    workspace: { ...MockWorkspace, allow_renames: false },
   },
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSettingsPageView.stories.tsx
@@ -21,3 +21,9 @@ export const AutoUpdates: Story = {
     templatePoliciesEnabled: true,
   },
 };
+
+export const RenamesDisabled: Story = {
+  args: {
+    workspace: {...MockWorkspace, allow_renames: false}
+  },
+};

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1006,6 +1006,7 @@ export const MockWorkspace: TypesGen.Workspace = {
     failing_agents: [],
   },
   automatic_updates: "never",
+  allow_renames: false,
 };
 
 export const MockStoppedWorkspace: TypesGen.Workspace = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1006,7 +1006,7 @@ export const MockWorkspace: TypesGen.Workspace = {
     failing_agents: [],
   },
   automatic_updates: "never",
-  allow_renames: false,
+  allow_renames: true,
 };
 
 export const MockStoppedWorkspace: TypesGen.Workspace = {


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/10922

- This allows renames to continue to function if the flag is enabled.
- Disables the form field and conditionally the form fotter containing the cancel and submit button in the workspace settings when renames disabled and template policies disabled.

<img width="1457" alt="Screenshot 2023-12-15 at 9 41 49 AM" src="https://github.com/coder/coder/assets/19379394/791fe7b7-bda6-4e83-afca-163d0989fb73">
<img width="1460" alt="image" src="https://github.com/coder/coder/assets/19379394/621492be-c56f-4cc8-9973-2616d5f95963">
<img width="1453" alt="image" src="https://github.com/coder/coder/assets/19379394/0ec7d2b9-a56e-4adb-ba96-6b9b051b0c5c">
<img width="1442" alt="image" src="https://github.com/coder/coder/assets/19379394/e77198e8-3524-455b-b968-8aab7e140312">


Considerations
- I personally like showing disabled fields because it gives the user information despite not being able to take action as oppose to a page being missing entirely. I removed the form footer with the cancel and submit buttons, but if we want to remove the page entirely conditionally this will take a little more work because I need to move that logic up to have the sidebar behave correctly too. 