### PR TITLE
fix(coderd): update last_used_at if RxBytes/RxPackets > 0

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1297,6 +1297,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 		slog.F("payload", req),
 	)
 
+	// TODO(Cian): Should we check if RxBytes / RxPackets > 0?
 	if req.ConnectionCount > 0 {
 		var nextAutostart time.Time
 		if workspace.AutostartSchedule.String != "" {
@@ -1365,7 +1366,9 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 		}
 		return nil
 	})
-	if req.SessionCount() > 0 {
+	// NOTE: we previously checked if SessionCount() > 0; however this does not handle the case
+	// where a user is only accessing their workspace via a coder_app (e.g. code-server).
+	if req.RxBytes > 0 || req.RxPackets > 0 {
 		errGroup.Go(func() error {
 			err := api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
 				ID:         workspace.ID,

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1297,7 +1297,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 		slog.F("payload", req),
 	)
 
-	// TODO(Cian): Should we check if RxBytes / RxPackets > 0?
+	// TODO(Cian): Should we check if RxBytes / RxPackets > 0 instead?
 	if req.ConnectionCount > 0 {
 		var nextAutostart time.Time
 		if workspace.AutostartSchedule.String != "" {
@@ -1366,8 +1366,8 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 		}
 		return nil
 	})
-	// NOTE: we previously checked if SessionCount() > 0; however this does not handle the case
-	// where a user is only accessing their workspace via a coder_app (e.g. code-server).
+	// NOTE(Cian): we previously checked if SessionCount() > 0; however this does not handle the
+	// case where a user is only accessing their workspace via a coder_app (e.g. code-server).
 	if req.RxBytes > 0 || req.RxPackets > 0 {
 		errGroup.Go(func() error {
 			err := api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/11509

https://github.com/coder/coder/pull/10808 modified the logic for bumping workspace last_used_at only if `SessionCount() > 0`. This has the side-effect that accessing a workspace solely via code-server (or any other `coder_app`) will result in the workspace last_used_at field never being updated. This could have negative knock-on effects for dormancy, or for a Coder admin manually cleaning up apparently "unused" workspaces.

Instead, I'm modifying the logic to check if `RxBytes` or `RxPackets` are greater than 0. I've observed this to be the case when closing all active windows of my workspace. I also updated the corresponding AgentAPI implementation for consistency, although I don't believe it's currently in use.

The same logic could potentially be applied to ActivityBumpWorkspace (see TODO), where we currently check the `ConnectionCount`. I've observed this to be non-zero for an inactive workspace (1 active TSMP connection, likely related to Tailscale connectivity checks). 

I think we could probably apply the same treatment here but I want to keep the scope of this change minimal for now and observe the result.