### PR TITLE
fix(cli): ssh: auto-update workspace

### DIFF
--- a/cli/restart.go
+++ b/cli/restart.go
@@ -64,7 +64,7 @@ func (r *RootCmd) restart() *clibase.Cmd {
 			// It's possible for a workspace build to fail due to the template requiring starting
 			// workspaces with the active version.
 			if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusForbidden {
-				_, _ = fmt.Fprintln(inv.Stdout, "Failed to restart with the template version from your last build. Policy may require you to restart with the current active template version.")
+				_, _ = fmt.Fprintln(inv.Stdout, "Unable to restart the workspace with the template version from the last build. Policy may require you to restart with the current active template version.")
 				build, err = startWorkspace(inv, client, workspace, parameterFlags, WorkspaceUpdate)
 				if err != nil {
 					return xerrors.Errorf("start workspace with active template version: %w", err)

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -575,13 +576,27 @@ func getWorkspaceAndAgent(ctx context.Context, inv *clibase.Invocation, client *
 					codersdk.WorkspaceStatusStopped,
 				)
 		}
-		// startWorkspace based on the last build parameters.
+
+		// Start workspace based on the last build parameters.
+		// It's possible for a workspace build to fail due to the template requiring starting
+		// workspaces with the active version.
 		_, _ = fmt.Fprintf(inv.Stderr, "Workspace was stopped, starting workspace to allow connecting to %q...\n", workspace.Name)
-		build, err := startWorkspace(inv, client, workspace, workspaceParameterFlags{}, WorkspaceStart)
-		if err != nil {
-			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.Errorf("unable to start workspace: %w", err)
+		_, err = startWorkspace(inv, client, workspace, workspaceParameterFlags{}, WorkspaceStart)
+		if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusForbidden {
+			_, _ = fmt.Fprintln(inv.Stdout, "Unable to start the workspace with template version from last build. The auto-update policy may require you to restart with the current active template version.")
+			_, err = startWorkspace(inv, client, workspace, workspaceParameterFlags{}, WorkspaceUpdate)
+			if err != nil {
+				return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.Errorf("start workspace with active template version: %w", err)
+			}
+		} else if err != nil {
+			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.Errorf("start workspace with current template version: %w", err)
 		}
-		workspace.LatestBuild = build
+
+		// Refresh workspace state so that `outdated`, `build`,`template_*` fields are up-to-date.
+		workspace, err = namedWorkspace(ctx, client, workspaceParts[0])
+		if err != nil {
+			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, err
+		}
 	}
 	if workspace.LatestBuild.Job.CompletedAt == nil {
 		err := cliui.WorkspaceBuild(ctx, inv.Stderr, client, workspace.LatestBuild.ID)

--- a/cli/start.go
+++ b/cli/start.go
@@ -49,7 +49,7 @@ func (r *RootCmd) start() *clibase.Cmd {
 				// It's possible for a workspace build to fail due to the template requiring starting
 				// workspaces with the active version.
 				if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusForbidden {
-					_, _ = fmt.Fprintln(inv.Stdout, "Unable to start with the template version from your last build. Policy may require you to restart with the current active template version.")
+					_, _ = fmt.Fprintln(inv.Stdout, "Unable to start the workspace with the template version from the last build. Policy may require you to restart with the current active template version.")
 					build, err = startWorkspace(inv, client, workspace, parameterFlags, WorkspaceUpdate)
 					if err != nil {
 						return xerrors.Errorf("start workspace with active template version: %w", err)

--- a/cli/start.go
+++ b/cli/start.go
@@ -49,7 +49,7 @@ func (r *RootCmd) start() *clibase.Cmd {
 				// It's possible for a workspace build to fail due to the template requiring starting
 				// workspaces with the active version.
 				if cerr, ok := codersdk.AsError(err); ok && cerr.StatusCode() == http.StatusForbidden {
-					_, _ = fmt.Fprintln(inv.Stdout, "Failed to restart with the template version from your last build. Policy may require you to restart with the current active template version.")
+					_, _ = fmt.Fprintln(inv.Stdout, "Unable to start with the template version from your last build. Policy may require you to restart with the current active template version.")
 					build, err = startWorkspace(inv, client, workspace, parameterFlags, WorkspaceUpdate)
 					if err != nil {
 						return xerrors.Errorf("start workspace with active template version: %w", err)
@@ -79,6 +79,7 @@ func (r *RootCmd) start() *clibase.Cmd {
 
 func buildWorkspaceStartRequest(inv *clibase.Invocation, client *codersdk.Client, workspace codersdk.Workspace, parameterFlags workspaceParameterFlags, action WorkspaceCLIAction) (codersdk.CreateWorkspaceBuildRequest, error) {
 	version := workspace.LatestBuild.TemplateVersionID
+
 	if workspace.AutomaticUpdates == codersdk.AutomaticUpdatesAlways || action == WorkspaceUpdate {
 		version = workspace.TemplateActiveVersionID
 		if version != workspace.LatestBuild.TemplateVersionID {

--- a/enterprise/cli/start_test.go
+++ b/enterprise/cli/start_test.go
@@ -159,8 +159,16 @@ func TestStart(t *testing.T) {
 
 						ws = coderdtest.MustWorkspace(t, c.Client, ws.ID)
 						require.Equal(t, c.ExpectedVersion, ws.LatestBuild.TemplateVersionID)
-						if initialTemplateVersion != ws.LatestBuild.TemplateVersionID {
+						if initialTemplateVersion == ws.LatestBuild.TemplateVersionID {
+							return
+						}
+
+						if cmd == "start" {
 							require.Contains(t, buf.String(), "Unable to start the workspace with the template version from the last build")
+						}
+
+						if cmd == "restart" {
+							require.Contains(t, buf.String(), "Unable to restart the workspace with the template version from the last build")
 						}
 					})
 				}

--- a/enterprise/cli/start_test.go
+++ b/enterprise/cli/start_test.go
@@ -160,7 +160,7 @@ func TestStart(t *testing.T) {
 						ws = coderdtest.MustWorkspace(t, c.Client, ws.ID)
 						require.Equal(t, c.ExpectedVersion, ws.LatestBuild.TemplateVersionID)
 						if initialTemplateVersion != ws.LatestBuild.TemplateVersionID {
-							require.Contains(t, buf.String(), "Failed to restart with the template version from your last build. Policy may require you to restart with the current active template version.")
+							require.Contains(t, buf.String(), "Unable to start the workspace with the template version from the last build")
 						}
 					})
 				}


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/11595

This PR adjusts CLI `ssh` logic to trigger auto-update of a stopped workspace before ssh'ing to the host. 