### PR TITLE
chore: implement 'coder external-auth link' for fuller auth-link info

### DIFF
--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -67,7 +67,17 @@ func (r *RootCmd) externalAuthLink() *serpent.Command {
 				}
 				return []agentsdk.ExternalAuthResponse{auth}, nil
 			}),
-			cliui.JSONFormat(),
+			cliui.ChangeFormatterData(cliui.JSONFormat(), func(data any) (any, error) {
+				auth, ok := data.(agentsdk.ExternalAuthResponse)
+				if !ok {
+					return nil, xerrors.Errorf("expected data to be of type codersdk.ExternalAuth, got %T", data)
+				}
+
+				// Deprecated fields, omit them from any output.
+				auth.Username = ""
+				auth.Password = ""
+				return auth, nil
+			}),
 		)
 	)
 

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"golang.org/x/xerrors"
 
@@ -22,16 +23,147 @@ func (r *RootCmd) externalAuth() *serpent.Command {
 		},
 		Children: []*serpent.Command{
 			r.externalAuthAccessToken(),
+			r.externalAuthLink(),
 		},
 	}
 }
 
+func (r *RootCmd) externalAuthLink() *serpent.Command {
+	var (
+		matchURL  string
+		only      string
+		formatter = cliui.NewOutputFormatter(
+			cliui.ChangeFormatterData(cliui.TextFormat(), func(data any) (any, error) {
+				auth, ok := data.(agentsdk.ExternalAuthResponse)
+				if !ok {
+					return nil, xerrors.Errorf("expected data to be of type codersdk.ExternalAuth, got %T", data)
+				}
+
+				// If the url is set, only return that. It will be accompanied by an error message.
+				// This is helpful for scripts to take this output and give it to the user.
+				if auth.URL != "" {
+					return auth.URL, nil
+				}
+
+				switch only {
+				case "access_token":
+					return auth.AccessToken, nil
+				case "refresh_token":
+					return auth.RefreshToken, nil
+				default:
+					refresh := ""
+					if auth.RefreshToken != "" {
+						refresh = fmt.Sprintf("\nrefresh_token: %s", auth.RefreshToken)
+					}
+					return fmt.Sprintf("type: %s\naccess_token: %s%s", auth.Type, auth.AccessToken, refresh), nil
+				}
+			},
+			),
+			// Table expects a slice of data.
+			cliui.ChangeFormatterData(cliui.TableFormat([]agentsdk.ExternalAuthResponse{}, []string{"type", "access_token"}), func(data any) (any, error) {
+				auth, ok := data.(agentsdk.ExternalAuthResponse)
+				if !ok {
+					return nil, xerrors.Errorf("expected data to be of type codersdk.ExternalAuth, got %T", data)
+				}
+				return []agentsdk.ExternalAuthResponse{auth}, nil
+			}),
+			cliui.JSONFormat(),
+		)
+	)
+
+	cmd := &serpent.Command{
+		Use:   "link <provider>",
+		Short: "Print auth link for an external provider by ID or match regex.",
+		Long: "Print auth link for an external provider by ID or match regex. " +
+			"Use the flags to tailor the output to your needs. " +
+			"If a valid access-token cannot be obtained, the URL to authenticate will be sent to stdout with exit code 1\n" + formatExamples(
+			example{
+				Description: "Only print the access token",
+				Command:     "external-auth link <provider_id> --only access_token",
+			},
+			example{
+				Description: "Dump auth link as json",
+				Command:     "external-auth link <provider_id> --o json",
+			},
+		),
+		Middleware: serpent.Chain(
+			serpent.RequireRangeArgs(0, 1),
+		),
+		Options: serpent.OptionSet{
+			{
+				Name:        "Match",
+				Flag:        "match",
+				Description: "Match a provider with a url. If a provider has a regex that matches the url, the provider will be returned.",
+				Value:       serpent.StringOf(&matchURL),
+			},
+			{
+				Name:        "Only",
+				Flag:        "only",
+				Description: "Only return the specified field from the external auth response. Only works with text response.",
+				Value:       serpent.EnumOf(&only, "access_token", "refresh_token"),
+			},
+		},
+
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			req := agentsdk.ExternalAuthRequest{
+				Match: matchURL,
+			}
+
+			if len(inv.Args) > 0 && matchURL != "" {
+				return xerrors.Errorf("cannot specify both provider id and --match")
+			}
+
+			if matchURL == "" {
+				if len(inv.Args) == 0 {
+					return xerrors.Errorf("missing provider argument")
+				}
+				req.ID = inv.Args[0]
+			}
+
+			ctx, stop := inv.SignalNotifyContext(ctx, StopSignals...)
+			defer stop()
+
+			client, err := r.createAgentClient()
+			if err != nil {
+				return xerrors.Errorf("create agent client: %w", err)
+			}
+
+			extAuth, err := client.ExternalAuth(ctx, req)
+			if err != nil {
+				return xerrors.Errorf("get external auth token: %w", err)
+			}
+
+			// We always write to the output because if the URL field is
+			// populated, we still want that information sent to the user.
+			out, err := formatter.Format(inv.Context(), extAuth)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(inv.Stdout, out)
+
+			// If the URL field is set, we need to accompany the output with the
+			// authentication error.
+			if extAuth.URL != "" {
+				// The text & json outputs will have the url. The table one will not,
+				// but the error message will. So this is ok.
+				return xerrors.Errorf("external auth requires login, visit %s", extAuth.URL)
+			}
+
+			return nil
+		},
+	}
+	formatter.AttachOptions(&cmd.Options)
+
+	return cmd
+}
+
 func (r *RootCmd) externalAuthAccessToken() *serpent.Command {
+
 	var extra string
-	var full bool
 	return &serpent.Command{
 		Use:   "access-token <provider>",
-		Short: "Print auth for an external provider",
+		Short: "Use 'link <provider> --only access_token' instead. Will print auth for an external provider",
 		Long: "Print an access-token for an external auth provider. " +
 			"The access-token will be validated and sent to stdout with exit code 0. " +
 			"If a valid access-token cannot be obtained, the URL to authenticate will be sent to stdout with exit code 1\n" + formatExamples(
@@ -62,14 +194,6 @@ fi
 				Flag:        "extra",
 				Description: "Extract a field from the \"extra\" properties of the OAuth token.",
 				Value:       serpent.StringOf(&extra),
-			}, {
-				Name:          "Full",
-				Description:   "Print the full response from the external auth provider as json.",
-				Required:      false,
-				Flag:          "full",
-				FlagShorthand: "",
-				Default:       "false",
-				Value:         serpent.BoolOf(&full),
 			},
 		},
 
@@ -96,19 +220,6 @@ fi
 					return err
 				}
 				return cliui.Canceled
-			}
-
-			if extra != "" && full {
-				return xerrors.Errorf("cannot specify both --extra and --full")
-			}
-
-			if full {
-				data, err := json.Marshal(extAuth)
-				if err != nil {
-					return xerrors.Errorf("marshal auth: %w", err)
-				}
-				_, _ = inv.Stdout.Write(data)
-				return nil
 			}
 
 			if extra != "" {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7764,6 +7764,9 @@ const docTemplate = `{
                 "password": {
                     "type": "string"
                 },
+                "refresh_token": {
+                    "type": "string"
+                },
                 "token_extra": {
                     "type": "object",
                     "additionalProperties": true

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6855,6 +6855,9 @@
         "password": {
           "type": "string"
         },
+        "refresh_token": {
+          "type": "string"
+        },
         "token_extra": {
           "type": "object",
           "additionalProperties": true

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -569,8 +569,8 @@ type ExternalAuthResponse struct {
 
 	// Deprecated: Only supported on `/workspaceagents/me/gitauth`
 	// for backwards compatibility.
-	Username string `json:"username" table:"-"`
-	Password string `json:"password" table:"-"`
+	Username string `json:"username,omitempty" table:"-"`
+	Password string `json:"password,omitempty" table:"-"`
 }
 
 // ExternalAuthRequest is used to request an access token for a provider.

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -561,15 +561,16 @@ func (c *Client) PostLogSource(ctx context.Context, req PostLogSource) (codersdk
 }
 
 type ExternalAuthResponse struct {
-	AccessToken string                 `json:"access_token"`
-	TokenExtra  map[string]interface{} `json:"token_extra"`
-	URL         string                 `json:"url"`
-	Type        string                 `json:"type"`
+	AccessToken  string                 `json:"access_token" table:"access_token"`
+	RefreshToken string                 `json:"refresh_token" table:"refresh_token"`
+	TokenExtra   map[string]interface{} `json:"token_extra" table:"-"`
+	URL          string                 `json:"url" table:"url"`
+	Type         string                 `json:"type" table:"type,default_sort"`
 
 	// Deprecated: Only supported on `/workspaceagents/me/gitauth`
 	// for backwards compatibility.
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username" table:"-"`
+	Password string `json:"password" table:"-"`
 }
 
 // ExternalAuthRequest is used to request an access token for a provider.

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -250,6 +250,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/external-auth?mat
 {
   "access_token": "string",
   "password": "string",
+  "refresh_token": "string",
   "token_extra": {},
   "type": "string",
   "url": "string",
@@ -294,6 +295,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/gitauth?match=str
 {
   "access_token": "string",
   "password": "string",
+  "refresh_token": "string",
   "token_extra": {},
   "type": "string",
   "url": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -115,6 +115,7 @@
 {
   "access_token": "string",
   "password": "string",
+  "refresh_token": "string",
   "token_extra": {},
   "type": "string",
   "url": "string",
@@ -124,14 +125,15 @@
 
 ### Properties
 
-| Name           | Type   | Required | Restrictions | Description                                                                              |
-| -------------- | ------ | -------- | ------------ | ---------------------------------------------------------------------------------------- |
-| `access_token` | string | false    |              |                                                                                          |
-| `password`     | string | false    |              |                                                                                          |
-| `token_extra`  | object | false    |              |                                                                                          |
-| `type`         | string | false    |              |                                                                                          |
-| `url`          | string | false    |              |                                                                                          |
-| `username`     | string | false    |              | Deprecated: Only supported on `/workspaceagents/me/gitauth` for backwards compatibility. |
+| Name            | Type   | Required | Restrictions | Description                                                                              |
+| --------------- | ------ | -------- | ------------ | ---------------------------------------------------------------------------------------- |
+| `access_token`  | string | false    |              |                                                                                          |
+| `password`      | string | false    |              |                                                                                          |
+| `refresh_token` | string | false    |              |                                                                                          |
+| `token_extra`   | object | false    |              |                                                                                          |
+| `type`          | string | false    |              |                                                                                          |
+| `url`           | string | false    |              |                                                                                          |
+| `username`      | string | false    |              | Deprecated: Only supported on `/workspaceagents/me/gitauth` for backwards compatibility. |
 
 ## agentsdk.GitSSHKey
 


### PR DESCRIPTION
The existing `external-auth access-token` was very restricting. It only printed the `access_token` as output. This restricted my ability to add a flag to print the refresh_token.

So instead, I made a new command. The new command allows printing all fields as a table, text, or json. Way more adaptable. The old command should probably be deprecated at some point.

# `coder external-auth link <provider_id> [--match url]`

`link` over `access-token` since it prints information about the auth_link.

Usage examples:

```shell
# No options
$ coder external-auth link primary-github
type: github                                                                            
access_token: ghu_....
refresh_token: ghr_....

# As json. 
$ coder external-auth link primary-github -o json
{
  "access_token": "ghu_...",
  "refresh_token": "ghr_...",
  "token_extra": null,
  "url": "",
  "type": "github"
}


# For scripting
$ coder external-auth link primary-github --only access_token
ghu_...

# Using match instead
$ coder external-auth link --match github.com --only access_token
ghu_...
```

When external auth is not authenticated
```
# The url is printed to stdout like before. The error message also contains it.
$ coder external-auth link fake
http://localhost:3000/external-auth/fake
Encountered an error running "coder external-auth link", see "coder external-auth link --help" for more information
error: external auth requires login, visit http://localhost:3000/external-auth/fake
```

Closes https://github.com/coder/coder/issues/12787#issuecomment-2025535338