### PR TITLE
fix(enterprise/cli): add CODER_PROVISIONER_DAEMON_LOG_* options

### DIFF
--- a/cli/clilog/clilog.go
+++ b/cli/clilog/clilog.go
@@ -19,15 +19,17 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-type Option func(*Builder)
-type Builder struct {
-	Filter      []string
-	Human       string
-	JSON        string
-	Stackdriver string
-	Trace       bool
-	Verbose     bool
-}
+type (
+	Option  func(*Builder)
+	Builder struct {
+		Filter      []string
+		Human       string
+		JSON        string
+		Stackdriver string
+		Trace       bool
+		Verbose     bool
+	}
+)
 
 func New(opts ...Option) *Builder {
 	b := &Builder{

--- a/cli/clilog/clilog.go
+++ b/cli/clilog/clilog.go
@@ -1,0 +1,192 @@
+package clilog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+	"cdr.dev/slog/sloggers/slogjson"
+	"cdr.dev/slog/sloggers/slogstackdriver"
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/coderd/tracing"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type Option func(*Builder)
+type Builder struct {
+	Filter      []string
+	Human       string
+	JSON        string
+	Stackdriver string
+	Trace       bool
+	Verbose     bool
+}
+
+func New() *Builder {
+	return &Builder{
+		Human:  "/dev/stderr",
+		Filter: []string{},
+	}
+}
+
+func (b *Builder) WithFilter(filters ...string) *Builder {
+	b.Filter = filters
+	return b
+}
+
+func (b *Builder) WithHuman(loc string) *Builder {
+	b.Human = loc
+	return b
+}
+
+func (b *Builder) WithJSON(loc string) *Builder {
+	b.JSON = loc
+	return b
+}
+
+func (b *Builder) WithStackdriver(loc string) *Builder {
+	b.Stackdriver = loc
+	return b
+}
+
+func (b *Builder) WithTrace() *Builder {
+	b.Trace = true
+	return b
+
+}
+func (b *Builder) WithVerbose() *Builder {
+	b.Verbose = true
+	return b
+}
+
+func (b *Builder) FromDeploymentValues(vals *codersdk.DeploymentValues) *Builder {
+	b.Filter = vals.Logging.Filter.Value()
+	b.Human = vals.Logging.Human.Value()
+	b.JSON = vals.Logging.JSON.Value()
+	b.Stackdriver = vals.Logging.Stackdriver.Value()
+	b.Trace = vals.Trace.Enable.Value()
+	b.Verbose = vals.Verbose.Value()
+	return b
+}
+
+func (b *Builder) Build(inv *clibase.Invocation) (slog.Logger, func(), error) {
+	var (
+		sinks   = []slog.Sink{}
+		closers = []func() error{}
+	)
+
+	addSinkIfProvided := func(sinkFn func(io.Writer) slog.Sink, loc string) error {
+		switch loc {
+		case "":
+
+		case "/dev/stdout":
+			sinks = append(sinks, sinkFn(inv.Stdout))
+
+		case "/dev/stderr":
+			sinks = append(sinks, sinkFn(inv.Stderr))
+
+		default:
+			fi, err := os.OpenFile(loc, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+			if err != nil {
+				return xerrors.Errorf("open log file %q: %w", loc, err)
+			}
+			closers = append(closers, fi.Close)
+			sinks = append(sinks, sinkFn(fi))
+		}
+		return nil
+	}
+
+	err := addSinkIfProvided(sloghuman.Sink, b.Human)
+	if err != nil {
+		return slog.Logger{}, nil, xerrors.Errorf("add human sink: %w", err)
+	}
+	err = addSinkIfProvided(slogjson.Sink, b.JSON)
+	if err != nil {
+		return slog.Logger{}, nil, xerrors.Errorf("add json sink: %w", err)
+	}
+	err = addSinkIfProvided(slogstackdriver.Sink, b.Stackdriver)
+	if err != nil {
+		return slog.Logger{}, nil, xerrors.Errorf("add stackdriver sink: %w", err)
+	}
+
+	if b.Trace {
+		sinks = append(sinks, tracing.SlogSink{})
+	}
+
+	// User should log to null device if they don't want logs.
+	if len(sinks) == 0 {
+		return slog.Logger{}, nil, xerrors.New("no loggers provided")
+	}
+
+	filter := &debugFilterSink{next: sinks}
+
+	err = filter.compile(b.Filter)
+	if err != nil {
+		return slog.Logger{}, nil, xerrors.Errorf("compile filters: %w", err)
+	}
+
+	level := slog.LevelInfo
+	// Debug logging is always enabled if a filter is present.
+	if b.Verbose || filter.re != nil {
+		level = slog.LevelDebug
+	}
+
+	return inv.Logger.AppendSinks(filter).Leveled(level), func() {
+		for _, closer := range closers {
+			_ = closer()
+		}
+	}, nil
+}
+
+var _ slog.Sink = &debugFilterSink{}
+
+type debugFilterSink struct {
+	next []slog.Sink
+	re   *regexp.Regexp
+}
+
+func (f *debugFilterSink) compile(res []string) error {
+	if len(res) == 0 {
+		return nil
+	}
+
+	var reb strings.Builder
+	for i, re := range res {
+		_, _ = fmt.Fprintf(&reb, "(%s)", re)
+		if i != len(res)-1 {
+			_, _ = reb.WriteRune('|')
+		}
+	}
+
+	re, err := regexp.Compile(reb.String())
+	if err != nil {
+		return xerrors.Errorf("compile regex: %w", err)
+	}
+	f.re = re
+	return nil
+}
+
+func (f *debugFilterSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
+	if ent.Level == slog.LevelDebug {
+		logName := strings.Join(ent.LoggerNames, ".")
+		if f.re != nil && !f.re.MatchString(logName) && !f.re.MatchString(ent.Message) {
+			return
+		}
+	}
+	for _, sink := range f.next {
+		sink.LogEntry(ctx, ent)
+	}
+}
+
+func (f *debugFilterSink) Sync() {
+	for _, sink := range f.next {
+		sink.Sync()
+	}
+}

--- a/cli/clilog/clilog.go
+++ b/cli/clilog/clilog.go
@@ -68,8 +68,8 @@ func WithTrace() Option {
 	return func(b *Builder) {
 		b.Trace = true
 	}
-
 }
+
 func WithVerbose() Option {
 	return func(b *Builder) {
 		b.Verbose = true

--- a/cli/clilog/clilog.go
+++ b/cli/clilog/clilog.go
@@ -29,51 +29,62 @@ type Builder struct {
 	Verbose     bool
 }
 
-func New() *Builder {
-	return &Builder{
+func New(opts ...Option) *Builder {
+	b := &Builder{
 		Human:  "/dev/stderr",
 		Filter: []string{},
 	}
-}
-
-func (b *Builder) WithFilter(filters ...string) *Builder {
-	b.Filter = filters
+	for _, opt := range opts {
+		opt(b)
+	}
 	return b
 }
 
-func (b *Builder) WithHuman(loc string) *Builder {
-	b.Human = loc
-	return b
+func WithFilter(filters ...string) Option {
+	return func(b *Builder) {
+		b.Filter = filters
+	}
 }
 
-func (b *Builder) WithJSON(loc string) *Builder {
-	b.JSON = loc
-	return b
+func WithHuman(loc string) Option {
+	return func(b *Builder) {
+		b.Human = loc
+	}
 }
 
-func (b *Builder) WithStackdriver(loc string) *Builder {
-	b.Stackdriver = loc
-	return b
+func WithJSON(loc string) Option {
+	return func(b *Builder) {
+		b.JSON = loc
+	}
 }
 
-func (b *Builder) WithTrace() *Builder {
-	b.Trace = true
-	return b
-
-}
-func (b *Builder) WithVerbose() *Builder {
-	b.Verbose = true
-	return b
+func WithStackdriver(loc string) Option {
+	return func(b *Builder) {
+		b.Stackdriver = loc
+	}
 }
 
-func (b *Builder) FromDeploymentValues(vals *codersdk.DeploymentValues) *Builder {
-	b.Filter = vals.Logging.Filter.Value()
-	b.Human = vals.Logging.Human.Value()
-	b.JSON = vals.Logging.JSON.Value()
-	b.Stackdriver = vals.Logging.Stackdriver.Value()
-	b.Trace = vals.Trace.Enable.Value()
-	b.Verbose = vals.Verbose.Value()
-	return b
+func WithTrace() Option {
+	return func(b *Builder) {
+		b.Trace = true
+	}
+
+}
+func WithVerbose() Option {
+	return func(b *Builder) {
+		b.Verbose = true
+	}
+}
+
+func FromDeploymentValues(vals *codersdk.DeploymentValues) Option {
+	return func(b *Builder) {
+		b.Filter = vals.Logging.Filter.Value()
+		b.Human = vals.Logging.Human.Value()
+		b.JSON = vals.Logging.JSON.Value()
+		b.Stackdriver = vals.Logging.Stackdriver.Value()
+		b.Trace = vals.Trace.Enable.Value()
+		b.Verbose = vals.Verbose.Value()
+	}
 }
 
 func (b *Builder) Build(inv *clibase.Invocation) (slog.Logger, func(), error) {

--- a/cli/clilog/clilog_test.go
+++ b/cli/clilog/clilog_test.go
@@ -1,0 +1,168 @@
+package clilog_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/clilog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithFilter", func(t *testing.T) {
+		t.Parallel()
+
+		tempFile := filepath.Join(t.TempDir(), "test.log")
+		cmd := &clibase.Cmd{
+			Use: "test",
+			Handler: func(inv *clibase.Invocation) error {
+				logger, closeLog, err := clilog.New().
+					WithFilter("foo", "baz").
+					WithHuman(tempFile).
+					WithVerbose().
+					Build(inv)
+				if err != nil {
+					return err
+				}
+				defer closeLog()
+				logger.Debug(inv.Context(), "foo is not a useful message")
+				logger.Debug(inv.Context(), "bar is also not a useful message")
+				return nil
+			},
+		}
+		err := cmd.Invoke().Run()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(tempFile)
+		require.NoError(t, err)
+		logs := strings.Split(strings.TrimSpace(string(data)), "\n")
+		if !assert.Len(t, logs, 1) {
+			t.Logf(string(data))
+			t.FailNow()
+		}
+		require.Contains(t, logs[0], "foo is not a useful message")
+	})
+
+	t.Run("WithHuman", func(t *testing.T) {
+		t.Parallel()
+
+		tempFile := filepath.Join(t.TempDir(), "test.log")
+		cmd := &clibase.Cmd{
+			Use: "test",
+			Handler: func(inv *clibase.Invocation) error {
+				logger, closeLog, err := clilog.New().
+					WithHuman(tempFile).
+					Build(inv)
+				if err != nil {
+					return err
+				}
+				defer closeLog()
+				logger.Debug(inv.Context(), "foo is not a useful message")
+				logger.Info(inv.Context(), "bar is also not a useful message")
+				return nil
+			},
+		}
+		err := cmd.Invoke().Run()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(tempFile)
+		require.NoError(t, err)
+		logs := strings.Split(strings.TrimSpace(string(data)), "\n")
+		if !assert.Len(t, logs, 1) {
+			t.Logf(string(data))
+			t.FailNow()
+		}
+		require.Contains(t, logs[0], "bar is also not a useful message")
+	})
+
+	t.Run("WithJSON", func(t *testing.T) {
+		t.Parallel()
+
+		tempFile := filepath.Join(t.TempDir(), "test.log")
+		cmd := &clibase.Cmd{
+			Use: "test",
+			Handler: func(inv *clibase.Invocation) error {
+				logger, closeLog, err := clilog.New().
+					WithJSON(tempFile).
+					Build(inv)
+				if err != nil {
+					return err
+				}
+				defer closeLog()
+				logger.Debug(inv.Context(), "foo is not a useful message")
+				logger.Info(inv.Context(), "bar is also not a useful message")
+				return nil
+			},
+		}
+		err := cmd.Invoke().Run()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(tempFile)
+		require.NoError(t, err)
+		logs := strings.Split(strings.TrimSpace(string(data)), "\n")
+		if !assert.Len(t, logs, 1) {
+			t.Logf(string(data))
+			t.FailNow()
+		}
+		require.Contains(t, logs[0], "bar")
+		var entry struct {
+			Level   string `json:"level"`
+			Message string `json:"msg"`
+		}
+
+		err = json.NewDecoder(strings.NewReader(logs[0])).Decode(&entry)
+		require.NoError(t, err)
+		require.Equal(t, "INFO", entry.Level)
+		require.Equal(t, "bar is also not a useful message", entry.Message)
+	})
+
+	t.Run("WithStackdriver", func(t *testing.T) {
+		t.Parallel()
+
+		tempFile := filepath.Join(t.TempDir(), "test.log")
+		cmd := &clibase.Cmd{
+			Use: "test",
+			Handler: func(inv *clibase.Invocation) error {
+				logger, closeLog, err := clilog.New().
+					WithStackdriver(tempFile).
+					Build(inv)
+				if err != nil {
+					return err
+				}
+				defer closeLog()
+				logger.Debug(inv.Context(), "foo is not a useful message")
+				logger.Info(inv.Context(), "bar is also not a useful message")
+				return nil
+			},
+		}
+		err := cmd.Invoke().Run()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(tempFile)
+		require.NoError(t, err)
+		logs := strings.Split(strings.TrimSpace(string(data)), "\n")
+		if !assert.Len(t, logs, 1) {
+			t.Logf(string(data))
+			t.FailNow()
+		}
+		require.Contains(t, logs[0], "bar is also not a useful message")
+
+		var entry struct {
+			Severity string `json:"severity"`
+			Message  string `json:"message"`
+		}
+
+		err = json.NewDecoder(strings.NewReader(logs[0])).Decode(&entry)
+		require.NoError(t, err)
+		require.Equal(t, "INFO", entry.Severity)
+		require.Equal(t, "bar is also not a useful message", entry.Message)
+	})
+}

--- a/cli/clilog/clilog_test.go
+++ b/cli/clilog/clilog_test.go
@@ -2,6 +2,7 @@ package clilog_test
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -166,7 +167,7 @@ func TestBuilder(t *testing.T) {
 			},
 		}
 		err := cmd.Invoke().Run()
-		require.ErrorContains(t, err, "no such file or directory")
+		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 }
 

--- a/cli/clilog/doc.go
+++ b/cli/clilog/doc.go
@@ -1,0 +1,2 @@
+// Package clilog provides a fluent API for configuring structured logging.
+package clilog

--- a/cli/server.go
+++ b/cli/server.go
@@ -57,10 +57,9 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
-	"cdr.dev/slog/sloggers/slogjson"
-	"cdr.dev/slog/sloggers/slogstackdriver"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/clilog"
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/cliutil"
 	"github.com/coder/coder/v2/cli/config"
@@ -325,7 +324,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			}
 
 			PrintLogo(inv, "Coder")
-			logger, logCloser, err := BuildLogger(inv, vals)
+			logger, logCloser, err := clilog.New(clilog.FromDeploymentValues(vals)).Build(inv)
 			if err != nil {
 				return xerrors.Errorf("make logger: %w", err)
 			}
@@ -2009,121 +2008,6 @@ func isDERPPath(p string) bool {
 // be called with `u.Hostname()`.
 func IsLocalhost(host string) bool {
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
-}
-
-var _ slog.Sink = &debugFilterSink{}
-
-type debugFilterSink struct {
-	next []slog.Sink
-	re   *regexp.Regexp
-}
-
-func (f *debugFilterSink) compile(res []string) error {
-	if len(res) == 0 {
-		return nil
-	}
-
-	var reb strings.Builder
-	for i, re := range res {
-		_, _ = fmt.Fprintf(&reb, "(%s)", re)
-		if i != len(res)-1 {
-			_, _ = reb.WriteRune('|')
-		}
-	}
-
-	re, err := regexp.Compile(reb.String())
-	if err != nil {
-		return xerrors.Errorf("compile regex: %w", err)
-	}
-	f.re = re
-	return nil
-}
-
-func (f *debugFilterSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
-	if ent.Level == slog.LevelDebug {
-		logName := strings.Join(ent.LoggerNames, ".")
-		if f.re != nil && !f.re.MatchString(logName) && !f.re.MatchString(ent.Message) {
-			return
-		}
-	}
-	for _, sink := range f.next {
-		sink.LogEntry(ctx, ent)
-	}
-}
-
-func (f *debugFilterSink) Sync() {
-	for _, sink := range f.next {
-		sink.Sync()
-	}
-}
-
-func BuildLogger(inv *clibase.Invocation, cfg *codersdk.DeploymentValues) (slog.Logger, func(), error) {
-	var (
-		sinks   = []slog.Sink{}
-		closers = []func() error{}
-	)
-
-	addSinkIfProvided := func(sinkFn func(io.Writer) slog.Sink, loc string) error {
-		switch loc {
-		case "":
-
-		case "/dev/stdout":
-			sinks = append(sinks, sinkFn(inv.Stdout))
-
-		case "/dev/stderr":
-			sinks = append(sinks, sinkFn(inv.Stderr))
-
-		default:
-			fi, err := os.OpenFile(loc, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
-			if err != nil {
-				return xerrors.Errorf("open log file %q: %w", loc, err)
-			}
-			closers = append(closers, fi.Close)
-			sinks = append(sinks, sinkFn(fi))
-		}
-		return nil
-	}
-
-	err := addSinkIfProvided(sloghuman.Sink, cfg.Logging.Human.String())
-	if err != nil {
-		return slog.Logger{}, nil, xerrors.Errorf("add human sink: %w", err)
-	}
-	err = addSinkIfProvided(slogjson.Sink, cfg.Logging.JSON.String())
-	if err != nil {
-		return slog.Logger{}, nil, xerrors.Errorf("add json sink: %w", err)
-	}
-	err = addSinkIfProvided(slogstackdriver.Sink, cfg.Logging.Stackdriver.String())
-	if err != nil {
-		return slog.Logger{}, nil, xerrors.Errorf("add stackdriver sink: %w", err)
-	}
-
-	if cfg.Trace.CaptureLogs {
-		sinks = append(sinks, tracing.SlogSink{})
-	}
-
-	// User should log to null device if they don't want logs.
-	if len(sinks) == 0 {
-		return slog.Logger{}, nil, xerrors.New("no loggers provided")
-	}
-
-	filter := &debugFilterSink{next: sinks}
-
-	err = filter.compile(cfg.Logging.Filter.Value())
-	if err != nil {
-		return slog.Logger{}, nil, xerrors.Errorf("compile filters: %w", err)
-	}
-
-	level := slog.LevelInfo
-	// Debug logging is always enabled if a filter is present.
-	if cfg.Verbose || filter.re != nil {
-		level = slog.LevelDebug
-	}
-
-	return inv.Logger.AppendSinks(filter).Leveled(level), func() {
-		for _, closer := range closers {
-			_ = closer()
-		}
-	}, nil
 }
 
 func ConnectToPostgres(ctx context.Context, logger slog.Logger, driver string, dbURL string) (sqlDB *sql.DB, err error) {

--- a/docs/cli/provisionerd_start.md
+++ b/docs/cli/provisionerd_start.md
@@ -22,6 +22,43 @@ coder provisionerd start [flags]
 
 Directory to store cached data.
 
+### --log-filter
+
+|             |                                             |
+| ----------- | ------------------------------------------- |
+| Type        | <code>string-array</code>                   |
+| Environment | <code>$CODER_PROVISIONERD_LOG_FILTER</code> |
+
+Filter debug logs by matching against a given regex. Use .\* to match all debug logs.
+
+### --log-human
+
+|             |                                            |
+| ----------- | ------------------------------------------ |
+| Type        | <code>string</code>                        |
+| Environment | <code>$CODER_PROVISIONERD_LOG_HUMAN</code> |
+| Default     | <code>/dev/stderr</code>                   |
+
+Log in human-readable format to the given path.
+
+### --log-json
+
+|             |                                           |
+| ----------- | ----------------------------------------- |
+| Type        | <code>string</code>                       |
+| Environment | <code>$CODER_PROVISIONERD_LOG_JSON</code> |
+
+Log in JSON format to the given path.
+
+### --log-stackdriver
+
+|             |                                                  |
+| ----------- | ------------------------------------------------ |
+| Type        | <code>string</code>                              |
+| Environment | <code>$CODER_PROVISIONERD_LOG_STACKDRIVER</code> |
+
+Log in Stackdriver format to the given path.
+
 ### --name
 
 |             |                                             |
@@ -68,3 +105,13 @@ Pre-shared key to authenticate with Coder server.
 | Environment | <code>$CODER_PROVISIONERD_TAGS</code> |
 
 Tags to filter provisioner jobs by.
+
+### --verbose
+
+|             |                                          |
+| ----------- | ---------------------------------------- |
+| Type        | <code>bool</code>                        |
+| Environment | <code>$CODER_PROVISIONERD_VERBOSE</code> |
+| Default     | <code>false</code>                       |
+
+Enable verbose logging. This is useful for debugging, but can be noisy when running in production.

--- a/docs/cli/provisionerd_start.md
+++ b/docs/cli/provisionerd_start.md
@@ -24,40 +24,40 @@ Directory to store cached data.
 
 ### --log-filter
 
-|             |                                             |
-| ----------- | ------------------------------------------- |
-| Type        | <code>string-array</code>                   |
-| Environment | <code>$CODER_PROVISIONERD_LOG_FILTER</code> |
+|             |                                                   |
+| ----------- | ------------------------------------------------- |
+| Type        | <code>string-array</code>                         |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_LOG_FILTER</code> |
 
 Filter debug logs by matching against a given regex. Use .\* to match all debug logs.
 
 ### --log-human
 
-|             |                                            |
-| ----------- | ------------------------------------------ |
-| Type        | <code>string</code>                        |
-| Environment | <code>$CODER_PROVISIONERD_LOG_HUMAN</code> |
-| Default     | <code>/dev/stderr</code>                   |
+|             |                                                      |
+| ----------- | ---------------------------------------------------- |
+| Type        | <code>string</code>                                  |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_LOGGING_HUMAN</code> |
+| Default     | <code>/dev/stderr</code>                             |
 
-Log in human-readable format to the given path.
+Output human-readable logs to a given file.
 
 ### --log-json
 
-|             |                                           |
-| ----------- | ----------------------------------------- |
-| Type        | <code>string</code>                       |
-| Environment | <code>$CODER_PROVISIONERD_LOG_JSON</code> |
+|             |                                                     |
+| ----------- | --------------------------------------------------- |
+| Type        | <code>string</code>                                 |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_LOGGING_JSON</code> |
 
-Log in JSON format to the given path.
+Output JSON logs to a given file.
 
 ### --log-stackdriver
 
-|             |                                                  |
-| ----------- | ------------------------------------------------ |
-| Type        | <code>string</code>                              |
-| Environment | <code>$CODER_PROVISIONERD_LOG_STACKDRIVER</code> |
+|             |                                                            |
+| ----------- | ---------------------------------------------------------- |
+| Type        | <code>string</code>                                        |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_LOGGING_STACKDRIVER</code> |
 
-Log in Stackdriver format to the given path.
+Output Stackdriver compatible logs to a given file.
 
 ### --name
 
@@ -108,10 +108,10 @@ Tags to filter provisioner jobs by.
 
 ### --verbose
 
-|             |                                          |
-| ----------- | ---------------------------------------- |
-| Type        | <code>bool</code>                        |
-| Environment | <code>$CODER_PROVISIONERD_VERBOSE</code> |
-| Default     | <code>false</code>                       |
+|             |                                                |
+| ----------- | ---------------------------------------------- |
+| Type        | <code>bool</code>                              |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_VERBOSE</code> |
+| Default     | <code>false</code>                             |
 
-Enable verbose logging. This is useful for debugging, but can be noisy when running in production.
+Output debug-level logs.

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -13,9 +13,9 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
-	"cdr.dev/slog/sloggers/sloghuman"
 	agpl "github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/clilog"
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/cliutil"
 	"github.com/coder/coder/v2/coderd/database"
@@ -55,12 +55,17 @@ func validateProvisionerDaemonName(name string) error {
 
 func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 	var (
-		cacheDir     string
-		rawTags      []string
-		pollInterval time.Duration
-		pollJitter   time.Duration
-		preSharedKey string
-		name         string
+		cacheDir       string
+		logHuman       string
+		logJSON        string
+		logStackdriver string
+		logFilter      []string
+		name           string
+		rawTags        []string
+		pollInterval   time.Duration
+		pollJitter     time.Duration
+		preSharedKey   string
+		verbose        bool
 	)
 	client := new(codersdk.Client)
 	cmd := &clibase.Cmd{
@@ -89,10 +94,18 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 				return err
 			}
 
-			logger := slog.Make(sloghuman.Sink(inv.Stderr))
-			if ok, _ := inv.ParsedFlags().GetBool("verbose"); ok {
-				logger = logger.Leveled(slog.LevelDebug)
+			logOpts := []clilog.Option{
+				clilog.WithFilter(logFilter...),
+				clilog.WithHuman(logHuman),
+				clilog.WithJSON(logJSON),
+				clilog.WithStackdriver(logStackdriver),
 			}
+			if verbose {
+				logOpts = append(logOpts, clilog.WithVerbose())
+			}
+
+			logger, closeLogger, err := clilog.New(logOpts...).Build(inv)
+			defer closeLogger()
 
 			if len(tags) != 0 {
 				logger.Info(ctx, "note: tagged provisioners can currently pick up jobs from untagged templates")
@@ -232,6 +245,41 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 			Env:         "CODER_PROVISIONER_DAEMON_NAME",
 			Description: "Name of this provisioner daemon. Defaults to the current hostname without FQDN.",
 			Value:       clibase.StringOf(&name),
+			Default:     "",
+		},
+		{
+			Flag:        "verbose",
+			Env:         "CODER_PROVISIONER_DAEMON_VERBOSE",
+			Description: "Output debug-level logs.",
+			Value:       clibase.BoolOf(&verbose),
+			Default:     "false",
+		},
+		{
+			Flag:        "log-human",
+			Env:         "CODER_PROVISIONER_DAEMON_LOGGING_HUMAN",
+			Description: "Output human-readable logs to a given file.",
+			Value:       clibase.StringOf(&logHuman),
+			Default:     "/dev/stderr",
+		},
+		{
+			Flag:        "log-json",
+			Env:         "CODER_PROVISIONER_DAEMON_LOGGING_JSON",
+			Description: "Output JSON logs to a given file.",
+			Value:       clibase.StringOf(&logJSON),
+			Default:     "",
+		},
+		{
+			Flag:        "log-stackdriver",
+			Env:         "CODER_PROVISIONER_DAEMON_LOGGING_STACKDRIVER",
+			Description: "Output Stackdriver compatible logs to a given file.",
+			Value:       clibase.StringOf(&logStackdriver),
+			Default:     "",
+		},
+		{
+			Flag:        "log-filter",
+			Env:         "CODER_PROVISIONER_DAEMON_LOG_FILTER",
+			Description: "Filter debug logs by matching against a given regex. Use .* to match all debug logs.",
+			Value:       clibase.StringArrayOf(&logFilter),
 			Default:     "",
 		},
 	}

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
 	agpl "github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/clilog"
@@ -105,6 +106,11 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 			}
 
 			logger, closeLogger, err := clilog.New(logOpts...).Build(inv)
+			if err != nil {
+				// Fall back to a basic logger
+				logger = slog.Make(sloghuman.Sink(inv.Stderr))
+				logger.Error(ctx, "failed to initialize logger", slog.Error(err))
+			}
 			defer closeLogger()
 
 			if len(tags) != 0 {

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -110,8 +110,9 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 				// Fall back to a basic logger
 				logger = slog.Make(sloghuman.Sink(inv.Stderr))
 				logger.Error(ctx, "failed to initialize logger", slog.Error(err))
+			} else {
+				defer closeLogger()
 			}
-			defer closeLogger()
 
 			if len(tags) != 0 {
 				logger.Info(ctx, "note: tagged provisioners can currently pick up jobs from untagged templates")

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -23,6 +23,7 @@ import (
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/clilog"
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -121,7 +122,7 @@ func (r *RootCmd) proxyServer() *clibase.Cmd {
 			go cli.DumpHandler(ctx)
 
 			cli.PrintLogo(inv, "Coder Workspace Proxy")
-			logger, logCloser, err := cli.BuildLogger(inv, cfg)
+			logger, logCloser, err := clilog.New(clilog.FromDeploymentValues(cfg)).Build(inv)
 			if err != nil {
 				return xerrors.Errorf("make logger: %w", err)
 			}

--- a/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
+++ b/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
@@ -9,6 +9,19 @@ OPTIONS:
   -c, --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           Directory to store cached data.
 
+      --log-filter string-array, $CODER_PROVISIONER_DAEMON_LOG_FILTER
+          Filter debug logs by matching against a given regex. Use .* to match
+          all debug logs.
+
+      --log-human string, $CODER_PROVISIONER_DAEMON_LOGGING_HUMAN (default: /dev/stderr)
+          Output human-readable logs to a given file.
+
+      --log-json string, $CODER_PROVISIONER_DAEMON_LOGGING_JSON
+          Output JSON logs to a given file.
+
+      --log-stackdriver string, $CODER_PROVISIONER_DAEMON_LOGGING_STACKDRIVER
+          Output Stackdriver compatible logs to a given file.
+
       --name string, $CODER_PROVISIONER_DAEMON_NAME
           Name of this provisioner daemon. Defaults to the current hostname
           without FQDN.
@@ -24,6 +37,9 @@ OPTIONS:
 
   -t, --tag string-array, $CODER_PROVISIONERD_TAGS
           Tags to filter provisioner jobs by.
+
+      --verbose bool, $CODER_PROVISIONER_DAEMON_VERBOSE (default: false)
+          Output debug-level logs.
 
 ———
 Run `coder --help` for a list of global options.


### PR DESCRIPTION
* Extracts `cli.BuildLogger` to `clilog` package
* Updates existing usage of `cli.BuildLogger` and removes it
* Use `clilog` to initialize provisionerd logger