### PR TITLE
fix(site): show wsproxy errors in context in WorkspaceProxyPage

### DIFF
--- a/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
+++ b/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
@@ -39,9 +39,9 @@ export const WorkspaceProxyPage = () => {
       </Header>
 
       <Main>
-        {workspace_proxy.error ? (
+        {workspace_proxy.error && (
           <Alert severity="error">{workspace_proxy.error}</Alert>
-        ) : null}
+        )}
         {workspace_proxy.warnings.map((warning) => {
           return (
             <Alert key={warning.code} severity="warning">
@@ -146,11 +146,8 @@ export const WorkspaceProxyPage = () => {
                   <span>OK</span>
                 ) : (
                   <div css={{ display: "flex", flexDirection: "column" }}>
-                    {errors.map((error, i) => (
-                      <span key={i}>{error}</span>
-                    ))}
-                    {warnings.map((warning, i) => (
-                      <span key={i}>{warning}</span>
+                    {[...errors, ...warnings].map((msg, i) => (
+                      <span key={i}>{msg}</span>
                     ))}
                   </div>
                 )}

--- a/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
+++ b/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
@@ -39,6 +39,9 @@ export const WorkspaceProxyPage = () => {
       </Header>
 
       <Main>
+        {workspace_proxy.error ? (
+          <Alert severity="error">{workspace_proxy.error}</Alert>
+        ) : null}
         {workspace_proxy.warnings.map((warning) => {
           return (
             <Alert key={warning.code} severity="warning">
@@ -48,6 +51,7 @@ export const WorkspaceProxyPage = () => {
         })}
 
         {regions.map((region) => {
+          const errors = region.status?.report?.errors ?? [];
           const warnings = region.status?.report?.warnings ?? [];
 
           return (
@@ -138,14 +142,17 @@ export const WorkspaceProxyPage = () => {
                   color: theme.palette.text.secondary,
                 }}
               >
-                {warnings.length > 0 ? (
+                {warnings.length === 0 && errors.length === 0 ? (
+                  <span>OK</span>
+                ) : (
                   <div css={{ display: "flex", flexDirection: "column" }}>
+                    {errors.map((error, i) => (
+                      <span key={i}>{error}</span>
+                    ))}
                     {warnings.map((warning, i) => (
                       <span key={i}>{warning}</span>
                     ))}
                   </div>
-                ) : (
-                  <span>No warnings</span>
                 )}
                 <span data-chromatic="ignore">
                   {createDayString(region.updated_at)}

--- a/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
+++ b/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
@@ -142,12 +142,21 @@ export const WorkspaceProxyPage = () => {
                   color: theme.palette.text.secondary,
                 }}
               >
-                {warnings.length === 0 && errors.length === 0 ? (
+                {region.status?.status === "unregistered" ? (
+                  <span>Has not connected yet</span>
+                ) : warnings.length === 0 && errors.length === 0 ? (
                   <span>OK</span>
                 ) : (
                   <div css={{ display: "flex", flexDirection: "column" }}>
                     {[...errors, ...warnings].map((msg, i) => (
-                      <span key={i}>{msg}</span>
+                      <span
+                        css={{
+                          ":first-letter": { textTransform: "uppercase" },
+                        }}
+                        key={i}
+                      >
+                        {msg}
+                      </span>
                     ))}
                   </div>
                 )}


### PR DESCRIPTION
- Shows the overall report error at the top of the page, if present.
- Shows workspaceproxy errors above warnings inside the corresponding element, if present.

![image](https://github.com/coder/coder/assets/4949514/ea67f60e-2181-4a3f-8b5f-d6debbe5cfb9)
