### PR TITLE
fix: always attempt external auth refresh when fetching

### DIFF
--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"golang.org/x/exp/maps"
+	"golang.org/x/oauth2"
 
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/rbac"
@@ -266,6 +267,14 @@ func (u GitSSHKey) RBACObject() rbac.Object {
 func (u ExternalAuthLink) RBACObject() rbac.Object {
 	// I assume UserData is ok?
 	return rbac.ResourceUserData.WithID(u.UserID).WithOwner(u.UserID.String())
+}
+
+func (u ExternalAuthLink) OAuthToken() *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  u.OAuthAccessToken,
+		RefreshToken: u.OAuthRefreshToken,
+		Expiry:       u.OAuthExpiry,
+	}
 }
 
 func (u UserLink) RBACObject() rbac.Object {

--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -57,7 +57,7 @@ func (api *API) externalAuthByID(w http.ResponseWriter, r *http.Request) {
 	}
 	var eg errgroup.Group
 	eg.Go(func() (err error) {
-		res.Authenticated, res.User, err = config.ValidateToken(ctx, link.OAuthAccessToken)
+		res.Authenticated, res.User, err = config.ValidateToken(ctx, link.OAuthToken())
 		return err
 	})
 	eg.Go(func() (err error) {

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -403,10 +403,15 @@ func (c *DeviceAuth) ExchangeDeviceCode(ctx context.Context, deviceCode string) 
 	if body.Error != "" {
 		return nil, xerrors.New(body.Error)
 	}
+	// If expiresIn is 0, then the token never expires.
+	expires := dbtime.Now().Add(time.Duration(body.ExpiresIn) * time.Second)
+	if body.ExpiresIn == 0 {
+		expires = time.Time{}
+	}
 	return &oauth2.Token{
 		AccessToken:  body.AccessToken,
 		RefreshToken: body.RefreshToken,
-		Expiry:       dbtime.Now().Add(time.Duration(body.ExpiresIn) * time.Second),
+		Expiry:       expires,
 	}, nil
 }
 

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -138,7 +138,7 @@ func (c *Config) RefreshToken(ctx context.Context, db database.Store, externalAu
 	retryCtx, retryCtxCancel := context.WithTimeout(ctx, time.Second)
 	defer retryCtxCancel()
 validate:
-	valid, _, err := c.ValidateToken(ctx, token.AccessToken)
+	valid, _, err := c.ValidateToken(ctx, token)
 	if err != nil {
 		return externalAuthLink, false, xerrors.Errorf("validate external auth token: %w", err)
 	}
@@ -179,7 +179,14 @@ validate:
 
 // ValidateToken ensures the Git token provided is valid!
 // The user is optionally returned if the provider supports it.
-func (c *Config) ValidateToken(ctx context.Context, token string) (bool, *codersdk.ExternalAuthUser, error) {
+func (c *Config) ValidateToken(ctx context.Context, link *oauth2.Token) (bool, *codersdk.ExternalAuthUser, error) {
+	if link == nil {
+		return false, nil, xerrors.New("validate external auth token: token is nil")
+	}
+	if !link.Expiry.IsZero() && link.Expiry.Before(dbtime.Now()) {
+		return false, nil, nil
+	}
+
 	if c.ValidateURL == "" {
 		// Default that the token is valid if no validation URL is provided.
 		return true, nil, nil
@@ -189,7 +196,7 @@ func (c *Config) ValidateToken(ctx context.Context, token string) (bool, *coders
 		return false, nil, err
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", link.AccessToken))
 	res, err := c.InstrumentedOAuth2Config.Do(ctx, promoauth.SourceValidateToken, req)
 	if err != nil {
 		return false, nil, err

--- a/coderd/promoauth/oauth2_test.go
+++ b/coderd/promoauth/oauth2_test.go
@@ -75,7 +75,7 @@ func TestInstrument(t *testing.T) {
 	require.Equal(t, count("TokenSource"), 1)
 
 	// Try a validate
-	valid, _, err := cfg.ValidateToken(ctx, refreshed.AccessToken)
+	valid, _, err := cfg.ValidateToken(ctx, refreshed)
 	require.NoError(t, err)
 	require.True(t, valid)
 	require.Equal(t, count("ValidateToken"), 1)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2164,6 +2164,7 @@ func (api *API) workspaceAgentsExternalAuthListen(ctx context.Context, rw http.R
 			return
 		}
 		httpapi.Write(ctx, rw, http.StatusOK, resp)
+		return
 	}
 }
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2043,7 +2043,7 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		api.workspaceAgentsExternalAuthListen(rw, ctx, externalAuthConfig, workspace)
+		api.workspaceAgentsExternalAuthListen(ctx, rw, externalAuthConfig, workspace)
 	}
 
 	// This is the URL that will redirect the user with a state token.

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2100,7 +2100,7 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
 
-func (api *API) workspaceAgentsExternalAuthListen(rw http.ResponseWriter, ctx context.Context, externalAuthConfig *externalauth.Config, workspace database.Workspace) {
+func (api *API) workspaceAgentsExternalAuthListen(ctx context.Context, rw http.ResponseWriter, externalAuthConfig *externalauth.Config, workspace database.Workspace) {
 	// Since we're ticking frequently and this sign-in operation is rare,
 	// we are OK with polling to avoid the complexity of pubsub.
 	ticker, done := api.NewTicker(time.Second)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2143,7 +2143,7 @@ func (api *API) workspaceAgentsExternalAuthListen(rw http.ResponseWriter, ctx co
 			continue
 		}
 
-		valid, _, err := externalAuthConfig.ValidateToken(ctx, externalAuthLink.OAuthAccessToken)
+		valid, _, err := externalAuthConfig.ValidateToken(ctx, externalAuthLink.OAuthToken())
 		if err != nil {
 			api.Logger.Warn(ctx, "failed to validate external auth token",
 				slog.F("workspace_owner_id", workspace.OwnerID.String()),

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1577,7 +1577,7 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 			},
 			ExternalAuthConfigs: []*externalauth.Config{
 				fake.ExternalAuthConfig(t, providerID, nil, func(cfg *externalauth.Config) {
-					cfg.Type = codersdk.EnhancedExternalAuthProviderGitHub.String()
+					cfg.Type = codersdk.EnhancedExternalAuthProviderGitLab.String()
 				}),
 			},
 		})
@@ -1623,7 +1623,8 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 			ticks <- time.Now()
 		}
 		cancel()
-		// We expect only 1
+		// We expect only 2. One from the initial "Refresh" attempt, and
+		// another from the first tick. Ideally this would be just one.
 		// In a failed test, you will likely see 9, as the last one
 		// gets canceled.
 		require.Equal(t, 1, validateCalls, "validate calls duplicated on same token")

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1623,8 +1623,8 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 			ticks <- time.Now()
 		}
 		cancel()
-		// We expect only 2. One from the initial "Refresh" attempt, and
-		// another from the first tick. Ideally this would be just one.
+		// We expect only 1. One from the initial "Refresh" attempt, and the
+		// other sshould be skipped.
 		// In a failed test, you will likely see 9, as the last one
 		// gets canceled.
 		require.Equal(t, 1, validateCalls, "validate calls duplicated on same token")

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -1624,7 +1624,7 @@ func TestWorkspaceAgentExternalAuthListen(t *testing.T) {
 		}
 		cancel()
 		// We expect only 1. One from the initial "Refresh" attempt, and the
-		// other sshould be skipped.
+		// other should be skipped.
 		// In a failed test, you will likely see 9, as the last one
 		// gets canceled.
 		require.Equal(t, 1, validateCalls, "validate calls duplicated on same token")


### PR DESCRIPTION
# What this does

Refactors the external auth code to:
- Always attempt to refresh when workspace agent fetches auth links. The agent uses this endpoint.
- `ValidateToken` takes into account `Expirary` information.