### PR TITLE
feat(cli): add favorite/unfavorite commands

### DIFF
--- a/cli/favorite.go
+++ b/cli/favorite.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func (r *RootCmd) favorite() *clibase.Cmd {
+	client := new(codersdk.Client)
+	cmd := &clibase.Cmd{
+		Aliases:     []string{"fav", "favou" + "rite"},
+		Annotations: workspaceCommand,
+		Use:         "favorite <workspace>",
+		Short:       "Add a workspace to your favorites",
+		Middleware: clibase.Chain(
+			clibase.RequireNArgs(1),
+			r.InitClient(client),
+		),
+		Handler: func(inv *clibase.Invocation) error {
+			ws, err := namedWorkspace(inv.Context(), client, inv.Args[0])
+			if err != nil {
+				return xerrors.Errorf("get workspace: %w", err)
+			}
+
+			if err := client.FavoriteWorkspace(inv.Context(), ws.ID); err != nil {
+				return xerrors.Errorf("favorite workspace: %w", err)
+			}
+			_, _ = fmt.Fprintf(inv.Stdout, "Workspace %q added to favorites.", ws.Name)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) unfavorite() *clibase.Cmd {
+	client := new(codersdk.Client)
+	cmd := &clibase.Cmd{
+		Aliases:     []string{"unfav", "unfavou" + "rite"},
+		Annotations: workspaceCommand,
+		Use:         "unfavorite <workspace>",
+		Short:       "Remove a workspace from your favorites",
+		Middleware: clibase.Chain(
+			clibase.RequireNArgs(1),
+			r.InitClient(client),
+		),
+		Handler: func(inv *clibase.Invocation) error {
+			ws, err := namedWorkspace(inv.Context(), client, inv.Args[0])
+			if err != nil {
+				return xerrors.Errorf("get workspace: %w", err)
+			}
+
+			if err := client.UnfavoriteWorkspace(inv.Context(), ws.ID); err != nil {
+				return xerrors.Errorf("unfavorite workspace: %w", err)
+			}
+			_, _ = fmt.Fprintf(inv.Stdout, "Workspace %q removed from favorites.", ws.Name)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cli/favorite.go
+++ b/cli/favorite.go
@@ -29,7 +29,7 @@ func (r *RootCmd) favorite() *clibase.Cmd {
 			if err := client.FavoriteWorkspace(inv.Context(), ws.ID); err != nil {
 				return xerrors.Errorf("favorite workspace: %w", err)
 			}
-			_, _ = fmt.Fprintf(inv.Stdout, "Workspace %q added to favorites.", ws.Name)
+			_, _ = fmt.Fprintf(inv.Stdout, "Workspace %q added to favorites.\n", ws.Name)
 			return nil
 		},
 	}
@@ -56,7 +56,7 @@ func (r *RootCmd) unfavorite() *clibase.Cmd {
 			if err := client.UnfavoriteWorkspace(inv.Context(), ws.ID); err != nil {
 				return xerrors.Errorf("unfavorite workspace: %w", err)
 			}
-			_, _ = fmt.Fprintf(inv.Stdout, "Workspace %q removed from favorites.", ws.Name)
+			_, _ = fmt.Fprintf(inv.Stdout, "Workspace %q removed from favorites.\n", ws.Name)
 			return nil
 		},
 	}

--- a/cli/favorite_test.go
+++ b/cli/favorite_test.go
@@ -1,0 +1,45 @@
+package cli_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFavoriteUnfavorite(t *testing.T) {
+	t.Parallel()
+
+	var (
+		client, db           = coderdtest.NewWithDatabase(t, nil)
+		owner                = coderdtest.CreateFirstUser(t, client)
+		memberClient, member = coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+		ws                   = dbfake.WorkspaceBuild(t, db, database.Workspace{OwnerID: member.ID, OrganizationID: owner.OrganizationID}).Do()
+	)
+
+	inv, root := clitest.New(t, "favorite", ws.Workspace.Name)
+	clitest.SetupConfig(t, memberClient, root)
+
+	var buf bytes.Buffer
+	inv.Stdout = &buf
+	err := inv.Run()
+	require.NoError(t, err)
+
+	updated := coderdtest.MustWorkspace(t, memberClient, ws.Workspace.ID)
+	require.True(t, updated.Favorite)
+
+	buf.Reset()
+
+	inv, root = clitest.New(t, "unfavorite", ws.Workspace.Name)
+	clitest.SetupConfig(t, memberClient, root)
+	inv.Stdout = &buf
+	err = inv.Run()
+	require.NoError(t, err)
+	updated = coderdtest.MustWorkspace(t, memberClient, ws.Workspace.ID)
+	require.False(t, updated.Favorite)
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -100,6 +100,7 @@ func (r *RootCmd) Core() []*clibase.Cmd {
 		r.configSSH(),
 		r.create(),
 		r.deleteWorkspace(),
+		r.favorite(),
 		r.list(),
 		r.open(),
 		r.ping(),
@@ -112,6 +113,7 @@ func (r *RootCmd) Core() []*clibase.Cmd {
 		r.start(),
 		r.stat(),
 		r.stop(),
+		r.unfavorite(),
 		r.update(),
 
 		// Hidden

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -22,6 +22,7 @@ SUBCOMMANDS:
     dotfiles          Personalize your workspace by applying a canonical
                       dotfiles repository
     external-auth     Manage external authentication
+    favorite          Add a workspace to your favorites
     list              List workspaces
     login             Authenticate with Coder deployment
     logout            Unauthenticate your local session
@@ -47,6 +48,7 @@ SUBCOMMANDS:
     stop              Stop a workspace
     templates         Manage templates
     tokens            Manage personal access tokens
+    unfavorite        Remove a workspace from your favorites
     update            Will update and start a given workspace if it is out of
                       date
     users             Manage users

--- a/cli/testdata/coder_favorite_--help.golden
+++ b/cli/testdata/coder_favorite_--help.golden
@@ -1,0 +1,11 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder favorite <workspace>
+
+  Add a workspace to your favorites
+
+  Aliases: fav, favourite
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_unfavorite_--help.golden
+++ b/cli/testdata/coder_unfavorite_--help.golden
@@ -1,0 +1,11 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder unfavorite <workspace>
+
+  Remove a workspace from your favorites
+
+  Aliases: unfav, unfavourite
+
+———
+Run `coder --help` for a list of global options.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 | [<code>delete</code>](./cli/delete.md)                 | Delete a workspace                                                                                    |
 | [<code>dotfiles</code>](./cli/dotfiles.md)             | Personalize your workspace by applying a canonical dotfiles repository                                |
 | [<code>external-auth</code>](./cli/external-auth.md)   | Manage external authentication                                                                        |
+| [<code>favorite</code>](./cli/favorite.md)             | Add a workspace to your favorites                                                                     |
 | [<code>features</code>](./cli/features.md)             | List Enterprise features                                                                              |
 | [<code>groups</code>](./cli/groups.md)                 | Manage groups                                                                                         |
 | [<code>licenses</code>](./cli/licenses.md)             | Add, delete, and list licenses                                                                        |
@@ -57,6 +58,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 | [<code>stop</code>](./cli/stop.md)                     | Stop a workspace                                                                                      |
 | [<code>templates</code>](./cli/templates.md)           | Manage templates                                                                                      |
 | [<code>tokens</code>](./cli/tokens.md)                 | Manage personal access tokens                                                                         |
+| [<code>unfavorite</code>](./cli/unfavorite.md)         | Remove a workspace from your favorites                                                                |
 | [<code>update</code>](./cli/update.md)                 | Will update and start a given workspace if it is out of date                                          |
 | [<code>users</code>](./cli/users.md)                   | Manage users                                                                                          |
 | [<code>version</code>](./cli/version.md)               | Show coder version                                                                                    |

--- a/docs/cli/favorite.md
+++ b/docs/cli/favorite.md
@@ -1,0 +1,16 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# favorite
+
+Add a workspace to your favorites
+
+Aliases:
+
+- fav
+- favourite
+
+## Usage
+
+```console
+coder favorite <workspace>
+```

--- a/docs/cli/unfavorite.md
+++ b/docs/cli/unfavorite.md
@@ -1,0 +1,16 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# unfavorite
+
+Remove a workspace from your favorites
+
+Aliases:
+
+- unfav
+- unfavourite
+
+## Usage
+
+```console
+coder unfavorite <workspace>
+```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -618,6 +618,11 @@
           "path": "cli/external-auth_access-token.md"
         },
         {
+          "title": "favorite",
+          "description": "Add a workspace to your favorites",
+          "path": "cli/favorite.md"
+        },
+        {
           "title": "features",
           "description": "List Enterprise features",
           "path": "cli/features.md"
@@ -950,6 +955,11 @@
           "title": "tokens remove",
           "description": "Delete a token",
           "path": "cli/tokens_remove.md"
+        },
+        {
+          "title": "unfavorite",
+          "description": "Remove a workspace from your favorites",
+          "path": "cli/unfavorite.md"
         },
         {
           "title": "update",


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/7912

Depends on https://github.com/coder/coder/pull/11791

Adds CLI commands allowing users to add/remove workspaces from their favorites.