### PR TITLE
fix: revert bump alpine from 3.19.1 to 3.20.0 in /scripts (#13375)

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -1,7 +1,7 @@
 # This is the base image used for Coder images. It's a multi-arch image that is
 # built in depot.dev for all supported architectures. Since it's built on real
 # hardware and not cross-compiled, it can have "RUN" commands.
-FROM alpine:3.20.0
+FROM alpine:3.19.1
 
 # We use a single RUN command to reduce the number of layers in the image.
 # NOTE: Keep the Terraform version in sync with minTerraformVersion and

--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
 		curl \
 		wget \
 		bash \
-		git=2.45.1-r0 \
+		git=2.43.4-r0 \
 		openssl \
 		openssh-client && \
 	addgroup \


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/13407

This reverts commit 5b78ec97b601027fdba5a55ff70e612bc3103185.