### PR TITLE
chore: reduce slack spam for manually run docs link checker workflows

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -24,7 +24,7 @@ jobs:
           file-path: "./README.md"
 
       - name: Send Slack notification
-        if: failure()
+        if: failure() && github.event_name != 'workflow_dispatch'
         run: |
           curl -X POST -H 'Content-type: application/json' -d '{"msg":"Broken links found in the documentation. Please check the logs at ${{ env.LOGS_URL }}"}' ${{ secrets.DOCS_LINK_SLACK_WEBHOOK }}
           echo "Sent Slack notification"


### PR DESCRIPTION
This was causing a lot of spam when the workflow was run manually to test any newly added doc links. 