### PR TITLE
chore: drop github per user rate limit tracking

### DIFF
--- a/coderd/promoauth/github.go
+++ b/coderd/promoauth/github.go
@@ -16,9 +16,21 @@ type rateLimits struct {
 	Resource  string
 }
 
-// githubRateLimits checks the returned response headers and
+// githubRateLimits returns rate limit information from a GitHub response.
+// GitHub rate limits are on a per-user basis, and tracking each user as
+// a prometheus label might be too much. So only track rate limits for
+// unauthorized responses.
+//
+// Unauthorized responses have a much stricter rate limit of 60 per hour.
+// Tracking this is vital to ensure we do not hit the limit.
 func githubRateLimits(resp *http.Response, err error) (rateLimits, bool) {
 	if err != nil || resp == nil {
+		return rateLimits{}, false
+	}
+
+	// Only track 401 responses which indicates we are using the 60 per hour
+	// rate limit.
+	if resp.StatusCode != http.StatusUnauthorized {
 		return rateLimits{}, false
 	}
 
@@ -29,7 +41,7 @@ func githubRateLimits(resp *http.Response, err error) (rateLimits, bool) {
 		Limit:     p.int("x-ratelimit-limit"),
 		Remaining: p.int("x-ratelimit-remaining"),
 		Used:      p.int("x-ratelimit-used"),
-		Resource:  p.string("x-ratelimit-resource"),
+		Resource:  p.string("x-ratelimit-resource")+"-unauthorized"",
 	}
 
 	if limits.Limit == 0 &&
@@ -49,18 +61,6 @@ func githubRateLimits(resp *http.Response, err error) (rateLimits, bool) {
 		resetAt = time.Time{}
 	}
 	limits.Reset = resetAt
-
-	// Unauthorized requests have their own rate limit, so we should
-	// track them separately.
-	if resp.StatusCode == http.StatusUnauthorized {
-		limits.Resource += "-unauthorized"
-	}
-
-	// A 401 or 429 means too many requests. This might mess up the
-	// "resource" string because we could hit the unauthorized limit,
-	// and we do not want that to override the authorized one.
-	// However, in testing, it seems a 401 is always a 401, even if
-	// the limit is hit.
 
 	if len(p.errors) > 0 {
 		// If we are missing any headers, then do not try and guess

--- a/coderd/promoauth/github.go
+++ b/coderd/promoauth/github.go
@@ -41,7 +41,7 @@ func githubRateLimits(resp *http.Response, err error) (rateLimits, bool) {
 		Limit:     p.int("x-ratelimit-limit"),
 		Remaining: p.int("x-ratelimit-remaining"),
 		Used:      p.int("x-ratelimit-used"),
-		Resource:  p.string("x-ratelimit-resource")+"-unauthorized"",
+		Resource:  p.string("x-ratelimit-resource") + "-unauthorized",
 	}
 
 	if limits.Limit == 0 &&

--- a/scripts/metricsdocgen/metrics
+++ b/scripts/metricsdocgen/metrics
@@ -12,8 +12,8 @@ coderd_oauth2_external_requests_rate_limit_reset_in_seconds{name="primary-github
 coderd_oauth2_external_requests_rate_limit_reset_in_seconds{name="secondary-github",resource="core"} 121.82186601
 # HELP coderd_oauth2_external_requests_rate_limit_total The total number of allowed requests per interval.
 # TYPE coderd_oauth2_external_requests_rate_limit_total gauge
-coderd_oauth2_external_requests_rate_limit_total{name="primary-github",resource="core"} 5000
-coderd_oauth2_external_requests_rate_limit_total{name="secondary-github",resource="core"} 5000
+coderd_oauth2_external_requests_rate_limit_total{name="primary-github",resource="core-unauthorized"} 5000
+coderd_oauth2_external_requests_rate_limit_total{name="secondary-github",resource="core-unauthorized"} 5000
 # HELP coderd_oauth2_external_requests_rate_limit_used The number of requests made in this interval.
 # TYPE coderd_oauth2_external_requests_rate_limit_used gauge
 coderd_oauth2_external_requests_rate_limit_used{name="primary-github",resource="core"} 148


### PR DESCRIPTION
Rate limits for authenticated requests are per user. This would be an excessive number of prometheus labels, so we only track the unauthorized limit.

The rate limit labels without a user label make no sense.

Closes: https://github.com/coder/coder/issues/10853

# Unauthenticated Rate Limit

We used to hit the unauthenticated rate limit as our ValidateToken always required an external auth request. With https://github.com/coder/coder/pull/11830, we no longer waste an external auth request if we know the token is invalid.

Additionally, if we have an invalid token (say it was revoked), https://github.com/coder/coder/pull/11598  prevents us from constantly making an external auth request with the same invalid token in the "listen" loop. So when requiring a re authentication, we only trigger 1 request.

There is still improvement to be made, as an invalid token can trigger multiple requests if the user hits the same endpoint multiple times. The caching of "invalid" is only in the scope of 1 request atm. We could either persist the cached "invalid" to the db, or delete the link when we get a 401 back?