### PR TITLE
feat: add port sharing frontend

### DIFF
--- a/coderd/workspaceagentportshare.go
+++ b/coderd/workspaceagentportshare.go
@@ -156,7 +156,7 @@ func (api *API) deleteWorkspaceAgentPortShare(rw http.ResponseWriter, r *http.Re
 }
 
 func convertPortShares(shares []database.WorkspaceAgentPortShare) []codersdk.WorkspaceAgentPortShare {
-	var converted []codersdk.WorkspaceAgentPortShare
+	converted := []codersdk.WorkspaceAgentPortShare{}
 	for _, share := range shares {
 		converted = append(converted, convertPortShare(share))
 	}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1167,17 +1167,17 @@ export const getWorkspaceAgentSharedPorts = async (
   workspaceID: string,
 ): Promise<TypesGen.WorkspaceAgentPortShares> => {
   const response = await axios.get(
-    `/api/v2/workspaces/${workspaceID}/shared-ports`,
+    `/api/v2/workspaces/${workspaceID}/port-share`,
   );
   return response.data;
 };
 
-export const postWorkspaceAgentSharedPort = async (
+export const upsertWorkspaceAgentSharedPort = async (
   workspaceID: string,
-  req: TypesGen.UpdateWorkspaceAgentPortShareRequest,
+  req: TypesGen.UpsertWorkspaceAgentPortShareRequest,
 ): Promise<TypesGen.WorkspaceAgentPortShares> => {
   const response = await axios.post(
-    `/api/v2/workspaces/${workspaceID}/shared-port`,
+    `/api/v2/workspaces/${workspaceID}/port-share`,
     req
   );
   return response.data;
@@ -1188,7 +1188,7 @@ export const deleteWorkspaceAgentSharedPort = async (
   req: TypesGen.DeleteWorkspaceAgentPortShareRequest,
 ): Promise<TypesGen.WorkspaceAgentPortShares> => {
   const response = await axios.delete(
-    `/api/v2/workspaces/${workspaceID}/shared-port`,
+    `/api/v2/workspaces/${workspaceID}/port-share`,
     {
       data: req,
     }

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1172,6 +1172,30 @@ export const getWorkspaceAgentSharedPorts = async (
   return response.data;
 };
 
+export const postWorkspaceAgentSharedPort = async (
+  workspaceID: string,
+  req: TypesGen.UpdateWorkspaceAgentPortShareRequest,
+): Promise<TypesGen.WorkspaceAgentPortShares> => {
+  const response = await axios.post(
+    `/api/v2/workspaces/${workspaceID}/shared-port`,
+    req
+  );
+  return response.data;
+};
+
+export const deleteWorkspaceAgentSharedPort = async (
+  workspaceID: string,
+  req: TypesGen.DeleteWorkspaceAgentPortShareRequest,
+): Promise<TypesGen.WorkspaceAgentPortShares> => {
+  const response = await axios.delete(
+    `/api/v2/workspaces/${workspaceID}/shared-port`,
+    {
+      data: req,
+    }
+  );
+  return response.data;
+};
+
 // getDeploymentSSHConfig is used by the VSCode-Extension.
 export const getDeploymentSSHConfig =
   async (): Promise<TypesGen.SSHConfigResponse> => {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1163,6 +1163,15 @@ export const getAgentListeningPorts = async (
   return response.data;
 };
 
+export const getWorkspaceAgentSharedPorts = async (
+  workspaceID: string,
+): Promise<TypesGen.WorkspaceAgentPortShares> => {
+  const response = await axios.get(
+    `/api/v2/workspaces/${workspaceID}/shared-ports`,
+  );
+  return response.data;
+};
+
 // getDeploymentSSHConfig is used by the VSCode-Extension.
 export const getDeploymentSSHConfig =
   async (): Promise<TypesGen.SSHConfigResponse> => {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1178,7 +1178,7 @@ export const upsertWorkspaceAgentSharedPort = async (
 ): Promise<TypesGen.WorkspaceAgentPortShares> => {
   const response = await axios.post(
     `/api/v2/workspaces/${workspaceID}/port-share`,
-    req
+    req,
   );
   return response.data;
 };
@@ -1191,7 +1191,7 @@ export const deleteWorkspaceAgentSharedPort = async (
     `/api/v2/workspaces/${workspaceID}/port-share`,
     {
       data: req,
-    }
+    },
   );
   return response.data;
 };

--- a/site/src/api/queries/workspaceportsharing.ts
+++ b/site/src/api/queries/workspaceportsharing.ts
@@ -1,25 +1,32 @@
-import { deleteWorkspaceAgentSharedPort, getWorkspaceAgentSharedPorts, upsertWorkspaceAgentSharedPort } from "api/api"
-import { DeleteWorkspaceAgentPortShareRequest, UpsertWorkspaceAgentPortShareRequest } from "api/typesGenerated"
+import {
+  deleteWorkspaceAgentSharedPort,
+  getWorkspaceAgentSharedPorts,
+  upsertWorkspaceAgentSharedPort,
+} from "api/api";
+import {
+  DeleteWorkspaceAgentPortShareRequest,
+  UpsertWorkspaceAgentPortShareRequest,
+} from "api/typesGenerated";
 
 export const workspacePortShares = (workspaceId: string) => {
   return {
     queryKey: ["sharedPorts", workspaceId],
     queryFn: () => getWorkspaceAgentSharedPorts(workspaceId),
-  }
-}
+  };
+};
 
 export const upsertWorkspacePortShare = (workspaceId: string) => {
   return {
     mutationFn: async (options: UpsertWorkspaceAgentPortShareRequest) => {
       await upsertWorkspaceAgentSharedPort(workspaceId, options);
     },
-  }
-}
+  };
+};
 
 export const deleteWorkspacePortShare = (workspaceId: string) => {
   return {
     mutationFn: async (options: DeleteWorkspaceAgentPortShareRequest) => {
       await deleteWorkspaceAgentSharedPort(workspaceId, options);
     },
-  }
-}
+  };
+};

--- a/site/src/api/queries/workspaceportsharing.ts
+++ b/site/src/api/queries/workspaceportsharing.ts
@@ -1,0 +1,25 @@
+import { deleteWorkspaceAgentSharedPort, getWorkspaceAgentSharedPorts, upsertWorkspaceAgentSharedPort } from "api/api"
+import { DeleteWorkspaceAgentPortShareRequest, UpsertWorkspaceAgentPortShareRequest } from "api/typesGenerated"
+
+export const workspacePortShares = (workspaceId: string) => {
+  return {
+    queryKey: ["sharedPorts", workspaceId],
+    queryFn: () => getWorkspaceAgentSharedPorts(workspaceId),
+  }
+}
+
+export const upsertWorkspacePortShare = (workspaceId: string) => {
+  return {
+    mutationFn: async (options: UpsertWorkspaceAgentPortShareRequest) => {
+      await upsertWorkspaceAgentSharedPort(workspaceId, options);
+    },
+  }
+}
+
+export const deleteWorkspacePortShare = (workspaceId: string) => {
+  return {
+    mutationFn: async (options: DeleteWorkspaceAgentPortShareRequest) => {
+      await deleteWorkspaceAgentSharedPort(workspaceId, options);
+    },
+  }
+}

--- a/site/src/components/Popover/Popover.tsx
+++ b/site/src/components/Popover/Popover.tsx
@@ -151,7 +151,7 @@ export const PopoverContent: FC<PopoverContentProps> = ({
         marginTop: hoverMode ? undefined : 8,
         pointerEvents: hoverMode ? "none" : undefined,
         "& .MuiPaper-root": {
-          minWidth: 320,
+          minWidth: 520,
           fontSize: 14,
           pointerEvents: hoverMode ? "auto" : undefined,
         },

--- a/site/src/components/Popover/Popover.tsx
+++ b/site/src/components/Popover/Popover.tsx
@@ -151,7 +151,7 @@ export const PopoverContent: FC<PopoverContentProps> = ({
         marginTop: hoverMode ? undefined : 8,
         pointerEvents: hoverMode ? "none" : undefined,
         "& .MuiPaper-root": {
-          minWidth: 520,
+          minWidth: 320,
           fontSize: 14,
           pointerEvents: hoverMode ? "auto" : undefined,
         },

--- a/site/src/modules/resources/AgentRow.test.tsx
+++ b/site/src/modules/resources/AgentRow.test.tsx
@@ -1,4 +1,8 @@
-import { MockTemplate, MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
+import {
+  MockTemplate,
+  MockWorkspace,
+  MockWorkspaceAgent,
+} from "testHelpers/entities";
 import { AgentRow, AgentRowProps } from "./AgentRow";
 import { DisplayAppNameMap } from "./AppLink/AppLink";
 import { screen } from "@testing-library/react";

--- a/site/src/modules/resources/AgentRow.test.tsx
+++ b/site/src/modules/resources/AgentRow.test.tsx
@@ -1,4 +1,4 @@
-import { MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
+import { MockTemplate, MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
 import { AgentRow, AgentRowProps } from "./AgentRow";
 import { DisplayAppNameMap } from "./AppLink/AppLink";
 import { screen } from "@testing-library/react";
@@ -80,6 +80,7 @@ describe.each<{
   const props: AgentRowProps = {
     agent: MockWorkspaceAgent,
     workspace: MockWorkspace,
+    template: MockTemplate,
     showApps: false,
     serverVersion: "",
     serverAPIVersion: "",

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -220,6 +220,7 @@ export const AgentRow: FC<AgentRowProps> = ({
                   workspaceName={workspace.name}
                   agent={agent}
                   username={workspace.owner_name}
+                  workspaceID={workspace.id}
                 />
               )}
           </div>

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -15,6 +15,7 @@ import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList as List, ListOnScrollProps } from "react-window";
 import * as API from "api/api";
 import type {
+  Template,
   Workspace,
   WorkspaceAgent,
   WorkspaceAgentLogSource,
@@ -59,6 +60,7 @@ export interface AgentRowProps {
   serverVersion: string;
   serverAPIVersion: string;
   onUpdateAgent: () => void;
+  template: Template;
   storybookLogs?: LineWithID[];
   storybookAgentMetadata?: WorkspaceAgentMetadata[];
 }
@@ -66,6 +68,7 @@ export interface AgentRowProps {
 export const AgentRow: FC<AgentRowProps> = ({
   agent,
   workspace,
+  template,
   showApps,
   showBuiltinApps = true,
   hideSSHButton,
@@ -221,6 +224,7 @@ export const AgentRow: FC<AgentRowProps> = ({
                   agent={agent}
                   username={workspace.owner_name}
                   workspaceID={workspace.id}
+                  template={template}
                 />
               )}
           </div>

--- a/site/src/modules/resources/PortForwardButton.stories.tsx
+++ b/site/src/modules/resources/PortForwardButton.stories.tsx
@@ -2,6 +2,7 @@ import { PortForwardButton } from "./PortForwardButton";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   MockListeningPortsResponse,
+  MockSharedPortsResponse,
   MockWorkspaceAgent,
 } from "testHelpers/entities";
 
@@ -20,6 +21,7 @@ export const Example: Story = {
   args: {
     storybook: {
       listeningPortsQueryData: MockListeningPortsResponse,
+      sharedPortsQueryData: MockSharedPortsResponse,
     },
   },
 };

--- a/site/src/modules/resources/PortForwardButton.stories.tsx
+++ b/site/src/modules/resources/PortForwardButton.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
   MockListeningPortsResponse,
   MockSharedPortsResponse,
+  MockWorkspace,
   MockWorkspaceAgent,
 } from "testHelpers/entities";
 
@@ -18,16 +19,18 @@ export default meta;
 type Story = StoryObj<typeof PortForwardButton>;
 
 export const Example: Story = {
-  args: {
-    storybook: {
-      listeningPortsQueryData: MockListeningPortsResponse,
-      sharedPortsQueryData: MockSharedPortsResponse,
-    },
+  parameters: {
+    queries: [
+      {
+        key: ["portForward", MockWorkspaceAgent.id],
+        data: MockListeningPortsResponse,
+      },
+      {
+        key: ["sharedPorts", MockWorkspace.id],
+        data: MockSharedPortsResponse,
+      },
+    ],
   },
 };
 
-export const Loading: Story = {
-  args: {
-    storybook: {},
-  },
-};
+export const Loading: Story = {};

--- a/site/src/modules/resources/PortForwardButton.stories.tsx
+++ b/site/src/modules/resources/PortForwardButton.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof PortForwardButton>;
 export const Example: Story = {
   args: {
     storybook: {
-      portsQueryData: MockListeningPortsResponse,
+      listeningPortsQueryData: MockListeningPortsResponse,
     },
   },
 };

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -184,12 +184,15 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
     });
   const getFieldHelpers = getFormHelpers(form, submitError);
 
+  // filter out shared ports that are not from this agent
+  const filteredSharedPorts = sharedPorts.filter(
+    (port) => port.agent_name === agent.name,
+  );
   // we don't want to show listening ports if it's a shared port
   const filteredListeningPorts = listeningPorts?.filter((port) => {
-    for (let i = 0; i < sharedPorts.length; i++) {
+    for (let i = 0; i < filteredSharedPorts.length; i++) {
       if (
-        sharedPorts[i].port === port.port &&
-        sharedPorts[i].agent_name === agent.name
+        filteredSharedPorts[i].port === port.port
       ) {
         return false;
       }
@@ -356,7 +359,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </HelpTooltipText>
           {canSharePorts && (
             <div>
-              {sharedPorts?.map((share) => {
+              {filteredSharedPorts?.map((share) => {
                 const url = portForwardURL(
                   host,
                   share.port,

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -106,7 +106,7 @@ export const PortForwardButton: FC<PortForwardButtonProps> = (props) => {
   );
 };
 
-export const getValidationSchema = (): Yup.AnyObjectSchema =>
+const getValidationSchema = (): Yup.AnyObjectSchema =>
   Yup.object({
     port: Yup.number().required().min(0).max(65535),
     sharing_level: Yup.string().required().oneOf(WorkspaceAppSharingLevels),

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -35,6 +35,9 @@ import TextField from "@mui/material/TextField";
 import SensorsIcon from "@mui/icons-material/Sensors";
 import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import Grid from "@mui/material/Grid";
 
 export interface PortForwardButtonProps {
   host: string;
@@ -215,8 +218,8 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
               <Stack
                 key={port.port}
                 direction="row"
-                justifyContent="space-between"
                 alignItems="center"
+                justifyContent="space-between"
               >
                 <Link
                   underline="none"
@@ -228,6 +231,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                   <SensorsIcon css={{ width: 14, height: 14 }} />
                   {label}
                 </Link>
+                <Stack direction="row" gap={2} justifyContent="flex-end" alignItems="center">
                 <Link
                   underline="none"
                   css={styles.portLink}
@@ -240,6 +244,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                 <Button size="small" variant="text">
                   Share
                 </Button>
+                </Stack>
               </Stack>
             );
           })}
@@ -252,9 +257,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
       >
         <HelpTooltipTitle>Shared Ports</HelpTooltipTitle>
         <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
-          {listeningPorts?.length === 0
-            ? "No ports are shared."
-            : "Ports can be shared with other Coder users or with the public."}
+          Ports can be shared with other Coder users or with the public.
         </HelpTooltipText>
         <div>
           {sharedPorts?.map((share) => {
@@ -287,27 +290,36 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                   )}
                   {label}
                 </Link>
-                <Stack direction="row" gap={1}>
-                  <FormControl size="small">
-                    <Select
-                      sx={{
-                        boxShadow: "none",
-                        ".MuiOutlinedInput-notchedOutline": { border: 0 },
-                        "&.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
-                          {
-                            border: 0,
-                          },
-                        "&.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
-                          {
-                            border: 0,
-                          },
-                      }}
-                      value={share.share_level}
-                    >
-                      <MenuItem value="Authenticated">Authenticated</MenuItem>
-                      <MenuItem value="Public">Public</MenuItem>
-                    </Select>
-                  </FormControl>
+                <Stack direction="row" justifyContent="flex-end">
+                <FormControl size="small">
+                  <Select
+                    sx={{
+                      boxShadow: "none",
+                      ".MuiOutlinedInput-notchedOutline": { border: 0 },
+                      "&.MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
+                        {
+                          border: 0,
+                        },
+                      "&.MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
+                        {
+                          border: 0,
+                        },
+                    }}
+                    value={share.share_level}
+                  >
+                    <MenuItem value="authenticated">Authenticated</MenuItem>
+                    <MenuItem value="public">Public</MenuItem>
+                  </Select>
+                </FormControl>
+                <IconButton>
+                  <CloseIcon
+                    css={{
+                      width: 14,
+                      height: 14,
+                      color: theme.palette.text.primary,
+                    }}
+                  />
+                </IconButton>
                 </Stack>
               </Stack>
             );
@@ -328,69 +340,9 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
               <MenuItem value="Public">Public</MenuItem>
             </Select>
           </FormControl>
-          <Button variant="contained">Add Shared Port</Button>
+          <Button variant="contained">Share Port</Button>
         </Stack>
       </div>
-
-      {/* <div css={{ padding: 20 }}>
-        <HelpTooltipTitle>Forward port</HelpTooltipTitle>
-        <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
-          Access ports running on the agent:
-        </HelpTooltipText>
-
-        <form
-          css={styles.newPortForm}
-          onSubmit={(e) => {
-            e.preventDefault();
-            const formData = new FormData(e.currentTarget);
-            const port = Number(formData.get("portNumber"));
-            const url = portForwardURL(
-              host,
-              port,
-              agent.name,
-              workspaceName,
-              username,
-            );
-            window.open(url, "_blank");
-          }}
-        >
-          <input
-            aria-label="Port number"
-            name="portNumber"
-            type="number"
-            placeholder="Type a port number..."
-            min={0}
-            max={65535}
-            required
-            css={styles.newPortInput}
-          />
-          <Button
-            type="submit"
-            size="small"
-            variant="text"
-            css={{
-              paddingLeft: 12,
-              paddingRight: 12,
-              minWidth: 0,
-            }}
-          >
-            <OpenInNewOutlined
-              css={{
-                flexShrink: 0,
-                width: 14,
-                height: 14,
-                color: theme.palette.text.primary,
-              }}
-            />
-          </Button>
-        </form>
-
-        <HelpTooltipLinksGroup>
-          <HelpTooltipLink href={docs("/networking/port-forwarding#dashboard")}>
-            Learn more
-          </HelpTooltipLink>
-        </HelpTooltipLinksGroup>
-      </div> */}
     </>
   );
 };

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -130,6 +130,23 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
 }) => {
   const theme = useTheme();
 
+  // we don't want to show listening ports if it's already a shared port
+  const filteredListeningPorts = listeningPorts?.filter(
+    (port) => {
+      if (sharedPorts === undefined) {
+        return true;
+      }
+
+      for (let i = 0; i < sharedPorts.length; i++) {
+        if (sharedPorts[i].port === port.port && sharedPorts[i].agent_name === agent.name) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  );
+
   return (
     <>
       <div
@@ -149,7 +166,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </HelpTooltipLink>
         </Stack>
         <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
-          {listeningPorts?.length === 0
+          {filteredListeningPorts?.length === 0
             ? "No open ports were detected."
             : "The listening ports are exclusively accessible to you."}
         </HelpTooltipText>
@@ -204,7 +221,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
             paddingTop: 10,
           }}
         >
-          {listeningPorts?.map((port) => {
+          {filteredListeningPorts?.map((port) => {
             const url = portForwardURL(
               host,
               port.port,

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -156,28 +156,29 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
   } = useMutation(upsertWorkspacePortShare(workspaceID));
   const validationSchema = getValidationSchema();
   // TODO: do partial here
-  const form: FormikContextType<Optional<UpsertWorkspaceAgentPortShareRequest, 'port'>> =
-    useFormik<Optional<UpsertWorkspaceAgentPortShareRequest, 'port'>>({
-      initialValues: {
-        agent_name: agent.name,
-        port: undefined,
-        share_level: "authenticated",
-      },
-      validationSchema,
-      onSubmit: async (values) => {
-        // we need port to be optional in the initialValues so it appears empty instead of 0.
-        // because of this we need to reset the form to clear the port field manually.
-        form.resetForm();
-        await form.setFieldValue("port", "");
+  const form: FormikContextType<
+    Optional<UpsertWorkspaceAgentPortShareRequest, "port">
+  > = useFormik<Optional<UpsertWorkspaceAgentPortShareRequest, "port">>({
+    initialValues: {
+      agent_name: agent.name,
+      port: undefined,
+      share_level: "authenticated",
+    },
+    validationSchema,
+    onSubmit: async (values) => {
+      // we need port to be optional in the initialValues so it appears empty instead of 0.
+      // because of this we need to reset the form to clear the port field manually.
+      form.resetForm();
+      await form.setFieldValue("port", "");
 
-        const port = Number(values.port);
-        await upsertWorkspacePortShareForm({
-          ...values,
-          port,
-        });
-        await sharedPortsQuery.refetch();
-      },
-    });
+      const port = Number(values.port);
+      await upsertWorkspacePortShareForm({
+        ...values,
+        port,
+      });
+      await sharedPortsQuery.refetch();
+    },
+  });
   const getFieldHelpers = getFormHelpers(form, submitError);
 
   // filter out shared ports that are not from this agent

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -48,7 +48,7 @@ export const Empty: Story = {
   args: {
     listeningPorts: [],
     storybook: {
-      sharedPortsQueryData: {shares:[]},
+      sharedPortsQueryData: { shares: [] },
     },
   },
 };
@@ -92,4 +92,3 @@ export const EnterprisePortSharingControlsAuthenticated: Story = {
     },
   },
 };
-

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -4,6 +4,7 @@ import {
   MockListeningPortsResponse,
   MockSharedPortsResponse,
   MockTemplate,
+  MockWorkspace,
   MockWorkspaceAgent,
 } from "testHelpers/entities";
 
@@ -27,6 +28,7 @@ const meta: Meta<typeof PortForwardPopoverView> = {
   args: {
     agent: MockWorkspaceAgent,
     template: MockTemplate,
+    workspaceID: MockWorkspace.id,
     portSharingExperimentEnabled: true,
     portSharingControlsEnabled: true,
   },
@@ -38,18 +40,28 @@ type Story = StoryObj<typeof PortForwardPopoverView>;
 export const WithPorts: Story = {
   args: {
     listeningPorts: MockListeningPortsResponse.ports,
-    storybook: {
-      sharedPortsQueryData: MockSharedPortsResponse,
-    },
+  },
+  parameters: {
+    queries: [
+      {
+        key: ["sharedPorts", MockWorkspace.id],
+        data: MockSharedPortsResponse,
+      },
+    ],
   },
 };
 
 export const Empty: Story = {
   args: {
     listeningPorts: [],
-    storybook: {
-      sharedPortsQueryData: { shares: [] },
-    },
+  },
+  parameters: {
+    queries: [
+      {
+        key: ["sharedPorts", MockWorkspace.id],
+        data: { shares: [] },
+      },
+    ],
   },
 };
 
@@ -63,10 +75,15 @@ export const NoPortSharingExperiment: Story = {
 export const AGPLPortSharing: Story = {
   args: {
     listeningPorts: MockListeningPortsResponse.ports,
-    storybook: {
-      sharedPortsQueryData: MockSharedPortsResponse,
-    },
     portSharingControlsEnabled: false,
+  },
+  parameters: {
+    queries: [
+      {
+        key: ["sharedPorts", MockWorkspace.id],
+        data: MockSharedPortsResponse,
+      },
+    ],
   },
 };
 
@@ -83,16 +100,21 @@ export const EnterprisePortSharingControlsOwner: Story = {
 export const EnterprisePortSharingControlsAuthenticated: Story = {
   args: {
     listeningPorts: MockListeningPortsResponse.ports,
-    storybook: {
-      sharedPortsQueryData: {
-        shares: MockSharedPortsResponse.shares.filter((share) => {
-          return share.share_level === "authenticated";
-        }),
-      },
-    },
     template: {
       ...MockTemplate,
       max_port_share_level: "authenticated",
     },
+  },
+  parameters: {
+    queries: [
+      {
+        key: ["sharedPorts", MockWorkspace.id],
+        data: {
+          shares: MockSharedPortsResponse.shares.filter((share) => {
+            return share.share_level === "authenticated";
+          }),
+        },
+      },
+    ],
   },
 };

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
   MockListeningPortsResponse,
   MockSharedPortsResponse,
+  MockTemplate,
   MockWorkspaceAgent,
 } from "testHelpers/entities";
 
@@ -25,6 +26,9 @@ const meta: Meta<typeof PortForwardPopoverView> = {
   ],
   args: {
     agent: MockWorkspaceAgent,
+    template: MockTemplate,
+    portSharingExperimentEnabled: true,
+    portSharingControlsEnabled: true,
   },
 };
 
@@ -35,7 +39,7 @@ export const WithPorts: Story = {
   args: {
     listeningPorts: MockListeningPortsResponse.ports,
     storybook: {
-      sharedPortsQueryData: MockSharedPortsResponse
+      sharedPortsQueryData: MockSharedPortsResponse,
     },
   },
 };
@@ -43,5 +47,49 @@ export const WithPorts: Story = {
 export const Empty: Story = {
   args: {
     listeningPorts: [],
+    storybook: {
+      sharedPortsQueryData: {shares:[]},
+    },
   },
 };
+
+export const NoPortSharingExperiment: Story = {
+  args: {
+    listeningPorts: MockListeningPortsResponse.ports,
+    portSharingExperimentEnabled: false,
+  },
+};
+
+export const AGPLPortSharing: Story = {
+  args: {
+    listeningPorts: MockListeningPortsResponse.ports,
+    storybook: {
+      sharedPortsQueryData: MockSharedPortsResponse,
+    },
+    portSharingControlsEnabled: false,
+  },
+};
+
+export const EnterprisePortSharingControlsOwner: Story = {
+  args: {
+    listeningPorts: MockListeningPortsResponse.ports,
+    template: {
+      ...MockTemplate,
+      max_port_share_level: "owner",
+    },
+  },
+};
+
+export const EnterprisePortSharingControlsAuthenticated: Story = {
+  args: {
+    listeningPorts: MockListeningPortsResponse.ports,
+    storybook: {
+      sharedPortsQueryData: MockSharedPortsResponse,
+    },
+    template: {
+      ...MockTemplate,
+      max_port_share_level: "authenticated",
+    },
+  },
+};
+

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -84,7 +84,11 @@ export const EnterprisePortSharingControlsAuthenticated: Story = {
   args: {
     listeningPorts: MockListeningPortsResponse.ports,
     storybook: {
-      sharedPortsQueryData: MockSharedPortsResponse,
+      sharedPortsQueryData: {
+        shares: MockSharedPortsResponse.shares.filter((share) => {
+          return share.share_level === "authenticated";
+        }),
+      },
     },
     template: {
       ...MockTemplate,

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -34,13 +34,15 @@ type Story = StoryObj<typeof PortForwardPopoverView>;
 export const WithPorts: Story = {
   args: {
     listeningPorts: MockListeningPortsResponse.ports,
-    sharedPorts: MockSharedPortsResponse.shares,
+    storybook: {
+      sharedPortsQueryData: MockSharedPortsResponse
+    },
   },
 };
 
 export const Empty: Story = {
   args: {
     listeningPorts: [],
-    sharedPorts: [],
+
   },
 };

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -2,6 +2,7 @@ import { PortForwardPopoverView } from "./PortForwardButton";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   MockListeningPortsResponse,
+  MockSharedPortsResponse,
   MockWorkspaceAgent,
 } from "testHelpers/entities";
 
@@ -32,12 +33,14 @@ type Story = StoryObj<typeof PortForwardPopoverView>;
 
 export const WithPorts: Story = {
   args: {
-    ports: MockListeningPortsResponse.ports,
+    listeningPorts: MockListeningPortsResponse.ports,
+    sharedPorts: MockSharedPortsResponse.shares,
   },
 };
 
 export const Empty: Story = {
   args: {
-    ports: [],
+    listeningPorts: [],
+    sharedPorts: [],
   },
 };

--- a/site/src/modules/resources/PortForwardPopoverView.stories.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.stories.tsx
@@ -43,6 +43,5 @@ export const WithPorts: Story = {
 export const Empty: Story = {
   args: {
     listeningPorts: [],
-
   },
 };

--- a/site/src/modules/resources/PortForwardPopoverView.test.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.test.tsx
@@ -1,0 +1,33 @@
+import { screen } from "@testing-library/react";
+import { MockListeningPortsResponse, MockTemplate, MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
+import { renderComponent } from "testHelpers/renderHelpers";
+import { PortForwardPopoverView } from "./PortForwardButton";
+import { QueryClientProvider, QueryClient } from "react-query";
+
+describe("Port Forward Popover View", () => {
+  it("renders component", async () => {
+    renderComponent(
+      <QueryClientProvider client={new QueryClient()}>
+        <PortForwardPopoverView
+          agent={MockWorkspaceAgent}
+          template={MockTemplate}
+          workspaceID={MockWorkspace.id}
+          listeningPorts={MockListeningPortsResponse.ports}
+          portSharingExperimentEnabled
+          portSharingControlsEnabled
+          host="host"
+          username="username"
+          workspaceName="workspaceName"
+        />
+      </QueryClientProvider>
+    );
+
+    expect(
+      screen.getByText(MockListeningPortsResponse.ports[0].port),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(MockListeningPortsResponse.ports[0].process_name),
+    ).toBeInTheDocument();
+  });
+});

--- a/site/src/modules/resources/PortForwardPopoverView.test.tsx
+++ b/site/src/modules/resources/PortForwardPopoverView.test.tsx
@@ -1,5 +1,10 @@
 import { screen } from "@testing-library/react";
-import { MockListeningPortsResponse, MockTemplate, MockWorkspace, MockWorkspaceAgent } from "testHelpers/entities";
+import {
+  MockListeningPortsResponse,
+  MockTemplate,
+  MockWorkspace,
+  MockWorkspaceAgent,
+} from "testHelpers/entities";
 import { renderComponent } from "testHelpers/renderHelpers";
 import { PortForwardPopoverView } from "./PortForwardButton";
 import { QueryClientProvider, QueryClient } from "react-query";
@@ -19,7 +24,7 @@ describe("Port Forward Popover View", () => {
           username="username"
           workspaceName="workspaceName"
         />
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     expect(

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -1,6 +1,6 @@
 import { type Interpolation, type Theme } from "@emotion/react";
 import TextField from "@mui/material/TextField";
-import type { Template, UpdateTemplateMeta } from "api/typesGenerated";
+import { WorkspaceAppSharingLevels, type Template, type UpdateTemplateMeta } from "api/typesGenerated";
 import { type FormikContextType, type FormikTouched, useFormik } from "formik";
 import { type FC } from "react";
 import {
@@ -43,6 +43,8 @@ export const getValidationSchema = (): Yup.AnyObjectSchema =>
     allow_user_cancel_workspace_jobs: Yup.boolean(),
     icon: iconValidator,
     require_active_version: Yup.boolean(),
+    deprecation_message: Yup.string(),
+    max_port_sharing_level: Yup.string().oneOf(WorkspaceAppSharingLevels),
   });
 
 export interface TemplateSettingsForm {
@@ -54,6 +56,8 @@ export interface TemplateSettingsForm {
   // Helpful to show field errors on Storybook
   initialTouched?: FormikTouched<UpdateTemplateMeta>;
   accessControlEnabled: boolean;
+  portSharingExperimentEnabled: boolean;
+  portSharingControlsEnabled: boolean;
 }
 
 export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
@@ -64,6 +68,8 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
   isSubmitting,
   initialTouched,
   accessControlEnabled,
+  portSharingExperimentEnabled,
+  portSharingControlsEnabled,
 }) => {
   const validationSchema = getValidationSchema();
   const form: FormikContextType<UpdateTemplateMeta> =
@@ -256,6 +262,46 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
           )}
         </FormFields>
       </FormSection>
+
+      {portSharingExperimentEnabled && (
+        <FormSection
+          title="Port Sharing"
+          description="Shared ports with the Public sharing level can be accessed by anyone,
+          while ports with the Authenticated sharing level can only be accessed
+          by authenticated Coder users. Ports with the Owner sharing level can
+          only be accessed by the workspace owner."
+        >
+          <FormFields>
+            <Stack direction="column" spacing={0.5}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                spacing={0.5}
+                css={styles.optionText}
+              >
+                Maximum Port Sharing Level
+              </Stack>
+              <span css={styles.optionHelperText}>
+                The maximum level of port sharing allowed for workspaces.
+              </span>
+            </Stack>
+            <TextField
+              {...getFieldHelpers("max_port_share_level")}
+              disabled={isSubmitting || !portSharingControlsEnabled}
+              fullWidth
+              label="Maximum Port Sharing Level"
+            />
+            {!portSharingControlsEnabled && (
+              <Stack direction="row">
+                <EnterpriseBadge />
+                <span css={styles.optionHelperText}>
+                  Enterprise license required to control max port sharing level.
+                </span>
+              </Stack>
+            )}
+          </FormFields>
+        </FormSection>
+      )}
 
       <FormFooter onCancel={onCancel} isLoading={isSubmitting} />
     </HorizontalForm>

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -1,6 +1,10 @@
 import { type Interpolation, type Theme } from "@emotion/react";
 import TextField from "@mui/material/TextField";
-import { WorkspaceAppSharingLevels, type Template, type UpdateTemplateMeta } from "api/typesGenerated";
+import {
+  WorkspaceAppSharingLevels,
+  type Template,
+  type UpdateTemplateMeta,
+} from "api/typesGenerated";
 import { type FormikContextType, type FormikTouched, useFormik } from "formik";
 import { type FC } from "react";
 import {

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -27,6 +27,8 @@ import {
   HelpTooltipTrigger,
 } from "components/HelpTooltip/HelpTooltip";
 import { EnterpriseBadge } from "components/Badges/Badges";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
 
 const MAX_DESCRIPTION_CHAR_LIMIT = 128;
 const MAX_DESCRIPTION_MESSAGE =
@@ -86,6 +88,7 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
         require_active_version: template.require_active_version,
         deprecation_message: template.deprecation_message,
         disable_everyone_group_access: false,
+        max_port_share_level: template.max_port_share_level,
       },
       validationSchema,
       onSubmit,
@@ -285,12 +288,20 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
                 The maximum level of port sharing allowed for workspaces.
               </span>
             </Stack>
-            <TextField
-              {...getFieldHelpers("max_port_share_level")}
+            <Select
+              id="max_port_share_level"
+              name="max_port_share_level"
               disabled={isSubmitting || !portSharingControlsEnabled}
               fullWidth
+              // TODO: Fix label being black on dark mode
               label="Maximum Port Sharing Level"
-            />
+              onChange={form.handleChange}
+              value={form.values.max_port_share_level}
+            >
+              <MenuItem value="owner">Owner</MenuItem>
+              <MenuItem value="authenticated">Authenticated</MenuItem>
+              <MenuItem value="public">Public</MenuItem>
+            </Select>
             {!portSharingControlsEnabled && (
               <Stack direction="row">
                 <EnterpriseBadge />

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -31,7 +31,6 @@ import {
   HelpTooltipTrigger,
 } from "components/HelpTooltip/HelpTooltip";
 import { EnterpriseBadge } from "components/Badges/Badges";
-import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 
 const MAX_DESCRIPTION_CHAR_LIMIT = 128;
@@ -279,33 +278,25 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
           only be accessed by the workspace owner."
         >
           <FormFields>
-            <Stack direction="column" spacing={0.5}>
-              <Stack
-                direction="row"
-                alignItems="center"
-                spacing={0.5}
-                css={styles.optionText}
-              >
-                Maximum Port Sharing Level
-              </Stack>
-              <span css={styles.optionHelperText}>
-                The maximum level of port sharing allowed for workspaces.
-              </span>
-            </Stack>
-            <Select
-              id="max_port_share_level"
-              name="max_port_share_level"
+            <TextField
+              {...getFieldHelpers("max_port_share_level", {
+                helperText:
+                  "The maximum level of port sharing allowed for workspaces.",
+              })}
               disabled={isSubmitting || !portSharingControlsEnabled}
               fullWidth
-              // TODO: Fix label being black on dark mode
+              select
+              value={
+                portSharingControlsEnabled
+                  ? form.values.max_port_share_level
+                  : "public"
+              }
               label="Maximum Port Sharing Level"
-              onChange={form.handleChange}
-              value={form.values.max_port_share_level}
             >
               <MenuItem value="owner">Owner</MenuItem>
               <MenuItem value="authenticated">Authenticated</MenuItem>
               <MenuItem value="public">Public</MenuItem>
-            </Select>
+            </TextField>
             {!portSharingControlsEnabled && (
               <Stack direction="row">
                 <EnterpriseBadge />

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
@@ -21,7 +21,8 @@ export const TemplateSettingsPage: FC = () => {
   const { entitlements, experiments } = useDashboard();
   const accessControlEnabled = entitlements.features.access_control.enabled;
   const sharedPortsExperimentEnabled = experiments.includes("shared-ports");
-  const sharedPortControlsEnabled = entitlements.features.control_shared_ports.enabled;
+  const sharedPortControlsEnabled =
+    entitlements.features.control_shared_ports.enabled;
 
   const {
     mutate: updateTemplate,

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPage.tsx
@@ -18,8 +18,10 @@ export const TemplateSettingsPage: FC = () => {
   const orgId = useOrganizationId();
   const { template } = useTemplateSettings();
   const queryClient = useQueryClient();
-  const { entitlements } = useDashboard();
+  const { entitlements, experiments } = useDashboard();
   const accessControlEnabled = entitlements.features.access_control.enabled;
+  const sharedPortsExperimentEnabled = experiments.includes("shared-ports");
+  const sharedPortControlsEnabled = entitlements.features.control_shared_ports.enabled;
 
   const {
     mutate: updateTemplate,
@@ -67,6 +69,8 @@ export const TemplateSettingsPage: FC = () => {
           });
         }}
         accessControlEnabled={accessControlEnabled}
+        sharedPortsExperimentEnabled={sharedPortsExperimentEnabled}
+        sharedPortControlsEnabled={sharedPortControlsEnabled}
       />
     </>
   );

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPageView.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPageView.tsx
@@ -13,6 +13,8 @@ export interface TemplateSettingsPageViewProps {
     typeof TemplateSettingsForm
   >["initialTouched"];
   accessControlEnabled: boolean;
+  sharedPortsExperimentEnabled: boolean;
+  sharedPortControlsEnabled: boolean;
 }
 
 export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
@@ -23,6 +25,8 @@ export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
   submitError,
   initialTouched,
   accessControlEnabled,
+  sharedPortsExperimentEnabled,
+  sharedPortControlsEnabled,
 }) => {
   return (
     <>
@@ -38,8 +42,8 @@ export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
         onCancel={onCancel}
         error={submitError}
         accessControlEnabled={accessControlEnabled}
-        portSharingExperimentEnabled
-        portSharingControlsEnabled
+        portSharingExperimentEnabled={sharedPortsExperimentEnabled}
+        portSharingControlsEnabled={sharedPortControlsEnabled}
       />
     </>
   );

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPageView.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsPageView.tsx
@@ -38,6 +38,8 @@ export const TemplateSettingsPageView: FC<TemplateSettingsPageViewProps> = ({
         onCancel={onCancel}
         error={submitError}
         accessControlEnabled={accessControlEnabled}
+        portSharingExperimentEnabled
+        portSharingControlsEnabled
       />
     </>
   );

--- a/site/src/pages/WorkspacePage/Workspace.tsx
+++ b/site/src/pages/WorkspacePage/Workspace.tsx
@@ -245,6 +245,7 @@ export const Workspace: FC<WorkspaceProps> = ({
                   key={agent.id}
                   agent={agent}
                   workspace={workspace}
+                  template={template}
                   sshPrefix={sshPrefix}
                   showApps={permissions.updateWorkspace}
                   showBuiltinApps={permissions.updateWorkspace}

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3247,16 +3247,18 @@ export const MockListeningPortsResponse: TypesGen.WorkspaceAgentListeningPortsRe
 export const MockSharedPortsResponse: TypesGen.WorkspaceAgentPortShares = {
   shares: [
     {
+      workspace_id: MockWorkspace.id,
       agent_name: "a-workspace-agent",
       port: 4000,
       share_level: "authenticated",
     },
     {
+      workspace_id: MockWorkspace.id,
       agent_name: "a-workspace-agent",
       port: 8080,
       share_level: "authenticated",
     },
-    { agent_name: "a-workspace-agent", port: 8081, share_level: "public" },
+    { workspace_id: MockWorkspace.id, agent_name: "a-workspace-agent", port: 8081, share_level: "public" },
   ],
 };
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -489,7 +489,7 @@ export const MockTemplate: TypesGen.Template = {
   require_active_version: false,
   deprecated: false,
   deprecation_message: "",
-  max_port_share_level: "owner",
+  max_port_share_level: "public",
 };
 
 export const MockTemplateVersionFiles: TemplateVersionFiles = {
@@ -3258,7 +3258,12 @@ export const MockSharedPortsResponse: TypesGen.WorkspaceAgentPortShares = {
       port: 8080,
       share_level: "authenticated",
     },
-    { workspace_id: MockWorkspace.id, agent_name: "a-workspace-agent", port: 8081, share_level: "public" },
+    {
+      workspace_id: MockWorkspace.id,
+      agent_name: "a-workspace-agent",
+      port: 8081,
+      share_level: "public",
+    },
   ],
 };
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3238,8 +3238,8 @@ export const MockHealth: TypesGen.HealthcheckReport = {
 export const MockListeningPortsResponse: TypesGen.WorkspaceAgentListeningPortsResponse =
   {
     ports: [
-      { process_name: "web", network: "", port: 3000 },
-      { process_name: "go", network: "", port: 8080 },
+      { process_name: "webb", network: "", port: 3000 },
+      { process_name: "gogo", network: "", port: 8080 },
       { process_name: "", network: "", port: 8081 },
     ],
   };

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3244,6 +3244,22 @@ export const MockListeningPortsResponse: TypesGen.WorkspaceAgentListeningPortsRe
     ],
   };
 
+export const MockSharedPortsResponse: TypesGen.WorkspaceAgentPortShares = {
+  shares: [
+    {
+      agent_name: "a-workspace-agent",
+      port: 4000,
+      share_level: "authenticated",
+    },
+    {
+      agent_name: "a-workspace-agent",
+      port: 8080,
+      share_level: "authenticated",
+    },
+    { agent_name: "a-workspace-agent", port: 8081, share_level: "public" },
+  ],
+};
+
 export const DeploymentHealthUnhealthy: TypesGen.HealthcheckReport = {
   healthy: false,
   severity: "ok",


### PR DESCRIPTION
The following improvements can be made in future PRs:
- Lack of loading states on share level changes and deletions make those actions feel laggy
- Lack of scrollbars means the popover eventually gets too big to fit on the screen with enough items

Template Setting:
<img width="1078" alt="image" src="https://github.com/coder/coder/assets/19379394/c8834ef6-3323-49b6-803b-b313b0b2cbb1">

PortsPopover:
<img width="333" alt="Screenshot 2024-02-20 at 12 43 06 PM" src="https://github.com/coder/coder/assets/19379394/39657541-6864-480e-a0a5-80bcedf8afe4">

Template Max Sharing Level Owner:
<img width="331" alt="Screenshot 2024-02-16 at 2 11 41 PM" src="https://github.com/coder/coder/assets/19379394/7912cc93-78cb-4782-baa8-d21a579d38d2">

Template Max Sharing Level Authenticated:
<img width="322" alt="Screenshot 2024-02-16 at 2 18 47 PM" src="https://github.com/coder/coder/assets/19379394/b0f0e461-8ce8-4a88-927e-d6528d020fa8">
<img width="323" alt="Screenshot 2024-02-16 at 2 18 55 PM" src="https://github.com/coder/coder/assets/19379394/b84adfd2-0308-4a29-ab53-aa8e3602c88d">

Experiment Not Enabled:
<img width="326" alt="Screenshot 2024-02-16 at 2 11 33 PM" src="https://github.com/coder/coder/assets/19379394/906354b6-2aa4-40d7-bdcf-da13128b5e00">

