### PR TITLE
chore: add test for enterprise server cli

### DIFF
--- a/enterprise/cli/server_test.go
+++ b/enterprise/cli/server_test.go
@@ -1,0 +1,62 @@
+package cli_test
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/enterprise/cli"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestServer runs the enterprise server command
+// and waits for /healthz to return "OK".
+func TestServer(t *testing.T) {
+	t.Parallel()
+
+	randomPort := func(t *testing.T) int {
+		random, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		_ = random.Close()
+		tcpAddr, valid := random.Addr().(*net.TCPAddr)
+		require.True(t, valid)
+		return tcpAddr.Port
+	}
+
+	var root cli.RootCmd
+	cmd, err := root.Command(root.EnterpriseSubcommands())
+	require.NoError(t, err)
+	port := randomPort(t)
+	inv, _ := clitest.NewWithCommand(t, cmd,
+		"server",
+		"--in-memory",
+		"--http-address", fmt.Sprintf(":%d", port),
+		"--access-url", "http://example.com",
+	)
+	waiter := clitest.StartWithWaiter(t, inv)
+	require.Eventually(t, func() bool {
+		reqCtx := testutil.Context(t, testutil.IntervalMedium)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("http://localhost:%d/healthz", port), nil)
+		if err != nil {
+			panic(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Log("/healthz not ready yet")
+			return false
+		}
+		defer resp.Body.Close()
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			panic(err)
+		}
+		return assert.Equal(t, "OK", string(bs))
+	}, testutil.WaitShort, testutil.IntervalMedium)
+	waiter.Cancel()
+}

--- a/enterprise/cli/server_test.go
+++ b/enterprise/cli/server_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"testing"
 
@@ -19,15 +18,6 @@ import (
 // and waits for /healthz to return "OK".
 func TestServer(t *testing.T) {
 	t.Parallel()
-
-	randomPort := func(t *testing.T) int {
-		random, err := net.Listen("tcp", "127.0.0.1:0")
-		require.NoError(t, err)
-		_ = random.Close()
-		tcpAddr, valid := random.Addr().(*net.TCPAddr)
-		require.True(t, valid)
-		return tcpAddr.Port
-	}
 
 	var root cli.RootCmd
 	cmd, err := root.Command(root.EnterpriseSubcommands())


### PR DESCRIPTION
To validate that this exercises the code path, add a panic into `enterprise/cli/server.go` and run the test:

```
=== RUN   TestServer
=== PAUSE TestServer
=== CONT  TestServer
    clitest.go:75: invoking command: coder --global-config /tmp/TestServer19218759/001 server --in-memory --http-address :40317 --access-url http://example.com
    t.go:99: 2024-02-28 17:00:39.503 [info]  cli: stdout: Started HTTP listener at http://[::]:40317
    t.go:99: 2024-02-28 17:00:39.503 [info]  cli: stdout: View the Web UI: http://example.com
    t.go:99: 2024-02-28 17:00:39.503 [warn]  cli: telemetry disabled, unable to notify of security issues. Read more: https://coder.com/docs/v2/latest/admin/telemetry
    t.go:99: 2024-02-28 17:00:39.504 [info]  cli: stderr: 2024-02-28 17:00:39.503 [warn]  cli: telemetry disabled, unable to notify of security issues. Read more: https://coder.com/docs/v2/latest/admin/telemetry
panic: got here [recovered]
        panic: panic recovered for coder server: got here
FAIL    github.com/coder/coder/v2/enterprise/cli        0.098s
FAIL
```