### PR TITLE
fix: avoid panic on nil connection

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1635,9 +1635,10 @@ func TestAgent_Dial(t *testing.T) {
 			go func() {
 				defer close(done)
 				c, err := l.Accept()
-				assert.NoError(t, err, "accept connection")
-				defer c.Close()
-				testAccept(ctx, t, c)
+				if assert.NoError(t, err, "accept connection") {
+					defer c.Close()
+					testAccept(ctx, t, c)
+				}
 			}()
 
 			//nolint:dogsled


### PR DESCRIPTION
Related to https://github.com/coder/coder/actions/runs/7286675441/job/19855871305

Fixes a panic if the listener returns an error, which can obfuscate the underlying problem and cause unrelated tests to be marked failed.
