### PR TITLE
chore: add validation errors to the cli output

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -1084,10 +1084,23 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 		_, _ = str.WriteString("\n")
 	}
 
+	// The main error message
 	_, _ = str.WriteString(pretty.Sprint(headLineStyle(), err.Message))
+
+	// Validation errors.
+	if len(err.Validations) > 0 {
+		_, _ = str.WriteString("\n")
+		_, _ = str.WriteString(pretty.Sprint(tailLineStyle(), fmt.Sprintf("%d validation error(s) found", len(err.Validations))))
+		for _, e := range err.Validations {
+			_, _ = str.WriteString("\n\t")
+			_, _ = str.WriteString(pretty.Sprint(cliui.DefaultStyles.Field, e.Field))
+			_, _ = str.WriteString(pretty.Sprintf(tailLineStyle(), ":%s", e.Detail))
+		}
+	}
+
 	if err.Helper != "" {
 		_, _ = str.WriteString("\n")
-		_, _ = str.WriteString(pretty.Sprint(tailLineStyle(), err.Helper))
+		_, _ = str.WriteString(pretty.Sprintf(tailLineStyle(), "Suggestion: %s", err.Helper))
 	}
 	// By default we do not show the Detail with the helper.
 	if opts.Verbose || (err.Helper == "" && err.Detail != "") {

--- a/cli/root.go
+++ b/cli/root.go
@@ -1094,7 +1094,7 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 		for _, e := range err.Validations {
 			_, _ = str.WriteString("\n\t")
 			_, _ = str.WriteString(pretty.Sprint(cliui.DefaultStyles.Field, e.Field))
-			_, _ = str.WriteString(pretty.Sprintf(tailLineStyle(), ": %s", e.Detail))
+			_, _ = str.WriteString(pretty.Sprintf(cliui.DefaultStyles.Warn, ": %s", e.Detail))
 		}
 	}
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -1094,7 +1094,7 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 		for _, e := range err.Validations {
 			_, _ = str.WriteString("\n\t")
 			_, _ = str.WriteString(pretty.Sprint(cliui.DefaultStyles.Field, e.Field))
-			_, _ = str.WriteString(pretty.Sprintf(tailLineStyle(), ":%s", e.Detail))
+			_, _ = str.WriteString(pretty.Sprintf(tailLineStyle(), ": %s", e.Detail))
 		}
 	}
 

--- a/cli/testdata/coder_exp_example-error_api.golden
+++ b/cli/testdata/coder_exp_example-error_api.golden
@@ -1,3 +1,5 @@
 Encountered an error running "coder exp example-error api", see "coder exp example-error api --help" for more information
 error: Top level sdk error message.
-Have you tried turning it off and on again?
+1 validation error(s) found
+	 region : magic dust is not available in your region
+Suggestion: Have you tried turning it off and on again?

--- a/cli/testdata/coder_exp_example-error_multi-error.golden
+++ b/cli/testdata/coder_exp_example-error_multi-error.golden
@@ -4,4 +4,6 @@ error: 3 errors encountered: Trace=[wrapped: ])
 2.  second error: function decided not to work, and it never will
 3.  Trace=[wrapped api error: ]
     Top level sdk error message.
+    1 validation error(s) found
+    	 region : magic dust is not available in your region
     magic dust unavailable, please try again later


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/12575

Error:

```golang
{
	Response: codersdk.Response{
		Message: "Top level sdk error message.",
		Detail:  "magic dust unavailable, please try again later",
		Validations: []codersdk.ValidationError{
			{
				Field:  "region",
				Detail: "magic dust is not available in your region",
			},
		},
	}
	Helper: "Have you tried turning it off and on again?"
}
```

Before:

![Screenshot from 2024-03-28 14-55-53](https://github.com/coder/coder/assets/5446298/f6d2480e-f5a8-4917-8e2a-7e8e14d35a19)


After:

![Screenshot from 2024-03-28 14-55-09](https://github.com/coder/coder/assets/5446298/c434ebc2-7a0d-4a74-8926-b0a0f2d44538)

If you did not know, `coder exp example-error <subcommand>` has a set of sub commands to see how different cli errors are rendered out. No need to make them occur naturally.
