### PR TITLE
chore(scaletest/dashboard): stub out initChromeDPCtx in unit tests

### DIFF
--- a/scaletest/dashboard/config.go
+++ b/scaletest/dashboard/config.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	"cdr.dev/slog"
@@ -28,6 +29,8 @@ type Config struct {
 	Screenshot func(ctx context.Context, filename string) (string, error)
 	// RandIntn is a function that returns a random number between 0 and n-1.
 	RandIntn func(int) int `json:"-"`
+	// InitChromeDPCtx is a function that initializes ChromeDP into the given context.Context.
+	InitChromeDPCtx func(ctx context.Context, log slog.Logger, u *url.URL, sessionToken string, headless bool) (context.Context, context.CancelFunc, error) `json:"-"`
 }
 
 func (c Config) Validate() error {

--- a/scaletest/dashboard/run.go
+++ b/scaletest/dashboard/run.go
@@ -39,6 +39,9 @@ func NewRunner(client *codersdk.Client, metrics Metrics, cfg Config) *Runner {
 	if cfg.RandIntn == nil {
 		cfg.RandIntn = rand.Intn
 	}
+	if cfg.InitChromeDPCtx == nil {
+		cfg.InitChromeDPCtx = initChromeDPCtx
+	}
 	return &Runner{
 		client:  client,
 		cfg:     cfg,
@@ -70,7 +73,7 @@ func (r *Runner) runUntilDeadlineExceeded(ctx context.Context) error {
 		return xerrors.Errorf("user has no organizations")
 	}
 
-	cdpCtx, cdpCancel, err := initChromeDPCtx(ctx, r.cfg.Logger, r.client.URL, r.client.SessionToken(), r.cfg.Headless)
+	cdpCtx, cdpCancel, err := r.cfg.InitChromeDPCtx(ctx, r.cfg.Logger, r.client.URL, r.client.SessionToken(), r.cfg.Headless)
 	if err != nil {
 		return xerrors.Errorf("init chromedp ctx: %w", err)
 	}


### PR DESCRIPTION
Should hopefully fix https://github.com/coder/coder/issues/13636
Stubs out initChromeDPCtx to avoid calling it at all in the dashboard tests.