### PR TITLE
ci: revert fly proxies to shared cpu type

### DIFF
--- a/.github/fly-wsproxies/paris-coder.toml
+++ b/.github/fly-wsproxies/paris-coder.toml
@@ -22,6 +22,6 @@ primary_region = "cdg"
   min_machines_running = 0
 
 [[vm]]
-  cpu_kind = "performance"
+  cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 512

--- a/.github/fly-wsproxies/paris-coder.toml
+++ b/.github/fly-wsproxies/paris-coder.toml
@@ -23,5 +23,5 @@ primary_region = "cdg"
 
 [[vm]]
   cpu_kind = "shared"
-  cpus = 1
+  cpus = 2
   memory_mb = 512

--- a/.github/fly-wsproxies/sao-paulo-coder.toml
+++ b/.github/fly-wsproxies/sao-paulo-coder.toml
@@ -23,5 +23,5 @@ primary_region = "gru"
 
 [[vm]]
   cpu_kind = "shared"
-  cpus = 1
+  cpus = 2
   memory_mb = 512

--- a/.github/fly-wsproxies/sao-paulo-coder.toml
+++ b/.github/fly-wsproxies/sao-paulo-coder.toml
@@ -22,6 +22,6 @@ primary_region = "gru"
   min_machines_running = 0
 
 [[vm]]
-  cpu_kind = "performance"
+  cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 512

--- a/.github/fly-wsproxies/sydney-coder.toml
+++ b/.github/fly-wsproxies/sydney-coder.toml
@@ -23,5 +23,5 @@ primary_region = "syd"
 
 [[vm]]
   cpu_kind = "shared"
-  cpus = 1
+  cpus = 2
   memory_mb = 512

--- a/.github/fly-wsproxies/sydney-coder.toml
+++ b/.github/fly-wsproxies/sydney-coder.toml
@@ -22,6 +22,6 @@ primary_region = "syd"
   min_machines_running = 0
 
 [[vm]]
-  cpu_kind = "performance"
+  cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 512


### PR DESCRIPTION
Performance cpu type is 10 times the cost and I do not think we need this now. We can upgrade if required.