### PR TITLE
test: add unit test helper to create templates in second organizations

### DIFF
--- a/enterprise/cli/templatecreate_test.go
+++ b/enterprise/cli/templatecreate_test.go
@@ -134,4 +134,70 @@ func TestTemplateCreate(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "your license is not entitled to use enterprise access control, so you cannot set --require-active-version")
 	})
+
+	// Create a template in a second organization via custom role
+	t.Run("SecondOrganization", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentCustomRoles)}
+		ownerClient, _ := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues: dv,
+				// This only affects the first org.
+				IncludeProvisionerDaemon: false,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAccessControl:              1,
+					codersdk.FeatureCustomRoles:                1,
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				},
+			},
+		})
+
+		// Create the second organization
+		secondOrg := coderdtest.CreateOrganization(t, ownerClient, coderdtest.CreateOrganizationOptions{
+			IncludeProvisionerDaemon: true,
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+
+		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, secondOrg.ID, codersdk.Role{
+			Name:           "org-template-admin",
+			OrganizationID: secondOrg.ID.String(),
+			OrganizationPermissions: codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceTemplate: codersdk.RBACResourceActions[codersdk.ResourceTemplate],
+			}),
+		})
+		require.NoError(t, err, "create admin role")
+
+		orgTemplateAdmin, _ := coderdtest.CreateAnotherUser(t, ownerClient, secondOrg.ID, rbac.RoleIdentifier{
+			Name:           orgTemplateAdminRole.Name,
+			OrganizationID: secondOrg.ID,
+		})
+
+		source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionApply: echo.ApplyComplete,
+		})
+
+		const templateName = "new-template"
+		inv, conf := newCLI(t, "templates",
+			"push", templateName,
+			"--directory", source,
+			"--test.provisioner", string(database.ProvisionerTypeEcho),
+			"-y",
+		)
+
+		clitest.SetupConfig(t, orgTemplateAdmin, conf)
+
+		err = inv.Run()
+		require.NoError(t, err)
+
+		ctx = testutil.Context(t, testutil.WaitMedium)
+		template, err := orgTemplateAdmin.TemplateByName(ctx, secondOrg.ID, templateName)
+		require.NoError(t, err)
+		require.Equal(t, template.OrganizationID, secondOrg.ID)
+	})
 }

--- a/enterprise/cli/templatecreate_test.go
+++ b/enterprise/cli/templatecreate_test.go
@@ -163,6 +163,7 @@ func TestTemplateCreate(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
+		//nolint:gocritic // owner required to make custom roles
 		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, secondOrg.ID, codersdk.Role{
 			Name:           "org-template-admin",
 			OrganizationID: secondOrg.ID.String(),

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -717,6 +717,56 @@ func TestTemplates(t *testing.T) {
 		_, err = owner.Template(ctx, template.ID)
 		require.NoError(t, err)
 	})
+
+	// Create a template in a second organization via custom role
+	t.Run("SecondOrganization", func(t *testing.T) {
+		t.Parallel()
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentCustomRoles)}
+		ownerClient, _ := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues:         dv,
+				IncludeProvisionerDaemon: false,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureAccessControl:              1,
+					codersdk.FeatureCustomRoles:                1,
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				},
+			},
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		secondOrg := coderdtest.CreateOrganization(t, ownerClient, coderdtest.CreateOrganizationOptions{
+			IncludeProvisionerDaemon: true,
+		})
+
+		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, secondOrg.ID, codersdk.Role{
+			Name:           "org-template-admin",
+			OrganizationID: secondOrg.ID.String(),
+			OrganizationPermissions: codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceTemplate: codersdk.RBACResourceActions[codersdk.ResourceTemplate],
+			}),
+		})
+		require.NoError(t, err, "create admin role")
+
+		orgTemplateAdmin, _ := coderdtest.CreateAnotherUser(t, ownerClient, secondOrg.ID, rbac.RoleIdentifier{
+			Name:           orgTemplateAdminRole.Name,
+			OrganizationID: secondOrg.ID,
+		})
+
+		version := coderdtest.CreateTemplateVersion(t, orgTemplateAdmin, secondOrg.ID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionApply: echo.ApplyComplete,
+			ProvisionPlan:  echo.PlanComplete,
+		})
+		coderdtest.AwaitTemplateVersionJobCompleted(t, orgTemplateAdmin, version.ID)
+
+		template := coderdtest.CreateTemplate(t, orgTemplateAdmin, secondOrg.ID, version.ID)
+		require.Equal(t, template.OrganizationID, secondOrg.ID)
+	})
 }
 
 func TestTemplateACL(t *testing.T) {

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -743,6 +743,7 @@ func TestTemplates(t *testing.T) {
 			IncludeProvisionerDaemon: true,
 		})
 
+		//nolint:gocritic // owner required to make custom roles
 		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, secondOrg.ID, codersdk.Role{
 			Name:           "org-template-admin",
 			OrganizationID: secondOrg.ID.String(),


### PR DESCRIPTION
# What this does

Adds a new coderdtest helper `CreateOrganization` that creates a provisioner. This allows making templates + workspaces in secondary orgs.