### PR TITLE
feat: change owner name using account form

### DIFF
--- a/examples/templates/devcontainer-docker/main.tf
+++ b/examples/templates/devcontainer-docker/main.tf
@@ -36,9 +36,9 @@ resource "coder_agent" "main" {
   # You can remove this block if you'd prefer to configure Git manually or using
   # dotfiles. (see docs/dotfiles.md)
   env = {
-    GIT_AUTHOR_NAME     = "${data.coder_workspace.me.owner}"
-    GIT_COMMITTER_NAME  = "${data.coder_workspace.me.owner}"
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace.me.owner_email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace.me.owner_email}"
   }
 

--- a/examples/templates/devcontainer-kubernetes/main.tf
+++ b/examples/templates/devcontainer-kubernetes/main.tf
@@ -61,9 +61,9 @@ resource "coder_agent" "main" {
   # You can remove this block if you'd prefer to configure Git manually or using
   # dotfiles. (see docs/dotfiles.md)
   env = {
-    GIT_AUTHOR_NAME     = "${data.coder_workspace.me.owner}"
-    GIT_COMMITTER_NAME  = "${data.coder_workspace.me.owner}"
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace.me.owner_email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace.me.owner_email}"
   }
 

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -39,9 +39,9 @@ resource "coder_agent" "main" {
   # You can remove this block if you'd prefer to configure Git manually or using
   # dotfiles. (see docs/dotfiles.md)
   env = {
-    GIT_AUTHOR_NAME     = "${data.coder_workspace.me.owner}"
-    GIT_COMMITTER_NAME  = "${data.coder_workspace.me.owner}"
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
     GIT_AUTHOR_EMAIL    = "${data.coder_workspace.me.owner_email}"
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace.me.owner_name, data.coder_workspace.me.owner)
     GIT_COMMITTER_EMAIL = "${data.coder_workspace.me.owner_email}"
   }
 

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountForm.stories.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountForm.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof AccountForm> = {
     isLoading: false,
     initialValues: {
       username: "test-user",
-      name: "",
+      name: "Test User",
     },
     updateProfileError: undefined,
   },

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountForm.test.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountForm.test.tsx
@@ -13,7 +13,7 @@ describe("AccountForm", () => {
       // Given
       const mockInitialValues: UpdateUserProfileRequest = {
         username: MockUser2.username,
-        name: "",
+        name: MockUser2.name,
       };
 
       // When
@@ -44,7 +44,7 @@ describe("AccountForm", () => {
       // Given
       const mockInitialValues: UpdateUserProfileRequest = {
         username: MockUser2.username,
-        name: "",
+        name: MockUser2.name,
       };
 
       // When

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountForm.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountForm.tsx
@@ -15,6 +15,7 @@ import LoadingButton from "@mui/lab/LoadingButton";
 export const Language = {
   usernameLabel: "Username",
   emailLabel: "Email",
+  nameLabel: "Name",
   updateSettings: "Update account",
 };
 
@@ -71,6 +72,18 @@ export const AccountForm: FC<AccountFormProps> = ({
           disabled={!editable}
           fullWidth
           label={Language.usernameLabel}
+        />
+        <TextField
+          {...getFieldHelpers("name")}
+          onBlur={(e) => {
+            e.target.value = e.target.value.trim();
+            form.handleChange(e);
+          }}
+          aria-disabled={!editable}
+          disabled={!editable}
+          fullWidth
+          label={Language.nameLabel}
+          helperText='The human-readable name is optional and can be accessed in a template via the "data.coder_workspace.me.owner_name" property.'
         />
 
         <div>

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.test.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.test.tsx
@@ -7,13 +7,17 @@ import { mockApiError } from "testHelpers/entities";
 
 const newData = {
   username: "user",
-  name: "",
+  name: "Mr User",
 };
 
 const fillAndSubmitForm = async () => {
   await waitFor(() => screen.findByLabelText("Username"));
   fireEvent.change(screen.getByLabelText("Username"), {
     target: { value: newData.username },
+  });
+  await waitFor(() => screen.findByLabelText("Name"));
+  fireEvent.change(screen.getByLabelText("Name"), {
+    target: { value: newData.name },
   });
   fireEvent.click(screen.getByText(AccountForm.Language.updateSettings));
 };

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -315,7 +315,7 @@ export const MockUser2: TypesGen.User = {
   last_seen_at: "2022-09-14T19:12:21Z",
   login_type: "oidc",
   theme_preference: "",
-  name: "",
+  name: "Mock User The Second",
 };
 
 export const SuspendedMockUser: TypesGen.User = {


### PR DESCRIPTION
Closes: https://github.com/coder/coder/issues/9883

This PR enables Coder users to edit their real names using the Account form. It also adjusts examples to show the usage of the new workspace "me" property.

<img width="845" alt="Screenshot 2024-01-18 at 11 44 23" src="https://github.com/coder/coder/assets/14044910/d295cd8e-92a2-4f45-9f1f-9391949ecdad">
