### PR TITLE
fix(site): ignore fileInfo if file is missing

### DIFF
--- a/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
+++ b/site/src/modules/templates/TemplateFiles/TemplateFiles.tsx
@@ -42,7 +42,7 @@ export const TemplateFiles: FC<TemplateFilesProps> = ({
   const fileInfo = useCallback(
     (filename: string) => {
       const value = currentFiles[filename].trim();
-      const previousValue = baseFiles ? baseFiles[filename].trim() : undefined;
+      const previousValue = baseFiles ? baseFiles[filename]?.trim() : undefined;
       const hasDiff = previousValue && value !== previousValue;
 
       return {


### PR DESCRIPTION
Spotted by @matifali.

It seems that the implementation changed over time, and some older template files may not be rendered. Let's fix it.

Rendering now:

<img width="1476" alt="Screenshot 2024-02-15 at 10 05 46" src="https://github.com/coder/coder/assets/14044910/b4646406-27d0-4ed3-adeb-f508cb6543c6">

Testing:

```
cd site
CODER_HOST=https://dev.coder.com pnpm dev
```