### PR TITLE
test(agent/agentscripts): fix test flake in `TestEnv`

### DIFF
--- a/agent/agentscripts/agentscripts_test.go
+++ b/agent/agentscripts/agentscripts_test.go
@@ -69,12 +69,18 @@ func TestEnv(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 
-	testutil.Go(t, func() {
+	done := testutil.Go(t, func() {
 		err := runner.Execute(ctx, func(script codersdk.WorkspaceAgentScript) bool {
 			return true
 		})
 		assert.NoError(t, err)
 	})
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case <-done:
+		}
+	}()
 
 	var log []agentsdk.Log
 	for {


### PR DESCRIPTION
This should hopefully fix the following flake: https://github.com/coder/coder/actions/runs/8066720038/job/22035474376

It looks like the test output was correct, but we errored on asserting no error on `Execute`. Thus it looks like our test-routine exited too quickly and called `runner.Close()` before `Execute` had completed.
