### PR TITLE
chore: reduce dashboard requests from seeded data

### DIFF
--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -6,22 +6,19 @@ import { getMetadataAsJSON } from "utils/metadata";
 const initialAppearanceData = getMetadataAsJSON<AppearanceConfig>("appearance");
 const appearanceConfigKey = ["appearance"] as const;
 
-export const appearance = () => {
-  const opts: UseQueryOptions<AppearanceConfig> = {
+export const appearance = (): UseQueryOptions<AppearanceConfig> => {
+  return {
+    // We either have our initial data or should immediately
+    // fetch and never again!
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
     queryKey: ["appearance"],
     initialData: initialAppearanceData,
     queryFn: () => API.getAppearance(),
   };
-  // If we have initial appearance data, we don't want to fetch
-  // the user again. We already have it!
-  if (initialAppearanceData) {
-    opts.cacheTime = Infinity;
-    opts.staleTime = Infinity;
-    opts.refetchOnMount = false;
-    opts.refetchOnReconnect = false;
-    opts.refetchOnWindowFocus = false;
-  }
-  return opts;
 };
 
 export const updateAppearance = (queryClient: QueryClient) => {

--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -6,12 +6,22 @@ import { getMetadataAsJSON } from "utils/metadata";
 const initialAppearanceData = getMetadataAsJSON<AppearanceConfig>("appearance");
 const appearanceConfigKey = ["appearance"] as const;
 
-export const appearance = (): UseQueryOptions<AppearanceConfig> => {
-  return {
+export const appearance = () => {
+  const opts: UseQueryOptions<AppearanceConfig> = {
     queryKey: ["appearance"],
     initialData: initialAppearanceData,
     queryFn: () => API.getAppearance(),
   };
+  // If we have initial appearance data, we don't want to fetch
+  // the user again. We already have it!
+  if (initialAppearanceData) {
+    opts.cacheTime = Infinity;
+    opts.staleTime = Infinity;
+    opts.refetchOnMount = false;
+    opts.refetchOnReconnect = false;
+    opts.refetchOnWindowFocus = false;
+  }
+  return opts;
 };
 
 export const updateAppearance = (queryClient: QueryClient) => {

--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -2,6 +2,7 @@ import type { QueryClient, UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import type { AppearanceConfig } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
+import { cachedQuery } from "./util";
 
 const initialAppearanceData = getMetadataAsJSON<AppearanceConfig>("appearance");
 const appearanceConfigKey = ["appearance"] as const;
@@ -10,11 +11,7 @@ export const appearance = (): UseQueryOptions<AppearanceConfig> => {
   return {
     // We either have our initial data or should immediately
     // fetch and never again!
-    cacheTime: Infinity,
-    staleTime: Infinity,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+    ...cachedQuery,
     queryKey: ["appearance"],
     initialData: initialAppearanceData,
     queryFn: () => API.getAppearance(),

--- a/site/src/api/queries/appearance.ts
+++ b/site/src/api/queries/appearance.ts
@@ -11,9 +11,8 @@ export const appearance = (): UseQueryOptions<AppearanceConfig> => {
   return {
     // We either have our initial data or should immediately
     // fetch and never again!
-    ...cachedQuery,
+    ...cachedQuery(initialAppearanceData),
     queryKey: ["appearance"],
-    initialData: initialAppearanceData,
     queryFn: () => API.getAppearance(),
   };
 };

--- a/site/src/api/queries/buildInfo.ts
+++ b/site/src/api/queries/buildInfo.ts
@@ -6,20 +6,17 @@ import { getMetadataAsJSON } from "utils/metadata";
 const initialBuildInfoData = getMetadataAsJSON<BuildInfoResponse>("build-info");
 const buildInfoKey = ["buildInfo"] as const;
 
-export const buildInfo = () => {
-  const opts: UseQueryOptions<BuildInfoResponse> = {
+export const buildInfo = (): UseQueryOptions<BuildInfoResponse> => {
+  return {
+    // We either have our initial data or should immediately
+    // fetch and never again!
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
     queryKey: buildInfoKey,
     initialData: initialBuildInfoData,
     queryFn: () => API.getBuildInfo(),
   };
-  // If we have initial build info data, we don't want to fetch
-  // the user again. We already have it!
-  if (initialBuildInfoData) {
-    opts.cacheTime = Infinity;
-    opts.staleTime = Infinity;
-    opts.refetchOnMount = false;
-    opts.refetchOnReconnect = false;
-    opts.refetchOnWindowFocus = false;
-  }
-  return opts;
 };

--- a/site/src/api/queries/buildInfo.ts
+++ b/site/src/api/queries/buildInfo.ts
@@ -6,10 +6,20 @@ import { getMetadataAsJSON } from "utils/metadata";
 const initialBuildInfoData = getMetadataAsJSON<BuildInfoResponse>("build-info");
 const buildInfoKey = ["buildInfo"] as const;
 
-export const buildInfo = (): UseQueryOptions<BuildInfoResponse> => {
-  return {
+export const buildInfo = () => {
+  const opts: UseQueryOptions<BuildInfoResponse> = {
     queryKey: buildInfoKey,
     initialData: initialBuildInfoData,
     queryFn: () => API.getBuildInfo(),
   };
+  // If we have initial build info data, we don't want to fetch
+  // the user again. We already have it!
+  if (initialBuildInfoData) {
+    opts.cacheTime = Infinity;
+    opts.staleTime = Infinity;
+    opts.refetchOnMount = false;
+    opts.refetchOnReconnect = false;
+    opts.refetchOnWindowFocus = false;
+  }
+  return opts;
 };

--- a/site/src/api/queries/buildInfo.ts
+++ b/site/src/api/queries/buildInfo.ts
@@ -2,6 +2,7 @@ import type { UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import type { BuildInfoResponse } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
+import { cachedQuery } from "./util";
 
 const initialBuildInfoData = getMetadataAsJSON<BuildInfoResponse>("build-info");
 const buildInfoKey = ["buildInfo"] as const;
@@ -10,11 +11,7 @@ export const buildInfo = (): UseQueryOptions<BuildInfoResponse> => {
   return {
     // We either have our initial data or should immediately
     // fetch and never again!
-    cacheTime: Infinity,
-    staleTime: Infinity,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+    ...cachedQuery,
     queryKey: buildInfoKey,
     initialData: initialBuildInfoData,
     queryFn: () => API.getBuildInfo(),

--- a/site/src/api/queries/buildInfo.ts
+++ b/site/src/api/queries/buildInfo.ts
@@ -11,9 +11,8 @@ export const buildInfo = (): UseQueryOptions<BuildInfoResponse> => {
   return {
     // We either have our initial data or should immediately
     // fetch and never again!
-    ...cachedQuery,
+    ...cachedQuery(initialBuildInfoData),
     queryKey: buildInfoKey,
-    initialData: initialBuildInfoData,
     queryFn: () => API.getBuildInfo(),
   };
 };

--- a/site/src/api/queries/entitlements.ts
+++ b/site/src/api/queries/entitlements.ts
@@ -9,10 +9,9 @@ const entitlementsQueryKey = ["entitlements"] as const;
 
 export const entitlements = (): UseQueryOptions<Entitlements> => {
   return {
-    ...cachedQuery,
+    ...cachedQuery(initialEntitlementsData),
     queryKey: entitlementsQueryKey,
     queryFn: () => API.getEntitlements(),
-    initialData: initialEntitlementsData,
   };
 };
 

--- a/site/src/api/queries/entitlements.ts
+++ b/site/src/api/queries/entitlements.ts
@@ -5,12 +5,12 @@ import { getMetadataAsJSON } from "utils/metadata";
 import { cachedQuery } from "./util";
 
 const initialEntitlementsData = getMetadataAsJSON<Entitlements>("entitlements");
-const ENTITLEMENTS_QUERY_KEY = ["entitlements"] as const;
+const entitlementsQueryKey = ["entitlements"] as const;
 
 export const entitlements = (): UseQueryOptions<Entitlements> => {
   return {
     ...cachedQuery,
-    queryKey: ENTITLEMENTS_QUERY_KEY,
+    queryKey: entitlementsQueryKey,
     queryFn: () => API.getEntitlements(),
     initialData: initialEntitlementsData,
   };
@@ -21,7 +21,7 @@ export const refreshEntitlements = (queryClient: QueryClient) => {
     mutationFn: API.refreshEntitlements,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ENTITLEMENTS_QUERY_KEY,
+        queryKey: entitlementsQueryKey,
       });
     },
   };

--- a/site/src/api/queries/entitlements.ts
+++ b/site/src/api/queries/entitlements.ts
@@ -2,12 +2,14 @@ import type { QueryClient, UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import type { Entitlements } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
+import { cachedQuery } from "./util"
 
 const initialEntitlementsData = getMetadataAsJSON<Entitlements>("entitlements");
 const ENTITLEMENTS_QUERY_KEY = ["entitlements"] as const;
 
 export const entitlements = (): UseQueryOptions<Entitlements> => {
   return {
+    ...cachedQuery,
     queryKey: ENTITLEMENTS_QUERY_KEY,
     queryFn: () => API.getEntitlements(),
     initialData: initialEntitlementsData,

--- a/site/src/api/queries/entitlements.ts
+++ b/site/src/api/queries/entitlements.ts
@@ -2,7 +2,7 @@ import type { QueryClient, UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import type { Entitlements } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
-import { cachedQuery } from "./util"
+import { cachedQuery } from "./util";
 
 const initialEntitlementsData = getMetadataAsJSON<Entitlements>("entitlements");
 const ENTITLEMENTS_QUERY_KEY = ["entitlements"] as const;

--- a/site/src/api/queries/experiments.ts
+++ b/site/src/api/queries/experiments.ts
@@ -9,9 +9,8 @@ const experimentsKey = ["experiments"] as const;
 
 export const experiments = (): UseQueryOptions<Experiments> => {
   return {
-    ...cachedQuery,
+    ...cachedQuery(initialExperimentsData),
     queryKey: experimentsKey,
-    initialData: initialExperimentsData,
     queryFn: () => API.getExperiments(),
   } satisfies UseQueryOptions<Experiments>;
 };

--- a/site/src/api/queries/experiments.ts
+++ b/site/src/api/queries/experiments.ts
@@ -2,12 +2,14 @@ import type { UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import type { Experiments } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
+import { cachedQuery } from "./util"
 
 const initialExperimentsData = getMetadataAsJSON<Experiments>("experiments");
 const experimentsKey = ["experiments"] as const;
 
 export const experiments = (): UseQueryOptions<Experiments> => {
   return {
+    ...cachedQuery,
     queryKey: experimentsKey,
     initialData: initialExperimentsData,
     queryFn: () => API.getExperiments(),

--- a/site/src/api/queries/experiments.ts
+++ b/site/src/api/queries/experiments.ts
@@ -2,7 +2,7 @@ import type { UseQueryOptions } from "react-query";
 import * as API from "api/api";
 import type { Experiments } from "api/typesGenerated";
 import { getMetadataAsJSON } from "utils/metadata";
-import { cachedQuery } from "./util"
+import { cachedQuery } from "./util";
 
 const initialExperimentsData = getMetadataAsJSON<Experiments>("experiments");
 const experimentsKey = ["experiments"] as const;

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -130,11 +130,8 @@ export const me = (): UseQueryOptions<User> & {
   queryKey: QueryKey;
 } => {
   return {
-    // We either have our initial data or should immediately
-    // fetch and never again!
-    ...cachedQuery,
+    ...cachedQuery(initialUserData),
     queryKey: meKey,
-    initialData: initialUserData,
     queryFn: API.getAuthenticatedUser,
   };
 };
@@ -148,11 +145,8 @@ export function apiKey(): UseQueryOptions<GenerateAPIKeyResponse> {
 
 export const hasFirstUser = (): UseQueryOptions<boolean> => {
   return {
-    // If there is initial user data, we don't want to make
-    // this request. It's a waste!
-    ...cachedQuery,
     // This cannot be false otherwise it will not fetch!
-    initialData: typeof initialUserData !== "undefined" ? true : undefined,
+    ...cachedQuery(typeof initialUserData !== "undefined" ? true : undefined),
     queryKey: ["hasFirstUser"],
     queryFn: API.hasFirstUser,
   };

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -19,6 +19,7 @@ import type { UsePaginatedQueryOptions } from "hooks/usePaginatedQuery";
 import { prepareQuery } from "utils/filters";
 import { getMetadataAsJSON } from "utils/metadata";
 import { getAuthorizationKey } from "./authCheck";
+import { cachedQuery } from "./util";
 
 export function usersKey(req: UsersRequest) {
   return ["users", req] as const;
@@ -131,11 +132,7 @@ export const me = (): UseQueryOptions<User> & {
   return {
     // We either have our initial data or should immediately
     // fetch and never again!
-    cacheTime: Infinity,
-    staleTime: Infinity,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+    ...cachedQuery,
     queryKey: meKey,
     initialData: initialUserData,
     queryFn: API.getAuthenticatedUser,
@@ -153,11 +150,7 @@ export const hasFirstUser = (): UseQueryOptions<boolean> => {
   return {
     // If there is initial user data, we don't want to make
     // this request. It's a waste!
-    cacheTime: Infinity,
-    staleTime: Infinity,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+    ...cachedQuery,
     // This cannot be false otherwise it will not fetch!
     initialData: typeof initialUserData !== "undefined" ? true : undefined,
     queryKey: ["hasFirstUser"],

--- a/site/src/api/queries/users.ts
+++ b/site/src/api/queries/users.ts
@@ -125,24 +125,21 @@ export const authMethods = () => {
 
 const meKey = ["me"];
 
-export const me = () => {
-  const opts: UseQueryOptions<User> & {
-    queryKey: QueryKey;
-  } = {
+export const me = (): UseQueryOptions<User> & {
+  queryKey: QueryKey;
+} => {
+  return {
+    // We either have our initial data or should immediately
+    // fetch and never again!
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
     queryKey: meKey,
     initialData: initialUserData,
     queryFn: API.getAuthenticatedUser,
   };
-  // If we have initial user data, we don't want to fetch
-  // the user again. We already have it!
-  if (initialUserData) {
-    opts.cacheTime = Infinity;
-    opts.staleTime = Infinity;
-    opts.refetchOnMount = false;
-    opts.refetchOnReconnect = false;
-    opts.refetchOnWindowFocus = false;
-  }
-  return opts;
 };
 
 export function apiKey(): UseQueryOptions<GenerateAPIKeyResponse> {
@@ -158,8 +155,11 @@ export const hasFirstUser = (): UseQueryOptions<boolean> => {
     // this request. It's a waste!
     cacheTime: Infinity,
     staleTime: Infinity,
-    initialData: Boolean(initialUserData),
-
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    // This cannot be false otherwise it will not fetch!
+    initialData: typeof initialUserData !== "undefined" ? true : undefined,
     queryKey: ["hasFirstUser"],
     queryFn: API.hasFirstUser,
   };

--- a/site/src/api/queries/util.ts
+++ b/site/src/api/queries/util.ts
@@ -1,0 +1,13 @@
+// cachedQuery allows the caller to only make a request
+// a single time, and use `initialData` if it is provided.
+//
+// This is particularly helpful for passing values injected
+// via metadata. We do this for the initial user fetch, buildinfo,
+// and a few others to reduce page load time.
+export const cachedQuery = {
+  cacheTime: Infinity,
+  staleTime: Infinity,
+  refetchOnMount: false,
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+};

--- a/site/src/api/queries/util.ts
+++ b/site/src/api/queries/util.ts
@@ -1,13 +1,23 @@
+import type { UseQueryOptions } from "react-query";
+
 // cachedQuery allows the caller to only make a request
 // a single time, and use `initialData` if it is provided.
 //
 // This is particularly helpful for passing values injected
 // via metadata. We do this for the initial user fetch, buildinfo,
 // and a few others to reduce page load time.
-export const cachedQuery = {
-  cacheTime: Infinity,
-  staleTime: Infinity,
-  refetchOnMount: false,
-  refetchOnReconnect: false,
-  refetchOnWindowFocus: false,
-};
+export const cachedQuery = <T>(initialData?: T): Partial<UseQueryOptions<T>> =>
+  // Only do this if there is initial data,
+  // otherwise it can conflict with tests.
+  initialData
+    ? {
+        cacheTime: Infinity,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        refetchOnWindowFocus: false,
+        initialData,
+      }
+    : {
+        initialData,
+      };

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   useState,
 } from "react";
-import { useQuery } from "react-query";
+import { type UseQueryOptions, useQuery } from "react-query";
 import { getWorkspaceProxies, getWorkspaceProxyRegions } from "api/api";
 import { cachedQuery } from "api/queries/util";
 import type { Region, WorkspaceProxy } from "api/typesGenerated";
@@ -132,12 +132,10 @@ export const ProxyProvider: FC<PropsWithChildren> = ({ children }) => {
     isLoading: proxiesLoading,
     isFetched: proxiesFetched,
   } = useQuery({
-    ...cachedQuery,
+    ...cachedQuery(initialData),
     queryKey,
     queryFn: query,
-    staleTime: initialData ? Infinity : undefined,
-    initialData,
-  });
+  } as UseQueryOptions<readonly Region[]>);
 
   // Every time we get a new proxiesResponse, update the latency check
   // to each workspace proxy.

--- a/site/src/contexts/ProxyContext.tsx
+++ b/site/src/contexts/ProxyContext.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { useQuery } from "react-query";
 import { getWorkspaceProxies, getWorkspaceProxyRegions } from "api/api";
+import { cachedQuery } from "api/queries/util";
 import type { Region, WorkspaceProxy } from "api/typesGenerated";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
 import { type ProxyLatencyReport, useProxyLatency } from "./useProxyLatency";
@@ -131,6 +132,7 @@ export const ProxyProvider: FC<PropsWithChildren> = ({ children }) => {
     isLoading: proxiesLoading,
     isFetched: proxiesFetched,
   } = useQuery({
+    ...cachedQuery,
     queryKey,
     queryFn: query,
     staleTime: initialData ? Infinity : undefined,

--- a/site/src/contexts/auth/AuthProvider.tsx
+++ b/site/src/contexts/auth/AuthProvider.tsx
@@ -9,18 +9,13 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { isApiError } from "api/errors";
 import { checkAuthorization } from "api/queries/authCheck";
 import {
-  authMethods,
   hasFirstUser,
   login,
   logout,
   me,
   updateProfile as updateProfileOptions,
 } from "api/queries/users";
-import type {
-  AuthMethods,
-  UpdateUserProfileRequest,
-  User,
-} from "api/typesGenerated";
+import type { UpdateUserProfileRequest, User } from "api/typesGenerated";
 import { displaySuccess } from "components/GlobalSnackbar/utils";
 import { permissionsToCheck, type Permissions } from "./permissions";
 
@@ -34,7 +29,6 @@ export type AuthContextValue = {
   isUpdatingProfile: boolean;
   user: User | undefined;
   permissions: Permissions | undefined;
-  authMethods: AuthMethods | undefined;
   organizationId: string | undefined;
   signInError: unknown;
   updateProfileError: unknown;
@@ -51,7 +45,6 @@ export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
   const queryClient = useQueryClient();
   const meOptions = me();
   const userQuery = useQuery(meOptions);
-  const authMethodsQuery = useQuery(authMethods());
   const hasFirstUserQuery = useQuery(hasFirstUser());
   const permissionsQuery = useQuery({
     ...checkAuthorization({ checks: permissionsToCheck }),
@@ -77,7 +70,6 @@ export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
     userQuery.error.response.status === 401;
   const isSigningOut = logoutMutation.isLoading;
   const isLoading =
-    authMethodsQuery.isLoading ||
     userQuery.isLoading ||
     hasFirstUserQuery.isLoading ||
     (userQuery.isSuccess && permissionsQuery.isLoading);
@@ -120,7 +112,6 @@ export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
         updateProfile,
         user: userQuery.data,
         permissions: permissionsQuery.data as Permissions | undefined,
-        authMethods: authMethodsQuery.data,
         signInError: loginMutation.error,
         updateProfileError: updateProfileMutation.error,
         organizationId: userQuery.data?.organization_ids[0],

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -235,6 +235,13 @@ const ProxyMenu: FC<ProxyMenuProps> = ({ proxyContextValue }) => {
     return proxy.healthy && latency !== undefined && latency.at < refetchDate;
   };
 
+  // This endpoint returns a 404 when not using enterprise.
+  // If we don't return null, then it looks like this is
+  // loading forever!
+  if (proxyContextValue.error) {
+    return null;
+  }
+
   if (isLoading) {
     return (
       <Skeleton

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -1,6 +1,8 @@
 import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
+import { useQuery } from "react-query";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
+import { authMethods } from "api/queries/users";
 import { useAuthContext } from "contexts/auth/AuthProvider";
 import { getApplicationName } from "utils/appearance";
 import { retrieveRedirect } from "utils/redirect";
@@ -14,9 +16,9 @@ export const LoginPage: FC = () => {
     isConfiguringTheFirstUser,
     signIn,
     isSigningIn,
-    authMethods,
     signInError,
   } = useAuthContext();
+  const authMethodsQuery = useQuery(authMethods());
   const redirectTo = retrieveRedirect(location.search);
   const applicationName = getApplicationName();
   const navigate = useNavigate();
@@ -60,9 +62,9 @@ export const LoginPage: FC = () => {
         <title>Sign in to {applicationName}</title>
       </Helmet>
       <LoginPageView
-        authMethods={authMethods}
+        authMethods={authMethodsQuery.data}
         error={signInError}
-        isLoading={isLoading}
+        isLoading={isLoading || authMethodsQuery.isLoading}
         isSigningIn={isSigningIn}
         onSignIn={async ({ email, password }) => {
           await signIn(email, password);

--- a/site/src/utils/metadata.ts
+++ b/site/src/utils/metadata.ts
@@ -1,10 +1,10 @@
 export const getMetadataAsJSON = <T extends NonNullable<unknown>>(
   property: string,
 ): T | undefined => {
-  const appearance = document.querySelector(`meta[property=${property}]`);
+  const metadata = document.querySelector(`meta[property=${property}]`);
 
-  if (appearance) {
-    const rawContent = appearance.getAttribute("content");
+  if (metadata) {
+    const rawContent = metadata.getAttribute("content");
 
     if (rawContent) {
       try {


### PR DESCRIPTION
We already inject all of this content in `index.html`.

There was also a bug with displaying a loading indicator when the workspace proxies endpoint 404s.