### PR TITLE
fix: use raw syscalls to write binary we execute

### DIFF
--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -123,6 +123,10 @@ func (e *executor) execParseJSON(ctx, killCtx context.Context, args, env []strin
 	cmd.Stdout = out
 	cmd.Stderr = stdErr
 
+	e.server.logger.Debug(ctx, "executing terraform command with JSON result",
+		slog.F("binary_path", e.binaryPath),
+		slog.F("args", args),
+	)
 	err := cmd.Start()
 	if err != nil {
 		return err
@@ -348,6 +352,10 @@ func (e *executor) graph(ctx, killCtx context.Context) (string, error) {
 	cmd.Dir = e.workdir
 	cmd.Env = e.basicEnv()
 
+	e.server.logger.Debug(ctx, "executing terraform command graph",
+		slog.F("binary_path", e.binaryPath),
+		slog.F("args", "graph"),
+	)
 	err := cmd.Start()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes flake seen here, I think

https://github.com/coder/coder/actions/runs/7565915337/job/20602500818

golang's file processing is complex, and in at least some cases it can return from a file.Close() call without having actually closed the file descriptor.

If we're holding open the file descriptor of an executable we just wrote, and try to execute it, it will fail with "text file busy" which is what we have seen.

So, to be extra sure, I've avoided the standard library and directly called the syscalls to open, write, and close the file we intend to use in the test.

I've also added some more logging so if it's some issue of multiple tests writing to the same location, the we might have a chance to see it.
