### PR TITLE
fix: improve wsproxy error when proxyurl is set to a primary

### DIFF
--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -284,7 +284,6 @@ func (p *ProxyHealth) runOnce(ctx context.Context, now time.Time) (map[uuid.UUID
 					// If the response is not json, then the user likely input a bad url that returns status code 200.
 					// This is very common, since most webpages do return a 200. So let's improve the error message.
 					if notJsonErr := codersdk.ExpectJSONMime(resp); notJsonErr != nil {
-
 						err = errors.Join(
 							isCoderErr,
 							fmt.Errorf("attempted to query health at %q but got back the incorrect content type: %w", reqURL, notJsonErr),

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -301,7 +301,7 @@ func (p *ProxyHealth) runOnce(ctx context.Context, now time.Time) (map[uuid.UUID
 					status.Report.Errors = []string{
 						errors.Join(
 							isCoderErr,
-							fmt.Errorf("received a status code 200, but failed to decode health report body: %w", err.Error()),
+							fmt.Errorf("received a status code 200, but failed to decode health report body: %w", err),
 						).Error(),
 					}
 					status.Status = Unhealthy

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -283,10 +283,10 @@ func (p *ProxyHealth) runOnce(ctx context.Context, now time.Time) (map[uuid.UUID
 
 					// If the response is not json, then the user likely input a bad url that returns status code 200.
 					// This is very common, since most webpages do return a 200. So let's improve the error message.
-					if notJsonErr := codersdk.ExpectJSONMime(resp); notJsonErr != nil {
+					if notJSONErr := codersdk.ExpectJSONMime(resp); notJSONErr != nil {
 						err = errors.Join(
 							isCoderErr,
-							fmt.Errorf("attempted to query health at %q but got back the incorrect content type: %w", reqURL, notJsonErr),
+							fmt.Errorf("attempted to query health at %q but got back the incorrect content type: %w", reqURL, notJSONErr),
 						)
 
 						status.Report.Errors = []string{

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -3,6 +3,7 @@ package proxyhealth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -275,8 +276,34 @@ func (p *ProxyHealth) runOnce(ctx context.Context, now time.Time) (map[uuid.UUID
 			case err == nil && resp.StatusCode == http.StatusOK:
 				err := json.NewDecoder(resp.Body).Decode(&status.Report)
 				if err != nil {
+					isCoderErr := fmt.Errorf("proxy url %q is not a coder proxy instance, verify the url is correct", reqURL)
+					if resp.Header.Get(codersdk.BuildVersionHeader) != "" {
+						isCoderErr = fmt.Errorf("proxy url %q is a coder instance, but unable to decode the response payload. Could this be a primary coderd and not a proxy?", reqURL)
+					}
+
+					// If the response is not json, then the user likely input a bad url that returns status code 200.
+					// This is very common, since most webpages do return a 200. So let's improve the error message.
+					if notJsonErr := codersdk.ExpectJSONMime(resp); notJsonErr != nil {
+
+						err = errors.Join(
+							isCoderErr,
+							fmt.Errorf("attempted to query health at %q but got back the incorrect content type: %w", reqURL, notJsonErr),
+						)
+
+						status.Report.Errors = []string{
+							err.Error(),
+						}
+						status.Status = Unhealthy
+						break
+					}
+
 					// If we cannot read the report, mark the proxy as unhealthy.
-					status.Report.Errors = []string{fmt.Sprintf("failed to decode health report: %s", err.Error())}
+					status.Report.Errors = []string{
+						errors.Join(
+							isCoderErr,
+							fmt.Errorf("received a status code 200, but failed to decode health report body: %w", err.Error()),
+						).Error(),
+					}
 					status.Status = Unhealthy
 					break
 				}


### PR DESCRIPTION
fixes: https://github.com/coder/coder/issues/11116

![Screenshot from 2024-01-11 16-51-38](https://github.com/coder/coder/assets/5446298/5025b679-4e38-423a-9195-92ce1df4f945)


Check header for proxy instance, and check content-type for non json. If it's not a json payload, the json error is almost completely useless.

I think this could be formatted better, but it has the helpful information, which is enough for now imo.