### PR TITLE
fix: tar: do not archive .tfvars

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -78,7 +78,7 @@ func (pf *templateUploadFlags) upload(inv *clibase.Invocation, client *codersdk.
 
 		pipeReader, pipeWriter := io.Pipe()
 		go func() {
-			err := provisionersdk.Tar(pipeWriter, pf.directory, provisionersdk.TemplateArchiveLimit)
+			err := provisionersdk.Tar(pipeWriter, inv.Logger, pf.directory, provisionersdk.TemplateArchiveLimit)
 			_ = pipeWriter.CloseWithError(err)
 		}()
 		defer pipeReader.Close()

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -96,6 +96,10 @@ func Tar(w io.Writer, directory string, limit int64) error {
 			// Don't store tfstate!
 			return nil
 		}
+		if rel == "terraform.tfvars" || rel == "terraform.tfvars.json" || strings.HasSuffix(rel, ".auto.tfvars") || strings.HasSuffix(rel, ".auto.tfvars.json") {
+			// Don't store .tfvars, as Coder uses their own variables file.
+			return nil
+		}
 		// Use unix paths in the tar archive.
 		header.Name = filepath.ToSlash(rel)
 		if err := tarWriter.WriteHeader(header); err != nil {

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -2,12 +2,15 @@ package provisionersdk
 
 import (
 	"archive/tar"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
 
 	"github.com/coder/coder/v2/coderd/util/xio"
 )
@@ -39,7 +42,7 @@ func DirHasLockfile(dir string) (bool, error) {
 }
 
 // Tar archives a Terraform directory.
-func Tar(w io.Writer, directory string, limit int64) error {
+func Tar(w io.Writer, logger slog.Logger, directory string, limit int64) error {
 	// The total bytes written must be under the limit, so use -1
 	w = xio.NewLimitWriter(w, limit-1)
 	tarWriter := tar.NewWriter(w)
@@ -94,10 +97,12 @@ func Tar(w io.Writer, directory string, limit int64) error {
 		}
 		if strings.Contains(rel, ".tfstate") {
 			// Don't store tfstate!
+			logger.Debug(context.Background(), "skip state", slog.F("name", rel))
 			return nil
 		}
 		if rel == "terraform.tfvars" || rel == "terraform.tfvars.json" || strings.HasSuffix(rel, ".auto.tfvars") || strings.HasSuffix(rel, ".auto.tfvars.json") {
 			// Don't store .tfvars, as Coder uses their own variables file.
+			logger.Debug(context.Background(), "skip variable definitions", slog.F("name", rel))
 			return nil
 		}
 		// Use unix paths in the tar archive.

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -122,6 +122,18 @@ func TestTar(t *testing.T) {
 			}, {
 				Name:     "terraform.tfstate",
 				Archives: false,
+			}, {
+				Name:     "terraform.tfvars",
+				Archives: false,
+			}, {
+				Name:     "terraform.tfvars.json",
+				Archives: false,
+			}, {
+				Name:     "*.auto.tfvars",
+				Archives: false,
+			}, {
+				Name:     "*.auto.tfvars.json",
+				Archives: false,
 			},
 		}
 		for _, file := range files {
@@ -149,18 +161,17 @@ func TestTar(t *testing.T) {
 		}
 		archive := new(bytes.Buffer)
 		// Headers are chonky so raise the limit to something reasonable
-		err := provisionersdk.Tar(archive, dir, 1024<<2)
+		err := provisionersdk.Tar(archive, dir, 1024<<3)
 		require.NoError(t, err)
 		dir = t.TempDir()
 		err = provisionersdk.Untar(dir, archive)
 		require.NoError(t, err)
 		for _, file := range files {
 			_, err = os.Stat(filepath.Join(dir, file.Name))
-			t.Logf("stat %q %+v", file.Name, err)
 			if file.Archives {
-				require.NoError(t, err)
+				require.NoError(t, err, "stat %q, got error: %+v", file.Name, err)
 			} else {
-				require.ErrorIs(t, err, os.ErrNotExist)
+				require.ErrorIs(t, err, os.ErrNotExist, "stat %q, expected ErrNotExist, got: %+v", file.Name, err)
 			}
 		}
 	})


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/8501

First baby step to correctly handle .tfvars in Coder. This PR prevents `provisionersdk.Tar` archiving all variations of `.tfvars` files.