### PR TITLE
chore(docs): fix quiet hours docs heading

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -116,7 +116,7 @@ Autostop requirement is disabled when the template is using the deprecated max
 lifetime feature. Templates can choose to use a max lifetime or an autostop
 requirement during the deprecation period, but only one can be used at a time.
 
-#### User quiet hours (enterprise)
+### User quiet hours (enterprise)
 
 User quiet hours can be configured in the user's schedule settings page.
 Workspaces on templates with an autostop requirement will only be forcibly


### PR DESCRIPTION
Quiet hours docs heading was not rendering correctly with the enterprise badge. 

<img width="407" alt="Screenshot 2024-02-27 at 4 51 52 PM" src="https://github.com/coder/coder/assets/58410745/28a4ff7b-07b7-40c3-89a7-a55b4be5615e">
