### PR TITLE
chore: add setting to enable multi-organization ui

### DIFF
--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -2,6 +2,7 @@ import Button from "@mui/material/Button";
 import { type FC, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { groupsForUser } from "api/queries/groups";
+import { DisabledBadge, EnabledBadge } from "components/Badges/Badges";
 import { Stack } from "components/Stack/Stack";
 import { useAuthContext } from "contexts/auth/AuthProvider";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
@@ -9,7 +10,6 @@ import { useDashboard } from "modules/dashboard/useDashboard";
 import { Section } from "../Section";
 import { AccountForm } from "./AccountForm";
 import { AccountUserGroups } from "./AccountUserGroups";
-import { DisabledBadge, EnabledBadge } from "components/Badges/Badges";
 
 export const AccountPage: FC = () => {
   const { user: me, permissions, organizationId } = useAuthenticated();

--- a/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
+++ b/site/src/pages/UserSettingsPage/AccountPage/AccountPage.tsx
@@ -1,4 +1,5 @@
-import type { FC } from "react";
+import Button from "@mui/material/Button";
+import { type FC, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { groupsForUser } from "api/queries/groups";
 import { Stack } from "components/Stack/Stack";
@@ -8,18 +9,34 @@ import { useDashboard } from "modules/dashboard/useDashboard";
 import { Section } from "../Section";
 import { AccountForm } from "./AccountForm";
 import { AccountUserGroups } from "./AccountUserGroups";
+import { DisabledBadge, EnabledBadge } from "components/Badges/Badges";
 
 export const AccountPage: FC = () => {
   const { user: me, permissions, organizationId } = useAuthenticated();
   const { updateProfile, updateProfileError, isUpdatingProfile } =
     useAuthContext();
-  const { entitlements } = useDashboard();
+  const { entitlements, experiments } = useDashboard();
 
   const hasGroupsFeature = entitlements.features.user_role_management.enabled;
   const groupsQuery = useQuery({
     ...groupsForUser(organizationId, me.id),
     enabled: hasGroupsFeature,
   });
+
+  const multiOrgExperimentEnabled = experiments.includes("multi-organization");
+  const [multiOrgUiEnabled, setMultiOrgUiEnabled] = useState(
+    () =>
+      multiOrgExperimentEnabled &&
+      Boolean(localStorage.getItem("enableMultiOrganizationUi")),
+  );
+
+  useEffect(() => {
+    if (multiOrgUiEnabled) {
+      localStorage.setItem("enableMultiOrganizationUi", "true");
+    } else {
+      localStorage.removeItem("enableMultiOrganizationUi");
+    }
+  }, [multiOrgUiEnabled]);
 
   return (
     <Stack spacing={6}>
@@ -40,6 +57,23 @@ export const AccountPage: FC = () => {
           loading={groupsQuery.isLoading}
           error={groupsQuery.error}
         />
+      )}
+
+      {multiOrgExperimentEnabled && (
+        <Section
+          title="Organizations"
+          description={
+            <span>Danger: enabling will break things in the UI.</span>
+          }
+        >
+          <Stack>
+            {multiOrgUiEnabled ? <EnabledBadge /> : <DisabledBadge />}
+            <Button onClick={() => setMultiOrgUiEnabled((enabled) => !enabled)}>
+              {multiOrgUiEnabled ? "Disable" : "Enable"} frontend
+              multi-organization support
+            </Button>
+          </Stack>
+        </Section>
       )}
     </Stack>
   );


### PR DESCRIPTION
The frontend code is absolutely plastered with code that assumes there is only one organization, and that you're only ever active in the default organization. As we begin working on the frontend bits of multi-org support, obviously that needs to change, but it is likely to result in breakages along the way. @Emyrk and I are fine dealing with those, but it'd be best to spare the rest of you. 😄

(The plan is to remove this once we've made some progress, and feel that it is stable enough)