### PR TITLE
ci: use repo secret for syncing winget-pkgs fork

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -411,7 +411,7 @@ jobs:
       - name: Sync fork
         run: gh repo sync cdrci/winget-pkgs -b master
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I believe we need to use a real token to sync winget-pkgs fork. Using `github.token` hasn't worked for the past few release runs. This is in hopes to unblock the publish failure occurring for some releases now.

Example: https://github.com/coder/coder/actions/runs/7867766212/job/21464043959

A reference implementation where the sync fork step is working correctly also uses the secret variable (implying a real token): https://github.com/microsoft/devhome/blob/7e962067f567de8044ab5a8a7f996d8a435d4392/.github/workflows/winget-submission.yml#L13-L15