### PR TITLE
chore: remove dependabot config for dogfood template

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -112,17 +112,3 @@ updates:
       offlinedocs:
         patterns:
           - "*"
-
-  # Update dogfood.
-  - package-ecosystem: "terraform"
-    directory: "/dogfood/"
-    schedule:
-      interval: "weekly"
-      time: "06:00"
-      timezone: "America/Chicago"
-    commit-message:
-      prefix: "chore"
-    labels: []
-    ignore:
-      # We likely want to update this ourselves.
-      - dependency-name: "coder/coder"


### PR DESCRIPTION
This was not doing anything. We do not pin the provider version of `coder`; for `docker`, there have been no updates for more than a year.
It was causing log [spam](https://github.com/coder/coder/network/updates/820943174).