### PR TITLE
chore: enforce orgid in audit logs where required

### DIFF
--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -315,7 +315,7 @@ func BackgroundAudit[T Auditable](ctx context.Context, p *BackgroundAuditParams[
 
 	if ResourceRequiresOrgID[T]() && p.OrganizationID == uuid.Nil {
 		// We panic as this is a developer error and should never happen.
-		panic(fmt.Sprintf("missing required organization ID for resource %s", either(p.Old, p.New, ResourceType[T], p.Action))
+		panic(fmt.Sprintf("missing required organization ID for resource %s", either(p.Old, p.New, ResourceType[T], p.Action)))
 	}
 
 	auditLog := database.AuditLog{

--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -281,11 +281,6 @@ func InitRequest[T Auditable](w http.ResponseWriter, p *RequestParams) (*Request
 			action = req.Action
 		}
 
-		if ResourceRequiresOrgID[T]() && p.OrganizationID == uuid.Nil {
-			// We panic as this is a developer error and should never happen.
-			panic(fmt.Sprintf("missing required organization ID for resource %s", either(req.Old, req.New, ResourceType[T], req.params.Action)))
-		}
-
 		ip := parseIP(p.Request.RemoteAddr)
 		auditLog := database.AuditLog{
 			ID:               uuid.New(),

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -57,10 +57,11 @@ func (api *API) deleteTemplate(rw http.ResponseWriter, r *http.Request) {
 		template          = httpmw.TemplateParam(r)
 		auditor           = *api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Template](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionDelete,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionDelete,
+			OrganizationID: template.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -123,16 +124,18 @@ func (api *API) postTemplateByOrganization(rw http.ResponseWriter, r *http.Reque
 		apiKey                             = httpmw.APIKey(r)
 		auditor                            = *api.Auditor.Load()
 		templateAudit, commitTemplateAudit = audit.InitRequest[database.Template](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionCreate,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionCreate,
+			OrganizationID: organization.ID,
 		})
 		templateVersionAudit, commitTemplateVersionAudit = audit.InitRequest[database.TemplateVersion](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: organization.ID,
 		})
 	)
 	defer commitTemplateAudit()
@@ -542,10 +545,11 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 		auditor           = *api.Auditor.Load()
 		portSharer        = *api.PortSharer.Load()
 		aReq, commitAudit = audit.InitRequest[database.Template](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: template.OrganizationID,
 		})
 	)
 	defer commitAudit()

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -1040,10 +1040,11 @@ func (api *API) postArchiveTemplateVersions(rw http.ResponseWriter, r *http.Requ
 		template          = httpmw.TemplateParam(r)
 		auditor           = *api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Template](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: template.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -1122,10 +1123,11 @@ func (api *API) setArchiveTemplateVersion(archive bool) func(rw http.ResponseWri
 			templateVersion   = httpmw.TemplateVersionParam(r)
 			auditor           = *api.Auditor.Load()
 			aReq, commitAudit = audit.InitRequest[database.TemplateVersion](rw, &audit.RequestParams{
-				Audit:   auditor,
-				Log:     api.Logger,
-				Request: r,
-				Action:  database.AuditActionWrite,
+				Audit:          auditor,
+				Log:            api.Logger,
+				Request:        r,
+				Action:         database.AuditActionWrite,
+				OrganizationID: templateVersion.OrganizationID,
 			})
 		)
 		defer commitAudit()
@@ -1207,10 +1209,11 @@ func (api *API) patchActiveTemplateVersion(rw http.ResponseWriter, r *http.Reque
 		template          = httpmw.TemplateParam(r)
 		auditor           = *api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Template](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: template.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -1310,10 +1313,11 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 		organization      = httpmw.OrganizationParam(r)
 		auditor           = *api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.TemplateVersion](rw, &audit.RequestParams{
-			Audit:   auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionCreate,
+			Audit:          auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionCreate,
+			OrganizationID: organization.ID,
 		})
 
 		req codersdk.CreateTemplateVersionRequest

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -345,6 +345,7 @@ func (api *API) postWorkspacesByOrganization(rw http.ResponseWriter, r *http.Req
 		Request:          r,
 		Action:           database.AuditActionCreate,
 		AdditionalFields: wriBytes,
+		OrganizationID:   organization.ID,
 	})
 
 	defer commitAudit()
@@ -644,10 +645,11 @@ func (api *API) patchWorkspace(rw http.ResponseWriter, r *http.Request) {
 		workspace         = httpmw.WorkspaceParam(r)
 		auditor           = api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: workspace.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -734,10 +736,11 @@ func (api *API) putWorkspaceAutostart(rw http.ResponseWriter, r *http.Request) {
 		workspace         = httpmw.WorkspaceParam(r)
 		auditor           = api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: workspace.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -808,10 +811,11 @@ func (api *API) putWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 		workspace         = httpmw.WorkspaceParam(r)
 		auditor           = api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: workspace.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -896,10 +900,11 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 		oldWorkspace      = workspace
 		auditor           = api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: workspace.OrganizationID,
 		})
 	)
 	aReq.Old = oldWorkspace
@@ -1094,10 +1099,11 @@ func (api *API) putFavoriteWorkspace(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	aReq, commitAudit := audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-		Audit:   *auditor,
-		Log:     api.Logger,
-		Request: r,
-		Action:  database.AuditActionWrite,
+		Audit:          *auditor,
+		Log:            api.Logger,
+		Request:        r,
+		Action:         database.AuditActionWrite,
+		OrganizationID: workspace.OrganizationID,
 	})
 	defer commitAudit()
 	aReq.Old = workspace
@@ -1140,10 +1146,11 @@ func (api *API) deleteFavoriteWorkspace(rw http.ResponseWriter, r *http.Request)
 	}
 
 	aReq, commitAudit := audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-		Audit:   *auditor,
-		Log:     api.Logger,
-		Request: r,
-		Action:  database.AuditActionWrite,
+		Audit:          *auditor,
+		Log:            api.Logger,
+		Request:        r,
+		Action:         database.AuditActionWrite,
+		OrganizationID: workspace.OrganizationID,
 	})
 
 	defer commitAudit()
@@ -1178,10 +1185,11 @@ func (api *API) putWorkspaceAutoupdates(rw http.ResponseWriter, r *http.Request)
 		workspace         = httpmw.WorkspaceParam(r)
 		auditor           = api.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Workspace](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: workspace.OrganizationID,
 		})
 	)
 	defer commitAudit()

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -34,10 +34,11 @@ func (api *API) postGroupByOrganization(rw http.ResponseWriter, r *http.Request)
 		org               = httpmw.OrganizationParam(r)
 		auditor           = api.AGPL.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.AuditableGroup](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionCreate,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionCreate,
+			OrganizationID: org.ID,
 		})
 	)
 	defer commitAudit()
@@ -97,10 +98,11 @@ func (api *API) patchGroup(rw http.ResponseWriter, r *http.Request) {
 		group             = httpmw.GroupParam(r)
 		auditor           = api.AGPL.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.AuditableGroup](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: group.OrganizationID,
 		})
 	)
 	defer commitAudit()
@@ -299,10 +301,11 @@ func (api *API) deleteGroup(rw http.ResponseWriter, r *http.Request) {
 		group             = httpmw.GroupParam(r)
 		auditor           = api.AGPL.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.AuditableGroup](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionDelete,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionDelete,
+			OrganizationID: group.OrganizationID,
 		})
 	)
 	defer commitAudit()

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -161,10 +161,11 @@ func (api *API) patchTemplateACL(rw http.ResponseWriter, r *http.Request) {
 		template          = httpmw.TemplateParam(r)
 		auditor           = api.AGPL.Auditor.Load()
 		aReq, commitAudit = audit.InitRequest[database.Template](rw, &audit.RequestParams{
-			Audit:   *auditor,
-			Log:     api.Logger,
-			Request: r,
-			Action:  database.AuditActionWrite,
+			Audit:          *auditor,
+			Log:            api.Logger,
+			Request:        r,
+			Action:         database.AuditActionWrite,
+			OrganizationID: template.OrganizationID,
 		})
 	)
 	defer commitAudit()


### PR DESCRIPTION
# What this does

Populates and requires the `organizationID` field to audit logs where it can be set.

Some resources are not scoped to an org. This is ok imo, but from a UI perspective, we might have org vs site audit log views in the future.

Closes https://github.com/coder/coder/issues/11930