### PR TITLE
fix(coderd): workspaceapps: update last_used_at when workspace app reports stats

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -695,6 +695,15 @@ func (q *querier) ArchiveUnusedTemplateVersions(ctx context.Context, arg databas
 	return q.db.ArchiveUnusedTemplateVersions(ctx, arg)
 }
 
+func (q *querier) BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg database.BatchUpdateWorkspaceLastUsedAtParams) error {
+	// Could be any workspace and checking auth to each workspace is overkill for the purpose
+	// of this function.
+	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceWorkspace.All()); err != nil {
+		return err
+	}
+	return q.db.BatchUpdateWorkspaceLastUsedAt(ctx, arg)
+}
+
 func (q *querier) CleanTailnetCoordinators(ctx context.Context) error {
 	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1549,6 +1549,13 @@ func (s *MethodTestSuite) TestWorkspace() {
 			ID: ws.ID,
 		}).Asserts(ws, rbac.ActionUpdate).Returns()
 	}))
+	s.Run("BatchUpdateWorkspaceLastUsedAt", s.Subtest(func(db database.Store, check *expects) {
+		ws1 := dbgen.Workspace(s.T(), db, database.Workspace{})
+		ws2 := dbgen.Workspace(s.T(), db, database.Workspace{})
+		check.Args(database.BatchUpdateWorkspaceLastUsedAtParams{
+			IDs: []uuid.UUID{ws1.ID, ws2.ID},
+		}).Asserts(rbac.ResourceWorkspace.All(), rbac.ActionUpdate).Returns()
+	}))
 	s.Run("UpdateWorkspaceTTL", s.Subtest(func(db database.Store, check *expects) {
 		ws := dbgen.Workspace(s.T(), db, database.Workspace{})
 		check.Args(database.UpdateWorkspaceTTLParams{

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -985,9 +985,6 @@ func (q *FakeQuerier) BatchUpdateWorkspaceLastUsedAt(_ context.Context, arg data
 		q.workspaces[i].LastUsedAt = arg.LastUsedAt
 		n++
 	}
-	if n == 0 {
-		return sql.ErrNoRows
-	}
 	return nil
 }
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -963,6 +963,34 @@ func (q *FakeQuerier) ArchiveUnusedTemplateVersions(_ context.Context, arg datab
 	return archived, nil
 }
 
+func (q *FakeQuerier) BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg database.BatchUpdateWorkspaceLastUsedAtParams) error {
+	err := validateDatabaseType(arg)
+	if err != nil {
+		return err
+	}
+
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	// temporary map to avoid O(q.workspaces*arg.workspaceIds)
+	m := make(map[uuid.UUID]struct{})
+	for _, id := range arg.IDs {
+		m[id] = struct{}{}
+	}
+	n := 0
+	for i := 0; i < len(q.workspaces); i++ {
+		if _, found := m[q.workspaces[i].ID]; !found {
+			continue
+		}
+		q.workspaces[i].LastUsedAt = arg.LastUsedAt
+		n++
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
 func (*FakeQuerier) CleanTailnetCoordinators(_ context.Context) error {
 	return ErrUnimplemented
 }

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -963,7 +963,7 @@ func (q *FakeQuerier) ArchiveUnusedTemplateVersions(_ context.Context, arg datab
 	return archived, nil
 }
 
-func (q *FakeQuerier) BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg database.BatchUpdateWorkspaceLastUsedAtParams) error {
+func (q *FakeQuerier) BatchUpdateWorkspaceLastUsedAt(_ context.Context, arg database.BatchUpdateWorkspaceLastUsedAtParams) error {
 	err := validateDatabaseType(arg)
 	if err != nil {
 		return err

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -114,6 +114,13 @@ func (m metricsStore) ArchiveUnusedTemplateVersions(ctx context.Context, arg dat
 	return r0, r1
 }
 
+func (m metricsStore) BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg database.BatchUpdateWorkspaceLastUsedAtParams) error {
+	start := time.Now()
+	r0 := m.s.BatchUpdateWorkspaceLastUsedAt(ctx, arg)
+	m.queryLatencies.WithLabelValues("BatchUpdateWorkspaceLastUsedAt").Observe(time.Since(start).Seconds())
+	return r0
+}
+
 func (m metricsStore) CleanTailnetCoordinators(ctx context.Context) error {
 	start := time.Now()
 	err := m.s.CleanTailnetCoordinators(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -117,6 +117,20 @@ func (mr *MockStoreMockRecorder) ArchiveUnusedTemplateVersions(arg0, arg1 any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveUnusedTemplateVersions", reflect.TypeOf((*MockStore)(nil).ArchiveUnusedTemplateVersions), arg0, arg1)
 }
 
+// BatchUpdateWorkspaceLastUsedAt mocks base method.
+func (m *MockStore) BatchUpdateWorkspaceLastUsedAt(arg0 context.Context, arg1 database.BatchUpdateWorkspaceLastUsedAtParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchUpdateWorkspaceLastUsedAt", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BatchUpdateWorkspaceLastUsedAt indicates an expected call of BatchUpdateWorkspaceLastUsedAt.
+func (mr *MockStoreMockRecorder) BatchUpdateWorkspaceLastUsedAt(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchUpdateWorkspaceLastUsedAt", reflect.TypeOf((*MockStore)(nil).BatchUpdateWorkspaceLastUsedAt), arg0, arg1)
+}
+
 // CleanTailnetCoordinators mocks base method.
 func (m *MockStore) CleanTailnetCoordinators(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -42,6 +42,7 @@ type sqlcQuerier interface {
 	// Only unused template versions will be archived, which are any versions not
 	// referenced by the latest build of a workspace.
 	ArchiveUnusedTemplateVersions(ctx context.Context, arg ArchiveUnusedTemplateVersionsParams) ([]uuid.UUID, error)
+	BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg BatchUpdateWorkspaceLastUsedAtParams) error
 	CleanTailnetCoordinators(ctx context.Context) error
 	CleanTailnetLostPeers(ctx context.Context) error
 	CleanTailnetTunnels(ctx context.Context) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10813,6 +10813,25 @@ func (q *sqlQuerier) InsertWorkspaceResourceMetadata(ctx context.Context, arg In
 	return items, nil
 }
 
+const batchUpdateWorkspaceLastUsedAt = `-- name: BatchUpdateWorkspaceLastUsedAt :exec
+UPDATE
+	workspaces
+SET
+	last_used_at = $1
+WHERE
+	id = ANY($2 :: uuid[])
+`
+
+type BatchUpdateWorkspaceLastUsedAtParams struct {
+	LastUsedAt time.Time   `db:"last_used_at" json:"last_used_at"`
+	IDs        []uuid.UUID `db:"ids" json:"ids"`
+}
+
+func (q *sqlQuerier) BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg BatchUpdateWorkspaceLastUsedAtParams) error {
+	_, err := q.db.ExecContext(ctx, batchUpdateWorkspaceLastUsedAt, arg.LastUsedAt, pq.Array(arg.IDs))
+	return err
+}
+
 const getDeploymentWorkspaceStats = `-- name: GetDeploymentWorkspaceStats :one
 WITH workspaces_with_jobs AS (
 	SELECT

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -357,6 +357,14 @@ SET
 WHERE
 	id = $1;
 
+-- name: BatchUpdateWorkspaceLastUsedAt :exec
+UPDATE
+	workspaces
+SET
+	last_used_at = @last_used_at
+WHERE
+	id = ANY(@ids :: uuid[]);
+
 -- name: GetDeploymentWorkspaceStats :one
 WITH workspaces_with_jobs AS (
 	SELECT

--- a/coderd/httpapi/websocket.go
+++ b/coderd/httpapi/websocket.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	"cdr.dev/slog"
 	"nhooyr.io/websocket"
+
+	"cdr.dev/slog"
 )
 
 // Heartbeat loops to ping a WebSocket to keep it alive.

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1626,7 +1626,7 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 		cancel()
 		// We expect only 1
 		// In a failed test, you will likely see 9, as the last one
-		// gets cancelled.
+		// gets canceled.
 		require.Equal(t, 1, validateCalls, "validate calls duplicated on same token")
 	})
 }

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -1570,10 +1570,9 @@ func testReconnectingPTY(ctx context.Context, t *testing.T, client *codersdk.Cli
 func assertWorkspaceLastUsedAtUpdated(t testing.TB, details *Details) {
 	t.Helper()
 
-	<-time.After(testutil.IntervalMedium) // Wait for Bicopy to finish.
-	details.FlushStats()
 	// Wait for stats to fully flush.
 	require.Eventually(t, func() bool {
+		details.FlushStats()
 		ws, err := details.SDKClient.Workspace(context.Background(), details.Workspace.ID)
 		assert.NoError(t, err)
 		return ws.LastUsedAt.After(details.Workspace.LastUsedAt)
@@ -1585,9 +1584,7 @@ func assertWorkspaceLastUsedAtUpdated(t testing.TB, details *Details) {
 func assertWorkspaceLastUsedAtNotUpdated(t testing.TB, details *Details) {
 	t.Helper()
 
-	<-time.After(testutil.IntervalMedium) // Wait for Bicopy to finish.
 	details.FlushStats()
-	<-time.After(testutil.IntervalMedium) // Wait for stats to fully flush.
 	ws, err := details.SDKClient.Workspace(context.Background(), details.Workspace.ID)
 	require.NoError(t, err)
 	require.Equal(t, ws.LastUsedAt, details.Workspace.LastUsedAt, "workspace LastUsedAt updated when it should not have been")

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -147,7 +147,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			require.NoError(t, err)
 			require.True(t, loc.Query().Has("message"))
 			require.True(t, loc.Query().Has("redirect"))
-			assertWorkspaceLastUsedAtUpdated(t, appDetails)
+			assertWorkspaceLastUsedAtNotUpdated(t, appDetails)
 		})
 
 		t.Run("LoginWithoutAuthOnProxy", func(t *testing.T) {
@@ -185,7 +185,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			// request is getting stripped.
 			require.Equal(t, u.Path, redirectURI.Path+"/")
 			require.Equal(t, u.RawQuery, redirectURI.RawQuery)
-			assertWorkspaceLastUsedAtUpdated(t, appDetails)
+			assertWorkspaceLastUsedAtNotUpdated(t, appDetails)
 		})
 
 		t.Run("NoAccessShould404", func(t *testing.T) {

--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -71,6 +71,7 @@ type Deployment struct {
 	SDKClient      *codersdk.Client
 	FirstUser      codersdk.CreateFirstUserResponse
 	PathAppBaseURL *url.URL
+	FlushStats     func()
 }
 
 // DeploymentFactory generates a deployment with an API client, a path base URL,

--- a/coderd/workspaceapps/stats.go
+++ b/coderd/workspaceapps/stats.go
@@ -126,7 +126,11 @@ func (r *StatsDBReporter) Report(ctx context.Context, stats []StatsReport) error
 			return err
 		}
 
-		// TODO: There should be a better way to do this.
+		// TODO: We currently measure workspace usage based on when we get stats from it.
+		// There are currently two paths for this:
+		// 1) From SSH -> workspace agent stats POSTed from agent
+		// 2) From workspace apps / rpty -> workspace app stats (from coderd / wsproxy)
+		// Ideally we would have a single code path for this.
 		uniqueIDs := slice.Unique(batch.WorkspaceID)
 		if err := tx.BatchUpdateWorkspaceLastUsedAt(ctx, database.BatchUpdateWorkspaceLastUsedAtParams{
 			IDs:        uniqueIDs,

--- a/coderd/workspaceapps/stats.go
+++ b/coderd/workspaceapps/stats.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/util/slice"
 )
 
 const (
@@ -117,11 +118,21 @@ func (r *StatsDBReporter) Report(ctx context.Context, stats []StatsReport) error
 				batch.Requests = batch.Requests[:0]
 			}
 		}
-		if len(batch.UserID) > 0 {
-			err := tx.InsertWorkspaceAppStats(ctx, batch)
-			if err != nil {
-				return err
-			}
+		if len(batch.UserID) == 0 {
+			return nil
+		}
+
+		if err := tx.InsertWorkspaceAppStats(ctx, batch); err != nil {
+			return err
+		}
+
+		// TODO: There should be a better way to do this.
+		uniqueIDs := slice.Unique(batch.WorkspaceID)
+		if err := tx.BatchUpdateWorkspaceLastUsedAt(ctx, database.BatchUpdateWorkspaceLastUsedAtParams{
+			IDs:        uniqueIDs,
+			LastUsedAt: dbtime.Now(), // This isn't 100% accurate, but it's good enough.
+		}); err != nil {
+			return err
 		}
 
 		return nil
@@ -234,6 +245,7 @@ func (sc *StatsCollector) Collect(report StatsReport) {
 		}
 		delete(sc.statsBySessionID, report.SessionID)
 	}
+	sc.opts.Logger.Debug(sc.ctx, "collected workspace app stats", slog.F("report", report))
 }
 
 // rollup performs stats rollup for sessions that fall within the

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -262,7 +262,7 @@ func TestWorkspaceApps(t *testing.T) {
 			opts.AppHost = ""
 		}
 
-		statsFlushCh := make(chan chan<- struct{}, 1)
+		statsFlushCh := make(chan chan<- struct{})
 		opts.StatsCollectorOptions.Flush = statsFlushCh
 		flushStats := func() {
 			flushDone := make(chan struct{})

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -262,6 +262,13 @@ func TestWorkspaceApps(t *testing.T) {
 			opts.AppHost = ""
 		}
 
+		statsFlushCh := make(chan chan<- struct{}, 1)
+		opts.StatsCollectorOptions.Flush = statsFlushCh
+		flushStats := func() {
+			flushDone := make(chan struct{})
+			statsFlushCh <- flushDone
+			<-flushDone
+		}
 		client := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:         deploymentValues,
 			AppHostname:              opts.AppHost,
@@ -285,6 +292,7 @@ func TestWorkspaceApps(t *testing.T) {
 			SDKClient:      client,
 			FirstUser:      user,
 			PathAppBaseURL: client.URL,
+			FlushStats:     flushStats,
 		}
 	})
 }

--- a/coderd/workspaceapps_test.go
+++ b/coderd/workspaceapps_test.go
@@ -262,12 +262,12 @@ func TestWorkspaceApps(t *testing.T) {
 			opts.AppHost = ""
 		}
 
-		statsFlushCh := make(chan chan<- struct{})
-		opts.StatsCollectorOptions.Flush = statsFlushCh
+		flushStatsCollectorCh := make(chan chan<- struct{}, 1)
+		opts.StatsCollectorOptions.Flush = flushStatsCollectorCh
 		flushStats := func() {
-			flushDone := make(chan struct{})
-			statsFlushCh <- flushDone
-			<-flushDone
+			flushStatsCollectorDone := make(chan struct{}, 1)
+			flushStatsCollectorCh <- flushStatsCollectorDone
+			<-flushStatsCollectorDone
 		}
 		client := coderdtest.New(t, &coderdtest.Options{
 			DeploymentValues:         deploymentValues,

--- a/enterprise/coderd/coderdenttest/proxytest.go
+++ b/enterprise/coderd/coderdenttest/proxytest.go
@@ -38,8 +38,8 @@ type ProxyOptions struct {
 	// ProxyURL is optional
 	ProxyURL *url.URL
 
-	// Flush is optional
-	Flush chan chan<- struct{}
+	// FlushStats is optional
+	FlushStats chan chan<- struct{}
 }
 
 // NewWorkspaceProxy will configure a wsproxy.Server with the given options.
@@ -116,8 +116,8 @@ func NewWorkspaceProxy(t *testing.T, coderdAPI *coderd.API, owner *codersdk.Clie
 	// Inherit collector options from coderd, but keep the wsproxy reporter.
 	statsCollectorOptions := coderdAPI.Options.WorkspaceAppsStatsCollectorOptions
 	statsCollectorOptions.Reporter = nil
-	if options.Flush != nil {
-		statsCollectorOptions.Flush = options.Flush
+	if options.FlushStats != nil {
+		statsCollectorOptions.Flush = options.FlushStats
 	}
 
 	wssrv, err := wsproxy.New(ctx, &wsproxy.Options{

--- a/enterprise/coderd/coderdenttest/proxytest.go
+++ b/enterprise/coderd/coderdenttest/proxytest.go
@@ -37,6 +37,9 @@ type ProxyOptions struct {
 
 	// ProxyURL is optional
 	ProxyURL *url.URL
+
+	// Flush is optional
+	Flush chan chan<- struct{}
 }
 
 // NewWorkspaceProxy will configure a wsproxy.Server with the given options.
@@ -113,6 +116,9 @@ func NewWorkspaceProxy(t *testing.T, coderdAPI *coderd.API, owner *codersdk.Clie
 	// Inherit collector options from coderd, but keep the wsproxy reporter.
 	statsCollectorOptions := coderdAPI.Options.WorkspaceAppsStatsCollectorOptions
 	statsCollectorOptions.Reporter = nil
+	if options.Flush != nil {
+		statsCollectorOptions.Flush = options.Flush
+	}
 
 	wssrv, err := wsproxy.New(ctx, &wsproxy.Options{
 		Logger:            slogtest.Make(t, nil).Leveled(slog.LevelDebug),

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -442,11 +442,11 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			"*",
 		}
 
-		proxyFlushCh := make(chan chan<- struct{})
+		proxyStatsCollectorFlushCh := make(chan chan<- struct{}, 1)
 		flushStats := func() {
-			proxyFlushDone := make(chan struct{})
-			proxyFlushCh <- proxyFlushDone
-			<-proxyFlushDone
+			proxyStatsCollectorFlushDone := make(chan struct{}, 1)
+			proxyStatsCollectorFlushCh <- proxyStatsCollectorFlushDone
+			<-proxyStatsCollectorFlushDone
 		}
 
 		client, closer, api, user := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
@@ -483,7 +483,7 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			Name:            "best-proxy",
 			AppHostname:     opts.AppHost,
 			DisablePathApps: opts.DisablePathApps,
-			Flush:           proxyFlushCh,
+			FlushStats:      proxyStatsCollectorFlushCh,
 		})
 
 		return &apptest.Deployment{

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -442,9 +442,9 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			"*",
 		}
 
-		proxyFlushCh := make(chan chan<- struct{}, 1)
+		proxyFlushCh := make(chan chan<- struct{})
 		flushStats := func() {
-			proxyFlushDone := make(chan struct{}, 1)
+			proxyFlushDone := make(chan struct{})
 			proxyFlushCh <- proxyFlushDone
 			<-proxyFlushDone
 		}

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -442,6 +442,13 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			"*",
 		}
 
+		proxyFlushCh := make(chan chan<- struct{}, 1)
+		flushStats := func() {
+			proxyFlushDone := make(chan struct{}, 1)
+			proxyFlushCh <- proxyFlushDone
+			<-proxyFlushDone
+		}
+
 		client, closer, api, user := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues:         deploymentValues,
@@ -476,6 +483,7 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			Name:            "best-proxy",
 			AppHostname:     opts.AppHost,
 			DisablePathApps: opts.DisablePathApps,
+			Flush:           proxyFlushCh,
 		})
 
 		return &apptest.Deployment{
@@ -483,6 +491,7 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			SDKClient:      client,
 			FirstUser:      user,
 			PathAppBaseURL: proxyAPI.Options.AccessURL,
+			FlushStats:     flushStats,
 		}
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/11509

- Adds a new query `BatchUpdateLastUsedAt`
- Adds calls to `BatchUpdateLastUsedAt` in app stats handler upon flush
- Passes a stats flush chan to apptest setup scaffolding

This is not the 'correct' solution, but it puts a decent enough bandage on the problem until we figure out a more unified solution to this issue of updating the "Last Used At" field of workspaces based on certain events. I'll be opening a follow-up PR for this.

Now when the workspace apps stats collector flushes a batch of stats, we bump `LastUsedAt` for all affected workspaces.

Note: I'm just updating `LastUsedAt` to the same value for all workspaces. I don't know if there's a good way to insert a whole bunch of distinct values for a number of rows in a single transaction, and I want to keep this to a single query if possible.

I've verified that this works experimentally but this is the sort of thing that should be ossified in tests. I'm currently putting this into `TestWorkspaceApps` as it seems to be the place where all the testing of proxying flows happens.

Also note: the tests are sadly a bit racy; I've done what I can for the moment but I may need to spend some follow-up time refactoring.