### PR TITLE
docs: fix header font

### DIFF
--- a/docs/templates/resource-ordering.md
+++ b/docs/templates/resource-ordering.md
@@ -8,7 +8,7 @@ The resource with the lower `order` is presented before the one with greater
 value. A missing `order` property defaults to 0. If two resources have the same
 `order` property, the resources will be ordered by property `name` (or `key`).
 
-## Using `order` property
+## Using "order" property
 
 ### Coder parameters
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/8995

It looks like headers do not render `<code>` tags properly.

<img width="345" alt="Screenshot 2024-02-16 at 14 26 42" src="https://github.com/coder/coder/assets/14044910/356ca462-418d-4f3b-9ebb-ce0b8383e193">
