### PR TITLE
feat(agent): add script data dir for binaries and files

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -969,7 +969,7 @@ func (a *agent) updateCommandEnv(current []string) (updated []string, err error)
 	if _, ok := envs["PATH"]; !ok {
 		envs["PATH"] = os.Getenv("PATH")
 	}
-	envs["PATH"] = a.scriptRunner.ScriptBinDir() + ":" + envs["PATH"]
+	envs["PATH"] = fmt.Sprintf("%s%c%s", a.scriptRunner.ScriptBinDir(), filepath.ListSeparator, envs["PATH"])
 
 	for k, v := range envs {
 		updated = append(updated, fmt.Sprintf("%s=%s", k, v))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -119,6 +119,8 @@ func New(options Options) Agent {
 	if options.ScriptDataDir == "" {
 		if options.TempDir != os.TempDir() {
 			options.Logger.Debug(context.Background(), "script data dir not set, using temp dir", slog.F("temp_dir", options.TempDir))
+		} else {
+			options.Logger.Debug(context.Background(), "using script data dir", slog.F("script_data_dir", options.ScriptDataDir))
 		}
 		options.ScriptDataDir = options.TempDir
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -258,12 +258,12 @@ func (a *agent) init(ctx context.Context) {
 	}
 	a.sshServer = sshSrv
 	a.scriptRunner = agentscripts.New(agentscripts.Options{
-		LogDir:     a.logDir,
-		DataDir:    a.scriptDataDir,
-		Logger:     a.logger,
-		SSHServer:  sshSrv,
-		Filesystem: a.filesystem,
-		PatchLogs:  a.client.PatchLogs,
+		LogDir:      a.logDir,
+		DataDirBase: a.scriptDataDir,
+		Logger:      a.logger,
+		SSHServer:   sshSrv,
+		Filesystem:  a.filesystem,
+		PatchLogs:   a.client.PatchLogs,
 	})
 	// Register runner metrics. If the prom registry is nil, the metrics
 	// will not report anywhere.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -113,6 +113,8 @@ func New(options Options) Agent {
 	if options.LogDir == "" {
 		if options.TempDir != os.TempDir() {
 			options.Logger.Debug(context.Background(), "log dir not set, using temp dir", slog.F("temp_dir", options.TempDir))
+		} else {
+			options.Logger.Debug(context.Background(), "using log dir", slog.F("log_dir", options.LogDir))
 		}
 		options.LogDir = options.TempDir
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -300,9 +300,7 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 		},
 	}
 	banner := codersdk.ServiceBannerConfig{}
-	fs := afero.NewMemMapFs()
 	session := setupSSHSession(t, manifest, banner, nil, func(_ *agenttest.Client, opts *agent.Options) {
-		opts.Filesystem = fs
 		opts.ScriptDataDir = tmpdir
 		opts.EnvironmentVariables["MY_OVERRIDE"] = "true"
 	})

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -349,7 +349,7 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 		"MY_OVERRIDE":         "true",  // From the agent environment variables option, overrides manifest.
 		"MY_SESSION_MANIFEST": "false", // From the manifest, overrides session env.
 		"MY_SESSION":          "true",  // From the session.
-		"PATH":                scriptBinDir + ":",
+		"PATH":                scriptBinDir + string(filepath.ListSeparator),
 	} {
 		t.Run(k, func(t *testing.T) {
 			echoEnv(t, stdin, k)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -288,7 +288,8 @@ func TestAgent_Session_EnvironmentVariables(t *testing.T) {
 
 	tmpdir := t.TempDir()
 
-	// Defined by the coder script runner.
+	// Defined by the coder script runner, hardcoded here since we don't
+	// have a reference to it.
 	scriptBinDir := filepath.Join(tmpdir, "coder-script-data", "bin")
 
 	manifest := agentsdk.Manifest{

--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -43,6 +43,7 @@ var (
 
 // Options are a set of options for the runner.
 type Options struct {
+	DataDir    string
 	LogDir     string
 	Logger     slog.Logger
 	SSHServer  *agentssh.Server
@@ -59,6 +60,7 @@ func New(opts Options) *Runner {
 		cronCtxCancel: cronCtxCancel,
 		cron:          cron.New(cron.WithParser(parser)),
 		closed:        make(chan struct{}),
+		dataDir:       filepath.Join(opts.DataDir, "coder-script-data"),
 		scriptsExecuted: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "agent",
 			Subsystem: "scripts",
@@ -78,11 +80,18 @@ type Runner struct {
 	cron          *cron.Cron
 	initialized   atomic.Bool
 	scripts       []codersdk.WorkspaceAgentScript
+	dataDir       string
 
 	// scriptsExecuted includes all scripts executed by the workspace agent. Agents
 	// execute startup scripts, and scripts on a cron schedule. Both will increment
 	// this counter.
 	scriptsExecuted *prometheus.CounterVec
+}
+
+// ScriptBinDir returns the directory where scripts can store executable
+// binaries.
+func (r *Runner) ScriptBinDir() string {
+	return filepath.Join(r.dataDir, "bin")
 }
 
 func (r *Runner) RegisterMetrics(reg prometheus.Registerer) {
@@ -103,6 +112,11 @@ func (r *Runner) Init(scripts []codersdk.WorkspaceAgentScript) error {
 	r.initialized.Store(true)
 	r.scripts = scripts
 	r.Logger.Info(r.cronCtx, "initializing agent scripts", slog.F("script_count", len(scripts)), slog.F("log_dir", r.LogDir))
+
+	err := r.Filesystem.MkdirAll(r.ScriptBinDir(), 0o700)
+	if err != nil {
+		return xerrors.Errorf("create script bin dir: %w", err)
+	}
 
 	for _, script := range scripts {
 		if script.Cron == "" {
@@ -208,7 +222,18 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript) 
 	if !filepath.IsAbs(logPath) {
 		logPath = filepath.Join(r.LogDir, logPath)
 	}
-	logger := r.Logger.With(slog.F("log_path", logPath))
+
+	scriptDataDir := filepath.Join(r.dataDir, script.LogSourceID.String())
+	err := r.Filesystem.MkdirAll(scriptDataDir, 0o700)
+	if err != nil {
+		return xerrors.Errorf("%s script: create script temp dir: %w", scriptDataDir, err)
+	}
+
+	logger := r.Logger.With(
+		slog.F("log_source_id", script.LogSourceID),
+		slog.F("log_path", logPath),
+		slog.F("script_data_dir", scriptDataDir),
+	)
 	logger.Info(ctx, "running agent script", slog.F("script", script.Script))
 
 	fileWriter, err := r.Filesystem.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0o600)
@@ -237,6 +262,13 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript) 
 	cmd.SysProcAttr = cmdSysProcAttr()
 	cmd.WaitDelay = 10 * time.Second
 	cmd.Cancel = cmdCancel(cmd)
+
+	// Expose env vars that can be used in the script for storing data
+	// and binaries. In the future, we may want to expose more env vars
+	// for the script to use, like CODER_SCRIPT_DATA_DIR for persistent
+	// storage.
+	cmd.Env = append(cmd.Env, "CODER_SCRIPT_DATA_DIR="+scriptDataDir)
+	cmd.Env = append(cmd.Env, "CODER_SCRIPT_BIN_DIR="+r.ScriptBinDir())
 
 	send, flushAndClose := agentsdk.LogsSender(script.LogSourceID, r.PatchLogs, logger)
 	// If ctx is canceled here (or in a writer below), we may be

--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -75,9 +76,13 @@ func TestEnv(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 
-	require.NoError(t, runner.Execute(ctx, func(script codersdk.WorkspaceAgentScript) bool {
-		return true
-	}))
+	testutil.Go(t, func() {
+		err := runner.Execute(ctx, func(script codersdk.WorkspaceAgentScript) bool {
+			return true
+		})
+		assert.NoError(t, err)
+	})
+
 	var log []agentsdk.Log
 	for {
 		select {

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -40,6 +40,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 	var (
 		auth                string
 		logDir              string
+		scriptDataDir       string
 		pprofAddress        string
 		noReap              bool
 		sshMaxTimeout       time.Duration
@@ -289,6 +290,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 				Client:            client,
 				Logger:            logger,
 				LogDir:            logDir,
+				ScriptDataDir:     scriptDataDir,
 				TailnetListenPort: uint16(tailnetListenPort),
 				ExchangeToken: func(ctx context.Context) (string, error) {
 					if exchangeToken == nil {
@@ -338,6 +340,13 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 			Description: "Specify the location for the agent log files.",
 			Env:         "CODER_AGENT_LOG_DIR",
 			Value:       clibase.StringOf(&logDir),
+		},
+		{
+			Flag:        "script-data-dir",
+			Default:     os.TempDir(),
+			Description: "Specify the location for storing script data.",
+			Env:         "CODER_AGENT_SCRIPT_DIR",
+			Value:       clibase.StringOf(&scriptDataDir),
 		},
 		{
 			Flag:        "pprof-address",

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -345,7 +345,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 			Flag:        "script-data-dir",
 			Default:     os.TempDir(),
 			Description: "Specify the location for storing script data.",
-			Env:         "CODER_AGENT_SCRIPT_DIR",
+			Env:         "CODER_AGENT_SCRIPT_DATA_DIR",
 			Value:       clibase.StringOf(&scriptDataDir),
 		},
 		{

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -33,7 +33,7 @@ OPTIONS:
       --prometheus-address string, $CODER_AGENT_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve Prometheus metrics.
 
-      --script-data-dir string, $CODER_AGENT_SCRIPT_DIR (default: /tmp)
+      --script-data-dir string, $CODER_AGENT_SCRIPT_DATA_DIR (default: /tmp)
           Specify the location for storing script data.
 
       --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 72h)

--- a/cli/testdata/coder_agent_--help.golden
+++ b/cli/testdata/coder_agent_--help.golden
@@ -33,6 +33,9 @@ OPTIONS:
       --prometheus-address string, $CODER_AGENT_PROMETHEUS_ADDRESS (default: 127.0.0.1:2112)
           The bind address to serve Prometheus metrics.
 
+      --script-data-dir string, $CODER_AGENT_SCRIPT_DIR (default: /tmp)
+          Specify the location for storing script data.
+
       --ssh-max-timeout duration, $CODER_AGENT_SSH_MAX_TIMEOUT (default: 72h)
           Specify the max timeout for a SSH connection, it is advisable to set
           it to a minimum of 60s, but no more than 72h.


### PR DESCRIPTION
The agent is extended with a `--script-data-dir` flag, defaulting to the
OS temp dir. This dir is used for storing `coder-script-data/bin` and
`coder-script/[script uuid]`. The former is a place for all scripts to
place executable binaries that will be available by other scripts, SSH
sessions, etc. The latter is a place for the script to store files.

Since we default to OS temp dir, files are ephemeral by default. In the
future, we may consider adding new env vars or changing the default
storage location. Workspace startup speed could potentially benefit from
scripts being able to skip steps that require downloading software. We
may also extend this with more env variables (e.g. persistent storage in
HOME).

Fixes #11131

This can be feature detected by checking if `$CODER_SCRIPT_DATA_DIR` and/or `$CODER_SCRIPT_BIN_DIR` is set.