### PR TITLE
fix: fix shallow clones not retrieving a valid semver

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -26,29 +26,28 @@ if [[ -n "${CODER_FORCE_VERSION:-}" ]]; then
 	exit 0
 fi
 
-
 # To make contributing easier, if there are no tags, we'll use a default
 # version.
 tag_list=$(git tag)
 if [[ -z ${tag_list} ]]; then
-    log
-    log "INFO(version.sh): It appears you've checked out a fork or shallow clone of Coder."
-    log "INFO(version.sh): By default GitHub does not include tags when forking."
-    log "INFO(version.sh): We will use the default version 2.0.0 for this build."
-    log "INFO(version.sh): To pull tags from upstream, use the following commands:"
-    log "INFO(version.sh):   - git remote add upstream https://github.com/coder/coder.git"
-    log "INFO(version.sh):   - git fetch upstream"
-    log
-    last_tag="v2.0.0"
+	log
+	log "INFO(version.sh): It appears you've checked out a fork or shallow clone of Coder."
+	log "INFO(version.sh): By default GitHub does not include tags when forking."
+	log "INFO(version.sh): We will use the default version 2.0.0 for this build."
+	log "INFO(version.sh): To pull tags from upstream, use the following commands:"
+	log "INFO(version.sh):   - git remote add upstream https://github.com/coder/coder.git"
+	log "INFO(version.sh):   - git fetch upstream"
+	log
+	last_tag="v2.0.0"
 else
-    current_commit=$(git rev-parse HEAD)
-    # Try to find the last tag that contains the current commit
-    last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
-    # If there is no tag that contains the current commit,
-    # get the latest tag sorted by semver.
-    if [[ -z "${last_tag}" ]]; then
-        last_tag=$(git tag --sort=version:refname | tail -n 1)
-    fi
+	current_commit=$(git rev-parse HEAD)
+	# Try to find the last tag that contains the current commit
+	last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
+	# If there is no tag that contains the current commit,
+	# get the latest tag sorted by semver.
+	if [[ -z "${last_tag}" ]]; then
+		last_tag=$(git tag --sort=version:refname | tail -n 1)
+	fi
 fi
 
 version="${last_tag}"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -26,29 +26,29 @@ if [[ -n "${CODER_FORCE_VERSION:-}" ]]; then
 	exit 0
 fi
 
-# To make contributing easier, if the upstream isn't coder/coder and there are
-# no tags we will fall back to 0.1.0 with devel suffix.
-remote_url=$(git remote get-url origin)
+
+# To make contributing easier, if there are no tags, we'll use a default
+# version.
 tag_list=$(git tag)
-if ! [[ ${remote_url} =~ [@/]github.com ]] && ! [[ ${remote_url} =~ [:/]coder/coder(\.git)?$ ]] && [[ -z ${tag_list} ]]; then
-	log
-	log "INFO(version.sh): It appears you've checked out a fork of Coder."
-	log "INFO(version.sh): By default GitHub does not include tags when forking."
-	log "INFO(version.sh): We will use the default version 2.0.0 for this build."
-	log "INFO(version.sh): To pull tags from upstream, use the following commands:"
-	log "INFO(version.sh):   - git remote add upstream https://github.com/coder/coder.git"
-	log "INFO(version.sh):   - git fetch upstream"
-	log
-	last_tag="v2.0.0"
+if [[ -z ${tag_list} ]]; then
+    log
+    log "INFO(version.sh): It appears you've checked out a fork or shallow clone of Coder."
+    log "INFO(version.sh): By default GitHub does not include tags when forking."
+    log "INFO(version.sh): We will use the default version 2.0.0 for this build."
+    log "INFO(version.sh): To pull tags from upstream, use the following commands:"
+    log "INFO(version.sh):   - git remote add upstream https://github.com/coder/coder.git"
+    log "INFO(version.sh):   - git fetch upstream"
+    log
+    last_tag="v2.0.0"
 else
-	current_commit=$(git rev-parse HEAD)
-	# Try to find the last tag that contains the current commit
-	last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
-	# If there is no tag that contains the current commit,
-	# get the latest tag sorted by semver.
-	if [[ -z "${last_tag}" ]]; then
-		last_tag=$(git tag --sort=version:refname | tail -n 1)
-	fi
+    current_commit=$(git rev-parse HEAD)
+    # Try to find the last tag that contains the current commit
+    last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
+    # If there is no tag that contains the current commit,
+    # get the latest tag sorted by semver.
+    if [[ -z "${last_tag}" ]]; then
+        last_tag=$(git tag --sort=version:refname | tail -n 1)
+    fi
 fi
 
 version="${last_tag}"


### PR DESCRIPTION
A shallow git clone of coder with `--depth=1` won't have any git tags when running `git tag`. 

`version.sh` currently doesn't properly handle this case, and sets the version to the empty string. This empty string is then read by `buildinfo`. This produces a broken build of coder server that is unable to start workspaces. 