### PR TITLE
chore: give additional time in tests for `tailnetAPIConnector` graceful disconnect

### DIFF
--- a/codersdk/workspacesdk/connector.go
+++ b/codersdk/workspacesdk/connector.go
@@ -20,6 +20,8 @@ import (
 	"github.com/coder/retry"
 )
 
+var tailnetConnectorGracefulTimeout = time.Second
+
 // tailnetConn is the subset of the tailnet.Conn methods that tailnetAPIConnector uses.  It is
 // included so that we can fake it in testing.
 //
@@ -86,7 +88,7 @@ func runTailnetAPIConnector(
 func (tac *tailnetAPIConnector) manageGracefulTimeout() {
 	defer tac.cancelGracefulCtx()
 	<-tac.ctx.Done()
-	timer := time.NewTimer(time.Second)
+	timer := time.NewTimer(tailnetConnectorGracefulTimeout)
 	defer timer.Stop()
 	select {
 	case <-tac.closed:

--- a/codersdk/workspacesdk/connector_internal_test.go
+++ b/codersdk/workspacesdk/connector_internal_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+func init() {
+	// Give tests a bit more time to timeout. Darwin is particularly slow.
+	tailnetConnectorGracefulTimeout = 5 * time.Second
+}
+
 func TestTailnetAPIConnector_Disconnects(t *testing.T) {
 	t.Parallel()
 	testCtx := testutil.Context(t, testutil.WaitShort)


### PR DESCRIPTION
Failure seen here: https://github.com/coder/coder/actions/runs/8711258577/job/23894964182?pr=12979