### PR TITLE
feat: support markdown in update messages

### DIFF
--- a/site/src/modules/templates/TemplateUpdateMessage.tsx
+++ b/site/src/modules/templates/TemplateUpdateMessage.tsx
@@ -1,0 +1,44 @@
+import { type Interpolation, type Theme } from "@emotion/react";
+import { type FC } from "react";
+import { MemoizedMarkdown } from "components/Markdown/Markdown";
+
+interface TemplateUpdateMessageProps {
+  children: string;
+}
+
+export const TemplateUpdateMessage: FC<TemplateUpdateMessageProps> = ({
+  children,
+}) => {
+  return (
+    <MemoizedMarkdown css={styles.versionMessage}>{children}</MemoizedMarkdown>
+  );
+};
+
+const styles = {
+  versionMessage: {
+    fontSize: 14,
+    lineHeight: 1.2,
+
+    "& h1, & h2, & h3, & h4, & h5, & h6": {
+      margin: "0 0 0.75em",
+    },
+    "& h1": {
+      fontSize: "1.2em",
+    },
+    "& h2": {
+      fontSize: "1.15em",
+    },
+    "& h3": {
+      fontSize: "1.1em",
+    },
+    "& h4": {
+      fontSize: "1.05em",
+    },
+    "& h5": {
+      fontSize: "1em",
+    },
+    "& h6": {
+      fontSize: "0.95em",
+    },
+  },
+} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.stories.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.stories.tsx
@@ -2,6 +2,7 @@ import {
   mockApiError,
   MockTemplate,
   MockTemplateVersion,
+  MockTemplateVersionWithMarkdownMessage,
 } from "testHelpers/entities";
 import {
   TemplateVersionPageView,
@@ -47,18 +48,7 @@ export const Default: Story = {};
 
 export const LongVersionMessage: Story = {
   args: {
-    currentVersion: {
-      ...MockTemplateVersion,
-      message: `
-# Abiding Grace
-## Enchantment
-At the beginning of your end step, choose one —
-
-- You gain 1 life.
-
-- Return target creature card with mana value 1 from your graveyard to the battlefield.
-`,
-    },
+    currentVersion: MockTemplateVersionWithMarkdownMessage,
   },
 };
 

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.stories.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.stories.tsx
@@ -45,6 +45,23 @@ type Story = StoryObj<typeof TemplateVersionPageView>;
 
 export const Default: Story = {};
 
+export const LongVersionMessage: Story = {
+  args: {
+    currentVersion: {
+      ...MockTemplateVersion,
+      message: `
+# Abiding Grace
+## Enchantment
+At the beginning of your end step, choose one —
+
+- You gain 1 life.
+
+- Return target creature card with mana value 1 from your graveyard to the battlefield.
+`,
+    },
+  },
+};
+
 export const Error: Story = {
   args: {
     ...defaultArgs,

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
@@ -9,7 +9,6 @@ import { Margins } from "components/Margins/Margins";
 import {
   PageHeader,
   PageHeaderCaption,
-  PageHeaderSubtitle,
   PageHeaderTitle,
 } from "components/PageHeader/PageHeader";
 import { Stack } from "components/Stack/Stack";

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
@@ -1,7 +1,6 @@
 import Button from "@mui/material/Button";
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
-import { type Interpolation, type Theme } from "@emotion/react";
 import { type FC } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { Loader } from "components/Loader/Loader";
@@ -18,7 +17,7 @@ import type { TemplateVersion } from "api/typesGenerated";
 import { createDayString } from "utils/createDayString";
 import { TemplateVersionFiles } from "utils/templateVersion";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
-import { MemoizedMarkdown } from "components/Markdown/Markdown";
+import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
 
 export interface TemplateVersionPageViewProps {
   versionName: string;
@@ -73,9 +72,9 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
       <Stack spacing={4}>
         {Boolean(error) && <ErrorAlert error={error} />}
         {currentVersion?.message && (
-          <MemoizedMarkdown css={styles.versionMessage}>
+          <TemplateUpdateMessage>
             {currentVersion.message}
-          </MemoizedMarkdown>
+          </TemplateUpdateMessage>
         )}
         {currentVersion && currentFiles && (
           <>
@@ -110,34 +109,5 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
     </Margins>
   );
 };
-
-const styles = {
-  versionMessage: {
-    fontSize: "0.9em",
-    lineHeight: 1.2,
-
-    "& h1, & h2, & h3, & h4, & h5, & h6": {
-      margin: "0 0 0.75em",
-    },
-    "& h1": {
-      fontSize: "1.2em",
-    },
-    "& h2": {
-      fontSize: "1.15em",
-    },
-    "& h3": {
-      fontSize: "1.1em",
-    },
-    "& h4": {
-      fontSize: "1.05em",
-    },
-    "& h5": {
-      fontSize: "1em",
-    },
-    "& h6": {
-      fontSize: "0.95em",
-    },
-  },
-} satisfies Record<string, Interpolation<Theme>>;
 
 export default TemplateVersionPageView;

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPageView.tsx
@@ -1,6 +1,7 @@
 import Button from "@mui/material/Button";
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
+import { type Interpolation, type Theme } from "@emotion/react";
 import { type FC } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { Loader } from "components/Loader/Loader";
@@ -18,6 +19,7 @@ import type { TemplateVersion } from "api/typesGenerated";
 import { createDayString } from "utils/createDayString";
 import { TemplateVersionFiles } from "utils/templateVersion";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { MemoizedMarkdown } from "components/Markdown/Markdown";
 
 export interface TemplateVersionPageViewProps {
   versionName: string;
@@ -65,17 +67,17 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
       >
         <PageHeaderCaption>Version</PageHeaderCaption>
         <PageHeaderTitle>{versionName}</PageHeaderTitle>
-        {currentVersion &&
-          currentVersion.message &&
-          currentVersion.message !== "" && (
-            <PageHeaderSubtitle>{currentVersion.message}</PageHeaderSubtitle>
-          )}
       </PageHeader>
 
       {!currentFiles && !error && <Loader />}
 
       <Stack spacing={4}>
         {Boolean(error) && <ErrorAlert error={error} />}
+        {currentVersion?.message && (
+          <MemoizedMarkdown css={styles.versionMessage}>
+            {currentVersion.message}
+          </MemoizedMarkdown>
+        )}
         {currentVersion && currentFiles && (
           <>
             <Stats>
@@ -109,5 +111,34 @@ export const TemplateVersionPageView: FC<TemplateVersionPageViewProps> = ({
     </Margins>
   );
 };
+
+const styles = {
+  versionMessage: {
+    fontSize: "0.9em",
+    lineHeight: 1.2,
+
+    "& h1, & h2, & h3, & h4, & h5, & h6": {
+      margin: "0 0 0.75em",
+    },
+    "& h1": {
+      fontSize: "1.2em",
+    },
+    "& h2": {
+      fontSize: "1.15em",
+    },
+    "& h3": {
+      fontSize: "1.1em",
+    },
+    "& h4": {
+      fontSize: "1.05em",
+    },
+    "& h5": {
+      fontSize: "1em",
+    },
+    "& h6": {
+      fontSize: "0.95em",
+    },
+  },
+} satisfies Record<string, Interpolation<Theme>>;
 
 export default TemplateVersionPageView;

--- a/site/src/pages/WorkspacePage/ChangeVersionDialog.stories.tsx
+++ b/site/src/pages/WorkspacePage/ChangeVersionDialog.stories.tsx
@@ -1,0 +1,49 @@
+import {
+  MockTemplate,
+  MockTemplateVersion,
+  MockTemplateVersionWithMarkdownMessage,
+} from "testHelpers/entities";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ChangeVersionDialog } from "./ChangeVersionDialog";
+
+const noMessage = {
+  ...MockTemplateVersion,
+  message: "",
+};
+
+const meta: Meta<typeof ChangeVersionDialog> = {
+  title: "pages/WorkspacePage/ChangeVersionDialog",
+  component: ChangeVersionDialog,
+  args: {
+    open: true,
+    template: MockTemplate,
+    templateVersions: [
+      MockTemplateVersion,
+      MockTemplateVersionWithMarkdownMessage,
+      noMessage,
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChangeVersionDialog>;
+
+export const NoVersionSelected: Story = {};
+
+export const NoMessage: Story = {
+  args: {
+    defaultTemplateVersion: noMessage,
+  },
+};
+
+export const ShortMessage: Story = {
+  args: {
+    defaultTemplateVersion: MockTemplateVersion,
+  },
+};
+
+export const LongMessage: Story = {
+  args: {
+    defaultTemplateVersion: MockTemplateVersionWithMarkdownMessage,
+  },
+};

--- a/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
+++ b/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
@@ -6,7 +6,7 @@ import AlertTitle from "@mui/material/AlertTitle";
 import InfoIcon from "@mui/icons-material/InfoOutlined";
 import { css } from "@emotion/css";
 import type { Template, TemplateVersion } from "api/typesGenerated";
-import { Alert, AlertDetail } from "components/Alert/Alert";
+import { Alert } from "components/Alert/Alert";
 import type { DialogProps } from "components/Dialogs/Dialog";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { FormFields } from "components/Form/Form";

--- a/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
+++ b/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
@@ -10,13 +10,13 @@ import { Alert, AlertDetail } from "components/Alert/Alert";
 import type { DialogProps } from "components/Dialogs/Dialog";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { FormFields } from "components/Form/Form";
-import { MemoizedMarkdown } from "components/Markdown/Markdown";
 import { Stack } from "components/Stack/Stack";
 import { Loader } from "components/Loader/Loader";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { Pill } from "components/Pill/Pill";
 import { Avatar } from "components/Avatar/Avatar";
 import { createDayString } from "utils/createDayString";
+import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
 
 export type ChangeVersionDialogProps = DialogProps & {
   template: Template | undefined;
@@ -35,7 +35,9 @@ export const ChangeVersionDialog: FC<ChangeVersionDialogProps> = ({
   ...dialogProps
 }) => {
   const [isAutocompleteOpen, setIsAutocompleteOpen] = useState(false);
-  const selectedTemplateVersion = useRef<TemplateVersion | undefined>();
+  const selectedTemplateVersion = useRef<TemplateVersion | undefined>(
+    defaultTemplateVersion,
+  );
   const version = selectedTemplateVersion.current;
   const validTemplateVersions = templateVersions?.filter((version) => {
     return version.job.status === "succeeded";
@@ -139,16 +141,18 @@ export const ChangeVersionDialog: FC<ChangeVersionDialogProps> = ({
                 />
               </FormFields>
               {version && (
-                <Alert severity="info">
-                  <AlertTitle>
-                    Published by {version.created_by.username}
-                  </AlertTitle>
+                <>
                   {version.message && (
-                    <AlertDetail>
-                      <MemoizedMarkdown>{version.message}</MemoizedMarkdown>
-                    </AlertDetail>
+                    <TemplateUpdateMessage>
+                      {version.message}
+                    </TemplateUpdateMessage>
                   )}
-                </Alert>
+                  <Alert severity="info">
+                    <AlertTitle>
+                      Published by {version.created_by.username}
+                    </AlertTitle>
+                  </Alert>
+                </>
               )}
             </>
           ) : (

--- a/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
+++ b/site/src/pages/WorkspacePage/ChangeVersionDialog.tsx
@@ -10,6 +10,7 @@ import { Alert, AlertDetail } from "components/Alert/Alert";
 import type { DialogProps } from "components/Dialogs/Dialog";
 import { ConfirmDialog } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { FormFields } from "components/Form/Form";
+import { MemoizedMarkdown } from "components/Markdown/Markdown";
 import { Stack } from "components/Stack/Stack";
 import { Loader } from "components/Loader/Loader";
 import { AvatarData } from "components/AvatarData/AvatarData";
@@ -143,7 +144,9 @@ export const ChangeVersionDialog: FC<ChangeVersionDialogProps> = ({
                     Published by {version.created_by.username}
                   </AlertTitle>
                   {version.message && (
-                    <AlertDetail>{version.message}</AlertDetail>
+                    <AlertDetail>
+                      <MemoizedMarkdown>{version.message}</MemoizedMarkdown>
+                    </AlertDetail>
                   )}
                 </Alert>
               )}

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/Notifications.tsx
@@ -22,21 +22,22 @@ type NotificationsProps = {
   items: NotificationItem[];
   severity: ThemeRole;
   icon: ReactNode;
-  isDefaultOpen?: boolean;
 };
 
 export const Notifications: FC<NotificationsProps> = ({
   items,
   severity,
   icon,
-  isDefaultOpen,
 }) => {
   const theme = useTheme();
 
   return (
-    <Popover mode="hover" isDefaultOpen={isDefaultOpen}>
+    <Popover mode="hover">
       <PopoverTrigger>
-        <div css={styles.pillContainer}>
+        <div
+          css={styles.pillContainer}
+          data-testid={`${severity}-notifications`}
+        >
           <NotificationPill items={items} severity={severity} icon={icon} />
         </div>
       </PopoverTrigger>

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
@@ -71,7 +71,11 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
       notifications.push({
         title: "An update is available for your workspace",
         severity: "info",
-        detail: latestVersion.message,
+        detail: (
+          <MemoizedInlineMarkdown allowedElements={["ol", "ul", "li"]}>
+            {latestVersion.message}
+          </MemoizedInlineMarkdown>
+        ),
         actions,
       });
     }

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
@@ -15,6 +15,7 @@ import {
   NotificationItem,
   Notifications,
 } from "./Notifications";
+import { TemplateUpdateMessage } from "modules/templates/TemplateUpdateMessage";
 
 type WorkspaceNotificationsProps = {
   workspace: Workspace;
@@ -69,9 +70,7 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
         title: "An update is available for your workspace",
         severity: "info",
         detail: (
-          <MemoizedInlineMarkdown allowedElements={["ol", "ul", "li"]}>
-            {latestVersion.message}
-          </MemoizedInlineMarkdown>
+          <TemplateUpdateMessage>{latestVersion.message}</TemplateUpdateMessage>
         ),
         actions,
       });

--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.tsx
@@ -24,8 +24,6 @@ type WorkspaceNotificationsProps = {
   onUpdateWorkspace: () => void;
   onActivateWorkspace: () => void;
   latestVersion?: TemplateVersion;
-  // Used for storybook
-  defaultOpen?: "info" | "warning";
 };
 
 export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
@@ -33,7 +31,6 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
   template,
   latestVersion,
   permissions,
-  defaultOpen,
   onRestartWorkspace,
   onUpdateWorkspace,
   onActivateWorkspace,
@@ -227,7 +224,6 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
     <div css={styles.notificationsGroup}>
       {infoNotifications.length > 0 && (
         <Notifications
-          isDefaultOpen={defaultOpen === "info"}
           items={infoNotifications}
           severity="info"
           icon={<InfoOutlined />}
@@ -236,7 +232,6 @@ export const WorkspaceNotifications: FC<WorkspaceNotificationsProps> = ({
 
       {warningNotifications.length > 0 && (
         <Notifications
-          isDefaultOpen={defaultOpen === "warning"}
           items={warningNotifications}
           severity="warning"
           icon={<WarningRounded />}

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -23,7 +23,7 @@ import {
   toggleFavorite,
   cancelBuild,
 } from "api/queries/workspaces";
-import { Alert } from "components/Alert/Alert";
+import { MemoizedInlineMarkdown } from "components/Markdown/Markdown";
 import { Stack } from "components/Stack/Stack";
 import {
   ConfirmDialog,
@@ -324,7 +324,9 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
               <strong>delete non-persistent data</strong>.
             </p>
             {latestVersion?.message && (
-              <Alert severity="info">{latestVersion.message}</Alert>
+              <MemoizedInlineMarkdown allowedElements={["ol", "ul", "li"]}>
+                {latestVersion.message}
+              </MemoizedInlineMarkdown>
             )}
           </Stack>
         }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -434,6 +434,20 @@ You can add instructions here
   archived: false,
 };
 
+export const MockTemplateVersionWithMarkdownMessage: TypesGen.TemplateVersion =
+  {
+    ...MockTemplateVersion,
+    message: `
+# Abiding Grace
+## Enchantment
+At the beginning of your end step, choose one —
+
+- You gain 1 life.
+
+- Return target creature card with mana value 1 from your graveyard to the battlefield.
+`,
+  };
+
 export const MockTemplate: TypesGen.Template = {
   id: "test-template",
   created_at: "2022-05-17T17:39:01.382927298Z",


### PR DESCRIPTION
Closes #12049

Adds the `TemplateUpdateMessage` component, that wraps our existing `Markdown` component with some specific styles suited well for this use case