### PR TITLE
chore: skip global.setup if first user already exists

### DIFF
--- a/site/e2e/README.md
+++ b/site/e2e/README.md
@@ -46,3 +46,11 @@ Enterprise tests require a license key to run.
 ```shell
 export CODER_E2E_ENTERPRISE_LICENSE=<license key>
 ```
+
+# Debugging tests
+
+To debug a test, it is more helpful to run it in `ui` mode.
+
+```
+pnpm playwright:test-ui
+```

--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -5,9 +5,11 @@ import { findSessionToken, randomName } from "./helpers";
 
 let currentOrgId: string;
 
-export const setupApiCalls = async (page: Page) => {
-  const token = await findSessionToken(page);
-  API.setSessionToken(token);
+export const setupApiCalls = async (page: Page, unauthenticated?: boolean) => {
+  if (!unauthenticated) {
+    const token = await findSessionToken(page);
+    API.setSessionToken(token);
+  }
   API.setHost(`http://127.0.0.1:${coderPort}`);
 };
 

--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -6,7 +6,7 @@ import { findSessionToken, randomName } from "./helpers";
 let currentOrgId: string;
 
 export const setupApiCalls = async (page: Page) => {
-  try{
+  try {
     const token = await findSessionToken(page);
     API.setSessionToken(token);
   } catch {

--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -5,10 +5,12 @@ import { findSessionToken, randomName } from "./helpers";
 
 let currentOrgId: string;
 
-export const setupApiCalls = async (page: Page, unauthenticated?: boolean) => {
-  if (!unauthenticated) {
+export const setupApiCalls = async (page: Page) => {
+  try{
     const token = await findSessionToken(page);
     API.setSessionToken(token);
+  } catch {
+    // If this fails, we have an unauthenticated client.
   }
   API.setHost(`http://127.0.0.1:${coderPort}`);
 };

--- a/site/e2e/global.setup.ts
+++ b/site/e2e/global.setup.ts
@@ -1,18 +1,19 @@
 import { expect, test } from "@playwright/test";
 import { hasFirstUser } from "api/api";
 import { Language } from "pages/CreateUserPage/CreateUserForm";
+import { setupApiCalls } from "./api";
 import * as constants from "./constants";
 import { storageState } from "./playwright.config";
 
 test("setup deployment", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await setupApiCalls(page, true);
   const exists = await hasFirstUser();
   if (exists) {
     // First user already exists, abort early. All tests execute this as a dependency,
     // if you run multiple tests in the UI, this will fail unless we check this.
     return;
   }
-
-  await page.goto("/", { waitUntil: "domcontentloaded" });
 
   // Setup first user
   await page.getByLabel(Language.usernameLabel).fill(constants.username);

--- a/site/e2e/global.setup.ts
+++ b/site/e2e/global.setup.ts
@@ -9,9 +9,9 @@ test("setup deployment", async ({ page }) => {
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await setupApiCalls(page);
   const exists = await hasFirstUser();
+  // First user already exists, abort early. All tests execute this as a dependency,
+  // if you run multiple tests in the UI, this will fail unless we check this.
   if (exists) {
-    // First user already exists, abort early. All tests execute this as a dependency,
-    // if you run multiple tests in the UI, this will fail unless we check this.
     return;
   }
 

--- a/site/e2e/global.setup.ts
+++ b/site/e2e/global.setup.ts
@@ -7,7 +7,7 @@ import { storageState } from "./playwright.config";
 
 test("setup deployment", async ({ page }) => {
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await setupApiCalls(page, true);
+  await setupApiCalls(page);
   const exists = await hasFirstUser();
   if (exists) {
     // First user already exists, abort early. All tests execute this as a dependency,

--- a/site/e2e/global.setup.ts
+++ b/site/e2e/global.setup.ts
@@ -1,9 +1,17 @@
 import { expect, test } from "@playwright/test";
+import { hasFirstUser } from "api/api";
 import { Language } from "pages/CreateUserPage/CreateUserForm";
 import * as constants from "./constants";
 import { storageState } from "./playwright.config";
 
 test("setup deployment", async ({ page }) => {
+  const exists = await hasFirstUser();
+  if (exists) {
+    // First user already exists, abort early. All tests execute this as a dependency,
+    // if you run multiple tests in the UI, this will fail unless we check this.
+    return;
+  }
+
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
   // Setup first user

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,6 @@
     "lint:types": "tsc -p .",
     "playwright:install": "playwright install --with-deps chromium",
     "playwright:test": "playwright test --config=e2e/playwright.config.ts",
-    "//": "If we are in a coder workspace, use the `ui-port` to allow opening remotely. If native, use the default app. It's generally a bit smoother to use.",
     "playwright:test-ui": "playwright test --config=e2e/playwright.config.ts --ui $([[ \"$CODER\" == \"true\" ]] && echo --ui-port=7500 --ui-host=0.0.0.0)",
     "gen:provisioner": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./e2e/ --ts_proto_opt=outputJsonMethods=false,outputEncodeMethods=encode-no-creation,outputClientImpl=false,nestJs=false,outputPartialMethods=false,fileSuffix=Generated,suffix=hey -I ../provisionersdk/proto ../provisionersdk/proto/provisioner.proto && pnpm exec prettier --ignore-path '/dev/null' --cache --write './e2e/provisionerGenerated.ts'",
     "storybook": "STORYBOOK=true storybook dev -p 6006",

--- a/site/package.json
+++ b/site/package.json
@@ -17,7 +17,7 @@
     "playwright:install": "playwright install --with-deps chromium",
     "playwright:test": "playwright test --config=e2e/playwright.config.ts",
     "//": "If we are in a coder workspace, use the `ui-port` to allow opening remotely. If native, use the default app. It's generally a bit smoother to use.",
-    "playwright:test-ui": "playwright test --config=e2e/playwright.config.ts --ui `[[ \"$CODER\" == \"true\" ]] && --ui-port=7500 --ui-host=0.0.0.0`",
+    "playwright:test-ui": "playwright test --config=e2e/playwright.config.ts --ui $([[ \"$CODER\" == \"true\" ]] && echo --ui-port=7500 --ui-host=0.0.0.0)",
     "gen:provisioner": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./e2e/ --ts_proto_opt=outputJsonMethods=false,outputEncodeMethods=encode-no-creation,outputClientImpl=false,nestJs=false,outputPartialMethods=false,fileSuffix=Generated,suffix=hey -I ../provisionersdk/proto ../provisionersdk/proto/provisioner.proto && pnpm exec prettier --ignore-path '/dev/null' --cache --write './e2e/provisionerGenerated.ts'",
     "storybook": "STORYBOOK=true storybook dev -p 6006",
     "storybook:build": "storybook build",

--- a/site/package.json
+++ b/site/package.json
@@ -16,6 +16,8 @@
     "lint:types": "tsc -p .",
     "playwright:install": "playwright install --with-deps chromium",
     "playwright:test": "playwright test --config=e2e/playwright.config.ts",
+    "//": "If we are in a coder workspace, use the `ui-port` to allow opening remotely. If native, use the default app. It's generally a bit smoother to use.",
+    "playwright:test-ui": "playwright test --config=e2e/playwright.config.ts --ui `[[ \"$CODER\" == \"true\" ]] && --ui-port=7500 --ui-host=0.0.0.0`",
     "gen:provisioner": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./e2e/ --ts_proto_opt=outputJsonMethods=false,outputEncodeMethods=encode-no-creation,outputClientImpl=false,nestJs=false,outputPartialMethods=false,fileSuffix=Generated,suffix=hey -I ../provisionersdk/proto ../provisionersdk/proto/provisioner.proto && pnpm exec prettier --ignore-path '/dev/null' --cache --write './e2e/provisionerGenerated.ts'",
     "storybook": "STORYBOOK=true storybook dev -p 6006",
     "storybook:build": "storybook build",


### PR DESCRIPTION
Treat `global.setup.ts` as a setup, rather than a test. This allows running in `--ui` mode and running tests more than once.

All tests currently share the same Coder instance. When running in UI mode, it allows running tests by choice. This should emulate the same behavior as running them as 1 set.

If you run a test more than once, it would have to be able to handle that, given it would run the same test in the same coderd state.

----

Since this is for debugging, I think that is ok for now.

[Screencast from 2024-04-10 15-56-28.webm](https://github.com/coder/coder/assets/5446298/937cb8ec-7020-40a5-a2c7-d1e1aac3ade3)

