### PR TITLE
feat(coderd/database): keep only 1 day of `workspace_agent_stats` after rollup

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -965,7 +965,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			defer shutdownConns()
 
 			// Ensures that old database entries are cleaned up over time!
-			purger := dbpurge.New(ctx, logger, options.Database)
+			purger := dbpurge.New(ctx, logger.Named("dbpurge"), options.Database)
 			defer purger.Close()
 
 			// Updates workspace usage

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1506,13 +1506,47 @@ func (q *FakeQuerier) DeleteOldWorkspaceAgentStats(_ context.Context) error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
+	/*
+		DELETE FROM
+			workspace_agent_stats
+		WHERE
+			created_at < (
+				SELECT
+					COALESCE(
+						-- When generating initial template usage stats, all the
+						-- raw agent stats are needed, after that only ~30 mins
+						-- from last rollup is needed. Deployment stats seem to
+						-- use between 15 mins and 1 hour of data. We keep a
+						-- little bit more (1 day) just in case.
+						MAX(start_time) - '1 days'::interval,
+						-- Fall back to 6 months ago if there are no template
+						-- usage stats so that we don't delete the data before
+						-- it's rolled up.
+						NOW() - '6 months'::interval
+					)
+				FROM
+					template_usage_stats
+			);
+	*/
+
 	now := dbtime.Now()
-	sixMonthInterval := 6 * 30 * 24 * time.Hour
-	sixMonthsAgo := now.Add(-sixMonthInterval)
+	var limit time.Time
+	// MAX
+	for _, stat := range q.templateUsageStats {
+		if stat.StartTime.After(limit) {
+			limit = stat.StartTime.AddDate(0, 0, -1)
+		}
+	}
+	// COALESCE
+	if limit.IsZero() {
+		limit = now.AddDate(0, -6, 0)
+	}
 
 	var validStats []database.WorkspaceAgentStat
 	for _, stat := range q.workspaceAgentStats {
-		if stat.CreatedAt.Before(sixMonthsAgo) {
+		fmt.Println(stat.CreatedAt, limit)
+		if stat.CreatedAt.Before(limit) {
+			fmt.Println("delete")
 			continue
 		}
 		validStats = append(validStats, stat)

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -24,7 +24,6 @@ const (
 // This is for cleaning up old, unused resources from the database that take up space.
 func New(ctx context.Context, logger slog.Logger, db database.Store) io.Closer {
 	closed := make(chan struct{})
-	logger = logger.Named("dbpurge")
 
 	ctx, cancelFunc := context.WithCancel(ctx)
 	//nolint:gocritic // The system purges old db records without user input.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10111,7 +10111,26 @@ func (q *sqlQuerier) UpdateWorkspaceAgentStartupByID(ctx context.Context, arg Up
 }
 
 const deleteOldWorkspaceAgentStats = `-- name: DeleteOldWorkspaceAgentStats :exec
-DELETE FROM workspace_agent_stats WHERE created_at < NOW() - INTERVAL '180 days'
+DELETE FROM
+	workspace_agent_stats
+WHERE
+	created_at < (
+		SELECT
+			COALESCE(
+				-- When generating initial template usage stats, all the
+				-- raw agent stats are needed, after that only ~30 mins
+				-- from last rollup is needed. Deployment stats seem to
+				-- use between 15 mins and 1 hour of data. We keep a
+				-- little bit more (1 day) just in case.
+				MAX(start_time) - '1 days'::interval,
+				-- Fall back to 6 months ago if there are no template
+				-- usage stats so that we don't delete the data before
+				-- it's rolled up.
+				NOW() - '6 months'::interval
+			)
+		FROM
+			template_usage_stats
+	)
 `
 
 func (q *sqlQuerier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10131,6 +10131,15 @@ WHERE
 		FROM
 			template_usage_stats
 	)
+	AND created_at < (
+		-- Delete at most in batches of 3 days (with a batch size of 3 days, we
+		-- can clear out the previous 6 months of data in ~60 iterations) whilst
+		-- keeping the DB load relatively low.
+		SELECT
+			COALESCE(MIN(created_at) + '3 days'::interval, NOW())
+		FROM
+			workspace_agent_stats
+	)
 `
 
 func (q *sqlQuerier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -90,7 +90,26 @@ ORDER BY
 	date ASC;
 
 -- name: DeleteOldWorkspaceAgentStats :exec
-DELETE FROM workspace_agent_stats WHERE created_at < NOW() - INTERVAL '180 days';
+DELETE FROM
+	workspace_agent_stats
+WHERE
+	created_at < (
+		SELECT
+			COALESCE(
+				-- When generating initial template usage stats, all the
+				-- raw agent stats are needed, after that only ~30 mins
+				-- from last rollup is needed. Deployment stats seem to
+				-- use between 15 mins and 1 hour of data. We keep a
+				-- little bit more (1 day) just in case.
+				MAX(start_time) - '1 days'::interval,
+				-- Fall back to 6 months ago if there are no template
+				-- usage stats so that we don't delete the data before
+				-- it's rolled up.
+				NOW() - '6 months'::interval
+			)
+		FROM
+			template_usage_stats
+	);
 
 -- name: GetDeploymentWorkspaceAgentStats :one
 WITH agent_stats AS (

--- a/coderd/database/queries/workspaceagentstats.sql
+++ b/coderd/database/queries/workspaceagentstats.sql
@@ -109,6 +109,15 @@ WHERE
 			)
 		FROM
 			template_usage_stats
+	)
+	AND created_at < (
+		-- Delete at most in batches of 3 days (with a batch size of 3 days, we
+		-- can clear out the previous 6 months of data in ~60 iterations) whilst
+		-- keeping the DB load relatively low.
+		SELECT
+			COALESCE(MIN(created_at) + '3 days'::interval, NOW())
+		FROM
+			workspace_agent_stats
 	);
 
 -- name: GetDeploymentWorkspaceAgentStats :one


### PR DESCRIPTION
This will free up many gigabytes of data for many customers, more for those that have a lot of workspaces running daily.

Refs #12122 