### PR TITLE
fix: find jetbrains on ipv6 when port collides

### DIFF
--- a/agent/agentssh/jetbrainstrack.go
+++ b/agent/agentssh/jetbrainstrack.go
@@ -10,6 +10,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/util/slice"
 )
 
 // localForwardChannelData is copied from the ssh package.
@@ -38,30 +39,51 @@ func NewJetbrainsChannelWatcher(ctx ssh.Context, logger slog.Logger, newChannel 
 		return newChannel
 	}
 
-	// If we do get a port, we should be able to get the matching PID and from
-	// there look up the invocation.
-	cmdline, err := getListeningPortProcessCmdline(d.DestPort)
+	// If we do get a port, we should be able to get the matching PID(s) and from
+	// there look up the invocation(s).  For now, ignore the address because we
+	// would need to resolve the address (for example `localhost` has a number of
+	// possibilities, or ::1 might route to ::, and so on).  The consequence is
+	// that if a user has another forwarded process listening on a different
+	// address but the same port as an active JetBrains process then the count
+	// will be inflated by however many processes are doing that.
+	cmdlines, err := getListeningPortProcessCmdlines(d.DestPort)
+
+	// If any of these are JetBrains processes, wrap the channel in a watcher so
+	// we can increment and decrement the session count when the channel
+	// opens/closes.  We attempt to match on something that appears unique to
+	// JetBrains software.  As mentioned above, this can give false positives
+	// since we are not checking the address of each process.
+	if slice.ContainsCompare(cmdlines, strings.ToLower(MagicProcessCmdlineJetBrains),
+		func(magic, cmdline string) bool {
+			return strings.Contains(strings.ToLower(cmdline), magic)
+		}) {
+		logger.Debug(ctx, "discovered forwarded JetBrains process",
+			slog.F("destination_address", d.DestAddr),
+			slog.F("destination_port", d.DestPort))
+
+		return &JetbrainsChannelWatcher{
+			NewChannel:       newChannel,
+			jetbrainsCounter: counter,
+			logger: logger.With(
+				slog.F("destination_address", d.DestAddr),
+				slog.F("destination_port", d.DestPort),
+			),
+		}
+	}
+
+	// We do not want to break the forwarding if we were unable to inspect the
+	// port, so only log any errors.  The consequence of failing port inspection
+	// is that the JetBrains session count might be lower than it should be.
 	if err != nil {
 		logger.Warn(ctx, "failed to inspect port",
+			slog.F("destination_addr", d.DestAddr),
 			slog.F("destination_port", d.DestPort),
 			slog.Error(err))
-		return newChannel
 	}
 
-	// If this is not JetBrains, then we do not need to do anything special.  We
-	// attempt to match on something that appears unique to JetBrains software.
-	if !strings.Contains(strings.ToLower(cmdline), strings.ToLower(MagicProcessCmdlineJetBrains)) {
-		return newChannel
-	}
-
-	logger.Debug(ctx, "discovered forwarded JetBrains process",
-		slog.F("destination_port", d.DestPort))
-
-	return &JetbrainsChannelWatcher{
-		NewChannel:       newChannel,
-		jetbrainsCounter: counter,
-		logger:           logger.With(slog.F("destination_port", d.DestPort)),
-	}
+	// Either not a JetBrains process or we failed to figure it out.  Do nothing;
+	// just return the channel as-is.
+	return newChannel
 }
 
 func (w *JetbrainsChannelWatcher) Accept() (gossh.Channel, <-chan *gossh.Request, error) {

--- a/agent/agentssh/portinspection_supported.go
+++ b/agent/agentssh/portinspection_supported.go
@@ -11,41 +11,42 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func getListeningPortProcessCmdline(port uint32) (string, error) {
+/**
+ * getListeningPortProcessCmdlines looks up the full command line for all
+ * processes listening on the specified port regardless of their address.  It
+ * returns all the commands it was able to find and any errors encountered while
+ * doing the search.
+ */
+func getListeningPortProcessCmdlines(port uint32) ([]string, error) {
 	acceptFn := func(s *netstat.SockTabEntry) bool {
 		return s.LocalAddr != nil && uint32(s.LocalAddr.Port) == port
 	}
+
 	tabs4, err4 := netstat.TCPSocks(acceptFn)
 	tabs6, err6 := netstat.TCP6Socks(acceptFn)
 
-	// In the common case, we want to check ipv4 listening addresses.  If this
-	// fails, we should return an error.  We also need to check ipv6.  The
-	// assumption is, if we have an err4, and 0 ipv6 addresses listed, then we are
-	// interested in the err4 (and vice versa).  So return both errors (at least 1
-	// is non-nil) if the other list is empty.
-	if (err4 != nil && len(tabs6) == 0) || (err6 != nil && len(tabs4) == 0) {
-		return "", xerrors.Errorf("inspect port %d: %w", port, errors.Join(err4, err6))
+	allErrs := errors.Join(err4, err6)
+
+	var cmdlines []string
+	for _, tab := range append(tabs4, tabs6...) {
+		// If the process is nil then perhaps we were unable to read the process
+		// details (permission issues reading /proc/$pid/* maybe).
+		if tab.Process == nil {
+			allErrs = errors.Join(allErrs, xerrors.Errorf("read process on port %d", port))
+			continue
+		}
+		// The process name provided by go-netstat does not include the full command
+		// line so grab that instead.
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", tab.Process.Pid))
+		if err != nil {
+			allErrs = errors.Join(allErrs, xerrors.Errorf("read /proc/%d/cmdline: %w", tab.Process.Pid, err))
+			continue
+		}
+		cmdlines = append(cmdlines, string(data))
 	}
 
-	var proc *netstat.Process
-	if len(tabs4) > 0 {
-		proc = tabs4[0].Process
-	} else if len(tabs6) > 0 {
-		proc = tabs6[0].Process
-	}
-	if proc == nil {
-		// Either nothing is listening on this port or we were unable to read the
-		// process details (permission issues reading /proc/$pid/* potentially).
-		// Or, perhaps /proc/net/tcp{,6} is not listing the port for some reason.
-		return "", nil
-	}
-
-	// The process name provided by go-netstat does not include the full command
-	// line so grab that instead.
-	pid := proc.Pid
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-	if err != nil {
-		return "", xerrors.Errorf("read /proc/%d/cmdline: %w", pid, err)
-	}
-	return string(data), nil
+	// Always send back as much as we found and the errors.  Note that if cmdlines
+	// is empty then either nothing is listening on this port or perhaps there
+	// were permission issues reading /proc/net/tcp{,6}.
+	return cmdlines, allErrs
 }

--- a/agent/agentssh/portinspection_unsupported.go
+++ b/agent/agentssh/portinspection_unsupported.go
@@ -2,8 +2,8 @@
 
 package agentssh
 
-func getListeningPortProcessCmdline(uint32) (string, error) {
+func getListeningPortProcessCmdlines(uint32) ([]string, error) {
 	// We are not worrying about other platforms at the moment because Gateway
 	// only supports Linux anyway.
-	return "", nil
+	return nil, nil
 }

--- a/scripts/echoserver/main.go
+++ b/scripts/echoserver/main.go
@@ -1,7 +1,10 @@
 package main
 
-// A simple echo server.  It listens on a random port, prints that port, then
-// echos back anything sent to it.
+// A simple echo server that listens on the specified network (tcp4 or tcp6) and
+// port, prints the resulting port (since you can use 0 to get a random port),
+// then echos back anything sent to it.  This is to test counting applications
+// that use port forwarding; currently only JetBrains uses this method.
+// Example usage: go run ./scripts/echoserver tcp6 0 -Didea.vendor.name=JetBrains
 
 import (
 	"errors"
@@ -9,10 +12,22 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 )
 
 func main() {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	network := os.Args[1]
+	var address string
+	switch network {
+	case "tcp4":
+		address = "127.0.0.1"
+	case "tcp6":
+		address = "[::]"
+	default:
+		log.Fatalf("invalid network: %s", network)
+	}
+	port := os.Args[2]
+	l, err := net.Listen(network, address+":"+port)
 	if err != nil {
 		log.Fatalf("listen error: err=%s", err)
 	}


### PR DESCRIPTION
This commit was mostly just to add a test for ipv6, but in so doing I discovered it was possible to miss a JetBrains process listening on ipv6 if there was something else non-JetBrains on ipv4 with the same port. This is fixed now, so we should never miss processes (aside from errors).

On the flip side, while it was already possible to get false positives if JetBrains was on ipv4 and something else was forwarded on the same port on ipv6, it is now possible to get false positives the other way around too.  

I am not sure it is worth trying to resolve these false positives as producing them requires a setup that seems quite unlikely (you need to forward another process on a different address using the same port as a JetBrains process) and the impact is low (user's JetBrains count is 2 instead of 1, or higher if they do this on multiple addresses). 

Resolving the false positives is unfortunately not as simple as just matching the address returned by netsat, we would need to resolve the addresses we get from the ssh library first, for example if you connect to `localhost` the process could be on at least `127.0.0.1` or `0.0.0.0`, or if you connect to `::1` the process could be listening on `::1` or `::`, or `127.0.0.1` to `0.0.0.0`, etc.

So if the increased count does end up being a problem, maybe a better solution is to limit the count to at most one from each workspace (or user), if we are not already doing this.