### PR TITLE
chore(docs): fix broken links

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 9 * * 1"
   workflow_dispatch: # allows to run manually for testing
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
 
 jobs:
   check-docs:

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   check-docs:

--- a/docs/about/architecture.md
+++ b/docs/about/architecture.md
@@ -330,7 +330,7 @@ across multiple regions and diverse cloud platforms.
 - Since the _Registry_ is isolated from the internet, platform engineers are
   responsible for maintaining Workspace container images and conducting periodic
   updates of base Docker images.
-- It is recommended to keep [Dev Containers](../templates/devcontainers.md) up
+- It is recommended to keep [Dev Containers](../templates/dev-containers.md) up
   to date with the latest released
   [Envbuilder](https://github.com/coder/envbuilder) runtime.
 
@@ -360,7 +360,7 @@ project-oriented [features](https://containers.dev/features) without requiring
 platform administrators to push altered Docker images.
 
 Learn more about
-[Dev containers support](https://coder.com/docs/v2/latest/templates/devcontainers)
+[Dev containers support](https://coder.com/docs/v2/latest/templates/dev-containers)
 in Coder.
 
 ![Architecture Diagram](../images/architecture-devcontainers.png)

--- a/docs/changelogs/v0.26.1.md
+++ b/docs/changelogs/v0.26.1.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- [Devcontainer templates](https://coder.com/docs/v2/latest/templates/devcontainers)
+- [Devcontainer templates](https://coder.com/docs/v2/latest/templates/dev-containers)
   for Coder (#8256)
 - The dashboard will warn users when a workspace is unhealthy (#8422)
 - Audit logs `resource_target` search query allows you to search by resource

--- a/examples/templates/devcontainer-docker/README.md
+++ b/examples/templates/devcontainer-docker/README.md
@@ -32,7 +32,7 @@ sudo -u coder docker ps
 
 ## Architecture
 
-Coder supports devcontainers with [envbuilder](https://github.com/coder/envbuilder), an open source project. Read more about this in [Coder's documentation](https://coder.com/docs/v2/latest/templates/devcontainers).
+Coder supports devcontainers with [envbuilder](https://github.com/coder/envbuilder), an open source project. Read more about this in [Coder's documentation](https://coder.com/docs/v2/latest/templates/dev-containers).
 
 This template provisions the following resources:
 

--- a/examples/templates/devcontainer-kubernetes/README.md
+++ b/examples/templates/devcontainer-kubernetes/README.md
@@ -27,7 +27,7 @@ This template authenticates using a `~/.kube/config`, if present on the server, 
 
 ## Architecture
 
-Coder supports devcontainers with [envbuilder](https://github.com/coder/envbuilder), an open source project. Read more about this in [Coder's documentation](https://coder.com/docs/v2/latest/templates/devcontainers).
+Coder supports devcontainers with [envbuilder](https://github.com/coder/envbuilder), an open source project. Read more about this in [Coder's documentation](https://coder.com/docs/v2/latest/templates/dev-containers).
 
 This template provisions the following resources:
 


### PR DESCRIPTION
Georgian team again.

When going through the documentation, I encountered a couple of broken links. It is frustrating for users to get 404s. I fixed the list of broken links from the [weekly-docs](https://github.com/coder/coder/actions/workflows/weekly-docs.yaml) ci step.

I also noticed that the ci step has been failing for several weeks. To ensure that broken links are fixed faster, I changed the check to run every time the documentation is changed.