### PR TITLE
fix(cli): port-forward: update workspace last_used_at

### DIFF
--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -136,6 +136,8 @@ func (r *RootCmd) portForward() *serpent.Command {
 				listeners[i] = l
 			}
 
+			stopUpdating := client.UpdateWorkspaceUsageContext(ctx, workspace.ID)
+
 			// Wait for the context to be canceled or for a signal and close
 			// all listeners.
 			var closeErr error
@@ -156,6 +158,7 @@ func (r *RootCmd) portForward() *serpent.Command {
 				}
 
 				cancel()
+				stopUpdating()
 				closeAllListeners()
 			}()
 

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -148,6 +148,10 @@ func TestPortForward(t *testing.T) {
 			cancel()
 			err = <-errC
 			require.ErrorIs(t, err, context.Canceled)
+
+			updated, err := client.Workspace(context.Background(), workspace.ID)
+			require.NoError(t, err)
+			require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)
 		})
 
 		t.Run(c.name+"_TwoPorts", func(t *testing.T) {
@@ -196,6 +200,10 @@ func TestPortForward(t *testing.T) {
 			cancel()
 			err = <-errC
 			require.ErrorIs(t, err, context.Canceled)
+
+			updated, err := client.Workspace(context.Background(), workspace.ID)
+			require.NoError(t, err)
+			require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)
 		})
 	}
 
@@ -257,6 +265,10 @@ func TestPortForward(t *testing.T) {
 		cancel()
 		err := <-errC
 		require.ErrorIs(t, err, context.Canceled)
+
+		updated, err := client.Workspace(context.Background(), workspace.ID)
+		require.NoError(t, err)
+		require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)
 	})
 }
 

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -160,8 +160,9 @@ func TestPortForward(t *testing.T) {
 			err = <-errC
 			require.ErrorIs(t, err, context.Canceled)
 
-			wuTick <- dbtime.Now()
-			<-wuFlush
+			flushCtx := testutil.Context(t, testutil.WaitShort)
+			testutil.RequireSendCtx(flushCtx, t, wuTick, dbtime.Now())
+			_ = testutil.RequireRecvCtx(flushCtx, t, wuFlush)
 			updated, err := client.Workspace(context.Background(), workspace.ID)
 			require.NoError(t, err)
 			require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)
@@ -214,8 +215,9 @@ func TestPortForward(t *testing.T) {
 			err = <-errC
 			require.ErrorIs(t, err, context.Canceled)
 
-			wuTick <- dbtime.Now()
-			<-wuFlush
+			flushCtx := testutil.Context(t, testutil.WaitShort)
+			testutil.RequireSendCtx(flushCtx, t, wuTick, dbtime.Now())
+			_ = testutil.RequireRecvCtx(flushCtx, t, wuFlush)
 			updated, err := client.Workspace(context.Background(), workspace.ID)
 			require.NoError(t, err)
 			require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)
@@ -281,8 +283,9 @@ func TestPortForward(t *testing.T) {
 		err := <-errC
 		require.ErrorIs(t, err, context.Canceled)
 
-		wuTick <- dbtime.Now()
-		<-wuFlush
+		flushCtx := testutil.Context(t, testutil.WaitShort)
+		testutil.RequireSendCtx(flushCtx, t, wuTick, dbtime.Now())
+		_ = testutil.RequireRecvCtx(flushCtx, t, wuFlush)
 		updated, err := client.Workspace(context.Background(), workspace.ID)
 		require.NoError(t, err)
 		require.Greater(t, updated.LastUsedAt, workspace.LastUsedAt)

--- a/cli/portforward_test.go
+++ b/cli/portforward_test.go
@@ -21,9 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
-	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
-	"github.com/coder/coder/v2/coderd/workspaceusage"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -99,14 +97,11 @@ func TestPortForward(t *testing.T) {
 	// Setup agent once to be shared between test-cases (avoid expensive
 	// non-parallel setup).
 	var (
-		db, ps  = dbtestutil.NewDB(t)
-		wuTick  = make(chan time.Time)
-		wuFlush = make(chan int, 1)
-		wut     = workspaceusage.New(db, workspaceusage.WithFlushChannel(wuFlush), workspaceusage.WithTickChannel(wuTick))
-		client  = coderdtest.New(t, &coderdtest.Options{
-			WorkspaceUsageTracker: wut,
-			Database:              db,
-			Pubsub:                ps,
+		wuTick     = make(chan time.Time)
+		wuFlush    = make(chan int, 1)
+		client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
+			WorkspaceUsageTrackerTick:  wuTick,
+			WorkspaceUsageTrackerFlush: wuFlush,
 		})
 		admin              = coderdtest.CreateFirstUser(t, client)
 		member, memberUser = coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)

--- a/cli/server.go
+++ b/cli/server.go
@@ -86,6 +86,7 @@ import (
 	stringutil "github.com/coder/coder/v2/coderd/util/strings"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
+	"github.com/coder/coder/v2/coderd/workspaceusage"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpc"
 	"github.com/coder/coder/v2/cryptorand"
@@ -967,6 +968,13 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			// Ensures that old database entries are cleaned up over time!
 			purger := dbpurge.New(ctx, logger, options.Database)
 			defer purger.Close()
+
+			// Updates workspace usage
+			tracker := workspaceusage.New(options.Database,
+				workspaceusage.WithLogger(logger.Named("workspace_usage_tracker")),
+			)
+			options.WorkspaceUsageTracker = tracker
+			defer tracker.Close()
 
 			// Wrap the server in middleware that redirects to the access URL if
 			// the request is not to a local IP.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7592,6 +7592,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{workspace}/usage": {
+            "post": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Post Workspace Usage by ID",
+                "operationId": "post-workspace-usage-by-id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace ID",
+                        "name": "workspace",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/workspaces/{workspace}/watch": {
             "get": {
                 "security": [

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6711,6 +6711,33 @@
         }
       }
     },
+    "/workspaces/{workspace}/usage": {
+      "post": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "tags": ["Workspaces"],
+        "summary": "Post Workspace Usage by ID",
+        "operationId": "post-workspace-usage-by-id",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Workspace ID",
+            "name": "workspace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
     "/workspaces/{workspace}/watch": {
       "get": {
         "security": [

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -66,6 +66,7 @@ import (
 	"github.com/coder/coder/v2/coderd/updatecheck"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
+	"github.com/coder/coder/v2/coderd/workspaceusage"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpc"
 	"github.com/coder/coder/v2/provisionerd/proto"
@@ -190,6 +191,9 @@ type Options struct {
 
 	// NewTicker is used for unit tests to replace "time.NewTicker".
 	NewTicker func(duration time.Duration) (tick <-chan time.Time, done func())
+
+	// WorkspaceUsageTracker tracks workspace usage by the CLI.
+	WorkspaceUsageTracker *workspaceusage.Tracker
 }
 
 // @title Coder API
@@ -362,6 +366,14 @@ func New(options *Options) *API {
 		OIDC:   options.OIDCConfig,
 	}
 
+	if options.WorkspaceUsageTracker == nil {
+		options.WorkspaceUsageTracker = workspaceusage.New(options.Database,
+			workspaceusage.WithFlushInterval(workspaceusage.DefaultFlushInterval),
+			workspaceusage.WithLogger(options.Logger.Named("workspace_usage_tracker")),
+		)
+	}
+	go options.WorkspaceUsageTracker.Loop()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	r := chi.NewRouter()
 
@@ -405,6 +417,7 @@ func New(options *Options) *API {
 			options.Logger.Named("acquirer"),
 			options.Database,
 			options.Pubsub),
+		workspaceUsageTracker: options.WorkspaceUsageTracker,
 	}
 
 	api.AppearanceFetcher.Store(&appearance.DefaultFetcher)
@@ -972,6 +985,7 @@ func New(options *Options) *API {
 				})
 				r.Get("/watch", api.watchWorkspace)
 				r.Put("/extend", api.putExtendWorkspace)
+				r.Post("/usage", api.postWorkspaceUsage)
 				r.Put("/dormant", api.putWorkspaceDormant)
 				r.Put("/favorite", api.putFavoriteWorkspace)
 				r.Delete("/favorite", api.deleteFavoriteWorkspace)
@@ -1179,6 +1193,8 @@ type API struct {
 	statsBatcher *batchstats.Batcher
 
 	Acquirer *provisionerdserver.Acquirer
+
+	workspaceUsageTracker *workspaceusage.Tracker
 }
 
 // Close waits for all WebSocket connections to drain before returning.
@@ -1200,6 +1216,7 @@ func (api *API) Close() error {
 		_ = (*coordinator).Close()
 	}
 	_ = api.agentProvider.Close()
+	api.workspaceUsageTracker.Close()
 	return nil
 }
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -368,7 +368,6 @@ func New(options *Options) *API {
 
 	if options.WorkspaceUsageTracker == nil {
 		options.WorkspaceUsageTracker = workspaceusage.New(options.Database,
-			workspaceusage.WithFlushInterval(workspaceusage.DefaultFlushInterval),
 			workspaceusage.WithLogger(options.Logger.Named("workspace_usage_tracker")),
 		)
 	}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -371,7 +371,6 @@ func New(options *Options) *API {
 			workspaceusage.WithLogger(options.Logger.Named("workspace_usage_tracker")),
 		)
 	}
-	go options.WorkspaceUsageTracker.Loop()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r := chi.NewRouter()

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -327,8 +327,8 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		//   })
 		//
 		// See TestPortForward for how this works in practice.
-		wutFlush := make(chan int)
-		wutTick := make(chan time.Time)
+		wutFlush := make(chan int, 1)      // buffering just in case
+		wutTick := make(chan time.Time, 1) // buffering just in case
 		options.WorkspaceUsageTracker = workspaceusage.New(
 			options.Database,
 			workspaceusage.WithLogger(options.Logger.Named("workspace_usage_tracker")),

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1046,6 +1046,10 @@ func (q *FakeQuerier) BatchUpdateWorkspaceLastUsedAt(_ context.Context, arg data
 		if _, found := m[q.workspaces[i].ID]; !found {
 			continue
 		}
+		// WHERE last_used_at < @last_used_at
+		if !q.workspaces[i].LastUsedAt.Before(arg.LastUsedAt) {
+			continue
+		}
 		q.workspaces[i].LastUsedAt = arg.LastUsedAt
 		n++
 	}

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -11518,6 +11518,9 @@ SET
 	last_used_at = $1
 WHERE
 	id = ANY($2 :: uuid[])
+AND
+  -- Do not overwrite with older data
+  last_used_at < $1
 `
 
 type BatchUpdateWorkspaceLastUsedAtParams struct {

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -433,7 +433,10 @@ UPDATE
 SET
 	last_used_at = @last_used_at
 WHERE
-	id = ANY(@ids :: uuid[]);
+	id = ANY(@ids :: uuid[])
+AND
+  -- Do not overwrite with older data
+  last_used_at < @last_used_at;
 
 -- name: GetDeploymentWorkspaceStats :one
 WITH workspaces_with_jobs AS (

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1096,6 +1096,24 @@ func (api *API) putExtendWorkspace(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, code, resp)
 }
 
+// @Summary Post Workspace Usage by ID
+// @ID post-workspace-usage-by-id
+// @Security CoderSessionToken
+// @Tags Workspaces
+// @Param workspace path string true "Workspace ID" format(uuid)
+// @Success 204
+// @Router /workspaces/{workspace}/usage [post]
+func (api *API) postWorkspaceUsage(rw http.ResponseWriter, r *http.Request) {
+	workspace := httpmw.WorkspaceParam(r)
+	if !api.Authorize(r, rbac.ActionUpdate, workspace) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	api.workspaceUsageTracker.Add(workspace.ID)
+	rw.WriteHeader(http.StatusNoContent)
+}
+
 // @Summary Favorite workspace by ID.
 // @ID favorite-workspace-by-id
 // @Security CoderSessionToken

--- a/coderd/workspaceusage/tracker.go
+++ b/coderd/workspaceusage/tracker.go
@@ -117,16 +117,14 @@ func (wut *Tracker) Add(workspaceID uuid.UUID) {
 // If this is held while a previous flush is in progress, it will
 // deadlock until the previous flush has completed.
 func (wut *Tracker) flush(now time.Time) {
-	var count int
+	// Copy our current set of IDs
+	ids := wut.m.UniqueAndClear()
+	count := len(ids)
 	if wut.flushCh != nil { // only used for testing
 		defer func() {
 			wut.flushCh <- count
 		}()
 	}
-
-	// Copy our current set of IDs
-	ids := wut.m.UniqueAndClear()
-	count = len(ids)
 	if count == 0 {
 		wut.log.Debug(context.Background(), "nothing to flush")
 		return

--- a/coderd/workspaceusage/tracker.go
+++ b/coderd/workspaceusage/tracker.go
@@ -1,0 +1,181 @@
+package workspaceusage
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/sloghuman"
+)
+
+var DefaultFlushInterval = 60 * time.Second
+
+// Store is a subset of database.Store
+type Store interface {
+	BatchUpdateWorkspaceLastUsedAt(context.Context, database.BatchUpdateWorkspaceLastUsedAtParams) error
+}
+
+// Tracker tracks and de-bounces updates to workspace usage activity.
+// It keeps an internal map of workspace IDs that have been used and
+// periodically flushes this to its configured Store.
+type Tracker struct {
+	log      slog.Logger            // you know, for logs
+	mut      sync.Mutex             // protects m
+	m        map[uuid.UUID]struct{} // stores workspace ids
+	s        Store                  // for flushing data
+	tickCh   <-chan time.Time       // controls flush interval
+	stopTick func()                 // stops flushing
+	stopCh   chan struct{}          // signals us to stop
+	stopOnce sync.Once              // because you only stop once
+	doneCh   chan struct{}          // signifies that we have stopped
+	flushCh  chan int               // used for testing.
+}
+
+// New returns a new Tracker. It is the caller's responsibility
+// to call Close().
+func New(s Store, opts ...Option) *Tracker {
+	hb := &Tracker{
+		log:      slog.Make(sloghuman.Sink(os.Stderr)),
+		m:        make(map[uuid.UUID]struct{}, 0),
+		s:        s,
+		tickCh:   nil,
+		stopTick: nil,
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+		flushCh:  nil,
+	}
+	for _, opt := range opts {
+		opt(hb)
+	}
+	if hb.tickCh == nil && hb.stopTick == nil {
+		ticker := time.NewTicker(DefaultFlushInterval)
+		hb.tickCh = ticker.C
+		hb.stopTick = ticker.Stop
+	}
+	return hb
+}
+
+type Option func(*Tracker)
+
+// WithLogger sets the logger to be used by Tracker.
+func WithLogger(log slog.Logger) Option {
+	return func(h *Tracker) {
+		h.log = log
+	}
+}
+
+// WithFlushInterval allows configuring the flush interval of Tracker.
+func WithFlushInterval(d time.Duration) Option {
+	return func(h *Tracker) {
+		ticker := time.NewTicker(d)
+		h.tickCh = ticker.C
+		h.stopTick = ticker.Stop
+	}
+}
+
+// WithFlushChannel allows passing a channel that receives
+// the number of marked workspaces every time Tracker flushes.
+// For testing only.
+func WithFlushChannel(c chan int) Option {
+	return func(h *Tracker) {
+		h.flushCh = c
+	}
+}
+
+// WithTickChannel allows passing a channel to replace a ticker.
+// For testing only.
+func WithTickChannel(c chan time.Time) Option {
+	return func(h *Tracker) {
+		h.tickCh = c
+		h.stopTick = func() {}
+	}
+}
+
+// Add marks the workspace with the given ID as having been used recently.
+// Tracker will periodically flush this to its configured Store.
+func (wut *Tracker) Add(workspaceID uuid.UUID) {
+	wut.mut.Lock()
+	wut.m[workspaceID] = struct{}{}
+	wut.mut.Unlock()
+}
+
+// flushLocked updates last_used_at of all current workspace IDs.
+// MUST HOLD LOCK BEFORE CALLING
+func (wut *Tracker) flushLocked(now time.Time) {
+	if wut.mut.TryLock() {
+		panic("developer error: must lock before calling flush()")
+	}
+	count := len(wut.m)
+	defer func() { // only used for testing
+		if wut.flushCh != nil {
+			wut.flushCh <- count
+		}
+	}()
+	if count == 0 {
+		wut.log.Debug(context.Background(), "nothing to flush")
+		return
+	}
+	// Copy our current set of IDs
+	ids := make([]uuid.UUID, 0)
+	for k := range wut.m {
+		ids = append(ids, k)
+	}
+	// Reset our internal map
+	wut.m = make(map[uuid.UUID]struct{})
+	// For ease of testing, sort the IDs lexically
+	sort.Slice(ids, func(i, j int) bool {
+		// For some unfathomable reason, byte arrays are not comparable?
+		return strings.Compare(ids[i].String(), ids[j].String()) < 0
+	})
+	// Set a short-ish timeout for this. We don't want to hang forever.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	// nolint: gocritic // system function
+	authCtx := dbauthz.AsSystemRestricted(ctx)
+	if err := wut.s.BatchUpdateWorkspaceLastUsedAt(authCtx, database.BatchUpdateWorkspaceLastUsedAtParams{
+		LastUsedAt: now,
+		IDs:        ids,
+	}); err != nil {
+		wut.log.Error(ctx, "failed updating workspaces last_used_at", slog.F("count", count), slog.Error(err))
+		return
+	}
+	wut.log.Info(ctx, "updated workspaces last_used_at", slog.F("count", count), slog.F("now", now))
+}
+
+func (wut *Tracker) Loop() {
+	defer func() {
+		wut.log.Debug(context.Background(), "workspace usage tracker loop exited")
+	}()
+	for {
+		select {
+		case <-wut.stopCh:
+			close(wut.doneCh)
+			return
+		case now, ok := <-wut.tickCh:
+			if !ok {
+				return
+			}
+			wut.mut.Lock()
+			wut.flushLocked(now.UTC())
+			wut.mut.Unlock()
+		}
+	}
+}
+
+// Close stops Tracker and performs a final flush.
+func (wut *Tracker) Close() {
+	wut.stopOnce.Do(func() {
+		wut.stopCh <- struct{}{}
+		wut.stopTick()
+		<-wut.doneCh
+	})
+}

--- a/coderd/workspaceusage/tracker.go
+++ b/coderd/workspaceusage/tracker.go
@@ -168,6 +168,12 @@ func (wut *Tracker) Loop() {
 			if !ok {
 				return
 			}
+			// NOTE: we do not update last_used_at with the time at which each workspace was added.
+			// Instead, we update with the time of the flush. If the BatchUpdateWorkspacesLastUsedAt
+			// query can be rewritten to update each id with a corresponding last_used_at timestamp
+			// then we could capture the exact usage time of each workspace. For now however, as
+			// we perform this query at a regular interval, the time of the flush is 'close enough'
+			// for the purposes of both dormancy (and for autostop, in future).
 			wut.flush(now.UTC())
 		}
 	}

--- a/coderd/workspaceusage/tracker.go
+++ b/coderd/workspaceusage/tracker.go
@@ -169,12 +169,12 @@ func (tr *Tracker) Loop() {
 	default:
 	}
 	defer func() {
+		close(tr.doneCh)
 		tr.log.Debug(context.Background(), "workspace usage tracker loop exited")
 	}()
 	for {
 		select {
 		case <-tr.stopCh:
-			close(tr.doneCh)
 			return
 		case now, ok := <-tr.tickCh:
 			if !ok {

--- a/coderd/workspaceusage/tracker.go
+++ b/coderd/workspaceusage/tracker.go
@@ -206,6 +206,7 @@ func (s *uuidSet) UniqueAndClear() []uuid.UUID {
 	defer s.l.Unlock()
 	if s.m == nil {
 		s.m = make(map[uuid.UUID]struct{})
+		return []uuid.UUID{}
 	}
 	l := make([]uuid.UUID, 0)
 	for k := range s.m {
@@ -214,8 +215,9 @@ func (s *uuidSet) UniqueAndClear() []uuid.UUID {
 	// For ease of testing, sort the IDs lexically
 	sort.Slice(l, func(i, j int) bool {
 		// For some unfathomable reason, byte arrays are not comparable?
+		// See https://github.com/golang/go/issues/61004
 		return bytes.Compare(l[i][:], l[j][:]) < 0
 	})
-	s.m = make(map[uuid.UUID]struct{})
+	clear(s.m)
 	return l
 }

--- a/coderd/workspaceusage/tracker_test.go
+++ b/coderd/workspaceusage/tracker_test.go
@@ -1,0 +1,80 @@
+package workspaceusage_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/mock/gomock"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/workspaceusage"
+)
+
+func TestTracker(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mDB := dbmock.NewMockStore(ctrl)
+	log := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+
+	tickCh := make(chan time.Time)
+	flushCh := make(chan int, 1)
+	wut := workspaceusage.New(mDB, workspaceusage.WithLogger(log), workspaceusage.WithTickChannel(tickCh), workspaceusage.WithFlushChannel(flushCh))
+	t.Cleanup(wut.Close)
+
+	go wut.Loop()
+
+	// 1. No marked workspaces should imply no flush.
+	now := dbtime.Now()
+	tickCh <- now
+	count := <-flushCh
+	require.Equal(t, 0, count, "expected zero flushes")
+
+	// 2. One marked workspace should cause a flush.
+	ids := []uuid.UUID{uuid.New()}
+	now = dbtime.Now()
+	wut.Add(ids[0])
+	mDB.EXPECT().BatchUpdateWorkspaceLastUsedAt(gomock.Any(), database.BatchUpdateWorkspaceLastUsedAtParams{
+		LastUsedAt: now,
+		IDs:        ids,
+	}).Times(1)
+	tickCh <- now
+	count = <-flushCh
+	require.Equal(t, 1, count, "expected one flush with one id")
+
+	// 3. Lots of marked workspaces should also cause a flush.
+	for i := 0; i < 10; i++ {
+		ids = append(ids, uuid.New())
+	}
+
+	// Sort ids so mockDB knows what to expect
+	sort.Slice(ids, func(i, j int) bool {
+		return strings.Compare(ids[i].String(), ids[j].String()) < 0
+	})
+
+	for _, id := range ids {
+		wut.Add(id)
+	}
+
+	now = dbtime.Now()
+	mDB.EXPECT().BatchUpdateWorkspaceLastUsedAt(gomock.Any(), database.BatchUpdateWorkspaceLastUsedAtParams{
+		LastUsedAt: now,
+		IDs:        ids,
+	}).Times(1)
+	tickCh <- now
+	count = <-flushCh
+	require.Equal(t, 11, count, "expected one flush with eleven ids")
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/coderd/workspaceusage/tracker_test.go
+++ b/coderd/workspaceusage/tracker_test.go
@@ -92,6 +92,13 @@ func TestTracker(t *testing.T) {
 
 	wg.Wait()
 	require.Equal(t, 11, count, "expected one flush with eleven ids")
+
+	// 4. Closing multiple times should not be a problem.
+	wut.Close()
+	wut.Close()
+
+	// 5. Running Loop() again should panic.
+	require.Panics(t, wut.Loop)
 }
 
 func TestMain(m *testing.M) {

--- a/coderd/workspaceusage/tracker_test.go
+++ b/coderd/workspaceusage/tracker_test.go
@@ -14,10 +14,15 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/workspaceusage"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestTracker(t *testing.T) {
@@ -103,6 +108,114 @@ func TestTracker(t *testing.T) {
 
 	// 6. Running Loop() again should panic.
 	require.Panics(t, wut.Loop)
+}
+
+// This test performs a more 'integration-style' test with multiple instances.
+func TestTracker_MultipleInstances(t *testing.T) {
+	t.Parallel()
+	if !dbtestutil.WillUsePostgres() {
+		t.Skip("this test only makes sense with postgres")
+	}
+
+	// Given we have two coderd instances connected to the same database
+	var (
+		ctx      = testutil.Context(t, testutil.WaitLong)
+		db, ps   = dbtestutil.NewDB(t)
+		wuTickA  = make(chan time.Time)
+		wuFlushA = make(chan int, 1)
+		wutA     = workspaceusage.New(db, workspaceusage.WithFlushChannel(wuFlushA), workspaceusage.WithTickChannel(wuTickA))
+		wuTickB  = make(chan time.Time)
+		wuFlushB = make(chan int, 1)
+		wutB     = workspaceusage.New(db, workspaceusage.WithFlushChannel(wuFlushB), workspaceusage.WithTickChannel(wuTickB))
+		clientA  = coderdtest.New(t, &coderdtest.Options{
+			WorkspaceUsageTracker: wutA,
+			Database:              db,
+			Pubsub:                ps,
+		})
+		clientB = coderdtest.New(t, &coderdtest.Options{
+			WorkspaceUsageTracker: wutB,
+			Database:              db,
+			Pubsub:                ps,
+		})
+		owner = coderdtest.CreateFirstUser(t, clientA)
+		now   = dbtime.Now()
+	)
+
+	clientB.SetSessionToken(clientA.SessionToken())
+
+	// Create a number of workspaces
+	numWorkspaces := 10
+	w := make([]dbfake.WorkspaceResponse, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		wr := dbfake.WorkspaceBuild(t, db, database.Workspace{
+			OwnerID:        owner.UserID,
+			OrganizationID: owner.OrganizationID,
+			LastUsedAt:     now,
+		}).WithAgent().Do()
+		w[i] = wr
+	}
+
+	// Use client A to update LastUsedAt of the first three
+	require.NoError(t, clientA.PostWorkspaceUsage(ctx, w[0].Workspace.ID))
+	require.NoError(t, clientA.PostWorkspaceUsage(ctx, w[1].Workspace.ID))
+	require.NoError(t, clientA.PostWorkspaceUsage(ctx, w[2].Workspace.ID))
+	// Use client B to update LastUsedAt of the next three
+	require.NoError(t, clientB.PostWorkspaceUsage(ctx, w[3].Workspace.ID))
+	require.NoError(t, clientB.PostWorkspaceUsage(ctx, w[4].Workspace.ID))
+	require.NoError(t, clientB.PostWorkspaceUsage(ctx, w[5].Workspace.ID))
+	// The next two will have updated from both instances
+	require.NoError(t, clientA.PostWorkspaceUsage(ctx, w[6].Workspace.ID))
+	require.NoError(t, clientB.PostWorkspaceUsage(ctx, w[6].Workspace.ID))
+	require.NoError(t, clientA.PostWorkspaceUsage(ctx, w[7].Workspace.ID))
+	require.NoError(t, clientB.PostWorkspaceUsage(ctx, w[7].Workspace.ID))
+	// The last two will not report any usage.
+
+	// Tick both with different times and wait for both flushes to complete
+	nowA := now.Add(time.Minute)
+	nowB := now.Add(2 * time.Minute)
+	var wg sync.WaitGroup
+	var flushedA, flushedB int
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wuTickA <- nowA
+		flushedA = <-wuFlushA
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wuTickB <- nowB
+		flushedB = <-wuFlushB
+	}()
+	wg.Wait()
+
+	// We expect 5 flushed IDs each
+	require.Equal(t, 5, flushedA)
+	require.Equal(t, 5, flushedB)
+
+	// Fetch updated workspaces
+	updated := make([]codersdk.Workspace, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		ws, err := clientA.Workspace(ctx, w[i].Workspace.ID)
+		require.NoError(t, err)
+		updated[i] = ws
+	}
+	// We expect the first three to have the timestamp of flushA
+	require.Equal(t, nowA.UTC(), updated[0].LastUsedAt.UTC())
+	require.Equal(t, nowA.UTC(), updated[1].LastUsedAt.UTC())
+	require.Equal(t, nowA.UTC(), updated[2].LastUsedAt.UTC())
+	// We expect the next three to have the timestamp of flushB
+	require.Equal(t, nowB.UTC(), updated[3].LastUsedAt.UTC())
+	require.Equal(t, nowB.UTC(), updated[4].LastUsedAt.UTC())
+	require.Equal(t, nowB.UTC(), updated[5].LastUsedAt.UTC())
+	// The next two should have the timestamp of flushB as it is newer than flushA
+	require.Equal(t, nowB.UTC(), updated[6].LastUsedAt.UTC())
+	require.Equal(t, nowB.UTC(), updated[7].LastUsedAt.UTC())
+	// And the last two should be untouched
+	require.Equal(t, w[8].Workspace.LastUsedAt.UTC(), updated[8].LastUsedAt.UTC())
+	require.Equal(t, w[8].Workspace.LastUsedAt.UTC(), updated[8].LastUsedAt.UTC())
+	require.Equal(t, w[9].Workspace.LastUsedAt.UTC(), updated[9].LastUsedAt.UTC())
+	require.Equal(t, w[9].Workspace.LastUsedAt.UTC(), updated[9].LastUsedAt.UTC())
 }
 
 func TestMain(m *testing.M) {

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog"
+
 	"github.com/coder/coder/v2/coderd/tracing"
 )
 
@@ -312,6 +314,54 @@ func (c *Client) PutExtendWorkspace(ctx context.Context, id uuid.UUID, req PutEx
 		return ReadBodyAsError(res)
 	}
 	return nil
+}
+
+// PostWorkspaceUsage marks the workspace as having been used recently.
+func (c *Client) PostWorkspaceUsage(ctx context.Context, id uuid.UUID) error {
+	path := fmt.Sprintf("/api/v2/workspaces/%s/usage", id.String())
+	res, err := c.Request(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return xerrors.Errorf("post workspace usage: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// UpdateWorkspaceUsageContext periodically posts workspace usage for the workspace
+// with the given id in the background.
+// The caller is responsible for calling the returned function to stop the background
+// process.
+func (c *Client) UpdateWorkspaceUsageContext(ctx context.Context, id uuid.UUID) func() {
+	hbCtx, hbCancel := context.WithCancel(ctx)
+	// Perform one initial heartbeat
+	if err := c.PostWorkspaceUsage(hbCtx, id); err != nil {
+		c.logger.Warn(ctx, "failed to post workspace usage", slog.Error(err))
+	}
+	ticker := time.NewTicker(time.Minute)
+	doneCh := make(chan struct{})
+	go func() {
+		defer func() {
+			ticker.Stop()
+			close(doneCh)
+		}()
+		for {
+			select {
+			case <-ticker.C:
+				if err := c.PostWorkspaceUsage(hbCtx, id); err != nil {
+					c.logger.Warn(ctx, "failed to post workspace usage in background", slog.Error(err))
+				}
+			case <-hbCtx.Done():
+				return
+			}
+		}
+	}()
+	return func() {
+		hbCancel()
+		<-doneCh
+	}
 }
 
 // UpdateWorkspaceDormancy is a request to activate or make a workspace dormant.

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -336,7 +336,7 @@ func (c *Client) PostWorkspaceUsage(ctx context.Context, id uuid.UUID) error {
 // process.
 func (c *Client) UpdateWorkspaceUsageContext(ctx context.Context, id uuid.UUID) func() {
 	hbCtx, hbCancel := context.WithCancel(ctx)
-	// Perform one initial heartbeat
+	// Perform one initial update
 	if err := c.PostWorkspaceUsage(hbCtx, id); err != nil {
 		c.logger.Warn(ctx, "failed to post workspace usage", slog.Error(err))
 	}

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -1385,6 +1385,32 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/ttl \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Post Workspace Usage by ID
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/usage \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /workspaces/{workspace}/usage`
+
+### Parameters
+
+| Name        | In   | Type         | Required | Description  |
+| ----------- | ---- | ------------ | -------- | ------------ |
+| `workspace` | path | string(uuid) | true     | Workspace ID |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+| ------ | --------------------------------------------------------------- | ----------- | ------ |
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Watch workspace by ID
 
 ### Code samples


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/12431

For the CLI to report workspace usage, we currently depend on the agent sending a stats report with a non-zero connection count. This is sourced from `SetConnStatsCallback` (`tailnet/conn.go:621`).
The problem with this approach is that the tailscale connection tracking only appears to track "connection established" events, and is not equivalent to running e.g. `ss -plunt`. This means:
- Having an open port-forward on its own will not be detected as an 'active connection'
- Having an open port-forward with a single long-lived connection (e.g. websocket conn) will only be counted as one activity datapoint, and subsequent stats collection intervals will ignore that active connection.

This PR updates the `coder port-forward` command to periodically inform coderd that the workspace is being used:
- Adds `workspaceusage.Tracker` which periodically batch-updates workspace LastUsedAt
- Adds coderd endpoint to signal workspace usage
- Updates `coder port-forward` to periodically hit this endpoint
- Modifies `BatchUpdateWorkspacesLastUsedAt` to avoid overwriting with stale data

In later PRs, we can:
- Update `coder ssh` to also use this behaviour,
- Update the workspace activity tracking package to also call `ActivityBumpWorkspace` so that `last_used_at` and `deadline` are handled in the same place,
- Remove the existing behaviour of updating the workspace when stats are received from the agent.

Follow-ups:
- We may need to ensure that multiple port-forwards to the same workspace only result in one `coder` process on a user's workstation updating the workspace at a time. My assumption here is that most users will have at most one or two port-forwards running at a time.