### PR TITLE
fix(cli): allow template name length of 32 in template push and create

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -79,8 +79,8 @@ func (r *RootCmd) templateCreate() *clibase.Cmd {
 				return err
 			}
 
-			if utf8.RuneCountInString(templateName) > 31 {
-				return xerrors.Errorf("Template name must be less than 32 characters")
+			if utf8.RuneCountInString(templateName) > 32 {
+				return xerrors.Errorf("Template name must be no more than 32 characters")
 			}
 
 			_, err = client.TemplateByName(inv.Context(), organization.ID, templateName)

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -56,8 +56,8 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 				return err
 			}
 
-			if utf8.RuneCountInString(name) >= 32 {
-				return xerrors.Errorf("Template name must be less than 32 characters")
+			if utf8.RuneCountInString(name) > 32 {
+				return xerrors.Errorf("Template name must be no more than 32 characters")
 			}
 
 			var createTemplate bool


### PR DESCRIPTION
This check resulted in a flake here: https://github.com/coder/coder/actions/runs/7709596330/job/21011185333?pr=11753

