### PR TITLE
chore(docs): remove the `template_update_policies` experiment from docs

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -141,13 +141,6 @@ quiet hours schedule, it will be ignored and the default will be used instead.
 
 ### Automatic updates
 
-> Automatic updates is part of an
-> [experimental feature](../contributing/feature-stages.md#experimental-features)
-> and the behavior is subject to change. Use
-> [GitHub issues](https://github.com/coder/coder) to leave feedback. This
-> experiment must be specifically enabled with the
-> `--experiments="template_update_policies"` option on your coderd deployment.
-
 It can be tedious to manually update a workspace everytime an update is pushed
 to a template. Users can choose to opt-in to automatic updates to update to the
 active template version whenever the workspace is started.


### PR DESCRIPTION
I think this was left as a residual unintentionally in #11250.