### PR TITLE
fix: avoid returning 500 on apps when workspace stopped

### DIFF
--- a/coderd/workspaceapps/db.go
+++ b/coderd/workspaceapps/db.go
@@ -103,6 +103,9 @@ func (p *DBTokenProvider) Issue(ctx context.Context, rw http.ResponseWriter, r *
 	if xerrors.Is(err, sql.ErrNoRows) {
 		WriteWorkspaceApp404(p.Logger, p.DashboardURL, rw, r, &appReq, nil, err.Error())
 		return nil, "", false
+	} else if xerrors.Is(err, errWorkspaceStopped) {
+		WriteWorkspaceOffline(p.Logger, p.DashboardURL, rw, r, &appReq)
+		return nil, "", false
 	} else if err != nil {
 		WriteWorkspaceApp500(p.Logger, p.DashboardURL, rw, r, &appReq, err, "get app details from database")
 		return nil, "", false

--- a/coderd/workspaceapps/request.go
+++ b/coderd/workspaceapps/request.go
@@ -17,6 +17,8 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+var errWorkspaceStopped = xerrors.New("stopped workspace")
+
 type AccessMethod string
 
 const (
@@ -260,10 +262,17 @@ func (r Request) getDatabase(ctx context.Context, db database.Store) (*databaseR
 	if err != nil {
 		return nil, xerrors.Errorf("get workspace agents: %w", err)
 	}
+	build, err := db.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
+	if err != nil {
+		return nil, xerrors.Errorf("get latest workspace build: %w", err)
+	}
+	if build.Transition == database.WorkspaceTransitionStop {
+		return nil, errWorkspaceStopped
+	}
 	if len(agents) == 0 {
 		// TODO(@deansheather): return a 404 if there are no agents in the
 		// workspace, requires a different error type.
-		return nil, xerrors.New("no agents in workspace")
+		return nil, xerrors.Errorf("no agents in workspace: %w", sql.ErrNoRows)
 	}
 
 	// Get workspace apps.

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -191,7 +191,8 @@ const TerminalPage: FC = () => {
       return;
     } else if (!workspaceAgent) {
       terminal.writeln(
-        Language.workspaceAgentErrorMessagePrefix + "no agent found with ID, is the workspace started?",
+        Language.workspaceAgentErrorMessagePrefix +
+          "no agent found with ID, is the workspace started?",
       );
       return;
     }

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -191,7 +191,7 @@ const TerminalPage: FC = () => {
       return;
     } else if (!workspaceAgent) {
       terminal.writeln(
-        Language.workspaceAgentErrorMessagePrefix + "no agent found with ID",
+        Language.workspaceAgentErrorMessagePrefix + "no agent found with ID, is the workspace started?",
       );
       return;
     }


### PR DESCRIPTION
Currently we return a 500 error when trying to access workspace apps when a workspace is in the stopped state. This is mainly because we weren't wrapping `sql.ErrNoRows` when no workspace agents are returned. In such cases we want to return a `404` which makes sense since we can't find the agent we want to route it to; however, this is more an implementation detail and would be confusing to the user in the majority of cases where the agents are "destroyed" due to terraform. I added a `400` for the case where the workspace is stopped to help the error be a bit more informative to the user.

fixes https://github.com/coder/coder/issues/11106

<img width="906" alt="Screenshot 2024-01-16 at 6 52 20 PM" src="https://github.com/coder/coder/assets/4856196/26dc02b7-99c4-4f58-94b3-b55ec2383bc8">
