### PR TITLE
fix: use DiscoPing (partially reverts #11306)

### DIFF
--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -376,7 +376,7 @@ func (c *Conn) Status() *ipnstate.Status {
 func (c *Conn) Ping(ctx context.Context, ip netip.Addr) (time.Duration, bool, *ipnstate.PingResult, error) {
 	errCh := make(chan error, 1)
 	prChan := make(chan *ipnstate.PingResult, 1)
-	go c.wireguardEngine.Ping(ip, tailcfg.PingTSMP, func(pr *ipnstate.PingResult) {
+	go c.wireguardEngine.Ping(ip, tailcfg.PingDisco, func(pr *ipnstate.PingResult) {
 		if pr.Err != "" {
 			errCh <- xerrors.New(pr.Err)
 			return


### PR DESCRIPTION
fixes #11732

This PR reverts the main focus of #11306 which returns us to using Disco instead of TSMP for pings.  TSMP doesn't support giving us information about whether we got the response via DERP or direct.

I've left the test changes from #11306 in place because I still want to use TSMP for `AwaitReachable()` eventually, but I'm going to hotfix this PR so we can get a patch ASAP.
