### PR TITLE
feat: add logging to client tailnet yamux

### DIFF
--- a/coderd/agentapi/servicebanner_internal_test.go
+++ b/coderd/agentapi/servicebanner_internal_test.go
@@ -5,12 +5,12 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetServiceBanner(t *testing.T) {

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -441,7 +441,10 @@ func (tac *tailnetAPIConnector) dial() (proto.DRPCTailnetClient, error) {
 		}
 		return nil, err
 	}
-	client, err := tailnet.NewDRPCClient(websocket.NetConn(tac.ctx, ws, websocket.MessageBinary))
+	client, err := tailnet.NewDRPCClient(
+		websocket.NetConn(tac.ctx, ws, websocket.MessageBinary),
+		tac.logger,
+	)
 	if err != nil {
 		tac.logger.Debug(tac.ctx, "failed to create DRPCClient", slog.Error(err))
 		_ = ws.Close(websocket.StatusInternalError, "")

--- a/tailnet/client.go
+++ b/tailnet/client.go
@@ -1,19 +1,21 @@
 package tailnet
 
 import (
-	"io"
+	"context"
 	"net"
 
 	"github.com/hashicorp/yamux"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
 	"github.com/coder/coder/v2/codersdk/drpc"
 	"github.com/coder/coder/v2/tailnet/proto"
 )
 
-func NewDRPCClient(conn net.Conn) (proto.DRPCTailnetClient, error) {
+func NewDRPCClient(conn net.Conn, logger slog.Logger) (proto.DRPCTailnetClient, error) {
 	config := yamux.DefaultConfig()
-	config.LogOutput = io.Discard
+	config.LogOutput = nil
+	config.Logger = slog.Stdlib(context.Background(), logger, slog.LevelInfo)
 	session, err := yamux.Client(conn, config)
 	if err != nil {
 		return nil, xerrors.Errorf("multiplex client: %w", err)

--- a/tailnet/coordinator_test.go
+++ b/tailnet/coordinator_test.go
@@ -464,7 +464,7 @@ func TestRemoteCoordination(t *testing.T) {
 		serveErr <- err
 	}()
 
-	client, err := tailnet.NewDRPCClient(cC)
+	client, err := tailnet.NewDRPCClient(cC, logger)
 	require.NoError(t, err)
 	protocol, err := client.Coordinate(ctx)
 	require.NoError(t, err)

--- a/tailnet/service_test.go
+++ b/tailnet/service_test.go
@@ -51,7 +51,7 @@ func TestClientService_ServeClient_V2(t *testing.T) {
 		errCh <- err
 	}()
 
-	client, err := tailnet.NewDRPCClient(c)
+	client, err := tailnet.NewDRPCClient(c, logger)
 	require.NoError(t, err)
 
 	// Coordinate


### PR DESCRIPTION
Adds logging to yamux when used for tailnet client connections, e.g. CLI and wsproxy.  This could be useful for debugging connection issues with tailnet v2 API.
