### PR TITLE
chore(docs): inline OIDC flow diagram

### DIFF
--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -1,6 +1,6 @@
 # Authentication
 
-[OIDC with Coder Sequence Diagram](https://raw.githubusercontent.com/coder/coder/138ee55abb3635cb2f3d12661f8caef2ca9d0961/docs/images/oidc-sequence-diagram.svg).
+![OIDC with Coder Sequence Diagram](../images/oidc-sequence-diagram.svg).
 
 By default, Coder is accessible via password authentication. Coder does not
 recommend using password authentication in production, and recommends using an


### PR DESCRIPTION
When viewing the Authentication page, the diagram showing the flow is a useful resource for understanding the rest of the page.

Rather than linking to a specific version of the SVG, inline it as part of the documentation.
