### PR TITLE
test(site): fix flaky outdated agent test

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -60,7 +60,9 @@ export const createWorkspace = async (
   await fillParameters(page, richParameters, buildParameters);
   await page.getByTestId("form-submit").click();
 
-  await expect(page).toHaveURL("/@admin/" + name);
+  // Workaround: OutdatedAgent lands at "http://localhost:3111/@admin/8d6225b7?resources=echo_dev"
+  // and this is also a correct location.
+  await page.waitForURL(new RegExp("/@admin/" + name));
 
   await page.waitForSelector("*[data-testid='build-status'] >> text=Running", {
     state: "visible",

--- a/site/e2e/tests/outdatedAgent.spec.ts
+++ b/site/e2e/tests/outdatedAgent.spec.ts
@@ -17,6 +17,8 @@ const agentVersion = "v0.27.0";
 test.beforeEach(async ({ page }) => await beforeCoderTest(page));
 
 test("ssh with agent " + agentVersion, async ({ page }) => {
+  test.setTimeout(40_000); // This is a slow test, 20s may not be enough on Mac.
+
   const token = randomUUID();
   const template = await createTemplate(page, {
     apply: [


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/issues/12508
Spotted in: https://github.com/coder/coder/actions/runs/8631687311/job/23660630419

This PR fixes the flaky `outdatedAgent` test.