### PR TITLE
chore: reduce azure CA cert validity check period to 2 months

### DIFF
--- a/coderd/azureidentity/azureidentity_test.go
+++ b/coderd/azureidentity/azureidentity_test.go
@@ -53,15 +53,17 @@ func TestValidate(t *testing.T) {
 
 func TestExpiresSoon(t *testing.T) {
 	t.Parallel()
+	const threshold = 2
+
 	for _, c := range azureidentity.Certificates {
 		block, rest := pem.Decode([]byte(c))
 		require.Zero(t, len(rest))
 		cert, err := x509.ParseCertificate(block.Bytes)
 		require.NoError(t, err)
 
-		expiresSoon := cert.NotAfter.Before(time.Now().AddDate(0, 3, 0))
+		expiresSoon := cert.NotAfter.Before(time.Now().AddDate(0, threshold, 0))
 		if expiresSoon {
-			t.Errorf("certificate expires within 6 months %s: %s", cert.NotAfter, cert.Subject.CommonName)
+			t.Errorf("certificate expires within %d months %s: %s", threshold, cert.NotAfter, cert.Subject.CommonName)
 		} else {
 			url := "no issuing url"
 			if len(cert.IssuingCertificateURL) > 0 {


### PR DESCRIPTION
`coderd/azureidentity/azureidentity_test.go:TestExpiresSoon` is failing currently, because a few Azure certificates have not yet been renewed.

For example, `Microsoft Azure TLS Issuing CA 01`:

```bash
$ curl -s https://crt.sh/\?d\=2616326024 | openssl x509 -in /dev/stdin -text | grep -e Validity -A2 -e Subject:    
        Validity
            Not Before: Jan 17 20:22:47 2020 GMT
            Not After : Jun 27 20:22:47 2024 GMT
        Subject: C = US, O = Microsoft Corporation, CN = Microsoft Azure TLS Issuing CA 01
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
```

Tagging @spikecurtis since you last changed this