### PR TITLE
fix: ensure wsproxy `MultiAgent` is closed when websocket dies

### DIFF
--- a/coderd/httpapi/websocket.go
+++ b/coderd/httpapi/websocket.go
@@ -26,10 +26,10 @@ func Heartbeat(ctx context.Context, conn *websocket.Conn) {
 	}
 }
 
-// Heartbeat loops to ping a WebSocket to keep it alive. It kills the connection
-// on ping failure.
+// Heartbeat loops to ping a WebSocket to keep it alive. It calls `exit` on ping
+// failure.
 func HeartbeatClose(ctx context.Context, exit func(), conn *websocket.Conn) {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 
 	for {

--- a/coderd/httpapi/websocket.go
+++ b/coderd/httpapi/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"cdr.dev/slog"
 	"nhooyr.io/websocket"
 )
 
@@ -28,7 +29,7 @@ func Heartbeat(ctx context.Context, conn *websocket.Conn) {
 
 // Heartbeat loops to ping a WebSocket to keep it alive. It calls `exit` on ping
 // failure.
-func HeartbeatClose(ctx context.Context, exit func(), conn *websocket.Conn) {
+func HeartbeatClose(ctx context.Context, logger slog.Logger, exit func(), conn *websocket.Conn) {
 	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 
@@ -41,6 +42,7 @@ func HeartbeatClose(ctx context.Context, exit func(), conn *websocket.Conn) {
 		err := conn.Ping(ctx)
 		if err != nil {
 			_ = conn.Close(websocket.StatusGoingAway, "Ping failed")
+			logger.Info(ctx, "failed to heartbeat ping", slog.Error(err))
 			exit()
 			return
 		}

--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -224,6 +224,7 @@ func (s *ServerTailnet) watchAgentUpdates() {
 		nodes, ok := conn.NextUpdate(s.ctx)
 		if !ok {
 			if conn.IsClosed() && s.ctx.Err() == nil {
+				s.logger.Warn(s.ctx, "multiagent closed, reinitializing")
 				s.reinitCoordinator()
 				continue
 			}

--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -248,6 +248,7 @@ func (s *ServerTailnet) getAgentConn() tailnet.MultiAgentConn {
 }
 
 func (s *ServerTailnet) reinitCoordinator() {
+	start := time.Now()
 	for retrier := retry.New(25*time.Millisecond, 5*time.Second); retrier.Wait(s.ctx); {
 		s.nodesMu.Lock()
 		agentConn, err := s.getMultiAgent(s.ctx)
@@ -265,6 +266,11 @@ func (s *ServerTailnet) reinitCoordinator() {
 				s.logger.Warn(s.ctx, "resubscribe to agent", slog.Error(err), slog.F("agent_id", agentID))
 			}
 		}
+
+		s.logger.Info(s.ctx, "successfully reinitialized multiagent",
+			slog.F("agents", len(s.agentConnectionTimes)),
+			slog.F("took", time.Since(start)),
+		)
 		s.nodesMu.Unlock()
 		return
 	}

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -473,6 +473,11 @@ func (c *Client) DialCoordinator(ctx context.Context) (agpl.MultiAgentConn, erro
 	}).Init()
 
 	go func() {
+		<-ctx.Done()
+		ma.Close()
+	}()
+
+	go func() {
 		defer cancel()
 		dec := json.NewDecoder(nc)
 		for {


### PR DESCRIPTION
The `SingleTailnet` behavior only checked to see if the `MultiAgent` was
closed, but the websocket error was not being propogated into the
`MultiAgent`, causing it to never be swapped for a new working one.

Fixes https://github.com/coder/coder/issues/11401

Before:
```
Coder Workspace Proxy v0.0.0-devel+85ff030 - Your Self-Hosted Remote Development Platform
Started HTTP listener at http://0.0.0.0:3001

View the Web UI: http://127.0.0.1:3001

==> Logs will stream in below (press ctrl+c to gracefully exit):
2024-01-04 20:11:56.376 [warn]  net.workspace-proxy.servertailnet: broadcast server node to agents ...
    error= write message:
               github.com/coder/coder/v2/enterprise/wsproxy/wsproxysdk.(*remoteMultiAgentHandler).writeJSON
                   /home/coder/coder/enterprise/wsproxy/wsproxysdk/wsproxysdk.go:524
             - failed to write msg: WebSocket closed: failed to read frame header: EOF
```

After:
```
Coder Workspace Proxy v0.0.0-devel+12f1878 - Your Self-Hosted Remote Development Platform
Started HTTP listener at http://0.0.0.0:3001

View the Web UI: http://127.0.0.1:3001

==> Logs will stream in below (press ctrl+c to gracefully exit):
2024-01-04 20:26:38.545 [warn]  net.workspace-proxy.servertailnet: multiagent closed, reinitializing
2024-01-04 20:26:38.546 [erro]  net.workspace-proxy.servertailnet: reinit multi agent ...
    error= dial coordinate websocket:
               github.com/coder/coder/v2/enterprise/wsproxy/wsproxysdk.(*Client).DialCoordinator
                   /home/coder/coder/enterprise/wsproxy/wsproxysdk/wsproxysdk.go:454
             - failed to WebSocket dial: failed to send handshake request: Get "http://127.0.0.1:3000/api/v2/workspaceproxies/me/coordinate": dial tcp 127.0.0.1:3000: connect: connection refused
2024-01-04 20:26:38.587 [erro]  net.workspace-proxy.servertailnet: reinit multi agent ...
    error= dial coordinate websocket:
               github.com/coder/coder/v2/enterprise/wsproxy/wsproxysdk.(*Client).DialCoordinator
                   /home/coder/coder/enterprise/wsproxy/wsproxysdk/wsproxysdk.go:454
             - failed to WebSocket dial: failed to send handshake request: Get "http://127.0.0.1:3000/api/v2/workspaceproxies/me/coordinate": dial tcp 127.0.0.1:3000: connect: connection refusedhandshake request: Get "http://127.0.0.1:3000/api/v2/workspaceproxies/me/coordinate": dial tcp 127.0.0.1:3000: connect: connection refused
2024-01-04 20:26:40.446 [info]  net.workspace-proxy.servertailnet: successfully reinitialized multiagent  agents=0  took=1.900892615s
```
