### PR TITLE
fix(dogfood): resolve `module.git-clone.repo_dir` containing `~/`

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -32,7 +32,7 @@ locals {
   }
 
   repo_base_dir  = data.coder_parameter.repo_base_dir.value == "~" ? "/home/coder" : replace(data.coder_parameter.repo_base_dir.value, "/^~\\//", "/home/coder/")
-  repo_dir       = module.git-clone.repo_dir
+  repo_dir       = replace(module.git-clone.repo_dir, "/^~\\//", "/home/coder/")
   container_name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
   jfrog_host     = replace(var.jfrog_url, "https://", "")
 }


### PR DESCRIPTION
We probably should make sure that `git-clone` outputs an absolute path instead of paths containing `~`, however, this fixes dogfood in the interim.