### PR TITLE
fix(coderd): remove websocket wait group on shutdown

### DIFF
--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -61,10 +61,6 @@ func (api *API) provisionerJobLogs(rw http.ResponseWriter, r *http.Request, job 
 	}
 
 	follower := newLogFollower(ctx, logger, api.Database, api.Pubsub, rw, r, job, after)
-	api.WebsocketWaitMutex.Lock()
-	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
-	defer api.WebsocketWaitGroup.Done()
 	follower.follow()
 }
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -515,11 +515,6 @@ func (api *API) workspaceAgentLogs(rw http.ResponseWriter, r *http.Request) {
 	}
 	workspace := row.Workspace
 
-	api.WebsocketWaitMutex.Lock()
-	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
-	defer api.WebsocketWaitGroup.Done()
-
 	opts := &websocket.AcceptOptions{}
 
 	// Allow client to request no compression. This is useful for buggy
@@ -867,11 +862,6 @@ func (api *API) workspaceAgentConnectionGeneric(rw http.ResponseWriter, r *http.
 func (api *API) derpMapUpdates(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	api.WebsocketWaitMutex.Lock()
-	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
-	defer api.WebsocketWaitGroup.Done()
-
 	ws, err := websocket.Accept(rw, r, nil)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -950,10 +940,6 @@ func (api *API) derpMapUpdates(rw http.ResponseWriter, r *http.Request) {
 func (api *API) workspaceAgentCoordinate(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	api.WebsocketWaitMutex.Lock()
-	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
-	defer api.WebsocketWaitGroup.Done()
 	// The middleware only accept agents for resources on the latest build.
 	workspaceAgent := httpmw.WorkspaceAgent(r)
 	build := httpmw.LatestBuild(r)
@@ -1058,10 +1044,6 @@ func (api *API) workspaceAgentClientCoordinate(rw http.ResponseWriter, r *http.R
 		return
 	}
 
-	api.WebsocketWaitMutex.Lock()
-	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
-	defer api.WebsocketWaitGroup.Done()
 	workspaceAgent := httpmw.WorkspaceAgentParam(r)
 
 	conn, err := websocket.Accept(rw, r, nil)

--- a/coderd/workspaceagentsrpc.go
+++ b/coderd/workspaceagentsrpc.go
@@ -56,10 +56,6 @@ func (api *API) workspaceAgentRPC(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.WebsocketWaitMutex.Lock()
-	api.WebsocketWaitGroup.Add(1)
-	api.WebsocketWaitMutex.Unlock()
-	defer api.WebsocketWaitGroup.Done()
 	workspaceAgent := httpmw.WorkspaceAgent(r)
 	build := httpmw.LatestBuild(r)
 

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -267,11 +267,6 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	api.AGPL.WebsocketWaitMutex.Lock()
-	api.AGPL.WebsocketWaitGroup.Add(1)
-	api.AGPL.WebsocketWaitMutex.Unlock()
-	defer api.AGPL.WebsocketWaitGroup.Done()
-
 	tep := telemetry.ConvertExternalProvisioner(id, tags, provisioners)
 	api.Telemetry.Report(&telemetry.Snapshot{ExternalProvisioners: []telemetry.ExternalProvisioner{tep}})
 	defer func() {

--- a/enterprise/coderd/workspaceproxycoordinate.go
+++ b/enterprise/coderd/workspaceproxycoordinate.go
@@ -43,11 +43,6 @@ func (api *API) workspaceProxyCoordinate(rw http.ResponseWriter, r *http.Request
 		msgType = websocket.MessageBinary
 	}
 
-	api.AGPL.WebsocketWaitMutex.Lock()
-	api.AGPL.WebsocketWaitGroup.Add(1)
-	api.AGPL.WebsocketWaitMutex.Unlock()
-	defer api.AGPL.WebsocketWaitGroup.Done()
-
 	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{


### PR DESCRIPTION
There's really no great way to shutdown websockets. In the code
currently it seems to assume that `(*http.Server).Shutdown()`
gracefully kills them, but that's not the case: https://pkg.go.dev/net/http#Server.Shutdown

This removes the mutex so that `coder server` no longer waits for them
to exit.