### PR TITLE
feat(site): add docs links on health page

### DIFF
--- a/site/src/pages/HealthPage/AccessURLPage.tsx
+++ b/site/src/pages/HealthPage/AccessURLPage.tsx
@@ -36,8 +36,12 @@ export const AccessURLPage = () => {
       <Main>
         {accessUrl.warnings.map((warning) => {
           return (
-            <Alert key={warning.code} severity="warning">
-              {HealthMessageDocsLink(warning)}: {warning.message}
+            <Alert
+              actions={HealthMessageDocsLink(warning)}
+              key={warning.code}
+              severity="warning"
+            >
+              {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/AccessURLPage.tsx
+++ b/site/src/pages/HealthPage/AccessURLPage.tsx
@@ -2,6 +2,7 @@ import { useOutletContext } from "react-router-dom";
 import {
   Header,
   HeaderTitle,
+  HealthMessageDocsLink,
   Main,
   GridData,
   GridDataLabel,
@@ -36,7 +37,7 @@ export const AccessURLPage = () => {
         {accessUrl.warnings.map((warning) => {
           return (
             <Alert key={warning.code} severity="warning">
-              {warning.message}
+              {HealthMessageDocsLink(warning)}: {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/Content.tsx
+++ b/site/src/pages/HealthPage/Content.tsx
@@ -9,9 +9,11 @@ import {
 import CheckCircleOutlined from "@mui/icons-material/CheckCircleOutlined";
 import ErrorOutline from "@mui/icons-material/ErrorOutline";
 import { healthyColor } from "./healthyColor";
+import { docs } from "utils/docs";
 import { css } from "@emotion/css";
 import DoNotDisturbOnOutlined from "@mui/icons-material/DoNotDisturbOnOutlined";
-import { HealthSeverity } from "api/typesGenerated";
+import { HealthMessage, HealthSeverity } from "api/typesGenerated";
+import Link from "@mui/material/Link";
 import { useTheme } from "@mui/material/styles";
 
 const CONTENT_PADDING = 36;
@@ -240,5 +242,17 @@ export const Logs = (props: LogsProps) => {
         </span>
       )}
     </div>
+  );
+};
+
+export const HealthMessageDocsLink = (msg: HealthMessage) => {
+  return (
+    <Link
+      href={docs(`/admin/healthcheck#${msg.code.toLocaleLowerCase()}`)}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {msg.code}
+    </Link>
   );
 };

--- a/site/src/pages/HealthPage/Content.tsx
+++ b/site/src/pages/HealthPage/Content.tsx
@@ -252,7 +252,7 @@ export const HealthMessageDocsLink = (msg: HealthMessage) => {
       target="_blank"
       rel="noreferrer"
     >
-      {msg.code}
+      Docs for {msg.code}
     </Link>
   );
 };

--- a/site/src/pages/HealthPage/DERPPage.tsx
+++ b/site/src/pages/HealthPage/DERPPage.tsx
@@ -60,8 +60,12 @@ export const DERPPage = () => {
       <Main>
         {derp.warnings.map((warning: HealthMessage) => {
           return (
-            <Alert key={warning.code} severity="warning">
-              {HealthMessageDocsLink(warning)}: {warning.message}
+            <Alert
+              actions={HealthMessageDocsLink(warning)}
+              key={warning.code}
+              severity="warning"
+            >
+              {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/DERPPage.tsx
+++ b/site/src/pages/HealthPage/DERPPage.tsx
@@ -2,6 +2,7 @@ import { Link, useOutletContext } from "react-router-dom";
 import {
   Header,
   HeaderTitle,
+  HealthMessageDocsLink,
   Main,
   SectionLabel,
   BooleanPill,
@@ -60,7 +61,7 @@ export const DERPPage = () => {
         {derp.warnings.map((warning: HealthMessage) => {
           return (
             <Alert key={warning.code} severity="warning">
-              {warning.message}
+              {HealthMessageDocsLink(warning)}: {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/DERPRegionPage.tsx
+++ b/site/src/pages/HealthPage/DERPRegionPage.tsx
@@ -76,8 +76,12 @@ export const DERPRegionPage: FC = () => {
       <Main>
         {warnings.map((warning: HealthMessage) => {
           return (
-            <Alert key={warning.code} severity="warning">
-              {HealthMessageDocsLink(warning)}: {warning.message}
+            <Alert
+              actions={HealthMessageDocsLink(warning)}
+              key={warning.code}
+              severity="warning"
+            >
+              {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/DERPRegionPage.tsx
+++ b/site/src/pages/HealthPage/DERPRegionPage.tsx
@@ -17,6 +17,7 @@ import { pageTitle } from "utils/page";
 import {
   Header,
   HeaderTitle,
+  HealthMessageDocsLink,
   Main,
   BooleanPill,
   Pill,
@@ -76,7 +77,7 @@ export const DERPRegionPage: FC = () => {
         {warnings.map((warning: HealthMessage) => {
           return (
             <Alert key={warning.code} severity="warning">
-              {warning.message}
+              {HealthMessageDocsLink(warning)}: {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/DatabasePage.tsx
+++ b/site/src/pages/HealthPage/DatabasePage.tsx
@@ -2,6 +2,7 @@ import { useOutletContext } from "react-router-dom";
 import {
   Header,
   HeaderTitle,
+  HealthMessageDocsLink,
   Main,
   GridData,
   GridDataLabel,
@@ -36,7 +37,7 @@ export const DatabasePage = () => {
         {database.warnings.map((warning) => {
           return (
             <Alert key={warning.code} severity="warning">
-              {warning.message}
+              {HealthMessageDocsLink(warning)}: {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/DatabasePage.tsx
+++ b/site/src/pages/HealthPage/DatabasePage.tsx
@@ -36,8 +36,12 @@ export const DatabasePage = () => {
       <Main>
         {database.warnings.map((warning) => {
           return (
-            <Alert key={warning.code} severity="warning">
-              {HealthMessageDocsLink(warning)}: {warning.message}
+            <Alert
+              actions={HealthMessageDocsLink(warning)}
+              key={warning.code}
+              severity="warning"
+            >
+              {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
+++ b/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
@@ -3,6 +3,7 @@ import {
   Header,
   HeaderTitle,
   HealthyDot,
+  HealthMessageDocsLink,
   Main,
   Pill,
 } from "./Content";
@@ -43,7 +44,7 @@ export const ProvisionerDaemonsPage = () => {
         {daemons.warnings.map((warning) => {
           return (
             <Alert key={warning.code} severity="warning">
-              {warning.message}
+              {HealthMessageDocsLink(warning)}: {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
+++ b/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
@@ -43,8 +43,12 @@ export const ProvisionerDaemonsPage = () => {
       <Main>
         {daemons.warnings.map((warning) => {
           return (
-            <Alert key={warning.code} severity="warning">
-              {HealthMessageDocsLink(warning)}: {warning.message}
+            <Alert
+              actions={HealthMessageDocsLink(warning)}
+              key={warning.code}
+              severity="warning"
+            >
+              {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
+++ b/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
@@ -3,6 +3,7 @@ import {
   BooleanPill,
   Header,
   HeaderTitle,
+  HealthMessageDocsLink,
   HealthyDot,
   Main,
   Pill,
@@ -45,7 +46,7 @@ export const WorkspaceProxyPage = () => {
         {workspace_proxy.warnings.map((warning) => {
           return (
             <Alert key={warning.code} severity="warning">
-              {warning.message}
+              {HealthMessageDocsLink(warning)}: {warning.message}
             </Alert>
           );
         })}

--- a/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
+++ b/site/src/pages/HealthPage/WorkspaceProxyPage.tsx
@@ -45,8 +45,12 @@ export const WorkspaceProxyPage = () => {
         )}
         {workspace_proxy.warnings.map((warning) => {
           return (
-            <Alert key={warning.code} severity="warning">
-              {HealthMessageDocsLink(warning)}: {warning.message}
+            <Alert
+              actions={HealthMessageDocsLink(warning)}
+              key={warning.code}
+              severity="warning"
+            >
+              {warning.message}
             </Alert>
           );
         })}


### PR DESCRIPTION
Adds links to the error mesages on the health page.
This is important as we provide specific codes to allow us to send operators to the relevant section of the docs.

![image](https://github.com/coder/coder/assets/4949514/f142c2b5-e923-400d-8228-8c4e23109b10)
