### PR TITLE
docs: update remote docker host docs

### DIFF
--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -88,7 +88,8 @@ Sysbox ahead of time will reduce disruption to your Coder instance.
 You can use a remote Docker host in 2 ways.
 
 1. Configuring docker provider to use a
-   [remote host](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts) over SSH or TCP.
+   [remote host](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts)
+   over SSH or TCP.
 2. Running an
    [external provisoner](https://coder.com/docs/v2/latest/admin/provisioners#external-provisioners)
    on the remote docker host.

--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -87,8 +87,11 @@ Sysbox ahead of time will reduce disruption to your Coder instance.
 
 You can use a remote Docker host in 2 ways.
 
-1. Configuring terraform docker provider to use a [remote docker host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
-2. Running an [external provisoner](https://coder.com/docs/v2/latest/admin/provisioners#external-provisioners) on the remote docker host.
+1. Configuring terraform docker provider to use a
+   [remote docker host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
+2. Running an
+   [external provisoner](https://coder.com/docs/v2/latest/admin/provisioners#external-provisioners)
+   on the remote docker host.
 
 ## Troubleshooting
 

--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -87,12 +87,8 @@ Sysbox ahead of time will reduce disruption to your Coder instance.
 
 You can use a remote Docker host in 2 ways.
 
-1. Over SSH. See
-   [here](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts)
-   for details.
-2. Over TCP. See
-   [here](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#certificate-information)
-   for details.
+1. Configuring terraform docker provider to use a [remote docker host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
+2. Running an [external provisoner](https://coder.com/docs/v2/latest/admin/provisioners#external-provisioners) on the remote docker host.
 
 ## Troubleshooting
 

--- a/docs/platforms/docker.md
+++ b/docs/platforms/docker.md
@@ -87,8 +87,8 @@ Sysbox ahead of time will reduce disruption to your Coder instance.
 
 You can use a remote Docker host in 2 ways.
 
-1. Configuring terraform docker provider to use a
-   [remote docker host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
+1. Configuring docker provider to use a
+   [remote host](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts) over SSH or TCP.
 2. Running an
    [external provisoner](https://coder.com/docs/v2/latest/admin/provisioners#external-provisioners)
    on the remote docker host.


### PR DESCRIPTION
Adds a link to external provisioners as a method to use remote docker hosts