### PR TITLE
fix(site): disable autostart and autostop according to template settings

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.stories.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.stories.tsx
@@ -19,8 +19,17 @@ const meta: Meta<typeof WorkspaceScheduleForm> = {
   title: "pages/WorkspaceSettingsPage/WorkspaceScheduleForm",
   component: WorkspaceScheduleForm,
   args: {
-    enableAutoStart: true,
-    enableAutoStop: true,
+    allowTemplateAutoStart: true,
+    allowTemplateAutoStop: true,
+    allowedTemplateAutoStartDays: [
+      "sunday",
+      "monday",
+      "tuesday",
+      "wednesday",
+      "thursday",
+      "friday",
+      "saturday",
+    ],
   },
 };
 
@@ -42,8 +51,8 @@ export const AllDisabled: Story = {
       autostopEnabled: false,
       ttl: emptyTTL,
     },
-    enableAutoStart: false,
-    enableAutoStop: false,
+    allowTemplateAutoStart: false,
+    allowTemplateAutoStop: false,
   },
 };
 
@@ -55,7 +64,7 @@ export const Autostart: Story = {
       autostopEnabled: false,
       ttl: emptyTTL,
     },
-    enableAutoStop: false,
+    allowTemplateAutoStop: false,
   },
 };
 

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.test.tsx
@@ -244,15 +244,7 @@ describe("ttlShutdownAt", () => {
   });
 });
 
-const autoStartDays = [
-  "sunday",
-  "monday",
-  "tuesday",
-  "wednesday",
-  "thursday",
-  "friday",
-  "saturday",
-];
+const autoStartDayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const defaultFormProps = {
   submitScheduleError: "",
   initialValues: {
@@ -265,7 +257,7 @@ const defaultFormProps = {
   defaultTTL: 24,
   onCancel: () => null,
   onSubmit: () => null,
-  allowedTemplateAutoStartDays: autoStartDays,
+  allowedTemplateAutoStartDays: autoStartDayLabels,
   allowTemplateAutoStart: true,
   allowTemplateAutoStop: true,
 };
@@ -290,19 +282,19 @@ describe("templateInheritance", () => {
     // MUI's input is wrapped in a div so we look at the aria-attribute instead
     expect(timezoneInput).toHaveAttribute("aria-disabled");
 
-    autoStartDays.forEach(async (label) => {
+    for (const label of autoStartDayLabels) {
       const checkbox = await screen.findByLabelText(label);
       expect(checkbox).toBeDisabled();
-    });
+    }
   });
   it("disables the autostart days of the week appropriately", async () => {
-    const enabledDays = ["saturday", "sunday"];
+    const enabledDayLabels = ["Sat", "Sun"];
 
     jest.spyOn(API, "getTemplateByName").mockResolvedValue(MockTemplate);
     render(
       <WorkspaceScheduleForm
         {...defaultFormProps}
-        allowedTemplateAutoStartDays={enabledDays}
+        allowedTemplateAutoStartDays={["saturday", "sunday"]}
       />,
     );
 
@@ -316,17 +308,17 @@ describe("templateInheritance", () => {
     // MUI's input is wrapped in a div so we look at the aria-attribute instead
     expect(timezoneInput).not.toHaveAttribute("aria-disabled");
 
-    enabledDays.forEach(async (label) => {
+    for (const label of enabledDayLabels) {
       const checkbox = await screen.findByLabelText(label);
       expect(checkbox).toBeEnabled();
-    });
+    }
 
-    autoStartDays
-      .filter((day) => !enabledDays.includes(day))
-      .forEach(async (label) => {
-        const checkbox = await screen.findByLabelText(label);
-        expect(checkbox).toBeDisabled();
-      });
+    for (const label of autoStartDayLabels.filter(
+      (day) => !enabledDayLabels.includes(day),
+    )) {
+      const checkbox = await screen.findByLabelText(label);
+      expect(checkbox).toBeDisabled();
+    }
   });
   it("disables the entire autostop feature appropriately", async () => {
     jest.spyOn(API, "getTemplateByName").mockResolvedValue(MockTemplate);
@@ -364,7 +356,7 @@ describe("templateInheritance", () => {
     // MUI's input is wrapped in a div so we look at the aria-attribute instead
     expect(timezoneInput).toHaveAttribute("aria-disabled");
 
-    autoStartDays.forEach(async (label) => {
+    autoStartDayLabels.forEach(async (label) => {
       const checkbox = await screen.findByLabelText(label);
       expect(checkbox).toBeDisabled();
     });

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.test.tsx
@@ -345,4 +345,45 @@ describe("templateInheritance", () => {
     );
     expect(ttlInput).toBeDisabled();
   });
+  it("disables secondary autostart fields if main feature switch is toggled off", async () => {
+    jest.spyOn(API, "getTemplateByName").mockResolvedValue(MockTemplate);
+    render(
+      <WorkspaceScheduleForm
+        {...defaultFormProps}
+        initialValues={{
+          ...defaultFormProps.initialValues,
+          autostartEnabled: false,
+        }}
+      />,
+    );
+
+    const startTimeInput = await screen.findByLabelText("Start time");
+    expect(startTimeInput).toBeDisabled();
+
+    const timezoneInput = await screen.findByLabelText("Timezone");
+    // MUI's input is wrapped in a div so we look at the aria-attribute instead
+    expect(timezoneInput).toHaveAttribute("aria-disabled");
+
+    autoStartDays.forEach(async (label) => {
+      const checkbox = await screen.findByLabelText(label);
+      expect(checkbox).toBeDisabled();
+    });
+  });
+  it("disables secondary autostop fields if main feature switch is toggled off", async () => {
+    jest.spyOn(API, "getTemplateByName").mockResolvedValue(MockTemplate);
+    render(
+      <WorkspaceScheduleForm
+        {...defaultFormProps}
+        initialValues={{
+          ...defaultFormProps.initialValues,
+          autostopEnabled: false,
+        }}
+      />,
+    );
+
+    const ttlInput = await screen.findByLabelText(
+      "Time until shutdown (hours)",
+    );
+    expect(ttlInput).toBeDisabled();
+  });
 });

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -212,11 +212,6 @@ export const WorkspaceScheduleForm: FC<
 
   const checkboxes: Array<{ value: boolean; name: string; label: string }> = [
     {
-      value: form.values.sunday,
-      name: "sunday",
-      label: Language.daySundayLabel,
-    },
-    {
       value: form.values.monday,
       name: "monday",
       label: Language.dayMondayLabel,
@@ -245,6 +240,11 @@ export const WorkspaceScheduleForm: FC<
       value: form.values.saturday,
       name: "saturday",
       label: Language.daySaturdayLabel,
+    },
+    {
+      value: form.values.sunday,
+      name: "sunday",
+      label: Language.daySundayLabel,
     },
   ];
 
@@ -441,7 +441,14 @@ export const WorkspaceScheduleForm: FC<
           />
         </FormFields>
       </FormSection>
-      <FormFooter onCancel={onCancel} isLoading={isLoading} />
+      <FormFooter
+        onCancel={onCancel}
+        isLoading={isLoading}
+        submitDisabled={
+          (!allowTemplateAutoStart && !allowTemplateAutoStop) ||
+          (!form.values.autostartEnabled && !form.values.autostopEnabled)
+        }
+      />
     </HorizontalForm>
   );
 };

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -315,14 +315,26 @@ export const WorkspaceScheduleForm: FC<
           <Stack direction="row">
             <TextField
               {...formHelpers("startTime")}
-              disabled={isLoading || !allowTemplateAutoStart}
+              // disabled if template does not allow autostart
+              // or if primary feature is toggled off via the switch above
+              disabled={
+                isLoading ||
+                !allowTemplateAutoStart ||
+                !form.values.autostartEnabled
+              }
               label={Language.startTimeLabel}
               type="time"
               fullWidth
             />
             <TextField
               {...formHelpers("timezone")}
-              disabled={isLoading || !allowTemplateAutoStart}
+              // disabled if template does not allow autostart
+              // or if primary feature is toggled off via the switch above
+              disabled={
+                isLoading ||
+                !allowTemplateAutoStart ||
+                !form.values.autostartEnabled
+              }
               label={Language.timezoneLabel}
               select
               fullWidth
@@ -354,11 +366,13 @@ export const WorkspaceScheduleForm: FC<
                     <Checkbox
                       checked={checkbox.value}
                       // template admins can disable the autostart feature in general,
-                      // or they can disallow autostart on specific days of the week
+                      // or they can disallow autostart on specific days of the week.
+                      // also disabled if primary feature switch (above) is toggled off
                       disabled={
                         isLoading ||
                         !allowTemplateAutoStart ||
-                        !allowedTemplateAutoStartDays.includes(checkbox.name)
+                        !allowedTemplateAutoStartDays.includes(checkbox.name) ||
+                        !form.values.autostartEnabled
                       }
                       onChange={form.handleChange}
                       name={checkbox.name}
@@ -413,7 +427,13 @@ export const WorkspaceScheduleForm: FC<
               helperText: ttlShutdownAt(form.values.ttl),
               backendFieldName: "ttl_ms",
             })}
-            disabled={isLoading || !allowTemplateAutoStop}
+            // disabled if autostop disabled at template level or
+            // if autostop feature is toggled off via the switch above
+            disabled={
+              isLoading ||
+              !allowTemplateAutoStop ||
+              !form.values.autostopEnabled
+            }
             inputProps={{ min: 0, step: "any" }}
             label={Language.ttlLabel}
             type="number"

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceScheduleForm.tsx
@@ -32,6 +32,8 @@ import { timeZones } from "utils/timeZones";
 import Tooltip from "@mui/material/Tooltip";
 import { formatDuration, intervalToDuration } from "date-fns";
 import { DisabledBadge } from "components/Badges/Badges";
+import { TemplateAutostartRequirement } from "api/typesGenerated";
+import { PropsWithChildren } from "react";
 
 // REMARK: some plugins depend on utc, so it's listed first. Otherwise they're
 //         sorted alphabetically.
@@ -73,8 +75,9 @@ export interface WorkspaceScheduleFormProps {
   submitScheduleError?: unknown;
   initialValues: WorkspaceScheduleFormValues;
   isLoading: boolean;
-  enableAutoStop: boolean;
-  enableAutoStart: boolean;
+  allowedTemplateAutoStartDays: TemplateAutostartRequirement["days_of_week"];
+  allowTemplateAutoStop: boolean;
+  allowTemplateAutoStart: boolean;
   onCancel: () => void;
   onSubmit: (values: WorkspaceScheduleFormValues) => void;
   // for storybook
@@ -182,7 +185,7 @@ export const validationSchema = Yup.object({
 });
 
 export const WorkspaceScheduleForm: FC<
-  React.PropsWithChildren<WorkspaceScheduleFormProps>
+  PropsWithChildren<WorkspaceScheduleFormProps>
 > = ({
   submitScheduleError,
   initialValues,
@@ -191,8 +194,9 @@ export const WorkspaceScheduleForm: FC<
   onSubmit,
   initialTouched,
   defaultTTL,
-  enableAutoStop,
-  enableAutoStart,
+  allowedTemplateAutoStartDays,
+  allowTemplateAutoStop,
+  allowTemplateAutoStart,
 }) => {
   const form = useFormik<WorkspaceScheduleFormValues>({
     initialValues,
@@ -288,7 +292,7 @@ export const WorkspaceScheduleForm: FC<
               Select the time and days of week on which you want the workspace
               starting automatically.
             </div>
-            {!enableAutoStart && (
+            {!allowTemplateAutoStart && (
               <Tooltip title="This option can be enabled in the template settings">
                 <DisabledBadge />
               </Tooltip>
@@ -300,7 +304,7 @@ export const WorkspaceScheduleForm: FC<
           <FormControlLabel
             control={
               <Switch
-                disabled={!enableAutoStart}
+                disabled={!allowTemplateAutoStart}
                 name="autostartEnabled"
                 checked={form.values.autostartEnabled}
                 onChange={handleToggleAutostart}
@@ -311,14 +315,14 @@ export const WorkspaceScheduleForm: FC<
           <Stack direction="row">
             <TextField
               {...formHelpers("startTime")}
-              disabled={isLoading || !form.values.autostartEnabled}
+              disabled={isLoading || !allowTemplateAutoStart}
               label={Language.startTimeLabel}
               type="time"
               fullWidth
             />
             <TextField
               {...formHelpers("timezone")}
-              disabled={isLoading || !form.values.autostartEnabled}
+              disabled={isLoading || !allowTemplateAutoStart}
               label={Language.timezoneLabel}
               select
               fullWidth
@@ -349,7 +353,13 @@ export const WorkspaceScheduleForm: FC<
                   control={
                     <Checkbox
                       checked={checkbox.value}
-                      disabled={isLoading || !form.values.autostartEnabled}
+                      // template admins can disable the autostart feature in general,
+                      // or they can disallow autostart on specific days of the week
+                      disabled={
+                        isLoading ||
+                        !allowTemplateAutoStart ||
+                        !allowedTemplateAutoStartDays.includes(checkbox.name)
+                      }
                       onChange={form.handleChange}
                       name={checkbox.name}
                       size="small"
@@ -378,7 +388,7 @@ export const WorkspaceScheduleForm: FC<
               extended by 1 hour after last activity in the workspace was
               detected.
             </div>
-            {!enableAutoStop && (
+            {!allowTemplateAutoStop && (
               <Tooltip title="This option can be enabled in the template settings">
                 <DisabledBadge />
               </Tooltip>
@@ -393,7 +403,7 @@ export const WorkspaceScheduleForm: FC<
                 name="autostopEnabled"
                 checked={form.values.autostopEnabled}
                 onChange={handleToggleAutostop}
-                disabled={!enableAutoStop}
+                disabled={!allowTemplateAutoStop}
               />
             }
             label={Language.stopSwitch}
@@ -403,7 +413,7 @@ export const WorkspaceScheduleForm: FC<
               helperText: ttlShutdownAt(form.values.ttl),
               backendFieldName: "ttl_ms",
             })}
-            disabled={isLoading || !form.values.autostopEnabled}
+            disabled={isLoading || !allowTemplateAutoStop}
             inputProps={{ min: 0, step: "any" }}
             label={Language.ttlLabel}
             type="number"

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -98,8 +98,11 @@ export const WorkspaceSchedulePage: FC = () => {
 
       {template && (
         <WorkspaceScheduleForm
-          enableAutoStart={template.allow_user_autostart}
-          enableAutoStop={template.allow_user_autostop}
+          allowedTemplateAutoStartDays={
+            template.autostart_requirement.days_of_week
+          }
+          allowTemplateAutoStart={template.allow_user_autostart}
+          allowTemplateAutoStop={template.allow_user_autostop}
           submitScheduleError={submitScheduleMutation.error}
           initialValues={{
             ...getAutostart(workspace),

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -59,7 +59,10 @@ export const WorkspaceSchedulePage: FC = () => {
     mutationFn: submitSchedule,
     onSuccess: async () => {
       await queryClient.invalidateQueries(
-        workspaceByOwnerAndNameKey(params.username, params.workspace),
+        workspaceByOwnerAndNameKey(
+          params.username.replace(/^@/, ""),
+          params.workspace,
+        ),
       );
     },
   });


### PR DESCRIPTION
resolves [#10930](https://github.com/coder/coder/issues/10930)
resolves [#10931](https://github.com/coder/coder/issues/10931)
Deployed a PR below

Disabling these fields on a template level:
![Screenshot 2024-01-24 at 2 02 33 PM](https://github.com/coder/coder/assets/19142439/4fd325a4-3a83-4a40-87aa-de4e27185f4d)

will disable them on a workspace level (but will not reset any workspace values set before disablement):
![Screenshot 2024-01-24 at 2 02 44 PM](https://github.com/coder/coder/assets/19142439/729d38bf-266f-4506-8bc6-488ec62430c3)

Similarly, when specific days of the week are allowed to be configured per the template:
![Screenshot 2024-01-24 at 2 04 48 PM](https://github.com/coder/coder/assets/19142439/41c036cb-9393-41e9-a316-279e9fa62741)

only those days of the week are enabled in the workspace settings:
![Screenshot 2024-01-24 at 2 05 02 PM](https://github.com/coder/coder/assets/19142439/d44af70b-8b25-42fc-8ee9-381ce2cd3b9d)
