### PR TITLE
chore(coderd): fix test flake in TestAgentWebsocketMonitor_SendPings

### DIFF
--- a/coderd/workspaceagentsrpc_internal_test.go
+++ b/coderd/workspaceagentsrpc_internal_test.go
@@ -219,14 +219,21 @@ func TestAgentWebsocketMonitor_BuildOutdated(t *testing.T) {
 
 func TestAgentWebsocketMonitor_SendPings(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitShort)
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+	t.Cleanup(cancel)
 	fConn := &fakePingerCloser{}
 	uut := &agentWebsocketMonitor{
 		pingPeriod: testutil.IntervalFast,
 		conn:       fConn,
 	}
-	go uut.sendPings(ctx)
+	done := make(chan struct{})
+	go func() {
+		uut.sendPings(ctx)
+		close(done)
+	}()
 	fConn.requireEventuallyHasPing(t)
+	cancel()
+	<-done
 	lastPing := uut.lastPing.Load()
 	require.NotNil(t, lastPing)
 }


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/11517

My read of the original issue is that `m.lastPing` can be stored in between 

```
        fConn.requireEventuallyHasPing(t)
```

and 

```
	lastPing := uut.lastPing.Load()
``` 

Triggering cancellation before checking lastPing should allow the for loop to complete its iteration through to storing lastPing.