### PR TITLE
feat: move agent v2 API connection monitoring to yamux layer

### DIFF
--- a/coderd/workspaceagentsrpc_internal_test.go
+++ b/coderd/workspaceagentsrpc_internal_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestAgentWebsocketMonitor_ContextCancel(t *testing.T) {
+func TestAgentConnectionMonitor_ContextCancel(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	now := dbtime.Now()
@@ -45,7 +45,7 @@ func TestAgentWebsocketMonitor_ContextCancel(t *testing.T) {
 	}
 	replicaID := uuid.New()
 
-	uut := &agentWebsocketMonitor{
+	uut := &agentConnectionMonitor{
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
@@ -97,7 +97,7 @@ func TestAgentWebsocketMonitor_ContextCancel(t *testing.T) {
 	require.Greater(t, m, n)
 }
 
-func TestAgentWebsocketMonitor_PingTimeout(t *testing.T) {
+func TestAgentConnectionMonitor_PingTimeout(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	now := dbtime.Now()
@@ -119,7 +119,7 @@ func TestAgentWebsocketMonitor_PingTimeout(t *testing.T) {
 	}
 	replicaID := uuid.New()
 
-	uut := &agentWebsocketMonitor{
+	uut := &agentConnectionMonitor{
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
@@ -157,7 +157,7 @@ func TestAgentWebsocketMonitor_PingTimeout(t *testing.T) {
 	fUpdater.requireEventuallySomeUpdates(t, build.WorkspaceID)
 }
 
-func TestAgentWebsocketMonitor_BuildOutdated(t *testing.T) {
+func TestAgentConnectionMonitor_BuildOutdated(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	now := dbtime.Now()
@@ -179,7 +179,7 @@ func TestAgentWebsocketMonitor_BuildOutdated(t *testing.T) {
 	}
 	replicaID := uuid.New()
 
-	uut := &agentWebsocketMonitor{
+	uut := &agentConnectionMonitor{
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,
@@ -217,12 +217,12 @@ func TestAgentWebsocketMonitor_BuildOutdated(t *testing.T) {
 	fUpdater.requireEventuallySomeUpdates(t, build.WorkspaceID)
 }
 
-func TestAgentWebsocketMonitor_SendPings(t *testing.T) {
+func TestAgentConnectionMonitor_SendPings(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 	t.Cleanup(cancel)
 	fConn := &fakePingerCloser{}
-	uut := &agentWebsocketMonitor{
+	uut := &agentConnectionMonitor{
 		pingPeriod: testutil.IntervalFast,
 		conn:       fConn,
 	}
@@ -238,7 +238,7 @@ func TestAgentWebsocketMonitor_SendPings(t *testing.T) {
 	require.NotNil(t, lastPing)
 }
 
-func TestAgentWebsocketMonitor_StartClose(t *testing.T) {
+func TestAgentConnectionMonitor_StartClose(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	fConn := &fakePingerCloser{}
@@ -259,7 +259,7 @@ func TestAgentWebsocketMonitor_StartClose(t *testing.T) {
 		WorkspaceID: uuid.New(),
 	}
 	replicaID := uuid.New()
-	uut := &agentWebsocketMonitor{
+	uut := &agentConnectionMonitor{
 		apiCtx:            ctx,
 		workspaceAgent:    agent,
 		workspaceBuild:    build,


### PR DESCRIPTION
Moves monitoring of the agent v2 API connection to the yamux layer.

Present behavior monitors this at the websocket layer, and closes the websocket on completion. This can cause yamux to hit unexpected errors since the connection is closed underneath it.

This might be the cause of yamux errors that some customers are seeing

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/tCz4CxRU9jhAJ7zH8RTi/53b8b5ef-e9e5-44a5-b559-99c37c136071.png)

In any case, it's more graceful to close yamux first and let yamux close the underlying websocket.  That should limit yamux error logging to truly unexpected/error cases.

The only downside is that the yamux `Close()` doesn't accept a reason, so if the agent becomes outdated and we close the API connection, the agent just sees the connection close without a reason.  I'm not sure we log this at the agent anyway, but it would be nice.  I think more accurate logging on Coderd are more important.

I've also added some logging when the monitor disconnects for reasons other than the context being canceled (e.g. agent outdated, failed pings).