### PR TITLE
feat(coderd/database): add api_version to provisioner_daemons table

### DIFF
--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -217,6 +217,8 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Tags:         database.StringMap{provisionersdk.TagScope: provisionersdk.ScopeOrganization},
 		CreatedAt:    now.Add(-14 * 24 * time.Hour),
 		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-7 * 24 * time.Hour).Add(time.Minute)},
+		Version:      "1.0.0",
+		APIVersion:   "1.0",
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -226,6 +228,8 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		Tags:         database.StringMap{provisionersdk.TagScope: provisionersdk.ScopeOrganization},
 		CreatedAt:    now.Add(-8 * 24 * time.Hour),
 		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-8 * 24 * time.Hour).Add(time.Hour)},
+		Version:      "1.0.0",
+		APIVersion:   "1.0",
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -236,7 +240,9 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 			provisionersdk.TagScope: provisionersdk.ScopeUser,
 			provisionersdk.TagOwner: uuid.NewString(),
 		},
-		CreatedAt: now.Add(-9 * 24 * time.Hour),
+		CreatedAt:  now.Add(-9 * 24 * time.Hour),
+		Version:    "1.0.0",
+		APIVersion: "1.0",
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -249,6 +255,8 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		},
 		CreatedAt:  now.Add(-6 * 24 * time.Hour),
 		LastSeenAt: sql.NullTime{Valid: true, Time: now.Add(-6 * 24 * time.Hour)},
+		Version:    "1.0.0",
+		APIVersion: "1.0",
 	})
 	require.NoError(t, err)
 

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -514,8 +514,11 @@ CREATE TABLE provisioner_daemons (
     replica_id uuid,
     tags jsonb DEFAULT '{}'::jsonb NOT NULL,
     last_seen_at timestamp with time zone,
-    version text DEFAULT ''::text NOT NULL
+    version text DEFAULT ''::text NOT NULL,
+    api_version text DEFAULT '1.0'::text NOT NULL
 );
+
+COMMENT ON COLUMN provisioner_daemons.api_version IS 'The API version of the provisioner daemon';
 
 CREATE TABLE provisioner_job_logs (
     job_id uuid NOT NULL,

--- a/coderd/database/migrations/000179_provisionerdaemon_add_apiversion.down.sql
+++ b/coderd/database/migrations/000179_provisionerdaemon_add_apiversion.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY provisioner_daemons
+		DROP COLUMN api_version;

--- a/coderd/database/migrations/000179_provisionerdaemon_add_apiversion.up.sql
+++ b/coderd/database/migrations/000179_provisionerdaemon_add_apiversion.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ONLY provisioner_daemons
+    ADD COLUMN api_version text NOT NULL DEFAULT '1.0';
+COMMENT ON COLUMN provisioner_daemons.api_version IS 'The API version of the provisioner daemon';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1845,6 +1845,8 @@ type ProvisionerDaemon struct {
 	Tags         StringMap         `db:"tags" json:"tags"`
 	LastSeenAt   sql.NullTime      `db:"last_seen_at" json:"last_seen_at"`
 	Version      string            `db:"version" json:"version"`
+	// The API version of the provisioner daemon
+	APIVersion string `db:"api_version" json:"api_version"`
 }
 
 type ProvisionerJob struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3066,7 +3066,8 @@ INSERT INTO
 		provisioners,
 		tags,
 		last_seen_at,
-		"version"
+		"version",
+		api_version
 	)
 VALUES (
 	gen_random_uuid(),
@@ -3075,12 +3076,14 @@ VALUES (
 	$3,
 	$4,
 	$5,
-	$6
+	$6,
+	$7
 ) ON CONFLICT("name", lower((tags ->> 'owner'::text))) DO UPDATE SET
 	provisioners = $3,
 	tags = $4,
 	last_seen_at = $5,
-	"version" = $6
+	"version" = $6,
+	api_version = $7
 WHERE
 	-- Only ones with the same tags are allowed clobber
 	provisioner_daemons.tags <@ $4 :: jsonb
@@ -3094,6 +3097,7 @@ type UpsertProvisionerDaemonParams struct {
 	Tags         StringMap         `db:"tags" json:"tags"`
 	LastSeenAt   sql.NullTime      `db:"last_seen_at" json:"last_seen_at"`
 	Version      string            `db:"version" json:"version"`
+	APIVersion   string            `db:"api_version" json:"api_version"`
 }
 
 func (q *sqlQuerier) UpsertProvisionerDaemon(ctx context.Context, arg UpsertProvisionerDaemonParams) (ProvisionerDaemon, error) {
@@ -3104,6 +3108,7 @@ func (q *sqlQuerier) UpsertProvisionerDaemon(ctx context.Context, arg UpsertProv
 		arg.Tags,
 		arg.LastSeenAt,
 		arg.Version,
+		arg.APIVersion,
 	)
 	var i ProvisionerDaemon
 	err := row.Scan(

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3019,7 +3019,7 @@ func (q *sqlQuerier) DeleteOldProvisionerDaemons(ctx context.Context) error {
 
 const getProvisionerDaemons = `-- name: GetProvisionerDaemons :many
 SELECT
-	id, created_at, name, provisioners, replica_id, tags, last_seen_at, version
+	id, created_at, name, provisioners, replica_id, tags, last_seen_at, version, api_version
 FROM
 	provisioner_daemons
 `
@@ -3042,6 +3042,7 @@ func (q *sqlQuerier) GetProvisionerDaemons(ctx context.Context) ([]ProvisionerDa
 			&i.Tags,
 			&i.LastSeenAt,
 			&i.Version,
+			&i.APIVersion,
 		); err != nil {
 			return nil, err
 		}
@@ -3083,7 +3084,7 @@ VALUES (
 WHERE
 	-- Only ones with the same tags are allowed clobber
 	provisioner_daemons.tags <@ $4 :: jsonb
-RETURNING id, created_at, name, provisioners, replica_id, tags, last_seen_at, version
+RETURNING id, created_at, name, provisioners, replica_id, tags, last_seen_at, version, api_version
 `
 
 type UpsertProvisionerDaemonParams struct {
@@ -3114,6 +3115,7 @@ func (q *sqlQuerier) UpsertProvisionerDaemon(ctx context.Context, arg UpsertProv
 		&i.Tags,
 		&i.LastSeenAt,
 		&i.Version,
+		&i.APIVersion,
 	)
 	return i, err
 }

--- a/coderd/database/queries/provisionerdaemons.sql
+++ b/coderd/database/queries/provisionerdaemons.sql
@@ -23,7 +23,8 @@ INSERT INTO
 		provisioners,
 		tags,
 		last_seen_at,
-		"version"
+		"version",
+		api_version
 	)
 VALUES (
 	gen_random_uuid(),
@@ -32,12 +33,14 @@ VALUES (
 	@provisioners,
 	@tags,
 	@last_seen_at,
-	@version
+	@version,
+	@api_version
 ) ON CONFLICT("name", lower((tags ->> 'owner'::text))) DO UPDATE SET
 	provisioners = @provisioners,
 	tags = @tags,
 	last_seen_at = @last_seen_at,
-	"version" = @version
+	"version" = @version,
+	api_version = @api_version
 WHERE
 	-- Only ones with the same tags are allowed clobber
 	provisioner_daemons.tags <@ @tags :: jsonb


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/10676

Adds column api_version to the provisioner_daemons table.
This is distinct from the coderd version, and is used to handle breaking changes in the provisioner daemon API.
