### PR TITLE
fix: devcontainer-docker bad default directory

### DIFF
--- a/examples/templates/devcontainer-docker/main.tf
+++ b/examples/templates/devcontainer-docker/main.tf
@@ -28,7 +28,7 @@ resource "coder_agent" "main" {
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
-  dir            = "/worskpaces"
+  dir            = "/workspaces"
 
   # These environment variables allow you to make Git commits right away after creating a
   # workspace. Note that they take precedence over configuration defined in ~/.gitconfig!


### PR DESCRIPTION
typo on directory name : was worskpaces instead of workspaces

I have read the CLA Document and I hereby sign the CLA