### PR TITLE
fix(coderd/database): fix limit in `GetUserWorkspaceBuildParameters`

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -9940,25 +9940,30 @@ func (q *sqlQuerier) InsertWorkspaceAppStats(ctx context.Context, arg InsertWork
 }
 
 const getUserWorkspaceBuildParameters = `-- name: GetUserWorkspaceBuildParameters :many
-SELECT DISTINCT ON (tvp.name)
-    tvp.name,
-    wbp.value
-FROM
-    workspace_build_parameters wbp
-JOIN
-    workspace_builds wb ON wb.id = wbp.workspace_build_id
-JOIN
-    workspaces w ON w.id = wb.workspace_id
-JOIN
-    template_version_parameters tvp ON tvp.template_version_id = wb.template_version_id
-WHERE
-    w.owner_id = $1
-    AND wb.transition = 'start'
-    AND w.template_id = $2
-    AND tvp.ephemeral = false
-    AND tvp.name = wbp.name
-ORDER BY
-    tvp.name, wb.created_at DESC
+SELECT name, value
+FROM (
+    SELECT DISTINCT ON (tvp.name)
+        tvp.name,
+        wbp.value,
+        wb.created_at
+    FROM
+        workspace_build_parameters wbp
+    JOIN
+        workspace_builds wb ON wb.id = wbp.workspace_build_id
+    JOIN
+        workspaces w ON w.id = wb.workspace_id
+    JOIN
+        template_version_parameters tvp ON tvp.template_version_id = wb.template_version_id
+    WHERE
+		w.owner_id = $1
+		AND wb.transition = 'start'
+		AND w.template_id = $2
+		AND tvp.ephemeral = false
+		AND tvp.name = wbp.name
+    ORDER BY
+        tvp.name, wb.created_at DESC
+) q1
+ORDER BY created_at DESC, name
 LIMIT 100
 `
 

--- a/coderd/database/queries/workspacebuildparameters.sql
+++ b/coderd/database/queries/workspacebuildparameters.sql
@@ -16,25 +16,28 @@ WHERE
     workspace_build_id = $1;
 
 -- name: GetUserWorkspaceBuildParameters :many
--- name: GetUserWorkspaceBuildParameters :many
-SELECT DISTINCT ON (tvp.name)
-    tvp.name,
-    wbp.value
-FROM
-    workspace_build_parameters wbp
-JOIN
-    workspace_builds wb ON wb.id = wbp.workspace_build_id
-JOIN
-    workspaces w ON w.id = wb.workspace_id
-JOIN
-    template_version_parameters tvp ON tvp.template_version_id = wb.template_version_id
-WHERE
-    w.owner_id = $1
-    AND wb.transition = 'start'
-    AND w.template_id = $2
-    AND tvp.ephemeral = false
-    AND tvp.name = wbp.name
-ORDER BY
-    tvp.name, wb.created_at DESC
+SELECT name, value
+FROM (
+    SELECT DISTINCT ON (tvp.name)
+        tvp.name,
+        wbp.value,
+        wb.created_at
+    FROM
+        workspace_build_parameters wbp
+    JOIN
+        workspace_builds wb ON wb.id = wbp.workspace_build_id
+    JOIN
+        workspaces w ON w.id = wb.workspace_id
+    JOIN
+        template_version_parameters tvp ON tvp.template_version_id = wb.template_version_id
+    WHERE
+		w.owner_id = $1
+		AND wb.transition = 'start'
+		AND w.template_id = $2
+		AND tvp.ephemeral = false
+		AND tvp.name = wbp.name
+    ORDER BY
+        tvp.name, wb.created_at DESC
+) q1
+ORDER BY created_at DESC, name
 LIMIT 100;
-


### PR DESCRIPTION
This is a fix for the query introduced in #11731 where the LIMIT is applied to a list of sorted names, potentially ignoring more recently used names if the number of results exceed 100.

First we select all the unique names with their values and latest dates, then we re-sort that list by date and select the 100 most recent ones.

Alternatively, we could remove the limit entirely.

