### PR TITLE
fix(site): show workspace start button when require active version is enabled

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -172,6 +172,10 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
         </>
       )}
 
+      {!canBeUpdated &&
+        workspace.template_require_active_version &&
+        buttonMapping.start}
+
       {isRestarting
         ? buttonMapping.restarting
         : actions.map((action) => (


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/13481

Before:
![image](https://github.com/coder/coder/assets/6332295/67ccc024-459c-4d9c-85ee-f6b4e4e20637)
After:
![image](https://github.com/coder/coder/assets/6332295/c6c854df-04e5-45c9-86dd-d3024440935e)
