### PR TITLE
feat: add support for Entra ID auth when using Azure DevOps external auth

### DIFF
--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -499,6 +499,9 @@ func ConvertConfig(instrument *promoauth.Factory, entries []codersdk.ExternalAut
 		if entry.Type == string(codersdk.EnhancedExternalAuthProviderAzureDevops) {
 			oauthConfig = &jwtConfig{oc}
 		}
+		if entry.Type == string(codersdk.EnhancedExternalAuthProviderAzureDevopsEntra) {
+			oauthConfig = &entraV1Oauth{oc}
+		}
 		if entry.Type == string(codersdk.EnhancedExternalAuthProviderJFrog) {
 			oauthConfig = &exchangeWithClientSecret{oc}
 		}
@@ -568,6 +571,9 @@ func applyDefaultsToConfig(config *codersdk.ExternalAuthConfig) {
 		return
 	case codersdk.EnhancedExternalAuthProviderGitea:
 		copyDefaultSettings(config, giteaDefaults(config))
+		return
+	case codersdk.EnhancedExternalAuthProviderAzureDevopsEntra:
+		copyDefaultSettings(config, azureDevopsEntraDefaults(config))
 		return
 	default:
 		// No defaults for this type. We still want to run this apply with
@@ -730,6 +736,41 @@ func giteaDefaults(config *codersdk.ExternalAuthConfig) codersdk.ExternalAuthCon
 	return defaults
 }
 
+func azureDevopsEntraDefaults(config *codersdk.ExternalAuthConfig) codersdk.ExternalAuthConfig {
+	defaults := codersdk.ExternalAuthConfig{
+		DisplayName: "Azure DevOps (Entra)",
+		DisplayIcon: "/icon/azure-devops.svg",
+		Regex:       `^(https?://)?dev\.azure\.com(/.*)?$`,
+	}
+	// The tenant ID is required for urls and is in the auth url.
+	if config.AuthURL == "" {
+		// No auth url, means we cannot guess the urls.
+		return defaults
+	}
+
+	auth, err := url.Parse(config.AuthURL)
+	if err != nil {
+		// We need a valid URL to continue with.
+		return defaults
+	}
+
+	// Only extract the tenant ID if the path is what we expect.
+	// The path should be /{tenantId}/oauth2/authorize.
+	parts := strings.Split(auth.Path, "/")
+	if len(parts) < 4 && parts[2] != "oauth2" || parts[3] != "authorize" {
+		// Not sure what this path is, abort.
+		return defaults
+	}
+	tenantID := parts[1]
+
+	tokenURL := auth.ResolveReference(&url.URL{Path: fmt.Sprintf("/%s/oauth2/token", tenantID)})
+	defaults.TokenURL = tokenURL.String()
+
+	// TODO: Discover a validate url for Azure DevOps.
+
+	return defaults
+}
+
 var staticDefaults = map[codersdk.EnhancedExternalAuthProvider]codersdk.ExternalAuthConfig{
 	codersdk.EnhancedExternalAuthProviderAzureDevops: {
 		AuthURL:     "https://app.vssps.visualstudio.com/oauth2/authorize",
@@ -807,6 +848,26 @@ func (c *jwtConfig) Exchange(ctx context.Context, code string, opts ...oauth2.Au
 			oauth2.SetAuthURLParam("assertion", code),
 			oauth2.SetAuthURLParam("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
 			oauth2.SetAuthURLParam("code", ""),
+		)...,
+	)
+}
+
+// When authenticating via Entra ID ADO only supports v1 tokens that requires the 'resource' rather than scopes
+// When ADO gets support for V2 Entra ID tokens this struct and functions can be removed
+type entraV1Oauth struct {
+	*oauth2.Config
+}
+
+const azureDevOpsAppID = "499b84ac-1321-427f-aa17-267ca6975798"
+
+func (c *entraV1Oauth) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+	return c.Config.AuthCodeURL(state, append(opts, oauth2.SetAuthURLParam("resource", azureDevOpsAppID))...)
+}
+
+func (c *entraV1Oauth) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return c.Config.Exchange(ctx, code,
+		append(opts,
+			oauth2.SetAuthURLParam("resource", azureDevOpsAppID),
 		)...,
 	)
 }

--- a/codersdk/externalauth.go
+++ b/codersdk/externalauth.go
@@ -25,6 +25,7 @@ func (e EnhancedExternalAuthProvider) Git() bool {
 		EnhancedExternalAuthProviderBitBucketCloud,
 		EnhancedExternalAuthProviderBitBucketServer,
 		EnhancedExternalAuthProviderAzureDevops,
+		EnhancedExternalAuthProviderAzureDevopsEntra,
 		EnhancedExternalAuthProviderGitea:
 		return true
 	default:
@@ -34,8 +35,10 @@ func (e EnhancedExternalAuthProvider) Git() bool {
 
 const (
 	EnhancedExternalAuthProviderAzureDevops EnhancedExternalAuthProvider = "azure-devops"
-	EnhancedExternalAuthProviderGitHub      EnhancedExternalAuthProvider = "github"
-	EnhancedExternalAuthProviderGitLab      EnhancedExternalAuthProvider = "gitlab"
+	// Authenticate to ADO using an app registration in Entra ID
+	EnhancedExternalAuthProviderAzureDevopsEntra EnhancedExternalAuthProvider = "azure-devops-entra"
+	EnhancedExternalAuthProviderGitHub           EnhancedExternalAuthProvider = "github"
+	EnhancedExternalAuthProviderGitLab           EnhancedExternalAuthProvider = "gitlab"
 	// EnhancedExternalAuthProviderBitBucketCloud is the Bitbucket Cloud provider.
 	// Not to be confused with the self-hosted 'EnhancedExternalAuthProviderBitBucketServer'
 	EnhancedExternalAuthProviderBitBucketCloud  EnhancedExternalAuthProvider = "bitbucket-cloud"

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -23,6 +23,7 @@ application. The following providers are supported:
 - [GitLab](https://docs.gitlab.com/ee/integration/oauth_provider.html)
 - [BitBucket](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/)
 - [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops)
+- [Azure DevOps (via Entra ID)](https://learn.microsoft.com/en-us/entra/architecture/auth-oauth2)
 
 Example callback URL:
 `https://coder.example.com/external-auth/primary-github/callback`. Use an
@@ -107,6 +108,20 @@ CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
 CODER_EXTERNAL_AUTH_0_AUTH_URL="https://app.vssps.visualstudio.com/oauth2/authorize"
 CODER_EXTERNAL_AUTH_0_TOKEN_URL="https://app.vssps.visualstudio.com/oauth2/token"
 ```
+
+### Azure DevOps (via Entra ID)
+
+Azure DevOps (via Entra ID) requires the following environment variables:
+
+```env
+CODER_EXTERNAL_AUTH_0_ID="primary-azure-devops"
+CODER_EXTERNAL_AUTH_0_TYPE=azure-devops-entra
+CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
+CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
+CODER_EXTERNAL_AUTH_0_AUTH_URL="https://login.microsoftonline.com/<TENANT ID>/oauth2/authorize"
+```
+
+> Note: Your app registration in Entra ID requires the `vso.code_write` scope
 
 ### GitLab self-managed
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2003,6 +2003,7 @@ export const DisplayApps: DisplayApp[] = [
 // From codersdk/externalauth.go
 export type EnhancedExternalAuthProvider =
   | "azure-devops"
+  | "azure-devops-entra"
   | "bitbucket-cloud"
   | "bitbucket-server"
   | "gitea"
@@ -2012,6 +2013,7 @@ export type EnhancedExternalAuthProvider =
   | "slack";
 export const EnhancedExternalAuthProviders: EnhancedExternalAuthProvider[] = [
   "azure-devops",
+  "azure-devops-entra",
   "bitbucket-cloud",
   "bitbucket-server",
   "gitea",


### PR DESCRIPTION
Very much a work in progress at the moment to prove the concept but I've hit a barrier and perhaps you'll be able to help.

To set a bit of context there are a few reasons I think Coder should support this method of authenticating to Azure DevOps:
- Microsoft suggest using it over Azure DevOps OAuth (https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops#available-oauth-models)
- Improved management 
   - Multiple owners can be set to enable teams of admins
   - The ability to choose how long secrets last for and the ability to create multiple secrets which is particularly handy when a secret is expiring for avoiding downtime
   - The ability to control which users access the app and in which tenants

So far I've just been editing the existing ADO connector, I appreciate this would need to be an additional connector to be merged as to not break anyone's existing deployments.

Entra app registration manifest 
```json
{
	"id": "<GUID>",
	"acceptMappedClaims": null,
	"accessTokenAcceptedVersion": null,
	"addIns": [],
	"allowPublicClient": null,
	"appId": "1f71dbec-936b-49d2-9552-e220fb29260a",
	"appRoles": [],
	"oauth2AllowUrlPathMatching": false,
	"createdDateTime": "2024-02-12T14:38:45Z",
	"description": null,
	"certification": null,
	"disabledByMicrosoftStatus": null,
	"groupMembershipClaims": null,
	"identifierUris": [],
	"informationalUrls": {
		"termsOfService": null,
		"support": null,
		"privacy": null,
		"marketing": null
	},
	"keyCredentials": [],
	"knownClientApplications": [],
	"logoUrl": null,
	"logoutUrl": null,
	"name": "Coder ADO Test",
	"notes": null,
	"oauth2AllowIdTokenImplicitFlow": false,
	"oauth2AllowImplicitFlow": false,
	"oauth2Permissions": [],
	"oauth2RequirePostResponse": false,
	"optionalClaims": null,
	"orgRestrictions": [],
	"parentalControlSettings": {
		"countriesBlockedForMinors": [],
		"legalAgeGroupRule": "Allow"
	},
	"passwordCredentials": [
		{
			"customKeyIdentifier": null,
			"endDate": "2024-08-10T13:39:18.311Z",
			"keyId": "442081e8-b295-4259-b1dc-5e0258745cc6",
			"startDate": "2024-02-12T14:39:18.311Z",
			"value": null,
			"createdOn": "2024-02-12T14:39:20.1029847Z",
			"hint": "iY~",
			"displayName": "test"
		}
	],
	"preAuthorizedApplications": [],
	"publisherDomain": "cloudsecure.ltd",
	"replyUrlsWithType": [
		{
			"url": "https://<ID>.pit-1.try.coder.app/external-auth/entra-azure-devops/callback",
			"type": "Web"
		}
	],
	"requiredResourceAccess": [
		{
			"resourceAppId": "499b84ac-1321-427f-aa17-267ca6975798",
			"resourceAccess": [
				{
					"id": "028ffaf1-6f06-490a-979e-38011f92fb7c",
					"type": "Scope"
				}
			]
		}
	],
	"samlMetadataUrl": null,
	"signInUrl": null,
	"signInAudience": "AzureADMyOrg",
	"tags": [],
	"tokenEncryptionKeyId": null
}
```

Signing in seems to work and I get a JWT back but the git clone operation always fails with `fatal: Authentication failed for...`

Any tips would be very welcome