### PR TITLE
chore(coderd): add update user profile test for members

### DIFF
--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -712,7 +712,6 @@ func TestUpdateUserProfile(t *testing.T) {
 			Name:     me.Name + "1",
 		})
 		numLogs++ // add an audit log for user update
-		numLogs++ // add an audit log for API key creation
 
 		require.NoError(t, err)
 		require.Equal(t, me.Username+"1", userProfile.Username)


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/13454

Previously we had only been testing that the first user was able to update user profiles.
This change adds a separate test that a member user is able to update their own user profile.