### PR TITLE
chore: deprecate gauge metrics with _total suffix (#12744)

### DIFF
--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -79,10 +79,22 @@ func Workspaces(ctx context.Context, logger slog.Logger, registerer prometheus.R
 		duration = defaultRefreshRate
 	}
 
-	workspaceLatestBuildTotals := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	// TODO: deprecated: remove in the future
+	// Deprecation reason: gauge metrics should avoid suffix `_total``
+	workspaceLatestBuildTotalsDeprecated := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "coderd",
 		Subsystem: "api",
 		Name:      "workspace_latest_build_total",
+		Help:      "DEPRECATED: use coderd_api_workspace_latest_build instead",
+	}, []string{"status"})
+	if err := registerer.Register(workspaceLatestBuildTotalsDeprecated); err != nil {
+		return nil, err
+	}
+
+	workspaceLatestBuildTotals := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "coderd",
+		Subsystem: "api",
+		Name:      "workspace_latest_build",
 		Help:      "The current number of workspace builds by status.",
 	}, []string{"status"})
 	if err := registerer.Register(workspaceLatestBuildTotals); err != nil {
@@ -131,6 +143,8 @@ func Workspaces(ctx context.Context, logger slog.Logger, registerer prometheus.R
 		for _, job := range jobs {
 			status := codersdk.ProvisionerJobStatus(job.JobStatus)
 			workspaceLatestBuildTotals.WithLabelValues(string(status)).Add(1)
+			// TODO: deprecated: remove in the future
+			workspaceLatestBuildTotalsDeprecated.WithLabelValues(string(status)).Add(1)
 		}
 	}
 

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -159,7 +159,7 @@ func TestWorkspaceLatestBuildTotals(t *testing.T) {
 				assert.NoError(t, err)
 				sum := 0
 				for _, m := range metrics {
-					if m.GetName() != "coderd_api_workspace_latest_build_total" {
+					if m.GetName() != "coderd_api_workspace_latest_build" {
 						continue
 					}
 

--- a/coderd/promoauth/oauth2.go
+++ b/coderd/promoauth/oauth2.go
@@ -62,9 +62,11 @@ type metrics struct {
 
 	// if the oauth supports it, rate limit metrics.
 	// rateLimit is the defined limit per interval
-	rateLimit          *prometheus.GaugeVec
-	rateLimitRemaining *prometheus.GaugeVec
-	rateLimitUsed      *prometheus.GaugeVec
+	rateLimit *prometheus.GaugeVec
+	// TODO: remove deprecated metrics in the future release
+	rateLimitDeprecated *prometheus.GaugeVec
+	rateLimitRemaining  *prometheus.GaugeVec
+	rateLimitUsed       *prometheus.GaugeVec
 	// rateLimitReset is unix time of the next interval (when the rate limit resets).
 	rateLimitReset *prometheus.GaugeVec
 	// rateLimitResetIn is the time in seconds until the rate limit resets.
@@ -91,12 +93,23 @@ func NewFactory(registry prometheus.Registerer) *Factory {
 			rateLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: "coderd",
 				Subsystem: "oauth2",
-				Name:      "external_requests_rate_limit_total",
+				Name:      "external_requests_rate_limit",
 				Help:      "The total number of allowed requests per interval.",
 			}, []string{
 				"name",
 				// Resource allows different rate limits for the same oauth2 provider.
 				// Some IDPs have different buckets for different rate limits.
+				"resource",
+			}),
+			// TODO: deprecated: remove in the future
+			// Deprecation reason: gauge metrics should avoid suffix `_total``
+			rateLimitDeprecated: factory.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "coderd",
+				Subsystem: "oauth2",
+				Name:      "external_requests_rate_limit_total",
+				Help:      "DEPRECATED: use coderd_oauth2_external_requests_rate_limit instead",
+			}, []string{
+				"name",
 				"resource",
 			}),
 			rateLimitRemaining: factory.NewGaugeVec(prometheus.GaugeOpts{
@@ -176,6 +189,8 @@ func (f *Factory) NewGithub(name string, under OAuth2Config) *Config {
 			}
 		}
 
+		// TODO: remove this metric in v3
+		f.metrics.rateLimitDeprecated.With(labels).Set(float64(limits.Limit))
 		f.metrics.rateLimit.With(labels).Set(float64(limits.Limit))
 		f.metrics.rateLimitRemaining.With(labels).Set(float64(limits.Remaining))
 		f.metrics.rateLimitUsed.With(labels).Set(float64(limits.Used))


### PR DESCRIPTION
Fixes #12744 

Deprecated metrics:
- `coderd_oauth2_external_requests_rate_limit_total`
- `coderd_api_workspace_latest_build_total`

New metrics:
- `coderd_oauth2_external_requests_rate_limit`
- `coderd_api_workspace_latest_build`

Should we specify at what release deprecated metrics are to be removed?

