### PR TITLE
test: prevent apptest from choosing ports in use

### DIFF
--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -309,15 +309,31 @@ func createWorkspaceWithApps(t *testing.T, client *codersdk.Client, orgID uuid.U
 		},
 	}, workspaceMutators...)
 
+	// Intentionally going to choose a port that will never be chosen.
+	// Ports <1k will never be selected. 396 is for some old OS over IP.
+	// It will never likely be provisioned. Using quick timeout since
+	// it's all localhost
+	fakeAppURL := "http://127.1.0.1:396"
+	conn, err := net.DialTimeout("tcp", fakeAppURL, time.Millisecond*100)
+	if err == nil {
+		// In the absolute rare case someone hits this. Writing code to find a free port
+		// seems like a waste of time to program and run.
+		_ = conn.Close()
+		t.Errorf("an unused port is required for the fake app. "+
+			"The url %q happens to be an active port. If you hit this, then this test"+
+			"will need to be modified to run on your system. Or you can stop serving an"+
+			"app on that port.", fakeAppURL)
+		t.FailNow()
+	}
+
 	appURL := fmt.Sprintf("%s://127.0.0.1:%d?%s", scheme, port, proxyTestAppQuery)
 	protoApps := []*proto.App{
 		{
 			Slug:         proxyTestAppNameFake,
 			DisplayName:  proxyTestAppNameFake,
 			SharingLevel: proto.AppSharingLevel_OWNER,
-			// Hopefully this IP and port doesn't exist.
-			Url:       "http://127.1.0.1:65535",
-			Subdomain: true,
+			Url:          fakeAppURL,
+			Subdomain:    true,
 		},
 		{
 			Slug:         proxyTestAppNameOwner,


### PR DESCRIPTION
Apptest requires a port without a listening server to test failure cases. This port was chosen and had a chance of actually being provisioned. To prevent this accident, a port <1k is chosen, since those will never be allocated.

Closes 2/3 of https://github.com/coder/coder/issues/12531#issue-2179092055

One of the flakes (https://github.com/coder/coder/issues/12531#issuecomment-1993643000) looks different.

I am able to reproduce the exact error if I spin up a server on `65535`. I think this fix should prevent this in future.