### PR TITLE
fix(coderd): correctly show warning when no provisioner daemons are registered

### DIFF
--- a/coderd/healthcheck/provisioner.go
+++ b/coderd/healthcheck/provisioner.go
@@ -152,7 +152,7 @@ func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDae
 
 	if len(r.Items) == 0 {
 		r.Severity = health.SeverityError
-		r.Error = ptr.Ref("No active provisioner daemons found!")
+		r.Warnings = append(r.Warnings, health.Messagef(health.CodeProvisionerDaemonsNoProvisionerDaemons, "No active provisioner daemons found!"))
 		return
 	}
 }

--- a/coderd/healthcheck/provisioner_test.go
+++ b/coderd/healthcheck/provisioner_test.go
@@ -48,8 +48,8 @@ func TestProvisionerDaemonReport(t *testing.T) {
 			currentVersion:         "v1.2.3",
 			currentAPIMajorVersion: provisionersdk.CurrentMajor,
 			expectedSeverity:       health.SeverityError,
-			expectedError:          "No active provisioner daemons found!",
 			expectedItems:          []healthcheck.ProvisionerDaemonsReportItem{},
+			expectedWarningCode:    health.CodeProvisionerDaemonsNoProvisionerDaemons,
 		},
 		{
 			name:                   "error fetching daemons",
@@ -303,7 +303,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 			currentVersion:         "v2.3.4",
 			currentAPIMajorVersion: provisionersdk.CurrentMajor,
 			expectedSeverity:       health.SeverityError,
-			expectedError:          "No active provisioner daemons found!",
+			expectedWarningCode:    health.CodeProvisionerDaemonsNoProvisionerDaemons,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemonStale(t, "pd-ok", "v1.2.3", "0.9", now.Add(-5*time.Minute), now)},
 			expectedItems:          []healthcheck.ProvisionerDaemonsReportItem{},
 		},

--- a/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
+++ b/site/src/pages/HealthPage/ProvisionerDaemonsPage.tsx
@@ -41,6 +41,7 @@ export const ProvisionerDaemonsPage = () => {
       </Header>
 
       <Main>
+        {daemons.error && <Alert severity="error">{daemons.error}</Alert>}
         {daemons.warnings.map((warning) => {
           return (
             <Alert


### PR DESCRIPTION
Quick fix - we weren't actually using EPD01 properly.
Also updates the provisioner daemons page to show the `error` field if present in the health response.