### PR TITLE
chore(examples): remove deprecated startup_script_timeout

### DIFF
--- a/.github/pr-deployments/template/main.tf
+++ b/.github/pr-deployments/template/main.tf
@@ -88,10 +88,9 @@ provider "kubernetes" {
 data "coder_workspace" "me" {}
 
 resource "coder_agent" "main" {
-  os                     = "linux"
-  arch                   = "amd64"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  os             = "linux"
+  arch           = "amd64"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -259,8 +259,7 @@ resource "coder_agent" "dev" {
     timeout      = 5
   }
 
-  startup_script_timeout = 60
-  startup_script         = <<-EOT
+  startup_script = <<-EOT
     set -eux -o pipefail
 
     # Allow synchronization between scripts.

--- a/examples/jfrog/docker/main.tf
+++ b/examples/jfrog/docker/main.tf
@@ -59,10 +59,9 @@ resource "artifactory_scoped_token" "me" {
 }
 
 resource "coder_agent" "main" {
-  arch                   = data.coder_provisioner.me.arch
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/parameters/main.tf
+++ b/examples/parameters/main.tf
@@ -23,10 +23,9 @@ data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "main" {
-  arch                   = data.coder_provisioner.me.arch
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -157,12 +157,11 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "coder_agent" "dev" {
-  count                  = data.coder_workspace.me.start_count
-  arch                   = "amd64"
-  auth                   = "aws-instance-identity"
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  count          = data.coder_workspace.me.start_count
+  arch           = "amd64"
+  auth           = "aws-instance-identity"
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/templates/devcontainer-docker/main.tf
+++ b/examples/templates/devcontainer-docker/main.tf
@@ -19,17 +19,16 @@ data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "main" {
-  arch                   = data.coder_provisioner.me.arch
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
-  dir                    = "/worskpaces"
+  dir            = "/worskpaces"
 
   # These environment variables allow you to make Git commits right away after creating a
   # workspace. Note that they take precedence over configuration defined in ~/.gitconfig!

--- a/examples/templates/devcontainer-kubernetes/main.tf
+++ b/examples/templates/devcontainer-kubernetes/main.tf
@@ -44,17 +44,16 @@ data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "main" {
-  arch                   = data.coder_provisioner.me.arch
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
-  dir                    = "/workspaces"
+  dir            = "/workspaces"
 
   # These environment variables allow you to make Git commits right away after creating a
   # workspace. Note that they take precedence over configuration defined in ~/.gitconfig!

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -23,10 +23,9 @@ data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "main" {
-  arch                   = data.coder_provisioner.me.arch
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  arch           = data.coder_provisioner.me.arch
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -73,11 +73,10 @@ resource "google_compute_disk" "root" {
 }
 
 resource "coder_agent" "main" {
-  auth                   = "google-instance-identity"
-  arch                   = "amd64"
-  os                     = "linux"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  auth           = "google-instance-identity"
+  arch           = "amd64"
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -63,12 +63,10 @@ data "coder_workspace" "me" {
 }
 
 resource "coder_agent" "main" {
-  auth = "google-instance-identity"
-  arch = "amd64"
-  os   = "linux"
-
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  auth           = "google-instance-identity"
+  arch           = "amd64"
+  os             = "linux"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -103,10 +103,9 @@ provider "kubernetes" {
 data "coder_workspace" "me" {}
 
 resource "coder_agent" "main" {
-  os                     = "linux"
-  arch                   = "amd64"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  os             = "linux"
+  arch           = "amd64"
+  startup_script = <<-EOT
     set -e
 
     # install and start code-server

--- a/examples/templates/nomad-docker/main.tf
+++ b/examples/templates/nomad-docker/main.tf
@@ -88,10 +88,9 @@ data "coder_parameter" "memory" {
 data "coder_workspace" "me" {}
 
 resource "coder_agent" "main" {
-  os                     = "linux"
-  arch                   = "amd64"
-  startup_script_timeout = 180
-  startup_script         = <<-EOT
+  os             = "linux"
+  arch           = "amd64"
+  startup_script = <<-EOT
     set -e
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server

--- a/scaletest/templates/scaletest-runner/main.tf
+++ b/scaletest/templates/scaletest-runner/main.tf
@@ -625,7 +625,6 @@ resource "coder_agent" "main" {
     vscode     = false
     ssh_helper = false
   }
-  shutdown_script_timeout = 7200
   startup_script_behavior = "blocking"
   startup_script          = file("startup.sh")
   shutdown_script         = file("shutdown.sh")

--- a/scaletest/templates/scaletest-runner/main.tf
+++ b/scaletest/templates/scaletest-runner/main.tf
@@ -625,7 +625,6 @@ resource "coder_agent" "main" {
     vscode     = false
     ssh_helper = false
   }
-  startup_script_timeout  = 86400
   shutdown_script_timeout = 7200
   startup_script_behavior = "blocking"
   startup_script          = file("startup.sh")

--- a/scaletest/terraform/k8s/coder.tf
+++ b/scaletest/terraform/k8s/coder.tf
@@ -304,7 +304,6 @@ resource "local_file" "kubernetes_template" {
     resource "coder_agent" "main" {
       os                     = "linux"
       arch                   = "amd64"
-      startup_script_timeout = 180
       startup_script         = ""
     }
 

--- a/scaletest/terraform/k8s/coder.tf
+++ b/scaletest/terraform/k8s/coder.tf
@@ -304,7 +304,6 @@ resource "local_file" "kubernetes_template" {
     resource "coder_agent" "main" {
       os                     = "linux"
       arch                   = "amd64"
-      startup_script         = ""
     }
 
     resource "kubernetes_pod" "main" {


### PR DESCRIPTION
Creating a template from examples results in deprecation warnings, which is a bit of a product smell from a user's perspective.