### PR TITLE
feat: display current version on coder list

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -22,17 +22,18 @@ type workspaceListRow struct {
 	codersdk.Workspace `table:"-"`
 
 	// For table format:
-	WorkspaceName string `json:"-" table:"workspace,default_sort"`
-	Template      string `json:"-" table:"template"`
-	Status        string `json:"-" table:"status"`
-	Healthy       string `json:"-" table:"healthy"`
-	LastBuilt     string `json:"-" table:"last built"`
-	Outdated      bool   `json:"-" table:"outdated"`
-	StartsAt      string `json:"-" table:"starts at"`
-	StartsNext    string `json:"-" table:"starts next"`
-	StopsAfter    string `json:"-" table:"stops after"`
-	StopsNext     string `json:"-" table:"stops next"`
-	DailyCost     string `json:"-" table:"daily cost"`
+	WorkspaceName  string `json:"-" table:"workspace,default_sort"`
+	Template       string `json:"-" table:"template"`
+	Status         string `json:"-" table:"status"`
+	Healthy        string `json:"-" table:"healthy"`
+	LastBuilt      string `json:"-" table:"last built"`
+	CurrentVersion string `json:"-" table:"current version"`
+	Outdated       bool   `json:"-" table:"outdated"`
+	StartsAt       string `json:"-" table:"starts at"`
+	StartsNext     string `json:"-" table:"starts next"`
+	StopsAfter     string `json:"-" table:"stops after"`
+	StopsNext      string `json:"-" table:"stops next"`
+	DailyCost      string `json:"-" table:"daily cost"`
 }
 
 func workspaceListRowFromWorkspace(now time.Time, workspace codersdk.Workspace) workspaceListRow {
@@ -46,18 +47,19 @@ func workspaceListRowFromWorkspace(now time.Time, workspace codersdk.Workspace) 
 		healthy = strconv.FormatBool(workspace.Health.Healthy)
 	}
 	return workspaceListRow{
-		Workspace:     workspace,
-		WorkspaceName: workspace.OwnerName + "/" + workspace.Name,
-		Template:      workspace.TemplateName,
-		Status:        status,
-		Healthy:       healthy,
-		LastBuilt:     durationDisplay(lastBuilt),
-		Outdated:      workspace.Outdated,
-		StartsAt:      schedRow.StartsAt,
-		StartsNext:    schedRow.StartsNext,
-		StopsAfter:    schedRow.StopsAfter,
-		StopsNext:     schedRow.StopsNext,
-		DailyCost:     strconv.Itoa(int(workspace.LatestBuild.DailyCost)),
+		Workspace:      workspace,
+		WorkspaceName:  workspace.OwnerName + "/" + workspace.Name,
+		Template:       workspace.TemplateName,
+		Status:         status,
+		Healthy:        healthy,
+		LastBuilt:      durationDisplay(lastBuilt),
+		CurrentVersion: workspace.LatestBuild.TemplateVersionName,
+		Outdated:       workspace.Outdated,
+		StartsAt:       schedRow.StartsAt,
+		StartsNext:     schedRow.StartsNext,
+		StopsAfter:     schedRow.StopsAfter,
+		StopsNext:      schedRow.StopsNext,
+		DailyCost:      strconv.Itoa(int(workspace.LatestBuild.DailyCost)),
 	}
 }
 
@@ -73,6 +75,7 @@ func (r *RootCmd) list() *clibase.Cmd {
 					"status",
 					"healthy",
 					"last built",
+					"current version",
 					"outdated",
 					"starts at",
 					"stops after",

--- a/cli/testdata/coder_list_--help.golden
+++ b/cli/testdata/coder_list_--help.golden
@@ -11,10 +11,10 @@ OPTIONS:
   -a, --all bool
           Specifies whether all workspaces will be listed or not.
 
-  -c, --column string-array (default: workspace,template,status,healthy,last built,outdated,starts at,stops after)
+  -c, --column string-array (default: workspace,template,status,healthy,last built,current version,outdated,starts at,stops after)
           Columns to display in table output. Available columns: workspace,
-          template, status, healthy, last built, outdated, starts at, starts
-          next, stops after, stops next, daily cost.
+          template, status, healthy, last built, current version, outdated,
+          starts at, starts next, stops after, stops next, daily cost.
 
   -o, --output string (default: table)
           Output format. Available formats: table, json.

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -26,12 +26,12 @@ Specifies whether all workspaces will be listed or not.
 
 ### -c, --column
 
-|         |                                                                                          |
-| ------- | ---------------------------------------------------------------------------------------- |
-| Type    | <code>string-array</code>                                                                |
-| Default | <code>workspace,template,status,healthy,last built,outdated,starts at,stops after</code> |
+|         |                                                                                                          |
+| ------- | -------------------------------------------------------------------------------------------------------- |
+| Type    | <code>string-array</code>                                                                                |
+| Default | <code>workspace,template,status,healthy,last built,current version,outdated,starts at,stops after</code> |
 
-Columns to display in table output. Available columns: workspace, template, status, healthy, last built, outdated, starts at, starts next, stops after, stops next, daily cost.
+Columns to display in table output. Available columns: workspace, template, status, healthy, last built, current version, outdated, starts at, starts next, stops after, stops next, daily cost.
 
 ### -o, --output
 


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/11410

Example:
```
➜  coder git:(main) ✗ go run cmd/coder/main.go list
WORKSPACE    TEMPLATE  STATUS   HEALTHY  LAST BUILT  CURRENT VERSION  OUTDATED  STARTS AT  STOPS AFTER  
f0ssel/dev   coder     Started  true     1d19h       sleepy_elion5    true                              
f0ssel/dev2  coder     Stopped           19d8h       4612c28          true                              
```