### PR TITLE
ci: re-enable test migrations in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,9 +178,9 @@ jobs:
         env:
           EV_SIGNING_CERT: ${{ secrets.EV_SIGNING_CERT }}
 
-      # - name: Test migrations from current ref to main
-      #   run: |
-      #     make test-migrations
+      - name: Test migrations from current ref to main
+        run: |
+          make test-migrations
 
       # Setup GCloud for signing Windows binaries.
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
Tested here: https://github.com/coder/coder/actions/runs/9126619620/job/25095263706#step:17:101

Also makes the output "friendlier" in case of failure:

```
Migrating from version "9f4d2966a" to "f23d4802b" failed:
        migrate setup: create iofs: failed to init driver with path .: duplicate migration file: 000208_notification_banners.down.sql
Check the following:
 - All migrations from version "f23d4802b" must exist in version "9f4d2966a" with the same migration numbers.
 - Each migration must have the same effect.
 - There must be no gaps or duplicates in the migration numbers.
```