### PR TITLE
ci: test with multiple postgres versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -329,11 +329,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     needs:
       - changes
-    strategy:
-      matrix:
-        POSTGRES_VERSION:
-          - "13"
-          - "16"
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
     # `make test-postgres` to ensure we receive a trace of running
@@ -354,7 +349,47 @@ jobs:
 
       - name: Test with PostgreSQL Database
         env:
-          POSTGRES_VERSION: "${{ matrix.POSTGRES_VERSION }}"
+          POSTGRES_VERSION: "13"
+          TS_DEBUG_DISCO: "true"
+        run: |
+          make test-postgres
+
+      - name: Upload test stats to Datadog
+        timeout-minutes: 1
+        continue-on-error: true
+        uses: ./.github/actions/upload-datadog
+        if: success() || failure()
+        with:
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+
+  # NOTE: this could instead be defined as a matrix strategy, but we want to
+  # only block merging if tests on postgres 13 fail. Using a matrix strategy
+  # here makes the check in the above `required` job rather complicated.
+  test-go-pg-16:
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    needs:
+      - changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    # This timeout must be greater than the timeout set by `go test` in
+    # `make test-postgres` to ensure we receive a trace of running
+    # goroutines. Setting this to the timeout +5m should work quite well
+    # even if some of the preceding steps are slow.
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Setup Terraform
+        uses: ./.github/actions/setup-tf
+
+      - name: Test with PostgreSQL Database
+        env:
+          POSTGRES_VERSION: "16"
           TS_DEBUG_DISCO: "true"
         run: |
           make test-postgres

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -329,6 +329,11 @@ jobs:
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     needs:
       - changes
+    strategy:
+      matrix:
+        POSTGRES_VERSION:
+          - "13"
+          - "16"
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     # This timeout must be greater than the timeout set by `go test` in
     # `make test-postgres` to ensure we receive a trace of running
@@ -348,8 +353,10 @@ jobs:
         uses: ./.github/actions/setup-tf
 
       - name: Test with PostgreSQL Database
+        env:
+          POSTGRES_VERSION: "${matrix.POSTGRES_VERSION}"
+          TS_DEBUG_DISCO: "true"
         run: |
-          export TS_DEBUG_DISCO=true
           make test-postgres
 
       - name: Upload test stats to Datadog

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -354,7 +354,7 @@ jobs:
 
       - name: Test with PostgreSQL Database
         env:
-          POSTGRES_VERSION: "${matrix.POSTGRES_VERSION}"
+          POSTGRES_VERSION: "${{ matrix.POSTGRES_VERSION }}"
           TS_DEBUG_DISCO: "true"
         run: |
           make test-postgres

--- a/Makefile
+++ b/Makefile
@@ -826,7 +826,7 @@ test-postgres-docker:
 		--restart no \
 		--detach \
 		--memory 16GB \
-		gcr.io/coder-dev-1/postgres:13 \
+		gcr.io/coder-dev-1/postgres:16 \
 		-c shared_buffers=1GB \
 		-c work_mem=1GB \
 		-c effective_cache_size=1GB \

--- a/Makefile
+++ b/Makefile
@@ -815,7 +815,7 @@ test-migrations: test-postgres-docker
 
 # NOTE: we set --memory to the same size as a GitHub runner.
 test-postgres-docker:
-	docker rm -f test-postgres-docker || true
+	docker rm -f test-postgres-docker-${POSTGRES_VERSION} || true
 	docker run \
 		--env POSTGRES_PASSWORD=postgres \
 		--env POSTGRES_USER=postgres \
@@ -823,7 +823,7 @@ test-postgres-docker:
 		--env PGDATA=/tmp \
 		--tmpfs /tmp \
 		--publish 5432:5432 \
-		--name test-postgres-docker \
+		--name test-postgres-docker-${POSTGRES_VERSION} \
 		--restart no \
 		--detach \
 		--memory 16GB \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ GOOS         := $(shell go env GOOS)
 GOARCH       := $(shell go env GOARCH)
 GOOS_BIN_EXT := $(if $(filter windows, $(GOOS)),.exe,)
 VERSION      := $(shell ./scripts/version.sh)
+POSTGRES_VERSION ?= 16
 
 # Use the highest ZSTD compression level in CI.
 ifdef CI
@@ -826,7 +827,7 @@ test-postgres-docker:
 		--restart no \
 		--detach \
 		--memory 16GB \
-		gcr.io/coder-dev-1/postgres:16 \
+		gcr.io/coder-dev-1/postgres:${POSTGRES_VERSION} \
 		-c shared_buffers=1GB \
 		-c work_mem=1GB \
 		-c effective_cache_size=1GB \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     # This is typically in line with "latest".
     # Minimum supported version is 13.
     # More versions here: https://hub.docker.com/_/postgres
-    image: "postgres:bookworm"
+    image: "postgres:16"
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,10 @@ services:
       database:
         condition: service_healthy
   database:
-    image: "postgres:14.2"
+    # This is typically in line with "latest".
+    # Minimum supported version is 13.
+    # More versions here: https://hub.docker.com/_/postgres
+    image: "postgres:bookworm"
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,6 @@ services:
       database:
         condition: service_healthy
   database:
-    # This is typically in line with "latest".
     # Minimum supported version is 13.
     # More versions here: https://hub.docker.com/_/postgres
     image: "postgres:16"

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -146,7 +146,7 @@ RUN apt-get update --quiet && apt-get install --yes \
 	openssl \
 	packer \
 	pkg-config \
-	postgresql-13 \
+	postgresql-16 \
 	python3 \
 	python3-pip \
 	rsync \
@@ -209,8 +209,8 @@ RUN apt-get update && \
 	npm cache clean --force
 
 # Ensure PostgreSQL binaries are in the users $PATH.
-RUN update-alternatives --install /usr/local/bin/initdb initdb /usr/lib/postgresql/13/bin/initdb 100 && \
-	update-alternatives --install /usr/local/bin/postgres postgres /usr/lib/postgresql/13/bin/postgres 100
+RUN update-alternatives --install /usr/local/bin/initdb initdb /usr/lib/postgresql/16/bin/initdb 100 && \
+	update-alternatives --install /usr/local/bin/postgres postgres /usr/lib/postgresql/16/bin/postgres 100
 
 # Create links for injected dependencies
 RUN ln --symbolic /var/tmp/coder/coder-cli/coder /usr/local/bin/coder && \

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
           pixman
           pkg-config
           playwright-driver.browsers
-          postgresql_13
+          postgresql_16
           protobuf
           protoc-gen-go
           ripgrep
@@ -97,7 +97,7 @@
             name = "coder-${osArch}";
             # Updated with ./scripts/update-flake.sh`.
             # This should be updated whenever go.mod changes!
-            vendorHash = "sha256-+K95kbYNMKiYk7obN2gjNCtBvaXBWPLKm12N6cF9ImQ=";
+            vendorHash = "sha256-e0L6osJwG0EF0M3TefxaAjDvN4jvQHxTGEUEECNO1Vw=";
             proxyVendor = true;
             src = ./.;
             nativeBuildInputs = with pkgs; [ getopt openssl zstd ];


### PR DESCRIPTION
- Tests now run on postgres 16 by default when run locally (can be specified with `POSTGRES_VERSION`)
- Adds  `test-go-pg-16` to test against postgres version 16
- Updates Dogfood dockerfile / nix flake to postgres version 16
- Updates `docker-compose.yaml` postgres tag to 16