### PR TITLE
fix(coderd/database): add missing v prefix to provisioner_daemons.api_version

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -537,7 +537,7 @@ CREATE TABLE provisioner_daemons (
     tags jsonb DEFAULT '{}'::jsonb NOT NULL,
     last_seen_at timestamp with time zone,
     version text DEFAULT ''::text NOT NULL,
-    api_version text DEFAULT '1.0'::text NOT NULL
+    api_version text DEFAULT 'v1.0'::text NOT NULL
 );
 
 COMMENT ON COLUMN provisioner_daemons.api_version IS 'The API version of the provisioner daemon';

--- a/coderd/database/migrations/000183_provisionerd_api_version_prefix.down.sql
+++ b/coderd/database/migrations/000183_provisionerd_api_version_prefix.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ONLY provisioner_daemons
+	ALTER COLUMN api_version SET DEFAULT '1.0'::text;
+UPDATE provisioner_daemons
+	SET api_version = '1.0'
+	WHERE api_version = 'v1.0';

--- a/coderd/database/migrations/000183_provisionerd_api_version_prefix.up.sql
+++ b/coderd/database/migrations/000183_provisionerd_api_version_prefix.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ONLY provisioner_daemons
+	ALTER COLUMN api_version SET DEFAULT 'v1.0'::text;
+UPDATE provisioner_daemons
+	SET api_version = 'v1.0'
+	WHERE api_version = '1.0';

--- a/provisionersdk/serve.go
+++ b/provisionersdk/serve.go
@@ -24,7 +24,7 @@ const (
 	// APIVersionCurrent is the current provisionerd API version.
 	// Breaking changes to the provisionerd API **MUST** increment
 	// the major version below.
-	APIVersionCurrent = "1.0"
+	APIVersionCurrent = "v1.0"
 )
 
 // ServeOptions are configurations to serve a provisioner.


### PR DESCRIPTION
When adding `provisioner_daemons.api_version` initially I missed the `v` prefix.
This is a requirement of `/x/mod/semver`, so adding a small migration to normalize this now.