### PR TITLE
chore: modify preview deployment script to work with forks

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -34,6 +34,17 @@ permissions:
   pull-requests: write # needed for commenting on PRs
 
 jobs:
+  check_membership:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if actor is a member
+        run: |
+          set -euo pipefail
+          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/orgs/coder/members/${{ github.actor }}")
+          if [[ "$response" == "404" ]]; then
+            echo "Error: Only members of the coder organization can trigger this workflow."
+            exit 1
+          fi
   check_pr:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -euo pipefail
           pr_open=true
-          if [[ "$(gh pr status --json state --repo=coder/coder --jq '.createdBy[0].state')" != "OPEN" ]]; then
+          if [[ "$(gh pr list --repo=coder/coder -H $(git rev-parse --abbrev-ref HEAD) --json state --jq '.[].state')" != "OPEN" ]]; then
             >&2 echo "PR doesn't exist or is closed."
             pr_open=false
           fi

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -47,8 +47,8 @@ jobs:
         run: |
           set -euo pipefail
           pr_open=true
-          if [[ "$(gh pr view --json state | jq -r '.state')" != "OPEN" ]]; then
-            echo "PR doesn't exist or is closed."
+          if [[ "$(gh pr status --json state --repo=coder/coder --jq '.createdBy[0].state')" != "OPEN" ]]; then
+            >&2 echo "PR doesn't exist or is closed."
             pr_open=false
           fi
           echo "pr_open=$pr_open" >> $GITHUB_OUTPUT

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -71,8 +71,9 @@ fi
 gh_auth
 
 # get branch name and pr number
-branchName=$(gh pr view --json headRefName | jq -r .headRefName)
-prNumber=$(gh pr view --json number | jq -r .number)
+info=$(gh pr status --repo=coder/coder --json headRefName,number --jq '.createdBy[0]')
+branchName=$(echo "${info}" | jq -r .headRefName)
+prNumber=$(echo "${info}" | jq -r .number)
 
 if [[ "$dryRun" = true ]]; then
 	echo "dry run"

--- a/scripts/deploy-pr.sh
+++ b/scripts/deploy-pr.sh
@@ -71,9 +71,8 @@ fi
 gh_auth
 
 # get branch name and pr number
-info=$(gh pr status --repo=coder/coder --json headRefName,number --jq '.createdBy[0]')
-branchName=$(echo "${info}" | jq -r .headRefName)
-prNumber=$(echo "${info}" | jq -r .number)
+branchName=$(git rev-parse --abbrev-ref HEAD)
+prNumber=$(gh pr list --repo=coder/coder -H ${branchName} --json number --jq '.[].number')
 
 if [[ "$dryRun" = true ]]; then
 	echo "dry run"


### PR DESCRIPTION
I maintain a fork of coder at `dannykopping/coder`.

When a branch exists in a fork only, the current preview deployment scripts break.
This PR modifies the script & action to reference the `coder/coder` repo explicitly for the PR.

_I also changed to `pr status` because `pr view` does not work with `--repo`._