### PR TITLE
fix(dogfood): fix startup script looping

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -31,7 +31,7 @@ locals {
     "sa-saopaulo"   = "tcp://oberstein-sao-cdr-dev.tailscale.svc.cluster.local:2375"
   }
 
-  repo_base_dir  = replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
+  repo_base_dir  = data.coder_parameter.repo_base_dir.value == "~" ? "/home/coder" : replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
   repo_dir       = module.git-clone.repo_dir
   container_name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
   jfrog_host     = replace(var.jfrog_url, "https://", "")


### PR DESCRIPTION
Seems to be on account of the quotes interpreting a ~ literally.  We do replace it with /home/coder but only if it matches ~/, not ~ alone.

See https://github.com/coder/coder/pull/11958#discussion_r1473638583.