### PR TITLE
fix: fix typo in audit log field

### DIFF
--- a/coderd/audit/audit.go
+++ b/coderd/audit/audit.go
@@ -21,7 +21,7 @@ type AdditionalFields struct {
 	BuildNumber    string               `json:"build_number"`
 	BuildReason    database.BuildReason `json:"build_reason"`
 	WorkspaceOwner string               `json:"workspace_owner"`
-	WorkspaceID    uuid.UUID            `json:"workpace_id"`
+	WorkspaceID    uuid.UUID            `json:"workspace_id"`
 }
 
 func NewNop() Auditor {


### PR DESCRIPTION
We noticed our logs had `workpace_id` instead of `workspace_id`.