### PR TITLE
chore(docs): replace git-auth with external-auth

### DIFF
--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -333,5 +333,5 @@ EOF
 ```
 
 See the
-[Terraform provider documentation](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/git_auth)
+[Terraform provider documentation](https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/external_auth)
 for all available options.


### PR DESCRIPTION
Replaces the now deprecated `coder_git_auth` with `coder_exernal_auth`.