### PR TITLE
chore(scripts): remove `gh_auth` from `release.sh`

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -113,9 +113,6 @@ done
 # Check dependencies.
 dependencies gh jq sort
 
-# Authenticate gh CLI
-gh_auth
-
 if [[ -z $increment ]]; then
 	# Default to patch versions.
 	increment="patch"


### PR DESCRIPTION
It breaks the `gh` cli for creating workflows.