### PR TITLE
chore: move docker installation warning to install/docker

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -1,6 +1,16 @@
 You can install and run Coder using the official Docker images published on
 [GitHub Container Registry](https://github.com/coder/coder/pkgs/container/coder).
 
+<blockquote class="warning">
+**Before you install**
+If you would like your workspaces to be able to run Docker, we recommend that you <a href="https://github.com/nestybox/sysbox#installation" target="_blank">install Sysbox</a> before proceeding.
+
+As part of the Sysbox installation you will be required to remove all existing
+Docker containers including containers used by Coder workspaces. Installing
+Sysbox ahead of time will reduce disruption to your Coder instance.
+
+</blockquote>
+
 ## Requirements
 
 Docker is required. See the

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,13 +1,3 @@
-<blockquote class="warning">
-**Before you install**
-If you would like your workspaces to be able to run Docker, we recommend that you <a href="https://github.com/nestybox/sysbox#installation" target="_blank">install Sysbox</a> before proceeding.
-
-As part of the Sysbox installation you will be required to remove all existing
-Docker containers including containers used by Coder workspaces. Installing
-Sysbox ahead of time will reduce disruption to your Coder instance.
-
-</blockquote>
-
 There are a number of different methods to install and run Coder:
 
 <children>


### PR DESCRIPTION
Our installation page had a scary warning that may deter some users away which only related to docker use-cases. I'm not sure if this is the best place but we needed to move it off the installation landing page.

