### PR TITLE
chore: add refresh token and error to user's external auth page 

### DIFF
--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
   MockGithubAuthLink,
   MockGithubExternalProvider,
-  MockGithubValidateErrorAuthLink,
 } from "testHelpers/entities";
 import { ExternalAuthPageView } from "./ExternalAuthPageView";
 
@@ -69,7 +68,23 @@ export const Failed: Story = {
       providers: [MockGithubExternalProvider],
       links: [
         {
-          ...MockGithubValidateErrorAuthLink,
+          ...MockGithubAuthLink,
+          validate_error: "Failed to refresh token",
+        },
+      ],
+    },
+  },
+};
+
+export const NoRefresh: Story = {
+  args: {
+    ...meta.args,
+    auths: {
+      providers: [MockGithubExternalProvider],
+      links: [
+        {
+          ...MockGithubAuthLink,
+          has_refresh_token: false,
         },
       ],
     },

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.stories.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
   MockGithubAuthLink,
   MockGithubExternalProvider,
+  MockGithubValidateErrorAuthLink,
 } from "testHelpers/entities";
 import { ExternalAuthPageView } from "./ExternalAuthPageView";
 
@@ -55,6 +56,20 @@ export const Unauthenticated: Story = {
         {
           ...MockGithubAuthLink,
           authenticated: false,
+        },
+      ],
+    },
+  },
+};
+
+export const Failed: Story = {
+  args: {
+    ...meta.args,
+    auths: {
+      providers: [MockGithubExternalProvider],
+      links: [
+        {
+          ...MockGithubValidateErrorAuthLink,
         },
       ],
     },

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -1,8 +1,9 @@
 import { useTheme } from "@emotion/react";
-import CachedIcon from "@mui/icons-material/Cached";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
 import LoadingButton from "@mui/lab/LoadingButton";
 import Badge from "@mui/material/Badge";
 import Divider from "@mui/material/Divider";
+import { styled } from "@mui/material/styles";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -32,6 +33,7 @@ import {
 } from "components/MoreMenu/MoreMenu";
 import { TableEmpty } from "components/TableEmpty/TableEmpty";
 import type { ExternalAuthPollingState } from "pages/CreateWorkspacePage/CreateWorkspacePage";
+import { minWidth, padding, width } from "@mui/system";
 
 export type ExternalAuthPageViewProps = {
   isLoading: boolean;
@@ -108,6 +110,29 @@ interface ExternalAuthRowProps {
   onValidateExternalAuth: () => void;
 }
 
+const StyledBadge = styled(Badge)(({ theme }) => ({
+  "& .MuiBadge-badge": {
+    // Make a circular background for the icon. Background provides contrast, with a thin
+    // border to separate it from the avatar image.
+    backgroundColor: `${theme.palette.background.paper}`,
+    borderStyle: "solid",
+    borderColor: `${theme.palette.secondary.main}`,
+    borderWidth: "thin",
+
+    // The size of the badge content should be small, and should perfectly encapsulate the icon.
+    // By default, the style has padding and a fixed size, which is too large.
+    // Remove all default padding, and base the size off of the icon size. All based around text
+    // sizing.
+    // Ideally, we could use padding to accomplis this, but you have to override the default 'height' and
+    // 'width' properties.
+    padding: "0px",
+    minHeight: "0px",
+    minWidth: "0px",
+    height: "1.4em",
+    width: "1.4em",
+  },
+}));
+
 const ExternalAuthRow: FC<ExternalAuthRowProps> = ({
   app,
   unlinked,
@@ -140,22 +165,28 @@ const ExternalAuthRow: FC<ExternalAuthRowProps> = ({
   // attempt to authenticate when the token expires.
   if (link?.has_refresh_token && authenticated) {
     avatar = (
-      <Badge
+      <StyledBadge
         anchorOrigin={{
           vertical: "bottom",
           horizontal: "right",
         }}
+        color="default"
+        overlap="circular"
         badgeContent={
           <Tooltip
             title="Authentication token will automatically refresh when expired."
             placement="right"
           >
-            <CachedIcon fontSize="small" />
+            <AutorenewIcon
+              sx={{
+                fontSize: "1em",
+              }}
+            />
           </Tooltip>
         }
       >
         {avatar}
-      </Badge>
+      </StyledBadge>
     );
   }
 

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -141,6 +141,8 @@ const ExternalAuthRow: FC<ExternalAuthRowProps> = ({
             )
           }
         />
+        {/* TODO: Style this! */}
+        {link?.validate_error}
       </TableCell>
       <TableCell css={{ textAlign: "right" }}>
         <LoadingButton

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from "@emotion/react";
 import CachedIcon from "@mui/icons-material/Cached";
 import LoadingButton from "@mui/lab/LoadingButton";
 import Badge from "@mui/material/Badge";
@@ -114,6 +115,7 @@ const ExternalAuthRow: FC<ExternalAuthRowProps> = ({
   onUnlinkExternalAuth,
   onValidateExternalAuth,
 }) => {
+  const theme = useTheme();
   const name = app.display_name || app.id || app.type;
   const authURL = "/external-auth/" + app.id;
 
@@ -161,8 +163,16 @@ const ExternalAuthRow: FC<ExternalAuthRowProps> = ({
     <TableRow key={app.id}>
       <TableCell>
         <AvatarData title={name} avatar={avatar} />
-        {/* TODO: Style this! */}
-        {link?.validate_error}
+        {link?.validate_error && (
+          <>
+            <span
+              css={{ paddingLeft: "1em", color: theme.palette.error.light }}
+            >
+              Error:{" "}
+            </span>
+            {link?.validate_error}
+          </>
+        )}
       </TableCell>
       <TableCell css={{ textAlign: "right" }}>
         <LoadingButton

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -33,7 +33,6 @@ import {
 } from "components/MoreMenu/MoreMenu";
 import { TableEmpty } from "components/TableEmpty/TableEmpty";
 import type { ExternalAuthPollingState } from "pages/CreateWorkspacePage/CreateWorkspacePage";
-import { margin, minWidth, padding, width } from "@mui/system";
 
 export type ExternalAuthPageViewProps = {
   isLoading: boolean;

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -33,7 +33,7 @@ import {
 } from "components/MoreMenu/MoreMenu";
 import { TableEmpty } from "components/TableEmpty/TableEmpty";
 import type { ExternalAuthPollingState } from "pages/CreateWorkspacePage/CreateWorkspacePage";
-import { minWidth, padding, width } from "@mui/system";
+import { margin, minWidth, padding, width } from "@mui/system";
 
 export type ExternalAuthPageViewProps = {
   isLoading: boolean;
@@ -119,17 +119,13 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
     borderColor: `${theme.palette.secondary.main}`,
     borderWidth: "thin",
 
-    // The size of the badge content should be small, and should perfectly encapsulate the icon.
-    // By default, the style has padding and a fixed size, which is too large.
-    // Remove all default padding, and base the size off of the icon size. All based around text
-    // sizing.
-    // Ideally, we could use padding to accomplis this, but you have to override the default 'height' and
-    // 'width' properties.
-    padding: "0px",
+    // Override the default minimum sizes, as they are larger than what we want.
     minHeight: "0px",
     minWidth: "0px",
-    height: "1.4em",
-    width: "1.4em",
+    // Override the default "height", which is usually set to some constant value.
+    height: "auto",
+    // Padding adds some room for the icon to live in.
+    padding: "0.1em",
   },
 }));
 

--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPageView.tsx
@@ -1,4 +1,6 @@
+import CachedIcon from "@mui/icons-material/Cached";
 import LoadingButton from "@mui/lab/LoadingButton";
+import Badge from "@mui/material/Badge";
 import Divider from "@mui/material/Divider";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -6,6 +8,7 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import Tooltip from "@mui/material/Tooltip";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import { type FC, useState, useCallback, useEffect } from "react";
 import { useQuery } from "react-query";
@@ -125,22 +128,39 @@ const ExternalAuthRow: FC<ExternalAuthRowProps> = ({
     ? externalAuth.authenticated
     : link?.authenticated ?? false;
 
+  let avatar = app.display_icon ? (
+    <Avatar src={app.display_icon} variant="square" fitImage size="sm" />
+  ) : (
+    <Avatar>{name}</Avatar>
+  );
+
+  // If the link is authenticated and has a refresh token, show that it will automatically
+  // attempt to authenticate when the token expires.
+  if (link?.has_refresh_token && authenticated) {
+    avatar = (
+      <Badge
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        badgeContent={
+          <Tooltip
+            title="Authentication token will automatically refresh when expired."
+            placement="right"
+          >
+            <CachedIcon fontSize="small" />
+          </Tooltip>
+        }
+      >
+        {avatar}
+      </Badge>
+    );
+  }
+
   return (
     <TableRow key={app.id}>
       <TableCell>
-        <AvatarData
-          title={name}
-          avatar={
-            app.display_icon && (
-              <Avatar
-                src={app.display_icon}
-                variant="square"
-                fitImage
-                size="sm"
-              />
-            )
-          }
-        />
+        <AvatarData title={name} avatar={avatar} />
         {/* TODO: Style this! */}
         {link?.validate_error}
       </TableCell>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3455,16 +3455,6 @@ export const MockGithubAuthLink: TypesGen.ExternalAuthLink = {
   validate_error: "",
 };
 
-export const MockGithubValidateErrorAuthLink: TypesGen.ExternalAuthLink = {
-  provider_id: "github",
-  created_at: "",
-  updated_at: "",
-  has_refresh_token: true,
-  expires: "",
-  authenticated: false,
-  validate_error: "Failed to refresh token.",
-};
-
 export const MockOAuth2ProviderApps: TypesGen.OAuth2ProviderApp[] = [
   {
     id: "1",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -3455,6 +3455,16 @@ export const MockGithubAuthLink: TypesGen.ExternalAuthLink = {
   validate_error: "",
 };
 
+export const MockGithubValidateErrorAuthLink: TypesGen.ExternalAuthLink = {
+  provider_id: "github",
+  created_at: "",
+  updated_at: "",
+  has_refresh_token: true,
+  expires: "",
+  authenticated: false,
+  validate_error: "Failed to refresh token.",
+};
+
 export const MockOAuth2ProviderApps: TypesGen.OAuth2ProviderApp[] = [
   {
     id: "1",


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/13381

# What this does

We have 2 fields, `has_refresh_token` and `validate_error` on external authentication links that are not being exposed to the UI. Multiple users have asked how to determine if refresh tokens are being returned from the IDP.

This allows more user self serve for debugging.

# `has_refresh_token` icon

A little "refresh" icon shown as an avatar badge with tooltip if the link has a refresh token.


![Screenshot from 2024-05-28 13-36-44](https://github.com/coder/coder/assets/5446298/cba5aee3-6181-46ec-9902-f470aa984b06)


# Validate error

Displays the error below the link. (Ignore my typo of "Refresh")

![Screenshot from 2024-05-28 09-32-18](https://github.com/coder/coder/assets/5446298/5f8046ab-dba5-44d2-b948-a64bb4ceb635)


# Future work

Can probably be styled better in the future.