### PR TITLE
ci: release: test migrations before building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,6 +130,10 @@ jobs:
           AC_CERTIFICATE_PASSWORD: ${{ secrets.AC_CERTIFICATE_PASSWORD }}
           AC_APIKEY_P8_BASE64: ${{ secrets.AC_APIKEY_P8_BASE64 }}
 
+      - name: Test migrations from current ref to main
+        run: |
+          make test-migrations
+
       - name: Build binaries
         run: |
           set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -785,10 +785,12 @@ test-postgres: test-postgres-docker
 
 test-migrations: test-postgres-docker
 	echo "--- test migrations"
+	set -euxo pipefail
 	COMMIT_FROM=$(shell git rev-parse --short HEAD)
 	COMMIT_TO=$(shell git rev-parse --short main)
-	DB_NAME=$(shell go run scripts/migrate-ci/main.go)
-	go run ./scripts/migrate-test/main.go --from="$$COMMIT_FROM" --to="$$COMMIT_TO" --postgres-url="postgresql://postgres:postgres@localhost:5432/$$DB_NAME?sslmode=disable"
+	REF=$(shell git rev-parse --short HEAD)
+	echo "DROP DATABASE IF EXISTS migrate_test_$${REF}; CREATE DATABASE migrate_test_$${REF};" | psql 'postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable'
+	go run ./scripts/migrate-test/main.go --from="$$COMMIT_FROM" --to="$$COMMIT_TO" --postgres-url="postgresql://postgres:postgres@localhost:5432/migrate_test_$${REF}?sslmode=disable"
 
 # NOTE: we set --memory to the same size as a GitHub runner.
 test-postgres-docker:

--- a/Makefile
+++ b/Makefile
@@ -788,9 +788,8 @@ test-migrations: test-postgres-docker
 	set -euxo pipefail
 	COMMIT_FROM=$(shell git rev-parse --short HEAD)
 	COMMIT_TO=$(shell git rev-parse --short main)
-	REF=$(shell git rev-parse --short HEAD)
-	echo "DROP DATABASE IF EXISTS migrate_test_$${REF}; CREATE DATABASE migrate_test_$${REF};" | psql 'postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable'
-	go run ./scripts/migrate-test/main.go --from="$$COMMIT_FROM" --to="$$COMMIT_TO" --postgres-url="postgresql://postgres:postgres@localhost:5432/migrate_test_$${REF}?sslmode=disable"
+	echo "DROP DATABASE IF EXISTS migrate_test_$${COMMIT_FROM}; CREATE DATABASE migrate_test_$${COMMIT_FROM};" | psql 'postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable'
+	go run ./scripts/migrate-test/main.go --from="$$COMMIT_FROM" --to="$$COMMIT_TO" --postgres-url="postgresql://postgres:postgres@localhost:5432/migrate_test_$${COMMIT_FROM}?sslmode=disable"
 
 # NOTE: we set --memory to the same size as a GitHub runner.
 test-postgres-docker:

--- a/Makefile
+++ b/Makefile
@@ -785,7 +785,7 @@ test-postgres: test-postgres-docker
 
 test-migrations: test-postgres-docker
 	echo "--- test migrations"
-	set -euxo pipefail
+	set -euo pipefail
 	COMMIT_FROM=$(shell git rev-parse --short HEAD)
 	COMMIT_TO=$(shell git rev-parse --short main)
 	echo "DROP DATABASE IF EXISTS migrate_test_$${COMMIT_FROM}; CREATE DATABASE migrate_test_$${COMMIT_FROM};" | psql 'postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable'


### PR DESCRIPTION
- Adds step to test migrations before releasing.
- Modifies `test-migrations` target to avoid using `migrate-ci`