### PR TITLE
chore: change mock clock to allow Advance() within timer/tick functions

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -26,6 +26,8 @@ type Clock interface {
 	Now(tags ...string) time.Time
 	// Since returns the time elapsed since t. It is shorthand for Clock.Now().Sub(t).
 	Since(t time.Time, tags ...string) time.Duration
+	// Until returns the duration until t. It is shorthand for t.Sub(Clock.Now()).
+	Until(t time.Time, tags ...string) time.Duration
 }
 
 // Waiter can be waited on for an error.

--- a/clock/real.go
+++ b/clock/real.go
@@ -68,4 +68,8 @@ func (realClock) Since(t time.Time, _ ...string) time.Duration {
 	return time.Since(t)
 }
 
+func (realClock) Until(t time.Time, _ ...string) time.Duration {
+	return time.Until(t)
+}
+
 var _ Clock = realClock{}

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/coder/v2/clock"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -337,7 +339,13 @@ func TestPGCoordinatorSingle_MissedHeartbeats(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancel()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-	coordinator, err := tailnet.NewPGCoord(ctx, logger, ps, store)
+	mClock := clock.NewMock(t)
+	nowTrap := mClock.Trap().Now("heartbeats", "recvBeat")
+	defer nowTrap.Close()
+	afTrap := mClock.Trap().AfterFunc("heartbeats", "recvBeat")
+	defer afTrap.Close()
+
+	coordinator, err := tailnet.NewTestPGCoord(ctx, logger, ps, store, mClock)
 	require.NoError(t, err)
 	defer coordinator.Close()
 
@@ -360,21 +368,11 @@ func TestPGCoordinatorSingle_MissedHeartbeats(t *testing.T) {
 		store: store,
 		id:    uuid.New(),
 	}
-	// heatbeat until canceled
-	ctx2, cancel2 := context.WithCancel(ctx)
-	go func() {
-		t := time.NewTicker(tailnet.HeartbeatPeriod)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx2.Done():
-				return
-			case <-t.C:
-				fCoord2.heartbeat()
-			}
-		}
-	}()
+
 	fCoord2.heartbeat()
+	nowTrap.MustWait(ctx).Release()
+	afTrap.MustWait(ctx).Release() // heartbeat timeout started
+
 	fCoord2.agentNode(agent.id, &agpl.Node{PreferredDERP: 12})
 	assertEventuallyHasDERPs(ctx, t, client, 12)
 
@@ -384,22 +382,31 @@ func TestPGCoordinatorSingle_MissedHeartbeats(t *testing.T) {
 		store: store,
 		id:    uuid.New(),
 	}
-	start := time.Now()
 	fCoord3.heartbeat()
+	nowTrap.MustWait(ctx).Release()
 	fCoord3.agentNode(agent.id, &agpl.Node{PreferredDERP: 13})
 	assertEventuallyHasDERPs(ctx, t, client, 13)
 
+	// fCoord2 sends in a second heartbeat, one period later (on time)
+	fCoord2.heartbeat()
+	c := nowTrap.MustWait(ctx)
+	mClock.Advance(tailnet.HeartbeatPeriod).MustWait(ctx)
+	c.Release()
+
 	// when the fCoord3 misses enough heartbeats, the real coordinator should send an update with the
 	// node from fCoord2 for the agent.
+	mClock.Advance(tailnet.HeartbeatPeriod).MustWait(ctx)
+	mClock.Advance(tailnet.HeartbeatPeriod).MustWait(ctx)
 	assertEventuallyHasDERPs(ctx, t, client, 12)
-	assert.Greater(t, time.Since(start), tailnet.HeartbeatPeriod*tailnet.MissedHeartbeats)
 
-	// stop fCoord2 heartbeats, which should cause us to revert to the original agent mapping
-	cancel2()
+	// one more heartbeat period will result in fCoord2 being expired, which should cause us to
+	// revert to the original agent mapping
+	mClock.Advance(tailnet.HeartbeatPeriod).MustWait(ctx)
 	assertEventuallyHasDERPs(ctx, t, client, 10)
 
 	// send fCoord3 heartbeat, which should trigger us to consider that mapping valid again.
 	fCoord3.heartbeat()
+	nowTrap.MustWait(ctx).Release()
 	assertEventuallyHasDERPs(ctx, t, client, 13)
 
 	err = agent.close()


### PR DESCRIPTION
I've modified the `Mock.Advance()` function to be more simple and allow more flexibility in testing.

tl;dr - `Advance()` now only allows you to advance up to the next timer/ticker event and no further, and _immediately_ advances the clock, rather than the clock advancing async as  ticks and timers are processed.

Why?
-----
Prior to this change, `Advance()` moves the clock forward, possibly triggering multiple timers/ticks.  You had to `Wait()` for the result before you could be sure the clock had moved as far as you asked.  And, crucially, the internal implementation didn't allow you to make another call to `Advance()` until the first one finished.

But, a test case that I want to support is being able to have time progress _during_ a timer/ticker functional callback.  The added UT to `enterprise/tailnet` is an example of this. `heartbeats` makes a call to `Now()` to record the time of a heartbeat, then later calls `Until()` to calculate when next to check for expiry. In a real system these calls can happen with different "current" times, and there was a bug that I noticed that if a coordinator is _just_ about to expire, but not quite, by the time we get around to calculated when next to check, it could already be in the past, and we would have ignored it. So, we need to `Trap()` the call to `Until` and advance the clock.

With the prior implementation, this fails.  I initially went down a rabbit hole of having a central goroutine manage advancing the clock, and allowing `Advance()` calls to come in while others have not fully resolved, but things get messy and complicated very quickly.  In particular, how does the thing managing the clock know the order to process advances when one is happening _during_ another?

That way lies madness, probably, and completely destroys the goal of writing tests where the time is predictable after every mock call.

The proposed solution
----------------------

So instead, we restrict `Advance()` to be able to, in a single call, move the clock up to the next event and no further. Then, it can immediately set the new time, even if you asynchronously wait for timers/ticker functions to return.

For cases where you don't know or want to compute how long to the next event, I've added `AdvanceNext()` which returns the amount advanced for asserting or use in further calculations.

This gets us back to a place where UTs are in the imperative style and the clock moves predictably, monotonically forward as the UT is executed.