### PR TITLE
fix(coderd/database): add fk index for `workspace_agent_scripts`

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1648,6 +1648,10 @@ CREATE UNIQUE INDEX users_email_lower_idx ON users USING btree (lower(email)) WH
 
 CREATE UNIQUE INDEX users_username_lower_idx ON users USING btree (lower(username)) WHERE (deleted = false);
 
+CREATE INDEX workspace_agent_scripts_workspace_agent_id_idx ON workspace_agent_scripts USING btree (workspace_agent_id);
+
+COMMENT ON INDEX workspace_agent_scripts_workspace_agent_id_idx IS 'Foreign key support index for faster lookups';
+
 CREATE INDEX workspace_agent_startup_logs_id_agent_id_idx ON workspace_agent_logs USING btree (agent_id, id);
 
 CREATE INDEX workspace_agent_stats_template_id_created_at_user_id_idx ON workspace_agent_stats USING btree (template_id, created_at, user_id) INCLUDE (session_count_vscode, session_count_jetbrains, session_count_reconnecting_pty, session_count_ssh, connection_median_latency_ms) WHERE (connection_count > 0);

--- a/coderd/database/migrations/000204_add_workspace_agent_scripts_fk_index.down.sql
+++ b/coderd/database/migrations/000204_add_workspace_agent_scripts_fk_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX workspace_agent_scripts_workspace_agent_id_idx;

--- a/coderd/database/migrations/000204_add_workspace_agent_scripts_fk_index.up.sql
+++ b/coderd/database/migrations/000204_add_workspace_agent_scripts_fk_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX workspace_agent_scripts_workspace_agent_id_idx ON workspace_agent_scripts (workspace_agent_id);
+
+COMMENT ON INDEX workspace_agent_scripts_workspace_agent_id_idx IS 'Foreign key support index for faster lookups';


### PR DESCRIPTION
I noticed we were missing this index while looking at query
performances, we were doing sequential scans on the table via the
`GetWorkspaceAgentScriptsByAgentIDs` query, which is relatively fast
whilst the table is small, but at 8.5k calls/hour in our dogfood
instance, it will become problematic eventually.