### PR TITLE
feat: add custom role creation to cli

### DIFF
--- a/cli/cliui/parameter.go
+++ b/cli/cliui/parameter.go
@@ -43,7 +43,10 @@ func RichParameter(inv *serpent.Invocation, templateVersionParameter codersdk.Te
 			return "", err
 		}
 
-		values, err := MultiSelect(inv, options)
+		values, err := MultiSelect(inv, MultiSelectOptions{
+			Options:  options,
+			Defaults: options,
+		})
 		if err == nil {
 			v, err := json.Marshal(&values)
 			if err != nil {

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -21,7 +21,7 @@ func init() {
     {{- .CurrentOpt.Value}}
     {{- color "reset"}}
 {{end}}
-
+{{- if .Message }}{{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}{{ end }}
 {{- if not .ShowAnswer }}
 {{- if .Config.Icons.Help.Text }}
 {{- if .FilterMessage }}{{ "Search:" }}{{ .FilterMessage }}
@@ -44,18 +44,20 @@ func init() {
     {{- " "}}{{- .CurrentOpt.Value}}
 {{end}}
 {{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- if .Message }}{{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}{{ end }}
 {{- if not .ShowAnswer }}
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- template "option" $.IterateOption $ix $option}}
   {{- end}}
-{{- end}}`
+{{- end }}`
 }
 
 type SelectOptions struct {
 	Options []string
 	// Default will be highlighted first if it's a valid option.
 	Default    string
+	Message    string
 	Size       int
 	HideSearch bool
 }
@@ -122,6 +124,7 @@ func Select(inv *serpent.Invocation, opts SelectOptions) (string, error) {
 		Options:  opts.Options,
 		Default:  defaultOption,
 		PageSize: opts.Size,
+		Message:  opts.Message,
 	}, &value, survey.WithIcons(func(is *survey.IconSet) {
 		is.Help.Text = "Type to search"
 		if opts.HideSearch {
@@ -138,15 +141,22 @@ func Select(inv *serpent.Invocation, opts SelectOptions) (string, error) {
 	return value, err
 }
 
-func MultiSelect(inv *serpent.Invocation, items []string) ([]string, error) {
+type MultiSelectOptions struct {
+	Message  string
+	Options  []string
+	Defaults []string
+}
+
+func MultiSelect(inv *serpent.Invocation, opts MultiSelectOptions) ([]string, error) {
 	// Similar hack is applied to Select()
 	if flag.Lookup("test.v") != nil {
-		return items, nil
+		return opts.Defaults, nil
 	}
 
 	prompt := &survey.MultiSelect{
-		Options: items,
-		Default: items,
+		Message: opts.Message,
+		Options: opts.Options,
+		Default: opts.Defaults,
 	}
 
 	var values []string

--- a/cli/cliui/select_test.go
+++ b/cli/cliui/select_test.go
@@ -107,7 +107,10 @@ func newMultiSelect(ptty *ptytest.PTY, items []string) ([]string, error) {
 	var values []string
 	cmd := &serpent.Command{
 		Handler: func(inv *serpent.Invocation) error {
-			selectedItems, err := cliui.MultiSelect(inv, items)
+			selectedItems, err := cliui.MultiSelect(inv, cliui.MultiSelectOptions{
+				Options:  items,
+				Defaults: items,
+			})
 			if err == nil {
 				values = selectedItems
 			}

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -230,12 +230,12 @@ func (r *RootCmd) configSSH() *serpent.Command {
 		Annotations: workspaceCommand,
 		Use:         "config-ssh",
 		Short:       "Add an SSH Host entry for your workspaces \"ssh coder.workspace\"",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "You can use -o (or --ssh-option) so set SSH options to be used for all your workspaces",
 				Command:     "coder config-ssh -o ForwardAgent=yes",
 			},
-			example{
+			Example{
 				Description: "You can use --dry-run (or -n) to see the changes that would be made",
 				Command:     "coder config-ssh --dry-run",
 			},

--- a/cli/create.go
+++ b/cli/create.go
@@ -35,8 +35,8 @@ func (r *RootCmd) create() *serpent.Command {
 		Annotations: workspaceCommand,
 		Use:         "create [name]",
 		Short:       "Create a workspace",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "Create a workspace for another user (if you have permission)",
 				Command:     "coder create <username>/<workspace_name>",
 			},

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -28,8 +28,8 @@ func (r *RootCmd) dotfiles() *serpent.Command {
 		Use:        "dotfiles <git_repo_url>",
 		Middleware: serpent.RequireNArgs(1),
 		Short:      "Personalize your workspace by applying a canonical dotfiles repository",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "Check out and install a dotfiles repository without prompts",
 				Command:     "coder dotfiles --yes git@github.com:example/dotfiles.git",
 			},

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -35,8 +35,8 @@ func (r *RootCmd) externalAuthAccessToken() *serpent.Command {
 		Short: "Print auth for an external provider",
 		Long: "Print an access-token for an external auth provider. " +
 			"The access-token will be validated and sent to stdout with exit code 0. " +
-			"If a valid access-token cannot be obtained, the URL to authenticate will be sent to stdout with exit code 1\n" + formatExamples(
-			example{
+			"If a valid access-token cannot be obtained, the URL to authenticate will be sent to stdout with exit code 1\n" + FormatExamples(
+			Example{
 				Description: "Ensure that the user is authenticated with GitHub before cloning.",
 				Command: `#!/usr/bin/env sh
 
@@ -49,7 +49,7 @@ else
 fi
 `,
 			},
-			example{
+			Example{
 				Description: "Obtain an extra property of an access token for additional metadata.",
 				Command:     "coder external-auth access-token slack --extra \"authed_user.id\"",
 			},

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -43,12 +43,12 @@ func (r *RootCmd) switchOrganization() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "set <organization name | ID>",
 		Short: "set the organization used by the CLI. Pass an empty string to reset to the default organization.",
-		Long: "set the organization used by the CLI. Pass an empty string to reset to the default organization.\n" + formatExamples(
-			example{
+		Long: "set the organization used by the CLI. Pass an empty string to reset to the default organization.\n" + FormatExamples(
+			Example{
 				Description: "Remove the current organization and defer to the default.",
 				Command:     "coder organizations set ''",
 			},
-			example{
+			Example{
 				Description: "Switch to a custom organization.",
 				Command:     "coder organizations set my-org",
 			},

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -35,24 +35,24 @@ func (r *RootCmd) portForward() *serpent.Command {
 		Use:     "port-forward <workspace>",
 		Short:   `Forward ports from a workspace to the local machine. For reverse port forwarding, use "coder ssh -R".`,
 		Aliases: []string{"tunnel"},
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "Port forward a single TCP port from 1234 in the workspace to port 5678 on your local machine",
 				Command:     "coder port-forward <workspace> --tcp 5678:1234",
 			},
-			example{
+			Example{
 				Description: "Port forward a single UDP port from port 9000 to port 9000 on your local machine",
 				Command:     "coder port-forward <workspace> --udp 9000",
 			},
-			example{
+			Example{
 				Description: "Port forward multiple TCP ports and a UDP port",
 				Command:     "coder port-forward <workspace> --tcp 8080:8080 --tcp 9000:3000 --udp 5353:53",
 			},
-			example{
+			Example{
 				Description: "Port forward multiple ports (TCP or UDP) in condensed syntax",
 				Command:     "coder port-forward <workspace> --tcp 8080,9000:3000,9090-9092,10000-10002:10010-10012",
 			},
-			example{
+			Example{
 				Description: "Port forward specifying the local address to bind to",
 				Command:     "coder port-forward <workspace> --tcp 1.2.3.4:8080:8080",
 			},

--- a/cli/root.go
+++ b/cli/root.go
@@ -181,12 +181,12 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 `
 	cmd := &serpent.Command{
 		Use: "coder [global-flags] <subcommand>",
-		Long: fmt.Sprintf(fmtLong, buildinfo.Version()) + formatExamples(
-			example{
+		Long: fmt.Sprintf(fmtLong, buildinfo.Version()) + FormatExamples(
+			Example{
 				Description: "Start a Coder server",
 				Command:     "coder server",
 			},
-			example{
+			Example{
 				Description: "Get started by creating a template from an example",
 				Command:     "coder templates init",
 			},
@@ -753,16 +753,16 @@ func isTTYWriter(inv *serpent.Invocation, writer io.Writer) bool {
 	return isatty.IsTerminal(file.Fd())
 }
 
-// example represents a standard example for command usage, to be used
-// with formatExamples.
-type example struct {
+// Example represents a standard example for command usage, to be used
+// with FormatExamples.
+type Example struct {
 	Description string
 	Command     string
 }
 
-// formatExamples formats the examples as width wrapped bulletpoint
+// FormatExamples formats the examples as width wrapped bulletpoint
 // descriptions with the command underneath.
-func formatExamples(examples ...example) string {
+func FormatExamples(examples ...Example) string {
 	var sb strings.Builder
 
 	padStyle := cliui.DefaultStyles.Wrap.With(pretty.XPad(4, 0))

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -45,7 +45,7 @@ func Test_formatExamples(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		examples    []example
+		examples    []Example
 		wantMatches []string
 	}{
 		{
@@ -55,7 +55,7 @@ func Test_formatExamples(t *testing.T) {
 		},
 		{
 			name: "Output examples",
-			examples: []example{
+			examples: []Example{
 				{
 					Description: "Hello world.",
 					Command:     "echo hello",
@@ -72,7 +72,7 @@ func Test_formatExamples(t *testing.T) {
 		},
 		{
 			name: "No description outputs commands",
-			examples: []example{
+			examples: []Example{
 				{
 					Command: "echo hello",
 				},
@@ -87,7 +87,7 @@ func Test_formatExamples(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := formatExamples(tt.examples...)
+			got := FormatExamples(tt.examples...)
 			if len(tt.wantMatches) == 0 {
 				require.Empty(t, got)
 			} else {

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -140,8 +140,8 @@ func (r *RootCmd) scheduleStart() *serpent.Command {
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
 		Use: "start <workspace-name> { <start-time> [day-of-week] [location] | manual }",
-		Long: scheduleStartDescriptionLong + "\n" + formatExamples(
-			example{
+		Long: scheduleStartDescriptionLong + "\n" + FormatExamples(
+			Example{
 				Description: "Set the workspace to start at 9:30am (in Dublin) from Monday to Friday",
 				Command:     "coder schedule start my-workspace 9:30AM Mon-Fri Europe/Dublin",
 			},
@@ -189,8 +189,8 @@ func (r *RootCmd) scheduleStop() *serpent.Command {
 	client := new(codersdk.Client)
 	return &serpent.Command{
 		Use: "stop <workspace-name> { <duration> | manual }",
-		Long: scheduleStopDescriptionLong + "\n" + formatExamples(
-			example{
+		Long: scheduleStopDescriptionLong + "\n" + FormatExamples(
+			Example{
 				Command: "coder schedule stop my-workspace 2h30m",
 			},
 		),
@@ -234,8 +234,8 @@ func (r *RootCmd) scheduleOverride() *serpent.Command {
 	overrideCmd := &serpent.Command{
 		Use:   "override-stop <workspace-name> <duration from now>",
 		Short: "Override the stop time of a currently running workspace instance.",
-		Long: scheduleOverrideDescriptionLong + "\n" + formatExamples(
-			example{
+		Long: scheduleOverrideDescriptionLong + "\n" + FormatExamples(
+			Example{
 				Command: "coder schedule override-stop my-workspace 90m",
 			},
 		),

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -16,12 +16,12 @@ func (r *RootCmd) templates() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "templates",
 		Short: "Manage templates",
-		Long: "Templates are written in standard Terraform and describe the infrastructure for workspaces\n" + formatExamples(
-			example{
+		Long: "Templates are written in standard Terraform and describe the infrastructure for workspaces\n" + FormatExamples(
+			Example{
 				Description: "Make changes to your template, and plan the changes",
 				Command:     "coder templates plan my-template",
 			},
-			example{
+			Example{
 				Description: "Create or push an update to the template. Your developers can update their workspaces",
 				Command:     "coder templates push my-template",
 			},

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -19,8 +19,8 @@ func (r *RootCmd) templateVersions() *serpent.Command {
 		Use:     "versions",
 		Short:   "Manage different versions of the specified template",
 		Aliases: []string{"version"},
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "List versions of a specific template",
 				Command:     "coder templates versions list my-template",
 			},

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -17,16 +17,16 @@ func (r *RootCmd) tokens() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "tokens",
 		Short: "Manage personal access tokens",
-		Long: "Tokens are used to authenticate automated clients to Coder.\n" + formatExamples(
-			example{
+		Long: "Tokens are used to authenticate automated clients to Coder.\n" + FormatExamples(
+			Example{
 				Description: "Create a token for automation",
 				Command:     "coder tokens create",
 			},
-			example{
+			Example{
 				Description: "List your tokens",
 				Command:     "coder tokens ls",
 			},
-			example{
+			Example{
 				Description: "Remove a token by ID",
 				Command:     "coder tokens rm WuoWs4ZsMX",
 			},

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -57,8 +57,8 @@ func (r *RootCmd) userSingle() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "show <username|user_id|'me'>",
 		Short: "Show a single user. Use 'me' to indicate the currently authenticated user.",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Command: "coder users show me",
 			},
 		),

--- a/cli/userstatus.go
+++ b/cli/userstatus.go
@@ -40,8 +40,8 @@ func (r *RootCmd) createUserStatusCommand(sdkStatus codersdk.UserStatus) *serpen
 		Use:     fmt.Sprintf("%s <username|user_id>", verb),
 		Short:   short,
 		Aliases: aliases,
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Command: fmt.Sprintf("coder users %s example_user", verb),
 			},
 		),

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -835,11 +835,12 @@ func (q *querier) CleanTailnetTunnels(ctx context.Context) error {
 	return q.db.CleanTailnetTunnels(ctx)
 }
 
-func (q *querier) CustomRolesByName(ctx context.Context, lookupRoles []string) ([]database.CustomRole, error) {
+// TODO: Handle org scoped lookups
+func (q *querier) CustomRoles(ctx context.Context, arg database.CustomRolesParams) ([]database.CustomRole, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAssignRole); err != nil {
 		return nil, err
 	}
-	return q.db.CustomRolesByName(ctx, lookupRoles)
+	return q.db.CustomRoles(ctx, arg)
 }
 
 func (q *querier) DeleteAPIKeyByID(ctx context.Context, id string) error {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1167,8 +1167,8 @@ func (s *MethodTestSuite) TestUser() {
 		b := dbgen.User(s.T(), db, database.User{})
 		check.Args().Asserts(rbac.ResourceSystem, policy.ActionRead).Returns(slice.New(a.ID, b.ID))
 	}))
-	s.Run("CustomRolesByName", s.Subtest(func(db database.Store, check *expects) {
-		check.Args([]string{}).Asserts(rbac.ResourceAssignRole, policy.ActionRead).Returns([]database.CustomRole{})
+	s.Run("CustomRoles", s.Subtest(func(db database.Store, check *expects) {
+		check.Args(database.CustomRolesParams{}).Asserts(rbac.ResourceAssignRole, policy.ActionRead).Returns([]database.CustomRole{})
 	}))
 	s.Run("Blank/UpsertCustomRole", s.Subtest(func(db database.Store, check *expects) {
 		// Blank is no perms in the role

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -1174,18 +1174,26 @@ func (*FakeQuerier) CleanTailnetTunnels(context.Context) error {
 	return ErrUnimplemented
 }
 
-func (q *FakeQuerier) CustomRolesByName(_ context.Context, lookupRoles []string) ([]database.CustomRole, error) {
+func (q *FakeQuerier) CustomRoles(_ context.Context, arg database.CustomRolesParams) ([]database.CustomRole, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
 	found := make([]database.CustomRole, 0)
 	for _, role := range q.data.customRoles {
-		if slices.ContainsFunc(lookupRoles, func(s string) bool {
-			return strings.EqualFold(s, role.Name)
-		}) {
-			role := role
-			found = append(found, role)
+		if len(arg.LookupRoles) > 0 {
+			if !slices.ContainsFunc(arg.LookupRoles, func(s string) bool {
+				return strings.EqualFold(s, role.Name)
+			}) {
+				continue
+			}
 		}
+
+		if arg.ExcludeOrgRoles && role.OrganizationID.Valid {
+			continue
+		}
+
+		role := role
+		found = append(found, role)
 	}
 
 	return found, nil

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -144,10 +144,10 @@ func (m metricsStore) CleanTailnetTunnels(ctx context.Context) error {
 	return r0
 }
 
-func (m metricsStore) CustomRolesByName(ctx context.Context, lookupRoles []string) ([]database.CustomRole, error) {
+func (m metricsStore) CustomRoles(ctx context.Context, arg database.CustomRolesParams) ([]database.CustomRole, error) {
 	start := time.Now()
-	r0, r1 := m.s.CustomRolesByName(ctx, lookupRoles)
-	m.queryLatencies.WithLabelValues("CustomRolesByName").Observe(time.Since(start).Seconds())
+	r0, r1 := m.s.CustomRoles(ctx, arg)
+	m.queryLatencies.WithLabelValues("CustomRoles").Observe(time.Since(start).Seconds())
 	return r0, r1
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -173,19 +173,19 @@ func (mr *MockStoreMockRecorder) CleanTailnetTunnels(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanTailnetTunnels", reflect.TypeOf((*MockStore)(nil).CleanTailnetTunnels), arg0)
 }
 
-// CustomRolesByName mocks base method.
-func (m *MockStore) CustomRolesByName(arg0 context.Context, arg1 []string) ([]database.CustomRole, error) {
+// CustomRoles mocks base method.
+func (m *MockStore) CustomRoles(arg0 context.Context, arg1 database.CustomRolesParams) ([]database.CustomRole, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CustomRolesByName", arg0, arg1)
+	ret := m.ctrl.Call(m, "CustomRoles", arg0, arg1)
 	ret0, _ := ret[0].([]database.CustomRole)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CustomRolesByName indicates an expected call of CustomRolesByName.
-func (mr *MockStoreMockRecorder) CustomRolesByName(arg0, arg1 any) *gomock.Call {
+// CustomRoles indicates an expected call of CustomRoles.
+func (mr *MockStoreMockRecorder) CustomRoles(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomRolesByName", reflect.TypeOf((*MockStore)(nil).CustomRolesByName), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomRoles", reflect.TypeOf((*MockStore)(nil).CustomRoles), arg0, arg1)
 }
 
 // DeleteAPIKeyByID mocks base method.

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -411,10 +411,13 @@ CREATE TABLE custom_roles (
     org_permissions jsonb DEFAULT '{}'::jsonb NOT NULL,
     user_permissions jsonb DEFAULT '[]'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    organization_id uuid
 );
 
 COMMENT ON TABLE custom_roles IS 'Custom roles allow dynamic roles expanded at runtime';
+
+COMMENT ON COLUMN custom_roles.organization_id IS 'Roles can optionally be scoped to an organization';
 
 CREATE TABLE dbcrypt_keys (
     number integer NOT NULL,

--- a/coderd/database/migrations/000210_custom_role_orgs.down.sql
+++ b/coderd/database/migrations/000210_custom_role_orgs.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE custom_roles
+	-- This column is nullable, meaning no organization scope
+	DROP COLUMN organization_id;

--- a/coderd/database/migrations/000210_custom_role_orgs.up.sql
+++ b/coderd/database/migrations/000210_custom_role_orgs.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE custom_roles
+	-- This column is nullable, meaning no organization scope
+	ADD COLUMN organization_id uuid;
+
+COMMENT ON COLUMN custom_roles.organization_id IS 'Roles can optionally be scoped to an organization'

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1790,6 +1790,8 @@ type CustomRole struct {
 	UserPermissions json.RawMessage `db:"user_permissions" json:"user_permissions"`
 	CreatedAt       time.Time       `db:"created_at" json:"created_at"`
 	UpdatedAt       time.Time       `db:"updated_at" json:"updated_at"`
+	// Roles can optionally be scoped to an organization
+	OrganizationID uuid.NullUUID `db:"organization_id" json:"organization_id"`
 }
 
 // A table used to store the keys used to encrypt the database.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -48,7 +48,7 @@ type sqlcQuerier interface {
 	CleanTailnetCoordinators(ctx context.Context) error
 	CleanTailnetLostPeers(ctx context.Context) error
 	CleanTailnetTunnels(ctx context.Context) error
-	CustomRolesByName(ctx context.Context, lookupRoles []string) ([]CustomRole, error)
+	CustomRoles(ctx context.Context, arg CustomRolesParams) ([]CustomRole, error)
 	DeleteAPIKeyByID(ctx context.Context, id string) error
 	DeleteAPIKeysByUserID(ctx context.Context, userID uuid.UUID) error
 	DeleteAllTailnetClientSubscriptions(ctx context.Context, arg DeleteAllTailnetClientSubscriptionsParams) error

--- a/coderd/database/queries/roles.sql
+++ b/coderd/database/queries/roles.sql
@@ -1,13 +1,22 @@
--- name: CustomRolesByName :many
+-- name: CustomRoles :many
 SELECT
 	*
 FROM
 	custom_roles
 WHERE
+  true
+  -- Lookup roles filter
+  AND CASE WHEN array_length(@lookup_roles :: text[], 1) > 0  THEN
 	-- Case insensitive
 	name ILIKE ANY(@lookup_roles :: text [])
+    ELSE true
+  END
+  -- Org scoping filter, to only fetch site wide roles
+  AND CASE WHEN @exclude_org_roles :: boolean  THEN
+	organization_id IS null
+	ELSE true
+  END
 ;
-
 
 -- name: UpsertCustomRole :one
 INSERT INTO

--- a/coderd/httpapi/name.go
+++ b/coderd/httpapi/name.go
@@ -38,7 +38,7 @@ func UsernameFrom(str string) string {
 }
 
 // NameValid returns whether the input string is a valid name.
-// It is a generic validator for any name (user, workspace, template, etc.).
+// It is a generic validator for any name (user, workspace, template, role name, etc.).
 func NameValid(str string) error {
 	if len(str) > 32 {
 		return xerrors.New("must be <= 32 characters")

--- a/coderd/rbac/rolestore/rolestore.go
+++ b/coderd/rbac/rolestore/rolestore.go
@@ -72,7 +72,9 @@ func Expand(ctx context.Context, db database.Store, names []string) (rbac.Roles,
 		// If some roles are missing from the database, they are omitted from
 		// the expansion. These roles are no-ops. Should we raise some kind of
 		// warning when this happens?
-		dbroles, err := db.CustomRolesByName(ctx, lookup)
+		dbroles, err := db.CustomRoles(ctx, database.CustomRolesParams{
+			LookupRoles: lookup,
+		})
 		if err != nil {
 			return nil, xerrors.Errorf("fetch custom roles: %w", err)
 		}

--- a/coderd/roles_test.go
+++ b/coderd/roles_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -143,12 +144,9 @@ func TestListRoles(t *testing.T) {
 	}
 }
 
-func convertRole(roleName string) codersdk.SlimRole {
+func convertRole(roleName string) codersdk.Role {
 	role, _ := rbac.RoleByName(roleName)
-	return codersdk.SlimRole{
-		DisplayName: role.DisplayName,
-		Name:        role.Name,
-	}
+	return db2sdk.Role(role)
 }
 
 func convertRoles(assignableRoles map[string]bool) []codersdk.AssignableRoles {
@@ -156,7 +154,7 @@ func convertRoles(assignableRoles map[string]bool) []codersdk.AssignableRoles {
 	for roleName, assignable := range assignableRoles {
 		role := convertRole(roleName)
 		converted = append(converted, codersdk.AssignableRoles{
-			SlimRole:   role,
+			Role:       role,
 			Assignable: assignable,
 		})
 	}

--- a/coderd/util/slice/slice.go
+++ b/coderd/util/slice/slice.go
@@ -4,6 +4,15 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+// ToStrings works for any type where the base type is a string.
+func ToStrings[T ~string](a []T) []string {
+	tmp := make([]string, 0, len(a))
+	for _, v := range a {
+		tmp = append(tmp, string(v))
+	}
+	return tmp
+}
+
 // Omit creates a new slice with the arguments omitted from the list.
 func Omit[T comparable](a []T, omits ...T) []T {
 	tmp := make([]T, 0, len(a))

--- a/codersdk/rbacresources_gen.go
+++ b/codersdk/rbacresources_gen.go
@@ -48,3 +48,33 @@ const (
 	ActionWorkspaceStart     RBACAction = "start"
 	ActionWorkspaceStop      RBACAction = "stop"
 )
+
+// RBACResourceActions is the mapping of resources to which actions are valid for
+// said resource type.
+var RBACResourceActions = map[RBACResource][]RBACAction{
+	ResourceWildcard:           []RBACAction{},
+	ResourceApiKey:             []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceAssignOrgRole:      []RBACAction{ActionAssign, ActionDelete, ActionRead},
+	ResourceAssignRole:         []RBACAction{ActionAssign, ActionCreate, ActionDelete, ActionRead},
+	ResourceAuditLog:           []RBACAction{ActionCreate, ActionRead},
+	ResourceDebugInfo:          []RBACAction{ActionRead},
+	ResourceDeploymentConfig:   []RBACAction{ActionRead, ActionUpdate},
+	ResourceDeploymentStats:    []RBACAction{ActionRead},
+	ResourceFile:               []RBACAction{ActionCreate, ActionRead},
+	ResourceGroup:              []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceLicense:            []RBACAction{ActionCreate, ActionDelete, ActionRead},
+	ResourceOauth2App:          []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceOauth2AppCodeToken: []RBACAction{ActionCreate, ActionDelete, ActionRead},
+	ResourceOauth2AppSecret:    []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceOrganization:       []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceOrganizationMember: []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceProvisionerDaemon:  []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceReplicas:           []RBACAction{ActionRead},
+	ResourceSystem:             []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceTailnetCoordinator: []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+	ResourceTemplate:           []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate, ActionViewInsights},
+	ResourceUser:               []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionReadPersonal, ActionUpdate, ActionUpdatePersonal},
+	ResourceWorkspace:          []RBACAction{ActionApplicationConnect, ActionCreate, ActionDelete, ActionRead, ActionSSH, ActionWorkspaceStart, ActionWorkspaceStop, ActionUpdate},
+	ResourceWorkspaceDormant:   []RBACAction{ActionApplicationConnect, ActionCreate, ActionDelete, ActionRead, ActionSSH, ActionWorkspaceStart, ActionWorkspaceStop, ActionUpdate},
+	ResourceWorkspaceProxy:     []RBACAction{ActionCreate, ActionDelete, ActionRead, ActionUpdate},
+}

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -19,7 +19,7 @@ type SlimRole struct {
 }
 
 type AssignableRoles struct {
-	SlimRole
+	Role
 	Assignable bool `json:"assignable"`
 }
 

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -19,8 +19,10 @@ type SlimRole struct {
 }
 
 type AssignableRoles struct {
-	Role
-	Assignable bool `json:"assignable"`
+	Role       `table:"r,recursive_inline"`
+	Assignable bool `json:"assignable" table:"assignable"`
+	// BuiltIn roles are immutable
+	BuiltIn bool `json:"built_in" table:"built_in"`
 }
 
 // Permission is the format passed into the rego.
@@ -33,12 +35,12 @@ type Permission struct {
 
 // Role is a longer form of SlimRole used to edit custom roles.
 type Role struct {
-	Name            string       `json:"name"`
-	DisplayName     string       `json:"display_name"`
-	SitePermissions []Permission `json:"site_permissions"`
+	Name            string       `json:"name" table:"name,default_sort"`
+	DisplayName     string       `json:"display_name" table:"display_name"`
+	SitePermissions []Permission `json:"site_permissions" table:"site_permissions"`
 	// map[<org_id>] -> Permissions
-	OrganizationPermissions map[string][]Permission `json:"organization_permissions"`
-	UserPermissions         []Permission            `json:"user_permissions"`
+	OrganizationPermissions map[string][]Permission `json:"organization_permissions" table:"org_permissions"`
+	UserPermissions         []Permission            `json:"user_permissions" table:"user_permissions"`
 }
 
 // PatchRole will upsert a custom site wide role

--- a/enterprise/cli/roleedit.go
+++ b/enterprise/cli/roleedit.go
@@ -1,0 +1,251 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli"
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/coderd/util/slice"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) editRole() *serpent.Command {
+	formatter := cliui.NewOutputFormatter(
+		cliui.ChangeFormatterData(
+			cliui.TableFormat([]codersdk.Role{}, []string{"name", "display_name", "site_permissions", "org_permissions", "user_permissions"}),
+			func(data any) (any, error) {
+				return []codersdk.Role{data.(codersdk.Role)}, nil
+			},
+		),
+		cliui.JSONFormat(),
+	)
+
+	var (
+		dryRun bool
+	)
+
+	client := new(codersdk.Client)
+	cmd := &serpent.Command{
+		Use:   "edit <role_name>",
+		Short: "Edit a custom role",
+		Long: cli.FormatExamples(
+			cli.Example{
+				Description: "Run with an input.json file",
+				Command:     "coder roles edit custom_name < role.json",
+			},
+		),
+		Options: []serpent.Option{
+			cliui.SkipPromptOption(),
+			{
+				Name:        "dry-run",
+				Description: "Does all the work, but does not submit the final updated role.",
+				Flag:        "dry-run",
+				Value:       serpent.BoolOf(&dryRun),
+			},
+		},
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(1),
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			roles, err := client.ListSiteRoles(ctx)
+			if err != nil {
+				return xerrors.Errorf("listing roles: %w", err)
+			}
+
+			// Make sure the role actually exists first
+			var originalRole codersdk.AssignableRoles
+			for _, r := range roles {
+				if strings.EqualFold(inv.Args[0], r.Name) {
+					originalRole = r
+					break
+				}
+			}
+
+			if originalRole.Name == "" {
+				_, err = cliui.Prompt(inv, cliui.PromptOptions{
+					Text:      "No role exists with that name, do you want to create one?",
+					Default:   "yes",
+					IsConfirm: true,
+				})
+				if err != nil {
+					return xerrors.Errorf("abort: %w", err)
+				}
+
+				originalRole.Role = codersdk.Role{
+					Name: inv.Args[0],
+				}
+			}
+
+			var customRole *codersdk.Role
+			// Either interactive, or take input mode.
+			fi, _ := os.Stdin.Stat()
+			if (fi.Mode() & os.ModeCharDevice) == 0 {
+				bytes, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return xerrors.Errorf("reading stdin: %w", err)
+				}
+
+				err = json.Unmarshal(bytes, customRole)
+				if err != nil {
+					return xerrors.Errorf("parsing stdin json: %w", err)
+				}
+			} else {
+				// Interactive mode
+				if len(originalRole.OrganizationPermissions) > 0 {
+					return xerrors.Errorf("unable to edit role in interactive mode, it contains organization permissions")
+				}
+
+				if len(originalRole.UserPermissions) > 0 {
+					return xerrors.Errorf("unable to edit role in interactive mode, it contains user permissions")
+				}
+
+				customRole, err = interactiveEdit(inv, &originalRole.Role)
+				if err != nil {
+					return xerrors.Errorf("editing role: %w", err)
+				}
+			}
+
+			totalOrg := 0
+			for _, o := range customRole.OrganizationPermissions {
+				totalOrg += len(o)
+			}
+			preview := fmt.Sprintf("perms: %d site, %d over %d orgs, %d user",
+				len(customRole.SitePermissions), totalOrg, len(customRole.OrganizationPermissions), len(customRole.UserPermissions))
+			_, err = cliui.Prompt(inv, cliui.PromptOptions{
+				Text:      "Are you sure you wish to update the role? " + preview,
+				Default:   "yes",
+				IsConfirm: true,
+			})
+			if err != nil {
+				return xerrors.Errorf("abort: %w", err)
+			}
+
+			var updated codersdk.Role
+			if dryRun {
+				// Do not actually post
+				updated = *customRole
+			} else {
+				updated, err = client.PatchRole(ctx, *customRole)
+				if err != nil {
+					return fmt.Errorf("patch role: %w", err)
+				}
+			}
+
+			_, err = formatter.Format(ctx, updated)
+			if err != nil {
+				return xerrors.Errorf("formatting: %w", err)
+			}
+			return nil
+		},
+	}
+
+	formatter.AttachOptions(&cmd.Options)
+	return cmd
+}
+
+func interactiveEdit(inv *serpent.Invocation, role *codersdk.Role) (*codersdk.Role, error) {
+	allowedResources := []codersdk.RBACResource{
+		codersdk.ResourceTemplate,
+		codersdk.ResourceWorkspace,
+		codersdk.ResourceUser,
+		codersdk.ResourceGroup,
+	}
+
+	const done = "Finish and submit changes"
+	const abort = "Cancel changes"
+
+	// Now starts the role editing "game".
+customRoleLoop:
+	for {
+		selected, err := cliui.Select(inv, cliui.SelectOptions{
+			Message: "Select which resources to edit permissions",
+			Options: append(permissionPreviews(role, allowedResources), done, abort),
+		})
+		if err != nil {
+			return role, xerrors.Errorf("selecting resource: %w", err)
+		}
+		switch selected {
+		case done:
+			break customRoleLoop
+		case abort:
+			return role, xerrors.Errorf("edit role %q aborted", role.Name)
+		default:
+			strs := strings.Split(selected, "::")
+			resource := strings.TrimSpace(strs[0])
+
+			actions, err := cliui.MultiSelect(inv, cliui.MultiSelectOptions{
+				Message:  fmt.Sprintf("Select actions to allow across the whole deployment for resources=%q", resource),
+				Options:  slice.ToStrings(codersdk.RBACResourceActions[codersdk.RBACResource(resource)]),
+				Defaults: defaultActions(role, resource),
+			})
+			if err != nil {
+				return role, xerrors.Errorf("selecting actions for resource %q: %w", resource, err)
+			}
+			applyResourceActions(role, resource, actions)
+			// back to resources!
+		}
+	}
+	// This println is required because the prompt ends us on the same line as some text.
+	fmt.Println()
+
+	return role, nil
+}
+
+func applyResourceActions(role *codersdk.Role, resource string, actions []string) {
+	// Construct new site perms with only new perms for the resource
+	keep := make([]codersdk.Permission, 0)
+	for _, perm := range role.SitePermissions {
+		perm := perm
+		if string(perm.ResourceType) != resource {
+			keep = append(keep, perm)
+		}
+	}
+
+	// Add new perms
+	for _, action := range actions {
+		keep = append(keep, codersdk.Permission{
+			Negate:       false,
+			ResourceType: codersdk.RBACResource(resource),
+			Action:       codersdk.RBACAction(action),
+		})
+	}
+
+	role.SitePermissions = keep
+}
+
+func defaultActions(role *codersdk.Role, resource string) []string {
+	defaults := make([]string, 0)
+	for _, perm := range role.SitePermissions {
+		if string(perm.ResourceType) == resource {
+			defaults = append(defaults, string(perm.Action))
+		}
+	}
+	return defaults
+}
+
+func permissionPreviews(role *codersdk.Role, resources []codersdk.RBACResource) []string {
+	previews := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		previews = append(previews, permissionPreview(role, resource))
+	}
+	return previews
+}
+
+func permissionPreview(role *codersdk.Role, resource codersdk.RBACResource) string {
+	count := 0
+	for _, perm := range role.SitePermissions {
+		if perm.ResourceType == resource {
+			count++
+		}
+	}
+	return fmt.Sprintf("%s :: %d permissions", resource, count)
+}

--- a/enterprise/cli/rolescmd.go
+++ b/enterprise/cli/rolescmd.go
@@ -1,6 +1,16 @@
 package cli
 
-import "github.com/coder/serpent"
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
 
 // **NOTE** Only covers site wide roles at present. Org scoped roles maybe
 // should be nested under some command that scopes to an org??
@@ -13,21 +23,131 @@ func (r *RootCmd) roles() *serpent.Command {
 		Handler: func(inv *serpent.Invocation) error {
 			return inv.Command.HelpHandler(inv)
 		},
-		Hidden:   true,
-		Children: []*serpent.Command{},
+		Hidden: true,
+		Children: []*serpent.Command{
+			r.showRole(),
+			r.editRole(),
+		},
 	}
 	return cmd
 }
 
-func (r *RootCmd) showRole() *serpent.Command {
+func (r *RootCmd) editRole() *serpent.Command {
+	formatter := roleFormatter()
+
+	client := new(codersdk.Client)
 	cmd := &serpent.Command{
-		Use:   "show",
-		Short: "Show role(s)",
-		Handler: func(i *serpent.Invocation) error {
+		Use:   "edit <role_name>",
+		Short: "Edit a role",
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(1),
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			roles, err := client.ListSiteRoles(ctx)
+			if err != nil {
+				return xerrors.Errorf("listing roles: %w", err)
+			}
+
+			// Make sure the role actually exists first
+			var role codersdk.AssignableRoles
+			for _, r := range roles {
+				if strings.EqualFold(inv.Args[0], r.Name) {
+					role = r
+					break
+				}
+			}
+
+			// TODO: Allow role creation
+			if role.Name == "" {
+				return xerrors.Errorf("role %q not found", inv.Args[0])
+			}
 
 			return nil
 		},
 	}
 
+	formatter.AttachOptions(&cmd.Options)
 	return cmd
+}
+
+type assignableRolesTableRow struct {
+	Name            string `table:"name,default_sort"`
+	DisplayName     string `table:"display_name"`
+	SitePermissions string ` table:"site_permissions"`
+	// map[<org_id>] -> Permissions
+	OrganizationPermissions string `table:"org_permissions"`
+	UserPermissions         string `table:"user_permissions"`
+	Assignable              bool   `table:"assignable"`
+	BuiltIn                 bool   `table:"built_in"`
+}
+
+func (r *RootCmd) showRole() *serpent.Command {
+	formatter := roleFormatter()
+
+	client := new(codersdk.Client)
+	cmd := &serpent.Command{
+		Use:   "show [role_names ...]",
+		Short: "Show role(s)",
+		Middleware: serpent.Chain(
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			roles, err := client.ListSiteRoles(ctx)
+			if err != nil {
+				return xerrors.Errorf("listing roles: %w", err)
+			}
+
+			if len(inv.Args) > 0 {
+				// filter roles
+				filtered := make([]codersdk.AssignableRoles, 0)
+				for _, role := range roles {
+					if slices.ContainsFunc(inv.Args, func(s string) bool {
+						return strings.EqualFold(s, role.Name)
+					}) {
+						filtered = append(filtered, role)
+					}
+				}
+				roles = filtered
+			}
+
+			out, err := formatter.Format(inv.Context(), roles)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintln(inv.Stdout, out)
+			return nil
+		},
+	}
+	formatter.AttachOptions(&cmd.Options)
+
+	return cmd
+}
+
+func roleFormatter() *cliui.OutputFormatter {
+	return cliui.NewOutputFormatter(
+		cliui.ChangeFormatterData(
+			cliui.TableFormat([]assignableRolesTableRow{}, []string{"name", "display_name", "built_in", "site_permissions", "org_permissions", "user_permissions"}),
+			func(data any) (any, error) {
+				input := data.([]codersdk.AssignableRoles)
+				rows := make([]assignableRolesTableRow, 0, len(input))
+				for _, role := range input {
+					rows = append(rows, assignableRolesTableRow{
+						Name:                    role.Name,
+						DisplayName:             role.DisplayName,
+						SitePermissions:         fmt.Sprintf("%d permissions", len(role.SitePermissions)),
+						OrganizationPermissions: fmt.Sprintf("%d organizations", len(role.OrganizationPermissions)),
+						UserPermissions:         fmt.Sprintf("%d permissions", len(role.UserPermissions)),
+						Assignable:              role.Assignable,
+						BuiltIn:                 role.BuiltIn,
+					})
+				}
+				return rows, nil
+			},
+		),
+		cliui.JSONFormat(),
+	)
 }

--- a/enterprise/cli/rolescmd.go
+++ b/enterprise/cli/rolescmd.go
@@ -32,59 +32,29 @@ func (r *RootCmd) roles() *serpent.Command {
 	return cmd
 }
 
-func (r *RootCmd) editRole() *serpent.Command {
-	formatter := roleFormatter()
-
-	client := new(codersdk.Client)
-	cmd := &serpent.Command{
-		Use:   "edit <role_name>",
-		Short: "Edit a role",
-		Middleware: serpent.Chain(
-			serpent.RequireNArgs(1),
-			r.InitClient(client),
-		),
-		Handler: func(inv *serpent.Invocation) error {
-			ctx := inv.Context()
-			roles, err := client.ListSiteRoles(ctx)
-			if err != nil {
-				return xerrors.Errorf("listing roles: %w", err)
-			}
-
-			// Make sure the role actually exists first
-			var role codersdk.AssignableRoles
-			for _, r := range roles {
-				if strings.EqualFold(inv.Args[0], r.Name) {
-					role = r
-					break
-				}
-			}
-
-			// TODO: Allow role creation
-			if role.Name == "" {
-				return xerrors.Errorf("role %q not found", inv.Args[0])
-			}
-
-			return nil
-		},
-	}
-
-	formatter.AttachOptions(&cmd.Options)
-	return cmd
-}
-
-type assignableRolesTableRow struct {
-	Name            string `table:"name,default_sort"`
-	DisplayName     string `table:"display_name"`
-	SitePermissions string ` table:"site_permissions"`
-	// map[<org_id>] -> Permissions
-	OrganizationPermissions string `table:"org_permissions"`
-	UserPermissions         string `table:"user_permissions"`
-	Assignable              bool   `table:"assignable"`
-	BuiltIn                 bool   `table:"built_in"`
-}
-
 func (r *RootCmd) showRole() *serpent.Command {
-	formatter := roleFormatter()
+	formatter := cliui.NewOutputFormatter(
+		cliui.ChangeFormatterData(
+			cliui.TableFormat([]assignableRolesTableRow{}, []string{"name", "display_name", "built_in", "site_permissions", "org_permissions", "user_permissions"}),
+			func(data any) (any, error) {
+				input := data.([]codersdk.AssignableRoles)
+				rows := make([]assignableRolesTableRow, 0, len(input))
+				for _, role := range input {
+					rows = append(rows, assignableRolesTableRow{
+						Name:                    role.Name,
+						DisplayName:             role.DisplayName,
+						SitePermissions:         fmt.Sprintf("%d permissions", len(role.SitePermissions)),
+						OrganizationPermissions: fmt.Sprintf("%d organizations", len(role.OrganizationPermissions)),
+						UserPermissions:         fmt.Sprintf("%d permissions", len(role.UserPermissions)),
+						Assignable:              role.Assignable,
+						BuiltIn:                 role.BuiltIn,
+					})
+				}
+				return rows, nil
+			},
+		),
+		cliui.JSONFormat(),
+	)
 
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
@@ -127,27 +97,13 @@ func (r *RootCmd) showRole() *serpent.Command {
 	return cmd
 }
 
-func roleFormatter() *cliui.OutputFormatter {
-	return cliui.NewOutputFormatter(
-		cliui.ChangeFormatterData(
-			cliui.TableFormat([]assignableRolesTableRow{}, []string{"name", "display_name", "built_in", "site_permissions", "org_permissions", "user_permissions"}),
-			func(data any) (any, error) {
-				input := data.([]codersdk.AssignableRoles)
-				rows := make([]assignableRolesTableRow, 0, len(input))
-				for _, role := range input {
-					rows = append(rows, assignableRolesTableRow{
-						Name:                    role.Name,
-						DisplayName:             role.DisplayName,
-						SitePermissions:         fmt.Sprintf("%d permissions", len(role.SitePermissions)),
-						OrganizationPermissions: fmt.Sprintf("%d organizations", len(role.OrganizationPermissions)),
-						UserPermissions:         fmt.Sprintf("%d permissions", len(role.UserPermissions)),
-						Assignable:              role.Assignable,
-						BuiltIn:                 role.BuiltIn,
-					})
-				}
-				return rows, nil
-			},
-		),
-		cliui.JSONFormat(),
-	)
+type assignableRolesTableRow struct {
+	Name            string `table:"name,default_sort"`
+	DisplayName     string `table:"display_name"`
+	SitePermissions string ` table:"site_permissions"`
+	// map[<org_id>] -> Permissions
+	OrganizationPermissions string `table:"org_permissions"`
+	UserPermissions         string `table:"user_permissions"`
+	Assignable              bool   `table:"assignable"`
+	BuiltIn                 bool   `table:"built_in"`
 }

--- a/enterprise/cli/rolescmd.go
+++ b/enterprise/cli/rolescmd.go
@@ -1,0 +1,33 @@
+package cli
+
+import "github.com/coder/serpent"
+
+// **NOTE** Only covers site wide roles at present. Org scoped roles maybe
+// should be nested under some command that scopes to an org??
+
+func (r *RootCmd) roles() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:     "roles",
+		Short:   "Manage roles",
+		Aliases: []string{"role"},
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Hidden:   true,
+		Children: []*serpent.Command{},
+	}
+	return cmd
+}
+
+func (r *RootCmd) showRole() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:   "show",
+		Short: "Show role(s)",
+		Handler: func(i *serpent.Invocation) error {
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/enterprise/cli/root.go
+++ b/enterprise/cli/root.go
@@ -17,6 +17,7 @@ func (r *RootCmd) enterpriseOnly() []*serpent.Command {
 		r.licenses(),
 		r.groups(),
 		r.provisionerDaemons(),
+		r.roles(),
 	}
 }
 

--- a/enterprise/coderd/roles.go
+++ b/enterprise/coderd/roles.go
@@ -27,6 +27,14 @@ func (api *API) patchRole(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := httpapi.NameValid(req.Name); err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid role name",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	if len(req.OrganizationPermissions) > 0 {
 		// Org perms should be assigned only in org specific roles. Otherwise,
 		// it gets complicated to keep track of who can do what.

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -2,6 +2,7 @@ package coderd_test
 
 import (
 	"bytes"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -63,13 +64,12 @@ func TestCustomRole(t *testing.T) {
 		coderdtest.CreateTemplateVersion(t, tmplAdmin, first.OrganizationID, nil)
 
 		// Verify the role exists in the list
-		// TODO: Turn this assertion back on when the cli api experience is created.
-		//allRoles, err := tmplAdmin.ListSiteRoles(ctx)
-		//require.NoError(t, err)
-		//
-		//require.True(t, slices.ContainsFunc(allRoles, func(selected codersdk.AssignableRoles) bool {
-		//	return selected.Name == role.Name
-		//}), "role missing from site role list")
+		allRoles, err := tmplAdmin.ListSiteRoles(ctx)
+		require.NoError(t, err)
+
+		require.True(t, slices.ContainsFunc(allRoles, func(selected codersdk.AssignableRoles) bool {
+			return selected.Name == role.Name
+		}), "role missing from site role list")
 	})
 
 	// Revoked licenses cannot modify/create custom roles, but they can

--- a/scripts/rbacgen/codersdk.gotmpl
+++ b/scripts/rbacgen/codersdk.gotmpl
@@ -16,3 +16,15 @@ const (
 	{{ $element.Enum }} RBACAction = "{{ $element.Value }}"
 	{{- end }}
 )
+
+// RBACResourceActions is the mapping of resources to which actions are valid for
+// said resource type.
+var RBACResourceActions = map[RBACResource][]RBACAction{
+	{{- range $element := . }}
+    Resource{{ pascalCaseName $element.FunctionName }}: []RBACAction{
+        {{- range $actionValue, $_ := $element.Actions }}
+            {{- actionEnum $actionValue -}},
+        {{- end -}}
+    },
+    {{- end }}
+}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -65,8 +65,9 @@ export interface ArchiveTemplateVersionsResponse {
 }
 
 // From codersdk/roles.go
-export interface AssignableRoles extends SlimRole {
+export interface AssignableRoles extends Role {
   readonly assignable: boolean;
+  readonly built_in: boolean;
 }
 
 // From codersdk/audit.go

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -229,19 +229,28 @@ export const MockUpdateCheck: TypesGen.UpdateCheckResponse = {
   version: "v99.999.9999+c9cdf14",
 };
 
-export const MockOwnerRole: TypesGen.SlimRole = {
+export const MockOwnerRole: TypesGen.Role = {
   name: "owner",
   display_name: "Owner",
+  site_permissions: [],
+  organization_permissions: {},
+  user_permissions: [],
 };
 
-export const MockUserAdminRole: TypesGen.SlimRole = {
+export const MockUserAdminRole: TypesGen.Role = {
   name: "user_admin",
   display_name: "User Admin",
+  site_permissions: [],
+  organization_permissions: {},
+  user_permissions: [],
 };
 
-export const MockTemplateAdminRole: TypesGen.SlimRole = {
+export const MockTemplateAdminRole: TypesGen.Role = {
   name: "template_admin",
   display_name: "Template Admin",
+  site_permissions: [],
+  organization_permissions: {},
+  user_permissions: [],
 };
 
 export const MockMemberRole: TypesGen.SlimRole = {
@@ -249,20 +258,24 @@ export const MockMemberRole: TypesGen.SlimRole = {
   display_name: "Member",
 };
 
-export const MockAuditorRole: TypesGen.SlimRole = {
+export const MockAuditorRole: TypesGen.Role = {
   name: "auditor",
   display_name: "Auditor",
+  site_permissions: [],
+  organization_permissions: {},
+  user_permissions: [],
 };
 
 // assignableRole takes a role and a boolean. The boolean implies if the
 // actor can assign (add/remove) the role from other users.
 export function assignableRole(
-  role: TypesGen.SlimRole,
+  role: TypesGen.Role,
   assignable: boolean,
 ): TypesGen.AssignableRoles {
   return {
     ...role,
     assignable: assignable,
+    built_in: true,
   };
 }
 


### PR DESCRIPTION
# Usage

## Listing roles

Listing roles has an `--output=json` to see the granular permissions

```
$ coder roles show
NAME            DISPLAY NAME    SITE PERMISSIONS  ORG PERMISSIONS  USER PERMISSIONS  ASSIGNABLE  BUILT IN  
auditor         Auditor         8 permissions     0 organizations  8 permissions     true        true      
owner           Owner           33 permissions    0 organizations  33 permissions    true        true      
template-admin  Template Admin  16 permissions    0 organizations  16 permissions    true        true      
user-admin      User Admin      17 permissions    0 organizations  17 permissions    true        true 
```

You can filter the returned roles, `coder roles show owner auditor`

