### PR TITLE
fix(site): allow triggering builds on non-dirtied template version in TemplateVersionEditor

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -184,7 +184,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 
   useLeaveSiteWarning(canPublish);
 
-  const canBuild = !isBuilding && dirty;
+  const canBuild = !isBuilding;
 
   return (
     <>


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/12545

#12406 added a feature to warn the user if they made changes to the template editor but also introduced new behaviour that disabled the `Build` button if no changes were made to the template source code. This PR restores the original behaviour. 