### PR TITLE
chore: log Coderd port

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -332,6 +332,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 
 	tcpAddr, ok := srv.Listener.Addr().(*net.TCPAddr)
 	require.True(t, ok)
+	t.Logf("Coderd listening on %s", tcpAddr.String())
 
 	serverURL, err := url.Parse(srv.URL)
 	require.NoError(t, err)


### PR DESCRIPTION
Log out the Coderd port when starting the server.

I have a hunch that maybe we're seeing some port conflicts between Coderd and some echo server, which we use a lot in tests.
