### PR TITLE
fix(coderd/agentapi): always write agent stats when provided

### DIFF
--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -47,11 +47,11 @@ func (a *StatsAPI) now() time.Time {
 }
 
 func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsRequest) (*agentproto.UpdateStatsResponse, error) {
-	// An empty stat means it's just looking for the report interval.
 	res := &agentproto.UpdateStatsResponse{
 		ReportInterval: durationpb.New(a.AgentStatsRefreshInterval),
 	}
-	if req.Stats == nil || len(req.Stats.ConnectionsByProto) == 0 {
+	// An empty stat means it's just looking for the report interval.
+	if req.Stats == nil {
 		return res, nil
 	}
 

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -222,9 +222,7 @@ func TestUpdateStates(t *testing.T) {
 
 			req = &agentproto.UpdateStatsRequest{
 				Stats: &agentproto.Stats{
-					ConnectionsByProto: map[string]int64{
-						"tcp": 1,
-					},
+					ConnectionsByProto:        map[string]int64{},
 					ConnectionCount:           0,
 					ConnectionMedianLatencyMs: 23,
 				},
@@ -262,16 +260,14 @@ func TestUpdateStates(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("NoConnectionsByProto", func(t *testing.T) {
+	t.Run("NoStats", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			dbM = dbmock.NewMockStore(gomock.NewController(t))
 			ps  = pubsub.NewInMemory()
 			req = &agentproto.UpdateStatsRequest{
-				Stats: &agentproto.Stats{
-					ConnectionsByProto: map[string]int64{}, // len() == 0
-				},
+				Stats: nil,
 			}
 		)
 		api := agentapi.StatsAPI{


### PR DESCRIPTION
Previously we were discarding agent stats due to the length of connections by proto being zero.

We no longer check `ConnectionsByProto` because this can be simplified to check `Stats == nil` due to the agentapi v2 refactor.

Previously we checked `nil` not `len`: https://github.com/coder/coder/blob/131d0bd2baf1ed775f83677fbf9e02cfc987afe2/coderd/workspaceagents.go#L1154