### PR TITLE
fix: only render tooltip when require_active_version enabled

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -244,7 +244,11 @@ function getTooltipText(
     return "";
   }
 
-  if (!mustUpdate && canChangeVersions && workspace.template_require_active_version) {
+  if (
+    !mustUpdate &&
+    canChangeVersions &&
+    workspace.template_require_active_version
+  ) {
     return "This template requires automatic updates on workspace startup, but template administrators can ignore this policy.";
   }
 

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -244,7 +244,7 @@ function getTooltipText(
     return "";
   }
 
-  if (!mustUpdate && canChangeVersions) {
+  if (!mustUpdate && canChangeVersions && workspace.template_require_active_version) {
     return "This template requires automatic updates on workspace startup, but template administrators can ignore this policy.";
   }
 


### PR DESCRIPTION
This was always rendering for the start button for admins even if the template didn't enable the setting.