### PR TITLE
feat: add cross-origin reporting for telemetry in the dashboard

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8351,6 +8351,10 @@ const docTemplate = `{
                     "description": "ExternalURL references the current Coder version.\nFor production builds, this will link directly to a release. For development builds, this will link to a commit.",
                     "type": "string"
                 },
+                "telemetry": {
+                    "description": "Telemetry is a boolean that indicates whether telemetry is enabled.",
+                    "type": "boolean"
+                },
                 "upgrade_message": {
                     "description": "UpgradeMessage is the message displayed to users when an outdated client\nis detected.",
                     "type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7430,6 +7430,10 @@
           "description": "ExternalURL references the current Coder version.\nFor production builds, this will link directly to a release. For development builds, this will link to a commit.",
           "type": "string"
         },
+        "telemetry": {
+          "description": "Telemetry is a boolean that indicates whether telemetry is enabled.",
+          "type": "boolean"
+        },
         "upgrade_message": {
           "description": "UpgradeMessage is the message displayed to users when an outdated client\nis detected.",
           "type": "string"

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -447,6 +447,7 @@ func New(options *Options) *API {
 		WorkspaceProxy:  false,
 		UpgradeMessage:  api.DeploymentValues.CLIUpgradeMessage.String(),
 		DeploymentID:    api.DeploymentID,
+		Telemetry:       api.Telemetry.Enabled(),
 	}
 	api.SiteHandler = site.New(&site.Options{
 		BinFS:             binFS,

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -110,7 +110,7 @@ type remoteReporter struct {
 	shutdownAt *time.Time
 }
 
-func (r *remoteReporter) Enabled() bool {
+func (*remoteReporter) Enabled() bool {
 	return true
 }
 

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -93,6 +93,7 @@ type Reporter interface {
 	// database. For example, if a new user is added, a snapshot can
 	// contain just that user entry.
 	Report(snapshot *Snapshot)
+	Enabled() bool
 	Close()
 }
 
@@ -107,6 +108,10 @@ type remoteReporter struct {
 	snapshotURL *url.URL
 	startedAt  time.Time
 	shutdownAt *time.Time
+}
+
+func (r *remoteReporter) Enabled() bool {
+	return true
 }
 
 func (r *remoteReporter) Report(snapshot *Snapshot) {
@@ -948,4 +953,5 @@ type ExternalProvisioner struct {
 type noopReporter struct{}
 
 func (*noopReporter) Report(_ *Snapshot) {}
+func (*noopReporter) Enabled() bool      { return false }
 func (*noopReporter) Close()             {}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2173,11 +2173,12 @@ type BuildInfoResponse struct {
 	ExternalURL string `json:"external_url"`
 	// Version returns the semantic version of the build.
 	Version string `json:"version"`
-
 	// DashboardURL is the URL to hit the deployment's dashboard.
 	// For external workspace proxies, this is the coderd they are connected
 	// to.
 	DashboardURL string `json:"dashboard_url"`
+	// Telemetry is a boolean that indicates whether telemetry is enabled.
+	Telemetry bool `json:"telemetry"`
 
 	WorkspaceProxy bool `json:"workspace_proxy"`
 

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -57,6 +57,7 @@ curl -X GET http://coder-server:8080/api/v2/buildinfo \
   "dashboard_url": "string",
   "deployment_id": "string",
   "external_url": "string",
+  "telemetry": true,
   "upgrade_message": "string",
   "version": "string",
   "workspace_proxy": true

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -865,6 +865,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "dashboard_url": "string",
   "deployment_id": "string",
   "external_url": "string",
+  "telemetry": true,
   "upgrade_message": "string",
   "version": "string",
   "workspace_proxy": true
@@ -879,6 +880,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `dashboard_url`     | string  | false    |              | Dashboard URL is the URL to hit the deployment's dashboard. For external workspace proxies, this is the coderd they are connected to.                               |
 | `deployment_id`     | string  | false    |              | Deployment ID is the unique identifier for this deployment.                                                                                                         |
 | `external_url`      | string  | false    |              | External URL references the current Coder version. For production builds, this will link directly to a release. For development builds, this will link to a commit. |
+| `telemetry`         | boolean | false    |              | Telemetry is a boolean that indicates whether telemetry is enabled.                                                                                                 |
 | `upgrade_message`   | string  | false    |              | Upgrade message is the message displayed to users when an outdated client is detected.                                                                              |
 | `version`           | string  | false    |              | Version returns the semantic version of the build.                                                                                                                  |
 | `workspace_proxy`   | boolean | false    |              |                                                                                                                                                                     |

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
@@ -216,7 +216,7 @@ func TestDialCoordinator(t *testing.T) {
 			Node: &proto.Node{
 				Id:            55,
 				AsOf:          timestamppb.New(time.Unix(1689653252, 0)),
-				Key:           peerNodeKey[:],
+				Key:           peerNodeKey,
 				Disco:         string(peerDiscoKey),
 				PreferredDerp: 0,
 				DerpLatency: map[string]float64{

--- a/site/jest.setup.ts
+++ b/site/jest.setup.ts
@@ -41,6 +41,7 @@ global.scrollTo = jest.fn();
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 window.open = jest.fn();
+navigator.sendBeacon = jest.fn();
 
 // Polyfill the getRandomValues that is used on utils/random.ts
 Object.defineProperty(global.self, "crypto", {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -171,6 +171,7 @@ export interface BuildInfoResponse {
   readonly external_url: string;
   readonly version: string;
   readonly dashboard_url: string;
+  readonly telemetry: boolean;
   readonly workspace_proxy: boolean;
   readonly agent_api_version: string;
   readonly upgrade_message: string;

--- a/site/src/hooks/useEmbeddedMetadata.ts
+++ b/site/src/hooks/useEmbeddedMetadata.ts
@@ -22,7 +22,6 @@ export const DEFAULT_METADATA_KEY = "property";
  * attributes
  */
 type AvailableMetadata = Readonly<{
-  telemetry: boolean;
   user: User;
   experiments: Experiments;
   appearance: AppearanceConfig;
@@ -82,7 +81,6 @@ export class MetadataManager implements MetadataManagerApi {
     this.trackedMetadataNodes = new Map();
 
     this.metadata = {
-      telemetry: this.registerValue("telemetry"),
       user: this.registerValue<User>("user"),
       appearance: this.registerValue<AppearanceConfig>("appearance"),
       entitlements: this.registerValue<Entitlements>("entitlements"),

--- a/site/src/hooks/useEmbeddedMetadata.ts
+++ b/site/src/hooks/useEmbeddedMetadata.ts
@@ -22,6 +22,7 @@ export const DEFAULT_METADATA_KEY = "property";
  * attributes
  */
 type AvailableMetadata = Readonly<{
+  telemetry: boolean;
   user: User;
   experiments: Experiments;
   appearance: AppearanceConfig;
@@ -81,6 +82,7 @@ export class MetadataManager implements MetadataManagerApi {
     this.trackedMetadataNodes = new Map();
 
     this.metadata = {
+      telemetry: this.registerValue("telemetry"),
       user: this.registerValue<User>("user"),
       appearance: this.registerValue<AppearanceConfig>("appearance"),
       entitlements: this.registerValue<Entitlements>("entitlements"),

--- a/site/src/pages/LoginPage/LoginPage.tsx
+++ b/site/src/pages/LoginPage/LoginPage.tsx
@@ -31,15 +31,14 @@ export const LoginPage: FC = () => {
   const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
 
   if (isSignedIn) {
-    // This uses `navigator.sendBeacon`, so window.href
-    // will not stop the request from being sent!
-    sendDeploymentEvent({
-      type: "deployment_login",
-      // This should work most of the time because of embedded
-      // metadata and the user being logged in.
-      deployment_id: buildInfoQuery.data?.deployment_id || "",
-      user_id: user?.id,
-    })
+    if (buildInfoQuery.data) {
+      // This uses `navigator.sendBeacon`, so window.href
+      // will not stop the request from being sent!
+      sendDeploymentEvent(buildInfoQuery.data, {
+        type: "deployment_login",
+        user_id: user?.id,
+      });
+    }
 
     // If the redirect is going to a workspace application, and we
     // are missing authentication, then we need to change the href location
@@ -86,13 +85,15 @@ export const LoginPage: FC = () => {
         isSigningIn={isSigningIn}
         onSignIn={async ({ email, password }) => {
           await signIn(email, password);
-          // This uses `navigator.sendBeacon`, so navigating away
-          // will not prevent it!
-          sendDeploymentEvent({
-            type: "deployment_login",
-            deployment_id: buildInfoQuery.data?.deployment_id || "",
-            user_id: user?.id,
-          })
+          if (buildInfoQuery.data) {
+            // This uses `navigator.sendBeacon`, so navigating away
+            // will not prevent it!
+            sendDeploymentEvent(buildInfoQuery.data, {
+              type: "deployment_login",
+              user_id: user?.id,
+            });
+          }
+
           navigate("/");
         }}
       />

--- a/site/src/pages/SetupPage/SetupPage.test.tsx
+++ b/site/src/pages/SetupPage/SetupPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { createMemoryRouter } from "react-router-dom";
 import type { Response, User } from "api/typesGenerated";
-import { MockUser } from "testHelpers/entities";
+import { MockBuildInfo, MockUser } from "testHelpers/entities";
 import {
   renderWithRouter,
   waitForLoaderToBeRemoved,
@@ -99,4 +99,34 @@ describe("Setup Page", () => {
     await fillForm();
     await waitFor(() => screen.findByText("Templates"));
   });
+  it("calls sendBeacon with telemetry", async () => {
+    const sendBeacon = jest.fn();
+    Object.defineProperty(window.navigator, "sendBeacon", {
+      value: sendBeacon,
+    });
+    renderWithRouter(
+      createMemoryRouter(
+        [
+          {
+            path: "/setup",
+            element: <SetupPage />,
+          },
+          {
+            path: "/templates",
+            element: <h1>Templates</h1>,
+          },
+        ],
+        { initialEntries: ["/setup"] },
+      ),
+    );
+    await waitForLoaderToBeRemoved();
+    await waitFor(() => {
+      expect(navigator.sendBeacon).toBeCalledWith("https://coder.com/api/track-deployment", new Blob([JSON.stringify({
+        type: "deployment_setup",
+        deployment_id: MockBuildInfo.deployment_id,
+      })], {
+        type: "application/json",
+      }))
+    })
+  })
 });

--- a/site/src/pages/SetupPage/SetupPage.test.tsx
+++ b/site/src/pages/SetupPage/SetupPage.test.tsx
@@ -121,12 +121,20 @@ describe("Setup Page", () => {
     );
     await waitForLoaderToBeRemoved();
     await waitFor(() => {
-      expect(navigator.sendBeacon).toBeCalledWith("https://coder.com/api/track-deployment", new Blob([JSON.stringify({
-        type: "deployment_setup",
-        deployment_id: MockBuildInfo.deployment_id,
-      })], {
-        type: "application/json",
-      }))
-    })
-  })
+      expect(navigator.sendBeacon).toBeCalledWith(
+        "https://coder.com/api/track-deployment",
+        new Blob(
+          [
+            JSON.stringify({
+              type: "deployment_setup",
+              deployment_id: MockBuildInfo.deployment_id,
+            }),
+          ],
+          {
+            type: "application/json",
+          },
+        ),
+      );
+    });
+  });
 });

--- a/site/src/pages/SetupPage/SetupPage.tsx
+++ b/site/src/pages/SetupPage/SetupPage.tsx
@@ -31,7 +31,7 @@ export const SetupPage: FC = () => {
     sendDeploymentEvent(buildInfoQuery.data, {
       type: "deployment_setup",
     });
-  }, [buildInfoQuery.data, metadata.telemetry.value]);
+  }, [buildInfoQuery.data]);
 
   if (isLoading) {
     return <Loader fullscreen />;

--- a/site/src/pages/SetupPage/SetupPage.tsx
+++ b/site/src/pages/SetupPage/SetupPage.tsx
@@ -11,9 +11,7 @@ import { pageTitle } from "utils/page";
 import { sendDeploymentEvent } from "utils/telemetry";
 import { SetupPageView } from "./SetupPageView";
 
-export const SetupPage: FC<{
-  telemetryURL?: string;
-}> = ({ telemetryURL }) => {
+export const SetupPage: FC = () => {
   const {
     isLoading,
     signIn,
@@ -30,14 +28,10 @@ export const SetupPage: FC<{
     if (!buildInfoQuery.data) {
       return;
     }
-    sendDeploymentEvent(
-      {
-        type: "deployment_setup",
-        deployment_id: buildInfoQuery.data.deployment_id,
-      },
-      telemetryURL,
-    );
-  }, [buildInfoQuery.data, telemetryURL]);
+    sendDeploymentEvent(buildInfoQuery.data, {
+      type: "deployment_setup",
+    });
+  }, [buildInfoQuery.data, metadata.telemetry.value]);
 
   if (isLoading) {
     return <Loader fullscreen />;

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -205,6 +205,7 @@ export const MockBuildInfo: TypesGen.BuildInfoResponse = {
   workspace_proxy: false,
   upgrade_message: "My custom upgrade message",
   deployment_id: "510d407f-e521-4180-b559-eab4a6d802b8",
+  telemetry: true,
 };
 
 export const MockSupportLinks: TypesGen.LinkConfig[] = [

--- a/site/src/utils/telemetry.ts
+++ b/site/src/utils/telemetry.ts
@@ -1,18 +1,33 @@
+import type { BuildInfoResponse } from "api/typesGenerated";
+
 // sendDeploymentEvent sends a CORs payload to coder.com
 // to track a deployment event.
-export const sendDeploymentEvent = (payload: {
-  type: "deployment_setup" | "deployment_login";
-  deployment_id: string;
-  user_id?: string;
-}) => {
+export const sendDeploymentEvent = (
+  buildInfo: BuildInfoResponse,
+  payload: {
+    type: "deployment_setup" | "deployment_login";
+    user_id?: string;
+  },
+) => {
   if (typeof navigator === "undefined" || !navigator.sendBeacon) {
     // It's fine if we don't report this, it's not required!
     return;
   }
+  if (!buildInfo.telemetry) {
+    return;
+  }
   navigator.sendBeacon(
     "https://coder.com/api/track-deployment",
-    new Blob([JSON.stringify(payload)], {
-      type: "application/json",
-    }),
+    new Blob(
+      [
+        JSON.stringify({
+          ...payload,
+          deployment_id: buildInfo.deployment_id,
+        }),
+      ],
+      {
+        type: "application/json",
+      },
+    ),
   );
 };

--- a/site/src/utils/telemetry.ts
+++ b/site/src/utils/telemetry.ts
@@ -1,0 +1,18 @@
+// sendDeploymentEvent sends a CORs payload to coder.com
+// to track a deployment event.
+export const sendDeploymentEvent = (payload: {
+  type: "deployment_setup" | "deployment_login";
+  deployment_id: string;
+  user_id?: string;
+}) => {
+  if (typeof navigator === "undefined" || !navigator.sendBeacon) {
+    // It's fine if we don't report this, it's not required!
+    return;
+  }
+  navigator.sendBeacon(
+    "https://coder.com/api/track-deployment",
+    new Blob([JSON.stringify(payload)], {
+      type: "application/json",
+    }),
+  );
+};


### PR DESCRIPTION
This will allow us to associate website users with product usage!

Needs to associate this with the telemetry flag before merge!