### PR TITLE
docs: escape enum pipe

### DIFF
--- a/cli/clibase/values.go
+++ b/cli/clibase/values.go
@@ -484,7 +484,7 @@ func (e *Enum) Set(v string) error {
 }
 
 func (e *Enum) Type() string {
-	return fmt.Sprintf("enum[%v]", strings.Join(e.Choices, "|"))
+	return fmt.Sprintf("enum[%v]", strings.Join(e.Choices, "\\|"))
 }
 
 func (e *Enum) String() string {

--- a/docs/cli/config-ssh.md
+++ b/docs/cli/config-ssh.md
@@ -93,8 +93,8 @@ Specifies whether or not to keep options from previous run of config-ssh.
 ### --wait
 
 |             |                                    |
-| ----------- | ---------------------------------- | --- | ------------ |
-| Type        | <code>enum[yes                     | no  | auto]</code> |
+| ----------- | ---------------------------------- |
+| Type        | <code>enum[yes\|no\|auto]</code>   |
 | Environment | <code>$CODER_CONFIGSSH_WAIT</code> |
 | Default     | <code>auto</code>                  |
 

--- a/docs/cli/speedtest.md
+++ b/docs/cli/speedtest.md
@@ -22,10 +22,10 @@ Specifies whether to wait for a direct connection before testing speed.
 
 ### --direction
 
-|         |                   |
-| ------- | ----------------- | ------------ |
-| Type    | <code>enum[up     | down]</code> |
-| Default | <code>down</code> |
+|         |                             |
+| ------- | --------------------------- |
+| Type    | <code>enum[up\|down]</code> |
+| Default | <code>down</code>           |
 
 Specifies whether to run in reverse mode where the client receives and the server sends.
 

--- a/docs/cli/ssh.md
+++ b/docs/cli/ssh.md
@@ -87,11 +87,11 @@ Specifies whether to emit SSH output over stdin/stdout.
 
 ### --wait
 
-|             |                              |
-| ----------- | ---------------------------- | --- | ------------ |
-| Type        | <code>enum[yes               | no  | auto]</code> |
-| Environment | <code>$CODER_SSH_WAIT</code> |
-| Default     | <code>auto</code>            |
+|             |                                  |
+| ----------- | -------------------------------- |
+| Type        | <code>enum[yes\|no\|auto]</code> |
+| Environment | <code>$CODER_SSH_WAIT</code>     |
+| Default     | <code>auto</code>                |
 
 Specifies whether or not to wait for the startup script to finish executing. Auto means that the agent startup script behavior configured in the workspace template is used.
 

--- a/docs/cli/stat_disk.md
+++ b/docs/cli/stat_disk.md
@@ -32,9 +32,9 @@ Path for which to check disk usage.
 
 ### --prefix
 
-|         |                 |
-| ------- | --------------- | --- | --- | ---------- |
-| Type    | <code>enum[Ki   | Mi  | Gi  | Ti]</code> |
-| Default | <code>Gi</code> |
+|         |                                   |
+| ------- | --------------------------------- |
+| Type    | <code>enum[Ki\|Mi\|Gi\|Ti]</code> |
+| Default | <code>Gi</code>                   |
 
 SI Prefix for disk measurement.

--- a/docs/cli/stat_mem.md
+++ b/docs/cli/stat_mem.md
@@ -31,9 +31,9 @@ Output format. Available formats: text, json.
 
 ### --prefix
 
-|         |                 |
-| ------- | --------------- | --- | --- | ---------- |
-| Type    | <code>enum[Ki   | Mi  | Gi  | Ti]</code> |
-| Default | <code>Gi</code> |
+|         |                                   |
+| ------- | --------------------------------- |
+| Type    | <code>enum[Ki\|Mi\|Gi\|Ti]</code> |
+| Default | <code>Gi</code>                   |
 
 SI Prefix for memory measurement.

--- a/docs/cli/templates_init.md
+++ b/docs/cli/templates_init.md
@@ -14,8 +14,8 @@ coder templates init [flags] [directory]
 
 ### --id
 
-|      |                             |
-| ---- | --------------------------- | --------- | ----------- | ----------- | -------- | ------ | ---------------- | --------- | ---------------- | ----------- | ---------- | -------------------- |
-| Type | <code>enum[aws-devcontainer | aws-linux | aws-windows | azure-linux | do-linux | docker | gcp-devcontainer | gcp-linux | gcp-vm-container | gcp-windows | kubernetes | nomad-docker]</code> |
+|      |                                                                                                                                                                                  |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Type | <code>enum[aws-devcontainer\|aws-linux\|aws-windows\|azure-linux\|do-linux\|docker\|gcp-devcontainer\|gcp-linux\|gcp-vm-container\|gcp-windows\|kubernetes\|nomad-docker]</code> |
 
 Specify a given example template by ID.


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/11247

This PR adjusts the `clidocgen` script to correctly escape pipes while rendering enum types.