### PR TITLE
chore: add Now, Since, AfterFunc to clock; use clock for configmaps test

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -17,6 +17,15 @@ type Clock interface {
 	// NewTimer creates a new Timer that will send the current time on its channel after at least
 	// duration d.
 	NewTimer(d time.Duration, tags ...string) *Timer
+	// AfterFunc waits for the duration to elapse and then calls f in its own goroutine. It returns
+	// a Timer that can be used to cancel the call using its Stop method. The returned Timer's C
+	// field is not used and will be nil.
+	AfterFunc(d time.Duration, f func(), tags ...string) *Timer
+
+	// Now returns the current local time.
+	Now(tags ...string) time.Time
+	// Since returns the time elapsed since t. It is shorthand for Clock.Now().Sub(t).
+	Since(t time.Time, tags ...string) time.Duration
 }
 
 // Waiter can be waited on for an error.

--- a/clock/real.go
+++ b/clock/real.go
@@ -55,4 +55,17 @@ func (realClock) NewTimer(d time.Duration, _ ...string) *Timer {
 	return &Timer{C: rt.C, timer: rt}
 }
 
+func (realClock) AfterFunc(d time.Duration, f func(), _ ...string) *Timer {
+	rt := time.AfterFunc(d, f)
+	return &Timer{C: rt.C, timer: rt}
+}
+
+func (realClock) Now(_ ...string) time.Time {
+	return time.Now()
+}
+
+func (realClock) Since(t time.Time, _ ...string) time.Duration {
+	return time.Since(t)
+}
+
 var _ Clock = realClock{}

--- a/clock/timer.go
+++ b/clock/timer.go
@@ -18,9 +18,10 @@ func (t *Timer) fire(tt time.Time) {
 		panic("mock timer fired at wrong time")
 	}
 	t.mock.removeTimer(t)
-	t.c <- tt
 	if t.fn != nil {
 		t.fn()
+	} else {
+		t.c <- tt
 	}
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
             name = "coder-${osArch}";
             # Updated with ./scripts/update-flake.sh`.
             # This should be updated whenever go.mod changes!
-            vendorHash = "sha256-PDA+Yd/tYvMTJfw8zyperTYnSBijvECc6XjxqnYgtkw=";
+            vendorHash = "sha256-BVgjKZeVogPb/kyCtZw/R898TI4YGnu9oWzzxHSVIyY=";
             proxyVendor = true;
             src = ./.;
             nativeBuildInputs = with pkgs; [ getopt openssl zstd ];

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,6 @@ require (
 require go.uber.org/mock v0.4.0
 
 require (
-	github.com/benbjohnson/clock v1.3.5
 	github.com/coder/serpent v0.7.0
 	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47
 	github.com/google/go-github/v61 v61.0.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
-github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bep/clocks v0.5.0 h1:hhvKVGLPQWRVsBP/UB7ErrHYIO42gINVbvqxvYTPVps=

--- a/tailnet/configmaps.go
+++ b/tailnet/configmaps.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/google/uuid"
 	"go4.org/netipx"
 	"tailscale.com/ipn/ipnstate"
@@ -25,6 +24,7 @@ import (
 	"tailscale.com/wgengine/wgcfg/nmcfg"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/clock"
 	"github.com/coder/coder/v2/tailnet/proto"
 )
 
@@ -116,7 +116,7 @@ func newConfigMaps(logger slog.Logger, engine engineConfigurable, nodeID tailcfg
 			}},
 		},
 		peers: make(map[uuid.UUID]*peerLifecycle),
-		clock: clock.New(),
+		clock: clock.NewReal(),
 	}
 	go c.configLoop()
 	return c


### PR DESCRIPTION
Add `Now()`, `Since()`, `AfterFunc()` to clock

Use `clock` for configmaps test