### PR TITLE
chore: build dogfood image on PRs and skip pushing to registry

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -7,11 +7,10 @@ on:
     paths:
       - "dogfood/**"
       - ".github/workflows/dogfood.yaml"
-  # Uncomment these lines when testing with CI.
-  # pull_request:
-  #   paths:
-  #     - "dogfood/**"
-  #     - ".github/workflows/dogfood.yaml"
+  pull_request:
+    paths:
+      - "dogfood/**"
+      - ".github/workflows/dogfood.yaml"
   workflow_dispatch:
 
 jobs:
@@ -37,6 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -47,13 +47,14 @@ jobs:
         with:
           context: "{{defaultContext}}:dogfood"
           pull: true
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: "codercom/oss-dogfood:${{ steps.docker-tag-name.outputs.tag }},codercom/oss-dogfood:latest"
           cache-from: type=registry,ref=codercom/oss-dogfood:latest
           cache-to: type=inline
 
   deploy_template:
     needs: deploy_image
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This will ensure the image builds on the PR before merging into the `main`. We are conditionally preventing the push and template update if not the `main` branch.

> [!NOTE]
> This is in preparation to make our dogfood image lighter by removing any unused pkgs like we install GoLand IDE in Dockerfile and use [`flake.nix`](https://github.com/coder/coder/blob/main/flake.nix) to mange build dependencies.