### PR TITLE
docs: remove empty page

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -174,7 +174,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Applications Enterprise"
+                    "Enterprise"
                 ],
                 "summary": "Issue signed app token for reconnecting PTY",
                 "operationId": "issue-signed-app-token-for-reconnecting-pty",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -141,7 +141,7 @@
         ],
         "consumes": ["application/json"],
         "produces": ["application/json"],
-        "tags": ["Applications Enterprise"],
+        "tags": ["Enterprise"],
         "summary": "Issue signed app token for reconnecting PTY",
         "operationId": "issue-signed-app-token-for-reconnecting-pty",
         "parameters": [

--- a/docs/api/applications enterprise.md
+++ b/docs/api/applications enterprise.md
@@ -1,1 +1,0 @@
-# Applications Enterprise

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -517,10 +517,6 @@
           "path": "./api/applications.md"
         },
         {
-          "title": "Applications Enterprise",
-          "path": "./api/applications enterprise.md"
-        },
-        {
           "title": "Audit",
           "path": "./api/audit.md"
         },

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -809,7 +809,7 @@ func (api *API) workspaceProxyDeregister(rw http.ResponseWriter, r *http.Request
 // @Summary Issue signed app token for reconnecting PTY
 // @ID issue-signed-app-token-for-reconnecting-pty
 // @Security CoderSessionToken
-// @Tags Applications Enterprise
+// @Tags Enterprise
 // @Accept json
 // @Produce json
 // @Param request body codersdk.IssueReconnectingPTYSignedTokenRequest true "Issue reconnecting PTY signed token request"


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/11289

This PR removes the empty docs page "Applications Enterprise". The only endpoint that used it was `/applications/reconnecting-pty-signed-token`, and it is marked as "skipped", so I'm going to skip it in the docs generation process.