### PR TITLE
fix(examples): copy /etc/skel on init in docker template

### DIFF
--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -28,6 +28,12 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
+    # Prepare user home with default files on first start.
+    if [ ! -f ~/.init_done ]; then
+      cp -rT /etc/skel ~
+      touch ~/.init_done
+    fi
+
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.19.1
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &


### PR DESCRIPTION
This will give users a nicer first-time experience using the docker template and will allow them to update their `~/.bashrc` and it'll just work ™️.

Fixes #10209

<img width="905" alt="image" src="https://github.com/coder/coder/assets/147409/ee266c6c-0e28-466a-a2ad-6702080d7d5a">

Edit: It seems `~/.bashrc` did work even without this, but this is still a nicer experience with colored prompt/better settings over of a basic black/white one. I only tested in web terminal though so that may be why the rcfile worked even without this PR.