### PR TITLE
docs: fix coder-logstream-kube typo in deployment-logs.md

### DIFF
--- a/docs/platforms/kubernetes/deployment-logs.md
+++ b/docs/platforms/kubernetes/deployment-logs.md
@@ -33,7 +33,7 @@ serviceAccount:
 
 ## Installation
 
-Install the `coder-kubestream-logs` helm chart on the cluster where the
+Install the `coder-logstream-kube` helm chart on the cluster where the
 deployment is running.
 
 ```shell


### PR DESCRIPTION
In [Deployment logs > Installation](https://coder.com/docs/v2/latest/platforms/kubernetes/deployment-logs#installation), the helm chart name `coder-kubestream-logs` seems a misspelling of `coder-logstream-kube`.