### PR TITLE
feat: enable oauth2 token exchange

### DIFF
--- a/enterprise/coderd/oauth2.go
+++ b/enterprise/coderd/oauth2.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
@@ -18,13 +17,6 @@ import (
 
 func (api *API) oAuth2ProviderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if !buildinfo.IsDev() {
-			httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-				Message: "OAuth2 provider is under development.",
-			})
-			return
-		}
-
 		api.entitlementsMu.RLock()
 		entitled := api.entitlements.Features[codersdk.FeatureOAuth2Provider].Entitlement != codersdk.EntitlementNotEntitled
 		api.entitlementsMu.RUnlock()

--- a/site/src/pages/DeploySettingsPage/Sidebar.tsx
+++ b/site/src/pages/DeploySettingsPage/Sidebar.tsx
@@ -7,7 +7,7 @@ import Globe from "@mui/icons-material/PublicOutlined";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import VpnKeyOutlined from "@mui/icons-material/VpnKeyOutlined";
 import MonitorHeartOutlined from "@mui/icons-material/MonitorHeartOutlined";
-// import Token from "@mui/icons-material/Token";
+import Token from "@mui/icons-material/Token";
 import { type FC } from "react";
 import { GitIcon } from "components/Icons/GitIcon";
 import {
@@ -33,10 +33,9 @@ export const Sidebar: FC = () => {
       <SidebarNavItem href="external-auth" icon={GitIcon}>
         External Authentication
       </SidebarNavItem>
-      {/* Not exposing this yet since token exchange is not finished yet.
       <SidebarNavItem href="oauth2-provider/apps" icon={Token}>
         OAuth2 Applications
-      </SidebarNavItem>*/}
+      </SidebarNavItem>
       <SidebarNavItem href="network" icon={Globe}>
         Network
       </SidebarNavItem>

--- a/site/src/pages/UserSettingsPage/Sidebar.tsx
+++ b/site/src/pages/UserSettingsPage/Sidebar.tsx
@@ -5,6 +5,7 @@ import AccountIcon from "@mui/icons-material/Person";
 import AppearanceIcon from "@mui/icons-material/Brush";
 import ScheduleIcon from "@mui/icons-material/EditCalendarOutlined";
 import SecurityIcon from "@mui/icons-material/LockOutlined";
+import Token from "@mui/icons-material/Token";
 import type { User } from "api/typesGenerated";
 import { UserAvatar } from "components/UserAvatar/UserAvatar";
 import {
@@ -23,6 +24,7 @@ export const Sidebar: FC<SidebarProps> = ({ user }) => {
   const { entitlements } = useDashboard();
   const showSchedulePage =
     entitlements.features.advanced_template_scheduling.enabled;
+  const showOAuth2Page = entitlements.features.oauth2_provider.enabled;
 
   return (
     <BaseSidebar>
@@ -42,6 +44,11 @@ export const Sidebar: FC<SidebarProps> = ({ user }) => {
       <SidebarNavItem href="external-auth" icon={GitIcon}>
         External Authentication
       </SidebarNavItem>
+      {showOAuth2Page && (
+        <SidebarNavItem href="oauth2-provider" icon={Token}>
+          OAuth2 Applications
+        </SidebarNavItem>
+      )}
       {showSchedulePage && (
         <SidebarNavItem href="schedule" icon={ScheduleIcon}>
           Schedule


### PR DESCRIPTION
Stale bot closed the other and will not let me reopen after I force pushed, so here is a new one.

Closes #11084 

Stacked manually so I can compare the experience to Graphite.  Depends on:
- https://github.com/coder/coder/pull/11713 (not an actual dependency, just tracking here)
- https://github.com/coder/coder/pull/11718
- https://github.com/coder/coder/pull/11715
- https://github.com/coder/coder/pull/12237
- https://github.com/coder/coder/pull/11778
- https://github.com/coder/coder/pull/12196

# TODO

- [x] /authorize static page
- [x] /authorize redirect
- [x] /tokens GET
- [x] /tokens DELETE (revoke)
- [x] Add endpoints for discoverability
- [x] Refresh auth grant flow
  - [ ] Disable auto-refresh on oauth-generated API keys
- [x] Hash secrets
- [ ] Handle other auth styles
- [ ] Handle no user agent for /authorize. Return text payload with href??
- [ ] Audit logs
  - [x] Create app
  - [x] Delete app
  - [x] Edit app
  - [x] Create secret
  - [x] Delete secret
  - [ ] Revoke app?
  - [ ] Authorize app?
  - [ ] Token exchange?
- [ ] Allow admin to revoke an app for a user
- [ ] Documentation
- [ ] Could use an upsert for replacing the code
- [x] Does not seem to be redirecting to login