### PR TITLE
chore: change `site_configs.value` to `text`

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -695,7 +695,7 @@ CREATE TABLE replicas (
 
 CREATE TABLE site_configs (
     key character varying(256) NOT NULL,
-    value character varying(8192) NOT NULL
+    value text NOT NULL
 );
 
 CREATE TABLE tailnet_agents (

--- a/coderd/database/migrations/000207_site_configs_text.down.sql
+++ b/coderd/database/migrations/000207_site_configs_text.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "site_configs" ALTER COLUMN "value" TYPE character varying(8192);

--- a/coderd/database/migrations/000207_site_configs_text.up.sql
+++ b/coderd/database/migrations/000207_site_configs_text.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "site_configs" ALTER COLUMN "value" TYPE text;


### PR DESCRIPTION
We're planning to add support for custom "Terms of Service" notifications, and customers will likely want to be able to specify values much longer than 8k characters for this. The limited text length for this table is pretty arbitrary, and (at least with Postgres) using `character varying` doesn't really provide any advantages over `text` in like 99% of cases.