### PR TITLE
chore(scripts): handle renamed cherry-pick commits in release script

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -96,6 +96,8 @@ main() {
 	# and main. These are sorted by commit title so that we can group
 	# two cherry-picks together.
 	declare -A cherry_pick_commits
+	declare -A renamed_cherry_pick_commits
+	declare -a renamed_cherry_pick_commits_pending
 	git_cherry_out=$(
 		{
 			git log --no-merges --cherry-mark --pretty=format:"%m %H %s" "${to_ref}...origin/main"
@@ -109,20 +111,45 @@ main() {
 		# Iterate over the array in groups of two
 		for ((i = 0; i < ${#cherry_picks[@]}; i += 2)); do
 			mapfile -d ' ' -t parts1 <<<"${cherry_picks[i]}"
-			mapfile -d ' ' -t parts2 <<<"${cherry_picks[i + 1]}"
 			commit1=${parts1[1]}
 			title1=${parts1[*]:2}
-			commit2=${parts2[1]}
-			title2=${parts2[*]:2}
+
+			title2=
+			if ((i + 1 < ${#cherry_picks[@]})); then
+				mapfile -d ' ' -t parts2 <<<"${cherry_picks[i + 1]}"
+				commit2=${parts2[1]}
+				title2=${parts2[*]:2}
+			fi
 
 			if [[ ${title1} != "${title2}" ]]; then
-				error "Invariant failed, cherry-picked commits have different titles: ${title1} != ${title2}"
+				log "Invariant failed, cherry-picked commits have different titles: ${title1} != ${title2}, attempting to check commit body for cherry-pick information..."
+
+				renamed=$(git show "${commit1}" | sed -ne 's/.*cherry picked from commit \([0-9a-f]*\).*/\1/p')
+				if [[ -n ${renamed} ]]; then
+					log "Found renamed cherry-pick commit ${commit1} -> ${renamed}"
+					renamed_cherry_pick_commits[${commit1}]=${renamed}
+					renamed_cherry_pick_commits[${renamed}]=${commit1}
+					continue
+				else
+					log "Not a cherry-pick commit, adding ${commit1} to pending list..."
+					renamed_cherry_pick_commits_pending+=("${commit1}")
+				fi
+				# error "Invariant failed, cherry-picked commits have different titles: ${title1} != ${title2}"
+				((i--))
+				continue
 			fi
 
 			cherry_pick_commits[${commit1}]=${commit2}
 			cherry_pick_commits[${commit2}]=${commit1}
 		done
 	fi
+	for commit in "${renamed_cherry_pick_commits_pending[@]}"; do
+		log "Checking if pending commit ${commit} has a corresponding cherry-pick..."
+		if [[ ! -v renamed_cherry_pick_commits[${commit}] ]]; then
+			error "Invariant failed, cherry-picked commit ${commit} has no corresponding original commit"
+		fi
+		log "Found matching cherry-pick commit ${commit} -> ${renamed_cherry_pick_commits[${commit}]}"
+	done
 
 	# Get abbreviated and full commit hashes and titles for each commit.
 	git_log_out="$(git log --no-merges --left-right --pretty=format:"%m %h %H %s" "${range}")"


### PR DESCRIPTION
This came up for the next release:

```
❯ ./scripts/release/check_commit_metadata.sh v2.11.2 5789ea5397c080058e254e3d7aa895fb5e95ad16
Checking commit metadata for changes between v2.11.2 and 5789ea5397c080058e254e3d7aa895fb5e95ad16...
ERROR: Invariant failed, cherry-picked commits have different titles: chore: generate terraform testdata with matching terraform version (#13343)
 != ci: disable make test-migrations in release.yaml (#13201)
```

Fix:

```
Checking commit metadata for changes between v2.11.2 and 5789ea5397c080058e254e3d7aa895fb5e95ad16...
Invariant failed, cherry-picked commits have different titles: chore: generate terraform testdata with matching terraform version (#13343)
 != ci: disable make test-migrations in release.yaml (#13201)
, attempting to check commit body for cherry-pick information...
Not a cherry-pick commit, adding 3364abecdd8bbbf89a82d073d2b405fc623bb174 to pending list...
Invariant failed, cherry-picked commits have different titles: fix: properly detect agent resouces in terraform (#13343)
 != , attempting to check commit body for cherry-pick information...
Found renamed cherry-pick commit 9c5fc3bbbb77a08ebe5cfd5de3bdd4a2e8cbc547 -> 3364abecdd8bbbf89a82d073d2b405fc623bb174
Checking if pending commit 3364abecdd8bbbf89a82d073d2b405fc623bb174 has a corresponding cherry-pick...
Found matching cherry-pick commit 3364abecdd8bbbf89a82d073d2b405fc623bb174 -> 9c5fc3bbbb77a08ebe5cfd5de3bdd4a2e8cbc547
```