### PR TITLE
fix(dogfood): fix startup script on workspace creation

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -272,7 +272,7 @@ resource "coder_agent" "dev" {
       cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
     else
       echo "The directory ${local.repo_dir}/site does not exist. Clone is not complete."
-      echo 'Please run "${local.repo_dir}/site && pnpm install && pnpm playwright:instal" after workspace creation'
+      echo 'Please run "cd ${local.repo_dir}/site && pnpm install && pnpm playwright:instal" after workspace creation'
     fi
   EOT
 }

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -266,8 +266,15 @@ resource "coder_agent" "dev" {
     sudo service docker start
     # Install playwright dependencies
     # We want to use the playwright version from site/package.json
-    cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
-EOT
+    # Check if the directory exists At workspace creation as the coder_script runs in parallel so clone does not exist.
+    # it will run on fine on a restart though 
+    if [ -d "${local.repo_dir}/site" ]; then
+      cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
+    else
+      echo "The directory ${local.repo_dir}/site does not exist. Clone is not complete."
+      echo 'Please run "${local.repo_dir}/site && pnpm install && pnpm playwright:instal" after workspace creation'
+    fi
+  EOT
 }
 
 resource "docker_volume" "home_volume" {

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -267,13 +267,9 @@ resource "coder_agent" "dev" {
     # Install playwright dependencies
     # We want to use the playwright version from site/package.json
     # Check if the directory exists At workspace creation as the coder_script runs in parallel so clone does not exist.
-    # it will run on fine on a restart though 
-    if [ -d "${local.repo_dir}/site" ]; then
-      cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
-    else
-      echo "The directory ${local.repo_dir}/site does not exist. Clone is not complete."
-      echo 'Please run "cd ${local.repo_dir}/site && pnpm install && pnpm playwright:instal" after workspace creation'
-    fi
+    while ! [[ -f "${local.repo_dir}/site/package.json" ]]; do
+      sleep 1
+    done
   EOT
 }
 

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -270,6 +270,7 @@ resource "coder_agent" "dev" {
     while ! [[ -f "${local.repo_dir}/site/package.json" ]]; do
       sleep 1
     done
+    cd "${local.repo_dir}/site" && pnpm install && pnpm playwright:install
   EOT
 }
 

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -266,7 +266,7 @@ resource "coder_agent" "dev" {
     sudo service docker start
     # Install playwright dependencies
     # We want to use the playwright version from site/package.json
-    # Check if the directory exists At workspace creation as the coder_script runs in parallel so clone does not exist.
+    # Check if the directory exists At workspace creation as the coder_script runs in parallel so clone might not exist yet.
     while ! [[ -f "${local.repo_dir}/site/package.json" ]]; do
       sleep 1
     done


### PR DESCRIPTION
As we run clone in parallel to startup_script, The clone does not exist when a new workspace is created.