### PR TITLE
fix(enterprise): mark nodes from unhealthy coordinators as lost

### DIFF
--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -1485,10 +1485,17 @@ func (h *heartbeats) filter(mappings []mapping) []mapping {
 		ok := m.coordinator == h.self
 		if !ok {
 			_, ok = h.coordinators[m.coordinator]
+			if !ok {
+				// If a mapping exists to a coordinator lost to heartbeats,
+				// still add the mapping as LOST. If a coordinator misses
+				// heartbeats but a client is still connected to it, this may be
+				// the only mapping available for it. Newer mappings will take
+				// precedence.
+				m.kind = proto.CoordinateResponse_PeerUpdate_LOST
+			}
 		}
-		if ok {
-			out = append(out, m)
-		}
+
+		out = append(out, m)
 	}
 	return out
 }

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/coder/coder/v2/enterprise/tailnet"
 	agpl "github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
-	"github.com/coder/coder/v2/tailnet/test"
 	agpltest "github.com/coder/coder/v2/tailnet/test"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -432,7 +431,7 @@ func TestPGCoordinatorSingle_MissedHeartbeats_NoDrop(t *testing.T) {
 
 	agentID := uuid.New()
 
-	client := test.NewPeer(ctx, t, coordinator, "client")
+	client := agpltest.NewPeer(ctx, t, coordinator, "client")
 	defer client.Close(ctx)
 	client.AddTunnel(agentID)
 


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/13041

Instead of removing the mappings of unhealthy coordinators entirely,
mark them as lost. This prevents peers from disappearing from
other peers if a coordinator misses a heartbeat.