### PR TITLE
chore: deprecate agent report-stats endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5904,6 +5904,7 @@ const docTemplate = `{
                 ],
                 "summary": "Submit workspace agent stats",
                 "operationId": "submit-workspace-agent-stats",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "Stats request",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -5201,6 +5201,7 @@
         "tags": ["Agents"],
         "summary": "Submit workspace agent stats",
         "operationId": "submit-workspace-agent-stats",
+        "deprecated": true,
         "parameters": [
           {
             "description": "Stats request",

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1132,7 +1132,7 @@ func convertScripts(dbScripts []database.WorkspaceAgentScript) []codersdk.Worksp
 // @Param request body agentsdk.Stats true "Stats request"
 // @Success 200 {object} agentsdk.StatsResponse
 // @Router /workspaceagents/me/report-stats [post]
-// @Deprecated Uses agent API v1 endpoint instead.
+// @Deprecated Uses agent API v2 endpoint instead.
 func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1132,6 +1132,7 @@ func convertScripts(dbScripts []database.WorkspaceAgentScript) []codersdk.Worksp
 // @Param request body agentsdk.Stats true "Stats request"
 // @Success 200 {object} agentsdk.StatsResponse
 // @Router /workspaceagents/me/report-stats [post]
+// @Deprecated Uses agent API v1 endpoint instead.
 func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 


### PR DESCRIPTION
Agent API is now used instead.

Was trying to debug some workspace activity stuff. This endpoint is no longer used, and should be more obviously marked as deprecated.

Can we remove the agentSDK side of this endpoint?