### PR TITLE
fix: stop waiting for Agent in a goroutine in ssh test

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -455,12 +455,9 @@ func TestSSH(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		tGo(t, func() {
-			// When the agent connects, the workspace was started, and we should
-			// have access to the shell.
-			_ = agenttest.New(t, client.URL, authToken)
-			coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
-		})
+		// When the agent connects, the workspace was started, and we should
+		// have access to the shell.
+		_ = agenttest.New(t, client.URL, authToken)
 
 		conn, channels, requests, err := ssh.NewClientConn(&stdioConn{
 			Reader: proxyCommandStdoutR,


### PR DESCRIPTION
Fixes race seen here: https://github.com/coder/coder/runs/21852483781

What happens is that the agent connects, completes the test, and then disconnects before the Eventually condition runs.  The waiter then times out because it's looking for a connected agent.

Then, since it's a `require` in a goroutine, that causes the `tGo` cleanup to hang and the whole test suite to timeout after 10 minutes.

Anyway, `agenttest.New` doesn't block, and we don't actually need to wait for the agent to connect, since a successful SSH session is evidence that it connected.