### PR TITLE
ci: ungroup go dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -43,10 +43,6 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
-    groups:
-      go:
-        patterns:
-          - "*"
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"


### PR DESCRIPTION
We enabled grouping to reduce dependabot noise, but it causes issues by combining breaking and nonbreaking dependencies in a single PR, which is hard to diagnose and merge.

An [example](https://github.com/coder/coder/pull/11431) is `otel` having breaking changes and restricting us from updating other dependencies.