### PR TITLE
fix(coderd): prevent nil err deref

### DIFF
--- a/coderd/files.go
+++ b/coderd/files.go
@@ -175,7 +175,6 @@ func (api *API) fileByID(rw http.ResponseWriter, r *http.Request) {
 		if file.Mimetype != codersdk.ContentTypeTar {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Only .tar files can be converted to .zip format",
-				Detail:  err.Error(),
 			})
 			return
 		}
@@ -192,7 +191,6 @@ func (api *API) fileByID(rw http.ResponseWriter, r *http.Request) {
 	default:
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Unsupported conversion format.",
-			Detail:  err.Error(),
 		})
 	}
 }


### PR DESCRIPTION
STACK:
https://github.com/coder/coder/pull/12477
https://github.com/coder/coder/pull/12476
https://github.com/coder/coder/pull/12475 <-- you are here
https://github.com/coder/coder/pull/12479

Drive-by: prevent a nil pointer deref; err should always be nil in these codepaths.