### PR TITLE
fix: verify parameter monotonicity when previous value exists

### DIFF
--- a/codersdk/richparameters.go
+++ b/codersdk/richparameters.go
@@ -60,7 +60,7 @@ func validateBuildParameter(richParameter TemplateVersionParameter, buildParamet
 		value = richParameter.DefaultValue
 	}
 
-	if lastBuildParameter != nil && richParameter.Type == "number" && len(richParameter.ValidationMonotonic) > 0 {
+	if lastBuildParameter != nil && lastBuildParameter.Value != "" && richParameter.Type == "number" && len(richParameter.ValidationMonotonic) > 0 {
 		prev, err := strconv.Atoi(lastBuildParameter.Value)
 		if err != nil {
 			return xerrors.Errorf("previous parameter value is not a number: %s", lastBuildParameter.Value)

--- a/codersdk/richparameters_test.go
+++ b/codersdk/richparameters_test.go
@@ -309,6 +309,26 @@ func TestRichParameterValidation(t *testing.T) {
 	})
 }
 
+func TestParameterResolver_ValidateResolve_EmptyString_Monotonic(t *testing.T) {
+	t.Parallel()
+	uut := codersdk.ParameterResolver{
+		Rich: []codersdk.WorkspaceBuildParameter{{Name: "n", Value: ""}},
+	}
+	p := codersdk.TemplateVersionParameter{
+		Name:                "n",
+		Type:                "number",
+		Mutable:             true,
+		DefaultValue:        "0",
+		ValidationMonotonic: codersdk.MonotonicOrderIncreasing,
+	}
+	v, err := uut.ValidateResolve(p, &codersdk.WorkspaceBuildParameter{
+		Name:  "n",
+		Value: "1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "1", v)
+}
+
 func TestParameterResolver_ValidateResolve_Ephemeral_OverridePrevious(t *testing.T) {
 	t.Parallel()
 	uut := codersdk.ParameterResolver{


### PR DESCRIPTION
If for some reason the last parameter value is stored as an empty string (`""`), and the parameter type becomes a number with monotonicity validation, coderd may block creating the workspace failing with `previous parameter value is not a number`.

This PR adds a workaround to prevent this state.

Notice: I wasn't able to fully reproduce the workflow. I focused on the recovery part here.