### PR TITLE
chore: disable pgcoord (HA) when --in-memory

### DIFF
--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -630,7 +630,7 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 
 	if initial, changed, enabled := featureChanged(codersdk.FeatureHighAvailability); shouldUpdate(initial, changed, enabled) {
 		var coordinator agpltailnet.Coordinator
-		if enabled && !api.DeploymentValues.InMemoryDatabase.Value() {
+		if enabled && api.DeploymentValues.InMemoryDatabase.Value() {
 			api.Logger.Warn(ctx, "high availability is enabled, but cannot be configured due to the database being set to in-memory")
 		}
 		if enabled && !api.DeploymentValues.InMemoryDatabase.Value() {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -630,7 +630,10 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 
 	if initial, changed, enabled := featureChanged(codersdk.FeatureHighAvailability); shouldUpdate(initial, changed, enabled) {
 		var coordinator agpltailnet.Coordinator
-		if enabled {
+		if enabled && !api.DeploymentValues.InMemoryDatabase.Value() {
+			api.Logger.Warn(ctx, "high availability is enabled, but cannot be configured due to the database being set to in-memory")
+		}
+		if enabled && !api.DeploymentValues.InMemoryDatabase.Value() {
 			haCoordinator, err := tailnet.NewPGCoord(api.ctx, api.Logger, api.Pubsub, api.Database)
 			if err != nil {
 				api.Logger.Error(ctx, "unable to set up high availability coordinator", slog.Error(err))

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -630,6 +630,9 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 
 	if initial, changed, enabled := featureChanged(codersdk.FeatureHighAvailability); shouldUpdate(initial, changed, enabled) {
 		var coordinator agpltailnet.Coordinator
+		// If HA is enabled, but the database is in-memory, we can't actually
+		// run HA and the PG coordinator. So throw a log line, and continue to use
+		// the in memory AGPL coordinator.
 		if enabled && api.DeploymentValues.InMemoryDatabase.Value() {
 			api.Logger.Warn(ctx, "high availability is enabled, but cannot be configured due to the database being set to in-memory")
 		}

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -1,11 +1,6 @@
 import { defineConfig } from "@playwright/test";
 import * as path from "path";
-import {
-  coderMain,
-  coderPort,
-  coderdPProfPort,
-  gitAuth,
-} from "./constants";
+import { coderMain, coderPort, coderdPProfPort, gitAuth } from "./constants";
 
 export const wsEndpoint = process.env.CODER_E2E_WS_ENDPOINT;
 

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -53,7 +53,6 @@ export default defineConfig({
       "--global-config $(mktemp -d -t e2e-XXXXXXXXXX)",
       `--access-url=http://localhost:${coderPort}`,
       `--http-address=localhost:${coderPort}`,
-      // Adding an enterprise license causes issues with pgcoord when running with `--in-memory`.
       "--in-memory",
       "--telemetry=false",
       "--dangerous-disable-rate-limits",

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -4,7 +4,6 @@ import {
   coderMain,
   coderPort,
   coderdPProfPort,
-  enterpriseLicense,
   gitAuth,
 } from "./constants";
 

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
       `--access-url=http://localhost:${coderPort}`,
       `--http-address=localhost:${coderPort}`,
       // Adding an enterprise license causes issues with pgcoord when running with `--in-memory`.
-      !enterpriseLicense && "--in-memory",
+      "--in-memory",
       "--telemetry=false",
       "--dangerous-disable-rate-limits",
       "--provisioner-daemons 10",


### PR DESCRIPTION
HA does not make any sense while using in-memory database

Some enterprise e2e tests still fail.

Supports https://github.com/coder/coder/issues/12920