### PR TITLE
feat(codersdk): support api token lifetime as a string

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -27,7 +27,6 @@ import (
 	"cdr.dev/slog/sloggers/sloghuman"
 
 	"github.com/coder/coder/v2/cli/cliui"
-	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/tracing"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -667,7 +666,7 @@ func (r *RootCmd) scaletestCreateWorkspaces() *serpent.Command {
 							Width:   80,
 							Command: runCommand,
 						},
-						Timeout:       httpapi.Duration(runTimeout),
+						Timeout:       codersdk.Duration(runTimeout),
 						ExpectTimeout: runExpectTimeout,
 						ExpectOutput:  runExpectOutput,
 						LogOutput:     runLogOutput,
@@ -679,12 +678,12 @@ func (r *RootCmd) scaletestCreateWorkspaces() *serpent.Command {
 						// The ConnectionMode gets validated by the Validate()
 						// call below.
 						ConnectionMode: agentconn.ConnectionMode(connectMode),
-						HoldDuration:   httpapi.Duration(connectHold),
+						HoldDuration:   codersdk.Duration(connectHold),
 						Connections: []agentconn.Connection{
 							{
 								URL:      connectURL,
-								Interval: httpapi.Duration(connectInterval),
-								Timeout:  httpapi.Duration(connectTimeout),
+								Interval: codersdk.Duration(connectInterval),
+								Timeout:  codersdk.Duration(connectTimeout),
 							},
 						},
 					}
@@ -1185,7 +1184,7 @@ func (r *RootCmd) scaletestDashboard() *serpent.Command {
 				rndGen := rand.New(rand.NewSource(randSeed))
 				name := fmt.Sprintf("dashboard-%s", usr.Username)
 				userTokResp, err := client.CreateToken(ctx, usr.ID.String(), codersdk.CreateTokenRequest{
-					Lifetime:  30 * 24 * time.Hour,
+					Lifetime:  codersdk.Duration(30 * 24 * time.Hour),
 					Scope:     "",
 					TokenName: fmt.Sprintf("scaletest-%d", time.Now().Unix()),
 				})

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -59,7 +59,7 @@ func (r *RootCmd) createToken() *serpent.Command {
 		),
 		Handler: func(inv *serpent.Invocation) error {
 			res, err := client.CreateToken(inv.Context(), codersdk.Me, codersdk.CreateTokenRequest{
-				Lifetime:  tokenLifetime,
+				Lifetime:  codersdk.Duration(tokenLifetime),
 				TokenName: name,
 			})
 			if err != nil {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9205,6 +9205,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "lifetime": {
+                    "description": "Lifetime is how long the api key should live for. It accepts either an\nint or a string. Ints should be specified as nanoseconds, and strings\nshould be formatted like ` + "`" + `24h0m0s` + "`" + `.",
                     "type": "integer"
                 },
                 "scope": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8206,6 +8206,7 @@
       "type": "object",
       "properties": {
         "lifetime": {
+          "description": "Lifetime is how long the api key should live for. It accepts either an\nint or a string. Ints should be specified as nanoseconds, and strings\nshould be formatted like `24h0m0s`.",
           "type": "integer"
         },
         "scope": {

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -712,7 +712,7 @@ func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationI
 		// Cannot log in with a disabled login user. So make it an api key from
 		// the client making this user.
 		token, err := client.CreateToken(context.Background(), user.ID.String(), codersdk.CreateTokenRequest{
-			Lifetime:  time.Hour * 24,
+			Lifetime:  codersdk.Duration(24 * time.Hour),
 			Scope:     codersdk.APIKeyScopeAll,
 			TokenName: "no-password-user-token",
 		})

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -1453,7 +1453,7 @@ func TestUserActivityInsights_Golden(t *testing.T) {
 				OrganizationID: firstUser.OrganizationID,
 			})
 			token, err := client.CreateToken(context.Background(), user.id.String(), codersdk.CreateTokenRequest{
-				Lifetime:  time.Hour * 24,
+				Lifetime:  codersdk.Duration(24 * time.Hour),
 				Scope:     codersdk.APIKeyScopeAll,
 				TokenName: "no-password-user-token",
 			})

--- a/codersdk/apikey.go
+++ b/codersdk/apikey.go
@@ -51,9 +51,12 @@ const (
 )
 
 type CreateTokenRequest struct {
-	Lifetime  time.Duration `json:"lifetime"`
-	Scope     APIKeyScope   `json:"scope" enums:"all,application_connect"`
-	TokenName string        `json:"token_name"`
+	// Lifetime is how long the api key should live for. It accepts either an
+	// int or a string. Ints should be specified as nanoseconds, and strings
+	// should be formatted like `24h0m0s`.
+	Lifetime  Duration    `json:"lifetime"`
+	Scope     APIKeyScope `json:"scope" enums:"all,application_connect"`
+	TokenName string      `json:"token_name"`
 }
 
 // GenerateAPIKeyResponse contains an API key for a user.

--- a/codersdk/json.go
+++ b/codersdk/json.go
@@ -1,4 +1,4 @@
-package httpapi
+package codersdk
 
 import (
 	"encoding/json"
@@ -14,6 +14,7 @@ import (
 //
 // This type marshals as a string like "1h30m", and unmarshals from either a
 // string or an integer.
+// @typescript-ignore Duration
 type Duration time.Duration
 
 var (
@@ -46,7 +47,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 		*d = Duration(tmp)
 		return nil
+	default:
+		return xerrors.Errorf("invalid duration type %T, expected string or int", value)
 	}
-
-	return xerrors.New("invalid duration")
 }

--- a/codersdk/json_test.go
+++ b/codersdk/json_test.go
@@ -1,6 +1,7 @@
-package httpapi_test
+package codersdk_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -161,6 +162,7 @@ func TestDuration(t *testing.T) {
 				var d codersdk.Duration
 				err := d.UnmarshalJSON([]byte(c.value))
 				require.Error(t, err)
+				fmt.Println(err)
 				require.Contains(t, err.Error(), c.errContains)
 			})
 		}

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1607,11 +1607,11 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name         | Type                                         | Required | Restrictions | Description |
-| ------------ | -------------------------------------------- | -------- | ------------ | ----------- |
-| `lifetime`   | integer                                      | false    |              |             |
-| `scope`      | [codersdk.APIKeyScope](#codersdkapikeyscope) | false    |              |             |
-| `token_name` | string                                       | false    |              |             |
+| Name         | Type                                         | Required | Restrictions | Description                                                                                                                                                                      |
+| ------------ | -------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lifetime`   | integer                                      | false    |              | Lifetime is how long the api key should live for. It accepts either an int or a string. Ints should be specified as nanoseconds, and strings should be formatted like `24h0m0s`. |
+| `scope`      | [codersdk.APIKeyScope](#codersdkapikeyscope) | false    |              |                                                                                                                                                                                  |
+| `token_name` | string                                       | false    |              |                                                                                                                                                                                  |
 
 #### Enumerated Values
 

--- a/scaletest/agentconn/config.go
+++ b/scaletest/agentconn/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 type ConnectionMode string
@@ -24,7 +24,7 @@ type Config struct {
 	// HoldDuration is the duration to hold the connection open for. If set to
 	// 0, the connection will be closed immediately after making each request
 	// once.
-	HoldDuration httpapi.Duration `json:"hold_duration"`
+	HoldDuration codersdk.Duration `json:"hold_duration"`
 
 	// Connections is the list of connections to make to services running
 	// inside the workspace. Only HTTP connections are supported.
@@ -40,10 +40,10 @@ type Connection struct {
 	// Interval is the duration to wait between connections to this endpoint. If
 	// set to 0, the connection will only be made once. Must be set to 0 if
 	// the parent config's hold_duration is set to 0.
-	Interval httpapi.Duration `json:"interval"`
+	Interval codersdk.Duration `json:"interval"`
 	// Timeout is the duration to wait for a connection to this endpoint to
 	// succeed. If set to 0, the default timeout will be used.
-	Timeout httpapi.Duration `json:"timeout"`
+	Timeout codersdk.Duration `json:"timeout"`
 }
 
 func (c Config) Validate() error {

--- a/scaletest/agentconn/config_test.go
+++ b/scaletest/agentconn/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/agentconn"
 )
 
@@ -25,17 +25,17 @@ func Test_Config(t *testing.T) {
 			config: agentconn.Config{
 				AgentID:        id,
 				ConnectionMode: agentconn.ConnectionModeDirect,
-				HoldDuration:   httpapi.Duration(time.Minute),
+				HoldDuration:   codersdk.Duration(time.Minute),
 				Connections: []agentconn.Connection{
 					{
 						URL:      "http://localhost:8080/path",
-						Interval: httpapi.Duration(time.Second),
-						Timeout:  httpapi.Duration(time.Second),
+						Interval: codersdk.Duration(time.Second),
+						Timeout:  codersdk.Duration(time.Second),
 					},
 					{
 						URL:      "http://localhost:8000/differentpath",
-						Interval: httpapi.Duration(2 * time.Second),
-						Timeout:  httpapi.Duration(2 * time.Second),
+						Interval: codersdk.Duration(2 * time.Second),
+						Timeout:  codersdk.Duration(2 * time.Second),
 					},
 				},
 			},

--- a/scaletest/agentconn/run_test.go
+++ b/scaletest/agentconn/run_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/provisionersdk/proto"
@@ -70,11 +69,11 @@ func Test_Runner(t *testing.T) {
 			Connections: []agentconn.Connection{
 				{
 					URL:     service1URL,
-					Timeout: httpapi.Duration(time.Second),
+					Timeout: codersdk.Duration(time.Second),
 				},
 				{
 					URL:     service2URL,
-					Timeout: httpapi.Duration(time.Second),
+					Timeout: codersdk.Duration(time.Second),
 				},
 			},
 		})
@@ -115,7 +114,7 @@ func Test_Runner_Timing(t *testing.T) {
 		runner := agentconn.NewRunner(client, agentconn.Config{
 			AgentID:        agentID,
 			ConnectionMode: agentconn.ConnectionModeDirect,
-			HoldDuration:   httpapi.Duration(testutil.WaitShort),
+			HoldDuration:   codersdk.Duration(testutil.WaitShort),
 		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
@@ -156,22 +155,22 @@ func Test_Runner_Timing(t *testing.T) {
 		runner := agentconn.NewRunner(client, agentconn.Config{
 			AgentID:        agentID,
 			ConnectionMode: agentconn.ConnectionModeDerp,
-			HoldDuration:   httpapi.Duration(testutil.WaitShort),
+			HoldDuration:   codersdk.Duration(testutil.WaitShort),
 			Connections: []agentconn.Connection{
 				{
 					URL: service1URL,
 					// No interval.
-					Timeout: httpapi.Duration(time.Second),
+					Timeout: codersdk.Duration(time.Second),
 				},
 				{
 					URL:      service2URL,
-					Interval: httpapi.Duration(1 * time.Second),
-					Timeout:  httpapi.Duration(time.Second),
+					Interval: codersdk.Duration(1 * time.Second),
+					Timeout:  codersdk.Duration(time.Second),
 				},
 				{
 					URL:      service3URL,
-					Interval: httpapi.Duration(500 * time.Millisecond),
-					Timeout:  httpapi.Duration(time.Second),
+					Interval: codersdk.Duration(500 * time.Millisecond),
+					Timeout:  codersdk.Duration(time.Second),
 				},
 			},
 		})

--- a/scaletest/createworkspaces/config_test.go
+++ b/scaletest/createworkspaces/config_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/agentconn"
 	"github.com/coder/coder/v2/scaletest/createworkspaces"
@@ -105,7 +104,7 @@ func Test_Config(t *testing.T) {
 	agentConnConfig := agentconn.Config{
 		AgentID:        id,
 		ConnectionMode: agentconn.ConnectionModeDirect,
-		HoldDuration:   httpapi.Duration(time.Minute),
+		HoldDuration:   codersdk.Duration(time.Minute),
 	}
 
 	cases := []struct {
@@ -158,7 +157,7 @@ func Test_Config(t *testing.T) {
 				User:      userConfig,
 				Workspace: workspaceConfig,
 				ReconnectingPTY: &reconnectingpty.Config{
-					Timeout: httpapi.Duration(-1 * time.Second),
+					Timeout: codersdk.Duration(-1 * time.Second),
 				},
 			},
 			errContains: "validate reconnecting pty",

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -15,7 +15,6 @@ import (
 	"cdr.dev/slog/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -133,7 +132,7 @@ func Test_Runner(t *testing.T) {
 					Width:   80,
 					Command: "echo hello",
 				},
-				Timeout: httpapi.Duration(testutil.WaitLong),
+				Timeout: codersdk.Duration(testutil.WaitLong),
 			},
 			AgentConn: &agentconn.Config{
 				ConnectionMode: agentconn.ConnectionModeDerp,
@@ -422,7 +421,7 @@ func Test_Runner(t *testing.T) {
 					Width:   80,
 					Command: "echo hello",
 				},
-				Timeout: httpapi.Duration(testutil.WaitLong),
+				Timeout: codersdk.Duration(testutil.WaitLong),
 			},
 			AgentConn: &agentconn.Config{
 				ConnectionMode: agentconn.ConnectionModeDerp,

--- a/scaletest/harness/results.go
+++ b/scaletest/harness/results.go
@@ -11,30 +11,30 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // Results is the full compiled results for a set of test runs.
 type Results struct {
-	TotalRuns int              `json:"total_runs"`
-	TotalPass int              `json:"total_pass"`
-	TotalFail int              `json:"total_fail"`
-	Elapsed   httpapi.Duration `json:"elapsed"`
-	ElapsedMS int64            `json:"elapsed_ms"`
+	TotalRuns int               `json:"total_runs"`
+	TotalPass int               `json:"total_pass"`
+	TotalFail int               `json:"total_fail"`
+	Elapsed   codersdk.Duration `json:"elapsed"`
+	ElapsedMS int64             `json:"elapsed_ms"`
 
 	Runs map[string]RunResult `json:"runs"`
 }
 
 // RunResult is the result of a single test run.
 type RunResult struct {
-	FullID     string           `json:"full_id"`
-	TestName   string           `json:"test_name"`
-	ID         string           `json:"id"`
-	Logs       string           `json:"logs"`
-	Error      error            `json:"error"`
-	StartedAt  time.Time        `json:"started_at"`
-	Duration   httpapi.Duration `json:"duration"`
-	DurationMS int64            `json:"duration_ms"`
+	FullID     string            `json:"full_id"`
+	TestName   string            `json:"test_name"`
+	ID         string            `json:"id"`
+	Logs       string            `json:"logs"`
+	Error      error             `json:"error"`
+	StartedAt  time.Time         `json:"started_at"`
+	Duration   codersdk.Duration `json:"duration"`
+	DurationMS int64             `json:"duration_ms"`
 }
 
 // MarshalJSON implements json.Marhshaler for RunResult.
@@ -65,7 +65,7 @@ func (r *TestRun) Result() RunResult {
 		Logs:       r.logs.String(),
 		Error:      r.err,
 		StartedAt:  r.started,
-		Duration:   httpapi.Duration(r.duration),
+		Duration:   codersdk.Duration(r.duration),
 		DurationMS: r.duration.Milliseconds(),
 	}
 }
@@ -84,7 +84,7 @@ func (h *TestHarness) Results() Results {
 	results := Results{
 		TotalRuns: len(h.runs),
 		Runs:      make(map[string]RunResult, len(h.runs)),
-		Elapsed:   httpapi.Duration(h.elapsed),
+		Elapsed:   codersdk.Duration(h.elapsed),
 		ElapsedMS: h.elapsed.Milliseconds(),
 	}
 	for _, run := range h.runs {

--- a/scaletest/harness/results_test.go
+++ b/scaletest/harness/results_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/harness"
 )
 
@@ -42,7 +42,7 @@ func Test_Results(t *testing.T) {
 				Logs:       "test-0/0 log line 1\ntest-0/0 log line 2",
 				Error:      xerrors.New("test-0/0 error"),
 				StartedAt:  now,
-				Duration:   httpapi.Duration(time.Second),
+				Duration:   codersdk.Duration(time.Second),
 				DurationMS: 1000,
 			},
 			"test-0/1": {
@@ -52,7 +52,7 @@ func Test_Results(t *testing.T) {
 				Logs:       "test-0/1 log line 1\ntest-0/1 log line 2",
 				Error:      nil,
 				StartedAt:  now.Add(333 * time.Millisecond),
-				Duration:   httpapi.Duration(time.Second),
+				Duration:   codersdk.Duration(time.Second),
 				DurationMS: 1000,
 			},
 			"test-0/2": {
@@ -62,11 +62,11 @@ func Test_Results(t *testing.T) {
 				Logs:       "test-0/2 log line 1\ntest-0/2 log line 2",
 				Error:      testError{hidden: xerrors.New("test-0/2 error")},
 				StartedAt:  now.Add(666 * time.Millisecond),
-				Duration:   httpapi.Duration(time.Second),
+				Duration:   codersdk.Duration(time.Second),
 				DurationMS: 1000,
 			},
 		},
-		Elapsed:   httpapi.Duration(time.Second),
+		Elapsed:   codersdk.Duration(time.Second),
 		ElapsedMS: 1000,
 	}
 

--- a/scaletest/placebo/config.go
+++ b/scaletest/placebo/config.go
@@ -3,17 +3,17 @@ package placebo
 import (
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 type Config struct {
 	// Sleep is how long to sleep for. If unspecified, the test run will finish
 	// instantly.
-	Sleep httpapi.Duration `json:"sleep"`
+	Sleep codersdk.Duration `json:"sleep"`
 	// Jitter is the maximum amount of jitter to add to the sleep duration. The
 	// sleep value will be increased by a random value between 0 and jitter if
 	// jitter is greater than 0.
-	Jitter httpapi.Duration `json:"jitter"`
+	Jitter codersdk.Duration `json:"jitter"`
 	// FailureChance is the chance that the test will fail. The value must be
 	// between 0 and 1.
 	FailureChance float64 `json:"failure_chance"`

--- a/scaletest/placebo/config_test.go
+++ b/scaletest/placebo/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/placebo"
 )
 
@@ -29,7 +29,7 @@ func Test_Config(t *testing.T) {
 		{
 			name: "Sleep",
 			config: placebo.Config{
-				Sleep:         httpapi.Duration(1 * time.Second),
+				Sleep:         codersdk.Duration(1 * time.Second),
 				Jitter:        0,
 				FailureChance: 0,
 			},
@@ -37,8 +37,8 @@ func Test_Config(t *testing.T) {
 		{
 			name: "SleepAndJitter",
 			config: placebo.Config{
-				Sleep:         httpapi.Duration(1 * time.Second),
-				Jitter:        httpapi.Duration(1 * time.Second),
+				Sleep:         codersdk.Duration(1 * time.Second),
+				Jitter:        codersdk.Duration(1 * time.Second),
 				FailureChance: 0,
 			},
 		},
@@ -53,7 +53,7 @@ func Test_Config(t *testing.T) {
 		{
 			name: "NegativeSleep",
 			config: placebo.Config{
-				Sleep:         httpapi.Duration(-1 * time.Second),
+				Sleep:         codersdk.Duration(-1 * time.Second),
 				Jitter:        0,
 				FailureChance: 0,
 			},
@@ -63,7 +63,7 @@ func Test_Config(t *testing.T) {
 			name: "NegativeJitter",
 			config: placebo.Config{
 				Sleep:         0,
-				Jitter:        httpapi.Duration(-1 * time.Second),
+				Jitter:        codersdk.Duration(-1 * time.Second),
 				FailureChance: 0,
 			},
 			errContains: "jitter must be set to a positive value",
@@ -72,7 +72,7 @@ func Test_Config(t *testing.T) {
 			name: "JitterWithoutSleep",
 			config: placebo.Config{
 				Sleep:         0,
-				Jitter:        httpapi.Duration(1 * time.Second),
+				Jitter:        codersdk.Duration(1 * time.Second),
 				FailureChance: 0,
 			},
 			errContains: "jitter must be 0 if sleep is 0",

--- a/scaletest/placebo/run_test.go
+++ b/scaletest/placebo/run_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/scaletest/placebo"
 )
 
@@ -34,7 +34,7 @@ func Test_Runner(t *testing.T) {
 		t.Parallel()
 
 		r := placebo.NewRunner(placebo.Config{
-			Sleep: httpapi.Duration(100 * time.Millisecond),
+			Sleep: codersdk.Duration(100 * time.Millisecond),
 		})
 
 		start := time.Now()
@@ -50,8 +50,8 @@ func Test_Runner(t *testing.T) {
 		t.Parallel()
 
 		r := placebo.NewRunner(placebo.Config{
-			Sleep:  httpapi.Duration(100 * time.Millisecond),
-			Jitter: httpapi.Duration(100 * time.Millisecond),
+			Sleep:  codersdk.Duration(100 * time.Millisecond),
+			Jitter: codersdk.Duration(100 * time.Millisecond),
 		})
 
 		start := time.Now()
@@ -69,7 +69,7 @@ func Test_Runner(t *testing.T) {
 		t.Parallel()
 
 		r := placebo.NewRunner(placebo.Config{
-			Sleep: httpapi.Duration(100 * time.Millisecond),
+			Sleep: codersdk.Duration(100 * time.Millisecond),
 		})
 
 		//nolint:gocritic // we're testing timeouts here so we want specific values

--- a/scaletest/reconnectingpty/config.go
+++ b/scaletest/reconnectingpty/config.go
@@ -6,14 +6,14 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )
 
 const (
 	DefaultWidth   = 80
 	DefaultHeight  = 24
-	DefaultTimeout = httpapi.Duration(5 * time.Minute)
+	DefaultTimeout = codersdk.Duration(5 * time.Minute)
 )
 
 type Config struct {
@@ -26,7 +26,7 @@ type Config struct {
 	Init workspacesdk.AgentReconnectingPTYInit `json:"init"`
 	// Timeout is the duration to wait for the command to exit. Defaults to
 	// 5 minutes.
-	Timeout httpapi.Duration `json:"timeout"`
+	Timeout codersdk.Duration `json:"timeout"`
 	// ExpectTimeout means we expect the timeout to be reached (i.e. the command
 	// doesn't exit within the given timeout).
 	ExpectTimeout bool `json:"expect_timeout"`

--- a/scaletest/reconnectingpty/config_test.go
+++ b/scaletest/reconnectingpty/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/scaletest/reconnectingpty"
 )
@@ -37,7 +37,7 @@ func Test_Config(t *testing.T) {
 					Height:  24,
 					Command: "echo 'hello world'",
 				},
-				Timeout:       httpapi.Duration(time.Minute),
+				Timeout:       codersdk.Duration(time.Minute),
 				ExpectTimeout: false,
 				ExpectOutput:  "hello world",
 				LogOutput:     true,
@@ -54,7 +54,7 @@ func Test_Config(t *testing.T) {
 			name: "NegativeTimeout",
 			config: reconnectingpty.Config{
 				AgentID: id,
-				Timeout: httpapi.Duration(-time.Minute),
+				Timeout: codersdk.Duration(-time.Minute),
 			},
 			errContains: "timeout must be a positive value",
 		},

--- a/scaletest/reconnectingpty/run_test.go
+++ b/scaletest/reconnectingpty/run_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/provisioner/echo"
@@ -90,7 +89,7 @@ func Test_Runner(t *testing.T) {
 				Init: workspacesdk.AgentReconnectingPTYInit{
 					Command: "echo 'hello world'",
 				},
-				Timeout:   httpapi.Duration(2 * testutil.WaitSuperLong),
+				Timeout:   codersdk.Duration(2 * testutil.WaitSuperLong),
 				LogOutput: true,
 			})
 
@@ -114,7 +113,7 @@ func Test_Runner(t *testing.T) {
 				Init: workspacesdk.AgentReconnectingPTYInit{
 					Command: "sleep 120",
 				},
-				Timeout:   httpapi.Duration(2 * time.Second),
+				Timeout:   codersdk.Duration(2 * time.Second),
 				LogOutput: true,
 			})
 
@@ -143,7 +142,7 @@ func Test_Runner(t *testing.T) {
 				Init: workspacesdk.AgentReconnectingPTYInit{
 					Command: "sleep 120",
 				},
-				Timeout:       httpapi.Duration(2 * time.Second),
+				Timeout:       codersdk.Duration(2 * time.Second),
 				ExpectTimeout: true,
 				LogOutput:     true,
 			})
@@ -168,7 +167,7 @@ func Test_Runner(t *testing.T) {
 				Init: workspacesdk.AgentReconnectingPTYInit{
 					Command: "echo 'hello world'",
 				},
-				Timeout:       httpapi.Duration(2 * testutil.WaitSuperLong),
+				Timeout:       codersdk.Duration(2 * testutil.WaitSuperLong),
 				ExpectTimeout: true,
 				LogOutput:     true,
 			})

--- a/scripts/apitypings/main.go
+++ b/scripts/apitypings/main.go
@@ -865,6 +865,8 @@ func (g *Generator) typescriptType(ty types.Type) (TypescriptType, error) {
 			return TypescriptType{ValueType: "string"}, nil
 		case "time.Duration":
 			return TypescriptType{ValueType: "number"}, nil
+		case "github.com/coder/coder/v2/codersdk.Duration":
+			return TypescriptType{ValueType: "number"}, nil
 		case "database/sql.NullTime":
 			return TypescriptType{ValueType: "string", Optional: true}, nil
 		case "github.com/coder/coder/v2/codersdk.NullTime":


### PR DESCRIPTION
Quick fix for a customer who was having trouble using the api. It's quite unintuitive that you need to specify nanoseconds. We already have a duration type that supports unmarshaling from strings, so use that.

This is technically a breaking change in the sdk, but it's a super easy find/replace fix.