### PR TITLE
feat(cli/exp): add target workspace/users to scaletest commands

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -857,11 +857,12 @@ func (r *RootCmd) scaletestCreateWorkspaces() *clibase.Cmd {
 
 func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 	var (
-		tickInterval time.Duration
-		bytesPerTick int64
-		ssh          bool
-		app          string
-		template     string
+		tickInterval     time.Duration
+		bytesPerTick     int64
+		ssh              bool
+		app              string
+		template         string
+		targetWorkspaces string
 
 		client          = &codersdk.Client{}
 		tracingFlags    = &scaletestTracingFlags{}
@@ -912,6 +913,10 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 					return xerrors.Errorf("parse template: %w", err)
 				}
 			}
+			targetWorkspaceStart, targetWorkspaceEnd, err := parseTargetWorkspaces(targetWorkspaces)
+			if err != nil {
+				return xerrors.Errorf("parse target workspaces: %w", err)
+			}
 
 			appHost, err := client.AppHost(ctx)
 			if err != nil {
@@ -923,8 +928,15 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 				return err
 			}
 
+			if targetWorkspaceEnd == 0 {
+				targetWorkspaceEnd = len(workspaces)
+			}
+
 			if len(workspaces) == 0 {
 				return xerrors.Errorf("no scaletest workspaces exist")
+			}
+			if targetWorkspaceEnd > len(workspaces) {
+				return xerrors.Errorf("target workspace end %d is greater than the number of workspaces %d", targetWorkspaceEnd, len(workspaces))
 			}
 
 			tracerProvider, closeTracing, tracingEnabled, err := tracingFlags.provider(ctx)
@@ -951,6 +963,10 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 
 			th := harness.NewTestHarness(strategy.toStrategy(), cleanupStrategy.toStrategy())
 			for idx, ws := range workspaces {
+				if idx < targetWorkspaceStart || idx >= targetWorkspaceEnd {
+					continue
+				}
+
 				var (
 					agent codersdk.WorkspaceAgent
 					name  = "workspace-traffic"
@@ -1038,6 +1054,12 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 			Env:           "CODER_SCALETEST_TEMPLATE",
 			Description:   "Name or ID of the template. Traffic generation will be limited to workspaces created from this template.",
 			Value:         clibase.StringOf(&template),
+		},
+		{
+			Flag:        "target-workspaces",
+			Env:         "CODER_SCALETEST_TARGET_WORKSPACES",
+			Description: "Target a specific range of workspaces in the format [START]:[END] (exclusive). Example: 0:10 will target workspaces the 10 first alphabetically sorted workspaces (0-9).",
+			Value:       clibase.StringOf(&targetWorkspaces),
 		},
 		{
 			Flag:        "bytes-per-tick",
@@ -1428,6 +1450,33 @@ func parseTemplate(ctx context.Context, client *codersdk.Client, organizationIDs
 	}
 
 	return tpl, nil
+}
+
+func parseTargetWorkspaces(targetWorkspaces string) (start, end int, err error) {
+	if targetWorkspaces == "" {
+		return 0, 0, nil
+	}
+
+	parts := strings.Split(targetWorkspaces, ":")
+	if len(parts) != 2 {
+		return 0, 0, xerrors.Errorf("invalid target workspaces %q", targetWorkspaces)
+	}
+
+	start, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, xerrors.Errorf("invalid target workspaces %q: %w", targetWorkspaces, err)
+	}
+
+	end, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, xerrors.Errorf("invalid target workspaces %q: %w", targetWorkspaces, err)
+	}
+
+	if start == end {
+		return 0, 0, xerrors.Errorf("invalid target workspaces %q: start and end cannot be equal", targetWorkspaces)
+	}
+
+	return start, end, nil
 }
 
 func createWorkspaceAppConfig(client *codersdk.Client, appHost, app string, workspace codersdk.Workspace, agent codersdk.WorkspaceAgent) (workspacetraffic.AppConfig, error) {

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1493,6 +1493,9 @@ func parseTargetRange(name, targets string) (start, end int, err error) {
 	if start == end {
 		return 0, 0, xerrors.Errorf("invalid target %s %q: start and end cannot be equal", name, targets)
 	}
+	if end < start {
+		return 0, 0, xerrors.Errorf("invalid target %s %q: end cannot be less than start", name, targets)
+	}
 
 	return start, end, nil
 }

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -1058,7 +1058,7 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *clibase.Cmd {
 		{
 			Flag:        "target-workspaces",
 			Env:         "CODER_SCALETEST_TARGET_WORKSPACES",
-			Description: "Target a specific range of workspaces in the format [START]:[END] (exclusive). Example: 0:10 will target workspaces the 10 first alphabetically sorted workspaces (0-9).",
+			Description: "Target a specific range of workspaces in the format [START]:[END] (exclusive). Example: 0:10 will target the 10 first alphabetically sorted workspaces (0-9).",
 			Value:       clibase.StringOf(&targetWorkspaces),
 		},
 		{

--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -117,6 +117,31 @@ func TestScaleTestWorkspaceTraffic_Template(t *testing.T) {
 }
 
 // This test just validates that the CLI command accepts its known arguments.
+func TestScaleTestWorkspaceTraffic_TargetWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancelFunc()
+
+	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	client := coderdtest.New(t, &coderdtest.Options{
+		Logger: &log,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	inv, root := clitest.New(t, "exp", "scaletest", "workspace-traffic",
+		"--target-workspaces", "0:0",
+	)
+	clitest.SetupConfig(t, client, root)
+	pty := ptytest.New(t)
+	inv.Stdout = pty.Output()
+	inv.Stderr = pty.Output()
+
+	err := inv.WithContext(ctx).Run()
+	require.ErrorContains(t, err, "invalid target workspaces \"0:0\": start and end cannot be equal")
+}
+
+// This test just validates that the CLI command accepts its known arguments.
 func TestScaleTestCleanup_Template(t *testing.T) {
 	t.Parallel()
 

--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -243,4 +243,27 @@ func TestScaleTestDashboard(t *testing.T) {
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err, "")
 	})
+
+	t.Run("TargetUsers", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
+		defer cancelFunc()
+
+		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		client := coderdtest.New(t, &coderdtest.Options{
+			Logger: &log,
+		})
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		inv, root := clitest.New(t, "exp", "scaletest", "dashboard",
+			"--target-users", "0:0",
+		)
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t)
+		inv.Stdout = pty.Output()
+		inv.Stderr = pty.Output()
+
+		err := inv.WithContext(ctx).Run()
+		require.ErrorContains(t, err, "invalid target users \"0:0\": start and end cannot be equal")
+	})
 }


### PR DESCRIPTION
This change allows us to create multiple workspaces and only perform certain tests against a range of them.
