### PR TITLE
chore(scripts): implement mainline and stable release channels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,16 @@
 # GitHub release workflow.
 name: Release
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
+      release_channel:
+        type: choice
+        description: Release channel
+        options:
+          - mainline
+          - stable
+      release_notes:
+        description: Release notes for the publishing the release. This is required to create a release.
       dry_run:
         description: Perform a dry-run release (devel). Note that ref must be an annotated tag when run without dry-run.
         type: boolean
@@ -28,6 +33,8 @@ env:
   # https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/
   CODER_RELEASE: ${{ !inputs.dry_run }}
   CODER_DRY_RUN: ${{ inputs.dry_run }}
+  CODER_RELEASE_CHANNEL: ${{ inputs.release_channel }}
+  CODER_RELEASE_NOTES: ${{ inputs.release_notes }}
 
 jobs:
   release:
@@ -62,21 +69,45 @@ jobs:
           echo "CODER_FORCE_VERSION=$version" >> $GITHUB_ENV
           echo "$version"
 
-      - name: Create release notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # We always have to set this since there might be commits on
-          # main that didn't have a PR.
-          CODER_IGNORE_MISSING_COMMIT_METADATA: "1"
+      # Verify that all expectations for a release are met.
+      - name: Verify release input
+        if: ${{ !inputs.dry_run }}
         run: |
           set -euo pipefail
-          ref=HEAD
-          old_version="$(git describe --abbrev=0 "$ref^1")"
-          version="v$(./scripts/version.sh)"
 
-          # Generate notes.
+          if [[ "${GITHUB_REF}" != "refs/tags/v"* ]]; then
+            echo "Ref must be a semver tag when creating a release, did you use scripts/release.sh?"
+            exit 1
+          fi
+
+          # 2.10.2 -> release/2.10
+          version="$(./scripts/version.sh)"
+          release_branch=release/${version%.*}
+          branch_contains_tag=$(git branch --remotes --contains "${GITHUB_REF}" --list "*/${release_branch}" --format='%(refname)')
+          if [[ -z "${branch_contains_tag}" ]]; then
+            echo "Ref tag must exist in a branch named ${release_branch} when creating a release, did you use scripts/release.sh?"
+            exit 1
+          fi
+
+          if [[ -z "${CODER_RELEASE_NOTES}" ]]; then
+            echo "Release notes are required to create a release, did you use scripts/release.sh?"
+            exit 1
+          fi
+
+          echo "Release inputs verified:"
+          echo
+          echo "- Ref: ${GITHUB_REF}"
+          echo "- Version: ${version}"
+          echo "- Release channel: ${CODER_RELEASE_CHANNEL}"
+          echo "- Release branch: ${release_branch}"
+          echo "- Release notes: true"
+
+      - name: Create release notes file
+        run: |
+          set -euo pipefail
+
           release_notes_file="$(mktemp -t release_notes.XXXXXX)"
-          ./scripts/release/generate_release_notes.sh --check-for-changelog --old-version "$old_version" --new-version "$version" --ref "$ref" >> "$release_notes_file"
+          echo "$CODER_RELEASE_NOTES" > "$release_notes_file"
           echo CODER_RELEASE_NOTES_FILE="$release_notes_file" >> $GITHUB_ENV
 
       - name: Show release notes
@@ -261,6 +292,9 @@ jobs:
           set -euo pipefail
 
           publish_args=()
+          if [[ $CODER_RELEASE_CHANNEL == "stable" ]]; then
+            publish_args+=(--stable)
+          fi
           if [[ $CODER_DRY_RUN == *t* ]]; then
             publish_args+=(--dry-run)
           fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,12 +44,16 @@ EOH
 }
 
 branch=main
+remote=origin
 dry_run=0
 ref=
 increment=
 force=0
+script_check=1
+mainline=1
+channel=mainline
 
-args="$(getopt -o h -l dry-run,help,ref:,major,minor,patch,force -- "$@")"
+args="$(getopt -o h -l dry-run,help,ref:,mainline,stable,major,minor,patch,force,ignore-script-out-of-date -- "$@")"
 eval set -- "$args"
 while true; do
 	case "$1" in
@@ -60,6 +64,16 @@ while true; do
 	-h | --help)
 		usage
 		exit 0
+		;;
+	--mainline)
+		mainline=1
+		channel=mainline
+		shift
+		;;
+	--stable)
+		mainline=0
+		channel=stable
+		shift
 		;;
 	--ref)
 		ref="$2"
@@ -76,6 +90,10 @@ while true; do
 		force=1
 		shift
 		;;
+	--ignore-script-out-of-date)
+		script_check=0
+		shift
+		;;
 	--)
 		shift
 		break
@@ -87,72 +105,208 @@ while true; do
 done
 
 # Check dependencies.
-dependencies gh sort
+dependencies gh jq sort
 
 if [[ -z $increment ]]; then
 	# Default to patch versions.
 	increment="patch"
 fi
 
+# Check if the working directory is clean.
+if ! git diff --quiet --exit-code; then
+	log "Working directory is not clean, it is highly recommended to stash changes."
+	while [[ ! ${stash:-} =~ ^[YyNn]$ ]]; do
+		read -p "Stash changes? (y/n) " -n 1 -r stash
+		log
+	done
+	if [[ ${stash} =~ ^[Yy]$ ]]; then
+		maybedryrun "${dry_run}" git stash push --message "scripts/release.sh: autostash"
+	fi
+	log
+fi
+
+# Check if the main is up-to-date with the remote.
+log "Checking remote ${remote} for repo..."
+remote_url=$(git remote get-url "${remote}")
+# Allow either SSH or HTTPS URLs.
+if ! [[ ${remote_url} =~ [@/]github.com ]] && ! [[ ${remote_url} =~ [:/]coder/coder(\.git)?$ ]]; then
+	error "This script is only intended to be run with github.com/coder/coder repository set as ${remote}."
+fi
+
 # Make sure the repository is up-to-date before generating release notes.
-log "Fetching $branch and tags from origin..."
-git fetch --quiet --tags origin "$branch"
+log "Fetching ${branch} and tags from ${remote}..."
+git fetch --quiet --tags "${remote}" "$branch"
 
 # Resolve to the latest ref on origin/main unless otherwise specified.
-ref=$(git rev-parse --short "${ref:-origin/$branch}")
+ref_name=${ref:-${remote}/${branch}}
+ref=$(git rev-parse --short "${ref_name}")
 
 # Make sure that we're running the latest release script.
-if [[ -n $(git diff --name-status origin/"$branch" -- ./scripts/release.sh) ]]; then
+script_diff=$(git diff --name-status "${remote}/${branch}" -- scripts/release.sh)
+if [[ ${script_check} = 1 ]] && [[ -n ${script_diff} ]]; then
 	error "Release script is out-of-date. Please check out the latest version and try again."
 fi
 
-# Check the current version tag from GitHub (by number) using the API to
-# ensure no local tags are considered.
-log "Checking GitHub for latest release..."
-versions_out="$(gh api -H "Accept: application/vnd.github+json" /repos/coder/coder/git/refs/tags -q '.[].ref | split("/") | .[2]' | grep '^v' | sort -r -V)"
-mapfile -t versions <<<"$versions_out"
-old_version=${versions[0]}
-log "Latest release: $old_version"
+# Make sure no other release contains this ref.
+release_contains_ref="$(git branch --remotes --contains "${ref}" --list "${remote}/release/*" --format='%(refname)')"
+if [[ -n ${release_contains_ref} ]]; then
+	error "Ref ${ref_name} is already part of another release: ${release_contains_ref#"refs/remotes/${remote}/"}."
+fi
+
+log "Checking GitHub for latest release(s)..."
+
+# Check the latest version tag from GitHub (by version) using the API.
+versions_out="$(gh api -H "Accept: application/vnd.github+json" /repos/coder/coder/git/refs/tags -q '.[].ref | split("/") | .[2]' | grep '^v[0-9]' | sort -r -V)"
+mapfile -t versions <<<"${versions_out}"
+latest_mainline_version=${versions[0]}
+
+latest_stable_version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/coder/coder/releases/latest)"
+latest_stable_version="${latest_stable_version#https://github.com/coder/coder/releases/tag/}"
+
+log "Latest mainline release: ${latest_mainline_version}"
+log "Latest stable release: ${latest_stable_version}"
 log
+
+old_version=${latest_mainline_version}
+if ((!mainline)); then
+	old_version=${latest_stable_version}
+fi
 
 trap 'log "Check commit metadata failed, you can try to set \"export CODER_IGNORE_MISSING_COMMIT_METADATA=1\" and try again, if you know what you are doing."' EXIT
 # shellcheck source=scripts/release/check_commit_metadata.sh
 source "$SCRIPT_DIR/release/check_commit_metadata.sh" "$old_version" "$ref"
 trap - EXIT
+log
 
 tag_version_args=(--old-version "$old_version" --ref "$ref" --"$increment")
 if ((force == 1)); then
 	tag_version_args+=(--force)
 fi
 log "Executing DRYRUN of release tagging..."
-new_version="$(execrelative ./release/tag_version.sh "${tag_version_args[@]}" --dry-run)"
+tag_version_out="$(execrelative ./release/tag_version.sh "${tag_version_args[@]}" --dry-run)"
 log
-read -p "Continue? (y/n) " -n 1 -r continue_release
-log
+while [[ ! ${continue_release:-} =~ ^[YyNn]$ ]]; do
+	read -p "Continue? (y/n) " -n 1 -r continue_release
+	log
+done
 if ! [[ $continue_release =~ ^[Yy]$ ]]; then
 	exit 0
 fi
-
-release_notes="$(execrelative ./release/generate_release_notes.sh --check-for-changelog --old-version "$old_version" --new-version "$new_version" --ref "$ref")"
-
-read -p "Preview release notes? (y/n) " -n 1 -r show_reply
 log
-if [[ $show_reply =~ ^[Yy]$ ]]; then
+
+mapfile -d ' ' -t tag_version <<<"$tag_version_out"
+release_branch=${tag_version[0]}
+new_version=${tag_version[1]}
+new_version="${new_version%$'\n'}" # Remove the trailing newline.
+
+release_notes="$(execrelative ./release/generate_release_notes.sh --old-version "$old_version" --new-version "$new_version" --ref "$ref")"
+
+release_notes_file="build/RELEASE-${new_version}.md"
+if ((dry_run)); then
+	release_notes_file="build/RELEASE-${new_version}-DRYRUN.md"
+fi
+get_editor() {
+	if command -v editor >/dev/null; then
+		readlink -f "$(command -v editor || true)"
+	elif [[ -n ${GIT_EDITOR:-} ]]; then
+		echo "${GIT_EDITOR}"
+	elif [[ -n ${EDITOR:-} ]]; then
+		echo "${EDITOR}"
+	fi
+}
+editor="$(get_editor)"
+write_release_notes() {
+	if [[ -z ${editor} ]]; then
+		log "Release notes written to $release_notes_file, you can now edit this file manually."
+	else
+		log "Release notes written to $release_notes_file, you can now edit this file manually or via your editor."
+	fi
+	echo -e "${release_notes}" >"${release_notes_file}"
+}
+log "Writing release notes to ${release_notes_file}"
+if [[ -f ${release_notes_file} ]]; then
+	log
+	while [[ ! ${overwrite:-} =~ ^[YyNn]$ ]]; do
+		read -p "Release notes already exists, overwrite? (y/n) " -n 1 -r overwrite
+		log
+	done
+	log
+	if [[ ${overwrite} =~ ^[Yy]$ ]]; then
+		write_release_notes
+	else
+		log "Release notes not overwritten, using existing release notes."
+		release_notes="$(<"$release_notes_file")"
+	fi
+else
+	write_release_notes
+fi
+log
+
+if [[ -z ${editor} ]]; then
+	log "No editor found, please set the \$EDITOR environment variable for edit prompt."
+else
+	while [[ ! ${edit:-} =~ ^[YyNn]$ ]]; do
+		read -p "Edit release notes in \"${editor}\"? (y/n) " -n 1 -r edit
+		log
+	done
+	if [[ ${edit} =~ ^[Yy]$ ]]; then
+		"${editor}" "${release_notes_file}"
+		release_notes2="$(<"$release_notes_file")"
+		if [[ "${release_notes}" != "${release_notes2}" ]]; then
+			log "Release notes have been updated!"
+			release_notes="${release_notes2}"
+		else
+			log "No changes detected..."
+		fi
+	fi
+fi
+log
+
+while [[ ! ${preview:-} =~ ^[YyNn]$ ]]; do
+	read -p "Preview release notes? (y/n) " -n 1 -r preview
+	log
+done
+if [[ ${preview} =~ ^[Yy]$ ]]; then
 	log
 	echo -e "$release_notes\n"
 fi
-
-read -p "Create release? (y/n) " -n 1 -r create
 log
-if ! [[ $create =~ ^[Yy]$ ]]; then
+
+while [[ ! ${create:-} =~ ^[YyNn]$ ]]; do
+	read -p "Create, build and publish release? (y/n) " -n 1 -r create
+	log
+done
+if ! [[ ${create} =~ ^[Yy]$ ]]; then
 	exit 0
 fi
-
 log
+
 # Run without dry-run to actually create the tag, note we don't update the
 # new_version variable here to ensure we're pushing what we showed before.
 maybedryrun "$dry_run" execrelative ./release/tag_version.sh "${tag_version_args[@]}" >/dev/null
+maybedryrun "$dry_run" git push -u origin "$release_branch"
 maybedryrun "$dry_run" git push --tags -u origin "$new_version"
+
+log
+log "Release tags for ${new_version} created successfully and pushed to ${remote}!"
+
+log
+# Write to a tmp file for ease of debugging.
+release_json_file=$(mktemp -t coder-release.json)
+log "Writing release JSON to ${release_json_file}"
+jq -n \
+	--argjson dry_run "${dry_run}" \
+	--arg release_channel "${channel}" \
+	--arg release_notes "${release_notes}" \
+	'{dry_run: ($dry_run > 0) | tostring, release_channel: $release_channel, release_notes: $release_notes}' \
+	>"${release_json_file}"
+
+log "Running release workflow..."
+maybedryrun "${dry_run}" cat "${release_json_file}" |
+	maybedryrun "${dry_run}" gh workflow run release.yaml --json --ref "${new_version}"
+
+log
+log "Release workflow started successfully!"
 
 if ((dry_run)); then
 	# We can't watch the release.yaml workflow if we're in dry-run mode.
@@ -160,15 +314,17 @@ if ((dry_run)); then
 fi
 
 log
-read -p "Watch release? (y/n) " -n 1 -r watch
-log
-if ! [[ $watch =~ ^[Yy]$ ]]; then
+while [[ ! ${watch:-} =~ ^[YyNn]$ ]]; do
+	read -p "Watch release? (y/n) " -n 1 -r watch
+	log
+done
+if ! [[ ${watch} =~ ^[Yy]$ ]]; then
 	exit 0
 fi
 
 log 'Waiting for job to become "in_progress"...'
 
-# Wait at most 3 minutes (3*60)/3 = 60 for the job to start.
+# Wait at most 10 minutes (60*10/60) for the job to start.
 for _ in $(seq 1 60); do
 	output="$(
 		# Output:
@@ -181,7 +337,7 @@ for _ in $(seq 1 60); do
 	)"
 	mapfile -t run <<<"$output"
 	if [[ ${run[1]} != "in_progress" ]]; then
-		sleep 3
+		sleep 10
 		continue
 	fi
 	gh run watch --exit-status "${run[0]}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,7 +90,9 @@ while true; do
 		force=1
 		shift
 		;;
-	--ignore-script-out-of-date)
+	# Allow the script to be run with an out-of-date script for
+	# development purposes.
+	--debug-ignore-script-out-of-date)
 		script_check=0
 		shift
 		;;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,7 +92,7 @@ while true; do
 		;;
 	# Allow the script to be run with an out-of-date script for
 	# development purposes.
-	--debug-ignore-script-out-of-date)
+	--ignore-script-out-of-date)
 		script_check=0
 		shift
 		;;
@@ -152,7 +152,7 @@ fi
 # Make sure no other release contains this ref.
 release_contains_ref="$(git branch --remotes --contains "${ref}" --list "${remote}/release/*" --format='%(refname)')"
 if [[ -n ${release_contains_ref} ]]; then
-	error "Ref ${ref_name} is already part of another release: ${release_contains_ref#"refs/remotes/${remote}/"}."
+	error "Ref ${ref_name} is already part of another release: $(git describe --always "${ref}") on ${release_contains_ref#"refs/remotes/${remote}/"}."
 fi
 
 log "Checking GitHub for latest release(s)..."

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -181,7 +181,7 @@ main() {
 
 	for commit in "${commits[@]}"; do
 		mapfile -d ' ' -t parts <<<"${commit}"
-		left_right=${parts[0]}
+		left_right=${parts[0]} # From `git log --left-right`, see `man git-log` for details.
 		commit_sha_short=${parts[1]}
 		commit_sha_long=${parts[2]}
 		commit_prefix=${parts[3]}

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -19,26 +19,29 @@ source "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib.sh"
 from_ref=${1:-}
 to_ref=${2:-}
 
-if [[ -z $from_ref ]]; then
+if [[ -z ${from_ref} ]]; then
 	error "No from_ref specified"
 fi
-if [[ -z $to_ref ]]; then
+if [[ -z ${to_ref} ]]; then
 	error "No to_ref specified"
 fi
 
-range="$from_ref..$to_ref"
+range="${from_ref}..${to_ref}"
 
 # Check dependencies.
 dependencies gh
 
 COMMIT_METADATA_BREAKING=0
-declare -A COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
+declare -a COMMIT_METADATA_COMMITS
+declare -A COMMIT_METADATA_TITLE COMMIT_METADATA_HUMAN_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
 
 # This environment variable can be set to 1 to ignore missing commit metadata,
 # useful for dry-runs.
 ignore_missing_metadata=${CODER_IGNORE_MISSING_COMMIT_METADATA:-0}
 
 main() {
+	log "Checking commit metadata for changes between ${from_ref} and ${to_ref}..."
+
 	# Match a commit prefix pattern, e.g. feat: or feat(site):.
 	prefix_pattern="^([a-z]+)(\([^)]+\))?:"
 
@@ -55,14 +58,93 @@ main() {
 	security_label=security
 	security_category=security
 
-	# Get abbreviated and full commit hashes and titles for each commit.
-	git_log_out="$(git log --no-merges --pretty=format:"%h %H %s" "$range")"
-	mapfile -t commits <<<"$git_log_out"
+	# Order is important here, first partial match wins.
+	declare -A humanized_areas=(
+		["agent/agentssh"]="Agent SSH"
+		["coderd/database"]="Database"
+		["enterprise/audit"]="Auditing"
+		["enterprise/cli"]="CLI"
+		["enterprise/coderd"]="Server"
+		["enterprise/dbcrypt"]="Database"
+		["enterprise/derpmesh"]="Networking"
+		["enterprise/provisionerd"]="Provisioner"
+		["enterprise/tailnet"]="Networking"
+		["enterprise/wsproxy"]="Workspace Proxy"
+		[agent]="Agent"
+		[cli]="CLI"
+		[coderd]="Server"
+		[codersdk]="SDK"
+		[docs]="Documentation"
+		[enterprise]="Enterprise"
+		[examples]="Examples"
+		[helm]="Helm"
+		[install.sh]="Installer"
+		[provisionersdk]="SDK"
+		[provisionerd]="Provisioner"
+		[provisioner]="Provisioner"
+		[pty]="CLI"
+		[scaletest]="Scale Testing"
+		[site]="Dashboard"
+		[support]="Support"
+		[tailnet]="Networking"
+	)
 
-	# If this is a tag, use rev-list to find the commit it points to.
-	from_commit=$(git rev-list -n 1 "$from_ref")
-	# Get the committer date of the commit so that we can list PRs merged.
-	from_commit_date=$(git show --no-patch --date=short --format=%cd "$from_commit")
+	# Get hashes for all cherry-picked commits between the selected ref
+	# and main. These are sorted by commit title so that we can group
+	# two cherry-picks together.
+	declare -A cherry_pick_commits
+	git_cherry_out=$(
+		{
+			git log --no-merges --cherry-mark --pretty=format:"%m %H %s" "${to_ref}...origin/main"
+			git log --no-merges --cherry-mark --pretty=format:"%m %H %s" "${from_ref}...origin/main"
+		} | { grep '^=' || true; } | sort -u | sort -k3
+	)
+	if [[ -n ${git_cherry_out} ]]; then
+		mapfile -t cherry_picks <<<"${git_cherry_out}"
+		# Iterate over the array in groups of two
+		for ((i = 0; i < ${#cherry_picks[@]}; i += 2)); do
+			mapfile -d ' ' -t parts1 <<<"${cherry_picks[i]}"
+			mapfile -d ' ' -t parts2 <<<"${cherry_picks[i + 1]}"
+			commit1=${parts1[1]}
+			title1=${parts1[*]:2}
+			commit2=${parts2[1]}
+			title2=${parts2[*]:2}
+
+			if [[ ${title1} != "${title2}" ]]; then
+				error "Invariant failed, cherry-picked commits have different titles: ${title1} != ${title2}"
+			fi
+
+			cherry_pick_commits[${commit1}]=${commit2}
+			cherry_pick_commits[${commit2}]=${commit1}
+		done
+	fi
+
+	# Get abbreviated and full commit hashes and titles for each commit.
+	git_log_out="$(git log --no-merges --left-right --pretty=format:"%m %h %H %s" "${range}")"
+	if [[ -z ${git_log_out} ]]; then
+		error "No commits found in range ${range}"
+	fi
+	mapfile -t commits <<<"${git_log_out}"
+
+	# Get the lowest committer date of the commits so that we can fetch
+	# the PRs that were merged.
+	lookback_date=$(
+		{
+			# Check all included commits.
+			for commit in "${commits[@]}"; do
+				mapfile -d ' ' -t parts <<<"${commit}"
+				sha_long=${parts[2]}
+				git show --no-patch --date=short --format='%cd' "${sha_long}"
+			done
+			# Include cherry-picks and their original commits (the
+			# original commit may be older than the cherry pick).
+			for cherry_pick in "${cherry_picks[@]}"; do
+				mapfile -d ' ' -t parts <<<"${cherry_pick}"
+				sha_long=${parts[1]}
+				git show --no-patch --date=short --format='%cd' "${sha_long}"
+			done
+		} | sort -t- -n | head -n 1
+	)
 
 	# Get the labels for all PRs merged since the last release, this is
 	# inexact based on date, so a few PRs part of the previous release may
@@ -78,84 +160,135 @@ main() {
 			--base main \
 			--state merged \
 			--limit 10000 \
-			--search "merged:>=$from_commit_date" \
+			--search "merged:>=${lookback_date}" \
 			--json mergeCommit,labels,author \
 			--jq '.[] | "\( .mergeCommit.oid ) author:\( .author.login ) labels:\(["label:\( .labels[].name )"] | join(" "))"'
 	)"
 
 	declare -A authors labels
-	if [[ -n $pr_list_out ]]; then
-		mapfile -t pr_metadata_raw <<<"$pr_list_out"
+	if [[ -n ${pr_list_out} ]]; then
+		mapfile -t pr_metadata_raw <<<"${pr_list_out}"
 
 		for entry in "${pr_metadata_raw[@]}"; do
 			commit_sha_long=${entry%% *}
 			commit_author=${entry#* author:}
 			commit_author=${commit_author%% *}
-			authors[$commit_sha_long]=$commit_author
+			authors[${commit_sha_long}]=${commit_author}
 			all_labels=${entry#* labels:}
-			labels[$commit_sha_long]=$all_labels
+			labels[${commit_sha_long}]=${all_labels}
 		done
 	fi
 
 	for commit in "${commits[@]}"; do
-		mapfile -d ' ' -t parts <<<"$commit"
-		commit_sha_short=${parts[0]}
-		commit_sha_long=${parts[1]}
-		commit_prefix=${parts[2]}
+		mapfile -d ' ' -t parts <<<"${commit}"
+		left_right=${parts[0]}
+		commit_sha_short=${parts[1]}
+		commit_sha_long=${parts[2]}
+		commit_prefix=${parts[3]}
+		title=${parts[*]:3}
+		title=${title%$'\n'}
+		title_no_prefix=${parts[*]:4}
+		title_no_prefix=${title_no_prefix%$'\n'}
+
+		# For COMMIT_METADATA_COMMITS in case of cherry-pick override.
+		commit_sha_long_orig=${commit_sha_long}
+
+		# Check if this is a potential cherry-pick.
+		if [[ -v cherry_pick_commits[${commit_sha_long}] ]]; then
+			# Is this the cherry-picked or the original commit?
+			if [[ ! -v authors[${commit_sha_long}] ]] || [[ ! -v labels[${commit_sha_long}] ]]; then
+				log "Cherry-picked commit ${commit_sha_long}, checking original commit ${cherry_pick_commits[${commit_sha_long}]}"
+				# Use the original commit's metadata from GitHub.
+				commit_sha_long=${cherry_pick_commits[${commit_sha_long}]}
+			else
+				# Skip the cherry-picked commit, we only need the original.
+				log "Skipping commit ${commit_sha_long} cherry-picked into ${from_ref} as ${cherry_pick_commits[${commit_sha_long}]} (${title})"
+				continue
+			fi
+		fi
+
+		if [[ ${left_right} == "<" ]]; then
+			# Skip commits that are already in main.
+			log "Skipping commit ${commit_sha_short} from other branch (${commit_sha_long} ${title})"
+			continue
+		fi
+
+		COMMIT_METADATA_COMMITS+=("${commit_sha_long_orig}")
 
 		# Safety-check, guarantee all commits had their metadata fetched.
-		if [[ ! -v authors[$commit_sha_long] ]] || [[ ! -v labels[$commit_sha_long] ]]; then
-			if [[ $ignore_missing_metadata != 1 ]]; then
-				error "Metadata missing for commit $commit_sha_short"
+		if [[ ! -v authors[${commit_sha_long}] ]] || [[ ! -v labels[${commit_sha_long}] ]]; then
+			if [[ ${ignore_missing_metadata} != 1 ]]; then
+				error "Metadata missing for commit ${commit_sha_short} (${commit_sha_long})"
 			else
-				log "WARNING: Metadata missing for commit $commit_sha_short"
+				log "WARNING: Metadata missing for commit ${commit_sha_short} (${commit_sha_long})"
 			fi
 		fi
 
 		# Store the commit title for later use.
-		title=${parts[*]:2}
-		title=${title%$'\n'}
-		COMMIT_METADATA_TITLE[$commit_sha_short]=$title
-		if [[ -v authors[$commit_sha_long] ]]; then
-			COMMIT_METADATA_AUTHORS[$commit_sha_short]="@${authors[$commit_sha_long]}"
+		COMMIT_METADATA_TITLE[${commit_sha_short}]=${title}
+		if [[ -v authors[${commit_sha_long}] ]]; then
+			COMMIT_METADATA_AUTHORS[${commit_sha_short}]="@${authors[${commit_sha_long}]}"
+		fi
+
+		# Create humanized titles where possible, examples:
+		#
+		# 	"feat: add foo" -> "Add foo".
+		# 	"feat(site): add bar" -> "Dashboard: Add bar".
+		COMMIT_METADATA_HUMAN_TITLE[${commit_sha_short}]=${title}
+		if [[ ${commit_prefix} =~ ${prefix_pattern} ]]; then
+			sub=${BASH_REMATCH[2]}
+			if [[ -z ${sub} ]]; then
+				# No parenthesis found, simply drop the prefix.
+				COMMIT_METADATA_HUMAN_TITLE[${commit_sha_short}]="${title_no_prefix^}"
+			else
+				# Drop the prefix and replace it with a humanized area,
+				# leave as-is for unknown areas.
+				sub=${sub#(}
+				for area in "${!humanized_areas[@]}"; do
+					if [[ ${sub} = "${area}"* ]]; then
+						COMMIT_METADATA_HUMAN_TITLE[${commit_sha_short}]="${humanized_areas[${area}]}: ${title_no_prefix^}"
+						break
+					fi
+				done
+			fi
 		fi
 
 		# First, check the title for breaking changes. This avoids doing a
 		# GH API request if there's a match.
-		if [[ $commit_prefix =~ $breaking_title ]] || [[ ${labels[$commit_sha_long]:-} = *"label:$breaking_label"* ]]; then
-			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$breaking_category
+		if [[ ${commit_prefix} =~ ${breaking_title} ]] || [[ ${labels[${commit_sha_long}]:-} = *"label:${breaking_label}"* ]]; then
+			COMMIT_METADATA_CATEGORY[${commit_sha_short}]=${breaking_category}
 			COMMIT_METADATA_BREAKING=1
 			continue
-		elif [[ ${labels[$commit_sha_long]:-} = *"label:$security_label"* ]]; then
-			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$security_category
+		elif [[ ${labels[${commit_sha_long}]:-} = *"label:${security_label}"* ]]; then
+			COMMIT_METADATA_CATEGORY[${commit_sha_short}]=${security_category}
 			continue
-		elif [[ ${labels[$commit_sha_long]:-} = *"label:$experimental_label"* ]]; then
-			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$experimental_category
+		elif [[ ${labels[${commit_sha_long}]:-} = *"label:${experimental_label}"* ]]; then
+			COMMIT_METADATA_CATEGORY[${commit_sha_short}]=${experimental_category}
 			continue
 		fi
 
-		if [[ $commit_prefix =~ $prefix_pattern ]]; then
+		if [[ ${commit_prefix} =~ ${prefix_pattern} ]]; then
 			commit_prefix=${BASH_REMATCH[1]}
 		fi
-		case $commit_prefix in
+		case ${commit_prefix} in
 		# From: https://github.com/commitizen/conventional-commit-types
 		feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert)
-			COMMIT_METADATA_CATEGORY[$commit_sha_short]=$commit_prefix
+			COMMIT_METADATA_CATEGORY[${commit_sha_short}]=${commit_prefix}
 			;;
 		*)
-			COMMIT_METADATA_CATEGORY[$commit_sha_short]=other
+			COMMIT_METADATA_CATEGORY[${commit_sha_short}]=other
 			;;
 		esac
 	done
 }
 
 declare_print_commit_metadata() {
-	declare -p COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
+	declare -p COMMIT_METADATA_COMMITS COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_HUMAN_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
 }
 
 export_commit_metadata() {
 	_COMMIT_METADATA_CACHE="${range}:$(declare_print_commit_metadata)"
-	export _COMMIT_METADATA_CACHE COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
+	export _COMMIT_METADATA_CACHE COMMIT_METADATA_COMMITS COMMIT_METADATA_BREAKING COMMIT_METADATA_TITLE COMMIT_METADATA_HUMAN_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
 }
 
 # _COMMIT_METADATA_CACHE is used to cache the results of this script in
@@ -163,7 +296,7 @@ export_commit_metadata() {
 if [[ ${_COMMIT_METADATA_CACHE:-} == "${range}:"* ]]; then
 	eval "${_COMMIT_METADATA_CACHE#*:}"
 else
-	if [[ $ignore_missing_metadata == 1 ]]; then
+	if [[ ${ignore_missing_metadata} == 1 ]]; then
 		log "WARNING: Ignoring missing commit metadata, breaking changes may be missed."
 	fi
 	main

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -183,6 +183,7 @@ if ((mainline)); then
 > This is a mainline Coder release. We advise enterprise customers without a staging environment to install our [latest stable release](https://github.com/coder/coder/releases/latest) while we refine this version. Learn more about our [Release Schedule](https://coder.com/docs/v2/latest/install/releases).
 "
 else
+	# Date format: April 23, 2024
 	d=$(date +'%B %d, %Y')
 	stable_since="> ## Stable (since ${d})"$'\n\n'
 fi

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -18,16 +18,12 @@ source "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib.sh"
 old_version=
 new_version=
 ref=
-check_for_changelog=0
+mainline=1
 
-args="$(getopt -o '' -l check-for-changelog,old-version:,new-version:,ref: -- "$@")"
-eval set -- "$args"
+args="$(getopt -o '' -l old-version:,new-version:,ref:,mainline,stable -- "$@")"
+eval set -- "${args}"
 while true; do
 	case "$1" in
-	--check-for-changelog)
-		check_for_changelog=1
-		shift
-		;;
 	--old-version)
 		old_version="$2"
 		shift 2
@@ -39,6 +35,14 @@ while true; do
 	--ref)
 		ref="$2"
 		shift 2
+		;;
+	--mainline)
+		mainline=1
+		shift
+		;;
+	--stable)
+		mainline=0
+		shift
 		;;
 	--)
 		shift
@@ -53,34 +57,31 @@ done
 # Check dependencies.
 dependencies gh sort
 
-if [[ -z $old_version ]]; then
+if [[ -z ${old_version} ]]; then
 	error "No old version specified"
 fi
-if [[ -z $new_version ]]; then
+if [[ -z ${new_version} ]]; then
 	error "No new version specified"
 fi
-if [[ $new_version != v* ]]; then
+if [[ ${new_version} != v* ]]; then
 	error "New version must start with a v"
 fi
-if [[ -z $ref ]]; then
+if [[ -z ${ref} ]]; then
 	error "No ref specified"
 fi
 
-# Use a manual changelog, if present
-changelog_path="$(git rev-parse --show-toplevel)/docs/changelogs/$new_version.md"
-if [ "$check_for_changelog" -eq 1 ]; then
-	if [ -f "$changelog_path" ]; then
-		cat "$changelog_path"
-		exit 0
-	fi
-fi
-
 # shellcheck source=scripts/release/check_commit_metadata.sh
-source "$SCRIPT_DIR/check_commit_metadata.sh" "$old_version" "$ref"
+source "${SCRIPT_DIR}/check_commit_metadata.sh" "${old_version}" "${ref}"
 
 # Sort commits by title prefix, then by date, only return sha at the end.
-git_log_out="$(git log --no-merges --pretty=format:"%ct %h %s" "$old_version..$ref" | sort -k3,3 -k1,1n | cut -d' ' -f2)"
-mapfile -t commits <<<"$git_log_out"
+git_show_out="$(
+	{
+		echo "${COMMIT_METADATA_COMMITS[@]}" |
+			tr ' ' '\n' |
+			xargs git show --no-patch --pretty=format:"%ct %h %s"
+	} | sort -k3,3 -k1,1n | cut -d' ' -f2
+)"
+mapfile -t commits <<<"${git_show_out}"
 
 # From: https://github.com/commitizen/conventional-commit-types
 # NOTE(mafredri): These need to be supported in check_commit_metadata.sh as well.
@@ -121,56 +122,75 @@ declare -A section_titles=(
 # Verify that all items in section_order exist as keys in section_titles and
 # vice-versa.
 for cat in "${section_order[@]}"; do
-	if [[ " ${!section_titles[*]} " != *" $cat "* ]]; then
-		error "BUG: category $cat does not exist in section_titles"
+	if [[ " ${!section_titles[*]} " != *" ${cat} "* ]]; then
+		error "BUG: category ${cat} does not exist in section_titles"
 	fi
 done
 for cat in "${!section_titles[@]}"; do
-	if [[ " ${section_order[*]} " != *" $cat "* ]]; then
-		error "BUG: Category $cat does not exist in section_order"
+	if [[ " ${section_order[*]} " != *" ${cat} "* ]]; then
+		error "BUG: Category ${cat} does not exist in section_order"
 	fi
 done
 
 for commit in "${commits[@]}"; do
-	line="- $commit ${COMMIT_METADATA_TITLE[$commit]}"
-	if [[ -v COMMIT_METADATA_AUTHORS[$commit] ]]; then
-		line+=" (${COMMIT_METADATA_AUTHORS[$commit]})"
+	title=${COMMIT_METADATA_TITLE[${commit}]}
+	if [[ -v COMMIT_METADATA_HUMAN_TITLE[${commit}] ]]; then
+		title=${COMMIT_METADATA_HUMAN_TITLE[${commit}]}
+	fi
+
+	if [[ ${title} =~ \(#[0-9]*\)$ ]]; then
+		title="${title%)}, ${commit})"
+	else
+		title="${title} (${commit})"
+	fi
+	line="- ${title}"
+	line=${line//) (/, )}
+	if [[ -v COMMIT_METADATA_AUTHORS[${commit}] ]]; then
+		line+=" (${COMMIT_METADATA_AUTHORS[${commit}]})"
 	fi
 
 	# Default to "other" category.
 	cat=other
 	for c in "${!section_titles[@]}"; do
-		if [[ $c == "${COMMIT_METADATA_CATEGORY[$commit]}" ]]; then
-			cat=$c
+		if [[ ${c} == "${COMMIT_METADATA_CATEGORY[${commit}]}" ]]; then
+			cat=${c}
 			break
 		fi
 	done
-	declare "$cat"_changelog+="$line"$'\n'
+	declare "${cat}"_changelog+="${line}"$'\n'
 done
 
 changelog="$(
 	for cat in "${section_order[@]}"; do
 		changes="$(eval "echo -e \"\${${cat}_changelog:-}\"")"
 		if ((${#changes} > 0)); then
-			echo -e "\n### ${section_titles["$cat"]}\n"
-			if [[ $cat == experimental ]]; then
+			echo -e "\n### ${section_titles["${cat}"]}\n"
+			if [[ ${cat} == experimental ]]; then
 				echo -e "These changes are feature-flagged and can be enabled with the \`--experiments\` server flag. They may change or be removed in future releases.\n"
 			fi
-			echo -e "$changes"
+			echo -e "${changes}"
 		fi
 	done
 )"
 
-image_tag="$(execrelative ../image_tag.sh --version "$new_version")"
+image_tag="$(execrelative ../image_tag.sh --version "${new_version}")"
+
+blurb=
+if ((mainline)); then
+	blurb="
+> [!NOTE]
+> This is a mainline Coder release. We advise enterprise customers without a staging environment to install our [latest stable release](https://github.com/coder/coder/releases/latest) while we refine this version. Learn more about our [Release Schedule](https://coder.com/docs/v2/latest/install/releases).
+"
+fi
 
 echo -e "## Changelog
-$changelog
+${blurb}${changelog}
 
-Compare: [\`$old_version...$new_version\`](https://github.com/coder/coder/compare/$old_version...$new_version)
+Compare: [\`${old_version}...${new_version}\`](https://github.com/coder/coder/compare/${old_version}...${new_version})
 
 ## Container image
 
-- \`docker pull $image_tag\`
+- \`docker pull ${image_tag}\`
 
 ## Install/upgrade
 

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -176,14 +176,18 @@ changelog="$(
 image_tag="$(execrelative ../image_tag.sh --version "${new_version}")"
 
 blurb=
+stable_since=
 if ((mainline)); then
 	blurb="
 > [!NOTE]
 > This is a mainline Coder release. We advise enterprise customers without a staging environment to install our [latest stable release](https://github.com/coder/coder/releases/latest) while we refine this version. Learn more about our [Release Schedule](https://coder.com/docs/v2/latest/install/releases).
 "
+else
+	d=$(date +'%B %d, %Y')
+	stable_since="> ## Stable (since ${d})"$'\n\n'
 fi
 
-echo -e "## Changelog
+echo -e "${stable_since}## Changelog
 ${blurb}${changelog}
 
 Compare: [\`${old_version}...${new_version}\`](https://github.com/coder/coder/compare/${old_version}...${new_version})

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -33,14 +33,19 @@ if [[ "${CI:-}" == "" ]]; then
 	error "This script must be run in CI"
 fi
 
+stable=0
 version=""
 release_notes_file=""
 dry_run=0
 
-args="$(getopt -o "" -l version:,release-notes-file:,dry-run -- "$@")"
+args="$(getopt -o "" -l stable,version:,release-notes-file:,dry-run -- "$@")"
 eval set -- "$args"
 while true; do
 	case "$1" in
+	--stable)
+		stable=1
+		shift
+		;;
 	--version)
 		version="$2"
 		shift 2
@@ -169,9 +174,15 @@ popd
 log
 log
 
+latest=false
+if [[ "$stable" == 1 ]]; then
+	latest=true
+fi
+
 # We pipe `true` into `gh` so that it never tries to be interactive.
 true |
 	maybedryrun "$dry_run" gh release create \
+		--latest="$latest" \
 		--title "$new_tag" \
 		--notes-file "$release_notes_file" \
 		"$new_tag" \

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -179,11 +179,19 @@ if [[ "$stable" == 1 ]]; then
 	latest=true
 fi
 
+target_commitish=main # This is the default.
+release_branch_refname=$(git branch --remotes --contains "${new_tag}" --format '%(refname)' '*/release/*')
+if [[ -n "${release_branch_refname}" ]]; then
+	# refs/remotes/origin/release/2.9 -> release/2.9
+	target_commitish="release/${release_branch_refname#*release/}"
+fi
+
 # We pipe `true` into `gh` so that it never tries to be interactive.
 true |
 	maybedryrun "$dry_run" gh release create \
 		--latest="$latest" \
 		--title "$new_tag" \
+		--target "$target_commitish" \
 		--notes-file "$release_notes_file" \
 		"$new_tag" \
 		"$temp_dir"/*

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -16,33 +16,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 cdroot
 
 # If in Sapling, just print the commit since we don't have tags.
-if [ -d ".sl" ]; then
+if [[ -d ".sl" ]]; then
 	sl log -l 1 | awk '/changeset/ { printf "0.0.0+sl-%s\n", substr($2, 0, 16) }'
 	exit 0
 fi
 
-if [[ "${CODER_FORCE_VERSION:-}" != "" ]]; then
-	echo "$CODER_FORCE_VERSION"
+if [[ -n "${CODER_FORCE_VERSION:-}" ]]; then
+	echo "${CODER_FORCE_VERSION}"
 	exit 0
 fi
 
 # To make contributing easier, if the upstream isn't coder/coder and there are
 # no tags we will fall back to 0.1.0 with devel suffix.
-if [[ "$(git remote get-url origin)" != *coder/coder* ]] && [[ "$(git tag)" == "" ]]; then
+remote_url=$(git remote get-url origin)
+tag_list=$(git tag)
+if ! [[ ${remote_url} =~ [@/]github.com ]] && ! [[ ${remote_url} =~ [:/]coder/coder(\.git)?$ ]] && [[ -z ${tag_list} ]]; then
 	log
 	log "INFO(version.sh): It appears you've checked out a fork of Coder."
 	log "INFO(version.sh): By default GitHub does not include tags when forking."
-	log "INFO(version.sh): We will use the default version 0.1.0 for this build."
+	log "INFO(version.sh): We will use the default version 2.0.0 for this build."
 	log "INFO(version.sh): To pull tags from upstream, use the following commands:"
 	log "INFO(version.sh):   - git remote add upstream https://github.com/coder/coder.git"
 	log "INFO(version.sh):   - git fetch upstream"
 	log
-	last_tag="v0.1.0"
+	last_tag="v2.0.0"
 else
 	last_tag="$(git describe --tags --abbrev=0)"
 fi
 
-version="$last_tag"
+version="${last_tag}"
 
 # If the HEAD has extra commits since the last tag then we are in a dev version.
 #
@@ -51,11 +53,11 @@ version="$last_tag"
 if [[ "${CODER_RELEASE:-}" == *t* ]]; then
 	# $last_tag will equal `git describe --always` if we currently have the tag
 	# checked out.
-	if [[ "$last_tag" != "$(git describe --always)" ]]; then
+	if [[ "${last_tag}" != "$(git describe --always)" ]]; then
 		# make won't exit on $(shell cmd) failures, so we have to kill it :(
-		if [[ "$(ps -o comm= "$PPID" || true)" == *make* ]]; then
+		if [[ "$(ps -o comm= "${PPID}" || true)" == *make* ]]; then
 			log "ERROR: version.sh: the current commit is not tagged with an annotated tag"
-			kill "$PPID" || true
+			kill "${PPID}" || true
 			exit 1
 		fi
 


### PR DESCRIPTION
This PR modifies the release scripts to add support for `--stable` and `--mainline` releases.

Fixes #12458

It also formalizes the release process.

- Creating a new minor (or major) release starts a new release branch: `release/2.10` (I'd prefer using the v-prefix here but I followed the existing convention)
- Creating a patch release (v2.10.1) must be applied to the `release/2.10` branch to enforce consistency
- If possible, the release branch (e.g. `release/2.10`) will be fast-forwarded to the commit we want to release
- If fast-forward is impossible, only new commits/cherry picks can be used in patch releases
- Pushing a new version tag (`v2.11.0`) will **not** trigger a release (build/publish)
- The `scripts/release.sh` should be used, in which case it will ask to start a release (build/publish) for you
- When cutting a new minor release, the autogenerated changelog will exclude commits cherry-picked into a patch release (e.g. `v2.10.2`)
- The release script will attempt to humanize the changelog for maintainer convenience (defined in `scripts/release/check_commit_metadata.sh`)

Running pre-release hooks will be part of an upcoming PR, there we will add sanity checks for patch-releases with migrations.

Here are two examples of running the release script:

<details>
<summary>Patch release on current `main` (not possible)</summary>

```console
❯ ./scripts/release.sh --ignore-script-out-of-date --ref main --mainline --dry-run
Working directory is not clean, it is highly recommended to stash changes.
Stash changes? (y/n) n

Checking remote origin for repo...
Fetching main and tags from origin...
Checking GitHub for latest release(s)...
Latest mainline release: v2.10.2
Latest stable release: v2.9.4

Checking commit metadata for changes between v2.10.2 and 81fcdf717...
Skipping commit 8d1220e0c814e709363cc22951f1b0238a4c1594 cherry-picked into v2.10.2 as 2a98123701655dadc659b84ac463b3b77b0172c0 (chore: add generate script for azure instance identity (#13028))
Skipping commit d426569d4a1bb40042af52244768848c56af5aac cherry-picked into v2.10.2 as bda13a2818b71cd104db2afd0e21a56acdd46f9d (fix: make terminal raw in ssh command on windows (#12990))
Skipping commit a231b5aef503ada90e37bd755a9574b858d8d60e cherry-picked into v2.10.2 as 353888a5d8fd971c2ed7e68260199eadadc60aa9 (feat: add src_id and dst_id indexes to tailnet_tunnels (#12911))
Skipping commit 06eae954c978db7767d984348f3d471f64858b19 cherry-picked into v2.10.2 as 3fc6111994b5e129afee416f002ae4f9710915ac (fix: stop sending DeleteTailnetPeer when coordinator is unhealthy (#12925))
Skipping commit a2b28f80d7a14e1a42af2f6527aedfce757727b1 cherry-picked into v2.10.2 as 3eb9abcbd3305cc2823a0493d889e031a850b563 (fix(coderd): prevent agent reverse proxy from using `HTTP[S]_PROXY` envs (#12875))

Executing DRYRUN of release tagging...
No breaking changes detected, using "patch" increment.
ERROR: Provided ref (81fcdf717) is not in the required release branch (release/2.10) and cannot be fast-forwarded, unable to increment patch version. Please increment minor or major.
```

</details>

<details>
<summary>Minor release of current `main`</summary>

```console
❯ ./scripts/release.sh --ignore-script-out-of-date --ref main --mainline --minor --dry-run
Working directory is not clean, it is highly recommended to stash changes.
Stash changes? (y/n) n

Checking remote origin for repo...
Fetching main and tags from origin...
Checking GitHub for latest release(s)...
Latest mainline release: v2.10.2
Latest stable release: v2.9.4

Checking commit metadata for changes between v2.10.2 and 81fcdf717...
Skipping commit 8d1220e0c814e709363cc22951f1b0238a4c1594 cherry-picked into v2.10.2 as 2a98123701655dadc659b84ac463b3b77b0172c0 (chore: add generate script for azure instance identity (#13028))
Skipping commit d426569d4a1bb40042af52244768848c56af5aac cherry-picked into v2.10.2 as bda13a2818b71cd104db2afd0e21a56acdd46f9d (fix: make terminal raw in ssh command on windows (#12990))
Skipping commit a231b5aef503ada90e37bd755a9574b858d8d60e cherry-picked into v2.10.2 as 353888a5d8fd971c2ed7e68260199eadadc60aa9 (feat: add src_id and dst_id indexes to tailnet_tunnels (#12911))
Skipping commit 06eae954c978db7767d984348f3d471f64858b19 cherry-picked into v2.10.2 as 3fc6111994b5e129afee416f002ae4f9710915ac (fix: stop sending DeleteTailnetPeer when coordinator is unhealthy (#12925))
Skipping commit a2b28f80d7a14e1a42af2f6527aedfce757727b1 cherry-picked into v2.10.2 as 3eb9abcbd3305cc2823a0493d889e031a850b563 (fix(coderd): prevent agent reverse proxy from using `HTTP[S]_PROXY` envs (#12875))

Executing DRYRUN of release tagging...
No breaking changes detected, using "minor" increment.
Old version: v2.10.2
New version: v2.11.0
Release branch: release/2.11
Creating new release branch
DRYRUN: git checkout -b release/2.11 81fcdf717
DRYRUN: git tag -a v2.11.0 -m Release v2.11.0 81fcdf717

Continue? (y/n) y

Writing release notes to build/RELEASE-v2.11.0-DRYRUN.md
Release notes written to build/RELEASE-v2.11.0-DRYRUN.md, you can now edit this file manually.

No editor found, please set the $EDITOR environment variable for edit prompt.

Preview release notes? (y/n) y

## Changelog

> [!NOTE]
> This is a mainline Coder release. We advise enterprise customers without a staging environment to install our [latest stable release](https://github.com/coder/coder/releases/latest) while we refine this version. Learn more about our [Release Schedule](https://coder.com/docs/v2/latest/install/releases).

### Features

- CLI: Support bundle: dump healthcheck summary (#12963, 407e61ecd) (@johnstcn)
- CLI: Support bundle: show links to docs/admin/healthcheck (#12974, 8e1e0f04a) (@johnstcn)
- CLI: Add `--env` flag for `coder ssh` (#12991, 8a1216254) (@aaronlehmann)
- Database: Keep only 1 day of `workspace_agent_stats` after rollup (#12674, e17e8aa3c) (@mafredri)
- Server: Improve detection of STUN issues (#12951, 9a4703a31) (@johnstcn)
- Enterprise: Add ready for handshake support to pgcoord (#12935, 777dfbe96) (@coadler)
- Add owner groups to workspace data (#12841, f96ce80ab) (@f0ssel)
- Remove health link from deployment sidebar (#12914, 08451ce80) (@mtojek)
- Add s suffix to use HTTPS for ports (#12862, 1d4bf30c0) (@f0ssel)
- Link with protocol on shared ports (#12908, acaa25409) (@f0ssel)
- Add agent acks to in-memory coordinator (#12786, e801e878b) (@coadler)
- Add listening ports protocol selector (#12915, 3ab5a51ec) (@f0ssel)
- Add warning about use of old/removed/invalid experiments (#12962, b85d5d849) (@dannykopping)

### Bug fixes

- CLI: Allow generating partial support bundles with no workspace or agent (#12933, fad97a14f) (@johnstcn)
- Server: Properly calculate query latency for tailnet queries (#12944, 231fc26c9) (@coadler)
- Database: Reduce db load via dbpurge advisory locking (#13021, 3adcccb61) (@mafredri)
- Server: Avoid logging error for no rows (#12988, 92190443f) (@mafredri)
- Examples: Copy /etc/skel on init in docker template (#12913, 0178bfe13) (@mafredri)
- Installer: Use `--version` when provided (#12873, 61e5721ca) (@michaelbrewer)
- Installer: Change post-install advisory when installing specific version (#12878, c243210ae) (@mafredri)
- Installer: Remove extracted files after installation (#12879, b06452ee8) (@mafredri)
- Support: Correctly rename existing agent connection info, add real netcheck (#12946, b163bc7f0) (@johnstcn)
- Fix race in assertWorkspaceLastUsedAtUpdated (#12899, 3b7380fa0) (@spikecurtis)
- Update typo in audit log field (#12907, d82f2fd41) (@coryb)
- Stop logging session shutdown as warning (#12922, 546901101) (@spikecurtis)
- Ignore gomock temporary files (#12924, b6359b0a8) (@mtojek)
- Show template autostop setting when it overrides the workspace setting (#12910, 2ad7fcc0b) (@aslilac)
- Use provided username when fetching workspaces (#12955, d3790bb5b) (@kylecarbs)
- Disable azureidentity test on darwin (#12979, 942e90270) (@coadler)
- Add grace period before showing replicas license error (#12989, 227e63205) (@kylecarbs)

### Documentation

- Describe multi-cloud architecture (#12857, 90efa1b84) (@mtojek)
- Describe devcontainers as deployment model (#12877, 7c0fac990) (@mtojek)
- Describe air-gapped architecture (#12897, 28754a79e) (@mtojek)
- Explain that mainline stays around for one month now (#12993, f5a32b3f2) (@bpmct)

### Code refactoring

- Dashboard: Verify deployment config flags in e2e tests (#12986, ee7dda811) (@mtojek)

### Tests

- Dashboard: Fix flaky outdated agent test (#12927, e266ecf91) (@mtojek)
- Dashboard: Add e2e tests for experiments (#12940, dcf1d3a9a) (@mtojek)
- Dashboard: Add e2e tests for appearance (#12950, cf2d2a98b) (@mtojek)
- Dashboard: Add e2e tests for security (#12961, 49689162b) (@mtojek)
- Dashboard: Add e2e tests for user auth (#12971, b598aef54) (@mtojek)
- Dashboard: Add e2e tests for network (#12987, cb8c576c9) (@mtojek)
- Dashboard: Add e2e tests for observability (75223dfd8) (@mtojek)
- Dashboard: Add e2e tests for workspace proxies (#13009, 3d7740bd3) (@mtojek)
- Verify that enterprise tests are being run (#12871, c4b26f335) (@aslilac)
- Verify actually uploaded license with assert (#12934, 8da8b89af) (@Emyrk)
- Fix url checks in e2e tests (#12881, c5367c201) (@aslilac)
- Add an e2e audit logs test (#12868, 00fcf3699) (@aslilac)

### Continuous integration

- Disable enterprise e2e tests temporarily (#12874, bc9ea61eb) (@aslilac)
- Execute enterprise and non-enterprise e2e tests concurrently (#12872, 9cf235811) (@aslilac)
- Bump crate-ci/typos from 1.19.0 to 1.20.9 in the github-actions group (#13027, 3af317317) (@app/dependabot)

### Chores

- Documentation: Add support bundle guide (#12931, b71af3211) (@johnstcn)
- Documentation: Make external auth docs easier to follow (#12970, b40f54f60) (@doodzik)
- Dashboard: Add e2e to test add and remove user (#12851, 41b8ff3e8) (@BrunoQuaresma)
- Dashboard: Add e2e tests for groups (#12866, 3fbcdb0dd) (@BrunoQuaresma)
- Bump golang.org/x/term from 0.18.0 to 0.19.0 (#12886, 24135a2d0) (@app/dependabot)
- Bump github.com/elastic/go-sysinfo from 1.13.1 to 1.14.0 (#12894, 8ba8ec2f1) (@app/dependabot)
- Bump golang.org/x/sync from 0.6.0 to 0.7.0 (#12895, f99fd807b) (@app/dependabot)
- Bump golang.org/x/net from 0.22.0 to 0.24.0 (#12888, 9a7d8034c) (@app/dependabot)
- Bump golang.org/x/tools from 0.19.0 to 0.20.0 (#12890, 589434e8d) (@app/dependabot)
- Bump google.golang.org/grpc from 1.62.1 to 1.63.0 (#12892, 11123018a) (@app/dependabot)
- Bump golang.org/x/oauth2 from 0.18.0 to 0.19.0 (#12893, 7179c86df) (@app/dependabot)
- Deprecate agent report-stats endpoint (#12880, 189b8626d) (@Emyrk)
- Remove InsertWorkspaceAgentStat query  (#12869, 0a8c8ce5c) (@Emyrk)
- Add date information to windows startup logs (#12905, 4dc293d93) (@Emyrk)
- Merge apikey/token session config values (#12817, 838e8df5b) (@Emyrk)
- Disable pgcoord (HA) when --in-memory (#12919, a607d5610) (@Emyrk)
- Add unit test for pass through external auth query params (#12928, 566f8f231) (@Emyrk)
- Nix shell to support playwright e2e tests (#12917, 7fd9a75ad) (@Emyrk)
- Deconflict e2e enterprise and AGPL artifacts in ci (#12941, b9936a467) (@Emyrk)
- Add -agpl to agpl e2e artifacts (#12943, 22785a307) (@Emyrk)
- Skip global.setup if first user already exists (#12930, 93b46fe1f) (@Emyrk)
- Update generated array type definitions in TypeScript to be readonly (#12947, d9da054c9) (@Emyrk)
- Fix broken links in the jfrog guide (#12835, c13909a1a) (@stirby)
- Add `created_at` to workspace resource telemetry (#12969, 41ca6e4f7) (@kylecarbs)
- Apply shellcheck recommendation which was causing "make lint" to fail locally (#12972, 06e042acf) (@dannykopping)
- Fix linting issue (#12945, ba52a4fbe) (@coadler)
- Add license review to CI (#12981, 80f597812) (@sreya)
- Bump github.com/moby/moby (#12960, 3338cdca7) (@app/dependabot)
- Give additional time in tests for `tailnetAPIConnector` graceful disconnect (#12980, 6b4eb0319) (@coadler)
- Add e2e test against an external auth provider during workspace creation (#12985, 319fd5bf1) (@dannykopping)
- Fix down migration 196 (#13006, 3aa0d7381) (@coadler)
- Fix 404 for managed terraform variables (#13018, 4a6693a17) (@michaelbrewer)
- Fix link to install (#13019, d2acb6776) (@michaelbrewer)
- Bump google.golang.org/api from 0.172.0 to 0.175.0 (#13026, ea472c538) (@app/dependabot)
- Bump github.com/coder/terraform-provider-coder (#13022, 2e49fa94d) (@app/dependabot)
- Fix broken mainline link (#13015, 7bd1b3bdb) (@michaelbrewer)
- Reduce dashboard requests from seeded data (#13034, d3f3ace22) (@kylecarbs)
- Change `site_configs.value` to `text` (#13036, fab5591cf) (@aslilac)
- Bump github.com/gohugoio/hugo from 0.124.0 to 0.125.2 (#13024, 81fcdf717) (@app/dependabot)

### Other changes

- added releases.md to manifest (#12936, ab116af54) (@stirby)
- e2e tests for deployment/licenses (#12926, 2f2a395ba) (@mtojek)
- Skip dependency license review on main (#12982, 0c993566d) (@sreya)
- label some template settings as enterprise (#12952, 7cf8577f1) (@aslilac)

Compare: [`v2.10.2...v2.11.0`](https://github.com/coder/coder/compare/v2.10.2...v2.11.0)

## Container image

- `docker pull ghcr.io/coder/coder:v2.11.0`

## Install/upgrade

Refer to our docs to [install](https://coder.com/docs/v2/latest/install) or [upgrade](https://coder.com/docs/v2/latest/admin/upgrade) Coder, or use a release asset below.


Create, build and publish release? (y/n) y

DRYRUN: execrelative ./release/tag_version.sh --old-version v2.10.2 --ref 81fcdf717 --minor
DRYRUN: git push -u origin release/2.11
DRYRUN: git push --tags -u origin v2.11.0

Release tags for v2.11.0 created successfully and pushed to origin!

Writing release JSON to /var/folders/xb/7t2r1stn5lj9z5mxstz6vymc0000gn/T/coder-release.json.WbcmOVOenQ
Running release workflow...
DRYRUN: cat /var/folders/xb/7t2r1stn5lj9z5mxstz6vymc0000gn/T/coder-release.json.WbcmOVOenQ
DRYRUN: gh workflow run release.yaml --json --ref v2.11.0

Release workflow started successfully!
```

</details>
