### PR TITLE
chore: use correct anchor link on `scale.md`

### DIFF
--- a/docs/admin/scale.md
+++ b/docs/admin/scale.md
@@ -1,5 +1,5 @@
-We scale-test Coder with [a built-in utility](#scale-testing-utility) that can be
-used in your environment for insights into how Coder scales with your
+We scale-test Coder with [a built-in utility](#scale-testing-utility) that can
+be used in your environment for insights into how Coder scales with your
 infrastructure.
 
 ## General concepts

--- a/docs/admin/scale.md
+++ b/docs/admin/scale.md
@@ -1,4 +1,4 @@
-We scale-test Coder with [a built-in utility](#scaletest-utility) that can be
+We scale-test Coder with [a built-in utility](#scale-testing-utility) that can be
 used in your environment for insights into how Coder scales with your
 infrastructure.
 


### PR DESCRIPTION
The correct anchor is https://coder.com/docs/v2/latest/admin/scale#scale-testing-utility