### PR TITLE
chore(docs): update helm install version flags to patch releases

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -132,7 +132,7 @@ locally in order to log in and manage templates.
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml \
-       --version 2.10.0
+       --version 2.10.2
    ```
 
    For the **stable** Coder release:
@@ -141,7 +141,7 @@ locally in order to log in and manage templates.
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml \
-       --version 2.9.1
+       --version 2.9.4
    ```
 
    You can watch Coder start up by running `kubectl get pods -n coder`. Once


### PR DESCRIPTION
We specify stable and latest version flags for helm in the kube install docs - they fell behind the patches. 

This will be automated soon in the [Stable Releases scripts](https://github.com/coder/coder/milestone/32).