### PR TITLE
feat(cli): unhide support bundle cmd

### DIFF
--- a/cli/support.go
+++ b/cli/support.go
@@ -30,7 +30,6 @@ func (r *RootCmd) support() *serpent.Command {
 		Handler: func(inv *serpent.Invocation) error {
 			return inv.Command.HelpHandler(inv)
 		},
-		Hidden: true, // TODO: un-hide once the must-haves from #12160 are completed.
 		Children: []*serpent.Command{
 			r.supportBundle(),
 		},
@@ -40,7 +39,7 @@ func (r *RootCmd) support() *serpent.Command {
 
 var supportBundleBlurb = cliui.Bold("This will collect the following information:\n") +
 	`  - Coder deployment version
-   - Coder deployment Configuration (sanitized), including enabled experiments
+  - Coder deployment Configuration (sanitized), including enabled experiments
   - Coder deployment health snapshot
   - Coder deployment Network troubleshooting information
   - Workspace configuration, parameters, and build logs

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -46,6 +46,8 @@ SUBCOMMANDS:
     stat              Show resource usage for the current workspace.
     state             Manually manage Terraform state to fix broken workspaces
     stop              Stop a workspace
+    support           Commands for troubleshooting issues with a Coder
+                      deployment.
     templates         Manage templates
     tokens            Manage personal access tokens
     unfavorite        Remove a workspace from your favorites

--- a/cli/testdata/coder_support_--help.golden
+++ b/cli/testdata/coder_support_--help.golden
@@ -1,0 +1,13 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder support
+
+  Commands for troubleshooting issues with a Coder deployment.
+
+SUBCOMMANDS:
+    bundle    Generate a support bundle to troubleshoot issues connecting to a
+              workspace.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_support_bundle_--help.golden
+++ b/cli/testdata/coder_support_bundle_--help.golden
@@ -1,0 +1,25 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder support bundle [flags] <workspace> [<agent>]
+
+  Generate a support bundle to troubleshoot issues connecting to a workspace.
+
+  This command generates a file containing detailed troubleshooting information
+  about the Coder deployment and workspace connections. You must specify a
+  single workspace (and optionally an agent name).
+
+OPTIONS:
+  -O, --output-file string, $CODER_SUPPORT_BUNDLE_OUTPUT_FILE
+          File path for writing the generated support bundle. Defaults to
+          coder-support-$(date +%s).zip.
+
+      --url-override string, $CODER_SUPPORT_BUNDLE_URL_OVERRIDE
+          Override the URL to your Coder deployment. This may be useful, for
+          example, if you need to troubleshoot a specific Coder replica.
+
+  -y, --yes bool
+          Bypass prompts.
+
+———
+Run `coder --help` for a list of global options.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 | [<code>stop</code>](./cli/stop.md)                     | Stop a workspace                                                                                      |
 | [<code>unfavorite</code>](./cli/unfavorite.md)         | Remove a workspace from your favorites                                                                |
 | [<code>update</code>](./cli/update.md)                 | Will update and start a given workspace if it is out of date                                          |
+| [<code>support</code>](./cli/support.md)               | Commands for troubleshooting issues with a Coder deployment.                                          |
 | [<code>server</code>](./cli/server.md)                 | Start a Coder server                                                                                  |
 | [<code>features</code>](./cli/features.md)             | List Enterprise features                                                                              |
 | [<code>licenses</code>](./cli/licenses.md)             | Add, delete, and list licenses                                                                        |

--- a/docs/cli/support.md
+++ b/docs/cli/support.md
@@ -1,0 +1,17 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# support
+
+Commands for troubleshooting issues with a Coder deployment.
+
+## Usage
+
+```console
+coder support
+```
+
+## Subcommands
+
+| Name                                       | Purpose                                                                     |
+| ------------------------------------------ | --------------------------------------------------------------------------- |
+| [<code>bundle</code>](./support_bundle.md) | Generate a support bundle to troubleshoot issues connecting to a workspace. |

--- a/docs/cli/support_bundle.md
+++ b/docs/cli/support_bundle.md
@@ -1,0 +1,45 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# support bundle
+
+Generate a support bundle to troubleshoot issues connecting to a workspace.
+
+## Usage
+
+```console
+coder support bundle [flags] <workspace> [<agent>]
+```
+
+## Description
+
+```console
+This command generates a file containing detailed troubleshooting information about the Coder deployment and workspace connections. You must specify a single workspace (and optionally an agent name).
+```
+
+## Options
+
+### -y, --yes
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+Bypass prompts.
+
+### -O, --output-file
+
+|             |                                                |
+| ----------- | ---------------------------------------------- |
+| Type        | <code>string</code>                            |
+| Environment | <code>$CODER_SUPPORT_BUNDLE_OUTPUT_FILE</code> |
+
+File path for writing the generated support bundle. Defaults to coder-support-$(date +%s).zip.
+
+### --url-override
+
+|             |                                                 |
+| ----------- | ----------------------------------------------- |
+| Type        | <code>string</code>                             |
+| Environment | <code>$CODER_SUPPORT_BUNDLE_URL_OVERRIDE</code> |
+
+Override the URL to your Coder deployment. This may be useful, for example, if you need to troubleshoot a specific Coder replica.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -901,6 +901,16 @@
           "path": "cli/stop.md"
         },
         {
+          "title": "support",
+          "description": "Commands for troubleshooting issues with a Coder deployment.",
+          "path": "cli/support.md"
+        },
+        {
+          "title": "support bundle",
+          "description": "Generate a support bundle to troubleshoot issues connecting to a workspace.",
+          "path": "cli/support_bundle.md"
+        },
+        {
           "title": "templates",
           "description": "Manage templates",
           "path": "cli/templates.md"


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/12160

Un-hides the support bundle command.
Also updates the tests for support bundle with some secret values in deployment config that we validate are not present in the bundle.
