### PR TITLE
fix: change servertailnet to register the DERP dialer before setting DERP map

### DIFF
--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -52,19 +52,41 @@ func NewServerTailnet(
 	traceProvider trace.TracerProvider,
 ) (*ServerTailnet, error) {
 	logger = logger.Named("servertailnet")
-	originalDerpMap := derpMapFn()
 	conn, err := tailnet.NewConn(&tailnet.Options{
 		Addresses:           []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
-		DERPMap:             originalDerpMap,
 		DERPForceWebSockets: derpForceWebSockets,
 		Logger:              logger,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("create tailnet conn: %w", err)
 	}
-
 	serverCtx, cancel := context.WithCancel(ctx)
+
+	// This is set to allow local DERP traffic to be proxied through memory
+	// instead of needing to hit the external access URL. Don't use the ctx
+	// given in this callback, it's only valid while connecting.
+	if derpServer != nil {
+		conn.SetDERPRegionDialer(func(_ context.Context, region *tailcfg.DERPRegion) net.Conn {
+			if !region.EmbeddedRelay {
+				return nil
+			}
+			logger.Debug(ctx, "connecting to embedded DERP via in-memory pipe")
+			left, right := net.Pipe()
+			go func() {
+				defer left.Close()
+				defer right.Close()
+				brw := bufio.NewReadWriter(bufio.NewReader(right), bufio.NewWriter(right))
+				derpServer.Accept(ctx, right, brw, "internal")
+			}()
+			return left
+		})
+	}
+
 	derpMapUpdaterClosed := make(chan struct{})
+	originalDerpMap := derpMapFn()
+	// it's important to set the DERPRegionDialer above _before_ we set the DERP map so that if
+	// there is an embedded relay, we use the local in-memory dialer.
+	conn.SetDERPMap(originalDerpMap)
 	go func() {
 		defer close(derpMapUpdaterClosed)
 
@@ -158,25 +180,6 @@ func NewServerTailnet(
 			tn.logger.Warn(context.Background(), "broadcast server node to agents", slog.Error(err))
 		}
 	})
-
-	// This is set to allow local DERP traffic to be proxied through memory
-	// instead of needing to hit the external access URL. Don't use the ctx
-	// given in this callback, it's only valid while connecting.
-	if derpServer != nil {
-		conn.SetDERPRegionDialer(func(_ context.Context, region *tailcfg.DERPRegion) net.Conn {
-			if !region.EmbeddedRelay {
-				return nil
-			}
-			left, right := net.Pipe()
-			go func() {
-				defer left.Close()
-				defer right.Close()
-				brw := bufio.NewReadWriter(bufio.NewReader(right), bufio.NewWriter(right))
-				derpServer.Accept(ctx, right, brw, "internal")
-			}()
-			return left
-		})
-	}
 
 	go tn.watchAgentUpdates()
 	go tn.expireOldAgents()

--- a/tailnet/configmaps.go
+++ b/tailnet/configmaps.go
@@ -204,7 +204,8 @@ func (c *configMaps) netMapLocked() *netmap.NetworkMap {
 	nm.Addresses = make([]netip.Prefix, len(c.addresses))
 	copy(nm.Addresses, c.addresses)
 
-	nm.DERPMap = c.derpMap.Clone()
+	// we don't need to set the DERPMap in the network map because we separately
+	// send the DERPMap directly via SetDERPMap
 	nm.Peers = c.peerConfigLocked()
 	nm.SelfNode.Addresses = nm.Addresses
 	nm.SelfNode.AllowedIPs = nm.Addresses

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -116,9 +116,6 @@ func NewConn(options *Options) (conn *Conn, err error) {
 	if len(options.Addresses) == 0 {
 		return nil, xerrors.New("At least one IP range must be provided")
 	}
-	if options.DERPMap == nil {
-		return nil, xerrors.New("DERPMap must be provided")
-	}
 
 	nodePrivateKey := key.NewNode()
 	var nodeID tailcfg.NodeID
@@ -219,7 +216,9 @@ func NewConn(options *Options) (conn *Conn, err error) {
 		magicConn.DiscoPublicKey(),
 	)
 	cfgMaps.setAddresses(options.Addresses)
-	cfgMaps.setDERPMap(options.DERPMap)
+	if options.DERPMap != nil {
+		cfgMaps.setDERPMap(options.DERPMap)
+	}
 	cfgMaps.setBlockEndpoints(options.BlockEndpoints)
 
 	nodeUp := newNodeUpdater(


### PR DESCRIPTION
I noticed a possible race where tailnet.Conn can try to dial the embedded region before we've set our custom dialer that send the DERP in-memory.  This closes that race and adds a test case for servertailnet with no STUN and an embedded relay
