### PR TITLE
feat: add custom error message on signups disabled page

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -179,6 +179,7 @@ func createOIDCConfig(ctx context.Context, vals *codersdk.DeploymentValues) (*co
 		UserRoleMapping:     vals.OIDC.UserRoleMapping.Value,
 		UserRolesDefault:    vals.OIDC.UserRolesDefault.GetSlice(),
 		SignInText:          vals.OIDC.SignInText.String(),
+		SignupsDisabledText: vals.OIDC.SignupsDisabledText.String(),
 		IconURL:             vals.OIDC.IconURL.String(),
 		IgnoreEmailVerified: vals.OIDC.IgnoreEmailVerified.Value(),
 	}, nil

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -9,7 +9,6 @@ SUBCOMMANDS:
     create-admin-user         Create a new admin user with the given username,
                               email and password and adds it to every
                               organization.
-    dbcrypt                   Manage database encryption.
     postgres-builtin-serve    Run the built-in PostgreSQL deployment.
     postgres-builtin-url      Output the connection URL for the built-in
                               PostgreSQL deployment.

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -61,7 +61,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-CLIENT OPTIONS: 
+CLIENT OPTIONS:
 These options change the behavior of how clients interact with the Coder.
 Clients include the coder cli, vs code extension, and the web UI.
 
@@ -83,17 +83,17 @@ Clients include the coder cli, vs code extension, and the web UI.
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.
 
-CONFIG OPTIONS: 
+CONFIG OPTIONS:
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-          
+
           Write out the current server config as YAML to stdout.
 
-INTROSPECTION / HEALTH CHECK OPTIONS: 
+INTROSPECTION / HEALTH CHECK OPTIONS:
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -102,7 +102,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS: 
+INTROSPECTION / LOGGING OPTIONS:
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -119,7 +119,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS: 
+INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -132,7 +132,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / TRACING OPTIONS: 
+INTROSPECTION / TRACING OPTIONS:
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -146,14 +146,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS: 
+INTROSPECTION / PPROF OPTIONS:
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS: 
+NETWORKING OPTIONS:
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -179,7 +179,7 @@ NETWORKING OPTIONS:
           Specifies the wildcard hostname to use for workspace applications in
           the form "*.example.com".
 
-NETWORKING / DERP OPTIONS: 
+NETWORKING / DERP OPTIONS:
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -221,7 +221,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS: 
+NETWORKING / HTTP OPTIONS:
       --disable-password-auth bool, $CODER_DISABLE_PASSWORD_AUTH
           Disable password authentication. This is recommended for security
           purposes in production deployments that rely on an identity provider.
@@ -252,7 +252,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS: 
+NETWORKING / TLS OPTIONS:
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -314,7 +314,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-OAUTH2 / GITHUB OPTIONS: 
+OAUTH2 / GITHUB OPTIONS:
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -339,7 +339,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS: 
+OIDC OPTIONS:
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -430,7 +430,7 @@ OIDC OPTIONS:
           The custom text to show on the error page informing about disabled
           OIDC signups.
 
-PROVISIONING OPTIONS: 
+PROVISIONING OPTIONS:
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -451,7 +451,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-TELEMETRY OPTIONS: 
+TELEMETRY OPTIONS:
 Telemetry is critical to our ability to improve Coder. We strip all
 personalinformation before sending data to our servers. Please only disable
 telemetrywhen required by your organization's security policy.
@@ -460,7 +460,7 @@ telemetrywhen required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS: 
+USER QUIET HOURS SCHEDULE OPTIONS:
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template max TTL.
 
@@ -480,7 +480,7 @@ workspaces stopping during the day due to template max TTL.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-⚠️ DANGEROUS OPTIONS: 
+⚠️ DANGEROUS OPTIONS:
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -497,7 +497,7 @@ workspaces stopping during the day due to template max TTL.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS: 
+ENTERPRISE OPTIONS:
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -9,6 +9,7 @@ SUBCOMMANDS:
     create-admin-user         Create a new admin user with the given username,
                               email and password and adds it to every
                               organization.
+    dbcrypt                   Manage database encryption.
     postgres-builtin-serve    Run the built-in PostgreSQL deployment.
     postgres-builtin-url      Output the connection URL for the built-in
                               PostgreSQL deployment.
@@ -61,7 +62,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-CLIENT OPTIONS:
+CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
 Clients include the coder cli, vs code extension, and the web UI.
 
@@ -83,17 +84,17 @@ Clients include the coder cli, vs code extension, and the web UI.
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.
 
-CONFIG OPTIONS:
+CONFIG OPTIONS: 
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-
+          
           Write out the current server config as YAML to stdout.
 
-INTROSPECTION / HEALTH CHECK OPTIONS:
+INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -102,7 +103,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS:
+INTROSPECTION / LOGGING OPTIONS: 
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -119,7 +120,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS:
+INTROSPECTION / PROMETHEUS OPTIONS: 
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -132,7 +133,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / TRACING OPTIONS:
+INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -146,14 +147,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS:
+INTROSPECTION / PPROF OPTIONS: 
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS:
+NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -179,7 +180,7 @@ NETWORKING OPTIONS:
           Specifies the wildcard hostname to use for workspace applications in
           the form "*.example.com".
 
-NETWORKING / DERP OPTIONS:
+NETWORKING / DERP OPTIONS: 
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -221,7 +222,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS:
+NETWORKING / HTTP OPTIONS: 
       --disable-password-auth bool, $CODER_DISABLE_PASSWORD_AUTH
           Disable password authentication. This is recommended for security
           purposes in production deployments that rely on an identity provider.
@@ -252,7 +253,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS:
+NETWORKING / TLS OPTIONS: 
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -314,7 +315,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-OAUTH2 / GITHUB OPTIONS:
+OAUTH2 / GITHUB OPTIONS: 
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -339,7 +340,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS:
+OIDC OPTIONS: 
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -430,7 +431,7 @@ OIDC OPTIONS:
           The custom text to show on the error page informing about disabled
           OIDC signups.
 
-PROVISIONING OPTIONS:
+PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -451,7 +452,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-TELEMETRY OPTIONS:
+TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all
 personalinformation before sending data to our servers. Please only disable
 telemetrywhen required by your organization's security policy.
@@ -460,7 +461,7 @@ telemetrywhen required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS:
+USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template max TTL.
 
@@ -480,7 +481,7 @@ workspaces stopping during the day due to template max TTL.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-⚠️ DANGEROUS OPTIONS:
+⚠️ DANGEROUS OPTIONS: 
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -497,7 +498,7 @@ workspaces stopping during the day due to template max TTL.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS:
+ENTERPRISE OPTIONS: 
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -426,6 +426,10 @@ OIDC OPTIONS:
       --oidc-icon-url url, $CODER_OIDC_ICON_URL
           URL pointing to the icon to use on the OpenID Connect login button.
 
+      --oidc-signups-disabled-text string, $CODER_OIDC_SIGNUPS_DISABLED_TEXT
+          The custom text to show on the error page informing about disabled
+          OIDC signups.
+
 PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -428,7 +428,7 @@ OIDC OPTIONS:
 
       --oidc-signups-disabled-text string, $CODER_OIDC_SIGNUPS_DISABLED_TEXT
           The custom text to show on the error page informing about disabled
-          OIDC signups.
+          OIDC signups. Markdown format is supported.
 
 PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -349,6 +349,7 @@ oidc:
   # (default: <unset>, type: url)
   iconURL:
   # The custom text to show on the error page informing about disabled OIDC signups.
+  # Markdown format is supported.
   # (default: <unset>, type: string)
   signupsDisabledText: ""
 # Telemetry is critical to our ability to improve Coder. We strip all personal

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -348,6 +348,9 @@ oidc:
   # URL pointing to the icon to use on the OpenID Connect login button.
   # (default: <unset>, type: url)
   iconURL:
+  # The custom text to show on the error page informing about disabled OIDC signups.
+  # (default: <unset>, type: string)
+  signupsDisabledText: ""
 # Telemetry is critical to our ability to improve Coder. We strip all personal
 # information before sending data to our servers. Please only disable telemetry
 # when required by your organization's security policy.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10071,6 +10071,9 @@ const docTemplate = `{
                 "sign_in_text": {
                     "type": "string"
                 },
+                "signups_disabled_text": {
+                    "type": "string"
+                },
                 "user_role_field": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9052,6 +9052,9 @@
         "sign_in_text": {
           "type": "string"
         },
+        "signups_disabled_text": {
+          "type": "string"
+        },
         "user_role_field": {
           "type": "string"
         },

--- a/coderd/parameter/renderer.go
+++ b/coderd/parameter/renderer.go
@@ -104,7 +104,8 @@ func HTML(markdown string) string {
 	p := parser.NewWithExtensions(parser.CommonExtensions)
 	doc := p.Parse([]byte(markdown))
 	renderer := html.NewRenderer(html.RendererOptions{
-		Flags: html.CommonFlags | html.SkipHTML},
+		Flags: html.CommonFlags | html.SkipHTML,
+	},
 	)
 	return string(bytes.TrimSpace(gomarkdown.Render(doc, renderer)))
 }

--- a/coderd/parameter/renderer.go
+++ b/coderd/parameter/renderer.go
@@ -1,6 +1,7 @@
 package parameter
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/glamour"
@@ -94,4 +95,34 @@ func Plaintext(markdown string) (string, error) {
 	defer renderer.Close()
 
 	return strings.TrimSpace(output), nil
+}
+
+var (
+	reBold          = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	reItalic        = regexp.MustCompile(`\*([^*]+)\*`)
+	reStrikethrough = regexp.MustCompile(`~~([^~]+)~~`)
+	reLink          = regexp.MustCompile(`\[([^]]+)\]\(([^)]+)\)`)
+)
+
+func HTML(markdown string) string {
+	draft := replaceBold(markdown) // bold regexp must go before italic - ** vs. *
+	draft = replaceItalic(draft)
+	draft = replaceStrikethrough(draft)
+	return replaceLinks(draft)
+}
+
+func replaceItalic(markdown string) string {
+	return reItalic.ReplaceAllString(markdown, "<i>$1</i>")
+}
+
+func replaceBold(markdown string) string {
+	return reBold.ReplaceAllString(markdown, "<strong>$1</strong>")
+}
+
+func replaceStrikethrough(markdown string) string {
+	return reStrikethrough.ReplaceAllString(markdown, "<del>$1</del>")
+}
+
+func replaceLinks(markdown string) string {
+	return reLink.ReplaceAllString(markdown, `<a href="$2">$1</a>`)
 }

--- a/coderd/parameter/renderer_test.go
+++ b/coderd/parameter/renderer_test.go
@@ -50,22 +50,37 @@ __This is bold text.__
 
 func TestHTML(t *testing.T) {
 	t.Parallel()
-	t.Run("Simple", func(t *testing.T) {
-		t.Parallel()
 
-		mdDescription := `**Coder** is in *early access* mode. To ~~register~~ request access, fill out [this form](https://internal.example.com). ***Thank you!***`
-		expected := `<strong>Coder</strong> is in <i>early access</i> mode. To <del>register</del> request access, fill out <a href="https://internal.example.com">this form</a>. <i><strong>Thank you!</strong></i>`
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple",
+			input:    `**Coder** is in *early access* mode. To ~~register~~ request access, fill out [this form](https://internal.example.com). ***Thank you!***`,
+			expected: `<p><strong>Coder</strong> is in <em>early access</em> mode. To <del>register</del> request access, fill out <a href="https://internal.example.com">this form</a>. <strong><em>Thank you!</em></strong></p>`,
+		},
+		{
+			name:     "Tricky",
+			input:    `**Cod*er** is in *early a**ccess** <img src="foobar">mode`,
+			expected: `<p><strong>Cod*er</strong> is in *early a<strong>ccess</strong> mode</p>`,
+		},
+		{
+			name:     "No Markdown tags",
+			input:    "This is a simple description, so nothing changes.",
+			expected: "<p>This is a simple description, so nothing changes.</p>",
+		},
+	}
 
-		rendered := parameter.HTML(mdDescription)
-		require.Equal(t, expected, rendered)
-	})
+	for _, tt := range tests {
+		tt := tt
 
-	t.Run("Nothing changes", func(t *testing.T) {
-		t.Parallel()
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		nothingChanges := "This is a simple description, so nothing changes."
-
-		rendered := parameter.HTML(nothingChanges)
-		require.Equal(t, nothingChanges, rendered)
-	})
+			rendered := parameter.HTML(tt.input)
+			require.Equal(t, tt.expected, rendered)
+		})
+	}
 }

--- a/coderd/parameter/renderer_test.go
+++ b/coderd/parameter/renderer_test.go
@@ -67,6 +67,11 @@ func TestHTML(t *testing.T) {
 			expected: `<p><strong>Cod*er</strong> is in *early a<strong>ccess</strong> mode</p>`,
 		},
 		{
+			name:     "XSS",
+			input:    `<p onclick="alert(\"omghax\")">Click here to get access!</p>?`,
+			expected: `<p>Click here to get access!?</p>`,
+		},
+		{
 			name:     "No Markdown tags",
 			input:    "This is a simple description, so nothing changes.",
 			expected: "<p>This is a simple description, so nothing changes.</p>",

--- a/coderd/parameter/renderer_test.go
+++ b/coderd/parameter/renderer_test.go
@@ -47,3 +47,25 @@ __This is bold text.__
 		require.Equal(t, nothingChanges, stripped)
 	})
 }
+
+func TestHTML(t *testing.T) {
+	t.Parallel()
+	t.Run("Simple", func(t *testing.T) {
+		t.Parallel()
+
+		mdDescription := `**Coder** is in *early access* mode. To ~~register~~ request access, fill out [this form](https://internal.example.com). ***Thank you!***`
+		expected := `<strong>Coder</strong> is in <i>early access</i> mode. To <del>register</del> request access, fill out <a href="https://internal.example.com">this form</a>. <i><strong>Thank you!</strong></i>`
+
+		rendered := parameter.HTML(mdDescription)
+		require.Equal(t, expected, rendered)
+	})
+
+	t.Run("Nothing changes", func(t *testing.T) {
+		t.Parallel()
+
+		nothingChanges := "This is a simple description, so nothing changes."
+
+		rendered := parameter.HTML(nothingChanges)
+		require.Equal(t, nothingChanges, rendered)
+	})
+}

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/parameter"
 	"github.com/coder/coder/v2/coderd/promoauth"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/userpassword"
@@ -1317,7 +1318,7 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 		if user.ID == uuid.Nil && !params.AllowSignups {
 			signupsDisabledText := "Please contact your Coder administrator to request access."
 			if api.OIDCConfig != nil && api.OIDCConfig.SignupsDisabledText != "" {
-				signupsDisabledText = api.OIDCConfig.SignupsDisabledText
+				signupsDisabledText = parameter.HTML(api.OIDCConfig.SignupsDisabledText)
 			}
 			return httpError{
 				code:             http.StatusForbidden,

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1320,7 +1320,7 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 				signupsDisabledText = api.OIDCConfig.SignupsDisabledText
 			}
 			return httpError{
-				code:             http.StatusBadRequest,
+				code:             http.StatusForbidden,
 				msg:              "Signups are disabled",
 				detail:           signupsDisabledText,
 				renderStaticPage: true,

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1255,6 +1255,8 @@ type httpError struct {
 	msg              string
 	detail           string
 	renderStaticPage bool
+
+	renderDetailMarkdown bool
 }
 
 func (e httpError) Write(rw http.ResponseWriter, r *http.Request) {
@@ -1266,6 +1268,8 @@ func (e httpError) Write(rw http.ResponseWriter, r *http.Request) {
 			Description:  e.detail,
 			RetryEnabled: false,
 			DashboardURL: "/login",
+
+			RenderDescriptionMarkdown: e.renderDetailMarkdown,
 		})
 		return
 	}
@@ -1325,6 +1329,8 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 				msg:              "Signups are disabled",
 				detail:           signupsDisabledText,
 				renderStaticPage: true,
+
+				renderDetailMarkdown: true,
 			}
 		}
 

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1315,9 +1315,9 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 		}
 
 		if user.ID == uuid.Nil && !params.AllowSignups {
-			signupsDisabledText := api.OIDCConfig.SignupsDisabledText
-			if signupsDisabledText == "" {
-				signupsDisabledText = "Please contact your Coder administrator to request access."
+			signupsDisabledText := "Please contact your Coder administrator to request access."
+			if api.OIDCConfig != nil && api.OIDCConfig.SignupsDisabledText != "" {
+				signupsDisabledText = api.OIDCConfig.SignupsDisabledText
 			}
 			return httpError{
 				code:             http.StatusBadRequest,

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -740,6 +740,8 @@ type OIDCConfig struct {
 	SignInText string
 	// IconURL points to the URL of an icon to display on the OIDC login button
 	IconURL string
+	// SignupsDisabledText is the text do display on the static error page.
+	SignupsDisabledText string
 }
 
 func (cfg OIDCConfig) RoleSyncEnabled() bool {
@@ -1313,9 +1315,15 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 		}
 
 		if user.ID == uuid.Nil && !params.AllowSignups {
+			signupsDisabledText := api.OIDCConfig.SignupsDisabledText
+			if signupsDisabledText == "" {
+				signupsDisabledText = "Please contact your Coder administrator to request access."
+			}
 			return httpError{
-				code: http.StatusForbidden,
-				msg:  fmt.Sprintf("Signups are not allowed for login type %q", params.LoginType),
+				code:             http.StatusBadRequest,
+				msg:              "Signups are disabled",
+				detail:           signupsDisabledText,
+				renderStaticPage: true,
 			}
 		}
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1269,7 +1269,7 @@ when required by your organization's security policy.`,
 		},
 		{
 			Name:        "Signups disabled text",
-			Description: "The custom text to show on the error page informing about disabled OIDC signups.",
+			Description: "The custom text to show on the error page informing about disabled OIDC signups. Markdown format is supported.",
 			Flag:        "oidc-signups-disabled-text",
 			Env:         "CODER_OIDC_SIGNUPS_DISABLED_TEXT",
 			Value:       &c.OIDC.SignupsDisabledText,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -303,6 +303,7 @@ type OIDCConfig struct {
 	UserRolesDefault    clibase.StringArray                 `json:"user_roles_default" typescript:",notnull"`
 	SignInText          clibase.String                      `json:"sign_in_text" typescript:",notnull"`
 	IconURL             clibase.URL                         `json:"icon_url" typescript:",notnull"`
+	SignupsDisabledText clibase.String                      `json:"signups_disabled_text" typescript:",notnull"`
 }
 
 type TelemetryConfig struct {
@@ -1265,6 +1266,15 @@ when required by your organization's security policy.`,
 			Value:       &c.OIDC.IconURL,
 			Group:       &deploymentGroupOIDC,
 			YAML:        "iconURL",
+		},
+		{
+			Name:        "Signups disabled text",
+			Description: "The custom text to show on the error page informing about disabled OIDC signups.",
+			Flag:        "oidc-signups-disabled-text",
+			Env:         "CODER_OIDC_SIGNUPS_DISABLED_TEXT",
+			Value:       &c.OIDC.SignupsDisabledText,
+			Group:       &deploymentGroupOIDC,
+			YAML:        "signupsDisabledText",
 		},
 		// Telemetry settings
 		{

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -298,6 +298,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "issuer_url": "string",
       "scopes": ["string"],
       "sign_in_text": "string",
+      "signups_disabled_text": "string",
       "user_role_field": "string",
       "user_role_mapping": {},
       "user_roles_default": ["string"],

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2273,6 +2273,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "issuer_url": "string",
       "scopes": ["string"],
       "sign_in_text": "string",
+      "signups_disabled_text": "string",
       "user_role_field": "string",
       "user_role_mapping": {},
       "user_roles_default": ["string"],
@@ -2640,6 +2641,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "issuer_url": "string",
     "scopes": ["string"],
     "sign_in_text": "string",
+    "signups_disabled_text": "string",
     "user_role_field": "string",
     "user_role_mapping": {},
     "user_roles_default": ["string"],
@@ -3747,6 +3749,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "issuer_url": "string",
   "scopes": ["string"],
   "sign_in_text": "string",
+  "signups_disabled_text": "string",
   "user_role_field": "string",
   "user_role_mapping": {},
   "user_roles_default": ["string"],
@@ -3777,6 +3780,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `issuer_url`            | string                           | false    |              |                                                                                  |
 | `scopes`                | array of string                  | false    |              |                                                                                  |
 | `sign_in_text`          | string                           | false    |              |                                                                                  |
+| `signups_disabled_text` | string                           | false    |              |                                                                                  |
 | `user_role_field`       | string                           | false    |              |                                                                                  |
 | `user_role_mapping`     | object                           | false    |              |                                                                                  |
 | `user_roles_default`    | array of string                  | false    |              |                                                                                  |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -905,7 +905,7 @@ The token expiry duration for browser sessions. Sessions may last longer if they
 | Environment | <code>$CODER_OIDC_SIGNUPS_DISABLED_TEXT</code> |
 | YAML        | <code>oidc.signupsDisabledText</code>          |
 
-The custom text to show on the error page informing about disabled OIDC signups.
+The custom text to show on the error page informing about disabled OIDC signups. Markdown format is supported.
 
 ### --log-stackdriver
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -897,6 +897,16 @@ Controls if the 'Secure' property is set on browser session cookies.
 
 The token expiry duration for browser sessions. Sessions may last longer if they are actively making requests, but this functionality can be disabled via --disable-session-expiry-refresh.
 
+### --oidc-signups-disabled-text
+
+|             |                                                |
+| ----------- | ---------------------------------------------- |
+| Type        | <code>string</code>                            |
+| Environment | <code>$CODER_OIDC_SIGNUPS_DISABLED_TEXT</code> |
+| YAML        | <code>oidc.signupsDisabledText</code>          |
+
+The custom text to show on the error page informing about disabled OIDC signups.
+
 ### --log-stackdriver
 
 |             |                                                    |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -62,7 +62,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-CLIENT OPTIONS: 
+CLIENT OPTIONS:
 These options change the behavior of how clients interact with the Coder.
 Clients include the coder cli, vs code extension, and the web UI.
 
@@ -84,17 +84,17 @@ Clients include the coder cli, vs code extension, and the web UI.
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.
 
-CONFIG OPTIONS: 
+CONFIG OPTIONS:
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-          
+
           Write out the current server config as YAML to stdout.
 
-INTROSPECTION / HEALTH CHECK OPTIONS: 
+INTROSPECTION / HEALTH CHECK OPTIONS:
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -103,7 +103,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS: 
+INTROSPECTION / LOGGING OPTIONS:
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -120,7 +120,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS: 
+INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -133,7 +133,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / TRACING OPTIONS: 
+INTROSPECTION / TRACING OPTIONS:
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -147,14 +147,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS: 
+INTROSPECTION / PPROF OPTIONS:
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS: 
+NETWORKING OPTIONS:
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -180,7 +180,7 @@ NETWORKING OPTIONS:
           Specifies the wildcard hostname to use for workspace applications in
           the form "*.example.com".
 
-NETWORKING / DERP OPTIONS: 
+NETWORKING / DERP OPTIONS:
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -222,7 +222,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS: 
+NETWORKING / HTTP OPTIONS:
       --disable-password-auth bool, $CODER_DISABLE_PASSWORD_AUTH
           Disable password authentication. This is recommended for security
           purposes in production deployments that rely on an identity provider.
@@ -253,7 +253,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS: 
+NETWORKING / TLS OPTIONS:
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -315,7 +315,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-OAUTH2 / GITHUB OPTIONS: 
+OAUTH2 / GITHUB OPTIONS:
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -340,7 +340,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS: 
+OIDC OPTIONS:
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -427,7 +427,11 @@ OIDC OPTIONS:
       --oidc-icon-url url, $CODER_OIDC_ICON_URL
           URL pointing to the icon to use on the OpenID Connect login button.
 
-PROVISIONING OPTIONS: 
+      --oidc-signups-disabled-text string, $CODER_OIDC_SIGNUPS_DISABLED_TEXT
+          The custom text to show on the error page informing about disabled
+          OIDC signups.
+
+PROVISIONING OPTIONS:
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -448,7 +452,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-TELEMETRY OPTIONS: 
+TELEMETRY OPTIONS:
 Telemetry is critical to our ability to improve Coder. We strip all
 personalinformation before sending data to our servers. Please only disable
 telemetrywhen required by your organization's security policy.
@@ -457,7 +461,7 @@ telemetrywhen required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS: 
+USER QUIET HOURS SCHEDULE OPTIONS:
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template max TTL.
 
@@ -477,7 +481,7 @@ workspaces stopping during the day due to template max TTL.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-⚠️ DANGEROUS OPTIONS: 
+⚠️ DANGEROUS OPTIONS:
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -494,7 +498,7 @@ workspaces stopping during the day due to template max TTL.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS: 
+ENTERPRISE OPTIONS:
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -429,7 +429,7 @@ OIDC OPTIONS:
 
       --oidc-signups-disabled-text string, $CODER_OIDC_SIGNUPS_DISABLED_TEXT
           The custom text to show on the error page informing about disabled
-          OIDC signups.
+          OIDC signups. Markdown format is supported.
 
 PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -62,7 +62,7 @@ OPTIONS:
           Periodically check for new releases of Coder and inform the owner. The
           check is performed once per day.
 
-CLIENT OPTIONS:
+CLIENT OPTIONS: 
 These options change the behavior of how clients interact with the Coder.
 Clients include the coder cli, vs code extension, and the web UI.
 
@@ -84,17 +84,17 @@ Clients include the coder cli, vs code extension, and the web UI.
           The renderer to use when opening a web terminal. Valid values are
           'canvas', 'webgl', or 'dom'.
 
-CONFIG OPTIONS:
+CONFIG OPTIONS: 
 Use a YAML configuration file when your server launch become unwieldy.
 
   -c, --config yaml-config-path, $CODER_CONFIG_PATH
           Specify a YAML file to load configuration from.
 
       --write-config bool
-
+          
           Write out the current server config as YAML to stdout.
 
-INTROSPECTION / HEALTH CHECK OPTIONS:
+INTROSPECTION / HEALTH CHECK OPTIONS: 
       --health-check-refresh duration, $CODER_HEALTH_CHECK_REFRESH (default: 10m0s)
           Refresh interval for healthchecks.
 
@@ -103,7 +103,7 @@ INTROSPECTION / HEALTH CHECK OPTIONS:
           the database exceeds this threshold over 5 attempts, the database is
           considered unhealthy. The default value is 15ms.
 
-INTROSPECTION / LOGGING OPTIONS:
+INTROSPECTION / LOGGING OPTIONS: 
       --enable-terraform-debug-mode bool, $CODER_ENABLE_TERRAFORM_DEBUG_MODE (default: false)
           Allow administrators to enable Terraform debug output.
 
@@ -120,7 +120,7 @@ INTROSPECTION / LOGGING OPTIONS:
       --log-stackdriver string, $CODER_LOGGING_STACKDRIVER
           Output Stackdriver compatible logs to a given file.
 
-INTROSPECTION / PROMETHEUS OPTIONS:
+INTROSPECTION / PROMETHEUS OPTIONS: 
       --prometheus-address host:port, $CODER_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve prometheus metrics.
 
@@ -133,7 +133,7 @@ INTROSPECTION / PROMETHEUS OPTIONS:
       --prometheus-enable bool, $CODER_PROMETHEUS_ENABLE
           Serve prometheus metrics on the address defined by prometheus address.
 
-INTROSPECTION / TRACING OPTIONS:
+INTROSPECTION / TRACING OPTIONS: 
       --trace-logs bool, $CODER_TRACE_LOGS
           Enables capturing of logs as events in traces. This is useful for
           debugging, but may result in a very large amount of events being sent
@@ -147,14 +147,14 @@ INTROSPECTION / TRACING OPTIONS:
       --trace-honeycomb-api-key string, $CODER_TRACE_HONEYCOMB_API_KEY
           Enables trace exporting to Honeycomb.io using the provided API Key.
 
-INTROSPECTION / PPROF OPTIONS:
+INTROSPECTION / PPROF OPTIONS: 
       --pprof-address host:port, $CODER_PPROF_ADDRESS (default: 127.0.0.1:6060)
           The bind address to serve pprof.
 
       --pprof-enable bool, $CODER_PPROF_ENABLE
           Serve pprof metrics on the address defined by pprof address.
 
-NETWORKING OPTIONS:
+NETWORKING OPTIONS: 
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
@@ -180,7 +180,7 @@ NETWORKING OPTIONS:
           Specifies the wildcard hostname to use for workspace applications in
           the form "*.example.com".
 
-NETWORKING / DERP OPTIONS:
+NETWORKING / DERP OPTIONS: 
 Most Coder deployments never have to think about DERP because all connections
 between workspaces and users are peer-to-peer. However, when Coder cannot
 establish a peer to peer connection, Coder uses a distributed relay network
@@ -222,7 +222,7 @@ backed by Tailscale and WireGuard.
           own DERP region, with region IDs starting at `--derp-server-region-id
           + 1`. Use special value 'disable' to turn off STUN completely.
 
-NETWORKING / HTTP OPTIONS:
+NETWORKING / HTTP OPTIONS: 
       --disable-password-auth bool, $CODER_DISABLE_PASSWORD_AUTH
           Disable password authentication. This is recommended for security
           purposes in production deployments that rely on an identity provider.
@@ -253,7 +253,7 @@ NETWORKING / HTTP OPTIONS:
           longer if they are actively making requests, but this functionality
           can be disabled via --disable-session-expiry-refresh.
 
-NETWORKING / TLS OPTIONS:
+NETWORKING / TLS OPTIONS: 
 Configure TLS / HTTPS for your Coder deployment. If you're running Coder behind
 a TLS-terminating reverse proxy or are accessing Coder over a secure link, you
 can safely ignore these settings.
@@ -315,7 +315,7 @@ can safely ignore these settings.
           Minimum supported version of TLS. Accepted values are "tls10",
           "tls11", "tls12" or "tls13".
 
-OAUTH2 / GITHUB OPTIONS:
+OAUTH2 / GITHUB OPTIONS: 
       --oauth2-github-allow-everyone bool, $CODER_OAUTH2_GITHUB_ALLOW_EVERYONE
           Allow all logins, setting this option means allowed orgs and teams
           must be empty.
@@ -340,7 +340,7 @@ OAUTH2 / GITHUB OPTIONS:
           Base URL of a GitHub Enterprise deployment to use for Login with
           GitHub.
 
-OIDC OPTIONS:
+OIDC OPTIONS: 
       --oidc-group-auto-create bool, $CODER_OIDC_GROUP_AUTO_CREATE (default: false)
           Automatically creates missing groups from a user's groups claim.
 
@@ -428,10 +428,10 @@ OIDC OPTIONS:
           URL pointing to the icon to use on the OpenID Connect login button.
 
       --oidc-signups-disabled-text string, $CODER_OIDC_SIGNUPS_DISABLED_TEXT
-          The custom text to show on the error page informing about disabled
-          OIDC signups.
+           The custom text to show on the error page informing about disabled
+           OIDC signups.
 
-PROVISIONING OPTIONS:
+PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,
 updating, and deleting workspace resources.
 
@@ -452,7 +452,7 @@ updating, and deleting workspace resources.
           Number of provisioner daemons to create on start. If builds are stuck
           in queued state for a long time, consider increasing this.
 
-TELEMETRY OPTIONS:
+TELEMETRY OPTIONS: 
 Telemetry is critical to our ability to improve Coder. We strip all
 personalinformation before sending data to our servers. Please only disable
 telemetrywhen required by your organization's security policy.
@@ -461,7 +461,7 @@ telemetrywhen required by your organization's security policy.
           Whether telemetry is enabled or not. Coder collects anonymized usage
           data to help improve our product.
 
-USER QUIET HOURS SCHEDULE OPTIONS:
+USER QUIET HOURS SCHEDULE OPTIONS: 
 Allow users to set quiet hours schedules each day for workspaces to avoid
 workspaces stopping during the day due to template max TTL.
 
@@ -481,7 +481,7 @@ workspaces stopping during the day due to template max TTL.
           must be *. Only one hour and minute can be specified (ranges or comma
           separated values are not supported).
 
-⚠️ DANGEROUS OPTIONS:
+⚠️ DANGEROUS OPTIONS: 
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -498,7 +498,7 @@ workspaces stopping during the day due to template max TTL.
           can be disabled entirely with --disable-path-apps for further
           security.
 
-ENTERPRISE OPTIONS:
+ENTERPRISE OPTIONS: 
 These options are only available in the Enterprise Edition.
 
       --browser-only bool, $CODER_BROWSER_ONLY

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -428,8 +428,8 @@ OIDC OPTIONS:
           URL pointing to the icon to use on the OpenID Connect login button.
 
       --oidc-signups-disabled-text string, $CODER_OIDC_SIGNUPS_DISABLED_TEXT
-           The custom text to show on the error page informing about disabled
-           OIDC signups.
+          The custom text to show on the error page informing about disabled
+          OIDC signups.
 
 PROVISIONING OPTIONS: 
 Tune the behavior of the provisioner, which is responsible for creating,

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,10 @@ require (
 
 require go.uber.org/mock v0.4.0
 
-require github.com/benbjohnson/clock v1.3.5
+require (
+	github.com/benbjohnson/clock v1.3.5
+	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47
+)
 
 require github.com/tdewolff/test v1.0.11-0.20240106005702-7de5f7df4739 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/flatbuffers v23.1.21+incompatible h1:bUqzx/MXCDxuS0hRJL2EfjyZL3uQrPbMocUa8zGqsTA=

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -752,6 +752,7 @@ export interface OIDCConfig {
   readonly user_roles_default: string[];
   readonly sign_in_text: string;
   readonly icon_url: string;
+  readonly signups_disabled_text: string;
 }
 
 // From codersdk/organizations.go

--- a/site/static/error.html
+++ b/site/static/error.html
@@ -167,12 +167,10 @@ running). */}}
         {{- if not .Error.HideStatus }}{{ .Error.Status }} - {{end}}{{
         .Error.Title }}
       </h1>
-      {{- if .Error.RenderDescriptionMarkdown }}
-      {{ .ErrorDescriptionHTML }}
-      {{ else }}
+      {{- if .Error.RenderDescriptionMarkdown }} {{ .ErrorDescriptionHTML }} {{
+      else }}
       <p>{{ .Error.Description }}</p>
-      {{ end }}
-      {{- if .Error.Warnings }}
+      {{ end }} {{- if .Error.Warnings }}
       <div class="warning">
         <div class="warning-title">
           <svg

--- a/site/static/error.html
+++ b/site/static/error.html
@@ -167,7 +167,11 @@ running). */}}
         {{- if not .Error.HideStatus }}{{ .Error.Status }} - {{end}}{{
         .Error.Title }}
       </h1>
+      {{- if .Error.RenderDescriptionMarkdown }}
+      {{ .ErrorDescriptionHTML }}
+      {{ else }}
       <p>{{ .Error.Description }}</p>
+      {{ end }}
       {{- if .Error.Warnings }}
       <div class="warning">
         <div class="warning-title">


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/11679

Once Coder administrators sets this custom error message: 

```bash
export CODER_OIDC_SIGNUPS_DISABLED_TEXT='**Coder** is in early access mode. To request access, fill out this [form](https://internal.form.com).'
```

It will be rendered as follows:
<img width="355" alt="Screenshot 2024-02-01 at 13 00 45" src="https://github.com/coder/coder/assets/14044910/b752cc89-59bb-4edd-84b2-382075329b7f">


