### PR TITLE
chore: consolidate various randomPort() implementations

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -837,7 +837,7 @@ func TestAgent_TCPRemoteForwarding(t *testing.T) {
 	var ll net.Listener
 	var err error
 	for {
-		randomPort = testutil.RandomPortNoListen()
+		randomPort = testutil.RandomPortNoListen(t)
 		addr := net.TCPAddrFromAddrPort(netip.AddrPortFrom(localhost, randomPort))
 		ll, err = sshClient.ListenTCP(addr)
 		if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -838,7 +837,7 @@ func TestAgent_TCPRemoteForwarding(t *testing.T) {
 	var ll net.Listener
 	var err error
 	for {
-		randomPort = pickRandomPort()
+		randomPort = testutil.RandomPortNoListen()
 		addr := net.TCPAddrFromAddrPort(netip.AddrPortFrom(localhost, randomPort))
 		ll, err = sshClient.ListenTCP(addr)
 		if err != nil {
@@ -2664,20 +2663,6 @@ func (s *syncWriter) Write(p []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.w.Write(p)
-}
-
-// pickRandomPort picks a random port number for the ephemeral range. We do this entirely randomly
-// instead of opening a listener and closing it to find a port that is likely to be free, since
-// sometimes the OS reallocates the port very quickly.
-func pickRandomPort() uint16 {
-	const (
-		// Overlap of windows, linux in https://en.wikipedia.org/wiki/Ephemeral_port
-		min = 49152
-		max = 60999
-	)
-	n := max - min
-	x := rand.Intn(n) //nolint: gosec
-	return uint16(min + x)
 }
 
 // echoOnce accepts a single connection, reads 4 bytes and echos them back

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -937,22 +937,13 @@ func TestServer(t *testing.T) {
 	t.Run("Prometheus", func(t *testing.T) {
 		t.Parallel()
 
-		randomPort := func(t *testing.T) int {
-			random, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err)
-			_ = random.Close()
-			tcpAddr, valid := random.Addr().(*net.TCPAddr)
-			require.True(t, valid)
-			return tcpAddr.Port
-		}
-
 		t.Run("DBMetricsDisabled", func(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 			defer cancel()
 
-			randPort := randomPort(t)
+			randPort := testutil.RandomPort(t)
 			inv, cfg := clitest.New(t,
 				"server",
 				"--in-memory",
@@ -1008,7 +999,7 @@ func TestServer(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 			defer cancel()
 
-			randPort := randomPort(t)
+			randPort := testutil.RandomPort(t)
 			inv, cfg := clitest.New(t,
 				"server",
 				"--in-memory",

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -170,7 +169,7 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 	t.Run("PrometheusEnabled", func(t *testing.T) {
 		t.Parallel()
 
-		prometheusPort := randomPort(t)
+		prometheusPort := testutil.RandomPort(t)
 
 		// Configure CLI client
 		client, admin := coderdenttest.New(t, &coderdenttest.Options{
@@ -241,14 +240,4 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		require.True(t, hasGoStats, "Go stats are missing")
 		require.True(t, hasPromHTTP, "Prometheus HTTP metrics are missing")
 	})
-}
-
-// randomPort is a helper function to find a free random port, for instance to spawn Prometheus endpoint.
-func randomPort(t *testing.T) int {
-	random, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	_ = random.Close()
-	tcpAddr, valid := random.Addr().(*net.TCPAddr)
-	require.True(t, valid)
-	return tcpAddr.Port
 }

--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -63,7 +63,7 @@ func Test_Headers(t *testing.T) {
 func TestWorkspaceProxy_Server_PrometheusEnabled(t *testing.T) {
 	t.Parallel()
 
-	prometheusPort := randomPort(t)
+	prometheusPort := testutil.RandomPort(t)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -96,7 +96,7 @@ func TestWorkspaceProxy_Server_PrometheusEnabled(t *testing.T) {
 		"--primary-access-url", srv.URL,
 		"--proxy-session-token", "test-token",
 		"--access-url", "http://foobar:3001",
-		"--http-address", fmt.Sprintf("127.0.0.1:%d", randomPort(t)),
+		"--http-address", fmt.Sprintf("127.0.0.1:%d", testutil.RandomPort(t)),
 		"--prometheus-enable",
 		"--prometheus-address", fmt.Sprintf("127.0.0.1:%d", prometheusPort),
 	)

--- a/enterprise/cli/server_test.go
+++ b/enterprise/cli/server_test.go
@@ -22,7 +22,7 @@ func TestServer(t *testing.T) {
 	var root cli.RootCmd
 	cmd, err := root.Command(root.EnterpriseSubcommands())
 	require.NoError(t, err)
-	port := randomPort(t)
+	port := testutil.RandomPort(t)
 	inv, _ := clitest.NewWithCommand(t, cmd,
 		"server",
 		"--in-memory",

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// RandomPort is a helper function to find a free random port.
+// Note that the OS may reallocate the port very quickly, so
+// this is not _guaranteed_.
+func RandomPort(t *testing.T) int {
+	random, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to listen on localhost")
+	_ = random.Close()
+	tcpAddr, valid := random.Addr().(*net.TCPAddr)
+	require.True(t, valid, "random port address is not a *net.TCPAddr?!")
+	return tcpAddr.Port
+}
+
+// RandomPortNoListen returns a random port in the ephemeral port range.
+// Does not attempt to listen and close to find a port as the OS may
+// reallocate the port very quickly.
+func RandomPortNoListen() uint16 {
+	const (
+		// Overlap of windows, linux in https://en.wikipedia.org/wiki/Ephemeral_port
+		min = 49152
+		max = 60999
+	)
+	n := max - min
+	x := rand.Intn(n) //nolint: gosec
+	return uint16(min + x)
+}

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -3,9 +3,17 @@ package testutil
 import (
 	"math/rand"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	// nolint:gosec // not used for cryptography
+	rnd   = rand.New(rand.NewSource(time.Now().Unix()))
+	rndMu sync.Mutex
 )
 
 // RandomPort is a helper function to find a free random port.
@@ -23,13 +31,15 @@ func RandomPort(t *testing.T) int {
 // RandomPortNoListen returns a random port in the ephemeral port range.
 // Does not attempt to listen and close to find a port as the OS may
 // reallocate the port very quickly.
-func RandomPortNoListen() uint16 {
+func RandomPortNoListen(*testing.T) uint16 {
 	const (
 		// Overlap of windows, linux in https://en.wikipedia.org/wiki/Ephemeral_port
 		min = 49152
 		max = 60999
 	)
 	n := max - min
-	x := rand.Intn(n) //nolint: gosec
+	rndMu.Lock()
+	x := rnd.Intn(n)
+	rndMu.Unlock()
 	return uint16(min + x)
 }


### PR DESCRIPTION
Consolidates our existing `randomPort()` implementations to `testutil.RandomPort(NoListen)?`.