### PR TITLE
chore: remove superfluous context.Canceled handling

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -903,9 +903,6 @@ func (a *agent) handleManifest(manifestOK chan<- struct{}) func(ctx context.Cont
 			Subsystems:        subsys,
 		}})
 		if err != nil {
-			if xerrors.Is(err, context.Canceled) {
-				return nil
-			}
 			return xerrors.Errorf("update workspace agent startup: %w", err)
 		}
 


### PR DESCRIPTION
Removes a check for `context.Canceled` inside the `handleManifest` routine.  This checking is handled in the `apiConnRoutineManager`, so checking inside the handler is redundant.
