### PR TITLE
chore(README): add contributing section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ Feel free to [open an issue](https://github.com/coder/coder/issues/new) if you h
 
 [Join our Discord](https://discord.gg/coder) to provide feedback on in-progress features, and chat with the community using Coder!
 
-## Contributing
-
-We are always happy to see new contributors to Coder. If you are new to the Coder codebase, we have
-[a guide on how to get started](https://coder.com/docs/v2/latest/CONTRIBUTING). We'd love to see your
-contributions!
-
 ## Integrations
 
 We are always working on new integrations. Feel free to open an issue to request an integration. Contributions are welcome in any official or community repositories.
@@ -122,3 +116,9 @@ We are always working on new integrations. Feel free to open an issue to request
 
 - [**Provision Coder with Terraform**](https://github.com/ElliotG/coder-oss-tf): Provision Coder on Google GKE, Azure AKS, AWS EKS, DigitalOcean DOKS, IBMCloud K8s, OVHCloud K8s, and Scaleway K8s Kapsule with Terraform
 - [**Coder Template GitHub Action**](https://github.com/marketplace/actions/update-coder-template): A GitHub Action that updates Coder templates
+
+## Contributing
+
+We are always happy to see new contributors to Coder. If you are new to the Coder codebase, we have
+[a guide on how to get started](https://coder.com/docs/v2/latest/CONTRIBUTING). We'd love to see your
+contributions!

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Feel free to [open an issue](https://github.com/coder/coder/issues/new) if you h
 
 [Join our Discord](https://discord.gg/coder) to provide feedback on in-progress features, and chat with the community using Coder!
 
+## Contributing
+
+We are always happy to see new contributors to Coder. If you are new to the Coder codebase, we have
+[a guide on how to get started](https://coder.com/docs/v2/latest/CONTRIBUTING). We'd love to see your
+contributions!
+
 ## Integrations
 
 We are always working on new integrations. Feel free to open an issue to request an integration. Contributions are welcome in any official or community repositories.


### PR DESCRIPTION
Finding the contributing manual to set up the repository so I could run `make fmt` was a bit annoying. I expect an open-source repo to have a section in the readme. To address this issue, I added a link to the contributing documentation in the readme.