### PR TITLE
chore: support multiple key:value search query params 

### DIFF
--- a/coderd/httpapi/queryparams.go
+++ b/coderd/httpapi/queryparams.go
@@ -61,7 +61,7 @@ func (p *QueryParamParser) UInt(vals url.Values, def uint64, queryParam string) 
 	if err != nil {
 		p.Errors = append(p.Errors, codersdk.ValidationError{
 			Field:  queryParam,
-			Detail: fmt.Sprintf("Query param %q must be a valid positive integer (%s)", queryParam, err.Error()),
+			Detail: fmt.Sprintf("Query param %q must be a valid positive integer: %s", queryParam, err.Error()),
 		})
 		return 0
 	}
@@ -73,7 +73,7 @@ func (p *QueryParamParser) Int(vals url.Values, def int, queryParam string) int 
 	if err != nil {
 		p.Errors = append(p.Errors, codersdk.ValidationError{
 			Field:  queryParam,
-			Detail: fmt.Sprintf("Query param %q must be a valid integer (%s)", queryParam, err.Error()),
+			Detail: fmt.Sprintf("Query param %q must be a valid integer: %s", queryParam, err.Error()),
 		})
 	}
 	return v
@@ -97,7 +97,7 @@ func (p *QueryParamParser) PositiveInt32(vals url.Values, def int32, queryParam 
 	if err != nil {
 		p.Errors = append(p.Errors, codersdk.ValidationError{
 			Field:  queryParam,
-			Detail: fmt.Sprintf("Query param %q must be a valid 32-bit positive integer (%s)", queryParam, err.Error()),
+			Detail: fmt.Sprintf("Query param %q must be a valid 32-bit positive integer: %s", queryParam, err.Error()),
 		})
 	}
 	return v
@@ -108,7 +108,7 @@ func (p *QueryParamParser) Boolean(vals url.Values, def bool, queryParam string)
 	if err != nil {
 		p.Errors = append(p.Errors, codersdk.ValidationError{
 			Field:  queryParam,
-			Detail: fmt.Sprintf("Query param %q must be a valid boolean (%s)", queryParam, err.Error()),
+			Detail: fmt.Sprintf("Query param %q must be a valid boolean: %s", queryParam, err.Error()),
 		})
 	}
 	return v
@@ -203,9 +203,15 @@ func (p *QueryParamParser) timeWithMutate(vals url.Values, def time.Time, queryP
 }
 
 func (p *QueryParamParser) String(vals url.Values, def string, queryParam string) string {
-	v, _ := parseQueryParam(p, vals, func(v string) (string, error) {
+	v, err := parseQueryParam(p, vals, func(v string) (string, error) {
 		return v, nil
 	}, def, queryParam)
+	if err != nil {
+		p.Errors = append(p.Errors, codersdk.ValidationError{
+			Field:  queryParam,
+			Detail: fmt.Sprintf("Query param %q must be a valid string: %s", queryParam, err.Error()),
+		})
+	}
 	return v
 }
 

--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -32,7 +32,7 @@ type queryParamTestCase[T any] struct {
 
 func TestParseQueryParams(t *testing.T) {
 	t.Parallel()
-	const multipleValuesError = "multiple values provided"
+	const multipleValuesError = "provided more than once"
 
 	t.Run("Enum", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/httpapi/queryparams_test.go
+++ b/coderd/httpapi/queryparams_test.go
@@ -32,6 +32,7 @@ type queryParamTestCase[T any] struct {
 
 func TestParseQueryParams(t *testing.T) {
 	t.Parallel()
+	const multipleValuesError = "multiple values provided"
 
 	t.Run("Enum", func(t *testing.T) {
 		t.Parallel()
@@ -62,6 +63,11 @@ func TestParseQueryParams(t *testing.T) {
 			{
 				QueryParam: "resource_type",
 				Value:      fmt.Sprintf("%s,%s", database.ResourceTypeWorkspace, database.ResourceTypeApiKey),
+				Expected:   []database.ResourceType{database.ResourceTypeWorkspace, database.ResourceTypeApiKey},
+			},
+			{
+				QueryParam: "resource_type_as_list",
+				Values:     []string{string(database.ResourceTypeWorkspace), string(database.ResourceTypeApiKey)},
 				Expected:   []database.ResourceType{database.ResourceTypeWorkspace, database.ResourceTypeApiKey},
 			},
 		}
@@ -156,6 +162,11 @@ func TestParseQueryParams(t *testing.T) {
 				Default:    "default",
 				Expected:   "default",
 			},
+			{
+				QueryParam:            "unexpected_list",
+				Values:                []string{"one", "two"},
+				ExpectedErrorContains: multipleValuesError,
+			},
 		}
 
 		parser := httpapi.NewQueryParamParser()
@@ -198,6 +209,11 @@ func TestParseQueryParams(t *testing.T) {
 				Expected:              false,
 				ExpectedErrorContains: "must be a valid boolean",
 			},
+			{
+				QueryParam:            "unexpected_list",
+				Values:                []string{"true", "false"},
+				ExpectedErrorContains: multipleValuesError,
+			},
 		}
 
 		parser := httpapi.NewQueryParamParser()
@@ -234,6 +250,11 @@ func TestParseQueryParams(t *testing.T) {
 				Value:                 "bogus",
 				Expected:              0,
 				ExpectedErrorContains: "must be a valid integer",
+			},
+			{
+				QueryParam:            "unexpected_list",
+				Values:                []string{"5", "10"},
+				ExpectedErrorContains: multipleValuesError,
 			},
 		}
 
@@ -279,6 +300,11 @@ func TestParseQueryParams(t *testing.T) {
 				Expected:              0,
 				ExpectedErrorContains: "must be a valid 32-bit positive integer",
 			},
+			{
+				QueryParam:            "unexpected_list",
+				Values:                []string{"5", "10"},
+				ExpectedErrorContains: multipleValuesError,
+			},
 		}
 
 		parser := httpapi.NewQueryParamParser()
@@ -315,6 +341,11 @@ func TestParseQueryParams(t *testing.T) {
 				Value:                 "bogus",
 				Expected:              0,
 				ExpectedErrorContains: "must be a valid positive integer",
+			},
+			{
+				QueryParam:            "unexpected_list",
+				Values:                []string{"5", "10"},
+				ExpectedErrorContains: multipleValuesError,
 			},
 		}
 

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -163,17 +163,6 @@ func searchTerms(query string, defaultKey func(term string, values url.Values) e
 		}
 	}
 
-	for k := range searchValues {
-		if len(searchValues[k]) > 1 {
-			return nil, []codersdk.ValidationError{
-				{
-					Field:  "q",
-					Detail: fmt.Sprintf("Query parameter %q provided more than once, found %d times", k, len(searchValues[k])),
-				},
-			}
-		}
-	}
-
 	return searchValues, nil
 }
 


### PR DESCRIPTION
GitHub does this in their label search. Including this for an upcoming feature where the csv format is a bit unwieldy.

supporting: https://github.com/coder/coder/issues/10661

Previously we enforced each key to only be used once, I changed this to be decided in the parse function, later in the process. This works better because the parser has more context.

# What this does

It allows syntax like this to search for 2 ids:


```
id:cfd1898c-f903-47fc-a896-dacf18ed0bef id:2b2d5add-8615-4d4a-8ba2-7e907ceb60f2
```

![Screenshot from 2024-03-20 16-27-14](https://github.com/coder/coder/assets/5446298/1f9e00c5-fd5e-4107-9107-fdd8abcef77c)


The old error is still there for params that do not support it.

![Screenshot from 2024-03-20 11-44-09](https://github.com/coder/coder/assets/5446298/35dc5ddc-12cd-4af4-bf02-985b258ffa91)

# Future work

We have things like `name:<workspace_name>`. It would be nice to allow this syntax there too. Currently we get this error:

![Screenshot from 2024-03-20 12-06-54](https://github.com/coder/coder/assets/5446298/8404e4d9-a38a-4efa-b501-8b1ea9cff52b)


