### PR TITLE
fix(enterprise/cli): add ID to licenses list output

### DIFF
--- a/docs/cli/licenses_list.md
+++ b/docs/cli/licenses_list.md
@@ -18,10 +18,10 @@ coder licenses list [flags]
 
 ### -c, --column
 
-|         |                                                   |
-| ------- | ------------------------------------------------- |
-| Type    | <code>string-array</code>                         |
-| Default | <code>UUID,Expires At,Uploaded At,Features</code> |
+|         |                                                      |
+| ------- | ---------------------------------------------------- |
+| Type    | <code>string-array</code>                            |
+| Default | <code>ID,UUID,Expires At,Uploaded At,Features</code> |
 
 Columns to display in table output. Available columns: id, uuid, uploaded at, features, expires at, trial.
 

--- a/enterprise/cli/licenses.go
+++ b/enterprise/cli/licenses.go
@@ -150,7 +150,7 @@ func (r *RootCmd) licensesList() *clibase.Cmd {
 
 	formatter := cliui.NewOutputFormatter(
 		cliui.ChangeFormatterData(
-			cliui.TableFormat([]tableLicense{}, []string{"UUID", "Expires At", "Uploaded At", "Features"}),
+			cliui.TableFormat([]tableLicense{}, []string{"ID", "UUID", "Expires At", "Uploaded At", "Features"}),
 			func(data any) (any, error) {
 				list, ok := data.([]codersdk.License)
 				if !ok {

--- a/enterprise/cli/testdata/coder_licenses_list_--help.golden
+++ b/enterprise/cli/testdata/coder_licenses_list_--help.golden
@@ -8,7 +8,7 @@ USAGE:
   Aliases: ls
 
 OPTIONS:
-  -c, --column string-array (default: UUID,Expires At,Uploaded At,Features)
+  -c, --column string-array (default: ID,UUID,Expires At,Uploaded At,Features)
           Columns to display in table output. Available columns: id, uuid,
           uploaded at, features, expires at, trial.
 


### PR DESCRIPTION
As the `licenses delete` command requires an ID (integer), the `licenses list` command should also default to showing license IDs. 