### PR TITLE
chore: add additional tailnet topology integration tests 

### DIFF
--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -236,10 +236,10 @@ func (o SimpleServerOptions) Router(t *testing.T, logger slog.Logger) *chi.Mux {
 	return r
 }
 
-func (n *SimpleServerOptions) StartServer(t *testing.T, logger slog.Logger, listenAddr string) {
+func (s *SimpleServerOptions) StartServer(t *testing.T, logger slog.Logger, listenAddr string) {
 	srv := http.Server{
 		Addr:        listenAddr,
-		Handler:     n.Router(t, logger),
+		Handler:     s.Router(t, logger),
 		ReadTimeout: 10 * time.Second,
 	}
 	serveDone := make(chan struct{})
@@ -254,7 +254,7 @@ func (n *SimpleServerOptions) StartServer(t *testing.T, logger slog.Logger, list
 		_ = srv.Close()
 		<-serveDone
 	})
-	n.Server = &srv
+	s.Server = &srv
 }
 
 type NGINXServerOptions struct {

--- a/tailnet/test/integration/integration_test.go
+++ b/tailnet/test/integration/integration_test.go
@@ -79,7 +79,7 @@ var topologies = []integration.TestTopology{
 		// Test that DERP over loopback works.
 		Name:            "BasicLoopbackDERP",
 		SetupNetworking: integration.SetupNetworkingLoopback,
-		Server:          integration.SimpleServerOptions{},
+		Server:          &integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDERP,
 		RunTests:        integration.TestSuite,
 	},
@@ -89,7 +89,7 @@ var topologies = []integration.TestTopology{
 		// by a bridge.
 		Name:            "EasyNATDERP",
 		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server:          integration.SimpleServerOptions{},
+		Server:          &integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDERP,
 		RunTests:        integration.TestSuite,
 	},
@@ -98,7 +98,7 @@ var topologies = []integration.TestTopology{
 		// STUN.
 		Name:            "EasyNATDirect",
 		SetupNetworking: integration.SetupNetworkingEasyNATWithSTUN,
-		Server:          integration.SimpleServerOptions{},
+		Server:          &integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDirect,
 		RunTests:        integration.TestSuite,
 	},
@@ -106,7 +106,7 @@ var topologies = []integration.TestTopology{
 		// Test that direct over hard NAT <=> easy NAT works.
 		Name:            "HardNATEasyNATDirect",
 		SetupNetworking: integration.SetupNetworkingHardNATEasyNATDirect,
-		Server:          integration.SimpleServerOptions{},
+		Server:          &integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDirect,
 		RunTests:        integration.TestSuite,
 	},
@@ -116,7 +116,7 @@ var topologies = []integration.TestTopology{
 		// automatic fallback.
 		Name:            "DERPForceWebSockets",
 		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server: integration.SimpleServerOptions{
+		Server: &integration.SimpleServerOptions{
 			FailUpgradeDERP:   false,
 			DERPWebsocketOnly: true,
 		},
@@ -127,7 +127,7 @@ var topologies = []integration.TestTopology{
 		// Test that falling back to DERP over WebSocket works.
 		Name:            "DERPFallbackWebSockets",
 		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server: integration.SimpleServerOptions{
+		Server: &integration.SimpleServerOptions{
 			FailUpgradeDERP:   true,
 			DERPWebsocketOnly: false,
 		},
@@ -138,7 +138,7 @@ var topologies = []integration.TestTopology{
 	{
 		Name:            "BasicLoopbackDERPNGINX",
 		SetupNetworking: integration.SetupNetworkingLoopback,
-		Server:          integration.NGINXServerOptions{},
+		Server:          &integration.NGINXServerOptions{},
 		StartClient:     integration.StartClientDERP,
 		RunTests:        integration.TestSuite,
 	},

--- a/tailnet/test/integration/integration_test.go
+++ b/tailnet/test/integration/integration_test.go
@@ -79,7 +79,7 @@ var topologies = []integration.TestTopology{
 		// Test that DERP over loopback works.
 		Name:            "BasicLoopbackDERP",
 		SetupNetworking: integration.SetupNetworkingLoopback,
-		Server:          &integration.SimpleServerOptions{},
+		Server:          integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDERP,
 		RunTests:        integration.TestSuite,
 	},
@@ -89,7 +89,7 @@ var topologies = []integration.TestTopology{
 		// by a bridge.
 		Name:            "EasyNATDERP",
 		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server:          &integration.SimpleServerOptions{},
+		Server:          integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDERP,
 		RunTests:        integration.TestSuite,
 	},
@@ -98,7 +98,7 @@ var topologies = []integration.TestTopology{
 		// STUN.
 		Name:            "EasyNATDirect",
 		SetupNetworking: integration.SetupNetworkingEasyNATWithSTUN,
-		Server:          &integration.SimpleServerOptions{},
+		Server:          integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDirect,
 		RunTests:        integration.TestSuite,
 	},
@@ -106,7 +106,7 @@ var topologies = []integration.TestTopology{
 		// Test that direct over hard NAT <=> easy NAT works.
 		Name:            "HardNATEasyNATDirect",
 		SetupNetworking: integration.SetupNetworkingHardNATEasyNATDirect,
-		Server:          &integration.SimpleServerOptions{},
+		Server:          integration.SimpleServerOptions{},
 		StartClient:     integration.StartClientDirect,
 		RunTests:        integration.TestSuite,
 	},
@@ -116,7 +116,7 @@ var topologies = []integration.TestTopology{
 		// automatic fallback.
 		Name:            "DERPForceWebSockets",
 		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server: &integration.SimpleServerOptions{
+		Server: integration.SimpleServerOptions{
 			FailUpgradeDERP:   false,
 			DERPWebsocketOnly: true,
 		},
@@ -127,7 +127,7 @@ var topologies = []integration.TestTopology{
 		// Test that falling back to DERP over WebSocket works.
 		Name:            "DERPFallbackWebSockets",
 		SetupNetworking: integration.SetupNetworkingEasyNAT,
-		Server: &integration.SimpleServerOptions{
+		Server: integration.SimpleServerOptions{
 			FailUpgradeDERP:   true,
 			DERPWebsocketOnly: false,
 		},
@@ -138,7 +138,7 @@ var topologies = []integration.TestTopology{
 	{
 		Name:            "BasicLoopbackDERPNGINX",
 		SetupNetworking: integration.SetupNetworkingLoopback,
-		Server:          &integration.NGINXServerOptions{},
+		Server:          integration.NGINXServerOptions{},
 		StartClient:     integration.StartClientDERP,
 		RunTests:        integration.TestSuite,
 	},

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -27,7 +27,6 @@ func sendRestart(t *testing.T, serverURL *url.URL, derp bool, coordinator bool) 
 		q.Set("derp", "true")
 	}
 	if coordinator {
-		q := serverURL.Query()
 		q.Set("coordinator", "true")
 	}
 	serverURL.RawQuery = q.Encode()

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -66,5 +66,13 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		require.NoError(t, err, "ping peer after coordinator restart")
 	})
 
-	// TODO: more
+	t.Run("RestartBoth", func(t *testing.T) {
+		peerIP := tailnet.IPFromUUID(peer.ID)
+		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
+		require.NoError(t, err, "ping peer")
+		sendRestart(t, serverURL, "/derp/restart")
+		sendRestart(t, serverURL, "/restart")
+		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
+		require.NoError(t, err, "ping peer after restart")
+	})
 }

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -22,16 +22,15 @@ func sendRestart(t *testing.T, serverURL *url.URL, derp bool, coordinator bool) 
 	ctx := testutil.Context(t, 2*time.Second)
 
 	serverURL, err := url.Parse(serverURL.String() + "/restart")
+	q := serverURL.Query()
 	if derp {
-		q := serverURL.Query()
 		q.Set("derp", "true")
-		serverURL.RawQuery = q.Encode()
 	}
 	if coordinator {
 		q := serverURL.Query()
 		q.Set("coordinator", "true")
-		serverURL.RawQuery = q.Encode()
 	}
+	serverURL.RawQuery = q.Encode()
 	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL.String(), nil)

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -16,10 +16,10 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func sendRestart(t *testing.T, serverURL *url.URL, endpoint string) {
+func restartDERP(t *testing.T, serverURL *url.URL) {
 	const reqTimeout = 2 * time.Second
 
-	serverURL, err := url.Parse(serverURL.String() + endpoint)
+	serverURL, err := url.Parse(serverURL.String() + "/derp/restart")
 	require.NoError(t, err)
 
 	client := http.Client{
@@ -52,7 +52,7 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		peerIP := tailnet.IPFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
-		sendRestart(t, serverURL, "/derp/restart")
+		restartDERP(t, serverURL)
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer after derp restart")
 	})

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -16,10 +16,10 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func restartDERP(t *testing.T, serverURL *url.URL) {
+func sendRestart(t *testing.T, serverURL *url.URL, endpoint string) {
 	const reqTimeout = 2 * time.Second
 
-	serverURL, err := url.Parse(serverURL.String() + "/derp/restart")
+	serverURL, err := url.Parse(serverURL.String() + endpoint)
 	require.NoError(t, err)
 
 	client := http.Client{
@@ -52,18 +52,18 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		peerIP := tailnet.IPFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
-		restartDERP(t, serverURL)
+		sendRestart(t, serverURL, "/derp/restart")
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer after derp restart")
 	})
 
-	t.Run("Restart server", func(t *testing.T) {
+	t.Run("RestartCoordinator", func(t *testing.T) {
 		peerIP := tailnet.IPFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
-		// TODO(ethan): restart here
+		sendRestart(t, serverURL, "/restart")
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
-		require.NoError(t, err, "ping peer after server restart")
+		require.NoError(t, err, "ping peer after coordinator restart")
 	})
 
 	// TODO: more

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -52,9 +52,8 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
 		restartDERP(t, serverURL)
-		peerIP = tailnet.IPFromUUID(peer.ID)
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
-		require.NoError(t, err, "ping peer")
+		require.NoError(t, err, "ping peer after derp restart")
 	})
 
 	// TODO: more

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -16,7 +16,7 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func doRestart(t *testing.T, serverURL *url.URL, endpoint string) {
+func sendRestart(t *testing.T, serverURL *url.URL, endpoint string) {
 	const reqTimeout = 2 * time.Second
 
 	serverURL, err := url.Parse(serverURL.String() + endpoint)
@@ -52,7 +52,7 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		peerIP := tailnet.IPFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
-		doRestart(t, serverURL, "/derp/restart")
+		sendRestart(t, serverURL, "/derp/restart")
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer after derp restart")
 	})
@@ -61,7 +61,7 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 		peerIP := tailnet.IPFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
-		doRestart(t, serverURL, "/restart")
+		// TODO(ethan): restart here
 		_, _, _, err = conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer after server restart")
 	})


### PR DESCRIPTION
Added functionality that allows a DERP server or tailnet coordinator to be restarted mid-test.
Added test cases that ensure a client can maintain it's session while either are restarted.
Closes #13460 