### PR TITLE
fix: use a privileged sidecar container in Kubernetes-based templates

### DIFF
--- a/docs/templates/docker-in-workspaces.md
+++ b/docs/templates/docker-in-workspaces.md
@@ -352,6 +352,7 @@ resource "kubernetes_pod" "main" {
       image = "docker:dind"
       security_context {
         privileged = true
+        run_as_user = 0
       }
       command = ["dockerd", "-H", "tcp://127.0.0.1:2375"]
     }


### PR DESCRIPTION
I am using K3S to deploy privileged sidecar container.
It doesn't work on default configurations.
Until I add this one line, it works.


Reference from this article: https://dev.to/techworld_with_nana/run-pod-with-root-privileges-41n9

