### PR TITLE
fix: set node callback each time we reinit the coordinator in servertailnet

### DIFF
--- a/coderd/tailnet_internal_test.go
+++ b/coderd/tailnet_internal_test.go
@@ -48,6 +48,7 @@ func TestServerTailnet_Reconnect(t *testing.T) {
 		agentConnectionTimes: make(map[uuid.UUID]time.Time),
 	}
 	// reinit the Coordinator once, to load mMultiAgent0
+	mCoord.EXPECT().SetNodeCallback(gomock.Any()).Times(1)
 	uut.reinitCoordinator()
 
 	mMultiAgent0.EXPECT().NextUpdate(gomock.Any()).
@@ -57,6 +58,7 @@ func TestServerTailnet_Reconnect(t *testing.T) {
 		Times(1).
 		Return(true) // this triggers reconnect
 	setLost := mCoord.EXPECT().SetAllPeersLost().Times(1).After(closed0)
+	mCoord.EXPECT().SetNodeCallback(gomock.Any()).Times(1).After(closed0)
 	mMultiAgent1.EXPECT().NextUpdate(gomock.Any()).
 		Times(1).
 		After(setLost).


### PR DESCRIPTION
I think this will resolve #12136 but lets get a proper test at the system level before closing.

Before this change, we only register the node callback at start of day for the server tailnet.  If the coordinator changes, like we know happens when we are licensed for the PGCoordinator, we close the connection to the old coord, and open a new one to the new coord.

The callback is designed to direct the updates to the new coordinator, but there is nothing that specifically triggers it to fire after we connect to the new coordinator.

If we have STUN, then period re-STUNs will generally get it to fire eventually, but without STUN it we could go indefinitely without a callback.

This PR changes the servertailnet to re-register the callback each time we reconnect to the coordinator.  Registering a callback (even if it's the same callback) triggers an immediate call with our node information, so the new coordinator will have it.