### PR TITLE
feat(cli): support bundle: dump healthcheck summary

### DIFF
--- a/cli/support.go
+++ b/cli/support.go
@@ -184,6 +184,15 @@ func (r *RootCmd) supportBundle() *serpent.Command {
 				_ = os.Remove(outputPath) // best effort
 				return xerrors.Errorf("create support bundle: %w", err)
 			}
+			deployHealthSummary := bun.Deployment.HealthReport.Summarize()
+			if len(deployHealthSummary) > 0 {
+				cliui.Warn(inv.Stdout, "Deployment health issues detected:", deployHealthSummary...)
+			}
+			clientNetcheckSummary := bun.Network.Netcheck.Summarize("Client netcheck:")
+			if len(clientNetcheckSummary) > 0 {
+				cliui.Warn(inv.Stdout, "Networking issues detected:", deployHealthSummary...)
+			}
+
 			bun.CLILogs = cliLogBuf.Bytes()
 
 			if err := writeBundle(bun, zwr); err != nil {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13607,6 +13607,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "healthy": {
+                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
                     "type": "boolean"
                 },
                 "node": {
@@ -13654,6 +13655,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "healthy": {
+                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
                     "type": "boolean"
                 },
                 "node_reports": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13603,6 +13603,9 @@ const docTemplate = `{
                         }
                     }
                 },
+                "dismissed": {
+                    "type": "boolean"
+                },
                 "error": {
                     "type": "string"
                 },
@@ -13651,6 +13654,9 @@ const docTemplate = `{
         "healthsdk.DERPRegionReport": {
             "type": "object",
             "properties": {
+                "dismissed": {
+                    "type": "boolean"
+                },
                 "error": {
                     "type": "string"
                 },
@@ -13827,6 +13833,10 @@ const docTemplate = `{
                 "error": {
                     "type": "string"
                 },
+                "healthy": {
+                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
+                    "type": "boolean"
+                },
                 "items": {
                     "type": "array",
                     "items": {
@@ -13834,7 +13844,16 @@ const docTemplate = `{
                     }
                 },
                 "severity": {
-                    "$ref": "#/definitions/health.Severity"
+                    "enum": [
+                        "ok",
+                        "warning",
+                        "error"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/health.Severity"
+                        }
+                    ]
                 },
                 "warnings": {
                     "type": "array",
@@ -13917,7 +13936,7 @@ const docTemplate = `{
                 "warnings": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/health.Message"
                     }
                 }
             }
@@ -13932,10 +13951,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "healthy": {
+                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
                     "type": "boolean"
                 },
                 "severity": {
-                    "$ref": "#/definitions/health.Severity"
+                    "enum": [
+                        "ok",
+                        "warning",
+                        "error"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/health.Severity"
+                        }
+                    ]
                 },
                 "warnings": {
                     "type": "array",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -13603,14 +13603,10 @@ const docTemplate = `{
                         }
                     }
                 },
-                "dismissed": {
-                    "type": "boolean"
-                },
                 "error": {
                     "type": "string"
                 },
                 "healthy": {
-                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
                     "type": "boolean"
                 },
                 "node": {
@@ -13654,14 +13650,10 @@ const docTemplate = `{
         "healthsdk.DERPRegionReport": {
             "type": "object",
             "properties": {
-                "dismissed": {
-                    "type": "boolean"
-                },
                 "error": {
                     "type": "string"
                 },
                 "healthy": {
-                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
                     "type": "boolean"
                 },
                 "node_reports": {
@@ -13832,10 +13824,6 @@ const docTemplate = `{
                 },
                 "error": {
                     "type": "string"
-                },
-                "healthy": {
-                    "description": "Healthy is deprecated and left for backward compatibility purposes, use ` + "`" + `Severity` + "`" + ` instead.",
-                    "type": "boolean"
                 },
                 "items": {
                     "type": "array",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12359,6 +12359,9 @@
             }
           }
         },
+        "dismissed": {
+          "type": "boolean"
+        },
         "error": {
           "type": "string"
         },
@@ -12403,6 +12406,9 @@
     "healthsdk.DERPRegionReport": {
       "type": "object",
       "properties": {
+        "dismissed": {
+          "type": "boolean"
+        },
         "error": {
           "type": "string"
         },
@@ -12567,6 +12573,10 @@
         "error": {
           "type": "string"
         },
+        "healthy": {
+          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
+          "type": "boolean"
+        },
         "items": {
           "type": "array",
           "items": {
@@ -12574,7 +12584,12 @@
           }
         },
         "severity": {
-          "$ref": "#/definitions/health.Severity"
+          "enum": ["ok", "warning", "error"],
+          "allOf": [
+            {
+              "$ref": "#/definitions/health.Severity"
+            }
+          ]
         },
         "warnings": {
           "type": "array",
@@ -12653,7 +12668,7 @@
         "warnings": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/health.Message"
           }
         }
       }
@@ -12668,10 +12683,16 @@
           "type": "string"
         },
         "healthy": {
+          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
           "type": "boolean"
         },
         "severity": {
-          "$ref": "#/definitions/health.Severity"
+          "enum": ["ok", "warning", "error"],
+          "allOf": [
+            {
+              "$ref": "#/definitions/health.Severity"
+            }
+          ]
         },
         "warnings": {
           "type": "array",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12363,6 +12363,7 @@
           "type": "string"
         },
         "healthy": {
+          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
           "type": "boolean"
         },
         "node": {
@@ -12406,6 +12407,7 @@
           "type": "string"
         },
         "healthy": {
+          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
           "type": "boolean"
         },
         "node_reports": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -12359,14 +12359,10 @@
             }
           }
         },
-        "dismissed": {
-          "type": "boolean"
-        },
         "error": {
           "type": "string"
         },
         "healthy": {
-          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
           "type": "boolean"
         },
         "node": {
@@ -12406,14 +12402,10 @@
     "healthsdk.DERPRegionReport": {
       "type": "object",
       "properties": {
-        "dismissed": {
-          "type": "boolean"
-        },
         "error": {
           "type": "string"
         },
         "healthy": {
-          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
           "type": "boolean"
         },
         "node_reports": {
@@ -12572,10 +12564,6 @@
         },
         "error": {
           "type": "string"
-        },
-        "healthy": {
-          "description": "Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.",
-          "type": "boolean"
         },
         "items": {
           "type": "array",

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -213,7 +213,7 @@ func TestDebugHealth(t *testing.T) {
 					return &healthsdk.HealthcheckReport{
 						Time:    time.Now(),
 						Healthy: true,
-						DERP:    healthsdk.DERPHealthReport{BaseReport: healthsdk.BaseReport{Healthy: true}},
+						DERP:    healthsdk.DERPHealthReport{Healthy: true},
 					}
 				},
 			})

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -213,7 +213,7 @@ func TestDebugHealth(t *testing.T) {
 					return &healthsdk.HealthcheckReport{
 						Time:    time.Now(),
 						Healthy: true,
-						DERP:    healthsdk.DERPHealthReport{Healthy: true},
+						DERP:    healthsdk.DERPHealthReport{BaseReport: healthsdk.BaseReport{Healthy: true}},
 					}
 				},
 			})

--- a/coderd/healthcheck/derphealth/derp.go
+++ b/coderd/healthcheck/derphealth/derp.go
@@ -133,8 +133,10 @@ func (r *RegionReport) Run(ctx context.Context) {
 			node       = node
 			nodeReport = NodeReport{
 				DERPNodeReport: healthsdk.DERPNodeReport{
-					Node:    node,
-					Healthy: true,
+					BaseReport: healthsdk.BaseReport{
+						Healthy: true,
+					},
+					Node: node,
 				},
 			}
 		)

--- a/coderd/healthcheck/derphealth/derp.go
+++ b/coderd/healthcheck/derphealth/derp.go
@@ -133,10 +133,8 @@ func (r *RegionReport) Run(ctx context.Context) {
 			node       = node
 			nodeReport = NodeReport{
 				DERPNodeReport: healthsdk.DERPNodeReport{
-					BaseReport: healthsdk.BaseReport{
-						Healthy: true,
-					},
-					Node: node,
+					Healthy: true,
+					Node:    node,
 				},
 			}
 		)

--- a/coderd/healthcheck/healthcheck_test.go
+++ b/coderd/healthcheck/healthcheck_test.go
@@ -58,32 +58,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "OK",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -100,32 +100,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "DERPFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -142,33 +142,33 @@ func TestHealthcheck(t *testing.T) {
 		name: "DERPWarning",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
 					Severity: health.SeverityWarning,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -185,32 +185,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "AccessURLFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityWarning,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -227,32 +227,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "WebsocketFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -269,32 +269,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "DatabaseFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -311,32 +311,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProxyFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
@@ -353,32 +353,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProxyWarn",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
 					Severity: health.SeverityWarning,
 				},
@@ -396,32 +396,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProvisionerDaemonsFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -438,32 +438,32 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProvisionerDaemonsWarn",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: true,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  true,
 					Severity: health.SeverityOK,
 				},
 			},
@@ -482,32 +482,32 @@ func TestHealthcheck(t *testing.T) {
 		healthy: false,
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
+				Healthy: false,
 				BaseReport: healthsdk.BaseReport{
-					Healthy:  false,
 					Severity: health.SeverityError,
 				},
 			},

--- a/coderd/healthcheck/healthcheck_test.go
+++ b/coderd/healthcheck/healthcheck_test.go
@@ -58,27 +58,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "OK",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		healthy:         true,
@@ -88,27 +100,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "DERPFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		healthy:         false,
@@ -118,28 +142,40 @@ func TestHealthcheck(t *testing.T) {
 		name: "DERPWarning",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
-				Severity: health.SeverityWarning,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
+					Severity: health.SeverityWarning,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		healthy:         true,
@@ -149,27 +185,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "AccessURLFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  false,
-				Severity: health.SeverityWarning,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityWarning,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		healthy:         false,
@@ -179,27 +227,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "WebsocketFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		healthy:         false,
@@ -209,27 +269,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "DatabaseFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		healthy:         false,
@@ -239,27 +311,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProxyFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		severity:        health.SeverityError,
@@ -269,28 +353,40 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProxyWarn",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
-				Severity: health.SeverityWarning,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
+					Severity: health.SeverityWarning,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityOK,
+				},
 			},
 		},
 		severity:        health.SeverityWarning,
@@ -300,27 +396,39 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProvisionerDaemonsFail",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityError,
+				},
 			},
 		},
 		severity:        health.SeverityError,
@@ -330,28 +438,40 @@ func TestHealthcheck(t *testing.T) {
 		name: "ProvisionerDaemonsWarn",
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  true,
-				Severity: health.SeverityOK,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  true,
+					Severity: health.SeverityOK,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityWarning,
-				Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityWarning,
+					Warnings: []health.Message{{Message: "foobar", Code: "EFOOBAR"}},
+				},
 			},
 		},
 		severity:        health.SeverityWarning,
@@ -362,27 +482,39 @@ func TestHealthcheck(t *testing.T) {
 		healthy: false,
 		checker: &testChecker{
 			DERPReport: healthsdk.DERPHealthReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			AccessURLReport: healthsdk.AccessURLReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			WebsocketReport: healthsdk.WebsocketReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			DatabaseReport: healthsdk.DatabaseReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			WorkspaceProxyReport: healthsdk.WorkspaceProxyReport{
-				Healthy:  false,
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Healthy:  false,
+					Severity: health.SeverityError,
+				},
 			},
 			ProvisionerDaemonsReport: healthsdk.ProvisionerDaemonsReport{
-				Severity: health.SeverityError,
+				BaseReport: healthsdk.BaseReport{
+					Severity: health.SeverityError,
+				},
 			},
 		},
 		severity: health.SeverityError,

--- a/coderd/healthcheck/websocket.go
+++ b/coderd/healthcheck/websocket.go
@@ -31,7 +31,7 @@ func (r *WebsocketReport) Run(ctx context.Context, opts *WebsocketReportOptions)
 	defer cancel()
 
 	r.Severity = health.SeverityOK
-	r.Warnings = []string{}
+	r.Warnings = []health.Message{}
 	r.Dismissed = opts.Dismissed
 
 	u, err := opts.AccessURL.Parse("/api/v2/debug/ws")

--- a/codersdk/healthsdk/healthsdk.go
+++ b/codersdk/healthsdk/healthsdk.go
@@ -133,8 +133,6 @@ func (r *HealthcheckReport) Summarize() []string {
 
 // BaseReport holds fields common to various health reports.
 type BaseReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy   bool             `json:"healthy"`
 	Error     *string          `json:"error"`
 	Severity  health.Severity  `json:"severity" enums:"ok,warning,error"`
 	Warnings  []health.Message `json:"warnings"`
@@ -174,6 +172,8 @@ func (b *BaseReport) Summarize(prefix string) []string {
 // AccessURLReport shows the results of performing a HTTP_GET to the /healthz endpoint through the configured access URL.
 type AccessURLReport struct {
 	BaseReport
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
+	Healthy         bool   `json:"healthy"`
 	AccessURL       string `json:"access_url"`
 	Reachable       bool   `json:"reachable"`
 	StatusCode      int    `json:"status_code"`
@@ -183,6 +183,8 @@ type AccessURLReport struct {
 // DERPHealthReport includes health details of each configured DERP/STUN region.
 type DERPHealthReport struct {
 	BaseReport
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
+	Healthy      bool                      `json:"healthy"`
 	Regions      map[int]*DERPRegionReport `json:"regions"`
 	Netcheck     *netcheck.Report          `json:"netcheck"`
 	NetcheckErr  *string                   `json:"netcheck_err"`
@@ -191,14 +193,20 @@ type DERPHealthReport struct {
 
 // DERPHealthReport includes health details of each node in a single region.
 type DERPRegionReport struct {
-	BaseReport
+	Healthy     bool                `json:"healthy"`
+	Severity    health.Severity     `json:"severity" enums:"ok,warning,error"`
+	Warnings    []health.Message    `json:"warnings"`
+	Error       *string             `json:"error"`
 	Region      *tailcfg.DERPRegion `json:"region"`
 	NodeReports []*DERPNodeReport   `json:"node_reports"`
 }
 
 // DERPHealthReport includes health details of a single node in a single region.
 type DERPNodeReport struct {
-	BaseReport
+	Healthy  bool             `json:"healthy"`
+	Severity health.Severity  `json:"severity" enums:"ok,warning,error"`
+	Warnings []health.Message `json:"warnings"`
+	Error    *string          `json:"error"`
 
 	Node *tailcfg.DERPNode `json:"node"`
 
@@ -223,6 +231,8 @@ type STUNReport struct {
 // DatabaseReport shows the results of pinging the configured database.Conn.
 type DatabaseReport struct {
 	BaseReport
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
+	Healthy     bool   `json:"healthy"`
 	Reachable   bool   `json:"reachable"`
 	Latency     string `json:"latency"`
 	LatencyMS   int64  `json:"latency_ms"`
@@ -242,6 +252,8 @@ type ProvisionerDaemonsReportItem struct {
 
 // WebsocketReport shows if the configured access URL allows establishing WebSocket connections.
 type WebsocketReport struct {
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
+	Healthy bool `json:"healthy"`
 	BaseReport
 	Body string `json:"body"`
 	Code int    `json:"code"`
@@ -249,6 +261,8 @@ type WebsocketReport struct {
 
 // WorkspaceProxyReport includes health details of each connected workspace proxy.
 type WorkspaceProxyReport struct {
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
+	Healthy bool `json:"healthy"`
 	BaseReport
 	WorkspaceProxies codersdk.RegionsResponse[codersdk.WorkspaceProxy] `json:"workspace_proxies"`
 }

--- a/codersdk/healthsdk/healthsdk.go
+++ b/codersdk/healthsdk/healthsdk.go
@@ -193,6 +193,7 @@ type DERPHealthReport struct {
 
 // DERPHealthReport includes health details of each node in a single region.
 type DERPRegionReport struct {
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
 	Healthy     bool                `json:"healthy"`
 	Severity    health.Severity     `json:"severity" enums:"ok,warning,error"`
 	Warnings    []health.Message    `json:"warnings"`
@@ -203,6 +204,7 @@ type DERPRegionReport struct {
 
 // DERPHealthReport includes health details of a single node in a single region.
 type DERPNodeReport struct {
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
 	Healthy  bool             `json:"healthy"`
 	Severity health.Severity  `json:"severity" enums:"ok,warning,error"`
 	Warnings []health.Message `json:"warnings"`

--- a/codersdk/healthsdk/healthsdk.go
+++ b/codersdk/healthsdk/healthsdk.go
@@ -95,6 +95,7 @@ func (c *HealthClient) PutHealthSettings(ctx context.Context, settings HealthSet
 	return nil
 }
 
+// HealthcheckReport contains information about the health status of a Coder deployment.
 type HealthcheckReport struct {
 	// Time is the time the report was generated at.
 	Time time.Time `json:"time" format:"date-time"`
@@ -117,52 +118,44 @@ type HealthcheckReport struct {
 	CoderVersion string `json:"coder_version"`
 }
 
+// BaseReport holds fields common to various health reports.
+type BaseReport struct {
+	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
+	Healthy   bool             `json:"healthy"`
+	Error     *string          `json:"error"`
+	Severity  health.Severity  `json:"severity" enums:"ok,warning,error"`
+	Warnings  []health.Message `json:"warnings"`
+	Dismissed bool             `json:"dismissed"`
+}
+
+// AccessURLReport shows the results of performing a HTTP_GET to the /healthz endpoint through the configured access URL.
 type AccessURLReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy   bool             `json:"healthy"`
-	Severity  health.Severity  `json:"severity" enums:"ok,warning,error"`
-	Warnings  []health.Message `json:"warnings"`
-	Dismissed bool             `json:"dismissed"`
-
-	AccessURL       string  `json:"access_url"`
-	Reachable       bool    `json:"reachable"`
-	StatusCode      int     `json:"status_code"`
-	HealthzResponse string  `json:"healthz_response"`
-	Error           *string `json:"error"`
+	BaseReport
+	AccessURL       string `json:"access_url"`
+	Reachable       bool   `json:"reachable"`
+	StatusCode      int    `json:"status_code"`
+	HealthzResponse string `json:"healthz_response"`
 }
 
+// DERPHealthReport includes health details of each configured DERP/STUN region.
 type DERPHealthReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy   bool             `json:"healthy"`
-	Severity  health.Severity  `json:"severity" enums:"ok,warning,error"`
-	Warnings  []health.Message `json:"warnings"`
-	Dismissed bool             `json:"dismissed"`
-
-	Regions map[int]*DERPRegionReport `json:"regions"`
-
-	Netcheck     *netcheck.Report `json:"netcheck"`
-	NetcheckErr  *string          `json:"netcheck_err"`
-	NetcheckLogs []string         `json:"netcheck_logs"`
-
-	Error *string `json:"error"`
+	BaseReport
+	Regions      map[int]*DERPRegionReport `json:"regions"`
+	Netcheck     *netcheck.Report          `json:"netcheck"`
+	NetcheckErr  *string                   `json:"netcheck_err"`
+	NetcheckLogs []string                  `json:"netcheck_logs"`
 }
 
+// DERPHealthReport includes health details of each node in a single region.
 type DERPRegionReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy  bool             `json:"healthy"`
-	Severity health.Severity  `json:"severity" enums:"ok,warning,error"`
-	Warnings []health.Message `json:"warnings"`
-
+	BaseReport
 	Region      *tailcfg.DERPRegion `json:"region"`
 	NodeReports []*DERPNodeReport   `json:"node_reports"`
-	Error       *string             `json:"error"`
 }
 
+// DERPHealthReport includes health details of a single node in a single region.
 type DERPNodeReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy  bool             `json:"healthy"`
-	Severity health.Severity  `json:"severity" enums:"ok,warning,error"`
-	Warnings []health.Message `json:"warnings"`
+	BaseReport
 
 	Node *tailcfg.DERPNode `json:"node"`
 
@@ -173,37 +166,29 @@ type DERPNodeReport struct {
 	UsesWebsocket       bool                   `json:"uses_websocket"`
 	ClientLogs          [][]string             `json:"client_logs"`
 	ClientErrs          [][]string             `json:"client_errs"`
-	Error               *string                `json:"error"`
 
 	STUN STUNReport `json:"stun"`
 }
 
+// STUNReport contains information about a given node's STUN capabilities.
 type STUNReport struct {
 	Enabled bool
 	CanSTUN bool
 	Error   *string
 }
 
+// DatabaseReport shows the results of pinging the configured database.Conn.
 type DatabaseReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy   bool             `json:"healthy"`
-	Severity  health.Severity  `json:"severity" enums:"ok,warning,error"`
-	Warnings  []health.Message `json:"warnings"`
-	Dismissed bool             `json:"dismissed"`
-
-	Reachable   bool    `json:"reachable"`
-	Latency     string  `json:"latency"`
-	LatencyMS   int64   `json:"latency_ms"`
-	ThresholdMS int64   `json:"threshold_ms"`
-	Error       *string `json:"error"`
+	BaseReport
+	Reachable   bool   `json:"reachable"`
+	Latency     string `json:"latency"`
+	LatencyMS   int64  `json:"latency_ms"`
+	ThresholdMS int64  `json:"threshold_ms"`
 }
 
+// ProvisionerDaemonsReport includes health details of each connected provisioner daemon.
 type ProvisionerDaemonsReport struct {
-	Severity  health.Severity  `json:"severity"`
-	Warnings  []health.Message `json:"warnings"`
-	Dismissed bool             `json:"dismissed"`
-	Error     *string          `json:"error"`
-
+	BaseReport
 	Items []ProvisionerDaemonsReportItem `json:"items"`
 }
 
@@ -212,24 +197,15 @@ type ProvisionerDaemonsReportItem struct {
 	Warnings                   []health.Message `json:"warnings"`
 }
 
+// WebsocketReport shows if the configured access URL allows establishing WebSocket connections.
 type WebsocketReport struct {
-	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
-	Healthy   bool            `json:"healthy"`
-	Severity  health.Severity `json:"severity" enums:"ok,warning,error"`
-	Warnings  []string        `json:"warnings"`
-	Dismissed bool            `json:"dismissed"`
-
-	Body  string  `json:"body"`
-	Code  int     `json:"code"`
-	Error *string `json:"error"`
+	BaseReport
+	Body string `json:"body"`
+	Code int    `json:"code"`
 }
 
+// WorkspaceProxyReport includes health details of each connected workspace proxy.
 type WorkspaceProxyReport struct {
-	Healthy   bool             `json:"healthy"`
-	Severity  health.Severity  `json:"severity"`
-	Warnings  []health.Message `json:"warnings"`
-	Dismissed bool             `json:"dismissed"`
-	Error     *string          `json:"error"`
-
+	BaseReport
 	WorkspaceProxies codersdk.RegionsResponse[codersdk.WorkspaceProxy] `json:"workspace_proxies"`
 }

--- a/codersdk/healthsdk/healthsdk_test.go
+++ b/codersdk/healthsdk/healthsdk_test.go
@@ -1,0 +1,127 @@
+package healthsdk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coder/coder/v2/coderd/healthcheck/health"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk/healthsdk"
+)
+
+func TestSummarize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HealthcheckReport", func(t *testing.T) {
+		unhealthy := healthsdk.BaseReport{
+			Error:    ptr.Ref("test error"),
+			Warnings: []health.Message{{Code: "TEST", Message: "testing"}},
+		}
+		hr := healthsdk.HealthcheckReport{
+			AccessURL: healthsdk.AccessURLReport{
+				BaseReport: unhealthy,
+			},
+			Database: healthsdk.DatabaseReport{
+				BaseReport: unhealthy,
+			},
+			DERP: healthsdk.DERPHealthReport{
+				BaseReport: unhealthy,
+			},
+			ProvisionerDaemons: healthsdk.ProvisionerDaemonsReport{
+				BaseReport: unhealthy,
+			},
+			Websocket: healthsdk.WebsocketReport{
+				BaseReport: unhealthy,
+			},
+			WorkspaceProxy: healthsdk.WorkspaceProxyReport{
+				BaseReport: unhealthy,
+			},
+		}
+		expected := []string{
+			"Access URL: Error: test error",
+			"Access URL: Warn: TEST: testing",
+			"Database: Error: test error",
+			"Database: Warn: TEST: testing",
+			"DERP: Error: test error",
+			"DERP: Warn: TEST: testing",
+			"Provisioner Daemons: Error: test error",
+			"Provisioner Daemons: Warn: TEST: testing",
+			"Websocket: Error: test error",
+			"Websocket: Warn: TEST: testing",
+			"Workspace Proxies: Error: test error",
+			"Workspace Proxies: Warn: TEST: testing",
+		}
+		actual := hr.Summarize()
+		assert.Equal(t, expected, actual)
+	})
+
+	for _, tt := range []struct {
+		name     string
+		br       healthsdk.BaseReport
+		pfx      string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			br:       healthsdk.BaseReport{},
+			pfx:      "",
+			expected: []string{},
+		},
+		{
+			name: "no prefix",
+			br: healthsdk.BaseReport{
+				Error: ptr.Ref("testing"),
+				Warnings: []health.Message{
+					{
+						Code:    "TEST01",
+						Message: "testing one",
+					},
+					{
+						Code:    "TEST02",
+						Message: "testing two",
+					},
+				},
+			},
+			pfx: "",
+			expected: []string{
+				"Error: testing",
+				"Warn: TEST01: testing one",
+				"Warn: TEST02: testing two",
+			},
+		},
+		{
+			name: "prefix",
+			br: healthsdk.BaseReport{
+				Error: ptr.Ref("testing"),
+				Warnings: []health.Message{
+					{
+						Code:    "TEST01",
+						Message: "testing one",
+					},
+					{
+						Code:    "TEST02",
+						Message: "testing two",
+					},
+				},
+			},
+			pfx: "TEST:",
+			expected: []string{
+				"TEST: Error: testing",
+				"TEST: Warn: TEST01: testing one",
+				"TEST: Warn: TEST02: testing two",
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.br.Summarize(tt.pfx)
+			if len(tt.expected) == 0 {
+				assert.Empty(t, actual)
+				return
+			}
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -116,7 +116,6 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
     "netcheck_logs": ["string"],
     "regions": {
       "property1": {
-        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -124,7 +123,6 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -196,7 +194,6 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
         ]
       },
       "property2": {
-        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -204,7 +201,6 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -289,7 +285,6 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
   "provisioner_daemons": {
     "dismissed": true,
     "error": "string",
-    "healthy": true,
     "items": [
       {
         "provisioner_daemon": {

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -116,6 +116,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
     "netcheck_logs": ["string"],
     "regions": {
       "property1": {
+        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -123,6 +124,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
+            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -194,6 +196,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
         ]
       },
       "property2": {
+        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -201,6 +204,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
+            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -285,6 +289,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
   "provisioner_daemons": {
     "dismissed": true,
     "error": "string",
+    "healthy": true,
     "items": [
       {
         "provisioner_daemon": {
@@ -325,7 +330,12 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
     "error": "string",
     "healthy": true,
     "severity": "ok",
-    "warnings": ["string"]
+    "warnings": [
+      {
+        "code": "EUNKNOWN",
+        "message": "string"
+      }
+    ]
   },
   "workspace_proxy": {
     "dismissed": true,

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7411,7 +7411,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "netcheck_logs": ["string"],
   "regions": {
     "property1": {
-      "dismissed": true,
       "error": "string",
       "healthy": true,
       "node_reports": [
@@ -7419,7 +7418,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           "can_exchange_messages": true,
           "client_errs": [["string"]],
           "client_logs": [["string"]],
-          "dismissed": true,
           "error": "string",
           "healthy": true,
           "node": {
@@ -7491,7 +7489,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       ]
     },
     "property2": {
-      "dismissed": true,
       "error": "string",
       "healthy": true,
       "node_reports": [
@@ -7499,7 +7496,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           "can_exchange_messages": true,
           "client_errs": [["string"]],
           "client_logs": [["string"]],
-          "dismissed": true,
           "error": "string",
           "healthy": true,
           "node": {
@@ -7611,7 +7607,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "can_exchange_messages": true,
   "client_errs": [["string"]],
   "client_logs": [["string"]],
-  "dismissed": true,
   "error": "string",
   "healthy": true,
   "node": {
@@ -7653,22 +7648,21 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name                    | Type                                             | Required | Restrictions | Description                                                                                 |
-| ----------------------- | ------------------------------------------------ | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| `can_exchange_messages` | boolean                                          | false    |              |                                                                                             |
-| `client_errs`           | array of array                                   | false    |              |                                                                                             |
-| `client_logs`           | array of array                                   | false    |              |                                                                                             |
-| `dismissed`             | boolean                                          | false    |              |                                                                                             |
-| `error`                 | string                                           | false    |              |                                                                                             |
-| `healthy`               | boolean                                          | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
-| `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)             | false    |              |                                                                                             |
-| `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage) | false    |              |                                                                                             |
-| `round_trip_ping`       | string                                           | false    |              |                                                                                             |
-| `round_trip_ping_ms`    | integer                                          | false    |              |                                                                                             |
-| `severity`              | [health.Severity](#healthseverity)               | false    |              |                                                                                             |
-| `stun`                  | [healthsdk.STUNReport](#healthsdkstunreport)     | false    |              |                                                                                             |
-| `uses_websocket`        | boolean                                          | false    |              |                                                                                             |
-| `warnings`              | array of [health.Message](#healthmessage)        | false    |              |                                                                                             |
+| Name                    | Type                                             | Required | Restrictions | Description |
+| ----------------------- | ------------------------------------------------ | -------- | ------------ | ----------- |
+| `can_exchange_messages` | boolean                                          | false    |              |             |
+| `client_errs`           | array of array                                   | false    |              |             |
+| `client_logs`           | array of array                                   | false    |              |             |
+| `error`                 | string                                           | false    |              |             |
+| `healthy`               | boolean                                          | false    |              |             |
+| `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)             | false    |              |             |
+| `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage) | false    |              |             |
+| `round_trip_ping`       | string                                           | false    |              |             |
+| `round_trip_ping_ms`    | integer                                          | false    |              |             |
+| `severity`              | [health.Severity](#healthseverity)               | false    |              |             |
+| `stun`                  | [healthsdk.STUNReport](#healthsdkstunreport)     | false    |              |             |
+| `uses_websocket`        | boolean                                          | false    |              |             |
+| `warnings`              | array of [health.Message](#healthmessage)        | false    |              |             |
 
 #### Enumerated Values
 
@@ -7682,7 +7676,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ```json
 {
-  "dismissed": true,
   "error": "string",
   "healthy": true,
   "node_reports": [
@@ -7690,7 +7683,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       "can_exchange_messages": true,
       "client_errs": [["string"]],
       "client_logs": [["string"]],
-      "dismissed": true,
       "error": "string",
       "healthy": true,
       "node": {
@@ -7765,15 +7757,14 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name           | Type                                                          | Required | Restrictions | Description                                                                                 |
-| -------------- | ------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| `dismissed`    | boolean                                                       | false    |              |                                                                                             |
-| `error`        | string                                                        | false    |              |                                                                                             |
-| `healthy`      | boolean                                                       | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
-| `node_reports` | array of [healthsdk.DERPNodeReport](#healthsdkderpnodereport) | false    |              |                                                                                             |
-| `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                      | false    |              |                                                                                             |
-| `severity`     | [health.Severity](#healthseverity)                            | false    |              |                                                                                             |
-| `warnings`     | array of [health.Message](#healthmessage)                     | false    |              |                                                                                             |
+| Name           | Type                                                          | Required | Restrictions | Description |
+| -------------- | ------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `error`        | string                                                        | false    |              |             |
+| `healthy`      | boolean                                                       | false    |              |             |
+| `node_reports` | array of [healthsdk.DERPNodeReport](#healthsdkderpnodereport) | false    |              |             |
+| `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                      | false    |              |             |
+| `severity`     | [health.Severity](#healthseverity)                            | false    |              |             |
+| `warnings`     | array of [health.Message](#healthmessage)                     | false    |              |             |
 
 #### Enumerated Values
 
@@ -7934,7 +7925,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
     "netcheck_logs": ["string"],
     "regions": {
       "property1": {
-        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -7942,7 +7932,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -8014,7 +8003,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
         ]
       },
       "property2": {
-        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -8022,7 +8010,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
-            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -8107,7 +8094,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "provisioner_daemons": {
     "dismissed": true,
     "error": "string",
-    "healthy": true,
     "items": [
       {
         "provisioner_daemon": {
@@ -8227,7 +8213,6 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 {
   "dismissed": true,
   "error": "string",
-  "healthy": true,
   "items": [
     {
       "provisioner_daemon": {
@@ -8263,14 +8248,13 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name        | Type                                                                                      | Required | Restrictions | Description                                                                                 |
-| ----------- | ----------------------------------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| `dismissed` | boolean                                                                                   | false    |              |                                                                                             |
-| `error`     | string                                                                                    | false    |              |                                                                                             |
-| `healthy`   | boolean                                                                                   | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
-| `items`     | array of [healthsdk.ProvisionerDaemonsReportItem](#healthsdkprovisionerdaemonsreportitem) | false    |              |                                                                                             |
-| `severity`  | [health.Severity](#healthseverity)                                                        | false    |              |                                                                                             |
-| `warnings`  | array of [health.Message](#healthmessage)                                                 | false    |              |                                                                                             |
+| Name        | Type                                                                                      | Required | Restrictions | Description |
+| ----------- | ----------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
+| `dismissed` | boolean                                                                                   | false    |              |             |
+| `error`     | string                                                                                    | false    |              |             |
+| `items`     | array of [healthsdk.ProvisionerDaemonsReportItem](#healthsdkprovisionerdaemonsreportitem) | false    |              |             |
+| `severity`  | [health.Severity](#healthseverity)                                                        | false    |              |             |
+| `warnings`  | array of [health.Message](#healthmessage)                                                 | false    |              |             |
 
 #### Enumerated Values
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7411,6 +7411,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "netcheck_logs": ["string"],
   "regions": {
     "property1": {
+      "dismissed": true,
       "error": "string",
       "healthy": true,
       "node_reports": [
@@ -7418,6 +7419,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           "can_exchange_messages": true,
           "client_errs": [["string"]],
           "client_logs": [["string"]],
+          "dismissed": true,
           "error": "string",
           "healthy": true,
           "node": {
@@ -7489,6 +7491,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       ]
     },
     "property2": {
+      "dismissed": true,
       "error": "string",
       "healthy": true,
       "node_reports": [
@@ -7496,6 +7499,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
           "can_exchange_messages": true,
           "client_errs": [["string"]],
           "client_logs": [["string"]],
+          "dismissed": true,
           "error": "string",
           "healthy": true,
           "node": {
@@ -7607,6 +7611,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "can_exchange_messages": true,
   "client_errs": [["string"]],
   "client_logs": [["string"]],
+  "dismissed": true,
   "error": "string",
   "healthy": true,
   "node": {
@@ -7653,6 +7658,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `can_exchange_messages` | boolean                                          | false    |              |                                                                                             |
 | `client_errs`           | array of array                                   | false    |              |                                                                                             |
 | `client_logs`           | array of array                                   | false    |              |                                                                                             |
+| `dismissed`             | boolean                                          | false    |              |                                                                                             |
 | `error`                 | string                                           | false    |              |                                                                                             |
 | `healthy`               | boolean                                          | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
 | `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)             | false    |              |                                                                                             |
@@ -7676,6 +7682,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ```json
 {
+  "dismissed": true,
   "error": "string",
   "healthy": true,
   "node_reports": [
@@ -7683,6 +7690,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
       "can_exchange_messages": true,
       "client_errs": [["string"]],
       "client_logs": [["string"]],
+      "dismissed": true,
       "error": "string",
       "healthy": true,
       "node": {
@@ -7759,6 +7767,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 | Name           | Type                                                          | Required | Restrictions | Description                                                                                 |
 | -------------- | ------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `dismissed`    | boolean                                                       | false    |              |                                                                                             |
 | `error`        | string                                                        | false    |              |                                                                                             |
 | `healthy`      | boolean                                                       | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
 | `node_reports` | array of [healthsdk.DERPNodeReport](#healthsdkderpnodereport) | false    |              |                                                                                             |
@@ -7925,6 +7934,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
     "netcheck_logs": ["string"],
     "regions": {
       "property1": {
+        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -7932,6 +7942,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
+            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -8003,6 +8014,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
         ]
       },
       "property2": {
+        "dismissed": true,
         "error": "string",
         "healthy": true,
         "node_reports": [
@@ -8010,6 +8022,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
             "can_exchange_messages": true,
             "client_errs": [["string"]],
             "client_logs": [["string"]],
+            "dismissed": true,
             "error": "string",
             "healthy": true,
             "node": {
@@ -8094,6 +8107,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "provisioner_daemons": {
     "dismissed": true,
     "error": "string",
+    "healthy": true,
     "items": [
       {
         "provisioner_daemon": {
@@ -8134,7 +8148,12 @@ If the schedule is empty, the user will be updated to use the default schedule.|
     "error": "string",
     "healthy": true,
     "severity": "ok",
-    "warnings": ["string"]
+    "warnings": [
+      {
+        "code": "EUNKNOWN",
+        "message": "string"
+      }
+    ]
   },
   "workspace_proxy": {
     "dismissed": true,
@@ -8208,6 +8227,7 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 {
   "dismissed": true,
   "error": "string",
+  "healthy": true,
   "items": [
     {
       "provisioner_daemon": {
@@ -8243,13 +8263,22 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name        | Type                                                                                      | Required | Restrictions | Description |
-| ----------- | ----------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `dismissed` | boolean                                                                                   | false    |              |             |
-| `error`     | string                                                                                    | false    |              |             |
-| `items`     | array of [healthsdk.ProvisionerDaemonsReportItem](#healthsdkprovisionerdaemonsreportitem) | false    |              |             |
-| `severity`  | [health.Severity](#healthseverity)                                                        | false    |              |             |
-| `warnings`  | array of [health.Message](#healthmessage)                                                 | false    |              |             |
+| Name        | Type                                                                                      | Required | Restrictions | Description                                                                                 |
+| ----------- | ----------------------------------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `dismissed` | boolean                                                                                   | false    |              |                                                                                             |
+| `error`     | string                                                                                    | false    |              |                                                                                             |
+| `healthy`   | boolean                                                                                   | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
+| `items`     | array of [healthsdk.ProvisionerDaemonsReportItem](#healthsdkprovisionerdaemonsreportitem) | false    |              |                                                                                             |
+| `severity`  | [health.Severity](#healthseverity)                                                        | false    |              |                                                                                             |
+| `warnings`  | array of [health.Message](#healthmessage)                                                 | false    |              |                                                                                             |
+
+#### Enumerated Values
+
+| Property   | Value     |
+| ---------- | --------- |
+| `severity` | `ok`      |
+| `severity` | `warning` |
+| `severity` | `error`   |
 
 ## healthsdk.ProvisionerDaemonsReportItem
 
@@ -8326,21 +8355,26 @@ If the schedule is empty, the user will be updated to use the default schedule.|
   "error": "string",
   "healthy": true,
   "severity": "ok",
-  "warnings": ["string"]
+  "warnings": [
+    {
+      "code": "EUNKNOWN",
+      "message": "string"
+    }
+  ]
 }
 ```
 
 ### Properties
 
-| Name        | Type                               | Required | Restrictions | Description                                                                                 |
-| ----------- | ---------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| `body`      | string                             | false    |              |                                                                                             |
-| `code`      | integer                            | false    |              |                                                                                             |
-| `dismissed` | boolean                            | false    |              |                                                                                             |
-| `error`     | string                             | false    |              |                                                                                             |
-| `healthy`   | boolean                            | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
-| `severity`  | [health.Severity](#healthseverity) | false    |              |                                                                                             |
-| `warnings`  | array of string                    | false    |              |                                                                                             |
+| Name        | Type                                      | Required | Restrictions | Description                                                                                 |
+| ----------- | ----------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `body`      | string                                    | false    |              |                                                                                             |
+| `code`      | integer                                   | false    |              |                                                                                             |
+| `dismissed` | boolean                                   | false    |              |                                                                                             |
+| `error`     | string                                    | false    |              |                                                                                             |
+| `healthy`   | boolean                                   | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
+| `severity`  | [health.Severity](#healthseverity)        | false    |              |                                                                                             |
+| `warnings`  | array of [health.Message](#healthmessage) | false    |              |                                                                                             |
 
 #### Enumerated Values
 
@@ -8396,14 +8430,22 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name                | Type                                                                                                 | Required | Restrictions | Description |
-| ------------------- | ---------------------------------------------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `dismissed`         | boolean                                                                                              | false    |              |             |
-| `error`             | string                                                                                               | false    |              |             |
-| `healthy`           | boolean                                                                                              | false    |              |             |
-| `severity`          | [health.Severity](#healthseverity)                                                                   | false    |              |             |
-| `warnings`          | array of [health.Message](#healthmessage)                                                            | false    |              |             |
-| `workspace_proxies` | [codersdk.RegionsResponse-codersdk_WorkspaceProxy](#codersdkregionsresponse-codersdk_workspaceproxy) | false    |              |             |
+| Name                | Type                                                                                                 | Required | Restrictions | Description                                                                                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `dismissed`         | boolean                                                                                              | false    |              |                                                                                             |
+| `error`             | string                                                                                               | false    |              |                                                                                             |
+| `healthy`           | boolean                                                                                              | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
+| `severity`          | [health.Severity](#healthseverity)                                                                   | false    |              |                                                                                             |
+| `warnings`          | array of [health.Message](#healthmessage)                                                            | false    |              |                                                                                             |
+| `workspace_proxies` | [codersdk.RegionsResponse-codersdk_WorkspaceProxy](#codersdkregionsresponse-codersdk_workspaceproxy) | false    |              |                                                                                             |
+
+#### Enumerated Values
+
+| Property   | Value     |
+| ---------- | --------- |
+| `severity` | `ok`      |
+| `severity` | `warning` |
+| `severity` | `error`   |
 
 ## key.NodePublic
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -7648,21 +7648,21 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name                    | Type                                             | Required | Restrictions | Description |
-| ----------------------- | ------------------------------------------------ | -------- | ------------ | ----------- |
-| `can_exchange_messages` | boolean                                          | false    |              |             |
-| `client_errs`           | array of array                                   | false    |              |             |
-| `client_logs`           | array of array                                   | false    |              |             |
-| `error`                 | string                                           | false    |              |             |
-| `healthy`               | boolean                                          | false    |              |             |
-| `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)             | false    |              |             |
-| `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage) | false    |              |             |
-| `round_trip_ping`       | string                                           | false    |              |             |
-| `round_trip_ping_ms`    | integer                                          | false    |              |             |
-| `severity`              | [health.Severity](#healthseverity)               | false    |              |             |
-| `stun`                  | [healthsdk.STUNReport](#healthsdkstunreport)     | false    |              |             |
-| `uses_websocket`        | boolean                                          | false    |              |             |
-| `warnings`              | array of [health.Message](#healthmessage)        | false    |              |             |
+| Name                    | Type                                             | Required | Restrictions | Description                                                                                 |
+| ----------------------- | ------------------------------------------------ | -------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `can_exchange_messages` | boolean                                          | false    |              |                                                                                             |
+| `client_errs`           | array of array                                   | false    |              |                                                                                             |
+| `client_logs`           | array of array                                   | false    |              |                                                                                             |
+| `error`                 | string                                           | false    |              |                                                                                             |
+| `healthy`               | boolean                                          | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
+| `node`                  | [tailcfg.DERPNode](#tailcfgderpnode)             | false    |              |                                                                                             |
+| `node_info`             | [derp.ServerInfoMessage](#derpserverinfomessage) | false    |              |                                                                                             |
+| `round_trip_ping`       | string                                           | false    |              |                                                                                             |
+| `round_trip_ping_ms`    | integer                                          | false    |              |                                                                                             |
+| `severity`              | [health.Severity](#healthseverity)               | false    |              |                                                                                             |
+| `stun`                  | [healthsdk.STUNReport](#healthsdkstunreport)     | false    |              |                                                                                             |
+| `uses_websocket`        | boolean                                          | false    |              |                                                                                             |
+| `warnings`              | array of [health.Message](#healthmessage)        | false    |              |                                                                                             |
 
 #### Enumerated Values
 
@@ -7757,14 +7757,14 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 
 ### Properties
 
-| Name           | Type                                                          | Required | Restrictions | Description |
-| -------------- | ------------------------------------------------------------- | -------- | ------------ | ----------- |
-| `error`        | string                                                        | false    |              |             |
-| `healthy`      | boolean                                                       | false    |              |             |
-| `node_reports` | array of [healthsdk.DERPNodeReport](#healthsdkderpnodereport) | false    |              |             |
-| `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                      | false    |              |             |
-| `severity`     | [health.Severity](#healthseverity)                            | false    |              |             |
-| `warnings`     | array of [health.Message](#healthmessage)                     | false    |              |             |
+| Name           | Type                                                          | Required | Restrictions | Description                                                                                 |
+| -------------- | ------------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `error`        | string                                                        | false    |              |                                                                                             |
+| `healthy`      | boolean                                                       | false    |              | Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead. |
+| `node_reports` | array of [healthsdk.DERPNodeReport](#healthsdkderpnodereport) | false    |              |                                                                                             |
+| `region`       | [tailcfg.DERPRegion](#tailcfgderpregion)                      | false    |              |                                                                                             |
+| `severity`     | [health.Severity](#healthseverity)                            | false    |              |                                                                                             |
+| `warnings`     | array of [health.Message](#healthmessage)                     | false    |              |                                                                                             |
 
 #### Enumerated Values
 

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -544,7 +544,8 @@ func (g *Generator) buildStruct(obj types.Object, st *types.Struct) (string, err
 		tag := reflect.StructTag(st.Tag(i))
 		// Adding a json struct tag causes the json package to consider
 		// the field unembedded.
-		if field.Embedded() && tag.Get("json") == "" && field.Pkg().Name() == "codersdk" {
+		// if field.Embedded() && tag.Get("json") == "" && field.Pkg().Name() == "codersdk" {
+		if field.Embedded() && tag.Get("json") == "" {
 			extendedFields[i] = true
 			extends = append(extends, field.Name())
 		}

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -544,7 +544,6 @@ func (g *Generator) buildStruct(obj types.Object, st *types.Struct) (string, err
 		tag := reflect.StructTag(st.Tag(i))
 		// Adding a json struct tag causes the json package to consider
 		// the field unembedded.
-		// if field.Embedded() && tag.Get("json") == "" && field.Pkg().Name() == "codersdk" {
 		if field.Embedded() && tag.Get("json") == "" {
 			extendedFields[i] = true
 			extends = append(extends, field.Name())

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2284,12 +2284,6 @@ export type RegionTypes = Region | WorkspaceProxy;
 // From healthsdk/healthsdk.go
 export interface AccessURLReport extends BaseReport {
   readonly healthy: boolean;
-<<<<<<< HEAD
-=======
-  readonly severity: HealthSeverity;
-  readonly warnings: readonly HealthMessage[];
-  readonly dismissed: boolean;
->>>>>>> origin/main
   readonly access_url: string;
   readonly reachable: boolean;
   readonly status_code: number;
@@ -2312,24 +2306,15 @@ export interface DERPHealthReport extends BaseReport {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly netcheck?: any;
   readonly netcheck_err?: string;
-<<<<<<< HEAD
-  readonly netcheck_logs: string[];
-=======
   readonly netcheck_logs: readonly string[];
-  readonly error?: string;
->>>>>>> origin/main
 }
 
 // From healthsdk/healthsdk.go
 export interface DERPNodeReport {
   readonly healthy: boolean;
   readonly severity: HealthSeverity;
-<<<<<<< HEAD
-  readonly warnings: HealthMessage[];
-  readonly error?: string;
-=======
   readonly warnings: readonly HealthMessage[];
->>>>>>> origin/main
+  readonly error?: string;
   // Named type "tailscale.com/tailcfg.DERPNode" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly node?: any;
@@ -2340,14 +2325,8 @@ export interface DERPNodeReport {
   readonly round_trip_ping: string;
   readonly round_trip_ping_ms: number;
   readonly uses_websocket: boolean;
-<<<<<<< HEAD
-  readonly client_logs: string[][];
-  readonly client_errs: string[][];
-=======
   readonly client_logs: readonly (readonly string[])[];
   readonly client_errs: readonly (readonly string[])[];
-  readonly error?: string;
->>>>>>> origin/main
   readonly stun: STUNReport;
 }
 
@@ -2355,32 +2334,17 @@ export interface DERPNodeReport {
 export interface DERPRegionReport {
   readonly healthy: boolean;
   readonly severity: HealthSeverity;
-<<<<<<< HEAD
-  readonly warnings: HealthMessage[];
-  readonly error?: string;
-  // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
-  readonly region?: any;
-  readonly node_reports: DERPNodeReport[];
-=======
   readonly warnings: readonly HealthMessage[];
+  readonly error?: string;
   // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly region?: any;
   readonly node_reports: readonly DERPNodeReport[];
-  readonly error?: string;
->>>>>>> origin/main
 }
 
 // From healthsdk/healthsdk.go
 export interface DatabaseReport extends BaseReport {
   readonly healthy: boolean;
-<<<<<<< HEAD
-=======
-  readonly severity: HealthSeverity;
-  readonly warnings: readonly HealthMessage[];
-  readonly dismissed: boolean;
->>>>>>> origin/main
   readonly reachable: boolean;
   readonly latency: string;
   readonly latency_ms: number;
@@ -2408,17 +2372,8 @@ export interface HealthcheckReport {
 }
 
 // From healthsdk/healthsdk.go
-<<<<<<< HEAD
 export interface ProvisionerDaemonsReport extends BaseReport {
-  readonly items: ProvisionerDaemonsReportItem[];
-=======
-export interface ProvisionerDaemonsReport {
-  readonly severity: HealthSeverity;
-  readonly warnings: readonly HealthMessage[];
-  readonly dismissed: boolean;
-  readonly error?: string;
   readonly items: readonly ProvisionerDaemonsReportItem[];
->>>>>>> origin/main
 }
 
 // From healthsdk/healthsdk.go
@@ -2442,12 +2397,6 @@ export interface UpdateHealthSettings {
 // From healthsdk/healthsdk.go
 export interface WebsocketReport extends BaseReport {
   readonly healthy: boolean;
-<<<<<<< HEAD
-=======
-  readonly severity: HealthSeverity;
-  readonly warnings: readonly string[];
-  readonly dismissed: boolean;
->>>>>>> origin/main
   readonly body: string;
   readonly code: number;
 }
@@ -2455,13 +2404,6 @@ export interface WebsocketReport extends BaseReport {
 // From healthsdk/healthsdk.go
 export interface WorkspaceProxyReport extends BaseReport {
   readonly healthy: boolean;
-<<<<<<< HEAD
-=======
-  readonly severity: HealthSeverity;
-  readonly warnings: readonly HealthMessage[];
-  readonly dismissed: boolean;
-  readonly error?: string;
->>>>>>> origin/main
   readonly workspace_proxies: RegionsResponse<WorkspaceProxy>;
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2282,8 +2282,8 @@ export type RegionTypes = Region | WorkspaceProxy;
 // The code below is generated from codersdk/healthsdk.
 
 // From healthsdk/healthsdk.go
-export interface AccessURLReport {
-  readonly BaseReport: BaseReport;
+export interface AccessURLReport extends BaseReport {
+  readonly healthy: boolean;
   readonly access_url: string;
   readonly reachable: boolean;
   readonly status_code: number;
@@ -2292,7 +2292,6 @@ export interface AccessURLReport {
 
 // From healthsdk/healthsdk.go
 export interface BaseReport {
-  readonly healthy: boolean;
   readonly error?: string;
   readonly severity: HealthSeverity;
   readonly warnings: HealthMessage[];
@@ -2300,8 +2299,8 @@ export interface BaseReport {
 }
 
 // From healthsdk/healthsdk.go
-export interface DERPHealthReport {
-  readonly BaseReport: BaseReport;
+export interface DERPHealthReport extends BaseReport {
+  readonly healthy: boolean;
   readonly regions: Record<number, DERPRegionReport>;
   // Named type "tailscale.com/net/netcheck.Report" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
@@ -2312,7 +2311,10 @@ export interface DERPHealthReport {
 
 // From healthsdk/healthsdk.go
 export interface DERPNodeReport {
-  readonly BaseReport: BaseReport;
+  readonly healthy: boolean;
+  readonly severity: HealthSeverity;
+  readonly warnings: HealthMessage[];
+  readonly error?: string;
   // Named type "tailscale.com/tailcfg.DERPNode" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly node?: any;
@@ -2330,7 +2332,10 @@ export interface DERPNodeReport {
 
 // From healthsdk/healthsdk.go
 export interface DERPRegionReport {
-  readonly BaseReport: BaseReport;
+  readonly healthy: boolean;
+  readonly severity: HealthSeverity;
+  readonly warnings: HealthMessage[];
+  readonly error?: string;
   // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly region?: any;
@@ -2338,8 +2343,8 @@ export interface DERPRegionReport {
 }
 
 // From healthsdk/healthsdk.go
-export interface DatabaseReport {
-  readonly BaseReport: BaseReport;
+export interface DatabaseReport extends BaseReport {
+  readonly healthy: boolean;
   readonly reachable: boolean;
   readonly latency: string;
   readonly latency_ms: number;
@@ -2367,8 +2372,7 @@ export interface HealthcheckReport {
 }
 
 // From healthsdk/healthsdk.go
-export interface ProvisionerDaemonsReport {
-  readonly BaseReport: BaseReport;
+export interface ProvisionerDaemonsReport extends BaseReport {
   readonly items: ProvisionerDaemonsReportItem[];
 }
 
@@ -2391,15 +2395,15 @@ export interface UpdateHealthSettings {
 }
 
 // From healthsdk/healthsdk.go
-export interface WebsocketReport {
-  readonly BaseReport: BaseReport;
+export interface WebsocketReport extends BaseReport {
+  readonly healthy: boolean;
   readonly body: string;
   readonly code: number;
 }
 
 // From healthsdk/healthsdk.go
-export interface WorkspaceProxyReport {
-  readonly BaseReport: BaseReport;
+export interface WorkspaceProxyReport extends BaseReport {
+  readonly healthy: boolean;
   readonly workspace_proxies: RegionsResponse<WorkspaceProxy>;
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2283,37 +2283,36 @@ export type RegionTypes = Region | WorkspaceProxy;
 
 // From healthsdk/healthsdk.go
 export interface AccessURLReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
-  readonly dismissed: boolean;
+  readonly BaseReport: BaseReport;
   readonly access_url: string;
   readonly reachable: boolean;
   readonly status_code: number;
   readonly healthz_response: string;
+}
+
+// From healthsdk/healthsdk.go
+export interface BaseReport {
+  readonly healthy: boolean;
   readonly error?: string;
+  readonly severity: HealthSeverity;
+  readonly warnings: HealthMessage[];
+  readonly dismissed: boolean;
 }
 
 // From healthsdk/healthsdk.go
 export interface DERPHealthReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
-  readonly dismissed: boolean;
+  readonly BaseReport: BaseReport;
   readonly regions: Record<number, DERPRegionReport>;
   // Named type "tailscale.com/net/netcheck.Report" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly netcheck?: any;
   readonly netcheck_err?: string;
   readonly netcheck_logs: string[];
-  readonly error?: string;
 }
 
 // From healthsdk/healthsdk.go
 export interface DERPNodeReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
+  readonly BaseReport: BaseReport;
   // Named type "tailscale.com/tailcfg.DERPNode" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly node?: any;
@@ -2326,33 +2325,25 @@ export interface DERPNodeReport {
   readonly uses_websocket: boolean;
   readonly client_logs: string[][];
   readonly client_errs: string[][];
-  readonly error?: string;
   readonly stun: STUNReport;
 }
 
 // From healthsdk/healthsdk.go
 export interface DERPRegionReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
+  readonly BaseReport: BaseReport;
   // Named type "tailscale.com/tailcfg.DERPRegion" unknown, using "any"
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- External type
   readonly region?: any;
   readonly node_reports: DERPNodeReport[];
-  readonly error?: string;
 }
 
 // From healthsdk/healthsdk.go
 export interface DatabaseReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
-  readonly dismissed: boolean;
+  readonly BaseReport: BaseReport;
   readonly reachable: boolean;
   readonly latency: string;
   readonly latency_ms: number;
   readonly threshold_ms: number;
-  readonly error?: string;
 }
 
 // From healthsdk/healthsdk.go
@@ -2377,10 +2368,7 @@ export interface HealthcheckReport {
 
 // From healthsdk/healthsdk.go
 export interface ProvisionerDaemonsReport {
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
-  readonly dismissed: boolean;
-  readonly error?: string;
+  readonly BaseReport: BaseReport;
   readonly items: ProvisionerDaemonsReportItem[];
 }
 
@@ -2404,22 +2392,14 @@ export interface UpdateHealthSettings {
 
 // From healthsdk/healthsdk.go
 export interface WebsocketReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: string[];
-  readonly dismissed: boolean;
+  readonly BaseReport: BaseReport;
   readonly body: string;
   readonly code: number;
-  readonly error?: string;
 }
 
 // From healthsdk/healthsdk.go
 export interface WorkspaceProxyReport {
-  readonly healthy: boolean;
-  readonly severity: HealthSeverity;
-  readonly warnings: HealthMessage[];
-  readonly dismissed: boolean;
-  readonly error?: string;
+  readonly BaseReport: BaseReport;
   readonly workspace_proxies: RegionsResponse<WorkspaceProxy>;
 }
 

--- a/site/src/pages/HealthPage/WebsocketPage.tsx
+++ b/site/src/pages/HealthPage/WebsocketPage.tsx
@@ -41,8 +41,8 @@ export const WebsocketPage = () => {
 
         {websocket.warnings.map((warning) => {
           return (
-            <Alert key={warning} severity="warning">
-              {warning}
+            <Alert key={warning.code} severity="warning">
+              {warning.message}
             </Alert>
           );
         })}


### PR DESCRIPTION
(From comment in https://github.com/coder/coder/pull/12951#discussion_r1565384132)
This PR modifies the `support bundle` command to dump a summary of deployment health and the CLI netcheck to stdout, when run:

```
$ go run ./cmd/coder rsupport bundle nonix --yes --output-file ~/tmp/coder-support.zip
Running inside Coder workspace; this can affect results!
WARN: Deployment health issues detected:
  | Workspace Proxies: Warn: EWP04: unhealthy: request to proxy failed: Get "http://127.0.0.1:3001/healthz-report": dial tcp 127.0.0.1:3001: connect: connection refused
Wrote support bundle to /home/coder/tmp/coder-support.zip
```

Note: I introduced the `BaseReport` as a way to avoid writing five or six different `Summarize()` methods.