### PR TITLE
chore: use sqlc-vet to verify schema

### DIFF
--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -17,6 +17,7 @@ sql:
       database: false
     rules:
       - sqlc/db-prepare
+      - do-not-use-public-schema-in-queries
     gen:
       go:
         package: "database"
@@ -104,3 +105,9 @@ sql:
           api_key_id: APIKeyID
           callback_url: CallbackURL
           login_type_oauth2_provider_app: LoginTypeOAuth2ProviderApp
+rules:
+  - name: do-not-use-public-schema-in-queries
+    message: "do not use public schema in queries"
+    # FIXME: It would be great to run sqlc-vet against `migrations` directory and `dump.sql`.
+    rule: >
+      query.sql.matches(r'[^a-z]public\.')


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/12619

I tried to find a clean way to lint our queries, migration files, and `dump.sql` against hardcoded `public` schema. This is a proposal for queries.

BTW We still have hardcoded `public` schema in [dump.sql](https://github.com/coder/coder/blob/cf50461ab4a05f82528383b428ac347e233dc4e1/coderd/database/dump.sql#L888).