### PR TITLE
feat(cli): add auth command (#11004)

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/pretty"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) auth() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "auth <subcommand>",
+		Short: "Manage information about internal authentication.",
+		Children: []*serpent.Command{
+			r.authStatus(),
+			r.authToken(),
+			r.login(),
+		},
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) authToken() *serpent.Command {
+	client := new(codersdk.Client)
+	cmd := &serpent.Command{
+		Use:   "token",
+		Short: "Show session token value and expiration time.",
+		Middleware: serpent.Chain(
+			r.InitClient(client),
+			validateUserMW(client, r),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			sessionID := strings.Split(client.SessionToken(), "-")[0]
+			key, err := client.APIKeyByID(inv.Context(), codersdk.Me, sessionID)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Your session token '%s' expires at %s.\n", client.SessionToken(), key.ExpiresAt)
+
+			return nil
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) authStatus() *serpent.Command {
+	client := new(codersdk.Client)
+	cmd := &serpent.Command{
+		Use:   "status",
+		Short: "Show user authentication status.",
+		Middleware: serpent.Chain(
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			res, err := client.User(inv.Context(), codersdk.Me)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Hello there, %s! You're authenticated at %s.\n", pretty.Sprint(cliui.DefaultStyles.Keyword, res.Username), r.clientURL)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func validateUserMW(client *codersdk.Client, _ *RootCmd) serpent.MiddlewareFunc {
+	return func(next serpent.HandlerFunc) serpent.HandlerFunc {
+		return func(inv *serpent.Invocation) error {
+			_, err := client.User(inv.Context(), codersdk.Me)
+			if err != nil {
+				return xerrors.Errorf("get user: %w", err)
+			}
+
+			return next(inv)
+		}
+	}
+}

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -1,0 +1,92 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestAuthToken(t *testing.T) {
+	t.Parallel()
+	t.Run("ValidUser", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		coderdtest.CreateFirstUser(t, client)
+
+		inv, root := clitest.New(t, "auth", "token")
+		clitest.SetupConfig(t, client, root)
+		pty := ptytest.New(t).Attach(inv)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		split := strings.Split(client.SessionToken(), "-")
+		loginKey, err := client.APIKeyByID(ctx, codersdk.Me, split[0])
+		require.NoError(t, err)
+
+		doneChan := make(chan struct{})
+		go func() {
+			defer close(doneChan)
+			err := inv.Run()
+			assert.NoError(t, err)
+		}()
+
+		pty.ExpectMatch(fmt.Sprintf("Your session token '%s' expires at %s.", client.SessionToken(), loginKey.ExpiresAt))
+		<-doneChan
+	})
+
+	t.Run("NoUser", func(t *testing.T) {
+		t.Parallel()
+		inv, _ := clitest.New(t, "auth", "token")
+
+		err := inv.Run()
+		errorMsg := "You are not logged in."
+		assert.ErrorContains(t, err, errorMsg)
+	})
+}
+
+func TestAuthStatus(t *testing.T) {
+	t.Parallel()
+	t.Run("ValidUser", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, nil)
+		coderdtest.CreateFirstUser(t, client)
+
+		inv, root := clitest.New(t, "auth", "status")
+		clitest.SetupConfig(t, client, root)
+
+		defaultUsername := "testuser"
+
+		pty := ptytest.New(t).Attach(inv)
+		doneChan := make(chan struct{})
+		go func() {
+			defer close(doneChan)
+			err := inv.Run()
+			assert.NoError(t, err)
+		}()
+
+		pty.ExpectMatch(fmt.Sprintf("Hello there, %s! You're authenticated at %s.", defaultUsername, client.URL.String()))
+		<-doneChan
+	})
+
+	t.Run("NoUser", func(t *testing.T) {
+		t.Parallel()
+		inv, _ := clitest.New(t, "auth", "status")
+
+		err := inv.Run()
+		errorMsg := "You are not logged in."
+		assert.ErrorContains(t, err, errorMsg)
+	})
+}

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -32,7 +32,7 @@ func TestAuthToken(t *testing.T) {
 		defer cancel()
 
 		split := strings.Split(client.SessionToken(), "-")
-		loginKey, err := client.APIKeyByID(ctx, codersdk.Me, split[0])
+		_, err := client.APIKeyByID(ctx, codersdk.Me, split[0])
 		require.NoError(t, err)
 
 		doneChan := make(chan struct{})
@@ -42,7 +42,8 @@ func TestAuthToken(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
-		pty.ExpectMatch(fmt.Sprintf("Your session token '%s' expires at %s.", client.SessionToken(), loginKey.ExpiresAt))
+		// token is valid for 24 hours by default
+		pty.ExpectMatch(fmt.Sprintf("Your session token '%s' expires in 24.0 hours.", client.SessionToken()))
 		<-doneChan
 	})
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -82,6 +82,7 @@ const (
 func (r *RootCmd) CoreSubcommands() []*serpent.Command {
 	// Please re-sort this list alphabetically if you change it!
 	return []*serpent.Command{
+		r.auth(),
 		r.dotfiles(),
 		r.externalAuth(),
 		r.login(),

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -14,7 +14,7 @@ USAGE:
        $ coder templates init
 
 SUBCOMMANDS:
-    auth              Manage information about internal authentication.
+    auth              Manage authentication for Coder deployment.
     autoupdate        Toggle auto-update policy for a workspace
     config-ssh        Add an SSH Host entry for your workspaces "ssh
                       coder.workspace"

--- a/cli/testdata/coder_--help.golden
+++ b/cli/testdata/coder_--help.golden
@@ -14,6 +14,7 @@ USAGE:
        $ coder templates init
 
 SUBCOMMANDS:
+    auth              Manage information about internal authentication.
     autoupdate        Toggle auto-update policy for a workspace
     config-ssh        Add an SSH Host entry for your workspaces "ssh
                       coder.workspace"

--- a/cli/testdata/coder_auth_--help.golden
+++ b/cli/testdata/coder_auth_--help.golden
@@ -1,0 +1,14 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder auth <subcommand>
+
+  Manage information about internal authentication.
+
+SUBCOMMANDS:
+    login     Authenticate with Coder deployment
+    status    Show user authentication status.
+    token     Show session token value and expiration time.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_auth_--help.golden
+++ b/cli/testdata/coder_auth_--help.golden
@@ -3,12 +3,12 @@ coder v0.0.0-devel
 USAGE:
   coder auth <subcommand>
 
-  Manage information about internal authentication.
+  Manage authentication for Coder deployment.
 
 SUBCOMMANDS:
     login     Authenticate with Coder deployment
     status    Show user authentication status.
-    token     Show session token value and expiration time.
+    token     Show the current session token and expiration time.
 
 ———
 Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_auth_login_--help.golden
+++ b/cli/testdata/coder_auth_login_--help.golden
@@ -1,0 +1,30 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder auth login [flags] [<url>]
+
+  Authenticate with Coder deployment
+
+OPTIONS:
+      --first-user-email string, $CODER_FIRST_USER_EMAIL
+          Specifies an email address to use if creating the first user for the
+          deployment.
+
+      --first-user-password string, $CODER_FIRST_USER_PASSWORD
+          Specifies a password to use if creating the first user for the
+          deployment.
+
+      --first-user-trial bool, $CODER_FIRST_USER_TRIAL
+          Specifies whether a trial license should be provisioned for the Coder
+          deployment or not.
+
+      --first-user-username string, $CODER_FIRST_USER_USERNAME
+          Specifies a username to use if creating the first user for the
+          deployment.
+
+      --use-token-as-session bool
+          By default, the CLI will generate a new session token when logging in.
+          This flag will instead use the provided token as the session token.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_auth_status_--help.golden
+++ b/cli/testdata/coder_auth_status_--help.golden
@@ -1,0 +1,9 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder auth status
+
+  Show user authentication status.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_auth_token_--help.golden
+++ b/cli/testdata/coder_auth_token_--help.golden
@@ -1,0 +1,9 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder auth token
+
+  Show session token value and expiration time.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_auth_token_--help.golden
+++ b/cli/testdata/coder_auth_token_--help.golden
@@ -3,7 +3,7 @@ coder v0.0.0-devel
 USAGE:
   coder auth token
 
-  Show session token value and expiration time.
+  Show the current session token and expiration time.
 
 ———
 Run `coder --help` for a list of global options.

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -169,7 +169,7 @@ func (c *Client) SessionToken() string {
 	return c.sessionToken
 }
 
-// SetSessionToken returns the currently set token for the client.
+// SetSessionToken sets sessionToken for the client.
 func (c *Client) SetSessionToken(token string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,7 +25,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 
 | Name                                                   | Purpose                                                                                               |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| [<code>auth</code>](./cli/auth.md)                     | Manage information about internal authentication.                                                     |
+| [<code>auth</code>](./cli/auth.md)                     | Manage authentication for Coder deployment.                                                           |
 | [<code>dotfiles</code>](./cli/dotfiles.md)             | Personalize your workspace by applying a canonical dotfiles repository                                |
 | [<code>external-auth</code>](./cli/external-auth.md)   | Manage external authentication                                                                        |
 | [<code>login</code>](./cli/login.md)                   | Authenticate with Coder deployment                                                                    |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ Coder — A tool for provisioning self-hosted development environments with Terr
 
 | Name                                                   | Purpose                                                                                               |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| [<code>auth</code>](./cli/auth.md)                     | Manage information about internal authentication.                                                     |
 | [<code>dotfiles</code>](./cli/dotfiles.md)             | Personalize your workspace by applying a canonical dotfiles repository                                |
 | [<code>external-auth</code>](./cli/external-auth.md)   | Manage external authentication                                                                        |
 | [<code>login</code>](./cli/login.md)                   | Authenticate with Coder deployment                                                                    |

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -2,7 +2,7 @@
 
 # auth
 
-Manage information about internal authentication.
+Manage authentication for Coder deployment.
 
 ## Usage
 
@@ -12,8 +12,8 @@ coder auth <subcommand>
 
 ## Subcommands
 
-| Name                                    | Purpose                                       |
-| --------------------------------------- | --------------------------------------------- |
-| [<code>status</code>](./auth_status.md) | Show user authentication status.              |
-| [<code>token</code>](./auth_token.md)   | Show session token value and expiration time. |
-| [<code>login</code>](./auth_login.md)   | Authenticate with Coder deployment            |
+| Name                                    | Purpose                                             |
+| --------------------------------------- | --------------------------------------------------- |
+| [<code>status</code>](./auth_status.md) | Show user authentication status.                    |
+| [<code>token</code>](./auth_token.md)   | Show the current session token and expiration time. |
+| [<code>login</code>](./auth_login.md)   | Authenticate with Coder deployment                  |

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -1,0 +1,19 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# auth
+
+Manage information about internal authentication.
+
+## Usage
+
+```console
+coder auth <subcommand>
+```
+
+## Subcommands
+
+| Name                                    | Purpose                                       |
+| --------------------------------------- | --------------------------------------------- |
+| [<code>status</code>](./auth_status.md) | Show user authentication status.              |
+| [<code>token</code>](./auth_token.md)   | Show session token value and expiration time. |
+| [<code>login</code>](./auth_login.md)   | Authenticate with Coder deployment            |

--- a/docs/cli/auth_login.md
+++ b/docs/cli/auth_login.md
@@ -1,0 +1,57 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# auth login
+
+Authenticate with Coder deployment
+
+## Usage
+
+```console
+coder auth login [flags] [<url>]
+```
+
+## Options
+
+### --first-user-email
+
+|             |                                      |
+| ----------- | ------------------------------------ |
+| Type        | <code>string</code>                  |
+| Environment | <code>$CODER_FIRST_USER_EMAIL</code> |
+
+Specifies an email address to use if creating the first user for the deployment.
+
+### --first-user-username
+
+|             |                                         |
+| ----------- | --------------------------------------- |
+| Type        | <code>string</code>                     |
+| Environment | <code>$CODER_FIRST_USER_USERNAME</code> |
+
+Specifies a username to use if creating the first user for the deployment.
+
+### --first-user-password
+
+|             |                                         |
+| ----------- | --------------------------------------- |
+| Type        | <code>string</code>                     |
+| Environment | <code>$CODER_FIRST_USER_PASSWORD</code> |
+
+Specifies a password to use if creating the first user for the deployment.
+
+### --first-user-trial
+
+|             |                                      |
+| ----------- | ------------------------------------ |
+| Type        | <code>bool</code>                    |
+| Environment | <code>$CODER_FIRST_USER_TRIAL</code> |
+
+Specifies whether a trial license should be provisioned for the Coder deployment or not.
+
+### --use-token-as-session
+
+|      |                   |
+| ---- | ----------------- |
+| Type | <code>bool</code> |
+
+By default, the CLI will generate a new session token when logging in. This flag will instead use the provided token as the session token.

--- a/docs/cli/auth_status.md
+++ b/docs/cli/auth_status.md
@@ -1,0 +1,11 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# auth status
+
+Show user authentication status.
+
+## Usage
+
+```console
+coder auth status
+```

--- a/docs/cli/auth_token.md
+++ b/docs/cli/auth_token.md
@@ -1,0 +1,11 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# auth token
+
+Show session token value and expiration time.
+
+## Usage
+
+```console
+coder auth token
+```

--- a/docs/cli/auth_token.md
+++ b/docs/cli/auth_token.md
@@ -2,7 +2,7 @@
 
 # auth token
 
-Show session token value and expiration time.
+Show the current session token and expiration time.
 
 ## Usage
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -608,6 +608,26 @@
       "icon_path": "./images/icons/terminal.svg",
       "children": [
         {
+          "title": "auth",
+          "description": "Manage information about internal authentication.",
+          "path": "cli/auth.md"
+        },
+        {
+          "title": "auth login",
+          "description": "Authenticate with Coder deployment",
+          "path": "cli/auth_login.md"
+        },
+        {
+          "title": "auth status",
+          "description": "Show user authentication status.",
+          "path": "cli/auth_status.md"
+        },
+        {
+          "title": "auth token",
+          "description": "Show session token value and expiration time.",
+          "path": "cli/auth_token.md"
+        },
+        {
           "title": "autoupdate",
           "description": "Toggle auto-update policy for a workspace",
           "path": "cli/autoupdate.md"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -609,7 +609,7 @@
       "children": [
         {
           "title": "auth",
-          "description": "Manage information about internal authentication.",
+          "description": "Manage authentication for Coder deployment.",
           "path": "cli/auth.md"
         },
         {
@@ -624,7 +624,7 @@
         },
         {
           "title": "auth token",
-          "description": "Show session token value and expiration time.",
+          "description": "Show the current session token and expiration time.",
           "path": "cli/auth_token.md"
         },
         {


### PR DESCRIPTION
Fixes #11004 (partially)

Creates the command `coder auth` for authentication purposes.

`coder auth` has 3 sub-commands `login`, `status` and `token`. Currently the sub-commands make 2 requests to the server: validation of the user and an additional command for sub-command info (token info, etc.)

`coder auth status` and `coder auth token` commands return an error if the user is not authenticated when they are called.

```console
$ > coder auth status
Encountered an error running "coder auth status", see "coder auth status --help" for more information
error: You are not logged in. Try logging in using 'coder login <url>'.
exit status 1
```

### `coder auth`

Just returns the help message.

### `coder auth login`

This is the same command as `coder login`.

### `coder auth status`

Informs the user about their authentication status. It may make sense for this to not show an error if called when user is not logged in.

```console
$ > coder auth status
Hello there, admin! You're authenticated at http://localhost:8080.
```

Additional info that is available from the current requests and could be shown:

- ID
- Username
- AvatarURL
- Name
- Email
- CreatedAt
- LastSeenAt
- Status
- LoginType
- ThemePreference
- OrganizationIDs
- Roles

### `coder auth token`

Informs the user of their token string and the expiration time of the token. (Maybe `coder auth session` is a better name or alias?)

```console
$ > coder auth token
Your session token 'DqSDeIXhgx-ABpLuIJ5PnLJjtvdUwmRK5' expires at 2024-04-13 18:08:59.278587 -0400 EDT.
```

Additional info that is available from the current requests and could be shown:

- ID
- UserID
- LastUsed
- ExpiresAt
- CreatedAt
- UpdatedAt
- LoginType
- Scope
- TokenName
- LifetimeSeconds
