### PR TITLE
fix: ignore surronding whitespace for cli config

### DIFF
--- a/cli/config/file.go
+++ b/cli/config/file.go
@@ -86,21 +86,14 @@ func (f File) Write(s string) error {
 	return write(string(f), 0o600, []byte(s))
 }
 
-func (f File) ReadNormalizeSpace() (string, error) {
-	str, err := f.Read()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(str), nil
-}
-
-// Read reads the file to a string.
+// Read reads the file to a string. All leading and trailing whitespace
+// is removed.
 func (f File) Read() (string, error) {
 	if f == "" {
 		return "", xerrors.Errorf("empty file path")
 	}
 	byt, err := read(string(f))
-	return string(byt), err
+	return strings.TrimSpace(string(byt)), err
 }
 
 // open opens a file in the configuration directory,

--- a/cli/config/file.go
+++ b/cli/config/file.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kirsle/configdir"
 	"golang.org/x/xerrors"
@@ -83,6 +84,14 @@ func (f File) Write(s string) error {
 		return xerrors.Errorf("empty file path")
 	}
 	return write(string(f), 0o600, []byte(s))
+}
+
+func (f File) ReadNormalizeSpace() (string, error) {
+	str, err := f.Read()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(str), nil
 }
 
 // Read reads the file to a string.

--- a/cli/root.go
+++ b/cli/root.go
@@ -558,7 +558,7 @@ func (r *RootCmd) initClientInternal(client *codersdk.Client, allowTokenMissing 
 			}
 
 			if r.token == "" {
-				r.token, err = conf.Session().Read()
+				r.token, err = conf.Session().ReadNormalizeSpace()
 				// If the configuration files are absent, the user is logged out
 				if os.IsNotExist(err) {
 					if !allowTokenMissing {

--- a/cli/root.go
+++ b/cli/root.go
@@ -558,7 +558,7 @@ func (r *RootCmd) initClientInternal(client *codersdk.Client, allowTokenMissing 
 			}
 
 			if r.token == "" {
-				r.token, err = conf.Session().ReadNormalizeSpace()
+				r.token, err = conf.Session().Read()
 				// If the configuration files are absent, the user is logged out
 				if os.IsNotExist(err) {
 					if !allowTokenMissing {


### PR DESCRIPTION
Cli config files break if you edit them manually with any editor.
Editors drop a newline at the end, and we not break on this.
If a developer manually edits a file, it should still work