### PR TITLE
fix: ensure auto-workspace creation waits until all parameters are ready

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -105,8 +105,14 @@ const CreateWorkspacePage: FC = () => {
     userParametersQuery.data ? userParametersQuery.data : [],
   );
 
+  const autoCreationStartedRef = useRef(false);
   const automateWorkspaceCreation = useEffectEvent(async () => {
+    if (autoCreationStartedRef.current) {
+      return;
+    }
+
     try {
+      autoCreationStartedRef.current = true;
       const newWorkspace = await autoCreateWorkspaceMutation.mutateAsync({
         templateName,
         organizationId,
@@ -122,18 +128,12 @@ const CreateWorkspacePage: FC = () => {
     }
   });
 
-  const autoCreationStartedRef = useRef(false);
+  const autoStartReady = mode === "auto" && userParametersQuery.isSuccess;
   useEffect(() => {
-    const shouldStartAutoCreation =
-      !autoCreationStartedRef.current &&
-      mode === "auto" &&
-      userParametersQuery.isSuccess;
-
-    if (shouldStartAutoCreation) {
-      autoCreationStartedRef.current = true;
+    if (autoStartReady) {
       void automateWorkspaceCreation();
     }
-  }, [automateWorkspaceCreation, mode, userParametersQuery.isSuccess]);
+  }, [automateWorkspaceCreation, autoStartReady]);
 
   return (
     <>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useState, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
@@ -122,11 +122,18 @@ const CreateWorkspacePage: FC = () => {
     }
   });
 
+  const autoCreationStartedRef = useRef(false);
   useEffect(() => {
-    if (mode === "auto") {
+    const shouldStartAutoCreation =
+      !autoCreationStartedRef.current &&
+      mode === "auto" &&
+      userParametersQuery.isSuccess;
+
+    if (shouldStartAutoCreation) {
+      autoCreationStartedRef.current = true;
       void automateWorkspaceCreation();
     }
-  }, [automateWorkspaceCreation, mode]);
+  }, [automateWorkspaceCreation, mode, userParametersQuery.isSuccess]);
 
   return (
     <>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -94,11 +94,11 @@ const CreateWorkspacePage: FC = () => {
   );
 
   // Auto fill parameters
+  const autofillEnabled = experiments.includes("auto-fill-parameters");
   const userParametersQuery = useQuery({
     queryKey: ["userParameters"],
     queryFn: () => getUserParameters(templateQuery.data!.id),
-    enabled:
-      experiments.includes("auto-fill-parameters") && templateQuery.isSuccess,
+    enabled: autofillEnabled && templateQuery.isSuccess,
   });
   const autofillParameters = getAutofillParameters(
     searchParams,
@@ -128,7 +128,8 @@ const CreateWorkspacePage: FC = () => {
     }
   });
 
-  const autoStartReady = mode === "auto" && userParametersQuery.isSuccess;
+  const autoStartReady =
+    mode === "auto" && (!autofillEnabled || userParametersQuery.isSuccess);
   useEffect(() => {
     if (autoStartReady) {
       void automateWorkspaceCreation();


### PR DESCRIPTION
No issue to link – realized we had a bug when I was looking at some of the Slack messages today

## Changes made
- Makes it so that auto workspace creation waits until `userParametersQuery` succeeds with fetching its data before it's allowed to start making a new workspace
   - To be extra, super cautious, I also made it so auto-creation can only ever be kicked off once, no matter what happens in the `useEffect` dependency array