### PR TITLE
feat(codersdk): add debug handlers for logs, manifest, and token to agent

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -36,8 +36,11 @@ func (a *agent) apiHandler() http.Handler {
 		cacheDuration: cacheDuration,
 	}
 	r.Get("/api/v0/listening-ports", lp.handler)
+	r.Get("/debug/logs", a.HandleHTTPDebugLogs)
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)
+	r.Get("/debug/manifest", a.HandleHTTPDebugManifest)
+	r.Get("/debug/token", a.HandleHTTPDebugToken)
 
 	return r
 }

--- a/codersdk/workspaceagentconn.go
+++ b/codersdk/workspaceagentconn.go
@@ -372,6 +372,39 @@ func (c *WorkspaceAgentConn) DebugMagicsock(ctx context.Context) ([]byte, error)
 	return bs, nil
 }
 
+// DebugManifest returns the agent's in-memory manifest. Unfortunately this must
+// be returns as a []byte to avoid an import cycle.
+func (c *WorkspaceAgentConn) DebugManifest(ctx context.Context) ([]byte, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+	res, err := c.apiRequest(ctx, http.MethodGet, "/debug/manifest", nil)
+	if err != nil {
+		return nil, xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	bs, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, xerrors.Errorf("read response body: %w", err)
+	}
+	return bs, nil
+}
+
+// DebugLogs returns up to the last 10MB of `/tmp/coder-agent.log`
+func (c *WorkspaceAgentConn) DebugLogs(ctx context.Context) ([]byte, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+	res, err := c.apiRequest(ctx, http.MethodGet, "/debug/logs", nil)
+	if err != nil {
+		return nil, xerrors.Errorf("do request: %w", err)
+	}
+	defer res.Body.Close()
+	bs, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, xerrors.Errorf("read response body: %w", err)
+	}
+	return bs, nil
+}
+
 // apiRequest makes a request to the workspace agent's HTTP API server.
 func (c *WorkspaceAgentConn) apiRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
 	ctx, span := tracing.StartSpan(ctx)


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/12161

Adds the following debug handlers to the agent API:
- `/debug/manifest`: returns the in-memory agent manifest
- `/debug/token`: returns the in-memory agent session token
- `/debug/logs`: returns up to the last 10MB of the agent log.

We can technically get these by connecting to the agent over SSH but this seems to be a better way overall.