### PR TITLE
chore: protect reserved builtin rolenames

### DIFF
--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -195,6 +195,13 @@ type RoleOptions struct {
 	NoOwnerWorkspaceExec bool
 }
 
+// ReservedRoleName exists because the database should only allow unique role
+// names, but some roles are built in. So these names are reserved
+func ReservedRoleName(name string) bool {
+	_, ok := builtInRoles[name]
+	return ok
+}
+
 // ReloadBuiltinRoles loads the static roles into the builtInRoles map.
 // This can be called again with a different config to change the behavior.
 //

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -210,6 +210,34 @@ func TestCustomOrganizationRole(t *testing.T) {
 		require.ErrorContains(t, err, "Validation")
 	})
 
+	t.Run("ReservedName", func(t *testing.T) {
+		t.Parallel()
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentCustomRoles)}
+		owner, first := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureCustomRoles: 1,
+				},
+			},
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		//nolint:gocritic // owner is required for this
+		_, err := owner.PatchOrganizationRole(ctx, first.OrganizationID, codersdk.Role{
+			Name:                    "owner", // Reserved
+			DisplayName:             "Testing Purposes",
+			SitePermissions:         nil,
+			OrganizationPermissions: nil,
+			UserPermissions:         nil,
+		})
+		require.ErrorContains(t, err, "Reserved")
+	})
+
 	t.Run("MismatchedOrganizations", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)


### PR DESCRIPTION
Conflicting built-in and database role names makes it hard to disambiguate. 