### PR TITLE
feat: allow users to select a provisioner based on tags

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8669,6 +8669,12 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "provisioner_tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "rich_parameter_values": {
                     "description": "RichParameterValues allows for additional parameters to be provided\nduring the initial provision.",
                     "type": "array",
@@ -10050,6 +10056,10 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time"
                 },
+                "disconnected_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
                 "id": {
                     "type": "string",
                     "format": "uuid"
@@ -10113,6 +10123,10 @@ const docTemplate = `{
                 "id": {
                     "type": "string",
                     "format": "uuid"
+                },
+                "matching_provisioners": {
+                    "description": "MatchingProvisioners is the number of available provisioner daemons that\nsatisfy the tags for this job.",
+                    "type": "integer"
                 },
                 "queue_position": {
                     "type": "integer"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7719,6 +7719,12 @@
         "name": {
           "type": "string"
         },
+        "provisioner_tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "rich_parameter_values": {
           "description": "RichParameterValues allows for additional parameters to be provided\nduring the initial provision.",
           "type": "array",
@@ -9034,6 +9040,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "disconnected_at": {
+          "type": "string",
+          "format": "date-time"
+        },
         "id": {
           "type": "string",
           "format": "uuid"
@@ -9095,6 +9105,10 @@
         "id": {
           "type": "string",
           "format": "uuid"
+        },
+        "matching_provisioners": {
+          "description": "MatchingProvisioners is the number of available provisioner daemons that\nsatisfy the tags for this job.",
+          "type": "integer"
         },
         "queue_position": {
           "type": "integer"

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2570,6 +2570,10 @@ func (q *querier) UpdateOAuth2ProviderAppSecretByID(ctx context.Context, arg dat
 	return q.db.UpdateOAuth2ProviderAppSecretByID(ctx, arg)
 }
 
+func (q *querier) UpdateProvisionerDaemonDisconnectedAt(ctx context.Context, arg database.UpdateProvisionerDaemonDisconnectedAtParams) error {
+	return q.db.UpdateProvisionerDaemonDisconnectedAt(ctx, arg)
+}
+
 func (q *querier) UpdateProvisionerDaemonLastSeenAt(ctx context.Context, arg database.UpdateProvisionerDaemonLastSeenAtParams) error {
 	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceProvisionerDaemon); err != nil {
 		return err

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -439,6 +439,23 @@ func ProvisionerJob(t testing.TB, db database.Store, ps pubsub.Pubsub, orig data
 	return job
 }
 
+func ProvisionerDaemon(t testing.TB, db database.Store, orig database.ProvisionerDaemon) database.ProvisionerDaemon {
+	daemon, err := db.UpsertProvisionerDaemon(genCtx, database.UpsertProvisionerDaemonParams{
+		Name:         takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+		CreatedAt:    takeFirst(orig.CreatedAt, dbtime.Now()),
+		Provisioners: []database.ProvisionerType{database.ProvisionerTypeEcho},
+		Tags:         orig.Tags,
+		LastSeenAt: takeFirst(orig.LastSeenAt, sql.NullTime{
+			Time:  dbtime.Now(),
+			Valid: true,
+		}),
+		Version:    takeFirst(orig.Version, "v0.0.0"),
+		APIVersion: takeFirst(orig.APIVersion, "v0.0.0"),
+	})
+	require.NoError(t, err, "insert daemon")
+	return daemon
+}
+
 func WorkspaceApp(t testing.TB, db database.Store, orig database.WorkspaceApp) database.WorkspaceApp {
 	resource, err := db.InsertWorkspaceApp(genCtx, database.InsertWorkspaceAppParams{
 		ID:          takeFirst(orig.ID, uuid.New()),

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -6161,6 +6161,27 @@ func (q *FakeQuerier) UpdateOAuth2ProviderAppSecretByID(_ context.Context, arg d
 	return database.OAuth2ProviderAppSecret{}, sql.ErrNoRows
 }
 
+func (q *FakeQuerier) UpdateProvisionerDaemonDisconnectedAt(ctx context.Context, arg database.UpdateProvisionerDaemonDisconnectedAtParams) error {
+	err := validateDatabaseType(arg)
+	if err != nil {
+		return err
+	}
+
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	for idx := range q.provisionerDaemons {
+		if q.provisionerDaemons[idx].ID != arg.ID {
+			continue
+		}
+		if q.provisionerDaemons[idx].DisconnectedAt.Time.After(arg.DisconnectedAt.Time) {
+			continue
+		}
+		q.provisionerDaemons[idx].DisconnectedAt = arg.DisconnectedAt
+		return nil
+	}
+	return sql.ErrNoRows
+}
+
 func (q *FakeQuerier) UpdateProvisionerDaemonLastSeenAt(_ context.Context, arg database.UpdateProvisionerDaemonLastSeenAtParams) error {
 	err := validateDatabaseType(arg)
 	if err != nil {

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -1663,6 +1663,13 @@ func (m metricsStore) UpdateOAuth2ProviderAppSecretByID(ctx context.Context, arg
 	return r0, r1
 }
 
+func (m metricsStore) UpdateProvisionerDaemonDisconnectedAt(ctx context.Context, arg database.UpdateProvisionerDaemonDisconnectedAtParams) error {
+	start := time.Now()
+	r0 := m.s.UpdateProvisionerDaemonDisconnectedAt(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateProvisionerDaemonDisconnectedAt").Observe(time.Since(start).Seconds())
+	return r0
+}
+
 func (m metricsStore) UpdateProvisionerDaemonLastSeenAt(ctx context.Context, arg database.UpdateProvisionerDaemonLastSeenAtParams) error {
 	start := time.Now()
 	r0 := m.s.UpdateProvisionerDaemonLastSeenAt(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3510,6 +3510,20 @@ func (mr *MockStoreMockRecorder) UpdateOAuth2ProviderAppSecretByID(arg0, arg1 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOAuth2ProviderAppSecretByID", reflect.TypeOf((*MockStore)(nil).UpdateOAuth2ProviderAppSecretByID), arg0, arg1)
 }
 
+// UpdateProvisionerDaemonDisconnectedAt mocks base method.
+func (m *MockStore) UpdateProvisionerDaemonDisconnectedAt(arg0 context.Context, arg1 database.UpdateProvisionerDaemonDisconnectedAtParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateProvisionerDaemonDisconnectedAt", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateProvisionerDaemonDisconnectedAt indicates an expected call of UpdateProvisionerDaemonDisconnectedAt.
+func (mr *MockStoreMockRecorder) UpdateProvisionerDaemonDisconnectedAt(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProvisionerDaemonDisconnectedAt", reflect.TypeOf((*MockStore)(nil).UpdateProvisionerDaemonDisconnectedAt), arg0, arg1)
+}
+
 // UpdateProvisionerDaemonLastSeenAt mocks base method.
 func (m *MockStore) UpdateProvisionerDaemonLastSeenAt(arg0 context.Context, arg1 database.UpdateProvisionerDaemonLastSeenAtParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -537,7 +537,8 @@ CREATE TABLE provisioner_daemons (
     tags jsonb DEFAULT '{}'::jsonb NOT NULL,
     last_seen_at timestamp with time zone,
     version text DEFAULT ''::text NOT NULL,
-    api_version text DEFAULT '1.0'::text NOT NULL
+    api_version text DEFAULT '1.0'::text NOT NULL,
+    disconnected_at timestamp with time zone
 );
 
 COMMENT ON COLUMN provisioner_daemons.api_version IS 'The API version of the provisioner daemon';

--- a/coderd/database/migrations/000183_provisioner_daemons_disconnected.down.sql
+++ b/coderd/database/migrations/000183_provisioner_daemons_disconnected.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE provisioner_daemons DROP COLUMN disconnected_at;

--- a/coderd/database/migrations/000183_provisioner_daemons_disconnected.up.sql
+++ b/coderd/database/migrations/000183_provisioner_daemons_disconnected.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE provisioner_daemons ADD COLUMN disconnected_at timestamp with time zone;

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1866,7 +1866,8 @@ type ProvisionerDaemon struct {
 	LastSeenAt   sql.NullTime      `db:"last_seen_at" json:"last_seen_at"`
 	Version      string            `db:"version" json:"version"`
 	// The API version of the provisioner daemon
-	APIVersion string `db:"api_version" json:"api_version"`
+	APIVersion     string       `db:"api_version" json:"api_version"`
+	DisconnectedAt sql.NullTime `db:"disconnected_at" json:"disconnected_at"`
 }
 
 type ProvisionerJob struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -328,6 +328,7 @@ type sqlcQuerier interface {
 	UpdateMemberRoles(ctx context.Context, arg UpdateMemberRolesParams) (OrganizationMember, error)
 	UpdateOAuth2ProviderAppByID(ctx context.Context, arg UpdateOAuth2ProviderAppByIDParams) (OAuth2ProviderApp, error)
 	UpdateOAuth2ProviderAppSecretByID(ctx context.Context, arg UpdateOAuth2ProviderAppSecretByIDParams) (OAuth2ProviderAppSecret, error)
+	UpdateProvisionerDaemonDisconnectedAt(ctx context.Context, arg UpdateProvisionerDaemonDisconnectedAtParams) error
 	UpdateProvisionerDaemonLastSeenAt(ctx context.Context, arg UpdateProvisionerDaemonLastSeenAtParams) error
 	UpdateProvisionerJobByID(ctx context.Context, arg UpdateProvisionerJobByIDParams) error
 	UpdateProvisionerJobWithCancelByID(ctx context.Context, arg UpdateProvisionerJobWithCancelByIDParams) error

--- a/coderd/database/queries/provisionerdaemons.sql
+++ b/coderd/database/queries/provisionerdaemons.sql
@@ -54,3 +54,10 @@ WHERE
 	id = @id
 AND
 	last_seen_at <= @last_seen_at;
+
+-- name: UpdateProvisionerDaemonDisconnectedAt :exec
+UPDATE provisioner_daemons
+SET
+	disconnected_at = @disconnected_at
+WHERE
+	id = @id;

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -236,14 +236,15 @@ func convertProvisionerJobLog(provisionerJobLog database.ProvisionerJobLog) code
 func convertProvisionerJob(pj database.GetProvisionerJobsByIDsWithQueuePositionRow) codersdk.ProvisionerJob {
 	provisionerJob := pj.ProvisionerJob
 	job := codersdk.ProvisionerJob{
-		ID:            provisionerJob.ID,
-		CreatedAt:     provisionerJob.CreatedAt,
-		Error:         provisionerJob.Error.String,
-		ErrorCode:     codersdk.JobErrorCode(provisionerJob.ErrorCode.String),
-		FileID:        provisionerJob.FileID,
-		Tags:          provisionerJob.Tags,
-		QueuePosition: int(pj.QueuePosition),
-		QueueSize:     int(pj.QueueSize),
+		ID:                   provisionerJob.ID,
+		CreatedAt:            provisionerJob.CreatedAt,
+		Error:                provisionerJob.Error.String,
+		ErrorCode:            codersdk.JobErrorCode(provisionerJob.ErrorCode.String),
+		FileID:               provisionerJob.FileID,
+		Tags:                 provisionerJob.Tags,
+		QueuePosition:        int(pj.QueuePosition),
+		QueueSize:            int(pj.QueueSize),
+		MatchingProvisioners: int(pj.MatchingProvisioners),
 	}
 	// Applying values optional to the struct.
 	if provisionerJob.StartedAt.Valid {

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -342,7 +342,8 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		Initiator(apiKey.UserID).
 		RichParameterValues(createBuild.RichParameterValues).
 		LogLevel(string(createBuild.LogLevel)).
-		DeploymentValues(api.Options.DeploymentValues)
+		DeploymentValues(api.Options.DeploymentValues).
+		ProvisionerTags(createBuild.ProvisionerTags)
 
 	if createBuild.TemplateVersionID != uuid.Nil {
 		builder = builder.VersionID(createBuild.TemplateVersionID)

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -342,8 +342,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 		Initiator(apiKey.UserID).
 		RichParameterValues(createBuild.RichParameterValues).
 		LogLevel(string(createBuild.LogLevel)).
-		DeploymentValues(api.Options.DeploymentValues).
-		ProvisionerTags(createBuild.ProvisionerTags)
+		DeploymentValues(api.Options.DeploymentValues)
 
 	if createBuild.TemplateVersionID != uuid.Nil {
 		builder = builder.VersionID(createBuild.TemplateVersionID)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -516,7 +516,8 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 			Reason(database.BuildReasonInitiator).
 			Initiator(apiKey.UserID).
 			ActiveVersion().
-			RichParameterValues(createWorkspace.RichParameterValues)
+			RichParameterValues(createWorkspace.RichParameterValues).
+			ProvisionerTags(createWorkspace.ProvisionerTags)
 		if createWorkspace.TemplateVersionID != uuid.Nil {
 			builder = builder.VersionID(createWorkspace.TemplateVersionID)
 		}

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -138,10 +138,11 @@ type CreateWorkspaceRequest struct {
 	// TemplateID specifies which template should be used for creating the workspace.
 	TemplateID uuid.UUID `json:"template_id,omitempty" validate:"required_without=TemplateVersionID,excluded_with=TemplateVersionID" format:"uuid"`
 	// TemplateVersionID can be used to specify a specific version of a template for creating the workspace.
-	TemplateVersionID uuid.UUID `json:"template_version_id,omitempty" validate:"required_without=TemplateID,excluded_with=TemplateID" format:"uuid"`
-	Name              string    `json:"name" validate:"workspace_name,required"`
-	AutostartSchedule *string   `json:"autostart_schedule"`
-	TTLMillis         *int64    `json:"ttl_ms,omitempty"`
+	TemplateVersionID uuid.UUID         `json:"template_version_id,omitempty" validate:"required_without=TemplateID,excluded_with=TemplateID" format:"uuid"`
+	Name              string            `json:"name" validate:"workspace_name,required"`
+	AutostartSchedule *string           `json:"autostart_schedule"`
+	TTLMillis         *int64            `json:"ttl_ms,omitempty"`
+	ProvisionerTags   map[string]string `json:"provisioner_tags,omitempty"`
 	// RichParameterValues allows for additional parameters to be provided
 	// during the initial provision.
 	RichParameterValues []WorkspaceBuildParameter `json:"rich_parameter_values,omitempty"`

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -36,13 +36,14 @@ const (
 )
 
 type ProvisionerDaemon struct {
-	ID           uuid.UUID         `json:"id" format:"uuid"`
-	CreatedAt    time.Time         `json:"created_at" format:"date-time"`
-	LastSeenAt   NullTime          `json:"last_seen_at,omitempty" format:"date-time"`
-	Name         string            `json:"name"`
-	Version      string            `json:"version"`
-	Provisioners []ProvisionerType `json:"provisioners"`
-	Tags         map[string]string `json:"tags"`
+	ID             uuid.UUID         `json:"id" format:"uuid"`
+	CreatedAt      time.Time         `json:"created_at" format:"date-time"`
+	LastSeenAt     NullTime          `json:"last_seen_at,omitempty" format:"date-time"`
+	DisconnectedAt NullTime          `json:"disconnected_at,omitempty" format:"date-time"`
+	Name           string            `json:"name"`
+	Version        string            `json:"version"`
+	Provisioners   []ProvisionerType `json:"provisioners"`
+	Tags           map[string]string `json:"tags"`
 }
 
 // ProvisionerJobStatus represents the at-time state of a job.
@@ -95,6 +96,9 @@ type ProvisionerJob struct {
 	Tags          map[string]string    `json:"tags"`
 	QueuePosition int                  `json:"queue_position"`
 	QueueSize     int                  `json:"queue_size"`
+	// MatchingProvisioners is the number of available provisioner daemons that
+	// satisfy the tags for this job.
+	MatchingProvisioners int `json:"matching_provisioners"`
 }
 
 // ProvisionerJobLog represents the provisioner log entry annotated with source and level.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -91,6 +91,7 @@ type CreateWorkspaceBuildRequest struct {
 	Transition        WorkspaceTransition `json:"transition" validate:"oneof=create start stop delete,required"`
 	DryRun            bool                `json:"dry_run,omitempty"`
 	ProvisionerState  []byte              `json:"state,omitempty"`
+	ProvisionerTags   map[string]string   `json:"tags,omitempty"`
 	// Orphan may be set for the Destroy transition.
 	Orphan bool `json:"orphan,omitempty"`
 	// ParameterValues are optional. It will write params to the 'workspace' scope.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -91,7 +91,6 @@ type CreateWorkspaceBuildRequest struct {
 	Transition        WorkspaceTransition `json:"transition" validate:"oneof=create start stop delete,required"`
 	DryRun            bool                `json:"dry_run,omitempty"`
 	ProvisionerState  []byte              `json:"state,omitempty"`
-	ProvisionerTags   map[string]string   `json:"tags,omitempty"`
 	// Orphan may be set for the Destroy transition.
 	Orphan bool `json:"orphan,omitempty"`
 	// ParameterValues are optional. It will write params to the 'workspace' scope.

--- a/docs/api/builds.md
+++ b/docs/api/builds.md
@@ -42,6 +42,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -223,6 +224,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild} \
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -832,6 +834,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/sta
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -1018,6 +1021,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -1180,6 +1184,7 @@ Status Code **200**
 | `»» error_code`                  | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                                               | false    |              |                                                                                                                                                                                                                                                |
 | `»» file_id`                     | string(uuid)                                                                                           | false    |              |                                                                                                                                                                                                                                                |
 | `»» id`                          | string(uuid)                                                                                           | false    |              |                                                                                                                                                                                                                                                |
+| `»» matching_provisioners`       | integer                                                                                                | false    |              | Matching provisioners is the number of available provisioner daemons that satisfy the tags for this job.                                                                                                                                       |
 | `»» queue_position`              | integer                                                                                                | false    |              |                                                                                                                                                                                                                                                |
 | `»» queue_size`                  | integer                                                                                                | false    |              |                                                                                                                                                                                                                                                |
 | `»» started_at`                  | string(date-time)                                                                                      | false    |              |                                                                                                                                                                                                                                                |
@@ -1396,6 +1401,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",

--- a/docs/api/enterprise.md
+++ b/docs/api/enterprise.md
@@ -1052,6 +1052,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
 [
   {
     "created_at": "2019-08-24T14:15:22Z",
+    "disconnected_at": "2019-08-24T14:15:22Z",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
     "last_seen_at": "2019-08-24T14:15:22Z",
     "name": "string",
@@ -1079,6 +1080,7 @@ Status Code **200**
 | ------------------- | ----------------- | -------- | ------------ | ----------- |
 | `[array item]`      | array             | false    |              |             |
 | `» created_at`      | string(date-time) | false    |              |             |
+| `» disconnected_at` | string(date-time) | false    |              |             |
 | `» id`              | string(uuid)      | false    |              |             |
 | `» last_seen_at`    | string(date-time) | false    |              |             |
 | `» name`            | string            | false    |              |             |

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1856,6 +1856,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "name": "string",
+  "provisioner_tags": {
+    "property1": "string",
+    "property2": "string"
+  },
   "rich_parameter_values": [
     {
       "name": "string",
@@ -1875,6 +1879,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `automatic_updates`     | [codersdk.AutomaticUpdates](#codersdkautomaticupdates)                        | false    |              |                                                                                                         |
 | `autostart_schedule`    | string                                                                        | false    |              |                                                                                                         |
 | `name`                  | string                                                                        | true     |              |                                                                                                         |
+| `provisioner_tags`      | object                                                                        | false    |              |                                                                                                         |
+| » `[any property]`      | string                                                                        | false    |              |                                                                                                         |
 | `rich_parameter_values` | array of [codersdk.WorkspaceBuildParameter](#codersdkworkspacebuildparameter) | false    |              | Rich parameter values allows for additional parameters to be provided during the initial provision.     |
 | `template_id`           | string                                                                        | false    |              | Template ID specifies which template should be used for creating the workspace.                         |
 | `template_version_id`   | string                                                                        | false    |              | Template version ID can be used to specify a specific version of a template for creating the workspace. |
@@ -3899,6 +3905,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 ```json
 {
   "created_at": "2019-08-24T14:15:22Z",
+  "disconnected_at": "2019-08-24T14:15:22Z",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
   "last_seen_at": "2019-08-24T14:15:22Z",
   "name": "string",
@@ -3916,6 +3923,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Name               | Type            | Required | Restrictions | Description |
 | ------------------ | --------------- | -------- | ------------ | ----------- |
 | `created_at`       | string          | false    |              |             |
+| `disconnected_at`  | string          | false    |              |             |
 | `id`               | string          | false    |              |             |
 | `last_seen_at`     | string          | false    |              |             |
 | `name`             | string          | false    |              |             |
@@ -3935,6 +3943,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "error_code": "REQUIRED_TEMPLATE_VARIABLES",
   "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "matching_provisioners": 0,
   "queue_position": 0,
   "queue_size": 0,
   "started_at": "2019-08-24T14:15:22Z",
@@ -3949,22 +3958,23 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name               | Type                                                           | Required | Restrictions | Description |
-| ------------------ | -------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `canceled_at`      | string                                                         | false    |              |             |
-| `completed_at`     | string                                                         | false    |              |             |
-| `created_at`       | string                                                         | false    |              |             |
-| `error`            | string                                                         | false    |              |             |
-| `error_code`       | [codersdk.JobErrorCode](#codersdkjoberrorcode)                 | false    |              |             |
-| `file_id`          | string                                                         | false    |              |             |
-| `id`               | string                                                         | false    |              |             |
-| `queue_position`   | integer                                                        | false    |              |             |
-| `queue_size`       | integer                                                        | false    |              |             |
-| `started_at`       | string                                                         | false    |              |             |
-| `status`           | [codersdk.ProvisionerJobStatus](#codersdkprovisionerjobstatus) | false    |              |             |
-| `tags`             | object                                                         | false    |              |             |
-| » `[any property]` | string                                                         | false    |              |             |
-| `worker_id`        | string                                                         | false    |              |             |
+| Name                    | Type                                                           | Required | Restrictions | Description                                                                                              |
+| ----------------------- | -------------------------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------- |
+| `canceled_at`           | string                                                         | false    |              |                                                                                                          |
+| `completed_at`          | string                                                         | false    |              |                                                                                                          |
+| `created_at`            | string                                                         | false    |              |                                                                                                          |
+| `error`                 | string                                                         | false    |              |                                                                                                          |
+| `error_code`            | [codersdk.JobErrorCode](#codersdkjoberrorcode)                 | false    |              |                                                                                                          |
+| `file_id`               | string                                                         | false    |              |                                                                                                          |
+| `id`                    | string                                                         | false    |              |                                                                                                          |
+| `matching_provisioners` | integer                                                        | false    |              | Matching provisioners is the number of available provisioner daemons that satisfy the tags for this job. |
+| `queue_position`        | integer                                                        | false    |              |                                                                                                          |
+| `queue_size`            | integer                                                        | false    |              |                                                                                                          |
+| `started_at`            | string                                                         | false    |              |                                                                                                          |
+| `status`                | [codersdk.ProvisionerJobStatus](#codersdkprovisionerjobstatus) | false    |              |                                                                                                          |
+| `tags`                  | object                                                         | false    |              |                                                                                                          |
+| » `[any property]`      | string                                                         | false    |              |                                                                                                          |
+| `worker_id`             | string                                                         | false    |              |                                                                                                          |
 
 #### Enumerated Values
 
@@ -5033,6 +5043,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -5883,6 +5894,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -6576,6 +6588,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -7146,6 +7159,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           "error_code": "REQUIRED_TEMPLATE_VARIABLES",
           "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "matching_provisioners": 0,
           "queue_position": 0,
           "queue_size": 0,
           "started_at": "2019-08-24T14:15:22Z",

--- a/docs/api/templates.md
+++ b/docs/api/templates.md
@@ -420,6 +420,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -491,6 +492,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -586,6 +588,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/templa
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -903,6 +906,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions \
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -934,38 +938,39 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions \
 
 Status Code **200**
 
-| Name                 | Type                                                                     | Required | Restrictions | Description |
-| -------------------- | ------------------------------------------------------------------------ | -------- | ------------ | ----------- |
-| `[array item]`       | array                                                                    | false    |              |             |
-| `» archived`         | boolean                                                                  | false    |              |             |
-| `» created_at`       | string(date-time)                                                        | false    |              |             |
-| `» created_by`       | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |             |
-| `»» avatar_url`      | string(uri)                                                              | false    |              |             |
-| `»» id`              | string(uuid)                                                             | true     |              |             |
-| `»» username`        | string                                                                   | true     |              |             |
-| `» id`               | string(uuid)                                                             | false    |              |             |
-| `» job`              | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |             |
-| `»» canceled_at`     | string(date-time)                                                        | false    |              |             |
-| `»» completed_at`    | string(date-time)                                                        | false    |              |             |
-| `»» created_at`      | string(date-time)                                                        | false    |              |             |
-| `»» error`           | string                                                                   | false    |              |             |
-| `»» error_code`      | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |             |
-| `»» file_id`         | string(uuid)                                                             | false    |              |             |
-| `»» id`              | string(uuid)                                                             | false    |              |             |
-| `»» queue_position`  | integer                                                                  | false    |              |             |
-| `»» queue_size`      | integer                                                                  | false    |              |             |
-| `»» started_at`      | string(date-time)                                                        | false    |              |             |
-| `»» status`          | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |             |
-| `»» tags`            | object                                                                   | false    |              |             |
-| `»»» [any property]` | string                                                                   | false    |              |             |
-| `»» worker_id`       | string(uuid)                                                             | false    |              |             |
-| `» message`          | string                                                                   | false    |              |             |
-| `» name`             | string                                                                   | false    |              |             |
-| `» organization_id`  | string(uuid)                                                             | false    |              |             |
-| `» readme`           | string                                                                   | false    |              |             |
-| `» template_id`      | string(uuid)                                                             | false    |              |             |
-| `» updated_at`       | string(date-time)                                                        | false    |              |             |
-| `» warnings`         | array                                                                    | false    |              |             |
+| Name                       | Type                                                                     | Required | Restrictions | Description                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------ | -------- | ------------ | -------------------------------------------------------------------------------------------------------- |
+| `[array item]`             | array                                                                    | false    |              |                                                                                                          |
+| `» archived`               | boolean                                                                  | false    |              |                                                                                                          |
+| `» created_at`             | string(date-time)                                                        | false    |              |                                                                                                          |
+| `» created_by`             | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |                                                                                                          |
+| `»» avatar_url`            | string(uri)                                                              | false    |              |                                                                                                          |
+| `»» id`                    | string(uuid)                                                             | true     |              |                                                                                                          |
+| `»» username`              | string                                                                   | true     |              |                                                                                                          |
+| `» id`                     | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» job`                    | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |                                                                                                          |
+| `»» canceled_at`           | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» completed_at`          | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» created_at`            | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» error`                 | string                                                                   | false    |              |                                                                                                          |
+| `»» error_code`            | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |                                                                                                          |
+| `»» file_id`               | string(uuid)                                                             | false    |              |                                                                                                          |
+| `»» id`                    | string(uuid)                                                             | false    |              |                                                                                                          |
+| `»» matching_provisioners` | integer                                                                  | false    |              | Matching provisioners is the number of available provisioner daemons that satisfy the tags for this job. |
+| `»» queue_position`        | integer                                                                  | false    |              |                                                                                                          |
+| `»» queue_size`            | integer                                                                  | false    |              |                                                                                                          |
+| `»» started_at`            | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» status`                | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |                                                                                                          |
+| `»» tags`                  | object                                                                   | false    |              |                                                                                                          |
+| `»»» [any property]`       | string                                                                   | false    |              |                                                                                                          |
+| `»» worker_id`             | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» message`                | string                                                                   | false    |              |                                                                                                          |
+| `» name`                   | string                                                                   | false    |              |                                                                                                          |
+| `» organization_id`        | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» readme`                 | string                                                                   | false    |              |                                                                                                          |
+| `» template_id`            | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» updated_at`             | string(date-time)                                                        | false    |              |                                                                                                          |
+| `» warnings`               | array                                                                    | false    |              |                                                                                                          |
 
 #### Enumerated Values
 
@@ -1132,6 +1137,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions/{templ
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -1163,38 +1169,39 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions/{templ
 
 Status Code **200**
 
-| Name                 | Type                                                                     | Required | Restrictions | Description |
-| -------------------- | ------------------------------------------------------------------------ | -------- | ------------ | ----------- |
-| `[array item]`       | array                                                                    | false    |              |             |
-| `» archived`         | boolean                                                                  | false    |              |             |
-| `» created_at`       | string(date-time)                                                        | false    |              |             |
-| `» created_by`       | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |             |
-| `»» avatar_url`      | string(uri)                                                              | false    |              |             |
-| `»» id`              | string(uuid)                                                             | true     |              |             |
-| `»» username`        | string                                                                   | true     |              |             |
-| `» id`               | string(uuid)                                                             | false    |              |             |
-| `» job`              | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |             |
-| `»» canceled_at`     | string(date-time)                                                        | false    |              |             |
-| `»» completed_at`    | string(date-time)                                                        | false    |              |             |
-| `»» created_at`      | string(date-time)                                                        | false    |              |             |
-| `»» error`           | string                                                                   | false    |              |             |
-| `»» error_code`      | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |             |
-| `»» file_id`         | string(uuid)                                                             | false    |              |             |
-| `»» id`              | string(uuid)                                                             | false    |              |             |
-| `»» queue_position`  | integer                                                                  | false    |              |             |
-| `»» queue_size`      | integer                                                                  | false    |              |             |
-| `»» started_at`      | string(date-time)                                                        | false    |              |             |
-| `»» status`          | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |             |
-| `»» tags`            | object                                                                   | false    |              |             |
-| `»»» [any property]` | string                                                                   | false    |              |             |
-| `»» worker_id`       | string(uuid)                                                             | false    |              |             |
-| `» message`          | string                                                                   | false    |              |             |
-| `» name`             | string                                                                   | false    |              |             |
-| `» organization_id`  | string(uuid)                                                             | false    |              |             |
-| `» readme`           | string                                                                   | false    |              |             |
-| `» template_id`      | string(uuid)                                                             | false    |              |             |
-| `» updated_at`       | string(date-time)                                                        | false    |              |             |
-| `» warnings`         | array                                                                    | false    |              |             |
+| Name                       | Type                                                                     | Required | Restrictions | Description                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------ | -------- | ------------ | -------------------------------------------------------------------------------------------------------- |
+| `[array item]`             | array                                                                    | false    |              |                                                                                                          |
+| `» archived`               | boolean                                                                  | false    |              |                                                                                                          |
+| `» created_at`             | string(date-time)                                                        | false    |              |                                                                                                          |
+| `» created_by`             | [codersdk.MinimalUser](schemas.md#codersdkminimaluser)                   | false    |              |                                                                                                          |
+| `»» avatar_url`            | string(uri)                                                              | false    |              |                                                                                                          |
+| `»» id`                    | string(uuid)                                                             | true     |              |                                                                                                          |
+| `»» username`              | string                                                                   | true     |              |                                                                                                          |
+| `» id`                     | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» job`                    | [codersdk.ProvisionerJob](schemas.md#codersdkprovisionerjob)             | false    |              |                                                                                                          |
+| `»» canceled_at`           | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» completed_at`          | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» created_at`            | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» error`                 | string                                                                   | false    |              |                                                                                                          |
+| `»» error_code`            | [codersdk.JobErrorCode](schemas.md#codersdkjoberrorcode)                 | false    |              |                                                                                                          |
+| `»» file_id`               | string(uuid)                                                             | false    |              |                                                                                                          |
+| `»» id`                    | string(uuid)                                                             | false    |              |                                                                                                          |
+| `»» matching_provisioners` | integer                                                                  | false    |              | Matching provisioners is the number of available provisioner daemons that satisfy the tags for this job. |
+| `»» queue_position`        | integer                                                                  | false    |              |                                                                                                          |
+| `»» queue_size`            | integer                                                                  | false    |              |                                                                                                          |
+| `»» started_at`            | string(date-time)                                                        | false    |              |                                                                                                          |
+| `»» status`                | [codersdk.ProvisionerJobStatus](schemas.md#codersdkprovisionerjobstatus) | false    |              |                                                                                                          |
+| `»» tags`                  | object                                                                   | false    |              |                                                                                                          |
+| `»»» [any property]`       | string                                                                   | false    |              |                                                                                                          |
+| `»» worker_id`             | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» message`                | string                                                                   | false    |              |                                                                                                          |
+| `» name`                   | string                                                                   | false    |              |                                                                                                          |
+| `» organization_id`        | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» readme`                 | string                                                                   | false    |              |                                                                                                          |
+| `» template_id`            | string(uuid)                                                             | false    |              |                                                                                                          |
+| `» updated_at`             | string(date-time)                                                        | false    |              |                                                                                                          |
+| `» warnings`               | array                                                                    | false    |              |                                                                                                          |
 
 #### Enumerated Values
 
@@ -1251,6 +1258,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion} \
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -1331,6 +1339,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templateversions/{templateversion}
     "error_code": "REQUIRED_TEMPLATE_VARIABLES",
     "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
     "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "matching_provisioners": 0,
     "queue_position": 0,
     "queue_size": 0,
     "started_at": "2019-08-24T14:15:22Z",
@@ -1501,6 +1510,7 @@ curl -X POST http://coder-server:8080/api/v2/templateversions/{templateversion}/
   "error_code": "REQUIRED_TEMPLATE_VARIABLES",
   "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "matching_provisioners": 0,
   "queue_position": 0,
   "queue_size": 0,
   "started_at": "2019-08-24T14:15:22Z",
@@ -1554,6 +1564,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
   "error_code": "REQUIRED_TEMPLATE_VARIABLES",
   "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
   "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "matching_provisioners": 0,
   "queue_position": 0,
   "queue_size": 0,
   "started_at": "2019-08-24T14:15:22Z",

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -21,6 +21,10 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
   "automatic_updates": "always",
   "autostart_schedule": "string",
   "name": "string",
+  "provisioner_tags": {
+    "property1": "string",
+    "property2": "string"
+  },
   "rich_parameter_values": [
     {
       "name": "string",
@@ -75,6 +79,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -286,6 +291,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -500,6 +506,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
           "error_code": "REQUIRED_TEMPLATE_VARIABLES",
           "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
           "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "matching_provisioners": 0,
           "queue_position": 0,
           "queue_size": 0,
           "started_at": "2019-08-24T14:15:22Z",
@@ -708,6 +715,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",
@@ -1035,6 +1043,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/dormant \
       "error_code": "REQUIRED_TEMPLATE_VARIABLES",
       "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
       "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "matching_provisioners": 0,
       "queue_position": 0,
       "queue_size": 0,
       "started_at": "2019-08-24T14:15:22Z",

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -89,7 +89,6 @@ func (r *RootCmd) provisionerDaemonStart() *clibase.Cmd {
 			if err != nil {
 				return err
 			}
-
 			if name == "" {
 				name = cliutil.Hostname()
 			}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -213,12 +213,14 @@ export const getOrganizations = async (): Promise<TypesGen.Organization[]> => {
   return response.data;
 };
 
-export const getProvisionerDaemons = async (organizationID: string): Promise<TypesGen.ProvisionerDaemon[]> => {
+export const getProvisionerDaemons = async (
+  organizationID: string,
+): Promise<TypesGen.ProvisionerDaemon[]> => {
   const response = await axios.get<TypesGen.ProvisionerDaemon[]>(
     `/api/v2/organizations/${organizationID}/provisionerdaemons`,
   );
   return response.data;
-}
+};
 
 export const getTemplate = async (
   templateId: string,

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -213,6 +213,13 @@ export const getOrganizations = async (): Promise<TypesGen.Organization[]> => {
   return response.data;
 };
 
+export const getProvisionerDaemons = async (organizationID: string): Promise<TypesGen.ProvisionerDaemon[]> => {
+  const response = await axios.get<TypesGen.ProvisionerDaemon[]>(
+    `/api/v2/organizations/${organizationID}/provisionerdaemons`,
+  );
+  return response.data;
+}
+
 export const getTemplate = async (
   templateId: string,
 ): Promise<TypesGen.Template> => {

--- a/site/src/api/queries/provisioners.ts
+++ b/site/src/api/queries/provisioners.ts
@@ -1,0 +1,12 @@
+import { UseQueryOptions } from "react-query";
+import * as API from "api/api";
+import { ProvisionerDaemon } from "api/typesGenerated";
+
+export const provisionerDaemons = (
+  orgId: string,
+): UseQueryOptions<ProvisionerDaemon[]> => {
+  return {
+    queryKey: [orgId, "provisionerDaemons"],
+    queryFn: () => API.getProvisionerDaemons(orgId),
+  };
+};

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -297,6 +297,7 @@ export interface CreateWorkspaceRequest {
   readonly name: string;
   readonly autostart_schedule?: string;
   readonly ttl_ms?: number;
+  readonly provisioner_tags?: Record<string, string>;
   readonly rich_parameter_values?: WorkspaceBuildParameter[];
   readonly automatic_updates?: AutomaticUpdates;
 }
@@ -807,6 +808,7 @@ export interface ProvisionerDaemon {
   readonly id: string;
   readonly created_at: string;
   readonly last_seen_at?: string;
+  readonly disconnected_at?: string;
   readonly name: string;
   readonly version: string;
   readonly provisioners: ProvisionerType[];
@@ -828,6 +830,7 @@ export interface ProvisionerJob {
   readonly tags: Record<string, string>;
   readonly queue_position: number;
   readonly queue_size: number;
+  readonly matching_provisioners: number;
 }
 
 // From codersdk/provisionerdaemons.go

--- a/site/src/pages/CreateWorkspacePage/ProvisionerDaemons.tsx
+++ b/site/src/pages/CreateWorkspacePage/ProvisionerDaemons.tsx
@@ -1,0 +1,94 @@
+import Person from "@mui/icons-material/Person";
+import Public from "@mui/icons-material/Public";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import { ProvisionerDaemon } from "api/typesGenerated";
+import { FC, useMemo } from "react";
+
+export interface ProvisionerGroupSelectProps {
+  groups: ProvisionerDaemon[][];
+  onSelectGroup: (group: ProvisionerDaemon[]) => void;
+}
+
+export const ProvisionerGroupSelect: FC<ProvisionerGroupSelectProps> = ({
+  groups,
+  onSelectGroup,
+}) => {
+  return (
+    <Select
+      defaultValue="0"
+      size="small"
+      onChange={async (e) => {
+        const index = parseInt(e.target.value);
+        onSelectGroup(groups[index]);
+      }}
+      renderValue={(value) => {
+        const daemons = groups[parseInt(value)];
+        return provisionerGroupDisplayName(daemons);
+      }}
+    >
+      {groups.map((group, index) => {
+        // This shouldn't be possible, but is a safeguard.
+        if (group.length === 0) {
+          return null;
+        }
+        const daemon = group[0];
+        // If the daemon is scoped to the organization, we should
+        // give it the global appearance.
+        const isGlobal = daemon.tags["scope"] === "organization";
+        const displayName = provisionerGroupDisplayName(group);
+
+        return (
+          <MenuItem key={index} value={index}>
+            {isGlobal ? <Public /> : <Person />}
+            {displayName}
+          </MenuItem>
+        );
+      })}
+    </Select>
+  );
+};
+
+const provisionerGroupDisplayName = (group: ProvisionerDaemon[]): string => {
+  const daemon = group[0];
+  // If the daemon is scoped to the organization, we should
+  // give it the global appearance.
+  const isGlobal = daemon.tags["scope"] === "organization";
+  let displayName = "Global";
+  if (!isGlobal) {
+    displayName = "Personal";
+    if (group.length === 1) {
+      displayName = daemon.tags["hostname"] || daemon.name;
+    }
+  }
+  return displayName;
+};
+
+export const useProvisionerDaemonGroups = (
+  provisionerDaemons: ProvisionerDaemon[],
+) => {
+  return useMemo((): ProvisionerDaemon[][] => {
+    // Group provisioner daemons that have the same sets of tags
+    const groups: ProvisionerDaemon[][] = [];
+    for (const daemon of provisionerDaemons) {
+      // Ignore daemons that aren't actively connected!
+      if (daemon.disconnected_at && daemon.last_seen_at) {
+        if (new Date(daemon.disconnected_at) > new Date(daemon.last_seen_at)) {
+          continue;
+        }
+      }
+
+      const group = groups.find((group) =>
+        Object.entries(group[0].tags).every(
+          ([key, value]) => daemon.tags[key] === value,
+        ),
+      );
+      if (group) {
+        group.push(daemon);
+      } else {
+        groups.push([daemon]);
+      }
+    }
+    return groups.sort((a, b) => b.length - a.length);
+  }, [provisionerDaemons]);
+};

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -356,6 +356,7 @@ export const MockProvisionerJob: TypesGen.ProvisionerJob = {
   tags: {},
   queue_position: 0,
   queue_size: 0,
+  matching_provisioners: 0,
 };
 
 export const MockFailedProvisionerJob: TypesGen.ProvisionerJob = {

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -247,7 +247,7 @@ const getPendingWorkspaceStatusText = (
     return "Pending";
   }
   if (provisionerJob.matching_provisioners === 0) {
-    return "No Matching Provisioners Running"
+    return "No Matching Provisioners Running";
   }
   return "Position in queue: " + provisionerJob.queue_position;
 };

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -246,6 +246,9 @@ const getPendingWorkspaceStatusText = (
   if (!provisionerJob || provisionerJob.queue_size === 0) {
     return "Pending";
   }
+  if (provisionerJob.matching_provisioners === 0) {
+    return "No Matching Provisioners Running"
+  }
   return "Position in queue: " + provisionerJob.queue_position;
 };
 


### PR DESCRIPTION
This enables manually selecting a set of provisioner daemons based on tags.

![image](https://github.com/coder/coder/assets/7122116/60b3495a-8989-4d3f-9115-06383ad980d7)

It also enhances the user experience when no matching provisioners are running:

![image](https://github.com/coder/coder/assets/7122116/be615b90-602e-43a8-ac13-c27412a8c57c)

Before this, the UI would indicate that the build is queued.