### PR TITLE
fix: fix MeasureLatencyRecvTimeout to accept send=0

### DIFF
--- a/coderd/database/pubsub/pubsub_linux_test.go
+++ b/coderd/database/pubsub/pubsub_linux_test.go
@@ -351,7 +351,7 @@ func TestMeasureLatency(t *testing.T) {
 
 		send, recv, err := pubsub.NewLatencyMeasurer(logger).Measure(ctx, ps)
 		require.ErrorContains(t, err, context.Canceled.Error())
-		require.Greater(t, send.Nanoseconds(), int64(0))
+		require.GreaterOrEqual(t, send.Nanoseconds(), int64(0))
 		require.EqualValues(t, recv, time.Duration(-1))
 	})
 


### PR DESCRIPTION
Fixes the flake seen here: https://github.com/coder/coder/runs/25832852690

Linux is not a real time operating system, and so there is no guarantee that subsequent `time.Now()` `time.Since()` calls will return a non-zero time.  This assert is mainly there to ensure we don't return `-1`.