### PR TITLE
chore: accept `COLORTERM` and `TERM` env variables in sshd

### DIFF
--- a/dogfood/files/ssh/sshd_config.d/term.conf
+++ b/dogfood/files/ssh/sshd_config.d/term.conf
@@ -1,0 +1,1 @@
+AcceptEnv COLORTERM TERM


### PR DESCRIPTION
because `COLORTERM=truecolor` good