### PR TITLE
feat(cli/exp): add app testing to scaletest workspace-traffic

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -952,56 +952,36 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 			th := harness.NewTestHarness(strategy.toStrategy(), cleanupStrategy.toStrategy())
 			for idx, ws := range workspaces {
 				var (
-					agentID   uuid.UUID
-					agentName string
-					name      = "workspace-traffic"
-					id        = strconv.Itoa(idx)
-					apps      []codersdk.WorkspaceApp
-					appConfig workspacetraffic.AppConfig
+					agent codersdk.WorkspaceAgent
+					name  = "workspace-traffic"
+					id    = strconv.Itoa(idx)
 				)
 
 				for _, res := range ws.LatestBuild.Resources {
 					if len(res.Agents) == 0 {
 						continue
 					}
-					agentID = res.Agents[0].ID
-					agentName = res.Agents[0].Name
-					apps = res.Agents[0].Apps
+					agent = res.Agents[0]
 				}
 
-				if agentID == uuid.Nil {
+				if agent.ID == uuid.Nil {
 					_, _ = fmt.Fprintf(inv.Stderr, "WARN: skipping workspace %s: no agent\n", ws.Name)
 					continue
 				}
 
-				if app != "" {
-					i := slices.IndexFunc(apps, func(a codersdk.WorkspaceApp) bool { return a.Slug == app })
-					if i == -1 {
-						return xerrors.Errorf("app %q not found in workspace %q", app, ws.Name)
-					}
-
-					appConfig = workspacetraffic.AppConfig{
-						Name: apps[i].Slug,
-					}
-					if apps[i].Subdomain {
-						if appHost.Host == "" {
-							return xerrors.Errorf("app %q is a subdomain app but no app host is configured", app)
-						}
-
-						appConfig.URL = fmt.Sprintf("%s://%s", client.URL.Scheme, strings.Replace(appHost.Host, "*", apps[i].SubdomainName, 1))
-					} else {
-						appConfig.URL = fmt.Sprintf("%s/@%s/%s.%s/apps/%s", client.URL.String(), ws.OwnerName, ws.Name, agentName, apps[i].Slug)
-					}
+				appConfig, err := createWorkspaceAppConfig(client, appHost.Host, app, ws, agent)
+				if err != nil {
+					return xerrors.Errorf("configure workspace app: %w", err)
 				}
 
 				// Setup our workspace agent connection.
 				config := workspacetraffic.Config{
-					AgentID:      agentID,
+					AgentID:      agent.ID,
 					BytesPerTick: bytesPerTick,
 					Duration:     strategy.timeout,
 					TickInterval: tickInterval,
-					ReadMetrics:  metrics.ReadMetrics(ws.OwnerName, ws.Name, agentName),
-					WriteMetrics: metrics.WriteMetrics(ws.OwnerName, ws.Name, agentName),
+					ReadMetrics:  metrics.ReadMetrics(ws.OwnerName, ws.Name, agent.Name),
+					WriteMetrics: metrics.WriteMetrics(ws.OwnerName, ws.Name, agent.Name),
 					SSH:          ssh,
 					Echo:         ssh,
 					App:          appConfig,
@@ -1448,4 +1428,30 @@ func parseTemplate(ctx context.Context, client *codersdk.Client, organizationIDs
 	}
 
 	return tpl, nil
+}
+
+func createWorkspaceAppConfig(client *codersdk.Client, appHost, app string, workspace codersdk.Workspace, agent codersdk.WorkspaceAgent) (workspacetraffic.AppConfig, error) {
+	if app == "" {
+		return workspacetraffic.AppConfig{}, nil
+	}
+
+	i := slices.IndexFunc(agent.Apps, func(a codersdk.WorkspaceApp) bool { return a.Slug == app })
+	if i == -1 {
+		return workspacetraffic.AppConfig{}, xerrors.Errorf("app %q not found in workspace %q", app, workspace.Name)
+	}
+
+	c := workspacetraffic.AppConfig{
+		Name: agent.Apps[i].Slug,
+	}
+	if agent.Apps[i].Subdomain {
+		if appHost == "" {
+			return workspacetraffic.AppConfig{}, xerrors.Errorf("app %q is a subdomain app but no app host is configured", app)
+		}
+
+		c.URL = fmt.Sprintf("%s://%s", client.URL.Scheme, strings.Replace(appHost, "*", agent.Apps[i].SubdomainName, 1))
+	} else {
+		c.URL = fmt.Sprintf("%s/@%s/%s.%s/apps/%s", client.URL.String(), workspace.OwnerName, workspace.Name, agent.Name, agent.Apps[i].Slug)
+	}
+
+	return c, nil
 }

--- a/scaletest/workspacetraffic/config.go
+++ b/scaletest/workspacetraffic/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	// to true will double the amount of data read from the agent for
 	// PTYs (e.g. reconnecting pty or SSH connections that request PTY).
 	Echo bool `json:"echo"`
+
+	App AppConfig `json:"app"`
 }
 
 func (c Config) Validate() error {
@@ -50,5 +52,14 @@ func (c Config) Validate() error {
 		return xerrors.Errorf("validate tick_interval: must be greater than zero")
 	}
 
+	if c.SSH && c.App.Name != "" {
+		return xerrors.Errorf("validate ssh: must be false when app is used")
+	}
+
 	return nil
+}
+
+type AppConfig struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }

--- a/scaletest/workspacetraffic/conn.go
+++ b/scaletest/workspacetraffic/conn.go
@@ -31,9 +31,9 @@ const (
 	//
 	// 	failed to write frame: WebSocket closed: received close frame: status = StatusMessageTooBig and reason = "read limited at 32769 bytes"
 	//
-	// Since we can't control fragmentation/buffer sizes, we use a conservative
-	// value. Derived from 1024 * 9 * 3 = <28KB.
-	rptyJSONMaxDataSize = 1024 * 9
+	// Since we can't control fragmentation/buffer sizes, we keep it simple and
+	// match the conservative payload size used by agent/reconnectingpty (1024).
+	rptyJSONMaxDataSize = 1024
 )
 
 func connectRPTY(ctx context.Context, client *codersdk.Client, agentID, reconnect uuid.UUID, cmd string) (*countReadWriteCloser, error) {

--- a/scaletest/workspacetraffic/run_test.go
+++ b/scaletest/workspacetraffic/run_test.go
@@ -2,6 +2,10 @@ package workspacetraffic_test
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"strings"
 	"sync"
@@ -9,6 +13,7 @@ import (
 	"time"
 
 	"golang.org/x/exp/slices"
+	"nhooyr.io/websocket"
 
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -139,9 +144,7 @@ func TestRun(t *testing.T) {
 		t.Logf("bytes written total: %.0f\n", writeMetrics.Total())
 
 		// We want to ensure the metrics are somewhat accurate.
-		// TODO: https://github.com/coder/coder/issues/11175
-		// assert.InDelta(t, bytesPerTick, writeMetrics.Total(), 0.1)
-
+		assert.InDelta(t, readMetrics.Total(), writeMetrics.Total(), float64(bytesPerTick))
 		// Read is highly variable, depending on how far we read before stopping.
 		// Just ensure it's not zero.
 		assert.NotZero(t, readMetrics.Total())
@@ -261,9 +264,102 @@ func TestRun(t *testing.T) {
 		t.Logf("bytes written total: %.0f\n", writeMetrics.Total())
 
 		// We want to ensure the metrics are somewhat accurate.
-		// TODO: https://github.com/coder/coder/issues/11175
-		// assert.InDelta(t, bytesPerTick, writeMetrics.Total(), 0.1)
+		assert.InDelta(t, readMetrics.Total(), writeMetrics.Total(), float64(bytesPerTick))
+		// Read is highly variable, depending on how far we read before stopping.
+		// Just ensure it's not zero.
+		assert.NotZero(t, readMetrics.Total())
+		// Latency should report non-zero values.
+		assert.NotEmpty(t, readMetrics.Latencies())
+		assert.NotEmpty(t, writeMetrics.Latencies())
+		// Should not report any errors!
+		assert.Zero(t, readMetrics.Errors())
+		assert.Zero(t, writeMetrics.Errors())
+	})
 
+	t.Run("App", func(t *testing.T) {
+		t.Parallel()
+
+		// Start a test server that will echo back the request body, this skips
+		// the roundtrip to coderd/agent and simply tests the http request conn
+		// directly.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c, err := websocket.Accept(w, r, &websocket.AcceptOptions{})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			nc := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
+			defer nc.Close()
+
+			_, err = io.Copy(nc, nc)
+			if err != nil && !errors.Is(err, io.EOF) {
+				t.Error(err)
+				return
+			}
+		}))
+		defer srv.Close()
+
+		// Now we can start the runner.
+		var (
+			bytesPerTick = 1024
+			tickInterval = 1000 * time.Millisecond
+			readMetrics  = &testMetrics{}
+			writeMetrics = &testMetrics{}
+		)
+		client := &codersdk.Client{
+			HTTPClient: &http.Client{},
+		}
+		runner := workspacetraffic.NewRunner(client, workspacetraffic.Config{
+			BytesPerTick: int64(bytesPerTick),
+			TickInterval: tickInterval,
+			Duration:     testutil.WaitLong,
+			ReadMetrics:  readMetrics,
+			WriteMetrics: writeMetrics,
+			App: workspacetraffic.AppConfig{
+				Name: "echo",
+				URL:  srv.URL,
+			},
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var logs strings.Builder
+
+		runDone := make(chan struct{})
+		go func() {
+			defer close(runDone)
+			err := runner.Run(ctx, "", &logs)
+			assert.NoError(t, err, "unexpected error calling Run()")
+		}()
+
+		gotMetrics := make(chan struct{})
+		go func() {
+			defer close(gotMetrics)
+			// Wait until we get some non-zero metrics before canceling.
+			assert.Eventually(t, func() bool {
+				readLatencies := readMetrics.Latencies()
+				writeLatencies := writeMetrics.Latencies()
+				return len(readLatencies) > 0 &&
+					len(writeLatencies) > 0 &&
+					slices.ContainsFunc(readLatencies, func(f float64) bool { return f > 0.0 }) &&
+					slices.ContainsFunc(writeLatencies, func(f float64) bool { return f > 0.0 })
+			}, testutil.WaitLong, testutil.IntervalMedium, "expected non-zero metrics")
+		}()
+
+		// Stop the test after we get some non-zero metrics.
+		<-gotMetrics
+		cancel()
+		<-runDone
+
+		t.Logf("read errors: %.0f\n", readMetrics.Errors())
+		t.Logf("write errors: %.0f\n", writeMetrics.Errors())
+		t.Logf("bytes read total: %.0f\n", readMetrics.Total())
+		t.Logf("bytes written total: %.0f\n", writeMetrics.Total())
+
+		// We want to ensure the metrics are somewhat accurate.
+		assert.InDelta(t, readMetrics.Total(), writeMetrics.Total(), float64(bytesPerTick))
 		// Read is highly variable, depending on how far we read before stopping.
 		// Just ensure it's not zero.
 		assert.NotZero(t, readMetrics.Total())

--- a/scaletest/workspacetraffic/run_test.go
+++ b/scaletest/workspacetraffic/run_test.go
@@ -293,10 +293,10 @@ func TestRun(t *testing.T) {
 			defer nc.Close()
 
 			_, err = io.Copy(nc, nc)
-			if err != nil && !errors.Is(err, io.EOF) {
-				t.Error(err)
+			if err == nil || errors.Is(err, io.EOF) {
 				return
 			}
+			t.Error(err)
 		}))
 		defer srv.Close()
 

--- a/scaletest/workspacetraffic/run_test.go
+++ b/scaletest/workspacetraffic/run_test.go
@@ -143,11 +143,11 @@ func TestRun(t *testing.T) {
 		t.Logf("bytes read total: %.0f\n", readMetrics.Total())
 		t.Logf("bytes written total: %.0f\n", writeMetrics.Total())
 
-		// We want to ensure the metrics are somewhat accurate.
-		assert.InDelta(t, readMetrics.Total(), writeMetrics.Total(), float64(bytesPerTick))
-		// Read is highly variable, depending on how far we read before stopping.
-		// Just ensure it's not zero.
+		// Ensure something was both read and written.
 		assert.NotZero(t, readMetrics.Total())
+		assert.NotZero(t, writeMetrics.Total())
+		// We want to ensure the metrics are somewhat accurate.
+		assert.InDelta(t, writeMetrics.Total(), readMetrics.Total(), float64(bytesPerTick)*10)
 		// Latency should report non-zero values.
 		assert.NotEmpty(t, readMetrics.Latencies())
 		assert.NotEmpty(t, writeMetrics.Latencies())
@@ -263,11 +263,11 @@ func TestRun(t *testing.T) {
 		t.Logf("bytes read total: %.0f\n", readMetrics.Total())
 		t.Logf("bytes written total: %.0f\n", writeMetrics.Total())
 
-		// We want to ensure the metrics are somewhat accurate.
-		assert.InDelta(t, readMetrics.Total(), writeMetrics.Total(), float64(bytesPerTick))
-		// Read is highly variable, depending on how far we read before stopping.
-		// Just ensure it's not zero.
+		// Ensure something was both read and written.
 		assert.NotZero(t, readMetrics.Total())
+		assert.NotZero(t, writeMetrics.Total())
+		// We want to ensure the metrics are somewhat accurate.
+		assert.InDelta(t, writeMetrics.Total(), readMetrics.Total(), float64(bytesPerTick)*10)
 		// Latency should report non-zero values.
 		assert.NotEmpty(t, readMetrics.Latencies())
 		assert.NotEmpty(t, writeMetrics.Latencies())
@@ -358,11 +358,11 @@ func TestRun(t *testing.T) {
 		t.Logf("bytes read total: %.0f\n", readMetrics.Total())
 		t.Logf("bytes written total: %.0f\n", writeMetrics.Total())
 
-		// We want to ensure the metrics are somewhat accurate.
-		assert.InDelta(t, readMetrics.Total(), writeMetrics.Total(), float64(bytesPerTick))
-		// Read is highly variable, depending on how far we read before stopping.
-		// Just ensure it's not zero.
+		// Ensure something was both read and written.
 		assert.NotZero(t, readMetrics.Total())
+		assert.NotZero(t, writeMetrics.Total())
+		// We want to ensure the metrics are somewhat accurate.
+		assert.InDelta(t, writeMetrics.Total(), readMetrics.Total(), float64(bytesPerTick)*10)
 		// Latency should report non-zero values.
 		assert.NotEmpty(t, readMetrics.Latencies())
 		assert.NotEmpty(t, writeMetrics.Latencies())


### PR DESCRIPTION
This implementation is quite specific to our usage and only supports app communication over WebSocket. An example command/workspace template could look like this:

```shell
coder exp scaletest workspace-traffic --template scaletest-ws --app wsec --bytes-per-tick $((1024*100)) --tick-interval 1ms --job-timeout 10s
```

```tf
resource "coder_script" "websocat" {
  agent_id     = coder_agent.main.id
  display_name = "websocat"
  script       = <<EOF
curl -sSL -o /tmp/websocat https://github.com/vi/websocat/releases/download/v1.12.0/websocat.x86_64-unknown-linux-musl
chmod +x /tmp/websocat

/tmp/websocat --exit-on-eof --binary ws-l:127.0.0.1:1234 mirror: &
/tmp/websocat --exit-on-eof --binary ws-l:127.0.0.1:1235 cmd:'dd if=/dev/urandom' &
/tmp/websocat --exit-on-eof --binary ws-l:127.0.0.1:1236 cmd:'dd of=/dev/null' &
wait
EOF
  run_on_start = true
}

resource "coder_app" "ws_echo" {
  agent_id     = coder_agent.main.id
  slug         = "wsec" # Short slug so URL doesn't exceed limit: https://wsec--main--scaletest-UN9UmkDA-0--scaletest-SMXCCYVP-0--apps.big.cdr.dev
  display_name = "WebSocket Echo"
  url          = "http://localhost:1234"
  subdomain    = true
  share        = "authenticated"
}

resource "coder_app" "ws_random" {
  agent_id     = coder_agent.main.id
  slug         = "wsra" # Short slug so URL doesn't exceed limit: https://wsra--main--scaletest-UN9UmkDA-0--scaletest-SMXCCYVP-0--apps.big.cdr.dev
  display_name = "WebSocket Random"
  url          = "http://localhost:1235"
  subdomain    = true
  share        = "authenticated"
}

resource "coder_app" "ws_discard" {
  agent_id     = coder_agent.main.id
  slug         = "wsdi" # Short slug so URL doesn't exceed limit: https://wsdi--main--scaletest-UN9UmkDA-0--scaletest-SMXCCYVP-0--apps.big.cdr.dev
  display_name = "WebSocket Discard"
  url          = "http://localhost:1236"
  subdomain    = true
  share        = "authenticated"
}
```

Closes #11175 by relaxing the read/write assertion in tests, the exact byte count is unimportant since our goal is to produce load.