### PR TITLE
fix(examples/templates/nomad-docker): ignore `NOMAD_NAMESPACE` and `NOMAD_REGION` when Coder is running in nomad

### DIFF
--- a/examples/templates/nomad-docker/main.tf
+++ b/examples/templates/nomad-docker/main.tf
@@ -27,6 +27,12 @@ provider "coder" {}
 provider "nomad" {
   address   = var.nomad_provider_address
   http_auth = var.nomad_provider_http_auth == "" ? null : var.nomad_provider_http_auth
+
+  # Fix reading the NOMAD_NAMESPACE and the NOMAD_REGION env var from the coder's allocation.
+  ignore_env_vars = {
+    "NOMAD_NAMESPACE" = true
+    "NOMAD_REGION"    = true
+  }
 }
 
 data "coder_parameter" "cpu" {


### PR DESCRIPTION
If coder is running the terraform CLI as a Nomad job, then it may be reading the NOMAD_NAMESPACE env var from that allocation.

Added the ignore_env_vars to fix this problem.

hashicorp/terraform-provider-nomad#386