### PR TITLE
chore: update git -> 2.43.4 and terraform -> 1.7.5

### DIFF
--- a/.github/actions/setup-tf/action.yaml
+++ b/.github/actions/setup-tf/action.yaml
@@ -7,5 +7,5 @@ runs:
     - name: Install Terraform
       uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: 1.6.6
+        terraform_version: 1.7.5
         terraform_wrapper: false

--- a/docs/install/offline.md
+++ b/docs/install/offline.md
@@ -54,7 +54,7 @@ RUN mkdir -p /opt/terraform
 # The below step is optional if you wish to keep the existing version.
 # See https://github.com/coder/coder/blob/main/provisioner/terraform/install.go#L23-L24
 # for supported Terraform versions.
-ARG TERRAFORM_VERSION=1.5.6
+ARG TERRAFORM_VERSION=1.7.5
 RUN apk update && \
     apk del terraform && \
     curl -LOs https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -169,9 +169,9 @@ RUN apt-get update --quiet && apt-get install --yes \
 	# Configure FIPS-compliant policies
 	update-crypto-policies --set FIPS
 
-# NOTE: In scripts/Dockerfile.base we specifically install Terraform version 1.6.6.
+# NOTE: In scripts/Dockerfile.base we specifically install Terraform version 1.7.5.
 # Installing the same version here to match.
-RUN wget -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip" && \
+RUN wget -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_amd64.zip" && \
 		unzip /tmp/terraform.zip -d /usr/local/bin && \
 		rm -f /tmp/terraform.zip && \
 		chmod +x /usr/local/bin/terraform && \

--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,7 @@ EOF
 main() {
 	MAINLINE=1
 	STABLE=0
-	TERRAFORM_VERSION="1.6.6"
+	TERRAFORM_VERSION="1.7.5"
 
 	if [ "${TRACE-}" ]; then
 		set -x

--- a/provisioner/terraform/install.go
+++ b/provisioner/terraform/install.go
@@ -20,10 +20,10 @@ var (
 	// when Terraform is not available on the system.
 	// NOTE: Keep this in sync with the version in scripts/Dockerfile.base.
 	// NOTE: Keep this in sync with the version in install.sh.
-	TerraformVersion = version.Must(version.NewVersion("1.6.6"))
+	TerraformVersion = version.Must(version.NewVersion("1.7.5"))
 
 	minTerraformVersion = version.Must(version.NewVersion("1.1.0"))
-	maxTerraformVersion = version.Must(version.NewVersion("1.6.9")) // use .9 to automatically allow patch releases
+	maxTerraformVersion = version.Must(version.NewVersion("1.7.9")) // use .9 to automatically allow patch releases
 
 	terraformMinorVersionMismatch = xerrors.New("Terraform binary minor version mismatch.")
 )

--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
 		curl \
 		wget \
 		bash \
-		git \
+		git=2.43.4-r0 \
 		openssl \
 		openssh-client && \
 	addgroup \
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
 # Terraform was disabled in the edge repo due to a build issue.
 # https://gitlab.alpinelinux.org/alpine/aports/-/commit/f3e263d94cfac02d594bef83790c280e045eba35
 # Using wget for now. Note that busybox unzip doesn't support streaming.
-RUN ARCH="$(arch)"; if [ "${ARCH}" == "x86_64" ]; then ARCH="amd64"; elif [ "${ARCH}" == "aarch64" ]; then ARCH="arm64"; fi; wget -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_${ARCH}.zip" && \
+RUN ARCH="$(arch)"; if [ "${ARCH}" == "x86_64" ]; then ARCH="amd64"; elif [ "${ARCH}" == "aarch64" ]; then ARCH="arm64"; fi; wget -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_${ARCH}.zip" && \
 		busybox unzip /tmp/terraform.zip -d /usr/local/bin && \
 		rm -f /tmp/terraform.zip && \
 		chmod +x /usr/local/bin/terraform && \


### PR DESCRIPTION
This fixes an RCE in git and gets us one minor version closer to fixing
a critical Terraform vulnerability. In the next release we'll bump to
1.8.x.

Fixes https://github.com/coder/coder/issues/13291