### PR TITLE
fix(coderd): mark provisioner daemon psk as secret

### DIFF
--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -383,9 +383,6 @@ provisioning:
   # Time to force cancel provisioning tasks that are stuck.
   # (default: 10m0s, type: duration)
   forceCancelInterval: 10m0s
-  # Pre-shared key to authenticate external provisioner daemons to Coder server.
-  # (default: <unset>, type: string)
-  daemonPSK: ""
 # Enable one or more experiments. These are not ready for production. Separate
 # multiple experiments with commas, or enter '*' to opt-in to all available
 # experiments.

--- a/coderd/deployment_test.go
+++ b/coderd/deployment_test.go
@@ -27,6 +27,7 @@ func TestDeploymentValues(t *testing.T) {
 	cfg.PostgresURL.Set(hi)
 	cfg.SCIMAPIKey.Set(hi)
 	cfg.ExternalTokenEncryptionKeys.Set("the_random_key_we_never_expected,an_other_key_we_never_unexpected")
+	cfg.Provisioner.DaemonPSK = "provisionersftw"
 
 	client := coderdtest.New(t, &coderdtest.Options{
 		DeploymentValues: cfg,
@@ -46,6 +47,7 @@ func TestDeploymentValues(t *testing.T) {
 	require.Empty(t, scrubbed.Values.PostgresURL.Value())
 	require.Empty(t, scrubbed.Values.SCIMAPIKey.Value())
 	require.Empty(t, scrubbed.Values.ExternalTokenEncryptionKeys.Value())
+	require.Empty(t, scrubbed.Values.Provisioner.DaemonPSK.Value())
 }
 
 func TestDeploymentStats(t *testing.T) {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1408,7 +1408,7 @@ when required by your organization's security policy.`,
 			Env:         "CODER_PROVISIONER_DAEMON_PSK",
 			Value:       &c.Provisioner.DaemonPSK,
 			Group:       &deploymentGroupProvisioning,
-			YAML:        "daemonPSK",
+			Annotations: clibase.Annotations{}.Mark(annotationSecretKey, "true"),
 		},
 		// RateLimit settings
 		{

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -71,6 +71,9 @@ func TestDeploymentValues_HighlyConfigurable(t *testing.T) {
 			flag: true,
 			env:  true,
 		},
+		"Provisioner Daemon Pre-shared Key (PSK)": {
+			yaml: true,
+		},
 	}
 
 	set := (&codersdk.DeploymentValues{}).Options()

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -779,7 +779,6 @@ Serve prometheus metrics on the address defined by prometheus address.
 | ----------- | ------------------------------------------ |
 | Type        | <code>string</code>                        |
 | Environment | <code>$CODER_PROVISIONER_DAEMON_PSK</code> |
-| YAML        | <code>provisioning.daemonPSK</code>        |
 
 Pre-shared key to authenticate external provisioner daemons to Coder server.
 


### PR DESCRIPTION
Marks provisioner daemon PSK with the secret annotation. This ensures it will be scrubbed from API requests to `/api/v2/deployment/config`.