### PR TITLE
feat: implement DERP streaming on tailnet Client API

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -479,7 +479,11 @@ func New(options *Options) *API {
 		}
 	}
 	api.TailnetClientService, err = tailnet.NewClientService(
-		api.Logger.Named("tailnetclient"), &api.TailnetCoordinator)
+		api.Logger.Named("tailnetclient"),
+		&api.TailnetCoordinator,
+		api.Options.DERPMapUpdateFrequency,
+		api.DERPMap,
+	)
 	if err != nil {
 		api.Logger.Fatal(api.ctx, "failed to initialize tailnet client service", slog.Error(err))
 	}


### PR DESCRIPTION
Implements DERPMap streaming from client API.

In a subsequent PR I plan to remove the implementation in coderd/agentapi in favor of the tailnet one
