### PR TITLE
chore: change e2e testing port

### DIFF
--- a/site/e2e/constants.ts
+++ b/site/e2e/constants.ts
@@ -1,5 +1,5 @@
 // Default port from the server
-export const defaultPort = 3000;
+export const defaultPort = 3111;
 export const prometheusPort = 2114;
 
 // Use alternate ports in case we're running in a Coder Workspace.

--- a/site/e2e/constants.ts
+++ b/site/e2e/constants.ts
@@ -1,5 +1,7 @@
 // Default port from the server
-export const defaultPort = 3111;
+export const coderPort = process.env.CODER_E2E_PORT
+  ? Number(process.env.CODER_E2E_PORT)
+  : 3111;
 export const prometheusPort = 2114;
 
 // Use alternate ports in case we're running in a Coder Workspace.

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -12,8 +12,7 @@ import type {
   UpdateTemplateMeta,
 } from "api/typesGenerated";
 import { TarWriter } from "utils/tar";
-import { prometheusPort, agentPProfPort } from "./constants";
-import { port } from "./playwright.config";
+import { agentPProfPort, coderPort, prometheusPort } from "./constants";
 import {
   Agent,
   type App,
@@ -156,7 +155,7 @@ export const sshIntoWorkspace = async (
       env: {
         ...process.env,
         CODER_SESSION_TOKEN: sessionToken,
-        CODER_URL: "http://localhost:3000",
+        CODER_URL: `http://localhost:${coderPort}`,
       },
     });
     cp.on("error", (err) => reject(err));
@@ -304,7 +303,7 @@ export const startAgentWithCommand = async (
   const cp = spawn(command, [...args, "agent", "--no-reap"], {
     env: {
       ...process.env,
-      CODER_AGENT_URL: "http://localhost:" + port,
+      CODER_AGENT_URL: `http://localhost:${coderPort}`,
       CODER_AGENT_TOKEN: token,
       CODER_AGENT_PPROF_ADDRESS: "127.0.0.1:" + agentPProfPort,
       CODER_AGENT_PROMETHEUS_ADDRESS: "127.0.0.1:" + prometheusPort,
@@ -701,7 +700,7 @@ export const updateTemplate = async (
       env: {
         ...process.env,
         CODER_SESSION_TOKEN: sessionToken,
-        CODER_URL: "http://localhost:3000",
+        CODER_URL: `http://localhost:${coderPort}`,
       },
     },
   );

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from "@playwright/test";
 import path from "path";
-import { defaultPort, coderdPProfPort, gitAuth } from "./constants";
-
-export const port = process.env.CODER_E2E_PORT
-  ? Number(process.env.CODER_E2E_PORT)
-  : defaultPort;
+import { coderPort, coderdPProfPort, gitAuth } from "./constants";
 
 export const wsEndpoint = process.env.CODER_E2E_WS_ENDPOINT;
 
@@ -35,7 +31,7 @@ export default defineConfig({
   ],
   reporter: [["./reporter.ts"]],
   use: {
-    baseURL: `http://localhost:${port}`,
+    baseURL: `http://localhost:${coderPort}`,
     video: "retain-on-failure",
     ...(wsEndpoint
       ? {
@@ -50,12 +46,12 @@ export default defineConfig({
         }),
   },
   webServer: {
-    url: `http://localhost:${port}/api/v2/deployment/config`,
+    url: `http://localhost:${coderPort}/api/v2/deployment/config`,
     command:
       `go run -tags embed ${coderMain} server ` +
       `--global-config $(mktemp -d -t e2e-XXXXXXXXXX) ` +
-      `--access-url=http://localhost:${port} ` +
-      `--http-address=localhost:${port} ` +
+      `--access-url=http://localhost:${coderPort} ` +
+      `--http-address=localhost:${coderPort} ` +
       `--in-memory --telemetry=false ` +
       `--dangerous-disable-rate-limits ` +
       `--provisioner-daemons 10 ` +

--- a/site/e2e/reporter.ts
+++ b/site/e2e/reporter.ts
@@ -11,6 +11,7 @@ import type {
 import axios from "axios";
 import * as fs from "fs/promises";
 import type { Writable } from "stream";
+import { coderdPProfPort } from "./constants";
 
 class CoderReporter implements Reporter {
   config: FullConfig | null = null;
@@ -119,7 +120,7 @@ const filteredServerLogLines = (chunk: string): string[] =>
 
 const exportDebugPprof = async (outputFile: string) => {
   const response = await axios.get(
-    "http://127.0.0.1:6062/debug/pprof/goroutine?debug=1",
+    `http://127.0.0.1:${coderdPProfPort}/debug/pprof/goroutine?debug=1`,
   );
   if (response.status !== 200) {
     throw new Error(`Error: Received status code ${response.status}`);


### PR DESCRIPTION
Running the tests on :3000 causes conflicts when running coder with `./scripts/develop.sh`, which is a thing you might reasonably want to do in parallel.