### PR TITLE
chore(docs): add note regarding vcredist for embedded postgres

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -24,6 +24,9 @@ alternate installation methods (e.g. standalone binaries, system packages).
 
 ## Windows
 
+> **Important:** If you plan to use the built-in PostgreSQL database, you will need to ensure that the 
+> [Visual C++ Runtime](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist#latest-microsoft-visual-c-redistributable-version) is installed.
+
 Use [GitHub releases](https://github.com/coder/coder/releases) to download the
 Windows installer (`.msi`) or standalone binary (`.exe`).
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -24,8 +24,10 @@ alternate installation methods (e.g. standalone binaries, system packages).
 
 ## Windows
 
-> **Important:** If you plan to use the built-in PostgreSQL database, you will need to ensure that the 
-> [Visual C++ Runtime](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist#latest-microsoft-visual-c-redistributable-version) is installed.
+> **Important:** If you plan to use the built-in PostgreSQL database, you will
+> need to ensure that the
+> [Visual C++ Runtime](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist#latest-microsoft-visual-c-redistributable-version)
+> is installed.
 
 Use [GitHub releases](https://github.com/coder/coder/releases) to download the
 Windows installer (`.msi`) or standalone binary (`.exe`).


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/13010

Adds a note regarding vcredist. Some Windows cloud images do not ship with this pre-installed.