### PR TITLE
chore: change Process to NetNamespace in tailnet integration tests

### DIFF
--- a/tailnet/test/integration/integration_test.go
+++ b/tailnet/test/integration/integration_test.go
@@ -331,7 +331,7 @@ func waitForServerAvailable(t *testing.T, serverURL *url.URL) {
 }
 
 func startServerSubprocess(t *testing.T, topologyName string, networking integration.TestNetworking) func() error {
-	_, closeFn := startSubprocess(t, "server", networking.Server.Process.NetNS, []string{
+	_, closeFn := startSubprocess(t, "server", networking.Server.Namespace.File, []string{
 		"--subprocess",
 		"--test-name=" + topologyName,
 		"--role=server",
@@ -341,7 +341,7 @@ func startServerSubprocess(t *testing.T, topologyName string, networking integra
 }
 
 func startSTUNSubprocess(t *testing.T, topologyName string, number int, stun integration.TestNetworkingSTUN) func() error {
-	_, closeFn := startSubprocess(t, "stun", stun.Process.NetNS, []string{
+	_, closeFn := startSubprocess(t, "stun", stun.Namespace.File, []string{
 		"--subprocess",
 		"--test-name=" + topologyName,
 		"--role=stun",
@@ -370,7 +370,7 @@ func startClientSubprocess(t *testing.T, topologyName string, networking integra
 		"--client-derp-map-path=" + derpMapPath,
 	}
 
-	return startSubprocess(t, clientName, clientProcessConfig.Process.NetNS, flags)
+	return startSubprocess(t, clientName, clientProcessConfig.Namespace.File, flags)
 }
 
 // startSubprocess launches the test binary with the same flags as the test, but


### PR DESCRIPTION
Renames `TestNetworkingProcess` to `NetNamespace` since that's what it is.

Refactors running commands in a namespace to be a method on the `NetNamespace` object.

Refactors `ip ...` commands running in net namespace to use `ip --netns <name> args` rather than `nsenter`.