### PR TITLE
fix:  revert "detect JetBrains running on local ipv6 (#11653)"

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -214,59 +214,46 @@ func TestAgent_Stats_Magic(t *testing.T) {
 		_, b, _, ok := runtime.Caller(0)
 		require.True(t, ok)
 		dir := filepath.Join(filepath.Dir(b), "../scripts/echoserver/main.go")
+		echoServerCmd := exec.Command("go", "run", dir,
+			"-D", agentssh.MagicProcessCmdlineJetBrains)
+		stdout, err := echoServerCmd.StdoutPipe()
+		require.NoError(t, err)
+		err = echoServerCmd.Start()
+		require.NoError(t, err)
+		defer echoServerCmd.Process.Kill()
 
-		spawnServer := func(network string) (string, *exec.Cmd) {
-			echoServerCmd := exec.Command("go", "run", dir,
-				network, "-D", agentssh.MagicProcessCmdlineJetBrains)
-			stdout, err := echoServerCmd.StdoutPipe()
-			require.NoError(t, err)
-			err = echoServerCmd.Start()
-			require.NoError(t, err)
-			t.Cleanup(func() {
-				echoServerCmd.Process.Kill()
-			})
-
-			// The echo server prints its port as the first line.
-			sc := bufio.NewScanner(stdout)
-			sc.Scan()
-			return sc.Text(), echoServerCmd
-		}
-
-		port4, cmd4 := spawnServer("tcp4")
-		port6, cmd6 := spawnServer("tcp6")
+		// The echo server prints its port as the first line.
+		sc := bufio.NewScanner(stdout)
+		sc.Scan()
+		remotePort := sc.Text()
 
 		//nolint:dogsled
 		conn, _, stats, _, _ := setupAgent(t, agentsdk.Manifest{}, 0)
-		defer conn.Close()
-
 		sshClient, err := conn.SSHClient(ctx)
 		require.NoError(t, err)
 
-		tunnel4, err := sshClient.Dial("tcp4", fmt.Sprintf("127.0.0.1:%s", port4))
+		tunneledConn, err := sshClient.Dial("tcp", fmt.Sprintf("127.0.0.1:%s", remotePort))
 		require.NoError(t, err)
-		defer tunnel4.Close()
-
-		tunnel6, err := sshClient.Dial("tcp6", fmt.Sprintf("[::]:%s", port6))
-		require.NoError(t, err)
-		defer tunnel6.Close()
+		t.Cleanup(func() {
+			// always close on failure of test
+			_ = conn.Close()
+			_ = tunneledConn.Close()
+		})
 
 		require.Eventuallyf(t, func() bool {
 			s, ok := <-stats
 			t.Logf("got stats with conn open: ok=%t, ConnectionCount=%d, SessionCountJetBrains=%d",
 				ok, s.ConnectionCount, s.SessionCountJetBrains)
 			return ok && s.ConnectionCount > 0 &&
-				s.SessionCountJetBrains == 2
+				s.SessionCountJetBrains == 1
 		}, testutil.WaitLong, testutil.IntervalFast,
 			"never saw stats with conn open",
 		)
 
 		// Kill the server and connection after checking for the echo.
-		requireEcho(t, tunnel4)
-		requireEcho(t, tunnel6)
-		_ = cmd4.Process.Kill()
-		_ = cmd6.Process.Kill()
-		_ = tunnel4.Close()
-		_ = tunnel6.Close()
+		requireEcho(t, tunneledConn)
+		_ = echoServerCmd.Process.Kill()
+		_ = tunneledConn.Close()
 
 		require.Eventuallyf(t, func() bool {
 			s, ok := <-stats

--- a/scripts/echoserver/main.go
+++ b/scripts/echoserver/main.go
@@ -9,21 +9,10 @@ import (
 	"io"
 	"log"
 	"net"
-	"os"
 )
 
 func main() {
-	network := os.Args[1]
-	var address string
-	switch network {
-	case "tcp4":
-		address = "127.0.0.1"
-	case "tcp6":
-		address = "[::]"
-	default:
-		log.Fatalf("invalid network: %s", network)
-	}
-	l, err := net.Listen(network, address+":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		log.Fatalf("listen error: err=%s", err)
 	}


### PR DESCRIPTION
Fixes #11659 

This reverts commit #11653 

I think what's happening is that Linux allows two different things to bind to the same port if one binds to IPv4 and another binds to IPv6. However, in `coderdtest` we start a test server which binds to `127.0.0.1:0`, and then overwrite the accessURL to `http://localhost:<port>`.  `localhost` is ambiguous, so when the HTTP client then tries to dial, it will first try the IPv6 local IP (`::1`) before it tries IPv4 (`127.0.0.1`).  If we happen to hit a port conflict, we hit the echo server, which triggers the HTTP protocol error.