### PR TITLE
fix: start timer before subscribing to avoid test race

### DIFF
--- a/coderd/database/pubsub/watchdog.go
+++ b/coderd/database/pubsub/watchdog.go
@@ -103,6 +103,8 @@ func (w *Watchdog) publishLoop() {
 
 func (w *Watchdog) subscribeMonitor() {
 	defer w.wg.Done()
+	tmr := w.clock.Timer(periodTimeout)
+	defer tmr.Stop()
 	beats := make(chan struct{})
 	unsub, err := w.ps.Subscribe(EventPubsubWatchdog, func(context.Context, []byte) {
 		w.logger.Debug(w.ctx, "got heartbeat for pubsub watchdog")
@@ -117,8 +119,6 @@ func (w *Watchdog) subscribeMonitor() {
 		return
 	}
 	defer unsub()
-	tmr := w.clock.Timer(periodTimeout)
-	defer tmr.Stop()
 	for {
 		select {
 		case <-w.ctx.Done():


### PR DESCRIPTION
Fixes #12030

This is a good example of the kind of thing I'd like to address with a time-testing lib.  The problem is that there is a race between the watchdog starting it's timer and the test incrementing the time.  What would make this easier is if the time-testing library could wait for and assert the call to start the timer before incrementing the time.
