### PR TITLE
fix(coderd): userOIDC: ignore leading @ of EmailDomain

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -960,6 +960,8 @@ func (api *API) userOIDC(rw http.ResponseWriter, r *http.Request) {
 		}
 		userEmailDomain := emailSp[len(emailSp)-1]
 		for _, domain := range api.OIDCConfig.EmailDomain {
+			// Folks sometimes enter EmailDomain with a leading '@'.
+			domain = strings.TrimPrefix(domain, "@")
 			if strings.EqualFold(userEmailDomain, domain) {
 				ok = true
 				break

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -942,6 +942,30 @@ func TestUserOIDC(t *testing.T) {
 			StatusCode: http.StatusForbidden,
 		},
 		{
+			Name: "EmailDomainWithLeadingAt",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "cian@coder.com",
+				"email_verified": true,
+			},
+			AllowSignups: true,
+			EmailDomain: []string{
+				"@coder.com",
+			},
+			StatusCode: http.StatusOK,
+		},
+		{
+			Name: "EmailDomainForbiddenWithLeadingAt",
+			IDTokenClaims: jwt.MapClaims{
+				"email":          "kyle@kwc.io",
+				"email_verified": true,
+			},
+			AllowSignups: true,
+			EmailDomain: []string{
+				"@coder.com",
+			},
+			StatusCode: http.StatusForbidden,
+		},
+		{
 			Name: "EmailDomainCaseInsensitive",
 			IDTokenClaims: jwt.MapClaims{
 				"email":          "kyle@KWC.io",


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/13509

This modifies our OIDC signup logic to strip a leading `@` sign from the configured OIDC EmailDomains before comparison. Folks had been adding this and it breaks OIDC logins.