### PR TITLE
fix: clean template destination path for `pull`

### DIFF
--- a/cli/templatepull.go
+++ b/cli/templatepull.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/codeclysm/extract/v3"
@@ -128,6 +129,17 @@ func (r *RootCmd) templatePull() *clibase.Cmd {
 
 			if dest == "" {
 				dest = templateName
+			}
+
+			clean, err := filepath.Abs(filepath.Clean(dest))
+			if err != nil {
+				cliui.Error(inv.Stderr, fmt.Sprintf("cleaning destination path %s failed: %q", dest, err))
+				return err
+			}
+
+			if dest != clean {
+				cliui.Warn(inv.Stderr, fmt.Sprintf("cleaning destination path from %s to %s", dest, clean))
+				dest = clean
 			}
 
 			err = os.MkdirAll(dest, 0o750)

--- a/cli/templatepull.go
+++ b/cli/templatepull.go
@@ -136,9 +136,7 @@ func (r *RootCmd) templatePull() *clibase.Cmd {
 				return xerrors.Errorf("cleaning destination path %s failed: %w", dest, err)
 			}
 
-			if dest != clean {
-				dest = clean
-			}
+			dest = clean
 
 			err = os.MkdirAll(dest, 0o750)
 			if err != nil {

--- a/cli/templatepull.go
+++ b/cli/templatepull.go
@@ -133,12 +133,10 @@ func (r *RootCmd) templatePull() *clibase.Cmd {
 
 			clean, err := filepath.Abs(filepath.Clean(dest))
 			if err != nil {
-				cliui.Error(inv.Stderr, fmt.Sprintf("cleaning destination path %s failed: %q", dest, err))
-				return err
+				return xerrors.Errorf("cleaning destination path %s failed: %w", dest, err)
 			}
 
 			if dest != clean {
-				cliui.Warn(inv.Stderr, fmt.Sprintf("cleaning destination path from %s to %s", dest, clean))
 				dest = clean
 			}
 

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -230,118 +230,93 @@ func TestTemplatePull_LatestStdout(t *testing.T) {
 
 // ToDir tests that 'templates pull' pulls down the active template
 // and writes it to the correct directory.
-func TestTemplatePull_ToDir(t *testing.T) {
-	t.Parallel()
-
-	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerDaemon: true,
-	})
-	owner := coderdtest.CreateFirstUser(t, client)
-	templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
-
-	// Create an initial template bundle.
-	source1 := genTemplateVersionSource()
-	// Create an updated template bundle. This will be used to ensure
-	// that templates are correctly returned in order from latest to oldest.
-	source2 := genTemplateVersionSource()
-
-	expected, err := echo.Tar(source2)
-	require.NoError(t, err)
-
-	version1 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, source1)
-	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version1.ID)
-
-	template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version1.ID)
-
-	// Update the template version so that we can assert that templates
-	// are being sorted correctly.
-	updatedVersion := coderdtest.UpdateTemplateVersion(t, client, owner.OrganizationID, source2, template.ID)
-	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, updatedVersion.ID)
-	coderdtest.UpdateActiveTemplateVersion(t, client, template.ID, updatedVersion.ID)
-
-	dir := t.TempDir()
-
-	expectedDest := filepath.Join(dir, "expected")
-	actualDest := filepath.Join(dir, "actual")
-	ctx := context.Background()
-
-	err = extract.Tar(ctx, bytes.NewReader(expected), expectedDest, nil)
-	require.NoError(t, err)
-
-	inv, root := clitest.New(t, "templates", "pull", template.Name, actualDest)
-	clitest.SetupConfig(t, templateAdmin, root)
-
-	ptytest.New(t).Attach(inv)
-
-	require.NoError(t, inv.Run())
-
-	require.Equal(t,
-		dirSum(t, expectedDest),
-		dirSum(t, actualDest),
-	)
-}
-
-// ToDir tests that 'templates pull' pulls down the active template and writes
-// it to a directory with the name of the template if the path is not implicitly
-// supplied.
 // nolint: paralleltest
-func TestTemplatePull_ToImplicit(t *testing.T) {
-	client := coderdtest.New(t, &coderdtest.Options{
-		IncludeProvisionerDaemon: true,
-	})
-	owner := coderdtest.CreateFirstUser(t, client)
-	templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+func TestTemplatePull_ToDir(t *testing.T) {
+	// Prevents the tests from running in parallel.
+	tmp := t.TempDir()
+	expectedDest := filepath.Join(tmp, "expected")
 
-	// Create an initial template bundle.
-	source1 := genTemplateVersionSource()
-	// Create an updated template bundle. This will be used to ensure
-	// that templates are correctly returned in order from latest to oldest.
-	source2 := genTemplateVersionSource()
+	tests := []struct {
+		name      string
+		givenPath string
+	}{
+		{
+			name:      "absolute path works",
+			givenPath: filepath.Join(tmp, "actual"),
+		},
+		{
+			name:      "relative path is cleaned up",
+			givenPath: "./pulltmp",
+		},
+		{
+			name:      "directory traversal is acceptable",
+			givenPath: "../../../mytmpl",
+		},
+		{
+			name:      "empty path falls back to using template name",
+			givenPath: "",
+		},
+	}
 
-	expected, err := echo.Tar(source2)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		tc := tc
 
-	version1 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, source1)
-	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version1.ID)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				_ = os.RemoveAll(tc.givenPath)
+				_ = os.RemoveAll(expectedDest)
+			})
 
-	template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version1.ID)
+			client := coderdtest.New(t, &coderdtest.Options{
+				IncludeProvisionerDaemon: true,
+			})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
 
-	// Update the template version so that we can assert that templates
-	// are being sorted correctly.
-	updatedVersion := coderdtest.UpdateTemplateVersion(t, client, owner.OrganizationID, source2, template.ID)
-	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, updatedVersion.ID)
-	coderdtest.UpdateActiveTemplateVersion(t, client, template.ID, updatedVersion.ID)
+			// Create an initial template bundle.
+			source1 := genTemplateVersionSource()
+			// Create an updated template bundle. This will be used to ensure
+			// that templates are correctly returned in order from latest to oldest.
+			source2 := genTemplateVersionSource()
 
-	// create a tempdir and change the working directory to it for the duration of the test (cannot run in parallel)
-	dir := t.TempDir()
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	err = os.Chdir(dir)
-	require.NoError(t, err)
-	defer func() {
-		err := os.Chdir(wd)
-		require.NoError(t, err, "if this fails, it can break other subsequent tests due to wrong working directory")
-	}()
+			expected, err := echo.Tar(source2)
+			require.NoError(t, err)
 
-	expectedDest := filepath.Join(dir, "expected")
-	actualDest := filepath.Join(dir, template.Name)
+			version1 := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, source1)
+			_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version1.ID)
 
-	ctx := context.Background()
+			template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version1.ID)
 
-	err = extract.Tar(ctx, bytes.NewReader(expected), expectedDest, nil)
-	require.NoError(t, err)
+			// Update the template version so that we can assert that templates
+			// are being sorted correctly.
+			updatedVersion := coderdtest.UpdateTemplateVersion(t, client, owner.OrganizationID, source2, template.ID)
+			_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, updatedVersion.ID)
+			coderdtest.UpdateActiveTemplateVersion(t, client, template.ID, updatedVersion.ID)
 
-	inv, root := clitest.New(t, "templates", "pull", template.Name)
-	clitest.SetupConfig(t, templateAdmin, root)
+			ctx := context.Background()
 
-	ptytest.New(t).Attach(inv)
+			err = extract.Tar(ctx, bytes.NewReader(expected), expectedDest, nil)
+			require.NoError(t, err)
 
-	require.NoError(t, inv.Run())
+			inv, root := clitest.New(t, "templates", "pull", template.Name, tc.givenPath)
+			clitest.SetupConfig(t, templateAdmin, root)
 
-	require.Equal(t,
-		dirSum(t, expectedDest),
-		dirSum(t, actualDest),
-	)
+			ptytest.New(t).Attach(inv)
+
+			require.NoError(t, inv.Run())
+
+			// Validate behaviour of choosing template name in the absence of an output path argument.
+			destPath := tc.givenPath
+			if destPath == "" {
+				destPath = template.Name
+			}
+
+			require.Equal(t,
+				dirSum(t, expectedDest),
+				dirSum(t, destPath),
+			)
+		})
+	}
 }
 
 // FolderConflict tests that 'templates pull' fails when a folder with has

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -263,10 +263,10 @@ func TestTemplatePull_ToDir(t *testing.T) {
 		},
 	}
 
+	// nolint: paralleltest // These tests all share expectedDest
 	for _, tc := range tests {
 		tc := tc
 
-		// nolint: paralleltest // These tests all share expectedDest
 		t.Run(tc.name, func(t *testing.T) {
 			// Use a different working directory to not interfere with actual directory when using relative paths.
 			newWD := t.TempDir()

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -231,10 +231,8 @@ func TestTemplatePull_LatestStdout(t *testing.T) {
 // ToDir tests that 'templates pull' pulls down the active template
 // and writes it to the correct directory.
 //
-// nolint: tparallel // The subtests cannot be run in parallel; see the inner loop.
+// nolint: paralleltest // The subtests cannot be run in parallel; see the inner loop.
 func TestTemplatePull_ToDir(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name           string
 		destPath       string

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -265,13 +265,13 @@ func TestTemplatePull_ToDir(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
 			cwd, err := os.Getwd()
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, os.Chdir(cwd))
 			})
-
-			dir := t.TempDir()
 
 			// Change working directory so that relative path tests don't affect the original working directory.
 			newWd := filepath.Join(dir, "new-cwd")

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -257,7 +257,7 @@ func TestTemplatePull_ToDir(t *testing.T) {
 		},
 		{
 			name:      "directory traversal is acceptable",
-			givenPath: "../../../mytmpl",
+			givenPath: "../mytmpl",
 		},
 		{
 			name:      "empty path falls back to using template name",

--- a/cli/templatepull_test.go
+++ b/cli/templatepull_test.go
@@ -230,6 +230,8 @@ func TestTemplatePull_LatestStdout(t *testing.T) {
 
 // ToDir tests that 'templates pull' pulls down the active template
 // and writes it to the correct directory.
+//
+// nolint: tparallel // The subtests cannot be run in parallel; see the inner loop.
 func TestTemplatePull_ToDir(t *testing.T) {
 	t.Parallel()
 
@@ -270,7 +272,13 @@ func TestTemplatePull_ToDir(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Use a different working directory to not interfere with actual directory when using relative paths.
 			newWD := t.TempDir()
+			cwd, err := os.Getwd()
+			require.NoError(t, err)
 			require.NoError(t, os.Chdir(newWD))
+
+			t.Cleanup(func() {
+				require.NoError(t, os.Chdir(cwd))
+			})
 
 			t.Cleanup(func() {
 				_ = os.RemoveAll(tc.givenPath)


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/10281

Cleaning the path and making it absolute causes the path to not be seen as [unsafe by the underlying library](https://github.com/coder/coder/issues/10281#issuecomment-1988553588).

**Note to reviewer:** this PR obviates the need for `TestTemplatePull_ToImplicit`.
It made sense to me to merge them together, but you may want to keep them separate; I'm easy either way.

Side-note: I was testing to see if I could inject problematic template names like `--help` and ended up finding a CLI bug: https://github.com/coder/coder/issues/12575