### PR TITLE
feat: implement global flag for org selection

### DIFF
--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -42,4 +42,35 @@ func TestCurrentOrganization(t *testing.T) {
 		require.NoError(t, <-errC)
 		pty.ExpectMatch(first.OrganizationID.String())
 	})
+
+	t.Run("UsingFlag", func(t *testing.T) {
+		t.Parallel()
+		ownerClient := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, ownerClient)
+		// Owner is required to make orgs
+		client, _ := coderdtest.CreateAnotherUser(t, ownerClient, first.OrganizationID, rbac.RoleOwner())
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		orgs := map[string]codersdk.Organization{
+			"foo": {},
+			"bar": {},
+		}
+		for orgName := range orgs {
+			org, err := client.CreateOrganization(ctx, codersdk.CreateOrganizationRequest{
+				Name: orgName,
+			})
+			require.NoError(t, err)
+			orgs[orgName] = org
+		}
+
+		inv, root := clitest.New(t, "organizations", "current", "--only-id", "-z=bar")
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t).Attach(inv)
+		errC := make(chan error)
+		go func() {
+			errC <- inv.Run()
+		}()
+		require.NoError(t, <-errC)
+		pty.ExpectMatch(orgs["bar"].ID.String())
+	})
 }

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -63,7 +63,7 @@ func TestCurrentOrganization(t *testing.T) {
 			orgs[orgName] = org
 		}
 
-		inv, root := clitest.New(t, "organizations", "current", "--only-id", "-z=bar")
+		inv, root := clitest.New(t, "organizations", "show", "current", "--only-id", "-z=bar")
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
 		errC := make(chan error)

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -83,8 +83,8 @@ variables or flags.
           Suppress warning when client and server versions do not match.
 
   -z, --organization string, $CODER_ORGANIZATION
-          Select which organization (uuid or name) to use as default. This
-          overrides what is present in the config file.
+          Select which organization (uuid or name) to use This overrides what is
+          present in the config file.
 
       --token string, $CODER_SESSION_TOKEN
           Specify an authentication token. For security reasons setting

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -82,6 +82,10 @@ variables or flags.
       --no-version-warning bool, $CODER_NO_VERSION_WARNING
           Suppress warning when client and server versions do not match.
 
+  -z, --organization string, $CODER_ORGANIZATION
+          Select which organization (uuid or name) to use as default. This
+          overrides what is present in the config file.
+
       --token string, $CODER_SESSION_TOKEN
           Specify an authentication token. For security reasons setting
           CODER_SESSION_TOKEN is preferred.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,6 +130,16 @@ Suppress warnings about unlicensed features.
 
 Suppress warning when client and server versions do not match.
 
+### -z, --organization
+
+|             |                                  |
+| ----------- | -------------------------------- |
+| Type        | <code>string</code>              |
+| Environment | <code>$CODER_ORGANIZATION</code> |
+
+Select which organization (uuid or name) to use as default. This overrides what
+is present in the config file.
+
 ### --token
 
 |             |                                   |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,8 +137,8 @@ Suppress warning when client and server versions do not match.
 | Type        | <code>string</code>              |
 | Environment | <code>$CODER_ORGANIZATION</code> |
 
-Select which organization (uuid or name) to use as default. This overrides what
-is present in the config file.
+Select which organization (uuid or name) to use This overrides what is present
+in the config file.
 
 ### --token
 

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -49,8 +49,8 @@ variables or flags.
           Suppress warning when client and server versions do not match.
 
   -z, --organization string, $CODER_ORGANIZATION
-          Select which organization (uuid or name) to use as default. This
-          overrides what is present in the config file.
+          Select which organization (uuid or name) to use This overrides what is
+          present in the config file.
 
       --token string, $CODER_SESSION_TOKEN
           Specify an authentication token. For security reasons setting

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -48,6 +48,10 @@ variables or flags.
       --no-version-warning bool, $CODER_NO_VERSION_WARNING
           Suppress warning when client and server versions do not match.
 
+  -z, --organization string, $CODER_ORGANIZATION
+          Select which organization (uuid or name) to use as default. This
+          overrides what is present in the config file.
+
       --token string, $CODER_SESSION_TOKEN
           Specify an authentication token. For security reasons setting
           CODER_SESSION_TOKEN is preferred.


### PR DESCRIPTION
# What this does

Adds a flag `-z <org_name | org_id>` that selects a given org. Works on all commands. This allows overriding whatever is in the config setting.

I used `-z` rather than `-o` because `-o` is used for `--output`.

```
$ coder organizations current
Current organization: steven-org (9616b384-38bb-4284-861b-8db4fc337d6d)

coder organizations current -z admin
Current organization: admin (653e414b-9eb7-41cb-b11c-38cf90b29db3)
```