### PR TITLE
chore: ensure default org always exists

### DIFF
--- a/cli/templatelist_test.go
+++ b/cli/templatelist_test.go
@@ -87,6 +87,10 @@ func TestTemplateList(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{})
 		owner := coderdtest.CreateFirstUser(t, client)
+
+		org, err := client.Organization(context.Background(), owner.OrganizationID)
+		require.NoError(t, err)
+
 		templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
 
 		inv, root := clitest.New(t, "templates", "list")
@@ -107,7 +111,7 @@ func TestTemplateList(t *testing.T) {
 		require.NoError(t, <-errC)
 
 		pty.ExpectMatch("No templates found in")
-		pty.ExpectMatch(coderdtest.FirstUserParams.Username)
+		pty.ExpectMatch(org.Name)
 		pty.ExpectMatch("Create one:")
 	})
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -229,7 +229,7 @@ var (
 					rbac.ResourceGroup.Type:              {rbac.ActionCreate, rbac.ActionUpdate},
 					rbac.ResourceRoleAssignment.Type:     {rbac.ActionCreate, rbac.ActionDelete},
 					rbac.ResourceSystem.Type:             {rbac.WildcardSymbol},
-					rbac.ResourceOrganization.Type:       {rbac.ActionCreate},
+					rbac.ResourceOrganization.Type:       {rbac.ActionCreate, rbac.ActionRead},
 					rbac.ResourceOrganizationMember.Type: {rbac.ActionCreate},
 					rbac.ResourceOrgRoleAssignment.Type:  {rbac.ActionCreate},
 					rbac.ResourceProvisionerDaemon.Type:  {rbac.ActionCreate, rbac.ActionUpdate},

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -568,7 +568,7 @@ func (s *MethodTestSuite) TestOrganization() {
 		check.Args(o.ID).Asserts(o, rbac.ActionRead).Returns(o)
 	}))
 	s.Run("GetDefaultOrganization", s.Subtest(func(db database.Store, check *expects) {
-		o := dbgen.Organization(s.T(), db, database.Organization{})
+		o, _ := db.GetDefaultOrganization(context.Background())
 		check.Args().Asserts(o, rbac.ActionRead).Returns(o)
 	}))
 	s.Run("GetOrganizationByName", s.Subtest(func(db database.Store, check *expects) {
@@ -597,9 +597,10 @@ func (s *MethodTestSuite) TestOrganization() {
 		check.Args(u.ID).Asserts(a, rbac.ActionRead, b, rbac.ActionRead).Returns(slice.New(a, b))
 	}))
 	s.Run("GetOrganizations", s.Subtest(func(db database.Store, check *expects) {
+		def, _ := db.GetDefaultOrganization(context.Background())
 		a := dbgen.Organization(s.T(), db, database.Organization{})
 		b := dbgen.Organization(s.T(), db, database.Organization{})
-		check.Args().Asserts(a, rbac.ActionRead, b, rbac.ActionRead).Returns(slice.New(a, b))
+		check.Args().Asserts(def, rbac.ActionRead, a, rbac.ActionRead, b, rbac.ActionRead).Returns(slice.New(def, a, b))
 	}))
 	s.Run("GetOrganizationsByUserID", s.Subtest(func(db database.Store, check *expects) {
 		u := dbgen.User(s.T(), db, database.User{})

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -77,6 +77,17 @@ func New() database.Store {
 			locks:                     map[int64]struct{}{},
 		},
 	}
+	// Always start with a default org. Matching migration 198.
+	_, err := q.InsertOrganization(context.Background(), database.InsertOrganizationParams{
+		ID:          uuid.New(),
+		Name:        "first-organization",
+		Description: "Builtin default organization.",
+		CreatedAt:   dbtime.Now(),
+		UpdatedAt:   dbtime.Now(),
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to create default organization: %w", err))
+	}
 	q.defaultProxyDisplayName = "Default"
 	q.defaultProxyIconURL = "/emojis/1f3e1.png"
 	return q

--- a/coderd/database/migrations/000198_ensure_default_org.down.sql
+++ b/coderd/database/migrations/000198_ensure_default_org.down.sql
@@ -1,0 +1,1 @@
+-- There is no down. If the org is created, just let it be. Deleting an org feels dangerous in a migration.

--- a/coderd/database/migrations/000198_ensure_default_org.up.sql
+++ b/coderd/database/migrations/000198_ensure_default_org.up.sql
@@ -12,4 +12,5 @@ SELECT
 	true
 WHERE
 	-- Only insert if no organizations exist.
-	NOT EXISTS (SELECT * FROM organizations)
+	NOT EXISTS (SELECT * FROM organizations);
+

--- a/coderd/database/migrations/000198_ensure_default_org.up.sql
+++ b/coderd/database/migrations/000198_ensure_default_org.up.sql
@@ -1,0 +1,15 @@
+-- This ensures a default organization always exists.
+INSERT INTO
+	organizations(id, name, description, created_at, updated_at, is_default)
+SELECT
+	-- Avoid calling it "default" as we are reserving that word as a keyword to fetch
+	-- the default org regardless of the name.
+	gen_random_uuid(),
+	'first-organization',
+	'Builtin default organization.',
+	now(),
+	now(),
+	true
+WHERE
+	-- Only insert if no organizations exist.
+	NOT EXISTS (SELECT * FROM organizations)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -506,20 +506,11 @@ func TestDefaultOrg(t *testing.T) {
 	db := database.New(sqlDB)
 	ctx := context.Background()
 
-	// Should start with 0 orgs
+	// Should start with the default org
 	all, err := db.GetOrganizations(ctx)
 	require.NoError(t, err)
-	require.Len(t, all, 0)
-
-	org, err := db.InsertOrganization(ctx, database.InsertOrganizationParams{
-		ID:          uuid.New(),
-		Name:        "default",
-		Description: "",
-		CreatedAt:   dbtime.Now(),
-		UpdatedAt:   dbtime.Now(),
-	})
-	require.NoError(t, err)
-	require.True(t, org.IsDefault, "first org should always be default")
+	require.Len(t, all, 1)
+	require.True(t, all[0].IsDefault, "first org should always be default")
 }
 
 type tvArgs struct {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -181,6 +181,18 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	//nolint:gocritic // ensure everyone group
+	_, err = api.Database.InsertAllUsersGroup(dbauthz.AsSystemRestricted(ctx), defaultOrg.ID)
+	// A unique constraint violation just means the group already exists.
+	// This should not happen, but is ok if it does.
+	if err != nil && !database.IsUniqueViolation(err) {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error creating all users group.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	//nolint:gocritic // needed to create first user
 	user, organizationID, err := api.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, CreateUserRequest{
 		CreateUserRequest: codersdk.CreateUserRequest{

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1040,7 +1040,7 @@ func (api *API) userRoles(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := codersdk.UserRoles{
-		Roles:             make([]string, 0),
+		Roles:             user.RBACRoles,
 		OrganizationRoles: make(map[uuid.UUID][]string),
 	}
 

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -171,7 +171,8 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	defaultOrg, err := api.Database.GetDefaultOrganization(ctx)
+	//nolint:gocritic // needed to create first user
+	defaultOrg, err := api.Database.GetDefaultOrganization(dbauthz.AsSystemRestricted(ctx))
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching default organization. If you are encountering this error, you will have to restart the Coder deployment.",

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1091,11 +1091,12 @@ func TestInitialRoles(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, roles.Roles, []string{
 		rbac.RoleOwner(),
+		rbac.RoleMember(),
 	}, "should be a member and admin")
 
 	require.ElementsMatch(t, roles.OrganizationRoles[first.OrganizationID], []string{
 		rbac.RoleOrgMember(first.OrganizationID),
-	}, "should be a member and admin")
+	}, "should be a member")
 }
 
 func TestPutUserSuspend(t *testing.T) {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1091,12 +1091,9 @@ func TestInitialRoles(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, roles.Roles, []string{
 		rbac.RoleOwner(),
-		rbac.RoleMember(),
 	}, "should be a member and admin")
 
-	require.ElementsMatch(t, roles.OrganizationRoles[first.OrganizationID], []string{
-		rbac.RoleOrgMember(first.OrganizationID),
-	}, "should be a member")
+	require.ElementsMatch(t, roles.OrganizationRoles[first.OrganizationID], []string{}, "should be a member")
 }
 
 func TestPutUserSuspend(t *testing.T) {


### PR DESCRIPTION
First user just joins the org created by the migration