### PR TITLE
fix: test for expiry 3 months on Azure certs

### DIFF
--- a/coderd/azureidentity/azureidentity_test.go
+++ b/coderd/azureidentity/azureidentity_test.go
@@ -59,7 +59,7 @@ func TestExpiresSoon(t *testing.T) {
 		cert, err := x509.ParseCertificate(block.Bytes)
 		require.NoError(t, err)
 
-		expiresSoon := cert.NotAfter.Before(time.Now().AddDate(0, 6, 0))
+		expiresSoon := cert.NotAfter.Before(time.Now().AddDate(0, 3, 0))
 		if expiresSoon {
 			t.Errorf("certificate expires within 6 months %s: %s", cert.NotAfter, cert.Subject.CommonName)
 		} else {


### PR DESCRIPTION
Changes TestExpiresSoon to check for 3 months of validity instead of 6.  The Azure certificates we have expire in June 2024, but Microsoft has not issued updated intermidiates yet, according to https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-ca-details?tabs=root-and-subordinate-cas-list

