### PR TITLE
feat: add listening ports protocol selector

### DIFF
--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -244,7 +244,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
             justifyContent="space-between"
             alignItems="start"
           >
-            <HelpTooltipTitle>Listening ports</HelpTooltipTitle>
+            <HelpTooltipTitle>Listening Ports</HelpTooltipTitle>
             <HelpTooltipLink
               href={docs("/networking/port-forwarding#dashboard")}
             >
@@ -253,7 +253,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </Stack>
           <Stack direction="column" gap={1}>
             <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
-              {"The listening ports are exclusively accessible to you."}
+              {"The listening ports are exclusively accessible to you. Selecting HTTP/S will change the protocol for all listening ports."}
             </HelpTooltipText>
             <Stack
               direction="row"

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -253,7 +253,9 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </Stack>
           <Stack direction="column" gap={1}>
             <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
-              {"The listening ports are exclusively accessible to you. Selecting HTTP/S will change the protocol for all listening ports."}
+              {
+                "The listening ports are exclusively accessible to you. Selecting HTTP/S will change the protocol for all listening ports."
+              }
             </HelpTooltipText>
             <Stack
               direction="row"

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -196,16 +196,8 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
     (port) => port.agent_name === agent.name,
   );
   // we don't want to show listening ports if it's a shared port
-  const filteredListeningPorts = (listeningPorts ? listeningPorts : []).filter(
-    (port) => {
-      for (let i = 0; i < filteredSharedPorts.length; i++) {
-        if (filteredSharedPorts[i].port === port.port) {
-          return false;
-        }
-      }
-
-      return true;
-    },
+  const filteredListeningPorts = (listeningPorts ?? []).filter((port) =>
+    filteredSharedPorts.every((sharedPort) => sharedPort.port !== port.port),
   );
   // only disable the form if shared port controls are entitled and the template doesn't allow sharing ports
   const canSharePorts =
@@ -253,9 +245,8 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </Stack>
           <Stack direction="column" gap={1}>
             <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
-              {
-                "The listening ports are exclusively accessible to you. Selecting HTTP/S will change the protocol for all listening ports."
-              }
+              The listening ports are exclusively accessible to you. Selecting
+              HTTP/S will change the protocol for all listening ports.
             </HelpTooltipText>
             <Stack
               direction="row"
@@ -334,7 +325,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </Stack>
           {filteredListeningPorts.length === 0 && (
             <HelpTooltipText css={styles.noPortText}>
-              {"No open ports were detected."}
+              No open ports were detected.
             </HelpTooltipText>
           )}
           {filteredListeningPorts.map((port) => {

--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -48,7 +48,11 @@ import { type ClassName, useClassName } from "hooks/useClassName";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import { docs } from "utils/docs";
 import { getFormHelpers } from "utils/formUtils";
-import { getWorkspaceListeningPortsProtocol, portForwardURL, saveWorkspaceListeningPortsProtocol } from "utils/portForward";
+import {
+  getWorkspaceListeningPortsProtocol,
+  portForwardURL,
+  saveWorkspaceListeningPortsProtocol,
+} from "utils/portForward";
 
 export interface PortForwardButtonProps {
   host: string;
@@ -135,7 +139,9 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
   portSharingControlsEnabled,
 }) => {
   const theme = useTheme();
-  const [listeningPortProtocol, setListeningPortProtocol]  = useState(getWorkspaceListeningPortsProtocol(workspaceID));
+  const [listeningPortProtocol, setListeningPortProtocol] = useState(
+    getWorkspaceListeningPortsProtocol(workspaceID),
+  );
 
   const sharedPortsQuery = useQuery({
     ...workspacePortShares(workspaceID),
@@ -190,15 +196,17 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
     (port) => port.agent_name === agent.name,
   );
   // we don't want to show listening ports if it's a shared port
-  const filteredListeningPorts = (listeningPorts ? listeningPorts : []).filter((port) => {
-    for (let i = 0; i < filteredSharedPorts.length; i++) {
-      if (filteredSharedPorts[i].port === port.port) {
-        return false;
+  const filteredListeningPorts = (listeningPorts ? listeningPorts : []).filter(
+    (port) => {
+      for (let i = 0; i < filteredSharedPorts.length; i++) {
+        if (filteredSharedPorts[i].port === port.port) {
+          return false;
+        }
       }
-    }
 
-    return true;
-  });
+      return true;
+    },
+  );
   // only disable the form if shared port controls are entitled and the template doesn't allow sharing ports
   const canSharePorts =
     portSharingExperimentEnabled &&
@@ -225,7 +233,8 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           overflowY: "auto",
         }}
       >
-        <Stack direction="column"
+        <Stack
+          direction="column"
           css={{
             padding: 20,
           }}
@@ -258,9 +267,14 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                   css={styles.listeningPortProtocol}
                   value={listeningPortProtocol}
                   onChange={async (event) => {
-                    const selectedProtocol = event.target.value as "http" | "https";
+                    const selectedProtocol = event.target.value as
+                      | "http"
+                      | "https";
                     setListeningPortProtocol(selectedProtocol);
-                    saveWorkspaceListeningPortsProtocol(workspaceID, selectedProtocol);
+                    saveWorkspaceListeningPortsProtocol(
+                      workspaceID,
+                      selectedProtocol,
+                    );
                   }}
                 >
                   <MenuItem value="http">HTTP</MenuItem>
@@ -318,28 +332,28 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
           </Stack>
           {filteredListeningPorts.length === 0 && (
             <HelpTooltipText css={styles.noPortText}>
-                {"No open ports were detected."}
+              {"No open ports were detected."}
             </HelpTooltipText>
           )}
-            {filteredListeningPorts.map((port) => {
-              const url = portForwardURL(
-                host,
-                port.port,
-                agent.name,
-                workspaceName,
-                username,
-                listeningPortProtocol,
-              );
-              const label =
-                port.process_name !== "" ? port.process_name : port.port;
-              return (
-                <Stack
-                  key={port.port}
-                  direction="row"
-                  alignItems="center"
-                  justifyContent="space-between"
-                >
-                  <Stack direction="row" gap={3}>
+          {filteredListeningPorts.map((port) => {
+            const url = portForwardURL(
+              host,
+              port.port,
+              agent.name,
+              workspaceName,
+              username,
+              listeningPortProtocol,
+            );
+            const label =
+              port.process_name !== "" ? port.process_name : port.port;
+            return (
+              <Stack
+                key={port.port}
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Stack direction="row" gap={3}>
                   <Link
                     underline="none"
                     css={styles.portLink}
@@ -351,43 +365,42 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
                     {port.port}
                   </Link>
                   <Link
-                      underline="none"
-                      css={styles.portLink}
-                      href={url}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      {label}
-                  </Link>
-                  </Stack>
-                  <Stack
-                    direction="row"
-                    gap={2}
-                    justifyContent="flex-end"
-                    alignItems="center"
+                    underline="none"
+                    css={styles.portLink}
+                    href={url}
+                    target="_blank"
+                    rel="noreferrer"
                   >
-
-                    {canSharePorts && (
-                      <Button
-                        size="small"
-                        variant="text"
-                        onClick={async () => {
-                          await upsertSharedPortMutation.mutateAsync({
-                            agent_name: agent.name,
-                            port: port.port,
-                            protocol: listeningPortProtocol,
-                            share_level: "authenticated",
-                          });
-                          await sharedPortsQuery.refetch();
-                        }}
-                      >
-                        Share
-                      </Button>
-                    )}
-                  </Stack>
+                    {label}
+                  </Link>
                 </Stack>
-              );
-            })}
+                <Stack
+                  direction="row"
+                  gap={2}
+                  justifyContent="flex-end"
+                  alignItems="center"
+                >
+                  {canSharePorts && (
+                    <Button
+                      size="small"
+                      variant="text"
+                      onClick={async () => {
+                        await upsertSharedPortMutation.mutateAsync({
+                          agent_name: agent.name,
+                          port: port.port,
+                          protocol: listeningPortProtocol,
+                          share_level: "authenticated",
+                        });
+                        await sharedPortsQuery.refetch();
+                      }}
+                    >
+                      Share
+                    </Button>
+                  )}
+                </Stack>
+              </Stack>
+            );
+          })}
         </Stack>
       </div>
       {portSharingExperimentEnabled && (

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3261,7 +3261,7 @@ export const MockHealth: TypesGen.HealthcheckReport = {
 export const MockListeningPortsResponse: TypesGen.WorkspaceAgentListeningPortsResponse =
   {
     ports: [
-      { process_name: "webb", network: "", port: 3000 },
+      { process_name: "webb", network: "", port: 30000 },
       { process_name: "gogo", network: "", port: 8080 },
       { process_name: "", network: "", port: 8081 },
     ],

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -66,10 +66,20 @@ export const openMaybePortForwardedURL = (
   }
 };
 
-export const saveWorkspaceListeningPortsProtocol = (workspaceID: string, protocol: WorkspaceAgentPortShareProtocol) => {
-  localStorage.setItem(`listening-ports-protocol-workspace-${workspaceID}`, protocol);
-}
+export const saveWorkspaceListeningPortsProtocol = (
+  workspaceID: string,
+  protocol: WorkspaceAgentPortShareProtocol,
+) => {
+  localStorage.setItem(
+    `listening-ports-protocol-workspace-${workspaceID}`,
+    protocol,
+  );
+};
 
-export const getWorkspaceListeningPortsProtocol = (workspaceID: string): WorkspaceAgentPortShareProtocol => {
-  return (localStorage.getItem(`listening-ports-protocol-workspace-${workspaceID}`) || "http") as WorkspaceAgentPortShareProtocol;
-}
+export const getWorkspaceListeningPortsProtocol = (
+  workspaceID: string,
+): WorkspaceAgentPortShareProtocol => {
+  return (localStorage.getItem(
+    `listening-ports-protocol-workspace-${workspaceID}`,
+  ) || "http") as WorkspaceAgentPortShareProtocol;
+};

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -1,13 +1,15 @@
+import type { WorkspaceAgentPortShareProtocol } from "api/typesGenerated";
+
 export const portForwardURL = (
   host: string,
   port: number,
   agentName: string,
   workspaceName: string,
   username: string,
-  https = false,
+  protocol: WorkspaceAgentPortShareProtocol,
 ): string => {
   const { location } = window;
-  const suffix = https ? "s" : "";
+  const suffix = protocol === "https" ? "s" : "";
 
   const subdomain = `${port}${suffix}--${agentName}--${workspaceName}--${username}`;
   return `${location.protocol}//${host}`.replace("*", subdomain);
@@ -56,6 +58,7 @@ export const openMaybePortForwardedURL = (
         agentName,
         workspaceName,
         username,
+        url.protocol.replace(":", "") as WorkspaceAgentPortShareProtocol,
       ) + url.pathname,
     );
   } catch (ex) {
@@ -63,10 +66,10 @@ export const openMaybePortForwardedURL = (
   }
 };
 
-export const saveWorkspaceListeningPortsProtocol = (workspaceID: string, protocol: "http" | "https") => {
+export const saveWorkspaceListeningPortsProtocol = (workspaceID: string, protocol: WorkspaceAgentPortShareProtocol) => {
   localStorage.setItem(`listening-ports-protocol-workspace-${workspaceID}`, protocol);
 }
 
-export const getWorkspaceListeningPortsProtocol = (workspaceID: string) => {
-  return localStorage.getItem(`listening-ports-protocol-workspace-${workspaceID}`) || "http";
+export const getWorkspaceListeningPortsProtocol = (workspaceID: string): WorkspaceAgentPortShareProtocol => {
+  return (localStorage.getItem(`listening-ports-protocol-workspace-${workspaceID}`) || "http") as WorkspaceAgentPortShareProtocol;
 }

--- a/site/src/utils/portForward.ts
+++ b/site/src/utils/portForward.ts
@@ -62,3 +62,11 @@ export const openMaybePortForwardedURL = (
     open(uri);
   }
 };
+
+export const saveWorkspaceListeningPortsProtocol = (workspaceID: string, protocol: "http" | "https") => {
+  localStorage.setItem(`listening-ports-protocol-workspace-${workspaceID}`, protocol);
+}
+
+export const getWorkspaceListeningPortsProtocol = (workspaceID: string) => {
+  return localStorage.getItem(`listening-ports-protocol-workspace-${workspaceID}`) || "http";
+}


### PR DESCRIPTION
~~Relies on https://github.com/coder/coder/pull/12908 to be merged first.~~
Closes https://github.com/coder/coder/issues/12902
<img width="419" alt="Screenshot 2024-04-10 at 12 38 39 PM" src="https://github.com/coder/coder/assets/19379394/67511561-35de-4a6e-af33-f42b148a9bba">
<img width="424" alt="Screenshot 2024-04-10 at 12 38 29 PM" src="https://github.com/coder/coder/assets/19379394/c03f25c6-bb97-4237-a949-271d4d6062d3">
<img width="421" alt="Screenshot 2024-04-10 at 12 38 08 PM" src="https://github.com/coder/coder/assets/19379394/f5d13d2a-0cb6-479e-934c-3d1c1ee33787">



Notes:
- The selector applies to all listening port links
- The selector also decides the protocol when sharing a listening port with the "Share" button
- The selector value is saved in localstorage by workspaceID
- I moved the no detected ports text to a more reactive position and updated helper text