### PR TITLE
feat(cli): show workspace favorite status in list output

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -22,6 +22,7 @@ type workspaceListRow struct {
 	codersdk.Workspace `table:"-"`
 
 	// For table format:
+	Favorite       bool   `json:"-" table:"favorite"`
 	WorkspaceName  string `json:"-" table:"workspace,default_sort"`
 	Template       string `json:"-" table:"template"`
 	Status         string `json:"-" table:"status"`
@@ -47,6 +48,7 @@ func workspaceListRowFromWorkspace(now time.Time, workspace codersdk.Workspace) 
 		healthy = strconv.FormatBool(workspace.Health.Healthy)
 	}
 	return workspaceListRow{
+		Favorite:       workspace.Favorite,
 		Workspace:      workspace,
 		WorkspaceName:  workspace.OwnerName + "/" + workspace.Name,
 		Template:       workspace.TemplateName,
@@ -70,6 +72,7 @@ func (r *RootCmd) list() *clibase.Cmd {
 			cliui.TableFormat(
 				[]workspaceListRow{},
 				[]string{
+					"favorite",
 					"workspace",
 					"template",
 					"status",

--- a/cli/list.go
+++ b/cli/list.go
@@ -47,10 +47,15 @@ func workspaceListRowFromWorkspace(now time.Time, workspace codersdk.Workspace) 
 	if status == "Starting" || status == "Started" {
 		healthy = strconv.FormatBool(workspace.Health.Healthy)
 	}
+	favIco := " "
+	if workspace.Favorite {
+		favIco = "★"
+	}
+	workspaceName := favIco + " " + workspace.OwnerName + "/" + workspace.Name
 	return workspaceListRow{
 		Favorite:       workspace.Favorite,
 		Workspace:      workspace,
-		WorkspaceName:  workspace.OwnerName + "/" + workspace.Name,
+		WorkspaceName:  workspaceName,
 		Template:       workspace.TemplateName,
 		Status:         status,
 		Healthy:        healthy,
@@ -72,7 +77,6 @@ func (r *RootCmd) list() *clibase.Cmd {
 			cliui.TableFormat(
 				[]workspaceListRow{},
 				[]string{
-					"favorite",
 					"workspace",
 					"template",
 					"status",

--- a/cli/testdata/coder_list_--help.golden
+++ b/cli/testdata/coder_list_--help.golden
@@ -11,10 +11,10 @@ OPTIONS:
   -a, --all bool
           Specifies whether all workspaces will be listed or not.
 
-  -c, --column string-array (default: workspace,template,status,healthy,last built,current version,outdated,starts at,stops after)
-          Columns to display in table output. Available columns: workspace,
-          template, status, healthy, last built, current version, outdated,
-          starts at, starts next, stops after, stops next, daily cost.
+  -c, --column string-array (default: favorite,workspace,template,status,healthy,last built,current version,outdated,starts at,stops after)
+          Columns to display in table output. Available columns: favorite,
+          workspace, template, status, healthy, last built, current version,
+          outdated, starts at, starts next, stops after, stops next, daily cost.
 
   -o, --output string (default: table)
           Output format. Available formats: table, json.

--- a/cli/testdata/coder_list_--help.golden
+++ b/cli/testdata/coder_list_--help.golden
@@ -11,7 +11,7 @@ OPTIONS:
   -a, --all bool
           Specifies whether all workspaces will be listed or not.
 
-  -c, --column string-array (default: favorite,workspace,template,status,healthy,last built,current version,outdated,starts at,stops after)
+  -c, --column string-array (default: workspace,template,status,healthy,last built,current version,outdated,starts at,stops after)
           Columns to display in table output. Available columns: favorite,
           workspace, template, status, healthy, last built, current version,
           outdated, starts at, starts next, stops after, stops next, daily cost.

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -26,10 +26,10 @@ Specifies whether all workspaces will be listed or not.
 
 ### -c, --column
 
-|         |                                                                                                                   |
-| ------- | ----------------------------------------------------------------------------------------------------------------- |
-| Type    | <code>string-array</code>                                                                                         |
-| Default | <code>favorite,workspace,template,status,healthy,last built,current version,outdated,starts at,stops after</code> |
+|         |                                                                                                          |
+| ------- | -------------------------------------------------------------------------------------------------------- |
+| Type    | <code>string-array</code>                                                                                |
+| Default | <code>workspace,template,status,healthy,last built,current version,outdated,starts at,stops after</code> |
 
 Columns to display in table output. Available columns: favorite, workspace, template, status, healthy, last built, current version, outdated, starts at, starts next, stops after, stops next, daily cost.
 

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -26,12 +26,12 @@ Specifies whether all workspaces will be listed or not.
 
 ### -c, --column
 
-|         |                                                                                                          |
-| ------- | -------------------------------------------------------------------------------------------------------- |
-| Type    | <code>string-array</code>                                                                                |
-| Default | <code>workspace,template,status,healthy,last built,current version,outdated,starts at,stops after</code> |
+|         |                                                                                                                   |
+| ------- | ----------------------------------------------------------------------------------------------------------------- |
+| Type    | <code>string-array</code>                                                                                         |
+| Default | <code>favorite,workspace,template,status,healthy,last built,current version,outdated,starts at,stops after</code> |
 
-Columns to display in table output. Available columns: workspace, template, status, healthy, last built, current version, outdated, starts at, starts next, stops after, stops next, daily cost.
+Columns to display in table output. Available columns: favorite, workspace, template, status, healthy, last built, current version, outdated, starts at, starts next, stops after, stops next, daily cost.
 
 ### -o, --output
 


### PR DESCRIPTION
```
WORKSPACE      TEMPLATE  STATUS   HEALTHY  LAST BUILT  CURRENT VERSION   OUTDATED  STARTS AT  STOPS AFTER  
  admin/test   docker    Stopped           16d17h      peaceful_yonath2  false                1d           
★ admin/test2  docker    Failed            3d23h       peaceful_yonath2  false                1d             
```

Note: `TableFormatter` currently only supports a single `default_sort`.