### PR TITLE
fix: remove assigning org-member role, this is implied from membership

### DIFF
--- a/coderd/organizations.go
+++ b/coderd/organizations.go
@@ -13,7 +13,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -95,12 +94,11 @@ func (api *API) postOrganizations(rw http.ResponseWriter, r *http.Request) {
 			UserID:         apiKey.UserID,
 			CreatedAt:      dbtime.Now(),
 			UpdatedAt:      dbtime.Now(),
-			Roles: []string{
+			Roles:          []string{
 				// TODO: When organizations are allowed to be created, we should
 				// come back to determining the default role of the person who
 				// creates the org. Until that happens, all users in an organization
 				// should be just regular members.
-				rbac.RoleOrgMember(),
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
`organization-member` is implied here: https://github.com/coder/coder/blob/635b041a209a88993599228610c24e2cf1cb9217/coderd/database/queries/users.sql#L234-L237

Remove manually setting it, because it is impossible to remove this role. This only affects the first user, so only 1 user per deployment has this role manually assigned. This is not a big deal, and can be ignored.