### PR TITLE
chore: instrument external oauth2 requests

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -767,11 +767,11 @@ func TestCreateWithGitAuth(t *testing.T) {
 
 	client := coderdtest.New(t, &coderdtest.Options{
 		ExternalAuthConfigs: []*externalauth.Config{{
-			OAuth2Config: &testutil.OAuth2Config{},
-			ID:           "github",
-			Regex:        regexp.MustCompile(`github\.com`),
-			Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
-			DisplayName:  "GitHub",
+			InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+			ID:                       "github",
+			Regex:                    regexp.MustCompile(`github\.com`),
+			Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
+			DisplayName:              "GitHub",
 		}},
 		IncludeProvisionerDaemon: true,
 	})

--- a/cli/server.go
+++ b/cli/server.go
@@ -80,6 +80,7 @@ import (
 	"github.com/coder/coder/v2/coderd/oauthpki"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics/insights"
+	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/tracing"
@@ -102,7 +103,7 @@ import (
 	"github.com/coder/wgtunnel/tunnelsdk"
 )
 
-func createOIDCConfig(ctx context.Context, vals *codersdk.DeploymentValues) (*coderd.OIDCConfig, error) {
+func createOIDCConfig(ctx context.Context, instrument *promoauth.Factory, vals *codersdk.DeploymentValues) (*coderd.OIDCConfig, error) {
 	if vals.OIDC.ClientID == "" {
 		return nil, xerrors.Errorf("OIDC client ID must be set!")
 	}
@@ -133,7 +134,7 @@ func createOIDCConfig(ctx context.Context, vals *codersdk.DeploymentValues) (*co
 		Scopes:       vals.OIDC.Scopes,
 	}
 
-	var useCfg httpmw.OAuth2Config = oauthCfg
+	var useCfg promoauth.OAuth2Config = oauthCfg
 	if vals.OIDC.ClientKeyFile != "" {
 		// PKI authentication is done in the params. If a
 		// counter example is found, we can add a config option to
@@ -159,7 +160,7 @@ func createOIDCConfig(ctx context.Context, vals *codersdk.DeploymentValues) (*co
 	}
 
 	return &coderd.OIDCConfig{
-		OAuth2Config: useCfg,
+		OAuth2Config: instrument.New("oidc-login", useCfg),
 		Provider:     oidcProvider,
 		Verifier: oidcProvider.Verifier(&oidc.Config{
 			ClientID: vals.OIDC.ClientID.String(),
@@ -523,8 +524,11 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				return xerrors.Errorf("read external auth providers from env: %w", err)
 			}
 
+			promRegistry := prometheus.NewRegistry()
+			oauthIntrument := promoauth.NewFactory(promRegistry)
 			vals.ExternalAuthConfigs.Value = append(vals.ExternalAuthConfigs.Value, extAuthEnv...)
 			externalAuthConfigs, err := externalauth.ConvertConfig(
+				oauthIntrument,
 				vals.ExternalAuthConfigs.Value,
 				vals.AccessURL.Value(),
 			)
@@ -571,7 +575,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				// the DeploymentValues instead, this just serves to indicate the source of each
 				// option. This is just defensive to prevent accidentally leaking.
 				DeploymentOptions:           codersdk.DeploymentOptionsWithoutSecrets(opts),
-				PrometheusRegistry:          prometheus.NewRegistry(),
+				PrometheusRegistry:          promRegistry,
 				APIRateLimit:                int(vals.RateLimit.API.Value()),
 				LoginRateLimit:              loginRateLimit,
 				FilesRateLimit:              filesRateLimit,
@@ -617,7 +621,9 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			}
 
 			if vals.OAuth2.Github.ClientSecret != "" {
-				options.GithubOAuth2Config, err = configureGithubOAuth2(vals.AccessURL.Value(),
+				options.GithubOAuth2Config, err = configureGithubOAuth2(
+					oauthIntrument,
+					vals.AccessURL.Value(),
 					vals.OAuth2.Github.ClientID.String(),
 					vals.OAuth2.Github.ClientSecret.String(),
 					vals.OAuth2.Github.AllowSignups.Value(),
@@ -636,7 +642,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					logger.Warn(ctx, "coder will not check email_verified for OIDC logins")
 				}
 
-				oc, err := createOIDCConfig(ctx, vals)
+				oc, err := createOIDCConfig(ctx, oauthIntrument, vals)
 				if err != nil {
 					return xerrors.Errorf("create oidc config: %w", err)
 				}
@@ -1737,7 +1743,7 @@ func configureCAPool(tlsClientCAFile string, tlsConfig *tls.Config) error {
 }
 
 //nolint:revive // Ignore flag-parameter: parameter 'allowEveryone' seems to be a control flag, avoid control coupling (revive)
-func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, allowSignups, allowEveryone bool, allowOrgs []string, rawTeams []string, enterpriseBaseURL string) (*coderd.GithubOAuth2Config, error) {
+func configureGithubOAuth2(instrument *promoauth.Factory, accessURL *url.URL, clientID, clientSecret string, allowSignups, allowEveryone bool, allowOrgs []string, rawTeams []string, enterpriseBaseURL string) (*coderd.GithubOAuth2Config, error) {
 	redirectURL, err := accessURL.Parse("/api/v2/users/oauth2/github/callback")
 	if err != nil {
 		return nil, xerrors.Errorf("parse github oauth callback url: %w", err)
@@ -1790,7 +1796,7 @@ func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, al
 	}
 
 	return &coderd.GithubOAuth2Config{
-		OAuth2Config: &oauth2.Config{
+		OAuth2Config: instrument.New("github-login", &oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint:     endpoint,
@@ -1800,7 +1806,7 @@ func configureGithubOAuth2(accessURL *url.URL, clientID, clientSecret string, al
 				"read:org",
 				"user:email",
 			},
-		},
+		}),
 		AllowSignups:       allowSignups,
 		AllowEveryone:      allowEveryone,
 		AllowOrganizations: allowOrgs,

--- a/cli/server.go
+++ b/cli/server.go
@@ -103,7 +103,7 @@ import (
 	"github.com/coder/wgtunnel/tunnelsdk"
 )
 
-func createOIDCConfig(ctx context.Context, instrument *promoauth.Factory, vals *codersdk.DeploymentValues) (*coderd.OIDCConfig, error) {
+func createOIDCConfig(ctx context.Context, vals *codersdk.DeploymentValues) (*coderd.OIDCConfig, error) {
 	if vals.OIDC.ClientID == "" {
 		return nil, xerrors.Errorf("OIDC client ID must be set!")
 	}
@@ -160,7 +160,7 @@ func createOIDCConfig(ctx context.Context, instrument *promoauth.Factory, vals *
 	}
 
 	return &coderd.OIDCConfig{
-		OAuth2Config: instrument.New("oidc-login", useCfg),
+		OAuth2Config: useCfg,
 		Provider:     oidcProvider,
 		Verifier: oidcProvider.Verifier(&oidc.Config{
 			ClientID: vals.OIDC.ClientID.String(),
@@ -642,7 +642,13 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					logger.Warn(ctx, "coder will not check email_verified for OIDC logins")
 				}
 
-				oc, err := createOIDCConfig(ctx, oauthInstrument, vals)
+				// This OIDC config is **not** being instrumented with the
+				// oauth2 instrument wrapper. If we implement the missing
+				// oidc methods, then we can instrument it.
+				// Missing:
+				//	- Userinfo
+				//	- Verify
+				oc, err := createOIDCConfig(ctx, vals)
 				if err != nil {
 					return xerrors.Errorf("create oidc config: %w", err)
 				}

--- a/cli/server.go
+++ b/cli/server.go
@@ -525,10 +525,10 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			}
 
 			promRegistry := prometheus.NewRegistry()
-			oauthIntrument := promoauth.NewFactory(promRegistry)
+			oauthInstrument := promoauth.NewFactory(promRegistry)
 			vals.ExternalAuthConfigs.Value = append(vals.ExternalAuthConfigs.Value, extAuthEnv...)
 			externalAuthConfigs, err := externalauth.ConvertConfig(
-				oauthIntrument,
+				oauthInstrument,
 				vals.ExternalAuthConfigs.Value,
 				vals.AccessURL.Value(),
 			)
@@ -622,7 +622,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 
 			if vals.OAuth2.Github.ClientSecret != "" {
 				options.GithubOAuth2Config, err = configureGithubOAuth2(
-					oauthIntrument,
+					oauthInstrument,
 					vals.AccessURL.Value(),
 					vals.OAuth2.Github.ClientID.String(),
 					vals.OAuth2.Github.ClientSecret.String(),
@@ -642,7 +642,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					logger.Warn(ctx, "coder will not check email_verified for OIDC logins")
 				}
 
-				oc, err := createOIDCConfig(ctx, oauthIntrument, vals)
+				oc, err := createOIDCConfig(ctx, oauthInstrument, vals)
 				if err != nil {
 					return xerrors.Errorf("create oidc config: %w", err)
 				}

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -223,6 +223,10 @@ func (f *FakeIDP) WellknownConfig() ProviderJSON {
 	return f.provider
 }
 
+func (f *FakeIDP) IssuerURL() *url.URL {
+	return f.issuerURL
+}
+
 func (f *FakeIDP) updateIssuerURL(t testing.TB, issuer string) {
 	t.Helper()
 

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -421,18 +421,19 @@ func (f *FakeIDP) CreateAuthCode(t testing.TB, state string, opts ...func(r *htt
 	rw := httptest.NewRecorder()
 	f.handler.ServeHTTP(rw, r)
 	resp := rw.Result()
+	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode, "expected redirect")
 	to := resp.Header.Get("Location")
 	require.NotEmpty(t, to, "expected redirect location")
 
-	toUrl, err := url.Parse(to)
+	toURL, err := url.Parse(to)
 	require.NoError(t, err, "failed to parse redirect location")
 
-	code := toUrl.Query().Get("code")
+	code := toURL.Query().Get("code")
 	require.NotEmpty(t, code, "expected code in redirect location")
 
-	newState := toUrl.Query().Get("state")
+	newState := toURL.Query().Get("state")
 	require.Equal(t, state, newState, "expected state to match")
 
 	return code

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -29,7 +29,7 @@ import (
 
 // Config is used for authentication for Git operations.
 type Config struct {
-	promoauth.InstrumentedeOAuth2Config
+	promoauth.InstrumentedOAuth2Config
 	// ID is a unique identifier for the authenticator.
 	ID string
 	// Type is the type of provider.
@@ -188,7 +188,7 @@ func (c *Config) ValidateToken(ctx context.Context, token string) (bool, *coders
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	res, err := c.InstrumentedeOAuth2Config.Do(ctx, "ValidateToken", req)
+	res, err := c.InstrumentedOAuth2Config.Do(ctx, "ValidateToken", req)
 	if err != nil {
 		return false, nil, err
 	}
@@ -238,7 +238,7 @@ func (c *Config) AppInstallations(ctx context.Context, token string) ([]codersdk
 		return nil, false, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	res, err := c.InstrumentedeOAuth2Config.Do(ctx, "AppInstallations", req)
+	res, err := c.InstrumentedOAuth2Config.Do(ctx, "AppInstallations", req)
 	if err != nil {
 		return nil, false, err
 	}
@@ -279,7 +279,7 @@ func (c *Config) AppInstallations(ctx context.Context, token string) ([]codersdk
 
 type DeviceAuth struct {
 	// Cfg is provided for the http client method.
-	Cfg      promoauth.InstrumentedeOAuth2Config
+	Cfg      promoauth.InstrumentedOAuth2Config
 	ClientID string
 	TokenURL string
 	Scopes   []string
@@ -456,17 +456,17 @@ func ConvertConfig(instrument *promoauth.Factory, entries []codersdk.ExternalAut
 		}
 
 		cfg := &Config{
-			InstrumentedeOAuth2Config: instrument.New(entry.ID, oauthConfig),
-			ID:                        entry.ID,
-			Regex:                     regex,
-			Type:                      entry.Type,
-			NoRefresh:                 entry.NoRefresh,
-			ValidateURL:               entry.ValidateURL,
-			AppInstallationsURL:       entry.AppInstallationsURL,
-			AppInstallURL:             entry.AppInstallURL,
-			DisplayName:               entry.DisplayName,
-			DisplayIcon:               entry.DisplayIcon,
-			ExtraTokenKeys:            entry.ExtraTokenKeys,
+			InstrumentedOAuth2Config: instrument.New(entry.ID, oauthConfig),
+			ID:                       entry.ID,
+			Regex:                    regex,
+			Type:                     entry.Type,
+			NoRefresh:                entry.NoRefresh,
+			ValidateURL:              entry.ValidateURL,
+			AppInstallationsURL:      entry.AppInstallationsURL,
+			AppInstallURL:            entry.AppInstallURL,
+			DisplayName:              entry.DisplayName,
+			DisplayIcon:              entry.DisplayIcon,
+			ExtraTokenKeys:           entry.ExtraTokenKeys,
 		}
 
 		if entry.DeviceFlow {

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -29,7 +29,7 @@ import (
 
 // Config is used for authentication for Git operations.
 type Config struct {
-	promoauth.OAuth2Config
+	promoauth.InstrumentedeOAuth2Config
 	// ID is a unique identifier for the authenticator.
 	ID string
 	// Type is the type of provider.
@@ -187,12 +187,8 @@ func (c *Config) ValidateToken(ctx context.Context, token string) (bool, *coders
 		return false, nil, err
 	}
 
-	cli := http.DefaultClient
-	if v, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
-		cli = v
-	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	res, err := cli.Do(req)
+	res, err := c.InstrumentedeOAuth2Config.Do(ctx, "ValidateToken", req)
 	if err != nil {
 		return false, nil, err
 	}
@@ -242,7 +238,7 @@ func (c *Config) AppInstallations(ctx context.Context, token string) ([]codersdk
 		return nil, false, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.InstrumentedeOAuth2Config.Do(ctx, "AppInstallations", req)
 	if err != nil {
 		return nil, false, err
 	}
@@ -282,6 +278,8 @@ func (c *Config) AppInstallations(ctx context.Context, token string) ([]codersdk
 }
 
 type DeviceAuth struct {
+	// Cfg is provided for the http client method.
+	Cfg      promoauth.InstrumentedeOAuth2Config
 	ClientID string
 	TokenURL string
 	Scopes   []string
@@ -302,8 +300,8 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 	if err != nil {
 		return nil, err
 	}
+	resp, err := c.Cfg.Do(ctx, "AuthorizeDevice", req)
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -458,17 +456,17 @@ func ConvertConfig(instrument *promoauth.Factory, entries []codersdk.ExternalAut
 		}
 
 		cfg := &Config{
-			OAuth2Config:        instrument.New(entry.ID, oauthConfig),
-			ID:                  entry.ID,
-			Regex:               regex,
-			Type:                entry.Type,
-			NoRefresh:           entry.NoRefresh,
-			ValidateURL:         entry.ValidateURL,
-			AppInstallationsURL: entry.AppInstallationsURL,
-			AppInstallURL:       entry.AppInstallURL,
-			DisplayName:         entry.DisplayName,
-			DisplayIcon:         entry.DisplayIcon,
-			ExtraTokenKeys:      entry.ExtraTokenKeys,
+			InstrumentedeOAuth2Config: instrument.New(entry.ID, oauthConfig),
+			ID:                        entry.ID,
+			Regex:                     regex,
+			Type:                      entry.Type,
+			NoRefresh:                 entry.NoRefresh,
+			ValidateURL:               entry.ValidateURL,
+			AppInstallationsURL:       entry.AppInstallationsURL,
+			AppInstallURL:             entry.AppInstallURL,
+			DisplayName:               entry.DisplayName,
+			DisplayIcon:               entry.DisplayIcon,
+			ExtraTokenKeys:            entry.ExtraTokenKeys,
 		}
 
 		if entry.DeviceFlow {
@@ -476,6 +474,7 @@ func ConvertConfig(instrument *promoauth.Factory, entries []codersdk.ExternalAut
 				return nil, xerrors.Errorf("external auth provider %q: device auth url must be provided", entry.ID)
 			}
 			cfg.DeviceAuth = &DeviceAuth{
+				Cfg:      cfg,
 				ClientID: entry.ClientID,
 				TokenURL: oc.Endpoint.TokenURL,
 				Scopes:   entry.Scopes,

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -300,7 +300,16 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Cfg.Do(ctx, "AuthorizeDevice", req)
+
+	do := http.DefaultClient.Do
+	if c.Cfg != nil {
+		// The cfg can be nil in unit tests.
+		do = func(req *http.Request) (*http.Response, error) {
+			return c.Cfg.Do(ctx, "AuthorizeDevice", req)
+		}
+	}
+
+	resp, err := do(req)
 	req.Header.Set("Accept", "application/json")
 	if err != nil {
 		return nil, err

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -188,7 +188,7 @@ func (c *Config) ValidateToken(ctx context.Context, token string) (bool, *coders
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	res, err := c.InstrumentedOAuth2Config.Do(ctx, "ValidateToken", req)
+	res, err := c.InstrumentedOAuth2Config.Do(ctx, promoauth.SourceValidateToken, req)
 	if err != nil {
 		return false, nil, err
 	}
@@ -238,7 +238,7 @@ func (c *Config) AppInstallations(ctx context.Context, token string) ([]codersdk
 		return nil, false, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	res, err := c.InstrumentedOAuth2Config.Do(ctx, "AppInstallations", req)
+	res, err := c.InstrumentedOAuth2Config.Do(ctx, promoauth.SourceAppInstallations, req)
 	if err != nil {
 		return nil, false, err
 	}
@@ -305,7 +305,7 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 	if c.Cfg != nil {
 		// The cfg can be nil in unit tests.
 		do = func(req *http.Request) (*http.Response, error) {
-			return c.Cfg.Do(ctx, "AuthorizeDevice", req)
+			return c.Cfg.Do(ctx, promoauth.SourceAuthorizeDevice, req)
 		}
 	}
 

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -278,8 +278,8 @@ func (c *Config) AppInstallations(ctx context.Context, token string) ([]codersdk
 }
 
 type DeviceAuth struct {
-	// Cfg is provided for the http client method.
-	Cfg      promoauth.InstrumentedOAuth2Config
+	// Config is provided for the http client method.
+	Config   promoauth.InstrumentedOAuth2Config
 	ClientID string
 	TokenURL string
 	Scopes   []string
@@ -302,10 +302,10 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 	}
 
 	do := http.DefaultClient.Do
-	if c.Cfg != nil {
+	if c.Config != nil {
 		// The cfg can be nil in unit tests.
 		do = func(req *http.Request) (*http.Response, error) {
-			return c.Cfg.Do(ctx, promoauth.SourceAuthorizeDevice, req)
+			return c.Config.Do(ctx, promoauth.SourceAuthorizeDevice, req)
 		}
 	}
 
@@ -483,7 +483,7 @@ func ConvertConfig(instrument *promoauth.Factory, entries []codersdk.ExternalAut
 				return nil, xerrors.Errorf("external auth provider %q: device auth url must be provided", entry.ID)
 			}
 			cfg.DeviceAuth = &DeviceAuth{
-				Cfg:      cfg,
+				Config:   cfg,
 				ClientID: entry.ClientID,
 				TokenURL: oc.Endpoint.TokenURL,
 				Scopes:   entry.Scopes,

--- a/coderd/externalauth/externalauth_test.go
+++ b/coderd/externalauth/externalauth_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"golang.org/x/xerrors"
@@ -22,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmem"
 	"github.com/coder/coder/v2/coderd/externalauth"
+	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -94,7 +96,7 @@ func TestRefreshToken(t *testing.T) {
 	t.Run("FalseIfTokenSourceFails", func(t *testing.T) {
 		t.Parallel()
 		config := &externalauth.Config{
-			OAuth2Config: &testutil.OAuth2Config{
+			InstrumentedOAuth2Config: &testutil.OAuth2Config{
 				TokenSourceFunc: func() (*oauth2.Token, error) {
 					return nil, xerrors.New("failure")
 				},
@@ -301,9 +303,10 @@ func TestRefreshToken(t *testing.T) {
 
 func TestExchangeWithClientSecret(t *testing.T) {
 	t.Parallel()
+	instrument := promoauth.NewFactory(prometheus.NewRegistry())
 	// This ensures a provider that requires the custom
 	// client secret exchange works.
-	configs, err := externalauth.ConvertConfig([]codersdk.ExternalAuthConfig{{
+	configs, err := externalauth.ConvertConfig(instrument, []codersdk.ExternalAuthConfig{{
 		// JFrog just happens to require this custom type.
 
 		Type:         codersdk.EnhancedExternalAuthProviderJFrog.String(),
@@ -335,6 +338,8 @@ func TestExchangeWithClientSecret(t *testing.T) {
 
 func TestConvertYAML(t *testing.T) {
 	t.Parallel()
+
+	instrument := promoauth.NewFactory(prometheus.NewRegistry())
 	for _, tc := range []struct {
 		Name   string
 		Input  []codersdk.ExternalAuthConfig
@@ -387,7 +392,7 @@ func TestConvertYAML(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			output, err := externalauth.ConvertConfig(tc.Input, &url.URL{})
+			output, err := externalauth.ConvertConfig(instrument, tc.Input, &url.URL{})
 			if tc.Error != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.Error)
@@ -399,7 +404,7 @@ func TestConvertYAML(t *testing.T) {
 
 	t.Run("CustomScopesAndEndpoint", func(t *testing.T) {
 		t.Parallel()
-		config, err := externalauth.ConvertConfig([]codersdk.ExternalAuthConfig{{
+		config, err := externalauth.ConvertConfig(instrument, []codersdk.ExternalAuthConfig{{
 			Type:         string(codersdk.EnhancedExternalAuthProviderGitLab),
 			ClientID:     "id",
 			ClientSecret: "secret",
@@ -433,10 +438,12 @@ func setupOauth2Test(t *testing.T, settings testConfig) (*oidctest.FakeIDP, *ext
 		append([]oidctest.FakeIDPOpt{}, settings.FakeIDPOpts...)...,
 	)
 
+	f := promoauth.NewFactory(prometheus.NewRegistry())
 	config := &externalauth.Config{
-		OAuth2Config: fake.OIDCConfig(t, nil, settings.CoderOIDCConfigOpts...),
-		ID:           providerID,
-		ValidateURL:  fake.WellknownConfig().UserInfoURL,
+		InstrumentedOAuth2Config: f.New("test-oauth2",
+			fake.OIDCConfig(t, nil, settings.CoderOIDCConfigOpts...)),
+		ID:          providerID,
+		ValidateURL: fake.WellknownConfig().UserInfoURL,
 	}
 	settings.ExternalAuthOpt(config)
 

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -316,10 +316,10 @@ func TestExternalAuthCallback(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				OAuth2Config: &testutil.OAuth2Config{},
-				ID:           "github",
-				Regex:        regexp.MustCompile(`github\.com`),
-				Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+				ID:                       "github",
+				Regex:                    regexp.MustCompile(`github\.com`),
+				Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
 			}},
 		})
 		user := coderdtest.CreateFirstUser(t, client)
@@ -347,10 +347,10 @@ func TestExternalAuthCallback(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				OAuth2Config: &testutil.OAuth2Config{},
-				ID:           "github",
-				Regex:        regexp.MustCompile(`github\.com`),
-				Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+				ID:                       "github",
+				Regex:                    regexp.MustCompile(`github\.com`),
+				Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
 			}},
 		})
 		resp := coderdtest.RequestExternalAuthCallback(t, "github", client)
@@ -361,10 +361,10 @@ func TestExternalAuthCallback(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				OAuth2Config: &testutil.OAuth2Config{},
-				ID:           "github",
-				Regex:        regexp.MustCompile(`github\.com`),
-				Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+				ID:                       "github",
+				Regex:                    regexp.MustCompile(`github\.com`),
+				Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
 			}},
 		})
 		_ = coderdtest.CreateFirstUser(t, client)
@@ -387,11 +387,11 @@ func TestExternalAuthCallback(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				ValidateURL:  srv.URL,
-				OAuth2Config: &testutil.OAuth2Config{},
-				ID:           "github",
-				Regex:        regexp.MustCompile(`github\.com`),
-				Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
+				ValidateURL:              srv.URL,
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+				ID:                       "github",
+				Regex:                    regexp.MustCompile(`github\.com`),
+				Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
 			}},
 		})
 		user := coderdtest.CreateFirstUser(t, client)
@@ -443,7 +443,7 @@ func TestExternalAuthCallback(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				OAuth2Config: &testutil.OAuth2Config{
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{
 					Token: &oauth2.Token{
 						AccessToken:  "token",
 						RefreshToken: "something",
@@ -497,10 +497,10 @@ func TestExternalAuthCallback(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				OAuth2Config: &testutil.OAuth2Config{},
-				ID:           "github",
-				Regex:        regexp.MustCompile(`github\.com`),
-				Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+				ID:                       "github",
+				Regex:                    regexp.MustCompile(`github\.com`),
+				Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
 			}},
 		})
 		user := coderdtest.CreateFirstUser(t, client)

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -74,8 +75,8 @@ func UserAuthorization(r *http.Request) Authorization {
 // OAuth2Configs is a collection of configurations for OAuth-based authentication.
 // This should be extended to support other authentication types in the future.
 type OAuth2Configs struct {
-	Github OAuth2Config
-	OIDC   OAuth2Config
+	Github promoauth.OAuth2Config
+	OIDC   promoauth.OAuth2Config
 }
 
 func (c *OAuth2Configs) IsZero() bool {
@@ -270,7 +271,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 				})
 			}
 
-			var oauthConfig OAuth2Config
+			var oauthConfig promoauth.OAuth2Config
 			switch key.LoginType {
 			case database.LoginTypeGithub:
 				oauthConfig = cfg.OAuth2Configs.Github

--- a/coderd/httpmw/oauth2.go
+++ b/coderd/httpmw/oauth2.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
 )
@@ -20,14 +21,6 @@ type OAuth2State struct {
 	Token       *oauth2.Token
 	Redirect    string
 	StateString string
-}
-
-// OAuth2Config exposes a subset of *oauth2.Config functions for easier testing.
-// *oauth2.Config should be used instead of implementing this in production.
-type OAuth2Config interface {
-	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
-	Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)
-	TokenSource(context.Context, *oauth2.Token) oauth2.TokenSource
 }
 
 // OAuth2 returns the state from an oauth request.
@@ -44,7 +37,7 @@ func OAuth2(r *http.Request) OAuth2State {
 // a "code" URL parameter will be redirected.
 // AuthURLOpts are passed to the AuthCodeURL function. If this is nil,
 // the default option oauth2.AccessTypeOffline will be used.
-func ExtractOAuth2(config OAuth2Config, client *http.Client, authURLOpts map[string]string) func(http.Handler) http.Handler {
+func ExtractOAuth2(config promoauth.OAuth2Config, client *http.Client, authURLOpts map[string]string) func(http.Handler) http.Handler {
 	opts := make([]oauth2.AuthCodeOption, 0, len(authURLOpts)+1)
 	opts = append(opts, oauth2.AccessTypeOffline)
 	for k, v := range authURLOpts {

--- a/coderd/oauthpki/oidcpki.go
+++ b/coderd/oauthpki/oidcpki.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/oauth2/jws"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/promoauth"
 )
 
 // Config uses jwt assertions over client_secret for oauth2 authentication of
@@ -33,7 +33,7 @@ import (
 //
 //	https://datatracker.ietf.org/doc/html/rfc7523
 type Config struct {
-	cfg httpmw.OAuth2Config
+	cfg promoauth.OAuth2Config
 
 	// These values should match those provided in the oauth2.Config.
 	// Because the inner config is an interface, we need to duplicate these
@@ -57,7 +57,7 @@ type ConfigParams struct {
 	PemEncodedKey  []byte
 	PemEncodedCert []byte
 
-	Config httpmw.OAuth2Config
+	Config promoauth.OAuth2Config
 }
 
 // NewOauth2PKIConfig creates the oauth2 config for PKI based auth. It requires the certificate and it's private key.

--- a/coderd/oauthpki/oidcpki.go
+++ b/coderd/oauthpki/oidcpki.go
@@ -180,6 +180,8 @@ func (src *jwtTokenSource) Token() (*oauth2.Token, error) {
 	}
 	cli := http.DefaultClient
 	if v, ok := src.ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		// This client should be the instrumented client already. So no need to
+		// handle this manually.
 		cli = v
 	}
 

--- a/coderd/promoauth/doc.go
+++ b/coderd/promoauth/doc.go
@@ -1,0 +1,4 @@
+// Package promoauth is for instrumenting oauth2 flows with prometheus metrics.
+// Specifically, it is intended to count the number of external requests made
+// by the underlying oauth2 exchanges.
+package promoauth

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -160,14 +160,6 @@ func (i *instrumentedTripper) RoundTrip(r *http.Request) (*http.Response, error)
 		"source":      i.source,
 		"status_code": fmt.Sprintf("%d", statusCode),
 	}).Inc()
-	if err == nil {
-		fmt.Println(map[string]string{
-			"limit":    resp.Header.Get("x-ratelimit-limit"),
-			"remain":   resp.Header.Get("x-ratelimit-remaining"),
-			"used":     resp.Header.Get("x-ratelimit-used"),
-			"reset":    resp.Header.Get("x-ratelimit-reset"),
-			"resource": resp.Header.Get("x-ratelimit-resource"),
-		})
-	}
+
 	return resp, err
 }

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -155,6 +155,14 @@ func (i *instrumentedTripper) RoundTrip(r *http.Request) (*http.Response, error)
 		"source":      i.source,
 		"status_code": fmt.Sprintf("%d", statusCode),
 	}).Inc()
-
+	if err == nil {
+		fmt.Println(map[string]string{
+			"limit":    resp.Header.Get("x-ratelimit-limit"),
+			"remain":   resp.Header.Get("x-ratelimit-remaining"),
+			"used":     resp.Header.Get("x-ratelimit-used"),
+			"reset":    resp.Header.Get("x-ratelimit-reset"),
+			"resource": resp.Header.Get("x-ratelimit-resource"),
+		})
+	}
 	return resp, err
 }

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -1,0 +1,128 @@
+package promoauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/oauth2"
+)
+
+// OAuth2Config exposes a subset of *oauth2.Config functions for easier testing.
+// *oauth2.Config should be used instead of implementing this in production.
+type OAuth2Config interface {
+	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
+	Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)
+	TokenSource(context.Context, *oauth2.Token) oauth2.TokenSource
+}
+
+var _ OAuth2Config = (*Config)(nil)
+
+type Factory struct {
+	metrics *metrics
+}
+
+// metrics is the reusable metrics for all oauth2 providers.
+type metrics struct {
+	externalRequestCount *prometheus.CounterVec
+}
+
+func NewFactory(registry prometheus.Registerer) *Factory {
+	factory := promauto.With(registry)
+
+	return &Factory{
+		metrics: &metrics{
+			externalRequestCount: factory.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "coderd",
+				Subsystem: "oauth2",
+				Name:      "external_requests_total",
+				Help:      "The total number of api calls made to external oauth2 providers. 'status_code' will be 0 if the request failed with no response.",
+			}, []string{
+				"name",
+				"status_code",
+				"domain",
+			}),
+		},
+	}
+}
+
+func (f *Factory) New(name string, under OAuth2Config) *Config {
+	return &Config{
+		name:       name,
+		underlying: under,
+		metrics:    f.metrics,
+	}
+}
+
+type Config struct {
+	// Name is a human friendly name to identify the oauth2 provider. This should be
+	// deterministic from restart to restart, as it is going to be used as a label in
+	// prometheus metrics.
+	name       string
+	underlying OAuth2Config
+	metrics    *metrics
+}
+
+func (c *Config) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+	// No external requests are made when constructing the auth code url.
+	return c.underlying.AuthCodeURL(state, opts...)
+}
+
+func (c *Config) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return c.underlying.Exchange(c.wrapClient(ctx), code, opts...)
+}
+
+func (c *Config) TokenSource(ctx context.Context, token *oauth2.Token) oauth2.TokenSource {
+	return c.underlying.TokenSource(c.wrapClient(ctx), token)
+}
+
+// wrapClient is the only way we can accurately instrument the oauth2 client.
+// This is because method calls to the 'OAuth2Config' interface are not 1:1 with
+// network requests.
+//
+// For example, the 'TokenSource' method will return a token
+// source that will make a network request when the 'Token' method is called on
+// it if the token is expired.
+func (c *Config) wrapClient(ctx context.Context) context.Context {
+	cli := http.DefaultClient
+
+	// Check if the context has an http client already.
+	if hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		cli = hc
+	}
+
+	// The new tripper will instrument every request made by the oauth2 client.
+	cli.Transport = newInstrumentedTripper(c, cli.Transport)
+	return context.WithValue(ctx, oauth2.HTTPClient, cli)
+}
+
+type instrumentedTripper struct {
+	c          *Config
+	underlying http.RoundTripper
+}
+
+func newInstrumentedTripper(c *Config, under http.RoundTripper) *instrumentedTripper {
+	if under == nil {
+		under = http.DefaultTransport
+	}
+	return &instrumentedTripper{
+		c:          c,
+		underlying: under,
+	}
+}
+
+func (i *instrumentedTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := i.underlying.RoundTrip(r)
+	var statusCode int
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	i.c.metrics.externalRequestCount.With(prometheus.Labels{
+		"name":        i.c.name,
+		"status_code": fmt.Sprintf("%d", statusCode),
+		"domain":      r.URL.Host,
+	}).Inc()
+	return resp, err
+}

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -24,7 +24,7 @@ type OAuth2Config interface {
 type InstrumentedOAuth2Config interface {
 	OAuth2Config
 
-	// Do is provided as a convience method to make a request with the oauth2 client.
+	// Do is provided as a convenience method to make a request with the oauth2 client.
 	// It mirrors `http.Client.Do`.
 	// We need this because Coder adds some extra functionality to
 	// oauth clients such as the `ValidateToken()` method.

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -155,14 +155,5 @@ func (i *instrumentedTripper) RoundTrip(r *http.Request) (*http.Response, error)
 		"source":      i.source,
 		"status_code": fmt.Sprintf("%d", statusCode),
 	}).Inc()
-	if err == nil {
-		fmt.Println(map[string]string{
-			"limit":    resp.Header.Get("x-ratelimit-limit"),
-			"remain":   resp.Header.Get("x-ratelimit-remaining"),
-			"used":     resp.Header.Get("x-ratelimit-used"),
-			"reset":    resp.Header.Get("x-ratelimit-reset"),
-			"resource": resp.Header.Get("x-ratelimit-resource"),
-		})
-	}
 	return resp, err
 }

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -18,17 +18,12 @@ type OAuth2Config interface {
 	TokenSource(context.Context, *oauth2.Token) oauth2.TokenSource
 }
 
-type InstrumentedeOAuth2Config interface {
+// InstrumentedOAuth2Config extends OAuth2Config with a `Do` method that allows
+// external oauth related calls to be instrumented. This is to support
+// "ValidateToken" which is not an oauth2 specified method.
+type InstrumentedOAuth2Config interface {
 	OAuth2Config
 
-	// Do is provided as a convience method to make a request with the oauth2 client.
-	// It mirrors `http.Client.Do`.
-	// We need this because Coder adds some extra functionality to
-	// oauth clients such as the `ValidateToken()` method.
-	Do(ctx context.Context, source string, req *http.Request) (*http.Response, error)
-}
-
-type HTTPDo interface {
 	// Do is provided as a convience method to make a request with the oauth2 client.
 	// It mirrors `http.Client.Do`.
 	// We need this because Coder adds some extra functionality to

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -59,10 +59,9 @@ func TestInstrument(t *testing.T) {
 	// Verify the default client was not broken. This check is added because we
 	// extend the http.DefaultTransport. If a `.Clone()` is not done, this can be
 	// mis-used. It is cheap to run this quick check.
-	req, err := http.NewRequest(http.MethodGet,
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		must(idp.IssuerURL().Parse("/.well-known/openid-configuration")).String(), nil)
 	require.NoError(t, err)
-	req = req.WithContext(ctx)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -47,7 +47,20 @@ func TestMaintainDefault(t *testing.T) {
 	// Verify the default client was not broken. This check is added because we
 	// extend the http.DefaultTransport. If a `.Clone()` is not done, this can be
 	// mis-used. It is cheap to run this quick check.
-	_, err = http.DefaultClient.Get("https://coder.com")
+	req, err := http.NewRequest(http.MethodGet,
+		must(idp.IssuerURL().Parse("/.well-known/openid-configuration")).String(), nil)
 	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
 	require.Equal(t, count(), 2)
+}
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
 }

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -50,6 +50,7 @@ func TestMaintainDefault(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet,
 		must(idp.IssuerURL().Parse("/.well-known/openid-configuration")).String(), nil)
 	require.NoError(t, err)
+	req = req.WithContext(ctx)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
+	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestMaintainDefault(t *testing.T) {
+func TestInstrument(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
@@ -25,7 +26,12 @@ func TestMaintainDefault(t *testing.T) {
 	}
 
 	factory := promoauth.NewFactory(reg)
-	cfg := factory.New("test", idp.OIDCConfig(t, []string{}))
+	const id = "test"
+	cfg := externalauth.Config{
+		InstrumentedOAuth2Config: factory.New(id, idp.OIDCConfig(t, []string{})),
+		ID:                       "test",
+		ValidateURL:              must(idp.IssuerURL().Parse("/oauth2/userinfo")).String(),
+	}
 
 	// 0 Requests before we start
 	require.Equal(t, count(), 0)
@@ -44,6 +50,12 @@ func TestMaintainDefault(t *testing.T) {
 	require.NotEqual(t, token.AccessToken, refreshed.AccessToken, "token refreshed")
 	require.Equal(t, count(), 2)
 
+	// Try a validate
+	valid, _, err := cfg.ValidateToken(ctx, refreshed.AccessToken)
+	require.NoError(t, err)
+	require.True(t, valid)
+	require.Equal(t, count(), 3)
+
 	// Verify the default client was not broken. This check is added because we
 	// extend the http.DefaultTransport. If a `.Clone()` is not done, this can be
 	// mis-used. It is cheap to run this quick check.
@@ -56,7 +68,7 @@ func TestMaintainDefault(t *testing.T) {
 	require.NoError(t, err)
 	_ = resp.Body.Close()
 
-	require.Equal(t, count(), 2)
+	require.Equal(t, count(), 3)
 }
 
 func must[V any](v V, err error) V {

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -25,7 +25,7 @@ func TestMaintainDefault(t *testing.T) {
 	}
 
 	factory := promoauth.NewFactory(reg)
-	cfg := factory.New("test", idp.OAuthConfig())
+	cfg := factory.New("test", idp.OIDCConfig(t, []string{}))
 
 	// 0 Requests before we start
 	require.Equal(t, count(), 0)

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -1,0 +1,53 @@
+package promoauth_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ptestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
+	"github.com/coder/coder/v2/coderd/promoauth"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestMaintainDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	idp := oidctest.NewFakeIDP(t, oidctest.WithServing())
+	reg := prometheus.NewRegistry()
+	count := func() int {
+		return ptestutil.CollectAndCount(reg, "coderd_oauth2_external_requests_total")
+	}
+
+	factory := promoauth.NewFactory(reg)
+	cfg := factory.New("test", idp.OAuthConfig())
+
+	// 0 Requests before we start
+	require.Equal(t, count(), 0)
+
+	// Exchange should trigger a request
+	code := idp.CreateAuthCode(t, "foo")
+	token, err := cfg.Exchange(ctx, code)
+	require.NoError(t, err)
+	require.Equal(t, count(), 1)
+
+	// Force a refresh
+	token.Expiry = time.Now().Add(time.Hour * -1)
+	src := cfg.TokenSource(ctx, token)
+	refreshed, err := src.Token()
+	require.NoError(t, err)
+	require.NotEqual(t, token.AccessToken, refreshed.AccessToken, "token refreshed")
+	require.Equal(t, count(), 2)
+
+	// Verify the default client was not broken. This check is added because we
+	// extend the http.DefaultTransport. If a `.Clone()` is not done, this can be
+	// mis-used. It is cheap to run this quick check.
+	_, err = http.DefaultClient.Get("https://coder.com")
+	require.NoError(t, err)
+	require.Equal(t, count(), 2)
+}

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -32,7 +32,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/externalauth"
-	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/tracing"
@@ -55,7 +55,7 @@ const (
 )
 
 type Options struct {
-	OIDCConfig          httpmw.OAuth2Config
+	OIDCConfig          promoauth.OAuth2Config
 	ExternalAuthConfigs []*externalauth.Config
 	// TimeNowFn is only used in tests
 	TimeNowFn func() time.Time
@@ -96,7 +96,7 @@ type server struct {
 	UserQuietHoursScheduleStore *atomic.Pointer[schedule.UserQuietHoursScheduleStore]
 	DeploymentValues            *codersdk.DeploymentValues
 
-	OIDCConfig httpmw.OAuth2Config
+	OIDCConfig promoauth.OAuth2Config
 
 	TimeNowFn func() time.Time
 
@@ -1736,7 +1736,7 @@ func deleteSessionToken(ctx context.Context, db database.Store, workspace databa
 
 // obtainOIDCAccessToken returns a valid OpenID Connect access token
 // for the user if it's able to obtain one, otherwise it returns an empty string.
-func obtainOIDCAccessToken(ctx context.Context, db database.Store, oidcConfig httpmw.OAuth2Config, userID uuid.UUID) (string, error) {
+func obtainOIDCAccessToken(ctx context.Context, db database.Store, oidcConfig promoauth.OAuth2Config, userID uuid.UUID) (string, error) {
 	link, err := db.GetUserLinkByUserIDLoginType(ctx, database.GetUserLinkByUserIDLoginTypeParams{
 		UserID:    userID,
 		LoginType: database.LoginTypeOIDC,

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -187,8 +187,8 @@ func TestAcquireJob(t *testing.T) {
 			srv, db, ps, _ := setup(t, false, &overrides{
 				deploymentValues: dv,
 				externalAuthConfigs: []*externalauth.Config{{
-					ID:           gitAuthProvider,
-					OAuth2Config: &testutil.OAuth2Config{},
+					ID:                       gitAuthProvider,
+					InstrumentedOAuth2Config: &testutil.OAuth2Config{},
 				}},
 			})
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -335,10 +335,10 @@ func TestTemplateVersionsExternalAuth(t *testing.T) {
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			ExternalAuthConfigs: []*externalauth.Config{{
-				OAuth2Config: &testutil.OAuth2Config{},
-				ID:           "github",
-				Regex:        regexp.MustCompile(`github\.com`),
-				Type:         codersdk.EnhancedExternalAuthProviderGitHub.String(),
+				InstrumentedOAuth2Config: &testutil.OAuth2Config{},
+				ID:                       "github",
+				Regex:                    regexp.MustCompile(`github\.com`),
+				Type:                     codersdk.EnhancedExternalAuthProviderGitHub.String(),
 			}},
 		})
 		user := coderdtest.CreateFirstUser(t, client)

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/userpassword"
 	"github.com/coder/coder/v2/codersdk"
@@ -438,7 +439,7 @@ type GithubOAuth2Team struct {
 
 // GithubOAuth2Provider exposes required functions for the Github authentication flow.
 type GithubOAuth2Config struct {
-	httpmw.OAuth2Config
+	promoauth.OAuth2Config
 	AuthenticatedUser           func(ctx context.Context, client *http.Client) (*github.User, error)
 	ListEmails                  func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error)
 	ListOrganizationMemberships func(ctx context.Context, client *http.Client) ([]*github.Membership, error)
@@ -662,7 +663,7 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 }
 
 type OIDCConfig struct {
-	httpmw.OAuth2Config
+	promoauth.OAuth2Config
 
 	Provider *oidc.Provider
 	Verifier *oidc.IDTokenVerifier

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2100,7 +2100,7 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 				})
 				return
 			}
-			httpapi.Write(ctx, rw, http.StatusOK, resp)
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, resp)
 			return
 		}
 	}

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2100,7 +2100,7 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 				})
 				return
 			}
-			httpapi.Write(ctx, rw, http.StatusInternalServerError, resp)
+			httpapi.Write(ctx, rw, http.StatusOK, resp)
 			return
 		}
 	}

--- a/testutil/oauth2.go
+++ b/testutil/oauth2.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+
+	"github.com/coder/coder/v2/coderd/promoauth"
 )
 
 type OAuth2Config struct {
@@ -14,7 +16,7 @@ type OAuth2Config struct {
 	TokenSourceFunc OAuth2TokenSource
 }
 
-func (*OAuth2Config) Do(_ context.Context, _ string, req *http.Request) (*http.Response, error) {
+func (*OAuth2Config) Do(_ context.Context, _ promoauth.Oauth2Source, req *http.Request) (*http.Response, error) {
 	return http.DefaultClient.Do(req)
 }
 

--- a/testutil/oauth2.go
+++ b/testutil/oauth2.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -11,6 +12,10 @@ import (
 type OAuth2Config struct {
 	Token           *oauth2.Token
 	TokenSourceFunc OAuth2TokenSource
+}
+
+func (*OAuth2Config) Do(_ context.Context, _ string, req *http.Request) (*http.Response, error) {
+	return http.DefaultClient.Do(req)
 }
 
 func (*OAuth2Config) AuthCodeURL(state string, _ ...oauth2.AuthCodeOption) string {


### PR DESCRIPTION
Supports https://github.com/coder/coder/issues/10853

# What this does

This adds an instrumentation layer to all of our oidc/oauth2 external requests. 

Debugging this has been very challenging because I cannot reproduce the issue. So I figured adding some instrumentation could at best help debug, at worst it is just some nice extra metrics :man_shrugging:.

What the metrics track for each oauth2 config.
- **name**: A human readable name to identify the provider. This is the `external_auth.id` or just `login-github` for primary authentication.
- **source**: Indicates which method was called to trigger the request. `[TokenSource|Exchange]`. I think this could be extended in debug logging if we need for debugging purposes. For now, this doubles the number of tracked metrics, and I don't think we should make this list any larger.
- ~~**domain**: The domain the request is sent to. **Is this redundant??**~~ **REMOVED**
- **status_code**: Returned status code. For alerting purposes, you could alert when 429s occur.

Example metrics
```
# HELP coderd_oauth2_external_requests_total The total number of api calls made to external oauth2 providers. 'status_code' will be 0 if the request failed with no response.
# TYPE coderd_oauth2_external_requests_total counter
coderd_oauth2_external_requests_total{name="github-login",source="Exchange",status_code="200"} 2
coderd_oauth2_external_requests_total{name="primary-github",source="TokenSource",status_code="200"} 1
coderd_oauth2_external_requests_total{name="github-login",source="Exchange",status_code="200"} 2
coderd_oauth2_external_requests_total{name="primary-github",source="TokenSource",status_code="200"} 1
coderd_oauth2_external_requests_total{name="github-login",source="Exchange",status_code="200"} 1
coderd_oauth2_external_requests_total{name="primary-github",source="AppInstallations",status_code="200"} 5
coderd_oauth2_external_requests_total{name="primary-github",source="ValidateToken",status_code="200"} 5

```

# What this does not do

This only instruments oauth and some related methods. Verify OIDC and userinfo OIDC are not instrumented. Therefore **OIDC is not instrumented at this time**

