### PR TITLE
feat(coderd): set full name from IDP name claim

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -169,6 +169,7 @@ func createOIDCConfig(ctx context.Context, vals *codersdk.DeploymentValues) (*co
 		EmailDomain:         vals.OIDC.EmailDomain,
 		AllowSignups:        vals.OIDC.AllowSignups.Value(),
 		UsernameField:       vals.OIDC.UsernameField.String(),
+		NameField:           vals.OIDC.NameField.String(),
 		EmailField:          vals.OIDC.EmailField.String(),
 		AuthURLParams:       vals.OIDC.AuthURLParams.Value,
 		IgnoreUserInfo:      vals.OIDC.IgnoreUserInfo.Value(),

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -407,6 +407,9 @@ OIDC OPTIONS:
       --oidc-issuer-url string, $CODER_OIDC_ISSUER_URL
           Issuer URL to use for Login with OIDC.
 
+      --oidc-name-field string, $CODER_OIDC_NAME_FIELD (default: name)
+          OIDC claim field to use as the name.
+
       --oidc-group-regex-filter regexp, $CODER_OIDC_GROUP_REGEX_FILTER (default: .*)
           If provided any group name not matching the regex is ignored. This
           allows for filtering out groups that are not needed. This filter is

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -306,6 +306,9 @@ oidc:
   # OIDC claim field to use as the username.
   # (default: preferred_username, type: string)
   usernameField: preferred_username
+  # OIDC claim field to use as the name.
+  # (default: name, type: string)
+  nameField: name
   # OIDC claim field to use as the email.
   # (default: email, type: string)
   emailField: email

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10551,6 +10551,9 @@ const docTemplate = `{
                 "issuer_url": {
                     "type": "string"
                 },
+                "name_field": {
+                    "type": "string"
+                },
                 "scopes": {
                     "type": "array",
                     "items": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9482,6 +9482,9 @@
         "issuer_url": {
           "type": "string"
         },
+        "name_field": {
+          "type": "string"
+        },
         "scopes": {
           "type": "array",
           "items": {

--- a/coderd/httpapi/name.go
+++ b/coderd/httpapi/name.go
@@ -91,3 +91,14 @@ func UserRealNameValid(str string) error {
 	}
 	return nil
 }
+
+// NormalizeUserRealName normalizes a user name such that it will pass
+// validation by UserRealNameValid. This is done to avoid blocking
+// little  Bobby  Whitespace  from using Coder.
+func NormalizeRealUsername(str string) string {
+	s := strings.TrimSpace(str)
+	if len(s) > 128 {
+		s = s[:128]
+	}
+	return s
+}

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -607,6 +607,9 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ghName := ghUser.GetName()
+	normName := httpapi.NormalizeRealUsername(ghName)
+
 	// If we have a nil GitHub ID, that is a big problem. That would mean we link
 	// this user and all other users with this bug to the same uuid.
 	// We should instead throw an error. This should never occur in production.
@@ -652,6 +655,7 @@ func (api *API) userOAuth2Github(rw http.ResponseWriter, r *http.Request) {
 		Email:        verifiedEmail.GetEmail(),
 		Username:     ghUser.GetLogin(),
 		AvatarURL:    ghUser.GetAvatarURL(),
+		Name:         normName,
 		DebugContext: OauthDebugContext{},
 	}).SetInitAuditRequest(func(params *audit.RequestParams) (*audit.Request[database.User], func()) {
 		return audit.InitRequest[database.User](rw, params)

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -701,6 +701,9 @@ type OIDCConfig struct {
 	// EmailField selects the claim field to be used as the created user's
 	// email.
 	EmailField string
+	// NameField selects the claim field to be used as the created user's
+	// full / given name.
+	NameField string
 	// AuthURLParams are additional parameters to be passed to the OIDC provider
 	// when requesting an access token.
 	AuthURLParams map[string]string
@@ -1222,6 +1225,7 @@ type oauthLoginParams struct {
 	AllowSignups bool
 	Email        string
 	Username     string
+	Name         string
 	AvatarURL    string
 	// Is UsingGroups is true, then the user will be assigned
 	// to the Groups provided.

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -961,11 +961,11 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 
 	// The 'name' is an optional property in Coder. If not specified,
 	// it will be left blank.
-	var fullName string
-	fullNameRaw, ok := mergedClaims[api.OIDCConfig.NameField]
+	var name string
+	nameRaw, ok := mergedClaims[api.OIDCConfig.NameField]
 	if ok {
-		fullName, _ = fullNameRaw.(string)
-		fullName = httpapi.NormalizeRealUsername(fullName)
+		name, _ = nameRaw.(string)
+		name = httpapi.NormalizeRealUsername(name)
 	}
 
 	var picture string
@@ -974,7 +974,7 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		picture, _ = pictureRaw.(string)
 	}
 
-	ctx = slog.With(ctx, slog.F("email", email), slog.F("username", username), slog.F("name", fullName))
+	ctx = slog.With(ctx, slog.F("email", email), slog.F("username", username), slog.F("name", name))
 	usingGroups, groups, groupErr := api.oidcGroups(ctx, mergedClaims)
 	if groupErr != nil {
 		groupErr.Write(rw, r)
@@ -1012,7 +1012,7 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		AllowSignups:        api.OIDCConfig.AllowSignups,
 		Email:               email,
 		Username:            username,
-		Name:                fullName,
+		Name:                name,
 		AvatarURL:           picture,
 		UsingRoles:          api.OIDCConfig.RoleSyncEnabled(),
 		Roles:               roles,

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -961,6 +961,7 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 	fullNameRaw, ok := mergedClaims[api.OIDCConfig.NameField]
 	if ok {
 		fullName, _ = fullNameRaw.(string)
+		fullName = httpapi.NormalizeRealUsername(fullName)
 	}
 
 	var picture string

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -494,6 +494,7 @@ func TestUserOAuth2Github(t *testing.T) {
 		require.Len(t, auditor.AuditLogs(), numLogs)
 		require.Equal(t, database.AuditActionRegister, auditor.AuditLogs()[numLogs-1].Action)
 	})
+	// nolint: dupl
 	t.Run("SignupAllowedTeamInFirstOrganization", func(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()
@@ -555,6 +556,7 @@ func TestUserOAuth2Github(t *testing.T) {
 		require.Len(t, auditor.AuditLogs(), numLogs)
 		require.Equal(t, database.AuditActionRegister, auditor.AuditLogs()[numLogs-1].Action)
 	})
+	// nolint: dupl
 	t.Run("SignupAllowedTeamInSecondOrganization", func(t *testing.T) {
 		t.Parallel()
 		auditor := audit.NewMock()

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -214,6 +214,7 @@ func TestUserOAuth2Github(t *testing.T) {
 					return &github.User{
 						ID:    github.Int64(100),
 						Login: github.String("kyle"),
+						Name:  github.String("Kylium Carbonate"),
 					}, nil
 				},
 				TeamMembership: func(ctx context.Context, client *http.Client, org, team, username string) (*github.Membership, error) {
@@ -273,7 +274,9 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
 					return &github.User{
-						ID: github.Int64(100),
+						ID:    github.Int64(100),
+						Login: github.String("testuser"),
+						Name:  github.String("The Right Honorable Sir Test McUser"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -306,7 +309,9 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
 					return &github.User{
-						ID: github.Int64(100),
+						ID:    github.Int64(100),
+						Login: github.String("testuser"),
+						Name:  github.String("The Right Honorable Sir Test McUser"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -347,9 +352,10 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 				AuthenticatedUser: func(ctx context.Context, _ *http.Client) (*github.User, error) {
 					return &github.User{
-						Login:     github.String("kyle"),
-						ID:        i64ptr(1234),
 						AvatarURL: github.String("/hello-world"),
+						ID:        i64ptr(1234),
+						Login:     github.String("kyle"),
+						Name:      github.String("Kylium Carbonate"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -373,6 +379,7 @@ func TestUserOAuth2Github(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "kyle@coder.com", user.Email)
 		require.Equal(t, "kyle", user.Username)
+		require.Equal(t, "Kylium Carbonate", user.Name)
 		require.Equal(t, "/hello-world", user.AvatarURL)
 
 		require.Len(t, auditor.AuditLogs(), numLogs)
@@ -402,8 +409,10 @@ func TestUserOAuth2Github(t *testing.T) {
 				},
 				AuthenticatedUser: func(ctx context.Context, client *http.Client) (*github.User, error) {
 					return &github.User{
-						ID:    github.Int64(100),
-						Login: github.String("kyle"),
+						AvatarURL: github.String("/hello-world"),
+						ID:        github.Int64(100),
+						Login:     github.String("kyle"),
+						Name:      github.String("Kylium Carbonate"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -419,6 +428,14 @@ func TestUserOAuth2Github(t *testing.T) {
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
+
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
+		user, err := client.User(context.Background(), "me")
+		require.NoError(t, err)
+		require.Equal(t, "kyle@coder.com", user.Email)
+		require.Equal(t, "kyle", user.Username)
+		require.Equal(t, "Kylium Carbonate", user.Name)
+		require.Equal(t, "/hello-world", user.AvatarURL)
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 		require.Len(t, auditor.AuditLogs(), numLogs)
@@ -457,6 +474,7 @@ func TestUserOAuth2Github(t *testing.T) {
 					return &github.User{
 						ID:    github.Int64(100),
 						Login: github.String("mathias"),
+						Name:  github.String("Mathias Mathias"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -472,6 +490,13 @@ func TestUserOAuth2Github(t *testing.T) {
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
+
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
+		user, err := client.User(context.Background(), "me")
+		require.NoError(t, err)
+		require.Equal(t, "mathias@coder.com", user.Email)
+		require.Equal(t, "mathias", user.Username)
+		require.Equal(t, "Mathias Mathias", user.Name)
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 		require.Len(t, auditor.AuditLogs(), numLogs)
@@ -510,6 +535,7 @@ func TestUserOAuth2Github(t *testing.T) {
 					return &github.User{
 						ID:    github.Int64(100),
 						Login: github.String("mathias"),
+						Name:  github.String("Mathias Mathias"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -525,6 +551,13 @@ func TestUserOAuth2Github(t *testing.T) {
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
+
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
+		user, err := client.User(context.Background(), "me")
+		require.NoError(t, err)
+		require.Equal(t, "mathias@coder.com", user.Email)
+		require.Equal(t, "mathias", user.Username)
+		require.Equal(t, "Mathias Mathias", user.Name)
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 		require.Len(t, auditor.AuditLogs(), numLogs)
@@ -549,6 +582,7 @@ func TestUserOAuth2Github(t *testing.T) {
 					return &github.User{
 						ID:    github.Int64(100),
 						Login: github.String("mathias"),
+						Name:  github.String("Mathias Mathias"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -564,6 +598,13 @@ func TestUserOAuth2Github(t *testing.T) {
 
 		resp := oauth2Callback(t, client)
 		numLogs++ // add an audit log for login
+
+		client.SetSessionToken(authCookieValue(resp.Cookies()))
+		user, err := client.User(context.Background(), "me")
+		require.NoError(t, err)
+		require.Equal(t, "mathias@coder.com", user.Email)
+		require.Equal(t, "mathias", user.Username)
+		require.Equal(t, "Mathias Mathias", user.Name)
 
 		require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 		require.Len(t, auditor.AuditLogs(), numLogs)
@@ -592,6 +633,7 @@ func TestUserOAuth2Github(t *testing.T) {
 					return &github.User{
 						ID:    github.Int64(100),
 						Login: github.String("kyle"),
+						Name:  github.String("Kylium Carbonate"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -653,6 +695,7 @@ func TestUserOAuth2Github(t *testing.T) {
 					return &github.User{
 						Login: github.String("alice"),
 						ID:    github.Int64(ghID),
+						Name:  github.String("Alice Liddell"),
 					}, nil
 				},
 				ListEmails: func(ctx context.Context, client *http.Client) ([]*github.UserEmail, error) {
@@ -740,7 +783,7 @@ func TestUserOIDC(t *testing.T) {
 		UserInfoClaims      jwt.MapClaims
 		AllowSignups        bool
 		EmailDomain         []string
-		AssertUser          func(u codersdk.User)
+		AssertUser          func(t testing.TB, u codersdk.User)
 		StatusCode          int
 		IgnoreEmailVerified bool
 		IgnoreUserInfo      bool
@@ -752,7 +795,7 @@ func TestUserOIDC(t *testing.T) {
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusOK,
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "kyle", u.Username)
 			},
 		},
@@ -782,7 +825,7 @@ func TestUserOIDC(t *testing.T) {
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusOK,
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, u.Username, "kyle")
 			},
 			IgnoreEmailVerified: true,
@@ -806,6 +849,9 @@ func TestUserOIDC(t *testing.T) {
 				"email_verified": true,
 			},
 			AllowSignups: true,
+			AssertUser: func(t testing.TB, u codersdk.User) {
+				assert.Equal(t, u.Username, "kyle")
+			},
 			EmailDomain: []string{
 				"kwc.io",
 			},
@@ -843,7 +889,7 @@ func TestUserOIDC(t *testing.T) {
 				"email":          "kyle@kwc.io",
 				"email_verified": true,
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "kyle", u.Username)
 			},
 			AllowSignups: true,
@@ -856,8 +902,21 @@ func TestUserOIDC(t *testing.T) {
 				"email_verified":     true,
 				"preferred_username": "hotdog",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "hotdog", u.Username)
+			},
+			AllowSignups: true,
+			StatusCode:   http.StatusOK,
+		},
+		{
+			Name: "FullNameFromClaims",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+				"name":           "Hot Dog",
+			},
+			AssertUser: func(t testing.TB, u codersdk.User) {
+				assert.Equal(t, "Hot Dog", u.Name)
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusOK,
@@ -869,9 +928,10 @@ func TestUserOIDC(t *testing.T) {
 			IDTokenClaims: jwt.MapClaims{
 				"email":              "kyle@kwc.io",
 				"email_verified":     true,
+				"name":               "Kylium Carbonate",
 				"preferred_username": "kyle@kwc.io",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "kyle", u.Username)
 			},
 			AllowSignups: true,
@@ -883,8 +943,9 @@ func TestUserOIDC(t *testing.T) {
 			IDTokenClaims: jwt.MapClaims{
 				"preferred_username": "kyle@kwc.io",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "kyle", u.Username)
+				assert.Equal(t, "Kylium Carbonate", u.Name)
 			},
 			AllowSignups: true,
 			StatusCode:   http.StatusOK,
@@ -897,7 +958,7 @@ func TestUserOIDC(t *testing.T) {
 				"preferred_username": "kyle",
 				"picture":            "/example.png",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "/example.png", u.AvatarURL)
 				assert.Equal(t, "kyle", u.Username)
 			},
@@ -913,9 +974,11 @@ func TestUserOIDC(t *testing.T) {
 			UserInfoClaims: jwt.MapClaims{
 				"preferred_username": "potato",
 				"picture":            "/example.png",
+				"name":               "Kylium Carbonate",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "/example.png", u.AvatarURL)
+				assert.Equal(t, "Kylium Carbonate", u.Name)
 				assert.Equal(t, "potato", u.Username)
 			},
 			AllowSignups: true,
@@ -941,7 +1004,7 @@ func TestUserOIDC(t *testing.T) {
 				"email_verified":     true,
 				"preferred_username": "user",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "user", u.Username)
 			},
 			AllowSignups:        true,
@@ -966,14 +1029,17 @@ func TestUserOIDC(t *testing.T) {
 			IDTokenClaims: jwt.MapClaims{
 				"email":              "user@internal.domain",
 				"email_verified":     true,
+				"name":               "User McName",
 				"preferred_username": "user",
 			},
 			UserInfoClaims: jwt.MapClaims{
 				"email":              "user.mcname@external.domain",
+				"name":               "Mr. User McName",
 				"preferred_username": "Mr. User McName",
 			},
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "user", u.Username)
+				assert.Equal(t, "User Name", u.Name)
 			},
 			IgnoreUserInfo: true,
 			AllowSignups:   true,
@@ -985,7 +1051,7 @@ func TestUserOIDC(t *testing.T) {
 				"email":          "user@domain.tld",
 				"email_verified": true,
 			}, 65536),
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "user", u.Username)
 			},
 			AllowSignups: true,
@@ -998,7 +1064,7 @@ func TestUserOIDC(t *testing.T) {
 				"email_verified": true,
 			},
 			UserInfoClaims: inflateClaims(t, jwt.MapClaims{}, 65536),
-			AssertUser: func(u codersdk.User) {
+			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "user", u.Username)
 			},
 			AllowSignups: true,
@@ -1041,7 +1107,7 @@ func TestUserOIDC(t *testing.T) {
 				user, err := client.User(ctx, "me")
 				require.NoError(t, err)
 
-				tc.AssertUser(user)
+				tc.AssertUser(t, user)
 				require.Len(t, auditor.AuditLogs(), numLogs)
 				require.NotEqual(t, uuid.Nil, auditor.AuditLogs()[numLogs-1].UserID)
 				require.Equal(t, database.AuditActionRegister, auditor.AuditLogs()[numLogs-1].Action)

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1039,7 +1039,7 @@ func TestUserOIDC(t *testing.T) {
 			},
 			AssertUser: func(t testing.TB, u codersdk.User) {
 				assert.Equal(t, "user", u.Username)
-				assert.Equal(t, "User Name", u.Name)
+				assert.Equal(t, "User McName", u.Name)
 			},
 			IgnoreUserInfo: true,
 			AllowSignups:   true,
@@ -1086,6 +1086,7 @@ func TestUserOIDC(t *testing.T) {
 				cfg.EmailDomain = tc.EmailDomain
 				cfg.IgnoreEmailVerified = tc.IgnoreEmailVerified
 				cfg.IgnoreUserInfo = tc.IgnoreUserInfo
+				cfg.NameField = "name"
 			})
 
 			auditor := audit.NewMock()

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -333,6 +333,7 @@ type OIDCConfig struct {
 	Scopes              serpent.StringArray                 `json:"scopes" typescript:",notnull"`
 	IgnoreEmailVerified serpent.Bool                        `json:"ignore_email_verified" typescript:",notnull"`
 	UsernameField       serpent.String                      `json:"username_field" typescript:",notnull"`
+	NameField           serpent.String                      `json:"name_field" typescript:",notnull"`
 	EmailField          serpent.String                      `json:"email_field" typescript:",notnull"`
 	AuthURLParams       serpent.Struct[map[string]string]   `json:"auth_url_params" typescript:",notnull"`
 	IgnoreUserInfo      serpent.Bool                        `json:"ignore_user_info" typescript:",notnull"`
@@ -1191,6 +1192,16 @@ when required by your organization's security policy.`,
 			Value:       &c.OIDC.UsernameField,
 			Group:       &deploymentGroupOIDC,
 			YAML:        "usernameField",
+		},
+		{
+			Name:        "OIDC Name Field",
+			Description: "OIDC claim field to use as the name.",
+			Flag:        "oidc-name-field",
+			Env:         "CODER_OIDC_NAME_FIELD",
+			Default:     "name",
+			Value:       &c.OIDC.NameField,
+			Group:       &deploymentGroupOIDC,
+			YAML:        "nameField",
 		},
 		{
 			Name:        "OIDC Email Field",

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -294,6 +294,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "ignore_email_verified": true,
       "ignore_user_info": true,
       "issuer_url": "string",
+      "name_field": "string",
       "scopes": ["string"],
       "sign_in_text": "string",
       "signups_disabled_text": "string",

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -2094,6 +2094,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "ignore_email_verified": true,
       "ignore_user_info": true,
       "issuer_url": "string",
+      "name_field": "string",
       "scopes": ["string"],
       "sign_in_text": "string",
       "signups_disabled_text": "string",
@@ -2467,6 +2468,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "ignore_email_verified": true,
     "ignore_user_info": true,
     "issuer_url": "string",
+    "name_field": "string",
     "scopes": ["string"],
     "sign_in_text": "string",
     "signups_disabled_text": "string",
@@ -3546,6 +3548,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "ignore_email_verified": true,
   "ignore_user_info": true,
   "issuer_url": "string",
+  "name_field": "string",
   "scopes": ["string"],
   "sign_in_text": "string",
   "signups_disabled_text": "string",
@@ -3577,6 +3580,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `ignore_email_verified` | boolean                          | false    |              |                                                                                  |
 | `ignore_user_info`      | boolean                          | false    |              |                                                                                  |
 | `issuer_url`            | string                           | false    |              |                                                                                  |
+| `name_field`            | string                           | false    |              |                                                                                  |
 | `scopes`                | array of string                  | false    |              |                                                                                  |
 | `sign_in_text`          | string                           | false    |              |                                                                                  |
 | `signups_disabled_text` | string                           | false    |              |                                                                                  |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -514,6 +514,17 @@ Ignore the email_verified claim from the upstream provider.
 
 OIDC claim field to use as the username.
 
+### --oidc-name-field
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Type        | <code>string</code>                 |
+| Environment | <code>$CODER_OIDC_NAME_FIELD</code> |
+| YAML        | <code>oidc.nameField</code>         |
+| Default     | <code>name</code>                   |
+
+OIDC claim field to use as the name.
+
 ### --oidc-email-field
 
 |             |                                      |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -408,6 +408,9 @@ OIDC OPTIONS:
       --oidc-issuer-url string, $CODER_OIDC_ISSUER_URL
           Issuer URL to use for Login with OIDC.
 
+      --oidc-name-field string, $CODER_OIDC_NAME_FIELD (default: name)
+          OIDC claim field to use as the name.
+
       --oidc-group-regex-filter regexp, $CODER_OIDC_GROUP_REGEX_FILTER (default: .*)
           If provided any group name not matching the regex is ignored. This
           allows for filtering out groups that are not needed. This filter is

--- a/scripts/dev-oidc.sh
+++ b/scripts/dev-oidc.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 KEYCLOAK_VERSION="${KEYCLOAK_VERSION:-22.0}"
 
+# NOTE: the trailing space in "lastName" is intentional.
 cat <<EOF >/tmp/example-realm.json
 {
   "realm": "coder",

--- a/scripts/dev-oidc.sh
+++ b/scripts/dev-oidc.sh
@@ -23,6 +23,8 @@ cat <<EOF >/tmp/example-realm.json
     {
       "username": "oidcuser",
       "email": "oidcuser@coder.com",
+      "firstName": "OIDC",
+      "lastName": "user ",
       "emailVerified": true,
       "enabled": true,
       "credentials": [

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -756,6 +756,7 @@ export interface OIDCConfig {
   readonly scopes: string[];
   readonly ignore_email_verified: boolean;
   readonly username_field: string;
+  readonly name_field: string;
   readonly email_field: string;
   readonly auth_url_params: Record<string, string>;
   readonly ignore_user_info: boolean;


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/11704

- Updates OIDC and GitHub OAuth login to fetch set name from relevant claim fields
- Adds `CODER_OIDC_NAME_FIELD` as configurable source of user name claim
- Adds httpapi function to normalize a username such that it will pass validation
- Adds `firstName` / `lastName` fields to dev OIDC setup

Screenshots:

1. Post-OIDC login:
![Screenshot 2024-06-06 at 11 39 20](https://github.com/coder/coder/assets/4949514/05c6ba93-acc0-4956-beca-18cb02e4d3d6)

2. OIDC claims from DB:
![Screenshot 2024-06-06 at 11 49 54](https://github.com/coder/coder/assets/4949514/83733270-3f34-4286-81df-d39e4866dd9a)


NOTE: does not update "first-time setup" in the UI to allow setting username. This will be done in a separate PR.