### PR TITLE
feat(cli/ssh): allow multiple remote forwards and allow missing local file

### DIFF
--- a/cli/remoteforward.go
+++ b/cli/remoteforward.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"regexp"
 	"strconv"
 
@@ -67,18 +66,12 @@ func parseRemoteForwardTCP(matches []string) (net.Addr, net.Addr, error) {
 	return localAddr, remoteAddr, nil
 }
 
+// parseRemoteForwardUnixSocket parses a remote forward flag. Note that
+// we don't verify that the local socket path exists because the user
+// may create it later. This behavior matches OpenSSH.
 func parseRemoteForwardUnixSocket(matches []string) (net.Addr, net.Addr, error) {
 	remoteSocket := matches[1]
 	localSocket := matches[2]
-
-	fileInfo, err := os.Stat(localSocket)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if fileInfo.Mode()&os.ModeSocket == 0 {
-		return nil, nil, xerrors.New("File is not a Unix domain socket file")
-	}
 
 	remoteAddr := &net.UnixAddr{
 		Name: remoteSocket,

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -883,6 +883,103 @@ func TestSSH(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	// Test that we can remote forward multiple sockets, whether or not the
+	// local sockets exists at the time of establishing xthe SSH connection.
+	t.Run("RemoteForwardMultipleUnixSockets", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Test not supported on windows")
+		}
+
+		t.Parallel()
+
+		client, workspace, agentToken := setupWorkspaceForAgent(t)
+
+		_ = agenttest.New(t, client.URL, agentToken)
+		coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
+
+		// Wait super long so this doesn't flake on -race test.
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
+		defer cancel()
+
+		tmpdir := tempDirUnixSocket(t)
+
+		type testSocket struct {
+			local  string
+			remote string
+		}
+
+		args := []string{"ssh", workspace.Name}
+		var sockets []testSocket
+		for i := 0; i < 2; i++ {
+			localSock := filepath.Join(tmpdir, fmt.Sprintf("local-%d.sock", i))
+			remoteSock := filepath.Join(tmpdir, fmt.Sprintf("remote-%d.sock", i))
+			sockets = append(sockets, testSocket{
+				local:  localSock,
+				remote: remoteSock,
+			})
+			args = append(args, "--remote-forward", fmt.Sprintf("%s:%s", remoteSock, localSock))
+		}
+
+		inv, root := clitest.New(t, args...)
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t).Attach(inv)
+		inv.Stderr = pty.Output()
+
+		clitest.Start(t, inv.WithContext(ctx))
+
+		// Since something was output, it should be safe to write input.
+		// This could show a prompt or "running startup scripts", so it's
+		// not indicative of the SSH connection being ready.
+		_ = pty.Peek(ctx, 1)
+
+		// Ensure the SSH connection is ready by testing the shell
+		// input/output.
+		pty.WriteLine("echo ping' 'pong")
+		pty.ExpectMatchContext(ctx, "ping pong")
+
+		for i, sock := range sockets {
+			i := i
+			// Start the listener on the "local machine".
+			l, err := net.Listen("unix", sock.local)
+			require.NoError(t, err)
+			defer l.Close() //nolint:revive // Defer is fine in this loop, we only run it twice.
+			testutil.Go(t, func() {
+				for {
+					fd, err := l.Accept()
+					if err != nil {
+						if !errors.Is(err, net.ErrClosed) {
+							assert.NoError(t, err, "listener accept failed", i)
+						}
+						return
+					}
+
+					testutil.Go(t, func() {
+						defer fd.Close()
+						agentssh.Bicopy(ctx, fd, fd)
+					})
+				}
+			})
+
+			// Dial the forwarded socket on the "remote machine".
+			d := &net.Dialer{}
+			fd, err := d.DialContext(ctx, "unix", sock.remote)
+			require.NoError(t, err, i)
+			defer fd.Close() //nolint:revive // Defer is fine in this loop, we only run it twice.
+
+			// Ping / pong to ensure the socket is working.
+			_, err = fd.Write([]byte("hello world"))
+			require.NoError(t, err, i)
+
+			buf := make([]byte, 11)
+			_, err = fd.Read(buf)
+			require.NoError(t, err, i)
+			require.Equal(t, "hello world", string(buf), i)
+		}
+
+		// And we're done.
+		pty.WriteLine("exit")
+	})
+
 	t.Run("FileLogging", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -925,7 +925,8 @@ func TestSSH(t *testing.T) {
 		pty := ptytest.New(t).Attach(inv)
 		inv.Stderr = pty.Output()
 
-		clitest.Start(t, inv.WithContext(ctx))
+		w := clitest.StartWithWaiter(t, inv.WithContext(ctx))
+		defer w.Wait() // We don't care about any exit error (exit code 255: SSH connection ended unexpectedly).
 
 		// Since something was output, it should be safe to write input.
 		// This could show a prompt or "running startup scripts", so it's

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -33,7 +33,7 @@ OPTIONS:
           behavior as non-blocking.
           DEPRECATED: Use --wait instead.
 
-  -R, --remote-forward string, $CODER_SSH_REMOTE_FORWARD
+  -R, --remote-forward string-array, $CODER_SSH_REMOTE_FORWARD
           Enable remote port forwarding (remote_port:local_address:local_port).
 
       --stdio bool, $CODER_SSH_STDIO

--- a/docs/cli/ssh.md
+++ b/docs/cli/ssh.md
@@ -71,7 +71,7 @@ Enter workspace immediately after the agent has connected. This is the default i
 
 |             |                                        |
 | ----------- | -------------------------------------- |
-| Type        | <code>string</code>                    |
+| Type        | <code>string-array</code>              |
 | Environment | <code>$CODER_SSH_REMOTE_FORWARD</code> |
 
 Enable remote port forwarding (remote_port:local_address:local_port).


### PR DESCRIPTION
While working on #11631 I found myself needing the ability to do multiple remote forwards to compare the behavior between our client and OpenSSH. Created a PR for this since I think it's a useful addition.

Similar to OpenSSH, we no longer require the presence of the local file. Its presence is only relevant at exactly the moment someone tries to connect to it. Likewise, we don't enforced the presence at runtime, so to achieve this you'd have to fool the SSH command during init, and then you can do whatever you want with the socket afterwards.