### PR TITLE
chore: remove git pinning in base image

### DIFF
--- a/scripts/Dockerfile.base
+++ b/scripts/Dockerfile.base
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
 		curl \
 		wget \
 		bash \
-		git=2.45.1-r0 \
+		git \
 		openssl \
 		openssh-client && \
 	addgroup \


### PR DESCRIPTION
Alpine 3.20 includes 2.45.1 by default: https://git.alpinelinux.org/aports/tree/main/git/APKBUILD?h=3.20-stable#n56

Follow-up from https://github.com/coder/coder/pull/13411#issuecomment-2139028721

@coadler heads up, this removes the pinning you needed to add in https://github.com/coder/coder/pull/13299.