### PR TITLE
fix(dogfood/Dockerfile): add explicit --chown to COPY directive

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -90,7 +90,7 @@ SHELL ["/bin/bash", "-c"]
 # the default mirror with teraswitch.
 RUN apt-get update && apt-get install --yes ca-certificates
 
-COPY files /
+COPY --chown root:root files /
 
 # Install packages from apt repositories
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -90,7 +90,7 @@ SHELL ["/bin/bash", "-c"]
 # the default mirror with teraswitch.
 RUN apt-get update && apt-get install --yes ca-certificates
 
-COPY --chown root:root files /
+COPY --chown=root:root files /
 
 # Install packages from apt repositories
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Problem: when building `dogfood/Dockerfile` with envbuilder, `/etc/sudoers.d/nopasswd` was owned by `coder:coder` until I did this.

This may be a bug in kaniko, but I haven't been able to figure out an explicit test to reproduce it. For now I'm just adding an explicit `--chown` to the COPY directive.