### PR TITLE
chore: prevent commit signing in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ GO_SRC_FILES := $(shell find . $(FIND_EXCLUSIONS) -type f -name '*.go' -not -nam
 # All the shell files in the repo, excluding ignored files.
 SHELL_SRC_FILES := $(shell find . $(FIND_EXCLUSIONS) -type f -name '*.sh')
 
+# Ensure we don't use the user's git configs which might cause side-effects
+GIT_FLAGS = GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
 # All ${OS}_${ARCH} combos we build for. Windows binaries have the .exe suffix.
 OS_ARCHES := \
 	linux_amd64 linux_arm64 linux_armv7 \
@@ -739,7 +742,7 @@ site/.eslintignore site/.prettierignore: .prettierignore Makefile
 	done < "$<"
 
 test:
-	gotestsum --format standard-quiet -- -v -short -count=1 ./...
+	$(GIT_FLAGS) gotestsum --format standard-quiet -- -v -short -count=1 ./...
 .PHONY: test
 
 # sqlc-cloud-is-setup will fail if no SQLc auth token is set. Use this as a
@@ -775,7 +778,7 @@ sqlc-vet: test-postgres-docker
 test-postgres: test-postgres-docker
 	# The postgres test is prone to failure, so we limit parallelism for
 	# more consistent execution.
-	DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum \
+	$(GIT_FLAGS)  DB=ci DB_FROM=$(shell go run scripts/migrate-ci/main.go) gotestsum \
 		--junitfile="gotests.xml" \
 		--jsonfile="gotests.json" \
 		--packages="./..." -- \
@@ -824,7 +827,7 @@ test-postgres-docker:
 
 # Make sure to keep this in sync with test-go-race from .github/workflows/ci.yaml.
 test-race:
-	gotestsum --junitfile="gotests.xml" -- -race -count=1 ./...
+	$(GIT_FLAGS) gotestsum --junitfile="gotests.xml" -- -race -count=1 ./...
 .PHONY: test-race
 
 test-tailnet-integration:

--- a/cli/dotfiles_test.go
+++ b/cli/dotfiles_test.go
@@ -37,7 +37,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))
@@ -64,7 +64,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))
@@ -95,7 +95,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))
@@ -129,7 +129,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add install.sh"`)
+		c = exec.Command("git", "commit", "-m", `"add install.sh"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		err = c.Run()
 		require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestDotfiles(t *testing.T) {
 		testRepo := testGitRepo(t, root)
 
 		// We need an initial commit to start the `main` branch
-		c := exec.Command("git", "commit", "--allow-empty", "-m", `"initial commit"`)
+		c := exec.Command("git", "commit", "--allow-empty", "-m", `"initial commit"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		err := c.Run()
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add install.sh"`)
+		c = exec.Command("git", "commit", "-m", `"add install.sh"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		err = c.Run()
 		require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))

--- a/cli/dotfiles_test.go
+++ b/cli/dotfiles_test.go
@@ -37,7 +37,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))
@@ -64,7 +64,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))
@@ -95,7 +95,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))
@@ -129,7 +129,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add install.sh"`, `--no-gpg-sign`)
+		c = exec.Command("git", "commit", "-m", `"add install.sh"`)
 		c.Dir = testRepo
 		err = c.Run()
 		require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestDotfiles(t *testing.T) {
 		testRepo := testGitRepo(t, root)
 
 		// We need an initial commit to start the `main` branch
-		c := exec.Command("git", "commit", "--allow-empty", "-m", `"initial commit"`, `--no-gpg-sign`)
+		c := exec.Command("git", "commit", "--allow-empty", "-m", `"initial commit"`)
 		c.Dir = testRepo
 		err := c.Run()
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add install.sh"`, `--no-gpg-sign`)
+		c = exec.Command("git", "commit", "-m", `"add install.sh"`)
 		c.Dir = testRepo
 		err = c.Run()
 		require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestDotfiles(t *testing.T) {
 		err = c.Run()
 		require.NoError(t, err)
 
-		c = exec.Command("git", "commit", "-m", `"add .bashrc"`, `--no-gpg-sign`)
+		c = exec.Command("git", "commit", "-m", `"add .bashrc"`)
 		c.Dir = testRepo
 		out, err := c.CombinedOutput()
 		require.NoError(t, err, string(out))


### PR DESCRIPTION
In my workspace, my git config contains this alias:

```bash
$ git config -l | grep alias.commit
alias.commit=commit -s
```

When `TestDotfiles` is called, it runs `git commit` which tries to sign the commits and causes my tests to hang and fail. We need to prevent this behaviour.

I tried using `GIT_CONFIG_NOSYSTEM`, but that doesn't prevent the use of the git config in my home directory.
_([source](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables))_

This feels like the cleanest approach to me; an alternative would be to override the `HOME` env var, but that could have other side-effects.

_Edit: @mafredri suggesting using GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` which solves the problem more elegantly than my original solution._