### PR TITLE
chore: revert "ci: bump the github-actions group with 1 update (#12303)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -511,7 +511,7 @@ jobs:
       # the check to pass. This is desired in PRs, but not in mainline.
       - name: Publish to Chromatic (non-mainline)
         if: github.ref != 'refs/heads/main' && github.repository_owner == 'coder'
-        uses: chromaui/action@v11
+        uses: chromaui/action@v10
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
           STORYBOOK: true
@@ -542,7 +542,7 @@ jobs:
       # infinitely "in progress" in mainline unless we re-review each build.
       - name: Publish to Chromatic (mainline)
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'coder'
-        uses: chromaui/action@v11
+        uses: chromaui/action@v10
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
           STORYBOOK: true


### PR DESCRIPTION
This reverts commit 5757321ba223a8afa9b774735270ca8d0f94732e.

This new action version includes some breaking changes, and needs some configuration/testing before we update.