### PR TITLE
fix(agent): remove unused token debug handler

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1714,18 +1714,6 @@ func (a *agent) HandleHTTPDebugManifest(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func (a *agent) HandleHTTPDebugToken(w http.ResponseWriter, r *http.Request) {
-	tok := a.sessionToken.Load()
-	if tok == nil {
-		a.logger.Error(r.Context(), "no session token in-memory")
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprintf(w, "no session token in-memory")
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprintf(w, *tok)
-}
-
 func (a *agent) HandleHTTPDebugLogs(w http.ResponseWriter, r *http.Request) {
 	logPath := filepath.Join(a.logDir, "coder-agent.log")
 	f, err := os.Open(logPath)
@@ -1753,7 +1741,6 @@ func (a *agent) HTTPDebug() http.Handler {
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)
 	r.Get("/debug/manifest", a.HandleHTTPDebugManifest)
-	r.Get("/debug/token", a.HandleHTTPDebugToken)
 	r.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("404 not found"))

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2088,22 +2088,6 @@ func TestAgent_DebugServer(t *testing.T) {
 		require.NotNil(t, v)
 	})
 
-	t.Run("Token", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := testutil.Context(t, testutil.WaitLong)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/debug/token", nil)
-		require.NoError(t, err)
-
-		res, err := srv.Client().Do(req)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, res.StatusCode)
-		defer res.Body.Close()
-		resBody, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "token", string(resBody))
-	})
-
 	t.Run("Logs", func(t *testing.T) {
 		t.Parallel()
 

--- a/agent/api.go
+++ b/agent/api.go
@@ -40,7 +40,6 @@ func (a *agent) apiHandler() http.Handler {
 	r.Get("/debug/magicsock", a.HandleHTTPDebugMagicsock)
 	r.Get("/debug/magicsock/debug-logging/{state}", a.HandleHTTPMagicsockDebugLoggingState)
 	r.Get("/debug/manifest", a.HandleHTTPDebugManifest)
-	r.Get("/debug/token", a.HandleHTTPDebugToken)
 
 	return r
 }


### PR DESCRIPTION
Removes an unused handler added in 63696d762f4a76a1bc935fc98a55405b79f549f4
