### PR TITLE
chore: shutdown provisioner should stop waiting on client

### DIFF
--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -239,6 +239,12 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 				return xerrors.Errorf("shutdown: %w", err)
 			}
 
+			// Shutdown does not call close. Must call it manually.
+			err = srv.Close()
+			if err != nil {
+				return xerrors.Errorf("close server: %w", err)
+			}
+
 			cancel()
 			if xerrors.Is(exitErr, context.Canceled) {
 				return nil

--- a/provisionerd/provisionerd.go
+++ b/provisionerd/provisionerd.go
@@ -236,6 +236,9 @@ func (p *Server) client() (proto.DRPCProvisionerDaemonClient, bool) {
 	select {
 	case <-p.closeContext.Done():
 		return nil, false
+	case <-p.shuttingDownCh:
+		// Shutting down should return a nil client and unblock
+		return nil, false
 	case client := <-p.clientCh:
 		return client, true
 	}


### PR DESCRIPTION
`provisionerd` does not respond to `ctrl+c` if no coderd exits.

Run `go run main.go provisionerd start` without a coderd. After a second or two, hit `ctrl +c`. The process will not terminate. The issue is we call `Shutdown` for a graceful closure.

Currently:
- `connect()` does not terminate on shutdown. [Only on `Close`](https://github.com/coder/coder/blob/4142fb3576ef2899efdd8a5eba024be95556779a/provisionerd/provisionerd.go#L195-L197)
- `Shutdown` does not call close. The caller needs to call [`Shutdown` and then `Close`](https://github.com/coder/coder/blob/4142fb3576ef2899efdd8a5eba024be95556779a/provisionerd/provisionerd_test.go#L674-L677). Updated the cli to do this, although it is not intuitive imo.
- `acquireLoop` blocks on a client, but if no client is ever established, the shutdown never gets checked, and this blocks forever.

This PR calls `Close` after `Shutdown` and makes `p.client()` return a nil client during shutdown.

----

I'd like to see provisionerd's `Shutdown` call `Close`.