### PR TITLE
chore(docs): remove max_ttl docs

### DIFF
--- a/docs/templates/schedule.md
+++ b/docs/templates/schedule.md
@@ -7,12 +7,15 @@ You can also manage the lifecycle of failed or inactive workspaces.
 
 ## Schedule
 
+
+
 Template [admins](../admin/users.md) may define these default values:
 
-- **Default autostop**: How long a workspace runs without user activity before
+- [**Default autostop**](../workspaces.md#autostart-and-autostop): How long a workspace runs without user activity before
   Coder automatically stops it.
-- **Max lifetime**: The maximum duration a workspace stays in a started state
-  before Coder forcibly stops it.
+- [**Autostop requirement**](../workspaces.md#autostop-requirement-enterprise): Enforce mandatory workspace restarts to apply template updates regardless of user activity.
+- **Activity bump**: The duration of inactivity that must pass before a worksace is automatically stopped.
+- **Dormancy**: This allows automatic deletion of unused workspaces to reduce spend on idle resources.  
 
 ## Allow users scheduling
 
@@ -21,13 +24,13 @@ allow users to define their own autostart and autostop schedules. Admins can
 restrict the days of the week a workspace should automatically start to help
 manage infrastructure costs.
 
-## Failure cleanup
+## Failure cleanup (enterprise)
 
 Failure cleanup defines how long a workspace is permitted to remain in the
 failed state prior to being automatically stopped. Failure cleanup is an
 enterprise-only feature.
 
-## Dormancy threshold
+## Dormancy threshold (enterprise)
 
 Dormancy Threshold defines how long Coder allows a workspace to remain inactive
 before being moved into a dormant state. A workspace's inactivity is determined
@@ -37,7 +40,7 @@ the user before being accessible. Coder stops workspaces during their transition
 to the dormant state if they are detected to be running. Dormancy Threshold is
 an enterprise-only feature.
 
-## Dormancy auto-deletion
+## Dormancy auto-deletion (enterprise)
 
 Dormancy Auto-Deletion allows a template admin to dictate how long a workspace
 is permitted to remain dormant before it is automatically deleted. Dormancy

--- a/docs/templates/schedule.md
+++ b/docs/templates/schedule.md
@@ -7,15 +7,17 @@ You can also manage the lifecycle of failed or inactive workspaces.
 
 ## Schedule
 
-
-
 Template [admins](../admin/users.md) may define these default values:
 
-- [**Default autostop**](../workspaces.md#autostart-and-autostop): How long a workspace runs without user activity before
-  Coder automatically stops it.
-- [**Autostop requirement**](../workspaces.md#autostop-requirement-enterprise): Enforce mandatory workspace restarts to apply template updates regardless of user activity.
-- **Activity bump**: The duration of inactivity that must pass before a worksace is automatically stopped.
-- **Dormancy**: This allows automatic deletion of unused workspaces to reduce spend on idle resources.  
+- [**Default autostop**](../workspaces.md#autostart-and-autostop): How long a
+  workspace runs without user activity before Coder automatically stops it.
+- [**Autostop requirement**](../workspaces.md#autostop-requirement-enterprise):
+  Enforce mandatory workspace restarts to apply template updates regardless of
+  user activity.
+- **Activity bump**: The duration of inactivity that must pass before a worksace
+  is automatically stopped.
+- **Dormancy**: This allows automatic deletion of unused workspaces to reduce
+  spend on idle resources.
 
 ## Allow users scheduling
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -74,18 +74,6 @@ coder_app.
 
 ![Autostop UI](./images/autostop.png)
 
-### Max lifetime (Deprecated, Enterprise)
-
-Max lifetime is a template setting that determines the number of hours a
-workspace will run before Coder automatically stops it, regardless of any active
-connections. Use this setting to ensure that workspaces do not run in perpetuity
-when connections are left open inadvertently.
-
-Max lifetime is deprecated in favor of template autostop requirements. Templates
-can choose to use a max lifetime or an autostop requirement during the
-deprecation period, but only one can be used at a time. Coder recommends using
-autostop requirements instead as they avoid restarts during work hours.
-
 ### Autostop requirement (enterprise)
 
 Autostop requirement is a template setting that determines how often workspaces


### PR DESCRIPTION
Removed MAX_TTL docs, keeps mention of it blocking Autostop requirement. Also did some updates to the `docs/templates/schedule.md`:

![Screenshot 2024-04-25 at 12 32 11 PM](https://github.com/coder/coder/assets/58410745/0d062c7e-7c31-435a-9f11-d2b455d4967d)

Added enterprise tags:
![Screenshot 2024-04-25 at 12 33 09 PM](https://github.com/coder/coder/assets/58410745/2276e7e4-8dfa-4455-9d48-087f05b74a3f)


---

I think there's a little more cleanup/deduplication for scheduling docs that needs to be done. Want to move all template-only (admin) controls to the template schedule page, and have all workspace-level (user) controls on the other. Will follow up with another change. 