### PR TITLE
chore: refactor user -> rbac.subject into a function

### DIFF
--- a/coderd/rbac/authz.go
+++ b/coderd/rbac/authz.go
@@ -75,6 +75,17 @@ type Subject struct {
 	cachedASTValue ast.Value
 }
 
+// RegoValueOk is only used for unit testing. There is no easy way
+// to get the error for the unexported method, and this is intentional.
+// Failed rego values can default to the backup json marshal method,
+// so errors are not fatal. Unit tests should be aware when the custom
+// rego marshaller fails.
+func (s Subject) RegoValueOk() error {
+	tmp := s
+	_, err := tmp.regoValue()
+	return err
+}
+
 // WithCachedASTValue can be called if the subject is static. This will compute
 // the ast value once and cache it for future calls.
 func (s Subject) WithCachedASTValue() Subject {

--- a/coderd/rbac/rolestore/rolestore.go
+++ b/coderd/rbac/rolestore/rolestore.go
@@ -39,6 +39,8 @@ func roleCache(ctx context.Context) *syncmap.Map[string, rbac.Role] {
 }
 
 // Expand will expand built in roles, and fetch custom roles from the database.
+// If a custom role is defined, but does not exist, the role will be omitted on
+// the response. This means deleted roles are silently dropped.
 func Expand(ctx context.Context, db database.Store, names []rbac.RoleIdentifier) (rbac.Roles, error) {
 	if len(names) == 0 {
 		// That was easy


### PR DESCRIPTION
`db.GetAuthorizationUserRoles` was being called in multiple places. Moved the logic to `httpmw.UserRBACSubject` for now. This logic handles custom roles.

Added unit tests for logging in with custom roles, and roles that no longer exist. Since the db schema does not assert the `[]text` in postgres actually exist in the `custom_roles` table. 

# What this does

There was a bug with password login and custom roles because the duplicated logic did not handle custom-roles.