### PR TITLE
fix: stop logging workspace agent unless verbose

### DIFF
--- a/cli/ping.go
+++ b/cli/ping.go
@@ -48,19 +48,17 @@ func (r *RootCmd) ping() *serpent.Command {
 				return err
 			}
 
-			logger := inv.Logger
+			opts := &workspacesdk.DialAgentOptions{}
+
 			if r.verbose {
-				logger = logger.AppendSinks(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelDebug)
+				opts.Logger = inv.Logger.AppendSinks(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelDebug)
 			}
 
 			if r.disableDirect {
 				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
+				opts.BlockEndpoints = true
 			}
-			conn, err := workspacesdk.New(client).
-				DialAgent(ctx, workspaceAgent.ID, &workspacesdk.DialAgentOptions{
-					Logger:         logger,
-					BlockEndpoints: r.disableDirect,
-				})
+			conn, err := workspacesdk.New(client).DialAgent(ctx, workspaceAgent.ID, opts)
 			if err != nil {
 				return err
 			}

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -95,19 +95,18 @@ func (r *RootCmd) portForward() *serpent.Command {
 				return xerrors.Errorf("await agent: %w", err)
 			}
 
+			opts := &workspacesdk.DialAgentOptions{}
+
 			logger := inv.Logger
 			if r.verbose {
-				logger = logger.AppendSinks(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelDebug)
+				opts.Logger = logger.AppendSinks(sloghuman.Sink(inv.Stdout)).Leveled(slog.LevelDebug)
 			}
 
 			if r.disableDirect {
 				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
+				opts.BlockEndpoints = true
 			}
-			conn, err := workspacesdk.New(client).
-				DialAgent(ctx, workspaceAgent.ID, &workspacesdk.DialAgentOptions{
-					Logger:         logger,
-					BlockEndpoints: r.disableDirect,
-				})
+			conn, err := workspacesdk.New(client).DialAgent(ctx, workspaceAgent.ID, opts)
 			if err != nil {
 				return err
 			}

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -56,13 +56,9 @@ func (r *RootCmd) speedtest() *serpent.Command {
 				return xerrors.Errorf("await agent: %w", err)
 			}
 
-			logger := inv.Logger.AppendSinks(sloghuman.Sink(inv.Stderr))
+			opts := &workspacesdk.DialAgentOptions{}
 			if r.verbose {
-				logger = logger.Leveled(slog.LevelDebug)
-			}
-
-			opts := &workspacesdk.DialAgentOptions{
-				Logger: logger,
+				opts.Logger = inv.Logger.AppendSinks(sloghuman.Sink(inv.Stderr)).Leveled(slog.LevelDebug)
 			}
 			if r.disableDirect {
 				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")


### PR DESCRIPTION
Output from `coder speedtest`, `coder port-forward` and `coder ping` includes logging from the `tailnet.Conn`, which doesn't really match the plain, human readable text output of these commands.  E.g.

```
2024-05-28 10:09:50.898 [info]  updating engine DERP map  derp_map="{\"Regions\":{\"1000\":{\"EmbeddedRelay\":false,\"RegionID\":1000,\"RegionCode\":\"coder_stun_1000\",\"RegionName\":\"Coder STUN 1000\",\"Nodes\":[{\"Name\":\"1000stun0\",\"RegionID\":1000,\"HostName\":\"stun.l.google.com\",\"STUNPort\":19302,\"STUNOnly\":true}]},\"1001\":{\"EmbeddedRelay\":false,\"RegionID\":1001,\"RegionCode\":\"coder_stun_1001\",\"RegionName\":\"Coder STUN 1001\",\"Nodes\":[{\"Name\":\"1001stun0\",\"RegionID\":1001,\"HostName\":\"stun1.l.google.com\",\"STUNPort\":19302,\"STUNOnly\":true}]},\"10013\":{\"EmbeddedRelay\":false,\"RegionID\":10013,\"RegionCode\":\"coder_paris-fly\",\"RegionName\":\"Europe Fly.io (Paris)\",\"Nodes\":[{\"Name\":\"10013a\",\"RegionID\":10013,\"HostName\":\"paris.fly.dev.coder.com\",\"STUNPort\":-1,\"DERPPort\":443}]},\"10015\":{\"EmbeddedRelay\":false,\"RegionID\":10015,\"RegionCode\":\"coder_sydney-fly\",\"RegionName\":\"Australia Fly.io (Sydney)\",\"Nodes\":[{\"Name\":\"10015a\",\"RegionID\":10015,\"HostName\":\"sydney.fly.dev.coder.com\",\"STUNPort\":-1,\"DERPPort\":443}]},\"10016\":{\"EmbeddedRelay\":false,\"RegionID\":10016,\"RegionCode\":\"coder_sao-paulo-fly\",\"RegionName\":\"Brazil Fly.io (Sao Paulo)\",\"Nodes\":[{\"Name\":\"10016a\",\"RegionID\":10016,\"HostName\":\"sao-paulo.fly.dev.coder.com\",\"STUNPort\":-1,\"DERPPort\":443}]},\"10018\":{\"EmbeddedRelay\":false,\"RegionID\":10018,\"RegionCode\":\"coder_johannesburg-fly\",\"RegionName\":\"South Africa Fly.io (Johannesburg)\",\"Nodes\":[{\"Name\":\"10018a\",\"RegionID\":10018,\"HostName\":\"jnb.fly.dev.coder.com\",\"STUNPort\":-1,\"DERPPort\":443}]},\"1002\":{\"EmbeddedRelay\":false,\"RegionID\":1002,\"RegionCode\":\"coder_stun_1002\",\"RegionName\":\"Coder STUN 1002\",\"Nodes\":[{\"Name\":\"1002stun0\",\"RegionID\":1002,\"HostName\":\"stun2.l.google.com\",\"STUNPort\":19302,\"STUNOnly\":true}]},\"1003\":{\"EmbeddedRelay\":false,\"RegionID\":1003,\"RegionCode\":\"coder_stun_1003\",\"RegionName\":\"Coder STUN 1003\",\"Nodes\":[{\"Name\":\"1003stun0\",\"RegionID\":1003,\"HostName\":\"stun3.l.google.com\",\"STUNPort\":19302,\"STUNOnly\":true}]},\"1004\":{\"EmbeddedRelay\":false,\"RegionID\":1004,\"RegionCode\":\"coder_stun_1004\",\"RegionName\":\"Coder STUN 1004\",\"Nodes\":[{\"Name\":\"1004stun0\",\"RegionID\":1004,\"HostName\":\"stun4.l.google.com\",\"STUNPort\":19302,\"STUNOnly\":true}]},\"999\":{\"EmbeddedRelay\":true,\"RegionID\":999,\"RegionCode\":\"coder\",\"RegionName\":\"Council Bluffs, Iowa\",\"Nodes\":[{\"Name\":\"999b\",\"RegionID\":999,\"HostName\":\"dev.coder.com\",\"STUNPort\":-1,\"DERPPort\":443}]}}}"
2024-05-28 10:09:50.898 [info]  updating engine network map  network_map="netmap: self: [bqyfb] auth=machine-unknown u=? [fd7a:115c:a1e0:46da:b312:5e11:ec77:f271/128]\n"
2024-05-28 10:09:50.899 [info]  updating engine filter  filter="&{logf:0x103ce9170 local:0x140007a0060 logIPs:0x140007a0078 matches4:[{IPProto:[6 17 1 58 132] Srcs:[{ip:{addr:{hi:0 lo:281470681743360} z:0x1400000e078} bitsPlusOne:1}] Dsts:[{Net:{ip:{addr:{hi:0 lo:281470681743360} z:0x1400000e078} bitsPlusOne:1} Ports:{First:0 Last:65535}}] Caps:[]}] matches6:[{IPProto:[6 17 1 58 132] Srcs:[{ip:{addr:{hi:0 lo:0} z:0x1400000e090} bitsPlusOne:1}] Dsts:[{Net:{ip:{addr:{hi:0 lo:0} z:0x1400000e090} bitsPlusOne:1} Ports:{First:0 Last:65535}}] Caps:[]}] cap4:[] cap6:[] state:0x14000788930 shieldsUp:false}"
2024-05-28 10:09:52.067 [info]  updating engine network map  network_map="netmap: self: [bqyfb] auth=machine-unknown u=? [fd7a:115c:a1e0:46da:b312:5e11:ec77:f271/128]\n [W+fRR] d:52eb7800464fe556 D999 fd7a:115c:a1e0:4f25:bb75:b198:9e47:ea4e/128 fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4/128 :      3.19.66.22:33328      10.1.2.106:33328\n"
209ms via coder
Starting a 5s download test...
INTERVAL       THROUGHPUT
0.00-1.53 sec  10.9499 Mbits/sec
1.53-2.62 sec  76.8738 Mbits/sec
2.62-3.68 sec  79.7098 Mbits/sec
3.68-4.73 sec  79.7699 Mbits/sec
4.73-5.36 sec  79.3592 Mbits/sec
----------------------------------
0.00-5.36 sec  59.4535 Mbits/sec
2024-05-28 10:10:00.341 [info]  closing tailnet Conn
2024-05-28 10:10:00.342 [info]  closing tailnet Conn
```

I don't think we should be writing logs out to stderr unless `--verbose` is set.