### PR TITLE
chore(site): remove max ttl from template scheduling description

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -472,8 +472,6 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
                 }}
               >
                 Workspaces will always use the default TTL if this is set.
-                Regardless of this setting, workspaces can only stay on for the
-                max lifetime.
               </span>
             </Stack>
           </Stack>


### PR DESCRIPTION
After `max_ttl` was removed in #12644, this phrase did not make sense. 