### PR TITLE
chore(scripts): fix a few release script changelog issues

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -210,6 +210,7 @@ new_version="${new_version%$'\n'}" # Remove the trailing newline.
 
 release_notes="$(execrelative ./release/generate_release_notes.sh --old-version "$old_version" --new-version "$new_version" --ref "$ref")"
 
+mkdir -p build
 release_notes_file="build/RELEASE-${new_version}.md"
 if ((dry_run)); then
 	release_notes_file="build/RELEASE-${new_version}-DRYRUN.md"

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -147,7 +147,6 @@ for commit in "${commits[@]}"; do
 		title="${title} (${commit})"
 	fi
 	line="- ${title}"
-	line=${line//) (/, )}
 	if [[ -v COMMIT_METADATA_AUTHORS[${commit}] ]]; then
 		line+=" (${COMMIT_METADATA_AUTHORS[${commit}]})"
 	fi


### PR DESCRIPTION
```diff
❯ diff -u build/RELEASE-v2.11.0-DRYRUN.md_ build/RELEASE-v2.11.0-DRYRUN.md | grep '^[+-]'
--- build/RELEASE-v2.11.0-DRYRUN.md_	2024-05-07 17:14:36
+++ build/RELEASE-v2.11.0-DRYRUN.md	2024-05-07 18:29:40
-- Agent: Keep track of lastReportIndex between invocations of reportLifecycle(, )#13075, 99dda4a43) (@johnstcn)
+- Agent: Keep track of lastReportIndex between invocations of reportLifecycle() (#13075, 99dda4a43) (@johnstcn)
-- Bump crate-ci/typos from 1.19.0 to 1.20.9 in the github-actions group (#13027, 3af317317) (@app/dependabot)
-- Bump crate-ci/typos from 1.20.9 to 1.20.10 in the github-actions group (#13090, ed0792175) (@app/dependabot)
-- Bump golang.org/x/term from 0.18.0 to 0.19.0 (#12886, 24135a2d0) (@app/dependabot)
-- Bump github.com/elastic/go-sysinfo from 1.13.1 to 1.14.0 (#12894, 8ba8ec2f1) (@app/dependabot)
-- Bump golang.org/x/sync from 0.6.0 to 0.7.0 (#12895, f99fd807b) (@app/dependabot)
-- Bump golang.org/x/net from 0.22.0 to 0.24.0 (#12888, 9a7d8034c) (@app/dependabot)
-- Bump golang.org/x/tools from 0.19.0 to 0.20.0 (#12890, 589434e8d) (@app/dependabot)
-- Bump google.golang.org/grpc from 1.62.1 to 1.63.0 (#12892, 11123018a) (@app/dependabot)
-- Bump golang.org/x/oauth2 from 0.18.0 to 0.19.0 (#12893, 7179c86df) (@app/dependabot)
-- Bump github.com/moby/moby (#12960, 3338cdca7) (@app/dependabot)
-- Bump google.golang.org/api from 0.172.0 to 0.175.0 (#13026, ea472c538) (@app/dependabot)
-- Bump github.com/coder/terraform-provider-coder (#13022, 2e49fa94d) (@app/dependabot)
-- Bump github.com/gohugoio/hugo from 0.124.0 to 0.125.2 (#13024, 81fcdf717) (@app/dependabot)
-- Deprecate gauge metrics with _total suffix (#12744, )#12976, 4682355ee) (@snark87)
-- Bump github.com/gohugoio/hugo from 0.125.2 to 0.125.3 (#13057, 39ccff97c) (@app/dependabot)
+- Deprecate gauge metrics with _total suffix (#12744) (#12976, 4682355ee) (@snark87)
-- Bump google.golang.org/api from 0.175.0 to 0.176.1 (#13092, 74b921cf8) (@app/dependabot)
-- Bump github.com/moby/moby (#13093, f2a21c604) (@app/dependabot)
-- Bump github.com/jmoiron/sqlx from 1.3.5 to 1.4.0 (#13095, 4a83e84a2) (@app/dependabot)
```

