### PR TITLE
feat: remove health link from deployment sidebar

### DIFF
--- a/site/src/pages/DeploySettingsPage/Sidebar.tsx
+++ b/site/src/pages/DeploySettingsPage/Sidebar.tsx
@@ -3,7 +3,6 @@ import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import InsertChartIcon from "@mui/icons-material/InsertChart";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import LockRounded from "@mui/icons-material/LockOutlined";
-import MonitorHeartOutlined from "@mui/icons-material/MonitorHeartOutlined";
 import Globe from "@mui/icons-material/PublicOutlined";
 import ApprovalIcon from "@mui/icons-material/VerifiedUserOutlined";
 import VpnKeyOutlined from "@mui/icons-material/VpnKeyOutlined";

--- a/site/src/pages/DeploySettingsPage/Sidebar.tsx
+++ b/site/src/pages/DeploySettingsPage/Sidebar.tsx
@@ -48,9 +48,6 @@ export const Sidebar: FC = () => {
       <SidebarNavItem href="observability" icon={InsertChartIcon}>
         Observability
       </SidebarNavItem>
-      <SidebarNavItem href="/health" icon={MonitorHeartOutlined}>
-        Health
-      </SidebarNavItem>
     </BaseSidebar>
   );
 };


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/issues/12508

This PR removes the _Health_ link from the _Deployment_ sidebar as _Health_ is a separate tab.