### PR TITLE
test: verify actually uploaded license with assert

### DIFF
--- a/site/e2e/global.setup.ts
+++ b/site/e2e/global.setup.ts
@@ -30,6 +30,8 @@ test("setup deployment", async ({ page }) => {
     await page.getByRole("textbox").fill(constants.enterpriseLicense);
     await page.getByText("Upload License").click();
 
-    await page.getByText("You have successfully added a license").isVisible();
+    await expect(
+      page.getByText("You have successfully added a license"),
+    ).toBeVisible();
   }
 });


### PR DESCRIPTION
Prior page.GetByText did not assert it existed. This would always pass, even if your license was invalid.