### PR TITLE
ci: add audit docs gen dependency on db gen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
           popd
 
       - name: make gen
-        run: "make --output-sync -j -B gen"
+        run: "make --output-sync -B gen"
 
       - name: Check for unstaged files
         run: ./scripts/check_unstaged.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
           popd
 
       - name: make gen
-        run: "make --output-sync -B gen"
+        run: "make --output-sync -j -B gen"
 
       - name: Check for unstaged files
         run: ./scripts/check_unstaged.sh

--- a/Makefile
+++ b/Makefile
@@ -588,7 +588,7 @@ docs/cli.md: scripts/clidocgen/main.go examples/examples.gen.json $(GO_SRC_FILES
 	CI=true BASE_PATH="." go run ./scripts/clidocgen
 	pnpm run format:write:only ./docs/cli.md ./docs/cli/*.md ./docs/manifest.json
 
-docs/admin/audit-logs.md: scripts/auditdocgen/main.go enterprise/audit/table.go coderd/rbac/object_gen.go
+docs/admin/audit-logs.md: coderd/database/querier.go scripts/auditdocgen/main.go enterprise/audit/table.go coderd/rbac/object_gen.go
 	go run scripts/auditdocgen/main.go
 	pnpm run format:write:only ./docs/admin/audit-logs.md
 


### PR DESCRIPTION
Updates https://github.com/coder/coder/pull/11231

My current hypothesis is that https://github.com/coder/coder/issues/11229 is due to a race condition in `make gen` where one target attempts to run before `queries.sql.go` is generated.


EDIT: trying instead with adding dependency on `queries.sql.go` in audit docs generation.