### PR TITLE
chore: fix link to install

### DIFF
--- a/docs/guides/support-bundle.md
+++ b/docs/guides/support-bundle.md
@@ -59,7 +59,7 @@ A brief overview of all files contained in the bundle is provided below:
    requires the Coder deployment to be available.
 
 2. Ensure you have the Coder CLI installed on a local machine. See
-   (installation)[../install/index.md] for steps on how to do this.
+   [installation](../install/index.md) for steps on how to do this.
 
    > Note: It is recommended to generate a support bundle from a location
    > experiencing workspace connectivity issues.


### PR DESCRIPTION
Guided uses invalid like to the installation guide. This pull request fixes this.

I would also point to example usages for the CLI: [support bundle](https://coder.com/docs/v2/latest/cli/support_bundle)