### PR TITLE
chore: pass lifetime directly into api key generate

### DIFF
--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -82,13 +82,13 @@ func (api *API) postToken(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	cookie, key, err := api.createAPIKey(ctx, apikey.CreateParams{
-		UserID:           user.ID,
-		LoginType:        database.LoginTypeToken,
-		DeploymentValues: api.DeploymentValues,
-		ExpiresAt:        dbtime.Now().Add(lifeTime),
-		Scope:            scope,
-		LifetimeSeconds:  int64(lifeTime.Seconds()),
-		TokenName:        tokenName,
+		UserID:          user.ID,
+		LoginType:       database.LoginTypeToken,
+		DefaultLifetime: api.DeploymentValues.SessionDuration.Value(),
+		ExpiresAt:       dbtime.Now().Add(lifeTime),
+		Scope:           scope,
+		LifetimeSeconds: int64(lifeTime.Seconds()),
+		TokenName:       tokenName,
 	})
 	if err != nil {
 		if database.IsUniqueViolation(err, database.UniqueIndexAPIKeyName) {
@@ -127,10 +127,10 @@ func (api *API) postAPIKey(rw http.ResponseWriter, r *http.Request) {
 
 	lifeTime := time.Hour * 24 * 7
 	cookie, _, err := api.createAPIKey(ctx, apikey.CreateParams{
-		UserID:           user.ID,
-		DeploymentValues: api.DeploymentValues,
-		LoginType:        database.LoginTypePassword,
-		RemoteAddr:       r.RemoteAddr,
+		UserID:          user.ID,
+		DefaultLifetime: api.DeploymentValues.SessionDuration.Value(),
+		LoginType:       database.LoginTypePassword,
+		RemoteAddr:      r.RemoteAddr,
 		// All api generated keys will last 1 week. Browser login tokens have
 		// a shorter life.
 		ExpiresAt:       dbtime.Now().Add(lifeTime),

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1683,11 +1683,11 @@ func workspaceSessionTokenName(workspace database.Workspace) string {
 
 func (s *server) regenerateSessionToken(ctx context.Context, user database.User, workspace database.Workspace) (string, error) {
 	newkey, sessionToken, err := apikey.Generate(apikey.CreateParams{
-		UserID:           user.ID,
-		LoginType:        user.LoginType,
-		DeploymentValues: s.DeploymentValues,
-		TokenName:        workspaceSessionTokenName(workspace),
-		LifetimeSeconds:  int64(s.DeploymentValues.MaxTokenLifetime.Value().Seconds()),
+		UserID:          user.ID,
+		LoginType:       user.LoginType,
+		DefaultLifetime: s.DeploymentValues.SessionDuration.Value(),
+		TokenName:       workspaceSessionTokenName(workspace),
+		LifetimeSeconds: int64(s.DeploymentValues.MaxTokenLifetime.Value().Seconds()),
 	})
 	if err != nil {
 		return "", xerrors.Errorf("generate API key: %w", err)

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -247,10 +247,10 @@ func (api *API) postLogin(rw http.ResponseWriter, r *http.Request) {
 
 	//nolint:gocritic // Creating the API key as the user instead of as system.
 	cookie, key, err := api.createAPIKey(dbauthz.As(ctx, userSubj), apikey.CreateParams{
-		UserID:           user.ID,
-		LoginType:        database.LoginTypePassword,
-		RemoteAddr:       r.RemoteAddr,
-		DeploymentValues: api.DeploymentValues,
+		UserID:          user.ID,
+		LoginType:       database.LoginTypePassword,
+		RemoteAddr:      r.RemoteAddr,
+		DefaultLifetime: api.DeploymentValues.SessionDuration.Value(),
 	})
 	if err != nil {
 		logger.Error(ctx, "unable to create API key", slog.Error(err))
@@ -1545,10 +1545,10 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 	} else {
 		//nolint:gocritic
 		cookie, newKey, err := api.createAPIKey(dbauthz.AsSystemRestricted(ctx), apikey.CreateParams{
-			UserID:           user.ID,
-			LoginType:        params.LoginType,
-			DeploymentValues: api.DeploymentValues,
-			RemoteAddr:       r.RemoteAddr,
+			UserID:          user.ID,
+			LoginType:       params.LoginType,
+			DefaultLifetime: api.DeploymentValues.SessionDuration.Value(),
+			RemoteAddr:      r.RemoteAddr,
 		})
 		if err != nil {
 			return nil, database.APIKey{}, xerrors.Errorf("create API key: %w", err)

--- a/coderd/workspaceapps.go
+++ b/coderd/workspaceapps.go
@@ -107,12 +107,12 @@ func (api *API) workspaceApplicationAuth(rw http.ResponseWriter, r *http.Request
 		lifetimeSeconds = int64(api.DeploymentValues.SessionDuration.Value().Seconds())
 	}
 	cookie, _, err := api.createAPIKey(ctx, apikey.CreateParams{
-		UserID:           apiKey.UserID,
-		LoginType:        database.LoginTypePassword,
-		DeploymentValues: api.DeploymentValues,
-		ExpiresAt:        exp,
-		LifetimeSeconds:  lifetimeSeconds,
-		Scope:            database.APIKeyScopeApplicationConnect,
+		UserID:          apiKey.UserID,
+		LoginType:       database.LoginTypePassword,
+		DefaultLifetime: api.DeploymentValues.SessionDuration.Value(),
+		ExpiresAt:       exp,
+		LifetimeSeconds: lifetimeSeconds,
+		Scope:           database.APIKeyScopeApplicationConnect,
 	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{


### PR DESCRIPTION
This was pulled out of https://github.com/coder/coder/pull/11609.  I am trying to split up that PR so we can review and merge more easily.

Rather than passing all the deployment values, pass just the lifetime since that is all we use.  This is to make it easier to generate API keys as part of the oauth flow (otherwise we will need send the deployment values into the identity provider).

I also added and fixed a test for when the lifetime is set and the default and expiration are unset (was just missing a multiplication by `time.Second` to use seconds instead of nanoseconds or whatever the default is).