### PR TITLE
docs: add guide for template ImagePullSecret

### DIFF
--- a/docs/guides/example-guide.md
+++ b/docs/guides/example-guide.md
@@ -3,7 +3,7 @@
 <div>
   <a href="https://github.com/<your_github_handle>" style="text-decoration: none; color: inherit;">
     <span style="vertical-align:middle;">Your Name</span>
-    <img src="<your_github_profile_photo_url>" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+    <img src="https://github.com/ericpaulsen.png" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>
 December 13, 2023

--- a/docs/guides/gcp-to-aws.md
+++ b/docs/guides/gcp-to-aws.md
@@ -1,5 +1,15 @@
 # Federating a Google Cloud service account to AWS
 
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Your Name</span>
+    <img src="https://github.com/ericpaulsen.png" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+January 4, 2024
+
+---
+
 This guide will walkthrough how to use a Google Cloud service account to
 authenticate the Coder control plane to AWS and create an EC2 workspace. The
 below steps assume your Coder control plane is running in Google Cloud and has

--- a/docs/guides/image-pull-secret.md
+++ b/docs/guides/image-pull-secret.md
@@ -10,10 +10,10 @@ January 12, 2024
 
 ---
 
-Coder workspaces are commonly run as Kubernetes pods. When run inside of an enterprise,
-the pod image is typically pulled from a private image registry. This guide walks
-through creating an ImagePullSecret to use for authenticating to your registry,
-and defining it in your workspace template.
+Coder workspaces are commonly run as Kubernetes pods. When run inside of an
+enterprise, the pod image is typically pulled from a private image registry.
+This guide walks through creating an ImagePullSecret to use for authenticating
+to your registry, and defining it in your workspace template.
 
 ## 1. Create Docker Config JSON File
 
@@ -34,8 +34,8 @@ actual Docker registry URL, username, and password.
 
 ## 2. Create Kubernetes Secret
 
-Run the below `kubectl` command in the K8s cluster where you intend to run your Coder
-workspaces:
+Run the below `kubectl` command in the K8s cluster where you intend to run your
+Coder workspaces:
 
 ```console
 kubectl create secret generic regcred \
@@ -53,7 +53,15 @@ kubectl get secret -n <workspaces-namespace> regcred --output="jsonpath={.data.\
 The output should look similar to this:
 
 ```json
-{"auths":{"your.private.registry.com":{"username":"ericpaulsen","password":"xxxx","auth":"c3R...zE2"}}}
+{
+  "auths": {
+    "your.private.registry.com": {
+      "username": "ericpaulsen",
+      "password": "xxxx",
+      "auth": "c3R...zE2"
+    }
+  }
+}
 ```
 
 ## 3. Define ImagePullSecret in Terraform template

--- a/docs/guides/image-pull-secret.md
+++ b/docs/guides/image-pull-secret.md
@@ -12,7 +12,8 @@ January 12, 2024
 
 Coder workspaces are commonly run as Kubernetes pods. When run inside of an enterprise,
 the pod image is typically pulled from a private image registry. This guide walks
-through creating an ImagePullSecret to use for authenticating to your registry.
+through creating an ImagePullSecret to use for authenticating to your registry,
+and defining it in your workspace template.
 
 ## 1. Create Docker Config JSON File
 
@@ -75,4 +76,3 @@ resource "kubernetes_pod" "dev" {
   }
 }
 ```
-

--- a/docs/guides/image-pull-secret.md
+++ b/docs/guides/image-pull-secret.md
@@ -1,0 +1,78 @@
+# Defining ImagePullSecrets for Coder workspaces
+
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">Your Name</span>
+    <img src="https://github.com/ericpaulsen.png" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+January 12, 2024
+
+---
+
+Coder workspaces are commonly run as Kubernetes pods. When run inside of an enterprise,
+the pod image is typically pulled from a private image registry. This guide walks
+through creating an ImagePullSecret to use for authenticating to your registry.
+
+## 1. Create Docker Config JSON File
+
+Create a Docker configuration JSON file containing your registry credentials.
+Replace `<your-registry>`, `<your-username>`, and `<your-password>` with your
+actual Docker registry URL, username, and password.
+
+```json
+{
+  "auths": {
+    "<your-registry>": {
+      "username": "<your-username>",
+      "password": "<your-password>"
+    }
+  }
+}
+```
+
+## 2. Create Kubernetes Secret
+
+Run the below `kubectl` command in the K8s cluster where you intend to run your Coder
+workspaces:
+
+```console
+kubectl create secret generic regcred \
+  --from-file=.dockerconfigjson=<path-to-docker-config.json> \
+  --type=kubernetes.io/dockerconfigjson \
+  --namespace=<workspaces-namespace>
+```
+
+Inspect the secret to confirm its contents:
+
+```console
+kubectl get secret -n <workspaces-namespace> regcred --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode
+```
+
+The output should look similar to this:
+
+```json
+{"auths":{"your.private.registry.com":{"username":"ericpaulsen","password":"xxxx","auth":"c3R...zE2"}}}
+```
+
+## 3. Define ImagePullSecret in Terraform template
+
+```hcl
+resource "kubernetes_pod" "dev" {
+  metadata {
+    # this must be the same namespace where workspaces will be deployed
+    namespace = "workspaces-namespace"
+  }
+
+  spec {
+    image_pull_secrets {
+      name = "regcred"
+    }
+    container {
+      name  = "dev"
+      image = "your-image:latest"
+    }
+  }
+}
+```
+

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1020,6 +1020,11 @@
           "title": "Google to AWS Federation",
           "description": "Federating a Google Cloud service account to AWS",
           "path": "./guides/gcp-to-aws.md"
+        },
+        {
+          "title": "Template ImagePullSecrets",
+          "description": "Creating ImagePullSecrets for private registries",
+          "path": "./guides/image-pull-secret.md"
         }
       ]
     }


### PR DESCRIPTION
this PR adds a guide for creating a K8s ImagePullSecret and defining it in the workspace template. this is a common configuration step for our customers, since they pull their workspace images from private registries.