### PR TITLE
docs: add steps to configure supportLinks in Helm chart

### DIFF
--- a/docs/admin/appearance.md
+++ b/docs/admin/appearance.md
@@ -69,12 +69,13 @@ The link icons are optional, and limited to: `bug`, `chat`, and `docs`.
 
 ### Kubernetes configuration
 
-To pass in the `supportLinks` YAML file above into your Coder Kubernetes deployment,
-follow the steps below.
+To pass in the `supportLinks` YAML file above into your Coder Kubernetes
+deployment, follow the steps below.
 
 #### 1. Create Kubernetes Secret From File
 
-Run the below commmand to create the YAML file as a Kubernetes secret in your cluster:
+Run the below commmand to create the YAML file as a Kubernetes secret in your
+cluster:
 
 ```console
 kubectl create secret generic coder-support-links -n <coder-namespace> --from-file=config.yaml
@@ -87,15 +88,15 @@ Next, update your Helm chart values as follows:
 ```yaml
 coder:
   env:
-  - name: CODER_CONFIG_PATH
-    value: /etc/coder/config.yaml
+    - name: CODER_CONFIG_PATH
+      value: /etc/coder/config.yaml
   volumes:
-  - name: coder-config
-    secret:
-      secretName: coder-support-links
+    - name: coder-config
+      secret:
+        secretName: coder-support-links
   volumeMounts:
-  - name: coder-config
-    mountPath: /etc/coder/
+    - name: coder-config
+      mountPath: /etc/coder/
 ```
 
 #### 3. Upgrade Coder

--- a/docs/admin/appearance.md
+++ b/docs/admin/appearance.md
@@ -74,7 +74,7 @@ deployment, follow the steps below.
 
 #### 1. Create Kubernetes Secret From File
 
-Run the below commmand to create the YAML file as a Kubernetes secret in your
+Run the below command to create the YAML file as a Kubernetes secret in your
 cluster:
 
 ```console

--- a/docs/admin/appearance.md
+++ b/docs/admin/appearance.md
@@ -67,6 +67,45 @@ supportLinks:
 
 The link icons are optional, and limited to: `bug`, `chat`, and `docs`.
 
+### Kubernetes configuration
+
+To pass in the `supportLinks` YAML file above into your Coder Kubernetes deployment,
+follow the steps below.
+
+#### 1. Create Kubernetes Secret From File
+
+Run the below commmand to create the YAML file as a Kubernetes secret in your cluster:
+
+```console
+kubectl create secret generic coder-support-links -n <coder-namespace> --from-file=config.yaml
+```
+
+#### 2. Mount Secret as Volume in Helm Chart
+
+Next, update your Helm chart values as follows:
+
+```yaml
+coder:
+  env:
+  - name: CODER_CONFIG_PATH
+    value: /etc/coder/config.yaml
+  volumes:
+  - name: coder-config
+    secret:
+      secretName: coder-support-links
+  volumeMounts:
+  - name: coder-config
+    mountPath: /etc/coder/
+```
+
+#### 3. Upgrade Coder
+
+Lastly, upgrade Coder using the following command:
+
+```console
+helm upgrade coder coder-v2/coder -n <coder-namespace> -f <values-file.yaml>
+```
+
 ## Up next
 
 - [Enterprise](../enterprise.md)


### PR DESCRIPTION
this PR documents steps for passing in `supportLinks` configuration into the Helm chart.