### PR TITLE
chore: push rbac actions to policy package

### DIFF
--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -18,7 +18,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -255,7 +255,7 @@ func (api *API) tokens(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	keys, err = AuthorizeFilter(api.HTTPAuth, r, rbac.ActionRead, keys)
+	keys, err = AuthorizeFilter(api.HTTPAuth, r, policy.ActionRead, keys)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching keys.",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -60,6 +60,7 @@ import (
 	"github.com/coder/coder/v2/coderd/prometheusmetrics"
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/tracing"
@@ -1106,7 +1107,7 @@ func New(options *Options) *API {
 				// Ensure only owners can access debug endpoints.
 				func(next http.Handler) http.Handler {
 					return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-						if !api.Authorize(r, rbac.ActionRead, rbac.ResourceDebugInfo) {
+						if !api.Authorize(r, policy.ActionRead, rbac.ResourceDebugInfo) {
 							httpapi.ResourceNotFound(rw)
 							return
 						}

--- a/coderd/coderdtest/authorize_test.go
+++ b/coderd/coderdtest/authorize_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 func TestAuthzRecorder(t *testing.T) {
@@ -101,7 +102,7 @@ func TestAuthzRecorder(t *testing.T) {
 }
 
 // fuzzAuthzPrep has same action and object types for all calls.
-func fuzzAuthzPrep(t *testing.T, prep rbac.PreparedAuthorized, n int, action rbac.Action, objectType string) []coderdtest.ActionObjectPair {
+func fuzzAuthzPrep(t *testing.T, prep rbac.PreparedAuthorized, n int, action policy.Action, objectType string) []coderdtest.ActionObjectPair {
 	t.Helper()
 	pairs := make([]coderdtest.ActionObjectPair, 0, n)
 

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi/httpapiconstraints"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/provisionersdk"
 )
@@ -130,7 +131,7 @@ func (q *querier) Wrappers() []string {
 }
 
 // authorizeContext is a helper function to authorize an action on an object.
-func (q *querier) authorizeContext(ctx context.Context, action rbac.Action, object rbac.Objecter) error {
+func (q *querier) authorizeContext(ctx context.Context, action policy.Action, object rbac.Objecter) error {
 	act, ok := ActorFromContext(ctx)
 	if !ok {
 		return NoActorError
@@ -161,20 +162,20 @@ var (
 			{
 				Name:        "provisionerd",
 				DisplayName: "Provisioner Daemon",
-				Site: rbac.Permissions(map[string][]rbac.Action{
+				Site: rbac.Permissions(map[string][]policy.Action{
 					// TODO: Add ProvisionerJob resource type.
-					rbac.ResourceFile.Type:           {rbac.ActionRead},
+					rbac.ResourceFile.Type:           {policy.ActionRead},
 					rbac.ResourceSystem.Type:         {rbac.WildcardSymbol},
-					rbac.ResourceTemplate.Type:       {rbac.ActionRead, rbac.ActionUpdate},
-					rbac.ResourceUser.Type:           {rbac.ActionRead},
-					rbac.ResourceWorkspace.Type:      {rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
-					rbac.ResourceWorkspaceBuild.Type: {rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
-					rbac.ResourceUserData.Type:       {rbac.ActionRead, rbac.ActionUpdate},
+					rbac.ResourceTemplate.Type:       {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceUser.Type:           {policy.ActionRead},
+					rbac.ResourceWorkspace.Type:      {policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+					rbac.ResourceWorkspaceBuild.Type: {policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+					rbac.ResourceUserData.Type:       {policy.ActionRead, policy.ActionUpdate},
 					rbac.ResourceAPIKey.Type:         {rbac.WildcardSymbol},
 					// When org scoped provisioner credentials are implemented,
 					// this can be reduced to read a specific org.
-					rbac.ResourceOrganization.Type: {rbac.ActionRead},
-					rbac.ResourceGroup.Type:        {rbac.ActionRead},
+					rbac.ResourceOrganization.Type: {policy.ActionRead},
+					rbac.ResourceGroup.Type:        {policy.ActionRead},
 				}),
 				Org:  map[string][]rbac.Permission{},
 				User: []rbac.Permission{},
@@ -190,12 +191,12 @@ var (
 			{
 				Name:        "autostart",
 				DisplayName: "Autostart Daemon",
-				Site: rbac.Permissions(map[string][]rbac.Action{
+				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceSystem.Type:         {rbac.WildcardSymbol},
-					rbac.ResourceTemplate.Type:       {rbac.ActionRead, rbac.ActionUpdate},
-					rbac.ResourceWorkspace.Type:      {rbac.ActionRead, rbac.ActionUpdate},
-					rbac.ResourceWorkspaceBuild.Type: {rbac.ActionRead, rbac.ActionUpdate, rbac.ActionDelete},
-					rbac.ResourceUser.Type:           {rbac.ActionRead},
+					rbac.ResourceTemplate.Type:       {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceWorkspace.Type:      {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceWorkspaceBuild.Type: {policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+					rbac.ResourceUser.Type:           {policy.ActionRead},
 				}),
 				Org:  map[string][]rbac.Permission{},
 				User: []rbac.Permission{},
@@ -212,10 +213,10 @@ var (
 			{
 				Name:        "hangdetector",
 				DisplayName: "Hang Detector Daemon",
-				Site: rbac.Permissions(map[string][]rbac.Action{
+				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceSystem.Type:    {rbac.WildcardSymbol},
-					rbac.ResourceTemplate.Type:  {rbac.ActionRead},
-					rbac.ResourceWorkspace.Type: {rbac.ActionRead, rbac.ActionUpdate},
+					rbac.ResourceTemplate.Type:  {policy.ActionRead},
+					rbac.ResourceWorkspace.Type: {policy.ActionRead, policy.ActionUpdate},
 				}),
 				Org:  map[string][]rbac.Permission{},
 				User: []rbac.Permission{},
@@ -231,22 +232,22 @@ var (
 			{
 				Name:        "system",
 				DisplayName: "Coder",
-				Site: rbac.Permissions(map[string][]rbac.Action{
-					rbac.ResourceWildcard.Type:           {rbac.ActionRead},
-					rbac.ResourceAPIKey.Type:             {rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
-					rbac.ResourceGroup.Type:              {rbac.ActionCreate, rbac.ActionUpdate},
-					rbac.ResourceRoleAssignment.Type:     {rbac.ActionCreate, rbac.ActionDelete},
+				Site: rbac.Permissions(map[string][]policy.Action{
+					rbac.ResourceWildcard.Type:           {policy.ActionRead},
+					rbac.ResourceAPIKey.Type:             {policy.ActionCreate, policy.ActionUpdate, policy.ActionDelete},
+					rbac.ResourceGroup.Type:              {policy.ActionCreate, policy.ActionUpdate},
+					rbac.ResourceRoleAssignment.Type:     {policy.ActionCreate, policy.ActionDelete},
 					rbac.ResourceSystem.Type:             {rbac.WildcardSymbol},
-					rbac.ResourceOrganization.Type:       {rbac.ActionCreate, rbac.ActionRead},
-					rbac.ResourceOrganizationMember.Type: {rbac.ActionCreate},
-					rbac.ResourceOrgRoleAssignment.Type:  {rbac.ActionCreate},
-					rbac.ResourceProvisionerDaemon.Type:  {rbac.ActionCreate, rbac.ActionUpdate},
-					rbac.ResourceUser.Type:               {rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
-					rbac.ResourceUserData.Type:           {rbac.ActionCreate, rbac.ActionUpdate},
-					rbac.ResourceWorkspace.Type:          {rbac.ActionUpdate},
-					rbac.ResourceWorkspaceBuild.Type:     {rbac.ActionUpdate},
-					rbac.ResourceWorkspaceExecution.Type: {rbac.ActionCreate},
-					rbac.ResourceWorkspaceProxy.Type:     {rbac.ActionCreate, rbac.ActionUpdate, rbac.ActionDelete},
+					rbac.ResourceOrganization.Type:       {policy.ActionCreate, policy.ActionRead},
+					rbac.ResourceOrganizationMember.Type: {policy.ActionCreate},
+					rbac.ResourceOrgRoleAssignment.Type:  {policy.ActionCreate},
+					rbac.ResourceProvisionerDaemon.Type:  {policy.ActionCreate, policy.ActionUpdate},
+					rbac.ResourceUser.Type:               {policy.ActionCreate, policy.ActionUpdate, policy.ActionDelete},
+					rbac.ResourceUserData.Type:           {policy.ActionCreate, policy.ActionUpdate},
+					rbac.ResourceWorkspace.Type:          {policy.ActionUpdate},
+					rbac.ResourceWorkspaceBuild.Type:     {policy.ActionUpdate},
+					rbac.ResourceWorkspaceExecution.Type: {policy.ActionCreate},
+					rbac.ResourceWorkspaceProxy.Type:     {policy.ActionCreate, policy.ActionUpdate, policy.ActionDelete},
 				}),
 				Org:  map[string][]rbac.Permission{},
 				User: []rbac.Permission{},
@@ -302,7 +303,7 @@ func As(ctx context.Context, actor rbac.Subject) context.Context {
 // Generic functions used to implement the database.Store methods.
 //
 
-// insert runs an rbac.ActionCreate on the rbac object argument before
+// insert runs an policy.ActionCreate on the rbac object argument before
 // running the insertFunc. The insertFunc is expected to return the object that
 // was inserted.
 func insert[
@@ -323,7 +324,7 @@ func insert[
 		}
 
 		// Authorize the action
-		err = authorizer.Authorize(ctx, act, rbac.ActionCreate, object.RBACObject())
+		err = authorizer.Authorize(ctx, act, policy.ActionCreate, object.RBACObject())
 		if err != nil {
 			return empty, logNotAuthorizedError(ctx, logger, err)
 		}
@@ -345,7 +346,7 @@ func deleteQ[
 	deleteFunc Delete,
 ) Delete {
 	return fetchAndExec(logger, authorizer,
-		rbac.ActionDelete, fetchFunc, deleteFunc)
+		policy.ActionDelete, fetchFunc, deleteFunc)
 }
 
 func updateWithReturn[
@@ -359,7 +360,7 @@ func updateWithReturn[
 	fetchFunc Fetch,
 	updateQuery UpdateQuery,
 ) UpdateQuery {
-	return fetchAndQuery(logger, authorizer, rbac.ActionUpdate, fetchFunc, updateQuery)
+	return fetchAndQuery(logger, authorizer, policy.ActionUpdate, fetchFunc, updateQuery)
 }
 
 func update[
@@ -373,7 +374,7 @@ func update[
 	fetchFunc Fetch,
 	updateExec Exec,
 ) Exec {
-	return fetchAndExec(logger, authorizer, rbac.ActionUpdate, fetchFunc, updateExec)
+	return fetchAndExec(logger, authorizer, policy.ActionUpdate, fetchFunc, updateExec)
 }
 
 // fetch is a generic function that wraps a database
@@ -406,7 +407,7 @@ func fetch[
 		}
 
 		// Authorize the action
-		err = authorizer.Authorize(ctx, act, rbac.ActionRead, object.RBACObject())
+		err = authorizer.Authorize(ctx, act, policy.ActionRead, object.RBACObject())
 		if err != nil {
 			return empty, logNotAuthorizedError(ctx, logger, err)
 		}
@@ -426,7 +427,7 @@ func fetchAndExec[
 ](
 	logger slog.Logger,
 	authorizer rbac.Authorizer,
-	action rbac.Action,
+	action policy.Action,
 	fetchFunc Fetch,
 	execFunc Exec,
 ) Exec {
@@ -452,7 +453,7 @@ func fetchAndQuery[
 ](
 	logger slog.Logger,
 	authorizer rbac.Authorizer,
-	action rbac.Action,
+	action policy.Action,
 	fetchFunc Fetch,
 	queryFunc Query,
 ) Query {
@@ -503,13 +504,13 @@ func fetchWithPostFilter[
 		}
 
 		// Authorize the action
-		return rbac.Filter(ctx, authorizer, act, rbac.ActionRead, objects)
+		return rbac.Filter(ctx, authorizer, act, policy.ActionRead, objects)
 	}
 }
 
 // prepareSQLFilter is a helper function that prepares a SQL filter using the
 // given authorization context.
-func prepareSQLFilter(ctx context.Context, authorizer rbac.Authorizer, action rbac.Action, resourceType string) (rbac.PreparedAuthorized, error) {
+func prepareSQLFilter(ctx context.Context, authorizer rbac.Authorizer, action policy.Action, resourceType string) (rbac.PreparedAuthorized, error) {
 	act, ok := ActorFromContext(ctx)
 	if !ok {
 		return nil, NoActorError
@@ -543,7 +544,7 @@ func (q *querier) authorizeUpdateFileTemplate(ctx context.Context, file database
 	// 1, so check them all.
 	for _, tpl := range tpls {
 		// If the user has update access to any template, they have read access to the file.
-		if err := q.authorizeContext(ctx, rbac.ActionUpdate, tpl); err == nil {
+		if err := q.authorizeContext(ctx, policy.ActionUpdate, tpl); err == nil {
 			return nil
 		}
 	}
@@ -584,13 +585,13 @@ func (q *querier) canAssignRoles(ctx context.Context, orgID *uuid.UUID, added, r
 	}
 
 	if len(added) > 0 {
-		if err := q.authorizeContext(ctx, rbac.ActionCreate, roleAssign); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionCreate, roleAssign); err != nil {
 			return err
 		}
 	}
 
 	if len(removed) > 0 {
-		if err := q.authorizeContext(ctx, rbac.ActionDelete, roleAssign); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionDelete, roleAssign); err != nil {
 			return err
 		}
 	}
@@ -660,7 +661,7 @@ func (q *querier) AcquireLock(ctx context.Context, id int64) error {
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) AcquireProvisionerJob(ctx context.Context, arg database.AcquireProvisionerJobParams) (database.ProvisionerJob, error) {
-	// if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 	// return database.ProvisionerJob{}, err
 	// }
 	return q.db.AcquireProvisionerJob(ctx, arg)
@@ -676,7 +677,7 @@ func (q *querier) ActivityBumpWorkspace(ctx context.Context, arg database.Activi
 func (q *querier) AllUserIDs(ctx context.Context) ([]uuid.UUID, error) {
 	// Although this technically only reads users, only system-related functions should be
 	// allowed to call this.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.AllUserIDs(ctx)
@@ -687,7 +688,7 @@ func (q *querier) ArchiveUnusedTemplateVersions(ctx context.Context, arg databas
 	if err != nil {
 		return nil, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, tpl); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, tpl); err != nil {
 		return nil, err
 	}
 	return q.db.ArchiveUnusedTemplateVersions(ctx, arg)
@@ -696,28 +697,28 @@ func (q *querier) ArchiveUnusedTemplateVersions(ctx context.Context, arg databas
 func (q *querier) BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg database.BatchUpdateWorkspaceLastUsedAtParams) error {
 	// Could be any workspace and checking auth to each workspace is overkill for the purpose
 	// of this function.
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceWorkspace.All()); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceWorkspace.All()); err != nil {
 		return err
 	}
 	return q.db.BatchUpdateWorkspaceLastUsedAt(ctx, arg)
 }
 
 func (q *querier) CleanTailnetCoordinators(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.CleanTailnetCoordinators(ctx)
 }
 
 func (q *querier) CleanTailnetLostPeers(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.CleanTailnetLostPeers(ctx)
 }
 
 func (q *querier) CleanTailnetTunnels(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.CleanTailnetTunnels(ctx)
@@ -729,7 +730,7 @@ func (q *querier) DeleteAPIKeyByID(ctx context.Context, id string) error {
 
 func (q *querier) DeleteAPIKeysByUserID(ctx context.Context, userID uuid.UUID) error {
 	// TODO: This is not 100% correct because it omits apikey IDs.
-	err := q.authorizeContext(ctx, rbac.ActionDelete,
+	err := q.authorizeContext(ctx, policy.ActionDelete,
 		rbac.ResourceAPIKey.WithOwner(userID.String()))
 	if err != nil {
 		return err
@@ -738,14 +739,14 @@ func (q *querier) DeleteAPIKeysByUserID(ctx context.Context, userID uuid.UUID) e
 }
 
 func (q *querier) DeleteAllTailnetClientSubscriptions(ctx context.Context, arg database.DeleteAllTailnetClientSubscriptionsParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.DeleteAllTailnetClientSubscriptions(ctx, arg)
 }
 
 func (q *querier) DeleteAllTailnetTunnels(ctx context.Context, arg database.DeleteAllTailnetTunnelsParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.DeleteAllTailnetTunnels(ctx, arg)
@@ -753,7 +754,7 @@ func (q *querier) DeleteAllTailnetTunnels(ctx context.Context, arg database.Dele
 
 func (q *querier) DeleteApplicationConnectAPIKeysByUserID(ctx context.Context, userID uuid.UUID) error {
 	// TODO: This is not 100% correct because it omits apikey IDs.
-	err := q.authorizeContext(ctx, rbac.ActionDelete,
+	err := q.authorizeContext(ctx, policy.ActionDelete,
 		rbac.ResourceAPIKey.WithOwner(userID.String()))
 	if err != nil {
 		return err
@@ -762,7 +763,7 @@ func (q *querier) DeleteApplicationConnectAPIKeysByUserID(ctx context.Context, u
 }
 
 func (q *querier) DeleteCoordinator(ctx context.Context, id uuid.UUID) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.DeleteCoordinator(ctx, id)
@@ -803,7 +804,7 @@ func (q *querier) DeleteLicense(ctx context.Context, id int32) (int32, error) {
 }
 
 func (q *querier) DeleteOAuth2ProviderAppByID(ctx context.Context, id uuid.UUID) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceOAuth2ProviderApp); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceOAuth2ProviderApp); err != nil {
 		return err
 	}
 	return q.db.DeleteOAuth2ProviderAppByID(ctx, id)
@@ -814,14 +815,14 @@ func (q *querier) DeleteOAuth2ProviderAppCodeByID(ctx context.Context, id uuid.U
 	if err != nil {
 		return err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, code); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, code); err != nil {
 		return err
 	}
 	return q.db.DeleteOAuth2ProviderAppCodeByID(ctx, id)
 }
 
 func (q *querier) DeleteOAuth2ProviderAppCodesByAppAndUserID(ctx context.Context, arg database.DeleteOAuth2ProviderAppCodesByAppAndUserIDParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete,
+	if err := q.authorizeContext(ctx, policy.ActionDelete,
 		rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(arg.UserID.String())); err != nil {
 		return err
 	}
@@ -829,14 +830,14 @@ func (q *querier) DeleteOAuth2ProviderAppCodesByAppAndUserID(ctx context.Context
 }
 
 func (q *querier) DeleteOAuth2ProviderAppSecretByID(ctx context.Context, id uuid.UUID) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
 		return err
 	}
 	return q.db.DeleteOAuth2ProviderAppSecretByID(ctx, id)
 }
 
 func (q *querier) DeleteOAuth2ProviderAppTokensByAppAndUserID(ctx context.Context, arg database.DeleteOAuth2ProviderAppTokensByAppAndUserIDParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete,
+	if err := q.authorizeContext(ctx, policy.ActionDelete,
 		rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(arg.UserID.String())); err != nil {
 		return err
 	}
@@ -844,63 +845,63 @@ func (q *querier) DeleteOAuth2ProviderAppTokensByAppAndUserID(ctx context.Contex
 }
 
 func (q *querier) DeleteOldProvisionerDaemons(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.DeleteOldProvisionerDaemons(ctx)
 }
 
 func (q *querier) DeleteOldWorkspaceAgentLogs(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.DeleteOldWorkspaceAgentLogs(ctx)
 }
 
 func (q *querier) DeleteOldWorkspaceAgentStats(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.DeleteOldWorkspaceAgentStats(ctx)
 }
 
 func (q *querier) DeleteReplicasUpdatedBefore(ctx context.Context, updatedAt time.Time) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.DeleteReplicasUpdatedBefore(ctx, updatedAt)
 }
 
 func (q *querier) DeleteTailnetAgent(ctx context.Context, arg database.DeleteTailnetAgentParams) (database.DeleteTailnetAgentRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.DeleteTailnetAgentRow{}, err
 	}
 	return q.db.DeleteTailnetAgent(ctx, arg)
 }
 
 func (q *querier) DeleteTailnetClient(ctx context.Context, arg database.DeleteTailnetClientParams) (database.DeleteTailnetClientRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.DeleteTailnetClientRow{}, err
 	}
 	return q.db.DeleteTailnetClient(ctx, arg)
 }
 
 func (q *querier) DeleteTailnetClientSubscription(ctx context.Context, arg database.DeleteTailnetClientSubscriptionParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.DeleteTailnetClientSubscription(ctx, arg)
 }
 
 func (q *querier) DeleteTailnetPeer(ctx context.Context, arg database.DeleteTailnetPeerParams) (database.DeleteTailnetPeerRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.DeleteTailnetPeerRow{}, err
 	}
 	return q.db.DeleteTailnetPeer(ctx, arg)
 }
 
 func (q *querier) DeleteTailnetTunnel(ctx context.Context, arg database.DeleteTailnetTunnelParams) (database.DeleteTailnetTunnelRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.DeleteTailnetTunnelRow{}, err
 	}
 	return q.db.DeleteTailnetTunnel(ctx, arg)
@@ -913,7 +914,7 @@ func (q *querier) DeleteWorkspaceAgentPortShare(ctx context.Context, arg databas
 	}
 
 	// deleting a workspace port share is more akin to just updating the workspace.
-	if err = q.authorizeContext(ctx, rbac.ActionUpdate, w.RBACObject()); err != nil {
+	if err = q.authorizeContext(ctx, policy.ActionUpdate, w.RBACObject()); err != nil {
 		return xerrors.Errorf("authorize context: %w", err)
 	}
 
@@ -926,7 +927,7 @@ func (q *querier) DeleteWorkspaceAgentPortSharesByTemplate(ctx context.Context, 
 		return err
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 		return err
 	}
 
@@ -961,7 +962,7 @@ func (q *querier) GetAPIKeysLastUsedAfter(ctx context.Context, lastUsed time.Tim
 }
 
 func (q *querier) GetActiveUserCount(ctx context.Context) (int64, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return 0, err
 	}
 	return q.db.GetActiveUserCount(ctx)
@@ -969,35 +970,35 @@ func (q *querier) GetActiveUserCount(ctx context.Context) (int64, error) {
 
 func (q *querier) GetActiveWorkspaceBuildsByTemplateID(ctx context.Context, templateID uuid.UUID) ([]database.WorkspaceBuild, error) {
 	// This is a system-only function.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return []database.WorkspaceBuild{}, err
 	}
 	return q.db.GetActiveWorkspaceBuildsByTemplateID(ctx, templateID)
 }
 
 func (q *querier) GetAllTailnetAgents(ctx context.Context) ([]database.TailnetAgent, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return []database.TailnetAgent{}, err
 	}
 	return q.db.GetAllTailnetAgents(ctx)
 }
 
 func (q *querier) GetAllTailnetCoordinators(ctx context.Context) ([]database.TailnetCoordinator, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetAllTailnetCoordinators(ctx)
 }
 
 func (q *querier) GetAllTailnetPeers(ctx context.Context) ([]database.TailnetPeer, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetAllTailnetPeers(ctx)
 }
 
 func (q *querier) GetAllTailnetTunnels(ctx context.Context) ([]database.TailnetTunnel, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetAllTailnetTunnels(ctx)
@@ -1017,28 +1018,28 @@ func (q *querier) GetAuditLogsOffset(ctx context.Context, arg database.GetAuditL
 	// To optimize audit logs, we only check the global audit log permission once.
 	// This is because we expect a large unbounded set of audit logs, and applying a SQL
 	// filter would slow down the query for no benefit.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceAuditLog); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAuditLog); err != nil {
 		return nil, err
 	}
 	return q.db.GetAuditLogsOffset(ctx, arg)
 }
 
 func (q *querier) GetAuthorizationUserRoles(ctx context.Context, userID uuid.UUID) (database.GetAuthorizationUserRolesRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.GetAuthorizationUserRolesRow{}, err
 	}
 	return q.db.GetAuthorizationUserRoles(ctx, userID)
 }
 
 func (q *querier) GetDBCryptKeys(ctx context.Context) ([]database.DBCryptKey, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetDBCryptKeys(ctx)
 }
 
 func (q *querier) GetDERPMeshKey(ctx context.Context) (string, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return "", err
 	}
 	return q.db.GetDERPMeshKey(ctx)
@@ -1057,7 +1058,7 @@ func (q *querier) GetDefaultProxyConfig(ctx context.Context) (database.GetDefaul
 
 // Only used by metrics cache.
 func (q *querier) GetDeploymentDAUs(ctx context.Context, tzOffset int32) ([]database.GetDeploymentDAUsRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetDeploymentDAUs(ctx, tzOffset)
@@ -1089,7 +1090,7 @@ func (q *querier) GetFileByHashAndCreator(ctx context.Context, arg database.GetF
 	if err != nil {
 		return database.File{}, err
 	}
-	err = q.authorizeContext(ctx, rbac.ActionRead, file)
+	err = q.authorizeContext(ctx, policy.ActionRead, file)
 	if err != nil {
 		// Check the user's access to the file's templates.
 		if q.authorizeUpdateFileTemplate(ctx, file) != nil {
@@ -1105,7 +1106,7 @@ func (q *querier) GetFileByID(ctx context.Context, id uuid.UUID) (database.File,
 	if err != nil {
 		return database.File{}, err
 	}
-	err = q.authorizeContext(ctx, rbac.ActionRead, file)
+	err = q.authorizeContext(ctx, policy.ActionRead, file)
 	if err != nil {
 		// Check the user's access to the file's templates.
 		if q.authorizeUpdateFileTemplate(ctx, file) != nil {
@@ -1117,7 +1118,7 @@ func (q *querier) GetFileByID(ctx context.Context, id uuid.UUID) (database.File,
 }
 
 func (q *querier) GetFileTemplates(ctx context.Context, fileID uuid.UUID) ([]database.GetFileTemplatesRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetFileTemplates(ctx, fileID)
@@ -1157,7 +1158,7 @@ func (q *querier) GetHealthSettings(ctx context.Context) (string, error) {
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) GetHungProvisionerJobs(ctx context.Context, hungSince time.Time) ([]database.ProvisionerJob, error) {
-	// if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 	// return nil, err
 	// }
 	return q.db.GetHungProvisionerJobs(ctx, hungSince)
@@ -1171,7 +1172,7 @@ func (q *querier) GetJFrogXrayScanByWorkspaceAndAgentID(ctx context.Context, arg
 }
 
 func (q *querier) GetLastUpdateCheck(ctx context.Context) (string, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return "", err
 	}
 	return q.db.GetLastUpdateCheck(ctx)
@@ -1189,7 +1190,7 @@ func (q *querier) GetLatestWorkspaceBuilds(ctx context.Context) ([]database.Work
 	// This is because we need to query for all related workspaces to the returned builds.
 	// This is a very inefficient method of fetching the latest workspace builds.
 	// We should just join the rbac properties.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetLatestWorkspaceBuilds(ctx)
@@ -1197,7 +1198,7 @@ func (q *querier) GetLatestWorkspaceBuilds(ctx context.Context) ([]database.Work
 
 func (q *querier) GetLatestWorkspaceBuildsByWorkspaceIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceBuild, error) {
 	// This function is a system function until we implement a join for workspace builds.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 
@@ -1226,7 +1227,7 @@ func (q *querier) GetNotificationBanners(ctx context.Context) (string, error) {
 }
 
 func (q *querier) GetOAuth2ProviderAppByID(ctx context.Context, id uuid.UUID) (database.OAuth2ProviderApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceOAuth2ProviderApp); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceOAuth2ProviderApp); err != nil {
 		return database.OAuth2ProviderApp{}, err
 	}
 	return q.db.GetOAuth2ProviderAppByID(ctx, id)
@@ -1241,7 +1242,7 @@ func (q *querier) GetOAuth2ProviderAppCodeByPrefix(ctx context.Context, secretPr
 }
 
 func (q *querier) GetOAuth2ProviderAppSecretByID(ctx context.Context, id uuid.UUID) (database.OAuth2ProviderAppSecret, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
 		return database.OAuth2ProviderAppSecret{}, err
 	}
 	return q.db.GetOAuth2ProviderAppSecretByID(ctx, id)
@@ -1252,7 +1253,7 @@ func (q *querier) GetOAuth2ProviderAppSecretByPrefix(ctx context.Context, secret
 }
 
 func (q *querier) GetOAuth2ProviderAppSecretsByAppID(ctx context.Context, appID uuid.UUID) ([]database.OAuth2ProviderAppSecret, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
 		return []database.OAuth2ProviderAppSecret{}, err
 	}
 	return q.db.GetOAuth2ProviderAppSecretsByAppID(ctx, appID)
@@ -1268,14 +1269,14 @@ func (q *querier) GetOAuth2ProviderAppTokenByPrefix(ctx context.Context, hashPre
 	if err != nil {
 		return database.OAuth2ProviderAppToken{}, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(key.UserID.String())); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(key.UserID.String())); err != nil {
 		return database.OAuth2ProviderAppToken{}, err
 	}
 	return token, nil
 }
 
 func (q *querier) GetOAuth2ProviderApps(ctx context.Context) ([]database.OAuth2ProviderApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceOAuth2ProviderApp); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceOAuth2ProviderApp); err != nil {
 		return []database.OAuth2ProviderApp{}, err
 	}
 	return q.db.GetOAuth2ProviderApps(ctx)
@@ -1283,7 +1284,7 @@ func (q *querier) GetOAuth2ProviderApps(ctx context.Context) ([]database.OAuth2P
 
 func (q *querier) GetOAuth2ProviderAppsByUserID(ctx context.Context, userID uuid.UUID) ([]database.GetOAuth2ProviderAppsByUserIDRow, error) {
 	// This authz check is to make sure the caller can read all their own tokens.
-	if err := q.authorizeContext(ctx, rbac.ActionRead,
+	if err := q.authorizeContext(ctx, policy.ActionRead,
 		rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(userID.String())); err != nil {
 		return []database.GetOAuth2ProviderAppsByUserIDRow{}, err
 	}
@@ -1291,7 +1292,7 @@ func (q *querier) GetOAuth2ProviderAppsByUserID(ctx context.Context, userID uuid
 }
 
 func (q *querier) GetOAuthSigningKey(ctx context.Context) (string, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return "", err
 	}
 	return q.db.GetOAuthSigningKey(ctx)
@@ -1344,7 +1345,7 @@ func (q *querier) GetParameterSchemasByJobID(ctx context.Context, jobID uuid.UUI
 		object = version.RBACObject(tpl)
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionRead, object)
+	err = q.authorizeContext(ctx, policy.ActionRead, object)
 	if err != nil {
 		return nil, err
 	}
@@ -1355,7 +1356,7 @@ func (q *querier) GetPreviousTemplateVersion(ctx context.Context, arg database.G
 	// An actor can read the previous template version if they can read the related template.
 	// If no linked template exists, we check if the actor can read *a* template.
 	if !arg.TemplateID.Valid {
-		if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplate.InOrg(arg.OrganizationID)); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplate.InOrg(arg.OrganizationID)); err != nil {
 			return database.TemplateVersion{}, err
 		}
 	}
@@ -1401,7 +1402,7 @@ func (q *querier) GetProvisionerJobByID(ctx context.Context, id uuid.UUID) (data
 
 // TODO: we need to add a provisioner job resource
 func (q *querier) GetProvisionerJobsByIDs(ctx context.Context, ids []uuid.UUID) ([]database.ProvisionerJob, error) {
-	// if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 	// 	return nil, err
 	// }
 	return q.db.GetProvisionerJobsByIDs(ctx, ids)
@@ -1414,7 +1415,7 @@ func (q *querier) GetProvisionerJobsByIDsWithQueuePosition(ctx context.Context, 
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) GetProvisionerJobsCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.ProvisionerJob, error) {
-	// if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 	// return nil, err
 	// }
 	return q.db.GetProvisionerJobsCreatedAfter(ctx, createdAt)
@@ -1430,7 +1431,7 @@ func (q *querier) GetProvisionerLogsAfterID(ctx context.Context, arg database.Ge
 }
 
 func (q *querier) GetQuotaAllowanceForUser(ctx context.Context, userID uuid.UUID) (int64, error) {
-	err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceUserObject(userID))
+	err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceUserObject(userID))
 	if err != nil {
 		return -1, err
 	}
@@ -1438,7 +1439,7 @@ func (q *querier) GetQuotaAllowanceForUser(ctx context.Context, userID uuid.UUID
 }
 
 func (q *querier) GetQuotaConsumedForUser(ctx context.Context, userID uuid.UUID) (int64, error) {
-	err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceUserObject(userID))
+	err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceUserObject(userID))
 	if err != nil {
 		return -1, err
 	}
@@ -1446,49 +1447,49 @@ func (q *querier) GetQuotaConsumedForUser(ctx context.Context, userID uuid.UUID)
 }
 
 func (q *querier) GetReplicaByID(ctx context.Context, id uuid.UUID) (database.Replica, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.Replica{}, err
 	}
 	return q.db.GetReplicaByID(ctx, id)
 }
 
 func (q *querier) GetReplicasUpdatedAfter(ctx context.Context, updatedAt time.Time) ([]database.Replica, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetReplicasUpdatedAfter(ctx, updatedAt)
 }
 
 func (q *querier) GetTailnetAgents(ctx context.Context, id uuid.UUID) ([]database.TailnetAgent, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetTailnetAgents(ctx, id)
 }
 
 func (q *querier) GetTailnetClientsForAgent(ctx context.Context, agentID uuid.UUID) ([]database.TailnetClient, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetTailnetClientsForAgent(ctx, agentID)
 }
 
 func (q *querier) GetTailnetPeers(ctx context.Context, id uuid.UUID) ([]database.TailnetPeer, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetTailnetPeers(ctx, id)
 }
 
 func (q *querier) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetTailnetTunnelPeerBindings(ctx, srcID)
 }
 
 func (q *querier) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetTailnetTunnelPeerIDs(ctx, srcID)
@@ -1497,19 +1498,19 @@ func (q *querier) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) 
 func (q *querier) GetTemplateAppInsights(ctx context.Context, arg database.GetTemplateAppInsightsParams) ([]database.GetTemplateAppInsightsRow, error) {
 	// Used by TemplateAppInsights endpoint
 	// For auditors, check read template_insights, and fall back to update template.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return nil, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return nil, err
 			}
 		}
@@ -1519,7 +1520,7 @@ func (q *querier) GetTemplateAppInsights(ctx context.Context, arg database.GetTe
 
 func (q *querier) GetTemplateAppInsightsByTemplate(ctx context.Context, arg database.GetTemplateAppInsightsByTemplateParams) ([]database.GetTemplateAppInsightsByTemplateRow, error) {
 	// Only used by prometheus metrics, so we don't strictly need to check update template perms.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateAppInsightsByTemplate(ctx, arg)
@@ -1527,7 +1528,7 @@ func (q *querier) GetTemplateAppInsightsByTemplate(ctx context.Context, arg data
 
 // Only used by metrics cache.
 func (q *querier) GetTemplateAverageBuildTime(ctx context.Context, arg database.GetTemplateAverageBuildTimeParams) (database.GetTemplateAverageBuildTimeRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.GetTemplateAverageBuildTimeRow{}, err
 	}
 	return q.db.GetTemplateAverageBuildTime(ctx, arg)
@@ -1543,7 +1544,7 @@ func (q *querier) GetTemplateByOrganizationAndName(ctx context.Context, arg data
 
 // Only used by metrics cache.
 func (q *querier) GetTemplateDAUs(ctx context.Context, arg database.GetTemplateDAUsParams) ([]database.GetTemplateDAUsRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateDAUs(ctx, arg)
@@ -1552,19 +1553,19 @@ func (q *querier) GetTemplateDAUs(ctx context.Context, arg database.GetTemplateD
 func (q *querier) GetTemplateInsights(ctx context.Context, arg database.GetTemplateInsightsParams) (database.GetTemplateInsightsRow, error) {
 	// Used by TemplateInsights endpoint
 	// For auditors, check read template_insights, and fall back to update template.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return database.GetTemplateInsightsRow{}, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return database.GetTemplateInsightsRow{}, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return database.GetTemplateInsightsRow{}, err
 			}
 		}
@@ -1575,19 +1576,19 @@ func (q *querier) GetTemplateInsights(ctx context.Context, arg database.GetTempl
 func (q *querier) GetTemplateInsightsByInterval(ctx context.Context, arg database.GetTemplateInsightsByIntervalParams) ([]database.GetTemplateInsightsByIntervalRow, error) {
 	// Used by TemplateInsights endpoint
 	// For auditors, check read template_insights, and fall back to update template.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return nil, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return nil, err
 			}
 		}
@@ -1597,7 +1598,7 @@ func (q *querier) GetTemplateInsightsByInterval(ctx context.Context, arg databas
 
 func (q *querier) GetTemplateInsightsByTemplate(ctx context.Context, arg database.GetTemplateInsightsByTemplateParams) ([]database.GetTemplateInsightsByTemplateRow, error) {
 	// Only used by prometheus metrics collector. No need to check update template perms.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateInsightsByTemplate(ctx, arg)
@@ -1606,19 +1607,19 @@ func (q *querier) GetTemplateInsightsByTemplate(ctx context.Context, arg databas
 func (q *querier) GetTemplateParameterInsights(ctx context.Context, arg database.GetTemplateParameterInsightsParams) ([]database.GetTemplateParameterInsightsRow, error) {
 	// Used by both insights endpoint and prometheus collector.
 	// For auditors, check read template_insights, and fall back to update template.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return nil, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return nil, err
 			}
 		}
@@ -1629,19 +1630,19 @@ func (q *querier) GetTemplateParameterInsights(ctx context.Context, arg database
 func (q *querier) GetTemplateUsageStats(ctx context.Context, arg database.GetTemplateUsageStatsParams) ([]database.TemplateUsageStat, error) {
 	// Used by dbrollup tests, use same safe-guard as other insights endpoints.
 	// For auditors, check read template_insights, and fall back to update template.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return nil, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return nil, err
 			}
 		}
@@ -1656,7 +1657,7 @@ func (q *querier) GetTemplateVersionByID(ctx context.Context, tvid uuid.UUID) (d
 	}
 	if !tv.TemplateID.Valid {
 		// If no linked template exists, check if the actor can read a template in the organization.
-		if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplate.InOrg(tv.OrganizationID)); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplate.InOrg(tv.OrganizationID)); err != nil {
 			return database.TemplateVersion{}, err
 		}
 	} else if _, err := q.GetTemplateByID(ctx, tv.TemplateID.UUID); err != nil {
@@ -1673,7 +1674,7 @@ func (q *querier) GetTemplateVersionByJobID(ctx context.Context, jobID uuid.UUID
 	}
 	if !tv.TemplateID.Valid {
 		// If no linked template exists, check if the actor can read a template in the organization.
-		if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplate.InOrg(tv.OrganizationID)); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplate.InOrg(tv.OrganizationID)); err != nil {
 			return database.TemplateVersion{}, err
 		}
 	} else if _, err := q.GetTemplateByID(ctx, tv.TemplateID.UUID); err != nil {
@@ -1690,7 +1691,7 @@ func (q *querier) GetTemplateVersionByTemplateIDAndName(ctx context.Context, arg
 	}
 	if !tv.TemplateID.Valid {
 		// If no linked template exists, check if the actor can read a template in the organization.
-		if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplate.InOrg(tv.OrganizationID)); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplate.InOrg(tv.OrganizationID)); err != nil {
 			return database.TemplateVersion{}, err
 		}
 	} else if _, err := q.GetTemplateByID(ctx, tv.TemplateID.UUID); err != nil {
@@ -1718,7 +1719,7 @@ func (q *querier) GetTemplateVersionParameters(ctx context.Context, templateVers
 		object = tv.RBACObject(template)
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionRead, object); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, object); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateVersionParameters(ctx, templateVersionID)
@@ -1741,7 +1742,7 @@ func (q *querier) GetTemplateVersionVariables(ctx context.Context, templateVersi
 		object = tv.RBACObject(template)
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionRead, object); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, object); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateVersionVariables(ctx, templateVersionID)
@@ -1750,7 +1751,7 @@ func (q *querier) GetTemplateVersionVariables(ctx context.Context, templateVersi
 // GetTemplateVersionsByIDs is only used for workspace build data.
 // The workspace is already fetched.
 func (q *querier) GetTemplateVersionsByIDs(ctx context.Context, ids []uuid.UUID) ([]database.TemplateVersion, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateVersionsByIDs(ctx, ids)
@@ -1763,7 +1764,7 @@ func (q *querier) GetTemplateVersionsByTemplateID(ctx context.Context, arg datab
 		return nil, err
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionRead, template); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, template); err != nil {
 		return nil, err
 	}
 
@@ -1772,21 +1773,21 @@ func (q *querier) GetTemplateVersionsByTemplateID(ctx context.Context, arg datab
 
 func (q *querier) GetTemplateVersionsCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.TemplateVersion, error) {
 	// An actor can read execute this query if they can read all templates.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplate.All()); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplate.All()); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateVersionsCreatedAfter(ctx, createdAt)
 }
 
 func (q *querier) GetTemplates(ctx context.Context) ([]database.Template, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplates(ctx)
 }
 
 func (q *querier) GetTemplatesWithFilter(ctx context.Context, arg database.GetTemplatesWithFilterParams) ([]database.Template, error) {
-	prep, err := prepareSQLFilter(ctx, q.auth, rbac.ActionRead, rbac.ResourceTemplate.Type)
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceTemplate.Type)
 	if err != nil {
 		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
 	}
@@ -1794,7 +1795,7 @@ func (q *querier) GetTemplatesWithFilter(ctx context.Context, arg database.GetTe
 }
 
 func (q *querier) GetUnexpiredLicenses(ctx context.Context) ([]database.License, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetUnexpiredLicenses(ctx)
@@ -1802,19 +1803,19 @@ func (q *querier) GetUnexpiredLicenses(ctx context.Context) ([]database.License,
 
 func (q *querier) GetUserActivityInsights(ctx context.Context, arg database.GetUserActivityInsightsParams) ([]database.GetUserActivityInsightsRow, error) {
 	// Used by insights endpoints. Need to check both for auditors and for regular users with template acl perms.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return nil, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return nil, err
 			}
 		}
@@ -1831,7 +1832,7 @@ func (q *querier) GetUserByID(ctx context.Context, id uuid.UUID) (database.User,
 }
 
 func (q *querier) GetUserCount(ctx context.Context) (int64, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return 0, err
 	}
 	return q.db.GetUserCount(ctx)
@@ -1839,19 +1840,19 @@ func (q *querier) GetUserCount(ctx context.Context) (int64, error) {
 
 func (q *querier) GetUserLatencyInsights(ctx context.Context, arg database.GetUserLatencyInsightsParams) ([]database.GetUserLatencyInsightsRow, error) {
 	// Used by insights endpoints. Need to check both for auditors and for regular users with template acl perms.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceTemplateInsights); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTemplateInsights); err != nil {
 		for _, templateID := range arg.TemplateIDs {
 			template, err := q.db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return nil, err
 			}
 
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 				return nil, err
 			}
 		}
 		if len(arg.TemplateIDs) == 0 {
-			if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
+			if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTemplate.All()); err != nil {
 				return nil, err
 			}
 		}
@@ -1860,21 +1861,21 @@ func (q *querier) GetUserLatencyInsights(ctx context.Context, arg database.GetUs
 }
 
 func (q *querier) GetUserLinkByLinkedID(ctx context.Context, linkedID string) (database.UserLink, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.UserLink{}, err
 	}
 	return q.db.GetUserLinkByLinkedID(ctx, linkedID)
 }
 
 func (q *querier) GetUserLinkByUserIDLoginType(ctx context.Context, arg database.GetUserLinkByUserIDLoginTypeParams) (database.UserLink, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.UserLink{}, err
 	}
 	return q.db.GetUserLinkByUserIDLoginType(ctx, arg)
 }
 
 func (q *querier) GetUserLinksByUserID(ctx context.Context, userID uuid.UUID) ([]database.UserLink, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetUserLinksByUserID(ctx, userID)
@@ -1885,7 +1886,7 @@ func (q *querier) GetUserWorkspaceBuildParameters(ctx context.Context, params da
 	if err != nil {
 		return nil, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionRead, u.UserWorkspaceBuildParametersObject()); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, u.UserWorkspaceBuildParametersObject()); err != nil {
 		return nil, err
 	}
 	return q.db.GetUserWorkspaceBuildParameters(ctx, params)
@@ -1893,7 +1894,7 @@ func (q *querier) GetUserWorkspaceBuildParameters(ctx context.Context, params da
 
 func (q *querier) GetUsers(ctx context.Context, arg database.GetUsersParams) ([]database.GetUsersRow, error) {
 	// This does the filtering in SQL.
-	prep, err := prepareSQLFilter(ctx, q.auth, rbac.ActionRead, rbac.ResourceUser.Type)
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceUser.Type)
 	if err != nil {
 		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
 	}
@@ -1905,7 +1906,7 @@ func (q *querier) GetUsers(ctx context.Context, arg database.GetUsersParams) ([]
 // itself.
 func (q *querier) GetUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]database.User, error) {
 	for _, uid := range ids {
-		if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceUserObject(uid)); err != nil {
+		if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceUserObject(uid)); err != nil {
 			return nil, err
 		}
 	}
@@ -1914,7 +1915,7 @@ func (q *querier) GetUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]databas
 
 func (q *querier) GetWorkspaceAgentAndLatestBuildByAuthToken(ctx context.Context, authToken uuid.UUID) (database.GetWorkspaceAgentAndLatestBuildByAuthTokenRow, error) {
 	// This is a system function
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.GetWorkspaceAgentAndLatestBuildByAuthTokenRow{}, err
 	}
 	return q.db.GetWorkspaceAgentAndLatestBuildByAuthToken(ctx, authToken)
@@ -1952,7 +1953,7 @@ func (q *querier) GetWorkspaceAgentLifecycleStateByID(ctx context.Context, id uu
 }
 
 func (q *querier) GetWorkspaceAgentLogSourcesByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceAgentLogSource, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceAgentLogSourcesByAgentIDs(ctx, ids)
@@ -1972,7 +1973,7 @@ func (q *querier) GetWorkspaceAgentMetadata(ctx context.Context, arg database.Ge
 		return nil, err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionRead, workspace)
+	err = q.authorizeContext(ctx, policy.ActionRead, workspace)
 	if err != nil {
 		return nil, err
 	}
@@ -1987,7 +1988,7 @@ func (q *querier) GetWorkspaceAgentPortShare(ctx context.Context, arg database.G
 	}
 
 	// reading a workspace port share is more akin to just reading the workspace.
-	if err = q.authorizeContext(ctx, rbac.ActionRead, w.RBACObject()); err != nil {
+	if err = q.authorizeContext(ctx, policy.ActionRead, w.RBACObject()); err != nil {
 		return database.WorkspaceAgentPortShare{}, xerrors.Errorf("authorize context: %w", err)
 	}
 
@@ -1995,7 +1996,7 @@ func (q *querier) GetWorkspaceAgentPortShare(ctx context.Context, arg database.G
 }
 
 func (q *querier) GetWorkspaceAgentScriptsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceAgentScript, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceAgentScriptsByAgentIDs(ctx, ids)
@@ -2012,14 +2013,14 @@ func (q *querier) GetWorkspaceAgentStatsAndLabels(ctx context.Context, createdAf
 // GetWorkspaceAgentsByResourceIDs
 // The workspace/job is already fetched.
 func (q *querier) GetWorkspaceAgentsByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceAgent, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceAgentsByResourceIDs(ctx, ids)
 }
 
 func (q *querier) GetWorkspaceAgentsCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.WorkspaceAgent, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceAgentsCreatedAfter(ctx, createdAt)
@@ -2053,14 +2054,14 @@ func (q *querier) GetWorkspaceAppsByAgentID(ctx context.Context, agentID uuid.UU
 // GetWorkspaceAppsByAgentIDs
 // The workspace/job is already fetched.
 func (q *querier) GetWorkspaceAppsByAgentIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceAppsByAgentIDs(ctx, ids)
 }
 
 func (q *querier) GetWorkspaceAppsCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.WorkspaceApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceAppsCreatedAfter(ctx, createdAt)
@@ -2119,7 +2120,7 @@ func (q *querier) GetWorkspaceBuildsByWorkspaceID(ctx context.Context, arg datab
 // telemetry data. Never called by a user.
 
 func (q *querier) GetWorkspaceBuildsCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.WorkspaceBuild, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceBuildsCreatedAfter(ctx, createdAt)
@@ -2148,7 +2149,7 @@ func (q *querier) GetWorkspaceProxies(ctx context.Context) ([]database.Workspace
 }
 
 func (q *querier) GetWorkspaceProxyByHostname(ctx context.Context, params database.GetWorkspaceProxyByHostnameParams) (database.WorkspaceProxy, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return database.WorkspaceProxy{}, err
 	}
 	return q.db.GetWorkspaceProxyByHostname(ctx, params)
@@ -2180,14 +2181,14 @@ func (q *querier) GetWorkspaceResourceByID(ctx context.Context, id uuid.UUID) (d
 // GetWorkspaceResourceMetadataByResourceIDs is only used for build data.
 // The workspace/job is already fetched.
 func (q *querier) GetWorkspaceResourceMetadataByResourceIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceResourceMetadatum, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceResourceMetadataByResourceIDs(ctx, ids)
 }
 
 func (q *querier) GetWorkspaceResourceMetadataCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.WorkspaceResourceMetadatum, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceResourceMetadataCreatedAfter(ctx, createdAt)
@@ -2232,7 +2233,7 @@ func (q *querier) GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.U
 		return nil, xerrors.Errorf("unknown job type: %s", job.Type)
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionRead, obj); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, obj); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceResourcesByJobID(ctx, jobID)
@@ -2242,28 +2243,28 @@ func (q *querier) GetWorkspaceResourcesByJobID(ctx context.Context, jobID uuid.U
 // The workspace is already fetched.
 // TODO: Find a way to replace this with proper authz.
 func (q *querier) GetWorkspaceResourcesByJobIDs(ctx context.Context, ids []uuid.UUID) ([]database.WorkspaceResource, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceResourcesByJobIDs(ctx, ids)
 }
 
 func (q *querier) GetWorkspaceResourcesCreatedAfter(ctx context.Context, createdAt time.Time) ([]database.WorkspaceResource, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceResourcesCreatedAfter(ctx, createdAt)
 }
 
 func (q *querier) GetWorkspaceUniqueOwnerCountByTemplateIDs(ctx context.Context, templateIds []uuid.UUID) ([]database.GetWorkspaceUniqueOwnerCountByTemplateIDsRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionRead, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.GetWorkspaceUniqueOwnerCountByTemplateIDs(ctx, templateIds)
 }
 
 func (q *querier) GetWorkspaces(ctx context.Context, arg database.GetWorkspacesParams) ([]database.GetWorkspacesRow, error) {
-	prep, err := prepareSQLFilter(ctx, q.auth, rbac.ActionRead, rbac.ResourceWorkspace.Type)
+	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceWorkspace.Type)
 	if err != nil {
 		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
 	}
@@ -2290,21 +2291,21 @@ func (q *querier) InsertAuditLog(ctx context.Context, arg database.InsertAuditLo
 }
 
 func (q *querier) InsertDBCryptKey(ctx context.Context, arg database.InsertDBCryptKeyParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.InsertDBCryptKey(ctx, arg)
 }
 
 func (q *querier) InsertDERPMeshKey(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.InsertDERPMeshKey(ctx, value)
 }
 
 func (q *querier) InsertDeploymentID(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.InsertDeploymentID(ctx, value)
@@ -2334,28 +2335,28 @@ func (q *querier) InsertGroupMember(ctx context.Context, arg database.InsertGrou
 }
 
 func (q *querier) InsertLicense(ctx context.Context, arg database.InsertLicenseParams) (database.License, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceLicense); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceLicense); err != nil {
 		return database.License{}, err
 	}
 	return q.db.InsertLicense(ctx, arg)
 }
 
 func (q *querier) InsertMissingGroups(ctx context.Context, arg database.InsertMissingGroupsParams) ([]database.Group, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.InsertMissingGroups(ctx, arg)
 }
 
 func (q *querier) InsertOAuth2ProviderApp(ctx context.Context, arg database.InsertOAuth2ProviderAppParams) (database.OAuth2ProviderApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceOAuth2ProviderApp); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceOAuth2ProviderApp); err != nil {
 		return database.OAuth2ProviderApp{}, err
 	}
 	return q.db.InsertOAuth2ProviderApp(ctx, arg)
 }
 
 func (q *querier) InsertOAuth2ProviderAppCode(ctx context.Context, arg database.InsertOAuth2ProviderAppCodeParams) (database.OAuth2ProviderAppCode, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate,
+	if err := q.authorizeContext(ctx, policy.ActionCreate,
 		rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(arg.UserID.String())); err != nil {
 		return database.OAuth2ProviderAppCode{}, err
 	}
@@ -2363,7 +2364,7 @@ func (q *querier) InsertOAuth2ProviderAppCode(ctx context.Context, arg database.
 }
 
 func (q *querier) InsertOAuth2ProviderAppSecret(ctx context.Context, arg database.InsertOAuth2ProviderAppSecretParams) (database.OAuth2ProviderAppSecret, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
 		return database.OAuth2ProviderAppSecret{}, err
 	}
 	return q.db.InsertOAuth2ProviderAppSecret(ctx, arg)
@@ -2374,7 +2375,7 @@ func (q *querier) InsertOAuth2ProviderAppToken(ctx context.Context, arg database
 	if err != nil {
 		return database.OAuth2ProviderAppToken{}, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(key.UserID.String())); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceOAuth2ProviderAppCodeToken.WithOwner(key.UserID.String())); err != nil {
 		return database.OAuth2ProviderAppToken{}, err
 	}
 	return q.db.InsertOAuth2ProviderAppToken(ctx, arg)
@@ -2398,7 +2399,7 @@ func (q *querier) InsertOrganizationMember(ctx context.Context, arg database.Ins
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) InsertProvisionerJob(ctx context.Context, arg database.InsertProvisionerJobParams) (database.ProvisionerJob, error) {
-	// if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 	// return database.ProvisionerJob{}, err
 	// }
 	return q.db.InsertProvisionerJob(ctx, arg)
@@ -2406,14 +2407,14 @@ func (q *querier) InsertProvisionerJob(ctx context.Context, arg database.InsertP
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) InsertProvisionerJobLogs(ctx context.Context, arg database.InsertProvisionerJobLogsParams) ([]database.ProvisionerJobLog, error) {
-	// if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 	// return nil, err
 	// }
 	return q.db.InsertProvisionerJobLogs(ctx, arg)
 }
 
 func (q *querier) InsertReplica(ctx context.Context, arg database.InsertReplicaParams) (database.Replica, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return database.Replica{}, err
 	}
 	return q.db.InsertReplica(ctx, arg)
@@ -2421,7 +2422,7 @@ func (q *querier) InsertReplica(ctx context.Context, arg database.InsertReplicaP
 
 func (q *querier) InsertTemplate(ctx context.Context, arg database.InsertTemplateParams) error {
 	obj := rbac.ResourceTemplate.InOrg(arg.OrganizationID)
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, obj); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, obj); err != nil {
 		return err
 	}
 	return q.db.InsertTemplate(ctx, arg)
@@ -2430,7 +2431,7 @@ func (q *querier) InsertTemplate(ctx context.Context, arg database.InsertTemplat
 func (q *querier) InsertTemplateVersion(ctx context.Context, arg database.InsertTemplateVersionParams) error {
 	if !arg.TemplateID.Valid {
 		// Making a new template version is the same permission as creating a new template.
-		err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceTemplate.InOrg(arg.OrganizationID))
+		err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceTemplate.InOrg(arg.OrganizationID))
 		if err != nil {
 			return err
 		}
@@ -2441,7 +2442,7 @@ func (q *querier) InsertTemplateVersion(ctx context.Context, arg database.Insert
 			return err
 		}
 		// Check the create permission on the template.
-		err = q.authorizeContext(ctx, rbac.ActionCreate, tpl)
+		err = q.authorizeContext(ctx, policy.ActionCreate, tpl)
 		if err != nil {
 			return err
 		}
@@ -2451,14 +2452,14 @@ func (q *querier) InsertTemplateVersion(ctx context.Context, arg database.Insert
 }
 
 func (q *querier) InsertTemplateVersionParameter(ctx context.Context, arg database.InsertTemplateVersionParameterParams) (database.TemplateVersionParameter, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return database.TemplateVersionParameter{}, err
 	}
 	return q.db.InsertTemplateVersionParameter(ctx, arg)
 }
 
 func (q *querier) InsertTemplateVersionVariable(ctx context.Context, arg database.InsertTemplateVersionVariableParams) (database.TemplateVersionVariable, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return database.TemplateVersionVariable{}, err
 	}
 	return q.db.InsertTemplateVersionVariable(ctx, arg)
@@ -2487,7 +2488,7 @@ func (q *querier) InsertUserGroupsByName(ctx context.Context, arg database.Inser
 
 // TODO: Should this be in system.go?
 func (q *querier) InsertUserLink(ctx context.Context, arg database.InsertUserLinkParams) (database.UserLink, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceUserObject(arg.UserID)); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceUserObject(arg.UserID)); err != nil {
 		return database.UserLink{}, err
 	}
 	return q.db.InsertUserLink(ctx, arg)
@@ -2499,7 +2500,7 @@ func (q *querier) InsertWorkspace(ctx context.Context, arg database.InsertWorksp
 }
 
 func (q *querier) InsertWorkspaceAgent(ctx context.Context, arg database.InsertWorkspaceAgentParams) (database.WorkspaceAgent, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return database.WorkspaceAgent{}, err
 	}
 	return q.db.InsertWorkspaceAgent(ctx, arg)
@@ -2518,7 +2519,7 @@ func (q *querier) InsertWorkspaceAgentLogs(ctx context.Context, arg database.Ins
 func (q *querier) InsertWorkspaceAgentMetadata(ctx context.Context, arg database.InsertWorkspaceAgentMetadataParams) error {
 	// We don't check for workspace ownership here since the agent metadata may
 	// be associated with an orphaned agent used by a dry run build.
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 
@@ -2526,14 +2527,14 @@ func (q *querier) InsertWorkspaceAgentMetadata(ctx context.Context, arg database
 }
 
 func (q *querier) InsertWorkspaceAgentScripts(ctx context.Context, arg database.InsertWorkspaceAgentScriptsParams) ([]database.WorkspaceAgentScript, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return []database.WorkspaceAgentScript{}, err
 	}
 	return q.db.InsertWorkspaceAgentScripts(ctx, arg)
 }
 
 func (q *querier) InsertWorkspaceAgentStats(ctx context.Context, arg database.InsertWorkspaceAgentStatsParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 
@@ -2541,14 +2542,14 @@ func (q *querier) InsertWorkspaceAgentStats(ctx context.Context, arg database.In
 }
 
 func (q *querier) InsertWorkspaceApp(ctx context.Context, arg database.InsertWorkspaceAppParams) (database.WorkspaceApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return database.WorkspaceApp{}, err
 	}
 	return q.db.InsertWorkspaceApp(ctx, arg)
 }
 
 func (q *querier) InsertWorkspaceAppStats(ctx context.Context, arg database.InsertWorkspaceAppStatsParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.InsertWorkspaceAppStats(ctx, arg)
@@ -2560,9 +2561,9 @@ func (q *querier) InsertWorkspaceBuild(ctx context.Context, arg database.InsertW
 		return xerrors.Errorf("get workspace by id: %w", err)
 	}
 
-	var action rbac.Action = rbac.ActionUpdate
+	var action policy.Action = policy.ActionUpdate
 	if arg.Transition == database.WorkspaceTransitionDelete {
-		action = rbac.ActionDelete
+		action = policy.ActionDelete
 	}
 
 	if err = q.authorizeContext(ctx, action, w.WorkspaceBuildRBAC(arg.Transition)); err != nil {
@@ -2583,7 +2584,7 @@ func (q *querier) InsertWorkspaceBuild(ctx context.Context, arg database.InsertW
 		// to use a non-active version then we must fail the request.
 		if accessControl.RequireActiveVersion {
 			if arg.TemplateVersionID != t.ActiveVersionID {
-				if err = q.authorizeContext(ctx, rbac.ActionUpdate, t); err != nil {
+				if err = q.authorizeContext(ctx, policy.ActionUpdate, t); err != nil {
 					return xerrors.Errorf("cannot use non-active version: %w", err)
 				}
 			}
@@ -2605,7 +2606,7 @@ func (q *querier) InsertWorkspaceBuildParameters(ctx context.Context, arg databa
 		return err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace)
+	err = q.authorizeContext(ctx, policy.ActionUpdate, workspace)
 	if err != nil {
 		return err
 	}
@@ -2618,14 +2619,14 @@ func (q *querier) InsertWorkspaceProxy(ctx context.Context, arg database.InsertW
 }
 
 func (q *querier) InsertWorkspaceResource(ctx context.Context, arg database.InsertWorkspaceResourceParams) (database.WorkspaceResource, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return database.WorkspaceResource{}, err
 	}
 	return q.db.InsertWorkspaceResource(ctx, arg)
 }
 
 func (q *querier) InsertWorkspaceResourceMetadata(ctx context.Context, arg database.InsertWorkspaceResourceMetadataParams) ([]database.WorkspaceResourceMetadatum, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.InsertWorkspaceResourceMetadata(ctx, arg)
@@ -2638,7 +2639,7 @@ func (q *querier) ListWorkspaceAgentPortShares(ctx context.Context, workspaceID 
 	}
 
 	// listing port shares is more akin to reading the workspace.
-	if err := q.authorizeContext(ctx, rbac.ActionRead, workspace); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, workspace); err != nil {
 		return nil, err
 	}
 
@@ -2651,7 +2652,7 @@ func (q *querier) ReduceWorkspaceAgentShareLevelToAuthenticatedByTemplate(ctx co
 		return err
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 		return err
 	}
 
@@ -2667,14 +2668,14 @@ func (q *querier) RegisterWorkspaceProxy(ctx context.Context, arg database.Regis
 
 func (q *querier) RemoveUserFromAllGroups(ctx context.Context, userID uuid.UUID) error {
 	// This is a system function to clear user groups in group sync.
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.RemoveUserFromAllGroups(ctx, userID)
 }
 
 func (q *querier) RevokeDBCryptKey(ctx context.Context, activeKeyDigest string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.RevokeDBCryptKey(ctx, activeKeyDigest)
@@ -2694,7 +2695,7 @@ func (q *querier) UnarchiveTemplateVersion(ctx context.Context, arg database.Una
 	if err != nil {
 		return err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, tpl); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, tpl); err != nil {
 		return err
 	}
 	return q.db.UnarchiveTemplateVersion(ctx, arg)
@@ -2736,7 +2737,7 @@ func (q *querier) UpdateGroupByID(ctx context.Context, arg database.UpdateGroupB
 }
 
 func (q *querier) UpdateInactiveUsersToDormant(ctx context.Context, lastSeenAfter database.UpdateInactiveUsersToDormantParams) ([]database.UpdateInactiveUsersToDormantRow, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceSystem); err != nil {
 		return nil, err
 	}
 	return q.db.UpdateInactiveUsersToDormant(ctx, lastSeenAfter)
@@ -2764,21 +2765,21 @@ func (q *querier) UpdateMemberRoles(ctx context.Context, arg database.UpdateMemb
 }
 
 func (q *querier) UpdateOAuth2ProviderAppByID(ctx context.Context, arg database.UpdateOAuth2ProviderAppByIDParams) (database.OAuth2ProviderApp, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceOAuth2ProviderApp); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceOAuth2ProviderApp); err != nil {
 		return database.OAuth2ProviderApp{}, err
 	}
 	return q.db.UpdateOAuth2ProviderAppByID(ctx, arg)
 }
 
 func (q *querier) UpdateOAuth2ProviderAppSecretByID(ctx context.Context, arg database.UpdateOAuth2ProviderAppSecretByIDParams) (database.OAuth2ProviderAppSecret, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceOAuth2ProviderAppSecret); err != nil {
 		return database.OAuth2ProviderAppSecret{}, err
 	}
 	return q.db.UpdateOAuth2ProviderAppSecretByID(ctx, arg)
 }
 
 func (q *querier) UpdateProvisionerDaemonLastSeenAt(ctx context.Context, arg database.UpdateProvisionerDaemonLastSeenAtParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceProvisionerDaemon); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceProvisionerDaemon); err != nil {
 		return err
 	}
 	return q.db.UpdateProvisionerDaemonLastSeenAt(ctx, arg)
@@ -2786,7 +2787,7 @@ func (q *querier) UpdateProvisionerDaemonLastSeenAt(ctx context.Context, arg dat
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) UpdateProvisionerJobByID(ctx context.Context, arg database.UpdateProvisionerJobByIDParams) error {
-	// if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 	// return err
 	// }
 	return q.db.UpdateProvisionerJobByID(ctx, arg)
@@ -2827,7 +2828,7 @@ func (q *querier) UpdateProvisionerJobWithCancelByID(ctx context.Context, arg da
 			}
 		}
 
-		err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace)
+		err = q.authorizeContext(ctx, policy.ActionUpdate, workspace)
 		if err != nil {
 			return err
 		}
@@ -2843,12 +2844,12 @@ func (q *querier) UpdateProvisionerJobWithCancelByID(ctx context.Context, arg da
 			if err != nil {
 				return err
 			}
-			err = q.authorizeContext(ctx, rbac.ActionUpdate, templateVersion.RBACObject(template))
+			err = q.authorizeContext(ctx, policy.ActionUpdate, templateVersion.RBACObject(template))
 			if err != nil {
 				return err
 			}
 		} else {
-			err = q.authorizeContext(ctx, rbac.ActionUpdate, templateVersion.RBACObjectNoTemplate())
+			err = q.authorizeContext(ctx, policy.ActionUpdate, templateVersion.RBACObjectNoTemplate())
 			if err != nil {
 				return err
 			}
@@ -2861,14 +2862,14 @@ func (q *querier) UpdateProvisionerJobWithCancelByID(ctx context.Context, arg da
 
 // TODO: We need to create a ProvisionerJob resource type
 func (q *querier) UpdateProvisionerJobWithCompleteByID(ctx context.Context, arg database.UpdateProvisionerJobWithCompleteByIDParams) error {
-	// if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	// if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 	// return err
 	// }
 	return q.db.UpdateProvisionerJobWithCompleteByID(ctx, arg)
 }
 
 func (q *querier) UpdateReplica(ctx context.Context, arg database.UpdateReplicaParams) (database.Replica, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return database.Replica{}, err
 	}
 	return q.db.UpdateReplica(ctx, arg)
@@ -2880,7 +2881,7 @@ func (q *querier) UpdateTemplateACLByID(ctx context.Context, arg database.Update
 	}
 	// UpdateTemplateACL uses the ActionCreate action. Only users that can create the template
 	// may update the ACL.
-	return fetchAndExec(q.log, q.auth, rbac.ActionCreate, fetch, q.db.UpdateTemplateACLByID)(ctx, arg)
+	return fetchAndExec(q.log, q.auth, policy.ActionCreate, fetch, q.db.UpdateTemplateACLByID)(ctx, arg)
 }
 
 func (q *querier) UpdateTemplateAccessControlByID(ctx context.Context, arg database.UpdateTemplateAccessControlByIDParams) error {
@@ -2932,7 +2933,7 @@ func (q *querier) UpdateTemplateVersionByID(ctx context.Context, arg database.Up
 		}
 		obj = tpl
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, obj); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, obj); err != nil {
 		return err
 	}
 	return q.db.UpdateTemplateVersionByID(ctx, arg)
@@ -2954,7 +2955,7 @@ func (q *querier) UpdateTemplateVersionDescriptionByJobID(ctx context.Context, a
 		}
 		obj = tpl
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, obj); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, obj); err != nil {
 		return err
 	}
 	return q.db.UpdateTemplateVersionDescriptionByJobID(ctx, arg)
@@ -2976,7 +2977,7 @@ func (q *querier) UpdateTemplateVersionExternalAuthProvidersByJobID(ctx context.
 		}
 		obj = tpl
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, obj); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, obj); err != nil {
 		return err
 	}
 	return q.db.UpdateTemplateVersionExternalAuthProvidersByJobID(ctx, arg)
@@ -2987,7 +2988,7 @@ func (q *querier) UpdateTemplateWorkspacesLastUsedAt(ctx context.Context, arg da
 		return q.db.GetTemplateByID(ctx, arg.TemplateID)
 	}
 
-	return fetchAndExec(q.log, q.auth, rbac.ActionUpdate, fetch, q.db.UpdateTemplateWorkspacesLastUsedAt)(ctx, arg)
+	return fetchAndExec(q.log, q.auth, policy.ActionUpdate, fetch, q.db.UpdateTemplateWorkspacesLastUsedAt)(ctx, arg)
 }
 
 func (q *querier) UpdateUserAppearanceSettings(ctx context.Context, arg database.UpdateUserAppearanceSettingsParams) (database.User, error) {
@@ -2995,7 +2996,7 @@ func (q *querier) UpdateUserAppearanceSettings(ctx context.Context, arg database
 	if err != nil {
 		return database.User{}, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, u.UserDataRBACObject()); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, u.UserDataRBACObject()); err != nil {
 		return database.User{}, err
 	}
 	return q.db.UpdateUserAppearanceSettings(ctx, arg)
@@ -3011,10 +3012,10 @@ func (q *querier) UpdateUserHashedPassword(ctx context.Context, arg database.Upd
 		return err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, user.UserDataRBACObject())
+	err = q.authorizeContext(ctx, policy.ActionUpdate, user.UserDataRBACObject())
 	if err != nil {
 		// Admins can update passwords for other users.
-		err = q.authorizeContext(ctx, rbac.ActionUpdate, user.RBACObject())
+		err = q.authorizeContext(ctx, policy.ActionUpdate, user.RBACObject())
 		if err != nil {
 			return err
 		}
@@ -3041,14 +3042,14 @@ func (q *querier) UpdateUserLink(ctx context.Context, arg database.UpdateUserLin
 }
 
 func (q *querier) UpdateUserLinkedID(ctx context.Context, arg database.UpdateUserLinkedIDParams) (database.UserLink, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return database.UserLink{}, err
 	}
 	return q.db.UpdateUserLinkedID(ctx, arg)
 }
 
 func (q *querier) UpdateUserLoginType(ctx context.Context, arg database.UpdateUserLoginTypeParams) (database.User, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return database.User{}, err
 	}
 	return q.db.UpdateUserLoginType(ctx, arg)
@@ -3059,7 +3060,7 @@ func (q *querier) UpdateUserProfile(ctx context.Context, arg database.UpdateUser
 	if err != nil {
 		return database.User{}, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, u.UserDataRBACObject()); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, u.UserDataRBACObject()); err != nil {
 		return database.User{}, err
 	}
 	return q.db.UpdateUserProfile(ctx, arg)
@@ -3070,7 +3071,7 @@ func (q *querier) UpdateUserQuietHoursSchedule(ctx context.Context, arg database
 	if err != nil {
 		return database.User{}, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, u.UserDataRBACObject()); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, u.UserDataRBACObject()); err != nil {
 		return database.User{}, err
 	}
 	return q.db.UpdateUserQuietHoursSchedule(ctx, arg)
@@ -3114,7 +3115,7 @@ func (q *querier) UpdateWorkspace(ctx context.Context, arg database.UpdateWorksp
 }
 
 func (q *querier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg database.UpdateWorkspaceAgentConnectionByIDParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpdateWorkspaceAgentConnectionByID(ctx, arg)
@@ -3126,7 +3127,7 @@ func (q *querier) UpdateWorkspaceAgentLifecycleStateByID(ctx context.Context, ar
 		return err
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, workspace); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, workspace); err != nil {
 		return err
 	}
 
@@ -3144,7 +3145,7 @@ func (q *querier) UpdateWorkspaceAgentLogOverflowByID(ctx context.Context, arg d
 		return err
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, workspace); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, workspace); err != nil {
 		return err
 	}
 
@@ -3157,7 +3158,7 @@ func (q *querier) UpdateWorkspaceAgentMetadata(ctx context.Context, arg database
 		return err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace)
+	err = q.authorizeContext(ctx, policy.ActionUpdate, workspace)
 	if err != nil {
 		return err
 	}
@@ -3176,7 +3177,7 @@ func (q *querier) UpdateWorkspaceAgentStartupByID(ctx context.Context, arg datab
 		return err
 	}
 
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, workspace); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, workspace); err != nil {
 		return err
 	}
 
@@ -3190,7 +3191,7 @@ func (q *querier) UpdateWorkspaceAppHealthByID(ctx context.Context, arg database
 		return err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace.RBACObject())
+	err = q.authorizeContext(ctx, policy.ActionUpdate, workspace.RBACObject())
 	if err != nil {
 		return err
 	}
@@ -3203,7 +3204,7 @@ func (q *querier) UpdateWorkspaceAutomaticUpdates(ctx context.Context, arg datab
 		return err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace.RBACObject())
+	err = q.authorizeContext(ctx, policy.ActionUpdate, workspace.RBACObject())
 	if err != nil {
 		return err
 	}
@@ -3219,7 +3220,7 @@ func (q *querier) UpdateWorkspaceAutostart(ctx context.Context, arg database.Upd
 
 // UpdateWorkspaceBuildCostByID is used by the provisioning system to update the cost of a workspace build.
 func (q *querier) UpdateWorkspaceBuildCostByID(ctx context.Context, arg database.UpdateWorkspaceBuildCostByIDParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpdateWorkspaceBuildCostByID(ctx, arg)
@@ -3236,7 +3237,7 @@ func (q *querier) UpdateWorkspaceBuildDeadlineByID(ctx context.Context, arg data
 		return err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace.RBACObject())
+	err = q.authorizeContext(ctx, policy.ActionUpdate, workspace.RBACObject())
 	if err != nil {
 		return err
 	}
@@ -3244,7 +3245,7 @@ func (q *querier) UpdateWorkspaceBuildDeadlineByID(ctx context.Context, arg data
 }
 
 func (q *querier) UpdateWorkspaceBuildProvisionerStateByID(ctx context.Context, arg database.UpdateWorkspaceBuildProvisionerStateByIDParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpdateWorkspaceBuildProvisionerStateByID(ctx, arg)
@@ -3300,7 +3301,7 @@ func (q *querier) UpdateWorkspacesDormantDeletingAtByTemplateID(ctx context.Cont
 		return q.db.GetTemplateByID(ctx, arg.TemplateID)
 	}
 
-	return fetchAndExec(q.log, q.auth, rbac.ActionUpdate, fetch, q.db.UpdateWorkspacesDormantDeletingAtByTemplateID)(ctx, arg)
+	return fetchAndExec(q.log, q.auth, policy.ActionUpdate, fetch, q.db.UpdateWorkspacesDormantDeletingAtByTemplateID)(ctx, arg)
 }
 
 func (q *querier) UpsertAppSecurityKey(ctx context.Context, data string) error {
@@ -3309,21 +3310,21 @@ func (q *querier) UpsertAppSecurityKey(ctx context.Context, data string) error {
 }
 
 func (q *querier) UpsertApplicationName(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
 	return q.db.UpsertApplicationName(ctx, value)
 }
 
 func (q *querier) UpsertDefaultProxy(ctx context.Context, arg database.UpsertDefaultProxyParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpsertDefaultProxy(ctx, arg)
 }
 
 func (q *querier) UpsertHealthSettings(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
 	return q.db.UpsertHealthSettings(ctx, value)
@@ -3344,35 +3345,35 @@ func (q *querier) UpsertJFrogXrayScanByWorkspaceAndAgentID(ctx context.Context, 
 	// Only template admins should be able to write JFrog Xray scans to a workspace.
 	// We don't want this to be a workspace-level permission because then users
 	// could overwrite their own results.
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, template); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, template); err != nil {
 		return err
 	}
 	return q.db.UpsertJFrogXrayScanByWorkspaceAndAgentID(ctx, arg)
 }
 
 func (q *querier) UpsertLastUpdateCheck(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpsertLastUpdateCheck(ctx, value)
 }
 
 func (q *querier) UpsertLogoURL(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
 	return q.db.UpsertLogoURL(ctx, value)
 }
 
 func (q *querier) UpsertNotificationBanners(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceDeploymentValues); err != nil {
 		return err
 	}
 	return q.db.UpsertNotificationBanners(ctx, value)
 }
 
 func (q *querier) UpsertOAuthSigningKey(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpsertOAuthSigningKey(ctx, value)
@@ -3383,56 +3384,56 @@ func (q *querier) UpsertProvisionerDaemon(ctx context.Context, arg database.Upse
 	if arg.Tags[provisionersdk.TagScope] == provisionersdk.ScopeUser {
 		res.Owner = arg.Tags[provisionersdk.TagOwner]
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, res); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, res); err != nil {
 		return database.ProvisionerDaemon{}, err
 	}
 	return q.db.UpsertProvisionerDaemon(ctx, arg)
 }
 
 func (q *querier) UpsertTailnetAgent(ctx context.Context, arg database.UpsertTailnetAgentParams) (database.TailnetAgent, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.TailnetAgent{}, err
 	}
 	return q.db.UpsertTailnetAgent(ctx, arg)
 }
 
 func (q *querier) UpsertTailnetClient(ctx context.Context, arg database.UpsertTailnetClientParams) (database.TailnetClient, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.TailnetClient{}, err
 	}
 	return q.db.UpsertTailnetClient(ctx, arg)
 }
 
 func (q *querier) UpsertTailnetClientSubscription(ctx context.Context, arg database.UpsertTailnetClientSubscriptionParams) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
 		return err
 	}
 	return q.db.UpsertTailnetClientSubscription(ctx, arg)
 }
 
 func (q *querier) UpsertTailnetCoordinator(ctx context.Context, id uuid.UUID) (database.TailnetCoordinator, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.TailnetCoordinator{}, err
 	}
 	return q.db.UpsertTailnetCoordinator(ctx, id)
 }
 
 func (q *querier) UpsertTailnetPeer(ctx context.Context, arg database.UpsertTailnetPeerParams) (database.TailnetPeer, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.TailnetPeer{}, err
 	}
 	return q.db.UpsertTailnetPeer(ctx, arg)
 }
 
 func (q *querier) UpsertTailnetTunnel(ctx context.Context, arg database.UpsertTailnetTunnelParams) (database.TailnetTunnel, error) {
-	if err := q.authorizeContext(ctx, rbac.ActionCreate, rbac.ResourceTailnetCoordinator); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionCreate, rbac.ResourceTailnetCoordinator); err != nil {
 		return database.TailnetTunnel{}, err
 	}
 	return q.db.UpsertTailnetTunnel(ctx, arg)
 }
 
 func (q *querier) UpsertTemplateUsageStats(ctx context.Context) error {
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, rbac.ResourceSystem); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err
 	}
 	return q.db.UpsertTemplateUsageStats(ctx)
@@ -3444,7 +3445,7 @@ func (q *querier) UpsertWorkspaceAgentPortShare(ctx context.Context, arg databas
 		return database.WorkspaceAgentPortShare{}, err
 	}
 
-	err = q.authorizeContext(ctx, rbac.ActionUpdate, workspace)
+	err = q.authorizeContext(ctx, policy.ActionUpdate, workspace)
 	if err != nil {
 		return database.WorkspaceAgentPortShare{}, err
 	}
@@ -3463,7 +3464,7 @@ func (q *querier) GetTemplateGroupRoles(ctx context.Context, id uuid.UUID) ([]da
 	if err != nil {
 		return nil, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateGroupRoles(ctx, id)
@@ -3475,7 +3476,7 @@ func (q *querier) GetTemplateUserRoles(ctx context.Context, id uuid.UUID) ([]dat
 	if err != nil {
 		return nil, err
 	}
-	if err := q.authorizeContext(ctx, rbac.ActionUpdate, template); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, template); err != nil {
 		return nil, err
 	}
 	return q.db.GetTemplateUserRoles(ctx, id)

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -338,7 +339,7 @@ func (m *expects) Errors(err error) *expects {
 // AssertRBAC contains the object and actions to be asserted.
 type AssertRBAC struct {
 	Object  rbac.Object
-	Actions []rbac.Action
+	Actions []policy.Action
 }
 
 // values is a convenience method for creating []reflect.Value.
@@ -368,15 +369,15 @@ func values(ins ...any) []reflect.Value {
 //
 // Even-numbered inputs are the objects, and odd-numbered inputs are the actions.
 // Objects must implement rbac.Objecter.
-// Inputs can be a single rbac.Action, or a slice of rbac.Action.
+// Inputs can be a single policy.Action, or a slice of policy.Action.
 //
-//	asserts(workspace, rbac.ActionRead, template, slice(rbac.ActionRead, rbac.ActionWrite), ...)
+//	asserts(workspace, policy.ActionRead, template, slice(policy.ActionRead, policy.ActionWrite), ...)
 //
 // is equivalent to
 //
 //	[]AssertRBAC{
-//	  {Object: workspace, Actions: []rbac.Action{rbac.ActionRead}},
-//	  {Object: template, Actions: []rbac.Action{rbac.ActionRead, rbac.ActionWrite)}},
+//	  {Object: workspace, Actions: []policy.Action{policy.ActionRead}},
+//	  {Object: template, Actions: []policy.Action{policy.ActionRead, policy.ActionWrite)}},
 //	   ...
 //	}
 func asserts(inputs ...any) []AssertRBAC {
@@ -392,19 +393,19 @@ func asserts(inputs ...any) []AssertRBAC {
 		}
 		rbacObj := obj.RBACObject()
 
-		var actions []rbac.Action
-		actions, ok = inputs[i+1].([]rbac.Action)
+		var actions []policy.Action
+		actions, ok = inputs[i+1].([]policy.Action)
 		if !ok {
-			action, ok := inputs[i+1].(rbac.Action)
+			action, ok := inputs[i+1].(policy.Action)
 			if !ok {
 				// Could be the string type.
 				actionAsString, ok := inputs[i+1].(string)
 				if !ok {
 					panic(fmt.Sprintf("action '%q' not a supported action", actionAsString))
 				}
-				action = rbac.Action(actionAsString)
+				action = policy.Action(actionAsString)
 			}
-			actions = []rbac.Action{action}
+			actions = []policy.Action{action}
 		}
 
 		out = append(out, AssertRBAC{

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/provisionerjobs"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/cryptorand"
 )
 
@@ -69,7 +70,7 @@ func Template(t testing.TB, db database.Store, seed database.Template) database.
 	if seed.GroupACL == nil {
 		// By default, all users in the organization can read the template.
 		seed.GroupACL = database.TemplateACL{
-			seed.OrganizationID.String(): []rbac.Action{rbac.ActionRead},
+			seed.OrganizationID.String(): []policy.Action{policy.ActionRead},
 		}
 	}
 	if seed.UserACL == nil {

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -14,12 +14,14 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 var (
 	// Force these imports, for some reason the autogen does not include them.
 	_ uuid.UUID
-	_ rbac.Action
+	_ policy.Action
+	_ rbac.Objecter
 )
 
 const wrapname = "dbmetrics.metricsStore"

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
 )
 
@@ -29,7 +29,7 @@ type HealthSettings struct {
 	DismissedHealthchecks []healthsdk.HealthSection `db:"dismissed_healthchecks" json:"dismissed_healthchecks"`
 }
 
-type Actions []rbac.Action
+type Actions []policy.Action
 
 func (a *Actions) Scan(src interface{}) error {
 	switch v := src.(type) {
@@ -46,7 +46,7 @@ func (a *Actions) Value() (driver.Value, error) {
 }
 
 // TemplateACL is a map of ids to permissions.
-type TemplateACL map[string][]rbac.Action
+type TemplateACL map[string][]policy.Action
 
 func (t *TemplateACL) Scan(src interface{}) error {
 	switch v := src.(type) {

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
 )
@@ -193,7 +194,7 @@ func (api *API) deploymentHealthSettings(rw http.ResponseWriter, r *http.Request
 func (api *API) putDeploymentHealthSettings(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	if !api.Authorize(r, rbac.ActionUpdate, rbac.ResourceDeploymentValues) {
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentValues) {
 		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 			Message: "Insufficient permissions to update health settings.",
 		})

--- a/coderd/deployment.go
+++ b/coderd/deployment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -16,7 +17,7 @@ import (
 // @Success 200 {object} codersdk.DeploymentConfig
 // @Router /deployment/config [get]
 func (api *API) deploymentValues(rw http.ResponseWriter, r *http.Request) {
-	if !api.Authorize(r, rbac.ActionRead, rbac.ResourceDeploymentValues) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentValues) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -44,7 +45,7 @@ func (api *API) deploymentValues(rw http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} codersdk.DeploymentStats
 // @Router /deployment/stats [get]
 func (api *API) deploymentStats(rw http.ResponseWriter, r *http.Request) {
-	if !api.Authorize(r, rbac.ActionRead, rbac.ResourceDeploymentStats) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentStats) {
 		httpapi.Forbidden(rw)
 		return
 	}

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -32,7 +33,7 @@ const insightsTimeLayout = time.RFC3339
 // @Success 200 {object} codersdk.DAUsResponse
 // @Router /insights/daus [get]
 func (api *API) deploymentDAUs(rw http.ResponseWriter, r *http.Request) {
-	if !api.Authorize(r, rbac.ActionRead, rbac.ResourceDeploymentValues) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentValues) {
 		httpapi.Forbidden(rw)
 		return
 	}

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -655,7 +656,7 @@ func TestTemplateInsights_Golden(t *testing.T) {
 				OrganizationID:  firstUser.OrganizationID,
 				CreatedBy:       firstUser.UserID,
 				GroupACL: database.TemplateACL{
-					firstUser.OrganizationID.String(): []rbac.Action{rbac.ActionRead},
+					firstUser.OrganizationID.String(): []policy.Action{policy.ActionRead},
 				},
 			})
 			err := db.UpdateTemplateVersionByID(context.Background(), database.UpdateTemplateVersionByIDParams{
@@ -1551,7 +1552,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 				OrganizationID:  firstUser.OrganizationID,
 				CreatedBy:       firstUser.UserID,
 				GroupACL: database.TemplateACL{
-					firstUser.OrganizationID.String(): []rbac.Action{rbac.ActionRead},
+					firstUser.OrganizationID.String(): []policy.Action{policy.ActionRead},
 				},
 			})
 			err := db.UpdateTemplateVersionByID(context.Background(), database.UpdateTemplateVersionByIDParams{

--- a/coderd/rbac/astvalue.go
+++ b/coderd/rbac/astvalue.go
@@ -3,12 +3,14 @@ package rbac
 import (
 	"github.com/open-policy-agent/opa/ast"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 // regoInputValue returns a rego input value for the given subject, action, and
 // object. This rego input is already parsed and can be used directly in a
 // rego query.
-func regoInputValue(subject Subject, action Action, object Object) (ast.Value, error) {
+func regoInputValue(subject Subject, action policy.Action, object Object) (ast.Value, error) {
 	regoSubj, err := subject.regoValue()
 	if err != nil {
 		return nil, xerrors.Errorf("subject: %w", err)
@@ -34,7 +36,7 @@ func regoInputValue(subject Subject, action Action, object Object) (ast.Value, e
 
 // regoPartialInputValue is the same as regoInputValue but only includes the
 // object type. This is for partial evaluations.
-func regoPartialInputValue(subject Subject, action Action, objectType string) (ast.Value, error) {
+func regoPartialInputValue(subject Subject, action policy.Action, objectType string) (ast.Value, error) {
 	regoSubj, err := subject.regoValue()
 	if err != nil {
 		return nil, xerrors.Errorf("subject: %w", err)
@@ -103,11 +105,11 @@ func (s Subject) regoValue() (ast.Value, error) {
 func (z Object) regoValue() ast.Value {
 	userACL := ast.NewObject()
 	for k, v := range z.ACLUserList {
-		userACL.Insert(ast.StringTerm(k), ast.NewTerm(regoSlice(v)))
+		userACL.Insert(ast.StringTerm(k), ast.NewTerm(regoSliceString(v...)))
 	}
 	grpACL := ast.NewObject()
 	for k, v := range z.ACLGroupList {
-		grpACL.Insert(ast.StringTerm(k), ast.NewTerm(regoSlice(v)))
+		grpACL.Insert(ast.StringTerm(k), ast.NewTerm(regoSliceString(v...)))
 	}
 	return ast.NewObject(
 		[2]*ast.Term{
@@ -200,10 +202,6 @@ func (perm Permission) regoValue() ast.Value {
 	)
 }
 
-func (act Action) regoValue() ast.Value {
-	return ast.StringTerm(string(act)).Value
-}
-
 type regoValue interface {
 	regoValue() ast.Value
 }
@@ -218,10 +216,10 @@ func regoSlice[T regoValue](slice []T) *ast.Array {
 	return ast.NewArray(terms...)
 }
 
-func regoSliceString(slice ...string) *ast.Array {
+func regoSliceString[T ~string](slice ...T) *ast.Array {
 	terms := make([]*ast.Term, len(slice))
 	for i, v := range slice {
-		terms[i] = ast.StringTerm(v)
+		terms[i] = ast.StringTerm(string(v))
 	}
 	return ast.NewArray(terms...)
 }

--- a/coderd/rbac/error.go
+++ b/coderd/rbac/error.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/httpapi/httpapiconstraints"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 const (
@@ -28,7 +29,7 @@ type UnauthorizedError struct {
 
 	// These fields are for debugging purposes.
 	subject Subject
-	action  Action
+	action  policy.Action
 	// Note only the object type is set for partial execution.
 	object Object
 
@@ -52,7 +53,7 @@ func IsUnauthorizedError(err error) bool {
 // ForbiddenWithInternal creates a new error that will return a simple
 // "forbidden" to the client, logging internally the more detailed message
 // provided.
-func ForbiddenWithInternal(internal error, subject Subject, action Action, object Object, output rego.ResultSet) *UnauthorizedError {
+func ForbiddenWithInternal(internal error, subject Subject, action policy.Action, object Object, output rego.ResultSet) *UnauthorizedError {
 	return &UnauthorizedError{
 		internal: internal,
 		subject:  subject,

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -2,6 +2,8 @@ package rbac
 
 import (
 	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 const WildcardSymbol = "*"
@@ -250,8 +252,8 @@ type Object struct {
 	// Type is "workspace", "project", "app", etc
 	Type string `json:"type"`
 
-	ACLUserList  map[string][]Action ` json:"acl_user_list"`
-	ACLGroupList map[string][]Action ` json:"acl_group_list"`
+	ACLUserList  map[string][]policy.Action ` json:"acl_user_list"`
+	ACLGroupList map[string][]policy.Action ` json:"acl_group_list"`
 }
 
 func (z Object) Equal(b Object) bool {
@@ -279,7 +281,7 @@ func (z Object) Equal(b Object) bool {
 	return true
 }
 
-func equalACLLists(a, b map[string][]Action) bool {
+func equalACLLists(a, b map[string][]policy.Action) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -307,8 +309,8 @@ func (z Object) All() Object {
 		Owner:        "",
 		OrgID:        "",
 		Type:         z.Type,
-		ACLUserList:  map[string][]Action{},
-		ACLGroupList: map[string][]Action{},
+		ACLUserList:  map[string][]policy.Action{},
+		ACLGroupList: map[string][]policy.Action{},
 	}
 }
 
@@ -359,7 +361,7 @@ func (z Object) WithOwner(ownerID string) Object {
 }
 
 // WithACLUserList adds an ACL list to a given object
-func (z Object) WithACLUserList(acl map[string][]Action) Object {
+func (z Object) WithACLUserList(acl map[string][]policy.Action) Object {
 	return Object{
 		ID:           z.ID,
 		Owner:        z.Owner,
@@ -370,7 +372,7 @@ func (z Object) WithACLUserList(acl map[string][]Action) Object {
 	}
 }
 
-func (z Object) WithGroupACL(groups map[string][]Action) Object {
+func (z Object) WithGroupACL(groups map[string][]policy.Action) Object {
 	return Object{
 		ID:           z.ID,
 		Owner:        z.Owner,

--- a/coderd/rbac/object_test.go
+++ b/coderd/rbac/object_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/util/slice"
 )
 
@@ -24,8 +25,8 @@ func TestObjectEqual(t *testing.T) {
 		{
 			Name: "NilVs0",
 			A: rbac.Object{
-				ACLGroupList: map[string][]rbac.Action{},
-				ACLUserList:  map[string][]rbac.Action{},
+				ACLGroupList: map[string][]policy.Action{},
+				ACLUserList:  map[string][]policy.Action{},
 			},
 			B:        rbac.Object{},
 			Expected: true,
@@ -37,16 +38,16 @@ func TestObjectEqual(t *testing.T) {
 				Owner:        "owner",
 				OrgID:        "orgID",
 				Type:         "type",
-				ACLUserList:  map[string][]rbac.Action{},
-				ACLGroupList: map[string][]rbac.Action{},
+				ACLUserList:  map[string][]policy.Action{},
+				ACLGroupList: map[string][]policy.Action{},
 			},
 			B: rbac.Object{
 				ID:           "id",
 				Owner:        "owner",
 				OrgID:        "orgID",
 				Type:         "type",
-				ACLUserList:  map[string][]rbac.Action{},
-				ACLGroupList: map[string][]rbac.Action{},
+				ACLUserList:  map[string][]policy.Action{},
+				ACLGroupList: map[string][]policy.Action{},
 			},
 			Expected: true,
 		},
@@ -93,13 +94,13 @@ func TestObjectEqual(t *testing.T) {
 		{
 			Name: "DifferentACLUserList",
 			A: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionRead},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionRead},
 				},
 			},
 			B: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user2": {rbac.ActionRead},
+				ACLUserList: map[string][]policy.Action{
+					"user2": {policy.ActionRead},
 				},
 			},
 			Expected: false,
@@ -107,13 +108,13 @@ func TestObjectEqual(t *testing.T) {
 		{
 			Name: "ACLUserDiff#Actions",
 			A: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionRead},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionRead},
 				},
 			},
 			B: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionRead, rbac.ActionUpdate},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionRead, policy.ActionUpdate},
 				},
 			},
 			Expected: false,
@@ -121,13 +122,13 @@ func TestObjectEqual(t *testing.T) {
 		{
 			Name: "ACLUserDiffAction",
 			A: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionRead},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionRead},
 				},
 			},
 			B: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionUpdate},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionUpdate},
 				},
 			},
 			Expected: false,
@@ -135,14 +136,14 @@ func TestObjectEqual(t *testing.T) {
 		{
 			Name: "ACLUserDiff#Users",
 			A: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionRead},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionRead},
 				},
 			},
 			B: rbac.Object{
-				ACLUserList: map[string][]rbac.Action{
-					"user1": {rbac.ActionRead},
-					"user2": {rbac.ActionRead},
+				ACLUserList: map[string][]policy.Action{
+					"user1": {policy.ActionRead},
+					"user2": {policy.ActionRead},
 				},
 			},
 			Expected: false,
@@ -150,13 +151,13 @@ func TestObjectEqual(t *testing.T) {
 		{
 			Name: "DifferentACLGroupList",
 			A: rbac.Object{
-				ACLGroupList: map[string][]rbac.Action{
-					"group1": {rbac.ActionRead},
+				ACLGroupList: map[string][]policy.Action{
+					"group1": {policy.ActionRead},
 				},
 			},
 			B: rbac.Object{
-				ACLGroupList: map[string][]rbac.Action{
-					"group2": {rbac.ActionRead},
+				ACLGroupList: map[string][]policy.Action{
+					"group2": {policy.ActionRead},
 				},
 			},
 			Expected: false,

--- a/coderd/rbac/policy/policy.go
+++ b/coderd/rbac/policy/policy.go
@@ -1,0 +1,11 @@
+package policy
+
+// Action represents the allowed actions to be done on an object.
+type Action string
+
+const (
+	ActionCreate Action = "create"
+	ActionRead   Action = "read"
+	ActionUpdate Action = "update"
+	ActionDelete Action = "delete"
+)

--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -8,6 +8,8 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 const (
@@ -144,22 +146,22 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 	memberRole := Role{
 		Name:        member,
 		DisplayName: "Member",
-		Site: Permissions(map[string][]Action{
-			ResourceRoleAssignment.Type: {ActionRead},
+		Site: Permissions(map[string][]policy.Action{
+			ResourceRoleAssignment.Type: {policy.ActionRead},
 			// All users can see the provisioner daemons.
-			ResourceProvisionerDaemon.Type: {ActionRead},
+			ResourceProvisionerDaemon.Type: {policy.ActionRead},
 			// All users can see OAuth2 provider applications.
-			ResourceOAuth2ProviderApp.Type: {ActionRead},
+			ResourceOAuth2ProviderApp.Type: {policy.ActionRead},
 		}),
 		Org: map[string][]Permission{},
 		User: append(allPermsExcept(ResourceWorkspaceDormant, ResourceUser, ResourceOrganizationMember),
-			Permissions(map[string][]Action{
+			Permissions(map[string][]policy.Action{
 				// Users cannot do create/update/delete on themselves, but they
 				// can read their own details.
-				ResourceUser.Type:                         {ActionRead},
-				ResourceUserWorkspaceBuildParameters.Type: {ActionRead},
+				ResourceUser.Type:                         {policy.ActionRead},
+				ResourceUserWorkspaceBuildParameters.Type: {policy.ActionRead},
 				// Users can create provisioner daemons scoped to themselves.
-				ResourceProvisionerDaemon.Type: {ActionCreate, ActionRead, ActionUpdate},
+				ResourceProvisionerDaemon.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate},
 			})...,
 		),
 	}.withCachedRegoValue()
@@ -167,19 +169,19 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 	auditorRole := Role{
 		Name:        auditor,
 		DisplayName: "Auditor",
-		Site: Permissions(map[string][]Action{
+		Site: Permissions(map[string][]policy.Action{
 			// Should be able to read all template details, even in orgs they
 			// are not in.
-			ResourceTemplate.Type:         {ActionRead},
-			ResourceTemplateInsights.Type: {ActionRead},
-			ResourceAuditLog.Type:         {ActionRead},
-			ResourceUser.Type:             {ActionRead},
-			ResourceGroup.Type:            {ActionRead},
+			ResourceTemplate.Type:         {policy.ActionRead},
+			ResourceTemplateInsights.Type: {policy.ActionRead},
+			ResourceAuditLog.Type:         {policy.ActionRead},
+			ResourceUser.Type:             {policy.ActionRead},
+			ResourceGroup.Type:            {policy.ActionRead},
 			// Allow auditors to query deployment stats and insights.
-			ResourceDeploymentStats.Type:  {ActionRead},
-			ResourceDeploymentValues.Type: {ActionRead},
+			ResourceDeploymentStats.Type:  {policy.ActionRead},
+			ResourceDeploymentValues.Type: {policy.ActionRead},
 			// Org roles are not really used yet, so grant the perm at the site level.
-			ResourceOrganizationMember.Type: {ActionRead},
+			ResourceOrganizationMember.Type: {policy.ActionRead},
 		}),
 		Org:  map[string][]Permission{},
 		User: []Permission{},
@@ -188,21 +190,21 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 	templateAdminRole := Role{
 		Name:        templateAdmin,
 		DisplayName: "Template Admin",
-		Site: Permissions(map[string][]Action{
-			ResourceTemplate.Type: {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
+		Site: Permissions(map[string][]policy.Action{
+			ResourceTemplate.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 			// CRUD all files, even those they did not upload.
-			ResourceFile.Type:      {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
-			ResourceWorkspace.Type: {ActionRead},
+			ResourceFile.Type:      {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+			ResourceWorkspace.Type: {policy.ActionRead},
 			// CRUD to provisioner daemons for now.
-			ResourceProvisionerDaemon.Type: {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
+			ResourceProvisionerDaemon.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 			// Needs to read all organizations since
-			ResourceOrganization.Type: {ActionRead},
-			ResourceUser.Type:         {ActionRead},
-			ResourceGroup.Type:        {ActionRead},
+			ResourceOrganization.Type: {policy.ActionRead},
+			ResourceUser.Type:         {policy.ActionRead},
+			ResourceGroup.Type:        {policy.ActionRead},
 			// Org roles are not really used yet, so grant the perm at the site level.
-			ResourceOrganizationMember.Type: {ActionRead},
+			ResourceOrganizationMember.Type: {policy.ActionRead},
 			// Template admins can read all template insights data
-			ResourceTemplateInsights.Type: {ActionRead},
+			ResourceTemplateInsights.Type: {policy.ActionRead},
 		}),
 		Org:  map[string][]Permission{},
 		User: []Permission{},
@@ -211,14 +213,14 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 	userAdminRole := Role{
 		Name:        userAdmin,
 		DisplayName: "User Admin",
-		Site: Permissions(map[string][]Action{
-			ResourceRoleAssignment.Type:               {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
-			ResourceUser.Type:                         {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
-			ResourceUserData.Type:                     {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
-			ResourceUserWorkspaceBuildParameters.Type: {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
+		Site: Permissions(map[string][]policy.Action{
+			ResourceRoleAssignment.Type:               {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+			ResourceUser.Type:                         {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+			ResourceUserData.Type:                     {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+			ResourceUserWorkspaceBuildParameters.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 			// Full perms to manage org members
-			ResourceOrganizationMember.Type: {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
-			ResourceGroup.Type:              {ActionCreate, ActionRead, ActionUpdate, ActionDelete},
+			ResourceOrganizationMember.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+			ResourceGroup.Type:              {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 		}),
 		Org:  map[string][]Permission{},
 		User: []Permission{},
@@ -277,19 +279,19 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 						{
 							// All org members can read the organization
 							ResourceType: ResourceOrganization.Type,
-							Action:       ActionRead,
+							Action:       policy.ActionRead,
 						},
 						{
 							// Can read available roles.
 							ResourceType: ResourceOrgRoleAssignment.Type,
-							Action:       ActionRead,
+							Action:       policy.ActionRead,
 						},
 					},
 				},
 				User: []Permission{
 					{
 						ResourceType: ResourceOrganizationMember.Type,
-						Action:       ActionRead,
+						Action:       policy.ActionRead,
 					},
 				},
 			}
@@ -349,9 +351,9 @@ type ExpandableRoles interface {
 // Permission is the format passed into the rego.
 type Permission struct {
 	// Negate makes this a negative permission
-	Negate       bool   `json:"negate"`
-	ResourceType string `json:"resource_type"`
-	Action       Action `json:"action"`
+	Negate       bool          `json:"negate"`
+	ResourceType string        `json:"resource_type"`
+	Action       policy.Action `json:"action"`
 }
 
 // Role is a set of permissions at multiple levels:
@@ -521,7 +523,7 @@ func SiteRoles() []Role {
 // ChangeRoleSet is a helper function that finds the difference of 2 sets of
 // roles. When setting a user's new roles, it is equivalent to adding and
 // removing roles. This set determines the changes, so that the appropriate
-// RBAC checks can be applied using "ActionCreate" and "ActionDelete" for
+// RBAC checks can be applied using "policy.ActionCreate" and "policy.ActionDelete" for
 // "added" and "removed" roles respectively.
 func ChangeRoleSet(from []string, to []string) (added []string, removed []string) {
 	has := make(map[string]struct{})
@@ -579,7 +581,7 @@ func roleSplit(role string) (name string, orgID string, err error) {
 
 // Permissions is just a helper function to make building roles that list out resources
 // and actions a bit easier.
-func Permissions(perms map[string][]Action) []Permission {
+func Permissions(perms map[string][]policy.Action) []Permission {
 	list := make([]Permission, 0, len(perms))
 	for k, actions := range perms {
 		for _, act := range actions {

--- a/coderd/rbac/roles_internal_test.go
+++ b/coderd/rbac/roles_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 // BenchmarkRBACValueAllocation benchmarks the cost of allocating a rego input
@@ -27,13 +29,13 @@ func BenchmarkRBACValueAllocation(b *testing.B) {
 		WithID(uuid.New()).
 		InOrg(uuid.New()).
 		WithOwner(uuid.NewString()).
-		WithGroupACL(map[string][]Action{
-			uuid.NewString(): {ActionRead, ActionCreate},
-			uuid.NewString(): {ActionRead, ActionCreate},
-			uuid.NewString(): {ActionRead, ActionCreate},
-		}).WithACLUserList(map[string][]Action{
-		uuid.NewString(): {ActionRead, ActionCreate},
-		uuid.NewString(): {ActionRead, ActionCreate},
+		WithGroupACL(map[string][]policy.Action{
+			uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+			uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+			uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+		}).WithACLUserList(map[string][]policy.Action{
+		uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+		uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
 	})
 
 	jsonSubject := authSubject{
@@ -45,7 +47,7 @@ func BenchmarkRBACValueAllocation(b *testing.B) {
 
 	b.Run("ManualRegoValue", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := regoInputValue(actor, ActionRead, obj)
+			_, err := regoInputValue(actor, policy.ActionRead, obj)
 			require.NoError(b, err)
 		}
 	})
@@ -53,7 +55,7 @@ func BenchmarkRBACValueAllocation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := ast.InterfaceToValue(map[string]interface{}{
 				"subject": jsonSubject,
-				"action":  ActionRead,
+				"action":  policy.ActionRead,
 				"object":  obj,
 			})
 			require.NoError(b, err)
@@ -90,16 +92,16 @@ func TestRegoInputValue(t *testing.T) {
 		WithID(uuid.New()).
 		InOrg(uuid.New()).
 		WithOwner(uuid.NewString()).
-		WithGroupACL(map[string][]Action{
-			uuid.NewString(): {ActionRead, ActionCreate},
-			uuid.NewString(): {ActionRead, ActionCreate},
-			uuid.NewString(): {ActionRead, ActionCreate},
-		}).WithACLUserList(map[string][]Action{
-		uuid.NewString(): {ActionRead, ActionCreate},
-		uuid.NewString(): {ActionRead, ActionCreate},
+		WithGroupACL(map[string][]policy.Action{
+			uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+			uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+			uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+		}).WithACLUserList(map[string][]policy.Action{
+		uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
+		uuid.NewString(): {policy.ActionRead, policy.ActionCreate},
 	})
 
-	action := ActionRead
+	action := policy.ActionRead
 
 	t.Run("InputValue", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/rbac/scopes.go
+++ b/coderd/rbac/scopes.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 
 	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
 type WorkspaceAgentScopeParams struct {
@@ -58,7 +60,7 @@ var builtinScopes = map[ScopeName]Scope{
 		Role: Role{
 			Name:        fmt.Sprintf("Scope_%s", ScopeAll),
 			DisplayName: "All operations",
-			Site: Permissions(map[string][]Action{
+			Site: Permissions(map[string][]policy.Action{
 				ResourceWildcard.Type: {WildcardSymbol},
 			}),
 			Org:  map[string][]Permission{},
@@ -71,8 +73,8 @@ var builtinScopes = map[ScopeName]Scope{
 		Role: Role{
 			Name:        fmt.Sprintf("Scope_%s", ScopeApplicationConnect),
 			DisplayName: "Ability to connect to applications",
-			Site: Permissions(map[string][]Action{
-				ResourceWorkspaceApplicationConnect.Type: {ActionCreate},
+			Site: Permissions(map[string][]policy.Action{
+				ResourceWorkspaceApplicationConnect.Type: {policy.ActionCreate},
 			}),
 			Org:  map[string][]Permission{},
 			User: []Permission{},

--- a/coderd/roles.go
+++ b/coderd/roles.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -22,7 +23,7 @@ import (
 func (api *API) assignableSiteRoles(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	actorRoles := httpmw.UserAuthorization(r)
-	if !api.Authorize(r, rbac.ActionRead, rbac.ResourceRoleAssignment) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceRoleAssignment) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -46,7 +47,7 @@ func (api *API) assignableOrgRoles(rw http.ResponseWriter, r *http.Request) {
 	organization := httpmw.OrganizationParam(r)
 	actorRoles := httpmw.UserAuthorization(r)
 
-	if !api.Authorize(r, rbac.ActionRead, rbac.ResourceOrgRoleAssignment.InOrg(organization.ID)) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceOrgRoleAssignment.InOrg(organization.ID)) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -322,7 +323,7 @@ func (api *API) postTemplateByOrganization(rw http.ResponseWriter, r *http.Reque
 	if !createTemplate.DisableEveryoneGroupAccess {
 		// The organization ID is used as the group ID for the everyone group
 		// in this organization.
-		defaultsGroups[organization.ID.String()] = []rbac.Action{rbac.ActionRead}
+		defaultsGroups[organization.ID.String()] = []policy.Action{policy.ActionRead}
 	}
 	err = api.Database.InTx(func(tx database.Store) error {
 		now := dbtime.Now()
@@ -455,7 +456,7 @@ func (api *API) templatesByOrganization(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	prepared, err := api.HTTPAuth.AuthorizeSQLFilter(r, rbac.ActionRead, rbac.ResourceTemplate.Type)
+	prepared, err := api.HTTPAuth.AuthorizeSQLFilter(r, policy.ActionRead, rbac.ResourceTemplate.Type)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error preparing sql filter.",
@@ -807,7 +808,7 @@ func (api *API) templateExamples(rw http.ResponseWriter, r *http.Request) {
 		organization = httpmw.OrganizationParam(r)
 	)
 
-	if !api.Authorize(r, rbac.ActionRead, rbac.ResourceTemplate.InOrg(organization.ID)) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceTemplate.InOrg(organization.ID)) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
@@ -430,7 +431,7 @@ func (api *API) postTemplateVersionDryRun(rw http.ResponseWriter, r *http.Reques
 
 	// We use the workspace RBAC check since we don't want to allow dry runs if
 	// the user can't create workspaces.
-	if !api.Authorize(r, rbac.ActionCreate,
+	if !api.Authorize(r, policy.ActionCreate,
 		rbac.ResourceWorkspace.InOrg(templateVersion.OrganizationID).WithOwner(apiKey.UserID.String())) {
 		httpapi.ResourceNotFound(rw)
 		return
@@ -603,7 +604,7 @@ func (api *API) patchTemplateVersionDryRunCancel(rw http.ResponseWriter, r *http
 	if !ok {
 		return
 	}
-	if !api.Authorize(r, rbac.ActionUpdate,
+	if !api.Authorize(r, policy.ActionUpdate,
 		rbac.ResourceWorkspace.InOrg(templateVersion.OrganizationID).WithOwner(job.ProvisionerJob.InitiatorID.String())) {
 		httpapi.ResourceNotFound(rw)
 		return
@@ -684,7 +685,7 @@ func (api *API) fetchTemplateVersionDryRunJob(rw http.ResponseWriter, r *http.Re
 	}
 
 	// Do a workspace resource check since it's basically a workspace dry-run.
-	if !api.Authorize(r, rbac.ActionRead,
+	if !api.Authorize(r, policy.ActionRead,
 		rbac.ResourceWorkspace.InOrg(templateVersion.OrganizationID).WithOwner(job.ProvisionerJob.InitiatorID.String())) {
 		httpapi.Forbidden(rw)
 		return database.GetProvisionerJobsByIDsWithQueuePositionRow{}, false
@@ -1359,12 +1360,12 @@ func (api *API) postTemplateVersionsByOrganization(rw http.ResponseWriter, r *ht
 	var err error
 	// if example id is specified we need to copy the embedded tar into a new file in the database
 	if req.ExampleID != "" {
-		if !api.Authorize(r, rbac.ActionCreate, rbac.ResourceFile.WithOwner(apiKey.UserID.String())) {
+		if !api.Authorize(r, policy.ActionCreate, rbac.ResourceFile.WithOwner(apiKey.UserID.String())) {
 			httpapi.Forbidden(rw)
 			return
 		}
 		// ensure we can read the file that either already exists or will be created
-		if !api.Authorize(r, rbac.ActionRead, rbac.ResourceFile.WithOwner(apiKey.UserID.String())) {
+		if !api.Authorize(r, policy.ActionRead, rbac.ResourceFile.WithOwner(apiKey.UserID.String())) {
 			httpapi.Forbidden(rw)
 			return
 		}

--- a/coderd/templateversions_test.go
+++ b/coderd/templateversions_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/examples"
 	"github.com/coder/coder/v2/provisioner/echo"
@@ -38,14 +39,14 @@ func TestTemplateVersion(t *testing.T) {
 			req.Name = "bananas"
 			req.Message = "first try"
 		})
-		authz.AssertChecked(t, rbac.ActionCreate, rbac.ResourceTemplate.InOrg(user.OrganizationID))
+		authz.AssertChecked(t, policy.ActionCreate, rbac.ResourceTemplate.InOrg(user.OrganizationID))
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
 		authz.Reset()
 		tv, err := client.TemplateVersion(ctx, version.ID)
-		authz.AssertChecked(t, rbac.ActionRead, tv)
+		authz.AssertChecked(t, policy.ActionRead, tv)
 		require.NoError(t, err)
 
 		assert.Equal(t, "bananas", tv.Name)

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/searchquery"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/userpassword"
@@ -1021,7 +1022,7 @@ func (api *API) userRoles(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	user := httpmw.UserParam(r)
 
-	if !api.Authorize(r, rbac.ActionRead, user.UserDataRBACObject()) {
+	if !api.Authorize(r, policy.ActionRead, user.UserDataRBACObject()) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}
@@ -1171,7 +1172,7 @@ func (api *API) organizationsByUser(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Only return orgs the user can read.
-	organizations, err = AuthorizeFilter(api.HTTPAuth, r, rbac.ActionRead, organizations)
+	organizations, err = AuthorizeFilter(api.HTTPAuth, r, policy.ActionRead, organizations)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching organizations.",

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/serpent"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -325,8 +326,8 @@ func TestDeleteUser(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
 
 		// RBAC checks
-		authz.AssertChecked(t, rbac.ActionCreate, rbac.ResourceUser)
-		authz.AssertChecked(t, rbac.ActionDelete, another)
+		authz.AssertChecked(t, policy.ActionCreate, rbac.ResourceUser)
+		authz.AssertChecked(t, policy.ActionDelete, another)
 	})
 	t.Run("NoPermission", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -35,7 +35,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -1030,7 +1030,7 @@ func (api *API) workspaceAgentClientCoordinate(rw http.ResponseWriter, r *http.R
 	// This route accepts user API key auth and workspace proxy auth. The moon actor has
 	// full permissions so should be able to pass this authz check.
 	workspace := httpmw.WorkspaceParam(r)
-	if !api.Authorize(r, rbac.ActionCreate, workspace.ExecutionRBAC()) {
+	if !api.Authorize(r, policy.ActionCreate, workspace.ExecutionRBAC()) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/workspaceapps.go
+++ b/coderd/workspaceapps.go
@@ -16,7 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
 	"github.com/coder/coder/v2/codersdk"
@@ -53,7 +53,7 @@ func (api *API) appHost(rw http.ResponseWriter, r *http.Request) {
 func (api *API) workspaceApplicationAuth(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	if !api.Authorize(r, rbac.ActionCreate, apiKey) {
+	if !api.Authorize(r, policy.ActionCreate, apiKey) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/workspaceapps/db.go
+++ b/coderd/workspaceapps/db.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -281,8 +282,8 @@ func (p *DBTokenProvider) authorizeRequest(ctx context.Context, roles *rbac.Subj
 	// Figure out which RBAC resource to check. For terminals we use execution
 	// instead of application connect.
 	var (
-		rbacAction   rbac.Action = rbac.ActionCreate
-		rbacResource rbac.Object = dbReq.Workspace.ApplicationConnectRBAC()
+		rbacAction   policy.Action = policy.ActionCreate
+		rbacResource rbac.Object   = dbReq.Workspace.ApplicationConnectRBAC()
 		// rbacResourceOwned is for the level "authenticated". We still need to
 		// make sure the API key has permissions to connect to the actor's own
 		// workspace. Scopes would prevent this.

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/wsbuilder"
 	"github.com/coder/coder/v2/codersdk"
 )
@@ -374,7 +375,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	workspaceBuild, provisionerJob, err := builder.Build(
 		ctx,
 		api.Database,
-		func(action rbac.Action, object rbac.Objecter) bool {
+		func(action policy.Action, object rbac.Objecter) bool {
 			return api.Authorize(r, action, object)
 		},
 		audit.WorkspaceBuildBaggageFromRequest(r),
@@ -636,7 +637,7 @@ func (api *API) workspaceBuildState(rw http.ResponseWriter, r *http.Request) {
 
 	// You must have update permissions on the template to get the state.
 	// This matches a push!
-	if !api.Authorize(r, rbac.ActionUpdate, template.RBACObject()) {
+	if !api.Authorize(r, policy.ActionUpdate, template.RBACObject()) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/parameter"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/schedule/cron"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -59,7 +60,7 @@ func TestWorkspace(t *testing.T) {
 
 		authz.Reset() // Reset all previous checks done in setup.
 		ws, err := client.Workspace(ctx, workspace.ID)
-		authz.AssertChecked(t, rbac.ActionRead, ws)
+		authz.AssertChecked(t, policy.ActionRead, ws)
 		require.NoError(t, err)
 		require.Equal(t, user.UserID, ws.LatestBuild.InitiatorID)
 		require.Equal(t, codersdk.BuildReasonInitiator, ws.LatestBuild.Reason)

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -136,7 +137,7 @@ func validateHexColor(color string) error {
 func (api *API) putAppearance(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	if !api.Authorize(r, rbac.ActionUpdate, rbac.ResourceDeploymentValues) {
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentValues) {
 		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 			Message: "Insufficient permissions to update appearance",
 		})

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/coderd/database"
 	agplportsharing "github.com/coder/coder/v2/coderd/portsharing"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/enterprise/coderd/portsharing"
 
 	"golang.org/x/xerrors"
@@ -132,7 +133,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		// If the user can read the workspace proxy resource, return that.
 		// If not, always default to the regions.
 		actor, ok := agpldbauthz.ActorFromContext(ctx)
-		if ok && api.Authorizer.Authorize(ctx, actor, rbac.ActionRead, rbac.ResourceWorkspaceProxy) == nil {
+		if ok && api.Authorizer.Authorize(ctx, actor, policy.ActionRead, rbac.ResourceWorkspaceProxy) == nil {
 			return api.fetchWorkspaceProxies(ctx)
 		}
 		return api.fetchRegions(ctx)
@@ -1016,6 +1017,6 @@ func (api *API) runEntitlementsLoop(ctx context.Context) {
 	}
 }
 
-func (api *API) Authorize(r *http.Request, action rbac.Action, object rbac.Objecter) bool {
+func (api *API) Authorize(r *http.Request, action policy.Action, object rbac.Objecter) bool {
 	return api.AGPL.HTTPAuth.Authorize(r, action, object)
 }

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/goleak"
 
 	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 
 	agplaudit "github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -498,7 +499,7 @@ func testDBAuthzRole(ctx context.Context) context.Context {
 			{
 				Name:        "testing",
 				DisplayName: "Unit Tests",
-				Site: rbac.Permissions(map[string][]rbac.Action{
+				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceWildcard.Type: {rbac.WildcardSymbol},
 				}),
 				Org:  map[string][]rbac.Permission{},

--- a/enterprise/coderd/groups.go
+++ b/enterprise/coderd/groups.go
@@ -14,7 +14,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -397,7 +397,7 @@ func (api *API) groups(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Filter groups based on rbac permissions
-	groups, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, rbac.ActionRead, groups)
+	groups, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, policy.ActionRead, groups)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching groups.",

--- a/enterprise/coderd/licenses.go
+++ b/enterprise/coderd/licenses.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
 )
@@ -75,7 +76,7 @@ func (api *API) postLicense(rw http.ResponseWriter, r *http.Request) {
 	)
 	defer commitAudit()
 
-	if !api.AGPL.Authorize(r, rbac.ActionCreate, rbac.ResourceLicense) {
+	if !api.AGPL.Authorize(r, policy.ActionCreate, rbac.ResourceLicense) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -181,7 +182,7 @@ func (api *API) postRefreshEntitlements(rw http.ResponseWriter, r *http.Request)
 	// If the user cannot create a new license, then they cannot refresh entitlements.
 	// Refreshing entitlements is a way to force a refresh of the license, so it is
 	// equivalent to creating a new license.
-	if !api.AGPL.Authorize(r, rbac.ActionCreate, rbac.ResourceLicense) {
+	if !api.AGPL.Authorize(r, policy.ActionCreate, rbac.ResourceLicense) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -258,7 +259,7 @@ func (api *API) licenses(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	licenses, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, rbac.ActionRead, licenses)
+	licenses, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, policy.ActionRead, licenses)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching licenses.",
@@ -315,7 +316,7 @@ func (api *API) deleteLicense(rw http.ResponseWriter, r *http.Request) {
 	defer commitAudit()
 	aReq.Old = dl
 
-	if !api.AGPL.Authorize(r, rbac.ActionDelete, rbac.ResourceLicense) {
+	if !api.AGPL.Authorize(r, policy.ActionDelete, rbac.ResourceLicense) {
 		httpapi.Forbidden(rw)
 		return
 	}

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
@@ -77,7 +78,7 @@ func (api *API) provisionerDaemons(rw http.ResponseWriter, r *http.Request) {
 	if daemons == nil {
 		daemons = []database.ProvisionerDaemon{}
 	}
-	daemons, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, rbac.ActionRead, daemons)
+	daemons, err = coderd.AuthorizeFilter(api.AGPL.HTTPAuth, r, policy.ActionRead, daemons)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching provisioner daemons.",
@@ -107,7 +108,7 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, tags map[string]strin
 			return tags, true
 		}
 		ua := httpmw.UserAuthorization(r)
-		if err := p.authorizer.Authorize(ctx, ua, rbac.ActionCreate, rbac.ResourceProvisionerDaemon); err == nil {
+		if err := p.authorizer.Authorize(ctx, ua, policy.ActionCreate, rbac.ResourceProvisionerDaemon); err == nil {
 			// User is allowed to create provisioner daemons
 			return tags, true
 		}

--- a/enterprise/coderd/replicas.go
+++ b/enterprise/coderd/replicas.go
@@ -6,6 +6,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -19,7 +20,7 @@ import (
 // @Success 200 {array} codersdk.Replica
 // @Router /replicas [get]
 func (api *API) replicas(rw http.ResponseWriter, r *http.Request) {
-	if !api.AGPL.Authorize(r, rbac.ActionRead, rbac.ResourceReplicas) {
+	if !api.AGPL.Authorize(r, policy.ActionRead, rbac.ResourceReplicas) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -35,7 +36,7 @@ func (api *API) templateAvailablePermissions(rw http.ResponseWriter, r *http.Req
 
 	// Requires update permission on the template to list all avail users/groups
 	// for assignment.
-	if !api.Authorize(r, rbac.ActionUpdate, template) {
+	if !api.Authorize(r, policy.ActionUpdate, template) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}
@@ -305,9 +306,9 @@ func validateTemplateRole(role codersdk.TemplateRole) error {
 	return nil
 }
 
-func convertToTemplateRole(actions []rbac.Action) codersdk.TemplateRole {
+func convertToTemplateRole(actions []policy.Action) codersdk.TemplateRole {
 	switch {
-	case len(actions) == 1 && actions[0] == rbac.ActionRead:
+	case len(actions) == 1 && actions[0] == policy.ActionRead:
 		return codersdk.TemplateRoleUse
 	case len(actions) == 1 && actions[0] == rbac.WildcardSymbol:
 		return codersdk.TemplateRoleAdmin
@@ -316,12 +317,12 @@ func convertToTemplateRole(actions []rbac.Action) codersdk.TemplateRole {
 	return ""
 }
 
-func convertSDKTemplateRole(role codersdk.TemplateRole) []rbac.Action {
+func convertSDKTemplateRole(role codersdk.TemplateRole) []policy.Action {
 	switch role {
 	case codersdk.TemplateRoleAdmin:
-		return []rbac.Action{rbac.WildcardSymbol}
+		return []policy.Action{rbac.WildcardSymbol}
 	case codersdk.TemplateRoleUse:
-		return []rbac.Action{rbac.ActionRead}
+		return []policy.Action{policy.ActionRead}
 	}
 
 	return nil

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
@@ -799,7 +799,7 @@ func (api *API) workspaceProxyDeregister(rw http.ResponseWriter, r *http.Request
 func (api *API) reconnectingPTYSignedToken(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
-	if !api.Authorize(r, rbac.ActionCreate, apiKey) {
+	if !api.Authorize(r, policy.ActionCreate, apiKey) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/enterprise/coderd/workspacequota.go
+++ b/enterprise/coderd/workspacequota.go
@@ -13,7 +13,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionerd/proto"
 )
@@ -123,7 +123,7 @@ func (c *committer) CommitQuota(
 func (api *API) workspaceQuota(rw http.ResponseWriter, r *http.Request) {
 	user := httpmw.UserParam(r)
 
-	if !api.AGPL.Authorize(r, rbac.ActionRead, user) {
+	if !api.AGPL.Authorize(r, policy.ActionRead, user) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	agpl "github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 )
@@ -101,7 +102,7 @@ var pgCoordSubject = rbac.Subject{
 		{
 			Name:        "tailnetcoordinator",
 			DisplayName: "Tailnet Coordinator",
-			Site: rbac.Permissions(map[string][]rbac.Action{
+			Site: rbac.Permissions(map[string][]policy.Action{
 				rbac.ResourceTailnetCoordinator.Type: {rbac.WildcardSymbol},
 			}),
 			Org:  map[string][]rbac.Permission{},

--- a/support/support.go
+++ b/support/support.go
@@ -16,12 +16,12 @@ import (
 	"tailscale.com/net/netcheck"
 
 	"github.com/coder/coder/v2/coderd/healthcheck/derphealth"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 
 	"github.com/google/uuid"
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
-	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
@@ -462,7 +462,7 @@ func Run(ctx context.Context, d *Deps) (*Bundle, error) {
 			Object: codersdk.AuthorizationObject{
 				ResourceType: codersdk.ResourceDeploymentValues,
 			},
-			Action: string(rbac.ActionRead),
+			Action: string(policy.ActionRead),
 		},
 	}
 


### PR DESCRIPTION
Just moved `rbac.Action` -> `policy.Action`. This is for the stacked PR to not have circular dependencies when doing autogen. Without this, the autogen can produce broken golang code, which prevents the autogen from compiling.

So just avoiding circular dependencies. Doing this in it's own PR to reduce LoC diffs in the primary PR, since this has 0 functional changes.