### PR TITLE
docs: add island integration guide

### DIFF
--- a/docs/guides/island-integration.md
+++ b/docs/guides/island-integration.md
@@ -43,7 +43,7 @@ remains in your centralized environment.
 1. [Create a Data Sandbox Profile](https://documentation.island.io/docs/create-and-configure-a-data-sandbox-profile)
 
 1. Configure the following actions to allow/block (based on your security
-   requirements):F
+   requirements):
 
 - Screenshot and Screen Share
 - Printing

--- a/docs/guides/island-integration.md
+++ b/docs/guides/island-integration.md
@@ -12,37 +12,38 @@ April 24, 2024
 
 [Island](https://www.island.io/) is an enterprise-grade browser, offering a
 Chromium-based experience similar to popular web browsers like Chrome and Edge.
-It includes built-in security features for corporate applications and data, aiming
-to bridge the gap between consumer-focused browsers and the security needs of the
-enterprise.
+It includes built-in security features for corporate applications and data,
+aiming to bridge the gap between consumer-focused browsers and the security
+needs of the enterprise.
 
-Coder natively integrates with Island's feature set, which include data loss protection
-(DLP), application awareness, browser session recording, and single sign-on (SSO).
-This guide intends to document these feature categories and how they apply to your
-Coder deployment.
+Coder natively integrates with Island's feature set, which include data loss
+protection (DLP), application awareness, browser session recording, and single
+sign-on (SSO). This guide intends to document these feature categories and how
+they apply to your Coder deployment.
 
 ## General Configuration
 
 ### Create an Application Group for Coder
 
-We recommend creating an Application Group specific to Coder in the Island Management
-console. This Application Group object will be referenced when creating browser
-policies.
+We recommend creating an Application Group specific to Coder in the Island
+Management console. This Application Group object will be referenced when
+creating browser policies.
 
 [See the Island documentation for creating an Application Group](https://documentation.island.io/docs/create-and-configure-an-application-group-object).
 
 ## Advanced Data Loss Protection
 
 Integrate Island's advanced data loss prevention (DLP) capabilities with Coder's
-cloud development environment (CDE), enabling you to control the “last mile” between
-developers’ CDE and their local devices, ensuring that sensitive IP remains in
-your centralized environment.
+cloud development environment (CDE), enabling you to control the “last mile”
+between developers’ CDE and their local devices, ensuring that sensitive IP
+remains in your centralized environment.
 
 ### Block cut, copy, paste, printing, screen share
 
 1. [Create a Data Sandbox Profile](https://documentation.island.io/docs/create-and-configure-a-data-sandbox-profile)
 
-1. Configure the following actions to allow/block (based on your security requirements):F
+1. Configure the following actions to allow/block (based on your security
+   requirements):F
 
 - Screenshot and Screen Share
 - Printing
@@ -50,16 +51,17 @@ your centralized environment.
 - Clipboard Limitations
 
 1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
-to apply the Data Sandbox Profile
+   to apply the Data Sandbox Profile
 
 1. Define the Coder Application group as the Destination Object
 
-1. Define the Data Sandbox Profile as the Action in the Last Mile Protection section
+1. Define the Data Sandbox Profile as the Action in the Last Mile Protection
+   section
 
 ### Conditionally allow copy on Coder's CLI authentication page
 
 1. [Create a URL Object](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
-with the following configuration:
+   with the following configuration:
 
 - **Include**
 - **URL type**: Wildcard
@@ -71,11 +73,12 @@ with the following configuration:
 1. Configure action to allow copy/paste
 
 1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
-to apply the Data Sandbox Profile
+   to apply the Data Sandbox Profile
 
 1. Define the URL Object you created as the Destination Object
 
-1. Define the Data Sandbox Profile as the Action in the Last Mile Protection section
+1. Define the Data Sandbox Profile as the Action in the Last Mile Protection
+   section
 
 ### Prevent file upload/download from the browser
 
@@ -85,30 +88,29 @@ to apply the Data Sandbox Profile
 - [Download documentation](https://documentation.island.io/v1/docs/en/create-and-configure-a-download-protection-profile)
 
 1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
-to apply the Protection Profiles
+   to apply the Protection Profiles
 
 1. Define the Coder Application group as the Destination Object
 
 1. Define the applicable Protection Profile as the Action in the Data Protection
-section
+   section
 
 ### Scan files for sensitive data
 
 1. [Create a Data Loss Prevention scanner](https://documentation.island.io/docs/create-a-data-loss-prevention-scanner)
 
 1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
-to apply the DLP Scanner
+   to apply the DLP Scanner
 
 1. Define the Coder Application group as the Destination Object
 
-1. Define the DLP Scanner as the Action in the Data Protection
-section
+1. Define the DLP Scanner as the Action in the Data Protection section
 
 ## Application Awareness and Boundaries
 
 Ensure that Coder is only accessed through the Island browser, guaranteeing that
-your browser-level DLP policies are always enforced, and developers can’t sidestep
-such policies simply by using another browser.
+your browser-level DLP policies are always enforced, and developers can’t
+sidestep such policies simply by using another browser.
 
 ### Configure browser enforcement, conditional access policies
 
@@ -116,14 +118,14 @@ such policies simply by using another browser.
 
 > Note: the configured IdP must be the same for both Coder and Island
 
-- [Azure Active Directory/Entra ID](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-azure-ad?highlight=conditional%20access#create-and-apply-a-conditional-access-policy)
+- [Azure Active Directory/Entra ID](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-azure-ad#create-and-apply-a-conditional-access-policy)
 - [Okta](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-okta)
 - [Google](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-google-enterprise)
 
 ## Browser Activity Logging
 
-Govern and audit in-browser terminal and IDE sessions using Island, such as screenshots,
-mouse clicks, and keystrokes.
+Govern and audit in-browser terminal and IDE sessions using Island, such as
+screenshots, mouse clicks, and keystrokes.
 
 ### Activity Logging Module
 
@@ -142,20 +144,20 @@ Supported browser events include:
 - Keystrokes
 
 1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
-to apply the Activity Logging Profile
+   to apply the Activity Logging Profile
 
 1. Define the Coder Application group as the Destination Object
 
-1. Define the Activity Logging Profile as the Action in the Security & Visibility
-section
+1. Define the Activity Logging Profile as the Action in the Security &
+   Visibility section
 
 ## Identity-aware logins (SSO)
 
-Integrate Island's identity management system with Coder's authentication mechanisms
-to enable identity-aware logins.
+Integrate Island's identity management system with Coder's authentication
+mechanisms to enable identity-aware logins.
 
 ### Configure single sign-on (SSO) seamless authentication between Coder and Island
 
-Configure the same identity provider (IdP) for both your Island and Coder deployment.
-Upon initial login to the Island browser, the user's session token will automatically
-be passed to Coder and authenticate their Coder session.
+Configure the same identity provider (IdP) for both your Island and Coder
+deployment. Upon initial login to the Island browser, the user's session token
+will automatically be passed to Coder and authenticate their Coder session.

--- a/docs/guides/island-integration.md
+++ b/docs/guides/island-integration.md
@@ -2,7 +2,7 @@
 
 <div>
   <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
-    <span style="vertical-align:middle;">M Atif Ali</span>
+    <span style="vertical-align:middle;">Eric Paulsen</span>
     <img src="https://github.com/ericpaulsen.png" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
   </a>
 </div>

--- a/docs/guides/island-integration.md
+++ b/docs/guides/island-integration.md
@@ -1,0 +1,161 @@
+# Island Browser Integration
+
+<div>
+  <a href="https://github.com/ericpaulsen" style="text-decoration: none; color: inherit;">
+    <span style="vertical-align:middle;">M Atif Ali</span>
+    <img src="https://github.com/ericpaulsen.png" width="24px" height="24px" style="vertical-align:middle; margin: 0px;"/>
+  </a>
+</div>
+April 24, 2024
+
+---
+
+[Island](https://www.island.io/) is an enterprise-grade browser, offering a
+Chromium-based experience similar to popular web browsers like Chrome and Edge.
+It includes built-in security features for corporate applications and data, aiming
+to bridge the gap between consumer-focused browsers and the security needs of the
+enterprise.
+
+Coder natively integrates with Island's feature set, which include data loss protection
+(DLP), application awareness, browser session recording, and single sign-on (SSO).
+This guide intends to document these feature categories and how they apply to your
+Coder deployment.
+
+## General Configuration
+
+### Create an Application Group for Coder
+
+We recommend creating an Application Group specific to Coder in the Island Management
+console. This Application Group object will be referenced when creating browser
+policies.
+
+[See the Island documentation for creating an Application Group](https://documentation.island.io/docs/create-and-configure-an-application-group-object).
+
+## Advanced Data Loss Protection
+
+Integrate Island's advanced data loss prevention (DLP) capabilities with Coder's
+cloud development environment (CDE), enabling you to control the “last mile” between
+developers’ CDE and their local devices, ensuring that sensitive IP remains in
+your centralized environment.
+
+### Block cut, copy, paste, printing, screen share
+
+1. [Create a Data Sandbox Profile](https://documentation.island.io/docs/create-and-configure-a-data-sandbox-profile)
+
+1. Configure the following actions to allow/block (based on your security requirements):F
+
+- Screenshot and Screen Share
+- Printing
+- Save Page
+- Clipboard Limitations
+
+1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
+to apply the Data Sandbox Profile
+
+1. Define the Coder Application group as the Destination Object
+
+1. Define the Data Sandbox Profile as the Action in the Last Mile Protection section
+
+### Conditionally allow copy on Coder's CLI authentication page
+
+1. [Create a URL Object](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
+with the following configuration:
+
+- **Include**
+- **URL type**: Wildcard
+- **URL address**: `coder.example.com/cli-auth`
+- **Casing**: Insensitive
+
+1. [Create a Data Sandbox Profile](https://documentation.island.io/docs/create-and-configure-a-data-sandbox-profile)
+
+1. Configure action to allow copy/paste
+
+1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
+to apply the Data Sandbox Profile
+
+1. Define the URL Object you created as the Destination Object
+
+1. Define the Data Sandbox Profile as the Action in the Last Mile Protection section
+
+### Prevent file upload/download from the browser
+
+1. Create a Protection Profiles for both upload/download
+
+- [Upload documentation](https://documentation.island.io/docs/create-and-configure-an-upload-protection-profile)
+- [Download documentation](https://documentation.island.io/v1/docs/en/create-and-configure-a-download-protection-profile)
+
+1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
+to apply the Protection Profiles
+
+1. Define the Coder Application group as the Destination Object
+
+1. Define the applicable Protection Profile as the Action in the Data Protection
+section
+
+### Scan files for sensitive data
+
+1. [Create a Data Loss Prevention scanner](https://documentation.island.io/docs/create-a-data-loss-prevention-scanner)
+
+1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
+to apply the DLP Scanner
+
+1. Define the Coder Application group as the Destination Object
+
+1. Define the DLP Scanner as the Action in the Data Protection
+section
+
+## Application Awareness and Boundaries
+
+Ensure that Coder is only accessed through the Island browser, guaranteeing that
+your browser-level DLP policies are always enforced, and developers can’t sidestep
+such policies simply by using another browser.
+
+### Configure browser enforcement, conditional access policies
+
+1. Create a conditional access policy for your configured identity provider.
+
+> Note: the configured IdP must be the same for both Coder and Island
+
+- [Azure Active Directory/Entra ID](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-azure-ad?highlight=conditional%20access#create-and-apply-a-conditional-access-policy)
+- [Okta](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-okta)
+- [Google](https://documentation.island.io/docs/configure-browser-enforcement-for-island-with-google-enterprise)
+
+## Browser Activity Logging
+
+Govern and audit in-browser terminal and IDE sessions using Island, such as screenshots,
+mouse clicks, and keystrokes.
+
+### Activity Logging Module
+
+1. [Create an Activity Logging Profile](https://documentation.island.io/docs/create-and-configure-an-activity-logging-profile)
+
+Supported browser events include:
+
+- Web Navigation
+- File Download
+- File Upload
+- Clipboard/Drag & Drop
+- Print
+- Save As
+- Screenshots
+- Mouse Clicks
+- Keystrokes
+
+1. [Create a Policy Rule](https://documentation.island.io/docs/create-and-configure-a-policy-rule-general)
+to apply the Activity Logging Profile
+
+1. Define the Coder Application group as the Destination Object
+
+1. Define the Activity Logging Profile as the Action in the Security & Visibility
+section
+
+## Identity-aware logins (SSO)
+
+Integrate Island's identity management system with Coder's authentication mechanisms
+to enable identity-aware logins.
+
+### Configure single sign-on (SSO) seamless authentication between Coder and Island
+
+Configure the same identity provider (IdP) for both your Island and Coder deployment.
+Upon initial login to the Island browser, the user's session token will automatically
+be passed to Coder and authenticate their Coder session.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1096,6 +1096,11 @@
           "path": "./guides/artifactory-integration.md"
         },
         {
+          "title": "Island Secure Browser Integration",
+          "description": "Integrate Coder with Island's Secure Browser",
+          "path": "./guides/island-integration.md"
+        },
+        {
           "title": "Template ImagePullSecrets",
           "description": "Creating ImagePullSecrets for private registries",
           "path": "./guides/image-pull-secret.md"


### PR DESCRIPTION
this PR adds a guide for our native integration with [island.io](https://island.io).