### PR TITLE
ci: build base image on PRs

### DIFF
--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -66,6 +66,7 @@ jobs:
             ghcr.io/coder/coder-base:latest
 
       - name: Verify that images are pushed properly
+        if : github.event_name != 'pull_request'
         run: |
           # retry 10 times with a 5 second delay as the images may not be
           # available immediately

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - scripts/Dockerfile.base
       - scripts/Dockerfile
+  
+  pull_request:
+    paths:
+      - scripts/Dockerfile.base
 
   schedule:
     # Run every week at 09:43 on Monday, Wednesday and Friday. We build this

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -7,7 +7,7 @@ on:
     paths:
       - scripts/Dockerfile.base
       - scripts/Dockerfile
-  
+
   pull_request:
     paths:
       - scripts/Dockerfile.base
@@ -66,7 +66,7 @@ jobs:
             ghcr.io/coder/coder-base:latest
 
       - name: Verify that images are pushed properly
-        if : github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           # retry 10 times with a 5 second delay as the images may not be
           # available immediately

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -61,7 +61,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           pull: true
           no-cache: true
-          push: true
+          push: github.event_name != 'pull_request'
           tags: |
             ghcr.io/coder/coder-base:latest
 


### PR DESCRIPTION
This will prevent events like #13407 in future.

@ammario @kylecarbs, we should probably also mark this as a required workflow.