### PR TITLE
ci: fix syntax for ipv6 address in fly.io wsproxies

### DIFF
--- a/.github/fly-wsproxies/paris-coder.toml
+++ b/.github/fly-wsproxies/paris-coder.toml
@@ -2,7 +2,7 @@ app = "paris-coder"
 primary_region = "cdg"
 
 [experimental]
-  entrypoint = ["/bin/sh", "-c", "CODER_DERP_SERVER_RELAY_URL=\"http://${FLY_PRIVATE_IP}:3000\" /opt/coder wsproxy server"]
+  entrypoint = ["/bin/sh", "-c", "CODER_DERP_SERVER_RELAY_URL=\"http://[${FLY_PRIVATE_IP}]:3000\" /opt/coder wsproxy server"]
   auto_rollback = true
 
 [build]

--- a/.github/fly-wsproxies/sao-paulo-coder.toml
+++ b/.github/fly-wsproxies/sao-paulo-coder.toml
@@ -2,7 +2,7 @@ app = "sao-paulo-coder"
 primary_region = "gru"
 
 [experimental]
-  entrypoint = ["/bin/sh", "-c", "CODER_DERP_SERVER_RELAY_URL=\"http://${FLY_PRIVATE_IP}:3000\" /opt/coder wsproxy server"]
+  entrypoint = ["/bin/sh", "-c", "CODER_DERP_SERVER_RELAY_URL=\"http://[${FLY_PRIVATE_IP}]:3000\" /opt/coder wsproxy server"]
   auto_rollback = true
 
 [build]

--- a/.github/fly-wsproxies/sydney-coder.toml
+++ b/.github/fly-wsproxies/sydney-coder.toml
@@ -2,7 +2,7 @@ app = "sydney-coder"
 primary_region = "syd"
 
 [experimental]
-  entrypoint = ["/bin/sh", "-c", "CODER_DERP_SERVER_RELAY_URL=\"http://${FLY_PRIVATE_IP}:3000\" /opt/coder wsproxy server"]
+  entrypoint = ["/bin/sh", "-c", "CODER_DERP_SERVER_RELAY_URL=\"http://[${FLY_PRIVATE_IP}]:3000\" /opt/coder wsproxy server"]
   auto_rollback = true
 
 [build]


### PR DESCRIPTION
If the IP address is an ipv6 address, we need to use square brackets [].