### PR TITLE
chore(site): refactor tests for global hooks  

### DIFF
--- a/site/src/hooks/events.test.ts
+++ b/site/src/hooks/events.test.ts
@@ -3,14 +3,15 @@ import { dispatchCustomEvent } from "utils/events";
 import { useCustomEvent } from "./events";
 
 describe("useCustomEvent", () => {
-  it("should listem a custom event", async () => {
-    const callback = jest.fn();
-    const detail = { title: "Test event" };
-    renderHook(() => useCustomEvent("testEvent", callback));
-    dispatchCustomEvent("testEvent", detail);
-    await waitFor(() => {
-      expect(callback).toBeCalledTimes(1);
-    });
-    expect(callback.mock.calls[0][0].detail).toBe(detail);
+  it("Should receive custom events dispatched by the dispatchCustomEvent function", async () => {
+    const mockCallback = jest.fn();
+    const eventType = "testEvent";
+    const detail = { title: "We have a new event!" };
+
+    renderHook(() => useCustomEvent(eventType, mockCallback));
+    dispatchCustomEvent(eventType, detail);
+
+    await waitFor(() => expect(mockCallback).toBeCalledTimes(1));
+    expect(mockCallback.mock.calls[0]?.[0]?.detail).toBe(detail);
   });
 });

--- a/site/src/hooks/events.test.ts
+++ b/site/src/hooks/events.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { dispatchCustomEvent } from "utils/events";
 import { useCustomEvent } from "./events";
 
-describe("useCustomEvent", () => {
+describe(useCustomEvent.name, () => {
   it("Should receive custom events dispatched by the dispatchCustomEvent function", async () => {
     const mockCallback = jest.fn();
     const eventType = "testEvent";

--- a/site/src/hooks/events.ts
+++ b/site/src/hooks/events.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
-import { CustomEventListener } from "utils/events";
 import { useEffectEvent } from "./hookPolyfills";
+import { type CustomEventListener } from "utils/events";
 
 /**
  * Handles a custom event with descriptive type information.
@@ -21,5 +21,5 @@ export const useCustomEvent = <T, E extends string = string>(
     return () => {
       window.removeEventListener(eventType, stableListener as EventListener);
     };
-  }, [eventType, stableListener]);
+  }, [stableListener, eventType]);
 };

--- a/site/src/hooks/hookPolyfills.test.ts
+++ b/site/src/hooks/hookPolyfills.test.ts
@@ -1,20 +1,19 @@
 import { renderHook } from "@testing-library/react";
 import { useEffectEvent } from "./hookPolyfills";
 
-function renderEffectEvent<TArgs extends unknown[], TReturn = unknown>(
-  callbackArg: (...args: TArgs) => TReturn,
-) {
-  return renderHook(
-    ({ callback }: { callback: typeof callbackArg }) => {
-      return useEffectEvent(callback);
-    },
-    {
-      initialProps: { callback: callbackArg },
-    },
-  );
-}
+describe(useEffectEvent.name, () => {
+  function renderEffectEvent<TArgs extends unknown[], TReturn = unknown>(
+    callbackArg: (...args: TArgs) => TReturn,
+  ) {
+    type Callback = typeof callbackArg;
+    type Props = Readonly<{ callback: Callback }>;
 
-describe(`${useEffectEvent.name}`, () => {
+    return renderHook<Callback, Props>(
+      ({ callback }) => useEffectEvent(callback),
+      { initialProps: { callback: callbackArg } },
+    );
+  }
+
   it("Should maintain a stable reference across all renders", () => {
     const callback = jest.fn();
     const { result, rerender } = renderEffectEvent(callback);
@@ -29,20 +28,14 @@ describe(`${useEffectEvent.name}`, () => {
   });
 
   it("Should always call the most recent callback passed in", () => {
-    let value: "A" | "B" | "C" = "A";
-    const flipToB = () => {
-      value = "B";
-    };
+    const mockCallback1 = jest.fn();
+    const mockCallback2 = jest.fn();
 
-    const flipToC = () => {
-      value = "C";
-    };
-
-    const { result, rerender } = renderEffectEvent(flipToB);
-    rerender({ callback: flipToC });
+    const { result, rerender } = renderEffectEvent(mockCallback1);
+    rerender({ callback: mockCallback2 });
 
     result.current();
-    expect(value).toEqual("C");
-    expect.hasAssertions();
+    expect(mockCallback1).not.toBeCalled();
+    expect(mockCallback2).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
Part 1 of many, because otherwise, this PR would be too big.
Helps us get closer to reaching our [hooks milestone](https://github.com/coder/coder/issues/11421)

## Changes made
- Refactors tests for the following hook files:
   - `debounce.test`
   - `events.test`
   - `hookPolyfills.test`