### PR TITLE
fix: fix GetOrganizationsByUserID error when multiple organizations exist

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3540,7 +3540,7 @@ SELECT
 FROM
 	organizations
 WHERE
-	id = (
+	id = ANY(
 		SELECT
 			organization_id
 		FROM

--- a/coderd/database/queries/organizations.sql
+++ b/coderd/database/queries/organizations.sql
@@ -38,7 +38,7 @@ SELECT
 FROM
 	organizations
 WHERE
-	id = (
+	id = ANY(
 		SELECT
 			organization_id
 		FROM

--- a/coderd/organizations_test.go
+++ b/coderd/organizations_test.go
@@ -12,6 +12,28 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+func TestMultiOrgFetch(t *testing.T) {
+	t.Parallel()
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	makeOrgs := []string{"foo", "bar", "baz"}
+	for _, name := range makeOrgs {
+		_, err := client.CreateOrganization(ctx, codersdk.CreateOrganizationRequest{
+			Name: name,
+		})
+		require.NoError(t, err)
+	}
+
+	orgs, err := client.OrganizationsByUser(ctx, codersdk.Me)
+	require.NoError(t, err)
+	require.NotNil(t, orgs)
+	require.Len(t, orgs, len(makeOrgs)+1)
+}
+
 func TestOrganizationsByUser(t *testing.T) {
 	t.Parallel()
 	client := coderdtest.New(t, nil)


### PR DESCRIPTION
Error was `[21000] ERROR: more than one row returned by a subquery used as an expression`

Closes https://github.com/coder/coder/issues/12258