### PR TITLE
feat(site): change stopped status color

### DIFF
--- a/site/src/components/Pill/Pill.stories.tsx
+++ b/site/src/components/Pill/Pill.stories.tsx
@@ -18,56 +18,56 @@ export const Default: Story = {};
 export const Danger: Story = {
   args: {
     children: "Danger",
-    type: "danger",
+    color: "danger",
   },
 };
 
 export const Error: Story = {
   args: {
     children: "Error",
-    type: "error",
+    color: "error",
   },
 };
 
 export const Warning: Story = {
   args: {
     children: "Warning",
-    type: "warning",
+    color: "warning",
   },
 };
 
 export const Notice: Story = {
   args: {
     children: "Notice",
-    type: "notice",
+    color: "notice",
   },
 };
 
 export const Info: Story = {
   args: {
     children: "Information",
-    type: "info",
+    color: "info",
   },
 };
 
 export const Success: Story = {
   args: {
     children: "Success",
-    type: "success",
+    color: "success",
   },
 };
 
 export const Active: Story = {
   args: {
     children: "Active",
-    type: "active",
+    color: "active",
   },
 };
 
 export const WithIcon: Story = {
   args: {
     children: "Information",
-    type: "info",
+    color: "info",
     icon: <InfoOutlined />,
   },
 };

--- a/site/src/components/Pill/Pill.tsx
+++ b/site/src/components/Pill/Pill.tsx
@@ -1,32 +1,18 @@
-import {
-  type FC,
-  type ReactNode,
-  useMemo,
-  forwardRef,
-  HTMLAttributes,
-} from "react";
-import { useTheme, type Interpolation, type Theme } from "@emotion/react";
+import { type FC, type ReactNode, forwardRef, HTMLAttributes } from "react";
+import { useTheme, type Theme } from "@emotion/react";
 import type { ThemeRole } from "theme/experimental";
 import CircularProgress, {
   CircularProgressProps,
 } from "@mui/material/CircularProgress";
 
-export type PillType = ThemeRole | keyof typeof themeOverrides;
-
 export type PillProps = HTMLAttributes<HTMLDivElement> & {
   icon?: ReactNode;
-  type?: PillType;
+  color?: ThemeRole;
 };
 
-const themeOverrides = {
-  neutral: (theme) => ({
-    backgroundColor: theme.experimental.l1.background,
-    borderColor: theme.experimental.l1.outline,
-  }),
-} satisfies Record<string, Interpolation<Theme>>;
+const themeStyles = (color: ThemeRole) => (theme: Theme) => {
+  const palette = theme.experimental.roles[color];
 
-const themeStyles = (type: ThemeRole) => (theme: Theme) => {
-  const palette = theme.experimental.roles[type];
   return {
     backgroundColor: palette.background,
     borderColor: palette.outline,
@@ -39,14 +25,9 @@ const PILL_ICON_SPACING = (PILL_HEIGHT - PILL_ICON_SIZE) / 2;
 
 export const Pill: FC<PillProps> = forwardRef<HTMLDivElement, PillProps>(
   (props, ref) => {
-    const { icon, type = "neutral", children, ...divProps } = props;
+    const { icon, color = "neutral", children, ...divProps } = props;
     const theme = useTheme();
-    const typeStyles = useMemo(() => {
-      if (type in themeOverrides) {
-        return themeOverrides[type as keyof typeof themeOverrides];
-      }
-      return themeStyles(type as ThemeRole);
-    }, [type]);
+    const typeStyles = themeStyles(color);
 
     return (
       <div

--- a/site/src/components/RichParameterInput/RichParameterInput.tsx
+++ b/site/src/components/RichParameterInput/RichParameterInput.tsx
@@ -125,7 +125,7 @@ const ParameterLabel: FC<ParameterLabelProps> = ({ parameter }) => {
       )}
       {!parameter.mutable && (
         <Tooltip title="This value cannot be modified after the workspace has been created.">
-          <Pill type="warning" icon={<ErrorOutline />}>
+          <Pill color="warning" icon={<ErrorOutline />}>
             Immutable
           </Pill>
         </Tooltip>

--- a/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
+++ b/site/src/components/WorkspaceStatusBadge/WorkspaceStatusBadge.tsx
@@ -2,9 +2,9 @@ import Tooltip, {
   type TooltipProps,
   tooltipClasses,
 } from "@mui/material/Tooltip";
-import ErrorOutline from "@mui/icons-material/ErrorOutline";
-import RecyclingIcon from "@mui/icons-material/Recycling";
-import AutoDeleteIcon from "@mui/icons-material/AutoDelete";
+import ErrorOutline from "@mui/icons-material/ErrorOutlined";
+import RecyclingIcon from "@mui/icons-material/RecyclingOutlined";
+import AutoDeleteIcon from "@mui/icons-material/AutoDeleteOutlined";
 import { type FC, type ReactNode } from "react";
 import type { Workspace } from "api/typesGenerated";
 import { Pill } from "components/Pill/Pill";
@@ -24,7 +24,7 @@ export const WorkspaceStatusBadge: FC<WorkspaceStatusBadgeProps> = ({
   workspace,
   className,
 }) => {
-  const { text, icon, type } = getDisplayWorkspaceStatus(
+  const { text, icon, color } = getDisplayWorkspaceStatus(
     workspace.latest_build.status,
     workspace.latest_build.job,
   );
@@ -52,7 +52,7 @@ export const WorkspaceStatusBadge: FC<WorkspaceStatusBadgeProps> = ({
             data-testid="build-status"
             className={className}
             icon={icon}
-            type={type}
+            color={color}
           >
             {text}
           </Pill>
@@ -64,7 +64,7 @@ export const WorkspaceStatusBadge: FC<WorkspaceStatusBadgeProps> = ({
           data-testid="build-status"
           className={className}
           icon={icon}
-          type={type}
+          color={color}
         >
           {text}
         </Pill>
@@ -111,8 +111,11 @@ export const DormantStatusBadge: FC<DormantStatusBadgeProps> = ({
       <Pill
         role="status"
         className={className}
-        icon={<AutoDeleteIcon />}
-        type="error"
+        // Material-UI doesn't provide uniform padding and sizing for icons.
+        // Therefore, visual adjustments are occasionally necessary to achieve
+        // the desired appearance.
+        icon={<AutoDeleteIcon css={{ width: 12, height: 12 }} />}
+        color="warning"
       >
         Deletion Pending
       </Pill>
@@ -132,7 +135,7 @@ export const DormantStatusBadge: FC<DormantStatusBadgeProps> = ({
         role="status"
         className={className}
         icon={<RecyclingIcon />}
-        type="warning"
+        color="warning"
       >
         Dormant
       </Pill>
@@ -144,7 +147,7 @@ export const WorkspaceStatusText: FC<WorkspaceStatusBadgeProps> = ({
   workspace,
   className,
 }) => {
-  const { text, type } = getDisplayWorkspaceStatus(
+  const { text, color } = getDisplayWorkspaceStatus(
     workspace.latest_build.status,
   );
 
@@ -160,8 +163,8 @@ export const WorkspaceStatusText: FC<WorkspaceStatusBadgeProps> = ({
           className={className}
           css={(theme) => ({
             fontWeight: 600,
-            color: type
-              ? theme.experimental.roles[type].fill.solid
+            color: color
+              ? theme.experimental.roles[color].fill.solid
               : theme.experimental.l1.text,
           })}
         >

--- a/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
+++ b/site/src/modules/dashboard/LicenseBanner/LicenseBannerView.tsx
@@ -55,7 +55,7 @@ export const LicenseBannerView: FC<LicenseBannerViewProps> = ({
   if (messages.length === 1) {
     return (
       <div css={containerStyles}>
-        <Pill type={type}>{Language.licenseIssue}</Pill>
+        <Pill color={type}>{Language.licenseIssue}</Pill>
         <div css={styles.leftContent}>
           <span>{messages[0]}</span>
           &nbsp;
@@ -73,7 +73,7 @@ export const LicenseBannerView: FC<LicenseBannerViewProps> = ({
 
   return (
     <div css={containerStyles}>
-      <Pill type={type}>{Language.licenseIssues(messages.length)}</Pill>
+      <Pill color={type}>{Language.licenseIssues(messages.length)}</Pill>
       <div css={styles.leftContent}>
         <div>
           {Language.exceeded}

--- a/site/src/modules/dashboard/ServiceBanner/ServiceBannerView.tsx
+++ b/site/src/modules/dashboard/ServiceBanner/ServiceBannerView.tsx
@@ -17,7 +17,7 @@ export const ServiceBannerView: FC<ServiceBannerViewProps> = ({
 }) => {
   return (
     <div css={[styles.banner, { backgroundColor }]}>
-      {isPreview && <Pill type="info">Preview</Pill>}
+      {isPreview && <Pill color="info">Preview</Pill>}
       <div
         css={[
           styles.wrapper,

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
@@ -3,7 +3,7 @@ import Collapse from "@mui/material/Collapse";
 import TableCell from "@mui/material/TableCell";
 import type { AuditLog } from "api/typesGenerated";
 import { DropdownArrow } from "components/DropdownArrow/DropdownArrow";
-import { Pill, type PillType } from "components/Pill/Pill";
+import { Pill } from "components/Pill/Pill";
 import { Stack } from "components/Stack/Stack";
 import { TimelineEntry } from "components/Timeline/TimelineEntry";
 import { UserAvatar } from "components/UserAvatar/UserAvatar";
@@ -12,8 +12,9 @@ import userAgentParser from "ua-parser-js";
 import { AuditLogDiff } from "./AuditLogDiff/AuditLogDiff";
 import { AuditLogDescription } from "./AuditLogDescription/AuditLogDescription";
 import { determineGroupDiff } from "./AuditLogDiff/auditUtils";
+import { ThemeRole } from "theme/experimental";
 
-const httpStatusColor = (httpStatus: number): PillType => {
+const httpStatusColor = (httpStatus: number): ThemeRole => {
   // redirects are successful
   if (httpStatus === 307) {
     return "success";
@@ -137,7 +138,7 @@ export const AuditLogRow: FC<AuditLogRowProps> = ({
 
                   <Pill
                     css={styles.httpStatusPill}
-                    type={httpStatusColor(auditLog.status_code)}
+                    color={httpStatusColor(auditLog.status_code)}
                   >
                     {auditLog.status_code.toString()}
                   </Pill>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -158,7 +158,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
             <PageHeaderSubtitle condensed>New workspace</PageHeaderSubtitle>
           </div>
 
-          {template.deprecated && <Pill type="warning">Deprecated</Pill>}
+          {template.deprecated && <Pill color="warning">Deprecated</Pill>}
         </Stack>
       </PageHeader>
 

--- a/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicenseCard.tsx
+++ b/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicenseCard.tsx
@@ -86,7 +86,7 @@ export const LicenseCard: FC<LicenseCardProps> = ({
               new Date(license.claims.license_expires * 1000),
               new Date(),
             ) < 1 ? (
-              <Pill css={styles.expiredBadge} type="error">
+              <Pill css={styles.expiredBadge} color="error">
                 Expired
               </Pill>
             ) : (

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -216,7 +216,7 @@ export const TemplatePageHeader: FC<TemplatePageHeaderProps> = ({
             )}
           </div>
 
-          {template.deprecated && <Pill type="warning">Deprecated</Pill>}
+          {template.deprecated && <Pill color="warning">Deprecated</Pill>}
         </Stack>
       </PageHeader>
     </Margins>

--- a/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
+++ b/site/src/pages/TemplatePage/TemplateVersionsPage/VersionRow.tsx
@@ -76,32 +76,32 @@ export const VersionRow: FC<VersionRowProps> = ({
 
           <Stack direction="row" alignItems="center" spacing={2}>
             {isActive && (
-              <Pill role="status" type="success">
+              <Pill role="status" color="success">
                 Active
               </Pill>
             )}
             {isLatest && (
-              <Pill role="status" type="info">
+              <Pill role="status" color="info">
                 Newest
               </Pill>
             )}
             {jobStatus === "pending" && (
-              <Pill role="status" type="warning">
+              <Pill role="status" color="warning">
                 Pending&hellip;
               </Pill>
             )}
             {jobStatus === "running" && (
-              <Pill role="status" type="warning">
+              <Pill role="status" color="warning">
                 Building&hellip;
               </Pill>
             )}
             {(jobStatus === "canceling" || jobStatus === "canceled") && (
-              <Pill role="status" type="neutral">
+              <Pill role="status" color="neutral">
                 Canceled
               </Pill>
             )}
             {jobStatus === "failed" && (
-              <Pill role="status" type="error">
+              <Pill role="status" color="error">
                 Failed
               </Pill>
             )}

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionStatusBadge.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionStatusBadge.tsx
@@ -2,7 +2,8 @@ import { type TemplateVersion } from "api/typesGenerated";
 import { type FC, type ReactNode } from "react";
 import ErrorIcon from "@mui/icons-material/ErrorOutline";
 import CheckIcon from "@mui/icons-material/CheckOutlined";
-import { Pill, PillSpinner, type PillType } from "components/Pill/Pill";
+import { Pill, PillSpinner } from "components/Pill/Pill";
+import { ThemeRole } from "theme/experimental";
 
 interface TemplateVersionStatusBadgeProps {
   version: TemplateVersion;
@@ -11,9 +12,9 @@ interface TemplateVersionStatusBadgeProps {
 export const TemplateVersionStatusBadge: FC<
   TemplateVersionStatusBadgeProps
 > = ({ version }) => {
-  const { text, icon, type } = getStatus(version);
+  const { text, icon, color } = getStatus(version);
   return (
-    <Pill icon={icon} type={type} title={`Build status is ${text}`}>
+    <Pill icon={icon} color={color} title={`Build status is ${text}`}>
       {text}
     </Pill>
   );
@@ -22,45 +23,45 @@ export const TemplateVersionStatusBadge: FC<
 export const getStatus = (
   version: TemplateVersion,
 ): {
-  type?: PillType;
+  color?: ThemeRole;
   text: string;
   icon: ReactNode;
 } => {
   switch (version.job.status) {
     case "running":
       return {
-        type: "info",
+        color: "info",
         text: "Running",
         icon: <PillSpinner />,
       };
     case "pending":
       return {
-        type: "info",
+        color: "info",
         text: "Pending",
         icon: <PillSpinner />,
       };
     case "canceling":
       return {
-        type: "warning",
+        color: "warning",
         text: "Canceling",
         icon: <PillSpinner />,
       };
     case "canceled":
       return {
-        type: "warning",
+        color: "warning",
         text: "Canceled",
         icon: <ErrorIcon />,
       };
     case "unknown":
     case "failed":
       return {
-        type: "error",
+        color: "error",
         text: "Failed",
         icon: <ErrorIcon />,
       };
     case "succeeded":
       return {
-        type: "success",
+        color: "success",
         text: "Success",
         icon: <CheckIcon />,
       };

--- a/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
+++ b/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
@@ -106,7 +106,7 @@ export const ChangeVersionDialog: FC<ChangeVersionDialogProps> = ({
                               )}
                             </Stack>
                             {template?.active_version_id === option.id && (
-                              <Pill type="success">Active</Pill>
+                              <Pill color="success">Active</Pill>
                             )}
                           </Stack>
                         }

--- a/site/src/pages/WorkspacesPage/filter/menus.ts
+++ b/site/src/pages/WorkspacesPage/filter/menus.ts
@@ -67,7 +67,7 @@ export const useStatusFilterMenu = ({
     return {
       label: display.text,
       value: status,
-      color: display.type ?? "warning",
+      color: display.color ?? "warning",
     } as StatusOption;
   });
   return useFilterMenu({

--- a/site/src/theme/dark/experimental.ts
+++ b/site/src/theme/dark/experimental.ts
@@ -185,5 +185,15 @@ export default {
         text: colors.white,
       },
     },
+    neutral: {
+      background: colors.zinc[900],
+      outline: colors.zinc[500],
+      text: colors.zinc[50],
+      fill: {
+        solid: colors.zinc[600],
+        outline: colors.zinc[600],
+        text: colors.white,
+      },
+    },
   },
 } satisfies NewTheme;

--- a/site/src/theme/darkBlue/experimental.ts
+++ b/site/src/theme/darkBlue/experimental.ts
@@ -185,5 +185,15 @@ export default {
         text: colors.white,
       },
     },
+    neutral: {
+      background: colors.gray[900],
+      outline: colors.gray[500],
+      text: colors.gray[50],
+      fill: {
+        solid: colors.gray[600],
+        outline: colors.gray[600],
+        text: colors.white,
+      },
+    },
   },
 } satisfies NewTheme;

--- a/site/src/theme/experimental.ts
+++ b/site/src/theme/experimental.ts
@@ -38,6 +38,10 @@ export interface NewTheme {
      * Preview features, experiments, unstable etc.
      */
     preview: Role;
+
+    /** This represents an action or information that is of secondary importance
+     * or neutral. It doesn't require significant attention. */
+    neutral: Role;
   };
 }
 

--- a/site/src/theme/light/experimental.ts
+++ b/site/src/theme/light/experimental.ts
@@ -185,5 +185,15 @@ export default {
         text: colors.white,
       },
     },
+    neutral: {
+      background: colors.gray[50],
+      outline: colors.gray[500],
+      text: colors.gray[950],
+      fill: {
+        solid: colors.gray[600],
+        outline: colors.gray[600],
+        text: colors.white,
+      },
+    },
   },
 } satisfies NewTheme;

--- a/site/src/utils/workspace.tsx
+++ b/site/src/utils/workspace.tsx
@@ -179,61 +179,61 @@ export const getDisplayWorkspaceStatus = (
       } as const;
     case "running":
       return {
-        type: "success",
+        color: "success",
         text: "Running",
         icon: <PlayIcon />,
       } as const;
     case "starting":
       return {
-        type: "active",
+        color: "active",
         text: "Starting",
         icon: <PillSpinner />,
       } as const;
     case "stopping":
       return {
-        type: "notice",
+        color: "notice",
         text: "Stopping",
         icon: <PillSpinner />,
       } as const;
     case "stopped":
       return {
-        type: "notice",
+        color: "neutral",
         text: "Stopped",
         icon: <StopIcon />,
       } as const;
     case "deleting":
       return {
-        type: "danger",
+        color: "danger",
         text: "Deleting",
         icon: <PillSpinner />,
       } as const;
     case "deleted":
       return {
-        type: "danger",
+        color: "danger",
         text: "Deleted",
         icon: <ErrorIcon />,
       } as const;
     case "canceling":
       return {
-        type: "notice",
+        color: "notice",
         text: "Canceling",
         icon: <PillSpinner />,
       } as const;
     case "canceled":
       return {
-        type: "notice",
+        color: "notice",
         text: "Canceled",
         icon: <ErrorIcon />,
       } as const;
     case "failed":
       return {
-        type: "error",
+        color: "error",
         text: "Failed",
         icon: <ErrorIcon />,
       } as const;
     case "pending":
       return {
-        type: "info",
+        color: "info",
         text: getPendingWorkspaceStatusText(provisionerJob),
         icon: <QueuedIcon />,
       } as const;


### PR DESCRIPTION
Before/Now

<img width="129" alt="Screenshot 2024-01-31 at 13 14 02" src="https://github.com/coder/coder/assets/3165839/2a0acb34-bedd-42f3-ae0f-590cb2db8b4d">
<img width="129" alt="Screenshot 2024-01-31 at 13 13 54" src="https://github.com/coder/coder/assets/3165839/2dff93d9-3acc-4d33-bed0-146412d3b14a">


Stopped is not a "warning" status so we want to make it more neutral.