### PR TITLE
test(cli): prevent flake due to outdated build in TestSSH

### DIFF
--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -365,7 +365,7 @@ func TestSSH(t *testing.T) {
 		workspaceBuild := coderdtest.CreateWorkspaceBuild(t, client, workspace, database.WorkspaceTransitionStop)
 		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspaceBuild.ID)
 
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 		defer cancel()
 
 		clientStdinR, clientStdinW := io.Pipe()
@@ -460,6 +460,18 @@ func TestSSH(t *testing.T) {
 			err := inv.WithContext(ctx).Run()
 			assert.NoError(t, err)
 		})
+
+		// Delay until workspace is starting, otherwise the agent may be
+		// booted due to outdated build.
+		var err error
+		for {
+			workspace, err = client.Workspace(ctx, workspace.ID)
+			require.NoError(t, err)
+			if workspace.LatestBuild.Transition == codersdk.WorkspaceTransitionStart {
+				break
+			}
+			time.Sleep(testutil.IntervalFast)
+		}
 
 		// When the agent connects, the workspace was started, and we should
 		// have access to the shell.

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -117,13 +117,25 @@ func TestSSH(t *testing.T) {
 		clitest.SetupConfig(t, client, root)
 		pty := ptytest.New(t).Attach(inv)
 
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 		defer cancel()
 
 		cmdDone := tGo(t, func() {
 			err := inv.WithContext(ctx).Run()
 			assert.NoError(t, err)
 		})
+
+		// Delay until workspace is starting, otherwise the agent may be
+		// booted due to outdated build.
+		var err error
+		for {
+			workspace, err = client.Workspace(ctx, workspace.ID)
+			require.NoError(t, err)
+			if workspace.LatestBuild.Transition == codersdk.WorkspaceTransitionStart {
+				break
+			}
+			time.Sleep(testutil.IntervalFast)
+		}
 
 		// When the agent connects, the workspace was started, and we should
 		// have access to the shell.


### PR DESCRIPTION
I got a bit suspicious about all the flakes for `TestSSH/Stdio_StartStoppedWorkspace_CleanStdout`, so we now ensure the build has started before trying to start the agent.

https://github.com/coder/coder/actions/runs/8420752158/job/23056129504?pr=12675#step:5:919

```
    t.go:99: 2024-03-25 13:23:28.691 [info]  coderd: disconnected possibly outdated agent  workspace_id=9915a34a-ec63-4b80-a2db-303abd1a9a23  agent_id=689042a0-a6fa-44c7-a15a-9cf89d3b5979  request_id=78afb83d-6655-43ab-b9ef-e1824eaa27a8 ...
```

Fixes #12752