### PR TITLE
test(site): add e2e tests for appearance

### DIFF
--- a/site/e2e/tests/deployment/appearance.spec.ts
+++ b/site/e2e/tests/deployment/appearance.spec.ts
@@ -9,21 +9,52 @@ test("set application name", async ({ page }) => {
   const applicationName = randomName();
 
   // Fill out the form
-  const form = page.locator("form", { hasText: "Application name"})
-  await form.getByLabel("Application name", { exact: true}).fill(applicationName);
-  await form.getByRole("button", { name: "Submit"}).click();
+  const form = page.locator("form", { hasText: "Application name" });
+  await form
+    .getByLabel("Application name", { exact: true })
+    .fill(applicationName);
+  await form.getByRole("button", { name: "Submit" }).click();
 
   // Open a new session without cookies to see the login page
-  const browser = await chromium.launch()
-  const incognitoContext = await browser.newContext()
-  await incognitoContext.clearCookies()
-  const incognitoPage = await incognitoContext.newPage()
+  const browser = await chromium.launch();
+  const incognitoContext = await browser.newContext();
+  await incognitoContext.clearCookies();
+  const incognitoPage = await incognitoContext.newPage();
   await incognitoPage.goto("/", { waitUntil: "domcontentloaded" });
 
-  const banner = incognitoPage.locator("h1", { hasText: applicationName})
-  await expect(banner).toBeVisible()
+  // Verify banner
+  const banner = incognitoPage.locator("h1", { hasText: applicationName });
+  await expect(banner).toBeVisible();
 
   // Shut down browser
-  await incognitoPage.close()
-  await browser.close()
+  await incognitoPage.close();
+  await browser.close();
+});
+
+test("set application logo", async ({ page }) => {
+  requiresEnterpriseLicense();
+
+  await page.goto("/deployment/appearance", { waitUntil: "domcontentloaded" });
+
+  const imageLink = "/icon/azure.png";
+
+  // Fill out the form
+  const form = page.locator("form", { hasText: "Logo URL" });
+  await form.getByLabel("Logo URL", { exact: true }).fill(imageLink);
+  await form.getByRole("button", { name: "Submit" }).click();
+
+  // Open a new session without cookies to see the login page
+  const browser = await chromium.launch();
+  const incognitoContext = await browser.newContext();
+  await incognitoContext.clearCookies();
+  const incognitoPage = await incognitoContext.newPage();
+  await incognitoPage.goto("/", { waitUntil: "domcontentloaded" });
+
+  // Verify banner
+  const logo = incognitoPage.locator("img");
+  await expect(logo).toHaveAttribute("src", imageLink);
+
+  // Shut down browser
+  await incognitoPage.close();
+  await browser.close();
 });

--- a/site/e2e/tests/deployment/appearance.spec.ts
+++ b/site/e2e/tests/deployment/appearance.spec.ts
@@ -1,0 +1,29 @@
+import { chromium, expect, test } from "@playwright/test";
+import { randomName, requiresEnterpriseLicense } from "../../helpers";
+
+test("set application name", async ({ page }) => {
+  requiresEnterpriseLicense();
+
+  await page.goto("/deployment/appearance", { waitUntil: "domcontentloaded" });
+
+  const applicationName = randomName();
+
+  // Fill out the form
+  const form = page.locator("form", { hasText: "Application name"})
+  await form.getByLabel("Application name", { exact: true}).fill(applicationName);
+  await form.getByRole("button", { name: "Submit"}).click();
+
+  // Open a new session without cookies to see the login page
+  const browser = await chromium.launch()
+  const incognitoContext = await browser.newContext()
+  await incognitoContext.clearCookies()
+  const incognitoPage = await incognitoContext.newPage()
+  await incognitoPage.goto("/", { waitUntil: "domcontentloaded" });
+
+  const banner = incognitoPage.locator("h1", { hasText: applicationName})
+  await expect(banner).toBeVisible()
+
+  // Shut down browser
+  await incognitoPage.close()
+  await browser.close()
+});

--- a/site/src/modules/dashboard/ServiceBanner/ServiceBannerView.tsx
+++ b/site/src/modules/dashboard/ServiceBanner/ServiceBannerView.tsx
@@ -16,7 +16,7 @@ export const ServiceBannerView: FC<ServiceBannerViewProps> = ({
   isPreview,
 }) => {
   return (
-    <div css={[styles.banner, { backgroundColor }]}>
+    <div css={[styles.banner, { backgroundColor }]} className="service-banner">
       {isPreview && <Pill type="info">Preview</Pill>}
       <div
         css={[

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -105,6 +105,9 @@ export const AppearanceSettingsPageView: FC<
           fullWidth
           placeholder='Leave empty to display "Coder".'
           disabled={!isEntitled}
+          inputProps={{
+            "aria-label": "Application name",
+          }}
         />
       </Fieldset>
 
@@ -149,6 +152,9 @@ export const AppearanceSettingsPageView: FC<
                 />
               </InputAdornment>
             ),
+          }}
+          inputProps={{
+            "aria-label": "Logo URL",
           }}
         />
       </Fieldset>
@@ -208,6 +214,7 @@ export const AppearanceSettingsPageView: FC<
                     );
                     await serviceBannerForm.setFieldValue("enabled", newState);
                   }}
+                  data-testid="switch-service-banner"
                 />
               }
               label="Enabled"
@@ -221,6 +228,9 @@ export const AppearanceSettingsPageView: FC<
                 fullWidth
                 label="Message"
                 multiline
+                inputProps={{
+                  "aria-label": "Message",
+                }}
               />
             </Stack>
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/12508

This PR adds e2e tests for the deployment/appearance page. Application name, Logo URL, and service banner are verified.