### PR TITLE
fix(site): fix workspace resource width on ultra wide screens

### DIFF
--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -182,7 +182,15 @@ export const Workspace: FC<WorkspaceProps> = ({
 
       <div css={styles.content}>
         <div css={styles.dotBackground}>
-          <div css={{ display: "flex", flexDirection: "column", gap: 24 }}>
+          <div
+            css={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 24,
+              maxWidth: 24 * 50,
+              margin: "auto",
+            }}
+          >
             {workspace.latest_build.status === "deleted" && (
               <WorkspaceDeletedBanner
                 handleClick={() => navigate(`/templates`)}


### PR DESCRIPTION
Before:
<img width="1512" alt="Screenshot 2024-01-12 at 16 01 14" src="https://github.com/coder/coder/assets/3165839/56f39d8a-0812-4dbe-9004-6dcfd3fe5d16">


After:
<img width="1512" alt="Screenshot 2024-01-12 at 16 01 26" src="https://github.com/coder/coder/assets/3165839/ee44d00d-b8ec-4d64-96dd-e9dfc1ffa622">
