### PR TITLE
ci: limit test parallelism

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -387,7 +387,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          gotestsum --junitfile="gotests.xml" -- -race ./...
+          make test-race
 
       - name: Upload test stats to Datadog
         timeout-minutes: 1

--- a/Makefile
+++ b/Makefile
@@ -780,7 +780,8 @@ test-postgres: test-postgres-docker
 		--packages="./..." -- \
 		-timeout=20m \
 		-failfast \
-		-count=1
+		-count=1 \
+		-parallel=4
 .PHONY: test-postgres
 
 # NOTE: we set --memory to the same size as a GitHub runner.
@@ -815,7 +816,7 @@ test-postgres-docker:
 
 # Make sure to keep this in sync with test-go-race from .github/workflows/ci.yaml.
 test-race:
-	gotestsum --junitfile="gotests.xml" -- -race -count=1 ./...
+	gotestsum --junitfile="gotests.xml" -- -race -count=1 -parallel=4 ./...
 .PHONY: test-race
 
 # Note: we used to add this to the test target, but it's not necessary and we can


### PR DESCRIPTION
Sets `-parallel=4` in `test-postgres` and `test-race` to match the [hosted runner spec](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)