### PR TITLE
chore: add a story for `WorkspaceOutdatedTooltip`

### DIFF
--- a/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.stories.tsx
+++ b/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.stories.tsx
@@ -1,0 +1,32 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useQueryClient } from "react-query";
+import { MockTemplateVersion, MockTemplate } from "testHelpers/entities";
+import { WorkspaceOutdatedTooltip } from "./WorkspaceOutdatedTooltip";
+
+const meta: Meta<typeof WorkspaceOutdatedTooltip> = {
+  title: "components/WorkspaceOutdatedTooltip",
+  component: WorkspaceOutdatedTooltip,
+  decorators: [
+    (Story) => {
+      const queryClient = useQueryClient();
+      queryClient.setQueryData(
+        ["templateVersion", MockTemplateVersion.id],
+        MockTemplateVersion,
+      );
+      return <Story />;
+    },
+  ],
+  args: {
+    onUpdateVersion: action("onUpdateVersion"),
+    templateName: MockTemplate.display_name,
+    latestVersionId: MockTemplateVersion.id,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof WorkspaceOutdatedTooltip>;
+
+const Example: Story = {};
+
+export { Example as WorkspaceOutdatedTooltip };

--- a/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.stories.tsx
+++ b/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.stories.tsx
@@ -1,22 +1,19 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useQueryClient } from "react-query";
 import { MockTemplateVersion, MockTemplate } from "testHelpers/entities";
 import { WorkspaceOutdatedTooltip } from "./WorkspaceOutdatedTooltip";
 
 const meta: Meta<typeof WorkspaceOutdatedTooltip> = {
   title: "components/WorkspaceOutdatedTooltip",
   component: WorkspaceOutdatedTooltip,
-  decorators: [
-    (Story) => {
-      const queryClient = useQueryClient();
-      queryClient.setQueryData(
-        ["templateVersion", MockTemplateVersion.id],
-        MockTemplateVersion,
-      );
-      return <Story />;
-    },
-  ],
+  parameters: {
+    queries: [
+      {
+        key: ["templateVersion", MockTemplateVersion.id],
+        data: MockTemplateVersion,
+      },
+    ],
+  },
   args: {
     onUpdateVersion: action("onUpdateVersion"),
     templateName: MockTemplate.display_name,

--- a/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
+++ b/site/src/components/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip.tsx
@@ -26,8 +26,8 @@ export const Language = {
 
 interface TooltipProps {
   onUpdateVersion: () => void;
-  latestVersionId: string;
   templateName: string;
+  latestVersionId: string;
   ariaLabel?: string;
 }
 


### PR DESCRIPTION
<img width="346" alt="Screenshot 2024-01-18 at 4 19 18 PM" src="https://github.com/coder/coder/assets/418348/d6996c4f-af67-4af7-8f4f-12b016cbb4a1">

Can be improved later when we figure out the whole Storybook/Chromatic interactions thing, but does the whole data mocking thing that the cool kids are on these days