### PR TITLE
fix: make yarn from nix flake use the right version of node

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
         # Workaround for: terraform has an unfree license (‘bsl11’), refusing to evaluate.
         pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
         formatter = pkgs.nixpkgs-fmt;
+        nodejs = pkgs.nodejs-18_x;
+        yarn = pkgs.yarn.override { inherit nodejs; };
         # Check in https://search.nixos.org/packages to find new packages.
         # Use `nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update`
         # to update the lock file if packages are out-of-date.
@@ -46,11 +48,11 @@
           libuuid
           mockgen
           nfpm
-          nodejs-18_x
-          nodejs-18_x.pkgs.pnpm
-          nodejs-18_x.pkgs.prettier
-          nodejs-18_x.pkgs.typescript
-          nodejs-18_x.pkgs.typescript-language-server
+          nodejs
+          nodejs.pkgs.pnpm
+          nodejs.pkgs.prettier
+          nodejs.pkgs.typescript
+          nodejs.pkgs.typescript-language-server
           openssh
           openssl
           pango


### PR DESCRIPTION
Otherwise if for example you try to run `yarn storybook` it complains that the version of Node is wrong.

`pnpm storybook` works fine and maybe that is what we should actually use, but as long as we have yarn installed might as well make use the right thing.