### PR TITLE
fix: do not set max deadline for workspaces on template update

### DIFF
--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -289,6 +289,12 @@ func (s *EnterpriseTemplateScheduleStore) updateWorkspaceBuild(ctx context.Conte
 		autostop.Deadline = autostop.MaxDeadline
 	}
 
+	// If there's a max_deadline but the deadline is 0, then set the deadline to
+	// the max_deadline.
+	if !autostop.MaxDeadline.IsZero() && autostop.Deadline.IsZero() {
+		autostop.Deadline = autostop.MaxDeadline
+	}
+
 	// Update the workspace build deadline.
 	err = db.UpdateWorkspaceBuildDeadlineByID(ctx, database.UpdateWorkspaceBuildDeadlineByIDParams{
 		ID:          build.ID,

--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -277,6 +277,9 @@ func (s *EnterpriseTemplateScheduleStore) updateWorkspaceBuild(ctx context.Conte
 	}
 
 	// If max deadline is before now()+2h, then set it to that.
+	// This is intended to give ample warning to this workspace about an upcoming auto-stop.
+	// If we were to omit this "grace" period, then this workspace could be set to be stopped "now".
+	// The "2 hours" was an arbitrary decision for this window.
 	now := s.now()
 	if !autostop.MaxDeadline.IsZero() && autostop.MaxDeadline.Before(now.Add(2*time.Hour)) {
 		autostop.MaxDeadline = now.Add(time.Hour * 2)

--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -278,7 +278,7 @@ func (s *EnterpriseTemplateScheduleStore) updateWorkspaceBuild(ctx context.Conte
 
 	// If max deadline is before now()+2h, then set it to that.
 	now := s.now()
-	if autostop.MaxDeadline.Before(now.Add(2 * time.Hour)) {
+	if !autostop.MaxDeadline.IsZero() && autostop.MaxDeadline.Before(now.Add(2*time.Hour)) {
 		autostop.MaxDeadline = now.Add(time.Hour * 2)
 	}
 

--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -285,7 +285,7 @@ func (s *EnterpriseTemplateScheduleStore) updateWorkspaceBuild(ctx context.Conte
 	// If the current deadline on the build is after the new max_deadline, then
 	// set it to the max_deadline.
 	autostop.Deadline = build.Deadline
-	if autostop.Deadline.After(autostop.MaxDeadline) {
+	if !autostop.MaxDeadline.IsZero() && autostop.Deadline.After(autostop.MaxDeadline) {
 		autostop.Deadline = autostop.MaxDeadline
 	}
 

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -131,7 +131,13 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			newMaxDeadline: nextQuietHours,
 		},
 		{
-			name:        "MaxDealineShouldBeUnset",
+			// There was a bug if a user has no quiet hours set, and autostop
+			// req is not turned on, then the max deadline is set to `time.Time{}`.
+			// This zero value was "in the past", so the workspace deadline would
+			// be set to "now" + 2 hours.
+			// This is a mistake because the max deadline being zero means
+			// there is no max deadline.
+			name:        "MaxDeadlineShouldBeUnset",
 			now:         buildTime,
 			deadline:    buildTime.Add(time.Hour * 8),
 			maxDeadline: time.Time{}, // No max set


### PR DESCRIPTION
When templates are updated and schedule data is changed, we update all running workspaces to have up-to-date scheduling information that sticks to the new policy.

When updating the `max_deadline` for existing running workspaces, if the `max_deadline` was before `now()+2h` we would set the `max_deadline` to `now()+2h`.

Builds that don't/shouldn't have a `max_deadline` have it set to `0`, which is always before `now()+2h`, and thus would always have the `max_deadline` updated.

Closes https://github.com/coder/customers/issues/530