### PR TITLE
fix: stop printing warnings on external provisioner daemon command

### DIFF
--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -73,6 +73,9 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 		Use:   "start",
 		Short: "Run a provisioner daemon",
 		Middleware: clibase.Chain(
+			// disable checks and warnings because this command starts a daemon; it is
+			// not meant for humans typing commands.  Furthermore, the checks are
+			// incompatible with PSK auth that this command uses
 			r.InitClientMissingTokenOK(client),
 		),
 		Handler: func(inv *clibase.Invocation) error {

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -36,7 +36,7 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 	ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 	defer cancel()
 	clitest.Start(t, inv)
-	pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+	pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
 	pty.ExpectMatchContext(ctx, "matt-daemon")
 
 	var daemons []codersdk.ProvisionerDaemon


### PR DESCRIPTION
fixes #11307
