### PR TITLE
fix: remove mention of protocol lag

### DIFF
--- a/site/src/modules/resources/PortForwardButton.tsx
+++ b/site/src/modules/resources/PortForwardButton.tsx
@@ -402,7 +402,7 @@ export const PortForwardPopoverView: FC<PortForwardPopoverViewProps> = ({
         <HelpTooltipTitle>Shared Ports</HelpTooltipTitle>
         <HelpTooltipText css={{ color: theme.palette.text.secondary }}>
           {canSharePorts
-            ? "Ports can be shared with other Coder users or with the public. Changing the protocol may take up to 1 minute to take effect."
+            ? "Ports can be shared with other Coder users or with the public."
             : "This workspace template does not allow sharing ports. Contact a template administrator to enable port sharing."}
         </HelpTooltipText>
         {canSharePorts && (


### PR DESCRIPTION
This statement isn't true since we switch to in-url protocol definitions.