### PR TITLE
feat: use agent v2 API to fetch manifest

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2043,6 +2043,9 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 	if metadata.WorkspaceName == "" {
 		metadata.WorkspaceName = "test-workspace"
 	}
+	if metadata.WorkspaceID == uuid.Nil {
+		metadata.WorkspaceID = uuid.New()
+	}
 	coordinator := tailnet.NewCoordinator(logger)
 	t.Cleanup(func() {
 		_ = coordinator.Close()

--- a/coderd/agentapi/api.go
+++ b/coderd/agentapi/api.go
@@ -97,6 +97,16 @@ func New(opts Options) *API {
 		AgentFn:                  api.agent,
 		Database:                 opts.Database,
 		DerpMapFn:                opts.DerpMapFn,
+		WorkspaceIDFn: func(ctx context.Context, wa *database.WorkspaceAgent) (uuid.UUID, error) {
+			if opts.WorkspaceID != uuid.Nil {
+				return opts.WorkspaceID, nil
+			}
+			ws, err := opts.Database.GetWorkspaceByAgentID(ctx, wa.ID)
+			if err != nil {
+				return uuid.Nil, err
+			}
+			return ws.Workspace.ID, nil
+		},
 	}
 
 	api.ServiceBannerAPI = &ServiceBannerAPI{

--- a/codersdk/workspaceagents_test.go
+++ b/codersdk/workspaceagents_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,37 +19,32 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestWorkspaceAgentMetadata(t *testing.T) {
+func TestWorkspaceRewriteDERPMap(t *testing.T) {
 	t.Parallel()
-	// This test ensures that the DERP map returned properly
-	// mutates built-in DERPs with the client access URL.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		httpapi.Write(context.Background(), w, http.StatusOK, agentsdk.Manifest{
-			DERPMap: &tailcfg.DERPMap{
-				Regions: map[int]*tailcfg.DERPRegion{
-					1: {
-						EmbeddedRelay: true,
-						RegionID:      1,
-						Nodes: []*tailcfg.DERPNode{{
-							HostName: "bananas.org",
-							DERPPort: 1,
-						}},
-					},
-				},
+	// This test ensures that RewriteDERPMap mutates built-in DERPs with the
+	// client access URL.
+	dm := &tailcfg.DERPMap{
+		Regions: map[int]*tailcfg.DERPRegion{
+			1: {
+				EmbeddedRelay: true,
+				RegionID:      1,
+				Nodes: []*tailcfg.DERPNode{{
+					HostName: "bananas.org",
+					DERPPort: 1,
+				}},
 			},
-		})
-	}))
-	parsed, err := url.Parse(srv.URL)
+		},
+	}
+	parsed, err := url.Parse("https://coconuts.org:44558")
 	require.NoError(t, err)
 	client := agentsdk.New(parsed)
-	manifest, err := client.Manifest(context.Background())
-	require.NoError(t, err)
-	region := manifest.DERPMap.Regions[1]
+	client.RewriteDERPMap(dm)
+	region := dm.Regions[1]
 	require.True(t, region.EmbeddedRelay)
 	require.Len(t, region.Nodes, 1)
 	node := region.Nodes[0]
-	require.Equal(t, parsed.Hostname(), node.HostName)
-	require.Equal(t, parsed.Port(), strconv.Itoa(node.DERPPort))
+	require.Equal(t, "coconuts.org", node.HostName)
+	require.Equal(t, 44558, node.DERPPort)
 }
 
 func TestAgentReportStats(t *testing.T) {


### PR DESCRIPTION
Agent uses the v2 API to obtain the manifest, instead of the HTTP API.