### PR TITLE
chore: added jetbrains fleet link to manifest.json

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -286,6 +286,11 @@
           "path": "./ides/gateway.md"
         },
         {
+          "title": "JetBrains Fleet",
+          "description": "Learn how to configure JetBrains Fleet for your workspaces",
+          "path": "./ides/fleet.md"
+        },
+        {
           "title": "Emacs",
           "description": "Learn how to configure Emacs with TRAMP in Coder",
           "path": "./ides/emacs-tramp.md"


### PR DESCRIPTION
fixes broken link:
- https://coder.com/docs/ides/fleet
On IDEs page
- https://coder.com/docs/ides