### PR TITLE
fix: delegate path based forwarding to code-server

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -681,7 +681,11 @@ func (s *Server) CreateCommand(ctx context.Context, script string, env []string)
 
 	// This adds the ports dialog to code-server that enables
 	// proxying a port dynamically.
-	cmd.Env = append(cmd.Env, fmt.Sprintf("VSCODE_PROXY_URI=%s", manifest.VSCodePortProxyURI))
+	// If this is empty string, do not set anything. Code-server auto defaults
+	// using its basepath to construct a path based port proxy.
+	if manifest.VSCodePortProxyURI != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("VSCODE_PROXY_URI=%s", manifest.VSCodePortProxyURI))
+	}
 
 	// Hide Coder message on code-server's "Getting Started" page
 	cmd.Env = append(cmd.Env, "CS_DISABLE_GETTING_STARTED_OVERRIDE=true")

--- a/coderd/agentapi/manifest.go
+++ b/coderd/agentapi/manifest.go
@@ -150,12 +150,14 @@ func (a *ManifestAPI) GetManifest(ctx context.Context, _ *agentproto.GetManifest
 }
 
 func vscodeProxyURI(app appurl.ApplicationURL, accessURL *url.URL, appHost string) string {
+	// Proxying by port only works for subdomains. If subdomain support is not
+	// available, return an empty string.
+	if appHost == "" {
+		return ""
+	}
+
 	// This will handle the ports from the accessURL or appHost.
 	appHost = appurl.SubdomainAppHost(appHost, accessURL)
-	// If there is no appHost, then we want to use the access url as the proxy uri.
-	if appHost == "" {
-		appHost = accessURL.Host
-	}
 	// Return the url with a scheme and any wildcards replaced with the app slug.
 	return accessURL.Scheme + "://" + strings.ReplaceAll(appHost, "*", app.String())
 }

--- a/coderd/agentapi/manifest_internal_test.go
+++ b/coderd/agentapi/manifest_internal_test.go
@@ -35,19 +35,18 @@ func Test_vscodeProxyURI(t *testing.T) {
 		Expected    string
 	}{
 		{
-			// No hostname proxies through the access url.
 			Name:        "NoHostname",
 			AccessURL:   coderAccessURL,
 			AppHostname: "",
 			App:         basicApp,
-			Expected:    coderAccessURL.String(),
+			Expected:    "",
 		},
 		{
 			Name:        "NoHostnameAccessURLPort",
 			AccessURL:   accessURLWithPort,
 			AppHostname: "",
 			App:         basicApp,
-			Expected:    accessURLWithPort.String(),
+			Expected:    "",
 		},
 		{
 			Name:        "Hostname",


### PR DESCRIPTION
Do not attempt to construct a path based port forward url. Always defer to code server, as it has it's own proxy method.

Closes https://github.com/coder/coder/issues/11754

# What this does

I am not sure how this ever worked. We used to always set the `VSCODE_PROXY_URI` no matter what to some url (access url or subdomain based). In the access url case, we never appended any path.

In practice, code-server can forward ports itself with `/@admin/adminlocal.main/apps/code-server/proxy/8000/`.

In the path based proxy case, we should default to not setting an env var. Code server handles this case appropriately:

https://github.com/coder/code-server/blob/d6ef385de271ca53520cdd459bfcc91e9ee4dd02/patches/proxy-uri.diff#L78

If the env var is unset, it will use `/proxy/{{port}}`, which is exactly what we want. If subdomains are available, the env var is set and are used instead.

![Screenshot from 2024-01-22 14-27-37](https://github.com/coder/coder/assets/5446298/bb164255-4371-4f6b-94d4-b2db9fead7d5)

