### PR TITLE
chore: fix broken mainline link

### DIFF
--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -8,9 +8,10 @@ their infrastructure on a staging environment before upgrading a production
 deployment.
 
 We support two release channels:
-[mainline](https://github.com/coder/coder/releases/tag/v2.10.1) for the edge version 
-of Coder and [stable](https://github.com/coder/coder/releases/latest) for those with
-lower tolerance for fault. We field our mainline releases publicly for one month
+[mainline](https://github.com/coder/coder/releases/tag/v2.10.1) for the bleeding
+edge version of Coder and
+[stable](https://github.com/coder/coder/releases/latest) for those with lower
+tolerance for fault. We field our mainline releases publicly for one month
 before promoting them to stable.
 
 ### Mainline releases

--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -8,8 +8,8 @@ their infrastructure on a staging environment before upgrading a production
 deployment.
 
 We support two release channels:
-[mainline](https://github.com/coder/coder/releases/tag/v2.10.1) for the edge version of Coder
-and [stable](https://github.com/coder/coder/releases/latest) for those with
+[mainline](https://github.com/coder/coder/releases/tag/v2.10.1) for the edge version 
+of Coder and [stable](https://github.com/coder/coder/releases/latest) for those with
 lower tolerance for fault. We field our mainline releases publicly for one month
 before promoting them to stable.
 

--- a/docs/install/releases.md
+++ b/docs/install/releases.md
@@ -8,7 +8,7 @@ their infrastructure on a staging environment before upgrading a production
 deployment.
 
 We support two release channels:
-[mainline](https://github.com/coder/coder/2.10.0) for the edge version of Coder
+[mainline](https://github.com/coder/coder/releases/tag/v2.10.1) for the edge version of Coder
 and [stable](https://github.com/coder/coder/releases/latest) for those with
 lower tolerance for fault. We field our mainline releases publicly for one month
 before promoting them to stable.

--- a/x.sh
+++ b/x.sh
@@ -1,5 +1,0 @@
-version="2.1"
-if [ -z "$version" ]; then
-   echo "Failed to fetch the latest version from GitHub."
-   exit 1
-fi

--- a/x.sh
+++ b/x.sh
@@ -1,0 +1,5 @@
+version="2.1"
+if [ -z "$version" ]; then
+   echo "Failed to fetch the latest version from GitHub."
+   exit 1
+fi


### PR DESCRIPTION
Fixes 404 when clicking on the `mainline` link

<img width="877" alt="Screenshot 2024-04-19 at 7 47 26 PM" src="https://github.com/coder/coder/assets/5442469/b83d42ae-c944-41c3-afca-7982dd586330">
