### PR TITLE
fix: properly convert max port share level for oss

### DIFF
--- a/coderd/portsharing/portsharing.go
+++ b/coderd/portsharing/portsharing.go
@@ -8,22 +8,22 @@ import (
 )
 
 type PortSharer interface {
-	AuthorizedPortSharingLevel(template database.Template, level codersdk.WorkspaceAgentPortShareLevel) error
-	ValidateTemplateMaxPortSharingLevel(level codersdk.WorkspaceAgentPortShareLevel) error
-	ConvertMaxPortSharingLevel(level database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel
+	AuthorizedLevel(template database.Template, level codersdk.WorkspaceAgentPortShareLevel) error
+	ValidateTemplateMaxLevel(level codersdk.WorkspaceAgentPortShareLevel) error
+	ConvertMaxLevel(level database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel
 }
 
 type AGPLPortSharer struct{}
 
-func (AGPLPortSharer) AuthorizedPortSharingLevel(_ database.Template, _ codersdk.WorkspaceAgentPortShareLevel) error {
+func (AGPLPortSharer) AuthorizedLevel(_ database.Template, _ codersdk.WorkspaceAgentPortShareLevel) error {
 	return nil
 }
 
-func (AGPLPortSharer) ValidateTemplateMaxPortSharingLevel(_ codersdk.WorkspaceAgentPortShareLevel) error {
+func (AGPLPortSharer) ValidateTemplateMaxLevel(_ codersdk.WorkspaceAgentPortShareLevel) error {
 	return xerrors.New("Restricting port sharing level is an enterprise feature that is not enabled.")
 }
 
-func (AGPLPortSharer) ConvertMaxPortSharingLevel(_ database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel {
+func (AGPLPortSharer) ConvertMaxLevel(_ database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel {
 	return codersdk.WorkspaceAgentPortShareLevelPublic
 }
 

--- a/coderd/portsharing/portsharing.go
+++ b/coderd/portsharing/portsharing.go
@@ -10,6 +10,7 @@ import (
 type PortSharer interface {
 	AuthorizedPortSharingLevel(template database.Template, level codersdk.WorkspaceAgentPortShareLevel) error
 	ValidateTemplateMaxPortSharingLevel(level codersdk.WorkspaceAgentPortShareLevel) error
+	ConvertMaxPortSharingLevel(level database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel
 }
 
 type AGPLPortSharer struct{}
@@ -20,6 +21,10 @@ func (AGPLPortSharer) AuthorizedPortSharingLevel(_ database.Template, _ codersdk
 
 func (AGPLPortSharer) ValidateTemplateMaxPortSharingLevel(_ codersdk.WorkspaceAgentPortShareLevel) error {
 	return xerrors.New("Restricting port sharing level is an enterprise feature that is not enabled.")
+}
+
+func (AGPLPortSharer) ConvertMaxPortSharingLevel(_ database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel {
+	return codersdk.WorkspaceAgentPortShareLevelPublic
 }
 
 var DefaultPortSharer PortSharer = AGPLPortSharer{}

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -623,8 +623,8 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 		validErrs = append(validErrs, codersdk.ValidationError{Field: "time_til_dormant_autodelete_ms", Detail: "Value must be at least one minute."})
 	}
 	maxPortShareLevel := template.MaxPortSharingLevel
-	if req.MaxPortShareLevel != nil && *req.MaxPortShareLevel != portSharer.ConvertMaxPortSharingLevel(template.MaxPortSharingLevel) {
-		err := portSharer.ValidateTemplateMaxPortSharingLevel(*req.MaxPortShareLevel)
+	if req.MaxPortShareLevel != nil && *req.MaxPortShareLevel != portSharer.ConvertMaxLevel(template.MaxPortSharingLevel) {
+		err := portSharer.ValidateTemplateMaxLevel(*req.MaxPortShareLevel)
 		if err != nil {
 			validErrs = append(validErrs, codersdk.ValidationError{Field: "max_port_sharing_level", Detail: err.Error()})
 		} else {
@@ -858,7 +858,7 @@ func (api *API) convertTemplate(
 	}
 
 	portSharer := *(api.PortSharer.Load())
-	maxPortShareLevel := portSharer.ConvertMaxPortSharingLevel(template.MaxPortSharingLevel)
+	maxPortShareLevel := portSharer.ConvertMaxLevel(template.MaxPortSharingLevel)
 
 	return codersdk.Template{
 		ID:                             template.ID,

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -623,7 +623,7 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 		validErrs = append(validErrs, codersdk.ValidationError{Field: "time_til_dormant_autodelete_ms", Detail: "Value must be at least one minute."})
 	}
 	maxPortShareLevel := template.MaxPortSharingLevel
-	if req.MaxPortShareLevel != nil && *req.MaxPortShareLevel != codersdk.WorkspaceAgentPortShareLevel(maxPortShareLevel) {
+	if req.MaxPortShareLevel != nil && *req.MaxPortShareLevel != portSharer.ConvertMaxPortSharingLevel(template.MaxPortSharingLevel) {
 		err := portSharer.ValidateTemplateMaxPortSharingLevel(*req.MaxPortShareLevel)
 		if err != nil {
 			validErrs = append(validErrs, codersdk.ValidationError{Field: "max_port_sharing_level", Detail: err.Error()})
@@ -857,6 +857,9 @@ func (api *API) convertTemplate(
 		autostopRequirementWeeks = 1
 	}
 
+	portSharer := *(api.PortSharer.Load())
+	maxPortShareLevel := portSharer.ConvertMaxPortSharingLevel(template.MaxPortSharingLevel)
+
 	return codersdk.Template{
 		ID:                             template.ID,
 		CreatedAt:                      template.CreatedAt,
@@ -891,6 +894,6 @@ func (api *API) convertTemplate(
 		RequireActiveVersion: templateAccessControl.RequireActiveVersion,
 		Deprecated:           templateAccessControl.IsDeprecated(),
 		DeprecationMessage:   templateAccessControl.Deprecated,
-		MaxPortShareLevel:    codersdk.WorkspaceAgentPortShareLevel(template.MaxPortSharingLevel),
+		MaxPortShareLevel:    maxPortShareLevel,
 	}
 }

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -600,9 +600,9 @@ func TestPatchTemplateMeta(t *testing.T) {
 		user := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		require.Equal(t, codersdk.WorkspaceAgentPortShareLevelOwner, template.MaxPortShareLevel)
+		require.Equal(t, codersdk.WorkspaceAgentPortShareLevelPublic, template.MaxPortShareLevel)
 
-		var level codersdk.WorkspaceAgentPortShareLevel = codersdk.WorkspaceAgentPortShareLevelPublic
+		var level codersdk.WorkspaceAgentPortShareLevel = codersdk.WorkspaceAgentPortShareLevelAuthenticated
 		req := codersdk.UpdateTemplateMeta{
 			MaxPortShareLevel: &level,
 		}
@@ -615,7 +615,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 		require.ErrorContains(t, err, "port sharing level is an enterprise feature")
 
 		// Ensure the same value port share level is a no-op
-		level = codersdk.WorkspaceAgentPortShareLevelOwner
+		level = codersdk.WorkspaceAgentPortShareLevelPublic
 		_, err = client.UpdateTemplateMeta(ctx, template.ID, codersdk.UpdateTemplateMeta{
 			Name:              coderdtest.RandomUsername(t),
 			MaxPortShareLevel: &level,

--- a/coderd/workspaceagentportshare.go
+++ b/coderd/workspaceagentportshare.go
@@ -69,7 +69,7 @@ func (api *API) postWorkspaceAgentPortShare(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	err = portSharer.AuthorizedPortSharingLevel(template, req.ShareLevel)
+	err = portSharer.AuthorizedLevel(template, req.ShareLevel)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: err.Error(),

--- a/enterprise/coderd/portsharing/portsharing.go
+++ b/enterprise/coderd/portsharing/portsharing.go
@@ -38,3 +38,7 @@ func (EnterprisePortSharer) ValidateTemplateMaxPortSharingLevel(level codersdk.W
 
 	return nil
 }
+
+func (EnterprisePortSharer) ConvertMaxPortSharingLevel(level database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel {
+	return codersdk.WorkspaceAgentPortShareLevel(level)
+}

--- a/enterprise/coderd/portsharing/portsharing.go
+++ b/enterprise/coderd/portsharing/portsharing.go
@@ -13,7 +13,7 @@ func NewEnterprisePortSharer() *EnterprisePortSharer {
 	return &EnterprisePortSharer{}
 }
 
-func (EnterprisePortSharer) AuthorizedPortSharingLevel(template database.Template, level codersdk.WorkspaceAgentPortShareLevel) error {
+func (EnterprisePortSharer) AuthorizedLevel(template database.Template, level codersdk.WorkspaceAgentPortShareLevel) error {
 	max := codersdk.WorkspaceAgentPortShareLevel(template.MaxPortSharingLevel)
 	switch level {
 	case codersdk.WorkspaceAgentPortShareLevelPublic:
@@ -31,7 +31,7 @@ func (EnterprisePortSharer) AuthorizedPortSharingLevel(template database.Templat
 	return nil
 }
 
-func (EnterprisePortSharer) ValidateTemplateMaxPortSharingLevel(level codersdk.WorkspaceAgentPortShareLevel) error {
+func (EnterprisePortSharer) ValidateTemplateMaxLevel(level codersdk.WorkspaceAgentPortShareLevel) error {
 	if !level.ValidMaxLevel() {
 		return xerrors.New("invalid max port sharing level, value must be 'authenticated' or 'public'.")
 	}
@@ -39,6 +39,6 @@ func (EnterprisePortSharer) ValidateTemplateMaxPortSharingLevel(level codersdk.W
 	return nil
 }
 
-func (EnterprisePortSharer) ConvertMaxPortSharingLevel(level database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel {
+func (EnterprisePortSharer) ConvertMaxLevel(level database.AppSharingLevel) codersdk.WorkspaceAgentPortShareLevel {
 	return codersdk.WorkspaceAgentPortShareLevel(level)
 }


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/13259

In the database we default to `owner` for the max port sharing level for existing and new templates. In OSS, the only valid option is `public` because changing max port share level is an enterprise feature. This change ensures we always return `public` for OSS and return the db value for Enterprise. 