### PR TITLE
chore: mark template update policies as GA in docs

### DIFF
--- a/docs/templates/general-settings.md
+++ b/docs/templates/general-settings.md
@@ -17,14 +17,7 @@ While this can be helpful for cases where a build is unlikely to finish, it also
 carries the risk of potentially corrupting your workspace. The setting is
 disabled by default.
 
-### Require automatic updates
-
-> Requiring automatic updates is in an
-> [experimental state](../contributing/feature-stages.md#experimental-features)
-> and the behavior is subject to change. Use
-> [GitHub issues](https://github.com/coder/coder) to leave feedback. This
-> experiment must be specifically enabled with the
-> `--experiments="template_update_policies"` option on your coderd deployment.
+### Require automatic updates (enterprise)
 
 Admins can require all workspaces update to the latest active template version
 when they're started. This can be used to enforce security patches or other

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -86,7 +86,7 @@ can choose to use a max lifetime or an autostop requirement during the
 deprecation period, but only one can be used at a time. Coder recommends using
 autostop requirements instead as they avoid restarts during work hours.
 
-### Autostop requirement (Enterprise)
+### Autostop requirement (enterprise)
 
 Autostop requirement is a template setting that determines how often workspaces
 using the template must automatically stop. Autostop requirement ignores any
@@ -116,7 +116,7 @@ Autostop requirement is disabled when the template is using the deprecated max
 lifetime feature. Templates can choose to use a max lifetime or an autostop
 requirement during the deprecation period, but only one can be used at a time.
 
-#### User quiet hours (Enterprise)
+#### User quiet hours (enterprise)
 
 User quiet hours can be configured in the user's schedule settings page.
 Workspaces on templates with an autostop requirement will only be forcibly


### PR DESCRIPTION
We made template update policies GA in https://github.com/coder/coder/pull/11250.

This PR also renames (Enterprise) to (enterprise) in several places render the nice little pill :)