### PR TITLE
feat: switch organization context in coder organizations

### DIFF
--- a/cli/organization.go
+++ b/cli/organization.go
@@ -98,7 +98,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 							Message: fmt.Sprintf("Organization %q not found. Is the name correct, and are you a member of it?", switchToOrg),
 							Detail:  "Ensure the organization argument is correct and you are a member of it.",
 						},
-						Helper: fmt.Sprintf("Valid organizations you can switch to: %q", strings.Join(orgNames(orgs), ", ")),
+						Helper: fmt.Sprintf("Valid organizations you can switch to: %s", strings.Join(orgNames(orgs), ", ")),
 					}
 					return err
 				}

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/pretty"
 )
 
 func (r *RootCmd) organizations() *clibase.Cmd {
@@ -52,54 +54,153 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 		),
 		Middleware: clibase.Chain(
 			r.InitClient(client),
+			clibase.RequireRangeArgs(0, 1),
 		),
 		Options: clibase.OptionSet{},
 		Handler: func(inv *clibase.Invocation) error {
-			orgArg := inv.Args[0]
 			conf := r.createConfig()
 			orgs, err := client.OrganizationsByUser(inv.Context(), codersdk.Me)
 			if err != nil {
 				return fmt.Errorf("failed to get organizations: %w", err)
 			}
+			// Keep the list of orgs sorted
+			slices.SortFunc(orgs, func(a, b codersdk.Organization) int {
+				return strings.Compare(a.Name, b.Name)
+			})
+
+			var orgArg string
+			if len(inv.Args) == 0 {
+				// Pull orgArg from a prompt selector, rather than command line
+				// args.
+				orgArg, err = promptUserSelectOrg(inv, conf, orgs)
+				if err != nil {
+					return err
+				}
+			} else {
+				orgArg = inv.Args[0]
+			}
 
 			// If the user passes an empty string, we want to remove the organization
+			// from the config file. This will defer to default behavior.
 			if orgArg == "" {
 				err := conf.Organization().Delete()
 				if err != nil && !errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf("failed to unset organization: %w", err)
 				}
+				_, _ = fmt.Fprintf(inv.Stdout, "Organization unset\n")
 			} else {
+				// Find the selected org in our list.
 				index := slices.IndexFunc(orgs, func(org codersdk.Organization) bool {
 					return org.Name == orgArg || org.ID.String() == orgArg
 				})
 				if index < 0 {
-					names := make([]string, 0, len(orgs))
-					for _, org := range orgs {
-						names = append(names, org.Name)
-					}
-
 					// Using this error for better error message formatting
 					err := &codersdk.Error{
 						Response: codersdk.Response{
-							Message: fmt.Sprintf("Organization %q not found.", orgArg),
+							Message: fmt.Sprintf("Organization %q not found. Is the name correct, and are you a member of it?", orgArg),
 							Detail:  "Ensure the organization argument is correct and you are a member of it.",
 						},
-						Helper: fmt.Sprintf("Valid organizations you can switch to: %q", strings.Join(names, ", ")),
+						Helper: fmt.Sprintf("Valid organizations you can switch to: %q", strings.Join(orgNames(orgs), ", ")),
 					}
 					return err
 				}
 
+				// Always write the uuid to the config file. Names can change.
 				err := conf.Organization().Write(orgs[index].ID.String())
 				if err != nil {
 					return fmt.Errorf("failed to write organization to config file: %w", err)
 				}
 			}
 
+			// Verify it worked.
+			current, err := CurrentOrganization(r, inv, client)
+			if err != nil {
+				// An SDK error could be a permission error. So offer the advice to unset the org
+				// and reset the context.
+				var sdkError *codersdk.Error
+				if errors.As(err, &sdkError) {
+					if sdkError.Helper == "" && sdkError.StatusCode() != 500 {
+						sdkError.Helper = fmt.Sprintf("If this error persists, try unsetting your org with 'coder organizations switch \"\"'")
+					}
+					return sdkError
+				}
+				return fmt.Errorf("failed to get current organization: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Current organization context set to %s (%s)\n", current.Name, current.ID.String())
 			return nil
 		},
 	}
 
 	return cmd
+}
+
+// promptUserSelectOrg will prompt the user to select an organization from a list
+// of their organizations.
+func promptUserSelectOrg(inv *clibase.Invocation, conf config.Root, orgs []codersdk.Organization) (string, error) {
+	// Default choice
+	var defaultOrg string
+	// Comes from config file
+	if conf.Organization().Exists() {
+		defaultOrg, _ = conf.Organization().Read()
+	}
+
+	// No config? Comes from default org in the list
+	if defaultOrg == "" {
+		defIndex := slices.IndexFunc(orgs, func(org codersdk.Organization) bool {
+			return org.IsDefault
+		})
+		if defIndex >= 0 {
+			defaultOrg = orgs[defIndex].Name
+		}
+	}
+
+	// Defer to first org
+	if defaultOrg == "" && len(orgs) > 0 {
+		defaultOrg = orgs[0].Name
+	}
+
+	// Ensure the `defaultOrg` value is an org name, not a uuid.
+	// If it is a uuid, change it to the org name.
+	index := slices.IndexFunc(orgs, func(org codersdk.Organization) bool {
+		return org.ID.String() == defaultOrg || org.Name == defaultOrg
+	})
+	if index >= 0 {
+		defaultOrg = orgs[index].Name
+	}
+
+	const deselectOption = "--Deselect--"
+	if defaultOrg == "" {
+		defaultOrg = deselectOption
+	}
+
+	// Pull value from a prompt
+	_, _ = fmt.Fprintln(inv.Stdout, pretty.Sprint(cliui.DefaultStyles.Wrap, "Select an organization below to switch the current cli context to:"))
+	value, err := cliui.Select(inv, cliui.SelectOptions{
+		Options:    append([]string{deselectOption}, orgNames(orgs)...),
+		Default:    defaultOrg,
+		Size:       10,
+		HideSearch: false,
+	})
+	if err != nil {
+		return "", err
+	}
+	// Deselect is an alias for ""
+	if value == deselectOption {
+		value = ""
+	}
+
+	return value, nil
+}
+
+// orgNames is a helper function to turn a list of organizations into a list of
+// their names as strings.
+func orgNames(orgs []codersdk.Organization) []string {
+	names := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		names = append(names, org.Name)
+	}
+	return names
 }
 
 func (r *RootCmd) currentOrganization() *clibase.Cmd {

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -66,21 +66,21 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 				return strings.Compare(a.Name, b.Name)
 			})
 
-			var orgArg string
+			var switchToOrg string
 			if len(inv.Args) == 0 {
-				// Pull orgArg from a prompt selector, rather than command line
+				// Pull switchToOrg from a prompt selector, rather than command line
 				// args.
-				orgArg, err = promptUserSelectOrg(inv, conf, orgs)
+				switchToOrg, err = promptUserSelectOrg(inv, conf, orgs)
 				if err != nil {
 					return err
 				}
 			} else {
-				orgArg = inv.Args[0]
+				switchToOrg = inv.Args[0]
 			}
 
 			// If the user passes an empty string, we want to remove the organization
 			// from the config file. This will defer to default behavior.
-			if orgArg == "" {
+			if switchToOrg == "" {
 				err := conf.Organization().Delete()
 				if err != nil && !errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf("failed to unset organization: %w", err)
@@ -89,13 +89,13 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 			} else {
 				// Find the selected org in our list.
 				index := slices.IndexFunc(orgs, func(org codersdk.Organization) bool {
-					return org.Name == orgArg || org.ID.String() == orgArg
+					return org.Name == switchToOrg || org.ID.String() == switchToOrg
 				})
 				if index < 0 {
 					// Using this error for better error message formatting
 					err := &codersdk.Error{
 						Response: codersdk.Response{
-							Message: fmt.Sprintf("Organization %q not found. Is the name correct, and are you a member of it?", orgArg),
+							Message: fmt.Sprintf("Organization %q not found. Is the name correct, and are you a member of it?", switchToOrg),
 							Detail:  "Ensure the organization argument is correct and you are a member of it.",
 						},
 						Helper: fmt.Sprintf("Valid organizations you can switch to: %q", strings.Join(orgNames(orgs), ", ")),

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -38,16 +38,16 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 	client := new(codersdk.Client)
 
 	cmd := &clibase.Cmd{
-		Use:   "switch <organization name | ID>",
-		Short: "Switch the organization used by the cli. Pass an empty string to reset to the default organization.",
-		Long: "Switch the organization used by the cli. Pass an empty string to reset to the default organization.\n" + formatExamples(
+		Use:   "set <organization name | ID>",
+		Short: "set the organization used by the CLI. Pass an empty string to reset to the default organization.",
+		Long: "set the organization used by the CLI. Pass an empty string to reset to the default organization.\n" + formatExamples(
 			example{
 				Description: "Remove the current organization and defer to the default.",
-				Command:     "coder organizations switch ''",
+				Command:     "coder organizations set ''",
 			},
 			example{
 				Description: "Switch to a custom organization.",
-				Command:     "coder organizations switch my-org",
+				Command:     "coder organizations set my-org",
 			},
 		),
 		Middleware: clibase.Chain(
@@ -118,7 +118,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 				var sdkError *codersdk.Error
 				if errors.As(err, &sdkError) {
 					if sdkError.Helper == "" && sdkError.StatusCode() != 500 {
-						sdkError.Helper = `If this error persists, try unsetting your org with 'coder organizations switch ""'`
+						sdkError.Helper = `If this error persists, try unsetting your org with 'coder organizations set ""'`
 					}
 					return sdkError
 				}
@@ -167,13 +167,15 @@ func promptUserSelectOrg(inv *clibase.Invocation, conf config.Root, orgs []coder
 		defaultOrg = orgs[index].Name
 	}
 
-	const deselectOption = "--Deselect--"
+	// deselectOption is the option to delete the organization config file and defer
+	// to default behavior.
+	const deselectOption = "[Default]"
 	if defaultOrg == "" {
 		defaultOrg = deselectOption
 	}
 
 	// Pull value from a prompt
-	_, _ = fmt.Fprintln(inv.Stdout, pretty.Sprint(cliui.DefaultStyles.Wrap, "Select an organization below to switch the current cli context to:"))
+	_, _ = fmt.Fprintln(inv.Stdout, pretty.Sprint(cliui.DefaultStyles.Wrap, "Select an organization below to set the current CLI context to:"))
 	value, err := cliui.Select(inv, cliui.SelectOptions{
 		Options:    append([]string{deselectOption}, orgNames(orgs)...),
 		Default:    defaultOrg,

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -35,9 +35,7 @@ func (r *RootCmd) organizations() *clibase.Cmd {
 }
 
 func (r *RootCmd) switchOrganization() *clibase.Cmd {
-	var (
-		client = new(codersdk.Client)
-	)
+	client := new(codersdk.Client)
 
 	cmd := &clibase.Cmd{
 		Use:   "switch <organization name | ID>",

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -120,7 +120,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 				var sdkError *codersdk.Error
 				if errors.As(err, &sdkError) {
 					if sdkError.Helper == "" && sdkError.StatusCode() != 500 {
-						sdkError.Helper = fmt.Sprintf("If this error persists, try unsetting your org with 'coder organizations switch \"\"'")
+						sdkError.Helper = `If this error persists, try unsetting your org with 'coder organizations switch ""'`
 					}
 					return sdkError
 				}

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -66,7 +66,7 @@ func TestOrganizationSwitch(t *testing.T) {
 		exp, err := client.OrganizationByName(ctx, codersdk.Me, "foo")
 		require.NoError(t, err)
 
-		inv, root := clitest.New(t, "organizations", "switch", "foo")
+		inv, root := clitest.New(t, "organizations", "set", "foo")
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
 		errC := make(chan error)

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -63,7 +63,7 @@ func TestOrganizationSwitch(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		exp, err := client.OrganizationByName(ctx, codersdk.Me, "foo")
+		exp, err := client.OrganizationByName(ctx, "foo")
 		require.NoError(t, err)
 
 		inv, root := clitest.New(t, "organizations", "set", "foo")

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -43,3 +43,37 @@ func TestCurrentOrganization(t *testing.T) {
 		pty.ExpectMatch(first.OrganizationID.String())
 	})
 }
+
+func TestOrganizationSwitch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Switch", func(t *testing.T) {
+		t.Parallel()
+		ownerClient := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, ownerClient)
+		// Owner is required to make orgs
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, first.OrganizationID, rbac.RoleOwner())
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		orgs := []string{"foo", "bar"}
+		for _, orgName := range orgs {
+			_, err := client.CreateOrganization(ctx, codersdk.CreateOrganizationRequest{
+				Name: orgName,
+			})
+			require.NoError(t, err)
+		}
+
+		exp, err := client.OrganizationByName(ctx, codersdk.Me, "foo")
+		require.NoError(t, err)
+
+		inv, root := clitest.New(t, "organizations", "switch", "foo")
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t).Attach(inv)
+		errC := make(chan error)
+		go func() {
+			errC <- inv.Run()
+		}()
+		require.NoError(t, <-errC)
+		pty.ExpectMatch(exp.ID.String())
+	})
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -733,7 +733,7 @@ func CurrentOrganization(r *RootCmd, inv *clibase.Invocation, client *codersdk.C
 		return org.IsDefault
 	})
 	if index < 0 {
-		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder organizations switch <org>' to select an organization to use")
+		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder set <org>' to select an organization to use")
 	}
 
 	return orgs[index], nil

--- a/cli/root.go
+++ b/cli/root.go
@@ -1192,8 +1192,12 @@ func formatRunCommandError(err *clibase.RunCommandError, opts *formatOpts) strin
 func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) string {
 	var str strings.Builder
 	if opts.Verbose {
-		_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("API request error to \"%s:%s\". Status code %d", err.Method(), err.URL(), err.StatusCode())))
-		_, _ = str.WriteString("\n")
+		// If all these fields are empty, then do not print this information.
+		// This can occur if the error is being used outside the api.
+		if !(err.Method() == "" && err.URL() == "" && err.StatusCode() == 0) {
+			_, _ = str.WriteString(pretty.Sprint(headLineStyle(), fmt.Sprintf("API request error to \"%s:%s\". Status code %d", err.Method(), err.URL(), err.StatusCode())))
+			_, _ = str.WriteString("\n")
+		}
 	}
 	// Always include this trace. Users can ignore this.
 	if from != "" {


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/11927:

Adds a `coder org set` to switch the org context.

## `coder org set`

```
$ coder org set "steven-org"
Current organization context set to steven-org (9616b384-38bb-4284-861b-8db4fc337d6d)

$ coder org set not-real-org
Encountered an error running "coder organizations switch"
Organization "not-real-org" not found. Is the name correct, and are you a member of it?
Valid organizations you can switch to: "admin, steven-org, other-org"

$ coder org switch
Type to search

    --Deselect--
    admin
    bia-org
  > steven-org

```