### PR TITLE
fix(site): improve rendering of provisioner tags

### DIFF
--- a/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
+++ b/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
@@ -1,4 +1,11 @@
-import { Header, HeaderTitle, HealthyDot, Main, Pill } from "./Content";
+import {
+  BooleanPill,
+  Header,
+  HeaderTitle,
+  HealthyDot,
+  Main,
+  Pill,
+} from "./Content";
 import { Helmet } from "react-helmet-async";
 import { pageTitle } from "utils/page";
 import { useTheme } from "@mui/material/styles";
@@ -116,13 +123,9 @@ export const ProvisionerDaemonsPage = () => {
                       </span>
                     </Pill>
                   </Tooltip>
-                  {Object.keys(extraTags).map((k) => (
-                    <Tooltip key={k} title={k}>
-                      <Pill key={k} icon={<Sell />}>
-                        {extraTags[k]}
-                      </Pill>
-                    </Tooltip>
-                  ))}
+                  {Object.keys(extraTags).map((k) =>
+                    renderTag(k, extraTags[k]),
+                  )}
                 </div>
               </header>
 
@@ -160,6 +163,34 @@ export const ProvisionerDaemonsPage = () => {
         })}
       </Main>
     </>
+  );
+};
+
+const parseBool = (s: string): { valid: boolean; value: boolean } => {
+  switch (s.toLowerCase()) {
+    case "true":
+    case "yes":
+    case "1":
+      return { valid: true, value: true };
+    case "false":
+    case "no":
+    case "0":
+    case "":
+      return { valid: true, value: false };
+    default:
+      return { valid: false, value: false };
+  }
+};
+
+const renderTag = (k: string, v: string) => {
+  const { valid, value: boolValue } = parseBool(v);
+  if (valid) {
+    return <BooleanPill value={boolValue}>{k}</BooleanPill>;
+  }
+  return (
+    <Pill icon={<Sell />}>
+      {k}: {v}
+    </Pill>
   );
 };
 

--- a/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
+++ b/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
@@ -184,18 +184,11 @@ const parseBool = (s: string): { valid: boolean; value: boolean } => {
 
 const renderTag = (k: string, v: string) => {
   const { valid, value: boolValue } = parseBool(v);
+  const kv = `${k}: ${v}`;
   if (valid) {
-    return (
-      <BooleanPill value={boolValue}>
-        {k}: {v}
-      </BooleanPill>
-    );
+    return <BooleanPill value={boolValue}>{kv}</BooleanPill>;
   }
-  return (
-    <Pill icon={<Sell />}>
-      {k}: {v}
-    </Pill>
-  );
+  return <Pill icon={<Sell />}>{kv}</Pill>;
 };
 
 export default ProvisionerDaemonsPage;

--- a/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
+++ b/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
@@ -185,7 +185,11 @@ const parseBool = (s: string): { valid: boolean; value: boolean } => {
 const renderTag = (k: string, v: string) => {
   const { valid, value: boolValue } = parseBool(v);
   if (valid) {
-    return <BooleanPill value={boolValue}>{k}</BooleanPill>;
+    return (
+      <BooleanPill value={boolValue}>
+        {k}: {v}
+      </BooleanPill>
+    );
   }
   return (
     <Pill icon={<Sell />}>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3129,7 +3129,30 @@ export const MockHealth: TypesGen.HealthcheckReport = {
           tags: {
             owner: "",
             scope: "organization",
-            custom_tag_name: "custom_tag_value",
+            tag_value: "value",
+            tag_true: "true",
+            tag_1: "1",
+            tag_yes: "yes",
+          },
+        },
+        warnings: [],
+      },
+      {
+        provisioner_daemon: {
+          id: "00000000-0000-0000-000000000000",
+          created_at: "2024-01-04T15:53:03.21563Z",
+          last_seen_at: "2024-01-04T16:05:03.967551Z",
+          name: "user-scoped",
+          version: "v2.34-devel+abcd1234",
+          api_version: "1.0",
+          provisioners: ["echo", "terraform"],
+          tags: {
+            owner: "12345678-1234-1234-1234-12345678abcd",
+            scope: "user",
+            tag_value: "value",
+            tag_true: "true",
+            tag_1: "1",
+            tag_yes: "yes",
           },
         },
         warnings: [],
@@ -3146,6 +3169,10 @@ export const MockHealth: TypesGen.HealthcheckReport = {
           tags: {
             owner: "",
             scope: "organization",
+            tag_string: "value",
+            tag_false: "false",
+            tag_0: "0",
+            tag_no: "no",
           },
         },
         warnings: [

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3149,10 +3149,10 @@ export const MockHealth: TypesGen.HealthcheckReport = {
           tags: {
             owner: "12345678-1234-1234-1234-12345678abcd",
             scope: "user",
-            tag_value: "value",
-            tag_true: "true",
+            tag_VALUE: "VALUE",
+            tag_TRUE: "TRUE",
             tag_1: "1",
-            tag_yes: "yes",
+            tag_YES: "YES",
           },
         },
         warnings: [],


### PR DESCRIPTION
Attempt at fixing https://github.com/coder/coder/issues/11542

- For tags with boolean values (`["true", "1", "yes", "false", "0", "no", ""]`), renders as `BooleanPill`.
- Otherwise, renders a Pill with `key: value`. 

![image](https://github.com/coder/coder/assets/4949514/9708c0ea-1892-47b0-a66b-bb37398b0fc3)
