### PR TITLE
chore(cli): skip support bundle test on windows

### DIFF
--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -21,6 +22,9 @@ import (
 
 func TestSupportBundle(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("for some reason, windows fails to remove tempdirs sometimes")
+	}
 
 	t.Run("Workspace", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Skips the support bundle test on Windows to avoid a test flake related to tempdir cleanup.
Seen here: https://github.com/coder/coder/actions/runs/8282640794/job/22663921557?pr=12593