### PR TITLE
feat: treat deprecation messages as markdown

### DIFF
--- a/site/src/pages/WorkspacePage/Workspace.stories.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.stories.tsx
@@ -230,7 +230,8 @@ export const Deprecated: Story = {
     template: {
       ...Mocks.MockTemplate,
       deprecated: true,
-      deprecation_message: "Template deprecated due to reasons",
+      deprecation_message:
+        "Template deprecated due to reasons. [Learn more](#)",
     },
   },
 };

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -26,6 +26,7 @@ import { SidebarIconButton } from "components/FullPageLayout/Sidebar";
 import HubOutlined from "@mui/icons-material/HubOutlined";
 import { ResourcesSidebar } from "./ResourcesSidebar";
 import { ResourceCard } from "components/Resources/ResourceCard";
+import { MemoizedInlineMarkdown } from "components/Markdown/Markdown";
 
 export type WorkspaceError =
   | "getBuildsError"
@@ -360,8 +361,14 @@ export const Workspace: FC<WorkspaceProps> = ({
 
             {template?.deprecated && (
               <Alert severity="warning">
-                <AlertTitle>Workspace using deprecated template</AlertTitle>
-                <AlertDetail>{template?.deprecation_message}</AlertDetail>
+                <AlertTitle>
+                  This workspace uses a deprecated template
+                </AlertTitle>
+                <AlertDetail>
+                  <MemoizedInlineMarkdown>
+                    {template?.deprecation_message}
+                  </MemoizedInlineMarkdown>
+                </AlertDetail>
               </Alert>
             )}
 


### PR DESCRIPTION

<img width="435" alt="Screenshot 2024-01-10 at 3 23 41 PM" src="https://github.com/coder/coder/assets/418348/5a468b45-ef29-4eee-9e0c-b5d45e59c3a4">


Closes #11138 

Use the `InlineMarkdown` component to render deprecation messages with simple markdown features like links