### PR TITLE
chore: move template meta last_used_at to workspacestats

### DIFF
--- a/coderd/schedule/template.go
+++ b/coderd/schedule/template.go
@@ -114,38 +114,38 @@ func VerifyTemplateAutostartRequirement(days uint8) error {
 }
 
 type TemplateScheduleOptions struct {
-	UserAutostartEnabled bool          `json:"user_autostart_enabled"`
-	UserAutostopEnabled  bool          `json:"user_autostop_enabled"`
-	DefaultTTL           time.Duration `json:"default_ttl"`
+	UserAutostartEnabled bool
+	UserAutostopEnabled  bool
+	DefaultTTL           time.Duration
 	// ActivityBump dictates the duration to bump the workspace's deadline by if
 	// Coder detects activity from the user. A value of 0 means no bumping.
-	ActivityBump time.Duration `json:"activity_bump"`
+	ActivityBump time.Duration
 	// AutostopRequirement dictates when the workspace must be restarted. This
 	// used to be handled by MaxTTL.
-	AutostopRequirement TemplateAutostopRequirement `json:"autostop_requirement"`
+	AutostopRequirement TemplateAutostopRequirement
 	// AutostartRequirement dictates when the workspace can be auto started.
-	AutostartRequirement TemplateAutostartRequirement `json:"autostart_requirement"`
+	AutostartRequirement TemplateAutostartRequirement
 	// FailureTTL dictates the duration after which failed workspaces will be
 	// stopped automatically.
-	FailureTTL time.Duration `json:"failure_ttl"`
+	FailureTTL time.Duration
 	// TimeTilDormant dictates the duration after which inactive workspaces will
 	// go dormant.
-	TimeTilDormant time.Duration `json:"time_til_dormant"`
+	TimeTilDormant time.Duration
 	// TimeTilDormantAutoDelete dictates the duration after which dormant workspaces will be
 	// permanently deleted.
-	TimeTilDormantAutoDelete time.Duration `json:"time_til_dormant_autodelete"`
+	TimeTilDormantAutoDelete time.Duration
 	// UpdateWorkspaceLastUsedAt updates the template's workspaces'
 	// last_used_at field. This is useful for preventing updates to the
 	// templates inactivity_ttl immediately triggering a dormant action against
 	// workspaces whose last_used_at field violates the new template
 	// inactivity_ttl threshold.
-	UpdateWorkspaceLastUsedAt bool `json:"update_workspace_last_used_at"`
+	UpdateWorkspaceLastUsedAt func(ctx context.Context, db database.Store, templateID uuid.UUID, lastUsedAt time.Time) error `json:"update_workspace_last_used_at"`
 	// UpdateWorkspaceDormantAt updates the template's workspaces'
 	// dormant_at field. This is useful for preventing updates to the
 	// templates locked_ttl immediately triggering a delete action against
 	// workspaces whose dormant_at field violates the new template time_til_dormant_autodelete
 	// threshold.
-	UpdateWorkspaceDormantAt bool `json:"update_workspace_dormant_at"`
+	UpdateWorkspaceDormantAt bool
 }
 
 // TemplateScheduleStore provides an interface for retrieving template

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/examples"
 )
@@ -726,6 +727,10 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 		failureTTL := time.Duration(req.FailureTTLMillis) * time.Millisecond
 		inactivityTTL := time.Duration(req.TimeTilDormantMillis) * time.Millisecond
 		timeTilDormantAutoDelete := time.Duration(req.TimeTilDormantAutoDeleteMillis) * time.Millisecond
+		var updateWorkspaceLastUsedAt workspacestats.UpdateTemplateWorkspacesLastUsedAtFunc
+		if req.UpdateWorkspaceLastUsedAt {
+			updateWorkspaceLastUsedAt = workspacestats.UpdateTemplateWorkspacesLastUsedAt
+		}
 
 		if defaultTTL != time.Duration(template.DefaultTTL) ||
 			activityBump != time.Duration(template.ActivityBump) ||
@@ -755,7 +760,7 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 				FailureTTL:                failureTTL,
 				TimeTilDormant:            inactivityTTL,
 				TimeTilDormantAutoDelete:  timeTilDormantAutoDelete,
-				UpdateWorkspaceLastUsedAt: req.UpdateWorkspaceLastUsedAt,
+				UpdateWorkspaceLastUsedAt: updateWorkspaceLastUsedAt,
 				UpdateWorkspaceDormantAt:  req.UpdateWorkspaceDormantAt,
 			})
 			if err != nil {

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -192,3 +192,16 @@ func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspac
 
 	return nil
 }
+
+type UpdateTemplateWorkspacesLastUsedAtFunc func(ctx context.Context, db database.Store, templateID uuid.UUID, lastUsedAt time.Time) error
+
+func UpdateTemplateWorkspacesLastUsedAt(ctx context.Context, db database.Store, templateID uuid.UUID, lastUsedAt time.Time) error {
+	err := db.UpdateTemplateWorkspacesLastUsedAt(ctx, database.UpdateTemplateWorkspacesLastUsedAtParams{
+		TemplateID: templateID,
+		LastUsedAt: lastUsedAt,
+	})
+	if err != nil {
+		return xerrors.Errorf("update template workspaces last used at: %w", err)
+	}
+	return nil
+}

--- a/enterprise/coderd/schedule/template.go
+++ b/enterprise/coderd/schedule/template.go
@@ -168,14 +168,10 @@ func (s *EnterpriseTemplateScheduleStore) Set(ctx context.Context, db database.S
 			return xerrors.Errorf("update deleting_at of all workspaces for new time_til_dormant_autodelete %q: %w", opts.TimeTilDormantAutoDelete, err)
 		}
 
-		if opts.UpdateWorkspaceLastUsedAt {
-			// nolint:gocritic // (#13146) Will be moved soon as part of refactor.
-			err = tx.UpdateTemplateWorkspacesLastUsedAt(ctx, database.UpdateTemplateWorkspacesLastUsedAtParams{
-				TemplateID: tpl.ID,
-				LastUsedAt: dbtime.Now(),
-			})
+		if opts.UpdateWorkspaceLastUsedAt != nil {
+			err = opts.UpdateWorkspaceLastUsedAt(ctx, tx, tpl.ID, s.now())
 			if err != nil {
-				return xerrors.Errorf("update template workspaces last_used_at: %w", err)
+				return xerrors.Errorf("update workspace last used at: %w", err)
 			}
 		}
 


### PR DESCRIPTION
Moves the updating of `last_used_at` for affected workspaces into the `workspacestat` package. 

Because of a cyclical import between `workspacestats` and `schedule` I've opted to pass the function into the schedule store. I've also removed the json tags from the options struct, as I don't believe the struct is serialized anywhere. 