### PR TITLE
chore: move ssh session tracking from agent to cli

### DIFF
--- a/tailnet/proto/version.go
+++ b/tailnet/proto/version.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	CurrentMajor = 2
-	CurrentMinor = 1
+	CurrentMinor = 2
 )
 
 var CurrentVersion = apiversion.New(CurrentMajor, CurrentMinor).WithBackwardCompat(1)


### PR DESCRIPTION
There were issues with the release rollout strategy in https://github.com/coder/coder/pull/13579. This PR follows the solution outlined in the [External API Matrix section of the RFC](https://www.notion.so/coderhq/Unified-Workspace-Statistics-and-Activity-Detection-11cdaf2b55bc493382ecfc302ca3d6f9?pvs=4#333a3789c0bf4ab180cb50866dae6ea7) to ensure no data loss or duplication of stats as we migrate over to cli reporting. 

Todo:
- [ ] tests