### PR TITLE
fix: handle CLI default organization when none exists in <v2.9.0 coderd

### DIFF
--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -26,6 +26,8 @@ func TestCurrentOrganization(t *testing.T) {
 	// 1. The user is not a part of the default organization, but only belongs to one.
 	// 2. The user is connecting to an older Coder instance.
 	t.Run("no-default", func(t *testing.T) {
+		t.Parallel()
+
 		orgID := uuid.New()
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			json.NewEncoder(w).Encode([]codersdk.Organization{

--- a/cli/organization_test.go
+++ b/cli/organization_test.go
@@ -1,8 +1,14 @@
 package cli_test
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
@@ -15,6 +21,36 @@ import (
 
 func TestCurrentOrganization(t *testing.T) {
 	t.Parallel()
+
+	// This test emulates 2 cases:
+	// 1. The user is not a part of the default organization, but only belongs to one.
+	// 2. The user is connecting to an older Coder instance.
+	t.Run("no-default", func(t *testing.T) {
+		orgID := uuid.New()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode([]codersdk.Organization{
+				{
+					ID:        orgID,
+					Name:      "not-default",
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+					IsDefault: false,
+				},
+			})
+		}))
+		defer srv.Close()
+
+		client := codersdk.New(must(url.Parse(srv.URL)))
+		inv, root := clitest.New(t, "organizations", "show", "current")
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t).Attach(inv)
+		errC := make(chan error)
+		go func() {
+			errC <- inv.Run()
+		}()
+		require.NoError(t, <-errC)
+		pty.ExpectMatch(orgID.String())
+	})
 
 	t.Run("OnlyID", func(t *testing.T) {
 		t.Parallel()
@@ -107,4 +143,11 @@ func TestOrganizationSwitch(t *testing.T) {
 		require.NoError(t, <-errC)
 		pty.ExpectMatch(exp.ID.String())
 	})
+}
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -749,7 +749,7 @@ func CurrentOrganization(r *RootCmd, inv *clibase.Invocation, client *codersdk.C
 		return org.IsDefault
 	})
 	if index < 0 {
-		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder set <org>' to select an organization to use")
+		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder org set <org>' to select an organization to use")
 	}
 
 	return orgs[index], nil

--- a/cli/root.go
+++ b/cli/root.go
@@ -749,6 +749,13 @@ func CurrentOrganization(r *RootCmd, inv *clibase.Invocation, client *codersdk.C
 		return org.IsDefault
 	})
 	if index < 0 {
+		if len(orgs) == 1 {
+			// If there is no "isDefault", but only 1 org is present. We can just
+			// assume the single organization is correct. This is mainly a helper
+			// for cli hitting an old instance, or a user that belongs to a single
+			// org that is not the default.
+			return orgs[0], nil
+		}
 		return codersdk.Organization{}, xerrors.Errorf("unable to determine current organization. Use 'coder org set <org>' to select an organization to use")
 	}
 


### PR DESCRIPTION
If the coder cli is talking to an older version of Coderd, the `isDefault` field will be false. 

This can also happen if a user does not belong to the default org.