### PR TITLE
feat: support custom validation errors for number-typed parameters

### DIFF
--- a/codersdk/richparameters_test.go
+++ b/codersdk/richparameters_test.go
@@ -376,3 +376,24 @@ func TestParameterResolver_ValidateResolve_Ephemeral_UseEmptyDefault(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, "", v)
 }
+
+func TestParameterResolver_ValidateResolve_Number_CustomError(t *testing.T) {
+	t.Parallel()
+	uut := codersdk.ParameterResolver{}
+	p := codersdk.TemplateVersionParameter{
+		Name:         "n",
+		Type:         "number",
+		Mutable:      true,
+		DefaultValue: "5",
+
+		ValidationMin:   ptr.Ref(int32(4)),
+		ValidationMax:   ptr.Ref(int32(6)),
+		ValidationError: "These are values for testing purposes: {min}, {max}, and {value}.",
+	}
+	_, err := uut.ValidateResolve(p, &codersdk.WorkspaceBuildParameter{
+		Name:  "n",
+		Value: "8",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "These are values for testing purposes: 4, 6, and 8.")
+}

--- a/docs/templates/parameters.md
+++ b/docs/templates/parameters.md
@@ -249,6 +249,23 @@ data "coder_parameter" "instances" {
 }
 ```
 
+It is possible to override the default `error` message for a `number` parameter,
+along with its associated `min` and/or `max` properties. The following message
+placeholders are available `{min}`, `{max}`, and `{value}`.
+
+```hcl
+data "coder_parameter" "instances" {
+  name        = "Instances"
+  type        = "number"
+  description = "Number of compute instances"
+  validation {
+    min       = 1
+    max       = 4
+    error     = "Sorry, we can't provision too many instances - maximum limit: {max}, wanted: {value}."
+  }
+}
+```
+
 ### String
 
 You can validate a `string` parameter to match a regular expression. The `regex`

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/coder/flog v1.1.0
 	github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0
 	github.com/coder/retry v1.5.1
-	github.com/coder/terraform-provider-coder v0.17.0
+	github.com/coder/terraform-provider-coder v0.18.0
 	github.com/coder/wgtunnel v0.1.13-0.20231127054351-578bfff9b92a
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/coder/ssh v0.0.0-20231128192721-70855dedb788 h1:YoUSJ19E8AtuUFVYBpXuO
 github.com/coder/ssh v0.0.0-20231128192721-70855dedb788/go.mod h1:aGQbuCLyhRLMzZF067xc84Lh7JDs1FKwCmF1Crl9dxQ=
 github.com/coder/tailscale v1.1.1-0.20240214140224-3788ab894ba1 h1:A7dZHNidAVH6Kxn5D3hTEH+iRO8slnM0aRer6/cxlyE=
 github.com/coder/tailscale v1.1.1-0.20240214140224-3788ab894ba1/go.mod h1:L8tPrwSi31RAMEMV8rjb0vYTGs7rXt8rAHbqY/p41j4=
-github.com/coder/terraform-provider-coder v0.17.0 h1:qwdLSbh6vPN+QDDvw1WNSYYEFlFwJFwzzP9vrvwr/ks=
-github.com/coder/terraform-provider-coder v0.17.0/go.mod h1:pACHRoXSHBGyY696mLeQ1hR/Ag1G2wFk5bw0mT5Zp2g=
+github.com/coder/terraform-provider-coder v0.18.0 h1:JWSBsOuzyiCev3C2Aj8Y1dvJkm5JMysIrIylMJtzPAY=
+github.com/coder/terraform-provider-coder v0.18.0/go.mod h1:pACHRoXSHBGyY696mLeQ1hR/Ag1G2wFk5bw0mT5Zp2g=
 github.com/coder/wgtunnel v0.1.13-0.20231127054351-578bfff9b92a h1:KhR9LUVllMZ+e9lhubZ1HNrtJDgH5YLoTvpKwmrGag4=
 github.com/coder/wgtunnel v0.1.13-0.20231127054351-578bfff9b92a/go.mod h1:QzfptVUdEO+XbkzMKx1kw13i9wwpJlfI1RrZ6SNZ0hA=
 github.com/coder/wireguard-go v0.0.0-20230807234434-d825b45ccbf5 h1:eDk/42Kj4xN4yfE504LsvcFEo3dWUiCOaBiWJ2uIH2A=

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -156,6 +156,35 @@ describe("CreateWorkspacePage", () => {
     expect(validationError).toBeInTheDocument();
   });
 
+  it("rich parameter: number validation fails with custom error", async () => {
+    jest
+      .spyOn(API, "getTemplateVersionRichParameters")
+      .mockResolvedValueOnce([
+        MockTemplateVersionParameter1,
+        {
+          ...MockTemplateVersionParameter2,
+          validation_error: "These are values: {min}, {max}, and {value}.",
+          validation_monotonic: undefined // only needs min-max rules
+        },
+      ]);
+
+    renderCreateWorkspacePage();
+    await waitForLoaderToBeRemoved();
+
+    const secondParameterField = await screen.findByLabelText(
+      MockTemplateVersionParameter2.name,
+      { exact: false },
+    );
+    expect(secondParameterField).toBeDefined();
+    fireEvent.change(secondParameterField, {
+      target: { value: "4" },
+    });
+    fireEvent.submit(secondParameterField);
+
+    const validationError = await screen.findByText("These are values: 1, 3, and 4.");
+    expect(validationError).toBeInTheDocument();
+  });
+
   it("auto create a workspace if uses mode=auto", async () => {
     const param = "first_parameter";
     const paramValue = "It works!";

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -25,7 +25,6 @@ import { rest } from "msw";
 const nameLabelText = "Workspace Name";
 const createWorkspaceText = "Create Workspace";
 const validationNumberNotInRangeText = "Value must be between 1 and 3.";
-const validationPatternNotMatched = `${MockTemplateVersionParameter3.validation_error} (value does not match the pattern ^[a-z]{3}$)`;
 
 const renderCreateWorkspacePage = () => {
   return renderWithAuth(<CreateWorkspacePage />, {
@@ -152,7 +151,7 @@ describe("CreateWorkspacePage", () => {
     fireEvent.submit(thirdParameterField);
 
     const validationError = await screen.findByText(
-      validationPatternNotMatched,
+      MockTemplateVersionParameter3.validation_error as string,
     );
     expect(validationError).toBeInTheDocument();
   });

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -157,16 +157,14 @@ describe("CreateWorkspacePage", () => {
   });
 
   it("rich parameter: number validation fails with custom error", async () => {
-    jest
-      .spyOn(API, "getTemplateVersionRichParameters")
-      .mockResolvedValueOnce([
-        MockTemplateVersionParameter1,
-        {
-          ...MockTemplateVersionParameter2,
-          validation_error: "These are values: {min}, {max}, and {value}.",
-          validation_monotonic: undefined // only needs min-max rules
-        },
-      ]);
+    jest.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce([
+      MockTemplateVersionParameter1,
+      {
+        ...MockTemplateVersionParameter2,
+        validation_error: "These are values: {min}, {max}, and {value}.",
+        validation_monotonic: undefined, // only needs min-max rules
+      },
+    ]);
 
     renderCreateWorkspacePage();
     await waitForLoaderToBeRemoved();
@@ -181,7 +179,9 @@ describe("CreateWorkspacePage", () => {
     });
     fireEvent.submit(secondParameterField);
 
-    const validationError = await screen.findByText("These are values: 1, 3, and 4.");
+    const validationError = await screen.findByText(
+      "These are values: 1, 3, and 4.",
+    );
     expect(validationError).toBeInTheDocument();
   });
 

--- a/site/src/utils/richParameters.ts
+++ b/site/src/utils/richParameters.ts
@@ -79,7 +79,10 @@ export const useValidationSchemaForRichParameters = (
                   if (Number(val) < templateParameter.validation_min) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: takeFirstError(errorRendered(templateParameter, val), `Value must be greater than ${templateParameter.validation_min}.`),
+                      message: takeFirstError(
+                        errorRendered(templateParameter, val),
+                        `Value must be greater than ${templateParameter.validation_min}.`,
+                      ),
                     });
                   }
                 } else if (
@@ -89,7 +92,10 @@ export const useValidationSchemaForRichParameters = (
                   if (templateParameter.validation_max < Number(val)) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: takeFirstError(errorRendered(templateParameter, val), `Value must be less than ${templateParameter.validation_max}.`),
+                      message: takeFirstError(
+                        errorRendered(templateParameter, val),
+                        `Value must be less than ${templateParameter.validation_max}.`,
+                      ),
                     });
                   }
                 } else if (
@@ -102,7 +108,10 @@ export const useValidationSchemaForRichParameters = (
                   ) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: takeFirstError(errorRendered(templateParameter, val), `Value must be between ${templateParameter.validation_min} and ${templateParameter.validation_max}.`),
+                      message: takeFirstError(
+                        errorRendered(templateParameter, val),
+                        `Value must be between ${templateParameter.validation_min} and ${templateParameter.validation_max}.`,
+                      ),
                     });
                   }
                 }
@@ -165,22 +174,38 @@ export const useValidationSchemaForRichParameters = (
 
 const takeFirstError = (...errorMessages: string[]): string => {
   for (const errorMessage of errorMessages) {
-      if (errorMessage) {
-          return errorMessage;
-      }
+    if (errorMessage) {
+      return errorMessage;
+    }
   }
   return "developer error: error message is not provided";
 };
 
-const errorRendered = (parameter: TemplateVersionParameter, value?: string): string => {
-    if (!parameter.validation_error || !value) {
-        return "";
-    }
+const errorRendered = (
+  parameter: TemplateVersionParameter,
+  value?: string,
+): string => {
+  if (!parameter.validation_error || !value) {
+    return "";
+  }
 
-    const r = new Map<string, string>([
-        ["{min}", parameter.validation_min !== undefined ? parameter.validation_min.toString() : ""],
-        ["{max}", parameter.validation_max !== undefined ? parameter.validation_max.toString() : ""],
-        ["{value}", value]
-    ]);
-    return parameter.validation_error.replace(/{min}|{max}|{value}/g, match => r.get(match) || "");
-}
+  const r = new Map<string, string>([
+    [
+      "{min}",
+      parameter.validation_min !== undefined
+        ? parameter.validation_min.toString()
+        : "",
+    ],
+    [
+      "{max}",
+      parameter.validation_max !== undefined
+        ? parameter.validation_max.toString()
+        : "",
+    ],
+    ["{value}", value],
+  ]);
+  return parameter.validation_error.replace(
+    /{min}|{max}|{value}/g,
+    (match) => r.get(match) || "",
+  );
+};

--- a/site/src/utils/richParameters.ts
+++ b/site/src/utils/richParameters.ts
@@ -79,10 +79,9 @@ export const useValidationSchemaForRichParameters = (
                   if (Number(val) < templateParameter.validation_min) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: takeFirstError(
-                        errorRendered(templateParameter, val),
+                      message:
+                        parameterError(templateParameter, val) ??
                         `Value must be greater than ${templateParameter.validation_min}.`,
-                      ),
                     });
                   }
                 } else if (
@@ -92,10 +91,9 @@ export const useValidationSchemaForRichParameters = (
                   if (templateParameter.validation_max < Number(val)) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: takeFirstError(
-                        errorRendered(templateParameter, val),
+                      message:
+                        parameterError(templateParameter, val) ??
                         `Value must be less than ${templateParameter.validation_max}.`,
-                      ),
                     });
                   }
                 } else if (
@@ -108,10 +106,9 @@ export const useValidationSchemaForRichParameters = (
                   ) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: takeFirstError(
-                        errorRendered(templateParameter, val),
+                      message:
+                        parameterError(templateParameter, val) ??
                         `Value must be between ${templateParameter.validation_min} and ${templateParameter.validation_max}.`,
-                      ),
                     });
                   }
                 }
@@ -158,7 +155,7 @@ export const useValidationSchemaForRichParameters = (
                   if (val && !regex.test(val)) {
                     return ctx.createError({
                       path: ctx.path,
-                      message: errorRendered(templateParameter, val),
+                      message: parameterError(templateParameter, val),
                     });
                   }
                 }
@@ -172,21 +169,12 @@ export const useValidationSchemaForRichParameters = (
     .required();
 };
 
-const takeFirstError = (...errorMessages: string[]): string => {
-  for (const errorMessage of errorMessages) {
-    if (errorMessage) {
-      return errorMessage;
-    }
-  }
-  return "developer error: error message is not provided";
-};
-
-const errorRendered = (
+const parameterError = (
   parameter: TemplateVersionParameter,
   value?: string,
-): string => {
+): string | undefined => {
   if (!parameter.validation_error || !value) {
-    return "";
+    return;
   }
 
   const r = new Map<string, string>([


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/12192

This PR modifies _coderd_, _site_, and _CLI_ to support custom validation errors. Fortunately, this PR is relatively small.

Template preview:

```
data "coder_parameter" "foobar_1" {
  name         = "foobar_1"
  display_name = "Foobar 1"
  type         = "number"
  description  = "Let's set the foobar."
  default      = "3"
  mutable      = true
  validation {
    min   = 3
    max   = 5
    error = "This is custom error {min}, {max}, {value}."
  }
}
```