### PR TITLE
chore: clean out site/out/assets/ when building to prevent "too much data" errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,8 @@ $(foreach chart,$(charts),build/$(chart)_helm_$(VERSION).tgz): build/%_helm_$(VE
 
 site/out/index.html: site/package.json $(shell find ./site $(FIND_EXCLUSIONS) -type f \( -name '*.ts' -o -name '*.tsx' \))
 	cd site
+	# prevents this directory from getting to big, and causing "too much data" errors
+	rm -rf out/assets/
 	../scripts/pnpm_install.sh
 	pnpm build
 


### PR DESCRIPTION
..by just emptying it out when doing a build. The generated file names have hashes in them, so once every couple months you'll usually end up with a builds failing until you `make clean`. We can prevent it altogether tho (and save a lot of disk usage) by just routinely deleting all of it.