### PR TITLE
chore: implement device auth flow for fake idp

### DIFF
--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -1080,7 +1080,7 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 			"verification_uri": {verifyURL},
 			"expires_in":       {strconv.Itoa(int(lifetime.Seconds()))},
 			"interval":         {"3"},
-		})
+		}.Encode())
 	}))
 
 	mux.NotFound(func(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -10,12 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -45,6 +47,13 @@ type token struct {
 	issued time.Time
 	email  string
 	exp    time.Time
+}
+
+type deviceFlow struct {
+	// userInput is the expected input to authenticate the device flow.
+	userInput string
+	exp       time.Time
+	granted   bool
 }
 
 // FakeIDP is a functional OIDC provider.
@@ -79,6 +88,9 @@ type FakeIDP struct {
 	refreshTokens        *syncmap.Map[string, string]
 	stateToIDTokenClaims *syncmap.Map[string, jwt.MapClaims]
 	refreshIDTokenClaims *syncmap.Map[string, jwt.MapClaims]
+	// Device flow
+	deviceCode      *syncmap.Map[string, deviceFlow]
+	deviceCodeInput *syncmap.Map[string, externalauth.ExchangeDeviceCodeResponse]
 
 	// hooks
 	// hookValidRedirectURL can be used to reject a redirect url from the
@@ -229,6 +241,7 @@ const (
 	keysPath      = "/oauth2/keys"
 	userInfoPath  = "/oauth2/userinfo"
 	deviceAuth    = "/login/device/code"
+	deviceVerify  = "/login/device"
 )
 
 func NewFakeIDP(t testing.TB, opts ...FakeIDPOpt) *FakeIDP {
@@ -249,6 +262,7 @@ func NewFakeIDP(t testing.TB, opts ...FakeIDPOpt) *FakeIDP {
 		refreshTokensUsed:    syncmap.New[string, bool](),
 		stateToIDTokenClaims: syncmap.New[string, jwt.MapClaims](),
 		refreshIDTokenClaims: syncmap.New[string, jwt.MapClaims](),
+		deviceCode:           syncmap.New[string, deviceFlow](),
 		hookOnRefresh:        func(_ string) error { return nil },
 		hookUserInfo:         func(email string) (jwt.MapClaims, error) { return jwt.MapClaims{}, nil },
 		hookValidRedirectURL: func(redirectURL string) error { return nil },
@@ -291,11 +305,12 @@ func (f *FakeIDP) updateIssuerURL(t testing.TB, issuer string) {
 	// ProviderJSON is the JSON representation of the OpenID Connect provider
 	// These are all the urls that the IDP will respond to.
 	f.provider = ProviderJSON{
-		Issuer:      issuer,
-		AuthURL:     u.ResolveReference(&url.URL{Path: authorizePath}).String(),
-		TokenURL:    u.ResolveReference(&url.URL{Path: tokenPath}).String(),
-		JWKSURL:     u.ResolveReference(&url.URL{Path: keysPath}).String(),
-		UserInfoURL: u.ResolveReference(&url.URL{Path: userInfoPath}).String(),
+		Issuer:        issuer,
+		AuthURL:       u.ResolveReference(&url.URL{Path: authorizePath}).String(),
+		TokenURL:      u.ResolveReference(&url.URL{Path: tokenPath}).String(),
+		JWKSURL:       u.ResolveReference(&url.URL{Path: keysPath}).String(),
+		UserInfoURL:   u.ResolveReference(&url.URL{Path: userInfoPath}).String(),
+		DeviceCodeURL: u.ResolveReference(&url.URL{Path: deviceAuth}).String(),
 		Algorithms: []string{
 			"RS256",
 		},
@@ -539,12 +554,13 @@ func (f *FakeIDP) OIDCCallback(t testing.TB, state string, idTokenClaims jwt.Map
 
 // ProviderJSON is the .well-known/configuration JSON
 type ProviderJSON struct {
-	Issuer      string   `json:"issuer"`
-	AuthURL     string   `json:"authorization_endpoint"`
-	TokenURL    string   `json:"token_endpoint"`
-	JWKSURL     string   `json:"jwks_uri"`
-	UserInfoURL string   `json:"userinfo_endpoint"`
-	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
+	Issuer        string   `json:"issuer"`
+	AuthURL       string   `json:"authorization_endpoint"`
+	TokenURL      string   `json:"token_endpoint"`
+	JWKSURL       string   `json:"jwks_uri"`
+	UserInfoURL   string   `json:"userinfo_endpoint"`
+	DeviceCodeURL string   `json:"device_authorization_endpoint"`
+	Algorithms    []string `json:"id_token_signing_alg_values_supported"`
 	// This is custom
 	ExternalAuthURL string `json:"external_auth_url"`
 }
@@ -712,8 +728,15 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 	}))
 
 	mux.Handle(tokenPath, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		values, err := f.authenticateOIDCClientRequest(t, r)
+		var values url.Values
+		var err error
+		if r.URL.Query().Get("grant_type") == "urn:ietf:params:oauth:grant-type:device_code" {
+			values = r.URL.Query()
+		} else {
+			values, err = f.authenticateOIDCClientRequest(t, r)
+		}
 		f.logger.Info(r.Context(), "http idp call token",
+			slog.F("url", r.URL.String()),
 			slog.F("valid", err == nil),
 			slog.F("grant_type", values.Get("grant_type")),
 			slog.F("values", values.Encode()),
@@ -789,6 +812,35 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 			f.refreshTokens.Delete(refreshToken)
 		case "urn:ietf:params:oauth:grant-type:device_code":
 			// Device flow
+			var resp externalauth.ExchangeDeviceCodeResponse
+			deviceCode := values.Get("device_code")
+			if deviceCode == "" {
+				resp.Error = "invalid_request"
+				resp.ErrorDescription = "missing device_code"
+				httpapi.Write(r.Context(), rw, http.StatusBadRequest, resp)
+				return
+			}
+
+			deviceFlow, ok := f.deviceCode.Load(deviceCode)
+			if !ok {
+				resp.Error = "invalid_request"
+				resp.ErrorDescription = "device_code provided not found"
+				httpapi.Write(r.Context(), rw, http.StatusBadRequest, resp)
+				return
+			}
+
+			if !deviceFlow.granted {
+				// Status code ok with the error as pending.
+				resp.Error = "authorization_pending"
+				resp.ErrorDescription = ""
+				httpapi.Write(r.Context(), rw, http.StatusOK, resp)
+				return
+			}
+
+			// Would be nice to get an actual email here.
+			claims = jwt.MapClaims{
+				"email": "unknown-dev-auth",
+			}
 		default:
 			t.Errorf("unexpected grant_type %q", values.Get("grant_type"))
 			http.Error(rw, "invalid grant_type", http.StatusBadRequest)
@@ -812,8 +864,19 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 		// Store the claims for the next refresh
 		f.refreshIDTokenClaims.Store(refreshToken, claims)
 
-		rw.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(rw).Encode(token)
+		if mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Accept")); mediaType == "application/json" {
+			rw.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(rw).Encode(token)
+			return
+		}
+
+		// Default to form encode. Just to make sure our code sets the right headers.
+		rw.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+		vals := url.Values{}
+		for k, v := range token {
+			vals.Set(k, fmt.Sprintf("%v", v))
+		}
+		_, _ = rw.Write([]byte(vals.Encode()))
 	}))
 
 	validateMW := func(rw http.ResponseWriter, r *http.Request) (email string, ok bool) {
@@ -891,10 +954,68 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 		_ = json.NewEncoder(rw).Encode(set)
 	}))
 
+	mux.Handle(deviceVerify, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		f.logger.Info(r.Context(), "http call device verify")
+
+		inputParam := "user_input"
+		userInput := r.URL.Query().Get(inputParam)
+		if userInput == "" {
+			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid user input",
+				Detail:  fmt.Sprintf("Hit this url again with ?%s=<user_code>", inputParam),
+			})
+			return
+		}
+
+		deviceCode := r.URL.Query().Get("device_code")
+		if deviceCode == "" {
+			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid device code",
+				Detail:  "Hit this url again with ?device_code=<device_code>",
+			})
+			return
+		}
+
+		flow, ok := f.deviceCode.Load(deviceCode)
+		if !ok {
+			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid device code",
+				Detail:  "Device code not found.",
+			})
+			return
+		}
+
+		if time.Now().After(flow.exp) {
+			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid device code",
+				Detail:  "Device code expired.",
+			})
+			return
+		}
+
+		if strings.TrimSpace(flow.userInput) != strings.TrimSpace(userInput) {
+			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid device code",
+				Detail:  "user code does not match",
+			})
+			return
+		}
+
+		f.deviceCode.Store(deviceCode, deviceFlow{
+			userInput: flow.userInput,
+			exp:       flow.exp,
+			granted:   true,
+		})
+		httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.Response{
+			Message: "Device authenticated!",
+		})
+	}))
+
 	mux.Handle(deviceAuth, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		f.logger.Info(r.Context(), "http call device auth")
+
 		p := httpapi.NewQueryParamParser()
 		p.Required("client_id")
-		p.Required("scopes")
 		clientID := p.String(r.URL.Query(), "", "client_id")
 		_ = p.String(r.URL.Query(), "", "scopes")
 		if len(p.Errors) > 0 {
@@ -912,24 +1033,42 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 			return
 		}
 
+		deviceCode := uuid.NewString()
+		lifetime := time.Second * 900
+		flow := deviceFlow{
+			userInput: fmt.Sprintf("%d", rand.Intn(9999999)+1e8),
+		}
+		f.deviceCode.Store(deviceCode, deviceFlow{
+			userInput: flow.userInput,
+			exp:       time.Now().Add(lifetime),
+		})
+
+		verifyURL := f.issuerURL.ResolveReference(&url.URL{
+			Path: deviceVerify,
+			RawQuery: url.Values{
+				"device_code": {deviceCode},
+				"user_input":  {flow.userInput},
+			}.Encode(),
+		}).String()
+
 		if mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Accept")); mediaType == "application/json" {
 			httpapi.Write(r.Context(), rw, http.StatusOK, map[string]any{
-				"device_code":      uuid.NewString(),
-				"user_code":        "1234",
-				"verification_uri": "",
-				"expires_in":       900,
-				"interval":         0,
+				"device_code":      deviceCode,
+				"user_code":        flow.userInput,
+				"verification_uri": verifyURL,
+				"expires_in":       int(lifetime.Seconds()),
+				"interval":         3,
 			})
 			return
 		}
 
 		// By default, GitHub form encodes these.
 		_, _ = fmt.Fprint(rw, url.Values{
-			"device_code":      {uuid.NewString()},
-			"user_code":        {"1234"},
-			"verification_uri": {""},
-			"expires_in":       {"900"},
-			"interval":         {"0"},
+			"device_code":      {deviceCode},
+			"user_code":        {flow.userInput},
+			"verification_uri": {verifyURL},
+			"expires_in":       {strconv.Itoa(int(lifetime.Seconds()))},
+			"interval":         {"3"},
 		})
 	}))
 
@@ -1034,6 +1173,8 @@ type ExternalAuthConfigOptions struct {
 	// completely customize the response. It captures all routes under the /external-auth-validate/*
 	// so the caller can do whatever they want and even add routes.
 	routes map[string]func(email string, rw http.ResponseWriter, r *http.Request)
+
+	UseDeviceAuth bool
 }
 
 func (o *ExternalAuthConfigOptions) AddRoute(route string, handle func(email string, rw http.ResponseWriter, r *http.Request)) *ExternalAuthConfigOptions {
@@ -1080,9 +1221,10 @@ func (f *FakeIDP) ExternalAuthConfig(t testing.TB, id string, custom *ExternalAu
 		}
 	}
 	instrumentF := promoauth.NewFactory(prometheus.NewRegistry())
+	oauthCfg := instrumentF.New(f.clientID, f.OIDCConfig(t, nil))
 	cfg := &externalauth.Config{
 		DisplayName:              id,
-		InstrumentedOAuth2Config: instrumentF.New(f.clientID, f.OIDCConfig(t, nil)),
+		InstrumentedOAuth2Config: oauthCfg,
 		ID:                       id,
 		// No defaults for these fields by omitting the type
 		Type:        "",
@@ -1090,7 +1232,19 @@ func (f *FakeIDP) ExternalAuthConfig(t testing.TB, id string, custom *ExternalAu
 		// Omit the /user for the validate so we can easily append to it when modifying
 		// the cfg for advanced tests.
 		ValidateURL: f.issuerURL.ResolveReference(&url.URL{Path: "/external-auth-validate/"}).String(),
+		DeviceAuth: &externalauth.DeviceAuth{
+			Config:   oauthCfg,
+			ClientID: f.clientID,
+			TokenURL: f.provider.TokenURL,
+			Scopes:   []string{},
+			CodeURL:  f.provider.DeviceCodeURL,
+		},
 	}
+
+	if !custom.UseDeviceAuth {
+		cfg.DeviceAuth = nil
+	}
+
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -1046,6 +1046,7 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 		deviceCode := uuid.NewString()
 		lifetime := time.Second * 900
 		flow := deviceFlow{
+			//nolint:gosec
 			userInput: fmt.Sprintf("%d", rand.Intn(9999999)+1e8),
 		}
 		f.deviceCode.Store(deviceCode, deviceFlow{

--- a/coderd/coderdtest/oidctest/idp.go
+++ b/coderd/coderdtest/oidctest/idp.go
@@ -89,8 +89,7 @@ type FakeIDP struct {
 	stateToIDTokenClaims *syncmap.Map[string, jwt.MapClaims]
 	refreshIDTokenClaims *syncmap.Map[string, jwt.MapClaims]
 	// Device flow
-	deviceCode      *syncmap.Map[string, deviceFlow]
-	deviceCodeInput *syncmap.Map[string, externalauth.ExchangeDeviceCodeResponse]
+	deviceCode *syncmap.Map[string, deviceFlow]
 
 	// hooks
 	// hookValidRedirectURL can be used to reject a redirect url from the
@@ -1031,7 +1030,7 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 		_ = p.String(r.URL.Query(), "", "scopes")
 		if len(p.Errors) > 0 {
 			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
-				Message:     fmt.Sprintf("Invalid query params"),
+				Message:     "Invalid query params",
 				Validations: p.Errors,
 			})
 			return
@@ -1039,7 +1038,7 @@ func (f *FakeIDP) httpHandler(t testing.TB) http.Handler {
 
 		if clientID != f.clientID {
 			httpapi.Write(r.Context(), rw, http.StatusBadRequest, codersdk.Response{
-				Message: fmt.Sprintf("Invalid client id"),
+				Message: "Invalid client id",
 			})
 			return
 		}

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -321,13 +323,31 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 	}
 	err = json.NewDecoder(resp.Body).Decode(&r)
 	if err != nil {
-		// Some status codes do not return json payloads, and we should
-		// return a better error.
-		switch resp.StatusCode {
-		case http.StatusTooManyRequests:
-			return nil, xerrors.New("rate limit hit, unable to authorize device. please try again later")
+		mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			mediaType = "unknown"
+		}
+
+		// If the json fails to decode, do a best effort to return a better error.
+		switch {
+		case resp.StatusCode == http.StatusTooManyRequests:
+			retryIn := "please try again later"
+			resetIn := resp.Header.Get("x-ratelimit-reset")
+			if resetIn != "" {
+				// Best effort to tell the user exactly how long they need
+				// to wait for.
+				unix, err := strconv.ParseInt(resetIn, 10, 64)
+				if err == nil {
+					waitFor := time.Unix(unix, 0).Sub(time.Now().Truncate(time.Second))
+					retryIn = fmt.Sprintf(" retry after %s", waitFor.Truncate(time.Second))
+				}
+			}
+			// 429 returns a plaintext payload with a message.
+			return nil, xerrors.New(fmt.Sprintf("rate limit hit, unable to authorize device. %s", retryIn))
+		case mediaType == "application/x-www-form-urlencoded":
+			return nil, xerrors.Errorf("status_code=%d, payload response is form-url encoded, expected a json payload", resp.StatusCode)
 		default:
-			return nil, fmt.Errorf("status_code=%d: %w", resp.StatusCode, err)
+			return nil, fmt.Errorf("status_code=%d, mediaType=%s: %w", resp.StatusCode, mediaType, err)
 		}
 	}
 	if r.ErrorDescription != "" {

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -321,13 +323,31 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 	}
 	err = json.NewDecoder(resp.Body).Decode(&r)
 	if err != nil {
-		// Some status codes do not return json payloads, and we should
-		// return a better error.
-		switch resp.StatusCode {
-		case http.StatusTooManyRequests:
-			return nil, xerrors.New("rate limit hit, unable to authorize device. please try again later")
+		mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			mediaType = "unknown"
+		}
+
+		// If the json fails to decode, do a best effort to return a better error.
+		switch {
+		case resp.StatusCode == http.StatusTooManyRequests:
+			retryIn := "please try again later"
+			resetIn := resp.Header.Get("x-ratelimit-reset")
+			if resetIn != "" {
+				// Best effort to tell the user exactly how long they need
+				// to wait for.
+				unix, err := strconv.ParseInt(resetIn, 10, 64)
+				if err == nil {
+					waitFor := time.Unix(unix, 0).Sub(time.Now().Truncate(time.Second))
+					retryIn = fmt.Sprintf(" retry after %s", waitFor.Truncate(time.Second))
+				}
+			}
+			// 429 returns a plaintext payload with a message.
+			return nil, xerrors.New(fmt.Sprintf("rate limit hit, unable to authorize device. %s", retryIn))
+		case mediaType == "application/x-www-form-urlencoded":
+			return nil, xerrors.Errorf("%s payload response is form-url encoded, expected a json payload", resp.StatusCode)
 		default:
-			return nil, xerrors.Errorf("status_code=%d: %w", resp.StatusCode, err)
+			return nil, fmt.Errorf("status_code=%d, mediaType=%s: %w", resp.StatusCode, mediaType, err)
 		}
 	}
 	if r.ErrorDescription != "" {

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -363,30 +362,6 @@ func TestExternalAuthDevice(t *testing.T) {
 		coderdtest.CreateFirstUser(t, client)
 		_, err := client.ExternalAuthDeviceByID(context.Background(), "test")
 		require.ErrorContains(t, err, "rate limit hit")
-	})
-
-	// If we forget to add the accept header, we get a form encoded body instead.
-	t.Run("FormEncodedBody", func(t *testing.T) {
-		t.Parallel()
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-			_, _ = w.Write([]byte(url.Values{"access_token": {"hey"}}.Encode()))
-		}))
-		defer srv.Close()
-		client := coderdtest.New(t, &coderdtest.Options{
-			ExternalAuthConfigs: []*externalauth.Config{{
-				ID: "test",
-				DeviceAuth: &externalauth.DeviceAuth{
-					ClientID: "test",
-					CodeURL:  srv.URL,
-					Scopes:   []string{"repo"},
-				},
-			}},
-		})
-		coderdtest.CreateFirstUser(t, client)
-		_, err := client.ExternalAuthDeviceByID(context.Background(), "test")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "is form-url encoded")
 	})
 }
 

--- a/coderd/externalauth_test.go
+++ b/coderd/externalauth_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -362,6 +363,30 @@ func TestExternalAuthDevice(t *testing.T) {
 		coderdtest.CreateFirstUser(t, client)
 		_, err := client.ExternalAuthDeviceByID(context.Background(), "test")
 		require.ErrorContains(t, err, "rate limit hit")
+	})
+
+	// If we forget to add the accept header, we get a form encoded body instead.
+	t.Run("FormEncodedBody", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+			_, _ = w.Write([]byte(url.Values{"access_token": {"hey"}}.Encode()))
+		}))
+		defer srv.Close()
+		client := coderdtest.New(t, &coderdtest.Options{
+			ExternalAuthConfigs: []*externalauth.Config{{
+				ID: "test",
+				DeviceAuth: &externalauth.DeviceAuth{
+					ClientID: "test",
+					CodeURL:  srv.URL,
+					Scopes:   []string{"repo"},
+				},
+			}},
+		})
+		coderdtest.CreateFirstUser(t, client)
+		_, err := client.ExternalAuthDeviceByID(context.Background(), "test")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "is form-url encoded")
 	})
 }
 


### PR DESCRIPTION
# Device Flow faking

**Device flow:** https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps

The fake IDP has been used to test all our oauth flows. I introduced a regression (fixed here https://github.com/coder/coder/pull/11706) because we were not checking the `Accept` header for the proper mime type. I could have just implemented that check, but I want to implement this for future testing. 

Will also implement better error handling to return a better error if this happens again.

https://github.com/coder/coder/assets/5446298/88309c55-45e0-4857-b21c-e4ecf6174be9

