### PR TITLE
fix: display tooltip when selection is disabled

### DIFF
--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -203,6 +203,23 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
   const canSharePortsPublic =
     canSharePorts && template.max_port_share_level === "public";
 
+  const publicMenuItem = (
+    <>
+      {canSharePortsPublic ? (
+        <MenuItem value="public">Public</MenuItem>
+      ) : (
+        <Tooltip title="This workspace template does not allow sharing ports with unauthenticated users.">
+        {/* Tooltips don't work directly on disabled MenuItem components so you must wrap in div. */}
+        <div>
+          <MenuItem value="public" disabled>
+            Public
+          </MenuItem>
+        </div>
+      </Tooltip>
+      )}
+    </>
+  )
+
   return (
     <>
       <div
@@ -403,12 +420,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                           <MenuItem value="authenticated">
                             Authenticated
                           </MenuItem>
-                          <MenuItem
-                            value="public"
-                            disabled={!canSharePortsPublic}
-                          >
-                            Public
-                          </MenuItem>
+                          {publicMenuItem}
                         </Select>
                       </FormControl>
                       <Button
@@ -462,18 +474,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                     label="Sharing Level"
                   >
                     <MenuItem value="authenticated">Authenticated</MenuItem>
-                    {canSharePortsPublic ? (
-                      <MenuItem value="public">Public</MenuItem>
-                    ) : (
-                      <Tooltip title="This workspace template does not allow sharing ports with unauthenticated users.">
-                        {/* Tooltips don't work directly on disabled MenuItem components so you must wrap in div. */}
-                        <div>
-                          <MenuItem value="public" disabled>
-                            Public
-                          </MenuItem>
-                        </div>
-                      </Tooltip>
-                    )}
+                    {publicMenuItem}
                   </TextField>
                   <LoadingButton
                     variant="contained"

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -468,11 +468,13 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                       </MenuItem>
                     ) : (
                       <Tooltip title="This workspace template does not allow sharing ports with unauthenticated users.">
-                        <MenuItem value="public" disabled>
-                          Public
-                        </MenuItem>
+                        {/* Tooltips don't work directly on disabled MenuItem components so you must wrap in div. */}
+                        <div>
+                          <MenuItem value="public" disabled>
+                            Public
+                          </MenuItem>
+                        </div>
                       </Tooltip>
-
                     )}
 
                   </TextField>

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -14,6 +14,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import { type FormikContextType, useFormik } from "formik";
 import type { FC } from "react";
 import { useQuery, useMutation } from "react-query";
@@ -461,9 +462,19 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                     label="Sharing Level"
                   >
                     <MenuItem value="authenticated">Authenticated</MenuItem>
-                    <MenuItem value="public" disabled={!canSharePortsPublic}>
-                      Public
-                    </MenuItem>
+                    {canSharePortsPublic ? (
+                      <MenuItem value="public">
+                        Public
+                      </MenuItem>
+                    ) : (
+                      <Tooltip title="This workspace template does not allow sharing ports with unauthenticated users.">
+                        <MenuItem value="public" disabled>
+                          Public
+                        </MenuItem>
+                      </Tooltip>
+
+                    )}
+
                   </TextField>
                   <LoadingButton
                     variant="contained"

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -209,16 +209,16 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
         <MenuItem value="public">Public</MenuItem>
       ) : (
         <Tooltip title="This workspace template does not allow sharing ports with unauthenticated users.">
-        {/* Tooltips don't work directly on disabled MenuItem components so you must wrap in div. */}
-        <div>
-          <MenuItem value="public" disabled>
-            Public
-          </MenuItem>
-        </div>
-      </Tooltip>
+          {/* Tooltips don't work directly on disabled MenuItem components so you must wrap in div. */}
+          <div>
+            <MenuItem value="public" disabled>
+              Public
+            </MenuItem>
+          </div>
+        </Tooltip>
       )}
     </>
-  )
+  );
 
   return (
     <>

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -463,9 +463,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                   >
                     <MenuItem value="authenticated">Authenticated</MenuItem>
                     {canSharePortsPublic ? (
-                      <MenuItem value="public">
-                        Public
-                      </MenuItem>
+                      <MenuItem value="public">Public</MenuItem>
                     ) : (
                       <Tooltip title="This workspace template does not allow sharing ports with unauthenticated users.">
                         {/* Tooltips don't work directly on disabled MenuItem components so you must wrap in div. */}
@@ -476,7 +474,6 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                         </div>
                       </Tooltip>
                     )}
-
                   </TextField>
                   <LoadingButton
                     variant="contained"


### PR DESCRIPTION
Screenshot is missing mouse but this is on hover. 

<img width="325" alt="image" src="https://github.com/coder/coder/assets/19379394/53d844fb-9318-46de-af92-8a56543df927">

<img width="396" alt="image" src="https://github.com/coder/coder/assets/19379394/e66e4fad-0ac4-47ae-9089-74e07f0d0840">
