### PR TITLE
chore: fix race in cron close behavior (TestAgent_WriteVSCodeConfigs)

### DIFF
--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -53,6 +53,15 @@ func TestTimeout(t *testing.T) {
 	require.ErrorIs(t, runner.Execute(context.Background(), nil), agentscripts.ErrTimeout)
 }
 
+// TestCronClose exists because StartCront() can happen after Close(),
+// so the cron go routine is not exited.
+func TestCronClose(t *testing.T) {
+	t.Parallel()
+	runner := agentscripts.New(agentscripts.Options{})
+	runner.StartCron()
+	require.NoError(t, runner.Close(), "close runner")
+}
+
 func setup(t *testing.T, patchLogs func(ctx context.Context, req agentsdk.PatchLogs) error) *agentscripts.Runner {
 	t.Helper()
 	if patchLogs == nil {

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -53,8 +53,8 @@ func TestTimeout(t *testing.T) {
 	require.ErrorIs(t, runner.Execute(context.Background(), nil), agentscripts.ErrTimeout)
 }
 
-// TestCronClose exists because StartCront() can happen after Close(),
-// so the cron go routine is not exited.
+// TestCronClose exists because cron.Run() can happen after cron.Close().
+// If this happens, there used to be a deadlock.
 func TestCronClose(t *testing.T) {
 	t.Parallel()
 	runner := agentscripts.New(agentscripts.Options{})


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/11226

# Problem

The problem is `cmdCloseWait` never closes, so there is an open agent go routine that will not close. In the unit test in Question, **`cron.Run()` is the only routine started**. So I figured it is likely the routine left open. You can exercise the test locally with `go test -run TestAgent_WriteVSCodeConfigs --timeout=8s -count=20`. Or I wrote a new test that always exercises what I think the bug is.

# What is happening

The cron package we are using allows `Run()` to be called after `Close()`. This essentially allows restarting the cron daemon, which is interesting.

`Run()` is called on a go routine. So in our unit tests, it is possible the `Close()` gets called first, then `Run()` is called. There exists a time period between these 2 lines of code:

https://github.com/coder/coder/blob/9b343c49578400cb6c60aa5e92ee0825e9575f91/agent/agentscripts/agentscripts.go#L330-L331

If `Run()` is called between there, the `cmdCloseWait` will never terminate.

# A fix

If the `cronCtx` is cancelled, we just never call `cron.Run()`. The ctx is always cancelled before the stop, so this should be _pretty good_. Ideally we implement this inside the cron package and hook on their `running` flag. However this should suffice.