### PR TITLE
fix(coderd): correctly handle tar dir entries with missing path separator

### DIFF
--- a/coderd/fileszip.go
+++ b/coderd/fileszip.go
@@ -87,6 +87,12 @@ func WriteZipArchive(w io.Writer, tarReader *tar.Reader) error {
 			return err
 		}
 		zipHeader.Name = tarHeader.Name
+		// Some versions of unzip do not check the mode on a file entry and
+		// simply assume that entries with a trailing path separator (/) are
+		// directories, and that everything else is a file. Give them a hint.
+		if tarHeader.FileInfo().IsDir() && !strings.HasSuffix(tarHeader.Name, "/") {
+			zipHeader.Name += "/"
+		}
 
 		zipEntry, err := zipWriter.CreateHeader(zipHeader)
 		if err != nil {

--- a/coderd/fileszip.go
+++ b/coderd/fileszip.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"strings"
 )
 
 func CreateTarFromZip(zipReader *zip.Reader) ([]byte, error) {

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -107,6 +107,11 @@ func Tar(w io.Writer, logger slog.Logger, directory string, limit int64) error {
 		}
 		// Use unix paths in the tar archive.
 		header.Name = filepath.ToSlash(rel)
+		// tar.FileInfoHeader() will do this, but filepath.Rel() calls filepath.Clean()
+		// which strips trailing path separators for directories.
+		if fileInfo.IsDir() {
+			header.Name += "/"
+		}
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}


### PR DESCRIPTION
STACK:
https://github.com/coder/coder/pull/12477
https://github.com/coder/coder/pull/12476
https://github.com/coder/coder/pull/12475
https://github.com/coder/coder/pull/12479 <-- you are here

I noticed that https://cs.opensource.google/go/go/+/refs/tags/go1.22.1:src/archive/tar/common.go;l=658 has a special case that adds a trailing slash to directory entries.

It turns out that `provisionersdk.Tar` has been [silently stripping](https://github.com/coder/coder/blob/1e17782ff6ab6983e0666f62075e8bdefa4e8315/provisionersdk/archive.go#L109) these when creating archives for a good while. Some versions of `unzip`* appear to ignore `fileinfo.IsDir()` and simply assume that any header without a trailing path separator in the name is a file.

This PR makes the following changes:
- Adds a unit test to reproduce the behaviour
- Modifies `coderd.CreateZipFromTar` to transparently add the trailing path separator
- Modifies `provisionersdk.Tar` to add the trailing path separator

\* I can reproduce this with `UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP.`