### PR TITLE
chore: expose formatExamples to enterprise commands

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -230,12 +230,12 @@ func (r *RootCmd) configSSH() *serpent.Command {
 		Annotations: workspaceCommand,
 		Use:         "config-ssh",
 		Short:       "Add an SSH Host entry for your workspaces \"ssh coder.workspace\"",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "You can use -o (or --ssh-option) so set SSH options to be used for all your workspaces",
 				Command:     "coder config-ssh -o ForwardAgent=yes",
 			},
-			example{
+			Example{
 				Description: "You can use --dry-run (or -n) to see the changes that would be made",
 				Command:     "coder config-ssh --dry-run",
 			},

--- a/cli/create.go
+++ b/cli/create.go
@@ -35,8 +35,8 @@ func (r *RootCmd) create() *serpent.Command {
 		Annotations: workspaceCommand,
 		Use:         "create [name]",
 		Short:       "Create a workspace",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "Create a workspace for another user (if you have permission)",
 				Command:     "coder create <username>/<workspace_name>",
 			},

--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -28,8 +28,8 @@ func (r *RootCmd) dotfiles() *serpent.Command {
 		Use:        "dotfiles <git_repo_url>",
 		Middleware: serpent.RequireNArgs(1),
 		Short:      "Personalize your workspace by applying a canonical dotfiles repository",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "Check out and install a dotfiles repository without prompts",
 				Command:     "coder dotfiles --yes git@github.com:example/dotfiles.git",
 			},

--- a/cli/externalauth.go
+++ b/cli/externalauth.go
@@ -35,8 +35,8 @@ func (r *RootCmd) externalAuthAccessToken() *serpent.Command {
 		Short: "Print auth for an external provider",
 		Long: "Print an access-token for an external auth provider. " +
 			"The access-token will be validated and sent to stdout with exit code 0. " +
-			"If a valid access-token cannot be obtained, the URL to authenticate will be sent to stdout with exit code 1\n" + formatExamples(
-			example{
+			"If a valid access-token cannot be obtained, the URL to authenticate will be sent to stdout with exit code 1\n" + FormatExamples(
+			Example{
 				Description: "Ensure that the user is authenticated with GitHub before cloning.",
 				Command: `#!/usr/bin/env sh
 
@@ -49,7 +49,7 @@ else
 fi
 `,
 			},
-			example{
+			Example{
 				Description: "Obtain an extra property of an access token for additional metadata.",
 				Command:     "coder external-auth access-token slack --extra \"authed_user.id\"",
 			},

--- a/cli/organization.go
+++ b/cli/organization.go
@@ -43,12 +43,12 @@ func (r *RootCmd) switchOrganization() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "set <organization name | ID>",
 		Short: "set the organization used by the CLI. Pass an empty string to reset to the default organization.",
-		Long: "set the organization used by the CLI. Pass an empty string to reset to the default organization.\n" + formatExamples(
-			example{
+		Long: "set the organization used by the CLI. Pass an empty string to reset to the default organization.\n" + FormatExamples(
+			Example{
 				Description: "Remove the current organization and defer to the default.",
 				Command:     "coder organizations set ''",
 			},
-			example{
+			Example{
 				Description: "Switch to a custom organization.",
 				Command:     "coder organizations set my-org",
 			},

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -35,24 +35,24 @@ func (r *RootCmd) portForward() *serpent.Command {
 		Use:     "port-forward <workspace>",
 		Short:   `Forward ports from a workspace to the local machine. For reverse port forwarding, use "coder ssh -R".`,
 		Aliases: []string{"tunnel"},
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "Port forward a single TCP port from 1234 in the workspace to port 5678 on your local machine",
 				Command:     "coder port-forward <workspace> --tcp 5678:1234",
 			},
-			example{
+			Example{
 				Description: "Port forward a single UDP port from port 9000 to port 9000 on your local machine",
 				Command:     "coder port-forward <workspace> --udp 9000",
 			},
-			example{
+			Example{
 				Description: "Port forward multiple TCP ports and a UDP port",
 				Command:     "coder port-forward <workspace> --tcp 8080:8080 --tcp 9000:3000 --udp 5353:53",
 			},
-			example{
+			Example{
 				Description: "Port forward multiple ports (TCP or UDP) in condensed syntax",
 				Command:     "coder port-forward <workspace> --tcp 8080,9000:3000,9090-9092,10000-10002:10010-10012",
 			},
-			example{
+			Example{
 				Description: "Port forward specifying the local address to bind to",
 				Command:     "coder port-forward <workspace> --tcp 1.2.3.4:8080:8080",
 			},

--- a/cli/root.go
+++ b/cli/root.go
@@ -181,12 +181,12 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 `
 	cmd := &serpent.Command{
 		Use: "coder [global-flags] <subcommand>",
-		Long: fmt.Sprintf(fmtLong, buildinfo.Version()) + formatExamples(
-			example{
+		Long: fmt.Sprintf(fmtLong, buildinfo.Version()) + FormatExamples(
+			Example{
 				Description: "Start a Coder server",
 				Command:     "coder server",
 			},
-			example{
+			Example{
 				Description: "Get started by creating a template from an example",
 				Command:     "coder templates init",
 			},
@@ -753,16 +753,16 @@ func isTTYWriter(inv *serpent.Invocation, writer io.Writer) bool {
 	return isatty.IsTerminal(file.Fd())
 }
 
-// example represents a standard example for command usage, to be used
-// with formatExamples.
-type example struct {
+// Example represents a standard example for command usage, to be used
+// with FormatExamples.
+type Example struct {
 	Description string
 	Command     string
 }
 
-// formatExamples formats the examples as width wrapped bulletpoint
+// FormatExamples formats the examples as width wrapped bulletpoint
 // descriptions with the command underneath.
-func formatExamples(examples ...example) string {
+func FormatExamples(examples ...Example) string {
 	var sb strings.Builder
 
 	padStyle := cliui.DefaultStyles.Wrap.With(pretty.XPad(4, 0))

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -45,7 +45,7 @@ func Test_formatExamples(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		examples    []example
+		examples    []Example
 		wantMatches []string
 	}{
 		{
@@ -55,7 +55,7 @@ func Test_formatExamples(t *testing.T) {
 		},
 		{
 			name: "Output examples",
-			examples: []example{
+			examples: []Example{
 				{
 					Description: "Hello world.",
 					Command:     "echo hello",
@@ -72,7 +72,7 @@ func Test_formatExamples(t *testing.T) {
 		},
 		{
 			name: "No description outputs commands",
-			examples: []example{
+			examples: []Example{
 				{
 					Command: "echo hello",
 				},
@@ -87,7 +87,7 @@ func Test_formatExamples(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := formatExamples(tt.examples...)
+			got := FormatExamples(tt.examples...)
 			if len(tt.wantMatches) == 0 {
 				require.Empty(t, got)
 			} else {

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -140,8 +140,8 @@ func (r *RootCmd) scheduleStart() *serpent.Command {
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
 		Use: "start <workspace-name> { <start-time> [day-of-week] [location] | manual }",
-		Long: scheduleStartDescriptionLong + "\n" + formatExamples(
-			example{
+		Long: scheduleStartDescriptionLong + "\n" + FormatExamples(
+			Example{
 				Description: "Set the workspace to start at 9:30am (in Dublin) from Monday to Friday",
 				Command:     "coder schedule start my-workspace 9:30AM Mon-Fri Europe/Dublin",
 			},
@@ -189,8 +189,8 @@ func (r *RootCmd) scheduleStop() *serpent.Command {
 	client := new(codersdk.Client)
 	return &serpent.Command{
 		Use: "stop <workspace-name> { <duration> | manual }",
-		Long: scheduleStopDescriptionLong + "\n" + formatExamples(
-			example{
+		Long: scheduleStopDescriptionLong + "\n" + FormatExamples(
+			Example{
 				Command: "coder schedule stop my-workspace 2h30m",
 			},
 		),
@@ -234,8 +234,8 @@ func (r *RootCmd) scheduleOverride() *serpent.Command {
 	overrideCmd := &serpent.Command{
 		Use:   "override-stop <workspace-name> <duration from now>",
 		Short: "Override the stop time of a currently running workspace instance.",
-		Long: scheduleOverrideDescriptionLong + "\n" + formatExamples(
-			example{
+		Long: scheduleOverrideDescriptionLong + "\n" + FormatExamples(
+			Example{
 				Command: "coder schedule override-stop my-workspace 90m",
 			},
 		),

--- a/cli/templates.go
+++ b/cli/templates.go
@@ -16,12 +16,12 @@ func (r *RootCmd) templates() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "templates",
 		Short: "Manage templates",
-		Long: "Templates are written in standard Terraform and describe the infrastructure for workspaces\n" + formatExamples(
-			example{
+		Long: "Templates are written in standard Terraform and describe the infrastructure for workspaces\n" + FormatExamples(
+			Example{
 				Description: "Make changes to your template, and plan the changes",
 				Command:     "coder templates plan my-template",
 			},
-			example{
+			Example{
 				Description: "Create or push an update to the template. Your developers can update their workspaces",
 				Command:     "coder templates push my-template",
 			},

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -19,8 +19,8 @@ func (r *RootCmd) templateVersions() *serpent.Command {
 		Use:     "versions",
 		Short:   "Manage different versions of the specified template",
 		Aliases: []string{"version"},
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Description: "List versions of a specific template",
 				Command:     "coder templates versions list my-template",
 			},

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -17,16 +17,16 @@ func (r *RootCmd) tokens() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "tokens",
 		Short: "Manage personal access tokens",
-		Long: "Tokens are used to authenticate automated clients to Coder.\n" + formatExamples(
-			example{
+		Long: "Tokens are used to authenticate automated clients to Coder.\n" + FormatExamples(
+			Example{
 				Description: "Create a token for automation",
 				Command:     "coder tokens create",
 			},
-			example{
+			Example{
 				Description: "List your tokens",
 				Command:     "coder tokens ls",
 			},
-			example{
+			Example{
 				Description: "Remove a token by ID",
 				Command:     "coder tokens rm WuoWs4ZsMX",
 			},

--- a/cli/userlist.go
+++ b/cli/userlist.go
@@ -57,8 +57,8 @@ func (r *RootCmd) userSingle() *serpent.Command {
 	cmd := &serpent.Command{
 		Use:   "show <username|user_id|'me'>",
 		Short: "Show a single user. Use 'me' to indicate the currently authenticated user.",
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Command: "coder users show me",
 			},
 		),

--- a/cli/userstatus.go
+++ b/cli/userstatus.go
@@ -40,8 +40,8 @@ func (r *RootCmd) createUserStatusCommand(sdkStatus codersdk.UserStatus) *serpen
 		Use:     fmt.Sprintf("%s <username|user_id>", verb),
 		Short:   short,
 		Aliases: aliases,
-		Long: formatExamples(
-			example{
+		Long: FormatExamples(
+			Example{
 				Command: fmt.Sprintf("coder users %s example_user", verb),
 			},
 		),


### PR DESCRIPTION
I was unable to use `FormatExample` for my enterprise command. Exported it so I could.