### PR TITLE
fix: make handleManifest always signal dependents

### DIFF
--- a/agent/checkpoint.go
+++ b/agent/checkpoint.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"cdr.dev/slog"
+)
+
+// checkpoint allows a goroutine to communicate when it is OK to proceed beyond some async condition
+// to other dependent goroutines.
+type checkpoint struct {
+	logger slog.Logger
+	mu     sync.Mutex
+	called bool
+	done   chan struct{}
+	err    error
+}
+
+// complete the checkpoint.  Pass nil to indicate the checkpoint was ok.  It is an error to call this
+// more than once.
+func (c *checkpoint) complete(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.called {
+		b := make([]byte, 2048)
+		n := runtime.Stack(b, false)
+		c.logger.Critical(context.Background(), "checkpoint complete called more than once", slog.F("stacktrace", b[:n]))
+		return
+	}
+	c.called = true
+	c.err = err
+	close(c.done)
+}
+
+func (c *checkpoint) wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.done:
+		return c.err
+	}
+}
+
+func newCheckpoint(logger slog.Logger) *checkpoint {
+	return &checkpoint{
+		logger: logger,
+		done:   make(chan struct{}),
+	}
+}

--- a/agent/checkpoint_internal_test.go
+++ b/agent/checkpoint_internal_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestCheckpoint_CompleteWait(t *testing.T) {
+	t.Parallel()
+	logger := slogtest.Make(t, nil)
+	ctx := testutil.Context(t, testutil.WaitShort)
+	uut := newCheckpoint(logger)
+	err := xerrors.New("test")
+	uut.complete(err)
+	got := uut.wait(ctx)
+	require.Equal(t, err, got)
+}
+
+func TestCheckpoint_CompleteTwice(t *testing.T) {
+	t.Parallel()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctx := testutil.Context(t, testutil.WaitShort)
+	uut := newCheckpoint(logger)
+	err := xerrors.New("test")
+	uut.complete(err)
+	uut.complete(nil) // drops CRITICAL log
+	got := uut.wait(ctx)
+	require.Equal(t, err, got)
+}
+
+func TestCheckpoint_WaitComplete(t *testing.T) {
+	t.Parallel()
+	logger := slogtest.Make(t, nil)
+	ctx := testutil.Context(t, testutil.WaitShort)
+	uut := newCheckpoint(logger)
+	err := xerrors.New("test")
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- uut.wait(ctx)
+	}()
+	uut.complete(err)
+	got := testutil.RequireRecvCtx(ctx, t, errCh)
+	require.Equal(t, err, got)
+}


### PR DESCRIPTION
Fixes #13139

Using a bare channel to signal dependent goroutines means that we can only signal success, not failure, which leads to deadlock if we fail in a way that doesn't cause the whole `apiConnRoutineManager` to tear down routines.

Instead, we use a new object called a `checkpoint` that signals success or failure, so that dependent routines get unblocked if the routine they depend on fails.