### PR TITLE
chore: add workspace activity linter

### DIFF
--- a/coderd/agentapi/activitybump.go
+++ b/coderd/agentapi/activitybump.go
@@ -41,6 +41,7 @@ func ActivityBumpWorkspace(ctx context.Context, log slog.Logger, db database.Sto
 	// low priority operations fail first.
 	ctx, cancel := context.WithTimeout(ctx, time.Second*15)
 	defer cancel()
+	// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 	err := db.ActivityBumpWorkspace(ctx, database.ActivityBumpWorkspaceParams{
 		NextAutostart: nextAutostart.UTC(),
 		WorkspaceID:   workspaceID,

--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -102,6 +102,7 @@ func (a *StatsAPI) UpdateStats(ctx context.Context, req *agentproto.UpdateStatsR
 		return nil
 	})
 	errGroup.Go(func() error {
+		// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 		err := a.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
 			ID:         workspace.ID,
 			LastUsedAt: now,

--- a/coderd/batchstats/batcher.go
+++ b/coderd/batchstats/batcher.go
@@ -240,6 +240,7 @@ func (b *Batcher) flush(ctx context.Context, forced bool, reason string) {
 		b.buf.ConnectionsByProto = payload
 	}
 
+	// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 	err = b.store.InsertWorkspaceAgentStats(ctx, *b.buf)
 	elapsed := time.Since(start)
 	if err != nil {

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1244,6 +1244,7 @@ func (api *API) workspaceAgentReportStats(rw http.ResponseWriter, r *http.Reques
 	})
 	if req.SessionCount() > 0 {
 		errGroup.Go(func() error {
+			// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 			err := api.Database.UpdateWorkspaceLastUsedAt(ctx, database.UpdateWorkspaceLastUsedAtParams{
 				ID:         workspace.ID,
 				LastUsedAt: now,

--- a/coderd/workspaceusage/tracker.go
+++ b/coderd/workspaceusage/tracker.go
@@ -130,6 +130,7 @@ func (tr *Tracker) flush(now time.Time) {
 	authCtx := dbauthz.AsSystemRestricted(ctx)
 	tr.flushLock.Lock()
 	defer tr.flushLock.Unlock()
+	// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 	if err := tr.s.BatchUpdateWorkspaceLastUsedAt(authCtx, database.BatchUpdateWorkspaceLastUsedAtParams{
 		LastUsedAt: now,
 		IDs:        ids,

--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -169,6 +169,7 @@ func (s *EnterpriseTemplateScheduleStore) Set(ctx context.Context, db database.S
 		}
 
 		if opts.UpdateWorkspaceLastUsedAt {
+			// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
 			err = tx.UpdateTemplateWorkspacesLastUsedAt(ctx, database.UpdateTemplateWorkspacesLastUsedAtParams{
 				TemplateID: tpl.ID,
 				LastUsedAt: dbtime.Now(),


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/13147

The idea is we stop developers from adding new usages of these db calls while the refactor is in progress and can also use the linter to keep track of what needs to be moved still. 