### PR TITLE
chore(coderd/provisionerdserver): fix test flake in TestHeartbeat

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -272,6 +272,9 @@ func (s *server) heartbeat(ctx context.Context) error {
 }
 
 func (s *server) defaultHeartbeat(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return nil // we are probably shutting down
+	}
 	//nolint:gocritic // This is specifically for updating the last seen at timestamp.
 	return s.Database.UpdateProvisionerDaemonLastSeenAt(dbauthz.AsSystemRestricted(ctx), database.UpdateProvisionerDaemonLastSeenAtParams{
 		ID:         s.ID,

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -110,6 +110,9 @@ func TestHeartbeat(t *testing.T) {
 		case <-hbCtx.Done():
 			return hbCtx.Err()
 		default:
+			if hbCtx.Err() != nil {
+				return nil // done
+			}
 			heartbeatChan <- struct{}{}
 			return nil
 		}


### PR DESCRIPTION
Fixes a test flake seen here: https://github.com/coder/coder/actions/runs/7423302316/job/20200458237?pr=11393#step:5:346

```
WARNING: DATA RACE
Write at 0x00c0000651b0 by goroutine 28:
  runtime.closechan()
      /opt/hostedtoolcache/go/1.21.5/x64/src/runtime/chan.go:357 +0x0
  github.com/coder/coder/v2/coderd/provisionerdserver_test.TestHeartbeat()
      /home/runner/actions-runner/_work/coder/coder/coderd/provisionerdserver/provisionerdserver_test.go:137 +0x3eb
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x44

Previous read at 0x00c0000651b0 by goroutine 59:
  runtime.chansend()
      /opt/hostedtoolcache/go/1.21.5/x64/src/runtime/chan.go:160 +0x0
  github.com/coder/coder/v2/coderd/provisionerdserver_test.TestHeartbeat.func1()
      /home/runner/actions-runner/_work/coder/coder/coderd/provisionerdserver/provisionerdserver_test.go:113 +0xb2
  github.com/coder/coder/v2/coderd/provisionerdserver.(*server).heartbeat()
      /home/runner/actions-runner/_work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:269 +0x88
  github.com/coder/coder/v2/coderd/provisionerdserver.(*server).heartbeatLoop()
      /home/runner/actions-runner/_work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:245 +0x308
  github.com/coder/coder/v2/coderd/provisionerdserver.NewServer.func1()
      /home/runner/actions-runner/_work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:216 +0x33
```

Should also address a test flake seen here: https://github.com/coder/coder/issues/11434

Now checking heartbeat ctx before sending on the channel.

