### PR TITLE
fix: check update permission to start workspace

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -1,7 +1,7 @@
 import { type FC, type ReactNode, Fragment } from "react";
 import { Workspace, WorkspaceBuildParameter } from "api/typesGenerated";
 import { useWorkspaceDuplication } from "pages/CreateWorkspacePage/useWorkspaceDuplication";
-import { workspaceUpdatePolicy } from "utils/workspace";
+import { mustUpdateWorkspace } from "utils/workspace";
 import { type ActionType, abilitiesByWorkspaceStatus } from "./constants";
 import {
   CancelButton,
@@ -79,10 +79,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
     canCancel &&
     (workspace.template_allow_user_cancel_workspace_jobs || isOwner);
 
-  const mustUpdate =
-    workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&
-    workspace.outdated;
-
+  const mustUpdate = mustUpdateWorkspace(workspace, canChangeVersions);
   const tooltipText = getTooltipText(workspace, mustUpdate, canChangeVersions);
   const canBeUpdated = workspace.outdated && canAcceptJobs;
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -85,6 +85,7 @@ const WorkspacesPage: FC = () => {
 
       <WorkspacesPageView
         canCreateTemplate={permissions.createTemplates}
+        canChangeVersions={permissions.updateTemplates}
         checkedWorkspaces={checkedWorkspaces}
         onCheckChange={setCheckedWorkspaces}
         canCheckWorkspaces={canCheckWorkspaces}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -26,6 +26,7 @@ import KeyboardArrowDownOutlined from "@mui/icons-material/KeyboardArrowDownOutl
 import Divider from "@mui/material/Divider";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { PaginationHeader } from "components/PaginationWidget/PaginationHeader";
+import { mustUpdateWorkspace } from "utils/workspace";
 
 export const Language = {
   pageTitle: "Workspaces",
@@ -59,6 +60,7 @@ export interface WorkspacesPageViewProps {
   templatesFetchStatus: TemplateQuery["status"];
   templates: TemplateQuery["data"];
   canCreateTemplate: boolean;
+  canChangeVersions: boolean;
 }
 
 export const WorkspacesPageView = ({
@@ -81,6 +83,7 @@ export const WorkspacesPageView = ({
   templates,
   templatesFetchStatus,
   canCreateTemplate,
+  canChangeVersions,
 }: WorkspacesPageViewProps) => {
   return (
     <Margins>
@@ -136,7 +139,7 @@ export const WorkspacesPageView = ({
                   onClick={onStartAll}
                   disabled={
                     !checkedWorkspaces?.every(
-                      (w) => w.latest_build.status === "stopped",
+                      (w) => w.latest_build.status === "stopped" && !mustUpdateWorkspace(w, canChangeVersions),
                     )
                   }
                 >

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -139,7 +139,9 @@ export const WorkspacesPageView = ({
                   onClick={onStartAll}
                   disabled={
                     !checkedWorkspaces?.every(
-                      (w) => w.latest_build.status === "stopped" && !mustUpdateWorkspace(w, canChangeVersions),
+                      (w) =>
+                        w.latest_build.status === "stopped" &&
+                        !mustUpdateWorkspace(w, canChangeVersions),
                     )
                   }
                 >

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -276,11 +276,13 @@ export const getMatchingAgentOrFirst = (
 
 export const mustUpdateWorkspace = (
   workspace: TypesGen.Workspace,
-  canChangeVersions: boolean
+  canChangeVersions: boolean,
 ): boolean => {
-  return workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&
-  workspace.outdated;
-}
+  return (
+    workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&
+    workspace.outdated
+  );
+};
 
 const workspaceUpdatePolicy = (
   workspace: TypesGen.Workspace,

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -274,7 +274,15 @@ export const getMatchingAgentOrFirst = (
     .filter((a) => a)[0];
 };
 
-export const workspaceUpdatePolicy = (
+export const mustUpdateWorkspace = (
+  workspace: TypesGen.Workspace,
+  canChangeVersions: boolean
+): boolean => {
+  return workspaceUpdatePolicy(workspace, canChangeVersions) === "always" &&
+  workspace.outdated;
+}
+
+const workspaceUpdatePolicy = (
   workspace: TypesGen.Workspace,
   canChangeVersions: boolean,
 ): TypesGen.AutomaticUpdates => {


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/11595

This PR adjusts the logic to select bulk actions to disable "start workspace" if the current user does not have permission to start a workspace with the enforced latest template version.