### PR TITLE
fix: fix nix flake sed command

### DIFF
--- a/scripts/update-flake.sh
+++ b/scripts/update-flake.sh
@@ -13,4 +13,4 @@ echo "Calculating SRI hash..."
 HASH=$(go run tailscale.com/cmd/nardump --sri "$OUT/pkg/mod/cache/download")
 sudo rm -rf "$OUT"
 
-sed -i "s/\(vendorHash = \"\)[^\"]*/\1${HASH}/" ./flake.nix
+sed -i "s#\(vendorHash = \"\)[^\"]*#\1${HASH}#" ./flake.nix


### PR DESCRIPTION
Seeing some errors:

```
Downloading Go modules...
Calculating SRI hash...
sed: -e expression #1, char 37: unknown option to `s'
```

[here](https://github.com/coder/coder/actions/runs/9036466674/job/24836282425?pr=13098)