### PR TITLE
fix: use provided username when fetching workspaces

### DIFF
--- a/cli/open.go
+++ b/cli/open.go
@@ -64,7 +64,7 @@ func (r *RootCmd) openVSCode() *serpent.Command {
 			// need to wait for the agent to start.
 			workspaceQuery := inv.Args[0]
 			autostart := true
-			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, autostart, codersdk.Me, workspaceQuery)
+			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, autostart, workspaceQuery)
 			if err != nil {
 				return xerrors.Errorf("get workspace and agent: %w", err)
 			}

--- a/cli/ping.go
+++ b/cli/ping.go
@@ -42,7 +42,7 @@ func (r *RootCmd) ping() *serpent.Command {
 			_, workspaceAgent, err := getWorkspaceAndAgent(
 				ctx, inv, client,
 				false, // Do not autostart for a ping.
-				codersdk.Me, workspaceName,
+				workspaceName,
 			)
 			if err != nil {
 				return err

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -73,7 +73,7 @@ func (r *RootCmd) portForward() *serpent.Command {
 				return xerrors.New("no port-forwards requested")
 			}
 
-			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, codersdk.Me, inv.Args[0])
+			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, inv.Args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -39,7 +39,7 @@ func (r *RootCmd) speedtest() *serpent.Command {
 			ctx, cancel := context.WithCancel(inv.Context())
 			defer cancel()
 
-			_, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, false, codersdk.Me, inv.Args[0])
+			_, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, false, inv.Args[0])
 			if err != nil {
 				return err
 			}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -157,7 +157,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
-			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, codersdk.Me, inv.Args[0])
+			workspace, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, !disableAutostart, inv.Args[0])
 			if err != nil {
 				return err
 			}
@@ -551,10 +551,12 @@ startWatchLoop:
 // getWorkspaceAgent returns the workspace and agent selected using either the
 // `<workspace>[.<agent>]` syntax via `in`.
 // If autoStart is true, the workspace will be started if it is not already running.
-func getWorkspaceAndAgent(ctx context.Context, inv *serpent.Invocation, client *codersdk.Client, autostart bool, userID string, in string) (codersdk.Workspace, codersdk.WorkspaceAgent, error) { //nolint:revive
+func getWorkspaceAndAgent(ctx context.Context, inv *serpent.Invocation, client *codersdk.Client, autostart bool, input string) (codersdk.Workspace, codersdk.WorkspaceAgent, error) { //nolint:revive
 	var (
-		workspace      codersdk.Workspace
-		workspaceParts = strings.Split(in, ".")
+		workspace codersdk.Workspace
+		// The input will be `owner/name.agent`
+		// The agent is optional.
+		workspaceParts = strings.Split(input, ".")
 		err            error
 	)
 

--- a/cli/vscodessh.go
+++ b/cli/vscodessh.go
@@ -110,7 +110,7 @@ func (r *RootCmd) vscodeSSH() *serpent.Command {
 			// will call this command after the workspace is started.
 			autostart := false
 
-			_, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, autostart, owner, name)
+			_, workspaceAgent, err := getWorkspaceAndAgent(ctx, inv, client, autostart, fmt.Sprintf("%s/%s", owner, name))
 			if err != nil {
 				return xerrors.Errorf("find workspace and agent: %w", err)
 			}


### PR DESCRIPTION
Some commands were ignoring the `<username>/<workspace>` syntax.