### PR TITLE
fix(coderd/database): improve data exclusion in `UpsertTemplateUsageStats`

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2760,7 +2760,9 @@ WITH
 		JOIN
 			workspace_agent_stats AS was
 		ON
-			date_trunc('minute', was.created_at) = mb.minute_bucket
+			was.created_at >= (SELECT t FROM latest_start)
+			AND was.created_at < NOW()
+			AND date_trunc('minute', was.created_at) = mb.minute_bucket
 			AND was.template_id = mb.template_id
 			AND was.user_id = mb.user_id
 			AND was.connection_median_latency_ms >= 0

--- a/coderd/database/queries/insights.sql
+++ b/coderd/database/queries/insights.sql
@@ -599,7 +599,9 @@ WITH
 		JOIN
 			workspace_agent_stats AS was
 		ON
-			date_trunc('minute', was.created_at) = mb.minute_bucket
+			was.created_at >= (SELECT t FROM latest_start)
+			AND was.created_at < NOW()
+			AND date_trunc('minute', was.created_at) = mb.minute_bucket
 			AND was.template_id = mb.template_id
 			AND was.user_id = mb.user_id
 			AND was.connection_median_latency_ms >= 0


### PR DESCRIPTION
The PostgreSQL query analyzer wasn't able to eliminate the agent stats without re-introducing this filter.

Before: https://explain.dalibo.com/plan/21h7gb4f4bef391g
After: https://explain.dalibo.com/plan/721ec1cccee91egc