### PR TITLE
chore: refactor agent routines that use the v2 API

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -162,7 +162,13 @@ func TestSSH(t *testing.T) {
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspaceBuild.ID)
 
 		// Update template version
-		version = coderdtest.UpdateTemplateVersion(t, ownerClient, owner.OrganizationID, echoResponses, template.ID)
+		authToken2 := uuid.NewString()
+		echoResponses2 := &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionPlan:  echo.PlanComplete,
+			ProvisionApply: echo.ProvisionApplyWithAgent(authToken2),
+		}
+		version = coderdtest.UpdateTemplateVersion(t, ownerClient, owner.OrganizationID, echoResponses2, template.ID)
 		coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version.ID)
 		err := ownerClient.UpdateActiveTemplateVersion(context.Background(), template.ID, codersdk.UpdateActiveTemplateVersion{
 			ID: version.ID,
@@ -184,7 +190,7 @@ func TestSSH(t *testing.T) {
 
 		// When the agent connects, the workspace was started, and we should
 		// have access to the shell.
-		_ = agenttest.New(t, client.URL, authToken)
+		_ = agenttest.New(t, client.URL, authToken2)
 		coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 
 		// Shells on Mac, Windows, and Linux all exit shells with the "exit" command.

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -193,7 +193,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		options = &Options{}
 	}
 	if options.Logger == nil {
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug).Named("coderd")
 		options.Logger = &logger
 	}
 	if options.GoogleTokenValidator == nil {

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -534,7 +534,7 @@ func (tac *tailnetAPIConnector) coordinate(client proto.DRPCTailnetClient) {
 		tac.logger.Debug(tac.ctx, "main context canceled; do graceful disconnect")
 		crdErr := coordination.Close()
 		if crdErr != nil {
-			tac.logger.Error(tac.ctx, "failed to close remote coordination", slog.Error(err))
+			tac.logger.Warn(tac.ctx, "failed to close remote coordination", slog.Error(err))
 		}
 	case err = <-coordination.Error():
 		if err != nil &&

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -231,13 +231,14 @@ func TestAuditLogging(t *testing.T) {
 			},
 			DontAddLicense: true,
 		})
-		workspace, agent := setupWorkspaceAgent(t, client, user, 0)
-		conn, err := client.DialWorkspaceAgent(ctx, agent.ID, nil) //nolint:gocritic // RBAC is not the purpose of this test
+		r := setupWorkspaceAgent(t, client, user, 0)
+		conn, err := client.DialWorkspaceAgent(ctx, r.sdkAgent.ID, nil) //nolint:gocritic // RBAC is not the purpose of this test
 		require.NoError(t, err)
 		defer conn.Close()
 		connected := conn.AwaitReachable(ctx)
 		require.True(t, connected)
-		build := coderdtest.CreateWorkspaceBuild(t, client, workspace, database.WorkspaceTransitionStop)
+		_ = r.agent.Close() // close first so we don't drop error logs from outdated build
+		build := coderdtest.CreateWorkspaceBuild(t, client, r.workspace, database.WorkspaceTransitionStop)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, build.ID)
 	})
 }

--- a/enterprise/coderd/replicas_test.go
+++ b/enterprise/coderd/replicas_test.go
@@ -81,8 +81,8 @@ func TestReplicas(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, replicas, 2)
 
-		_, agent := setupWorkspaceAgent(t, firstClient, firstUser, 0)
-		conn, err := secondClient.DialWorkspaceAgent(context.Background(), agent.ID, &codersdk.DialWorkspaceAgentOptions{
+		r := setupWorkspaceAgent(t, firstClient, firstUser, 0)
+		conn, err := secondClient.DialWorkspaceAgent(context.Background(), r.sdkAgent.ID, &codersdk.DialWorkspaceAgentOptions{
 			BlockEndpoints: true,
 			Logger:         slogtest.Make(t, nil).Leveled(slog.LevelDebug),
 		})
@@ -127,8 +127,8 @@ func TestReplicas(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, replicas, 2)
 
-		_, agent := setupWorkspaceAgent(t, firstClient, firstUser, 0)
-		conn, err := secondClient.DialWorkspaceAgent(context.Background(), agent.ID, &codersdk.DialWorkspaceAgentOptions{
+		r := setupWorkspaceAgent(t, firstClient, firstUser, 0)
+		conn, err := secondClient.DialWorkspaceAgent(context.Background(), r.sdkAgent.ID, &codersdk.DialWorkspaceAgentOptions{
 			BlockEndpoints: true,
 			Logger:         slogtest.Make(t, nil).Named("client").Leveled(slog.LevelDebug),
 		})

--- a/enterprise/coderd/workspaceportshare_test.go
+++ b/enterprise/coderd/workspaceportshare_test.go
@@ -31,7 +31,7 @@ func TestWorkspacePortShare(t *testing.T) {
 		},
 	})
 	client, user := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleTemplateAdmin())
-	workspace, agent := setupWorkspaceAgent(t, client, codersdk.CreateFirstUserResponse{
+	r := setupWorkspaceAgent(t, client, codersdk.CreateFirstUserResponse{
 		UserID:         user.ID,
 		OrganizationID: owner.OrganizationID,
 	}, 0)
@@ -39,8 +39,8 @@ func TestWorkspacePortShare(t *testing.T) {
 	defer cancel()
 
 	// try to update port share with template max port share level owner
-	_, err := client.UpsertWorkspaceAgentPortShare(ctx, workspace.ID, codersdk.UpsertWorkspaceAgentPortShareRequest{
-		AgentName:  agent.Name,
+	_, err := client.UpsertWorkspaceAgentPortShare(ctx, r.workspace.ID, codersdk.UpsertWorkspaceAgentPortShareRequest{
+		AgentName:  r.sdkAgent.Name,
 		Port:       8080,
 		ShareLevel: codersdk.WorkspaceAgentPortShareLevelPublic,
 	})
@@ -48,13 +48,13 @@ func TestWorkspacePortShare(t *testing.T) {
 
 	// update the template max port share level to public
 	var level codersdk.WorkspaceAgentPortShareLevel = codersdk.WorkspaceAgentPortShareLevelPublic
-	client.UpdateTemplateMeta(ctx, workspace.TemplateID, codersdk.UpdateTemplateMeta{
+	client.UpdateTemplateMeta(ctx, r.workspace.TemplateID, codersdk.UpdateTemplateMeta{
 		MaxPortShareLevel: &level,
 	})
 
 	// OK
-	ps, err := client.UpsertWorkspaceAgentPortShare(ctx, workspace.ID, codersdk.UpsertWorkspaceAgentPortShareRequest{
-		AgentName:  agent.Name,
+	ps, err := client.UpsertWorkspaceAgentPortShare(ctx, r.workspace.ID, codersdk.UpsertWorkspaceAgentPortShareRequest{
+		AgentName:  r.sdkAgent.Name,
 		Port:       8080,
 		ShareLevel: codersdk.WorkspaceAgentPortShareLevelPublic,
 	})

--- a/tailnet/coordinator.go
+++ b/tailnet/coordinator.go
@@ -131,7 +131,8 @@ func (c *remoteCoordination) Close() (retErr error) {
 		}
 	}()
 	err := c.protocol.Send(&proto.CoordinateRequest{Disconnect: &proto.CoordinateRequest_Disconnect{}})
-	if err != nil {
+	if err != nil && !xerrors.Is(err, io.EOF) {
+		// Coordinator RPC hangs up when it gets disconnect, so EOF is expected.
 		return xerrors.Errorf("send disconnect: %w", err)
 	}
 	c.logger.Debug(context.Background(), "sent disconnect")


### PR DESCRIPTION
In anticipation of needing the `LogSender` to run on a context that doesn't get immediately canceled when you `Close()` the agent, I've undertaken a little refactor to manage the goroutines that get run against the Tailnet and Agent API connection.

This handles controlling two contexts, one that gets canceled right away at the start of graceful shutdown, and another that stays up to allow graceful shutdown to complete.