### PR TITLE
chore: handle errors in wsproxy server for cli using buildinfo

### DIFF
--- a/cli/errors.go
+++ b/cli/errors.go
@@ -70,10 +70,10 @@ func (RootCmd) errorExample() *clibase.Cmd {
 			{
 				Use: "multi-error",
 				Handler: func(inv *clibase.Invocation) error {
-					return xerrors.Errorf("wrapped %w", errors.Join(
+					return xerrors.Errorf("wrapped: %w", errors.Join(
 						xerrors.Errorf("first error: %w", errorWithStackTrace()),
 						xerrors.Errorf("second error: %w", errorWithStackTrace()),
-						apiErrorNoHelper,
+						xerrors.Errorf("wrapped api error: %w", apiErrorNoHelper),
 					))
 				},
 			},

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -70,12 +70,11 @@ func (RootCmd) errorExample() *clibase.Cmd {
 			{
 				Use: "multi-error",
 				Handler: func(inv *clibase.Invocation) error {
-					return errors.Join(
+					return xerrors.Errorf("wrapped %w", errors.Join(
 						xerrors.Errorf("first error: %w", errorWithStackTrace()),
 						xerrors.Errorf("second error: %w", errorWithStackTrace()),
 						apiErrorNoHelper,
-					)
-
+					))
 				},
 			},
 			{

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -66,13 +67,28 @@ func (RootCmd) errorExample() *clibase.Cmd {
 			{
 				Use: "multi-error",
 				Handler: func(inv *clibase.Invocation) error {
+					return errors.Join(
+						xerrors.Errorf("first error: %w", errorWithStackTrace()),
+						xerrors.Errorf("second error: %w", errorWithStackTrace()),
+					)
+
+				},
+			},
+			{
+				Use:   "multi-multi-error",
+				Short: "This is a multi error inside a multi error",
+				Handler: func(inv *clibase.Invocation) error {
 					// Closing the stdin file descriptor will cause the next close
 					// to fail. This is joined to the returned Command error.
 					if f, ok := inv.Stdin.(*os.File); ok {
 						_ = f.Close()
 					}
 
-					return xerrors.Errorf("some error: %w", errorWithStackTrace())
+					return errors.Join(
+						xerrors.Errorf("first error: %w", errorWithStackTrace()),
+						xerrors.Errorf("second error: %w", errorWithStackTrace()),
+					)
+
 				},
 			},
 

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -44,6 +44,7 @@ func (RootCmd) errorExample() *clibase.Cmd {
 	//nolint:errorlint,forcetypeassert
 	apiError.(*codersdk.Error).Helper = "Have you tried turning it off and on again?"
 
+	//nolint:errorlint,forcetypeassert
 	apiErrorNoHelper := apiError.(*codersdk.Error)
 	apiErrorNoHelper.Helper = ""
 

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -44,6 +44,9 @@ func (RootCmd) errorExample() *clibase.Cmd {
 	//nolint:errorlint,forcetypeassert
 	apiError.(*codersdk.Error).Helper = "Have you tried turning it off and on again?"
 
+	apiErrorNoHelper := apiError.(*codersdk.Error)
+	apiErrorNoHelper.Helper = ""
+
 	// Some flags
 	var magicWord clibase.String
 
@@ -70,6 +73,7 @@ func (RootCmd) errorExample() *clibase.Cmd {
 					return errors.Join(
 						xerrors.Errorf("first error: %w", errorWithStackTrace()),
 						xerrors.Errorf("second error: %w", errorWithStackTrace()),
+						apiErrorNoHelper,
 					)
 
 				},

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -92,7 +92,6 @@ func (RootCmd) errorExample() *clibase.Cmd {
 						xerrors.Errorf("first error: %w", errorWithStackTrace()),
 						xerrors.Errorf("second error: %w", errorWithStackTrace()),
 					)
-
 				},
 			},
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -1041,6 +1041,8 @@ const indent = "    "
 //	       go run main.go exp example-error cmd
 //	       go run main.go exp example-error multi-error
 //	       go run main.go exp example-error validation
+//
+//nolint:errorlint
 func cliHumanFormatError(from string, err error, opts *formatOpts) (string, bool) {
 	if opts == nil {
 		opts = &formatOpts{}

--- a/cli/root.go
+++ b/cli/root.go
@@ -1109,7 +1109,10 @@ func formatMultiError(from string, multi []error, opts *formatOpts) string {
 
 	// Write errors out
 	var str strings.Builder
-	traceMsg := fmt.Sprintf("Trace=[%s])", from)
+	var traceMsg string
+	if from != "" {
+		traceMsg = fmt.Sprintf("Trace=[%s])", from)
+	}
 	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("%d errors encountered: %s", len(multi), traceMsg)))
 	for i, errStr := range errorStrings {
 		// Indent each error
@@ -1159,8 +1162,10 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 		_, _ = str.WriteString("\n")
 	}
 	// Always include this trace. Users can ignore this.
-	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("Trace=[%s]", from)))
-	_, _ = str.WriteString("\n")
+	if from != "" {
+		_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("Trace=[%s]", from)))
+		_, _ = str.WriteString("\n")
+	}
 
 	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), err.Message))
 	if err.Helper != "" {

--- a/cli/root.go
+++ b/cli/root.go
@@ -1109,10 +1109,7 @@ func formatMultiError(from string, multi []error, opts *formatOpts) string {
 
 	// Write errors out
 	var str strings.Builder
-	var traceMsg string
-	if opts.Verbose {
-		traceMsg = fmt.Sprintf("Trace=[%s])", from)
-	}
+	traceMsg := fmt.Sprintf("Trace=[%s])", from)
 	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("%d errors encountered: %s", len(multi), traceMsg)))
 	for i, errStr := range errorStrings {
 		// Indent each error
@@ -1160,11 +1157,10 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 	if opts.Verbose {
 		_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("API request error to \"%s:%s\". Status code %d", err.Method(), err.URL(), err.StatusCode())))
 		_, _ = str.WriteString("\n")
-		if from != "" {
-			_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("Trace=[%s]", from)))
-			_, _ = str.WriteString("\n")
-		}
 	}
+	// Always include this trace. Users can ignore this.
+	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("Trace=[%s]", from)))
+	_, _ = str.WriteString("\n")
 
 	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), err.Message))
 	if err.Helper != "" {

--- a/cli/root.go
+++ b/cli/root.go
@@ -1183,6 +1183,8 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 // commands. When we pretty print errors, we lose the context in which they came.
 // This function adds the context back. Unfortunately there is no easy way to get
 // the prefix to: "error string: %w", so we do a bit of string manipulation.
+//
+//nolint:errorlint
 func traceError(err error) string {
 	if uw, ok := err.(interface{ Unwrap() error }); ok {
 		a, b := err.Error(), uw.Unwrap().Error()

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2065,7 +2065,7 @@ func (c *Client) BuildInfo(ctx context.Context) (BuildInfoResponse, error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusBadRequest || ExpectJSONMime(res) != nil {
 		return BuildInfoResponse{}, ReadBodyAsError(res)
 	}
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2065,7 +2065,7 @@ func (c *Client) BuildInfo(ctx context.Context) (BuildInfoResponse, error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusBadRequest || ExpectJSONMime(res) != nil {
+	if res.StatusCode != http.StatusOK || ExpectJSONMime(res) != nil {
 		return BuildInfoResponse{}, ReadBodyAsError(res)
 	}
 

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -158,10 +158,10 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 	// TODO: Probably do some version checking here
 	info, err := client.SDKClient.BuildInfo(ctx)
 	if err != nil {
-		return nil, errors.Join(
+		return nil, fmt.Errorf("buildinfo: %w", errors.Join(
 			fmt.Errorf("unable to fetch build info from primary coderd. Are you sure %q is a coderd instance?", opts.DashboardURL),
 			err,
-		)
+		))
 	}
 	if info.WorkspaceProxy {
 		return nil, xerrors.Errorf("%q is a workspace proxy, not a primary coderd instance", opts.DashboardURL)

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -157,7 +158,10 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 	// TODO: Probably do some version checking here
 	info, err := client.SDKClient.BuildInfo(ctx)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to fetch build info from %q: %w", opts.DashboardURL, err)
+		return nil, errors.Join(
+			fmt.Errorf("unable to fetch build info from primary coderd. Are you sure %q is a coderd instance?", opts.DashboardURL),
+			err,
+		)
 	}
 	if info.WorkspaceProxy {
 		return nil, xerrors.Errorf("%q is a workspace proxy, not a primary coderd instance", opts.DashboardURL)


### PR DESCRIPTION
See for yourself. I don't think encoding this into a static unit test would be very helpful. It would just cost more time to fix when you change things. Maybe a golden-file type test would be appropriate here at some point.
```
go run main.go exp example-error api
go run main.go exp example-error cmd
go run main.go exp example-error multi-error
go run main.go exp example-error validation
```

# Before

```
Coder Workspace Proxy v0.0.0-devel - Your Self-Hosted Remote Development Platform
Started HTTP listener at http://127.0.0.1:3000

View the Web UI: http://136.49.34.247:9344
Encountered an error running "coder workspace-proxy server"
create workspace proxy: failed to fetch build info from "https://filebrowser--dev--coder--emyrk--apps.dev.coder.com/": invalid character '<' looking for beginning of value
exit status 1
```

# After

We have to show the html because we have no clue what the response body is. This error is not perfect, but it is a lot better.

```
Coder Workspace Proxy v0.0.0-devel - Your Self-Hosted Remote Development Platform
Started HTTP listener at http://127.0.0.1:3000

View the Web UI: http://136.49.34.247:9344
Encountered an error running "coder workspace-proxy server"
2 errors encountered:
1.  unable to fetch build info from primary coderd. Are you sure "https://filebrowser--dev--coder--emyrk--apps.dev.coder.com/" is a coderd instance?
2.  unexpected non-JSON response "text/html; charset=utf-8"
    <!doctype html>
    
    <!--
        ▄█▀    ▀█▄
         ▄▄ ▀▀▀  █▌   ██▀▀█▄          ▐█
     ▄▄██▀▀█▄▄▄  ██  ██      █▀▀█ ▐█▀▀██ ▄█▀▀█ █▀▀
    █▌   ▄▌   ▐█ █▌  ▀█▄▄▄█▌ █  █ ▐█  ██ ██▀▀  █
         ██████▀▄█    ▀▀▀▀   ▀▀▀▀  ▀▀▀▀▀  ▀▀▀▀ ▀
      -->
    
    <head>
      <meta charset="utf-8" />
      <title>Coder</title>
      <meta name="viewport" content="width=device-width, initial-scale=1" />
      <meta name="theme-color" content="#17172E" />
      <meta name="application-name" content="Coder" />
      <meta property="og:type" content="website" />
      <meta property="csrf-token" content="8bkWpep/Yq0LhtA3Viok+2hrQ2vqhG+znnp88OSR3Q8LD/wfVJG00NPh8WEL5yVgkmbadKGwB0p6xXGtnX76Bw==" />
      <meta property="build-info" content="{&#34;external_url&#34;:&#34;https://github.com/coder/coder/commit/5b122d108e101219e21a05229c5959108b359e78&#34;,&#34;version&#34;:&#34;v2.6.0-devel+5b122d108&#34;,&#34;dashboard_url&#34;:&#34;&#34;,&#34;workspace_proxy&#34;:false,&#34;agent_api_version&#34;:&#34;&#34;}" />
      <meta property="user" content="" />
      <meta property="entitlements" content="" />
      <meta property="appearance" content="" />
      <meta property="experiments" content="" />
      <meta property="regions" content="" />
      <meta property="docs-url" content="" />
      <meta property="logo-url" content="" />
      <!-- We need to set data-react-helmet to be able to override it in the workspace page -->
      <link
        rel="alternate icon"
        type="image/png"
        href="/favicons/favicon-light.png"
        media="(prefers-color-scheme: dark)"
        data-react-helmet="true"
      />
      <link
        rel="icon"
        type="image/svg+xml"
        href="/favicons/favicon-light.svg"
        media="(prefers-color-scheme: dark)"
        data-react-helmet="true"
      />
      <link
        rel="alternate icon"
        type="image/png"
        href="/favicons/favicon-dark.png"
        media="(prefers-color-scheme: light)"
        data-react-helmet="true"
      />
      <link...
exit status 1
```
