### PR TITLE
feat: add `deployment_id` to the ui and licenses

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "tailscale.com"
+    },
+    {
+      "pattern": "wireguard.com"
     }
   ],
   "aliveStatusCodes": [200, 0]

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8541,6 +8541,10 @@ const docTemplate = `{
                     "description": "DashboardURL is the URL to hit the deployment's dashboard.\nFor external workspace proxies, this is the coderd they are connected\nto.",
                     "type": "string"
                 },
+                "deployment_id": {
+                    "description": "DeploymentID is the unique identifier for this deployment.",
+                    "type": "string"
+                },
                 "external_url": {
                     "description": "ExternalURL references the current Coder version.\nFor production builds, this will link directly to a release. For development builds, this will link to a commit.",
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7599,6 +7599,10 @@
           "description": "DashboardURL is the URL to hit the deployment's dashboard.\nFor external workspace proxies, this is the coderd they are connected\nto.",
           "type": "string"
         },
+        "deployment_id": {
+          "description": "DeploymentID is the unique identifier for this deployment.",
+          "type": "string"
+        },
         "external_url": {
           "description": "ExternalURL references the current Coder version.\nFor production builds, this will link directly to a release. For development builds, this will link to a commit.",
           "type": "string"

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -735,7 +735,7 @@ func New(options *Options) *API {
 		// All CSP errors will be logged
 		r.Post("/csp/reports", api.logReportCSPViolations)
 
-		r.Get("/buildinfo", buildInfo(api.AccessURL, api.DeploymentValues.CLIUpgradeMessage.String()))
+		r.Get("/buildinfo", buildInfo(api.AccessURL, api.DeploymentValues.CLIUpgradeMessage.String(), api.DeploymentID))
 		// /regions is overridden in the enterprise version
 		r.Group(func(r chi.Router) {
 			r.Use(apiKeyMiddleware)

--- a/coderd/deployment.go
+++ b/coderd/deployment.go
@@ -68,7 +68,7 @@ func (api *API) deploymentStats(rw http.ResponseWriter, r *http.Request) {
 // @Tags General
 // @Success 200 {object} codersdk.BuildInfoResponse
 // @Router /buildinfo [get]
-func buildInfo(accessURL *url.URL, upgradeMessage string) http.HandlerFunc {
+func buildInfo(accessURL *url.URL, upgradeMessage, deploymentID string) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.BuildInfoResponse{
 			ExternalURL:     buildinfo.ExternalURL(),
@@ -77,6 +77,7 @@ func buildInfo(accessURL *url.URL, upgradeMessage string) http.HandlerFunc {
 			DashboardURL:    accessURL.String(),
 			WorkspaceProxy:  false,
 			UpgradeMessage:  upgradeMessage,
+			DeploymentID:    deploymentID,
 		})
 	}
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2151,6 +2151,9 @@ type BuildInfoResponse struct {
 	// UpgradeMessage is the message displayed to users when an outdated client
 	// is detected.
 	UpgradeMessage string `json:"upgrade_message"`
+
+	// DeploymentID is the unique identifier for this deployment.
+	DeploymentID string `json:"deployment_id"`
 }
 
 type WorkspaceProxyBuildInfo struct {

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -55,6 +55,7 @@ curl -X GET http://coder-server:8080/api/v2/buildinfo \
 {
   "agent_api_version": "string",
   "dashboard_url": "string",
+  "deployment_id": "string",
   "external_url": "string",
   "upgrade_message": "string",
   "version": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1178,6 +1178,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 {
   "agent_api_version": "string",
   "dashboard_url": "string",
+  "deployment_id": "string",
   "external_url": "string",
   "upgrade_message": "string",
   "version": "string",
@@ -1191,6 +1192,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | ------------------- | ------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `agent_api_version` | string  | false    |              | Agent api version is the current version of the Agent API (back versions MAY still be supported).                                                                   |
 | `dashboard_url`     | string  | false    |              | Dashboard URL is the URL to hit the deployment's dashboard. For external workspace proxies, this is the coderd they are connected to.                               |
+| `deployment_id`     | string  | false    |              | Deployment ID is the unique identifier for this deployment.                                                                                                         |
 | `external_url`      | string  | false    |              | External URL references the current Coder version. For production builds, this will link directly to a release. For development builds, this will link to a commit. |
 | `upgrade_message`   | string  | false    |              | Upgrade message is the message displayed to users when an outdated client is detected.                                                                              |
 | `version`           | string  | false    |              | Version returns the semantic version of the build.                                                                                                                  |

--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -147,13 +147,14 @@ func NewWithAPI(t *testing.T, options *Options) (
 }
 
 type LicenseOptions struct {
-	AccountType string
-	AccountID   string
-	Trial       bool
-	AllFeatures bool
-	GraceAt     time.Time
-	ExpiresAt   time.Time
-	Features    license.Features
+	AccountType   string
+	AccountID     string
+	DeploymentIDs []string
+	Trial         bool
+	AllFeatures   bool
+	GraceAt       time.Time
+	ExpiresAt     time.Time
+	Features      license.Features
 }
 
 // AddFullLicense generates a license with all features enabled.
@@ -190,6 +191,7 @@ func GenerateLicense(t *testing.T, options LicenseOptions) string {
 		LicenseExpires: jwt.NewNumericDate(options.GraceAt),
 		AccountType:    options.AccountType,
 		AccountID:      options.AccountID,
+		DeploymentIDs:  options.DeploymentIDs,
 		Trial:          options.Trial,
 		Version:        license.CurrentVersion,
 		AllFeatures:    options.AllFeatures,

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -257,14 +257,16 @@ type Claims struct {
 	// the end of the grace period (identical to LicenseExpires if there is no grace period).
 	// The reason we use the standard claim for the end of the grace period is that we want JWT
 	// processing libraries to consider the token "valid" until then.
-	LicenseExpires   *jwt.NumericDate `json:"license_expires,omitempty"`
-	AccountType      string           `json:"account_type,omitempty"`
-	AccountID        string           `json:"account_id,omitempty"`
-	Trial            bool             `json:"trial"`
-	AllFeatures      bool             `json:"all_features"`
-	Version          uint64           `json:"version"`
-	Features         Features         `json:"features"`
-	RequireTelemetry bool             `json:"require_telemetry,omitempty"`
+	LicenseExpires *jwt.NumericDate `json:"license_expires,omitempty"`
+	AccountType    string           `json:"account_type,omitempty"`
+	AccountID      string           `json:"account_id,omitempty"`
+	// DeploymentIDs enforces the license can only be used on a set of deployments.
+	DeploymentIDs    []string `json:"deployment_ids,omitempty"`
+	Trial            bool     `json:"trial"`
+	AllFeatures      bool     `json:"all_features"`
+	Version          uint64   `json:"version"`
+	Features         Features `json:"features"`
+	RequireTelemetry bool     `json:"require_telemetry,omitempty"`
 }
 
 // ParseRaw consumes a license and returns the claims.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -165,6 +165,7 @@ export interface BuildInfoResponse {
   readonly workspace_proxy: boolean;
   readonly agent_api_version: string;
   readonly upgrade_message: string;
+  readonly deployment_id: string;
 }
 
 // From codersdk/insights.go

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -175,7 +175,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
           </a>
         </Tooltip>
 
-        {buildInfo?.deployment_id && (
+        {Boolean(buildInfo?.deployment_id) && (
           <div
             css={css`
               font-size: 12px;
@@ -195,7 +195,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
               </div>
             </Tooltip>
             <CopyButton
-              text={buildInfo.deployment_id}
+              text={buildInfo!.deployment_id}
               buttonStyles={css`
                 width: 16px;
                 height: 16px;
@@ -205,7 +205,7 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
                   height: 16px;
                 }
               `}
-            />{" "}
+            />
           </div>
         )}
 

--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -12,9 +12,11 @@ import LaunchIcon from "@mui/icons-material/LaunchOutlined";
 import DocsIcon from "@mui/icons-material/MenuBook";
 import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
+import Tooltip from "@mui/material/Tooltip";
 import type { FC } from "react";
 import { Link } from "react-router-dom";
 import type * as TypesGen from "api/typesGenerated";
+import { CopyButton } from "components/CopyButton/CopyButton";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { usePopover } from "components/Popover/Popover";
 import { Stack } from "components/Stack/Stack";
@@ -161,15 +163,51 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
       <Divider css={{ marginBottom: "0 !important" }} />
 
       <Stack css={styles.info} spacing={0}>
-        <a
-          title="Browse Source Code"
-          css={[styles.footerText, styles.buildInfo]}
-          href={buildInfo?.external_url}
-          target="_blank"
-          rel="noreferrer"
-        >
-          {buildInfo?.version} <LaunchIcon />
-        </a>
+        <Tooltip title="Coder Version">
+          <a
+            title="Browse Source Code"
+            css={[styles.footerText, styles.buildInfo]}
+            href={buildInfo?.external_url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {buildInfo?.version} <LaunchIcon />
+          </a>
+        </Tooltip>
+
+        {buildInfo?.deployment_id && (
+          <div
+            css={css`
+              font-size: 12px;
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <Tooltip title="Deployment Identifier">
+              <div
+                css={css`
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                `}
+              >
+                {buildInfo?.deployment_id}
+              </div>
+            </Tooltip>
+            <CopyButton
+              text={buildInfo.deployment_id}
+              buttonStyles={css`
+                width: 16px;
+                height: 16px;
+
+                svg {
+                  width: 16px;
+                  height: 16px;
+                }
+              `}
+            />{" "}
+          </div>
+        )}
 
         <div css={styles.footerText}>{Language.copyrightText}</div>
       </Stack>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -201,6 +201,7 @@ export const MockBuildInfo: TypesGen.BuildInfoResponse = {
   dashboard_url: "https:///mock-url",
   workspace_proxy: false,
   upgrade_message: "My custom upgrade message",
+  deployment_id: "510d407f-e521-4180-b559-eab4a6d802b8",
 };
 
 export const MockSupportLinks: TypesGen.LinkConfig[] = [


### PR DESCRIPTION
Allows customers to send us the deployment ID easily. I put this in the user dropdown because it's so global. If users find this confusing, we can happily move it!
![image](https://github.com/coder/coder/assets/7122116/67cc5d7a-191b-47e9-8054-5def9292334b)

Soon, licenses can be generated with specific deployment IDs to match against. This is to prevent customers from having a bunch of Coder deployments with the same license.
