### PR TITLE
chore: refactor Appearance to an interface callable by AGPL code

### DIFF
--- a/coderd/appearance/appearance.go
+++ b/coderd/appearance/appearance.go
@@ -1,0 +1,39 @@
+package appearance
+
+import (
+	"context"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+type Fetcher interface {
+	Fetch(ctx context.Context) (codersdk.AppearanceConfig, error)
+}
+
+var DefaultSupportLinks = []codersdk.LinkConfig{
+	{
+		Name:   "Documentation",
+		Target: "https://coder.com/docs/coder-oss",
+		Icon:   "docs",
+	},
+	{
+		Name:   "Report a bug",
+		Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body={CODER_BUILD_INFO}",
+		Icon:   "bug",
+	},
+	{
+		Name:   "Join the Coder Discord",
+		Target: "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer",
+		Icon:   "chat",
+	},
+}
+
+type AGPLFetcher struct{}
+
+func (AGPLFetcher) Fetch(context.Context) (codersdk.AppearanceConfig, error) {
+	return codersdk.AppearanceConfig{
+		SupportLinks: DefaultSupportLinks,
+	}, nil
+}
+
+var DefaultFetcher Fetcher = AGPLFetcher{}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -17,10 +17,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coder/coder/v2/coderd/prometheusmetrics"
-
-	agentproto "github.com/coder/coder/v2/agent/proto"
-
 	"github.com/andybalholm/brotli"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -40,11 +36,12 @@ import (
 	"tailscale.com/util/singleflight"
 
 	"cdr.dev/slog"
+
+	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/clibase"
-
-	// Used for swagger docs.
-	_ "github.com/coder/coder/v2/coderd/apidoc"
+	_ "github.com/coder/coder/v2/coderd/apidoc" // Used for swagger docs.
+	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/awsidentity"
 	"github.com/coder/coder/v2/coderd/batchstats"
@@ -59,6 +56,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/metricscache"
+	"github.com/coder/coder/v2/coderd/prometheusmetrics"
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/schedule"
@@ -357,16 +355,6 @@ func New(options *Options) *API {
 		OIDC:   options.OIDCConfig,
 	}
 
-	staticHandler := site.New(&site.Options{
-		BinFS:         binFS,
-		BinHashes:     binHashes,
-		Database:      options.Database,
-		SiteFS:        site.FS(),
-		OAuth2Configs: oauthConfigs,
-		DocsURL:       options.DeploymentValues.DocsURL.String(),
-	})
-	staticHandler.Experiments.Store(&experiments)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	r := chi.NewRouter()
 
@@ -383,7 +371,6 @@ func New(options *Options) *API {
 		ID:          uuid.New(),
 		Options:     options,
 		RootHandler: r,
-		SiteHandler: staticHandler,
 		HTTPAuth: &HTTPAuthorizer{
 			Authorizer: options.Authorizer,
 			Logger:     options.Logger,
@@ -412,6 +399,19 @@ func New(options *Options) *API {
 			options.Database,
 			options.Pubsub),
 	}
+
+	api.AppearanceFetcher.Store(&appearance.DefaultFetcher)
+	api.SiteHandler = site.New(&site.Options{
+		BinFS:             binFS,
+		BinHashes:         binHashes,
+		Database:          options.Database,
+		SiteFS:            site.FS(),
+		OAuth2Configs:     oauthConfigs,
+		DocsURL:           options.DeploymentValues.DocsURL.String(),
+		AppearanceFetcher: &api.AppearanceFetcher,
+	})
+	api.SiteHandler.Experiments.Store(&experiments)
+
 	if options.UpdateCheckOptions != nil {
 		api.updateChecker = updatecheck.New(
 			options.Database,
@@ -1089,6 +1089,7 @@ type API struct {
 	TailnetCoordinator                atomic.Pointer[tailnet.Coordinator]
 	TailnetClientService              *tailnet.ClientService
 	QuotaCommitter                    atomic.Pointer[proto.QuotaCommitter]
+	AppearanceFetcher                 atomic.Pointer[appearance.Fetcher]
 	// WorkspaceProxyHostsFn returns the hosts of healthy workspace proxies
 	// for header reasons.
 	WorkspaceProxyHostsFn atomic.Pointer[func() []string]

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -6,19 +6,17 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
-
-	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbfake"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
-	"github.com/coder/coder/v2/enterprise/coderd"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/testutil"
@@ -214,9 +212,9 @@ func TestCustomSupportLinks(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
 
-	appearance, err := anotherClient.Appearance(ctx)
+	appr, err := anotherClient.Appearance(ctx)
 	require.NoError(t, err)
-	require.Equal(t, supportLinks, appearance.SupportLinks)
+	require.Equal(t, supportLinks, appr.SupportLinks)
 }
 
 func TestDefaultSupportLinks(t *testing.T) {
@@ -229,7 +227,7 @@ func TestDefaultSupportLinks(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
 
-	appearance, err := anotherClient.Appearance(ctx)
+	appr, err := anotherClient.Appearance(ctx)
 	require.NoError(t, err)
-	require.Equal(t, coderd.DefaultSupportLinks, appearance.SupportLinks)
+	require.Equal(t, appearance.DefaultSupportLinks, appr.SupportLinks)
 }


### PR DESCRIPTION
The new Agent API needs an interface for ServiceBanners, so this PR creates it and refactors the AGPL and Enterprise code to achieve it.

Before we depended on the fact that the HTTP endpoint was missing to serve an empty ServiceBanner on AGPL deployments, but that won't work with dRPC, so we need a real interface to call.