### PR TITLE
chore: verify validity of built in rbac roles

### DIFF
--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -1,9 +1,8 @@
 package rbac
 
 import (
-	"fmt"
-
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
@@ -36,10 +35,10 @@ type Object struct {
 func (z Object) ValidAction(action policy.Action) error {
 	perms, ok := policy.RBACPermissions[z.Type]
 	if !ok {
-		return fmt.Errorf("invalid type %q", z.Type)
+		return xerrors.Errorf("invalid type %q", z.Type)
 	}
 	if _, ok := perms.Actions[action]; !ok {
-		return fmt.Errorf("invalid action %q for type %q", action, z.Type)
+		return xerrors.Errorf("invalid action %q for type %q", action, z.Type)
 	}
 
 	return nil

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -20,6 +20,27 @@ type authSubject struct {
 	Actor rbac.Subject
 }
 
+// TestBuiltInRoles makes sure our built-in roles are valid by our own policy
+// rules. If this is incorrect, that is a mistake.
+func TestBuiltInRoles(t *testing.T) {
+	t.Parallel()
+	for _, r := range rbac.SiteRoles() {
+		r := r
+		t.Run(r.Name, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, r.Valid(), "invalid role")
+		})
+	}
+
+	for _, r := range rbac.OrganizationRoles(uuid.New()) {
+		r := r
+		t.Run(r.Name, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, r.Valid(), "invalid role")
+		})
+	}
+}
+
 //nolint:tparallel,paralleltest
 func TestOwnerExec(t *testing.T) {
 	owner := rbac.Subject{

--- a/scripts/rbacgen/main.go
+++ b/scripts/rbacgen/main.go
@@ -16,6 +16,8 @@ import (
 	"slices"
 	"strings"
 
+	"golang.org/x/xerrors"
+
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 )
 
@@ -148,7 +150,7 @@ func generateRbacObjects(templateSource string) ([]byte, error) {
 	// Parse the policy.go file for the action enums
 	f, err := parser.ParseFile(token.NewFileSet(), "./coderd/rbac/policy/policy.go", nil, parser.ParseComments)
 	if err != nil {
-		return nil, fmt.Errorf("parsing policy.go: %w", err)
+		return nil, xerrors.Errorf("parsing policy.go: %w", err)
 	}
 	actionMap := fileActions(f)
 	actionList := make([]ActionDetails, 0)
@@ -176,14 +178,14 @@ func generateRbacObjects(templateSource string) ([]byte, error) {
 			x++
 			v, ok := actionMap[string(action)]
 			if !ok {
-				errorList = append(errorList, fmt.Errorf("action value %q does not have a constant a matching enum constant", action))
+				errorList = append(errorList, xerrors.Errorf("action value %q does not have a constant a matching enum constant", action))
 			}
 			return v
 		},
 		"concat": func(strs ...string) string { return strings.Join(strs, "") },
 	}).Parse(templateSource)
 	if err != nil {
-		return nil, fmt.Errorf("parse template: %w", err)
+		return nil, xerrors.Errorf("parse template: %w", err)
 	}
 
 	// Convert to sorted list for autogen consistency.
@@ -203,7 +205,7 @@ func generateRbacObjects(templateSource string) ([]byte, error) {
 
 	err = tpl.Execute(&out, list)
 	if err != nil {
-		return nil, fmt.Errorf("execute template: %w", err)
+		return nil, xerrors.Errorf("execute template: %w", err)
 	}
 
 	if len(errorList) > 0 {


### PR DESCRIPTION
# What this does

Verifies our built in roles are valid according to our policy.go. Working on custom roles requires the dynamic roles to adhere to these rules. Feels fair the built in ones do too.

Also some xerrors linting cleanup that somehow got missed before.