### PR TITLE
fix(cli/ssh): prevent reads/writes to stdin/stdout in stdio mode

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -385,8 +385,9 @@ func TestSSH(t *testing.T) {
 			closePipes()
 		})
 
-		// Here we start a monitor for the input going to the server
-		// (i.e. client stdout) to ensure that the output is clean.
+		// Here we start a monitor for the output produced by the proxy command,
+		// which is read by the SSH client. This is done to validate that the
+		// output is clean.
 		proxyCommandOutputBuf := make(chan byte, 4096)
 		tGo(t, func() {
 			defer close(proxyCommandOutputBuf)


### PR DESCRIPTION
This PR prevents writes to stdout in stdio mode (assuming no developer error that uses `os.Stdout`).

For absolute safety, we also swap stdin with an EOF reader that logs errors on attempts to read. We can't make reads panic (or similar) since there's a high chance that such an issue could slip unnoticed into a release and trigger at runtime.

Fixes #11530

---

The added test, without the fix, would catch the issue at two stages:

```
    ssh_test.go:400: monitorServerOutput: "Planning workspace..." (0x506c616e6e696e6720776f726b73706163652e2e2e)
    ssh_test.go:409:
        	Error Trace:	/home/coder/coder/cli/ssh_test.go:409
        	            				/home/coder/coder/cli/ssh_test.go:1479
        	            				/usr/local/go/src/runtime/asm_amd64.s:1650
        	Error:      	Not equal:
        	            	expected: "SSH-2.0-Go"
        	            	actual  : "Planning workspace..."

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-SSH-2.0-Go
        	            	+Planning workspace...
        	Test:       	TestSSH/Stdio_StartStoppedWorkspace_NoStdinOrStdout
        	Messages:   	invalid header
    ssh_test.go:400: monitorServerOutput: "==> ⧗ Queued" (0x3d3d3e20e2a79720517565756564)

    [...]

    ssh_test.go:463:
        	Error Trace:	/home/coder/coder/cli/ssh_test.go:463
        	Error:      	Received unexpected error:
        	            	ssh: handshake failed: ssh: overflow reading version string
        	Test:       	TestSSH/Stdio_StartStoppedWorkspace_NoStdinOrStdout
```