### PR TITLE
fix(cli): generate correctly named file in DumpHandler

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -149,7 +149,7 @@ func (r *RootCmd) workspaceAgent() *clibase.Cmd {
 
 			// DumpHandler does signal handling, so we call it after the
 			// reaper.
-			go DumpHandler(ctx)
+			go DumpHandler(ctx, "agent")
 
 			logWriter := &lumberjackWriteCloseFixer{w: &lumberjack.Logger{
 				Filename: filepath.Join(logDir, "coder-agent.log"),

--- a/cli/root.go
+++ b/cli/root.go
@@ -993,7 +993,8 @@ func DumpHandler(ctx context.Context, name string) {
 			dir = os.TempDir()
 		}
 		// Make the time filesystem-safe, for example ":" is not
-		// permitted on many filesystems.
+		// permitted on many filesystems. Note that Z here only appends
+		// Z to the string, it does not actually change the time zone.
 		filesystemSafeTime := time.Now().UTC().Format("2006-01-02T15-04-05.000Z")
 		fpath := filepath.Join(dir, fmt.Sprintf("coder-%s-%s.dump", name, filesystemSafeTime))
 		_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)

--- a/cli/root.go
+++ b/cli/root.go
@@ -992,7 +992,10 @@ func DumpHandler(ctx context.Context, name string) {
 		if err != nil {
 			dir = os.TempDir()
 		}
-		fpath := filepath.Join(dir, fmt.Sprintf("coder-%s-%s.dump", name, time.Now().Format("2006-01-02T15:04:05.000Z")))
+		// Make the time filesystem-safe, for example ":" is not
+		// permitted on many filesystems.
+		filesystemSafeTime := time.Now().Format("2006-01-02T15-04-05.000Z")
+		fpath := filepath.Join(dir, fmt.Sprintf("coder-%s-%s.dump", name, filesystemSafeTime))
 		_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)
 
 		f, err := os.Create(fpath)

--- a/cli/root.go
+++ b/cli/root.go
@@ -994,7 +994,7 @@ func DumpHandler(ctx context.Context, name string) {
 		}
 		// Make the time filesystem-safe, for example ":" is not
 		// permitted on many filesystems.
-		filesystemSafeTime := time.Now().Format("2006-01-02T15-04-05.000Z")
+		filesystemSafeTime := time.Now().UTC().Format("2006-01-02T15-04-05.000Z")
 		fpath := filepath.Join(dir, fmt.Sprintf("coder-%s-%s.dump", name, filesystemSafeTime))
 		_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -937,7 +937,7 @@ func (r *RootCmd) Verbosef(inv *clibase.Invocation, fmtStr string, args ...inter
 // A SIGQUIT handler will not be registered if GOTRACEBACK=crash.
 //
 // On Windows this immediately returns.
-func DumpHandler(ctx context.Context) {
+func DumpHandler(ctx context.Context, name string) {
 	if runtime.GOOS == "windows" {
 		// free up the goroutine since it'll be permanently blocked anyways
 		return
@@ -992,7 +992,7 @@ func DumpHandler(ctx context.Context) {
 		if err != nil {
 			dir = os.TempDir()
 		}
-		fpath := filepath.Join(dir, fmt.Sprintf("coder-agent-%s.dump", time.Now().Format("2006-01-02T15:04:05.000Z")))
+		fpath := filepath.Join(dir, fmt.Sprintf("coder-%s-%s.dump", name, time.Now().Format("2006-01-02T15:04:05.000Z")))
 		_, _ = fmt.Fprintf(os.Stderr, "writing dump to %q\n", fpath)
 
 		f, err := os.Create(fpath)

--- a/cli/server.go
+++ b/cli/server.go
@@ -289,7 +289,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				cliui.Warnf(inv.Stderr, "YAML support is experimental and offers no compatibility guarantees.")
 			}
 
-			go DumpHandler(ctx)
+			go DumpHandler(ctx, "coderd")
 
 			// Validate bind addresses.
 			if vals.Address.String() != "" {

--- a/enterprise/cli/proxyserver.go
+++ b/enterprise/cli/proxyserver.go
@@ -119,7 +119,7 @@ func (r *RootCmd) proxyServer() *clibase.Cmd {
 			defer topCancel()
 			closers.Add(topCancel)
 
-			go cli.DumpHandler(ctx)
+			go cli.DumpHandler(ctx, "workspace-proxy")
 
 			cli.PrintLogo(inv, "Coder Workspace Proxy")
 			logger, logCloser, err := clilog.New(clilog.FromDeploymentValues(cfg)).Build(inv)


### PR DESCRIPTION
Noticed we always write the filenames with "agent" in the name, this fixes that.

EDIT: As a bonus we did `s/:/-/` on time so that files are safe on any filesystem, e.g. NTFS.
EDIT2: As a bonus2 we use `time.Now().UTC()` since our formatting string appends `Z` to the filename, but we were actually rendering the local time.