### PR TITLE
chore: add package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   },
   "dependencies": {
     "exec": "^0.2.1"
-  }
+  },
+  "packageManager": "pnpm@8.14.0+sha1.bb42032ff80dba5f9245bc1b03470d2fa0b7fb2f"
 }


### PR DESCRIPTION
Every time I run `pnpm` in the project it adds the package manager attribute on package.json so I just decided to push it since it does not look like an issue and we can make sure everyone is running the same pnpm version.