### PR TITLE
chore(cli): use xerrors.Errorf instead of fmt.Errorf

### DIFF
--- a/cli/organization.go
+++ b/cli/organization.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	"golang.org/x/xerrors"
+
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/config"

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -60,7 +60,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 			conf := r.createConfig()
 			orgs, err := client.OrganizationsByUser(inv.Context(), codersdk.Me)
 			if err != nil {
-				return fmt.Errorf("failed to get organizations: %w", err)
+				return xerrors.Errorf("failed to get organizations: %w", err)
 			}
 			// Keep the list of orgs sorted
 			slices.SortFunc(orgs, func(a, b codersdk.Organization) int {
@@ -84,7 +84,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 			if switchToOrg == "" {
 				err := conf.Organization().Delete()
 				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("failed to unset organization: %w", err)
+					return xerrors.Errorf("failed to unset organization: %w", err)
 				}
 				_, _ = fmt.Fprintf(inv.Stdout, "Organization unset\n")
 			} else {
@@ -107,7 +107,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 				// Always write the uuid to the config file. Names can change.
 				err := conf.Organization().Write(orgs[index].ID.String())
 				if err != nil {
-					return fmt.Errorf("failed to write organization to config file: %w", err)
+					return xerrors.Errorf("failed to write organization to config file: %w", err)
 				}
 			}
 
@@ -123,7 +123,7 @@ func (r *RootCmd) switchOrganization() *clibase.Cmd {
 					}
 					return sdkError
 				}
-				return fmt.Errorf("failed to get current organization: %w", err)
+				return xerrors.Errorf("failed to get current organization: %w", err)
 			}
 
 			_, _ = fmt.Fprintf(inv.Stdout, "Current organization context set to %s (%s)\n", current.Name, current.ID.String())
@@ -213,7 +213,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 				typed, ok := data.([]codersdk.Organization)
 				if !ok {
 					// This should never happen
-					return "", fmt.Errorf("expected []Organization, got %T", data)
+					return "", xerrors.Errorf("expected []Organization, got %T", data)
 				}
 				return stringFormat(typed)
 			}),
@@ -250,7 +250,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 			case "current":
 				stringFormat = func(orgs []codersdk.Organization) (string, error) {
 					if len(orgs) != 1 {
-						return "", fmt.Errorf("expected 1 organization, got %d", len(orgs))
+						return "", xerrors.Errorf("expected 1 organization, got %d", len(orgs))
 					}
 					return fmt.Sprintf("Current CLI Organization: %s (%s)\n", orgs[0].Name, orgs[0].ID.String()), nil
 				}
@@ -275,7 +275,7 @@ func (r *RootCmd) currentOrganization() *clibase.Cmd {
 			default:
 				stringFormat = func(orgs []codersdk.Organization) (string, error) {
 					if len(orgs) != 1 {
-						return "", fmt.Errorf("expected 1 organization, got %d", len(orgs))
+						return "", xerrors.Errorf("expected 1 organization, got %d", len(orgs))
 					}
 					return fmt.Sprintf("Organization: %s (%s)\n", orgs[0].Name, orgs[0].ID.String()), nil
 				}

--- a/cli/organizationmanage.go
+++ b/cli/organizationmanage.go
@@ -34,7 +34,7 @@ func (r *RootCmd) createOrganization() *clibase.Cmd {
 			// from creating it.
 			existing, _ := client.OrganizationByName(inv.Context(), orgName)
 			if existing.ID != uuid.Nil {
-				return fmt.Errorf("organization %q already exists", orgName)
+				return xerrors.Errorf("organization %q already exists", orgName)
 			}
 
 			_, err := cliui.Prompt(inv, cliui.PromptOptions{
@@ -53,7 +53,7 @@ func (r *RootCmd) createOrganization() *clibase.Cmd {
 				Name: orgName,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to create organization: %w", err)
+				return xerrors.Errorf("failed to create organization: %w", err)
 			}
 
 			_, _ = fmt.Fprintf(inv.Stdout, "Organization %s (%s) created.\n", organization.Name, organization.ID)

--- a/cli/organizationmanage.go
+++ b/cli/organizationmanage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/cli/clibase"
 	"github.com/coder/coder/v2/cli/cliui"

--- a/cli/root.go
+++ b/cli/root.go
@@ -715,7 +715,7 @@ func CurrentOrganization(r *RootCmd, inv *clibase.Invocation, client *codersdk.C
 	if selected == "" && conf.Organization().Exists() {
 		org, err := conf.Organization().Read()
 		if err != nil {
-			return codersdk.Organization{}, fmt.Errorf("read selected organization from config file %q: %w", conf.Organization(), err)
+			return codersdk.Organization{}, xerrors.Errorf("read selected organization from config file %q: %w", conf.Organization(), err)
 		}
 		selected = org
 	}


### PR DESCRIPTION
Recently my linter has been auto-fixing this. Figure it's best to put it in its own commit before someone just adds this to their own in anger.