### PR TITLE
docs: add faq for gateway reconnects

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -530,3 +530,23 @@ prerequisites for Linux, please look at the VSCode docs.
 https://code.visualstudio.com/docs/remote/linux#_local-linux-prerequisites
 
 </details>
+
+<details style="margin-bottom: 28px;">
+  <summary style="font-size: larger; font-weight: bold;">How can I resolve disconnects when connected to Coder via JetBrains Gateway?</summary>
+
+If you leave your JetBrains IDE open for some time while connected to Coder, you
+may encounter a message similar to the below:
+
+```console
+No internet connection. Changes in the document might be lost. Trying to reconnect…
+```
+
+To resolve this, add this entry to your SSH host file on your local machine:
+
+```console
+Host coder-jetbrains--*
+  ServerAliveInterval 5
+```
+
+Note that your SSH config file will be overwritten by the JetBrains Gateway client
+if it is re-authenticated to your Coder deployment.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -548,5 +548,5 @@ Host coder-jetbrains--*
   ServerAliveInterval 5
 ```
 
-Note that your SSH config file will be overwritten by the JetBrains Gateway client
-if it is re-authenticated to your Coder deployment.
+Note that your SSH config file will be overwritten by the JetBrains Gateway
+client if it is re-authenticated to your Coder deployment.


### PR DESCRIPTION
this PR adds an FAQ and solution for JetBrains Gateway disconnects/reconnects. @code-asher recommended the below change to a user's SSH config file and they confirmed it resolved the disconnects:

```console
Host coder-jetbrains--*
  ServerAliveInterval 5
```

we support a server-side flag to append `ServerAliveInternal` to Coder's SSH config entries, but this does not apply to Gateway entries. i opened an issue on this here: https://github.com/coder/jetbrains-coder/issues/354

here is the original IntelliJ support ticket created by the end-user: https://intellij-support.jetbrains.com/hc/en-us/community/posts/16295898616082-PyCharm-No-Connection-while-using-JetBrains-Gateway-Coder