### PR TITLE
perf(coderd/database): optimize `GetWorkspaceAgentAndLatestBuildByAuthToken`

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -9081,33 +9081,34 @@ SELECT
 	workspace_agents.id, workspace_agents.created_at, workspace_agents.updated_at, workspace_agents.name, workspace_agents.first_connected_at, workspace_agents.last_connected_at, workspace_agents.disconnected_at, workspace_agents.resource_id, workspace_agents.auth_token, workspace_agents.auth_instance_id, workspace_agents.architecture, workspace_agents.environment_variables, workspace_agents.operating_system, workspace_agents.instance_metadata, workspace_agents.resource_metadata, workspace_agents.directory, workspace_agents.version, workspace_agents.last_connected_replica_id, workspace_agents.connection_timeout_seconds, workspace_agents.troubleshooting_url, workspace_agents.motd_file, workspace_agents.lifecycle_state, workspace_agents.expanded_directory, workspace_agents.logs_length, workspace_agents.logs_overflowed, workspace_agents.started_at, workspace_agents.ready_at, workspace_agents.subsystems, workspace_agents.display_apps, workspace_agents.api_version, workspace_agents.display_order,
 	workspace_build_with_user.id, workspace_build_with_user.created_at, workspace_build_with_user.updated_at, workspace_build_with_user.workspace_id, workspace_build_with_user.template_version_id, workspace_build_with_user.build_number, workspace_build_with_user.transition, workspace_build_with_user.initiator_id, workspace_build_with_user.provisioner_state, workspace_build_with_user.job_id, workspace_build_with_user.deadline, workspace_build_with_user.reason, workspace_build_with_user.daily_cost, workspace_build_with_user.max_deadline, workspace_build_with_user.initiator_by_avatar_url, workspace_build_with_user.initiator_by_username
 FROM
-	-- Only get the latest build for each workspace
-	(
-	SELECT
-		workspace_id, MAX(build_number) as max_build_number
-	FROM
-		workspace_build_with_user
-	GROUP BY
-		workspace_id
-	) as latest_builds
-	-- Pull the workspace_build rows for returning
-INNER JOIN workspace_build_with_user
-	ON workspace_build_with_user.workspace_id = latest_builds.workspace_id
-	AND workspace_build_with_user.build_number = latest_builds.max_build_number
-	-- For each latest build, grab the resources to relate to an agent
-INNER JOIN workspace_resources
-	ON workspace_resources.job_id = workspace_build_with_user.job_id
-	-- Agent <-> Resource is 1:1
-INNER JOIN workspace_agents
-	ON workspace_agents.resource_id = workspace_resources.id
-	-- We need the owner ID
-INNER JOIN workspaces
-	ON workspace_build_with_user.workspace_id = workspaces.id
+	workspace_agents
+JOIN
+	workspace_resources
+ON
+	workspace_agents.resource_id = workspace_resources.id
+JOIN
+	workspace_build_with_user
+ON
+	workspace_resources.job_id = workspace_build_with_user.job_id
+JOIN
+	workspaces
+ON
+	workspace_build_with_user.workspace_id = workspaces.id
 WHERE
-	-- This should only match 1 agent, so 1 returned row or 0
-	workspace_agents.auth_token = $1
-AND
-	workspaces.deleted = FALSE
+	-- This should only match 1 agent, so 1 returned row or 0.
+	workspace_agents.auth_token = $1::uuid
+	AND workspaces.deleted = FALSE
+	-- Filter out builds that are not the latest.
+	AND workspace_build_with_user.build_number = (
+		-- Select from workspace_builds as it's one less join compared
+		-- to workspace_build_with_user.
+		SELECT
+			MAX(build_number)
+		FROM
+			workspace_builds
+		WHERE
+			workspace_id = workspace_build_with_user.workspace_id
+	)
 `
 
 type GetWorkspaceAgentAndLatestBuildByAuthTokenRow struct {


### PR DESCRIPTION
This query is run 35k/hour on dev.coder.com, this refactor lowers the execution time from 10ms to <0.2ms in my testing (against dev.coder.com DB) and should result in a bit less load.

Original: https://explain.dalibo.com/plan/ggdbc4b4dbeg6b1c
New: https://explain.dalibo.com/plan/ee87631976a2dh62