### PR TITLE
chore: implement assign organization roles from the cli

### DIFF
--- a/cli/organizationmembers.go
+++ b/cli/organizationmembers.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -11,6 +12,66 @@ import (
 )
 
 func (r *RootCmd) organizationMembers() *serpent.Command {
+	cmd := &serpent.Command{
+		Use:     "members",
+		Aliases: []string{"member"},
+		Short:   "Manage organization members",
+		Children: []*serpent.Command{
+			r.listOrganizationMembers(),
+			r.assignOrganizationRoles(),
+		},
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+	}
+
+	return cmd
+}
+
+func (r *RootCmd) assignOrganizationRoles() *serpent.Command {
+	client := new(codersdk.Client)
+
+	cmd := &serpent.Command{
+		Use:     "edit-roles <username | user_id> [roles...]",
+		Aliases: []string{"edit-role"},
+		Short:   "Edit organization member's roles",
+		Middleware: serpent.Chain(
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			organization, err := CurrentOrganization(r, inv, client)
+			if err != nil {
+				return err
+			}
+
+			if len(inv.Args) < 1 {
+				return xerrors.Errorf("user_id or username is required as the first argument")
+			}
+			userIdentifier := inv.Args[0]
+			roles := inv.Args[1:]
+
+			member, err := client.UpdateOrganizationMemberRoles(ctx, organization.ID, userIdentifier, codersdk.UpdateRoles{
+				Roles: roles,
+			})
+			if err != nil {
+				return xerrors.Errorf("update member roles: %w", err)
+			}
+
+			updatedTo := make([]string, 0)
+			for _, role := range member.Roles {
+				updatedTo = append(updatedTo, role.String())
+			}
+
+			_, _ = fmt.Fprintf(inv.Stdout, "Member roles updated to [%s]\n", strings.Join(updatedTo, ", "))
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func (r *RootCmd) listOrganizationMembers() *serpent.Command {
 	formatter := cliui.NewOutputFormatter(
 		cliui.TableFormat([]codersdk.OrganizationMemberWithName{}, []string{"username", "organization_roles"}),
 		cliui.JSONFormat(),
@@ -18,9 +79,8 @@ func (r *RootCmd) organizationMembers() *serpent.Command {
 
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
-		Use:     "members",
-		Short:   "List all organization members",
-		Aliases: []string{"member"},
+		Use:   "list",
+		Short: "List all organization members",
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(0),
 			r.InitClient(client),

--- a/cli/organizationmembers_test.go
+++ b/cli/organizationmembers_test.go
@@ -23,7 +23,7 @@ func TestListOrganizationMembers(t *testing.T) {
 		client, user := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleUserAdmin())
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
-		inv, root := clitest.New(t, "organization", "members", "-c", "user_id,username,roles")
+		inv, root := clitest.New(t, "organization", "members", "list", "-c", "user_id,username,roles")
 		clitest.SetupConfig(t, client, root)
 
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
Basic functionality to assign roles to an organization member via cli.

```shell
coder organizations members edit-roles <username> [roles ...]
# example
coder organizations members edit-roles emyrk organization-admin custom-role
```