### PR TITLE
fix(flake.nix): add google-chrome to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
           go_1_21
           go-migrate
           golangci-lint
+          google-chrome
           gopls
           gotestsum
           jq


### PR DESCRIPTION
Required for scaletest tests.