### PR TITLE
chore: remove href from external auth flow, href opened in new window

### DIFF
--- a/site/src/pages/CreateWorkspacePage/ExternalAuthButton.tsx
+++ b/site/src/pages/CreateWorkspacePage/ExternalAuthButton.tsx
@@ -29,7 +29,6 @@ export const ExternalAuthButton: FC<ExternalAuthButtonProps> = ({
         <LoadingButton
           fullWidth
           loading={isLoading}
-          href={auth.authenticate_url}
           variant="contained"
           size="xlarge"
           startIcon={


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/12581

The opened window in `window.open` handles the auth flow. We do not need the button to redirect the current page.