### PR TITLE
fix: use `replace` when redirecting from /health

### DIFF
--- a/site/src/AppRouter.tsx
+++ b/site/src/AppRouter.tsx
@@ -387,7 +387,7 @@ export const AppRouter: FC = () => {
               </Route>
 
               <Route path="/health" element={<HealthLayout />}>
-                <Route index element={<Navigate to="access-url" />} />
+                <Route index element={<Navigate to="access-url" replace />} />
                 <Route path="access-url" element={<AccessURLPage />} />
                 <Route path="database" element={<DatabasePage />} />
                 <Route path="derp" element={<DERPPage />} />


### PR DESCRIPTION
`pushHistory` will break the back button, so we need to use `replaceHistory` instead