### PR TITLE
docs: describe operational readiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -605,7 +605,7 @@ jobs:
         uses: ./.github/actions/setup-sqlc
 
       - name: make gen
-        run: "make --output-sync -j -B gen"
+        run: "make --output-sync -B gen"
 
       - name: Format
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,7 +202,7 @@ jobs:
           popd
 
       - name: make gen
-        run: "make --output-sync -j -B gen"
+        run: "make --output-sync -B gen"
 
       - name: Check for unstaged files
         run: ./scripts/check_unstaged.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,6 +202,8 @@ jobs:
           popd
 
       - name: make gen
+        # no `-j` flag as `make` fails with:
+        # coderd/rbac/object_gen.go:1:1: syntax error: package statement must be first
         run: "make --output-sync -B gen"
 
       - name: Check for unstaged files
@@ -604,9 +606,6 @@ jobs:
       - name: Setup sqlc
         uses: ./.github/actions/setup-sqlc
 
-      - name: make gen
-        run: "make --output-sync -B gen"
-
       - name: Format
         run: |
           cd offlinedocs
@@ -618,8 +617,10 @@ jobs:
           pnpm lint
 
       - name: Build
+        # no `-j` flag as `make` fails with:
+        # coderd/rbac/object_gen.go:1:1: syntax error: package statement must be first
         run: |
-          make -j build/coder_docs_"$(./scripts/version.sh)".tgz
+          make build/coder_docs_"$(./scripts/version.sh)".tgz
 
   required:
     runs-on: ubuntu-latest

--- a/docs/admin/architectures/index.md
+++ b/docs/admin/architectures/index.md
@@ -357,17 +357,25 @@ in the
 
 ### Configuration
 
-1. Create `values.yaml` and add it to a version control system.
-1. Determine the necessary environment variables.
 1. Identify the required Helm values for configuration.
+1. Create `values.yaml` and add it to a version control system. _Note:_ it is
+   highly recommended that you create a custom `values.yaml` as opposed to
+   copying the entire default values.
+1. Determine the necessary environment variables.
 
 ### Template configuration
 
 1. Establish a dedicated user account for the _Template Administrator_.
 1. Maintain Coder templates using version control.
-1. Consider implementing a GitOps workflow to automatically push new template
-   versions to Coder.
+1. Consider implementing a GitOps workflow to automatically push new template.
+   For example, on Github, you can use the
+   [Update Coder Template](https://github.com/marketplace/actions/update-coder-template)
+   action.
 1. Evaluate enabling automatic template updates upon workspace startup.
+
+### Deployment
+
+1. Leverage automation tooling to automate deployment and upgrades of Coder.
 
 ### Observability
 

--- a/docs/admin/architectures/index.md
+++ b/docs/admin/architectures/index.md
@@ -345,14 +345,38 @@ We provide the following general recommendations for PostgreSQL settings:
 
 ## Operational readiness
 
-TODO Configuration: Helm values, environment variables
+Operational readiness in Coder is about ensuring that everything is set up
+correctly before launching a platform into production. It involves making sure
+that the service is reliable, secure, and easily scales accordingly to user-base
+needs. Operational readiness is crucial because it helps prevent issues that
+could affect workspace users experience once the platform is live.
 
-TODO Template configuration managed via CI/CD.
+### Configuration
 
-TODO Observability, e.g. Promethus/Grafana
+#### Helm values
 
-TODO Database backups link scripts if we have any
+TODO
 
-TODO Custom support links
+#### Environment variables
 
-TODO Custom agent troubleshooting links
+TODO
+
+### Template configuration
+
+TODO managed via CI/CD
+
+### Observability
+
+TODO Prometheus, Grafana, logging
+
+### Database backups
+
+TODO link scripts if we have any
+
+### Support links
+
+TODO
+
+### Troubleshooting agent
+
+TODO links

--- a/docs/admin/architectures/index.md
+++ b/docs/admin/architectures/index.md
@@ -351,32 +351,43 @@ that the service is reliable, secure, and easily scales accordingly to user-base
 needs. Operational readiness is crucial because it helps prevent issues that
 could affect workspace users experience once the platform is live.
 
+Learn about Coder design principles and architectural best practices described
+in the
+[Well-Architected Framework](https://coder.com/blog/coder-well-architected-framework).
+
 ### Configuration
 
-#### Helm values
-
-TODO
-
-#### Environment variables
-
-TODO
+1. Create `values.yaml` and add it to a version control system.
+1. Determine the necessary environment variables.
+1. Identify the required Helm values for configuration.
 
 ### Template configuration
 
-TODO managed via CI/CD
+1. Establish a dedicated user account for the _Template Administrator_.
+1. Maintain Coder templates using version control.
+1. Consider implementing a GitOps workflow to automatically push new template
+   versions to Coder.
+1. Evaluate enabling automatic template updates upon workspace startup.
 
 ### Observability
 
-TODO Prometheus, Grafana, logging
+1. Enable the Prometheus endpoint (environment variable:
+   `CODER_PROMETHEUS_ENABLE`).
+1. Deploy a visual monitoring system such as Grafana for metrics visualization.
+1. Deploy a centralized logs aggregation solution to collect and monitor
+   application logs.
+1. Review the [Prometheus response](../prometheus.md) and set up alarms on
+   selected metrics.
 
 ### Database backups
 
-TODO link scripts if we have any
+1. Prepare internal scripts for dumping and restoring databases.
+1. Schedule regular database backups, especially before release upgrades.
 
-### Support links
+### User support
 
-TODO
-
-### Troubleshooting agent
-
-TODO links
+1. Incorporate [support links](../appearance.md#support-links) into internal
+   documentation accessible from the user context menu. Ensure that hyperlinks
+   are valid and lead to up-to-date materials.
+1. Encourage the use of `coder support bundle` to allow workspace users to
+   generate and provide network-related diagnostic data.

--- a/docs/admin/architectures/index.md
+++ b/docs/admin/architectures/index.md
@@ -342,3 +342,17 @@ We provide the following general recommendations for PostgreSQL settings:
   and memory utilization is high.
 - Utilize faster disk options (higher IOPS) such as SSDs or NVMe drives for
   optimal performance enhancement and possibly reduce database load.
+
+## Operational readiness
+
+TODO Configuration: Helm values, environment variables
+
+TODO Template configuration managed via CI/CD.
+
+TODO Observability, e.g. Promethus/Grafana
+
+TODO Database backups link scripts if we have any
+
+TODO Custom support links
+
+TODO Custom agent troubleshooting links


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/12426

This PR extends Reference Architectures with a paragraph about the operational readiness of Coder deployment. Feel free to add more ideas to the checklist.

Extra changes:
* do no use parallel mode while running `make gen` and `make build/coder_docs...`. It fails with `coderd/rbac/object_gen.go:1:1: syntax error: package statement must be first`.