### PR TITLE
chore(docs):  add k8s terraform link to k8s installation docs

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -18,7 +18,7 @@ locally in order to log in and manage templates.
 
 > If you need help setting up k8s, we have a
 > [repo with Terraform configuration](https://github.com/ElliotG/coder-oss-tf)
-> to provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS, 
+> to provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS,
 > IBMCloud K8s, OVHCloud K8s, and Scaleway K8s Kapsule.
 
 ## Install Coder with Helm

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -16,6 +16,11 @@ locally in order to log in and manage templates.
 > The version flags for both stable and mainline are automatically filled in
 > this page.
 
+> If you need help setting up k8s, we have a
+> [repo with Terraform configuration](https://github.com/ElliotG/coder-oss-tf)
+> to provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS, 
+> IBMCloud K8s, OVHCloud K8s, and Scaleway K8s Kapsule.
+
 ## Install Coder with Helm
 
 1. Create a namespace for Coder, such as `coder`:


### PR DESCRIPTION
Hello from Georgian again. 

I've set up a GKE cluster for Coder with Terraform. The setup would have been much less work if I had known Terraform scripts were available. I copied the link from the [Coder README](https://github.com/coder/coder/blob/main/README.md?plain=1#L117) pointing to your Terraform scripts and added it to the k8s installation guide. This will make it much easier to discover for someone who wants to install Coder on k8s.

As a side note, the link to the Terraform repo points to a user unaffiliated with Coder. This is a security risk because you don't control that repo. To fix this issue in the longer term, I would suggest creating a repo with Terraform scripts in your Coder organization.

\cc @ericpaulsen 