### PR TITLE
refactor(site): simplify workspace topbar

### DIFF
--- a/site/src/components/AvatarData/AvatarData.tsx
+++ b/site/src/components/AvatarData/AvatarData.tsx
@@ -1,11 +1,11 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { useTheme } from "@emotion/react";
 import { Avatar } from "components/Avatar/Avatar";
 import { Stack } from "components/Stack/Stack";
 
 export interface AvatarDataProps {
-  title: string | JSX.Element;
-  subtitle?: string;
+  title: ReactNode;
+  subtitle?: ReactNode;
   src?: string;
   avatar?: React.ReactNode;
 }

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar/WorkspaceTopbar.tsx
@@ -11,11 +11,8 @@ import {
 } from "components/FullPageLayout/Topbar";
 import Tooltip from "@mui/material/Tooltip";
 import ArrowBackOutlined from "@mui/icons-material/ArrowBackOutlined";
-import { WorkspaceOutdatedTooltipContent } from "components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip";
-import { Popover, PopoverTrigger } from "components/Popover/Popover";
 import ScheduleOutlined from "@mui/icons-material/ScheduleOutlined";
 import { WorkspaceStatusBadge } from "components/WorkspaceStatusBadge/WorkspaceStatusBadge";
-import { Pill } from "components/Pill/Pill";
 import {
   WorkspaceScheduleControls,
   shouldDisplayScheduleControls,
@@ -24,12 +21,15 @@ import { workspaceQuota } from "api/queries/workspaceQuota";
 import { useQuery } from "react-query";
 import MonetizationOnOutlined from "@mui/icons-material/MonetizationOnOutlined";
 import { useTheme } from "@mui/material/styles";
-import InfoOutlined from "@mui/icons-material/InfoOutlined";
 import Link from "@mui/material/Link";
 import { useDashboard } from "components/Dashboard/DashboardProvider";
 import { displayDormantDeletion } from "utils/dormant";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
 import PersonOutline from "@mui/icons-material/PersonOutline";
+import { Popover, PopoverTrigger } from "components/Popover/Popover";
+import { HelpTooltipContent } from "components/HelpTooltip/HelpTooltip";
+import { AvatarData } from "components/AvatarData/AvatarData";
+import { Avatar } from "components/Avatar/Avatar";
 
 export type WorkspaceError =
   | "getBuildsError"
@@ -127,52 +127,70 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
             <span>{workspace.owner_name}</span>
           </Tooltip>
           <TopbarDivider />
-          <Tooltip
-            title={workspace.template_display_name ?? workspace.template_name}
+          <Popover
+            mode="hover"
+            // title={`${
+            //   workspace.template_display_name ?? workspace.template_name
+            // } on version ${workspace.latest_build.template_version_name}`}
           >
-            <Link
-              component={RouterLink}
-              to={`/templates/${workspace.template_name}`}
-              css={{ color: "inherit" }}
+            <PopoverTrigger>
+              <span
+                css={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  cursor: "default",
+                  padding: "4px 0",
+                }}
+              >
+                <TopbarAvatar src={workspace.template_icon} />
+                <span css={{ fontWeight: 500 }}>{workspace.name}</span>
+              </span>
+            </PopoverTrigger>
+
+            <HelpTooltipContent
+              anchorOrigin={{
+                vertical: "bottom",
+                horizontal: "center",
+              }}
+              transformOrigin={{
+                vertical: "top",
+                horizontal: "center",
+              }}
             >
-              <TopbarAvatar src={workspace.template_icon} />
-            </Link>
-          </Tooltip>
-
-          <span css={{ fontWeight: 500 }}>{workspace.name}</span>
-
-          {workspace.outdated ? (
-            <Popover mode="hover">
-              <PopoverTrigger>
-                {/* Added to give some bottom space from the popover content */}
-                <div css={{ padding: "4px 0", margin: "-4px 0" }}>
-                  <Pill
-                    icon={
-                      <InfoOutlined
-                        css={{
-                          width: "12px !important",
-                          height: "12px !important",
-                          color: theme.palette.warning.light,
-                        }}
-                      />
-                    }
+              <AvatarData
+                title={
+                  <Link
+                    component={RouterLink}
+                    to={`/templates/${workspace.template_name}`}
+                    css={{ color: "inherit" }}
                   >
-                    <span css={{ color: theme.palette.warning.light }}>
-                      {workspace.latest_build.template_version_name}
-                    </span>
-                  </Pill>
-                </div>
-              </PopoverTrigger>
-              <WorkspaceOutdatedTooltipContent
-                templateName={workspace.template_name}
-                latestVersionId={workspace.template_active_version_id}
-                onUpdateVersion={handleUpdate}
-                ariaLabel="update version"
+                    {workspace.template_display_name.length > 0
+                      ? workspace.template_display_name
+                      : workspace.template_name}
+                  </Link>
+                }
+                subtitle={
+                  <Link
+                    component={RouterLink}
+                    to={`/templates/${workspace.template_name}/versions/${workspace.latest_build.template_version_name}`}
+                    css={{ color: "inherit" }}
+                  >
+                    {workspace.latest_build.template_version_name}
+                  </Link>
+                }
+                avatar={
+                  workspace.template_icon !== "" && (
+                    <Avatar
+                      src={workspace.template_icon}
+                      variant="square"
+                      fitImage
+                    />
+                  )
+                }
               />
-            </Popover>
-          ) : (
-            <Pill>{workspace.latest_build.template_version_name}</Pill>
-          )}
+            </HelpTooltipContent>
+          </Popover>
         </TopbarData>
 
         {shouldDisplayDormantData && (

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar/WorkspaceTopbar.tsx
@@ -11,7 +11,6 @@ import {
 } from "components/FullPageLayout/Topbar";
 import Tooltip from "@mui/material/Tooltip";
 import ArrowBackOutlined from "@mui/icons-material/ArrowBackOutlined";
-import PersonOutlineOutlined from "@mui/icons-material/PersonOutlineOutlined";
 import { WorkspaceOutdatedTooltipContent } from "components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip";
 import { Popover, PopoverTrigger } from "components/Popover/Popover";
 import ScheduleOutlined from "@mui/icons-material/ScheduleOutlined";
@@ -30,6 +29,7 @@ import Link from "@mui/material/Link";
 import { useDashboard } from "components/Dashboard/DashboardProvider";
 import { displayDormantDeletion } from "utils/dormant";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
+import PersonOutline from "@mui/icons-material/PersonOutline";
 
 export type WorkspaceError =
   | "getBuildsError"
@@ -120,16 +120,26 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
         }}
       >
         <TopbarData>
-          <TopbarAvatar src={workspace.template_icon} />
-          <span css={{ fontWeight: 500 }}>{workspace.name}</span>
+          <TopbarIcon>
+            <PersonOutline />
+          </TopbarIcon>
+          <Tooltip title="Owner">
+            <span>{workspace.owner_name}</span>
+          </Tooltip>
           <TopbarDivider />
-          <Link
-            component={RouterLink}
-            to={`/templates/${workspace.template_name}`}
-            css={{ color: "inherit" }}
+          <Tooltip
+            title={workspace.template_display_name ?? workspace.template_name}
           >
-            {workspace.template_display_name ?? workspace.template_name}
-          </Link>
+            <Link
+              component={RouterLink}
+              to={`/templates/${workspace.template_name}`}
+              css={{ color: "inherit" }}
+            >
+              <TopbarAvatar src={workspace.template_icon} />
+            </Link>
+          </Tooltip>
+
+          <span css={{ fontWeight: 500 }}>{workspace.name}</span>
 
           {workspace.outdated ? (
             <Popover mode="hover">
@@ -163,15 +173,6 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
           ) : (
             <Pill>{workspace.latest_build.template_version_name}</Pill>
           )}
-        </TopbarData>
-
-        <TopbarData>
-          <Tooltip title="Owner">
-            <TopbarIcon>
-              <PersonOutlineOutlined aria-label="Owner" />
-            </TopbarIcon>
-          </Tooltip>
-          <span>{workspace.owner_name}</span>
         </TopbarData>
 
         {shouldDisplayDormantData && (

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar/WorkspaceTopbar.tsx
@@ -127,12 +127,7 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
             <span>{workspace.owner_name}</span>
           </Tooltip>
           <TopbarDivider />
-          <Popover
-            mode="hover"
-            // title={`${
-            //   workspace.template_display_name ?? workspace.template_name
-            // } on version ${workspace.latest_build.template_version_name}`}
-          >
+          <Popover mode="hover">
             <PopoverTrigger>
               <span
                 css={{


### PR DESCRIPTION
From @mafredri feedback:
- It looks a bit busy in my eyes, I think it could be simplified further.
- Maybe we can change the beginning to [template icon] [username] / [workspace] (i) [Stops in ...]. My thought is that behind (i) (info) we can show template name, current version, etc.
-  the current version of the workspace/template is quite uninteresting and only needed in special circumstances.

Changes:
- Moved template name and version into a tooltip when hovering the template icon
- Moved the user name to be the first info in the "workspace path"
- Removed the outdated pill as well since we already have on the page an update button and alert with this information.

Before:
<img width="1512" alt="Screenshot 2024-01-02 at 14 24 34" src="https://github.com/coder/coder/assets/3165839/6f200500-eef8-43b3-87f3-074ddd31dfbf">

After:
<img width="1512" alt="Screenshot 2024-01-02 at 14 50 34" src="https://github.com/coder/coder/assets/3165839/649c0ef2-b9dd-4ad3-b771-95678829781e">

