### PR TITLE
chore: make workspace template fields nullable

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -89,8 +89,8 @@ func (r *RootCmd) create() *clibase.Cmd {
 					return xerrors.Errorf("get source workspace: %w", err)
 				}
 
-				_, _ = fmt.Fprintf(inv.Stdout, "Coder will use the same template %q as the source workspace.\n", sourceWorkspace.TemplateName)
-				templateName = sourceWorkspace.TemplateName
+				_, _ = fmt.Fprintf(inv.Stdout, "Coder will use the same template %q as the source workspace.\n", sourceWorkspace.SafeTemplate().Name)
+				templateName = sourceWorkspace.SafeTemplate().Name
 			}
 
 			var template codersdk.Template

--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -68,7 +68,7 @@ func TestCreate(t *testing.T) {
 
 		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-workspace", codersdk.WorkspaceOptions{})
 		if assert.NoError(t, err, "expected workspace to be created") {
-			assert.Equal(t, ws.TemplateName, template.Name)
+			assert.Equal(t, ws.Template.Name, template.Name)
 			if assert.NotNil(t, ws.AutostartSchedule) {
 				assert.Equal(t, *ws.AutostartSchedule, "CRON_TZ=US/Central 30 9 * * Mon-Fri")
 			}
@@ -123,7 +123,7 @@ func TestCreate(t *testing.T) {
 
 		ws, err := client.WorkspaceByOwnerAndName(context.Background(), user.Username, "their-workspace", codersdk.WorkspaceOptions{})
 		if assert.NoError(t, err, "expected workspace to be created") {
-			assert.Equal(t, ws.TemplateName, template.Name)
+			assert.Equal(t, ws.Template.Name, template.Name)
 			if assert.NotNil(t, ws.AutostartSchedule) {
 				assert.Equal(t, *ws.AutostartSchedule, "CRON_TZ=US/Central 30 9 * * Mon-Fri")
 			}
@@ -171,7 +171,7 @@ func TestCreate(t *testing.T) {
 
 		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-workspace", codersdk.WorkspaceOptions{})
 		require.NoError(t, err, "expected workspace to be created")
-		assert.Equal(t, ws.TemplateName, template.Name)
+		assert.Equal(t, ws.Template.Name, template.Name)
 		assert.Equal(t, *ws.TTLMillis, template.DefaultTTLMillis)
 	})
 
@@ -228,7 +228,7 @@ func TestCreate(t *testing.T) {
 
 		ws, err := member.WorkspaceByOwnerAndName(inv.Context(), codersdk.Me, "my-workspace", codersdk.WorkspaceOptions{})
 		if assert.NoError(t, err, "expected workspace to be created") {
-			assert.Equal(t, ws.TemplateName, template.Name)
+			assert.Equal(t, ws.Template.Name, template.Name)
 			assert.Nil(t, ws.AutostartSchedule, "expected workspace autostart schedule to be nil")
 		}
 	})

--- a/cli/list.go
+++ b/cli/list.go
@@ -52,11 +52,12 @@ func workspaceListRowFromWorkspace(now time.Time, workspace codersdk.Workspace) 
 		favIco = "★"
 	}
 	workspaceName := favIco + " " + workspace.OwnerName + "/" + workspace.Name
+
 	return workspaceListRow{
 		Favorite:       workspace.Favorite,
 		Workspace:      workspace,
 		WorkspaceName:  workspaceName,
-		Template:       workspace.TemplateName,
+		Template:       workspace.SafeTemplate().Name,
 		Status:         status,
 		Healthy:        healthy,
 		LastBuilt:      durationDisplay(lastBuilt),

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -200,8 +200,8 @@ func TestSSH(t *testing.T) {
 		// Double-check if workspace's template version is up-to-date
 		workspace, err = client.Workspace(context.Background(), workspace.ID)
 		require.NoError(t, err)
-		assert.Equal(t, version.ID, workspace.TemplateActiveVersionID)
-		assert.Equal(t, workspace.TemplateActiveVersionID, workspace.LatestBuild.TemplateVersionID)
+		assert.Equal(t, version.ID, workspace.Template.ActiveVersionID)
+		assert.Equal(t, workspace.Template.ActiveVersionID, workspace.LatestBuild.TemplateVersionID)
 		assert.False(t, workspace.Outdated)
 	})
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -80,8 +80,8 @@ func (r *RootCmd) start() *clibase.Cmd {
 func buildWorkspaceStartRequest(inv *clibase.Invocation, client *codersdk.Client, workspace codersdk.Workspace, parameterFlags workspaceParameterFlags, action WorkspaceCLIAction) (codersdk.CreateWorkspaceBuildRequest, error) {
 	version := workspace.LatestBuild.TemplateVersionID
 
-	if workspace.AutomaticUpdates == codersdk.AutomaticUpdatesAlways || action == WorkspaceUpdate {
-		version = workspace.TemplateActiveVersionID
+	if (workspace.AutomaticUpdates == codersdk.AutomaticUpdatesAlways || action == WorkspaceUpdate) && workspace.Template != nil {
+		version = workspace.Template.ActiveVersionID
 		if version != workspace.LatestBuild.TemplateVersionID {
 			action = WorkspaceUpdate
 		}

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13036,28 +13036,18 @@ const docTemplate = `{
                 "owner_name": {
                     "type": "string"
                 },
-                "template_active_version_id": {
-                    "type": "string",
-                    "format": "uuid"
-                },
-                "template_allow_user_cancel_workspace_jobs": {
-                    "type": "boolean"
-                },
-                "template_display_name": {
-                    "type": "string"
-                },
-                "template_icon": {
-                    "type": "string"
+                "template": {
+                    "description": "` + "`" + `Template` + "`" + ` can only be returned if the caller has read access to the template.\nIt is possible to have those perms revoked, and the workspace owner can\nno longer see the template fields.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.WorkspaceTemplateInfo"
+                        }
+                    ]
                 },
                 "template_id": {
+                    "description": "TemplateID is the ID of the template that this workspace is based on.",
                     "type": "string",
                     "format": "uuid"
-                },
-                "template_name": {
-                    "type": "string"
-                },
-                "template_require_active_version": {
-                    "type": "boolean"
                 },
                 "ttl_ms": {
                     "type": "integer"
@@ -13939,6 +13929,30 @@ const docTemplate = `{
                 "WorkspaceStatusDeleting",
                 "WorkspaceStatusDeleted"
             ]
+        },
+        "codersdk.WorkspaceTemplateInfo": {
+            "type": "object",
+            "properties": {
+                "active_version_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "allow_user_cancel_workspace_jobs": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "equire_active_version": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
         },
         "codersdk.WorkspaceTransition": {
             "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -11834,28 +11834,18 @@
         "owner_name": {
           "type": "string"
         },
-        "template_active_version_id": {
-          "type": "string",
-          "format": "uuid"
-        },
-        "template_allow_user_cancel_workspace_jobs": {
-          "type": "boolean"
-        },
-        "template_display_name": {
-          "type": "string"
-        },
-        "template_icon": {
-          "type": "string"
+        "template": {
+          "description": "`Template` can only be returned if the caller has read access to the template.\nIt is possible to have those perms revoked, and the workspace owner can\nno longer see the template fields.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/codersdk.WorkspaceTemplateInfo"
+            }
+          ]
         },
         "template_id": {
+          "description": "TemplateID is the ID of the template that this workspace is based on.",
           "type": "string",
           "format": "uuid"
-        },
-        "template_name": {
-          "type": "string"
-        },
-        "template_require_active_version": {
-          "type": "boolean"
         },
         "ttl_ms": {
           "type": "integer"
@@ -12700,6 +12690,30 @@
         "WorkspaceStatusDeleting",
         "WorkspaceStatusDeleted"
       ]
+    },
+    "codersdk.WorkspaceTemplateInfo": {
+      "type": "object",
+      "properties": {
+        "active_version_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "allow_user_cancel_workspace_jobs": {
+          "type": "boolean"
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "equire_active_version": {
+          "type": "boolean"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "codersdk.WorkspaceTransition": {
       "type": "string",

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -188,10 +188,10 @@ func TestWorkspace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, user.UserID, ws.LatestBuild.InitiatorID)
 		assert.Equal(t, codersdk.BuildReasonInitiator, ws.LatestBuild.Reason)
-		assert.Equal(t, template.Name, ws.TemplateName)
-		assert.Equal(t, templateIcon, ws.TemplateIcon)
-		assert.Equal(t, templateDisplayName, ws.TemplateDisplayName)
-		assert.Equal(t, templateAllowUserCancelWorkspaceJobs, ws.TemplateAllowUserCancelWorkspaceJobs)
+		assert.Equal(t, template.Name, ws.Template.Name)
+		assert.Equal(t, templateIcon, ws.Template.Icon)
+		assert.Equal(t, templateDisplayName, ws.Template.DisplayName)
+		assert.Equal(t, templateAllowUserCancelWorkspaceJobs, ws.Template.AllowUserCancelWorkspaceJobs)
 	})
 
 	t.Run("Health", func(t *testing.T) {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -24,26 +24,26 @@ const (
 // Workspace is a deployment of a template. It references a specific
 // version and can be updated.
 type Workspace struct {
-	ID                                   uuid.UUID      `json:"id" format:"uuid"`
-	CreatedAt                            time.Time      `json:"created_at" format:"date-time"`
-	UpdatedAt                            time.Time      `json:"updated_at" format:"date-time"`
-	OwnerID                              uuid.UUID      `json:"owner_id" format:"uuid"`
-	OwnerName                            string         `json:"owner_name"`
-	OwnerAvatarURL                       string         `json:"owner_avatar_url"`
-	OrganizationID                       uuid.UUID      `json:"organization_id" format:"uuid"`
-	TemplateID                           uuid.UUID      `json:"template_id" format:"uuid"`
-	TemplateName                         string         `json:"template_name"`
-	TemplateDisplayName                  string         `json:"template_display_name"`
-	TemplateIcon                         string         `json:"template_icon"`
-	TemplateAllowUserCancelWorkspaceJobs bool           `json:"template_allow_user_cancel_workspace_jobs"`
-	TemplateActiveVersionID              uuid.UUID      `json:"template_active_version_id" format:"uuid"`
-	TemplateRequireActiveVersion         bool           `json:"template_require_active_version"`
-	LatestBuild                          WorkspaceBuild `json:"latest_build"`
-	Outdated                             bool           `json:"outdated"`
-	Name                                 string         `json:"name"`
-	AutostartSchedule                    *string        `json:"autostart_schedule,omitempty"`
-	TTLMillis                            *int64         `json:"ttl_ms,omitempty"`
-	LastUsedAt                           time.Time      `json:"last_used_at" format:"date-time"`
+	ID                uuid.UUID      `json:"id" format:"uuid"`
+	CreatedAt         time.Time      `json:"created_at" format:"date-time"`
+	UpdatedAt         time.Time      `json:"updated_at" format:"date-time"`
+	OwnerID           uuid.UUID      `json:"owner_id" format:"uuid"`
+	OwnerName         string         `json:"owner_name"`
+	OwnerAvatarURL    string         `json:"owner_avatar_url"`
+	OrganizationID    uuid.UUID      `json:"organization_id" format:"uuid"`
+	LatestBuild       WorkspaceBuild `json:"latest_build"`
+	Outdated          bool           `json:"outdated"`
+	Name              string         `json:"name"`
+	AutostartSchedule *string        `json:"autostart_schedule,omitempty"`
+	TTLMillis         *int64         `json:"ttl_ms,omitempty"`
+	LastUsedAt        time.Time      `json:"last_used_at" format:"date-time"`
+
+	// TemplateID is the ID of the template that this workspace is based on.
+	TemplateID uuid.UUID `json:"template_id" format:"uuid"`
+	// `Template` can only be returned if the caller has read access to the template.
+	// It is possible to have those perms revoked, and the workspace owner can
+	// no longer see the template fields.
+	Template *WorkspaceTemplateInfo `json:"template_info,omitempty"`
 
 	// DeletingAt indicates the time at which the workspace will be permanently deleted.
 	// A workspace is eligible for deletion if it is dormant (a non-nil dormant_at value)
@@ -60,6 +60,16 @@ type Workspace struct {
 	AutomaticUpdates AutomaticUpdates `json:"automatic_updates" enums:"always,never"`
 	AllowRenames     bool             `json:"allow_renames"`
 	Favorite         bool             `json:"favorite"`
+}
+
+// WorkspaceTemplateInfo is a subset of Template fields for a workspace.
+type WorkspaceTemplateInfo struct {
+	TemplateName                         string    `json:"template_name"`
+	TemplateDisplayName                  string    `json:"template_display_name"`
+	TemplateIcon                         string    `json:"template_icon"`
+	TemplateAllowUserCancelWorkspaceJobs bool      `json:"template_allow_user_cancel_workspace_jobs"`
+	TemplateActiveVersionID              uuid.UUID `json:"template_active_version_id" format:"uuid"`
+	TemplateRequireActiveVersion         bool      `json:"template_require_active_version"`
 }
 
 func (w Workspace) FullName() string {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -62,6 +62,22 @@ type Workspace struct {
 	Favorite         bool             `json:"favorite"`
 }
 
+// SafeTemplate returns some sane value if the template is nil.
+// This can happen if the caller cannot read the template.
+func (w Workspace) SafeTemplate() WorkspaceTemplateInfo {
+	if w.Template != nil {
+		return *w.Template
+	}
+	return WorkspaceTemplateInfo{
+		Name:                         "<forbidden>",
+		DisplayName:                  "<forbidden>",
+		Icon:                         "",
+		AllowUserCancelWorkspaceJobs: false,
+		ActiveVersionID:              uuid.Nil,
+		RequireActiveVersion:         false,
+	}
+}
+
 // WorkspaceTemplateInfo is a subset of Template fields for a workspace.
 type WorkspaceTemplateInfo struct {
 	Name                         string    `json:"name"`

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -43,7 +43,7 @@ type Workspace struct {
 	// `Template` can only be returned if the caller has read access to the template.
 	// It is possible to have those perms revoked, and the workspace owner can
 	// no longer see the template fields.
-	Template *WorkspaceTemplateInfo `json:"template_info,omitempty"`
+	Template *WorkspaceTemplateInfo `json:"template,omitempty"`
 
 	// DeletingAt indicates the time at which the workspace will be permanently deleted.
 	// A workspace is eligible for deletion if it is dormant (a non-nil dormant_at value)
@@ -64,12 +64,12 @@ type Workspace struct {
 
 // WorkspaceTemplateInfo is a subset of Template fields for a workspace.
 type WorkspaceTemplateInfo struct {
-	TemplateName                         string    `json:"template_name"`
-	TemplateDisplayName                  string    `json:"template_display_name"`
-	TemplateIcon                         string    `json:"template_icon"`
-	TemplateAllowUserCancelWorkspaceJobs bool      `json:"template_allow_user_cancel_workspace_jobs"`
-	TemplateActiveVersionID              uuid.UUID `json:"template_active_version_id" format:"uuid"`
-	TemplateRequireActiveVersion         bool      `json:"template_require_active_version"`
+	Name                         string    `json:"name"`
+	DisplayName                  string    `json:"display_name"`
+	Icon                         string    `json:"icon"`
+	AllowUserCancelWorkspaceJobs bool      `json:"allow_user_cancel_workspace_jobs"`
+	ActiveVersionID              uuid.UUID `json:"active_version_id" format:"uuid"`
+	RequireActiveVersion         bool      `json:"equire_active_version"`
 }
 
 func (w Workspace) FullName() string {

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7174,13 +7174,15 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "owner_avatar_url": "string",
   "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
   "owner_name": "string",
-  "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-  "template_allow_user_cancel_workspace_jobs": true,
-  "template_display_name": "string",
-  "template_icon": "string",
+  "template": {
+    "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+    "allow_user_cancel_workspace_jobs": true,
+    "display_name": "string",
+    "equire_active_version": true,
+    "icon": "string",
+    "name": "string"
+  },
   "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-  "template_name": "string",
-  "template_require_active_version": true,
   "ttl_ms": 0,
   "updated_at": "2019-08-24T14:15:22Z"
 }
@@ -7188,34 +7190,29 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name                                        | Type                                                   | Required | Restrictions | Description                                                                                                                                                                                                                                           |
-| ------------------------------------------- | ------------------------------------------------------ | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `allow_renames`                             | boolean                                                | false    |              |                                                                                                                                                                                                                                                       |
-| `automatic_updates`                         | [codersdk.AutomaticUpdates](#codersdkautomaticupdates) | false    |              |                                                                                                                                                                                                                                                       |
-| `autostart_schedule`                        | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `created_at`                                | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `deleting_at`                               | string                                                 | false    |              | Deleting at indicates the time at which the workspace will be permanently deleted. A workspace is eligible for deletion if it is dormant (a non-nil dormant_at value) and a value has been specified for time_til_dormant_autodelete on its template. |
-| `dormant_at`                                | string                                                 | false    |              | Dormant at being non-nil indicates a workspace that is dormant. A dormant workspace is no longer accessible must be activated. It is subject to deletion if it breaches the duration of the time*til* field on its template.                          |
-| `favorite`                                  | boolean                                                | false    |              |                                                                                                                                                                                                                                                       |
-| `health`                                    | [codersdk.WorkspaceHealth](#codersdkworkspacehealth)   | false    |              | Health shows the health of the workspace and information about what is causing an unhealthy status.                                                                                                                                                   |
-| `id`                                        | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `last_used_at`                              | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `latest_build`                              | [codersdk.WorkspaceBuild](#codersdkworkspacebuild)     | false    |              |                                                                                                                                                                                                                                                       |
-| `name`                                      | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `organization_id`                           | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `outdated`                                  | boolean                                                | false    |              |                                                                                                                                                                                                                                                       |
-| `owner_avatar_url`                          | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `owner_id`                                  | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `owner_name`                                | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `template_active_version_id`                | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `template_allow_user_cancel_workspace_jobs` | boolean                                                | false    |              |                                                                                                                                                                                                                                                       |
-| `template_display_name`                     | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `template_icon`                             | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `template_id`                               | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `template_name`                             | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
-| `template_require_active_version`           | boolean                                                | false    |              |                                                                                                                                                                                                                                                       |
-| `ttl_ms`                                    | integer                                                | false    |              |                                                                                                                                                                                                                                                       |
-| `updated_at`                                | string                                                 | false    |              |                                                                                                                                                                                                                                                       |
+| Name                 | Type                                                             | Required | Restrictions | Description                                                                                                                                                                                                                                           |
+| -------------------- | ---------------------------------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow_renames`      | boolean                                                          | false    |              |                                                                                                                                                                                                                                                       |
+| `automatic_updates`  | [codersdk.AutomaticUpdates](#codersdkautomaticupdates)           | false    |              |                                                                                                                                                                                                                                                       |
+| `autostart_schedule` | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `created_at`         | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `deleting_at`        | string                                                           | false    |              | Deleting at indicates the time at which the workspace will be permanently deleted. A workspace is eligible for deletion if it is dormant (a non-nil dormant_at value) and a value has been specified for time_til_dormant_autodelete on its template. |
+| `dormant_at`         | string                                                           | false    |              | Dormant at being non-nil indicates a workspace that is dormant. A dormant workspace is no longer accessible must be activated. It is subject to deletion if it breaches the duration of the time*til* field on its template.                          |
+| `favorite`           | boolean                                                          | false    |              |                                                                                                                                                                                                                                                       |
+| `health`             | [codersdk.WorkspaceHealth](#codersdkworkspacehealth)             | false    |              | Health shows the health of the workspace and information about what is causing an unhealthy status.                                                                                                                                                   |
+| `id`                 | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `last_used_at`       | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `latest_build`       | [codersdk.WorkspaceBuild](#codersdkworkspacebuild)               | false    |              |                                                                                                                                                                                                                                                       |
+| `name`               | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `organization_id`    | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `outdated`           | boolean                                                          | false    |              |                                                                                                                                                                                                                                                       |
+| `owner_avatar_url`   | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `owner_id`           | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `owner_name`         | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
+| `template`           | [codersdk.WorkspaceTemplateInfo](#codersdkworkspacetemplateinfo) | false    |              | `Template` can only be returned if the caller has read access to the template. It is possible to have those perms revoked, and the workspace owner can no longer see the template fields.                                                             |
+| `template_id`        | string                                                           | false    |              | Template ID is the ID of the template that this workspace is based on.                                                                                                                                                                                |
+| `ttl_ms`             | integer                                                          | false    |              |                                                                                                                                                                                                                                                       |
+| `updated_at`         | string                                                           | false    |              |                                                                                                                                                                                                                                                       |
 
 #### Enumerated Values
 
@@ -8366,6 +8363,30 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `deleting`  |
 | `deleted`   |
 
+## codersdk.WorkspaceTemplateInfo
+
+```json
+{
+  "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+  "allow_user_cancel_workspace_jobs": true,
+  "display_name": "string",
+  "equire_active_version": true,
+  "icon": "string",
+  "name": "string"
+}
+```
+
+### Properties
+
+| Name                               | Type    | Required | Restrictions | Description |
+| ---------------------------------- | ------- | -------- | ------------ | ----------- |
+| `active_version_id`                | string  | false    |              |             |
+| `allow_user_cancel_workspace_jobs` | boolean | false    |              |             |
+| `display_name`                     | string  | false    |              |             |
+| `equire_active_version`            | boolean | false    |              |             |
+| `icon`                             | string  | false    |              |             |
+| `name`                             | string  | false    |              |             |
+
 ## codersdk.WorkspaceTransition
 
 ```json
@@ -8552,13 +8573,15 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       "owner_avatar_url": "string",
       "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
       "owner_name": "string",
-      "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-      "template_allow_user_cancel_workspace_jobs": true,
-      "template_display_name": "string",
-      "template_icon": "string",
+      "template": {
+        "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+        "allow_user_cancel_workspace_jobs": true,
+        "display_name": "string",
+        "equire_active_version": true,
+        "icon": "string",
+        "name": "string"
+      },
       "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-      "template_name": "string",
-      "template_require_active_version": true,
       "ttl_ms": 0,
       "updated_at": "2019-08-24T14:15:22Z"
     }

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -214,13 +214,15 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
   "owner_avatar_url": "string",
   "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
   "owner_name": "string",
-  "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-  "template_allow_user_cancel_workspace_jobs": true,
-  "template_display_name": "string",
-  "template_icon": "string",
+  "template": {
+    "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+    "allow_user_cancel_workspace_jobs": true,
+    "display_name": "string",
+    "equire_active_version": true,
+    "icon": "string",
+    "name": "string"
+  },
   "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-  "template_name": "string",
-  "template_require_active_version": true,
   "ttl_ms": 0,
   "updated_at": "2019-08-24T14:15:22Z"
 }
@@ -428,13 +430,15 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
   "owner_avatar_url": "string",
   "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
   "owner_name": "string",
-  "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-  "template_allow_user_cancel_workspace_jobs": true,
-  "template_display_name": "string",
-  "template_icon": "string",
+  "template": {
+    "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+    "allow_user_cancel_workspace_jobs": true,
+    "display_name": "string",
+    "equire_active_version": true,
+    "icon": "string",
+    "name": "string"
+  },
   "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-  "template_name": "string",
-  "template_require_active_version": true,
   "ttl_ms": 0,
   "updated_at": "2019-08-24T14:15:22Z"
 }
@@ -641,13 +645,15 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
       "owner_avatar_url": "string",
       "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
       "owner_name": "string",
-      "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-      "template_allow_user_cancel_workspace_jobs": true,
-      "template_display_name": "string",
-      "template_icon": "string",
+      "template": {
+        "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+        "allow_user_cancel_workspace_jobs": true,
+        "display_name": "string",
+        "equire_active_version": true,
+        "icon": "string",
+        "name": "string"
+      },
       "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-      "template_name": "string",
-      "template_require_active_version": true,
       "ttl_ms": 0,
       "updated_at": "2019-08-24T14:15:22Z"
     }
@@ -856,13 +862,15 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
   "owner_avatar_url": "string",
   "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
   "owner_name": "string",
-  "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-  "template_allow_user_cancel_workspace_jobs": true,
-  "template_display_name": "string",
-  "template_icon": "string",
+  "template": {
+    "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+    "allow_user_cancel_workspace_jobs": true,
+    "display_name": "string",
+    "equire_active_version": true,
+    "icon": "string",
+    "name": "string"
+  },
   "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-  "template_name": "string",
-  "template_require_active_version": true,
   "ttl_ms": 0,
   "updated_at": "2019-08-24T14:15:22Z"
 }
@@ -1186,13 +1194,15 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/dormant \
   "owner_avatar_url": "string",
   "owner_id": "8826ee2e-7933-4665-aef2-2393f84a0d05",
   "owner_name": "string",
-  "template_active_version_id": "b0da9c29-67d8-4c87-888c-bafe356f7f3c",
-  "template_allow_user_cancel_workspace_jobs": true,
-  "template_display_name": "string",
-  "template_icon": "string",
+  "template": {
+    "active_version_id": "eae64611-bd53-4a80-bb77-df1e432c0fbc",
+    "allow_user_cancel_workspace_jobs": true,
+    "display_name": "string",
+    "equire_active_version": true,
+    "icon": "string",
+    "name": "string"
+  },
   "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
-  "template_name": "string",
-  "template_require_active_version": true,
   "ttl_ms": 0,
   "updated_at": "2019-08-24T14:15:22Z"
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1640,19 +1640,14 @@ export interface Workspace {
   readonly owner_name: string;
   readonly owner_avatar_url: string;
   readonly organization_id: string;
-  readonly template_id: string;
-  readonly template_name: string;
-  readonly template_display_name: string;
-  readonly template_icon: string;
-  readonly template_allow_user_cancel_workspace_jobs: boolean;
-  readonly template_active_version_id: string;
-  readonly template_require_active_version: boolean;
   readonly latest_build: WorkspaceBuild;
   readonly outdated: boolean;
   readonly name: string;
   readonly autostart_schedule?: string;
   readonly ttl_ms?: number;
   readonly last_used_at: string;
+  readonly template_id: string;
+  readonly template?: WorkspaceTemplateInfo;
   readonly deleting_at?: string;
   readonly dormant_at?: string;
   readonly health: WorkspaceHealth;
@@ -1927,6 +1922,16 @@ export interface WorkspaceResourceMetadata {
   readonly key: string;
   readonly value: string;
   readonly sensitive: boolean;
+}
+
+// From codersdk/workspaces.go
+export interface WorkspaceTemplateInfo {
+  readonly name: string;
+  readonly display_name: string;
+  readonly icon: string;
+  readonly allow_user_cancel_workspace_jobs: boolean;
+  readonly active_version_id: string;
+  readonly equire_active_version: boolean;
 }
 
 // From codersdk/workspaces.go


### PR DESCRIPTION
https://github.com/coder/coder/issues/12359#issuecomment-1971791714

If a user can read a workspace, but not the template, we need to omit those fields returned.

This is an imperfect solution, but atm we just do not return the workspace. 

Some other solutions:

1. Create some "Minimal Template" that a user can read if they can read the workspace. 
2. Just allow read access to the template if you have workspace access.
3. Block workspace access if you do not have template access. (This is a bit complex since rego -> sql cannot take into account 2 resources atm.)

I don't see many good solutions. This PR just nulls out some api fields, and the FE is going to require an update to handle this.

Thoughts?


---

**Note:** If this is the right direction for now:

- FE needs to be updated alongside this
- Unit tests
- Comb it all over
