### PR TITLE
chore: nolint function 'forwardNodesToWorkspaceProxy' that aways returns error

### DIFF
--- a/enterprise/tailnet/workspaceproxy.go
+++ b/enterprise/tailnet/workspaceproxy.go
@@ -67,6 +67,7 @@ func (s *ClientService) ServeMultiAgentClient(ctx context.Context, version strin
 
 func ServeWorkspaceProxy(ctx context.Context, conn net.Conn, ma agpl.MultiAgentConn) error {
 	go func() {
+		//nolint:staticcheck
 		err := forwardNodesToWorkspaceProxy(ctx, conn, ma)
 		//nolint:staticcheck
 		if err != nil {
@@ -112,6 +113,10 @@ func ServeWorkspaceProxy(ctx context.Context, conn net.Conn, ma agpl.MultiAgentC
 	}
 }
 
+// Linter fails because this function always returns an error. This function blocks
+// until it errors, so this is ok.
+//
+//nolint:staticcheck
 func forwardNodesToWorkspaceProxy(ctx context.Context, conn net.Conn, ma agpl.MultiAgentConn) error {
 	var lastData []byte
 	for {


### PR DESCRIPTION
This lint is occasionally failing? My local golangci-lint does not pick this up. I'm not 100% sure what is happening, but this is not a false positive.

https://github.com/coder/coder/actions/runs/8375922935/job/22935269854?pr=12694