### PR TITLE
fix: refresh all oauth links on external auth page

### DIFF
--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -362,7 +362,6 @@ func (api *API) listUserExternalAuths(rw http.ResponseWriter, r *http.Request) {
 				if err == nil && valid {
 					links[i] = newLink
 				}
-				break
 			}
 		}
 	}

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -336,6 +336,10 @@ func ExpectJSONMime(res *http.Response) error {
 
 // ReadBodyAsError reads the response as a codersdk.Response, and
 // wraps it in a codersdk.Error type for easy marshaling.
+//
+// This will always return an error, so only call it if the response failed
+// your expectations. Usually via status code checking.
+// nolint:staticcheck
 func ReadBodyAsError(res *http.Response) error {
 	if res == nil {
 		return xerrors.Errorf("no body returned")

--- a/codersdk/client_internal_test.go
+++ b/codersdk/client_internal_test.go
@@ -283,6 +283,17 @@ func Test_readBodyAsError(t *testing.T) {
 				assert.Equal(t, unexpectedJSON, sdkErr.Response.Detail)
 			},
 		},
+		{
+			// Even status code 200 should be considered an error if this function
+			// is called. There are parts of the code that require this function
+			// to always return an error.
+			name: "OKResp",
+			req:  nil,
+			res:  newResponse(http.StatusOK, jsonCT, marshal(map[string]any{})),
+			assert: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
 	}
 
 	for _, c := range tests {

--- a/enterprise/coderd/proxyhealth/proxyhealth.go
+++ b/enterprise/coderd/proxyhealth/proxyhealth.go
@@ -321,19 +321,17 @@ func (p *ProxyHealth) runOnce(ctx context.Context, now time.Time) (map[uuid.UUID
 				// readable.
 				builder.WriteString(fmt.Sprintf("unexpected status code %d. ", resp.StatusCode))
 				builder.WriteString(fmt.Sprintf("\nEncountered error, send a request to %q from the Coderd environment to debug this issue.", reqURL))
+				// err will always be non-nil
 				err := codersdk.ReadBodyAsError(resp)
-				if err != nil {
-					var apiErr *codersdk.Error
-					if xerrors.As(err, &apiErr) {
-						builder.WriteString(fmt.Sprintf("\nError Message: %s\nError Detail: %s", apiErr.Message, apiErr.Detail))
-						for _, v := range apiErr.Validations {
-							// Pretty sure this is not possible from the called endpoint, but just in case.
-							builder.WriteString(fmt.Sprintf("\n\tValidation: %s=%s", v.Field, v.Detail))
-						}
-					} else {
-						builder.WriteString(fmt.Sprintf("\nError: %s", err.Error()))
+				var apiErr *codersdk.Error
+				if xerrors.As(err, &apiErr) {
+					builder.WriteString(fmt.Sprintf("\nError Message: %s\nError Detail: %s", apiErr.Message, apiErr.Detail))
+					for _, v := range apiErr.Validations {
+						// Pretty sure this is not possible from the called endpoint, but just in case.
+						builder.WriteString(fmt.Sprintf("\n\tValidation: %s=%s", v.Field, v.Detail))
 					}
 				}
+				builder.WriteString(fmt.Sprintf("\nError: %s", err.Error()))
 
 				status.Report.Errors = []string{builder.String()}
 			case err != nil:


### PR DESCRIPTION
This does cause more traffic, but we were only refreshing the first oauth access token. 