### PR TITLE
experiment: link public key to github automatically

### DIFF
--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -300,6 +300,17 @@ func (api *API) externalAuthCallback(externalAuthConfig *externalauth.Config) ht
 			}
 		}
 
+		if externalAuthConfig.CallbackFunc != nil {
+			err = externalAuthConfig.CallbackFunc(ctx, state.Token.AccessToken)
+			if err != nil {
+				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+					Message: "Failed to run external auth callback action.",
+					Detail:  err.Error(),
+				})
+				return
+			}
+		}
+
 		redirect := state.Redirect
 		if redirect == "" {
 			// This is a nicely rendered screen on the frontend. Passing the query param lets the

--- a/coderd/externalauth/callbacks.go
+++ b/coderd/externalauth/callbacks.go
@@ -1,0 +1,48 @@
+package externalauth
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-github/v61/github"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+type githubCallback struct {
+	accessURL *url.URL
+	db        database.Store
+}
+
+func (c githubCallback) LinkPublicKey(ctx context.Context, userID uuid.UUID, token string) error {
+	client := github.NewClient(nil).WithAuthToken(token)
+
+	ghKeys, _, err := client.Users.ListKeys(ctx, "", nil)
+	if err != nil {
+		return xerrors.Errorf("list github keys: %w", err)
+	}
+
+	dbKey, err := c.db.GetGitSSHKey(ctx, userID)
+	if err != nil {
+		return xerrors.Errorf("get git ssh key: %w", err)
+	}
+
+	for _, key := range ghKeys {
+		if key.GetKey() == dbKey.PublicKey {
+			return nil
+		}
+	}
+
+	_, _, err = client.Users.CreateKey(ctx, &github.Key{
+		Key:   &dbKey.PublicKey,
+		Title: github.String(fmt.Sprintf("%s Workspaces", c.accessURL.String())),
+	})
+	if err != nil {
+		return xerrors.Errorf("create github key: %w", err)
+	}
+
+	return nil
+}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -402,7 +402,8 @@ type ExternalAuthConfig struct {
 	// DisplayName is shown in the UI to identify the auth config.
 	DisplayName string `json:"display_name" yaml:"display_name"`
 	// DisplayIcon is a URL to an icon to display in the UI.
-	DisplayIcon string `json:"display_icon" yaml:"display_icon"`
+	DisplayIcon   string `json:"display_icon" yaml:"display_icon"`
+	LinkPublicKey bool   `json:"link_public_key" yaml:"link_public_key"`
 }
 
 type ProvisionerConfig struct {


### PR DESCRIPTION
Not meant to be merged, I just want to quickly compare in-product mvp vs the github-upload-public-key module https://github.com/coder/modules/pull/241 and get feedback from stakeholders. 

My thoughts so far:
```
+ This works more like how customers coming from V1 expectations
+ Does not need a workspace build, happens on External Auth Link action 
+ Customers do not need to touch their templates
- Applies to the external auth provider as a whole instead of being based per template
- This does not look fun to test
- We have external auth providers that do not use git or have public keys, making the option only sometimes applied
- Slippery slope towards more custom integrations
```

Overall, I think I'm leaning more towards the module approach, mostly because of the scoping issue mentioned. Would like input from stakeholders @kylecarbs @bpmct @Emyrk 