### PR TITLE
fix(install.sh): install from github when using `--stable` on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -373,14 +373,6 @@ main() {
 	ARCH=${ARCH:-$(arch)}
 	TERRAFORM_ARCH=${TERRAFORM_ARCH:-$(terraform_arch)}
 
-	# We can't reasonably support installing specific versions of Coder through
-	# Homebrew, so if we're on macOS and the `--version` flag was set, we should
-	# "detect" standalone to be the appropriate installation method. This check
-	# needs to occur before we set `VERSION` to a default of the latest release.
-	if [ "$OS" = "darwin" ] && [ "${VERSION-}" ]; then
-		METHOD=standalone
-	fi
-
 	# If we've been provided a flag which is specific to the standalone installation
 	# method, we should "detect" standalone to be the appropriate installation method.
 	# This check needs to occur before we set these variables with defaults.
@@ -393,6 +385,15 @@ main() {
 		echoerr "Unknown install method \"$METHOD\""
 		echoerr "Run with --help to see usage."
 		exit 1
+	fi
+
+	# We can't reasonably support installing specific versions of Coder through
+	# Homebrew, so if we're on macOS and the `--version` flag or the `--stable`
+	# flag (our tap follows mainline) was set, we should "detect" standalone to
+	# be the appropriate installation method. This check needs to occur before we
+	# set `VERSION` to a default of the latest release.
+	if [ "$OS" = "darwin" ] && ( [ "${VERSION-}" ] || [ "${STABLE}" = 1 ] ); then
+		METHOD=standalone
 	fi
 
 	# These are used by the various install_* functions that make use of GitHub

--- a/install.sh
+++ b/install.sh
@@ -392,7 +392,7 @@ main() {
 	# flag (our tap follows mainline) was set, we should "detect" standalone to
 	# be the appropriate installation method. This check needs to occur before we
 	# set `VERSION` to a default of the latest release.
-	if [ "$OS" = "darwin" ] && ([ "${VERSION-}" ] || [ "${STABLE}" = 1 ]); then
+	if [ "$OS" = "darwin" ] && { [ "${VERSION-}" ] || [ "${STABLE}" = 1 ]; }; then
 		METHOD=standalone
 	fi
 

--- a/install.sh
+++ b/install.sh
@@ -392,7 +392,7 @@ main() {
 	# flag (our tap follows mainline) was set, we should "detect" standalone to
 	# be the appropriate installation method. This check needs to occur before we
 	# set `VERSION` to a default of the latest release.
-	if [ "$OS" = "darwin" ] && ( [ "${VERSION-}" ] || [ "${STABLE}" = 1 ] ); then
+	if [ "$OS" = "darwin" ] && ([ "${VERSION-}" ] || [ "${STABLE}" = 1 ]); then
 		METHOD=standalone
 	fi
 


### PR DESCRIPTION
Similar to the existing behavior for the `--version` flag. Our Homebrew tap only tracks mainline, so using it when `--stable` is passed in will always result in an incorrect version being installed.