### PR TITLE
feat: implement organization context in the cli

### DIFF
--- a/cli/config/file.go
+++ b/cli/config/file.go
@@ -70,6 +70,14 @@ func (r Root) PostgresPort() File {
 // File provides convenience methods for interacting with *os.File.
 type File string
 
+func (f File) Exists() bool {
+	if f == "" {
+		return false
+	}
+	_, err := os.Stat(string(f))
+	return err == nil
+}
+
 // Delete deletes the file.
 func (f File) Delete() error {
 	if f == "" {

--- a/cli/create.go
+++ b/cli/create.go
@@ -43,7 +43,7 @@ func (r *RootCmd) create() *clibase.Cmd {
 		),
 		Middleware: clibase.Chain(r.InitClient(client)),
 		Handler: func(inv *clibase.Invocation) error {
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func (r *RootCmd) organizations() *clibase.Cmd {
+	cmd := &clibase.Cmd{
+		Annotations: workspaceCommand,
+		Use:         "organizations { current }",
+		Short:       "Organization related commands",
+		Aliases:     []string{"organization", "org", "orgs"},
+
+		Handler: func(inv *clibase.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Children: []*clibase.Cmd{
+			r.currentOrganization(),
+		},
+	}
+
+	cmd.Options = clibase.OptionSet{}
+	return cmd
+}
+
+func (r *RootCmd) currentOrganization() *clibase.Cmd {
+	var (
+		client    = new(codersdk.Client)
+		formatter = cliui.NewOutputFormatter(
+			cliui.ChangeFormatterData(cliui.TextFormat(), func(data any) (any, error) {
+				typed := data.([]codersdk.Organization)
+				if len(typed) != 1 {
+					return "", fmt.Errorf("expected 1 organization, got %d", len(typed))
+				}
+				return fmt.Sprintf("Current organization: %s (%s)\n", typed[0].Name, typed[0].ID.String()), nil
+			}),
+			cliui.TableFormat([]codersdk.Organization{}, []string{"id", "name", "default"}),
+			cliui.JSONFormat(),
+		)
+	)
+	cmd := &clibase.Cmd{
+		Use:   "current",
+		Short: "Show the current selected organization the cli will use",
+		Middleware: clibase.Chain(
+			r.InitClient(client),
+		),
+		Handler: func(inv *clibase.Invocation) error {
+			org, err := CurrentOrganization(r, inv, client)
+			if err != nil {
+				return err
+			}
+
+			out, err := formatter.Format(inv.Context(), []codersdk.Organization{org})
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(inv.Stdout, out)
+			return nil
+		},
+	}
+	formatter.AttachOptions(&cmd.Options)
+
+	return cmd
+}

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -48,7 +48,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 	)
 	cmd := &clibase.Cmd{
 		Use:   "show [current|me|uuid]",
-		Short: "Show organization information. By default, if no argument is provided, the current cli configured organization is shown.",
+		Short: "Show the organization, if no argument is given, the organization currently in use will be shown.",
 		Middleware: clibase.Chain(
 			r.InitClient(client),
 			clibase.RequireRangeArgs(0, 1),
@@ -64,7 +64,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 		},
 		Handler: func(inv *clibase.Invocation) error {
 			orgArg := "current"
-			if len(inv.Args) == 1 {
+			if len(inv.Args) >= 1 {
 				orgArg = inv.Args[0]
 			}
 

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -14,7 +14,7 @@ func (r *RootCmd) organizations() *clibase.Cmd {
 		Use:         "organizations { current }",
 		Short:       "Organization related commands",
 		Aliases:     []string{"organization", "org", "orgs"},
-
+		Hidden:      true, // Hidden until these commands are complete.
 		Handler: func(inv *clibase.Invocation) error {
 			return inv.Command.HelpHandler(inv)
 		},
@@ -45,7 +45,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 	)
 	cmd := &clibase.Cmd{
 		Use:   "current",
-		Short: "Show the current selected organization the cli will use",
+		Short: "Show the current selected organization the cli will use.",
 		Middleware: clibase.Chain(
 			r.InitClient(client),
 		),

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -71,7 +71,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 				if err != nil {
 					return err
 				}
-				_, _ = fmt.Fprintf(inv.Stdout, out)
+				_, _ = fmt.Fprint(inv.Stdout, out)
 			}
 			return nil
 		},

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -71,7 +71,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 				if err != nil {
 					return err
 				}
-				_, err = fmt.Fprintf(inv.Stdout, out)
+				_, _ = fmt.Fprintf(inv.Stdout, out)
 			}
 			return nil
 		},

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -11,7 +11,7 @@ import (
 func (r *RootCmd) organizations() *clibase.Cmd {
 	cmd := &clibase.Cmd{
 		Annotations: workspaceCommand,
-		Use:         "organizations { current }",
+		Use:         "organizations [subcommand]",
 		Short:       "Organization related commands",
 		Aliases:     []string{"organization", "org", "orgs"},
 		Hidden:      true, // Hidden until these commands are complete.

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -32,7 +32,11 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 		client    = new(codersdk.Client)
 		formatter = cliui.NewOutputFormatter(
 			cliui.ChangeFormatterData(cliui.TextFormat(), func(data any) (any, error) {
-				typed := data.([]codersdk.Organization)
+				typed, ok := data.([]codersdk.Organization)
+				if !ok {
+					// This should never happen
+					return "", fmt.Errorf("expected []Organization, got %T", data)
+				}
 				if len(typed) != 1 {
 					return "", fmt.Errorf("expected 1 organization, got %d", len(typed))
 				}

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -17,8 +18,10 @@ func TestCurrentOrganization(t *testing.T) {
 
 	t.Run("OnlyID", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		ownerClient := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, ownerClient)
+		// Owner is required to make orgs
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, first.OrganizationID, rbac.RoleOwner())
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		orgs := []string{"foo", "bar"}

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -32,7 +32,7 @@ func TestCurrentOrganization(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		inv, root := clitest.New(t, "organizations", "current", "--only-id")
+		inv, root := clitest.New(t, "organizations", "show", "--only-id")
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
 		errC := make(chan error)

--- a/cli/root.go
+++ b/cli/root.go
@@ -733,7 +733,7 @@ func CurrentOrganization(r *RootCmd, inv *clibase.Invocation, client *codersdk.C
 		return org.IsDefault
 	})
 	if index < 0 {
-		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder switch <org>' to select an organization to use")
+		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder organizations switch <org>' to select an organization to use")
 	}
 
 	return orgs[index], nil

--- a/cli/root.go
+++ b/cli/root.go
@@ -94,6 +94,7 @@ func (r *RootCmd) Core() []*clibase.Cmd {
 		r.tokens(),
 		r.users(),
 		r.version(defaultVersionInfo),
+		r.organizations(),
 
 		// Workspace Commands
 		r.autoupdate(),
@@ -698,14 +699,44 @@ func (r *RootCmd) createAgentClient() (*agentsdk.Client, error) {
 }
 
 // CurrentOrganization returns the currently active organization for the authenticated user.
-func CurrentOrganization(inv *clibase.Invocation, client *codersdk.Client) (codersdk.Organization, error) {
+func CurrentOrganization(r *RootCmd, inv *clibase.Invocation, client *codersdk.Client) (codersdk.Organization, error) {
+	conf := r.createConfig()
+	selected := ""
+	if conf.Organization().Exists() {
+		org, err := conf.Organization().Read()
+		if err != nil {
+			return codersdk.Organization{}, fmt.Errorf("read selected organization from config file %q: %w", conf.Organization(), err)
+		}
+		selected = org
+	}
+
+	// Verify the org exists and the user is a member
 	orgs, err := client.OrganizationsByUser(inv.Context(), codersdk.Me)
 	if err != nil {
-		return codersdk.Organization{}, nil
+		return codersdk.Organization{}, err
 	}
-	// For now, we won't use the config to set this.
-	// Eventually, we will support changing using "coder switch <org>"
-	return orgs[0], nil
+
+	// User manually selected an organization
+	if selected != "" {
+		index := slices.IndexFunc(orgs, func(org codersdk.Organization) bool {
+			return org.Name == selected || org.ID.String() == selected
+		})
+
+		if index < 0 {
+			return codersdk.Organization{}, xerrors.Errorf("organization %q not found, are you sure you are a member of this organization?", selected)
+		}
+		return orgs[index], nil
+	}
+
+	// User did not select an organization, so use the default.
+	index := slices.IndexFunc(orgs, func(org codersdk.Organization) bool {
+		return org.IsDefault
+	})
+	if index < 0 {
+		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder switch <org>' to select an organization to use")
+	}
+
+	return orgs[index], nil
 }
 
 func splitNamedWorkspace(identifier string) (owner string, workspaceName string, err error) {

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -69,7 +69,7 @@ func (r *RootCmd) templateCreate() *clibase.Cmd {
 				}
 			}
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/cli/templatecreate_test.go
+++ b/cli/templatecreate_test.go
@@ -243,19 +243,7 @@ func TestTemplateCreate(t *testing.T) {
 			assert.Error(t, err)
 		}()
 
-		matches := []struct {
-			match string
-			write string
-		}{
-			{match: "Upload", write: "yes"},
-		}
-		for _, m := range matches {
-			pty.ExpectMatch(m.match)
-			if len(m.write) > 0 {
-				pty.WriteLine(m.write)
-			}
-		}
-
+		pty.ExpectMatch("context canceled")
 		<-ctx.Done()
 	})
 

--- a/cli/templatedelete.go
+++ b/cli/templatedelete.go
@@ -32,7 +32,7 @@ func (r *RootCmd) templateDelete() *clibase.Cmd {
 				templates     = []codersdk.Template{}
 			)
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/cli/templateedit.go
+++ b/cli/templateedit.go
@@ -79,7 +79,7 @@ func (r *RootCmd) templateEdit() *clibase.Cmd {
 				}
 			}
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return xerrors.Errorf("get current organization: %w", err)
 			}

--- a/cli/templatelist.go
+++ b/cli/templatelist.go
@@ -25,7 +25,7 @@ func (r *RootCmd) templateList() *clibase.Cmd {
 			r.InitClient(client),
 		),
 		Handler: func(inv *clibase.Invocation) error {
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/cli/templatepull.go
+++ b/cli/templatepull.go
@@ -44,7 +44,7 @@ func (r *RootCmd) templatePull() *clibase.Cmd {
 				return xerrors.Errorf("either tar or zip can be selected")
 			}
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return xerrors.Errorf("get current organization: %w", err)
 			}

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -46,7 +46,7 @@ func (r *RootCmd) templatePush() *clibase.Cmd {
 		Handler: func(inv *clibase.Invocation) error {
 			uploadFlags.setWorkdir(workdir)
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/cli/templateversionarchive.go
+++ b/cli/templateversionarchive.go
@@ -47,7 +47,7 @@ func (r *RootCmd) setArchiveTemplateVersion(archive bool) *clibase.Cmd {
 				versions []codersdk.TemplateVersion
 			)
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}
@@ -121,7 +121,7 @@ func (r *RootCmd) archiveTemplateVersions() *clibase.Cmd {
 				templates     = []codersdk.Template{}
 			)
 
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -93,7 +93,7 @@ func (r *RootCmd) templateVersionsList() *clibase.Cmd {
 			},
 		},
 		Handler: func(inv *clibase.Invocation) error {
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return xerrors.Errorf("get current organization: %w", err)
 			}

--- a/cli/usercreate.go
+++ b/cli/usercreate.go
@@ -31,7 +31,7 @@ func (r *RootCmd) userCreate() *clibase.Cmd {
 			r.InitClient(client),
 		),
 		Handler: func(inv *clibase.Invocation) error {
-			organization, err := CurrentOrganization(inv, client)
+			organization, err := CurrentOrganization(r, inv, client)
 			if err != nil {
 				return err
 			}

--- a/coderd/organizations_test.go
+++ b/coderd/organizations_test.go
@@ -66,7 +66,7 @@ func TestOrganizationByUserAndName(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		_, err := client.OrganizationByName(ctx, codersdk.Me, "nothing")
+		_, err := client.OrganizationByUserAndName(ctx, codersdk.Me, "nothing")
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
@@ -85,7 +85,7 @@ func TestOrganizationByUserAndName(t *testing.T) {
 			Name: "another",
 		})
 		require.NoError(t, err)
-		_, err = other.OrganizationByName(ctx, codersdk.Me, org.Name)
+		_, err = other.OrganizationByUserAndName(ctx, codersdk.Me, org.Name)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
@@ -101,7 +101,7 @@ func TestOrganizationByUserAndName(t *testing.T) {
 
 		org, err := client.Organization(ctx, user.OrganizationID)
 		require.NoError(t, err)
-		_, err = client.OrganizationByName(ctx, codersdk.Me, org.Name)
+		_, err = client.OrganizationByUserAndName(ctx, codersdk.Me, org.Name)
 		require.NoError(t, err)
 	})
 }

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -153,8 +153,8 @@ type CreateWorkspaceRequest struct {
 	AutomaticUpdates    AutomaticUpdates          `json:"automatic_updates,omitempty"`
 }
 
-func (c *Client) Organization(ctx context.Context, id uuid.UUID) (Organization, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s", id.String()), nil)
+func (c *Client) OrganizationByName(ctx context.Context, name string) (Organization, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/organizations/%s", name), nil)
 	if err != nil {
 		return Organization{}, xerrors.Errorf("execute request: %w", err)
 	}
@@ -166,6 +166,12 @@ func (c *Client) Organization(ctx context.Context, id uuid.UUID) (Organization, 
 
 	var organization Organization
 	return organization, json.NewDecoder(res.Body).Decode(&organization)
+}
+
+func (c *Client) Organization(ctx context.Context, id uuid.UUID) (Organization, error) {
+	// OrganizationByName uses the exact same endpoint. It accepts a name or uuid.
+	// We just provide this function for type safety.
+	return c.OrganizationByName(ctx, id.String())
 }
 
 // ProvisionerDaemons returns provisioner daemons available.

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -26,11 +26,11 @@ const (
 
 // Organization is the JSON representation of a Coder organization.
 type Organization struct {
-	ID        uuid.UUID `json:"id" validate:"required" format:"uuid"`
-	Name      string    `json:"name" validate:"required"`
-	CreatedAt time.Time `json:"created_at" validate:"required" format:"date-time"`
-	UpdatedAt time.Time `json:"updated_at" validate:"required" format:"date-time"`
-	IsDefault bool      `json:"is_default" validate:"required"`
+	ID        uuid.UUID `table:"id" json:"id" validate:"required" format:"uuid"`
+	Name      string    `table:"name,default_sort" json:"name" validate:"required"`
+	CreatedAt time.Time `table:"created_at" json:"created_at" validate:"required" format:"date-time"`
+	UpdatedAt time.Time `table:"updated_at" json:"updated_at" validate:"required" format:"date-time"`
+	IsDefault bool      `table:"default" json:"is_default" validate:"required"`
 }
 
 type OrganizationMember struct {

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -573,7 +573,7 @@ func (c *Client) OrganizationsByUser(ctx context.Context, user string) ([]Organi
 	return orgs, json.NewDecoder(res.Body).Decode(&orgs)
 }
 
-func (c *Client) OrganizationByName(ctx context.Context, user string, name string) (Organization, error) {
+func (c *Client) OrganizationByUserAndName(ctx context.Context, user string, name string) (Organization, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/organizations/%s", user, name), nil)
 	if err != nil {
 		return Organization{}, err

--- a/enterprise/cli/groupcreate.go
+++ b/enterprise/cli/groupcreate.go
@@ -29,7 +29,7 @@ func (r *RootCmd) groupCreate() *clibase.Cmd {
 		Handler: func(inv *clibase.Invocation) error {
 			ctx := inv.Context()
 
-			org, err := agpl.CurrentOrganization(inv, client)
+			org, err := agpl.CurrentOrganization(&r.RootCmd, inv, client)
 			if err != nil {
 				return xerrors.Errorf("current organization: %w", err)
 			}

--- a/enterprise/cli/groupdelete.go
+++ b/enterprise/cli/groupdelete.go
@@ -27,7 +27,7 @@ func (r *RootCmd) groupDelete() *clibase.Cmd {
 				groupName = inv.Args[0]
 			)
 
-			org, err := agpl.CurrentOrganization(inv, client)
+			org, err := agpl.CurrentOrganization(&r.RootCmd, inv, client)
 			if err != nil {
 				return xerrors.Errorf("current organization: %w", err)
 			}

--- a/enterprise/cli/groupedit.go
+++ b/enterprise/cli/groupedit.go
@@ -37,7 +37,7 @@ func (r *RootCmd) groupEdit() *clibase.Cmd {
 				groupName = inv.Args[0]
 			)
 
-			org, err := agpl.CurrentOrganization(inv, client)
+			org, err := agpl.CurrentOrganization(&r.RootCmd, inv, client)
 			if err != nil {
 				return xerrors.Errorf("current organization: %w", err)
 			}

--- a/enterprise/cli/grouplist.go
+++ b/enterprise/cli/grouplist.go
@@ -30,7 +30,7 @@ func (r *RootCmd) groupList() *clibase.Cmd {
 		Handler: func(inv *clibase.Invocation) error {
 			ctx := inv.Context()
 
-			org, err := agpl.CurrentOrganization(inv, client)
+			org, err := agpl.CurrentOrganization(&r.RootCmd, inv, client)
 			if err != nil {
 				return xerrors.Errorf("current organization: %w", err)
 			}


### PR DESCRIPTION
# What this does

The cli now uses the config files to store what organization it is currently referencing.

Adds `coder organizations current` to display the currently selected organization.

**This is a hidden command until we finish all related commands**

# Discussion

Currently I have this under `coder organizations { current | switch | ... }. Should we name this something else? Like `coder ctx current`, `coder ctx switch` etc? 

This could maybe include different deployments and logins if we do `ctx`.

## `coder organizations current`

Below is all the format options.

```
$ go install && coder organizations current                                                                                                                                
Current organization: admin (3736ca3e-840f-4473-88ad-7056f1a9d22a)

$ coder organizations show current --output=json
[
  {
    "id": "3736ca3e-840f-4473-88ad-7056f1a9d22a",
    "name": "admin",
    "created_at": "2024-02-21T23:22:42.667305Z",
    "updated_at": "2024-02-21T23:22:42.667305Z",
    "is_default": true
  }
]

$ coder organizations show current --output=table
ID                                    NAME   DEFAULT  
3736ca3e-840f-4473-88ad-7056f1a9d22a  admin  true   

# coder organizations show current --only-id
3736ca3e-840f-4473-88ad-7056f1a9d22a
```