### PR TITLE
fix: wait for coordinator in Test_agentIsLegacy

### DIFF
--- a/enterprise/coderd/workspaceproxycoordinator_test.go
+++ b/enterprise/coderd/workspaceproxycoordinator_test.go
@@ -75,6 +75,9 @@ func Test_agentIsLegacy(t *testing.T) {
 			AllowedIPs:          []netip.Prefix{netip.PrefixFrom(codersdk.WorkspaceAgentIP, 128)},
 			Endpoints:           []string{"192.168.1.1:18842"},
 		}))
+		require.Eventually(t, func() bool {
+			return coordinator.Node(nodeID) != nil
+		}, testutil.WaitShort, testutil.IntervalFast)
 
 		proxyRes, err := client.CreateWorkspaceProxy(ctx, codersdk.CreateWorkspaceProxyRequest{
 			Name: namesgenerator.GetRandomName(1),
@@ -139,6 +142,9 @@ func Test_agentIsLegacy(t *testing.T) {
 			AllowedIPs:          []netip.Prefix{netip.PrefixFrom(agpl.IPFromUUID(nodeID), 128)},
 			Endpoints:           []string{"192.168.1.1:18842"},
 		}))
+		require.Eventually(t, func() bool {
+			return coordinator.Node(nodeID) != nil
+		}, testutil.WaitShort, testutil.IntervalFast)
 
 		proxyRes, err := client.CreateWorkspaceProxy(ctx, codersdk.CreateWorkspaceProxyRequest{
 			Name: namesgenerator.GetRandomName(1),


### PR DESCRIPTION
Fixes flake https://github.com/coder/coder/runs/19639217635

AGPL coordinator used to process node updates for single_tailnet synchronously, but it's been refactored to process async, so in this test we need to wait for it to be processed.
