### PR TITLE
fix: remove cancel button if user cannot cancel job

### DIFF
--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -55,7 +55,7 @@ export interface WorkspaceProps {
   workspaceErrors: WorkspaceErrors;
   buildInfo?: TypesGen.BuildInfoResponse;
   sshPrefix?: string;
-  template?: TypesGen.Template;
+  template: TypesGen.Template;
   canRetryDebugMode: boolean;
   handleBuildRetry: () => void;
   handleBuildRetryDebug: () => void;

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -61,6 +61,7 @@ export interface WorkspaceProps {
   handleBuildRetryDebug: () => void;
   buildLogs?: React.ReactNode;
   canAutostart: boolean;
+  isOwner: boolean;
 }
 
 /**
@@ -93,6 +94,7 @@ export const Workspace: FC<WorkspaceProps> = ({
   handleBuildRetryDebug,
   buildLogs,
   canAutostart,
+  isOwner,
 }) => {
   const navigate = useNavigate();
   const { saveLocal, getLocal } = useLocalStorage();
@@ -199,6 +201,7 @@ export const Workspace: FC<WorkspaceProps> = ({
         isUpdating={isUpdating}
         isRestarting={isRestarting}
         canUpdateWorkspace={canUpdateWorkspace}
+        isOwner={isOwner}
       />
 
       <div

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
@@ -107,3 +107,31 @@ export const AlwaysUpdateStopped: Story = {
     canChangeVersions: true,
   },
 };
+
+export const CancelShownForOwner: Story = {
+  args: {
+    workspace: {
+      ...Mocks.MockStartingWorkspace,
+      template_allow_user_cancel_workspace_jobs: false,
+    },
+    isOwner: true,
+  },
+};
+export const CancelShownForUser: Story = {
+  args: {
+    workspace: Mocks.MockStartingWorkspace,
+    isOwner: false,
+  },
+};
+
+export const CancelHiddenForUser: Story = {
+  args: {
+    workspace: {
+      ...Mocks.MockStartingWorkspace,
+      template_allow_user_cancel_workspace_jobs: false,
+    },
+    isOwner: false,
+  },
+};
+
+

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.stories.tsx
@@ -133,5 +133,3 @@ export const CancelHiddenForUser: Story = {
     isOwner: false,
   },
 };
-
-

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -77,7 +77,9 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
     workspace,
     canRetryDebug,
   );
-  const cancelEnabled = canCancel || isOwner;
+  const showCancel =
+    canCancel &&
+    (workspace.template_allow_user_cancel_workspace_jobs || isOwner);
 
   const mustUpdate =
     workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&
@@ -151,7 +153,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
             <Fragment key={action}>{buttonMapping[action]}</Fragment>
           ))}
 
-      {cancelEnabled && <CancelButton handleAction={handleCancel} />}
+      {showCancel && <CancelButton handleAction={handleCancel} />}
 
       <MoreMenu>
         <MoreMenuTrigger>

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -27,6 +27,7 @@ import {
 } from "components/MoreMenu/MoreMenu";
 import { TopbarIconButton } from "components/FullPageLayout/Topbar";
 import MoreVertOutlined from "@mui/icons-material/MoreVertOutlined";
+import { useMe } from "hooks";
 
 export interface WorkspaceActionsProps {
   workspace: Workspace;
@@ -46,7 +47,6 @@ export interface WorkspaceActionsProps {
   children?: ReactNode;
   canChangeVersions: boolean;
   canRetryDebug: boolean;
-  templateUserCanCancel: boolean;
 }
 
 export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
@@ -66,8 +66,10 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   isRestarting,
   canChangeVersions,
   canRetryDebug,
-  templateUserCanCancel,
 }) => {
+  const me = useMe();
+  const isOwner = me.roles.find((role) => role.name === "owner");
+
   const { duplicateWorkspace, isDuplicationReady } =
     useWorkspaceDuplication(workspace);
 
@@ -75,7 +77,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
     workspace,
     canRetryDebug,
   );
-  const cancelEnabled = canCancel && templateUserCanCancel
+  const cancelEnabled = canCancel || isOwner
 
   const mustUpdate =
     workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -46,6 +46,7 @@ export interface WorkspaceActionsProps {
   children?: ReactNode;
   canChangeVersions: boolean;
   canRetryDebug: boolean;
+  templateUserCanCancel: boolean;
 }
 
 export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
@@ -65,6 +66,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   isRestarting,
   canChangeVersions,
   canRetryDebug,
+  templateUserCanCancel,
 }) => {
   const { duplicateWorkspace, isDuplicationReady } =
     useWorkspaceDuplication(workspace);
@@ -73,6 +75,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
     workspace,
     canRetryDebug,
   );
+  const cancelEnabled = canCancel && templateUserCanCancel
 
   const mustUpdate =
     workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&
@@ -146,7 +149,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
             <Fragment key={action}>{buttonMapping[action]}</Fragment>
           ))}
 
-      {canCancel && <CancelButton handleAction={handleCancel} />}
+      {cancelEnabled && <CancelButton handleAction={handleCancel} />}
 
       <MoreMenu>
         <MoreMenuTrigger>

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -27,7 +27,6 @@ import {
 } from "components/MoreMenu/MoreMenu";
 import { TopbarIconButton } from "components/FullPageLayout/Topbar";
 import MoreVertOutlined from "@mui/icons-material/MoreVertOutlined";
-import { useMe } from "hooks";
 
 export interface WorkspaceActionsProps {
   workspace: Workspace;
@@ -47,6 +46,7 @@ export interface WorkspaceActionsProps {
   children?: ReactNode;
   canChangeVersions: boolean;
   canRetryDebug: boolean;
+  isOwner: boolean;
 }
 
 export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
@@ -66,10 +66,8 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
   isRestarting,
   canChangeVersions,
   canRetryDebug,
+  isOwner,
 }) => {
-  const me = useMe();
-  const isOwner = me.roles.find((role) => role.name === "owner");
-
   const { duplicateWorkspace, isDuplicationReady } =
     useWorkspaceDuplication(workspace);
 

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -77,7 +77,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
     workspace,
     canRetryDebug,
   );
-  const cancelEnabled = canCancel || isOwner
+  const cancelEnabled = canCancel || isOwner;
 
   const mustUpdate =
     workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -36,6 +36,7 @@ import { WorkspacePermissions } from "./permissions";
 import { workspaceResolveAutostart } from "api/queries/workspaceQuota";
 import { WorkspaceDeleteDialog } from "./WorkspaceDeleteDialog";
 import dayjs from "dayjs";
+import { useMe } from "hooks";
 
 interface WorkspaceReadyPageProps {
   template: TypesGen.Template;
@@ -55,6 +56,10 @@ export const WorkspaceReadyPage = ({
   if (workspace === undefined) {
     throw Error("Workspace is undefined");
   }
+
+  // Owner
+  const me = useMe();
+  const isOwner = me.roles.find((role) => role.name === "owner") !== undefined;
 
   // Debug mode
   const { data: deploymentValues } = useQuery({
@@ -247,6 +252,7 @@ export const WorkspaceReadyPage = ({
           )
         }
         canAutostart={canAutostart}
+        isOwner={isOwner}
       />
 
       <WorkspaceDeleteDialog

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -30,6 +30,7 @@ import { Popover, PopoverTrigger } from "components/Popover/Popover";
 import { HelpTooltipContent } from "components/HelpTooltip/HelpTooltip";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { ExternalAvatar } from "components/Avatar/Avatar";
+import { usePermissions } from "hooks";
 
 export type WorkspaceError =
   | "getBuildsError"
@@ -79,6 +80,7 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
     handleBuildRetryDebug,
   } = props;
   const theme = useTheme();
+  const permissions = usePermissions();
 
   // Quota
   const hasDailyCost = workspace.latest_build.daily_cost > 0;
@@ -265,6 +267,7 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
           canChangeVersions={canChangeVersions}
           isUpdating={isUpdating}
           isRestarting={isRestarting}
+          userCanCancel={permissions.updateTemplates}
         />
       </div>
     </Topbar>

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -56,6 +56,7 @@ export interface WorkspaceProps {
   canRetryDebugMode: boolean;
   handleBuildRetry: () => void;
   handleBuildRetryDebug: () => void;
+  isOwner: boolean;
 }
 
 export const WorkspaceTopbar = (props: WorkspaceProps) => {
@@ -77,6 +78,7 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
     canRetryDebugMode,
     handleBuildRetry,
     handleBuildRetryDebug,
+    isOwner,
   } = props;
   const theme = useTheme();
 
@@ -265,6 +267,7 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
           canChangeVersions={canChangeVersions}
           isUpdating={isUpdating}
           isRestarting={isRestarting}
+          isOwner={isOwner}
         />
       </div>
     </Topbar>

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -30,7 +30,6 @@ import { Popover, PopoverTrigger } from "components/Popover/Popover";
 import { HelpTooltipContent } from "components/HelpTooltip/HelpTooltip";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { ExternalAvatar } from "components/Avatar/Avatar";
-import { usePermissions } from "hooks";
 
 export type WorkspaceError =
   | "getBuildsError"
@@ -80,7 +79,6 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
     handleBuildRetryDebug,
   } = props;
   const theme = useTheme();
-  const permissions = usePermissions();
 
   // Quota
   const hasDailyCost = workspace.latest_build.daily_cost > 0;
@@ -267,7 +265,6 @@ export const WorkspaceTopbar = (props: WorkspaceProps) => {
           canChangeVersions={canChangeVersions}
           isUpdating={isUpdating}
           isRestarting={isRestarting}
-          userCanCancel={permissions.updateTemplates}
         />
       </div>
     </Topbar>


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/11449

The user can only cancel under the following circumstances according to the backend:
1. You have the owner role.
OR
2. The template specifies that ANY user can cancel the builds based on it.  

Owner View if user cancelation is disabled:
![Screenshot 2024-01-10 at 11 42 10 AM](https://github.com/coder/coder/assets/19379394/72d8585c-9993-4d7f-b64b-adf727f95c96)

Member View if user cancelation is disabled:
![Screenshot 2024-01-10 at 11 41 50 AM](https://github.com/coder/coder/assets/19379394/ae08f304-964e-4230-b96a-252ab2b18fbd)
