### PR TITLE
feat: implement create org commands from cli

### DIFF
--- a/cli/organization.go
+++ b/cli/organization.go
@@ -27,6 +27,7 @@ func (r *RootCmd) organizations() *clibase.Cmd {
 		Children: []*clibase.Cmd{
 			r.currentOrganization(),
 			r.switchOrganization(),
+			r.createOrganization(),
 		},
 	}
 

--- a/cli/organizationmanage.go
+++ b/cli/organizationmanage.go
@@ -37,7 +37,6 @@ func (r *RootCmd) createOrganization() *clibase.Cmd {
 				return fmt.Errorf("organization %q already exists", orgName)
 			}
 
-			// Confirm deletion of the template.
 			_, err := cliui.Prompt(inv, cliui.PromptOptions{
 				Text: fmt.Sprintf("Are you sure you want to create an organization with the name %s?\n%s",
 					pretty.Sprint(cliui.DefaultStyles.Code, orgName),

--- a/cli/organizationmanage.go
+++ b/cli/organizationmanage.go
@@ -17,6 +17,8 @@ func (r *RootCmd) createOrganization() *clibase.Cmd {
 	cmd := &clibase.Cmd{
 		Use:   "create <organization name>",
 		Short: "Create a new organization.",
+		// This action is currently irreversible, so it's hidden until we have a way to delete organizations.
+		Hidden: true,
 		Middleware: clibase.Chain(
 			r.InitClient(client),
 			clibase.RequireNArgs(1),
@@ -37,7 +39,10 @@ func (r *RootCmd) createOrganization() *clibase.Cmd {
 
 			// Confirm deletion of the template.
 			_, err := cliui.Prompt(inv, cliui.PromptOptions{
-				Text:      fmt.Sprintf("Are you sure you want to create an organization with the name %q?", pretty.Sprint(cliui.DefaultStyles.Code, orgName)),
+				Text: fmt.Sprintf("Are you sure you want to create an organization with the name %s?\n%s",
+					pretty.Sprint(cliui.DefaultStyles.Code, orgName),
+					pretty.Sprint(cliui.BoldFmt(), "This action is irreversible."),
+				),
 				IsConfirm: true,
 				Default:   cliui.ConfirmNo,
 			})
@@ -49,7 +54,7 @@ func (r *RootCmd) createOrganization() *clibase.Cmd {
 				Name: orgName,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to create organization: %w")
+				return fmt.Errorf("failed to create organization: %w", err)
 			}
 
 			_, _ = fmt.Fprintf(inv.Stdout, "Organization %s (%s) created.\n", organization.Name, organization.ID)

--- a/cli/organizationmanage.go
+++ b/cli/organizationmanage.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/cli/clibase"
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/pretty"
+)
+
+func (r *RootCmd) createOrganization() *clibase.Cmd {
+	client := new(codersdk.Client)
+
+	cmd := &clibase.Cmd{
+		Use:   "create <organization name>",
+		Short: "Create a new organization.",
+		Middleware: clibase.Chain(
+			r.InitClient(client),
+			clibase.RequireNArgs(1),
+		),
+		Options: clibase.OptionSet{
+			cliui.SkipPromptOption(),
+		},
+		Handler: func(inv *clibase.Invocation) error {
+			orgName := inv.Args[0]
+
+			// This check is not perfect since not all users can read all organizations.
+			// So ignore the error and if the org already exists, prevent the user
+			// from creating it.
+			existing, _ := client.OrganizationByName(inv.Context(), orgName)
+			if existing.ID != uuid.Nil {
+				return fmt.Errorf("organization %q already exists", orgName)
+			}
+
+			// Confirm deletion of the template.
+			_, err := cliui.Prompt(inv, cliui.PromptOptions{
+				Text:      fmt.Sprintf("Are you sure you want to create an organization with the name %q?", pretty.Sprint(cliui.DefaultStyles.Code, orgName)),
+				IsConfirm: true,
+				Default:   cliui.ConfirmNo,
+			})
+			if err != nil {
+				return err
+			}
+
+			organization, err := client.CreateOrganization(inv.Context(), codersdk.CreateOrganizationRequest{
+				Name: orgName,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create organization: %w")
+			}
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Organization %s (%s) created.\n", organization.Name, organization.ID)
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
Adding a command to add organizations because the only other way currently is with a curl command. When developing multi-org stuff, it is a little annoying to have to do.

The command is hidden and should not be made visible while the action is irreversible. Organizations cannot be deleted at the moment.

![Screenshot from 2024-02-26 12-36-53](https://github.com/coder/coder/assets/5446298/3b78bd28-4bbd-4db3-b706-a2edb79459d0)
