### PR TITLE
ci: fix test-migrations target when main branch is not present locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -797,8 +797,11 @@ test-postgres: test-postgres-docker
 test-migrations: test-postgres-docker
 	echo "--- test migrations"
 	set -euo pipefail
-	COMMIT_FROM=$(shell git rev-parse --short HEAD)
-	COMMIT_TO=$(shell git rev-parse --short main)
+	COMMIT_FROM=$(shell git log -1 --format='%h' HEAD)
+	echo "COMMIT_FROM=$${COMMIT_FROM}"
+	COMMIT_TO=$(shell git log -1 --format='%h' origin/main)
+	echo "COMMIT_TO=$${COMMIT_TO}"
+	if [[ "$${COMMIT_FROM}" == "$${COMMIT_TO}" ]]; then echo "Nothing to do!"; exit 0; fi
 	echo "DROP DATABASE IF EXISTS migrate_test_$${COMMIT_FROM}; CREATE DATABASE migrate_test_$${COMMIT_FROM};" | psql 'postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable'
 	go run ./scripts/migrate-test/main.go --from="$$COMMIT_FROM" --to="$$COMMIT_TO" --postgres-url="postgresql://postgres:postgres@localhost:5432/migrate_test_$${COMMIT_FROM}?sslmode=disable"
 


### PR DESCRIPTION
https://github.com/coder/coder/actions/runs/8989166240/job/24691648877 appears to have failed because the local reference to `main` was not present. Additionally, `git rev-parse` produces a slightly cryptic error message when the ref specified does not exit.

To validate this, I deleted the `main` branch locally and observed the same error before the change. After the change, this works as intended.