### PR TITLE
chore(scripts): auto authenticate gh CLI in scripts on dogfood

### DIFF
--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -4,6 +4,7 @@
 # [#pr-deployments](https://codercom.slack.com/archives/C05DNE982E8) Slack channel
 
 set -euo pipefail
+# shellcheck source=scripts/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 cdroot
 

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -4,6 +4,8 @@
 # [#pr-deployments](https://codercom.slack.com/archives/C05DNE982E8) Slack channel
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cdroot
 
 # default settings
 dryRun=false
@@ -63,6 +65,9 @@ if $confirm; then
 		exit 1
 	fi
 fi
+
+# Authenticate gh CLI
+gh_auth
 
 # get branch name and pr number
 branchName=$(gh pr view --json headRefName | jq -r .headRefName)

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -130,6 +130,13 @@ requiredenvs() {
 	fi
 }
 
+gh_auth() {
+	local fail=0
+	if [[ "${CODER:-}" == "true" ]]; then
+		export GITHUB_TOKEN=$(coder external-auth access-token github)
+	fi
+}
+
 # maybedryrun prints the given program and flags, and then, if the first
 # argument is 0, executes it. The reason the first argument should be 0 is that
 # it is expected that you have a dry_run variable in your script that is set to

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -133,7 +133,16 @@ requiredenvs() {
 gh_auth() {
 	local fail=0
 	if [[ "${CODER:-}" == "true" ]]; then
-		export GITHUB_TOKEN=$(coder external-auth access-token github)
+		if ! output=$(coder external-auth access-token github 2>&1); then
+			log "ERROR: Could not authenticate with GitHub."
+			log "$output"
+			fail=1
+		else
+			GITHUB_TOKEN=$(coder external-auth access-token github)
+			export GITHUB_TOKEN
+		fi
+	else
+		log "Please authenticate gh CLI by running 'gh auth login'"
 	fi
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -113,6 +113,9 @@ done
 # Check dependencies.
 dependencies gh jq sort
 
+# Authenticate gh CLI
+gh_auth
+
 if [[ -z $increment ]]; then
 	# Default to patch versions.
 	increment="patch"

--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -31,6 +31,9 @@ range="${from_ref}..${to_ref}"
 # Check dependencies.
 dependencies gh
 
+# Authenticate gh CLI
+gh_auth
+
 COMMIT_METADATA_BREAKING=0
 declare -a COMMIT_METADATA_COMMITS
 declare -A COMMIT_METADATA_TITLE COMMIT_METADATA_HUMAN_TITLE COMMIT_METADATA_CATEGORY COMMIT_METADATA_AUTHORS
@@ -145,7 +148,6 @@ main() {
 			done
 		} | sort -t- -n | head -n 1
 	)
-
 	# Get the labels for all PRs merged since the last release, this is
 	# inexact based on date, so a few PRs part of the previous release may
 	# be included.

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -57,6 +57,9 @@ done
 # Check dependencies.
 dependencies gh sort
 
+# Authticate gh CLI
+gh_auth
+
 if [[ -z ${old_version} ]]; then
 	error "No old version specified"
 fi

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -71,6 +71,9 @@ done
 # Check dependencies
 dependencies gh
 
+# Authenticate gh CLI
+gh_auth
+
 # Remove the "v" prefix.
 version="${version#v}"
 if [[ "$version" == "" ]]; then


### PR DESCRIPTION
Continuing #13106, This PR automatically authenticates gh CLI in scripts with a fresh access_token. This only works in a dogfood workspace where the users are already [authenticated](https://github.com/coder/coder/blob/d302570091421229b193b14cb5a931062de718d9/dogfood/main.tf#L149-153) with Coder.