### PR TITLE
fix(cli): avoid panic when external auth name isn't provided

### DIFF
--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -52,6 +52,9 @@ fi
 				Command:     "coder external-auth access-token slack --extra \"authed_user.id\"",
 			},
 		),
+		Middleware: clibase.Chain(
+			clibase.RequireNArgs(1),
+		),
 		Options: clibase.OptionSet{{
 			Name:        "Extra",
 			Flag:        "extra",

--- a/cli/externalauth_test.go
+++ b/cli/externalauth_test.go
@@ -46,6 +46,19 @@ func TestExternalAuth(t *testing.T) {
 		clitest.Start(t, inv)
 		pty.ExpectMatch("bananas")
 	})
+	t.Run("NoArgs", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpapi.Write(context.Background(), w, http.StatusOK, agentsdk.ExternalAuthResponse{
+				AccessToken: "bananas",
+			})
+		}))
+		t.Cleanup(srv.Close)
+		url := srv.URL
+		inv, _ := clitest.New(t, "--agent-url", url, "external-auth", "access-token")
+		watier := clitest.StartWithWaiter(t, inv)
+		watier.RequireContains("wanted 1 args but got 0")
+	})
 	t.Run("SuccessWithExtra", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/10216