### PR TITLE
ci: use linter version from Dockerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,8 @@ jobs:
 
       - name: Get golangci-lint cache dir
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
+          linter_ver=$(egrep -o 'GOLANGCI_LINT_VERSION=\S+' dogfood/Dockerfile | cut -d '=' -f 2)
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v$linter_ver
           dir=$(golangci-lint cache status | awk '/Dir/ { print $2 }')
           echo "LINT_CACHE_DIR=$dir" >> $GITHUB_ENV
 


### PR DESCRIPTION
Ensures we run the same golangci-lint version as in Dockerfile instead of hard-coding