### PR TITLE
feat(install.sh): add support for `--mainline` (default) and `--stable`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,27 +91,25 @@ The installer will cache all downloaded assets into ~/.cache/coder
 EOF
 }
 
-echo_latest_version() {
-	if [ "${MAINLINE}" = 0 ]; then
-		# https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c#gistcomment-2758860
-		version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/coder/coder/releases/latest)"
-		version="${version#https://github.com/coder/coder/releases/tag/v}"
-	else
-		# Fetch the releases from the GitHub API, sort by version number,
-		# and take the first result. Note that we're sorting by space-
-		# separated numbers and without utilizing the sort -V flag for the
-		# best compatibility.
-		version="$(
-			curl -fsSL https://api.github.com/repos/coder/coder/releases |
-				awk -F'"' '/"tag_name"/ {print $4}' |
-				tr -d v |
-				tr . ' ' |
-				sort -k1,1nr -k2,2nr -k3,3nr |
-				head -n1 |
-				tr ' ' .
-		)"
-	fi
+echo_latest_stable_version() {
+	# https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c#gistcomment-2758860
+	version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/coder/coder/releases/latest)"
+	version="${version#https://github.com/coder/coder/releases/tag/v}"
 	echo "${version}"
+}
+
+echo_latest_mainline_version() {
+	# Fetch the releases from the GitHub API, sort by version number,
+	# and take the first result. Note that we're sorting by space-
+	# separated numbers and without utilizing the sort -V flag for the
+	# best compatibility.
+	curl -fsSL https://api.github.com/repos/coder/coder/releases |
+		awk -F'"' '/"tag_name"/ {print $4}' |
+		tr -d v |
+		tr . ' ' |
+		sort -k1,1nr -k2,2nr -k3,3nr |
+		head -n1 |
+		tr ' ' .
 }
 
 echo_standalone_postinstall() {
@@ -120,9 +118,18 @@ echo_standalone_postinstall() {
 		return
 	fi
 
+	channel=mainline
+	advisory="To install our stable release (v${STABLE_VERSION}), use the --stable flag. "
+	if [ "${MAINLINE}" = 0 ]; then
+		channel=stable
+		advisory=""
+	fi
+
 	cath <<EOF
 
-Coder has been installed to
+Coder ${channel} release v${VERSION} installed. ${advisory}See our releases documentation or GitHub for more information on versioning.
+
+The Coder binary has been placed in the following location:
 
   $STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME
 
@@ -232,7 +239,7 @@ There is another binary in your PATH that conflicts with the binary we've instal
 
 This is likely because of an existing installation of Coder. See our documentation for suggestions on how to resolve this.
 
-	https://coder.com/docs/v2/latest/install/install.sh#path-conflicts
+  https://coder.com/docs/v2/latest/install/install.sh#path-conflicts
 
 EOF
 }
@@ -382,7 +389,12 @@ main() {
 	TERRAFORM_INSTALL_PREFIX=${TERRAFORM_INSTALL_PREFIX:-/usr/local}
 	STANDALONE_INSTALL_PREFIX=${STANDALONE_INSTALL_PREFIX:-/usr/local}
 	STANDALONE_BINARY_NAME=${STANDALONE_BINARY_NAME:-coder}
-	VERSION=${VERSION:-$(echo_latest_version)}
+	STABLE_VERSION=$(echo_latest_stable_version)
+	if [ "${MAINLINE}" = 0 ]; then
+		VERSION=${STABLE_VERSION}
+	else
+		VERSION=$(echo_latest_mainline_version)
+	fi
 
 	distro_name
 
@@ -394,6 +406,13 @@ main() {
 	# Start by installing Terraform, if requested
 	if [ "${WITH_TERRAFORM-}" ]; then
 		with_terraform
+	fi
+
+	# If the version is the same as the stable version, we're installing
+	# the stable version.
+	if [ "${MAINLINE}" != 0 ] && [ "${VERSION}" = "${STABLE_VERSION}" ]; then
+		echoh "The latest mainline version has been promoted to stable, selecting stable."
+		MAINLINE=0
 	fi
 
 	# Standalone installs by pulling pre-built releases from GitHub.

--- a/install.sh
+++ b/install.sh
@@ -303,7 +303,7 @@ main() {
 		--version=*)
 			VERSION="$(parse_arg "$@")"
 			;;
-		# Support edge for backwards compatibility.
+		# Support edge for backward compatibility.
 		--mainline | --edge)
 			MAINLINE=1
 			;;


### PR DESCRIPTION
This PR adds support for installing either the mainline or stable version of Coder.

The `--edge` flag was deprecated and `--mainline` (default) and `--stable` added in it's place.

The previous implementation for "edge" did not take into account that the release order might not be reliable, so the implementation was updated to perform version-based sorting on all the tags available in the JSON response for releases, and the highest version numer is selected.

In the future we may want to filter out releases on a certain criteria (e.g. exclude draft/prerelease), however, I decided to ommit this to avoid premature feature development and to keep the change simpler.

**Note:** I decided against embedding `CODER_MAINLINE_VERSION` in the script because this introduces added complexity in the release flow:

1. The release would have to be coupled by a commit updating the variable
2. There's a race between updating the script with the new `CODER_MAINLINE_VERSION` and the GitHub Actions build completing, before build completion, the new version is not available, even if cut

Fixes #12461