### PR TITLE
refactor(provisionerd): move provisionersdk.VersionCurrent -> provisionerdproto.VersionCurrent

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -457,7 +457,7 @@ func New(options *Options) *API {
 				},
 				ProvisionerDaemons: healthcheck.ProvisionerDaemonsReportDeps{
 					CurrentVersion:         buildinfo.Version(),
-					CurrentAPIMajorVersion: provisionersdk.CurrentMajor,
+					CurrentAPIMajorVersion: proto.CurrentMajor,
 					Store:                  options.Database,
 					// TimeNow and StaleInterval set to defaults, see healthcheck/provisioner.go
 				},
@@ -1239,7 +1239,7 @@ func (api *API) CreateInMemoryProvisionerDaemon(dialCtx context.Context, name st
 		Tags:       provisionersdk.MutateTags(uuid.Nil, nil),
 		LastSeenAt: sql.NullTime{Time: dbtime.Now(), Valid: true},
 		Version:    buildinfo.Version(),
-		APIVersion: provisionersdk.VersionCurrent.String(),
+		APIVersion: proto.VersionCurrent.String(),
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create in-memory provisioner daemon: %w", err)

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbpurge"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -218,7 +219,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		CreatedAt:    now.Add(-14 * 24 * time.Hour),
 		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-7 * 24 * time.Hour).Add(time.Minute)},
 		Version:      "1.0.0",
-		APIVersion:   provisionersdk.VersionCurrent.String(),
+		APIVersion:   proto.VersionCurrent.String(),
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -229,7 +230,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		CreatedAt:    now.Add(-8 * 24 * time.Hour),
 		LastSeenAt:   sql.NullTime{Valid: true, Time: now.Add(-8 * 24 * time.Hour).Add(time.Hour)},
 		Version:      "1.0.0",
-		APIVersion:   provisionersdk.VersionCurrent.String(),
+		APIVersion:   proto.VersionCurrent.String(),
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -242,7 +243,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		},
 		CreatedAt:  now.Add(-9 * 24 * time.Hour),
 		Version:    "1.0.0",
-		APIVersion: provisionersdk.VersionCurrent.String(),
+		APIVersion: proto.VersionCurrent.String(),
 	})
 	require.NoError(t, err)
 	_, err = db.UpsertProvisionerDaemon(ctx, database.UpsertProvisionerDaemonParams{
@@ -256,7 +257,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 		CreatedAt:  now.Add(-6 * 24 * time.Hour),
 		LastSeenAt: sql.NullTime{Valid: true, Time: now.Add(-6 * 24 * time.Hour)},
 		Version:    "1.0.0",
-		APIVersion: provisionersdk.VersionCurrent.String(),
+		APIVersion: proto.VersionCurrent.String(),
 	})
 	require.NoError(t, err)
 

--- a/coderd/healthcheck/provisioner.go
+++ b/coderd/healthcheck/provisioner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/provisionersdk"
+	"github.com/coder/coder/v2/provisionerd/proto"
 )
 
 // @typescript-generate ProvisionerDaemonsReport
@@ -144,7 +144,7 @@ func (r *ProvisionerDaemonsReport) Run(ctx context.Context, opts *ProvisionerDae
 				r.Severity = health.SeverityWarning
 			}
 			r.Warnings = append(r.Warnings, health.Messagef(health.CodeProvisionerDaemonAPIMajorVersionDeprecated, "Some provisioner daemons report deprecated major API versions. Consider upgrading!"))
-			it.Warnings = append(it.Warnings, health.Messagef(health.CodeProvisionerDaemonAPIMajorVersionDeprecated, "Deprecated major API version %d.", provisionersdk.CurrentMajor))
+			it.Warnings = append(it.Warnings, health.Messagef(health.CodeProvisionerDaemonAPIMajorVersionDeprecated, "Deprecated major API version %d.", proto.CurrentMajor))
 		}
 
 		r.Items = append(r.Items, it)

--- a/coderd/healthcheck/provisioner_test.go
+++ b/coderd/healthcheck/provisioner_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/coder/coder/v2/coderd/healthcheck"
 	"github.com/coder/coder/v2/coderd/healthcheck/health"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/provisionersdk"
+	"github.com/coder/coder/v2/provisionerd/proto"
 
 	gomock "go.uber.org/mock/gomock"
 )
@@ -46,7 +46,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "no daemons",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityError,
 			expectedItems:          []healthcheck.ProvisionerDaemonsReportItem{},
 			expectedWarningCode:    health.CodeProvisionerDaemonsNoProvisionerDaemons,
@@ -54,7 +54,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "error fetching daemons",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			provisionerDaemonsErr:  assert.AnError,
 			expectedSeverity:       health.SeverityError,
 			expectedError:          assert.AnError.Error(),
@@ -63,7 +63,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "one daemon up to date",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityOK,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemon(t, "pd-ok", "v1.2.3", "1.0", now)},
 			expectedItems: []healthcheck.ProvisionerDaemonsReportItem{
@@ -85,7 +85,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "one daemon out of date",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityWarning,
 			expectedWarningCode:    health.CodeProvisionerDaemonVersionMismatch,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemon(t, "pd-old", "v1.1.2", "1.0", now)},
@@ -113,7 +113,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "invalid daemon version",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityError,
 			expectedWarningCode:    health.CodeUnknown,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemon(t, "pd-invalid-version", "invalid", "1.0", now)},
@@ -141,7 +141,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "invalid daemon api version",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityError,
 			expectedWarningCode:    health.CodeUnknown,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemon(t, "pd-invalid-api", "v1.2.3", "invalid", now)},
@@ -197,7 +197,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "one up to date, one out of date",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityWarning,
 			expectedWarningCode:    health.CodeProvisionerDaemonVersionMismatch,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemon(t, "pd-ok", "v1.2.3", "1.0", now), fakeProvisionerDaemon(t, "pd-old", "v1.1.2", "1.0", now)},
@@ -238,7 +238,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "one up to date, one newer",
 			currentVersion:         "v1.2.3",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityWarning,
 			expectedWarningCode:    health.CodeProvisionerDaemonVersionMismatch,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemon(t, "pd-ok", "v1.2.3", "1.0", now), fakeProvisionerDaemon(t, "pd-new", "v2.3.4", "1.0", now)},
@@ -279,7 +279,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "one up to date, one stale older",
 			currentVersion:         "v2.3.4",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityOK,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemonStale(t, "pd-stale", "v1.2.3", "0.9", now.Add(-5*time.Minute), now), fakeProvisionerDaemon(t, "pd-ok", "v2.3.4", "1.0", now)},
 			expectedItems: []healthcheck.ProvisionerDaemonsReportItem{
@@ -301,7 +301,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 		{
 			name:                   "one stale",
 			currentVersion:         "v2.3.4",
-			currentAPIMajorVersion: provisionersdk.CurrentMajor,
+			currentAPIMajorVersion: proto.CurrentMajor,
 			expectedSeverity:       health.SeverityError,
 			expectedWarningCode:    health.CodeProvisionerDaemonsNoProvisionerDaemons,
 			provisionerDaemons:     []database.ProvisionerDaemon{fakeProvisionerDaemonStale(t, "pd-ok", "v1.2.3", "0.9", now.Add(-5*time.Minute), now)},
@@ -317,7 +317,7 @@ func TestProvisionerDaemonReport(t *testing.T) {
 			deps.CurrentVersion = tt.currentVersion
 			deps.CurrentAPIMajorVersion = tt.currentAPIMajorVersion
 			if tt.currentAPIMajorVersion == 0 {
-				deps.CurrentAPIMajorVersion = provisionersdk.CurrentMajor
+				deps.CurrentAPIMajorVersion = proto.CurrentMajor
 			}
 			deps.TimeNow = func() time.Time {
 				return now

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1776,7 +1776,7 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 		Tags:         database.StringMap{},
 		LastSeenAt:   sql.NullTime{},
 		Version:      buildinfo.Version(),
-		APIVersion:   provisionersdk.VersionCurrent.String(),
+		APIVersion:   proto.VersionCurrent.String(),
 	})
 	require.NoError(t, err)
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -18,7 +18,6 @@ import (
 	"github.com/coder/coder/v2/codersdk/drpc"
 	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionerd/runner"
-	"github.com/coder/coder/v2/provisionersdk"
 )
 
 type LogSource string
@@ -202,7 +201,7 @@ func (c *Client) ServeProvisionerDaemon(ctx context.Context, req ServeProvisione
 	query := serverURL.Query()
 	query.Add("id", req.ID.String())
 	query.Add("name", req.Name)
-	query.Add("version", provisionersdk.VersionCurrent.String())
+	query.Add("version", proto.VersionCurrent.String())
 
 	for _, provisioner := range req.Provisioners {
 		query.Add("provisioner", string(provisioner))

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/provisionerd/proto"
 	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -51,7 +52,7 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 	require.Equal(t, "matt-daemon", daemons[0].Name)
 	require.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
 	require.Equal(t, buildinfo.Version(), daemons[0].Version)
-	require.Equal(t, provisionersdk.VersionCurrent.String(), daemons[0].APIVersion)
+	require.Equal(t, proto.VersionCurrent.String(), daemons[0].APIVersion)
 }
 
 func TestProvisionerDaemon_SessionToken(t *testing.T) {
@@ -88,7 +89,7 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		assert.Equal(t, provisionersdk.ScopeUser, daemons[0].Tags[provisionersdk.TagScope])
 		assert.Equal(t, anotherUser.ID.String(), daemons[0].Tags[provisionersdk.TagOwner])
 		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
-		assert.Equal(t, provisionersdk.VersionCurrent.String(), daemons[0].APIVersion)
+		assert.Equal(t, proto.VersionCurrent.String(), daemons[0].APIVersion)
 	})
 
 	t.Run("ScopeAnotherUser", func(t *testing.T) {
@@ -124,7 +125,7 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		// This should get clobbered to the user who started the daemon.
 		assert.Equal(t, anotherUser.ID.String(), daemons[0].Tags[provisionersdk.TagOwner])
 		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
-		assert.Equal(t, provisionersdk.VersionCurrent.String(), daemons[0].APIVersion)
+		assert.Equal(t, proto.VersionCurrent.String(), daemons[0].APIVersion)
 	})
 
 	t.Run("ScopeOrg", func(t *testing.T) {
@@ -158,6 +159,6 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		assert.Equal(t, "org-daemon", daemons[0].Name)
 		assert.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
 		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
-		assert.Equal(t, provisionersdk.VersionCurrent.String(), daemons[0].APIVersion)
+		assert.Equal(t, proto.VersionCurrent.String(), daemons[0].APIVersion)
 	})
 }

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -239,7 +239,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		apiVersion = qv
 	}
 
-	if err := provisionersdk.VersionCurrent.Validate(apiVersion); err != nil {
+	if err := proto.VersionCurrent.Validate(apiVersion); err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Incompatible or unparsable version",
 			Validations: []codersdk.ValidationError{

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -62,7 +62,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 		if assert.Len(t, daemons, 1) {
 			assert.Equal(t, daemonName, daemons[0].Name)
 			assert.Equal(t, buildinfo.Version(), daemons[0].Version)
-			assert.Equal(t, provisionersdk.VersionCurrent.String(), daemons[0].APIVersion)
+			assert.Equal(t, provisionerdproto.VersionCurrent.String(), daemons[0].APIVersion)
 		}
 	})
 
@@ -149,7 +149,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 		q.Add("provisioner", "echo")
 
 		// Set a different (newer) version than the current.
-		v := apiversion.New(provisionersdk.CurrentMajor+1, provisionersdk.CurrentMinor+1)
+		v := apiversion.New(provisionerdproto.CurrentMajor+1, provisionerdproto.CurrentMinor+1)
 		q.Add("version", v.String())
 		srvURL.RawQuery = q.Encode()
 

--- a/provisionerd/proto/version.go
+++ b/provisionerd/proto/version.go
@@ -1,0 +1,13 @@
+package proto
+
+import "github.com/coder/coder/v2/apiversion"
+
+const (
+	CurrentMajor = 1
+	CurrentMinor = 0
+)
+
+// VersionCurrent is the current provisionerd API version.
+// Breaking changes to the provisionerd API **MUST** increment
+// CurrentMajor above.
+var VersionCurrent = apiversion.New(CurrentMajor, CurrentMinor)

--- a/provisionersdk/serve.go
+++ b/provisionersdk/serve.go
@@ -16,20 +16,9 @@ import (
 
 	"cdr.dev/slog"
 
-	"github.com/coder/coder/v2/apiversion"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 )
-
-const (
-	CurrentMajor = 1
-	CurrentMinor = 0
-)
-
-// VersionCurrent is the current provisionerd API version.
-// Breaking changes to the provisionerd API **MUST** increment
-// CurrentMajor above.
-var VersionCurrent = apiversion.New(CurrentMajor, CurrentMinor)
 
 // ServeOptions are configurations to serve a provisioner.
 type ServeOptions struct {


### PR DESCRIPTION
From https://github.com/coder/coder/pull/12021#discussion_r1495557641

Moves provisioner API proto version to the correct location. 