### PR TITLE
docs: unset cred helper

### DIFF
--- a/docs/admin/external-auth.md
+++ b/docs/admin/external-auth.md
@@ -227,6 +227,13 @@ add this to the
 git config --global credential.useHttpPath true
 ```
 
+We also recommend unsetting the `credentialHelper` git configuration, to prevent
+any possible conflicts:
+
+```shell
+git config --global --unset credential.helper
+```
+
 ### Kubernetes environment variables
 
 If you deployed Coder with Kubernetes you can set the environment variables in


### PR DESCRIPTION
a large customer provided feedback when configuring an external auth flow. they had a conflict with a previously set `credentialHelper`, which caused friction and troubleshooting time.

this PR adds a note recommending to unset this value.