### PR TITLE
feat(coderd): allow customizing provisioner daemon binary path via env

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1353,6 +1353,12 @@ func newProvisionerDaemon(
 			return nil, xerrors.Errorf("mkdir terraform dir: %w", err)
 		}
 
+		if cfg.Provisioner.BinaryPath != "" {
+			if _, err := os.Stat(cfg.Provisioner.BinaryPath.Value()); errors.Is(err, os.ErrNotExist) {
+				return nil, xerrors.Errorf("stat provisioner binary path: %w", err)
+			}
+		}
+
 		tracer := coderAPI.TracerProvider.Tracer(tracing.TracerName)
 		terraformClient, terraformServer := drpc.MemTransportPipe()
 		wg.Add(1)
@@ -1368,6 +1374,7 @@ func newProvisionerDaemon(
 			defer cancel()
 
 			err := terraform.Serve(ctx, &terraform.ServeOptions{
+				BinaryPath: cfg.Provisioner.BinaryPath.String(),
 				ServeOptions: &provisionersdk.ServeOptions{
 					Listener:      terraformServer,
 					Logger:        logger.Named("terraform"),

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1487,6 +1487,26 @@ func TestServer(t *testing.T) {
 		})
 	})
 
+	t.Run("Provisioners", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("CustomBinaryNotFound", func(t *testing.T) {
+			t.Parallel()
+
+			inv, _ := clitest.New(t,
+				"server",
+				"--in-memory",
+				"--http-address", ":0",
+				"--access-url", "http://example.com",
+				"--provisioner-daemons", "1",
+				"--provisioner-daemon-binary-path", "/this/path/will/never/exist",
+			)
+			waiter := clitest.StartWithWaiter(t, inv)
+			waiter.Cancel()
+			waiter.RequireIs(os.ErrNotExist)
+		})
+	})
+
 	t.Run("YAML", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -443,6 +443,11 @@ updating, and deleting workspace resources.
       --provisioner-daemon-poll-jitter duration, $CODER_PROVISIONER_DAEMON_POLL_JITTER (default: 100ms)
           Deprecated and ignored.
 
+      --provisioner-daemon-binary-path string, $CODER_PROVISIONER_DAEMON_BINARY_PATH
+          Override the binary used by the provisioner. This can allow, for
+          example, overriding the Terraform version in use. If unset, the first
+          available match in path will be used.
+
       --provisioner-daemon-psk string, $CODER_PROVISIONER_DAEMON_PSK
           Pre-shared key to authenticate external provisioner daemons to Coder
           server.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -386,6 +386,11 @@ provisioning:
   # Pre-shared key to authenticate external provisioner daemons to Coder server.
   # (default: <unset>, type: string)
   daemonPSK: ""
+  # Override the binary used by the provisioner. This can allow, for example,
+  # overriding the Terraform version in use. If unset, the first available match in
+  # path will be used.
+  # (default: <unset>, type: string)
+  binaryPath: ""
 # Enable one or more experiments. These are not ready for production. Separate
 # multiple experiments with commas, or enter '*' to opt-in to all available
 # experiments.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10260,6 +10260,10 @@ const docTemplate = `{
         "codersdk.ProvisionerConfig": {
             "type": "object",
             "properties": {
+                "binary_path": {
+                    "description": "BinaryPath is the absolute path to the provisioner binary to use.\nThis may be interpreted differently depending on the provisioner type.",
+                    "type": "string"
+                },
                 "daemon_poll_interval": {
                     "type": "integer"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9228,6 +9228,10 @@
     "codersdk.ProvisionerConfig": {
       "type": "object",
       "properties": {
+        "binary_path": {
+          "description": "BinaryPath is the absolute path to the provisioner binary to use.\nThis may be interpreted differently depending on the provisioner type.",
+          "type": "string"
+        },
         "daemon_poll_interval": {
           "type": "integer"
         },

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -372,6 +372,9 @@ type ProvisionerConfig struct {
 	DaemonPollJitter    clibase.Duration `json:"daemon_poll_jitter" typescript:",notnull"`
 	ForceCancelInterval clibase.Duration `json:"force_cancel_interval" typescript:",notnull"`
 	DaemonPSK           clibase.String   `json:"daemon_psk" typescript:",notnull"`
+	// BinaryPath is the absolute path to the provisioner binary to use.
+	// This may be interpreted differently depending on the provisioner type.
+	BinaryPath clibase.String `json:"binary_path" typescript:",notnull"`
 }
 
 type RateLimitConfig struct {
@@ -1407,6 +1410,15 @@ when required by your organization's security policy.`,
 			Value:       &c.Provisioner.DaemonPSK,
 			Group:       &deploymentGroupProvisioning,
 			YAML:        "daemonPSK",
+		},
+		{
+			Name:        "Provisioner Daemon Binary Path",
+			Description: "Override the binary used by the provisioner. This can allow, for example, overriding the Terraform version in use. If unset, the first available match in path will be used.",
+			Flag:        "provisioner-daemon-binary-path",
+			Env:         "CODER_PROVISIONER_DAEMON_BINARY_PATH",
+			Value:       &c.Provisioner.BinaryPath,
+			Group:       &deploymentGroupProvisioning,
+			YAML:        "binaryPath",
 		},
 		// RateLimit settings
 		{

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -322,6 +322,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "enable": true
     },
     "provisioner": {
+      "binary_path": "string",
       "daemon_poll_interval": 0,
       "daemon_poll_jitter": 0,
       "daemon_psk": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2297,6 +2297,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       "enable": true
     },
     "provisioner": {
+      "binary_path": "string",
       "daemon_poll_interval": 0,
       "daemon_poll_jitter": 0,
       "daemon_psk": "string",
@@ -2665,6 +2666,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "enable": true
   },
   "provisioner": {
+    "binary_path": "string",
     "daemon_poll_interval": 0,
     "daemon_poll_jitter": 0,
     "daemon_psk": "string",
@@ -3959,6 +3961,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
+  "binary_path": "string",
   "daemon_poll_interval": 0,
   "daemon_poll_jitter": 0,
   "daemon_psk": "string",
@@ -3970,14 +3973,15 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name                    | Type    | Required | Restrictions | Description |
-| ----------------------- | ------- | -------- | ------------ | ----------- |
-| `daemon_poll_interval`  | integer | false    |              |             |
-| `daemon_poll_jitter`    | integer | false    |              |             |
-| `daemon_psk`            | string  | false    |              |             |
-| `daemons`               | integer | false    |              |             |
-| `daemons_echo`          | boolean | false    |              |             |
-| `force_cancel_interval` | integer | false    |              |             |
+| Name                    | Type    | Required | Restrictions | Description                                                                                                                               |
+| ----------------------- | ------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `binary_path`           | string  | false    |              | Binary path is the absolute path to the provisioner binary to use. This may be interpreted differently depending on the provisioner type. |
+| `daemon_poll_interval`  | integer | false    |              |                                                                                                                                           |
+| `daemon_poll_jitter`    | integer | false    |              |                                                                                                                                           |
+| `daemon_psk`            | string  | false    |              |                                                                                                                                           |
+| `daemons`               | integer | false    |              |                                                                                                                                           |
+| `daemons_echo`          | boolean | false    |              |                                                                                                                                           |
+| `force_cancel_interval` | integer | false    |              |                                                                                                                                           |
 
 ## codersdk.ProvisionerDaemon
 

--- a/docs/cli/provisionerd_start.md
+++ b/docs/cli/provisionerd_start.md
@@ -88,6 +88,15 @@ Deprecated and ignored.
 
 Deprecated and ignored.
 
+### --provisioner-daemon-binary-path
+
+|             |                                                    |
+| ----------- | -------------------------------------------------- |
+| Type        | <code>string</code>                                |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_BINARY_PATH</code> |
+
+Override the binary used by the provisioner. This can allow, for example, overriding the Terraform version in use. If unset, the first available match in path will be used.
+
 ### --psk
 
 |             |                                            |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -773,6 +773,16 @@ Collect database metrics (may increase charges for metrics storage).
 
 Serve prometheus metrics on the address defined by prometheus address.
 
+### --provisioner-daemon-binary-path
+
+|             |                                                    |
+| ----------- | -------------------------------------------------- |
+| Type        | <code>string</code>                                |
+| Environment | <code>$CODER_PROVISIONER_DAEMON_BINARY_PATH</code> |
+| YAML        | <code>provisioning.binaryPath</code>               |
+
+Override the binary used by the provisioner. This can allow, for example, overriding the Terraform version in use. If unset, the first available match in path will be used.
+
 ### --provisioner-daemon-psk
 
 |             |                                            |

--- a/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
+++ b/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
@@ -32,6 +32,11 @@ OPTIONS:
       --poll-jitter duration, $CODER_PROVISIONERD_POLL_JITTER (default: 100ms)
           Deprecated and ignored.
 
+      --provisioner-daemon-binary-path string, $CODER_PROVISIONER_DAEMON_BINARY_PATH
+          Override the binary used by the provisioner. This can allow, for
+          example, overriding the Terraform version in use. If unset, the first
+          available match in path will be used.
+
       --psk string, $CODER_PROVISIONER_DAEMON_PSK
           Pre-shared key to authenticate with Coder server.
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -444,6 +444,11 @@ updating, and deleting workspace resources.
       --provisioner-daemon-poll-jitter duration, $CODER_PROVISIONER_DAEMON_POLL_JITTER (default: 100ms)
           Deprecated and ignored.
 
+      --provisioner-daemon-binary-path string, $CODER_PROVISIONER_DAEMON_BINARY_PATH
+          Override the binary used by the provisioner. This can allow, for
+          example, overriding the Terraform version in use. If unset, the first
+          available match in path will be used.
+
       --provisioner-daemon-psk string, $CODER_PROVISIONER_DAEMON_PSK
           Pre-shared key to authenticate external provisioner daemons to Coder
           server.

--- a/provisioner/terraform/install.go
+++ b/provisioner/terraform/install.go
@@ -22,7 +22,7 @@ var (
 	TerraformVersion = version.Must(version.NewVersion("1.4.6"))
 
 	minTerraformVersion = version.Must(version.NewVersion("1.1.0"))
-	maxTerraformVersion = version.Must(version.NewVersion("1.5.9")) // use .9 to automatically allow patch releases
+	maxTerraformVersion = version.Must(version.NewVersion("1.6.1")) // use .9 to automatically allow patch releases
 
 	terraformMinorVersionMismatch = xerrors.New("Terraform binary minor version mismatch.")
 )

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -833,6 +833,7 @@ export interface ProvisionerConfig {
   readonly daemon_poll_jitter: number;
   readonly force_cancel_interval: number;
   readonly daemon_psk: string;
+  readonly binary_path: string;
 }
 
 // From codersdk/provisionerdaemons.go


### PR DESCRIPTION
Allows specifying the path to the `terraform` binary, thereby allowing testing out different versions side-by-side.