### PR TITLE
chore: write speedtest direct connection updates to stderr

### DIFF
--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -139,14 +139,14 @@ func (r *RootCmd) speedtest() *serpent.Command {
 					}
 					peer := status.Peer[status.Peers()[0]]
 					if !p2p && direct {
-						cliui.Infof(inv.Stdout, "Waiting for a direct connection... (%dms via %s)", dur.Milliseconds(), peer.Relay)
+						cliui.Infof(inv.Stderr, "Waiting for a direct connection... (%dms via %s)", dur.Milliseconds(), peer.Relay)
 						continue
 					}
 					via := peer.Relay
 					if via == "" {
 						via = "direct"
 					}
-					cliui.Infof(inv.Stdout, "%dms via %s", dur.Milliseconds(), via)
+					cliui.Infof(inv.Stderr, "%dms via %s", dur.Milliseconds(), via)
 					break
 				}
 			} else {


### PR DESCRIPTION
Currently, when performing a `coder speedtest` using `--direct`, the cli writes a status update to `stdout` when it establishes a direct connection. 
When using #13475, we want the output to be valid `json`, so we need to write these updates to stderr instead.

```
$ coder speedtest --output='json' --direct pog2 | jq
0ms via coder_sydney-fly
Starting a 5s download test...
{
  "overall": {
    "start_time_seconds": 0,
    "end_time_seconds": 5.019088141,
    "throughput_mbits": 1701.4251800524416
  },
  "intervals": [
    {
      "start_time_seconds": 0,
      "end_time_seconds": 1.008231443,
      "throughput_mbits": 1697.304764576758
    },
    {
      "start_time_seconds": 1.008231443,
      "end_time_seconds": 2.013730979,
      "throughput_mbits": 1952.1980883340755
    },
    {
      "start_time_seconds": 2.013730979,
      "end_time_seconds": 3.014306128,
      "throughput_mbits": 1961.8059412746816
    },
    {
      "start_time_seconds": 3.014306128,
      "end_time_seconds": 4.016784299,
      "throughput_mbits": 1138.030453931949
    },
    {
      "start_time_seconds": 4.016784299,
      "end_time_seconds": 5.019088141,
      "throughput_mbits": 1757.5585428116121
    }
  ]
}
```

