### PR TITLE
ci: broaden scope of needs.changes.db

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
               - "examples/lima/**"
             db:
               - "**.sql"
-              - "coderd/database/**
+              - "coderd/database/**"
             go:
               - "**.sql"
               - "**.go"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,10 +60,7 @@ jobs:
               - "examples/lima/**"
             db:
               - "**.sql"
-              - "coderd/database/queries/**"
-              - "coderd/database/migrations"
-              - "coderd/database/sqlc.yaml"
-              - "coderd/database/dump.sql"
+              - "coderd/database/**
             go:
               - "**.sql"
               - "**.go"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,7 +321,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'buildjet-8vcpu-ubuntu-2204' || 'ubuntu-latest' }}
     needs:
       - changes
-      - sqlc-vet # No point in testing the DB if the queries are invalid
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
     # `make test-postgres` to ensure we receive a trace of running


### PR DESCRIPTION
https://github.com/coder/coder/pull/11381 made changes to `coderd/database/dbfake`.
Because `test-go-pg` got skipped, a test flake snuck onto `main`.
https://github.com/coder/coder/actions/runs/7395536966/job/20118913609

To prevent this from happening in future:
- Broadening scope of `needs.changes.db` to include _anything_ under the path `coderd/database`.
- Removing dependency of `test-go-pg` on `sqlc-vet`.