### PR TITLE
fix(install.sh): remove extracted files after installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -639,20 +639,21 @@ install_standalone() {
 	# fails we can ignore the error as the -w check will then swap us to sudo.
 	sh_c mkdir -p "$STANDALONE_INSTALL_PREFIX" 2>/dev/null || true
 
+	sh_c mkdir -p "$CACHE_DIR/tmp"
+	if [ "$STANDALONE_ARCHIVE_FORMAT" = tar.gz ]; then
+		sh_c tar -C "$CACHE_DIR/tmp" -xzf "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.tar.gz"
+	else
+		sh_c unzip -d "$CACHE_DIR/tmp" -o "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.zip"
+	fi
+
+	STANDALONE_BINARY_LOCATION="$STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME"
+
 	sh_c="sh_c"
 	if [ ! -w "$STANDALONE_INSTALL_PREFIX" ]; then
 		sh_c="sudo_sh_c"
 	fi
 
 	"$sh_c" mkdir -p "$STANDALONE_INSTALL_PREFIX/bin"
-	"$sh_c" mkdir -p "$CACHE_DIR/tmp"
-	if [ "$STANDALONE_ARCHIVE_FORMAT" = tar.gz ]; then
-		"$sh_c" tar -C "$CACHE_DIR/tmp" -xzf "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.tar.gz"
-	else
-		"$sh_c" unzip -d "$CACHE_DIR/tmp" -o "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.zip"
-	fi
-
-	STANDALONE_BINARY_LOCATION="$STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME"
 
 	# Remove the file if it already exists to
 	# avoid https://github.com/coder/coder/issues/2086
@@ -662,7 +663,9 @@ install_standalone() {
 
 	# Copy the binary to the correct location.
 	"$sh_c" cp "$CACHE_DIR/tmp/coder" "$STANDALONE_BINARY_LOCATION"
-	"$sh_c" rm -rv "$CACHE_DIR/tmp"
+
+	# Clean up the extracted files (note, not using sudo: $sh_c -> sh_c).
+	sh_c rm -rv "$CACHE_DIR/tmp"
 
 	echo_standalone_postinstall
 }

--- a/install.sh
+++ b/install.sh
@@ -645,10 +645,11 @@ install_standalone() {
 	fi
 
 	"$sh_c" mkdir -p "$STANDALONE_INSTALL_PREFIX/bin"
+	"$sh_c" mkdir -p "$CACHE_DIR/tmp"
 	if [ "$STANDALONE_ARCHIVE_FORMAT" = tar.gz ]; then
-		"$sh_c" tar -C "$CACHE_DIR" -xzf "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.tar.gz"
+		"$sh_c" tar -C "$CACHE_DIR/tmp" -xzf "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.tar.gz"
 	else
-		"$sh_c" unzip -d "$CACHE_DIR" -o "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.zip"
+		"$sh_c" unzip -d "$CACHE_DIR/tmp" -o "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.zip"
 	fi
 
 	STANDALONE_BINARY_LOCATION="$STANDALONE_INSTALL_PREFIX/bin/$STANDALONE_BINARY_NAME"
@@ -660,7 +661,8 @@ install_standalone() {
 	fi
 
 	# Copy the binary to the correct location.
-	"$sh_c" cp "$CACHE_DIR/coder" "$STANDALONE_BINARY_LOCATION"
+	"$sh_c" cp "$CACHE_DIR/tmp/coder" "$STANDALONE_BINARY_LOCATION"
+	"$sh_c" rm -rv "$CACHE_DIR/tmp"
 
 	echo_standalone_postinstall
 }


### PR DESCRIPTION
This PR creates a subdirectory in `CACHE_DIR` named `tmp` that is deleted after installation.

This is _important_ because the script executes `sudo unzip` which leaves files with root permission in the users personal cache directory `~/.cache/coder`. Removing the extracted files frees up 200 MB on the users drive as well. We don't attempt to fix past mistakes, but future users will be happier.

```console
❯ cat install.sh | sh -s -- --method=standalone --version 2.9.1
macOS v14.4.1
Installing v2.9.1 of the arm64 release from GitHub.

+ mkdir -p ~/.cache/coder
+ curl -#fL -o ~/.cache/coder/coder_2.9.1_darwin_arm64.zip.incomplete -C - https://github.com/coder/coder/releases/download/v2.9.1/coder_2.9.1_darwin_arm64.zip
######################################################################## 100.0%
+ mv ~/.cache/coder/coder_2.9.1_darwin_arm64.zip.incomplete ~/.cache/coder/coder_2.9.1_darwin_arm64.zip
+ mkdir -p /usr/local
+ sudo mkdir -p /usr/local/bin
+ sudo mkdir -p ~/.cache/coder/tmp
+ sudo unzip -d ~/.cache/coder/tmp -o ~/.cache/coder/coder_2.9.1_darwin_arm64.zip
Archive:  /Users/maf/.cache/coder/coder_2.9.1_darwin_arm64.zip
  inflating: /Users/maf/.cache/coder/tmp/LICENSE
  inflating: /Users/maf/.cache/coder/tmp/LICENSE.enterprise
  inflating: /Users/maf/.cache/coder/tmp/README.md
  inflating: /Users/maf/.cache/coder/tmp/coder
+ sudo rm /usr/local/bin/coder
+ sudo cp ~/.cache/coder/tmp/coder /usr/local/bin/coder
+ sudo rm -rv ~/.cache/coder/tmp
/Users/maf/.cache/coder/tmp/LICENSE
/Users/maf/.cache/coder/tmp/README.md
/Users/maf/.cache/coder/tmp/coder
/Users/maf/.cache/coder/tmp/LICENSE.enterprise
/Users/maf/.cache/coder/tmp

Coder stable release v2.9.1 installed. See our releases documentation or GitHub for more information on versioning.
```

**Note:** We should probably downgrade the unzip to run as normal user, no point in doing it as root. **Fixed!**