### PR TITLE
fix(helm)!: remove prometheus-http port declaration from coderd service spec

### DIFF
--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -37,7 +37,26 @@ setting the environment variable `CODER_PROMETHEUS_ADDRESS` to `0.0.0.0:2112`.
 The environment variable `CODER_PROMETHEUS_ENABLE` will be enabled
 automatically. A Service Endpoint will not be exposed; if you need to expose the
 Prometheus port on a Service, (for example, to use a `ServiceMonitor`), create a
-separate service instead.
+separate headless service instead:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder-prom
+  namespace: coder
+spec:
+  clusterIP: None
+  ports:
+  - name: prom-http
+    port: 2112
+    protocol: TCP
+    targetPort: 2112
+  selector:
+    app.kubernetes.io/instance: coder
+    app.kubernetes.io/name: coder
+  type: ClusterIP
+```
 
 ### Prometheus configuration
 

--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -35,8 +35,9 @@ The Prometheus endpoint can be enabled in the
 [Helm chart's](https://github.com/coder/coder/tree/main/helm) `values.yml` by
 setting the environment variable `CODER_PROMETHEUS_ADDRESS` to `0.0.0.0:2112`.
 The environment variable `CODER_PROMETHEUS_ENABLE` will be enabled
-automatically. A Service Endpoint will also be exposed allowing Prometheus
-Service Monitors to be used.
+automatically. A Service Endpoint will not be exposed; if you need to expose the
+Prometheus port on a Service, (for example, to use a `ServiceMonitor`), create a
+separate service instead.
 
 ### Prometheus configuration
 

--- a/docs/admin/prometheus.md
+++ b/docs/admin/prometheus.md
@@ -48,10 +48,10 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: prom-http
-    port: 2112
-    protocol: TCP
-    targetPort: 2112
+    - name: prom-http
+      port: 2112
+      protocol: TCP
+      targetPort: 2112
   selector:
     app.kubernetes.io/instance: coder
     app.kubernetes.io/name: coder

--- a/helm/coder/templates/service.yaml
+++ b/helm/coder/templates/service.yaml
@@ -28,25 +28,6 @@ spec:
       nodePort: {{ .Values.coder.service.httpsNodePort }}
       {{ end }}
     {{- end }}
-    {{- range .Values.coder.env }}
-    {{- if eq .name "CODER_PROMETHEUS_ENABLE" }}
-    {{/*
-      This sadly has to be nested to avoid evaluating the second part
-      of the condition too early and potentially getting type errors if
-      the value is not a string (like a `valueFrom`). We do not support
-      `valueFrom` for this env var specifically.
-      */}}
-    {{- if eq .value "true" }}
-    - name: "prometheus-http"
-      port: 2112
-      targetPort: "prometheus-http"
-      protocol: TCP
-      {{ if eq $.Values.coder.service.type "NodePort" }}
-      nodePort: {{ $.Values.coder.service.prometheusNodePort }}
-      {{ end }}
-    {{- end }}
-    {{- end }}
-    {{- end }}
   {{- if eq "LoadBalancer" .Values.coder.service.type }}
   {{- with .Values.coder.service.loadBalancerIP }}
   loadBalancerIP: {{ . | quote }}

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -93,14 +93,6 @@ spec:
       
       nodePort: 
       
-    
-    - name: "prometheus-http"
-      port: 2112
-      targetPort: "prometheus-http"
-      protocol: TCP
-      
-      nodePort: 31112
-      
   selector:
     app.kubernetes.io/name: coder
     app.kubernetes.io/instance: release-name

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -282,11 +282,6 @@ coder:
     # NodePort. If not set, Kubernetes will allocate a port from the default
     # range, 30000-32767.
     httpsNodePort: ""
-    # coder.service.prometheusNodePort -- Enabled if coder.service.type is set
-    # to NodePort. If not set, Kubernetes will allocate a port from the default
-    # range, 30000-32767. The "prometheus-http" port on the coder service is
-    # not exposed if CODER_PROMETHEUS_ENABLE is set to true.
-    prometheusNodePort: ""
 
   # coder.ingress -- The Ingress object to expose for Coder.
   ingress:

--- a/helm/coder/values.yaml
+++ b/helm/coder/values.yaml
@@ -285,7 +285,7 @@ coder:
     # coder.service.prometheusNodePort -- Enabled if coder.service.type is set
     # to NodePort. If not set, Kubernetes will allocate a port from the default
     # range, 30000-32767. The "prometheus-http" port on the coder service is
-    # only exposed if CODER_PROMETHEUS_ENABLE is set to true.
+    # not exposed if CODER_PROMETHEUS_ENABLE is set to true.
     prometheusNodePort: ""
 
   # coder.ingress -- The Ingress object to expose for Coder.


### PR DESCRIPTION
This PR removes the `prometheus-http` port entirely from the coder service specification (originally added in https://github.com/coder/coder/pull/10448). It also removes the Helm value `coder.service.prometheusNodePort`.

Rationale: some cloud providers will helpfully expose all ports on a `LoadBalancer` service for you. The net effect of this is that setting `CODER_PROMETHEUS_ENABLE` will end up exposing port 2112 on your coderd service to the internet, which is likely undesired behaviour.

cc @bpmct for visibility, this will need to be called out in release notes
