### PR TITLE
fix(site): correct the size and position of the timeline trail in safari

### DIFF
--- a/site/src/components/Timeline/TimelineEntry.tsx
+++ b/site/src/components/Timeline/TimelineEntry.tsx
@@ -14,16 +14,19 @@ export const TimelineEntry = forwardRef<
       ref={ref}
       css={(theme) => [
         {
-          position: "relative",
           "&:focus": {
             outlineStyle: "solid",
             outlineOffset: -1,
             outlineWidth: 2,
             outlineColor: theme.palette.primary.main,
           },
+          "& td": {
+            position: "relative",
+            overflow: "hidden",
+          },
           "& td:before": {
             position: "absolute",
-            left: 50,
+            left: 49, // 50px - (width / 2)
             display: "block",
             content: "''",
             height: "100%",


### PR DESCRIPTION
Closes #11257

See the issue for a screenshot of the bug. This change just makes the behavior in Safari match the existing appearance in Chromium.