### PR TITLE
test(site): add e2e tests for observability

### DIFF
--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -91,6 +91,13 @@ export async function verifyConfigFlagString(
   await expect(configOption).toHaveText(opt.value);
 }
 
+export async function verifyConfigFlagEmpty(page: Page, flag: string) {
+  const configOption = page.locator(
+    `div.options-table .option-${flag} .option-value-empty`,
+  );
+  await expect(configOption).toHaveText("Not set");
+}
+
 export async function verifyConfigFlagArray(
   page: Page,
   config: API.DeploymentConfig,

--- a/site/e2e/tests/deployment/network.spec.ts
+++ b/site/e2e/tests/deployment/network.spec.ts
@@ -9,7 +9,7 @@ import {
   verifyConfigFlagString,
 } from "../../api";
 
-test("login with OIDC", async ({ page }) => {
+test("enabled network settings", async ({ page }) => {
   await setupApiCalls(page);
   const config = await getDeploymentConfig();
 

--- a/site/e2e/tests/deployment/observability.spec.ts
+++ b/site/e2e/tests/deployment/observability.spec.ts
@@ -1,0 +1,39 @@
+import { test } from "@playwright/test";
+import { getDeploymentConfig } from "api/api";
+import {
+  setupApiCalls,
+  verifyConfigFlagArray,
+  verifyConfigFlagBoolean,
+  verifyConfigFlagDuration,
+  verifyConfigFlagEmpty,
+  verifyConfigFlagString,
+} from "../../api";
+
+test("enabled observability settings", async ({ page }) => {
+  await setupApiCalls(page);
+  const config = await getDeploymentConfig();
+
+  await page.goto("/deployment/observability", {
+    waitUntil: "domcontentloaded",
+  });
+
+  await verifyConfigFlagBoolean(page, config, "trace-logs");
+  await verifyConfigFlagBoolean(page, config, "enable-terraform-debug-mode");
+  await verifyConfigFlagBoolean(page, config, "enable-terraform-debug-mode");
+  await verifyConfigFlagDuration(page, config, "health-check-refresh");
+  await verifyConfigFlagEmpty(page, "health-check-threshold-database");
+  await verifyConfigFlagString(page, config, "log-human");
+  await verifyConfigFlagString(page, config, "prometheus-address");
+  await verifyConfigFlagArray(
+    page,
+    config,
+    "prometheus-aggregate-agent-stats-by",
+  );
+  await verifyConfigFlagBoolean(page, config, "prometheus-collect-agent-stats");
+  await verifyConfigFlagBoolean(page, config, "prometheus-collect-db-metrics");
+  await verifyConfigFlagBoolean(page, config, "prometheus-enable");
+  await verifyConfigFlagBoolean(page, config, "trace-datadog");
+  await verifyConfigFlagBoolean(page, config, "trace");
+  await verifyConfigFlagBoolean(page, config, "verbose");
+  await verifyConfigFlagBoolean(page, config, "pprof-enable");
+});


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/12508

This quick PR covers config flags on the _Deployment_ / _Observability_ page.