### PR TITLE
chore: insert enterprise license for e2e testing in actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -476,6 +476,7 @@ jobs:
       - run: pnpm playwright:test --forbid-only --workers 1
         env:
           DEBUG: pw:api
+          CODER_E2E_ENTERPRISE_LICENSE: ${{ secrets.CODER_E2E_ENTERPRISE_LICENSE }}
         working-directory: site
 
       - name: Upload Playwright Failed Tests


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/12920

Still need to put the secret in the repo settings.