### PR TITLE
fix: improve pagination parser

### DIFF
--- a/coderd/httpapi/queryparams.go
+++ b/coderd/httpapi/queryparams.go
@@ -80,7 +80,9 @@ func (p *QueryParamParser) Int(vals url.Values, def int, queryParam string) int 
 }
 
 // PositiveInt32 function checks if the given value is 32-bit and positive.
+//
 // We can't use `uint32` as the value must be within the range  <0,2147483647>
+// as database expects it. Otherwise, the database query fails with `pq: OFFSET must not be negative`.
 func (p *QueryParamParser) PositiveInt32(vals url.Values, def int32, queryParam string) int32 {
 	v, err := parseQueryParam(p, vals, func(v string) (int32, error) {
 		intValue, err := strconv.ParseInt(v, 10, 32)

--- a/coderd/httpapi/queryparams.go
+++ b/coderd/httpapi/queryparams.go
@@ -79,6 +79,28 @@ func (p *QueryParamParser) Int(vals url.Values, def int, queryParam string) int 
 	return v
 }
 
+// PositiveInt32 function checks if the given value is 32-bit and positive.
+// We can't use `uint32` as the value must be within the range  <0,2147483647>
+func (p *QueryParamParser) PositiveInt32(vals url.Values, def int32, queryParam string) int32 {
+	v, err := parseQueryParam(p, vals, func(v string) (int32, error) {
+		intValue, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		if intValue < 0 {
+			return 0, xerrors.Errorf("value is negative")
+		}
+		return int32(intValue), nil
+	}, def, queryParam)
+	if err != nil {
+		p.Errors = append(p.Errors, codersdk.ValidationError{
+			Field:  queryParam,
+			Detail: fmt.Sprintf("Query param %q must be a valid 32-bit positive integer (%s)", queryParam, err.Error()),
+		})
+	}
+	return v
+}
+
 func (p *QueryParamParser) Boolean(vals url.Values, def bool, queryParam string) bool {
 	v, err := parseQueryParam(p, vals, strconv.ParseBool, def, queryParam)
 	if err != nil {

--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -236,6 +236,50 @@ func TestParseQueryParams(t *testing.T) {
 		testQueryParams(t, expParams, parser, parser.Int)
 	})
 
+	t.Run("PositiveInt32", func(t *testing.T) {
+		t.Parallel()
+		expParams := []queryParamTestCase[int32]{
+			{
+				QueryParam: "valid_integer",
+				Value:      "100",
+				Expected:   100,
+			},
+			{
+				QueryParam: "empty",
+				Value:      "",
+				Expected:   0,
+			},
+			{
+				QueryParam: "no_value",
+				NoSet:      true,
+				Default:    5,
+				Expected:   5,
+			},
+			{
+				QueryParam:            "negative",
+				Value:                 "-1",
+				Expected:              0,
+				Default:               5,
+				ExpectedErrorContains: "must be a valid 32-bit positive integer",
+			},
+			{
+				QueryParam:            "invalid_integer",
+				Value:                 "bogus",
+				Expected:              0,
+				ExpectedErrorContains: "must be a valid 32-bit positive integer",
+			},
+			{
+				QueryParam:            "max_int_plus_one",
+				Value:                 "2147483648",
+				Expected:              0,
+				ExpectedErrorContains: "must be a valid 32-bit positive integer",
+			},
+		}
+
+		parser := httpapi.NewQueryParamParser()
+		testQueryParams(t, expParams, parser, parser.PositiveInt32)
+	})
+
 	t.Run("UInt", func(t *testing.T) {
 		t.Parallel()
 		expParams := []queryParamTestCase[uint64]{

--- a/coderd/pagination.go
+++ b/coderd/pagination.go
@@ -17,9 +17,8 @@ func parsePagination(w http.ResponseWriter, r *http.Request) (p codersdk.Paginat
 	parser := httpapi.NewQueryParamParser()
 	params := codersdk.Pagination{
 		AfterID: parser.UUID(queryParams, uuid.Nil, "after_id"),
-		// Limit default to "-1" which returns all results
-		Limit:  parser.Int(queryParams, 0, "limit"),
-		Offset: parser.Int(queryParams, 0, "offset"),
+		Limit:   int(parser.PositiveInt32(queryParams, 0, "limit")),
+		Offset:  int(parser.PositiveInt32(queryParams, 0, "offset")),
 	}
 	if len(parser.Errors) > 0 {
 		httpapi.Write(ctx, w, http.StatusBadRequest, codersdk.Response{

--- a/coderd/pagination_internal_test.go
+++ b/coderd/pagination_internal_test.go
@@ -47,8 +47,28 @@ func TestPagination(t *testing.T) {
 			ExpectedError: invalidValues,
 		},
 		{
+			Name:          "TooHighLimit",
+			Limit:         "2147483648",
+			ExpectedError: invalidValues,
+		},
+		{
+			Name:          "NegativeLimit",
+			Limit:         "-1",
+			ExpectedError: invalidValues,
+		},
+		{
 			Name:          "BadOffset",
 			Offset:        "bogus",
+			ExpectedError: invalidValues,
+		},
+		{
+			Name:          "TooHighOffset",
+			Offset:        "2147483648",
+			ExpectedError: invalidValues,
+		},
+		{
+			Name:          "NegativeOffset",
+			Offset:        "-1",
 			ExpectedError: invalidValues,
 		},
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/11795

This PR improves pagination logic to prevent HTTP 500s caused by PostgreSQL errors.

**Before**

URL: http://localhost:3000/api/v2/workspaces?limit=1&offset=1000000000000
Reply: `{"message":"Internal error fetching workspaces.","detail":"pq: OFFSET must not be negative"}`

URL: http://localhost:3000/api/v2/workspaces?limit=1000000000000&offset=-2
Reply: `{"message":"Internal error fetching workspaces.","detail":"pq: OFFSET must not be negative"}`

URL: http://localhost:3000/api/v2/workspaces?limit=1&offset=991000000000000
Reply: `{"workspaces":[],"count":2}` // This one works in a weird way :)

**After**

URL: http://localhost:3000/api/v2/workspaces?limit=1000000000000&offset=-2
Reply: `{"message":"Query parameters have invalid values.","validations":[{"field":"limit","detail":"Query param \"limit\" must be a valid 32-bit positive integer (strconv.ParseInt: parsing \"1000000000000\": value out of range)"},{"field":"offset","detail":"Query param \"offset\" must be a valid 32-bit positive integer (value is negative)"}]}`

URL: http://localhost:3000/api/v2/workspaces?limit=1&offset=2147483648
Reply: `{"message":"Query parameters have invalid values.","validations":[{"field":"offset","detail":"Query param \"offset\" must be a valid 32-bit positive integer (strconv.ParseInt: parsing \"2147483648\": value out of range)"}]}`

