### PR TITLE
feat: add name field to setup screen + CLI

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -58,6 +58,21 @@ func promptFirstUsername(inv *serpent.Invocation) (string, error) {
 	return username, nil
 }
 
+func promptFirstName(inv *serpent.Invocation) (string, error) {
+	name, err := cliui.Prompt(inv, cliui.PromptOptions{
+		Text:    "(Optional) What " + pretty.Sprint(cliui.DefaultStyles.Field, "name") + " would you like?",
+		Default: "",
+	})
+	if errors.Is(err, cliui.Canceled) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return name, nil
+}
+
 func promptFirstPassword(inv *serpent.Invocation) (string, error) {
 retry:
 	password, err := cliui.Prompt(inv, cliui.PromptOptions{
@@ -130,6 +145,7 @@ func (r *RootCmd) login() *serpent.Command {
 	var (
 		email              string
 		username           string
+		name               string
 		password           string
 		trial              bool
 		useTokenForSession bool
@@ -212,6 +228,10 @@ func (r *RootCmd) login() *serpent.Command {
 					if err != nil {
 						return err
 					}
+					name, err = promptFirstName(inv)
+					if err != nil {
+						return err
+					}
 				}
 
 				if email == "" {
@@ -249,6 +269,7 @@ func (r *RootCmd) login() *serpent.Command {
 				_, err = client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
 					Email:    email,
 					Username: username,
+					Name:     name,
 					Password: password,
 					Trial:    trial,
 				})
@@ -351,6 +372,12 @@ func (r *RootCmd) login() *serpent.Command {
 			Flag:        "first-user-username",
 			Env:         "CODER_FIRST_USER_USERNAME",
 			Description: "Specifies a username to use if creating the first user for the deployment.",
+			Value:       serpent.StringOf(&username),
+		},
+		{
+			Flag:        "first-user-name",
+			Env:         "CODER_FIRST_USER_AME",
+			Description: "Specifies a human-readable name for the first user of the deployment.",
 			Value:       serpent.StringOf(&username),
 		},
 		{

--- a/cli/login.go
+++ b/cli/login.go
@@ -207,6 +207,7 @@ func (r *RootCmd) login() *serpent.Command {
 
 			_, _ = fmt.Fprintf(inv.Stdout, "Attempting to authenticate with %s URL: '%s'\n", urlSource, serverURL)
 
+			// nolint: nestif
 			if !hasFirstUser {
 				_, _ = fmt.Fprintf(inv.Stdout, Caret+"Your Coder deployment hasn't been set up!\n")
 

--- a/cli/login.go
+++ b/cli/login.go
@@ -376,9 +376,9 @@ func (r *RootCmd) login() *serpent.Command {
 		},
 		{
 			Flag:        "first-user-name",
-			Env:         "CODER_FIRST_USER_AME",
+			Env:         "CODER_FIRST_USER_NAME",
 			Description: "Specifies a human-readable name for the first user of the deployment.",
-			Value:       serpent.StringOf(&username),
+			Value:       serpent.StringOf(&name),
 		},
 		{
 			Flag:        "first-user-password",

--- a/cli/login.go
+++ b/cli/login.go
@@ -269,7 +269,7 @@ func (r *RootCmd) login() *serpent.Command {
 				_, err = client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
 					Email:    email,
 					Username: username,
-					Name:     name,
+					FullName: name,
 					Password: password,
 					Trial:    trial,
 				})
@@ -375,8 +375,8 @@ func (r *RootCmd) login() *serpent.Command {
 			Value:       serpent.StringOf(&username),
 		},
 		{
-			Flag:        "first-user-name",
-			Env:         "CODER_FIRST_USER_NAME",
+			Flag:        "first-user-full-name",
+			Env:         "CODER_FIRST_USER_FULL_NAME",
 			Description: "Specifies a human-readable name for the first user of the deployment.",
 			Value:       serpent.StringOf(&name),
 		},

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -90,11 +90,11 @@ func TestLogin(t *testing.T) {
 
 		matches := []string{
 			"first user?", "yes",
-			"username", "testuser",
-			"name", "Test User",
-			"email", "user@coder.com",
-			"password", "SomeSecurePassword!",
-			"password", "SomeSecurePassword!", // Confirm.
+			"username", coderdtest.FirstUserParams.Username,
+			"name", coderdtest.FirstUserParams.Name,
+			"email", coderdtest.FirstUserParams.Email,
+			"password", coderdtest.FirstUserParams.Password,
+			"password", coderdtest.FirstUserParams.Password, // confirm
 			"trial", "yes",
 		}
 		for i := 0; i < len(matches); i += 2 {
@@ -107,16 +107,16 @@ func TestLogin(t *testing.T) {
 		<-doneChan
 		ctx := testutil.Context(t, testutil.WaitShort)
 		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
-			Email:    "user@coder.com",
-			Password: "SomeSecurePassword!",
+			Email:    coderdtest.FirstUserParams.Email,
+			Password: coderdtest.FirstUserParams.Password,
 		})
 		require.NoError(t, err)
 		client.SetSessionToken(resp.SessionToken)
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
-		assert.Equal(t, "testuser", me.Username)
-		assert.Equal(t, "Test User", me.Name)
-		assert.Equal(t, "user@coder.com", me.Email)
+		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
+		assert.Equal(t, coderdtest.FirstUserParams.Name, me.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
 	})
 
 	t.Run("InitialUserTTYFlag", func(t *testing.T) {
@@ -133,11 +133,11 @@ func TestLogin(t *testing.T) {
 		pty.ExpectMatch(fmt.Sprintf("Attempting to authenticate with flag URL: '%s'", client.URL.String()))
 		matches := []string{
 			"first user?", "yes",
-			"username", "testuser",
-			"name", "Test User",
-			"email", "user@coder.com",
-			"password", "SomeSecurePassword!",
-			"password", "SomeSecurePassword!", // Confirm.
+			"username", coderdtest.FirstUserParams.Username,
+			"name", coderdtest.FirstUserParams.Name,
+			"email", coderdtest.FirstUserParams.Email,
+			"password", coderdtest.FirstUserParams.Password,
+			"password", coderdtest.FirstUserParams.Password, // confirm
 			"trial", "yes",
 		}
 		for i := 0; i < len(matches); i += 2 {
@@ -149,16 +149,16 @@ func TestLogin(t *testing.T) {
 		pty.ExpectMatch("Welcome to Coder")
 		ctx := testutil.Context(t, testutil.WaitShort)
 		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
-			Email:    "user@coder.com",
-			Password: "SomeSecurePassword!",
+			Email:    coderdtest.FirstUserParams.Email,
+			Password: coderdtest.FirstUserParams.Password,
 		})
 		require.NoError(t, err)
 		client.SetSessionToken(resp.SessionToken)
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
-		assert.Equal(t, "testuser", me.Username)
-		assert.Equal(t, "Test User", me.Name)
-		assert.Equal(t, "user@coder.com", me.Email)
+		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
+		assert.Equal(t, coderdtest.FirstUserParams.Name, me.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
 	})
 
 	t.Run("InitialUserFlags", func(t *testing.T) {
@@ -166,10 +166,10 @@ func TestLogin(t *testing.T) {
 		client := coderdtest.New(t, nil)
 		inv, _ := clitest.New(
 			t, "login", client.URL.String(),
-			"--first-user-username", "testuser",
-			"--first-user-name", "Test User",
-			"--first-user-email", "user@coder.com",
-			"--first-user-password", "SomeSecurePassword!",
+			"--first-user-username", coderdtest.FirstUserParams.Username,
+			"--first-user-name", coderdtest.FirstUserParams.Name,
+			"--first-user-email", coderdtest.FirstUserParams.Email,
+			"--first-user-password", coderdtest.FirstUserParams.Password,
 			"--first-user-trial",
 		)
 		pty := ptytest.New(t).Attach(inv)
@@ -178,16 +178,44 @@ func TestLogin(t *testing.T) {
 		w.RequireSuccess()
 		ctx := testutil.Context(t, testutil.WaitShort)
 		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
-			Email:    "user@coder.com",
-			Password: "SomeSecurePassword!",
+			Email:    coderdtest.FirstUserParams.Email,
+			Password: coderdtest.FirstUserParams.Password,
 		})
 		require.NoError(t, err)
 		client.SetSessionToken(resp.SessionToken)
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
-		assert.Equal(t, "testuser", me.Username)
-		assert.Equal(t, "Test User", me.Name)
-		assert.Equal(t, "user@coder.com", me.Email)
+		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
+		assert.Equal(t, coderdtest.FirstUserParams.Name, me.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
+	})
+
+	t.Run("InitialUserFlagsNameOptional", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		inv, _ := clitest.New(
+			t, "login", client.URL.String(),
+			"--first-user-username", coderdtest.FirstUserParams.Username,
+			"--first-user-email", coderdtest.FirstUserParams.Email,
+			"--first-user-password", coderdtest.FirstUserParams.Password,
+			"--first-user-trial",
+		)
+		pty := ptytest.New(t).Attach(inv)
+		w := clitest.StartWithWaiter(t, inv)
+		pty.ExpectMatch("Welcome to Coder")
+		w.RequireSuccess()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    coderdtest.FirstUserParams.Email,
+			Password: coderdtest.FirstUserParams.Password,
+		})
+		require.NoError(t, err)
+		client.SetSessionToken(resp.SessionToken)
+		me, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
+		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
+		assert.Empty(t, me.Name)
 	})
 
 	t.Run("InitialUserTTYConfirmPasswordFailAndReprompt", func(t *testing.T) {

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -91,7 +91,7 @@ func TestLogin(t *testing.T) {
 		matches := []string{
 			"first user?", "yes",
 			"username", coderdtest.FirstUserParams.Username,
-			"name", coderdtest.FirstUserParams.Name,
+			"name", coderdtest.FirstUserParams.FullName,
 			"email", coderdtest.FirstUserParams.Email,
 			"password", coderdtest.FirstUserParams.Password,
 			"password", coderdtest.FirstUserParams.Password, // confirm
@@ -115,7 +115,7 @@ func TestLogin(t *testing.T) {
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
 		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
-		assert.Equal(t, coderdtest.FirstUserParams.Name, me.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.FullName, me.Name)
 		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
 	})
 
@@ -180,7 +180,7 @@ func TestLogin(t *testing.T) {
 		matches := []string{
 			"first user?", "yes",
 			"username", coderdtest.FirstUserParams.Username,
-			"name", coderdtest.FirstUserParams.Name,
+			"name", coderdtest.FirstUserParams.FullName,
 			"email", coderdtest.FirstUserParams.Email,
 			"password", coderdtest.FirstUserParams.Password,
 			"password", coderdtest.FirstUserParams.Password, // confirm
@@ -203,7 +203,7 @@ func TestLogin(t *testing.T) {
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
 		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
-		assert.Equal(t, coderdtest.FirstUserParams.Name, me.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.FullName, me.Name)
 		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
 	})
 
@@ -213,7 +213,7 @@ func TestLogin(t *testing.T) {
 		inv, _ := clitest.New(
 			t, "login", client.URL.String(),
 			"--first-user-username", coderdtest.FirstUserParams.Username,
-			"--first-user-name", coderdtest.FirstUserParams.Name,
+			"--first-user-full-name", coderdtest.FirstUserParams.FullName,
 			"--first-user-email", coderdtest.FirstUserParams.Email,
 			"--first-user-password", coderdtest.FirstUserParams.Password,
 			"--first-user-trial",
@@ -232,7 +232,7 @@ func TestLogin(t *testing.T) {
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
 		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
-		assert.Equal(t, coderdtest.FirstUserParams.Name, me.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.FullName, me.Name)
 		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
 	})
 
@@ -284,7 +284,7 @@ func TestLogin(t *testing.T) {
 		matches := []string{
 			"first user?", "yes",
 			"username", coderdtest.FirstUserParams.Username,
-			"name", coderdtest.FirstUserParams.Name,
+			"name", coderdtest.FirstUserParams.FullName,
 			"email", coderdtest.FirstUserParams.Email,
 			"password", coderdtest.FirstUserParams.Password,
 			"password", "something completely different",

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -90,6 +90,7 @@ func TestLogin(t *testing.T) {
 		matches := []string{
 			"first user?", "yes",
 			"username", "testuser",
+			"name", "Test User",
 			"email", "user@coder.com",
 			"password", "SomeSecurePassword!",
 			"password", "SomeSecurePassword!", // Confirm.
@@ -120,6 +121,7 @@ func TestLogin(t *testing.T) {
 		matches := []string{
 			"first user?", "yes",
 			"username", "testuser",
+			"name", "Test User",
 			"email", "user@coder.com",
 			"password", "SomeSecurePassword!",
 			"password", "SomeSecurePassword!", // Confirm.
@@ -139,8 +141,11 @@ func TestLogin(t *testing.T) {
 		client := coderdtest.New(t, nil)
 		inv, _ := clitest.New(
 			t, "login", client.URL.String(),
-			"--first-user-username", "testuser", "--first-user-email", "user@coder.com",
-			"--first-user-password", "SomeSecurePassword!", "--first-user-trial",
+			"--first-user-username", "testuser",
+			"--first-user-name", `'Test User'`,
+			"--first-user-email", "user@coder.com",
+			"--first-user-password", "SomeSecurePassword!",
+			"--first-user-trial",
 		)
 		pty := ptytest.New(t).Attach(inv)
 		w := clitest.StartWithWaiter(t, inv)

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -119,6 +119,52 @@ func TestLogin(t *testing.T) {
 		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
 	})
 
+	t.Run("InitialUserTTYNameOptional", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		// The --force-tty flag is required on Windows, because the `isatty` library does not
+		// accurately detect Windows ptys when they are not attached to a process:
+		// https://github.com/mattn/go-isatty/issues/59
+		doneChan := make(chan struct{})
+		root, _ := clitest.New(t, "login", "--force-tty", client.URL.String())
+		pty := ptytest.New(t).Attach(root)
+		go func() {
+			defer close(doneChan)
+			err := root.Run()
+			assert.NoError(t, err)
+		}()
+
+		matches := []string{
+			"first user?", "yes",
+			"username", coderdtest.FirstUserParams.Username,
+			"name", "",
+			"email", coderdtest.FirstUserParams.Email,
+			"password", coderdtest.FirstUserParams.Password,
+			"password", coderdtest.FirstUserParams.Password, // confirm
+			"trial", "yes",
+		}
+		for i := 0; i < len(matches); i += 2 {
+			match := matches[i]
+			value := matches[i+1]
+			pty.ExpectMatch(match)
+			pty.WriteLine(value)
+		}
+		pty.ExpectMatch("Welcome to Coder")
+		<-doneChan
+		ctx := testutil.Context(t, testutil.WaitShort)
+		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    coderdtest.FirstUserParams.Email,
+			Password: coderdtest.FirstUserParams.Password,
+		})
+		require.NoError(t, err)
+		client.SetSessionToken(resp.SessionToken)
+		me, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		assert.Equal(t, coderdtest.FirstUserParams.Username, me.Username)
+		assert.Equal(t, coderdtest.FirstUserParams.Email, me.Email)
+		assert.Empty(t, me.Name)
+	})
+
 	t.Run("InitialUserTTYFlag", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -237,10 +237,11 @@ func TestLogin(t *testing.T) {
 
 		matches := []string{
 			"first user?", "yes",
-			"username", "testuser",
-			"email", "user@coder.com",
-			"password", "MyFirstSecurePassword!",
-			"password", "MyNonMatchingSecurePassword!", // Confirm.
+			"username", coderdtest.FirstUserParams.Username,
+			"name", coderdtest.FirstUserParams.Name,
+			"email", coderdtest.FirstUserParams.Email,
+			"password", coderdtest.FirstUserParams.Password,
+			"password", "something completely different",
 		}
 		for i := 0; i < len(matches); i += 2 {
 			match := matches[i]
@@ -253,9 +254,9 @@ func TestLogin(t *testing.T) {
 		pty.ExpectMatch("Passwords do not match")
 		pty.ExpectMatch("Enter a " + pretty.Sprint(cliui.DefaultStyles.Field, "password"))
 
-		pty.WriteLine("SomeSecurePassword!")
+		pty.WriteLine(coderdtest.FirstUserParams.Password)
 		pty.ExpectMatch("Confirm")
-		pty.WriteLine("SomeSecurePassword!")
+		pty.WriteLine(coderdtest.FirstUserParams.Password)
 		pty.ExpectMatch("trial")
 		pty.WriteLine("yes")
 		pty.ExpectMatch("Welcome to Coder")

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestLogin(t *testing.T) {
@@ -104,6 +105,18 @@ func TestLogin(t *testing.T) {
 		}
 		pty.ExpectMatch("Welcome to Coder")
 		<-doneChan
+		ctx := testutil.Context(t, testutil.WaitShort)
+		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    "user@coder.com",
+			Password: "SomeSecurePassword!",
+		})
+		require.NoError(t, err)
+		client.SetSessionToken(resp.SessionToken)
+		me, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		assert.Equal(t, "testuser", me.Username)
+		assert.Equal(t, "Test User", me.Name)
+		assert.Equal(t, "user@coder.com", me.Email)
 	})
 
 	t.Run("InitialUserTTYFlag", func(t *testing.T) {
@@ -134,6 +147,18 @@ func TestLogin(t *testing.T) {
 			pty.WriteLine(value)
 		}
 		pty.ExpectMatch("Welcome to Coder")
+		ctx := testutil.Context(t, testutil.WaitShort)
+		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    "user@coder.com",
+			Password: "SomeSecurePassword!",
+		})
+		require.NoError(t, err)
+		client.SetSessionToken(resp.SessionToken)
+		me, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		assert.Equal(t, "testuser", me.Username)
+		assert.Equal(t, "Test User", me.Name)
+		assert.Equal(t, "user@coder.com", me.Email)
 	})
 
 	t.Run("InitialUserFlags", func(t *testing.T) {
@@ -142,7 +167,7 @@ func TestLogin(t *testing.T) {
 		inv, _ := clitest.New(
 			t, "login", client.URL.String(),
 			"--first-user-username", "testuser",
-			"--first-user-name", `'Test User'`,
+			"--first-user-name", "Test User",
 			"--first-user-email", "user@coder.com",
 			"--first-user-password", "SomeSecurePassword!",
 			"--first-user-trial",
@@ -151,6 +176,18 @@ func TestLogin(t *testing.T) {
 		w := clitest.StartWithWaiter(t, inv)
 		pty.ExpectMatch("Welcome to Coder")
 		w.RequireSuccess()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		resp, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
+			Email:    "user@coder.com",
+			Password: "SomeSecurePassword!",
+		})
+		require.NoError(t, err)
+		client.SetSessionToken(resp.SessionToken)
+		me, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		assert.Equal(t, "testuser", me.Username)
+		assert.Equal(t, "Test User", me.Name)
+		assert.Equal(t, "user@coder.com", me.Email)
 	})
 
 	t.Run("InitialUserTTYConfirmPasswordFailAndReprompt", func(t *testing.T) {

--- a/cli/testdata/coder_login_--help.golden
+++ b/cli/testdata/coder_login_--help.golden
@@ -10,7 +10,7 @@ OPTIONS:
           Specifies an email address to use if creating the first user for the
           deployment.
 
-      --first-user-name string, $CODER_FIRST_USER_NAME
+      --first-user-full-name string, $CODER_FIRST_USER_FULL_NAME
           Specifies a human-readable name for the first user of the deployment.
 
       --first-user-password string, $CODER_FIRST_USER_PASSWORD

--- a/cli/testdata/coder_login_--help.golden
+++ b/cli/testdata/coder_login_--help.golden
@@ -10,6 +10,9 @@ OPTIONS:
           Specifies an email address to use if creating the first user for the
           deployment.
 
+      --first-user-name string, $CODER_FIRST_USER_NAME
+          Specifies a human-readable name for the first user of the deployment.
+
       --first-user-password string, $CODER_FIRST_USER_PASSWORD
           Specifies a password to use if creating the first user for the
           deployment.

--- a/cli/testdata/coder_users_list_--output_json.golden
+++ b/cli/testdata/coder_users_list_--output_json.golden
@@ -3,7 +3,7 @@
     "id": "[first user ID]",
     "username": "testuser",
     "avatar_url": "",
-    "name": "",
+    "name": "Test User",
     "email": "testuser@coder.com",
     "created_at": "[timestamp]",
     "last_seen_at": "[timestamp]",

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8897,6 +8897,9 @@ const docTemplate = `{
                 "email": {
                     "type": "string"
                 },
+                "name": {
+                    "type": "string"
+                },
                 "password": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7921,6 +7921,9 @@
         "email": {
           "type": "string"
         },
+        "name": {
+          "type": "string"
+        },
         "password": {
           "type": "string"
         },

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -645,6 +645,7 @@ var FirstUserParams = codersdk.CreateFirstUserRequest{
 	Email:    "testuser@coder.com",
 	Username: "testuser",
 	Password: "SomeSecurePassword!",
+	Name:     "Test User",
 }
 
 // CreateFirstUser creates a user with preset credentials and authenticates

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -645,7 +645,7 @@ var FirstUserParams = codersdk.CreateFirstUserRequest{
 	Email:    "testuser@coder.com",
 	Username: "testuser",
 	Password: "SomeSecurePassword!",
-	Name:     "Test User",
+	FullName: "Test User",
 }
 
 // CreateFirstUser creates a user with preset credentials and authenticates

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -320,6 +320,7 @@ func convertUsers(users []database.User, count int64) []database.GetUsersRow {
 			ID:             u.ID,
 			Email:          u.Email,
 			Username:       u.Username,
+			Name:           u.Name,
 			HashedPassword: u.HashedPassword,
 			CreatedAt:      u.CreatedAt,
 			UpdatedAt:      u.UpdatedAt,

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -313,6 +313,7 @@ func ConvertUserRows(rows []GetUsersRow) []User {
 			ID:              r.ID,
 			Email:           r.Email,
 			Username:        r.Username,
+			Name:            r.Name,
 			HashedPassword:  r.HashedPassword,
 			CreatedAt:       r.CreatedAt,
 			UpdatedAt:       r.UpdatedAt,

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -202,14 +202,14 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//nolint:gocritic // Neded to create first user.
+	//nolint:gocritic // Needed to create first user.
 	if _, err := api.Database.UpdateUserProfile(dbauthz.AsSystemRestricted(ctx), database.UpdateUserProfileParams{
 		ID:        user.ID,
 		UpdatedAt: dbtime.Now(),
 		Email:     user.Email,
 		Username:  user.Username,
 		AvatarURL: user.AvatarURL,
-		Name:      createUser.Name,
+		Name:      createUser.FullName,
 	}); err != nil {
 		// This should not be a fatal error. Updating the user's profile can be done separately.
 		api.Logger.Error(ctx, "failed to update userprofile.Name", slog.Error(err))

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -70,8 +70,14 @@ func TestFirstUser(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
 		client := coderdtest.New(t, nil)
 		_ = coderdtest.CreateFirstUser(t, client)
+		u, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		assert.Equal(t, coderdtest.FirstUserParams.Name, u.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.Email, u.Email)
+		assert.Equal(t, coderdtest.FirstUserParams.Username, u.Username)
 	})
 
 	t.Run("Trial", func(t *testing.T) {
@@ -96,6 +102,7 @@ func TestFirstUser(t *testing.T) {
 		req := codersdk.CreateFirstUserRequest{
 			Email:    "testuser@coder.com",
 			Username: "testuser",
+			Name:     "Test User",
 			Password: "SomeSecurePassword!",
 			Trial:    true,
 		}
@@ -1486,7 +1493,7 @@ func TestUsersFilter(t *testing.T) {
 					exp = append(exp, made)
 				}
 			}
-			require.ElementsMatch(t, exp, matched.Users, "expected workspaces returned")
+			require.ElementsMatch(t, exp, matched.Users, "expected users returned")
 		})
 	}
 }

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -75,7 +75,7 @@ func TestFirstUser(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client)
 		u, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
-		assert.Equal(t, coderdtest.FirstUserParams.Name, u.Name)
+		assert.Equal(t, coderdtest.FirstUserParams.FullName, u.Name)
 		assert.Equal(t, coderdtest.FirstUserParams.Email, u.Email)
 		assert.Equal(t, coderdtest.FirstUserParams.Username, u.Username)
 	})
@@ -102,7 +102,7 @@ func TestFirstUser(t *testing.T) {
 		req := codersdk.CreateFirstUserRequest{
 			Email:    "testuser@coder.com",
 			Username: "testuser",
-			Name:     "Test User",
+			FullName: "Test User",
 			Password: "SomeSecurePassword!",
 			Trial:    true,
 		}

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -728,7 +728,7 @@ func TestWorkspaceDeleteSuspendedUser(t *testing.T) {
 					validateCalls++
 					if userSuspended {
 						// Simulate the user being suspended from the IDP too.
-						return "", http.StatusForbidden, fmt.Errorf("user is suspended")
+						return "", http.StatusForbidden, xerrors.New("user is suspended")
 					}
 					return "OK", 0, nil
 				},

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -90,6 +90,7 @@ type LicensorTrialRequest struct {
 type CreateFirstUserRequest struct {
 	Email     string                   `json:"email" validate:"required,email"`
 	Username  string                   `json:"username" validate:"required,username"`
+	Name      string                   `json:"name" validate:"user_real_name"`
 	Password  string                   `json:"password" validate:"required"`
 	Trial     bool                     `json:"trial"`
 	TrialInfo CreateFirstUserTrialInfo `json:"trial_info"`

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -90,7 +90,7 @@ type LicensorTrialRequest struct {
 type CreateFirstUserRequest struct {
 	Email     string                   `json:"email" validate:"required,email"`
 	Username  string                   `json:"username" validate:"required,username"`
-	Name      string                   `json:"name" validate:"user_real_name"`
+	FullName  string                   `json:"name" validate:"user_real_name"`
 	Password  string                   `json:"password" validate:"required"`
 	Trial     bool                     `json:"trial"`
 	TrialInfo CreateFirstUserTrialInfo `json:"trial_info"`

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1325,6 +1325,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 ```json
 {
   "email": "string",
+  "name": "string",
   "password": "string",
   "trial": true,
   "trial_info": {
@@ -1345,6 +1346,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Name         | Type                                                                   | Required | Restrictions | Description |
 | ------------ | ---------------------------------------------------------------------- | -------- | ------------ | ----------- |
 | `email`      | string                                                                 | true     |              |             |
+| `name`       | string                                                                 | false    |              |             |
 | `password`   | string                                                                 | true     |              |             |
 | `trial`      | boolean                                                                | false    |              |             |
 | `trial_info` | [codersdk.CreateFirstUserTrialInfo](#codersdkcreatefirstusertrialinfo) | false    |              |             |

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -229,6 +229,7 @@ curl -X POST http://coder-server:8080/api/v2/users/first \
 ```json
 {
   "email": "string",
+  "name": "string",
   "password": "string",
   "trial": true,
   "trial_info": {

--- a/docs/cli/login.md
+++ b/docs/cli/login.md
@@ -30,6 +30,15 @@ Specifies an email address to use if creating the first user for the deployment.
 
 Specifies a username to use if creating the first user for the deployment.
 
+### --first-user-name
+
+|             |                                    |
+| ----------- | ---------------------------------- |
+| Type        | <code>string</code>                |
+| Environment | <code>$CODER_FIRST_USER_AME</code> |
+
+Specifies a human-readable name for the first user of the deployment.
+
 ### --first-user-password
 
 |             |                                         |

--- a/docs/cli/login.md
+++ b/docs/cli/login.md
@@ -30,12 +30,12 @@ Specifies an email address to use if creating the first user for the deployment.
 
 Specifies a username to use if creating the first user for the deployment.
 
-### --first-user-name
+### --first-user-full-name
 
-|             |                                    |
-| ----------- | ---------------------------------- |
-| Type        | <code>string</code>                |
-| Environment | <code>$CODER_FIRST_USER_AME</code> |
+|             |                                          |
+| ----------- | ---------------------------------------- |
+| Type        | <code>string</code>                      |
+| Environment | <code>$CODER_FIRST_USER_FULL_NAME</code> |
 
 Specifies a human-readable name for the first user of the deployment.
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -193,6 +193,7 @@ export interface ConvertLoginRequest {
 export interface CreateFirstUserRequest {
   readonly email: string;
   readonly username: string;
+  readonly name: string;
   readonly password: string;
   readonly trial: boolean;
   readonly trial_info: CreateFirstUserTrialInfo;

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -168,7 +168,6 @@ export const SetupPageView: FC<SetupPageViewProps> = ({
             type="password"
           />
           <TextField
-            autoFocus
             {...getFieldHelpers("name")}
             onBlur={(e) => {
               e.target.value = e.target.value.trim();

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -23,7 +23,7 @@ import { countries } from "./countries";
 export const Language = {
   emailLabel: "Email",
   passwordLabel: "Password",
-  nameLabel: "Name",
+  fullNameLabel: "Full Name",
   nameHelperText: "Optional human-readable name",
   usernameLabel: "Username",
   emailInvalid: "Please enter a valid email address.",
@@ -175,7 +175,7 @@ export const SetupPageView: FC<SetupPageViewProps> = ({
             }}
             autoComplete="name"
             fullWidth
-            label={Language.nameLabel}
+            label={Language.fullNameLabel}
             helperText={Language.nameHelperText}
           />
           <label

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -23,6 +23,8 @@ import { countries } from "./countries";
 export const Language = {
   emailLabel: "Email",
   passwordLabel: "Password",
+  nameLabel: "Name",
+  nameHelperText: 'Optional human-readable name',
   usernameLabel: "Username",
   emailInvalid: "Please enter a valid email address.",
   emailRequired: "Please enter an email address.",
@@ -93,6 +95,7 @@ export const SetupPageView: FC<SetupPageViewProps> = ({
         email: "",
         password: "",
         username: "",
+        name: "",
         trial: false,
         trial_info: {
           first_name: "",
@@ -164,7 +167,18 @@ export const SetupPageView: FC<SetupPageViewProps> = ({
             label={Language.passwordLabel}
             type="password"
           />
-
+          <TextField
+            autoFocus
+            {...getFieldHelpers("name")}
+            onBlur={(e) => {
+              e.target.value = e.target.value.trim();
+              form.handleChange(e);
+            }}
+            autoComplete="name"
+            fullWidth
+            label={Language.nameLabel}
+            helperText={Language.nameHelperText}
+          />
           <label
             htmlFor="trial"
             css={{

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -24,7 +24,7 @@ export const Language = {
   emailLabel: "Email",
   passwordLabel: "Password",
   nameLabel: "Name",
-  nameHelperText: 'Optional human-readable name',
+  nameHelperText: "Optional human-readable name",
   usernameLabel: "Username",
   emailInvalid: "Please enter a valid email address.",
   emailRequired: "Please enter an email address.",


### PR DESCRIPTION
Part of https://github.com/coder/coder/issues/13490

This takes the simpler approach of simply adding Name to the CreateFirstUser payload.

Still need to add the "name" field to the new user creation flow (UI/CLI), but that will be a separate PR.