### PR TITLE
chore: remove middleware to request version and entitlement warnings

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/coder/pretty"
 
-	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/coderd/userpassword"
 	"github.com/coder/coder/v2/codersdk"
@@ -180,19 +179,9 @@ func (r *RootCmd) login() *serpent.Command {
 				serverURL.Scheme = "https"
 			}
 
-			client, err := r.createUnauthenticatedClient(ctx, serverURL)
+			client, err := r.createUnauthenticatedClient(ctx, serverURL, inv)
 			if err != nil {
 				return err
-			}
-
-			// Try to check the version of the server prior to logging in.
-			// It may be useful to warn the user if they are trying to login
-			// on a very old client.
-			err = r.checkVersions(inv, client, buildinfo.Version())
-			if err != nil {
-				// Checking versions isn't a fatal error so we print a warning
-				// and proceed.
-				_, _ = fmt.Fprintln(inv.Stderr, pretty.Sprint(cliui.DefaultStyles.Warn, err.Error()))
 			}
 
 			hasFirstUser, err := client.HasFirstUser(ctx)

--- a/cli/logout_test.go
+++ b/cli/logout_test.go
@@ -97,33 +97,6 @@ func TestLogout(t *testing.T) {
 
 		<-logoutChan
 	})
-	t.Run("NoSessionFile", func(t *testing.T) {
-		t.Parallel()
-
-		pty := ptytest.New(t)
-		config := login(t, pty)
-
-		// Ensure session files exist.
-		require.FileExists(t, string(config.URL()))
-		require.FileExists(t, string(config.Session()))
-
-		err := os.Remove(string(config.Session()))
-		require.NoError(t, err)
-
-		logoutChan := make(chan struct{})
-		logout, _ := clitest.New(t, "logout", "--global-config", string(config))
-
-		logout.Stdin = pty.Input()
-		logout.Stdout = pty.Output()
-
-		go func() {
-			defer close(logoutChan)
-			err = logout.Run()
-			assert.ErrorContains(t, err, "You are not logged in. Try logging in using 'coder login'.")
-		}()
-
-		<-logoutChan
-	})
 	t.Run("CannotDeleteFiles", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"runtime"
 	"testing"
@@ -13,13 +16,29 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli/cliui"
-	"github.com/coder/coder/v2/coderd"
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/pretty"
+	"github.com/coder/serpent"
 )
+
+func TestMain(m *testing.M) {
+	if runtime.GOOS == "windows" {
+		// Don't run goleak on windows tests, they're super flaky right now.
+		// See: https://github.com/coder/coder/issues/8954
+		os.Exit(m.Run())
+	}
+	goleak.VerifyTestMain(m,
+		// The lumberjack library is used by by agent and seems to leave
+		// goroutines after Close(), fails TestGitSSH tests.
+		// https://github.com/natefinch/lumberjack/pull/100
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1"),
+		// The pq library appears to leave around a goroutine after Close().
+		goleak.IgnoreTopFunction("github.com/lib/pq.NewDialListener"),
+	)
+}
 
 func Test_formatExamples(t *testing.T) {
 	t.Parallel()
@@ -80,48 +99,36 @@ func Test_formatExamples(t *testing.T) {
 	}
 }
 
-func TestMain(m *testing.M) {
-	if runtime.GOOS == "windows" {
-		// Don't run goleak on windows tests, they're super flaky right now.
-		// See: https://github.com/coder/coder/issues/8954
-		os.Exit(m.Run())
-	}
-	goleak.VerifyTestMain(m,
-		// The lumberjack library is used by by agent and seems to leave
-		// goroutines after Close(), fails TestGitSSH tests.
-		// https://github.com/natefinch/lumberjack/pull/100
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1"),
-		// The pq library appears to leave around a goroutine after Close().
-		goleak.IgnoreTopFunction("github.com/lib/pq.NewDialListener"),
-	)
-}
-
-func Test_checkVersions(t *testing.T) {
+func Test_wrapTransportWithVersionMismatchCheck(t *testing.T) {
 	t.Parallel()
+
+	t.Run("NoOutput", func(t *testing.T) {
+		t.Parallel()
+		r := &RootCmd{}
+		cmd, err := r.Command(nil)
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		inv := cmd.Invoke()
+		inv.Stderr = &buf
+		rt := wrapTransportWithVersionMismatchCheck(roundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					// Provider a version that will not match!
+					codersdk.BuildVersionHeader: []string{"v2.0.0"},
+				},
+				Body: io.NopCloser(nil),
+			}, nil
+		}), inv, "v2.0.0", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, "", buf.String())
+	})
 
 	t.Run("CustomUpgradeMessage", func(t *testing.T) {
 		t.Parallel()
-
-		expectedUpgradeMessage := "My custom upgrade message"
-
-		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.BuildInfoResponse{
-				ExternalURL: buildinfo.ExternalURL(),
-				// Provide a version that will not match
-				Version:         "v1.0.0",
-				AgentAPIVersion: coderd.AgentAPIVersionREST,
-				// does not matter what the url is
-				DashboardURL:   "https://example.com",
-				WorkspaceProxy: false,
-				UpgradeMessage: expectedUpgradeMessage,
-			})
-		}))
-		defer srv.Close()
-		surl, err := url.Parse(srv.URL)
-		require.NoError(t, err)
-
-		client := codersdk.New(surl)
 
 		r := &RootCmd{}
 
@@ -131,50 +138,85 @@ func Test_checkVersions(t *testing.T) {
 		var buf bytes.Buffer
 		inv := cmd.Invoke()
 		inv.Stderr = &buf
-
-		err = r.checkVersions(inv, client, "v2.0.0")
+		expectedUpgradeMessage := "My custom upgrade message"
+		rt := wrapTransportWithVersionMismatchCheck(roundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					// Provider a version that will not match!
+					codersdk.BuildVersionHeader: []string{"v1.0.0"},
+				},
+				Body: io.NopCloser(nil),
+			}, nil
+		}), inv, "v2.0.0", func(ctx context.Context) (codersdk.BuildInfoResponse, error) {
+			return codersdk.BuildInfoResponse{
+				UpgradeMessage: expectedUpgradeMessage,
+			}, nil
+		})
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
+		defer res.Body.Close()
+
+		// Run this twice to ensure the upgrade message is only printed once.
+		res, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
 
 		fmtOutput := fmt.Sprintf("version mismatch: client v2.0.0, server v1.0.0\n%s", expectedUpgradeMessage)
 		expectedOutput := fmt.Sprintln(pretty.Sprint(cliui.DefaultStyles.Warn, fmtOutput))
 		require.Equal(t, expectedOutput, buf.String())
 	})
+}
 
-	t.Run("DefaultUpgradeMessage", func(t *testing.T) {
-		t.Parallel()
+func Test_wrapTransportWithTelemetryHeader(t *testing.T) {
+	t.Parallel()
 
-		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.BuildInfoResponse{
-				ExternalURL: buildinfo.ExternalURL(),
-				// Provide a version that will not match
-				Version:         "v1.0.0",
-				AgentAPIVersion: coderd.AgentAPIVersionREST,
-				// does not matter what the url is
-				DashboardURL:   "https://example.com",
-				WorkspaceProxy: false,
-				UpgradeMessage: "",
-			})
-		}))
-		defer srv.Close()
-		surl, err := url.Parse(srv.URL)
-		require.NoError(t, err)
-
-		client := codersdk.New(surl)
-
-		r := &RootCmd{}
-
-		cmd, err := r.Command(nil)
-		require.NoError(t, err)
-
-		var buf bytes.Buffer
-		inv := cmd.Invoke()
-		inv.Stderr = &buf
-
-		err = r.checkVersions(inv, client, "v2.0.0")
-		require.NoError(t, err)
-
-		fmtOutput := fmt.Sprintf("version mismatch: client v2.0.0, server v1.0.0\n%s", defaultUpgradeMessage("v1.0.0"))
-		expectedOutput := fmt.Sprintln(pretty.Sprint(cliui.DefaultStyles.Warn, fmtOutput))
-		require.Equal(t, expectedOutput, buf.String())
+	rt := wrapTransportWithTelemetryHeader(roundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			Body: io.NopCloser(nil),
+		}, nil
+	}), &serpent.Invocation{
+		Command: &serpent.Command{
+			Use: "test",
+			Options: serpent.OptionSet{{
+				Name:        "bananas",
+				Description: "hey",
+			}},
+		},
 	})
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	resp := req.Header.Get(codersdk.CLITelemetryHeader)
+	require.NotEmpty(t, resp)
+	data, err := base64.StdEncoding.DecodeString(resp)
+	require.NoError(t, err)
+	var ti telemetry.Invocation
+	err = json.Unmarshal(data, &ti)
+	require.NoError(t, err)
+	require.Equal(t, ti.Command, "test")
+}
+
+func Test_wrapTransportWithEntitlementsCheck(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{"First Warning", "Second Warning"}
+	var buf bytes.Buffer
+	rt := wrapTransportWithEntitlementsCheck(roundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				codersdk.EntitlementsWarningHeader: lines,
+			},
+			Body: io.NopCloser(nil),
+		}, nil
+	}), &buf)
+	res, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "http://example.com", nil))
+	require.NoError(t, err)
+	defer res.Body.Close()
+	expectedOutput := fmt.Sprintf("%s\n%s\n", pretty.Sprint(cliui.DefaultStyles.Warn, lines[0]),
+		pretty.Sprint(cliui.DefaultStyles.Warn, lines[1]))
+	require.Equal(t, expectedOutput, buf.String())
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -253,7 +253,7 @@ func TestHandlersOK(t *testing.T) {
 	t.Parallel()
 
 	var root cli.RootCmd
-	cmd, err := root.Command(root.Core())
+	cmd, err := root.Command(root.CoreSubcommands())
 	require.NoError(t, err)
 
 	clitest.HandlersOK(t, cmd)

--- a/cli/userlist_test.go
+++ b/cli/userlist_test.go
@@ -77,7 +77,7 @@ func TestUserList(t *testing.T) {
 
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
-		require.Contains(t, err.Error(), "Try logging in using 'coder login <url>'.")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login'.")
 	})
 }
 

--- a/cli/vscodessh.go
+++ b/cli/vscodessh.go
@@ -90,7 +90,7 @@ func (r *RootCmd) vscodeSSH() *serpent.Command {
 			client.SetSessionToken(string(sessionToken))
 
 			// This adds custom headers to the request!
-			err = r.setClient(ctx, client, serverURL)
+			err = r.configureClient(ctx, client, serverURL, inv)
 			if err != nil {
 				return xerrors.Errorf("set client: %w", err)
 			}

--- a/cmd/coder/main.go
+++ b/cmd/coder/main.go
@@ -8,5 +8,5 @@ import (
 
 func main() {
 	var rootCmd cli.RootCmd
-	rootCmd.RunMain(rootCmd.AGPL())
+	rootCmd.RunWithSubcommands(rootCmd.AGPL())
 }

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -171,7 +171,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
-		require.Contains(t, err.Error(), "Try logging in using 'coder login <url>'.")
+		require.Contains(t, err.Error(), "Try logging in using 'coder login'.")
 	})
 
 	t.Run("AllowUserScheduling", func(t *testing.T) {

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -81,6 +81,9 @@ const (
 
 	// BuildVersionHeader contains build information of Coder.
 	BuildVersionHeader = "X-Coder-Build-Version"
+
+	// EntitlementsWarnings contains active warnings for the user's entitlements.
+	EntitlementsWarningHeader = "X-Coder-Entitlements-Warning"
 )
 
 // loggableMimeTypes is a list of MIME types that are safe to log
@@ -358,7 +361,7 @@ func ReadBodyAsError(res *http.Response) error {
 	if res.StatusCode == http.StatusUnauthorized {
 		// 401 means the user is not logged in
 		// 403 would mean that the user is not authorized
-		helpMessage = "Try logging in using 'coder login <url>'."
+		helpMessage = "Try logging in using 'coder login'."
 	}
 
 	resp, err := io.ReadAll(res.Body)

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -82,7 +82,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			// disable checks and warnings because this command starts a daemon; it is
 			// not meant for humans typing commands.  Furthermore, the checks are
 			// incompatible with PSK auth that this command uses
-			r.InitClientMissingTokenOK(client),
+			r.InitClient(client),
 		),
 		Handler: func(inv *serpent.Invocation) error {
 			ctx, cancel := context.WithCancel(inv.Context())

--- a/enterprise/cli/root.go
+++ b/enterprise/cli/root.go
@@ -21,6 +21,6 @@ func (r *RootCmd) enterpriseOnly() []*serpent.Command {
 }
 
 func (r *RootCmd) EnterpriseSubcommands() []*serpent.Command {
-	all := append(r.Core(), r.enterpriseOnly()...)
+	all := append(r.CoreSubcommands(), r.enterpriseOnly()...)
 	return all
 }

--- a/enterprise/cmd/coder/main.go
+++ b/enterprise/cmd/coder/main.go
@@ -8,5 +8,5 @@ import (
 
 func main() {
 	var rootCmd entcli.RootCmd
-	rootCmd.RunMain(rootCmd.EnterpriseSubcommands())
+	rootCmd.RunWithSubcommands(rootCmd.EnterpriseSubcommands())
 }


### PR DESCRIPTION
This cleans up `root.go` a bit, adds tests for middleware HTTP transport functions, and removes two HTTP requests we have always performed previously when executing *any* client command. It should improve CLI performance (especially for users with higher latency).

Version information was already sent as a header to every request. This adds entitlement warnings to requests if they exist. This seems reasonable because it's rare for users to have entitlement warnings.

The only behavior this breaks is when running `coder logout`; if you're already logged out, it will no longer error.

I removed a test that regressed in [this commit](https://github.com/coder/coder/commit/d2998c6b7b9fe9f3d7922108dab536dbf08d6fc5#diff-e1d0a50ee0a7500620f021bf79f28ffe6f0fc754c08ce01f8a07d8d5f7fd50a2). It's for the deprecated command, so it seems minimal risk since it wasn't working anyways.