### PR TITLE
chore: change SSH wording on workspace page

### DIFF
--- a/site/src/components/Resources/SSHButton/SSHButton.tsx
+++ b/site/src/components/Resources/SSHButton/SSHButton.tsx
@@ -41,7 +41,7 @@ export const SSHButton: FC<PropsWithChildren<SSHButtonProps>> = ({
           endIcon={<KeyboardArrowDown />}
           css={{ fontSize: 13, padding: "8px 12px" }}
         >
-          Connect to SSH
+          Connect via SSH
         </Button>
       </PopoverTrigger>
 


### PR DESCRIPTION
I think this is more accurate. I'm also ok with just `SSH`