### PR TITLE
chore: add test for workspace proxy derp meshing

### DIFF
--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -99,7 +99,7 @@ func TestRegions(t *testing.T) {
 		require.NoError(t, err)
 
 		const proxyName = "hello"
-		_ = coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+		_ = coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 			Name:        proxyName,
 			AppHostname: appHostname + ".proxy",
 		})
@@ -734,7 +734,7 @@ func TestReconnectingPTYSignedToken(t *testing.T) {
 	proxyURL, err := url.Parse(fmt.Sprintf("https://%s.com", namesgenerator.GetRandomName(1)))
 	require.NoError(t, err)
 
-	_ = coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+	_ = coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 		Name:        namesgenerator.GetRandomName(1),
 		ProxyURL:    proxyURL,
 		AppHostname: "*.sub.example.com",

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -410,8 +410,8 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) RegisterNow(ctx context.Context) error {
-	_, err := s.registerLoop.RegisterNow(ctx)
+func (s *Server) RegisterNow() error {
+	_, err := s.registerLoop.RegisterNow()
 	return err
 }
 

--- a/enterprise/wsproxy/wsproxy.go
+++ b/enterprise/wsproxy/wsproxy.go
@@ -128,7 +128,7 @@ type Server struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	derpCloseFunc func()
-	registerDone  <-chan struct{}
+	registerLoop  *wsproxysdk.RegisterWorkspaceProxyLoop
 }
 
 // New creates a new workspace proxy server. This requires a primary coderd
@@ -210,7 +210,7 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 	// goroutine to periodically re-register.
 	replicaID := uuid.New()
 	osHostname := cliutil.Hostname()
-	regResp, registerDone, err := client.RegisterWorkspaceProxyLoop(ctx, wsproxysdk.RegisterWorkspaceProxyLoopOpts{
+	registerLoop, regResp, err := client.RegisterWorkspaceProxyLoop(ctx, wsproxysdk.RegisterWorkspaceProxyLoopOpts{
 		Logger: opts.Logger,
 		Request: wsproxysdk.RegisterWorkspaceProxyRequest{
 			AccessURL:           opts.AccessURL.String(),
@@ -230,12 +230,13 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("register proxy: %w", err)
 	}
-	s.registerDone = registerDone
-	err = s.handleRegister(ctx, regResp)
+	s.registerLoop = registerLoop
+
+	derpServer.SetMeshKey(regResp.DERPMeshKey)
+	err = s.handleRegister(regResp)
 	if err != nil {
 		return nil, xerrors.Errorf("handle register: %w", err)
 	}
-	derpServer.SetMeshKey(regResp.DERPMeshKey)
 
 	secKey, err := workspaceapps.KeyFromString(regResp.AppSecurityKey)
 	if err != nil {
@@ -409,16 +410,16 @@ func New(ctx context.Context, opts *Options) (*Server, error) {
 	return s, nil
 }
 
+func (s *Server) RegisterNow(ctx context.Context) error {
+	_, err := s.registerLoop.RegisterNow(ctx)
+	return err
+}
+
 func (s *Server) Close() error {
 	s.cancel()
 
 	var err error
-	registerDoneWaitTicker := time.NewTicker(11 * time.Second) // the attempt timeout is 10s
-	select {
-	case <-registerDoneWaitTicker.C:
-		err = multierror.Append(err, xerrors.New("timed out waiting for registerDone"))
-	case <-s.registerDone:
-	}
+	s.registerLoop.Close()
 	s.derpCloseFunc()
 	appServerErr := s.AppServer.Close()
 	if appServerErr != nil {
@@ -437,11 +438,12 @@ func (*Server) mutateRegister(_ *wsproxysdk.RegisterWorkspaceProxyRequest) {
 	// package in the primary and update req.ReplicaError accordingly.
 }
 
-func (s *Server) handleRegister(_ context.Context, res wsproxysdk.RegisterWorkspaceProxyResponse) error {
+func (s *Server) handleRegister(res wsproxysdk.RegisterWorkspaceProxyResponse) error {
 	addresses := make([]string, len(res.SiblingReplicas))
 	for i, replica := range res.SiblingReplicas {
 		addresses[i] = replica.RelayAddress
 	}
+	s.Logger.Debug(s.ctx, "setting DERP mesh sibling addresses", slog.F("addresses", addresses))
 	s.derpMesh.SetAddresses(addresses, false)
 
 	s.latestDERPMap.Store(res.DERPMap)

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -66,7 +66,7 @@ func TestDERPOnly(t *testing.T) {
 	})
 
 	// Create an external proxy.
-	_ = coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+	_ = coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 		Name:     "best-proxy",
 		DerpOnly: true,
 	})
@@ -113,15 +113,15 @@ func TestDERP(t *testing.T) {
 	})
 
 	// Create two running external proxies.
-	proxyAPI1 := coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+	proxyAPI1 := coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 		Name: "best-proxy",
 	})
-	proxyAPI2 := coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+	proxyAPI2 := coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 		Name: "worst-proxy",
 	})
 
 	// Create a running external proxy with DERP disabled.
-	proxyAPI3 := coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+	proxyAPI3 := coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 		Name:         "no-derp-proxy",
 		DerpDisabled: true,
 	})
@@ -344,7 +344,7 @@ func TestDERPEndToEnd(t *testing.T) {
 		_ = closer.Close()
 	})
 
-	coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+	coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 		Name: "best-proxy",
 	})
 
@@ -480,7 +480,7 @@ func TestDERPMesh(t *testing.T) {
 		derpURLs     = [count]string{}
 	)
 	for i := range proxies {
-		proxies[i] = coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+		proxies[i] = coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 			Name:     "best-proxy",
 			Token:    sessionToken,
 			ProxyURL: proxyURL,
@@ -498,77 +498,8 @@ func TestDERPMesh(t *testing.T) {
 	// is up-to-date. In production this will happen automatically after about
 	// 15 seconds.
 	for i, proxy := range proxies {
-		err := proxy.RegisterNow(testutil.Context(t, testutil.WaitLong))
+		err := proxy.RegisterNow()
 		require.NoErrorf(t, err, "failed to force proxy %d to re-register", i)
-	}
-
-	createClient := func(t *testing.T, name string, derpURL string) (*derphttp.Client, <-chan derp.ReceivedPacket) {
-		t.Helper()
-
-		client, err := derphttp.NewClient(key.NewNode(), derpURLs[0], func(format string, args ...any) {
-			t.Logf(name+": "+format, args...)
-		})
-		require.NoError(t, err, "create client")
-		t.Cleanup(func() {
-			_ = client.Close()
-		})
-		err = client.Connect(testutil.Context(t, testutil.WaitLong))
-		require.NoError(t, err, "connect to DERP server")
-
-		ch := make(chan derp.ReceivedPacket, 64)
-		go func() {
-			defer close(ch)
-			for {
-				msg, err := client.Recv()
-				if err != nil {
-					t.Logf("Recv error: %v", err)
-					return
-				}
-				switch msg := msg.(type) {
-				case derp.ReceivedPacket:
-					ch <- msg
-					return
-				default:
-					// We don't care about other messages.
-				}
-			}
-		}()
-
-		return client, ch
-	}
-
-	sendTest := func(t *testing.T, dstKey key.NodePublic, dstCh <-chan derp.ReceivedPacket, src *derphttp.Client) {
-		t.Helper()
-
-		const msgStrPrefix = "test_packet_"
-		msgStr, err := cryptorand.String(64 - len(msgStrPrefix))
-		require.NoError(t, err, "generate random msg string")
-		msg := []byte(msgStrPrefix + msgStr)
-
-		err = src.Send(dstKey, msg)
-		require.NoError(t, err, "send message via DERP")
-
-		waitCtx := testutil.Context(t, testutil.WaitLong)
-		ticker := time.NewTicker(time.Millisecond * 500)
-		defer ticker.Stop()
-		for {
-			select {
-			case pkt := <-dstCh:
-				assert.Equal(t, src.SelfPublicKey(), pkt.Source, "packet came from wrong source")
-				assert.Equal(t, msg, pkt.Data, "packet data is wrong")
-				return
-			case <-waitCtx.Done():
-				t.Fatal("timed out waiting for packet")
-				return
-			case <-ticker.C:
-			}
-
-			// Send another packet. Since we're sending packets immediately
-			// after opening the clients, they might not be meshed together
-			// properly yet.
-			err = src.Send(dstKey, msg)
-			require.NoError(t, err, "send message via DERP")
-		}
 	}
 
 	// Generate cases. We have a case for:
@@ -589,14 +520,14 @@ func TestDERPMesh(t *testing.T) {
 			t.Parallel()
 
 			t.Logf("derp1=%s, derp2=%s", c[0], c[1])
-			client1, client1Recv := createClient(t, "client1", c[0])
-			client2, client2Recv := createClient(t, "client2", c[1])
+			client1, client1Recv := createDERPClient(t, "client1", c[0])
+			client2, client2Recv := createDERPClient(t, "client2", c[1])
 
 			// Send a packet from client 1 to client 2.
-			sendTest(t, client2.SelfPublicKey(), client2Recv, client1)
+			testDERPSend(t, client2.SelfPublicKey(), client2Recv, client1)
 
 			// Send a packet from client 2 to client 1.
-			sendTest(t, client1.SelfPublicKey(), client1Recv, client2)
+			testDERPSend(t, client1.SelfPublicKey(), client1Recv, client2)
 		})
 	}
 }
@@ -653,7 +584,7 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 		if opts.DisableSubdomainApps {
 			opts.AppHost = ""
 		}
-		proxyAPI := coderdenttest.NewWorkspaceProxy(t, api, client, &coderdenttest.ProxyOptions{
+		proxyAPI := coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
 			Name:            "best-proxy",
 			AppHostname:     opts.AppHost,
 			DisablePathApps: opts.DisablePathApps,
@@ -668,4 +599,87 @@ func TestWorkspaceProxyWorkspaceApps(t *testing.T) {
 			FlushStats:     flushStats,
 		}
 	})
+}
+
+// createDERPClient creates a DERP client and spawns a goroutine that reads from
+// the client and sends the received packets to a channel.
+func createDERPClient(t *testing.T, name string, derpURL string) (*derphttp.Client, <-chan derp.ReceivedPacket) {
+	t.Helper()
+
+	client, err := derphttp.NewClient(key.NewNode(), derpURL, func(format string, args ...any) {
+		t.Logf(name+": "+format, args...)
+	})
+	require.NoError(t, err, "create client")
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	err = client.Connect(testutil.Context(t, testutil.WaitLong))
+	require.NoError(t, err, "connect to DERP server")
+
+	ch := make(chan derp.ReceivedPacket, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(ch)
+		defer close(done)
+		for {
+			msg, err := client.Recv()
+			if err != nil {
+				t.Logf("Recv error: %v", err)
+				return
+			}
+			switch msg := msg.(type) {
+			case derp.ReceivedPacket:
+				ch <- msg
+				return
+			default:
+				// We don't care about other messages.
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		<-done
+	})
+
+	return client, ch
+}
+
+// testDERPSend sends a message from src to dstKey and waits for it to be
+// received on dstCh.
+//
+// If the packet doesn't arrive within 500ms, it will try to send it again until
+// testutil.WaitLong is reached.
+func testDERPSend(t *testing.T, dstKey key.NodePublic, dstCh <-chan derp.ReceivedPacket, src *derphttp.Client) {
+	t.Helper()
+
+	// The prefix helps identify where the packet starts if you get garbled data
+	// in logs.
+	const msgStrPrefix = "test_packet_"
+	msgStr, err := cryptorand.String(64 - len(msgStrPrefix))
+	require.NoError(t, err, "generate random msg string")
+	msg := []byte(msgStrPrefix + msgStr)
+
+	err = src.Send(dstKey, msg)
+	require.NoError(t, err, "send message via DERP")
+
+	waitCtx := testutil.Context(t, testutil.WaitLong)
+	ticker := time.NewTicker(time.Millisecond * 500)
+	defer ticker.Stop()
+	for {
+		select {
+		case pkt := <-dstCh:
+			require.Equal(t, src.SelfPublicKey(), pkt.Source, "packet came from wrong source")
+			require.Equal(t, msg, pkt.Data, "packet data is wrong")
+			return
+		case <-waitCtx.Done():
+			t.Fatal("timed out waiting for packet")
+			return
+		case <-ticker.C:
+		}
+
+		// Send another packet. Since we're sending packets immediately
+		// after opening the clients, they might not be meshed together
+		// properly yet.
+		err = src.Send(dstKey, msg)
+		require.NoError(t, err, "send message via DERP")
+	}
 }

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -277,135 +277,201 @@ type RegisterWorkspaceProxyLoopOpts struct {
 	// called in a blocking manner, so it should avoid blocking for too long. If
 	// the callback returns an error, the loop will stop immediately and the
 	// error will be returned to the FailureFn.
-	CallbackFn func(ctx context.Context, res RegisterWorkspaceProxyResponse) error
+	CallbackFn func(res RegisterWorkspaceProxyResponse) error
 	// FailureFn is called with the last error returned from the server if the
 	// context is canceled, registration fails for more than MaxFailureCount,
 	// or if any permanent values in the response change.
 	FailureFn func(err error)
 }
 
-// RegisterWorkspaceProxyLoop will register the workspace proxy and then start a
-// goroutine to keep registering periodically in the background.
-//
-// The first response is returned immediately, and subsequent responses will be
-// notified to the given CallbackFn. When the context is canceled the loop will
-// stop immediately and the context error will be returned to the FailureFn.
-//
-// The returned channel will be closed when the loop stops and can be used to
-// ensure the loop is dead before continuing. When a fatal error is encountered,
-// the proxy will be deregistered (with the same ReplicaID and AttemptTimeout)
-// before calling the FailureFn.
-func (c *Client) RegisterWorkspaceProxyLoop(ctx context.Context, opts RegisterWorkspaceProxyLoopOpts) (RegisterWorkspaceProxyResponse, <-chan struct{}, error) {
-	if opts.Interval == 0 {
-		opts.Interval = 30 * time.Second
-	}
-	if opts.MaxFailureCount == 0 {
-		opts.MaxFailureCount = 10
-	}
-	if opts.AttemptTimeout == 0 {
-		opts.AttemptTimeout = 10 * time.Second
-	}
-	if opts.MutateFn == nil {
-		opts.MutateFn = func(_ *RegisterWorkspaceProxyRequest) {}
-	}
-	if opts.CallbackFn == nil {
-		opts.CallbackFn = func(_ context.Context, _ RegisterWorkspaceProxyResponse) error {
-			return nil
-		}
+type RegisterWorkspaceProxyLoop struct {
+	opts        RegisterWorkspaceProxyLoopOpts
+	c           *Client
+	originalRes *RegisterWorkspaceProxyResponse
+
+	closedCtx context.Context
+	close     context.CancelFunc
+	done      chan struct{}
+}
+
+// register registers once. It returns the response, whether the loop should
+// exit immediately, and any error that occurred.
+func (l *RegisterWorkspaceProxyLoop) register(ctx context.Context) (RegisterWorkspaceProxyResponse, bool, error) {
+	// If it's not the first registration, call the mutate function.
+	if l.originalRes != nil {
+		l.mutateFn(&l.opts.Request)
 	}
 
-	failureFn := func(err error) {
-		// We have to use background context here because the original context
-		// may be canceled.
-		deregisterCtx, cancel := context.WithTimeout(context.Background(), opts.AttemptTimeout)
-		defer cancel()
-		deregisterErr := c.DeregisterWorkspaceProxy(deregisterCtx, DeregisterWorkspaceProxyRequest{
-			ReplicaID: opts.Request.ReplicaID,
-		})
-		if deregisterErr != nil {
-			opts.Logger.Error(ctx,
-				"failed to deregister workspace proxy with Coder primary (it will be automatically deregistered shortly)",
-				slog.Error(deregisterErr),
-			)
-		}
-
-		if opts.FailureFn != nil {
-			opts.FailureFn(err)
-		}
-	}
-
-	originalRes, err := c.RegisterWorkspaceProxy(ctx, opts.Request)
+	registerCtx, registerCancel := context.WithTimeout(ctx, l.opts.AttemptTimeout)
+	res, err := l.c.RegisterWorkspaceProxy(registerCtx, l.opts.Request)
+	registerCancel()
 	if err != nil {
-		return RegisterWorkspaceProxyResponse{}, nil, xerrors.Errorf("register workspace proxy: %w", err)
+		return RegisterWorkspaceProxyResponse{}, false, xerrors.Errorf("register workspace proxy: %w", err)
 	}
 
-	done := make(chan struct{})
+	// Catastrophic failures if any of the "permanent" values change.
+	if l.originalRes != nil && res.AppSecurityKey != l.originalRes.AppSecurityKey {
+		return RegisterWorkspaceProxyResponse{}, true, xerrors.New("app security key has changed, proxy must be restarted")
+	}
+	if l.originalRes != nil && res.DERPMeshKey != l.originalRes.DERPMeshKey {
+		return RegisterWorkspaceProxyResponse{}, true, xerrors.New("DERP mesh key has changed, proxy must be restarted")
+	}
+	if l.originalRes != nil && res.DERPRegionID != l.originalRes.DERPRegionID {
+		return RegisterWorkspaceProxyResponse{}, true, xerrors.New("DERP region ID has changed, proxy must be restarted")
+	}
+
+	// If it's not the first registration, call the callback function.
+	if l.originalRes != nil {
+		err = l.callbackFn(res)
+		if err != nil {
+			return RegisterWorkspaceProxyResponse{}, true, xerrors.Errorf("callback err: %w", err)
+		}
+	} else {
+		l.originalRes = &res
+	}
+
+	return res, false, nil
+}
+
+// Start starts the proxy registration loop. The provided context is only used
+// for the initial registration. Use Close() to stop.
+func (l *RegisterWorkspaceProxyLoop) Start(ctx context.Context) (RegisterWorkspaceProxyResponse, error) {
+	if l.opts.Interval == 0 {
+		l.opts.Interval = 15 * time.Second
+	}
+	if l.opts.MaxFailureCount == 0 {
+		l.opts.MaxFailureCount = 10
+	}
+	if l.opts.AttemptTimeout == 0 {
+		l.opts.AttemptTimeout = 10 * time.Second
+	}
+
+	originalRes, _, err := l.register(ctx)
+	if err != nil {
+		return RegisterWorkspaceProxyResponse{}, xerrors.Errorf("initial registration: %w", err)
+	}
+
 	go func() {
-		defer close(done)
+		defer close(l.done)
 
 		var (
 			failedAttempts = 0
-			ticker         = time.NewTicker(opts.Interval)
+			ticker         = time.NewTicker(l.opts.Interval)
 		)
 		for {
 			select {
-			case <-ctx.Done():
-				failureFn(ctx.Err())
+			case <-l.closedCtx.Done():
+				l.failureFn(xerrors.Errorf("proxy registration loop closed"))
 				return
 			case <-ticker.C:
 			}
 
-			opts.Logger.Debug(ctx,
+			l.opts.Logger.Debug(context.Background(),
 				"re-registering workspace proxy with Coder primary",
-				slog.F("req", opts.Request),
-				slog.F("timeout", opts.AttemptTimeout),
+				slog.F("req", l.opts.Request),
+				slog.F("timeout", l.opts.AttemptTimeout),
 				slog.F("failed_attempts", failedAttempts),
 			)
-			opts.MutateFn(&opts.Request)
-			registerCtx, cancel := context.WithTimeout(ctx, opts.AttemptTimeout)
-			res, err := c.RegisterWorkspaceProxy(registerCtx, opts.Request)
-			cancel()
+
+			_, catastrophicErr, err := l.register(l.closedCtx)
 			if err != nil {
+				if catastrophicErr {
+					l.failureFn(err)
+					return
+				}
 				failedAttempts++
-				opts.Logger.Warn(ctx,
+				l.opts.Logger.Warn(context.Background(),
 					"failed to re-register workspace proxy with Coder primary",
-					slog.F("req", opts.Request),
-					slog.F("timeout", opts.AttemptTimeout),
+					slog.F("req", l.opts.Request),
+					slog.F("timeout", l.opts.AttemptTimeout),
 					slog.F("failed_attempts", failedAttempts),
 					slog.Error(err),
 				)
 
-				if failedAttempts > opts.MaxFailureCount {
-					failureFn(xerrors.Errorf("exceeded re-registration failure count of %d: last error: %w", opts.MaxFailureCount, err))
+				if failedAttempts > l.opts.MaxFailureCount {
+					l.failureFn(xerrors.Errorf("exceeded re-registration failure count of %d: last error: %w", l.opts.MaxFailureCount, err))
 					return
 				}
 				continue
 			}
 			failedAttempts = 0
 
-			if res.AppSecurityKey != originalRes.AppSecurityKey {
-				failureFn(xerrors.New("app security key has changed, proxy must be restarted"))
-				return
-			}
-			if res.DERPMeshKey != originalRes.DERPMeshKey {
-				failureFn(xerrors.New("DERP mesh key has changed, proxy must be restarted"))
-				return
-			}
-			if res.DERPRegionID != originalRes.DERPRegionID {
-				failureFn(xerrors.New("DERP region ID has changed, proxy must be restarted"))
-			}
-
-			err = opts.CallbackFn(ctx, res)
-			if err != nil {
-				failureFn(xerrors.Errorf("callback fn returned error: %w", err))
-				return
-			}
-
-			ticker.Reset(opts.Interval)
+			ticker.Reset(l.opts.Interval)
 		}
 	}()
 
-	return originalRes, done, nil
+	return originalRes, nil
+}
+
+func (l *RegisterWorkspaceProxyLoop) RegisterNow(ctx context.Context) (RegisterWorkspaceProxyResponse, error) {
+	// Catastrophic failures don't affect the loop when manually re-registering.
+	res, _, err := l.register(ctx)
+	return res, err
+}
+
+func (l *RegisterWorkspaceProxyLoop) Close() {
+	l.close()
+	<-l.done
+}
+
+func (l *RegisterWorkspaceProxyLoop) mutateFn(req *RegisterWorkspaceProxyRequest) {
+	if l.opts.MutateFn != nil {
+		l.opts.MutateFn(req)
+	}
+}
+
+func (l *RegisterWorkspaceProxyLoop) callbackFn(res RegisterWorkspaceProxyResponse) error {
+	if l.opts.CallbackFn != nil {
+		return l.opts.CallbackFn(res)
+	}
+	return nil
+}
+
+func (l *RegisterWorkspaceProxyLoop) failureFn(err error) {
+	// We have to use background context here because the original context may
+	// be canceled.
+	deregisterCtx, cancel := context.WithTimeout(context.Background(), l.opts.AttemptTimeout)
+	defer cancel()
+	deregisterErr := l.c.DeregisterWorkspaceProxy(deregisterCtx, DeregisterWorkspaceProxyRequest{
+		ReplicaID: l.opts.Request.ReplicaID,
+	})
+	if deregisterErr != nil {
+		l.opts.Logger.Error(context.Background(),
+			"failed to deregister workspace proxy with Coder primary (it will be automatically deregistered shortly)",
+			slog.Error(deregisterErr),
+		)
+	}
+
+	if l.opts.FailureFn != nil {
+		l.opts.FailureFn(err)
+	}
+}
+
+// RegisterWorkspaceProxyLoop will register the workspace proxy and then start a
+// goroutine to keep registering periodically in the background.
+//
+// The first response is returned immediately, and subsequent responses will be
+// notified to the given CallbackFn. When the loop is Close()d it will stop
+// immediately and an error will be returned to the FailureFn.
+//
+// When a fatal error is encountered (or the proxy is closed), the proxy will be
+// deregistered (with the same ReplicaID and AttemptTimeout) before calling the
+// FailureFn.
+func (c *Client) RegisterWorkspaceProxyLoop(ctx context.Context, opts RegisterWorkspaceProxyLoopOpts) (*RegisterWorkspaceProxyLoop, RegisterWorkspaceProxyResponse, error) {
+	closedCtx, closeFn := context.WithCancel(context.Background())
+	loop := &RegisterWorkspaceProxyLoop{
+		opts:      opts,
+		c:         c,
+		closedCtx: closedCtx,
+		close:     closeFn,
+		done:      make(chan struct{}),
+	}
+
+	regResp, err := loop.Start(ctx)
+	if err != nil {
+		return nil, RegisterWorkspaceProxyResponse{}, xerrors.Errorf("start loop: %w", err)
+	}
+	return loop, regResp, nil
 }
 
 type CoordinateMessageType int


### PR DESCRIPTION
- Reworks the proxy registration loop into a struct (so I can add a `RegisterNow` method)
- Changes the proxy registration loop interval to 15s (previously 30s)
- Adds test which tests bidirectional DERP meshing on all possible paths between 6 workspace proxy replicas

Related to https://github.com/coder/customers/issues/438