### PR TITLE
fix: fix flake in TestDERPEndToEnd

### DIFF
--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -324,6 +324,7 @@ func TestDERPEndToEnd(t *testing.T) {
 	deploymentValues.Experiments = []string{
 		"*",
 	}
+	deploymentValues.DERP.Config.BlockDirect = true
 
 	client, closer, api, user := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 		Options: &coderdtest.Options{


### PR DESCRIPTION
Fixes flake seen here:

https://github.com/coder/coder/actions/runs/9484556007/job/26134323535

Only the client had BlockEndpoints set, and so the workspace sent endpoints via Disco for the client to connect to.