### PR TITLE
fix(agent/agentssh): allow scp to exit with zero status

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -557,7 +557,7 @@ func (s *Server) sftpHandler(logger slog.Logger, session ssh.Session) {
 	defer server.Close()
 
 	err = server.Serve()
-	if errors.Is(err, io.EOF) {
+	if err == nil || errors.Is(err, io.EOF) {
 		// Unless we call `session.Exit(0)` here, the client won't
 		// receive `exit-status` because `(*sftp.Server).Close()`
 		// calls `Close()` on the underlying connection (session),


### PR DESCRIPTION
I wanted to add a test for this but I didn't manage to do it with the SCP client library we use in tests. The exit code is always EOF, whereas the exit is cleaner live:

```
2024-02-06 14:34:34.404 [warn]  ssh-server: sftp server closed with error  remote_addr=[fd7a:115c:a1e0:4a91:860b:c4d9:67b2:eed1]:42916  local_addr=[fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4]:1  id=7b45d6dd-e187-4800-99fd-026bf8a2e1c3  error=<nil>
```

Fixes #11786
