### PR TITLE
feat(scripts/develop.sh): add --debug flag to develop.sh

### DIFF
--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -38,6 +38,7 @@ sign_darwin="${CODER_SIGN_DARWIN:-0}"
 output_path=""
 agpl="${CODER_BUILD_AGPL:-0}"
 boringcrypto=${CODER_BUILD_BORINGCRYPTO:-0}
+devel=${CODER_BUILD_DEVEL:-0}
 
 args="$(getopt -o "" -l version:,os:,arch:,output:,slim,agpl,sign-darwin,boringcrypto -- "$@")"
 eval set -- "$args"
@@ -76,6 +77,10 @@ while true; do
 		boringcrypto=1
 		shift
 		;;
+  --devel)
+  	devel=1
+  	shift
+  	;;
 	--)
 		shift
 		break
@@ -102,10 +107,13 @@ if [[ "$sign_darwin" == 1 ]]; then
 fi
 
 ldflags=(
-	-s
-	-w
 	-X "'github.com/coder/coder/v2/buildinfo.tag=$version'"
 )
+
+# Outside of development we always want to strip debug information
+if [[ "$devel" == 0 ]]; then
+	ldflags+=(-s -w)
+fi
 
 # We use ts_omit_aws here because on Linux it prevents Tailscale from importing
 # github.com/aws/aws-sdk-go-v2/aws, which adds 7 MB to the binary.

--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -76,10 +76,6 @@ while true; do
 		boringcrypto=1
 		shift
 		;;
-  --devel)
-  	devel=1
-  	shift
-  	;;
 	--)
 		shift
 		break
@@ -106,13 +102,10 @@ if [[ "$sign_darwin" == 1 ]]; then
 fi
 
 ldflags=(
+	-s
+	-w
 	-X "'github.com/coder/coder/v2/buildinfo.tag=$version'"
 )
-
-# Outside of development we always want to strip debug information
-if [[ "$devel" == 0 ]]; then
-	ldflags+=(-s -w)
-fi
 
 # We use ts_omit_aws here because on Linux it prevents Tailscale from importing
 # github.com/aws/aws-sdk-go-v2/aws, which adds 7 MB to the binary.

--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -38,7 +38,6 @@ sign_darwin="${CODER_SIGN_DARWIN:-0}"
 output_path=""
 agpl="${CODER_BUILD_AGPL:-0}"
 boringcrypto=${CODER_BUILD_BORINGCRYPTO:-0}
-devel=${CODER_BUILD_DEVEL:-0}
 
 args="$(getopt -o "" -l version:,os:,arch:,output:,slim,agpl,sign-darwin,boringcrypto -- "$@")"
 eval set -- "$args"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}/lib.sh"
 
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
-debug="${debug:-0}"
+DEBUG_DELVE="${DEBUG_DELVE:-0}"
 BINARY_TYPE=coder-slim
 if [[ ${1:-} == server ]]; then
 	BINARY_TYPE=coder
@@ -56,11 +56,11 @@ coder)
 	;;
 esac
 
-runcmd="${CODER_DEV_BIN}"
-if [[ "${debug}" == 1 ]]; then
+runcmd=("${CODER_DEV_BIN}")
+if [[ "${DEBUG_DELVE}" == 1 ]]; then
 	set -x
-	runcmd="dlv debug --headless --continue --listen 127.0.0.1:12345 --accept-multiclient ./cmd/coder --"
+	runcmd=(dlv debug --headless --continue --listen 127.0.0.1:12345 --accept-multiclient ./cmd/coder --)
 fi
 
 # shellcheck disable=SC2086 # This is probably one of the few times you actually want this.
-exec $runcmd --global-config "${CODER_DEV_DIR}" "$@"
+exec "${runcmd[@]}" --global-config "${CODER_DEV_DIR}" "$@"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -10,6 +10,8 @@ source "${SCRIPT_DIR}/lib.sh"
 
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
+CODER_BUILD_DEVEL=1
+debug="${debug:-0}"
 BINARY_TYPE=coder-slim
 if [[ ${1:-} == server ]]; then
 	BINARY_TYPE=coder
@@ -55,4 +57,11 @@ coder)
 	;;
 esac
 
-exec "${CODER_DEV_BIN}" --global-config "${CODER_DEV_DIR}" "$@"
+runcmd="${CODER_DEV_BIN}"
+if [[ "${debug}" == 1 ]]; then
+	set -x
+	runcmd="dlv debug ./cmd/coder --"
+fi
+
+# shellcheck disable=SC2086 # This is probably one of the few times you actually want this.
+exec $runcmd --global-config "${CODER_DEV_DIR}" "$@"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -62,5 +62,4 @@ if [[ "${DEBUG_DELVE}" == 1 ]]; then
 	runcmd=(dlv debug --headless --continue --listen 127.0.0.1:12345 --accept-multiclient ./cmd/coder --)
 fi
 
-# shellcheck disable=SC2086 # This is probably one of the few times you actually want this.
 exec "${runcmd[@]}" --global-config "${CODER_DEV_DIR}" "$@"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -10,7 +10,6 @@ source "${SCRIPT_DIR}/lib.sh"
 
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
-CODER_BUILD_DEVEL=1
 debug="${debug:-0}"
 BINARY_TYPE=coder-slim
 if [[ ${1:-} == server ]]; then

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -62,4 +62,4 @@ if [[ "${DEBUG_DELVE}" == 1 ]]; then
 	runcmd=(dlv debug --headless --continue --listen 127.0.0.1:12345 --accept-multiclient ./cmd/coder --)
 fi
 
-exec "${runcmd[@]}" --global-config "${CODER_DEV_DIR}" "$@"
+CGO_ENABLED=0 exec "${runcmd[@]}" --global-config "${CODER_DEV_DIR}" "$@"

--- a/scripts/coder-dev.sh
+++ b/scripts/coder-dev.sh
@@ -59,7 +59,7 @@ esac
 runcmd="${CODER_DEV_BIN}"
 if [[ "${debug}" == 1 ]]; then
 	set -x
-	runcmd="dlv debug ./cmd/coder --"
+	runcmd="dlv debug --headless --continue --listen 127.0.0.1:12345 --accept-multiclient ./cmd/coder --"
 fi
 
 # shellcheck disable=SC2086 # This is probably one of the few times you actually want this.

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -14,7 +14,6 @@ source "${SCRIPT_DIR}/lib.sh"
 set -euo pipefail
 
 CODER_DEV_ACCESS_URL="${CODER_DEV_ACCESS_URL:-http://127.0.0.1:3000}"
-CODER_BUILD_DEVEL=1
 debug=0
 DEFAULT_PASSWORD="SomeSecurePassword!"
 password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -141,7 +141,7 @@ fatal() {
 	trap 'fatal "Script encountered an error"' ERR
 
 	cdroot
-	debug="${debug}" start_cmd API "" "${CODER_DEV_SHIM}" server --http-address 0.0.0.0:3000 --swagger-enable --access-url "${CODER_DEV_ACCESS_URL}" --dangerous-allow-cors-requests=true "$@"
+	DEBUG_DELVE="${debug}" start_cmd API "" "${CODER_DEV_SHIM}" server --http-address 0.0.0.0:3000 --swagger-enable --access-url "${CODER_DEV_ACCESS_URL}" --dangerous-allow-cors-requests=true "$@"
 
 	echo '== Waiting for Coder to become ready'
 	# Start the timeout in the background so interrupting this script

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -14,11 +14,13 @@ source "${SCRIPT_DIR}/lib.sh"
 set -euo pipefail
 
 CODER_DEV_ACCESS_URL="${CODER_DEV_ACCESS_URL:-http://127.0.0.1:3000}"
+CODER_BUILD_DEVEL=1
+debug=0
 DEFAULT_PASSWORD="SomeSecurePassword!"
 password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"
 use_proxy=0
 
-args="$(getopt -o "" -l access-url:,use-proxy,agpl,password: -- "$@")"
+args="$(getopt -o "" -l access-url:,use-proxy,agpl,debug,password: -- "$@")"
 eval set -- "$args"
 while true; do
 	case "$1" in
@@ -36,6 +38,10 @@ while true; do
 		;;
 	--use-proxy)
 		use_proxy=1
+		shift
+		;;
+	--debug)
+		debug=1
 		shift
 		;;
 	--)
@@ -136,7 +142,7 @@ fatal() {
 	trap 'fatal "Script encountered an error"' ERR
 
 	cdroot
-	start_cmd API "" "${CODER_DEV_SHIM}" server --http-address 0.0.0.0:3000 --swagger-enable --access-url "${CODER_DEV_ACCESS_URL}" --dangerous-allow-cors-requests=true "$@"
+	debug="${debug}" start_cmd API "" "${CODER_DEV_SHIM}" server --http-address 0.0.0.0:3000 --swagger-enable --access-url "${CODER_DEV_ACCESS_URL}" --dangerous-allow-cors-requests=true "$@"
 
 	echo '== Waiting for Coder to become ready'
 	# Start the timeout in the background so interrupting this script


### PR DESCRIPTION
Adds a `--debug` flag to `scripts/develop.sh` that will start coder under `dlv debug` instead.
You can then use e.g. the following launch snippet to connect dlv:
```
    {
      "name": "Delve Remote",
      "type": "go",
      "request": "attach",
      "mode": "remote",
      "port": 12345,
    }
```

You can also run invididual CLI commands under dlv e.g.

```
DEBUG_DELVE=1 scripts/coder-dev.sh list
```