### PR TITLE
fix: stop spamming DERP map updates for equivalent maps

### DIFF
--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -904,7 +904,7 @@ func (api *API) _dialWorkspaceAgentTailnet(agentID uuid.UUID) (*codersdk.Workspa
 				}
 
 				derpMap := api.DERPMap()
-				if lastDERPMap == nil || tailnet.CompareDERPMaps(lastDERPMap, derpMap) {
+				if lastDERPMap == nil || !tailnet.CompareDERPMaps(lastDERPMap, derpMap) {
 					conn.SetDERPMap(derpMap)
 					lastDERPMap = derpMap
 				}

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -218,7 +218,7 @@ func NewConn(options *Options) (conn *Conn, err error) {
 		magicConn.DiscoPublicKey(),
 	)
 	cfgMaps.setAddresses(options.Addresses)
-	cfgMaps.setDERPMap(DERPMapToProto(options.DERPMap))
+	cfgMaps.setDERPMap(options.DERPMap)
 	cfgMaps.setBlockEndpoints(options.BlockEndpoints)
 
 	nodeUp := newNodeUpdater(
@@ -326,7 +326,7 @@ func (c *Conn) SetNodeCallback(callback func(node *Node)) {
 
 // SetDERPMap updates the DERPMap of a connection.
 func (c *Conn) SetDERPMap(derpMap *tailcfg.DERPMap) {
-	c.configMaps.setDERPMap(DERPMapToProto(derpMap))
+	c.configMaps.setDERPMap(derpMap)
 }
 
 func (c *Conn) SetDERPForceWebSockets(v bool) {

--- a/tailnet/proto/compare.go
+++ b/tailnet/proto/compare.go
@@ -18,15 +18,3 @@ func (s *Node) Equal(o *Node) (bool, error) {
 	}
 	return bytes.Equal(sBytes, oBytes), nil
 }
-
-func (s *DERPMap) Equal(o *DERPMap) (bool, error) {
-	sBytes, err := gProto.Marshal(s)
-	if err != nil {
-		return false, err
-	}
-	oBytes, err := gProto.Marshal(o)
-	if err != nil {
-		return false, err
-	}
-	return bytes.Equal(sBytes, oBytes), nil
-}


### PR DESCRIPTION
Fixes 2 related issues:

1. wsconncache had incorrect logic to test whether to send DERPMap updates, sending if the maps were equivalent, instead of if they were _not equivalent_.
2. configmaps used a bugged check to test equality between DERPMaps, since it contains a map and the map entries are serialized in random order. Instead, we avoid comparing the protobufs and instead depend on the existing function that compares `tailcfg.DERPMap`. This also has the effect of reducing the number of times we convert to and from protobuf.