### PR TITLE
feat(cli): add golden tests for errors (#11588)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -642,7 +642,7 @@ update-golden-files: \
 .PHONY: update-golden-files
 
 cli/testdata/.gen-golden: $(wildcard cli/testdata/*.golden) $(wildcard cli/*.tpl) $(GO_SRC_FILES) $(wildcard cli/*_test.go)
-	go test ./cli -run="Test(CommandHelp|ServerYAML)" -update
+	go test ./cli -run="Test(CommandHelp|ServerYAML|ErrorExamples)" -update
 	touch "$@"
 
 enterprise/cli/testdata/.gen-golden: $(wildcard enterprise/cli/testdata/*.golden) $(wildcard cli/*.tpl) $(GO_SRC_FILES) $(wildcard enterprise/cli/*_test.go)

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 
 	"golang.org/x/xerrors"
 
@@ -83,15 +82,12 @@ func (RootCmd) errorExample() *serpent.Command {
 				Use:   "multi-multi-error",
 				Short: "This is a multi error inside a multi error",
 				Handler: func(inv *serpent.Invocation) error {
-					// Closing the stdin file descriptor will cause the next close
-					// to fail. This is joined to the returned Command error.
-					if f, ok := inv.Stdin.(*os.File); ok {
-						_ = f.Close()
-					}
-
 					return errors.Join(
-						xerrors.Errorf("first error: %w", errorWithStackTrace()),
-						xerrors.Errorf("second error: %w", errorWithStackTrace()),
+						xerrors.Errorf("parent error: %w", errorWithStackTrace()),
+						errors.Join(
+							xerrors.Errorf("child first error: %w", errorWithStackTrace()),
+							xerrors.Errorf("child second error: %w", errorWithStackTrace()),
+						),
 					)
 				},
 			},

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -61,12 +60,6 @@ ExtractCommandPathsLoop:
 			inv, _ := clitest.NewWithCommand(t, coderRootCmd, tt.Cmd...)
 			inv.Stderr = &outBuf
 			inv.Stdout = &outBuf
-
-			// This example expects to close stdin twice and joins
-			// the error messages to create a multi-multi error.
-			if tt.Name == "coder exp example-error multi-multi-error" {
-				inv.Stdin = os.Stdin
-			}
 
 			err := inv.Run()
 

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -1,0 +1,100 @@
+package cli_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli"
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/serpent"
+)
+
+type commandErrorCase struct {
+	Name string
+	Cmd  []string
+}
+
+// TestErrorExamples will test the help output of the
+// coder exp example-error using golden files.
+func TestErrorExamples(t *testing.T) {
+	t.Parallel()
+
+	coderRootCmd := getRoot(t)
+
+	var exampleErrorRootCmd *serpent.Command
+	coderRootCmd.Walk(func(command *serpent.Command) {
+		if command.Name() == "example-error" {
+			// cannot abort early, but list is small
+			exampleErrorRootCmd = command
+		}
+	})
+	require.NotNil(t, exampleErrorRootCmd, "example-error command not found")
+
+	var cases []commandErrorCase
+
+ExtractCommandPathsLoop:
+	for _, cp := range extractCommandPaths(nil, exampleErrorRootCmd.Children) {
+		cmd := append([]string{"exp", "example-error"}, cp...)
+		name := fmt.Sprintf("coder %s", strings.Join(cmd, " "))
+		for _, tt := range cases {
+			if tt.Name == name {
+				continue ExtractCommandPathsLoop
+			}
+		}
+		cases = append(cases, commandErrorCase{Name: name, Cmd: cmd})
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			var outBuf bytes.Buffer
+
+			coderRootCmd := getRoot(t)
+
+			inv, _ := clitest.NewWithCommand(t, coderRootCmd, tt.Cmd...)
+			inv.Stderr = &outBuf
+			inv.Stdout = &outBuf
+
+			// This example expects to close stdin twice and joins
+			// the error messages to create a multi-multi error.
+			if tt.Name == "coder exp example-error multi-multi-error" {
+				inv.Stdin = os.Stdin
+			}
+
+			err := inv.Run()
+
+			errFormatter := cli.NewPrettyErrorFormatter(&outBuf, false)
+			errFormatter.Format(err)
+
+			clitest.TestGoldenFile(t, tt.Name, outBuf.Bytes(), nil)
+		})
+	}
+}
+
+func extractCommandPaths(cmdPath []string, cmds []*serpent.Command) [][]string {
+	var cmdPaths [][]string
+	for _, c := range cmds {
+		cmdPath := append(cmdPath, c.Name())
+		cmdPaths = append(cmdPaths, cmdPath)
+		cmdPaths = append(cmdPaths, extractCommandPaths(cmdPath, c.Children)...)
+	}
+	return cmdPaths
+}
+
+// Must return a fresh instance of cmds each time.
+func getRoot(t *testing.T) *serpent.Command {
+	t.Helper()
+
+	var root cli.RootCmd
+	rootCmd, err := root.Command(root.AGPL())
+	require.NoError(t, err)
+
+	return rootCmd
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -167,9 +167,9 @@ func (r *RootCmd) RunWithSubcommands(subcommands []*serpent.Command) {
 			//nolint:revive
 			os.Exit(code)
 		}
-		f := prettyErrorFormatter{w: os.Stderr, verbose: r.verbose}
+		f := PrettyErrorFormatter{w: os.Stderr, verbose: r.verbose}
 		if err != nil {
-			f.format(err)
+			f.Format(err)
 		}
 		//nolint:revive
 		os.Exit(code)
@@ -909,15 +909,23 @@ func ExitError(code int, err error) error {
 	return &exitError{code: code, err: err}
 }
 
-type prettyErrorFormatter struct {
+// NewPrettyErrorFormatter creates a new PrettyErrorFormatter.
+func NewPrettyErrorFormatter(w io.Writer, verbose bool) *PrettyErrorFormatter {
+	return &PrettyErrorFormatter{
+		w:       w,
+		verbose: verbose,
+	}
+}
+
+type PrettyErrorFormatter struct {
 	w io.Writer
 	// verbose turns on more detailed error logs, such as stack traces.
 	verbose bool
 }
 
-// format formats the error to the console. This error should be human
-// readable.
-func (p *prettyErrorFormatter) format(err error) {
+// Format formats the error to the writer in PrettyErrorFormatter.
+// This error should be human readable.
+func (p *PrettyErrorFormatter) Format(err error) {
 	output, _ := cliHumanFormatError("", err, &formatOpts{
 		Verbose: p.verbose,
 	})

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -1774,21 +1774,7 @@ func TestServerYAMLConfig(t *testing.T) {
 	err = enc.Encode(n)
 	require.NoError(t, err)
 
-	wantByt := wantBuf.Bytes()
-
-	goldenPath := filepath.Join("testdata", "server-config.yaml.golden")
-
-	wantByt = clitest.NormalizeGoldenFile(t, wantByt)
-	if *clitest.UpdateGoldenFiles {
-		require.NoError(t, os.WriteFile(goldenPath, wantByt, 0o600))
-		return
-	}
-
-	got, err := os.ReadFile(goldenPath)
-	require.NoError(t, err)
-	got = clitest.NormalizeGoldenFile(t, got)
-
-	require.Equal(t, string(wantByt), string(got))
+	clitest.TestGoldenFile(t, "server-config.yaml", wantBuf.Bytes(), nil)
 }
 
 func TestConnectToPostgres(t *testing.T) {

--- a/cli/testdata/coder_exp_example-error_api.golden
+++ b/cli/testdata/coder_exp_example-error_api.golden
@@ -1,0 +1,3 @@
+Encountered an error running "coder exp example-error api", see "coder exp example-error api --help" for more information
+error: Top level sdk error message.
+Have you tried turning it off and on again?

--- a/cli/testdata/coder_exp_example-error_arg-required.golden
+++ b/cli/testdata/coder_exp_example-error_arg-required.golden
@@ -1,0 +1,2 @@
+Encountered an error running "coder exp example-error arg-required", see "coder exp example-error arg-required --help" for more information
+error: wanted 1 args but got 0 []

--- a/cli/testdata/coder_exp_example-error_cmd.golden
+++ b/cli/testdata/coder_exp_example-error_cmd.golden
@@ -1,0 +1,2 @@
+Encountered an error running "coder exp example-error cmd", see "coder exp example-error cmd --help" for more information
+error: some error: function decided not to work, and it never will

--- a/cli/testdata/coder_exp_example-error_multi-error.golden
+++ b/cli/testdata/coder_exp_example-error_multi-error.golden
@@ -1,0 +1,7 @@
+Encountered an error running "coder exp example-error multi-error", see "coder exp example-error multi-error --help" for more information
+error: 3 errors encountered: Trace=[wrapped: ])
+1.  first error: function decided not to work, and it never will
+2.  second error: function decided not to work, and it never will
+3.  Trace=[wrapped api error: ]
+    Top level sdk error message.
+    magic dust unavailable, please try again later

--- a/cli/testdata/coder_exp_example-error_multi-multi-error.golden
+++ b/cli/testdata/coder_exp_example-error_multi-multi-error.golden
@@ -1,6 +1,6 @@
-2 errors encountered: 
-1.  Encountered an error running "coder exp example-error multi-multi-error", see "coder exp example-error multi-multi-error --help" for more information
-    error: 2 errors encountered: 
-    1.  first error: function decided not to work, and it never will
-    2.  second error: function decided not to work, and it never will
-2.  close /dev/stdin: file already closed
+Encountered an error running "coder exp example-error multi-multi-error", see "coder exp example-error multi-multi-error --help" for more information
+error: 2 errors encountered: 
+1.  parent error: function decided not to work, and it never will
+2.  2 errors encountered: 
+    1.  child first error: function decided not to work, and it never will
+    2.  child second error: function decided not to work, and it never will

--- a/cli/testdata/coder_exp_example-error_multi-multi-error.golden
+++ b/cli/testdata/coder_exp_example-error_multi-multi-error.golden
@@ -1,0 +1,6 @@
+2 errors encountered: 
+1.  Encountered an error running "coder exp example-error multi-multi-error", see "coder exp example-error multi-multi-error --help" for more information
+    error: 2 errors encountered: 
+    1.  first error: function decided not to work, and it never will
+    2.  second error: function decided not to work, and it never will
+2.  close /dev/stdin: file already closed

--- a/cli/testdata/coder_exp_example-error_validation.golden
+++ b/cli/testdata/coder_exp_example-error_validation.golden
@@ -1,0 +1,1 @@
+Missing values for the required flags: magic-word


### PR DESCRIPTION
Fixes #11588

Creates golden files from `coder/cli/errors.go`.
Adds a unit test to test against golden files.
Adds a make file command to regenerate golden files. 
Abstracts test against golden files.

~~Most of the error printing is handled by `cli.prettyErrorFormatter` and `prettyErrorFormatter.format(err)`, neither is exported. I wanted to add tests in `root_internal_test.go` but that resulted in a circular dependency since it needed `clitest`.~~

~~I solved this issue by creating an `export_cli_test.go` file in which I exported those values. Since it is an `_test` file its exports will limited to `cli_test` package files.~~

Exported the formatted for testing purposes.
