### PR TITLE
fix(codersdk): abort in-progress writes/reads when closing websocket

### DIFF
--- a/codersdk/websocket.go
+++ b/codersdk/websocket.go
@@ -32,7 +32,7 @@ func (c *wsNetConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *wsNetConn) Close() error {
-	defer c.cancel()
+	c.cancel()
 	return c.Conn.Close()
 }
 


### PR DESCRIPTION
Fixes #9203

Related #12065

Also, adds some basic tracing infrastructure that we can build upon for more improvements.