### PR TITLE
chore: clean up databases after test finishes in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -783,6 +783,7 @@ test-postgres: test-postgres-docker
 		-count=1
 .PHONY: test-postgres
 
+# NOTE: we set --memory to the same size as a GitHub runner.
 test-postgres-docker:
 	docker rm -f test-postgres-docker || true
 	docker run \
@@ -795,6 +796,7 @@ test-postgres-docker:
 		--name test-postgres-docker \
 		--restart no \
 		--detach \
+		--memory 16GB \
 		gcr.io/coder-dev-1/postgres:13 \
 		-c shared_buffers=1GB \
 		-c work_mem=1GB \

--- a/cli/resetpassword_test.go
+++ b/cli/resetpassword_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
-	"github.com/coder/coder/v2/coderd/database/postgres"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -18,7 +18,7 @@ import (
 
 // nolint:paralleltest
 func TestResetPassword(t *testing.T) {
-	// postgres.Open() seems to be creating race conditions when run in parallel.
+	// dbtestutil.Open() seems to be creating race conditions when run in parallel.
 	// t.Parallel()
 
 	if runtime.GOOS != "linux" || testing.Short() {
@@ -32,7 +32,7 @@ func TestResetPassword(t *testing.T) {
 	const newPassword = "MyNewPassword!"
 
 	// start postgres and coder server processes
-	connectionURL, closeFunc, err := postgres.Open()
+	connectionURL, closeFunc, err := dbtestutil.Open()
 	require.NoError(t, err)
 	defer closeFunc()
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/userpassword"
 	"github.com/coder/coder/v2/pty/ptytest"
@@ -84,7 +84,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 			// Skip on non-Linux because it spawns a PostgreSQL instance.
 			t.SkipNow()
 		}
-		connectionURL, closeFunc, err := postgres.Open()
+		connectionURL, closeFunc, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closeFunc()
 
@@ -150,7 +150,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 			// Skip on non-Linux because it spawns a PostgreSQL instance.
 			t.SkipNow()
 		}
-		connectionURL, closeFunc, err := postgres.Open()
+		connectionURL, closeFunc, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closeFunc()
 
@@ -184,7 +184,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 			// Skip on non-Linux because it spawns a PostgreSQL instance.
 			t.SkipNow()
 		}
-		connectionURL, closeFunc, err := postgres.Open()
+		connectionURL, closeFunc, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closeFunc()
 
@@ -224,7 +224,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 			// Skip on non-Linux because it spawns a PostgreSQL instance.
 			t.SkipNow()
 		}
-		connectionURL, closeFunc, err := postgres.Open()
+		connectionURL, closeFunc, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closeFunc()
 		ctx, cancelFunc := context.WithCancel(context.Background())

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
@@ -1582,7 +1581,7 @@ func TestServer_Production(t *testing.T) {
 		// Skip on non-Linux because it spawns a PostgreSQL instance.
 		t.SkipNow()
 	}
-	connectionURL, closeFunc, err := postgres.Open()
+	connectionURL, closeFunc, err := dbtestutil.Open()
 	require.NoError(t, err)
 	defer closeFunc()
 
@@ -1801,7 +1800,7 @@ func TestConnectToPostgres(t *testing.T) {
 
 	log := slogtest.Make(t, nil)
 
-	dbURL, closeFunc, err := postgres.Open()
+	dbURL, closeFunc, err := dbtestutil.Open()
 	require.NoError(t, err)
 	t.Cleanup(closeFunc)
 

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/migrations"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 )
 
 func TestSerializedRetry(t *testing.T) {
@@ -87,7 +87,7 @@ func TestNestedInTx(t *testing.T) {
 func testSQLDB(t testing.TB) *sql.DB {
 	t.Helper()
 
-	connection, closeFn, err := postgres.Open()
+	connection, closeFn, err := dbtestutil.Open()
 	require.NoError(t, err)
 	t.Cleanup(closeFn)
 

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -21,7 +21,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmem"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 )
 
@@ -97,7 +96,7 @@ func NewDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub) {
 				err     error
 				closePg func()
 			)
-			connectionURL, closePg, err = postgres.Open()
+			connectionURL, closePg, err = Open()
 			require.NoError(t, err)
 			t.Cleanup(closePg)
 		}

--- a/coderd/database/dbtestutil/postgres_test.go
+++ b/coderd/database/dbtestutil/postgres_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package postgres_test
+package dbtestutil_test
 
 import (
 	"database/sql"
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/coder/coder/v2/coderd/database/postgres"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 )
 
 func TestMain(m *testing.M) {
@@ -27,7 +27,7 @@ func TestPostgres(t *testing.T) {
 		return
 	}
 
-	connect, closePg, err := postgres.Open()
+	connect, closePg, err := dbtestutil.Open()
 	require.NoError(t, err)
 	defer closePg()
 	db, err := sql.Open("postgres", connect)

--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -11,14 +11,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/migrations"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 )
 
 const minimumPostgreSQLVersion = 13
 
 func main() {
-	connection, closeFn, err := postgres.Open()
+	connection, closeFn, err := dbtestutil.Open()
 	if err != nil {
 		panic(err)
 	}

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -22,8 +22,8 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/migrations"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -95,7 +95,7 @@ func TestMigrate(t *testing.T) {
 func testSQLDB(t testing.TB) *sql.DB {
 	t.Helper()
 
-	connection, closeFn, err := postgres.Open()
+	connection, closeFn, err := dbtestutil.Open()
 	require.NoError(t, err)
 	t.Cleanup(closeFn)
 
@@ -103,7 +103,7 @@ func testSQLDB(t testing.TB) *sql.DB {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	// postgres.Open automatically runs migrations, but we want to actually test
+	// dbtestutil.Open automatically runs migrations, but we want to actually test
 	// migration behavior in this package.
 	_, err = db.Exec(`DROP SCHEMA public CASCADE`)
 	require.NoError(t, err)

--- a/coderd/database/pubsub/pubsub_linux_test.go
+++ b/coderd/database/pubsub/pubsub_linux_test.go
@@ -17,7 +17,7 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
-	"github.com/coder/coder/v2/coderd/database/postgres"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -36,7 +36,7 @@ func TestPubsub(t *testing.T) {
 		defer cancelFunc()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
-		connectionURL, closePg, err := postgres.Open()
+		connectionURL, closePg, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closePg()
 		db, err := sql.Open("postgres", connectionURL)
@@ -65,7 +65,7 @@ func TestPubsub(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-		connectionURL, closePg, err := postgres.Open()
+		connectionURL, closePg, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closePg()
 		db, err := sql.Open("postgres", connectionURL)
@@ -81,7 +81,7 @@ func TestPubsub(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-		connectionURL, closePg, err := postgres.Open()
+		connectionURL, closePg, err := dbtestutil.Open()
 		require.NoError(t, err)
 		defer closePg()
 		db, err := sql.Open("postgres", connectionURL)
@@ -118,7 +118,7 @@ func TestPubsub_ordering(t *testing.T) {
 	defer cancelFunc()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
-	connectionURL, closePg, err := postgres.Open()
+	connectionURL, closePg, err := dbtestutil.Open()
 	require.NoError(t, err)
 	defer closePg()
 	db, err := sql.Open("postgres", connectionURL)
@@ -163,7 +163,7 @@ const disconnectTestPort = 26892
 func TestPubsub_Disconnect(t *testing.T) {
 	// we always use a Docker container for this test, even in CI, since we need to be able to kill
 	// postgres and bring it back on the same port.
-	connectionURL, closePg, err := postgres.OpenContainerized(disconnectTestPort)
+	connectionURL, closePg, err := dbtestutil.OpenContainerized(disconnectTestPort)
 	require.NoError(t, err)
 	defer closePg()
 	db, err := sql.Open("postgres", connectionURL)
@@ -234,7 +234,7 @@ func TestPubsub_Disconnect(t *testing.T) {
 
 	// restart postgres on the same port --- since we only use LISTEN/NOTIFY it doesn't
 	// matter that the new postgres doesn't have any persisted state from before.
-	_, closeNewPg, err := postgres.OpenContainerized(disconnectTestPort)
+	_, closeNewPg, err := dbtestutil.OpenContainerized(disconnectTestPort)
 	require.NoError(t, err)
 	defer closeNewPg()
 

--- a/coderd/database/pubsub/pubsub_test.go
+++ b/coderd/database/pubsub/pubsub_test.go
@@ -12,7 +12,6 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -24,7 +23,7 @@ func TestPGPubsub_Metrics(t *testing.T) {
 	}
 
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-	connectionURL, closePg, err := postgres.Open()
+	connectionURL, closePg, err := dbtestutil.Open()
 	require.NoError(t, err)
 	defer closePg()
 	db, err := sql.Open("postgres", connectionURL)

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
-	"github.com/coder/coder/v2/coderd/database/postgres"
 	"github.com/coder/coder/v2/enterprise/dbcrypt"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -33,7 +32,7 @@ func TestServerDBCrypt(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Setup a postgres database.
-	connectionURL, closePg, err := postgres.Open()
+	connectionURL, closePg, err := dbtestutil.Open()
 	require.NoError(t, err)
 	t.Cleanup(closePg)
 	t.Cleanup(func() { dbtestutil.DumpOnFailure(t, connectionURL) })


### PR DESCRIPTION
- Moves `postgres.Open` and friends to `dbtestutil` as that is the only place they're used
- Adds logic to `DROP` CI databases when we're done with them otherwise our DB container can fill up

**Reduces `make test-postgres` memory usage from ~16GB down to approx. 2.3GB**