### PR TITLE
chore: return failed refresh errors on external auth as string (was boolean)

### DIFF
--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -351,16 +351,17 @@ func (api *API) listUserExternalAuths(rw http.ResponseWriter, r *http.Request) {
 		if link.OAuthAccessToken != "" {
 			cfg, ok := configs[link.ProviderID]
 			if ok {
-				newLink, invalidReason, err := cfg.RefreshToken(ctx, api.Database, link)
+				newLink, err := cfg.RefreshToken(ctx, api.Database, link)
 				meta := db2sdk.ExternalAuthMeta{
-					Authenticated: invalidReason.Valid(),
-					ValidateError: invalidReason.String(),
+					Authenticated: err == nil,
 				}
 				if err != nil {
 					meta.ValidateError = err.Error()
 				}
+				linkMeta[link.ProviderID] = meta
+
 				// Update the link if it was potentially refreshed.
-				if err == nil && invalidReason.Valid() {
+				if err == nil {
 					links[i] = newLink
 				}
 			}

--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -351,15 +351,16 @@ func (api *API) listUserExternalAuths(rw http.ResponseWriter, r *http.Request) {
 		if link.OAuthAccessToken != "" {
 			cfg, ok := configs[link.ProviderID]
 			if ok {
-				newLink, valid, err := cfg.RefreshToken(ctx, api.Database, link)
+				newLink, invalidReason, err := cfg.RefreshToken(ctx, api.Database, link)
 				meta := db2sdk.ExternalAuthMeta{
-					Authenticated: valid,
+					Authenticated: invalidReason.Valid(),
+					ValidateError: invalidReason.String(),
 				}
 				if err != nil {
 					meta.ValidateError = err.Error()
 				}
 				// Update the link if it was potentially refreshed.
-				if err == nil && valid {
+				if err == nil && invalidReason.Valid() {
 					links[i] = newLink
 				}
 			}

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -123,9 +123,11 @@ func (c *Config) RefreshToken(ctx context.Context, db database.Store, externalAu
 		Expiry:       externalAuthLink.OAuthExpiry,
 	}).Token()
 	if err != nil {
-		// Even if the token fails to be obtained, we still return false because
-		// we aren't trying to surface an error, we're just trying to obtain a valid token.
-		return externalAuthLink, false, nil
+		// TokenSource will always return the current status token if not-expired.
+		// If the token is expired, it will attempt to refresh. An error is returned
+		// if the refresh fails, meaning the existing token is expired and this function
+		// was unable to obtain a valid one.
+		return externalAuthLink, false, err
 	}
 
 	extra, err := c.GenerateTokenExtra(token)

--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -105,10 +105,7 @@ func (e InvalidTokenError) Error() string {
 
 func IsInvalidTokenError(err error) bool {
 	var invalidTokenError InvalidTokenError
-	if xerrors.As(err, &invalidTokenError) {
-		return true
-	}
-	return false
+	return xerrors.As(err, &invalidTokenError)
 }
 
 // RefreshToken automatically refreshes the token if expired and permitted.

--- a/coderd/externalauth/externalauth_test.go
+++ b/coderd/externalauth/externalauth_test.go
@@ -108,7 +108,7 @@ func TestRefreshToken(t *testing.T) {
 		_, refreshed, err := config.RefreshToken(context.Background(), nil, database.ExternalAuthLink{
 			OAuthExpiry: expired,
 		})
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.False(t, refreshed)
 	})
 

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -559,11 +559,11 @@ func (s *server) acquireProtoJob(ctx context.Context, job database.ProvisionerJo
 				continue
 			}
 
-			link, valid, err := config.RefreshToken(ctx, s.Database, link)
+			link, invalidReason, err := config.RefreshToken(ctx, s.Database, link)
 			if err != nil {
 				return nil, failJob(fmt.Sprintf("refresh external auth link %q: %s", p.ID, err))
 			}
-			if !valid {
+			if invalidReason.Invalid() {
 				continue
 			}
 			externalAuthProviders = append(externalAuthProviders, &sdkproto.ExternalAuthProvider{

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -353,7 +353,7 @@ func (api *API) templateVersionExternalAuth(rw http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		_, updated, err := config.RefreshToken(ctx, api.Database, authLink)
+		_, invalidReason, err := config.RefreshToken(ctx, api.Database, authLink)
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to refresh external auth token.",
@@ -361,13 +361,8 @@ func (api *API) templateVersionExternalAuth(rw http.ResponseWriter, r *http.Requ
 			})
 			return
 		}
-		// If the token couldn't be validated, then we assume the user isn't
-		// authenticated and return early.
-		if !updated {
-			providers = append(providers, provider)
-			continue
-		}
-		provider.Authenticated = true
+
+		provider.Authenticated = invalidReason.Valid()
 		providers = append(providers, provider)
 	}
 

--- a/coderd/templateversions.go
+++ b/coderd/templateversions.go
@@ -353,8 +353,8 @@ func (api *API) templateVersionExternalAuth(rw http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		_, invalidReason, err := config.RefreshToken(ctx, api.Database, authLink)
-		if err != nil {
+		_, err = config.RefreshToken(ctx, api.Database, authLink)
+		if err != nil && !externalauth.IsInvalidTokenError(err) {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to refresh external auth token.",
 				Detail:  err.Error(),
@@ -362,7 +362,7 @@ func (api *API) templateVersionExternalAuth(rw http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		provider.Authenticated = invalidReason.Valid()
+		provider.Authenticated = err == nil
 		providers = append(providers, provider)
 	}
 

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1912,7 +1912,7 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	externalAuthLink, valid, err := externalAuthConfig.RefreshToken(ctx, api.Database, externalAuthLink)
+	externalAuthLink, invalidReason, err := externalAuthConfig.RefreshToken(ctx, api.Database, externalAuthLink)
 	if err != nil {
 		handleRetrying(http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to refresh external auth token.",
@@ -1920,7 +1920,7 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 		})
 		return
 	}
-	if !valid {
+	if invalidReason.Invalid() {
 		// Set the previous token so the retry logic will skip validating the
 		// same token again. This should only be set if the token is invalid and there
 		// was no error. If it is invalid because of an error, then we should recheck.

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1912,25 +1912,25 @@ func (api *API) workspaceAgentsExternalAuth(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	externalAuthLink, invalidReason, err := externalAuthConfig.RefreshToken(ctx, api.Database, externalAuthLink)
-	if err != nil {
+	refreshedLink, err := externalAuthConfig.RefreshToken(ctx, api.Database, externalAuthLink)
+	if err != nil && !externalauth.IsInvalidTokenError(err) {
 		handleRetrying(http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to refresh external auth token.",
 			Detail:  err.Error(),
 		})
 		return
 	}
-	if invalidReason.Invalid() {
+	if err != nil {
 		// Set the previous token so the retry logic will skip validating the
 		// same token again. This should only be set if the token is invalid and there
 		// was no error. If it is invalid because of an error, then we should recheck.
-		previousToken = &externalAuthLink
+		previousToken = &refreshedLink
 		handleRetrying(http.StatusOK, agentsdk.ExternalAuthResponse{
 			URL: redirectURL.String(),
 		})
 		return
 	}
-	resp, err := createExternalAuthResponse(externalAuthConfig.Type, externalAuthLink.OAuthAccessToken, externalAuthLink.OAuthExtra)
+	resp, err := createExternalAuthResponse(externalAuthConfig.Type, refreshedLink.OAuthAccessToken, refreshedLink.OAuthExtra)
 	if err != nil {
 		handleRetrying(http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to create external auth response.",


### PR DESCRIPTION
Failed refreshing of tokens should return the error for debugging. The function no longer returns a boolean, and only returns an error. So the error can be checked if it is a validation error, or a runtime error.

This was added because multiple reports of failed refreshes have occurred. Debugging these failures are extremely difficult since errors are silenced. This will begin to raise said errors.

We might want to clean up errors from IDPs in the future if they get a bit too technical in their verbage.