### PR TITLE
feat(coderd): add `times_used` to `coder_app`s in insights API

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11372,6 +11372,10 @@ const docTemplate = `{
                         "format": "uuid"
                     }
                 },
+                "times_used": {
+                    "type": "integer",
+                    "example": 2
+                },
                 "type": {
                     "allOf": [
                         {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10272,6 +10272,10 @@
             "format": "uuid"
           }
         },
+        "times_used": {
+          "type": "integer",
+          "example": 2
+        },
         "type": {
           "allOf": [
             {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -1805,7 +1805,7 @@ WITH
 			apps.slug,
 			apps.display_name,
 			apps.icon,
-			tus.app_usage_mins
+			(tus.app_usage_mins -> apps.slug)::smallint AS usage_mins
 		FROM
 			apps
 		JOIN
@@ -1829,13 +1829,35 @@ WITH
 			display_name,
 			icon,
 			-- See motivation in GetTemplateInsights for LEAST(SUM(n), 30).
-			LEAST(SUM(app_usage.value::smallint), 30) AS usage_mins
+			LEAST(SUM(usage_mins), 30) AS usage_mins
 		FROM
-			template_usage_stats_with_apps, jsonb_each(app_usage_mins) AS app_usage
-		WHERE
-			app_usage.key = slug
+			template_usage_stats_with_apps
 		GROUP BY
 			start_time, user_id, slug, display_name, icon
+	),
+	-- Analyze the users unique app usage across all templates. Count
+	-- usage across consecutive intervals as continuous usage.
+	times_used AS (
+		SELECT DISTINCT ON (user_id, slug, display_name, icon, uniq)
+			slug,
+			display_name,
+			icon,
+			-- Turn start_time into a unique identifier that identifies a users
+			-- continuous app usage. The value of uniq is otherwise garbage.
+			--
+			-- Since we're aggregating per user app usage across templates,
+			-- there can be duplicate start_times. To handle this, we use the
+			-- dense_rank() function, otherwise row_number() would suffice.
+			start_time - (
+				dense_rank() OVER (
+					PARTITION BY
+						user_id, slug, display_name, icon
+					ORDER BY
+						start_time
+				) * '30 minutes'::interval
+			) AS uniq
+		FROM
+			template_usage_stats_with_apps
 	),
 	-- Even though we allow identical apps to be aggregated across
 	-- templates, we still want to be able to report which templates
@@ -1858,7 +1880,17 @@ SELECT
 	ai.slug,
 	ai.display_name,
 	ai.icon,
-	(SUM(ai.usage_mins) * 60)::bigint AS usage_seconds
+	(SUM(ai.usage_mins) * 60)::bigint AS usage_seconds,
+	COALESCE((
+		SELECT
+			COUNT(*)
+		FROM
+			times_used
+		WHERE
+			times_used.slug = ai.slug
+			AND times_used.display_name = ai.display_name
+			AND times_used.icon = ai.icon
+	), 0)::bigint AS times_used
 FROM
 	app_insights AS ai
 JOIN
@@ -1884,6 +1916,7 @@ type GetTemplateAppInsightsRow struct {
 	DisplayName  string      `db:"display_name" json:"display_name"`
 	Icon         string      `db:"icon" json:"icon"`
 	UsageSeconds int64       `db:"usage_seconds" json:"usage_seconds"`
+	TimesUsed    int64       `db:"times_used" json:"times_used"`
 }
 
 // GetTemplateAppInsights returns the aggregate usage of each app in a given
@@ -1905,6 +1938,7 @@ func (q *sqlQuerier) GetTemplateAppInsights(ctx context.Context, arg GetTemplate
 			&i.DisplayName,
 			&i.Icon,
 			&i.UsageSeconds,
+			&i.TimesUsed,
 		); err != nil {
 			return nil, err
 		}

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -543,6 +543,7 @@ func convertTemplateInsightsApps(usage database.GetTemplateInsightsRow, appUsage
 			Slug:        app.Slug,
 			Icon:        app.Icon,
 			Seconds:     app.UsageSeconds,
+			TimesUsed:   app.TimesUsed,
 		})
 	}
 

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template.json.golden
@@ -15,7 +15,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -23,7 +24,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -33,7 +35,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 7200
+        "seconds": 7200,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -43,7 +46,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 10800
+        "seconds": 10800,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -51,7 +55,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -61,7 +66,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25200
+        "seconds": 25200,
+        "times_used": 2
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_report.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_three_weeks_second_template_only_report.json.golden
@@ -15,7 +15,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -23,7 +24,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -33,7 +35,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 7200
+        "seconds": 7200,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -43,7 +46,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 10800
+        "seconds": 10800,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -51,7 +55,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -61,7 +66,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25200
+        "seconds": 25200,
+        "times_used": 2
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_week_all_templates.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_week_all_templates.json.golden
@@ -18,7 +18,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -28,7 +29,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -38,7 +40,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -50,7 +53,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 11520
+        "seconds": 11520,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -58,7 +62,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -69,7 +74,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25380
+        "seconds": 25380,
+        "times_used": 4
       },
       {
         "template_ids": [
@@ -79,7 +85,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 720
+        "seconds": 720,
+        "times_used": 1
       },
       {
         "template_ids": [
@@ -89,7 +96,8 @@
         "display_name": "otherapp1",
         "slug": "otherapp1",
         "icon": "/icon1.png",
-        "seconds": 300
+        "seconds": 300,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_week_deployment_wide.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_week_deployment_wide.json.golden
@@ -18,7 +18,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -28,7 +29,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -38,7 +40,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -50,7 +53,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 11520
+        "seconds": 11520,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -58,7 +62,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -69,7 +74,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25380
+        "seconds": 25380,
+        "times_used": 4
       },
       {
         "template_ids": [
@@ -79,7 +85,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 720
+        "seconds": 720,
+        "times_used": 1
       },
       {
         "template_ids": [
@@ -89,7 +96,8 @@
         "display_name": "otherapp1",
         "slug": "otherapp1",
         "icon": "/icon1.png",
-        "seconds": 300
+        "seconds": 300,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_week_first_template.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_week_first_template.json.golden
@@ -15,7 +15,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -25,7 +26,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -33,7 +35,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -43,7 +46,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 7920
+        "seconds": 7920,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -51,7 +55,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -61,7 +66,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 3780
+        "seconds": 3780,
+        "times_used": 3
       },
       {
         "template_ids": [
@@ -71,7 +77,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 720
+        "seconds": 720,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_week_other_timezone_(São_Paulo).json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_week_other_timezone_(São_Paulo).json.golden
@@ -17,7 +17,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -27,7 +28,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -35,7 +37,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -45,7 +48,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 4320
+        "seconds": 4320,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -53,7 +57,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -64,7 +69,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 21720
+        "seconds": 21720,
+        "times_used": 2
       },
       {
         "template_ids": [
@@ -74,7 +80,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 4320
+        "seconds": 4320,
+        "times_used": 2
       },
       {
         "template_ids": [
@@ -84,7 +91,8 @@
         "display_name": "otherapp1",
         "slug": "otherapp1",
         "icon": "/icon1.png",
-        "seconds": 300
+        "seconds": 300,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_week_second_template.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_week_second_template.json.golden
@@ -15,7 +15,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -23,7 +24,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -31,7 +33,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -41,7 +44,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -49,7 +53,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -59,7 +64,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25200
+        "seconds": 25200,
+        "times_used": 2
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_week_third_template.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_week_third_template.json.golden
@@ -13,7 +13,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -21,7 +22,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -31,7 +33,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -41,7 +44,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -49,7 +53,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -59,7 +64,8 @@
         "display_name": "otherapp1",
         "slug": "otherapp1",
         "icon": "/icon1.png",
-        "seconds": 300
+        "seconds": 300,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_weekly_aggregated_deployment_wide.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_weekly_aggregated_deployment_wide.json.golden
@@ -18,7 +18,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 7200
+        "seconds": 7200,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -28,7 +29,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -38,7 +40,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -50,7 +53,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 15120
+        "seconds": 15120,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -58,7 +62,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -69,7 +74,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25380
+        "seconds": 25380,
+        "times_used": 4
       },
       {
         "template_ids": [
@@ -79,7 +85,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 1
       },
       {
         "template_ids": [
@@ -89,7 +96,8 @@
         "display_name": "otherapp1",
         "slug": "otherapp1",
         "icon": "/icon1.png",
-        "seconds": 300
+        "seconds": 300,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_weekly_aggregated_first_template.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_weekly_aggregated_first_template.json.golden
@@ -15,7 +15,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -25,7 +26,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -33,7 +35,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -43,7 +46,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 7920
+        "seconds": 7920,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -51,7 +55,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -61,7 +66,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 3780
+        "seconds": 3780,
+        "times_used": 3
       },
       {
         "template_ids": [
@@ -71,7 +77,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 720
+        "seconds": 720,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/multiple_users_and_workspaces_weekly_aggregated_templates.json.golden
+++ b/coderd/testdata/insights/template/multiple_users_and_workspaces_weekly_aggregated_templates.json.golden
@@ -18,7 +18,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 7200
+        "seconds": 7200,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -28,7 +29,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 120
+        "seconds": 120,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -38,7 +40,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -50,7 +53,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 15120
+        "seconds": 15120,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -58,7 +62,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [
@@ -69,7 +74,8 @@
         "display_name": "app1",
         "slug": "app1",
         "icon": "/icon1.png",
-        "seconds": 25380
+        "seconds": 25380,
+        "times_used": 4
       },
       {
         "template_ids": [
@@ -79,7 +85,8 @@
         "display_name": "app3",
         "slug": "app3",
         "icon": "/icon2.png",
-        "seconds": 3600
+        "seconds": 3600,
+        "times_used": 1
       },
       {
         "template_ids": [
@@ -89,7 +96,8 @@
         "display_name": "otherapp1",
         "slug": "otherapp1",
         "icon": "/icon1.png",
-        "seconds": 300
+        "seconds": 300,
+        "times_used": 1
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/parameters_two_days_ago,_no_data.json.golden
+++ b/coderd/testdata/insights/template/parameters_two_days_ago,_no_data.json.golden
@@ -11,7 +11,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -19,7 +20,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -27,7 +29,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -35,7 +38,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -43,7 +47,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       }
     ],
     "parameters_usage": []

--- a/coderd/testdata/insights/template/parameters_yesterday_and_today_deployment_wide.json.golden
+++ b/coderd/testdata/insights/template/parameters_yesterday_and_today_deployment_wide.json.golden
@@ -11,7 +11,8 @@
         "display_name": "Visual Studio Code",
         "slug": "vscode",
         "icon": "/icon/code.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -19,7 +20,8 @@
         "display_name": "JetBrains",
         "slug": "jetbrains",
         "icon": "/icon/intellij.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -27,7 +29,8 @@
         "display_name": "Web Terminal",
         "slug": "reconnecting-pty",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -35,7 +38,8 @@
         "display_name": "SSH",
         "slug": "ssh",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       },
       {
         "template_ids": [],
@@ -43,7 +47,8 @@
         "display_name": "SFTP",
         "slug": "sftp",
         "icon": "/icon/terminal.svg",
-        "seconds": 0
+        "seconds": 0,
+        "times_used": 0
       }
     ],
     "parameters_usage": [

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -217,6 +217,7 @@ type TemplateAppUsage struct {
 	Slug        string           `json:"slug" example:"vscode"`
 	Icon        string           `json:"icon"`
 	Seconds     int64            `json:"seconds" example:"80500"`
+	TimesUsed   int64            `json:"times_used" example:"2"`
 }
 
 // TemplateParameterUsage shows the usage of a parameter for one or more

--- a/docs/api/insights.md
+++ b/docs/api/insights.md
@@ -81,6 +81,7 @@ curl -X GET http://coder-server:8080/api/v2/insights/templates?before=0&after=0 
         "seconds": 80500,
         "slug": "vscode",
         "template_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+        "times_used": 2,
         "type": "builtin"
       }
     ],

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -4558,6 +4558,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "seconds": 80500,
   "slug": "vscode",
   "template_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+  "times_used": 2,
   "type": "builtin"
 }
 ```
@@ -4571,6 +4572,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `seconds`      | integer                                                | false    |              |             |
 | `slug`         | string                                                 | false    |              |             |
 | `template_ids` | array of string                                        | false    |              |             |
+| `times_used`   | integer                                                | false    |              |             |
 | `type`         | [codersdk.TemplateAppsType](#codersdktemplateappstype) | false    |              |             |
 
 ## codersdk.TemplateAppsType
@@ -4700,6 +4702,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "seconds": 80500,
       "slug": "vscode",
       "template_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+      "times_used": 2,
       "type": "builtin"
     }
   ],
@@ -4765,6 +4768,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
         "seconds": 80500,
         "slug": "vscode",
         "template_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+        "times_used": 2,
         "type": "builtin"
       }
     ],

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1093,6 +1093,7 @@ export interface TemplateAppUsage {
   readonly slug: string;
   readonly icon: string;
   readonly seconds: number;
+  readonly times_used: number;
 }
 
 // From codersdk/templates.go

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.stories.tsx
@@ -68,6 +68,7 @@ export const Loaded: Story = {
             slug: "vscode",
             icon: "/icon/code.svg",
             seconds: 2513400,
+            times_used: 0,
           },
           {
             template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
@@ -76,6 +77,7 @@ export const Loaded: Story = {
             slug: "jetbrains",
             icon: "/icon/intellij.svg",
             seconds: 0,
+            times_used: 0,
           },
           {
             template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
@@ -84,6 +86,7 @@ export const Loaded: Story = {
             slug: "reconnecting-pty",
             icon: "/icon/terminal.svg",
             seconds: 110400,
+            times_used: 0,
           },
           {
             template_ids: ["0d286645-29aa-4eaf-9b52-cc5d2740c90b"],
@@ -92,6 +95,7 @@ export const Loaded: Story = {
             slug: "ssh",
             icon: "/icon/terminal.svg",
             seconds: 1020900,
+            times_used: 0,
           },
         ],
         parameters_usage: [


### PR DESCRIPTION
For now, only applied to `coder_app`s, same logic can be implemented for
VS Code, SSH, etc.

Part of #13099