### PR TITLE
feat: add src_id and dst_id indexes to tailnet_tunnels

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1624,6 +1624,10 @@ CREATE INDEX idx_tailnet_clients_coordinator ON tailnet_clients USING btree (coo
 
 CREATE INDEX idx_tailnet_peers_coordinator ON tailnet_peers USING btree (coordinator_id);
 
+CREATE INDEX idx_tailnet_tunnels_dst_id ON tailnet_tunnels USING hash (dst_id);
+
+CREATE INDEX idx_tailnet_tunnels_src_id ON tailnet_tunnels USING hash (src_id);
+
 CREATE UNIQUE INDEX idx_users_email ON users USING btree (email) WHERE (deleted = false);
 
 CREATE UNIQUE INDEX idx_users_username ON users USING btree (username) WHERE (deleted = false);

--- a/coderd/database/migrations/000206_add_tailnet_tunnels_indexes.down.sql
+++ b/coderd/database/migrations/000206_add_tailnet_tunnels_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_tailnet_tunnels_src_id;
+DROP INDEX idx_tailnet_tunnels_dst_id;

--- a/coderd/database/migrations/000206_add_tailnet_tunnels_indexes.up.sql
+++ b/coderd/database/migrations/000206_add_tailnet_tunnels_indexes.up.sql
@@ -1,0 +1,3 @@
+-- Since src_id and dst_id are UUIDs, we only every compare them with equality, so hash is better
+CREATE INDEX idx_tailnet_tunnels_src_id ON tailnet_tunnels USING hash (src_id);
+CREATE INDEX idx_tailnet_tunnels_dst_id ON tailnet_tunnels USING hash (dst_id);

--- a/coderd/database/migrations/000206_add_tailnet_tunnels_indexes.up.sql
+++ b/coderd/database/migrations/000206_add_tailnet_tunnels_indexes.up.sql
@@ -1,3 +1,3 @@
--- Since src_id and dst_id are UUIDs, we only every compare them with equality, so hash is better
+-- Since src_id and dst_id are UUIDs, we only ever compare them with equality, so hash is better
 CREATE INDEX idx_tailnet_tunnels_src_id ON tailnet_tunnels USING hash (src_id);
 CREATE INDEX idx_tailnet_tunnels_dst_id ON tailnet_tunnels USING hash (dst_id);


### PR DESCRIPTION
Fixes #12780

Adds indexes to the `tailnet_tunnels` table to speed up `GetTailnetTunnelPeerIDs` and `GetTailnetTunnelPeerBindings` queries, which match on `src_id` and `dst_id`.