### PR TITLE
chore: "fix: prevent data race when mutating tags (#11200)"

### DIFF
--- a/provisionersdk/provisionertags.go
+++ b/provisionersdk/provisionertags.go
@@ -16,25 +16,21 @@ const (
 // own their own operations.
 // Otherwise, the "owner" tag is always empty.
 func MutateTags(userID uuid.UUID, tags map[string]string) map[string]string {
-	// We copy the tags here to avoid overwriting the provided map. This can
-	// cause data races when using dbmem.
-	cp := map[string]string{}
-	for k, v := range tags {
-		cp[k] = v
+	if tags == nil {
+		tags = map[string]string{}
 	}
-
-	_, ok := cp[TagScope]
+	_, ok := tags[TagScope]
 	if !ok {
-		cp[TagScope] = ScopeOrganization
-		delete(cp, TagOwner)
+		tags[TagScope] = ScopeOrganization
+		delete(tags, TagOwner)
 	}
-	switch cp[TagScope] {
+	switch tags[TagScope] {
 	case ScopeUser:
-		cp[TagOwner] = userID.String()
+		tags[TagOwner] = userID.String()
 	case ScopeOrganization:
-		delete(cp, TagOwner)
+		delete(tags, TagOwner)
 	default:
-		cp[TagScope] = ScopeOrganization
+		tags[TagScope] = ScopeOrganization
 	}
-	return cp
+	return tags
 }


### PR DESCRIPTION
This reverts commit 82f7b0cef42a591755342a402232d5f2ac138816.

This was kind of a lazy fix for a data race. @spikecurtis properly fixed it in `dbmem` so this is unnecessary. Also TIL about `maps.Clone`.

I still think that this function signature should either not return a map if it's going to mutate the provided one or we should return a copy to make it less ambiguous about what's happening. 