### PR TITLE
fix: fix flake in TestAgentWebsocketMonitor_SendPings

### DIFF
--- a/coderd/workspaceagentsrpc_internal_test.go
+++ b/coderd/workspaceagentsrpc_internal_test.go
@@ -227,8 +227,10 @@ func TestAgentWebsocketMonitor_SendPings(t *testing.T) {
 	}
 	go uut.sendPings(ctx)
 	fConn.requireEventuallyHasPing(t)
-	lastPing := uut.lastPing.Load()
-	require.NotNil(t, lastPing)
+	require.Eventually(t, func() bool {
+		lastPing := uut.lastPing.Load()
+		return lastPing != nil
+	}, testutil.WaitShort, testutil.IntervalFast)
 }
 
 func TestAgentWebsocketMonitor_StartClose(t *testing.T) {


### PR DESCRIPTION
Fixes flake seen here: https://github.com/coder/coder/runs/20330641188

Root cause is that we check the lastPing is non-nil after seeing the ping call, but this races with actually setting lastPing, which happens after the call.
