### PR TITLE
chore(coderd): add tests for big oidc tokens

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/mail"
 	"regexp"
@@ -14,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -1191,26 +1189,6 @@ func blankFields(claims map[string]interface{}) []string {
 	return fields
 }
 
-// fieldSizes returns the sorted sizes of fields in the claims map
-func fieldSizes(claims map[string]interface{}) []int {
-	fs := claimFields(claims)
-	lens := make([]int, len(fs))
-	for i, f := range fs {
-		v, ok := claims[f]
-		if !ok {
-			lens[i] = -1
-			continue
-		}
-		vs, ok := v.(string)
-		if !ok {
-			lens[i] = -1
-			continue
-		}
-		lens[i] = len(vs)
-	}
-	return lens
-}
-
 // mergeClaims merges the claims from a and b and returns the merged set.
 // claims from b take precedence over claims from a.
 func mergeClaims(a, b map[string]interface{}) map[string]interface{} {
@@ -1893,21 +1871,4 @@ func parseStringSliceClaim(claim interface{}) ([]string, error) {
 
 	// Not sure what the user gave us.
 	return nil, xerrors.Errorf("invalid claim type. Expected an array of strings, got: %T", claim)
-}
-
-type countWriter struct {
-	w            io.Writer
-	bytesWritten atomic.Int64
-}
-
-func (cw *countWriter) Write(p []byte) (int, error) {
-	n, err := cw.w.Write(p)
-	if n > 0 {
-		cw.bytesWritten.Add(int64(n))
-	}
-	return n, err
-}
-
-func (cw *countWriter) Length() int {
-	return int(cw.bytesWritten.Load())
 }

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -744,202 +744,221 @@ func TestUserOIDC(t *testing.T) {
 		StatusCode          int
 		IgnoreEmailVerified bool
 		IgnoreUserInfo      bool
-	}{{
-		Name: "EmailOnly",
-		IDTokenClaims: jwt.MapClaims{
-			"email": "kyle@kwc.io",
+	}{
+		{
+			Name: "EmailOnly",
+			IDTokenClaims: jwt.MapClaims{
+				"email": "kyle@kwc.io",
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
+			Username:     "kyle",
 		},
-		AllowSignups: true,
-		StatusCode:   http.StatusOK,
-		Username:     "kyle",
-	}, {
-		Name: "EmailNotVerified",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": false,
+		{
+			Name: "EmailNotVerified",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": false,
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusForbidden,
 		},
-		AllowSignups: true,
-		StatusCode:   http.StatusForbidden,
-	}, {
-		Name: "EmailNotAString",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          3.14159,
-			"email_verified": false,
+		{
+			Name: "EmailNotAString",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          3.14159,
+				"email_verified": false,
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusBadRequest,
 		},
-		AllowSignups: true,
-		StatusCode:   http.StatusBadRequest,
-	}, {
-		Name: "EmailNotVerifiedIgnored",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": false,
+		{
+			Name: "EmailNotVerifiedIgnored",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": false,
+			},
+			AllowSignups:        true,
+			StatusCode:          http.StatusOK,
+			Username:            "kyle",
+			IgnoreEmailVerified: true,
 		},
-		AllowSignups:        true,
-		StatusCode:          http.StatusOK,
-		Username:            "kyle",
-		IgnoreEmailVerified: true,
-	}, {
-		Name: "NotInRequiredEmailDomain",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": true,
+		{
+			Name: "NotInRequiredEmailDomain",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+			},
+			AllowSignups: true,
+			EmailDomain: []string{
+				"coder.com",
+			},
+			StatusCode: http.StatusForbidden,
 		},
-		AllowSignups: true,
-		EmailDomain: []string{
-			"coder.com",
+		{
+			Name: "EmailDomainCaseInsensitive",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@KWC.io",
+				"email_verified": true,
+			},
+			AllowSignups: true,
+			EmailDomain: []string{
+				"kwc.io",
+			},
+			StatusCode: http.StatusOK,
 		},
-		StatusCode: http.StatusForbidden,
-	}, {
-		Name: "EmailDomainCaseInsensitive",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@KWC.io",
-			"email_verified": true,
+		{
+			Name: "EmailDomainSubset",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "colin@gmail.com",
+				"email_verified": true,
+			},
+			AllowSignups: true,
+			EmailDomain: []string{
+				"mail.com",
+			},
+			StatusCode: http.StatusForbidden,
 		},
-		AllowSignups: true,
-		EmailDomain: []string{
-			"kwc.io",
+		{
+			Name:          "EmptyClaims",
+			IDTokenClaims: jwt.MapClaims{},
+			AllowSignups:  true,
+			StatusCode:    http.StatusBadRequest,
 		},
-		StatusCode: http.StatusOK,
-	}, {
-		Name: "EmailDomainSubset",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "colin@gmail.com",
-			"email_verified": true,
+		{
+			Name: "NoSignups",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+			},
+			StatusCode: http.StatusForbidden,
 		},
-		AllowSignups: true,
-		EmailDomain: []string{
-			"mail.com",
+		{
+			Name: "UsernameFromEmail",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+			},
+			Username:     "kyle",
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
 		},
-		StatusCode: http.StatusForbidden,
-	}, {
-		Name:          "EmptyClaims",
-		IDTokenClaims: jwt.MapClaims{},
-		AllowSignups:  true,
-		StatusCode:    http.StatusBadRequest,
-	}, {
-		Name: "NoSignups",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": true,
+		{
+			Name: "UsernameFromClaims",
+			IDTokenClaims: jwt.MapClaims{
+				"email":              "kyle@kwc.io",
+				"email_verified":     true,
+				"preferred_username": "hotdog",
+			},
+			Username:     "hotdog",
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
 		},
-		StatusCode: http.StatusForbidden,
-	}, {
-		Name: "UsernameFromEmail",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": true,
+		{
+			// Services like Okta return the email as the username:
+			// https://developer.okta.com/docs/reference/api/oidc/#base-claims-always-present
+			Name: "UsernameAsEmail",
+			IDTokenClaims: jwt.MapClaims{
+				"email":              "kyle@kwc.io",
+				"email_verified":     true,
+				"preferred_username": "kyle@kwc.io",
+			},
+			Username:     "kyle",
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
 		},
-		Username:     "kyle",
-		AllowSignups: true,
-		StatusCode:   http.StatusOK,
-	}, {
-		Name: "UsernameFromClaims",
-		IDTokenClaims: jwt.MapClaims{
-			"email":              "kyle@kwc.io",
-			"email_verified":     true,
-			"preferred_username": "hotdog",
+		{
+			// See: https://github.com/coder/coder/issues/4472
+			Name: "UsernameIsEmail",
+			IDTokenClaims: jwt.MapClaims{
+				"preferred_username": "kyle@kwc.io",
+			},
+			Username:     "kyle",
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
 		},
-		Username:     "hotdog",
-		AllowSignups: true,
-		StatusCode:   http.StatusOK,
-	}, {
-		// Services like Okta return the email as the username:
-		// https://developer.okta.com/docs/reference/api/oidc/#base-claims-always-present
-		Name: "UsernameAsEmail",
-		IDTokenClaims: jwt.MapClaims{
-			"email":              "kyle@kwc.io",
-			"email_verified":     true,
-			"preferred_username": "kyle@kwc.io",
+		{
+			Name: "WithPicture",
+			IDTokenClaims: jwt.MapClaims{
+				"email":              "kyle@kwc.io",
+				"email_verified":     true,
+				"preferred_username": "kyle",
+				"picture":            "/example.png",
+			},
+			Username:     "kyle",
+			AllowSignups: true,
+			AvatarURL:    "/example.png",
+			StatusCode:   http.StatusOK,
 		},
-		Username:     "kyle",
-		AllowSignups: true,
-		StatusCode:   http.StatusOK,
-	}, {
-		// See: https://github.com/coder/coder/issues/4472
-		Name: "UsernameIsEmail",
-		IDTokenClaims: jwt.MapClaims{
-			"preferred_username": "kyle@kwc.io",
+		{
+			Name: "WithUserInfoClaims",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+			},
+			UserInfoClaims: jwt.MapClaims{
+				"preferred_username": "potato",
+				"picture":            "/example.png",
+			},
+			Username:     "potato",
+			AllowSignups: true,
+			AvatarURL:    "/example.png",
+			StatusCode:   http.StatusOK,
 		},
-		Username:     "kyle",
-		AllowSignups: true,
-		StatusCode:   http.StatusOK,
-	}, {
-		Name: "WithPicture",
-		IDTokenClaims: jwt.MapClaims{
-			"email":              "kyle@kwc.io",
-			"email_verified":     true,
-			"preferred_username": "kyle",
-			"picture":            "/example.png",
+		{
+			Name: "GroupsDoesNothing",
+			IDTokenClaims: jwt.MapClaims{
+				"email":  "coolin@coder.com",
+				"groups": []string{"pingpong"},
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
 		},
-		Username:     "kyle",
-		AllowSignups: true,
-		AvatarURL:    "/example.png",
-		StatusCode:   http.StatusOK,
-	}, {
-		Name: "WithUserInfoClaims",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "kyle@kwc.io",
-			"email_verified": true,
+		{
+			Name: "UserInfoOverridesIDTokenClaims",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "internaluser@internal.domain",
+				"email_verified": false,
+			},
+			UserInfoClaims: jwt.MapClaims{
+				"email":              "externaluser@external.domain",
+				"email_verified":     true,
+				"preferred_username": "user",
+			},
+			Username:            "user",
+			AllowSignups:        true,
+			IgnoreEmailVerified: false,
+			StatusCode:          http.StatusOK,
 		},
-		UserInfoClaims: jwt.MapClaims{
-			"preferred_username": "potato",
-			"picture":            "/example.png",
+		{
+			Name: "InvalidUserInfo",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "internaluser@internal.domain",
+				"email_verified": false,
+			},
+			UserInfoClaims: jwt.MapClaims{
+				"email": 1,
+			},
+			AllowSignups:        true,
+			IgnoreEmailVerified: false,
+			StatusCode:          http.StatusInternalServerError,
 		},
-		Username:     "potato",
-		AllowSignups: true,
-		AvatarURL:    "/example.png",
-		StatusCode:   http.StatusOK,
-	}, {
-		Name: "GroupsDoesNothing",
-		IDTokenClaims: jwt.MapClaims{
-			"email":  "coolin@coder.com",
-			"groups": []string{"pingpong"},
+		{
+			Name: "IgnoreUserInfo",
+			IDTokenClaims: jwt.MapClaims{
+				"email":              "user@internal.domain",
+				"email_verified":     true,
+				"preferred_username": "user",
+			},
+			UserInfoClaims: jwt.MapClaims{
+				"email":              "user.mcname@external.domain",
+				"preferred_username": "Mr. User McName",
+			},
+			Username:       "user",
+			IgnoreUserInfo: true,
+			AllowSignups:   true,
+			StatusCode:     http.StatusOK,
 		},
-		AllowSignups: true,
-		StatusCode:   http.StatusOK,
-	}, {
-		Name: "UserInfoOverridesIDTokenClaims",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "internaluser@internal.domain",
-			"email_verified": false,
-		},
-		UserInfoClaims: jwt.MapClaims{
-			"email":              "externaluser@external.domain",
-			"email_verified":     true,
-			"preferred_username": "user",
-		},
-		Username:            "user",
-		AllowSignups:        true,
-		IgnoreEmailVerified: false,
-		StatusCode:          http.StatusOK,
-	}, {
-		Name: "InvalidUserInfo",
-		IDTokenClaims: jwt.MapClaims{
-			"email":          "internaluser@internal.domain",
-			"email_verified": false,
-		},
-		UserInfoClaims: jwt.MapClaims{
-			"email": 1,
-		},
-		AllowSignups:        true,
-		IgnoreEmailVerified: false,
-		StatusCode:          http.StatusInternalServerError,
-	}, {
-		Name: "IgnoreUserInfo",
-		IDTokenClaims: jwt.MapClaims{
-			"email":              "user@internal.domain",
-			"email_verified":     true,
-			"preferred_username": "user",
-		},
-		UserInfoClaims: jwt.MapClaims{
-			"email":              "user.mcname@external.domain",
-			"preferred_username": "Mr. User McName",
-		},
-		Username:       "user",
-		IgnoreUserInfo: true,
-		AllowSignups:   true,
-		StatusCode:     http.StatusOK,
-	},
 		{
 			Name: "HugeIDToken",
 			IDTokenClaims: inflateClaims(t, jwt.MapClaims{
@@ -960,7 +979,8 @@ func TestUserOIDC(t *testing.T) {
 			Username:       "user",
 			AllowSignups:   true,
 			StatusCode:     http.StatusOK,
-		}} {
+		},
+	} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
- Adds two test cases for a 64k+ ID token and a 64k+ userinfo payload.
- Unfortunately it then wanted me to reformat the entire test cases array.