### PR TITLE
chore: deprecate API workspace build resources

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6370,6 +6370,7 @@ const docTemplate = `{
                 ],
                 "summary": "Removed: Get workspace resources for workspace build",
                 "operationId": "removed-get-workspace-resources-for-workspace-build",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6369,7 +6369,7 @@ const docTemplate = `{
                     "Builds"
                 ],
                 "summary": "Removed: Get workspace resources for workspace build",
-                "operationId": "get-workspace-resources-for-workspace-build",
+                "operationId": "removed-get-workspace-resources-for-workspace-build",
                 "parameters": [
                     {
                         "type": "string",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -6368,7 +6368,7 @@ const docTemplate = `{
                 "tags": [
                     "Builds"
                 ],
-                "summary": "Get workspace resources for workspace build",
+                "summary": "Removed: Get workspace resources for workspace build",
                 "operationId": "get-workspace-resources-for-workspace-build",
                 "parameters": [
                     {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5620,6 +5620,7 @@
         "tags": ["Builds"],
         "summary": "Removed: Get workspace resources for workspace build",
         "operationId": "removed-get-workspace-resources-for-workspace-build",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5619,7 +5619,7 @@
         "produces": ["application/json"],
         "tags": ["Builds"],
         "summary": "Removed: Get workspace resources for workspace build",
-        "operationId": "get-workspace-resources-for-workspace-build",
+        "operationId": "removed-get-workspace-resources-for-workspace-build",
         "parameters": [
           {
             "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5618,7 +5618,7 @@
         ],
         "produces": ["application/json"],
         "tags": ["Builds"],
-        "summary": "Get workspace resources for workspace build",
+        "summary": "Removed: Get workspace resources for workspace build",
         "operationId": "get-workspace-resources-for-workspace-build",
         "parameters": [
           {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -992,7 +992,7 @@ func New(options *Options) *API {
 			r.Patch("/cancel", api.patchCancelWorkspaceBuild)
 			r.Get("/logs", api.workspaceBuildLogs)
 			r.Get("/parameters", api.workspaceBuildParameters)
-			r.Get("/resources", api.workspaceBuildResources)
+			r.Get("/resources", api.workspaceBuildResourcesDeprecated)
 			r.Get("/state", api.workspaceBuildState)
 		})
 		r.Route("/authcheck", func(r chi.Router) {

--- a/coderd/deprecated.go
+++ b/coderd/deprecated.go
@@ -124,6 +124,7 @@ func (api *API) workspaceAgentPostMetadataDeprecated(rw http.ResponseWriter, r *
 // @Param workspacebuild path string true "Workspace build ID"
 // @Success 200 {array} codersdk.WorkspaceResource
 // @Router /workspacebuilds/{workspacebuild}/resources [get]
+// @Deprecated this endpoint is unused and will be removed in future.
 func (api *API) workspaceBuildResourcesDeprecated(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceBuild := httpmw.WorkspaceBuildParam(r)

--- a/coderd/deprecated.go
+++ b/coderd/deprecated.go
@@ -117,7 +117,7 @@ func (api *API) workspaceAgentPostMetadataDeprecated(rw http.ResponseWriter, r *
 }
 
 // @Summary Removed: Get workspace resources for workspace build
-// @ID get-workspace-resources-for-workspace-build
+// @ID removed-get-workspace-resources-for-workspace-build
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Builds

--- a/coderd/deprecated.go
+++ b/coderd/deprecated.go
@@ -8,6 +8,7 @@ import (
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 )
 
@@ -113,4 +114,27 @@ func (api *API) workspaceAgentPostMetadataDeprecated(rw http.ResponseWriter, r *
 	}
 
 	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+}
+
+// @Summary Removed: Get workspace resources for workspace build
+// @ID get-workspace-resources-for-workspace-build
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Builds
+// @Param workspacebuild path string true "Workspace build ID"
+// @Success 200 {array} codersdk.WorkspaceResource
+// @Router /workspacebuilds/{workspacebuild}/resources [get]
+func (api *API) workspaceBuildResourcesDeprecated(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceBuild := httpmw.WorkspaceBuildParam(r)
+
+	job, err := api.Database.GetProvisionerJobByID(ctx, workspaceBuild.JobID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching provisioner job.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	api.provisionerJobResources(rw, r, job)
 }

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -557,29 +557,6 @@ func (api *API) verifyUserCanCancelWorkspaceBuilds(ctx context.Context, userID u
 	return slices.Contains(user.RBACRoles, rbac.RoleOwner()), nil // only user with "owner" role can cancel workspace builds
 }
 
-// @Summary Get workspace resources for workspace build
-// @ID get-workspace-resources-for-workspace-build
-// @Security CoderSessionToken
-// @Produce json
-// @Tags Builds
-// @Param workspacebuild path string true "Workspace build ID"
-// @Success 200 {array} codersdk.WorkspaceResource
-// @Router /workspacebuilds/{workspacebuild}/resources [get]
-func (api *API) workspaceBuildResources(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	workspaceBuild := httpmw.WorkspaceBuildParam(r)
-
-	job, err := api.Database.GetProvisionerJobByID(ctx, workspaceBuild.JobID)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching provisioner job.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	api.provisionerJobResources(rw, r, job)
-}
-
 // @Summary Get build parameters for workspace build
 // @ID get-build-parameters-for-workspace-build
 // @Security CoderSessionToken

--- a/docs/api/builds.md
+++ b/docs/api/builds.md
@@ -533,7 +533,7 @@ Status Code **200**
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Get workspace resources for workspace build
+## Removed: Get workspace resources for workspace build
 
 ### Code samples
 
@@ -674,7 +674,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/res
 | ------ | ------------------------------------------------------- | ----------- | --------------------------------------------------------------------------- |
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.WorkspaceResource](schemas.md#codersdkworkspaceresource) |
 
-<h3 id="get-workspace-resources-for-workspace-build-responseschema">Response Schema</h3>
+<h3 id="removed:-get-workspace-resources-for-workspace-build-responseschema">Response Schema</h3>
 
 Status Code **200**
 


### PR DESCRIPTION
While working on https://github.com/coder/coder/issues/8995, I noticed that this endpoint is not used by the frontend or CLI, so let's park it for removal in the future.

