### PR TITLE
fix: fix build error background color

### DIFF
--- a/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
+++ b/site/src/pages/WorkspaceBuildPage/WorkspaceBuildPageView.tsx
@@ -167,7 +167,7 @@ export const WorkspaceBuildPageView: FC<WorkspaceBuildPageViewProps> = ({
               css={{
                 borderRadius: 0,
                 border: 0,
-                background: theme.palette.error.dark,
+                background: theme.roles.error.background,
                 borderBottom: `1px solid ${theme.palette.divider}`,
               }}
             >


### PR DESCRIPTION
Closes #13370

See the issue for the bad screenshot. Just switches the MUI color out for a more correct role-based color.