### PR TITLE
fix(site): modify leaveSiteWarning for un-built changes

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -182,7 +182,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
     }
   }, [buildLogs]);
 
-  useLeaveSiteWarning(canPublish);
+  useLeaveSiteWarning(dirty);
 
   const canBuild = !isBuilding && dirty;
 


### PR DESCRIPTION
Spotted in https://github.com/coder/coder/pull/12547

#12406 added a feature to warn the user if they made changes, but this only triggers if you make changes to the template source code and trigger a successful build. This modifies the behaviour to alert if the user attempts to leave the editor with any pending 'dirty' changes.