### PR TITLE
chore: move Batcher and Tracker to workspacestats

### DIFF
--- a/coderd/agentapi/stats.go
+++ b/coderd/agentapi/stats.go
@@ -7,18 +7,12 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"github.com/google/uuid"
-
 	"cdr.dev/slog"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/workspacestats"
 )
-
-type StatsBatcher interface {
-	Add(now time.Time, agentID uuid.UUID, templateID uuid.UUID, userID uuid.UUID, workspaceID uuid.UUID, st *agentproto.Stats) error
-}
 
 type StatsAPI struct {
 	AgentFn                   func(context.Context) (database.WorkspaceAgent, error)

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -39,7 +39,7 @@ type statsBatcher struct {
 	lastStats       *agentproto.Stats
 }
 
-var _ workspacestats.StatsBatcher = &statsBatcher{}
+var _ workspacestats.Batcher = &statsBatcher{}
 
 func (b *statsBatcher) Add(now time.Time, agentID uuid.UUID, templateID uuid.UUID, userID uuid.UUID, workspaceID uuid.UUID, st *agentproto.Stats) error {
 	b.mu.Lock()

--- a/coderd/agentapi/stats_test.go
+++ b/coderd/agentapi/stats_test.go
@@ -39,7 +39,7 @@ type statsBatcher struct {
 	lastStats       *agentproto.Stats
 }
 
-var _ agentapi.StatsBatcher = &statsBatcher{}
+var _ workspacestats.StatsBatcher = &statsBatcher{}
 
 func (b *statsBatcher) Add(now time.Time, agentID uuid.UUID, templateID uuid.UUID, userID uuid.UUID, workspaceID uuid.UUID, st *agentproto.Stats) error {
 	b.mu.Lock()

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -187,7 +187,7 @@ type Options struct {
 	HTTPClient *http.Client
 
 	UpdateAgentMetrics func(ctx context.Context, labels prometheusmetrics.AgentMetricLabels, metrics []*agentproto.Stats_Metric)
-	StatsBatcher       *workspacestats.Batcher
+	StatsBatcher       *workspacestats.DBBatcher
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -43,7 +43,6 @@ import (
 	"github.com/coder/coder/v2/coderd/appearance"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/awsidentity"
-	"github.com/coder/coder/v2/coderd/batchstats"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
@@ -69,7 +68,6 @@ import (
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/workspacestats"
-	"github.com/coder/coder/v2/coderd/workspaceusage"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpc"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
@@ -189,7 +187,7 @@ type Options struct {
 	HTTPClient *http.Client
 
 	UpdateAgentMetrics func(ctx context.Context, labels prometheusmetrics.AgentMetricLabels, metrics []*agentproto.Stats_Metric)
-	StatsBatcher       *batchstats.Batcher
+	StatsBatcher       *workspacestats.Batcher
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
 
@@ -206,7 +204,7 @@ type Options struct {
 	// stats. This is used to provide insights in the WebUI.
 	DatabaseRolluper *dbrollup.Rolluper
 	// WorkspaceUsageTracker tracks workspace usage by the CLI.
-	WorkspaceUsageTracker *workspaceusage.Tracker
+	WorkspaceUsageTracker *workspacestats.UsageTracker
 }
 
 // @title Coder API
@@ -384,8 +382,8 @@ func New(options *Options) *API {
 	}
 
 	if options.WorkspaceUsageTracker == nil {
-		options.WorkspaceUsageTracker = workspaceusage.New(options.Database,
-			workspaceusage.WithLogger(options.Logger.Named("workspace_usage_tracker")),
+		options.WorkspaceUsageTracker = workspacestats.NewTracker(options.Database,
+			workspacestats.TrackerWithLogger(options.Logger.Named("workspace_usage_tracker")),
 		)
 	}
 
@@ -434,8 +432,7 @@ func New(options *Options) *API {
 			options.Database,
 			options.Pubsub,
 		),
-		dbRolluper:            options.DatabaseRolluper,
-		workspaceUsageTracker: options.WorkspaceUsageTracker,
+		dbRolluper: options.DatabaseRolluper,
 	}
 
 	var customRoleHandler CustomRoleHandler = &agplCustomRoleHandler{}
@@ -557,6 +554,7 @@ func New(options *Options) *API {
 		Pubsub:                options.Pubsub,
 		TemplateScheduleStore: options.TemplateScheduleStore,
 		StatsBatcher:          options.StatsBatcher,
+		UsageTracker:          options.WorkspaceUsageTracker,
 		UpdateAgentMetricsFn:  options.UpdateAgentMetrics,
 		AppStatBatchSize:      workspaceapps.DefaultStatsDBReporterBatchSize,
 	})
@@ -1301,8 +1299,7 @@ type API struct {
 	Acquirer *provisionerdserver.Acquirer
 	// dbRolluper rolls up template usage stats from raw agent and app
 	// stats. This is used to provide insights in the WebUI.
-	dbRolluper            *dbrollup.Rolluper
-	workspaceUsageTracker *workspaceusage.Tracker
+	dbRolluper *dbrollup.Rolluper
 }
 
 // Close waits for all WebSocket connections to drain before returning.
@@ -1341,7 +1338,7 @@ func (api *API) Close() error {
 		_ = (*coordinator).Close()
 	}
 	_ = api.agentProvider.Close()
-	api.workspaceUsageTracker.Close()
+	_ = api.statsReporter.Close()
 	return nil
 }
 

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -54,7 +54,6 @@ import (
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/autobuild"
 	"github.com/coder/coder/v2/coderd/awsidentity"
-	"github.com/coder/coder/v2/coderd/batchstats"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
@@ -71,7 +70,7 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
-	"github.com/coder/coder/v2/coderd/workspaceusage"
+	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/codersdk/drpc"
@@ -145,7 +144,7 @@ type Options struct {
 	// Logger should only be overridden if you expect errors
 	// as part of your test.
 	Logger       *slog.Logger
-	StatsBatcher *batchstats.Batcher
+	StatsBatcher *workspacestats.Batcher
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
 	AllowWorkspaceRenames              bool
@@ -272,10 +271,10 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	if options.StatsBatcher == nil {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		batcher, closeBatcher, err := batchstats.New(ctx,
-			batchstats.WithStore(options.Database),
+		batcher, closeBatcher, err := workspacestats.NewBatcher(ctx,
+			workspacestats.BatcherWithStore(options.Database),
 			// Avoid cluttering up test output.
-			batchstats.WithLogger(slog.Make(sloghuman.Sink(io.Discard))),
+			workspacestats.BatcherWithLogger(slog.Make(sloghuman.Sink(io.Discard))),
 		)
 		require.NoError(t, err, "create stats batcher")
 		options.StatsBatcher = batcher
@@ -337,10 +336,10 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		options.WorkspaceUsageTrackerTick = make(chan time.Time, 1) // buffering just in case
 	}
 	// Close is called by API.Close()
-	wuTracker := workspaceusage.New(
+	wuTracker := workspacestats.NewTracker(
 		options.Database,
-		workspaceusage.WithLogger(options.Logger.Named("workspace_usage_tracker")),
-		workspaceusage.WithTickFlush(options.WorkspaceUsageTrackerTick, options.WorkspaceUsageTrackerFlush),
+		workspacestats.TrackerWithLogger(options.Logger.Named("workspace_usage_tracker")),
+		workspacestats.TrackerWithTickFlush(options.WorkspaceUsageTrackerTick, options.WorkspaceUsageTrackerFlush),
 	)
 
 	var mutex sync.RWMutex

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -144,7 +144,7 @@ type Options struct {
 	// Logger should only be overridden if you expect errors
 	// as part of your test.
 	Logger       *slog.Logger
-	StatsBatcher *workspacestats.Batcher
+	StatsBatcher *workspacestats.DBBatcher
 
 	WorkspaceAppsStatsCollectorOptions workspaceapps.StatsCollectorOptions
 	AllowWorkspaceRenames              bool

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -21,7 +21,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agenttest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
-	"github.com/coder/coder/v2/coderd/batchstats"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -684,11 +683,11 @@ func TestTemplateInsights_Golden(t *testing.T) {
 		// NOTE(mafredri): Ideally we would pass batcher as a coderd option and
 		// insert using the agentClient, but we have a circular dependency on
 		// the database.
-		batcher, batcherCloser, err := batchstats.New(
+		batcher, batcherCloser, err := workspacestats.NewBatcher(
 			ctx,
-			batchstats.WithStore(db),
-			batchstats.WithLogger(logger.Named("batchstats")),
-			batchstats.WithInterval(time.Hour),
+			workspacestats.BatcherWithStore(db),
+			workspacestats.BatcherWithLogger(logger.Named("batchstats")),
+			workspacestats.BatcherWithInterval(time.Hour),
 		)
 		require.NoError(t, err)
 		defer batcherCloser() // Flushes the stats, this is to ensure they're written.
@@ -1583,11 +1582,11 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 		// NOTE(mafredri): Ideally we would pass batcher as a coderd option and
 		// insert using the agentClient, but we have a circular dependency on
 		// the database.
-		batcher, batcherCloser, err := batchstats.New(
+		batcher, batcherCloser, err := workspacestats.NewBatcher(
 			ctx,
-			batchstats.WithStore(db),
-			batchstats.WithLogger(logger.Named("batchstats")),
-			batchstats.WithInterval(time.Hour),
+			workspacestats.BatcherWithStore(db),
+			workspacestats.BatcherWithLogger(logger.Named("batchstats")),
+			workspacestats.BatcherWithInterval(time.Hour),
 		)
 		require.NoError(t, err)
 		defer batcherCloser() // Flushes the stats, this is to ensure they're written.

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -21,7 +21,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 
 	"github.com/coder/coder/v2/coderd/agentmetrics"
-	"github.com/coder/coder/v2/coderd/batchstats"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -29,6 +28,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics"
+	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/cryptorand"
@@ -391,14 +391,14 @@ func TestAgentStats(t *testing.T) {
 	db, pubsub := dbtestutil.NewDB(t)
 	log := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
-	batcher, closeBatcher, err := batchstats.New(ctx,
+	batcher, closeBatcher, err := workspacestats.NewBatcher(ctx,
 		// We had previously set the batch size to 1 here, but that caused
 		// intermittent test flakes due to a race between the batcher completing
 		// its flush and the test asserting that the metrics were collected.
 		// Instead, we close the batcher after all stats have been posted, which
 		// forces a flush.
-		batchstats.WithStore(db),
-		batchstats.WithLogger(log),
+		workspacestats.BatcherWithStore(db),
+		workspacestats.BatcherWithLogger(log),
 	)
 	require.NoError(t, err, "create stats batcher failed")
 	t.Cleanup(closeBatcher)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -1115,7 +1115,7 @@ func (api *API) postWorkspaceUsage(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	api.workspaceUsageTracker.Add(workspace.ID)
+	api.statsReporter.TrackUsage(workspace.ID)
 	rw.WriteHeader(http.StatusNoContent)
 }
 

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -1,4 +1,4 @@
-package batchstats
+package workspacestats
 
 import (
 	"context"
@@ -35,9 +35,9 @@ func TestBatchStats(t *testing.T) {
 	tick := make(chan time.Time)
 	flushed := make(chan int, 1)
 
-	b, closer, err := New(ctx,
-		WithStore(store),
-		WithLogger(log),
+	b, closer, err := NewBatcher(ctx,
+		BatcherWithStore(store),
+		BatcherWithLogger(log),
 		func(b *Batcher) {
 			b.tickCh = tick
 			b.flushed = flushed

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -38,7 +38,7 @@ func TestBatchStats(t *testing.T) {
 	b, closer, err := NewBatcher(ctx,
 		BatcherWithStore(store),
 		BatcherWithLogger(log),
-		func(b *Batcher) {
+		func(b *DBBatcher) {
 			b.tickCh = tick
 			b.flushed = flushed
 		},

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -22,16 +22,13 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-type StatsBatcher interface {
-	Add(now time.Time, agentID uuid.UUID, templateID uuid.UUID, userID uuid.UUID, workspaceID uuid.UUID, st *agentproto.Stats) error
-}
-
 type ReporterOptions struct {
 	Database              database.Store
 	Logger                slog.Logger
 	Pubsub                pubsub.Pubsub
 	TemplateScheduleStore *atomic.Pointer[schedule.TemplateScheduleStore]
 	StatsBatcher          StatsBatcher
+	UsageTracker          *UsageTracker
 	UpdateAgentMetricsFn  func(ctx context.Context, labels prometheusmetrics.AgentMetricLabels, metrics []*agentproto.Stats_Metric)
 
 	AppStatBatchSize int
@@ -204,4 +201,12 @@ func UpdateTemplateWorkspacesLastUsedAt(ctx context.Context, db database.Store, 
 		return xerrors.Errorf("update template workspaces last used at: %w", err)
 	}
 	return nil
+}
+
+func (r *Reporter) TrackUsage(workspaceID uuid.UUID) {
+	r.opts.UsageTracker.Add(workspaceID)
+}
+
+func (r *Reporter) Close() error {
+	return r.opts.UsageTracker.Close()
 }

--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -27,7 +27,7 @@ type ReporterOptions struct {
 	Logger                slog.Logger
 	Pubsub                pubsub.Pubsub
 	TemplateScheduleStore *atomic.Pointer[schedule.TemplateScheduleStore]
-	StatsBatcher          StatsBatcher
+	StatsBatcher          Batcher
 	UsageTracker          *UsageTracker
 	UpdateAgentMetricsFn  func(ctx context.Context, labels prometheusmetrics.AgentMetricLabels, metrics []*agentproto.Stats_Metric)
 

--- a/coderd/workspacestats/tracker_test.go
+++ b/coderd/workspacestats/tracker_test.go
@@ -1,4 +1,4 @@
-package workspaceusage_test
+package workspacestats_test
 
 import (
 	"bytes"
@@ -21,7 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
-	"github.com/coder/coder/v2/coderd/workspaceusage"
+	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -35,9 +35,9 @@ func TestTracker(t *testing.T) {
 
 	tickCh := make(chan time.Time)
 	flushCh := make(chan int, 1)
-	wut := workspaceusage.New(mDB,
-		workspaceusage.WithLogger(log),
-		workspaceusage.WithTickFlush(tickCh, flushCh),
+	wut := workspacestats.NewTracker(mDB,
+		workspacestats.TrackerWithLogger(log),
+		workspacestats.TrackerWithTickFlush(tickCh, flushCh),
 	)
 	defer wut.Close()
 


### PR DESCRIPTION
This moves the `batchstats.Batcher` and `workspaceusage.Tracker` into the `workspacestats` package to keep all updates to `last_used_at` inside the same package. There are no functional changes in this PR. 