### PR TITLE
chore(dogfood): replace `repo_dir` with `base_repo_dir` in `git-clone` module

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -32,7 +32,7 @@ locals {
   }
 
   repo_base_dir  = replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
-  repo_dir       = "${replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")}/coder"
+  repo_dir       = module.git-clone.repo_dir
   container_name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
   registry_name  = "codercom/oss-dogfood"
   jfrog_host     = replace(var.jfrog_url, "https://", "")
@@ -87,20 +87,20 @@ data "coder_workspace" "me" {}
 
 module "slackme" {
   source           = "registry.coder.com/modules/slackme/coder"
-  version          = "1.0.1"
+  version          = "1.0.2"
   agent_id         = coder_agent.dev.id
   auth_provider_id = "slack"
 }
 
 module "dotfiles" {
   source   = "registry.coder.com/modules/dotfiles/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
 }
 
 module "git-clone" {
   source   = "registry.coder.com/modules/git-clone/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
   url      = "https://github.com/coder/coder"
   path     = local.repo_base_dir
@@ -108,20 +108,20 @@ module "git-clone" {
 
 module "personalize" {
   source   = "registry.coder.com/modules/personalize/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
 }
 
 module "code-server" {
   source   = "registry.coder.com/modules/code-server/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
   folder   = local.repo_dir
 }
 
 module "jetbrains_gateway" {
   source         = "registry.coder.com/modules/jetbrains-gateway/coder"
-  version        = "1.0.1"
+  version        = "1.0.2"
   agent_id       = coder_agent.dev.id
   agent_name     = "dev"
   folder         = local.repo_dir
@@ -131,26 +131,26 @@ module "jetbrains_gateway" {
 
 module "vscode-desktop" {
   source   = "registry.coder.com/modules/vscode-desktop/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
   folder   = local.repo_dir
 }
 
 module "filebrowser" {
   source   = "registry.coder.com/modules/filebrowser/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
 }
 
 module "coder-login" {
   source   = "registry.coder.com/modules/coder-login/coder"
-  version  = "1.0.1"
+  version  = "1.0.2"
   agent_id = coder_agent.dev.id
 }
 
 module "jfrog" {
   source                = "registry.coder.com/modules/jfrog-oauth/coder"
-  version               = "1.0.1"
+  version               = "1.0.2"
   agent_id              = coder_agent.dev.id
   jfrog_url             = var.jfrog_url
   configure_code_server = true

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -42,7 +42,7 @@ data "coder_parameter" "repo_base_dir" {
   type        = "string"
   name        = "Coder Repository Base Directory"
   default     = "~"
-  description = "The directory specified will be created and [coder/coder](https://github.com/coder/coder) will be automatically cloned into `coder` subdirectory in it 🪄."
+  description = "The directory specified will be created (if missing) and [coder/coder](https://github.com/coder/coder) will be automatically cloned into `[base directory]/coder` 🪄."
   mutable     = true
 }
 

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -42,7 +42,7 @@ data "coder_parameter" "repo_base_dir" {
   type        = "string"
   name        = "Coder Repository Base Directory"
   default     = "~"
-  description = "The directory specified will be created (if missing) and [coder/coder](https://github.com/coder/coder) will be automatically cloned into `[base directory]/coder` 🪄."
+  description = "The directory specified will be created (if missing) and [coder/coder](https://github.com/coder/coder) will be automatically cloned into [base directory]/coder 🪄."
   mutable     = true
 }
 


### PR DESCRIPTION
After coder/modules#124, the `git-clone` module automatically appends and creates the path with the repo name, so we need to change the `path` input to specify the `repo_base_dir`. 

The `repo_dir` must still be passed to `code-server` and `jetbrains-gateway` modules and to set the `dir` field of `coder_agent`

Depends on coder/modules#132
