### PR TITLE
fix(cli/server): do not redirect /healthz

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1991,6 +1991,13 @@ func redirectToAccessURL(handler http.Handler, accessURL *url.URL, tunnel bool, 
 			http.Redirect(w, r, accessURL.String(), http.StatusTemporaryRedirect)
 		}
 
+		// Exception: /healthz
+		// Kubernetes doesn't like it if you redirect your healthcheck or liveness check endpoint.
+		if r.URL.Path == "/healthz" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
 		// Exception: DERP
 		// We use this endpoint when creating a DERP-mesh in the enterprise version to directly
 		// dial other Coderd derpers.  Redirecting to the access URL breaks direct dial since the

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -685,11 +685,17 @@ func TestServer(t *testing.T) {
 						require.Equal(t, c.expectRedirect, resp.Header.Get("Location"))
 					}
 
+					// We should never readirect /healthz
+					respHealthz, err := client.Request(ctx, http.MethodGet, "/healthz", nil)
+					require.NoError(t, err)
+					defer respHealthz.Body.Close()
+					require.Equal(t, http.StatusOK, respHealthz.StatusCode, "/healthz should never redirect")
+
 					// We should never redirect DERP
 					respDERP, err := client.Request(ctx, http.MethodGet, "/derp", nil)
 					require.NoError(t, err)
 					defer respDERP.Body.Close()
-					require.Equal(t, http.StatusUpgradeRequired, respDERP.StatusCode)
+					require.Equal(t, http.StatusUpgradeRequired, respDERP.StatusCode, "/derp should never redirect")
 				}
 
 				// Verify TLS


### PR DESCRIPTION
If you set `--redirect-access-url=true`, then you would have seen these warnings from Kubelet:

```
   Warning  ProbeWarning  5m52s (x121 over 25m)  kubelet            Liveness probe warning: Probe terminated redirects, Response body: <a href="https://dev.coder.com">Temporary Redirect</a>.                                             │
│   Warning  ProbeWarning  52s (x152 over 26m)    kubelet            Readiness probe warning: Probe terminated redirects, Response body: <a href="https://dev.coder.com">Temporary Redirect</a>.   
```

We have specific checks for `/derp` to not redirect in this case, so extending this for `/healthz`.