### PR TITLE
chore: implement typed database for custom permissions (breaks existing custom roles)

### DIFF
--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -36,7 +36,7 @@ func (r *RootCmd) organizationRoles() *serpent.Command {
 func (r *RootCmd) showOrganizationRoles() *serpent.Command {
 	formatter := cliui.NewOutputFormatter(
 		cliui.ChangeFormatterData(
-			cliui.TableFormat([]roleTableRow{}, []string{"name", "display_name", "site_permissions", "org_permissions", "user_permissions"}),
+			cliui.TableFormat([]roleTableRow{}, []string{"name", "display_name", "site_permissions", "organization_permissions", "user_permissions"}),
 			func(data any) (any, error) {
 				inputs, ok := data.([]codersdk.AssignableRoles)
 				if !ok {
@@ -103,7 +103,7 @@ func (r *RootCmd) showOrganizationRoles() *serpent.Command {
 func (r *RootCmd) editOrganizationRole() *serpent.Command {
 	formatter := cliui.NewOutputFormatter(
 		cliui.ChangeFormatterData(
-			cliui.TableFormat([]roleTableRow{}, []string{"name", "display_name", "site_permissions", "org_permissions", "user_permissions"}),
+			cliui.TableFormat([]roleTableRow{}, []string{"name", "display_name", "site_permissions", "organization_permissions", "user_permissions"}),
 			func(data any) (any, error) {
 				typed, _ := data.(codersdk.Role)
 				return []roleTableRow{roleToTableView(typed)}, nil

--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -391,6 +391,6 @@ type roleTableRow struct {
 	OrganizationID  string `table:"organization_id"`
 	SitePermissions string ` table:"site_permissions"`
 	// map[<org_id>] -> Permissions
-	OrganizationPermissions string `table:"org_permissions"`
+	OrganizationPermissions string `table:"organization_permissions"`
 	UserPermissions         string `table:"user_permissions"`
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3441,13 +3441,20 @@ func (q *querier) UpsertCustomRole(ctx context.Context, arg database.UpsertCusto
 		return database.CustomRole{}, err
 	}
 
-	// There is quite a bit of validation we should do here. First, let's make sure the json data is correct.
+	if arg.OrganizationID.UUID == uuid.Nil && len(arg.OrgPermissions) > 0 {
+		return database.CustomRole{}, xerrors.Errorf("organization permissions require specifying an organization id")
+	}
+
+	// There is quite a bit of validation we should do here.
+	// The rbac.Role has a 'Valid()' function on it that will do a lot
+	// of checks.
 	rbacRole, err := rolestore.ConvertDBRole(database.CustomRole{
 		Name:            arg.Name,
 		DisplayName:     arg.DisplayName,
 		SitePermissions: arg.SitePermissions,
 		OrgPermissions:  arg.OrgPermissions,
 		UserPermissions: arg.UserPermissions,
+		OrganizationID:  arg.OrganizationID,
 	})
 	if err != nil {
 		return database.CustomRole{}, xerrors.Errorf("invalid args: %w", err)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -13,7 +13,9 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/codersdk"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -1202,22 +1204,22 @@ func (s *MethodTestSuite) TestUser() {
 		check.Args(database.UpsertCustomRoleParams{
 			Name:            "test",
 			DisplayName:     "Test Name",
-			SitePermissions: []byte(`[]`),
-			OrgPermissions:  []byte(`{}`),
-			UserPermissions: []byte(`[]`),
+			SitePermissions: nil,
+			OrgPermissions:  nil,
+			UserPermissions: nil,
 		}).Asserts(rbac.ResourceAssignRole, policy.ActionCreate)
 	}))
 	s.Run("SitePermissions/UpsertCustomRole", s.Subtest(func(db database.Store, check *expects) {
 		check.Args(database.UpsertCustomRoleParams{
 			Name:        "test",
 			DisplayName: "Test Name",
-			SitePermissions: must(json.Marshal(rbac.Permissions(map[string][]policy.Action{
-				rbac.ResourceTemplate.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete, policy.ActionViewInsights},
-			}))),
-			OrgPermissions: []byte(`{}`),
-			UserPermissions: must(json.Marshal(rbac.Permissions(map[string][]policy.Action{
-				rbac.ResourceWorkspace.Type: {policy.ActionRead},
-			}))),
+			SitePermissions: db2sdk.List(codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceTemplate: {codersdk.ActionCreate, codersdk.ActionRead, codersdk.ActionUpdate, codersdk.ActionDelete, codersdk.ActionViewInsights},
+			}), convertSDKPerm),
+			OrgPermissions: nil,
+			UserPermissions: db2sdk.List(codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceWorkspace: {codersdk.ActionRead},
+			}), convertSDKPerm),
 		}).Asserts(
 			// First check
 			rbac.ResourceAssignRole, policy.ActionCreate,
@@ -1234,17 +1236,19 @@ func (s *MethodTestSuite) TestUser() {
 	s.Run("OrgPermissions/UpsertCustomRole", s.Subtest(func(db database.Store, check *expects) {
 		orgID := uuid.New()
 		check.Args(database.UpsertCustomRoleParams{
-			Name:            "test",
-			DisplayName:     "Test Name",
-			SitePermissions: []byte(`[]`),
-			OrgPermissions: must(json.Marshal(map[string][]rbac.Permission{
-				orgID.String(): rbac.Permissions(map[string][]policy.Action{
-					rbac.ResourceTemplate.Type: {policy.ActionCreate, policy.ActionRead},
-				}),
-			})),
-			UserPermissions: must(json.Marshal(rbac.Permissions(map[string][]policy.Action{
-				rbac.ResourceWorkspace.Type: {policy.ActionRead},
-			}))),
+			Name:        "test",
+			DisplayName: "Test Name",
+			OrganizationID: uuid.NullUUID{
+				UUID:  orgID,
+				Valid: true,
+			},
+			SitePermissions: nil,
+			OrgPermissions: db2sdk.List(codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceWorkspace: {codersdk.ActionRead, codersdk.ActionCreate},
+			}), convertSDKPerm),
+			UserPermissions: db2sdk.List(codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceWorkspace: {codersdk.ActionRead},
+			}), convertSDKPerm),
 		}).Asserts(
 			// First check
 			rbac.ResourceAssignRole, policy.ActionCreate,

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1244,7 +1244,7 @@ func (s *MethodTestSuite) TestUser() {
 			},
 			SitePermissions: nil,
 			OrgPermissions: db2sdk.List(codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
-				codersdk.ResourceWorkspace: {codersdk.ActionRead, codersdk.ActionCreate},
+				codersdk.ResourceTemplate: {codersdk.ActionCreate, codersdk.ActionRead},
 			}), convertSDKPerm),
 			UserPermissions: db2sdk.List(codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
 				codersdk.ResourceWorkspace: {codersdk.ActionRead},

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -823,9 +823,9 @@ func CustomRole(t testing.TB, db database.Store, seed database.CustomRole) datab
 		Name:            takeFirst(seed.Name, strings.ToLower(namesgenerator.GetRandomName(1))),
 		DisplayName:     namesgenerator.GetRandomName(1),
 		OrganizationID:  seed.OrganizationID,
-		SitePermissions: takeFirstSlice(seed.SitePermissions, []byte("[]")),
-		OrgPermissions:  takeFirstSlice(seed.SitePermissions, []byte("{}")),
-		UserPermissions: takeFirstSlice(seed.SitePermissions, []byte("[]")),
+		SitePermissions: takeFirstSlice(seed.SitePermissions, []database.CustomRolePermission{}),
+		OrgPermissions:  takeFirstSlice(seed.SitePermissions, []database.CustomRolePermission{}),
+		UserPermissions: takeFirstSlice(seed.SitePermissions, []database.CustomRolePermission{}),
 	})
 	require.NoError(t, err, "insert custom role")
 	return role

--- a/coderd/database/migrations/000214_org_custom_role_array.down.sql
+++ b/coderd/database/migrations/000214_org_custom_role_array.down.sql
@@ -1,0 +1,1 @@
+UPDATE custom_roles SET org_permissions = '{}';

--- a/coderd/database/migrations/000214_org_custom_role_array.up.sql
+++ b/coderd/database/migrations/000214_org_custom_role_array.up.sql
@@ -1,0 +1,4 @@
+-- Previous custom roles are now invalid, as the json changed. Since this is an
+-- experimental feature, there is no point in trying to save the perms.
+-- This does not elevate any permissions, so it is not a security issue.
+UPDATE custom_roles SET org_permissions = '[]';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1783,13 +1783,13 @@ type AuditLog struct {
 
 // Custom roles allow dynamic roles expanded at runtime
 type CustomRole struct {
-	Name            string          `db:"name" json:"name"`
-	DisplayName     string          `db:"display_name" json:"display_name"`
-	SitePermissions json.RawMessage `db:"site_permissions" json:"site_permissions"`
-	OrgPermissions  json.RawMessage `db:"org_permissions" json:"org_permissions"`
-	UserPermissions json.RawMessage `db:"user_permissions" json:"user_permissions"`
-	CreatedAt       time.Time       `db:"created_at" json:"created_at"`
-	UpdatedAt       time.Time       `db:"updated_at" json:"updated_at"`
+	Name            string                `db:"name" json:"name"`
+	DisplayName     string                `db:"display_name" json:"display_name"`
+	SitePermissions CustomRolePermissions `db:"site_permissions" json:"site_permissions"`
+	OrgPermissions  CustomRolePermissions `db:"org_permissions" json:"org_permissions"`
+	UserPermissions CustomRolePermissions `db:"user_permissions" json:"user_permissions"`
+	CreatedAt       time.Time             `db:"created_at" json:"created_at"`
+	UpdatedAt       time.Time             `db:"updated_at" json:"updated_at"`
 	// Roles can optionally be scoped to an organization
 	OrganizationID uuid.NullUUID `db:"organization_id" json:"organization_id"`
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5696,12 +5696,12 @@ RETURNING name, display_name, site_permissions, org_permissions, user_permission
 `
 
 type UpsertCustomRoleParams struct {
-	Name            string          `db:"name" json:"name"`
-	DisplayName     string          `db:"display_name" json:"display_name"`
-	OrganizationID  uuid.NullUUID   `db:"organization_id" json:"organization_id"`
-	SitePermissions json.RawMessage `db:"site_permissions" json:"site_permissions"`
-	OrgPermissions  json.RawMessage `db:"org_permissions" json:"org_permissions"`
-	UserPermissions json.RawMessage `db:"user_permissions" json:"user_permissions"`
+	Name            string                `db:"name" json:"name"`
+	DisplayName     string                `db:"display_name" json:"display_name"`
+	OrganizationID  uuid.NullUUID         `db:"organization_id" json:"organization_id"`
+	SitePermissions CustomRolePermissions `db:"site_permissions" json:"site_permissions"`
+	OrgPermissions  CustomRolePermissions `db:"org_permissions" json:"org_permissions"`
+	UserPermissions CustomRolePermissions `db:"user_permissions" json:"user_permissions"`
 }
 
 func (q *sqlQuerier) UpsertCustomRole(ctx context.Context, arg UpsertCustomRoleParams) (CustomRole, error) {

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -28,6 +28,15 @@ sql:
         emit_enum_valid_method: true
         emit_all_enum_values: true
         overrides:
+          - column: "custom_roles.site_permissions"
+            go_type:
+              type: "CustomRolePermissions"
+          - column: "custom_roles.org_permissions"
+            go_type:
+              type: "CustomRolePermissions"
+          - column: "custom_roles.user_permissions"
+            go_type:
+              type: "CustomRolePermissions"
           - column: "provisioner_daemons.tags"
             go_type:
               type: "StringMap"

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -112,3 +112,33 @@ func (m *StringMapOfInt) Scan(src interface{}) error {
 func (m StringMapOfInt) Value() (driver.Value, error) {
 	return json.Marshal(m)
 }
+
+type CustomRolePermissions []CustomRolePermission
+
+func (a *CustomRolePermissions) Scan(src interface{}) error {
+	switch v := src.(type) {
+	case string:
+		return json.Unmarshal([]byte(v), &a)
+	case []byte:
+		return json.Unmarshal(v, &a)
+	}
+	return xerrors.Errorf("unexpected type %T", src)
+}
+
+func (a CustomRolePermissions) Value() (driver.Value, error) {
+	return json.Marshal(a)
+}
+
+type CustomRolePermission struct {
+	Negate       bool          `json:"negate"`
+	ResourceType string        `json:"resource_type"`
+	Action       policy.Action `json:"action"`
+}
+
+func (a CustomRolePermission) String() string {
+	str := a.ResourceType + "." + string(a.Action)
+	if a.Negate {
+		return "-" + str
+	}
+	return str
+}

--- a/coderd/rbac/rolestore/rolestore.go
+++ b/coderd/rbac/rolestore/rolestore.go
@@ -2,7 +2,6 @@ package rolestore
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -96,6 +95,20 @@ func Expand(ctx context.Context, db database.Store, names []string) (rbac.Roles,
 	return roles, nil
 }
 
+func convertPermissions(dbPerms []database.CustomRolePermission) []rbac.Permission {
+	n := make([]rbac.Permission, 0, len(dbPerms))
+	for _, dbPerm := range dbPerms {
+		n = append(n, rbac.Permission{
+			Negate:       dbPerm.Negate,
+			ResourceType: dbPerm.ResourceType,
+			Action:       dbPerm.Action,
+		})
+	}
+	return n
+}
+
+// ConvertDBRole should not be used by any human facing apis. It is used
+// for authz purposes.
 func ConvertDBRole(dbRole database.CustomRole) (rbac.Role, error) {
 	name := dbRole.Name
 	if dbRole.OrganizationID.Valid {
@@ -104,68 +117,21 @@ func ConvertDBRole(dbRole database.CustomRole) (rbac.Role, error) {
 	role := rbac.Role{
 		Name:        name,
 		DisplayName: dbRole.DisplayName,
-		Site:        nil,
+		Site:        convertPermissions(dbRole.SitePermissions),
 		Org:         nil,
-		User:        nil,
+		User:        convertPermissions(dbRole.UserPermissions),
 	}
 
-	err := json.Unmarshal(dbRole.SitePermissions, &role.Site)
-	if err != nil {
-		return role, xerrors.Errorf("unmarshal site permissions: %w", err)
+	// Org permissions only make sense if an org id is specified.
+	if len(dbRole.OrgPermissions) > 0 && dbRole.OrganizationID.UUID == uuid.Nil {
+		return rbac.Role{}, xerrors.Errorf("role has organization perms without an org id specified")
 	}
 
-	err = json.Unmarshal(dbRole.OrgPermissions, &role.Org)
-	if err != nil {
-		return role, xerrors.Errorf("unmarshal org permissions: %w", err)
-	}
-
-	err = json.Unmarshal(dbRole.UserPermissions, &role.User)
-	if err != nil {
-		return role, xerrors.Errorf("unmarshal user permissions: %w", err)
+	if dbRole.OrganizationID.UUID != uuid.Nil {
+		role.Org = map[string][]rbac.Permission{
+			dbRole.OrganizationID.UUID.String(): convertPermissions(dbRole.OrgPermissions),
+		}
 	}
 
 	return role, nil
-}
-
-func ConvertRoleToDB(role rbac.Role) (database.CustomRole, error) {
-	roleName, orgIDStr, err := rbac.RoleSplit(role.Name)
-	if err != nil {
-		return database.CustomRole{}, xerrors.Errorf("split role %q: %w", role.Name, err)
-	}
-
-	dbRole := database.CustomRole{
-		Name:        roleName,
-		DisplayName: role.DisplayName,
-	}
-
-	if orgIDStr != "" {
-		orgID, err := uuid.Parse(orgIDStr)
-		if err != nil {
-			return database.CustomRole{}, xerrors.Errorf("parse org id %q: %w", orgIDStr, err)
-		}
-		dbRole.OrganizationID = uuid.NullUUID{
-			UUID:  orgID,
-			Valid: true,
-		}
-	}
-
-	siteData, err := json.Marshal(role.Site)
-	if err != nil {
-		return dbRole, xerrors.Errorf("marshal site permissions: %w", err)
-	}
-	dbRole.SitePermissions = siteData
-
-	orgData, err := json.Marshal(role.Org)
-	if err != nil {
-		return dbRole, xerrors.Errorf("marshal org permissions: %w", err)
-	}
-	dbRole.OrgPermissions = orgData
-
-	userData, err := json.Marshal(role.User)
-	if err != nil {
-		return dbRole, xerrors.Errorf("marshal user permissions: %w", err)
-	}
-	dbRole.UserPermissions = userData
-
-	return dbRole, nil
 }

--- a/coderd/roles.go
+++ b/coderd/roles.go
@@ -20,12 +20,12 @@ import (
 // roles. Ideally only included in the enterprise package, but the routes are
 // intermixed with AGPL endpoints.
 type CustomRoleHandler interface {
-	PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.Role) (codersdk.Role, bool)
+	PatchOrganizationRole(ctx context.Context, db database.Store, rw http.ResponseWriter, orgID uuid.UUID, role codersdk.Role) (codersdk.Role, bool)
 }
 
 type agplCustomRoleHandler struct{}
 
-func (agplCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, _ *http.Request, _ uuid.UUID, _ codersdk.Role) (codersdk.Role, bool) {
+func (agplCustomRoleHandler) PatchOrganizationRole(ctx context.Context, _ database.Store, rw http.ResponseWriter, _ uuid.UUID, _ codersdk.Role) (codersdk.Role, bool) {
 	httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 		Message: "Creating and updating custom roles is an Enterprise feature. Contact sales!",
 	})
@@ -54,7 +54,7 @@ func (api *API) patchOrgRoles(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, ok := handler.PatchOrganizationRole(ctx, rw, r, organization.ID, req)
+	updated, ok := handler.PatchOrganizationRole(ctx, api.Database, rw, organization.ID, req)
 	if !ok {
 		return
 	}

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -40,7 +40,7 @@ type Role struct {
 	DisplayName     string       `json:"display_name" table:"display_name"`
 	SitePermissions []Permission `json:"site_permissions" table:"site_permissions"`
 	// OrganizationPermissions are specific for the organization in the field 'OrganizationID' above.
-	OrganizationPermissions []Permission `json:"organization_permissions" table:"org_permissions"`
+	OrganizationPermissions []Permission `json:"organization_permissions" table:"organization_permissions"`
 	UserPermissions         []Permission `json:"user_permissions" table:"user_permissions"`
 }
 


### PR DESCRIPTION
Custom roles in the db were raw json. Using sqlc overrides, I can make these typed which is much better. This is just a refactor. Fixed up the tests to match.

Forgot this was something we could easily do. It removes some converting that we used to have to do.

**Any existing custom org roles will be replaced with 0 permissions. This is a change in format.**