### PR TITLE
fix(dogfood): allow sync with startup script via done file

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -262,6 +262,10 @@ resource "coder_agent" "dev" {
   startup_script_timeout = 60
   startup_script         = <<-EOT
     set -eux -o pipefail
+
+    # Allow synchronization between scripts.
+    trap 'touch /tmp/.coder-startup-script.done' EXIT
+
     # Start Docker service
     sudo service docker start
     # Install playwright dependencies


### PR DESCRIPTION
To utilize this change, place the following snippet at the top of your startup script:

```shell
while ! [ -f /tmp/.coder-startup-script.done ]; do sleep 1; done
```

Useful for avoiding conflicts with e.g. apt install/lock file.