### PR TITLE
chore: nix shell to support playwright e2e tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1712439257,
+        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,6 @@
         devShell = pkgs.mkShell {
         buildInputs = devShellPackages;
         shellHook = ''
-          echo "Welcome to the nix shell development environment!"
           export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
           export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
           pango
           pixman
           pkg-config
+          playwright-driver.browsers
           postgresql_13
           protobuf
           protoc-gen-go
@@ -86,7 +87,14 @@
       in
       {
         defaultPackage = formatter; # or replace it with your desired default package.
-        devShell = pkgs.mkShell { buildInputs = devShellPackages; };
+        devShell = pkgs.mkShell {
+        buildInputs = devShellPackages;
+        shellHook = ''
+          echo "Welcome to the development environment!"
+          export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+          export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+        '';
+        };
         packages.all = allPackages;
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
         devShell = pkgs.mkShell {
         buildInputs = devShellPackages;
         shellHook = ''
-          echo "Welcome to the development environment!"
+          echo "Welcome to the nix shell development environment!"
           export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
           export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
         '';

--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -32,6 +32,7 @@ chromium version, and adjust the playwright version in the package.json.
 # Optionally add '--command zsh' to choose your shell.
 nix develop
 cd site
+pnpm install
 pnpm build
 pnpm playwright:test
 ```

--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -21,7 +21,6 @@ pnpm playwright:test
 pnpm playwright:test -g '<your test here>'
 ```
 
-
 # Using nix
 
 If this breaks, it is likely because the flake chromium version and playwright
@@ -40,6 +39,7 @@ pnpm playwright:test
 # Enterprise tests
 
 Enterprise tests require a license key to run.
+
 ```shell
 export CODER_E2E_ENTERPRISE_LICENSE=<license key>
 ```

--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -27,7 +27,8 @@ If this breaks, it is likely because the flake chromium version and playwright
 are no longer compatible. To fix this, update the flake to get the latest
 chromium version, and adjust the playwright version in the package.json.
 
-You can see the playwright version here: https://search.nixos.org/packages?channel=unstable&show=playwright-driver&from=0&size=50&sort=relevance&type=packages&query=playwright-driver
+You can see the playwright version here:
+https://search.nixos.org/packages?channel=unstable&show=playwright-driver&from=0&size=50&sort=relevance&type=packages&query=playwright-driver
 
 ```shell
 # Optionally add '--command zsh' to choose your shell.

--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -27,6 +27,8 @@ If this breaks, it is likely because the flake chromium version and playwright
 are no longer compatible. To fix this, update the flake to get the latest
 chromium version, and adjust the playwright version in the package.json.
 
+You can see the playwright version here: https://search.nixos.org/packages?channel=unstable&show=playwright-driver&from=0&size=50&sort=relevance&type=packages&query=playwright-driver
+
 ```shell
 # Optionally add '--command zsh' to choose your shell.
 nix develop

--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -20,3 +20,18 @@ pnpm playwright:test
 # Run a specific test (`-g` stands for grep. It accepts regex).
 pnpm playwright:test -g '<your test here>'
 ```
+
+
+# Using nix
+
+If this breaks, it is likely because the flake chromium version and playwright
+are no longer compatible. To fix this, update the flake to get the latest
+chromium version, and adjust the playwright version in the package.json.
+
+```shell
+# Optionally add '--command zsh' to choose your shell.
+nix develop
+cd site
+pnpm build
+pnpm playwright:test
+```

--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -35,3 +35,10 @@ cd site
 pnpm build
 pnpm playwright:test
 ```
+
+# Enterprise tests
+
+Enterprise tests require a license key to run.
+```shell
+export CODER_E2E_ENTERPRISE_LICENSE=<license key>
+```

--- a/site/package.json
+++ b/site/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@octokit/types": "12.3.0",
-    "@playwright/test": "1.42.1",
+    "@playwright/test": "1.40.1",
     "@storybook/addon-actions": "8.0.5",
     "@storybook/addon-essentials": "8.0.5",
     "@storybook/addon-interactions": "8.0.5",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -204,8 +204,8 @@ devDependencies:
     specifier: 12.3.0
     version: 12.3.0
   '@playwright/test':
-    specifier: 1.42.1
-    version: 1.42.1
+    specifier: 1.40.1
+    version: 1.40.1
   '@storybook/addon-actions':
     specifier: 8.0.5
     version: 8.0.5
@@ -3295,12 +3295,12 @@ packages:
     dev: true
     optional: true
 
-  /@playwright/test@1.42.1:
-    resolution: {integrity: sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==}
+  /@playwright/test@1.40.1:
+    resolution: {integrity: sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright: 1.42.1
+      playwright: 1.40.1
     dev: true
 
   /@popperjs/core@2.11.8:
@@ -10706,18 +10706,18 @@ packages:
       find-up: 5.0.0
     dev: true
 
-  /playwright-core@1.42.1:
-    resolution: {integrity: sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==}
+  /playwright-core@1.40.1:
+    resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
     engines: {node: '>=16'}
     hasBin: true
     dev: true
 
-  /playwright@1.42.1:
-    resolution: {integrity: sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==}
+  /playwright@1.40.1:
+    resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright-core: 1.42.1
+      playwright-core: 1.40.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
nix is running an older version of chromium, so had to reduce the playwright version.