### PR TITLE
feat(cli): prompt user for authentication on subsequent logins (#11004, #9329)

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -289,18 +289,9 @@ func (r *RootCmd) login() *serpent.Command {
 				// a session token.
 				key, err := client.CreateAPIKey(ctx, codersdk.Me)
 				if err != nil {
-					_, err = cliui.Prompt(inv, cliui.PromptOptions{
-						Text:      fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", sessionToken),
-						IsConfirm: true,
-						Default:   cliui.ConfirmYes,
-					})
-					if err != nil {
-						return xerrors.Errorf("create api key: %w", err)
-					}
-					sessionToken = ""
-				} else {
-					sessionToken = key.Key
+					return xerrors.Errorf("create api key: %w", err)
 				}
+				sessionToken = key.Key
 			}
 
 			// Check for existing session token on disk, and validate user data.

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -312,7 +312,7 @@ func TestLogin(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
-		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token '%s'. Login normally?", invalidToken))
+		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", invalidToken))
 		pty.WriteLine("yes")
 		pty.ExpectMatch("Are you sure you want to log in again?")
 		pty.WriteLine("yes")
@@ -364,7 +364,7 @@ func TestLogin(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
-		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token '%s'. Login normally?", invalidToken))
+		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", invalidToken))
 		pty.WriteLine("yes")
 		pty.ExpectMatch("Paste your token here:")
 		pty.WriteLine(client.SessionToken())
@@ -469,7 +469,7 @@ func TestLogin(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
-		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token '%s'. Login normally?", invalidToken))
+		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", invalidToken))
 		pty.WriteLine("yes")
 		pty.ExpectMatch("Are you sure you want to log in again?")
 		pty.WriteLine("yes")

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -293,35 +293,6 @@ func TestLogin(t *testing.T) {
 		<-doneChan
 	})
 
-	t.Run("AuthenticatedUserInvalidEnvToken", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		coderdtest.CreateFirstUser(t, client)
-
-		inv, root := clitest.New(t, "login", "--no-open")
-		clitest.SetupConfig(t, client, root)
-		pty := ptytest.New(t).Attach(inv)
-
-		invalidToken := "an-invalid-token"
-		inv.Environ.Set("CODER_SESSION_TOKEN", invalidToken)
-
-		doneChan := make(chan struct{})
-		go func() {
-			defer close(doneChan)
-			err := inv.Run()
-			assert.NoError(t, err)
-		}()
-
-		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", invalidToken))
-		pty.WriteLine("yes")
-		pty.ExpectMatch("Are you sure you want to log in again?")
-		pty.WriteLine("yes")
-		pty.ExpectMatch("Paste your token here:")
-		pty.WriteLine(client.SessionToken())
-		pty.ExpectMatch("Welcome to Coder")
-		<-doneChan
-	})
-
 	t.Run("ExistingUserExpiredSessionToken", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
@@ -340,32 +311,6 @@ func TestLogin(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
-		pty.ExpectMatch("Paste your token here:")
-		pty.WriteLine(client.SessionToken())
-		pty.ExpectMatch("Welcome to Coder")
-		<-doneChan
-	})
-
-	t.Run("ExistingUserInvalidEnvToken", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		coderdtest.CreateFirstUser(t, client)
-
-		inv, _ := clitest.New(t, "login", "--no-open", client.URL.String())
-		pty := ptytest.New(t).Attach(inv)
-
-		invalidToken := "an-invalid-token"
-		inv.Environ.Set("CODER_SESSION_TOKEN", invalidToken)
-
-		doneChan := make(chan struct{})
-		go func() {
-			defer close(doneChan)
-			err := inv.Run()
-			assert.NoError(t, err)
-		}()
-
-		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", invalidToken))
-		pty.WriteLine("yes")
 		pty.ExpectMatch("Paste your token here:")
 		pty.WriteLine(client.SessionToken())
 		pty.ExpectMatch("Welcome to Coder")
@@ -450,33 +395,6 @@ func TestLogin(t *testing.T) {
 		sessionFile, err := root.Session().Read()
 		require.NoError(t, err)
 		require.Equal(t, client.SessionToken(), sessionFile)
-	})
-
-	t.Run("AuthenticatedUserTokenFlagInvalid", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		coderdtest.CreateFirstUser(t, client)
-
-		invalidToken := "an-invalid-token"
-		inv, root := clitest.New(t, "login", client.URL.String(), "--no-open", "--token", invalidToken)
-		clitest.SetupConfig(t, client, root)
-		pty := ptytest.New(t).Attach(inv)
-
-		doneChan := make(chan struct{})
-		go func() {
-			defer close(doneChan)
-			err := inv.Run()
-			assert.NoError(t, err)
-		}()
-
-		pty.ExpectMatch(fmt.Sprintf("Failed to authenticate with provided token %q. Login normally?", invalidToken))
-		pty.WriteLine("yes")
-		pty.ExpectMatch("Are you sure you want to log in again?")
-		pty.WriteLine("yes")
-		pty.ExpectMatch("Paste your token here:")
-		pty.WriteLine(client.SessionToken())
-		pty.ExpectMatch("Welcome to Coder")
-		<-doneChan
 	})
 
 	// TokenFlag should generate a new session token and store it in the session file.

--- a/cli/testdata/coder_login_--help.golden
+++ b/cli/testdata/coder_login_--help.golden
@@ -25,6 +25,7 @@ OPTIONS:
       --use-token-as-session bool
           By default, the CLI will generate a new session token when logging in.
           This flag will instead use the provided token as the session token.
+          See `coder --help` for more information on how to set a token.
 
 ———
 Run `coder --help` for a list of global options.

--- a/docs/cli/login.md
+++ b/docs/cli/login.md
@@ -54,4 +54,4 @@ Specifies whether a trial license should be provisioned for the Coder deployment
 | ---- | ----------------- |
 | Type | <code>bool</code> |
 
-By default, the CLI will generate a new session token when logging in. This flag will instead use the provided token as the session token.
+By default, the CLI will generate a new session token when logging in. This flag will instead use the provided token as the session token. See `coder --help` for more information on how to set a token.


### PR DESCRIPTION
Fixes #11004 (partially)

### `coder login` When Already Authenticated

 Currently if a user runs `coder login` when logged in they will get the default login flow:

```console
$ > coder login http://localhost:8080
Attempting to authenticate with argument URL: 'http://localhost:8080'
Your browser has been opened to visit:

        http://localhost:8080/cli-auth

> Paste your token here: DqSDeIXhgx-ABpLuIJ5PnLJjtvdUwmRK5
> Welcome to Coder, admin! You're authenticated.
```

Instead prompt the user if they want to re-authenticate if they run `coder login` when already authenticated. Authenticated is defined as having a valid session token stored in the config directory.

```console
$ > coder login http://localhost:8080
Attempting to authenticate with argument URL: 'http://localhost:8080'
> You are already authenticated admin. Are you sure you want to log in again? (yes/no) no
```

Does not apply if they provided a **valid** token via flag or ENV variable. A new token should be generated an stored in that situation unless the `--use-token-as-session` flag was also used.

### Invalid Token

~If an invalid token was set as `ENV` variable a user would be unable to login until the `ENV` variable was cleared. (The same behavior will occur for invalid flags)~

~User will now be informed that the token is invalid and prompted to login normally. The ENV variable won't be cleared but a valid session token will be created.~

I was incorrect about this part. While we can create a new **valid** token at login subsequent commands will still prefer the **invalid** ENV token. A potential solution would be to check if the ENV token if valid and fall back to the config token in that situation, however, that creates the overhead of an additional API call on every authed CLI command invocation.
