### PR TITLE
fix: prevent UI from jumping around when selecting workspaces

### DIFF
--- a/site/src/components/PaginationWidget/PaginationHeader.tsx
+++ b/site/src/components/PaginationWidget/PaginationHeader.tsx
@@ -7,6 +7,10 @@ type PaginationHeaderProps = {
   limit: number;
   totalRecords: number | undefined;
   currentOffsetStart: number | undefined;
+
+  // Temporary escape hatch until Workspaces can be switched over to using
+  // PaginationContainer
+  className?: string;
 };
 
 export const PaginationHeader: FC<PaginationHeaderProps> = ({
@@ -14,6 +18,7 @@ export const PaginationHeader: FC<PaginationHeaderProps> = ({
   limit,
   totalRecords,
   currentOffsetStart,
+  className,
 }) => {
   const theme = useTheme();
 
@@ -32,6 +37,7 @@ export const PaginationHeader: FC<PaginationHeaderProps> = ({
           color: theme.palette.text.primary,
         },
       }}
+      className={className}
     >
       {totalRecords !== undefined ? (
         <>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -162,6 +162,7 @@ export const WorkspacesPageView = ({
             limit={limit}
             totalRecords={count}
             currentOffsetStart={(page - 1) * limit + 1}
+            css={{ paddingBottom: "0" }}
           />
         )}
       </TableToolbar>


### PR DESCRIPTION
Exactly what it says on the tin.
Makes it so that when you select a workspace, the line indicating the status ("Selected 1 of 25 workspaces") doesn't jump down

Video of things working properly:

https://github.com/coder/coder/assets/28937484/85297460-c2d1-4ca9-b31e-14604843c683

