### PR TITLE
feat(coderd): export metric indicating each experiment's status

### DIFF
--- a/cli/cliui/provisionerjob_test.go
+++ b/cli/cliui/provisionerjob_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coder/coder/v2/testutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/coder/coder/v2/testutil"
 
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/database/dbtime"

--- a/cli/server.go
+++ b/cli/server.go
@@ -894,7 +894,12 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}
 				defer closeAgentsFunc()
 
-				if err = prometheusmetrics.Experiments(logger, options.PrometheusRegistry, options.DeploymentValues.Experiments.Value(), codersdk.ExperimentsAll); err != nil {
+				var active codersdk.Experiments
+				for _, exp := range options.DeploymentValues.Experiments.Value() {
+					active = append(active, codersdk.Experiment(exp))
+				}
+
+				if err = prometheusmetrics.Experiments(options.PrometheusRegistry, active); err != nil {
 					return xerrors.Errorf("register experiments metric: %w", err)
 				}
 			}

--- a/cli/server.go
+++ b/cli/server.go
@@ -892,6 +892,10 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 					return xerrors.Errorf("register agents prometheus metric: %w", err)
 				}
 				defer closeAgentsFunc()
+
+				if err = prometheusmetrics.Experiments(logger, options.PrometheusRegistry, options.DeploymentValues.Experiments.Value(), codersdk.ExperimentsAll); err != nil {
+					return xerrors.Errorf("register experiments metric: %w", err)
+				}
 			}
 
 			client := codersdk.New(localURL)

--- a/cli/server.go
+++ b/cli/server.go
@@ -258,6 +258,7 @@ func enablePrometheus(
 	), nil
 }
 
+//nolint:gocognit // TODO(dannyk): reduce complexity of this function
 func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.API, io.Closer, error)) *serpent.Command {
 	if newAPI == nil {
 		newAPI = func(_ context.Context, o *coderd.Options) (*coderd.API, io.Closer, error) {

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -532,6 +532,7 @@ func Experiments(_ slog.Logger, registerer prometheus.Registerer, exps []string,
 		for _, enabled := range exps {
 			if string(exp) == enabled {
 				val = 1
+				break
 			}
 		}
 

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -517,7 +517,7 @@ func AgentStats(ctx context.Context, logger slog.Logger, registerer prometheus.R
 }
 
 // Experiments registers a metric which indicates whether each experiment is enabled or not.
-func Experiments(_ slog.Logger, registerer prometheus.Registerer, exps []string, all codersdk.Experiments) error {
+func Experiments(registerer prometheus.Registerer, active codersdk.Experiments) error {
 	experimentsGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "coderd",
 		Name:      "experiments",
@@ -527,10 +527,10 @@ func Experiments(_ slog.Logger, registerer prometheus.Registerer, exps []string,
 		return err
 	}
 
-	for _, exp := range all {
+	for _, exp := range codersdk.ExperimentsAll {
 		var val float64
-		for _, enabled := range exps {
-			if string(exp) == enabled {
+		for _, enabled := range active {
+			if exp == enabled {
 				val = 1
 				break
 			}

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -525,6 +525,8 @@ func TestExperimentsMetric(t *testing.T) {
 	require.Lenf(t, out, 1, "unexpected number of registered metrics")
 
 	for _, metric := range out[0].GetMetric() {
+		require.Equal(t, "coderd_experiments", out[0].GetName())
+
 		labels := metric.GetLabel()
 		require.Lenf(t, labels, 1, "unexpected number of labels")
 


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/12070

Exposes a metric indicating which experiments are active/inactive.
I chose to expose the experiments that are not active as well because this will allow operators to get the same view in metrics as what we expose in the frontend.