### PR TITLE
fix: replace invalid utf-8 sequences in agent logs

### DIFF
--- a/codersdk/agentsdk/convert.go
+++ b/codersdk/agentsdk/convert.go
@@ -348,7 +348,7 @@ func ProtoFromLog(log Log) (*proto.Log, error) {
 	}
 	return &proto.Log{
 		CreatedAt: timestamppb.New(log.CreatedAt),
-		Output:    strings.ToValidUTF8(log.Output, ""),
+		Output:    strings.ToValidUTF8(log.Output, "❌"),
 		Level:     proto.Log_Level(lvl),
 	}, nil
 }

--- a/codersdk/agentsdk/convert.go
+++ b/codersdk/agentsdk/convert.go
@@ -348,7 +348,7 @@ func ProtoFromLog(log Log) (*proto.Log, error) {
 	}
 	return &proto.Log{
 		CreatedAt: timestamppb.New(log.CreatedAt),
-		Output:    log.Output,
+		Output:    strings.ToValidUTF8(log.Output, ""),
 		Level:     proto.Log_Level(lvl),
 	}, nil
 }


### PR DESCRIPTION
Fixes #13433.