### PR TITLE
fix: enhance readability of license key rows

### DIFF
--- a/site/src/pages/DeploySettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
+++ b/site/src/pages/DeploySettingsPage/LicensesSettingsPage/AddNewLicensePageView.tsx
@@ -98,7 +98,7 @@ export const AddNewLicensePageView: FC<AddNewLicenseProps> = ({
             name="licenseKey"
             placeholder="Enter your license..."
             multiline
-            rows={1}
+            rows={3}
             fullWidth
           />
         </Fieldset>


### PR DESCRIPTION
It was pretty hard to tell when you pasted something in
this box with only displaying a single line.

This should help!