### PR TITLE
feat: implement deadline bumping from workspace app activity

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -541,7 +541,7 @@ func New(options *Options) *API {
 		options.WorkspaceAppsStatsCollectorOptions.Logger = &named
 	}
 	if options.WorkspaceAppsStatsCollectorOptions.Reporter == nil {
-		options.WorkspaceAppsStatsCollectorOptions.Reporter = workspaceapps.NewStatsDBReporter(options.Database, workspaceapps.DefaultStatsDBReporterBatchSize)
+		options.WorkspaceAppsStatsCollectorOptions.Reporter = workspaceapps.NewStatsDBReporter(options.Database, options.Logger.Named("stats-reporter"), workspaceapps.DefaultStatsDBReporterBatchSize)
 	}
 
 	api.workspaceAppServer = &workspaceapps.Server{

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -735,7 +735,7 @@ func TestTemplateInsights_Golden(t *testing.T) {
 				})
 			}
 		}
-		reporter := workspaceapps.NewStatsDBReporter(db, workspaceapps.DefaultStatsDBReporterBatchSize)
+		reporter := workspaceapps.NewStatsDBReporter(db, slogtest.Make(t, nil), workspaceapps.DefaultStatsDBReporterBatchSize)
 		//nolint:gocritic // This is a test.
 		err = reporter.Report(dbauthz.AsSystemRestricted(ctx), stats)
 		require.NoError(t, err, "want no error inserting app stats")
@@ -1631,7 +1631,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 				})
 			}
 		}
-		reporter := workspaceapps.NewStatsDBReporter(db, workspaceapps.DefaultStatsDBReporterBatchSize)
+		reporter := workspaceapps.NewStatsDBReporter(db,  slogtest.Make(t, nil),workspaceapps.DefaultStatsDBReporterBatchSize)
 		//nolint:gocritic // This is a test.
 		err = reporter.Report(dbauthz.AsSystemRestricted(ctx), stats)
 		require.NoError(t, err, "want no error inserting app stats")

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -109,7 +109,7 @@ func TestCollectInsights(t *testing.T) {
 	require.NoError(t, err, "unable to post fake stats")
 
 	// Fake app usage
-	reporter := workspaceapps.NewStatsDBReporter(db, workspaceapps.DefaultStatsDBReporterBatchSize)
+	reporter := workspaceapps.NewStatsDBReporter(db, slogtest.Make(t, nil), workspaceapps.DefaultStatsDBReporterBatchSize)
 	refTime := time.Now().Add(-3 * time.Minute).Truncate(time.Minute)
 	//nolint:gocritic // This is a test.
 	err = reporter.Report(dbauthz.AsSystemRestricted(context.Background()), []workspaceapps.StatsReport{


### PR DESCRIPTION
closes https://github.com/coder/coder/issues/11812

**This is very inefficient in it's current state**

The current interval at which these stats are flushed is 30s. There could be a large number of workspaces here, and this would essentially go against the work @mafredri did with rollups to reduce db load.


[`ActivityBumpWorkspace`](https://github.com/coder/coder/blob/5cec68b3175eba8889a482bf5b0c9ab8a3f8ab3c/coderd/database/queries/activitybump.sql#L8-L8) cannot be made to take multiple workspace ids because of this [`LIMIT 1`](https://github.com/coder/coder/blob/5cec68b3175eba8889a482bf5b0c9ab8a3f8ab3c/coderd/database/queries/activitybump.sql#L57-L57). Creating temporary tables for the "latest workspace build" has been a pain spot in so many queries.

If we could make `ActivityBumpWorkspace` take multiple workspace ids, then this could be a decent patch for the time being?

I think the best way to make it take multiple workspace ids is to create a view for `latest_builds`. Then we can reuse that in all our queries. 



---

This might be the answer?? https://github.com/coder/coder/blob/5cec68b3175eba8889a482bf5b0c9ab8a3f8ab3c/coderd/database/queries/workspacebuilds.sql#L78-L92