### PR TITLE
chore: dynamically determine gitlab external auth defaults

### DIFF
--- a/coderd/externalauth/externalauth_internal_test.go
+++ b/coderd/externalauth/externalauth_internal_test.go
@@ -8,6 +8,111 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+func TestGitlabDefaults(t *testing.T) {
+	t.Parallel()
+
+	// The default cloud setup. Copying this here as hard coded
+	// values.
+	cloud := codersdk.ExternalAuthConfig{
+		Type:        string(codersdk.EnhancedExternalAuthProviderGitLab),
+		ID:          string(codersdk.EnhancedExternalAuthProviderGitLab),
+		AuthURL:     "https://gitlab.com/oauth/authorize",
+		TokenURL:    "https://gitlab.com/oauth/token",
+		ValidateURL: "https://gitlab.com/oauth/token/info",
+		DisplayName: "GitLab",
+		DisplayIcon: "/icon/gitlab.svg",
+		Regex:       `^(https?://)?gitlab\.com(/.*)?$`,
+		Scopes:      []string{"write_repository"},
+	}
+
+	tests := []struct {
+		name           string
+		input          codersdk.ExternalAuthConfig
+		expected       codersdk.ExternalAuthConfig
+		mutateExpected func(*codersdk.ExternalAuthConfig)
+	}{
+		// Cloud
+		{
+			name: "OnlyType",
+			input: codersdk.ExternalAuthConfig{
+				Type: string(codersdk.EnhancedExternalAuthProviderGitLab),
+			},
+			expected: cloud,
+		},
+		{
+			// If someone was to manually configure the gitlab cli.
+			name: "CloudByConfig",
+			input: codersdk.ExternalAuthConfig{
+				Type:    string(codersdk.EnhancedExternalAuthProviderGitLab),
+				AuthURL: "https://gitlab.com/oauth/authorize",
+			},
+			expected: cloud,
+		},
+		{
+			// Changing some of the defaults of the cloud option
+			name: "CloudWithChanges",
+			input: codersdk.ExternalAuthConfig{
+				Type: string(codersdk.EnhancedExternalAuthProviderGitLab),
+				// Adding an extra query param intentionally to break simple
+				// string comparisons.
+				AuthURL:     "https://gitlab.com/oauth/authorize?foo=bar",
+				DisplayName: "custom",
+				Regex:       ".*",
+			},
+			expected: cloud,
+			mutateExpected: func(config *codersdk.ExternalAuthConfig) {
+				config.DisplayName = "custom"
+				config.Regex = ".*"
+			},
+		},
+		// Self-hosted
+		{
+			// Dynamically figures out the Validate, Token, and Regex fields.
+			name: "SelfHostedOnlyAuthURL",
+			input: codersdk.ExternalAuthConfig{
+				Type:    string(codersdk.EnhancedExternalAuthProviderGitLab),
+				AuthURL: "https://gitlab.company.org/oauth/authorize?foo=bar",
+			},
+			expected: cloud,
+			mutateExpected: func(config *codersdk.ExternalAuthConfig) {
+				config.AuthURL = "https://gitlab.company.org/oauth/authorize?foo=bar"
+				config.ValidateURL = "https://gitlab.company.org/oauth/token/info"
+				config.TokenURL = "https://gitlab.company.org/oauth/token"
+				config.Regex = `^(https?://)?gitlab\.company\.org(/.*)?$`
+			},
+		},
+		{
+			// Strange values
+			name: "RandomValues",
+			input: codersdk.ExternalAuthConfig{
+				Type:        string(codersdk.EnhancedExternalAuthProviderGitLab),
+				AuthURL:     "https://auth.com/auth",
+				ValidateURL: "https://validate.com/validate",
+				TokenURL:    "https://token.com/token",
+				Regex:       "random",
+			},
+			expected: cloud,
+			mutateExpected: func(config *codersdk.ExternalAuthConfig) {
+				config.AuthURL = "https://auth.com/auth"
+				config.ValidateURL = "https://validate.com/validate"
+				config.TokenURL = "https://token.com/token"
+				config.Regex = `random`
+			},
+		},
+	}
+	for _, c := range tests {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			applyDefaultsToConfig(&c.input)
+			if c.mutateExpected != nil {
+				c.mutateExpected(&c.expected)
+			}
+			require.Equal(t, c.input, c.expected)
+		})
+	}
+}
+
 func Test_bitbucketServerConfigDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/externalauth/externalauth_internal_test.go
+++ b/coderd/externalauth/externalauth_internal_test.go
@@ -61,6 +61,7 @@ func TestGitlabDefaults(t *testing.T) {
 			},
 			expected: cloud,
 			mutateExpected: func(config *codersdk.ExternalAuthConfig) {
+				config.AuthURL = "https://gitlab.com/oauth/authorize?foo=bar"
 				config.DisplayName = "custom"
 				config.Regex = ".*"
 			},


### PR DESCRIPTION
Static defaults work for github cloud, but not self hosted. Self hosted setups will now have sane defaults if omitted.

Closes https://github.com/coder/coder/issues/8293

Our docs do specify to include all values. This is just a safeguard against some mis-configuration. We do this for all other self hosted types, gitlab is just a special case where the same codersdk type is used for self hosted and cloud offering.