### PR TITLE
chore(docs): make external auth docs easier to follow

### DIFF
--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -28,7 +28,7 @@ application. The following providers are supported:
 The next step is to [configure the Coder server](./configure.md) to use the OAuth application by setting the following environment variables:
 
 ```env
-CODER_EXTERNAL_AUTH_0_ID="USER_DEFINED_ID"
+CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>"
 CODER_EXTERNAL_AUTH_0_TYPE=<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>
 CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
 CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -25,7 +25,8 @@ application. The following providers are supported:
 - [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops)
 - [Azure DevOps (via Entra ID)](https://learn.microsoft.com/en-us/entra/architecture/auth-oauth2)
 
-The next step is to [configure the Coder server](./configure.md) to use the OAuth application by setting the following environment variables:
+The next step is to [configure the Coder server](./configure.md) to use the
+OAuth application by setting the following environment variables:
 
 ```env
 CODER_EXTERNAL_AUTH_0_ID="<USER_DEFINED_ID>"
@@ -38,18 +39,22 @@ CODER_EXTERNAL_AUTH_0_DISPLAY_NAME="Google Calendar"
 CODER_EXTERNAL_AUTH_0_DISPLAY_ICON="https://mycustomicon.com/google.svg"
 ```
 
-The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your GitHub provider).
+The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
+reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
+GitHub provider).
 
 
 ### GitHub
 
-> If you don't require fine-grained access control, it's easier to configure a GitHub OAuth app!
+> If you don't require fine-grained access control, it's easier to configure a
+> GitHub OAuth app!
 
 1. [Create a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app)
-    * Set the callback URL to `https://coder.example.com/external-auth/USER_DEFINED_ID/callback`.
-    * Deactivate Webhooks.
-    * Enable fine-grained access to specific repositories or a subset of
-   permissions for security.
+    - Set the callback URL to
+      `https://coder.example.com/external-auth/USER_DEFINED_ID/callback`.
+    - Deactivate Webhooks.
+    - Enable fine-grained access to specific repositories or a subset of
+      permissions for security.
 
    ![Register GitHub App](../images/admin/github-app-register.png)
 
@@ -215,7 +220,9 @@ git config --global credential.useHttpPath true
 
 ### Kubernetes environment variables
 
-If you deployed Coder with Kubernetes you can set the environment variables in your `values.yaml` file:
+If you deployed Coder with Kubernetes you can set the environment variables in
+your `values.yaml` file:
+
 ```yaml
 coder:
   env:
@@ -239,7 +246,8 @@ coder:
           key: client-secret
 ```
 
-You can set the secrets by creating a `github-primary-basic-auth.yaml` file and applying it.
+You can set the secrets by creating a `github-primary-basic-auth.yaml` file and
+applying it.
 
 ```yaml
 apiVersion: v1

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -43,18 +43,18 @@ The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal
 reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your
 GitHub provider).
 
-
 ### GitHub
 
 > If you don't require fine-grained access control, it's easier to configure a
 > GitHub OAuth app!
 
 1. [Create a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app)
-    - Set the callback URL to
-      `https://coder.example.com/external-auth/USER_DEFINED_ID/callback`.
-    - Deactivate Webhooks.
-    - Enable fine-grained access to specific repositories or a subset of
-      permissions for security.
+
+   - Set the callback URL to
+     `https://coder.example.com/external-auth/USER_DEFINED_ID/callback`.
+   - Deactivate Webhooks.
+   - Enable fine-grained access to specific repositories or a subset of
+     permissions for security.
 
    ![Register GitHub App](../images/admin/github-app-register.png)
 

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -25,16 +25,11 @@ application. The following providers are supported:
 - [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops)
 - [Azure DevOps (via Entra ID)](https://learn.microsoft.com/en-us/entra/architecture/auth-oauth2)
 
-Example callback URL:
-`https://coder.example.com/external-auth/primary-github/callback`. Use an
-arbitrary ID for your provider (e.g. `primary-github`).
-
-Set the following environment variables to
-[configure the Coder server](./configure.md):
+The next step is to [configure the Coder server](./configure.md) to use the OAuth application by setting the following environment variables:
 
 ```env
-CODER_EXTERNAL_AUTH_0_ID="primary-github"
-CODER_EXTERNAL_AUTH_0_TYPE=github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|<name of service e.g. jfrog>
+CODER_EXTERNAL_AUTH_0_ID="USER_DEFINED"
+CODER_EXTERNAL_AUTH_0_TYPE=<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>
 CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
 CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
 
@@ -43,10 +38,17 @@ CODER_EXTERNAL_AUTH_0_DISPLAY_NAME="Google Calendar"
 CODER_EXTERNAL_AUTH_0_DISPLAY_ICON="https://mycustomicon.com/google.svg"
 ```
 
+The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal reference. Therefore, it can be set to an arbitrary ID (e.g., `primary-github` for your GitHub provider).
+
+
 ### GitHub
 
+> If you don't fined-grained control you can configure a GitHub OAuth app, which is less overhead.
+
 1. [Create a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app)
-   to enable fine-grained access to specific repositories, or a subset of
+    * Set the callback URL to `https://coder.example.com/external-auth/primary-github/callback`.
+    * Deactivate Webhooks.
+    * Enable fine-grained access to specific repositories or a subset of
    permissions for security.
 
    ![Register GitHub App](../images/admin/github-app-register.png)
@@ -68,6 +70,13 @@ CODER_EXTERNAL_AUTH_0_DISPLAY_ICON="https://mycustomicon.com/google.svg"
    repositories to grant access to.
 
    ![Install GitHub App](../images/admin/github-app-install.png)
+
+```env
+CODER_EXTERNAL_AUTH_0_ID="primary-github"
+CODER_EXTERNAL_AUTH_0_TYPE=github
+CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
+CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
+```
 
 ### GitHub Enterprise
 
@@ -203,6 +212,47 @@ add this to the
 ```shell
 git config --global credential.useHttpPath true
 ```
+
+### Kubernetes environment variables
+
+If you deployed Coder with Kubernetes you can set the environment variables in your `values.yaml` file:
+```yaml
+coder:
+  env:
+    # […]
+    - name: CODER_EXTERNAL_AUTH_0_ID
+      value: primary-github
+
+    - name: CODER_EXTERNAL_AUTH_0_TYPE
+      value: github
+
+    - name: CODER_EXTERNAL_AUTH_0_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: github-primary-basic-auth
+          key: client-id
+
+    - name: CODER_EXTERNAL_AUTH_0_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: github-primary-basic-auth
+          key: client-secret
+```
+
+You can set the secrets by creating a `github-primary-basic-auth.yaml` file and applying it.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-primary-basic-auth
+type: Opaque
+stringData:
+  client-secret: xxxxxxxxx
+  client-id: xxxxxxxxx
+```
+
+Make sure to restart the affected pods for the change to take effect.
 
 ## Require git authentication in templates
 

--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -28,7 +28,7 @@ application. The following providers are supported:
 The next step is to [configure the Coder server](./configure.md) to use the OAuth application by setting the following environment variables:
 
 ```env
-CODER_EXTERNAL_AUTH_0_ID="USER_DEFINED"
+CODER_EXTERNAL_AUTH_0_ID="USER_DEFINED_ID"
 CODER_EXTERNAL_AUTH_0_TYPE=<github|gitlab|azure-devops|bitbucket-cloud|bitbucket-server|etc>
 CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
 CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
@@ -38,15 +38,15 @@ CODER_EXTERNAL_AUTH_0_DISPLAY_NAME="Google Calendar"
 CODER_EXTERNAL_AUTH_0_DISPLAY_ICON="https://mycustomicon.com/google.svg"
 ```
 
-The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal reference. Therefore, it can be set to an arbitrary ID (e.g., `primary-github` for your GitHub provider).
+The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal reference. Therefore, it can be set arbitrarily (e.g., `primary-github` for your GitHub provider).
 
 
 ### GitHub
 
-> If you don't fined-grained control you can configure a GitHub OAuth app, which is less overhead.
+> If you don't require fine-grained access control, it's easier to configure a GitHub OAuth app!
 
 1. [Create a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app)
-    * Set the callback URL to `https://coder.example.com/external-auth/primary-github/callback`.
+    * Set the callback URL to `https://coder.example.com/external-auth/USER_DEFINED_ID/callback`.
     * Deactivate Webhooks.
     * Enable fine-grained access to specific repositories or a subset of
    permissions for security.
@@ -72,7 +72,7 @@ The `CODER_EXTERNAL_AUTH_0_ID` environment variable is used for internal referen
    ![Install GitHub App](../images/admin/github-app-install.png)
 
 ```env
-CODER_EXTERNAL_AUTH_0_ID="primary-github"
+CODER_EXTERNAL_AUTH_0_ID="USER_DEFINED_ID"
 CODER_EXTERNAL_AUTH_0_TYPE=github
 CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
 CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
@@ -221,7 +221,7 @@ coder:
   env:
     # […]
     - name: CODER_EXTERNAL_AUTH_0_ID
-      value: primary-github
+      value: USER_DEFINED_ID
 
     - name: CODER_EXTERNAL_AUTH_0_TYPE
       value: github


### PR DESCRIPTION
I was working with @ericpaulsen on setting up Coder. I found the external auth documentation confusing for a first-time reader, so I changed the docs a tiny bit to make it easier to follow.

I also added a k8s environment variable setup section because converting the environment variable to the k8s environment variables was annoying. Now, it can be copy and pasted.

@ericpaulsen, In our call you mentioned that you prefer using GitHub OAuth applications for external auth. Would you like me to switch the docs to use the OAuth application setup proccess instead of the GitHub App one?