### PR TITLE
feat(coderd/database): support exact tags match in AcquireProvisionerJob query

### DIFF
--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -192,8 +192,9 @@ func (b WorkspaceBuildBuilder) Do() WorkspaceResponse {
 					UUID:  uuid.New(),
 					Valid: true,
 				},
-				Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
-				Tags:  []byte(`{"scope": "organization"}`),
+				Types:         []database.ProvisionerType{database.ProvisionerTypeEcho},
+				Tags:          []byte(`{"scope": "organization"}`),
+				ExactTagMatch: false,
 			})
 			require.NoError(b.t, err, "acquire starting job")
 			if j.ID == job.ID {

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -417,10 +417,11 @@ func ProvisionerJob(t testing.TB, db database.Store, ps pubsub.Pubsub, orig data
 	}
 	if !orig.StartedAt.Time.IsZero() {
 		job, err = db.AcquireProvisionerJob(genCtx, database.AcquireProvisionerJobParams{
-			StartedAt: orig.StartedAt,
-			Types:     []database.ProvisionerType{database.ProvisionerTypeEcho},
-			Tags:      must(json.Marshal(orig.Tags)),
-			WorkerID:  uuid.NullUUID{},
+			StartedAt:     orig.StartedAt,
+			Types:         []database.ProvisionerType{database.ProvisionerTypeEcho},
+			Tags:          must(json.Marshal(orig.Tags)),
+			WorkerID:      uuid.NullUUID{},
+			ExactTagMatch: false,
 		})
 		require.NoError(t, err)
 		// There is no easy way to make sure we acquire the correct job.

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -748,10 +748,9 @@ var deletedUserLinkError = &pq.Error{
 	Routine: "exec_stmt_raise",
 }
 
-// m1 and m2 are equal if m1 is a subset of m2
-// and m2 is a subset of m1.
+// m1 and m2 are equal iff |m1| = |m2| ^ m1 ⊆ m2
 func tagsEqual(m1, m2 map[string]string) bool {
-	return tagsSubset(m1, m2) && tagsSubset(m2, m1)
+	return len(m1) == len(m2) && tagsSubset(m1, m2)
 }
 
 // m2 is a subset of m1 if each key in m1 exists in m2

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -748,7 +748,7 @@ var deletedUserLinkError = &pq.Error{
 	Routine: "exec_stmt_raise",
 }
 
-// m1 and m2 are equal iff |m1| = |m2| ^ m1 ⊆ m2
+// m1 and m2 are equal iff |m1| = |m2| ^ m2 ⊆ m1
 func tagsEqual(m1, m2 map[string]string) bool {
 	return len(m1) == len(m2) && tagsSubset(m1, m2)
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3936,9 +3936,10 @@ WHERE
 			nested.started_at IS NULL
 			-- Ensure the caller has the correct provisioner.
 			AND nested.provisioner = ANY($3 :: provisioner_type [ ])
-			-- Ensure the job matches satisfies all requested tags.
+			-- Ensure the caller satisfies all job tags if requested,
 			AND CASE
 				WHEN $4 :: boolean THEN nested.tags = $5 :: jsonb
+			-- Otherwise, ensure caller satisfies a subset of tags.
 			ELSE
 				nested.tags <@ $5 :: jsonb
 			END

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -21,9 +21,10 @@ WHERE
 			nested.started_at IS NULL
 			-- Ensure the caller has the correct provisioner.
 			AND nested.provisioner = ANY(@types :: provisioner_type [ ])
-			-- Ensure the job matches satisfies all requested tags.
+			-- Ensure the caller satisfies all job tags if requested,
 			AND CASE
 				WHEN @exact_tag_match :: boolean THEN nested.tags = @tags :: jsonb
+			-- Otherwise, ensure caller satisfies a subset of tags.
 			ELSE
 				nested.tags <@ @tags :: jsonb
 			END

--- a/coderd/database/queries/provisionerjobs.sql
+++ b/coderd/database/queries/provisionerjobs.sql
@@ -21,8 +21,12 @@ WHERE
 			nested.started_at IS NULL
 			-- Ensure the caller has the correct provisioner.
 			AND nested.provisioner = ANY(@types :: provisioner_type [ ])
-			-- Ensure the caller satisfies all job tags.
-			AND nested.tags <@ @tags :: jsonb
+			-- Ensure the job matches satisfies all requested tags.
+			AND CASE
+				WHEN @exact_tag_match :: boolean THEN nested.tags = @tags :: jsonb
+			ELSE
+				nested.tags <@ @tags :: jsonb
+			END
 		ORDER BY
 			nested.created_at
 		FOR UPDATE

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -573,7 +573,8 @@ func TestUpdateJob(t *testing.T) {
 				UUID:  srvID,
 				Valid: true,
 			},
-			Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
+			Types:         []database.ProvisionerType{database.ProvisionerTypeEcho},
+			ExactTagMatch: false,
 		})
 		require.NoError(t, err)
 		return job.ID

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -181,8 +181,9 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 					UUID:  uuid.New(),
 					Valid: true,
 				},
-				Types: []database.ProvisionerType{database.ProvisionerTypeEcho},
-				Tags:  json.RawMessage(fmt.Sprintf(`{%q: "yeah"}`, c.name)),
+				Types:         []database.ProvisionerType{database.ProvisionerTypeEcho},
+				Tags:          json.RawMessage(fmt.Sprintf(`{%q: "yeah"}`, c.name)),
+				ExactTagMatch: false,
 			})
 			require.NoError(t, err)
 			require.Equal(t, job.ID, acquiredJob.ID)


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/6442

Updates AcquireProvisionerJob query with parameter ExactTagMatch which toggles between existing behaviour (subset matches) or new behaviour (all match).
Adds unit tests for new behaviour.
A separate PR will wire this up to a configuration knob in coderd and provisionerd.