### PR TITLE
feat: limit queued logs to database limit in agent

### DIFF
--- a/agent/logs.go
+++ b/agent/logs.go
@@ -14,9 +14,14 @@ import (
 )
 
 const (
-	flushInterval     = time.Second
-	logOutputMaxBytes = 1 << 20 // 1MiB
-	overheadPerLog    = 21      // found by testing
+	flushInterval    = time.Second
+	maxBytesPerBatch = 1 << 20 // 1MiB
+	overheadPerLog   = 21      // found by testing
+
+	// maxBytesQueued is the maximum length of logs we will queue in memory.  The number is taken
+	// from dump.sql `max_logs_length` constraint, as there is no point queuing more logs than we'll
+	// accept in the database.
+	maxBytesQueued = 1048576
 )
 
 type logQueue struct {
@@ -33,6 +38,7 @@ type logSender struct {
 	queues           map[uuid.UUID]*logQueue
 	logger           slog.Logger
 	exceededLogLimit bool
+	outputLen        int
 }
 
 type logDest interface {
@@ -46,6 +52,8 @@ func newLogSender(logger slog.Logger) *logSender {
 		queues: make(map[uuid.UUID]*logQueue),
 	}
 }
+
+var MaxQueueExceededError = xerrors.New("maximum queued logs exceeded")
 
 func (l *logSender) enqueue(src uuid.UUID, logs ...agentsdk.Log) error {
 	logger := l.logger.With(slog.F("log_source_id", src))
@@ -66,12 +74,25 @@ func (l *logSender) enqueue(src uuid.UUID, logs ...agentsdk.Log) error {
 		q = &logQueue{}
 		l.queues[src] = q
 	}
-	for _, log := range logs {
+	for k, log := range logs {
+		// Here we check the queue size before adding a log because we want to queue up slightly
+		// more logs than the database would store to ensure we trigger "logs truncated" at the
+		// database layer.  Otherwise, the end user wouldn't know logs are truncated unless they
+		// examined the Coder agent logs.
+		if l.outputLen > maxBytesQueued {
+			logger.Warn(context.Background(), "log queue full; truncating new logs", slog.F("new_logs", k), slog.F("queued_logs", len(q.logs)))
+			return MaxQueueExceededError
+		}
 		pl, err := agentsdk.ProtoFromLog(log)
 		if err != nil {
 			return xerrors.Errorf("failed to convert log: %w", err)
 		}
+		if len(pl.Output) > maxBytesPerBatch {
+			logger.Warn(context.Background(), "dropping log line that exceeds our limit")
+			continue
+		}
 		q.logs = append(q.logs, pl)
+		l.outputLen += len(pl.Output)
 	}
 	logger.Debug(context.Background(), "enqueued agent logs", slog.F("new_logs", len(logs)), slog.F("queued_logs", len(q.logs)))
 	return nil
@@ -140,21 +161,22 @@ func (l *logSender) sendLoop(ctx context.Context, dest logDest) error {
 		req := &proto.BatchCreateLogsRequest{
 			LogSourceId: src[:],
 		}
-		o := 0
+
+		// outputToSend keeps track of the size of the protobuf message we send, while
+		// outputToRemove keeps track of the size of the output we'll remove from the queues on
+		// success.  They are different because outputToSend also counts protocol message overheads.
+		outputToSend := 0
+		outputToRemove := 0
 		n := 0
 		for n < len(q.logs) {
 			log := q.logs[n]
-			if len(log.Output) > logOutputMaxBytes {
-				logger.Warn(ctx, "dropping log line that exceeds our limit")
-				n++
-				continue
-			}
-			o += len(log.Output) + overheadPerLog
-			if o > logOutputMaxBytes {
+			outputToSend += len(log.Output) + overheadPerLog
+			if outputToSend > maxBytesPerBatch {
 				break
 			}
 			req.Logs = append(req.Logs, log)
 			n++
+			outputToRemove += len(log.Output)
 		}
 
 		l.L.Unlock()
@@ -181,6 +203,7 @@ func (l *logSender) sendLoop(ctx context.Context, dest logDest) error {
 			q.logs[i] = nil
 		}
 		q.logs = q.logs[n:]
+		l.outputLen -= outputToRemove
 		if len(q.logs) == 0 {
 			// no empty queues
 			delete(l.queues, src)


### PR DESCRIPTION
Limits the total output length of queued logs to the same limit as we impose in the database for agent logs.