### PR TITLE
feat: show tailnet peer diagnostics after coder ping

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -135,6 +135,8 @@ func (r *RootCmd) ping() *clibase.Cmd {
 				)
 
 				if n == int(pingNum) {
+					diags := conn.GetPeerDiagnostics()
+					cliui.PeerDiagnostics(inv.Stdout, diags)
 					return nil
 				}
 			}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -563,7 +563,7 @@ func getWorkspaceAndAgent(ctx context.Context, inv *clibase.Invocation, client *
 
 	if workspace.LatestBuild.Transition != codersdk.WorkspaceTransitionStart {
 		if !autostart {
-			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.New("workspace must be in start transition to ssh")
+			return codersdk.Workspace{}, codersdk.WorkspaceAgent{}, xerrors.New("workspace must be started")
 		}
 		// Autostart the workspace for the user.
 		// For some failure modes, return a better message.
@@ -579,7 +579,7 @@ func getWorkspaceAndAgent(ctx context.Context, inv *clibase.Invocation, client *
 		// It cannot be in any pending or failed state.
 		if workspace.LatestBuild.Status != codersdk.WorkspaceStatusStopped {
 			return codersdk.Workspace{}, codersdk.WorkspaceAgent{},
-				xerrors.Errorf("workspace must be in start transition to ssh, was unable to autostart as the last build job is %q, expected %q",
+				xerrors.Errorf("workspace must be started; was unable to autostart as the last build job is %q, expected %q",
 					workspace.LatestBuild.Status,
 					codersdk.WorkspaceStatusStopped,
 				)

--- a/codersdk/workspaceagentconn.go
+++ b/codersdk/workspaceagentconn.go
@@ -414,3 +414,7 @@ func (c *WorkspaceAgentConn) apiClient() *http.Client {
 		},
 	}
 }
+
+func (c *WorkspaceAgentConn) GetPeerDiagnostics() tailnet.PeerDiagnostics {
+	return c.Conn.GetPeerDiagnostics(c.opts.AgentID)
+}

--- a/tailnet/configmaps.go
+++ b/tailnet/configmaps.go
@@ -521,6 +521,27 @@ func (c *configMaps) nodeAddresses(publicKey key.NodePublic) ([]netip.Prefix, bo
 	return nil, false
 }
 
+func (c *configMaps) fillPeerDiagnostics(d *PeerDiagnostics, peerID uuid.UUID) {
+	status := c.status()
+	c.L.Lock()
+	defer c.L.Unlock()
+	if c.derpMap != nil {
+		for j, r := range c.derpMap.Regions {
+			d.DERPRegionNames[j] = r.RegionName
+		}
+	}
+	lc, ok := c.peers[peerID]
+	if !ok {
+		return
+	}
+	d.ReceivedNode = lc.node
+	ps, ok := status.Peer[lc.node.Key]
+	if !ok {
+		return
+	}
+	d.LastWireguardHandshake = ps.LastHandshake
+}
+
 type peerLifecycle struct {
 	peerID        uuid.UUID
 	node          *tailcfg.Node

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -645,6 +645,30 @@ func (c *Conn) MagicsockServeHTTPDebug(w http.ResponseWriter, r *http.Request) {
 	c.magicConn.ServeHTTPDebug(w, r)
 }
 
+// PeerDiagnostics is a checklist of human-readable conditions necessary to establish an encrypted
+// tunnel to a peer via a Conn
+type PeerDiagnostics struct {
+	// PreferredDERP is 0 if we are not connected to a DERP region. If non-zero, we are connected to
+	// the given region as our home or "preferred" DERP.
+	PreferredDERP   int
+	DERPRegionNames map[int]string
+	// SentNode is true if we have successfully transmitted our local Node via the most recently set
+	// NodeCallback.
+	SentNode bool
+	// ReceivedNode is the last Node we received for the peer, or nil if we haven't received the node.
+	ReceivedNode *tailcfg.Node
+	// LastWireguardHandshake is the last time we completed a wireguard handshake
+	LastWireguardHandshake time.Time
+	// TODO: surface Discovery (disco) protocol problems
+}
+
+func (c *Conn) GetPeerDiagnostics(peerID uuid.UUID) PeerDiagnostics {
+	d := PeerDiagnostics{DERPRegionNames: make(map[int]string)}
+	c.nodeUpdater.fillPeerDiagnostics(&d)
+	c.configMaps.fillPeerDiagnostics(&d, peerID)
+	return d
+}
+
 type listenKey struct {
 	network string
 	host    string


### PR DESCRIPTION
Beginnings of a solution to #12297 

Doesn't cover disco or definitively display whether we successfully connected to DERP, but shows some checklist diagnostics for connecting to an agent.

For this first PR, I just added it to `coder ping` to see how we like it, but could be incorporated into `coder ssh` _et al._ after a timeout.

```
$ coder ping dogfood2
p2p connection established in 147ms
pong from dogfood2 p2p via  95.217.xxx.yyy:42631  in 147ms
pong from dogfood2 p2p via  95.217.xxx.yyy:42631  in 140ms
pong from dogfood2 p2p via  95.217.xxx.yyy:42631  in 140ms
✔ preferred DERP region 999 (Council Bluffs, Iowa)
✔ sent local data to Coder networking coodinator
✔ received remote agent data from Coder networking coordinator
    preferred DERP 10013 (Europe Fly.io (Paris))
    endpoints: 95.217.xxx.yyy:42631, 95.217.xxx.yyy:37576, 172.17.0.1:37576, 172.20.0.10:37576
✔ Wireguard handshake 11s ago
```