### PR TITLE
fix(site): fix form layout for tablet viewports

### DIFF
--- a/site/src/components/Form/Form.tsx
+++ b/site/src/components/Form/Form.tsx
@@ -144,7 +144,7 @@ const styles = {
     flexDirection: "column",
     gap: 24,
 
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("lg")]: {
       flexDirection: "column",
       gap: 16,
     },


### PR DESCRIPTION
Close #7609 

Before:
![image](https://github.com/coder/coder/assets/3165839/0b7d9aad-ad98-4b09-96a8-1906c8ee3bec)

Now: 
<img width="845" alt="Screenshot 2024-02-29 at 16 10 25" src="https://github.com/coder/coder/assets/3165839/9cc08e13-e39e-41d2-a72e-de2a7a9f7ea7">
