### PR TITLE
fix(tailnet): enforce valid agent and client addresses

### DIFF
--- a/agent/agenttest/client.go
+++ b/agent/agenttest/client.go
@@ -108,11 +108,10 @@ func (c *Client) ConnectRPC(ctx context.Context) (drpc.Conn, error) {
 	c.t.Cleanup(c.LastWorkspaceAgent)
 	serveCtx, cancel := context.WithCancel(ctx)
 	c.t.Cleanup(cancel)
-	auth := tailnet.AgentTunnelAuth{}
 	streamID := tailnet.StreamID{
 		Name: "agenttest",
 		ID:   c.agentID,
-		Auth: auth,
+		Auth: tailnet.AgentCoordinateeAuth{ID: c.agentID},
 	}
 	serveCtx = tailnet.WithStreamID(serveCtx, streamID)
 	go func() {

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -155,7 +155,7 @@ func (api *API) workspaceAgentRPC(rw http.ResponseWriter, r *http.Request) {
 	streamID := tailnet.StreamID{
 		Name: fmt.Sprintf("%s-%s-%s", owner.Username, workspace.Name, workspaceAgent.Name),
 		ID:   workspaceAgent.ID,
-		Auth: tailnet.AgentTunnelAuth{},
+		Auth: tailnet.AgentCoordinateeAuth{ID: workspaceAgent.ID},
 	}
 	ctx = tailnet.WithStreamID(ctx, streamID)
 	ctx = agentapi.WithAPIVersion(ctx, version)

--- a/codersdk/workspaceagents_internal_test.go
+++ b/codersdk/workspaceagents_internal_test.go
@@ -54,7 +54,7 @@ func TestTailnetAPIConnector_Disconnects(t *testing.T) {
 		err = svc.ServeConnV2(ctx, nc, tailnet.StreamID{
 			Name: "client",
 			ID:   clientID,
-			Auth: tailnet.ClientTunnelAuth{AgentID: agentID},
+			Auth: tailnet.ClientCoordinateeAuth{AgentID: agentID},
 		})
 		assert.NoError(t, err)
 	}))

--- a/enterprise/tailnet/connio.go
+++ b/enterprise/tailnet/connio.go
@@ -31,7 +31,7 @@ type connIO struct {
 	responses    chan<- *proto.CoordinateResponse
 	bindings     chan<- binding
 	tunnels      chan<- tunnel
-	auth         agpl.TunnelAuth
+	auth         agpl.CoordinateeAuth
 	mu           sync.Mutex
 	closed       bool
 	disconnected bool
@@ -51,7 +51,7 @@ func newConnIO(coordContext context.Context,
 	responses chan<- *proto.CoordinateResponse,
 	id uuid.UUID,
 	name string,
-	auth agpl.TunnelAuth,
+	auth agpl.CoordinateeAuth,
 ) *connIO {
 	peerCtx, cancel := context.WithCancel(peerCtx)
 	now := time.Now().Unix()
@@ -135,7 +135,7 @@ func (c *connIO) handleRequest(req *proto.CoordinateRequest) error {
 				return xerrors.Errorf("parse address: %w", err)
 			}
 
-			if !c.auth.AuthorizeIP(c.id, pre) {
+			if !c.auth.AuthorizeIP(pre) {
 				return xerrors.Errorf("unauthorized address sent %q", pre.String())
 			}
 		}

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -224,7 +224,7 @@ func (c *pgCoord) Close() error {
 }
 
 func (c *pgCoord) Coordinate(
-	ctx context.Context, id uuid.UUID, name string, a agpl.TunnelAuth,
+	ctx context.Context, id uuid.UUID, name string, a agpl.CoordinateeAuth,
 ) (
 	chan<- *proto.CoordinateRequest, <-chan *proto.CoordinateResponse,
 ) {

--- a/enterprise/tailnet/workspaceproxy.go
+++ b/enterprise/tailnet/workspaceproxy.go
@@ -52,7 +52,7 @@ func (s *ClientService) ServeMultiAgentClient(ctx context.Context, version strin
 		sub := coord.ServeMultiAgent(id)
 		return ServeWorkspaceProxy(ctx, conn, sub)
 	case 2:
-		auth := agpl.SingleTailnetTunnelAuth{}
+		auth := agpl.SingleTailnetCoordinateeAuth{}
 		streamID := agpl.StreamID{
 			Name: id.String(),
 			ID:   id,

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
@@ -182,7 +182,7 @@ func TestDialCoordinator(t *testing.T) {
 		// avoid blocking
 		reqs := make(chan *proto.CoordinateRequest, 100)
 		resps := make(chan *proto.CoordinateResponse, 100)
-		mCoord.EXPECT().Coordinate(gomock.Any(), proxyID, gomock.Any(), agpl.SingleTailnetTunnelAuth{}).
+		mCoord.EXPECT().Coordinate(gomock.Any(), proxyID, gomock.Any(), agpl.SingleTailnetCoordinateeAuth{}).
 			Times(1).
 			Return(reqs, resps)
 

--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -661,6 +661,17 @@ func (c *core) nodeUpdateLocked(p *peer, node *proto.Node) error {
 		slog.F("peer_id", p.id),
 		slog.F("node", node.String()))
 
+	for _, addrStr := range node.Addresses {
+		pre, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			return xerrors.Errorf("parse address: %w", err)
+		}
+
+		if !p.auth.AuthorizeIP(p.id, pre) {
+			return xerrors.Errorf("unauthorized address sent %q", pre.String())
+		}
+	}
+
 	p.node = node
 	c.updateTunnelPeersLocked(p.id, node, proto.CoordinateResponse_PeerUpdate_NODE, "node update")
 	return nil

--- a/tailnet/peer.go
+++ b/tailnet/peer.go
@@ -19,7 +19,7 @@ type peer struct {
 	node   *proto.Node
 	resps  chan<- *proto.CoordinateResponse
 	reqs   <-chan *proto.CoordinateRequest
-	auth   TunnelAuth
+	auth   CoordinateeAuth
 	sent   map[uuid.UUID]*proto.Node
 
 	name       string

--- a/tailnet/service.go
+++ b/tailnet/service.go
@@ -29,7 +29,7 @@ type streamIDContextKey struct{}
 type StreamID struct {
 	Name string
 	ID   uuid.UUID
-	Auth TunnelAuth
+	Auth CoordinateeAuth
 }
 
 func WithStreamID(ctx context.Context, streamID StreamID) context.Context {
@@ -91,7 +91,7 @@ func (s *ClientService) ServeClient(ctx context.Context, version string, conn ne
 		coord := *(s.CoordPtr.Load())
 		return coord.ServeClient(conn, id, agent)
 	case 2:
-		auth := ClientTunnelAuth{AgentID: agent}
+		auth := ClientCoordinateeAuth{AgentID: agent}
 		streamID := StreamID{
 			Name: "client",
 			ID:   id,

--- a/tailnet/service_test.go
+++ b/tailnet/service_test.go
@@ -64,7 +64,6 @@ func TestClientService_ServeClient_V2(t *testing.T) {
 	require.NotNil(t, call)
 	require.Equal(t, call.ID, clientID)
 	require.Equal(t, call.Name, "client")
-	// require.True(t, call.Auth.Authorize(agentID))
 	require.NoError(t, call.Auth.Authorize(&proto.CoordinateRequest{
 		AddTunnel: &proto.CoordinateRequest_Tunnel{Id: agentID[:]},
 	}))

--- a/tailnet/service_test.go
+++ b/tailnet/service_test.go
@@ -64,7 +64,10 @@ func TestClientService_ServeClient_V2(t *testing.T) {
 	require.NotNil(t, call)
 	require.Equal(t, call.ID, clientID)
 	require.Equal(t, call.Name, "client")
-	require.True(t, call.Auth.Authorize(agentID))
+	// require.True(t, call.Auth.Authorize(agentID))
+	require.NoError(t, call.Auth.Authorize(&proto.CoordinateRequest{
+		AddTunnel: &proto.CoordinateRequest_Tunnel{Id: agentID[:]},
+	}))
 	req := testutil.RequireRecvCtx(ctx, t, call.Reqs)
 	require.Equal(t, int32(11), req.GetUpdateSelf().GetNode().GetPreferredDerp())
 

--- a/tailnet/tailnettest/coordinatormock.go
+++ b/tailnet/tailnettest/coordinatormock.go
@@ -59,7 +59,7 @@ func (mr *MockCoordinatorMockRecorder) Close() *gomock.Call {
 }
 
 // Coordinate mocks base method.
-func (m *MockCoordinator) Coordinate(arg0 context.Context, arg1 uuid.UUID, arg2 string, arg3 tailnet.TunnelAuth) (chan<- *proto.CoordinateRequest, <-chan *proto.CoordinateResponse) {
+func (m *MockCoordinator) Coordinate(arg0 context.Context, arg1 uuid.UUID, arg2 string, arg3 tailnet.CoordinateeAuth) (chan<- *proto.CoordinateRequest, <-chan *proto.CoordinateResponse) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Coordinate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(chan<- *proto.CoordinateRequest)

--- a/tailnet/tailnettest/tailnettest.go
+++ b/tailnet/tailnettest/tailnettest.go
@@ -312,7 +312,7 @@ func (*FakeCoordinator) ServeMultiAgent(uuid.UUID) tailnet.MultiAgentConn {
 	panic("unimplemented")
 }
 
-func (f *FakeCoordinator) Coordinate(ctx context.Context, id uuid.UUID, name string, a tailnet.TunnelAuth) (chan<- *proto.CoordinateRequest, <-chan *proto.CoordinateResponse) {
+func (f *FakeCoordinator) Coordinate(ctx context.Context, id uuid.UUID, name string, a tailnet.CoordinateeAuth) (chan<- *proto.CoordinateRequest, <-chan *proto.CoordinateResponse) {
 	reqs := make(chan *proto.CoordinateRequest, 100)
 	resps := make(chan *proto.CoordinateResponse, 100)
 	f.CoordinateCalls <- &FakeCoordinate{
@@ -337,7 +337,7 @@ type FakeCoordinate struct {
 	Ctx   context.Context
 	ID    uuid.UUID
 	Name  string
-	Auth  tailnet.TunnelAuth
+	Auth  tailnet.CoordinateeAuth
 	Reqs  chan *proto.CoordinateRequest
 	Resps chan *proto.CoordinateResponse
 }

--- a/tailnet/test/peer.go
+++ b/tailnet/test/peer.go
@@ -40,7 +40,7 @@ func NewPeer(ctx context.Context, t testing.TB, coord tailnet.CoordinatorV2, nam
 		p.ID = uuid.New()
 	}
 	// SingleTailnetTunnelAuth allows connections to arbitrary peers
-	p.reqs, p.resps = coord.Coordinate(p.ctx, p.ID, name, tailnet.SingleTailnetTunnelAuth{})
+	p.reqs, p.resps = coord.Coordinate(p.ctx, p.ID, name, tailnet.SingleTailnetCoordinateeAuth{})
 	return p
 }
 

--- a/tailnet/tunnel.go
+++ b/tailnet/tunnel.go
@@ -1,15 +1,26 @@
 package tailnet
 
-import "github.com/google/uuid"
+import (
+	"net/netip"
+
+	"github.com/google/uuid"
+)
+
+var legacyWorkspaceAgentIP = netip.MustParseAddr("fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4")
 
 type TunnelAuth interface {
 	Authorize(dst uuid.UUID) bool
+	AuthorizeIP(src uuid.UUID, ip netip.Prefix) bool
 }
 
 // SingleTailnetTunnelAuth allows all tunnels, since Coderd and wsproxy are allowed to initiate a tunnel to any agent
 type SingleTailnetTunnelAuth struct{}
 
 func (SingleTailnetTunnelAuth) Authorize(uuid.UUID) bool {
+	return true
+}
+
+func (SingleTailnetTunnelAuth) AuthorizeIP(uuid.UUID, netip.Prefix) bool {
 	return true
 }
 
@@ -22,11 +33,25 @@ func (c ClientTunnelAuth) Authorize(dst uuid.UUID) bool {
 	return c.AgentID == dst
 }
 
+func (ClientTunnelAuth) AuthorizeIP(_ uuid.UUID, ip netip.Prefix) bool {
+	// Clients can pick whatever IP they like, since they can only connect to
+	// one agent.
+	return ip.Bits() == 128
+}
+
 // AgentTunnelAuth disallows all tunnels, since agents are not allowed to initiate their own tunnels
 type AgentTunnelAuth struct{}
 
 func (AgentTunnelAuth) Authorize(uuid.UUID) bool {
 	return false
+}
+
+func (AgentTunnelAuth) AuthorizeIP(id uuid.UUID, ip netip.Prefix) bool {
+	// Ensure the CIDR is /128
+	return ip.Bits() == 128 &&
+		// Allow both the legacy ip and the new ip derived from the agent ip.
+		(IPFromUUID(id).Compare(ip.Addr()) == 0 ||
+			legacyWorkspaceAgentIP.Compare(ip.Addr()) == 0)
 }
 
 // tunnelStore contains tunnel information and allows querying it.  It is not threadsafe and all

--- a/tailnet/tunnel.go
+++ b/tailnet/tunnel.go
@@ -29,8 +29,7 @@ type ClientCoordinateeAuth struct {
 
 func (c ClientCoordinateeAuth) Authorize(req *proto.CoordinateRequest) error {
 	if tun := req.GetAddTunnel(); tun != nil {
-		var uid uuid.UUID
-		err := uid.UnmarshalBinary(tun.Id)
+		uid, err := uuid.FromBytes(tun.Id)
 		if err != nil {
 			return xerrors.Errorf("parse add tunnel id: %w", err)
 		}

--- a/tailnet/tunnel.go
+++ b/tailnet/tunnel.go
@@ -8,49 +8,51 @@ import (
 
 var legacyWorkspaceAgentIP = netip.MustParseAddr("fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4")
 
-type TunnelAuth interface {
+type CoordinateeAuth interface {
 	Authorize(dst uuid.UUID) bool
-	AuthorizeIP(src uuid.UUID, ip netip.Prefix) bool
+	AuthorizeIP(ip netip.Prefix) bool
 }
 
-// SingleTailnetTunnelAuth allows all tunnels, since Coderd and wsproxy are allowed to initiate a tunnel to any agent
-type SingleTailnetTunnelAuth struct{}
+// SingleTailnetCoordinateeAuth allows all tunnels, since Coderd and wsproxy are allowed to initiate a tunnel to any agent
+type SingleTailnetCoordinateeAuth struct{}
 
-func (SingleTailnetTunnelAuth) Authorize(uuid.UUID) bool {
+func (SingleTailnetCoordinateeAuth) Authorize(uuid.UUID) bool {
 	return true
 }
 
-func (SingleTailnetTunnelAuth) AuthorizeIP(uuid.UUID, netip.Prefix) bool {
+func (SingleTailnetCoordinateeAuth) AuthorizeIP(netip.Prefix) bool {
 	return true
 }
 
-// ClientTunnelAuth allows connecting to a single, given agent
-type ClientTunnelAuth struct {
+// ClientCoordinateeAuth allows connecting to a single, given agent
+type ClientCoordinateeAuth struct {
 	AgentID uuid.UUID
 }
 
-func (c ClientTunnelAuth) Authorize(dst uuid.UUID) bool {
+func (c ClientCoordinateeAuth) Authorize(dst uuid.UUID) bool {
 	return c.AgentID == dst
 }
 
-func (ClientTunnelAuth) AuthorizeIP(_ uuid.UUID, ip netip.Prefix) bool {
+func (ClientCoordinateeAuth) AuthorizeIP(ip netip.Prefix) bool {
 	// Clients can pick whatever IP they like, since they can only connect to
 	// one agent.
 	return ip.Bits() == 128
 }
 
-// AgentTunnelAuth disallows all tunnels, since agents are not allowed to initiate their own tunnels
-type AgentTunnelAuth struct{}
+// AgentCoordinateeAuth disallows all tunnels, since agents are not allowed to initiate their own tunnels
+type AgentCoordinateeAuth struct {
+	ID uuid.UUID
+}
 
-func (AgentTunnelAuth) Authorize(uuid.UUID) bool {
+func (AgentCoordinateeAuth) Authorize(uuid.UUID) bool {
 	return false
 }
 
-func (AgentTunnelAuth) AuthorizeIP(id uuid.UUID, ip netip.Prefix) bool {
+func (a AgentCoordinateeAuth) AuthorizeIP(ip netip.Prefix) bool {
 	// Ensure the CIDR is /128
 	return ip.Bits() == 128 &&
 		// Allow both the legacy ip and the new ip derived from the agent ip.
-		(IPFromUUID(id).Compare(ip.Addr()) == 0 ||
+		(IPFromUUID(a.ID).Compare(ip.Addr()) == 0 ||
 			legacyWorkspaceAgentIP.Compare(ip.Addr()) == 0)
 }
 

--- a/tailnet/tunnel.go
+++ b/tailnet/tunnel.go
@@ -29,7 +29,8 @@ type ClientCoordinateeAuth struct {
 
 func (c ClientCoordinateeAuth) Authorize(req *proto.CoordinateRequest) error {
 	if tun := req.GetAddTunnel(); tun != nil {
-		uid, err := uuid.ParseBytes(tun.Id)
+		var uid uuid.UUID
+		err := uid.UnmarshalBinary(tun.Id)
 		if err != nil {
 			return xerrors.Errorf("parse add tunnel id: %w", err)
 		}
@@ -84,14 +85,6 @@ func (a AgentCoordinateeAuth) Authorize(req *proto.CoordinateRequest) error {
 	}
 
 	return nil
-}
-
-func (a AgentCoordinateeAuth) AuthorizeIP(ip netip.Prefix) bool {
-	// Ensure the CIDR is /128
-	return ip.Bits() == 128 &&
-		// Allow both the legacy ip and the new ip derived from the agent ip.
-		(IPFromUUID(a.ID).Compare(ip.Addr()) == 0 ||
-			legacyWorkspaceAgentIP.Compare(ip.Addr()) == 0)
 }
 
 // tunnelStore contains tunnel information and allows querying it.  It is not threadsafe and all


### PR DESCRIPTION
This adds the ability for `TunnelAuth` to also authorize incoming wireguard node IPs, preventing agents from reporting anything other than their static IP generated from the agent ID.