### PR TITLE
ci: fix close reason type for stale issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -68,7 +68,7 @@ jobs:
                     repo: context.repo.repo,
                     issue_number: issue.number,
                     state: 'closed',
-                    state_reason: 'not planned'
+                    state_reason: 'not_planned'
                   });
                 }
               } else {


### PR DESCRIPTION
The action was faking because we were incorrectly using `not planned` instead of `not_planned`.