### PR TITLE
docs: describe mutually exclusive create workspace template fields

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -2211,6 +2211,7 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
+                "description": "Create a new workspace using a template. The request must\nspecify either the Template ID or the Template Version ID,\nnot both. If the Template ID is specified, the active version\nof the template will be used.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9045,7 +9046,7 @@ const docTemplate = `{
             }
         },
         "codersdk.CreateWorkspaceRequest": {
-            "description": "CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the latest version of the template will be used.",
+            "description": "CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the active version of the template will be used.",
             "type": "object",
             "required": [
                 "name"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9045,6 +9045,7 @@ const docTemplate = `{
             }
         },
         "codersdk.CreateWorkspaceRequest": {
+            "description": "CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the latest version of the template will be used.",
             "type": "object",
             "required": [
                 "name"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1932,6 +1932,7 @@
             "CoderSessionToken": []
           }
         ],
+        "description": "Create a new workspace using a template. The request must\nspecify either the Template ID or the Template Version ID,\nnot both. If the Template ID is specified, the active version\nof the template will be used.",
         "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["Workspaces"],
@@ -8052,7 +8053,7 @@
       }
     },
     "codersdk.CreateWorkspaceRequest": {
-      "description": "CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the latest version of the template will be used.",
+      "description": "CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the active version of the template will be used.",
       "type": "object",
       "required": ["name"],
       "properties": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8052,6 +8052,7 @@
       }
     },
     "codersdk.CreateWorkspaceRequest": {
+      "description": "CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the latest version of the template will be used.",
       "type": "object",
       "required": ["name"],
       "properties": {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -332,6 +332,10 @@ func (api *API) workspaceByOwnerAndName(rw http.ResponseWriter, r *http.Request)
 // Create a new workspace for the currently authenticated user.
 //
 // @Summary Create user workspace by organization
+// @Description Create a new workspace using a template. The request must
+// @Description specify either the Template ID or the Template Version ID,
+// @Description not both. If the Template ID is specified, the active version
+// @Description of the template will be used.
 // @ID create-user-workspace-by-organization
 // @Security CoderSessionToken
 // @Accept json

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -138,6 +138,9 @@ type CreateTemplateRequest struct {
 
 // CreateWorkspaceRequest provides options for creating a new workspace.
 // Either TemplateID or TemplateVersionID must be specified. They cannot both be present.
+// @Description CreateWorkspaceRequest provides options for creating a new workspace.
+// @Description Only one of TemplateID or TemplateVersionID can be specified, not both.
+// @Description If TemplateID is specified, the latest version of the template will be used.
 type CreateWorkspaceRequest struct {
 	// TemplateID specifies which template should be used for creating the workspace.
 	TemplateID uuid.UUID `json:"template_id,omitempty" validate:"required_without=TemplateVersionID,excluded_with=TemplateVersionID" format:"uuid"`

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -140,7 +140,7 @@ type CreateTemplateRequest struct {
 // Either TemplateID or TemplateVersionID must be specified. They cannot both be present.
 // @Description CreateWorkspaceRequest provides options for creating a new workspace.
 // @Description Only one of TemplateID or TemplateVersionID can be specified, not both.
-// @Description If TemplateID is specified, the latest version of the template will be used.
+// @Description If TemplateID is specified, the active version of the template will be used.
 type CreateWorkspaceRequest struct {
 	// TemplateID specifies which template should be used for creating the workspace.
 	TemplateID uuid.UUID `json:"template_id,omitempty" validate:"required_without=TemplateVersionID,excluded_with=TemplateVersionID" format:"uuid"`

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1646,7 +1646,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 }
 ```
 
-CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the latest version of the template will be used.
+CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the active version of the template will be used.
 
 ### Properties
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1646,6 +1646,8 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 }
 ```
 
+CreateWorkspaceRequest provides options for creating a new workspace. Only one of TemplateID or TemplateVersionID can be specified, not both. If TemplateID is specified, the latest version of the template will be used.
+
 ### Properties
 
 | Name                    | Type                                                                          | Required | Restrictions | Description                                                                                             |

--- a/docs/api/workspaces.md
+++ b/docs/api/workspaces.md
@@ -14,6 +14,11 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
 
 `POST /organizations/{organization}/members/{user}/workspaces`
 
+Create a new workspace using a template. The request must
+specify either the Template ID or the Template Version ID,
+not both. If the Template ID is specified, the active version
+of the template will be used.
+
 > Body parameter
 
 ```json


### PR DESCRIPTION
Ideally we could do this in the OpenAPI spec, but there is no first class "mutually exclusive" feature in OpenAPI. So in lieu of something more complex, or changing our struct/validation, a description comment should suffice.

I added the description to both the struct and the api call. So any place the fields are encountered in the docs, there should be the description of the mutually exclusive fields.

Closes https://github.com/coder/coder/issues/12090