### PR TITLE
feat: automatically activate dormant workspaces when manually started

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -125,6 +125,16 @@ func buildWorkspaceStartRequest(inv *clibase.Invocation, client *codersdk.Client
 }
 
 func startWorkspace(inv *clibase.Invocation, client *codersdk.Client, workspace codersdk.Workspace, parameterFlags workspaceParameterFlags, action WorkspaceCLIAction) (codersdk.WorkspaceBuild, error) {
+	if workspace.DormantAt != nil {
+		_, _ = fmt.Fprint(inv.Stdout, "Activating dormant workspace...")
+		err := client.UpdateWorkspaceDormancy(inv.Context(), workspace.ID, codersdk.UpdateWorkspaceDormancy{
+			Dormant: false,
+		})
+		if err != nil {
+			return codersdk.WorkspaceBuild{}, xerrors.Errorf("activate workspace: %w", err)
+		}
+		_, _ = fmt.Fprintln(inv.Stdout, "OK")
+	}
 	req, err := buildWorkspaceStartRequest(inv, client, workspace, parameterFlags, action)
 	if err != nil {
 		return codersdk.WorkspaceBuild{}, err

--- a/cli/start.go
+++ b/cli/start.go
@@ -126,14 +126,13 @@ func buildWorkspaceStartRequest(inv *clibase.Invocation, client *codersdk.Client
 
 func startWorkspace(inv *clibase.Invocation, client *codersdk.Client, workspace codersdk.Workspace, parameterFlags workspaceParameterFlags, action WorkspaceCLIAction) (codersdk.WorkspaceBuild, error) {
 	if workspace.DormantAt != nil {
-		_, _ = fmt.Fprint(inv.Stdout, "Activating dormant workspace...")
+		_, _ = fmt.Fprintln(inv.Stdout, "Activating dormant workspace...")
 		err := client.UpdateWorkspaceDormancy(inv.Context(), workspace.ID, codersdk.UpdateWorkspaceDormancy{
 			Dormant: false,
 		})
 		if err != nil {
 			return codersdk.WorkspaceBuild{}, xerrors.Errorf("activate workspace: %w", err)
 		}
-		_, _ = fmt.Fprintln(inv.Stdout, "OK")
 	}
 	req, err := buildWorkspaceStartRequest(inv, client, workspace, parameterFlags, action)
 	if err != nil {

--- a/enterprise/cli/start_test.go
+++ b/enterprise/cli/start_test.go
@@ -167,4 +167,46 @@ func TestStart(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("StartActivatesDormant", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		ownerClient, owner := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAdvancedTemplateScheduling: 1,
+				},
+			},
+		})
+
+		version := coderdtest.CreateTemplateVersion(t, ownerClient, owner.OrganizationID, nil)
+		_ = coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version.ID)
+		template := coderdtest.CreateTemplate(t, ownerClient, owner.OrganizationID, version.ID)
+
+		memberClient, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+		workspace := coderdtest.CreateWorkspace(t, memberClient, owner.OrganizationID, template.ID)
+		_ = coderdtest.AwaitWorkspaceBuildJobCompleted(t, memberClient, workspace.LatestBuild.ID)
+		_ = coderdtest.MustTransitionWorkspace(t, memberClient, workspace.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+		err := memberClient.UpdateWorkspaceDormancy(ctx, workspace.ID, codersdk.UpdateWorkspaceDormancy{
+			Dormant: true,
+		})
+		require.NoError(t, err)
+
+		inv, root := newCLI(t, "start", workspace.Name)
+		clitest.SetupConfig(t, memberClient, root)
+
+		var buf bytes.Buffer
+		inv.Stdout = &buf
+
+		err = inv.Run()
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "Activating dormant workspace...OK")
+
+		workspace = coderdtest.MustWorkspace(t, memberClient, workspace.ID)
+		require.Equal(t, codersdk.WorkspaceTransitionStart, workspace.LatestBuild.Transition)
+	})
 }

--- a/enterprise/cli/start_test.go
+++ b/enterprise/cli/start_test.go
@@ -204,7 +204,7 @@ func TestStart(t *testing.T) {
 
 		err = inv.Run()
 		require.NoError(t, err)
-		require.Contains(t, buf.String(), "Activating dormant workspace...OK")
+		require.Contains(t, buf.String(), "Activating dormant workspace...")
 
 		workspace = coderdtest.MustWorkspace(t, memberClient, workspace.ID)
 		require.Equal(t, codersdk.WorkspaceTransitionStart, workspace.LatestBuild.Transition)


### PR DESCRIPTION
If a user is manually starting a workspace then we should automatically activate it if it's dormant. 