### PR TITLE
chore(cli): hide --organization

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -447,6 +447,7 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 			Env:           "CODER_ORGANIZATION",
 			Description:   "Select which organization (uuid or name) to use This overrides what is present in the config file.",
 			Value:         serpent.StringOf(&r.organizationSelect),
+			Hidden:        true,
 			Group:         globalGroup,
 		},
 		{

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -82,10 +82,6 @@ variables or flags.
       --no-version-warning bool, $CODER_NO_VERSION_WARNING
           Suppress warning when client and server versions do not match.
 
-  -z, --organization string, $CODER_ORGANIZATION
-          Select which organization (uuid or name) to use This overrides what is
-          present in the config file.
-
       --token string, $CODER_SESSION_TOKEN
           Specify an authentication token. For security reasons setting
           CODER_SESSION_TOKEN is preferred.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,13 +157,3 @@ Disable direct (P2P) connections to workspaces.
 | Default     | <code>~/.config/coderv2</code> |
 
 Path to the global `coder` config directory.
-
-### -z, --organization
-
-|             |                                  |
-| ----------- | -------------------------------- |
-| Type        | <code>string</code>              |
-| Environment | <code>$CODER_ORGANIZATION</code> |
-
-Select which organization (uuid or name) to use This overrides what is present
-in the config file.

--- a/enterprise/cli/testdata/coder_--help.golden
+++ b/enterprise/cli/testdata/coder_--help.golden
@@ -48,10 +48,6 @@ variables or flags.
       --no-version-warning bool, $CODER_NO_VERSION_WARNING
           Suppress warning when client and server versions do not match.
 
-  -z, --organization string, $CODER_ORGANIZATION
-          Select which organization (uuid or name) to use This overrides what is
-          present in the config file.
-
       --token string, $CODER_SESSION_TOKEN
           Specify an authentication token. For security reasons setting
           CODER_SESSION_TOKEN is preferred.


### PR DESCRIPTION
It's potentially confusing to users since we aren't fleshing out organizations right now.