### PR TITLE
feat: use Agent v2 API for Service Banner

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp/fasthttputil"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/crypto/ssh"
@@ -2026,7 +2027,10 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 	afero.Fs,
 	agent.Agent,
 ) {
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := slogtest.Make(t, &slogtest.Options{
+		// we get this error when closing the Agent API
+		IgnoredErrorIs: append(slogtest.DefaultIgnoredErrorIs, fasthttputil.ErrInmemoryListenerClosed),
+	}).Leveled(slog.LevelDebug)
 	if metadata.DERPMap == nil {
 		metadata.DERPMap, _ = tailnettest.RunDERPAndSTUN(t)
 	}

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -83,7 +83,8 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		ctx := inv.Context()
 		clitest.Start(t, inv)
-		coderdtest.AwaitWorkspaceAgents(t, client, r.Workspace.ID)
+		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
+			MatchResources(matchAgentWithVersion).Wait()
 		workspace, err := client.Workspace(ctx, r.Workspace.ID)
 		require.NoError(t, err)
 		resources := workspace.LatestBuild.Resources
@@ -120,7 +121,9 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		clitest.Start(t, inv)
 		ctx := inv.Context()
-		coderdtest.AwaitWorkspaceAgents(t, client, r.Workspace.ID)
+		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
+			MatchResources(matchAgentWithVersion).
+			Wait()
 		workspace, err := client.Workspace(ctx, r.Workspace.ID)
 		require.NoError(t, err)
 		resources := workspace.LatestBuild.Resources
@@ -161,7 +164,9 @@ func TestWorkspaceAgent(t *testing.T) {
 		)
 
 		ctx := inv.Context()
-		coderdtest.AwaitWorkspaceAgents(t, client, r.Workspace.ID)
+		coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
+			MatchResources(matchAgentWithVersion).
+			Wait()
 		workspace, err := client.Workspace(ctx, r.Workspace.ID)
 		require.NoError(t, err)
 		resources := workspace.LatestBuild.Resources
@@ -212,7 +217,8 @@ func TestWorkspaceAgent(t *testing.T) {
 
 		clitest.Start(t, inv)
 
-		resources := coderdtest.AwaitWorkspaceAgents(t, client, r.Workspace.ID)
+		resources := coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
+			MatchResources(matchAgentWithSubsystems).Wait()
 		require.Len(t, resources, 1)
 		require.Len(t, resources[0].Agents, 1)
 		require.Len(t, resources[0].Agents[0].Subsystems, 2)
@@ -220,4 +226,30 @@ func TestWorkspaceAgent(t *testing.T) {
 		require.Equal(t, codersdk.AgentSubsystemEnvbox, resources[0].Agents[0].Subsystems[0])
 		require.Equal(t, codersdk.AgentSubsystemExectrace, resources[0].Agents[0].Subsystems[1])
 	})
+}
+
+func matchAgentWithVersion(rs []codersdk.WorkspaceResource) bool {
+	if len(rs) < 1 {
+		return false
+	}
+	if len(rs[0].Agents) < 1 {
+		return false
+	}
+	if rs[0].Agents[0].Version == "" {
+		return false
+	}
+	return true
+}
+
+func matchAgentWithSubsystems(rs []codersdk.WorkspaceResource) bool {
+	if len(rs) < 1 {
+		return false
+	}
+	if len(rs[0].Agents) < 1 {
+		return false
+	}
+	if len(rs[0].Agents[0].Subsystems) < 1 {
+		return false
+	}
+	return true
 }

--- a/coderd/agentapi/servicebanner_internal_test.go
+++ b/coderd/agentapi/servicebanner_internal_test.go
@@ -5,12 +5,12 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetServiceBanner(t *testing.T) {

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -915,23 +915,67 @@ func AwaitWorkspaceBuildJobCompleted(t testing.TB, client *codersdk.Client, buil
 // AwaitWorkspaceAgents waits for all resources with agents to be connected. If
 // specific agents are provided, it will wait for those agents to be connected
 // but will not fail if other agents are not connected.
+//
+// Deprecated: Use NewWorkspaceAgentWaiter
 func AwaitWorkspaceAgents(t testing.TB, client *codersdk.Client, workspaceID uuid.UUID, agentNames ...string) []codersdk.WorkspaceResource {
-	t.Helper()
+	return NewWorkspaceAgentWaiter(t, client, workspaceID).AgentNames(agentNames).Wait()
+}
 
-	agentNamesMap := make(map[string]struct{}, len(agentNames))
-	for _, name := range agentNames {
+// WorkspaceAgentWaiter waits for all resources with agents to be connected. If
+// specific agents are provided using AgentNames(), it will wait for those agents
+// to be connected but will not fail if other agents are not connected.
+type WorkspaceAgentWaiter struct {
+	t                testing.TB
+	client           *codersdk.Client
+	workspaceID      uuid.UUID
+	agentNames       []string
+	resourcesMatcher func([]codersdk.WorkspaceResource) bool
+}
+
+// NewWorkspaceAgentWaiter returns an object that waits for agents to connect when
+// you call Wait() on it.
+func NewWorkspaceAgentWaiter(t testing.TB, client *codersdk.Client, workspaceID uuid.UUID) WorkspaceAgentWaiter {
+	return WorkspaceAgentWaiter{
+		t:           t,
+		client:      client,
+		workspaceID: workspaceID,
+	}
+}
+
+// AgentNames instructs the waiter to wait for the given, named agents to be connected and will
+// return even if other agents are not connected.
+func (w WorkspaceAgentWaiter) AgentNames(names []string) WorkspaceAgentWaiter {
+	//nolint: revive // returns modified struct
+	w.agentNames = names
+	return w
+}
+
+// MatchResources instructs the waiter to wait until the workspace has resources that cause the
+// provided matcher function to return true.
+func (w WorkspaceAgentWaiter) MatchResources(m func([]codersdk.WorkspaceResource) bool) WorkspaceAgentWaiter {
+	//nolint: revive // returns modified struct
+	w.resourcesMatcher = m
+	return w
+}
+
+// Wait waits for the agent(s) to connect and fails the test if they do not within testutil.WaitLong
+func (w WorkspaceAgentWaiter) Wait() []codersdk.WorkspaceResource {
+	w.t.Helper()
+
+	agentNamesMap := make(map[string]struct{}, len(w.agentNames))
+	for _, name := range w.agentNames {
 		agentNamesMap[name] = struct{}{}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	t.Logf("waiting for workspace agents (workspace %s)", workspaceID)
+	w.t.Logf("waiting for workspace agents (workspace %s)", w.workspaceID)
 	var resources []codersdk.WorkspaceResource
-	require.Eventually(t, func() bool {
+	require.Eventually(w.t, func() bool {
 		var err error
-		workspace, err := client.Workspace(ctx, workspaceID)
-		if !assert.NoError(t, err) {
+		workspace, err := w.client.Workspace(ctx, w.workspaceID)
+		if !assert.NoError(w.t, err) {
 			return false
 		}
 		if workspace.LatestBuild.Job.CompletedAt == nil {
@@ -943,23 +987,25 @@ func AwaitWorkspaceAgents(t testing.TB, client *codersdk.Client, workspaceID uui
 
 		for _, resource := range workspace.LatestBuild.Resources {
 			for _, agent := range resource.Agents {
-				if len(agentNames) > 0 {
+				if len(w.agentNames) > 0 {
 					if _, ok := agentNamesMap[agent.Name]; !ok {
 						continue
 					}
 				}
 
 				if agent.Status != codersdk.WorkspaceAgentConnected {
-					t.Logf("agent %s not connected yet", agent.Name)
+					w.t.Logf("agent %s not connected yet", agent.Name)
 					return false
 				}
 			}
 		}
 		resources = workspace.LatestBuild.Resources
-
-		return true
+		if w.resourcesMatcher == nil {
+			return true
+		}
+		return w.resourcesMatcher(resources)
 	}, testutil.WaitLong, testutil.IntervalMedium)
-	t.Logf("got workspace agents (workspace %s)", workspaceID)
+	w.t.Logf("got workspace agents (workspace %s)", w.workspaceID)
 	return resources
 }
 

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -637,24 +637,6 @@ func (c *Client) PostLogSource(ctx context.Context, req PostLogSource) (codersdk
 	return logSource, json.NewDecoder(res.Body).Decode(&logSource)
 }
 
-// GetServiceBanner relays the service banner config.
-func (c *Client) GetServiceBanner(ctx context.Context) (codersdk.ServiceBannerConfig, error) {
-	res, err := c.SDK.Request(ctx, http.MethodGet, "/api/v2/appearance", nil)
-	if err != nil {
-		return codersdk.ServiceBannerConfig{}, err
-	}
-	defer res.Body.Close()
-	// If the route does not exist then Enterprise code is not enabled.
-	if res.StatusCode == http.StatusNotFound {
-		return codersdk.ServiceBannerConfig{}, nil
-	}
-	if res.StatusCode != http.StatusOK {
-		return codersdk.ServiceBannerConfig{}, codersdk.ReadBodyAsError(res)
-	}
-	var cfg codersdk.AppearanceConfig
-	return cfg.ServiceBanner, json.NewDecoder(res.Body).Decode(&cfg)
-}
-
 type ExternalAuthResponse struct {
 	AccessToken string                 `json:"access_token"`
 	TokenExtra  map[string]interface{} `json:"token_extra"`

--- a/enterprise/coderd/appearance_test.go
+++ b/enterprise/coderd/appearance_test.go
@@ -157,34 +157,25 @@ func TestServiceBanners(t *testing.T) {
 
 		agentClient := agentsdk.New(client.URL)
 		agentClient.SetSessionToken(r.AgentToken)
-		banner, err := agentClient.GetServiceBanner(ctx)
-		require.NoError(t, err)
-		require.Equal(t, cfg.ServiceBanner, banner)
-		banner = requireGetServiceBannerV2(ctx, t, agentClient)
+		banner := requireGetServiceBanner(ctx, t, agentClient)
 		require.Equal(t, cfg.ServiceBanner, banner)
 
 		// Create an AGPL Coderd against the same database
 		agplClient := coderdtest.New(t, &coderdtest.Options{Database: store, Pubsub: ps})
 		agplAgentClient := agentsdk.New(agplClient.URL)
 		agplAgentClient.SetSessionToken(r.AgentToken)
-		banner, err = agplAgentClient.GetServiceBanner(ctx)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServiceBannerConfig{}, banner)
-		banner = requireGetServiceBannerV2(ctx, t, agplAgentClient)
+		banner = requireGetServiceBanner(ctx, t, agplAgentClient)
 		require.Equal(t, codersdk.ServiceBannerConfig{}, banner)
 
 		// No license means no banner.
 		err = client.DeleteLicense(ctx, lic.ID)
 		require.NoError(t, err)
-		banner, err = agentClient.GetServiceBanner(ctx)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServiceBannerConfig{}, banner)
-		banner = requireGetServiceBannerV2(ctx, t, agentClient)
+		banner = requireGetServiceBanner(ctx, t, agentClient)
 		require.Equal(t, codersdk.ServiceBannerConfig{}, banner)
 	})
 }
 
-func requireGetServiceBannerV2(ctx context.Context, t *testing.T, client *agentsdk.Client) codersdk.ServiceBannerConfig {
+func requireGetServiceBanner(ctx context.Context, t *testing.T, client *agentsdk.Client) codersdk.ServiceBannerConfig {
 	cc, err := client.Listen(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ replace github.com/imulab/go-scim/pkg/v2 => github.com/coder/go-scim/pkg/v2 v2.0
 replace github.com/pkg/sftp => github.com/mafredri/sftp v1.13.6-0.20231212144145-8218e927edb0
 
 require (
-	cdr.dev/slog v1.6.2-0.20230929193652-f0c466fabe10
+	cdr.dev/slog v1.6.2-0.20240126064726-20367d4aede6
 	cloud.google.com/go/compute/metadata v0.2.3
 	github.com/AlecAivazis/survey/v2 v2.3.5
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-cdr.dev/slog v1.6.2-0.20230929193652-f0c466fabe10 h1:gnB1By6Hzs2PVQXyi/cvo6L3kHPb8utLuzycWHfCztQ=
-cdr.dev/slog v1.6.2-0.20230929193652-f0c466fabe10/go.mod h1:NaoTA7KwopCrnaSb0JXTC0PTp/O/Y83Lndnq0OEV3ZQ=
+cdr.dev/slog v1.6.2-0.20240126064726-20367d4aede6 h1:KHblWIE/KHOwQ6lEbMZt6YpcGve2FEZ1sDtrW1Am5UI=
+cdr.dev/slog v1.6.2-0.20240126064726-20367d4aede6/go.mod h1:NaoTA7KwopCrnaSb0JXTC0PTp/O/Y83Lndnq0OEV3ZQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiVlk=
 cloud.google.com/go/compute v1.23.3/go.mod h1:VCgBUoMnIVIR0CscqQiPJLAG25E3ZRZMzcFZeQ+h8CI=


### PR DESCRIPTION
Agent uses the v2 API for the service banner, rather than the v1 HTTP API.

One of several for #10534