### PR TITLE
chore: update Ashby link to be position agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ contributions!
 
 ## Hiring
 
-Apply [here](https://cdr.co/github-apply) if you're interested in joining our team.
+Apply [here](https://jobs.ashbyhq.com/coder?utm_source=github&utm_medium=readme&utm_campaign=unknown) if you're interested in joining our team.


### PR DESCRIPTION
The old URL was tied to a now-defunct OS role. Now we show all jobs but still source from GitHub.

[Thread](https://codercom.slack.com/archives/C0603CTFZPU/p1718116923831249)