### PR TITLE
ci: bump memory to 1024 MB for fly.io proxies 

### DIFF
--- a/.github/fly-wsproxies/paris-coder.toml
+++ b/.github/fly-wsproxies/paris-coder.toml
@@ -24,4 +24,4 @@ primary_region = "cdg"
 [[vm]]
   cpu_kind = "performance"
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024

--- a/.github/fly-wsproxies/sao-paulo-coder.toml
+++ b/.github/fly-wsproxies/sao-paulo-coder.toml
@@ -24,4 +24,4 @@ primary_region = "gru"
 [[vm]]
   cpu_kind = "performance"
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024

--- a/.github/fly-wsproxies/sydney-coder.toml
+++ b/.github/fly-wsproxies/sydney-coder.toml
@@ -24,4 +24,4 @@ primary_region = "syd"
 [[vm]]
   cpu_kind = "performance"
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024


### PR DESCRIPTION
Looks like fly.io doesn't allow using less than 1024 MB when cpu type is performance. 