### PR TITLE
fix(coderd/healthcheck): add daemon-specific warnings to healthcheck output

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13109,14 +13109,28 @@ const docTemplate = `{
                 "error": {
                     "type": "string"
                 },
-                "provisioner_daemons": {
+                "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/codersdk.ProvisionerDaemon"
+                        "$ref": "#/definitions/healthcheck.ProvisionerDaemonsReportItem"
                     }
                 },
                 "severity": {
                     "$ref": "#/definitions/health.Severity"
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/health.Message"
+                    }
+                }
+            }
+        },
+        "healthcheck.ProvisionerDaemonsReportItem": {
+            "type": "object",
+            "properties": {
+                "provisioner_daemon": {
+                    "$ref": "#/definitions/codersdk.ProvisionerDaemon"
                 },
                 "warnings": {
                     "type": "array",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -11933,14 +11933,28 @@
         "error": {
           "type": "string"
         },
-        "provisioner_daemons": {
+        "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/codersdk.ProvisionerDaemon"
+            "$ref": "#/definitions/healthcheck.ProvisionerDaemonsReportItem"
           }
         },
         "severity": {
           "$ref": "#/definitions/health.Severity"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/health.Message"
+          }
+        }
+      }
+    },
+    "healthcheck.ProvisionerDaemonsReportItem": {
+      "type": "object",
+      "properties": {
+        "provisioner_daemon": {
+          "$ref": "#/definitions/codersdk.ProvisionerDaemon"
         },
         "warnings": {
           "type": "array",

--- a/coderd/healthcheck/provisioner.go
+++ b/coderd/healthcheck/provisioner.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"golang.org/x/mod/semver"
@@ -26,7 +27,13 @@ type ProvisionerDaemonsReport struct {
 	Dismissed bool             `json:"dismissed"`
 	Error     *string          `json:"error"`
 
-	ProvisionerDaemons []codersdk.ProvisionerDaemon `json:"provisioner_daemons"`
+	Items []ProvisionerDaemonsReportItem `json:"items"`
+}
+
+// @typescript-generate ProvisionerDaemonsReportItem
+type ProvisionerDaemonsReportItem struct {
+	codersdk.ProvisionerDaemon `json:"provisioner_daemon"`
+	Warnings                   []health.Message `json:"warnings"`
 }
 
 type ProvisionerDaemonsReportDeps struct {
@@ -47,7 +54,7 @@ type ProvisionerDaemonsStore interface {
 }
 
 func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDaemonsReportDeps) {
-	r.ProvisionerDaemons = make([]codersdk.ProvisionerDaemon, 0)
+	r.Items = make([]ProvisionerDaemonsReportItem, 0)
 	r.Severity = health.SeverityOK
 	r.Warnings = make([]health.Message, 0)
 	r.Dismissed = opts.Dismissed
@@ -86,6 +93,12 @@ func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDae
 		r.Error = ptr.Ref("error fetching provisioner daemons: " + err.Error())
 		return
 	}
+
+	// Ensure stable order for display and for tests
+	sort.Slice(daemons, func(i, j int) bool {
+		return daemons[i].Name < daemons[j].Name
+	})
+
 	for _, daemon := range daemons {
 		// Daemon never connected, skip.
 		if !daemon.LastSeenAt.Valid {
@@ -96,19 +109,24 @@ func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDae
 			continue
 		}
 
-		r.ProvisionerDaemons = append(r.ProvisionerDaemons, db2sdk.ProvisionerDaemon(daemon))
+		it := ProvisionerDaemonsReportItem{
+			ProvisionerDaemon: db2sdk.ProvisionerDaemon(daemon),
+			Warnings:          make([]health.Message, 0),
+		}
 
 		// For release versions, just check MAJOR.MINOR and ignore patch.
 		if !semver.IsValid(daemon.Version) {
 			if r.Severity.Value() < health.SeverityError.Value() {
 				r.Severity = health.SeverityError
 			}
-			r.Warnings = append(r.Warnings, health.Messagef(health.CodeUnknown, "Provisioner daemon %q reports invalid version %q", opts.CurrentVersion, daemon.Version))
+			r.Warnings = append(r.Warnings, health.Messagef(health.CodeUnknown, "Some provisioner daemons report invalid version information."))
+			it.Warnings = append(it.Warnings, health.Messagef(health.CodeUnknown, "Invalid version %q", daemon.Version))
 		} else if !buildinfo.VersionsMatch(opts.CurrentVersion, daemon.Version) {
 			if r.Severity.Value() < health.SeverityWarning.Value() {
 				r.Severity = health.SeverityWarning
 			}
-			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProvisionerDaemonVersionMismatch, "Provisioner daemon %q has outdated version %q", daemon.Name, daemon.Version))
+			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProvisionerDaemonVersionMismatch, "Some provisioner daemons report mismatched versions."))
+			it.Warnings = append(it.Warnings, health.Messagef(health.CodeProvisionerDaemonVersionMismatch, "Mismatched version %q", daemon.Version))
 		}
 
 		// Provisioner daemon API version follows different rules; we just want to check the major API version and
@@ -119,16 +137,20 @@ func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDae
 			if r.Severity.Value() < health.SeverityError.Value() {
 				r.Severity = health.SeverityError
 			}
-			r.Warnings = append(r.Warnings, health.Messagef(health.CodeUnknown, "Provisioner daemon %q reports invalid API version: %s", daemon.Name, err.Error()))
+			r.Warnings = append(r.Warnings, health.Messagef(health.CodeUnknown, "Some provisioner daemons reports invalid API version information"))
+			it.Warnings = append(it.Warnings, health.Messagef(health.CodeUnknown, "Invalid API version: %s", err.Error())) // contains version string
 		} else if maj != opts.CurrentAPIMajorVersion {
 			if r.Severity.Value() < health.SeverityWarning.Value() {
 				r.Severity = health.SeverityWarning
 			}
-			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProvisionerDaemonAPIMajorVersionDeprecated, "Provisioner daemon %q reports deprecated major API version %d. Consider upgrading!", daemon.Name, provisionersdk.CurrentMajor))
+			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProvisionerDaemonAPIMajorVersionDeprecated, "Some provisioner daemons report deprecated major API versions. Consider upgrading!"))
+			it.Warnings = append(it.Warnings, health.Messagef(health.CodeProvisionerDaemonAPIMajorVersionDeprecated, "Deprecated major API version %d.", provisionersdk.CurrentMajor))
 		}
+
+		r.Items = append(r.Items, it)
 	}
 
-	if len(r.ProvisionerDaemons) == 0 {
+	if len(r.Items) == 0 {
 		r.Severity = health.SeverityError
 		r.Error = ptr.Ref("No active provisioner daemons found!")
 		return

--- a/coderd/healthcheck/provisioner.go
+++ b/coderd/healthcheck/provisioner.go
@@ -137,7 +137,7 @@ func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDae
 			if r.Severity.Value() < health.SeverityError.Value() {
 				r.Severity = health.SeverityError
 			}
-			r.Warnings = append(r.Warnings, health.Messagef(health.CodeUnknown, "Some provisioner daemons reports invalid API version information"))
+			r.Warnings = append(r.Warnings, health.Messagef(health.CodeUnknown, "Some provisioner daemons report invalid API version information."))
 			it.Warnings = append(it.Warnings, health.Messagef(health.CodeUnknown, "Invalid API version: %s", err.Error())) // contains version string
 		} else if maj != opts.CurrentAPIMajorVersion {
 			if r.Severity.Value() < health.SeverityWarning.Value() {

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -285,19 +285,27 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
   "provisioner_daemons": {
     "dismissed": true,
     "error": "string",
-    "provisioner_daemons": [
+    "items": [
       {
-        "api_version": "string",
-        "created_at": "2019-08-24T14:15:22Z",
-        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-        "last_seen_at": "2019-08-24T14:15:22Z",
-        "name": "string",
-        "provisioners": ["string"],
-        "tags": {
-          "property1": "string",
-          "property2": "string"
+        "provisioner_daemon": {
+          "api_version": "string",
+          "created_at": "2019-08-24T14:15:22Z",
+          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "last_seen_at": "2019-08-24T14:15:22Z",
+          "name": "string",
+          "provisioners": ["string"],
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          },
+          "version": "string"
         },
-        "version": "string"
+        "warnings": [
+          {
+            "code": "EUNKNOWN",
+            "message": "string"
+          }
+        ]
       }
     ],
     "severity": "ok",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7900,19 +7900,27 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 {
   "dismissed": true,
   "error": "string",
-  "provisioner_daemons": [
+  "items": [
     {
-      "api_version": "string",
-      "created_at": "2019-08-24T14:15:22Z",
-      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-      "last_seen_at": "2019-08-24T14:15:22Z",
-      "name": "string",
-      "provisioners": ["string"],
-      "tags": {
-        "property1": "string",
-        "property2": "string"
+      "provisioner_daemon": {
+        "api_version": "string",
+        "created_at": "2019-08-24T14:15:22Z",
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "last_seen_at": "2019-08-24T14:15:22Z",
+        "name": "string",
+        "provisioners": ["string"],
+        "tags": {
+          "property1": "string",
+          "property2": "string"
+        },
+        "version": "string"
       },
-      "version": "string"
+      "warnings": [
+        {
+          "code": "EUNKNOWN",
+          "message": "string"
+        }
+      ]
     }
   ],
   "severity": "ok",
@@ -7927,13 +7935,46 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name                  | Type                                                              | Required | Restrictions | Description |
-| --------------------- | ----------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `dismissed`           | boolean                                                           | false    |              |             |
-| `error`               | string                                                            | false    |              |             |
-| `provisioner_daemons` | array of [codersdk.ProvisionerDaemon](#codersdkprovisionerdaemon) | false    |              |             |
-| `severity`            | [health.Severity](#healthseverity)                                | false    |              |             |
-| `warnings`            | array of [health.Message](#healthmessage)                         | false    |              |             |
+| Name        | Type                                                                                          | Required | Restrictions | Description |
+| ----------- | --------------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `dismissed` | boolean                                                                                       | false    |              |             |
+| `error`     | string                                                                                        | false    |              |             |
+| `items`     | array of [healthcheck.ProvisionerDaemonsReportItem](#healthcheckprovisionerdaemonsreportitem) | false    |              |             |
+| `severity`  | [health.Severity](#healthseverity)                                                            | false    |              |             |
+| `warnings`  | array of [health.Message](#healthmessage)                                                     | false    |              |             |
+
+## healthcheck.ProvisionerDaemonsReportItem
+
+```json
+{
+  "provisioner_daemon": {
+    "api_version": "string",
+    "created_at": "2019-08-24T14:15:22Z",
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "last_seen_at": "2019-08-24T14:15:22Z",
+    "name": "string",
+    "provisioners": ["string"],
+    "tags": {
+      "property1": "string",
+      "property2": "string"
+    },
+    "version": "string"
+  },
+  "warnings": [
+    {
+      "code": "EUNKNOWN",
+      "message": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name                 | Type                                                     | Required | Restrictions | Description |
+| -------------------- | -------------------------------------------------------- | -------- | ------------ | ----------- |
+| `provisioner_daemon` | [codersdk.ProvisionerDaemon](#codersdkprovisionerdaemon) | false    |              |             |
+| `warnings`           | array of [health.Message](#healthmessage)                | false    |              |             |
 
 ## healthcheck.Report
 
@@ -8179,19 +8220,27 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "provisioner_daemons": {
     "dismissed": true,
     "error": "string",
-    "provisioner_daemons": [
+    "items": [
       {
-        "api_version": "string",
-        "created_at": "2019-08-24T14:15:22Z",
-        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-        "last_seen_at": "2019-08-24T14:15:22Z",
-        "name": "string",
-        "provisioners": ["string"],
-        "tags": {
-          "property1": "string",
-          "property2": "string"
+        "provisioner_daemon": {
+          "api_version": "string",
+          "created_at": "2019-08-24T14:15:22Z",
+          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "last_seen_at": "2019-08-24T14:15:22Z",
+          "name": "string",
+          "provisioners": ["string"],
+          "tags": {
+            "property1": "string",
+            "property2": "string"
+          },
+          "version": "string"
         },
-        "version": "string"
+        "warnings": [
+          {
+            "code": "EUNKNOWN",
+            "message": "string"
+          }
+        ]
       }
     ],
     "severity": "ok",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2211,7 +2211,13 @@ export interface HealthcheckProvisionerDaemonsReport {
   readonly warnings: HealthMessage[];
   readonly dismissed: boolean;
   readonly error?: string;
-  readonly provisioner_daemons: ProvisionerDaemon[];
+  readonly items: HealthcheckProvisionerDaemonsReportItem[];
+}
+
+// From healthcheck/provisioner.go
+export interface HealthcheckProvisionerDaemonsReportItem {
+  readonly provisioner_daemon: ProvisionerDaemon;
+  readonly warnings: HealthMessage[];
 }
 
 // From healthcheck/healthcheck.go

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3105,19 +3105,22 @@ export const MockHealth: TypesGen.HealthcheckReport = {
     severity: "ok",
     warnings: [],
     dismissed: false,
-    provisioner_daemons: [
+    items: [
       {
-        id: "e455b582-ac04-4323-9ad6-ab71301fa006",
-        created_at: "2024-01-04T15:53:03.21563Z",
-        last_seen_at: "2024-01-04T16:05:03.967551Z",
-        name: "vvuurrkk-2",
-        version: "v2.6.0-devel+965ad5e96",
-        api_version: "1.0",
-        provisioners: ["echo", "terraform"],
-        tags: {
-          owner: "",
-          scope: "organization",
+        provisioner_daemon: {
+          id: "e455b582-ac04-4323-9ad6-ab71301fa006",
+          created_at: "2024-01-04T15:53:03.21563Z",
+          last_seen_at: "2024-01-04T16:05:03.967551Z",
+          name: "vvuurrkk-2",
+          version: "v2.6.0-devel+965ad5e96",
+          api_version: "1.0",
+          provisioners: ["echo", "terraform"],
+          tags: {
+            owner: "",
+            scope: "organization",
+          },
         },
+        warnings: [],
       },
     ],
   },
@@ -3211,10 +3214,37 @@ export const DeploymentHealthUnhealthy: TypesGen.HealthcheckReport = {
   },
   provisioner_daemons: {
     severity: "error",
-    error: "something went wrong lol",
-    warnings: [],
+    error: "something went wrong",
+    warnings: [
+      {
+        message: "this is a message",
+        code: "EUNKNOWN",
+      },
+    ],
     dismissed: false,
-    provisioner_daemons: [],
+    items: [
+      {
+        provisioner_daemon: {
+          id: "e455b582-ac04-4323-9ad6-ab71301fa006",
+          created_at: "2024-01-04T15:53:03.21563Z",
+          last_seen_at: "2024-01-04T16:05:03.967551Z",
+          name: "vvuurrkk-2",
+          version: "v2.6.0-devel+965ad5e96",
+          api_version: "1.0",
+          provisioners: ["echo", "terraform"],
+          tags: {
+            owner: "",
+            scope: "organization",
+          },
+        },
+        warnings: [
+          {
+            message: "this is a specific message for this thing",
+            code: "EUNKNOWN",
+          },
+        ],
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/coder/coder/pull/11393
Part of https://github.com/coder/coder/issues/10676

- Sorts provisioner daemons by name ascending in output
- Adds daemon-specific warnings to healthcheck output
- Reword some messages