### PR TITLE
fix: importing api into vscode-coder

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1,13 +1,15 @@
+/**
+ * @fileoverview This file is imported externally by things like vscode-coder so
+ * it must not import anything using aliases otherwise it will break when being
+ * imported by those external consumers.  For example, `utils/delay` must be
+ * imported using `../utils/delay` instead.
+ */
+
 import axios, { isAxiosError } from "axios";
 import type dayjs from "dayjs";
 import userAgentParser from "ua-parser-js";
 import { delay } from "../utils/delay";
 import * as TypesGen from "./typesGenerated";
-
-// This file is imported externally by things like vscode-coder so it must not
-// import anything using aliases otherwise it will break when being imported by
-// those external consumers.  For example, `utils/delay` must be imported using
-// `../utils/delay` instead.
 
 // Adds 304 for the default axios validateStatus function
 // https://github.com/axios/axios#handling-errors Check status here

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1,10 +1,13 @@
 import axios, { isAxiosError } from "axios";
 import type dayjs from "dayjs";
 import userAgentParser from "ua-parser-js";
-import { delay } from "utils/delay";
+import { delay } from "../utils/delay";
 import * as TypesGen from "./typesGenerated";
-// This needs to include the `../`, otherwise it breaks when importing into
-// vscode-coder.
+
+// This file is imported externally by things like vscode-coder so it must not
+// import anything using aliases otherwise it will break when being imported by
+// those external consumers.  For example, `utils/delay` must be imported using
+// `../utils/delay` instead.
 
 // Adds 304 for the default axios validateStatus function
 // https://github.com/axios/axios#handling-errors Check status here


### PR DESCRIPTION
We import this file in vscode-coder to make use of the API, and eventually the Backstage plugin as well probably.

Likely we want to export an official SDK, but in the meantime we need to make sure we are not importing anything using aliases in this file.

Example of the error we get in vscode-coder:

```
ERROR in /home/runner/work/vscode-coder/vscode-coder/node_modules/coder/site/src/api/api.ts
./node_modules/coder/site/src/api/api.ts 4:22-35
[tsl] ERROR in /home/runner/work/vscode-coder/vscode-coder/node_modules/coder/site/src/api/api.ts(4,23)
      TS2[30](https://github.com/coder/vscode-coder/actions/runs/8255588769/job/22582395856#step:5:31)7: Cannot find module 'utils/delay' or its corresponding type declarations.
ts-loader-default_ab4862433a94faea
 @ ./src/extension.ts 40:14-47
```

https://github.com/coder/vscode-coder/actions/runs/8255588769/job/22582395856#step:5:29