### PR TITLE
fix: refresh entitlements after creating first user

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -188,6 +188,9 @@ type Options struct {
 
 	// NewTicker is used for unit tests to replace "time.NewTicker".
 	NewTicker func(duration time.Duration) (tick <-chan time.Time, done func())
+
+	// RefreshEntitlements is used to set correct entitlements after creating first user and generating trial license.
+	RefreshEntitlements func(ctx context.Context) error
 }
 
 // @title Coder API

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -125,6 +125,8 @@ type Options struct {
 	ExternalAuthConfigs            []*externalauth.Config
 	RealIPConfig                   *httpmw.RealIPConfig
 	TrialGenerator                 func(ctx context.Context, body codersdk.LicensorTrialRequest) error
+	// RefreshEntitlements is used to set correct entitlements after creating first user and generating trial license.
+	RefreshEntitlements func(ctx context.Context) error
 	// TLSCertificates is used to mesh DERP servers securely.
 	TLSCertificates    []tls.Certificate
 	TailnetCoordinator tailnet.Coordinator
@@ -188,9 +190,6 @@ type Options struct {
 
 	// NewTicker is used for unit tests to replace "time.NewTicker".
 	NewTicker func(duration time.Duration) (tick <-chan time.Time, done func())
-
-	// RefreshEntitlements is used to set correct entitlements after creating first user and generating trial license.
-	RefreshEntitlements func(ctx context.Context) error
 }
 
 // @title Coder API

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -108,6 +108,7 @@ type Options struct {
 	TLSCertificates       []tls.Certificate
 	ExternalAuthConfigs   []*externalauth.Config
 	TrialGenerator        func(ctx context.Context, body codersdk.LicensorTrialRequest) error
+	RefreshEntitlements   func(ctx context.Context) error
 	TemplateScheduleStore schedule.TemplateScheduleStore
 	Coordinator           tailnet.Coordinator
 
@@ -435,6 +436,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			AccessControlStore:                 accessControlStore,
 			TLSCertificates:                    options.TLSCertificates,
 			TrialGenerator:                     options.TrialGenerator,
+			RefreshEntitlements:                options.RefreshEntitlements,
 			TailnetCoordinator:                 options.Coordinator,
 			BaseDERPMap:                        derpMap,
 			DERPMapUpdateFrequency:             150 * time.Millisecond,

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -191,6 +191,18 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Refresh entitlements independently of trial generator as admin may not want to generate license,
+	// and actual "user_limit" entitlement should be equal to 1 (first user only).
+	if api.RefreshEntitlements != nil {
+		err = api.RefreshEntitlements(ctx)
+		if err != nil {
+			api.Logger.Error(ctx, "failed to refresh entitlements after generating trial license")
+			return
+		}
+	} else {
+		api.Logger.Debug(ctx, "entitlements will not be refreshed")
+	}
+
 	telemetryUser := telemetry.ConvertUser(user)
 	// Send the initial users email address!
 	telemetryUser.Email = &user.Email

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -191,8 +191,6 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Refresh entitlements independently of trial generator as admin may not want to generate license,
-	// and actual "user_limit" entitlement should be equal to 1 (first user only).
 	if api.RefreshEntitlements != nil {
 		err = api.RefreshEntitlements(ctx)
 		if err != nil {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -100,8 +100,9 @@ func TestFirstUser(t *testing.T) {
 		}
 		_, err := client.CreateFirstUser(ctx, req)
 		require.NoError(t, err)
-		<-trialGenerated
-		<-entitlementsRefreshed
+
+		_ = testutil.RequireRecvCtx(ctx, t, trialGenerated)
+		_ = testutil.RequireRecvCtx(ctx, t, entitlementsRefreshed)
 	})
 }
 

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -75,10 +75,16 @@ func TestFirstUser(t *testing.T) {
 
 	t.Run("Trial", func(t *testing.T) {
 		t.Parallel()
-		called := make(chan struct{})
+		trialGenerated := make(chan struct{})
+		entitlementsRefreshed := make(chan struct{})
+
 		client := coderdtest.New(t, &coderdtest.Options{
 			TrialGenerator: func(context.Context, codersdk.LicensorTrialRequest) error {
-				close(called)
+				close(trialGenerated)
+				return nil
+			},
+			RefreshEntitlements: func(context.Context) error {
+				close(entitlementsRefreshed)
 				return nil
 			},
 		})
@@ -94,7 +100,8 @@ func TestFirstUser(t *testing.T) {
 		}
 		_, err := client.CreateFirstUser(ctx, req)
 		require.NoError(t, err)
-		<-called
+		<-trialGenerated
+		<-entitlementsRefreshed
 	})
 }
 

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -203,6 +203,9 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			})
 		})
 	})
+	api.AGPL.RefreshEntitlements = func(ctx context.Context) error {
+		return api.refreshEntitlements(ctx)
+	}
 
 	api.AGPL.APIHandler.Group(func(r chi.Router) {
 		r.Get("/entitlements", api.serveEntitlements)

--- a/enterprise/coderd/licenses.go
+++ b/enterprise/coderd/licenses.go
@@ -200,7 +200,7 @@ func (api *API) postRefreshEntitlements(rw http.ResponseWriter, r *http.Request)
 	err = api.refreshEntitlements(ctx)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Failed to update entitlements",
+			Message: "Failed to refresh entitlements",
 			Detail:  err.Error(),
 		})
 		return

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -1,6 +1,7 @@
 package coderd_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -217,4 +218,22 @@ func TestUserQuietHours(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
 		require.Contains(t, sdkErr.Message, "cannot set custom quiet hours schedule")
 	})
+}
+
+func TestCreateFirstUser_Entitlements_Trial(t *testing.T) {
+	t.Parallel()
+
+	adminClient, _ := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Trial: true,
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+	defer cancel()
+
+	//nolint:gocritic // we need the first user so admin
+	entitlements, err := adminClient.Entitlements(ctx)
+	require.NoError(t, err)
+	require.True(t, entitlements.Trial, "Trial license should be immediately active.")
 }


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/6080

This PR extends `postFirstUser` API operation to refresh entitlements after generating the trial license and creating the first user. Without this change, entitlements are refreshed after 10 minutes interval.

How to test:

1. Start coder:
```
rm -rf ./.coderv2 # need a fresh database
./scripts/develop.sh # the script will create the first user and generate the trial license
```

2. See entitlements: http://localhost:3000/api/v2/entitlements . Trial should be active. 