### PR TITLE
fix: avoid race between replicas on start

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1874,6 +1874,7 @@ func (s *MethodTestSuite) TestSystemFunctions() {
 		check.Args(u.ID).Asserts(rbac.ResourceSystem, rbac.ActionRead)
 	}))
 	s.Run("GetDERPMeshKey", s.Subtest(func(db database.Store, check *expects) {
+		db.InsertDERPMeshKey(context.Background(), "testing")
 		check.Args().Asserts(rbac.ResourceSystem, rbac.ActionRead)
 	}))
 	s.Run("InsertDERPMeshKey", s.Subtest(func(db database.Store, check *expects) {

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1761,6 +1761,9 @@ func (q *FakeQuerier) GetDERPMeshKey(_ context.Context) (string, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
+	if q.derpMeshKey == "" {
+		return "", sql.ErrNoRows
+	}
 	return q.derpMeshKey, nil
 }
 

--- a/coderd/database/lock.go
+++ b/coderd/database/lock.go
@@ -9,6 +9,7 @@ const (
 	// Keep the unused iota here so we don't need + 1 every time
 	lockIDUnused = iota
 	LockIDDeploymentSetup
+	LockIDEnterpriseDeploymentSetup
 )
 
 // GenLockID generates a unique and consistent lock ID from a given string.


### PR DESCRIPTION
DERP mesh key setup would do a SELECT and then an INSERT on failure, without a lock. During some testing with multiple replicas, I managed to cause a replica to crash due to them initializing simultaneously.
```
Started HTTP listener at http://0.0.0.0:7080

View the Web UI: http://192.168.208.3:7080
2024-02-28 11:25:00.457 [info]  pubsub: pubsub dialing postgres  network=tcp  address=database:5432  timeout_ms=0
2024-02-28 11:25:00.457 [info]  pubsub: pubsub postgres TCP connection established  network=tcp  address=database:5432  timeout_ms=0  elapsed_ms=0
2024-02-28 11:25:00.462 [info]  pubsub: pubsub connected to postgres
2024-02-28 11:25:00.462 [info]  pubsub: pubsub has started
2024-02-28 11:25:02.307 [info]  pubsub: pubsub is closing
2024-02-28 11:25:02.307 [info]  pubsub: pubsub listen stopped receiving notify
Encountered an error running "coder server"
create coder API: insert mesh key: pq: duplicate key value violates unique constraint "site_configs_key_key"
```