### PR TITLE
fix broken formatting docs/cli/configssh

### DIFF
--- a/docs/cli/config-ssh.md
+++ b/docs/cli/config-ssh.md
@@ -93,8 +93,8 @@ Specifies whether or not to keep options from previous run of config-ssh.
 ### --wait
 
 |             |                                    |
-| ----------- | ---------------------------------- | --- | ------------ |
-| Type        | <code>enum[yes                     | no  | auto]</code> |
+| ----------- | ---------------------------------- |
+| Type        | <code>enum[yes/ no/ auto]</code> |
 | Environment | <code>$CODER_CONFIGSSH_WAIT</code> |
 | Default     | <code>auto</code>                  |
 


### PR DESCRIPTION
Rectified the formatting in the documentation docs/cli/configssh.

```diff
### --wait

|             |                                    |
-| ----------- | ---------------------------------- | --- | ------------ |
-| Type        | <code>enum[yes                     | no  | auto]</code> |
| Environment | <code>$CODER_CONFIGSSH_WAIT</code> |
| Default     | <code>auto</code>                  |

### --wait

|             |                                    |
+| ----------- | ---------------------------------- |
+| Type        | <code>enum[yes/ no/ auto]</code> |
| Environment | <code>$CODER_CONFIGSSH_WAIT</code> |
| Default     | <code>auto</code>                  |