### PR TITLE
chore: add date information to windows startup logs

### DIFF
--- a/provisionersdk/scripts/bootstrap_windows.ps1
+++ b/provisionersdk/scripts/bootstrap_windows.ps1
@@ -14,20 +14,20 @@ while ($true) {
 		# executing shell to be named "sshd", otherwise it fails. See:
 		# https://github.com/microsoft/vscode-remote-release/issues/5699
 		$BINARY_URL="${ACCESS_URL}/bin/coder-windows-${ARCH}.exe"
-		Write-Output "Fetching coder agent from ${BINARY_URL}"
+		Write-Output "$(Get-Date) Fetching coder agent from ${BINARY_URL}"
 		Invoke-WebRequest -Uri "${BINARY_URL}" -OutFile $env:TEMP\sshd.exe
 		break
 	} catch {
-		Write-Output "error: unhandled exception fetching coder agent:"
+		Write-Output "$(Get-Date) error: unhandled exception fetching coder agent:"
 		Write-Output $_
-		Write-Output "trying again in 30 seconds..."
+		Write-Output "$(Get-Date) trying again in 30 seconds..."
 		Start-Sleep -Seconds 30
 	}
 }
 
 # Check if running in a Windows container
 if (-not (Get-Command 'Set-MpPreference' -ErrorAction SilentlyContinue)) {
-    Write-Output "Set-MpPreference not available, skipping..."
+    Write-Output "$(Get-Date) Set-MpPreference not available, skipping..."
 } else {
     Set-MpPreference -DisableRealtimeMonitoring $true -ExclusionPath $env:TEMP\sshd.exe
 }


### PR DESCRIPTION
Logs are appended. When on a debugging call, there was a list of these logs, but it was impossible to tell if they were over a long or short period of time. 

This user also was restoring snapshots of old workspaces, so it was impossible to tell if the logs were from previous "workspaces".

We should probably include even more information like the workspace ID and other things. 

This is just an easy thing to add today.

![Screenshot from 2024-04-08 12-01-52](https://github.com/coder/coder/assets/5446298/861e1099-c6a0-4438-b7e8-a9e76ad3e66c)
