### PR TITLE
fix(site): remove refetch on windows focus

### DIFF
--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -131,7 +131,6 @@ export const me = (): UseQueryOptions<User> & {
     queryKey: meKey,
     initialData: initialUserData,
     queryFn: API.getAuthenticatedUser,
-    refetchOnWindowFocus: true,
   };
 };
 


### PR DESCRIPTION
It causes the sign-in page to reload whenever a user enters a page or changes the window's focus. This is happening because when the "user" fetch is made, the server returns an error, making the react-query mark the data as stale and try to load it whenever possible.