### PR TITLE
feat(coderd/database): use `template_usage_stats` in `GetUserActivityInsights` query

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -939,7 +939,7 @@ func (s *MethodTestSuite) TestTemplate() {
 		check.Args(database.GetUserLatencyInsightsParams{}).Asserts(rbac.ResourceTemplateInsights, rbac.ActionRead)
 	}))
 	s.Run("GetUserActivityInsights", s.Subtest(func(db database.Store, check *expects) {
-		check.Args(database.GetUserActivityInsightsParams{}).Asserts(rbac.ResourceTemplateInsights, rbac.ActionRead)
+		check.Args(database.GetUserActivityInsightsParams{}).Asserts(rbac.ResourceTemplateInsights, rbac.ActionRead).Errors(sql.ErrNoRows)
 	}))
 	s.Run("GetTemplateParameterInsights", s.Subtest(func(db database.Store, check *expects) {
 		check.Args(database.GetTemplateParameterInsightsParams{}).Asserts(rbac.ResourceTemplateInsights, rbac.ActionRead)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -212,11 +212,11 @@ type sqlcQuerier interface {
 	GetTemplatesWithFilter(ctx context.Context, arg GetTemplatesWithFilterParams) ([]Template, error)
 	GetUnexpiredLicenses(ctx context.Context) ([]License, error)
 	// GetUserActivityInsights returns the ranking with top active users.
-	// The result can be filtered on template_ids, meaning only user data from workspaces
-	// based on those templates will be included.
-	// Note: When selecting data from multiple templates or the entire deployment,
-	// be aware that it may lead to an increase in "usage" numbers (cumulative). In such cases,
-	// users may be counted multiple times for the same time interval if they have used multiple templates
+	// The result can be filtered on template_ids, meaning only user data
+	// from workspaces based on those templates will be included.
+	// Note: The usage_seconds and usage_seconds_cumulative differ only when
+	// requesting deployment-wide (or multiple template) data. Cumulative
+	// produces a bloated value if a user has used multiple templates
 	// simultaneously.
 	GetUserActivityInsights(ctx context.Context, arg GetUserActivityInsightsParams) ([]GetUserActivityInsightsRow, error)
 	GetUserByEmailOrUsername(ctx context.Context, arg GetUserByEmailOrUsernameParams) (User, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2352,80 +2352,57 @@ func (q *sqlQuerier) GetTemplateUsageStats(ctx context.Context, arg GetTemplateU
 }
 
 const getUserActivityInsights = `-- name: GetUserActivityInsights :many
-WITH app_stats AS (
+WITH deployment_stats AS (
 	SELECT
-		s.start_time,
-		was.user_id,
-		w.template_id,
-		60 as seconds
-	FROM workspace_app_stats was
-	JOIN workspaces w ON (
-		w.id = was.workspace_id
-		AND CASE WHEN COALESCE(array_length($1::uuid[], 1), 0) > 0 THEN w.template_id = ANY($1::uuid[]) ELSE TRUE END
-	)
-	-- This table contains both 1 minute entries and >1 minute entries,
-	-- to calculate this with our uniqueness constraints, we generate series
-	-- for the longer intervals.
-	CROSS JOIN LATERAL generate_series(
-		date_trunc('minute', was.session_started_at),
-		-- Subtract 1 microsecond to avoid creating an extra series.
-		date_trunc('minute', was.session_ended_at - '1 microsecond'::interval),
-		'1 minute'::interval
-	) s(start_time)
+		start_time,
+		user_id,
+		array_agg(template_id) AS template_ids,
+		-- See motivation in GetTemplateInsights for LEAST(SUM(n), 30).
+		LEAST(SUM(usage_mins), 30) AS usage_mins
+	FROM
+		template_usage_stats
 	WHERE
-		s.start_time >= $2::timestamptz
-		-- Subtract one minute because the series only contains the start time.
-		AND s.start_time < ($3::timestamptz) - '1 minute'::interval
-	GROUP BY s.start_time, w.template_id, was.user_id
-), session_stats AS (
-	SELECT
-		date_trunc('minute', was.created_at) as start_time,
-		was.user_id,
-		was.template_id,
-		CASE WHEN
-			SUM(was.session_count_vscode) > 0 OR
-			SUM(was.session_count_jetbrains) > 0 OR
-			SUM(was.session_count_reconnecting_pty) > 0 OR
-			SUM(was.session_count_ssh) > 0
-		THEN 60 ELSE 0 END as seconds
-	FROM workspace_agent_stats was
-	WHERE
-		was.created_at >= $2::timestamptz
-		AND was.created_at < $3::timestamptz
-		AND was.connection_count > 0
-		AND CASE WHEN COALESCE(array_length($1::uuid[], 1), 0) > 0 THEN was.template_id = ANY($1::uuid[]) ELSE TRUE END
-	GROUP BY date_trunc('minute', was.created_at), was.user_id, was.template_id
-), combined_stats AS (
+		start_time >= $1::timestamptz
+		AND end_time <= $2::timestamptz
+		AND CASE WHEN COALESCE(array_length($3::uuid[], 1), 0) > 0 THEN template_id = ANY($3::uuid[]) ELSE TRUE END
+	GROUP BY
+		start_time, user_id
+), template_ids AS (
 	SELECT
 		user_id,
-		template_id,
-		start_time,
-		seconds
-	FROM app_stats
-	UNION
-	SELECT
-		user_id,
-		template_id,
-		start_time,
-		seconds
-	FROM session_stats
+		array_agg(DISTINCT template_id) AS ids
+	FROM
+		deployment_stats, unnest(template_ids) template_id
+	GROUP BY
+		user_id
 )
+
 SELECT
-	users.id as user_id,
-	users.username,
-	users.avatar_url,
-	array_agg(DISTINCT template_id)::uuid[] AS template_ids,
-	SUM(seconds) AS usage_seconds
-FROM combined_stats
-JOIN users ON (users.id = combined_stats.user_id)
-GROUP BY users.id, username, avatar_url
-ORDER BY user_id ASC
+	ds.user_id,
+	u.username,
+	u.avatar_url,
+	t.ids::uuid[] AS template_ids,
+	(SUM(ds.usage_mins) * 60)::bigint AS usage_seconds
+FROM
+	deployment_stats ds
+JOIN
+	users u
+ON
+	u.id = ds.user_id
+JOIN
+	template_ids t
+ON
+	ds.user_id = t.user_id
+GROUP BY
+	ds.user_id, u.username, u.avatar_url, t.ids
+ORDER BY
+	ds.user_id ASC
 `
 
 type GetUserActivityInsightsParams struct {
-	TemplateIDs []uuid.UUID `db:"template_ids" json:"template_ids"`
 	StartTime   time.Time   `db:"start_time" json:"start_time"`
 	EndTime     time.Time   `db:"end_time" json:"end_time"`
+	TemplateIDs []uuid.UUID `db:"template_ids" json:"template_ids"`
 }
 
 type GetUserActivityInsightsRow struct {
@@ -2437,14 +2414,14 @@ type GetUserActivityInsightsRow struct {
 }
 
 // GetUserActivityInsights returns the ranking with top active users.
-// The result can be filtered on template_ids, meaning only user data from workspaces
-// based on those templates will be included.
-// Note: When selecting data from multiple templates or the entire deployment,
-// be aware that it may lead to an increase in "usage" numbers (cumulative). In such cases,
-// users may be counted multiple times for the same time interval if they have used multiple templates
+// The result can be filtered on template_ids, meaning only user data
+// from workspaces based on those templates will be included.
+// Note: The usage_seconds and usage_seconds_cumulative differ only when
+// requesting deployment-wide (or multiple template) data. Cumulative
+// produces a bloated value if a user has used multiple templates
 // simultaneously.
 func (q *sqlQuerier) GetUserActivityInsights(ctx context.Context, arg GetUserActivityInsightsParams) ([]GetUserActivityInsightsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getUserActivityInsights, pq.Array(arg.TemplateIDs), arg.StartTime, arg.EndTime)
+	rows, err := q.db.QueryContext(ctx, getUserActivityInsights, arg.StartTime, arg.EndTime, pq.Array(arg.TemplateIDs))
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -27,80 +27,57 @@ ORDER BY
 
 -- name: GetUserActivityInsights :many
 -- GetUserActivityInsights returns the ranking with top active users.
--- The result can be filtered on template_ids, meaning only user data from workspaces
--- based on those templates will be included.
--- Note: When selecting data from multiple templates or the entire deployment,
--- be aware that it may lead to an increase in "usage" numbers (cumulative). In such cases,
--- users may be counted multiple times for the same time interval if they have used multiple templates
+-- The result can be filtered on template_ids, meaning only user data
+-- from workspaces based on those templates will be included.
+-- Note: The usage_seconds and usage_seconds_cumulative differ only when
+-- requesting deployment-wide (or multiple template) data. Cumulative
+-- produces a bloated value if a user has used multiple templates
 -- simultaneously.
-WITH app_stats AS (
+WITH deployment_stats AS (
 	SELECT
-		s.start_time,
-		was.user_id,
-		w.template_id,
-		60 as seconds
-	FROM workspace_app_stats was
-	JOIN workspaces w ON (
-		w.id = was.workspace_id
-		AND CASE WHEN COALESCE(array_length(@template_ids::uuid[], 1), 0) > 0 THEN w.template_id = ANY(@template_ids::uuid[]) ELSE TRUE END
-	)
-	-- This table contains both 1 minute entries and >1 minute entries,
-	-- to calculate this with our uniqueness constraints, we generate series
-	-- for the longer intervals.
-	CROSS JOIN LATERAL generate_series(
-		date_trunc('minute', was.session_started_at),
-		-- Subtract 1 microsecond to avoid creating an extra series.
-		date_trunc('minute', was.session_ended_at - '1 microsecond'::interval),
-		'1 minute'::interval
-	) s(start_time)
+		start_time,
+		user_id,
+		array_agg(template_id) AS template_ids,
+		-- See motivation in GetTemplateInsights for LEAST(SUM(n), 30).
+		LEAST(SUM(usage_mins), 30) AS usage_mins
+	FROM
+		template_usage_stats
 	WHERE
-		s.start_time >= @start_time::timestamptz
-		-- Subtract one minute because the series only contains the start time.
-		AND s.start_time < (@end_time::timestamptz) - '1 minute'::interval
-	GROUP BY s.start_time, w.template_id, was.user_id
-), session_stats AS (
-	SELECT
-		date_trunc('minute', was.created_at) as start_time,
-		was.user_id,
-		was.template_id,
-		CASE WHEN
-			SUM(was.session_count_vscode) > 0 OR
-			SUM(was.session_count_jetbrains) > 0 OR
-			SUM(was.session_count_reconnecting_pty) > 0 OR
-			SUM(was.session_count_ssh) > 0
-		THEN 60 ELSE 0 END as seconds
-	FROM workspace_agent_stats was
-	WHERE
-		was.created_at >= @start_time::timestamptz
-		AND was.created_at < @end_time::timestamptz
-		AND was.connection_count > 0
-		AND CASE WHEN COALESCE(array_length(@template_ids::uuid[], 1), 0) > 0 THEN was.template_id = ANY(@template_ids::uuid[]) ELSE TRUE END
-	GROUP BY date_trunc('minute', was.created_at), was.user_id, was.template_id
-), combined_stats AS (
+		start_time >= @start_time::timestamptz
+		AND end_time <= @end_time::timestamptz
+		AND CASE WHEN COALESCE(array_length(@template_ids::uuid[], 1), 0) > 0 THEN template_id = ANY(@template_ids::uuid[]) ELSE TRUE END
+	GROUP BY
+		start_time, user_id
+), template_ids AS (
 	SELECT
 		user_id,
-		template_id,
-		start_time,
-		seconds
-	FROM app_stats
-	UNION
-	SELECT
-		user_id,
-		template_id,
-		start_time,
-		seconds
-	FROM session_stats
+		array_agg(DISTINCT template_id) AS ids
+	FROM
+		deployment_stats, unnest(template_ids) template_id
+	GROUP BY
+		user_id
 )
+
 SELECT
-	users.id as user_id,
-	users.username,
-	users.avatar_url,
-	array_agg(DISTINCT template_id)::uuid[] AS template_ids,
-	SUM(seconds) AS usage_seconds
-FROM combined_stats
-JOIN users ON (users.id = combined_stats.user_id)
-GROUP BY users.id, username, avatar_url
-ORDER BY user_id ASC;
+	ds.user_id,
+	u.username,
+	u.avatar_url,
+	t.ids::uuid[] AS template_ids,
+	(SUM(ds.usage_mins) * 60)::bigint AS usage_seconds
+FROM
+	deployment_stats ds
+JOIN
+	users u
+ON
+	u.id = ds.user_id
+JOIN
+	template_ids t
+ON
+	ds.user_id = t.user_id
+GROUP BY
+	ds.user_id, u.username, u.avatar_url, t.ids
+ORDER BY
+	ds.user_id ASC;
 
 -- name: GetTemplateInsights :one
 -- GetTemplateInsights returns the aggregate user-produced usage of all

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -136,7 +136,7 @@ func TestUserActivityInsights_SanityCheck(t *testing.T) {
 		Pubsub:                    ps,
 		Logger:                    &logger,
 		IncludeProvisionerDaemon:  true,
-		AgentStatsRefreshInterval: time.Millisecond * 50,
+		AgentStatsRefreshInterval: time.Millisecond * 100,
 		DatabaseRolluper: dbrollup.New(
 			logger.Named("dbrollup"),
 			db,
@@ -170,7 +170,7 @@ func TestUserActivityInsights_SanityCheck(t *testing.T) {
 	y, m, d := time.Now().UTC().Date()
 	today := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
 
 	// Connect to the agent to generate usage/latency stats.
@@ -212,7 +212,7 @@ func TestUserActivityInsights_SanityCheck(t *testing.T) {
 			return false
 		}
 		return len(userActivities.Report.Users) > 0 && userActivities.Report.Users[0].Seconds > 0
-	}, testutil.WaitMedium, testutil.IntervalFast, "user activity is missing")
+	}, testutil.WaitSuperLong, testutil.IntervalMedium, "user activity is missing")
 
 	// We got our latency data, close the connection.
 	_ = sess.Close()

--- a/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_week_all_templates.json.golden
+++ b/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_week_all_templates.json.golden
@@ -16,7 +16,7 @@
         "user_id": "00000000-0000-0000-0000-000000000004",
         "username": "user1",
         "avatar_url": "",
-        "seconds": 30540
+        "seconds": 26820
       },
       {
         "template_ids": [

--- a/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_week_deployment_wide.json.golden
+++ b/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_week_deployment_wide.json.golden
@@ -16,7 +16,7 @@
         "user_id": "00000000-0000-0000-0000-000000000004",
         "username": "user1",
         "avatar_url": "",
-        "seconds": 30540
+        "seconds": 26820
       },
       {
         "template_ids": [

--- a/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_week_other_timezone_(São_Paulo).json.golden
+++ b/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_week_other_timezone_(São_Paulo).json.golden
@@ -16,7 +16,7 @@
         "user_id": "00000000-0000-0000-0000-000000000004",
         "username": "user1",
         "avatar_url": "",
-        "seconds": 23280
+        "seconds": 23160
       },
       {
         "template_ids": [

--- a/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_weekly_aggregated_deployment_wide.json.golden
+++ b/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_weekly_aggregated_deployment_wide.json.golden
@@ -16,7 +16,7 @@
         "user_id": "00000000-0000-0000-0000-000000000004",
         "username": "user1",
         "avatar_url": "",
-        "seconds": 29820
+        "seconds": 26100
       },
       {
         "template_ids": [

--- a/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_weekly_aggregated_templates.json.golden
+++ b/coderd/testdata/insights/user-activity/multiple_users_and_workspaces_weekly_aggregated_templates.json.golden
@@ -16,7 +16,7 @@
         "user_id": "00000000-0000-0000-0000-000000000004",
         "username": "user1",
         "avatar_url": "",
-        "seconds": 29820
+        "seconds": 26100
       },
       {
         "template_ids": [


### PR DESCRIPTION
This PR updates the `GetUserActivityInsights` query to use rolled up `template_usage_stats` instead of raw agent and app stats.