### PR TITLE
fix: disable keepalives in workspaceapps transport

### DIFF
--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -347,7 +347,7 @@ func (c *DeviceAuth) AuthorizeDevice(ctx context.Context) (*codersdk.ExternalAut
 		case mediaType == "application/x-www-form-urlencoded":
 			return nil, xerrors.Errorf("status_code=%d, payload response is form-url encoded, expected a json payload", resp.StatusCode)
 		default:
-			return nil, fmt.Errorf("status_code=%d, mediaType=%s: %w", resp.StatusCode, mediaType, err)
+			return nil, xerrors.Errorf("status_code=%d, mediaType=%s: %w", resp.StatusCode, mediaType, err)
 		}
 	}
 	if r.ErrorDescription != "" {

--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -103,7 +103,14 @@ func NewServerTailnet(
 		transport:            tailnetTransport.Clone(),
 	}
 	tn.transport.DialContext = tn.dialContext
-	tn.transport.MaxIdleConnsPerHost = 10
+
+	// Bugfix: for some reason all calls to tn.dialContext come from
+	// "localhost", causing connections to be cached and requests to go to the
+	// wrong workspaces. This disables keepalives for now until the root cause
+	// can be found.
+	tn.transport.MaxIdleConnsPerHost = -1
+	tn.transport.DisableKeepAlives = true
+
 	tn.transport.MaxIdleConns = 0
 	// We intentionally don't verify the certificate chain here.
 	// The connection to the workspace is already established and most


### PR DESCRIPTION
Connection caching causes requests to hit the wrong workspaces. See
comment.

Fixes https://github.com/coder/coder/issues/11767