### PR TITLE
fix: update `DeleteWorkspaceOptions` to pick properties correctly

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -314,7 +314,7 @@ type RestartWorkspaceParameters = Readonly<{
 
 export type DeleteWorkspaceOptions = Pick<
   TypesGen.CreateWorkspaceBuildRequest,
-  "log_level" & "orphan"
+  "log_level" | "orphan"
 >;
 
 export type DeploymentConfig = Readonly<{

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -427,8 +427,10 @@ describe("WorkspacePage", () => {
 
       test("Retry with debug logs", async () => {
         await testButton(failedDelete, retryDebugButtonRe, mockDelete);
-        expect(mockDelete).toBeCalledWith(failedDelete.id, {
-          logLevel: "debug",
+        expect(mockDelete).toBeCalledWith<
+          [string, apiModule.DeleteWorkspaceOptions]
+        >(failedDelete.id, {
+          log_level: "debug",
         });
       });
     });

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -161,7 +161,9 @@ describe("WorkspacePage", () => {
     });
     await user.click(confirmButton);
     // arguments are workspace.name, log level (undefined), and orphan
-    expect(deleteWorkspaceMock).toBeCalledWith(MockFailedWorkspace.id, {
+    expect(deleteWorkspaceMock).toBeCalledWith<
+      [string, apiModule.DeleteWorkspaceOptions]
+    >(MockFailedWorkspace.id, {
       log_level: undefined,
       orphan: true,
     });

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -173,7 +173,7 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
         stopWorkspaceMutation.mutate({ logLevel });
         break;
       case "delete":
-        deleteWorkspaceMutation.mutate({ logLevel });
+        deleteWorkspaceMutation.mutate({ log_level: logLevel });
         break;
     }
   };


### PR DESCRIPTION
Found this while writing the docs for the Backstage Coder SDK:

```tsx
export type DeleteWorkspaceOptions = Pick<
  TypesGen.CreateWorkspaceBuildRequest,
  "log_level" & "orphan"
>;
```

It's literally a single character difference, but the second `Pick` argument should be:
```tsx
"log_level" | "orphan"
```

## Changes made
- Changed the `&` to a `|`
- Updated one of the calls to the deletion method to fix a typo that was being allowed because of the incorrect type
- Updated one the test files to use the correct property format

## Explanation
With the `&`, you have an intersection instead of a union. Basically, that says "give me a type that is both the literal `"log_level"` and the literal `"orphan"` at the same time". It's impossible for a value to be two different things at the exact same time, so the resulting type is `never`. When you pick `never` from an object, you pick nothing, so the ultimate resulting type is the type `{}` (which is equivalent to `Nonullable<unknown>`). `Nonullable<unknown>` isn't much better than an `any` type – it's basically `any`, but with `null` and `undefined` removed