### PR TITLE
fix: switch node version to v18 in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,11 +46,11 @@
           libuuid
           mockgen
           nfpm
-          nodejs
-          nodePackages.pnpm
-          nodePackages.prettier
-          nodePackages.typescript
-          nodePackages.typescript-language-server
+          nodejs-18_x
+          nodejs-18_x.pkgs.pnpm
+          nodejs-18_x.pkgs.prettier
+          nodejs-18_x.pkgs.typescript
+          nodejs-18_x.pkgs.typescript-language-server
           openssh
           openssl
           pango


### PR DESCRIPTION
I was unable to build coder site locally:

```
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "/Users/mtojek/code/coder/site".

Expected version: >=18.0.0 <19.0.0
Got: v20.10.0

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
make: *** [Makefile:363: site/out/index.html] Error 1
```

We need to force nix to use expect node version.
