### PR TITLE
docs: update reference architecture: glossary, scale tests methodology

### DIFF
--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -73,15 +73,16 @@ allowing for efficient resource allocation and workload management.
 
 ### Registry
 
-The Coder Registry hosts starter templates for various cloud providers and
-orchestration platforms, enabling self-service cloud development environments
-via Terraform-defined infrastructure. Additionally, Coder introduces _Modules_
-to streamline template creation by extracting commonly used functionalities such
-as web IDEs, third-party integrations, and helper scripts into reusable
-components.
+The Coder Registry is a platform where you can find starter templates and
+_Modules_ for various cloud services and platforms.
 
-The Registry is a hosted service and it is not available for air-gapped
-deployments.
+Templates help create self-service development environments using
+Terraform-defined infrastructure, while _Modules_ simplify template creation by
+providing common features like workspace applications, third-party integrations,
+or helper scripts.
+
+Please note that the Registry is a hosted service and isn't available for
+offline use.
 
 ## Scale-testing methodology
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -126,13 +126,14 @@ based on the workflow configuration:
 
 |                      | T0  | T1  | T2  | T3  | T4  | T5  | T6  |
 | -------------------- | --- | --- | --- | --- | --- | --- | --- |
-| SSH connection       | X   | X   | X   | X   |     |     |     |
+| SSH connections      | X   | X   | X   | X   |     |     |     |
 | Web Terminal (PTY)   |     | X   | X   | X   | X   |     |     |
 | Workspace apps       |     |     | X   | X   | X   | X   |     |
 | Dashboard (headless) |     |     |     | X   | X   | X   | X   |
 
-This distribution closely mirrors natural user behavior observed among our
-customers.
+This pattern closely reflects how our customers naturally use the system. SSH
+connections are heavily utilized because they're the primary communication
+channel for IDEs with VS Code and JetBrains plugins.
 
 The basic setup of scale tests environment involves:
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -68,15 +68,22 @@ allowing for efficient resource allocation and workload management.
 
 ## Registry
 
-A registry in Coder is a centralized repository for storing and managing
-container images used within the platform. By leveraging a registry, users can
-easily share, distribute, and deploy containerized applications across their
-development workflows, ensuring consistency and reliability.
+The Coder Registry hosts starter templates for various cloud providers and
+orchestration platforms, enabling self-service cloud development environments
+via Terraform-defined infrastructure. Additionally, Coder introduces _Modules_
+to streamline template creation by extracting commonly used functionalities such
+as web IDEs, third-party integrations, and helper scripts into reusable
+components.
 
-## Kubernetes Cluster for Coder
+The Registry is hosted service and it is not available for air-gapped
+deployments.
 
-A Kubernetes cluster for Coder is a dedicated cluster specifically configured to
+## Kubernetes cluster for Coder
+
+A dedicated cluster for Coder is Kubernetes cluster specifically configured to
 host and manage Coder workloads. Kubernetes provides container orchestration
 capabilities, allowing Coder to efficiently deploy, scale, and manage workspaces
 across a distributed infrastructure. This ensures high availability, fault
 tolerance, and scalability for Coder deployments.
+
+The cluster can be deployed using the Helm chart.

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -97,10 +97,47 @@ bottlenecks.
 
 ### Infrastructure and setup requirements
 
-TODO
+In a single workflow, the scale tests runner maintains a consistent load
+distribution as follows:
+
+- 80% of users open and utilize SSH connections.
+- 25% of users connect to the workspace using the Web Terminal.
+- 40% of users simulate traffic for workspace apps.
+- 20% of users interact with the Coder UI via a headless browser.
+
+This distribution closely mirrors natural user behavior, as observed among our
+customers.
+
+The basic setup of scale tests environment involves:
+
+1. Scale tests runner: `c2d-standard-32` (32 vCPU, 128 GB RAM)
+2. Coderd: 2 replicas (4 vCPU, 16 GB RAM)
+3. Database: 1 replica (2 vCPU, 32 GB RAM)
+4. Provisioner: 50 instances (0.5 vCPU, 512 MB RAM)
+
+No pod restarts or internal errors were observed.
 
 ### Traffic Projections
 
-<!-- during scale tests -->
+In our scale tests, we simulate activity from 2000 users, 2000 workspaces, and
+2000 agents, with metadata being sent 2 x every 10 s. Here are the resulting
+metrics:
 
-TODO
+Coder:
+
+- coderd: Median CPU usage for coderd: 3 vCPU, peaking at 3.7 vCPU during
+  dashboard tests.
+- provisionerd: Median CPU usage is 0.35 vCPU during workspace provisioning.
+
+API:
+
+- Median request rate: 350 req/s during dashboard tests, 250 req/s during Web
+  Terminal and workspace apps tests.
+- 2000 agent connections with latency: p90 at 60 ms, p95 at 220 ms.
+- on average 2400 websocket connections during dashboard tests.
+
+Database:
+
+- Median CPU utilization: 80%.
+- Median memory utilization: 40%.
+- Average write_ops_count per minute: between 400 and 500 operations.

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -116,17 +116,17 @@ Our scale tests include the following stages:
 
 ### Infrastructure and setup requirements
 
-The scale tests runner
+The scale tests runner can distribute the workload to overlap single scenarios
+based on the workflow configuration:
 
-In a single workflow, the scale tests runner evenly spreads out the workload
-like this:
+|                      | T0  | T1  | T2  | T3  | T4  | T5  | T6  |
+| -------------------- | --- | --- | --- | --- | --- | --- | --- |
+| SSH connection       | X   | X   | X   | X   |     |     |     |
+| Web Terminal (PTY)   |     | X   | X   | X   | X   |     |     |
+| Workspace apps       |     |     | X   | X   | X   | X   |     |
+| Dashboard (headless) |     |     |     | X   | X   | X   | X   |
 
-- 80% of users open and utilize SSH connections.
-- 25% of users connect to the workspace using the Web Terminal.
-- 40% of users simulate traffic for workspace apps.
-- 20% of users interact with the Coder UI via a headless browser.
-
-This distribution closely mirrors natural user behavior, as observed among our
+This distribution closely mirrors natural user behavior observed among our
 customers.
 
 The basic setup of scale tests environment involves:

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -4,10 +4,10 @@ This document provides prescriptive solutions and reference architectures to
 support successful deployments of up to 2000 users and outlines at a high-level
 the methodology currently used to scale-test Coder.
 
+## General concepts
+
 This section outlines core concepts and terminology essential for understanding
 Coder's architecture and deployment strategies.
-
-## General concepts
 
 ### Administrator
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -86,9 +86,9 @@ deployments.
 ## Scale tests methodology
 
 Scaling Coder involves careful planning and testing to ensure it can handle more
-users without slowing down. This process encompasses infrastructure setup,
-traffic projections, and aggressive testing to identify and mitigate potential
-bottlenecks.
+load without compromising service. This process encompasses infrastructure
+setup, traffic projections, and aggressive testing to identify and mitigate
+potential bottlenecks.
 
 A dedicated cluster for Coder is Kubernetes cluster specifically configured to
 host and manage Coder workloads. Kubernetes provides container orchestration
@@ -97,8 +97,7 @@ across a distributed infrastructure. This ensures high availability, fault
 tolerance, and scalability for Coder deployments. The cluster can be deployed
 using the Helm chart.
 
-In our scale tests, we adopt an approach with various stages to thoroughly
-evaluate the system's performance. These stages include:
+Our scale tests include the following stages:
 
 1. Prepare environment: create expected users and provision workspaces.
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -165,6 +165,7 @@ Provisionerd:
 
 Database:
 
-- Median CPU utilization: 80%.
-- Median memory utilization: 40%.
+- Median CPU utilization is 80%, with a significant portion dedicated to writing
+  metadata.
+- Memory utilization averages at 40%.
 - `write_ops_count` between 6.7 and 8.4 operations per second.

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -90,12 +90,13 @@ without compromising service. This process encompasses infrastructure setup,
 traffic projections, and aggressive testing to identify and mitigate potential
 bottlenecks.
 
-A dedicated cluster for Coder is Kubernetes cluster specifically configured to
-host and manage Coder workloads. Kubernetes provides container orchestration
-capabilities, allowing Coder to efficiently deploy, scale, and manage workspaces
-across a distributed infrastructure. This ensures high availability, fault
-tolerance, and scalability for Coder deployments. Code is deployed on this
-cluster using the [Helm chart](../install/kubernetes#install-coder-with-helm).
+A dedicated Kubernetes cluster for Coder is Kubernetes cluster specifically
+configured to host and manage Coder workloads. Kubernetes provides container
+orchestration capabilities, allowing Coder to efficiently deploy, scale, and
+manage workspaces across a distributed infrastructure. This ensures high
+availability, fault tolerance, and scalability for Coder deployments. Code is
+deployed on this cluster using the
+[Helm chart](../install/kubernetes#install-coder-with-helm).
 
 Our scale tests include the following stages:
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -116,6 +116,8 @@ Our scale tests include the following stages:
 
 ### Infrastructure and setup requirements
 
+The scale tests runner
+
 In a single workflow, the scale tests runner evenly spreads out the workload
 like this:
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -141,8 +141,9 @@ The basic setup of scale tests environment involves:
 3. Database: 1 instance (2 vCPU, 32 GB RAM)
 4. Provisioner: 50 instances (0.5 vCPU, 512 MB RAM)
 
-The test is deemed successful if no crashes or restarts of `coderd` or other
-internal errors were observed.
+The test is deemed successful if users did not experience interruptions in their
+workflows, `coderd` did not crash or require restarts, and no other internal
+errors were observed.
 
 ### Traffic Projections
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -51,17 +51,20 @@ infrastructure resources offered by cloud providers.
 
 ## Proxy
 
-A proxy in Coder serves as an intermediary between users and the Coder platform,
-facilitating secure communication and access control. The proxy handles requests
-from users, routes them to the appropriate services within Coder, and enforces
-security policies to safeguard sensitive information.
+A workspace proxy serves as a relay connection option for developers connecting
+to their workspace over SSH, a workspace app, or through port forwarding. It
+helps reduce network latency for geo-distributed teams by minimizing the
+distance network traffic needs to travel. Notably, workspace proxies do not
+handle dashboard connections or API calls.
 
-## Provisionerd
+## Provisioner
 
-A provisioner in Coder is responsible for provisioning and managing resources
-required for workspace creation. This includes allocating computing resources
-such as CPU, memory, and storage, as well as configuring networking settings to
-ensure seamless connectivity within the workspace environment.
+Provisioners in Coder execute Terraform during workspace and template builds.
+While the platform includes built-in provisioner daemons by default, there are
+advantages to employing external provisioners. These external daemons provide
+secure build environments, and reduce server load, improving performance and
+scalability. Each provisioner can handle a single concurrent workspace build,
+allowing for efficient resource allocation and workload management.
 
 ## Registry
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -20,7 +20,7 @@ management, template definitions, insights, and deployment configuration.
 Coder, also known as _coderd_, is the main service recommended for deployment
 with multiple replicas to ensure high availability. It provides an API for
 managing workspaces and templates. Each _coderd_ replica has the capability to
-host multiple provisioners (`provisionerd`).
+host multiple [provisioners](#provisioner).
 
 ### User
 
@@ -52,7 +52,7 @@ administrators on top of Terraform, allowing for efficient management of
 infrastructure resources. Additionally, templates can utilize Coder modules to
 leverage existing features shared with other templates, enhancing flexibility
 and consistency across deployments. Templates describe provisioning rules for
-infrastructure resources offered by cloud providers.
+infrastructure resources offered by Terraform providers.
 
 ### Workspace Proxy
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -54,7 +54,7 @@ leverage existing features shared with other templates, enhancing flexibility
 and consistency across deployments. Templates describe provisioning rules for
 infrastructure resources offered by cloud providers.
 
-### Proxy
+### Workspace Proxy
 
 A workspace proxy serves as a relay connection option for developers connecting
 to their workspace over SSH, a workspace app, or through port forwarding. It
@@ -67,7 +67,7 @@ handle dashboard connections or API calls.
 Provisioners in Coder execute Terraform during workspace and template builds.
 While the platform includes built-in provisioner daemons by default, there are
 advantages to employing external provisioners. These external daemons provide
-secure build environments, and reduce server load, improving performance and
+secure build environments and reduce server load, improving performance and
 scalability. Each provisioner can handle a single concurrent workspace build,
 allowing for efficient resource allocation and workload management.
 
@@ -94,8 +94,8 @@ A dedicated cluster for Coder is Kubernetes cluster specifically configured to
 host and manage Coder workloads. Kubernetes provides container orchestration
 capabilities, allowing Coder to efficiently deploy, scale, and manage workspaces
 across a distributed infrastructure. This ensures high availability, fault
-tolerance, and scalability for Coder deployments. The cluster can be deployed
-using the Helm chart.
+tolerance, and scalability for Coder deployments. Code is deployed on this
+cluster using the [Helm chart](../install/kubernetes#install-coder-with-helm).
 
 Our scale tests include the following stages:
 
@@ -133,7 +133,7 @@ The basic setup of scale tests environment involves:
 
 1. Scale tests runner (32 vCPU, 128 GB RAM)
 2. Coder: 2 replicas (4 vCPU, 16 GB RAM)
-3. Database: 1 replica (2 vCPU, 32 GB RAM)
+3. Database: 1 instance (2 vCPU, 32 GB RAM)
 4. Provisioner: 50 instances (0.5 vCPU, 512 MB RAM)
 
 The test is deemed successful if no crashes or restarts of `coderd` or other

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -49,7 +49,7 @@ leverage existing features shared with other templates, enhancing flexibility
 and consistency across deployments. Templates describe provisioning rules for
 infrastructure resources offered by cloud providers.
 
-## Proxy
+### Proxy
 
 A workspace proxy serves as a relay connection option for developers connecting
 to their workspace over SSH, a workspace app, or through port forwarding. It
@@ -57,7 +57,7 @@ helps reduce network latency for geo-distributed teams by minimizing the
 distance network traffic needs to travel. Notably, workspace proxies do not
 handle dashboard connections or API calls.
 
-## Provisioner
+### Provisioner
 
 Provisioners in Coder execute Terraform during workspace and template builds.
 While the platform includes built-in provisioner daemons by default, there are
@@ -66,7 +66,7 @@ secure build environments, and reduce server load, improving performance and
 scalability. Each provisioner can handle a single concurrent workspace build,
 allowing for efficient resource allocation and workload management.
 
-## Registry
+### Registry
 
 The Coder Registry hosts starter templates for various cloud providers and
 orchestration platforms, enabling self-service cloud development environments
@@ -78,7 +78,7 @@ components.
 The Registry is hosted service and it is not available for air-gapped
 deployments.
 
-## Kubernetes cluster for Coder
+### Kubernetes cluster for Coder
 
 A dedicated cluster for Coder is Kubernetes cluster specifically configured to
 host and manage Coder workloads. Kubernetes provides container orchestration
@@ -87,3 +87,20 @@ across a distributed infrastructure. This ensures high availability, fault
 tolerance, and scalability for Coder deployments.
 
 The cluster can be deployed using the Helm chart.
+
+## Scale tests methodology
+
+Scaling Coder involves careful planning and testing to ensure it can handle more
+users without slowing down. This process encompasses infrastructure setup,
+traffic projections, and aggressive testing to identify and mitigate potential
+bottlenecks.
+
+### Infrastructure and setup requirements
+
+TODO
+
+### Traffic Projections
+
+<!-- during scale tests -->
+
+TODO

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -1,0 +1,79 @@
+# Reference architectures
+
+As Coder evolves to meet the demands of modern development workflows, ensuring
+scalability is paramount. Today, we're stress-testing our platform with 2000
+concurrent users, preparing for deployments of up to 5000 users. This
+documentation provides prescriptive solutions and reference architectures to
+support successful customer deployments.
+
+Let's dive into the core concepts and terminology essential for understanding
+Coder's architecture and deployment strategies.
+
+## Glossary
+
+### Administrator
+
+An administrator is a user role within the Coder platform with elevated
+privileges. Admins have access to administrative functions such as user
+management, template definitions, insights, and deployment configuration.
+
+### User
+
+A user is an individual who utilizes the Coder platform to develop, test, and
+deploy applications using workspaces. Users can select available templates to
+provision workspaces. They interact with Coder using the web interface, the CLI
+tool, or directly calling API methods.
+
+### Workspace
+
+A workspace refers to an isolated development environment where users can write,
+build, and run code. Workspaces are fully configurable and can be tailored to
+specific project requirements, providing developers with a consistent and
+efficient development environment. Workspaces can be autostarted and
+autostopped, enabling efficient resource management.
+
+Users can connect to workspaces using SSH or via workspace applications like
+`code-server`, facilitating collaboration and remote access. Additionally,
+workspaces can be parameterized, allowing users to customize settings and
+configurations based on their unique needs. Workspaces are instantiated using
+Coder templates and deployed on nodes by provisioners.
+
+### Template
+
+A template in Coder is a predefined configuration for creating workspaces.
+Templates streamline the process of workspace creation by providing
+pre-configured settings, tooling, and dependencies. They are built by template
+administrators on top of Terraform, allowing for efficient management of
+infrastructure resources. Additionally, templates can utilize Coder modules to
+leverage existing features shared with other templates, enhancing flexibility
+and consistency across deployments. Templates describe provisioning rules for
+infrastructure resources offered by cloud providers.
+
+## Proxy
+
+A proxy in Coder serves as an intermediary between users and the Coder platform,
+facilitating secure communication and access control. The proxy handles requests
+from users, routes them to the appropriate services within Coder, and enforces
+security policies to safeguard sensitive information.
+
+## Provisionerd
+
+A provisioner in Coder is responsible for provisioning and managing resources
+required for workspace creation. This includes allocating computing resources
+such as CPU, memory, and storage, as well as configuring networking settings to
+ensure seamless connectivity within the workspace environment.
+
+## Registry
+
+A registry in Coder is a centralized repository for storing and managing
+container images used within the platform. By leveraging a registry, users can
+easily share, distribute, and deploy containerized applications across their
+development workflows, ensuring consistency and reliability.
+
+## Kubernetes Cluster for Coder
+
+A Kubernetes cluster for Coder is a dedicated cluster specifically configured to
+host and manage Coder workloads. Kubernetes provides container orchestration
+capabilities, allowing Coder to efficiently deploy, scale, and manage workspaces
+across a distributed infrastructure. This ensures high availability, fault
+tolerance, and scalability for Coder deployments.

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -123,18 +123,18 @@ In our scale tests, we simulate activity from 2000 users, 2000 workspaces, and
 2000 agents, with metadata being sent 2 x every 10 s. Here are the resulting
 metrics:
 
-Coder:
+Coderd:
 
-- coderd: Median CPU usage for coderd: 3 vCPU, peaking at 3.7 vCPU during
-  dashboard tests.
-- provisionerd: Median CPU usage is 0.35 vCPU during workspace provisioning.
+- Median CPU usage for coderd: 3 vCPU, peaking at 3.7 vCPU during dashboard
+  tests.
+- Median API request rate: 350 req/s during dashboard tests, 250 req/s during
+  Web Terminal and workspace apps tests.
+- 2000 agent API connections with latency: p90 at 60 ms, p95 at 220 ms.
+- on average 2400 Web Socket connections during dashboard tests.
 
-API:
+Provisionerd:
 
-- Median request rate: 350 req/s during dashboard tests, 250 req/s during Web
-  Terminal and workspace apps tests.
-- 2000 agent connections with latency: p90 at 60 ms, p95 at 220 ms.
-- on average 2400 websocket connections during dashboard tests.
+- Median CPU usage is 0.35 vCPU during workspace provisioning.
 
 Database:
 

--- a/docs/admin/reference-architectures.md
+++ b/docs/admin/reference-architectures.md
@@ -80,15 +80,15 @@ to streamline template creation by extracting commonly used functionalities such
 as web IDEs, third-party integrations, and helper scripts into reusable
 components.
 
-The Registry is hosted service and it is not available for air-gapped
+The Registry is a hosted service and it is not available for air-gapped
 deployments.
 
-## Scale tests methodology
+## Scale-testing methodology
 
-Scaling Coder involves careful planning and testing to ensure it can handle more
-load without compromising service. This process encompasses infrastructure
-setup, traffic projections, and aggressive testing to identify and mitigate
-potential bottlenecks.
+Scaling Coder involves planning and testing to ensure it can handle more load
+without compromising service. This process encompasses infrastructure setup,
+traffic projections, and aggressive testing to identify and mitigate potential
+bottlenecks.
 
 A dedicated cluster for Coder is Kubernetes cluster specifically configured to
 host and manage Coder workloads. Kubernetes provides container orchestration
@@ -101,18 +101,21 @@ Our scale tests include the following stages:
 
 1. Prepare environment: create expected users and provision workspaces.
 
-2. Dashboard evaluation: verify the responsiveness and stability of Coder
-   dashboards under varying load conditions. This is achieved by simulating user
-   interactions using instances of headless Chromium browsers.
-
-3. SSH connections: establish user connections with agents, verifying their
+2. SSH connections: establish user connections with agents, verifying their
    ability to echo back received content.
+
+3. Web Terminal: verify the PTY connection used for communication with Web
+   Terminal.
 
 4. Workspace application traffic: assess the handling of user connections with
    specific workspace apps, confirming their capability to echo back received
    content effectively.
 
-5. Cleanup: delete workspaces and users created in step 1.
+5. Dashboard evaluation: verify the responsiveness and stability of Coder
+   dashboards under varying load conditions. This is achieved by simulating user
+   interactions using instances of headless Chromium browsers.
+
+6. Cleanup: delete workspaces and users created in step 1.
 
 ### Infrastructure and setup requirements
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/12426
Preview: [link](https://github.com/coder/coder/blob/12426-build-public-facing-docs/docs/admin/reference-architectures.md)

This pull request adds public-facing docs for Reference Architectures. This is the 1st part and will be merged into the feature branch. By the way, I noticed that some topics might be interleaving with [Scaling Coder](https://coder.com/docs/v2/latest/admin/scale), so most likely the latter one will be worth editing afterward.

Covered sections:
 * Coder Glossary (admin, user, workspace, template, proxy, provisioner, registry, Kubernetes cluster for Coder)
 * Describe scale tests methodology 
   * infra/setup requirements, web terminal, applications
   * traffic projections during scale tests (continuous volume, req/s, users, aggressive approach)
