### PR TITLE
feat(site): show deprecation message on template page

### DIFF
--- a/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
@@ -26,3 +26,13 @@ export const CanNotUpdate: Story = {
     },
   },
 };
+
+export const Deprecated: Story = {
+  args: {
+    template: {
+      ...MockTemplate,
+      deprecated: true,
+      deprecation_message: "This template is not going to be used anymore.",
+    },
+  },
+};

--- a/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.stories.tsx
@@ -32,7 +32,8 @@ export const Deprecated: Story = {
     template: {
       ...MockTemplate,
       deprecated: true,
-      deprecation_message: "This template is not going to be used anymore.",
+      deprecation_message:
+        "This template is not going to be used anymore. [See details](#details).",
     },
   },
 };

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -203,20 +203,27 @@ export const TemplatePageHeader: FC<TemplatePageHeaderProps> = ({
           )}
 
           <div>
-            <PageHeaderTitle>
-              {template.display_name.length > 0
-                ? template.display_name
-                : template.name}
-            </PageHeaderTitle>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <PageHeaderTitle>
+                {template.display_name.length > 0
+                  ? template.display_name
+                  : template.name}
+              </PageHeaderTitle>
+              {template.deprecated && <Pill type="warning">Deprecated</Pill>}
+            </Stack>
 
-            {template.description !== "" && (
+            {template.deprecation_message !== "" ? (
               <PageHeaderSubtitle condensed>
-                {template.description}
+                {template.deprecation_message}
               </PageHeaderSubtitle>
+            ) : (
+              template.description !== "" && (
+                <PageHeaderSubtitle condensed>
+                  {template.description}
+                </PageHeaderSubtitle>
+              )
             )}
           </div>
-
-          {template.deprecated && <Pill type="warning">Deprecated</Pill>}
         </Stack>
       </PageHeader>
     </Margins>

--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -35,6 +35,7 @@ import {
 } from "components/MoreMenu/MoreMenu";
 import Divider from "@mui/material/Divider";
 import { Pill } from "components/Pill/Pill";
+import { MemoizedInlineMarkdown } from "components/Markdown/Markdown";
 
 type TemplateMenuProps = {
   templateName: string;
@@ -214,7 +215,9 @@ export const TemplatePageHeader: FC<TemplatePageHeaderProps> = ({
 
             {template.deprecation_message !== "" ? (
               <PageHeaderSubtitle condensed>
-                {template.deprecation_message}
+                <MemoizedInlineMarkdown>
+                  {template.deprecation_message}
+                </MemoizedInlineMarkdown>
               </PageHeaderSubtitle>
             ) : (
               template.description !== "" && (


### PR DESCRIPTION
Before:
<img width="694" alt="Screenshot 2024-02-02 at 10 57 05" src="https://github.com/coder/coder/assets/3165839/64936878-cf01-4c07-b92e-85a770c9d660">

Now:
<img width="962" alt="Screenshot 2024-02-02 at 10 56 51" src="https://github.com/coder/coder/assets/3165839/0b8ef37b-d9a2-4890-885b-24e709d53835">

Close https://github.com/coder/coder/issues/11660
