### PR TITLE
fix: disable agent app buttons while a blocking startup script is running

### DIFF
--- a/site/src/modules/resources/AppLink/AppLink.stories.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.stories.tsx
@@ -151,3 +151,15 @@ export const InternalApp: Story = {
     agent: MockWorkspaceAgent,
   },
 };
+
+export const BlockingStartupScriptRunning: Story = {
+  args: {
+    workspace: MockWorkspace,
+    app: MockWorkspaceApp,
+    agent: {
+      ...MockWorkspaceAgent,
+      lifecycle_state: "starting",
+      startup_script_behavior: "blocking",
+    },
+  },
+};

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -16,7 +16,7 @@ import { ShareIcon } from "./ShareIcon";
 export const DisplayAppNameMap: Record<TypesGen.DisplayApp, string> = {
   port_forwarding_helper: "Ports",
   ssh_helper: "SSH",
-  vscode: "VS Code Desktop",
+  vscode: "VS Code",
   vscode_insiders: "VS Code Insiders",
   web_terminal: "Terminal",
 };
@@ -94,17 +94,17 @@ export const AppLink: FC<AppLinkProps> = ({ app, workspace, agent }) => {
   }
   if (!appsHost && app.subdomain) {
     canClick = false;
-    icon = (
-      <ErrorOutlineIcon
-        css={{
-          color: theme.palette.grey[300],
-        }}
-      />
-    );
+    icon = <ErrorOutlineIcon css={{ color: theme.palette.grey[300] }} />;
     primaryTooltip =
       "Your admin has not configured subdomain application access";
   }
   if (fetchingSessionToken) {
+    canClick = false;
+  }
+  if (
+    agent.lifecycle_state === "starting" &&
+    agent.startup_script_behavior === "blocking"
+  ) {
     canClick = false;
   }
 

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -16,8 +16,8 @@ import { ShareIcon } from "./ShareIcon";
 export const DisplayAppNameMap: Record<TypesGen.DisplayApp, string> = {
   port_forwarding_helper: "Ports",
   ssh_helper: "SSH",
-  vscode: "VS Code (Remote)",
-  vscode_insiders: "VS Code Insiders (Remote)",
+  vscode: "VS Code Desktop",
+  vscode_insiders: "VS Code Insiders",
   web_terminal: "Terminal",
 };
 

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -16,8 +16,8 @@ import { ShareIcon } from "./ShareIcon";
 export const DisplayAppNameMap: Record<TypesGen.DisplayApp, string> = {
   port_forwarding_helper: "Ports",
   ssh_helper: "SSH",
-  vscode: "VS Code",
-  vscode_insiders: "VS Code Insiders",
+  vscode: "VS Code (Remote)",
+  vscode_insiders: "VS Code Insiders (Remote)",
   web_terminal: "Terminal",
 };
 


### PR DESCRIPTION
From a customer in Zendesk (loosely paraphrased)

> The behavior we would like to have is for `coder_app​` resources to _not_ be accessible until after the startup script has completed. To do this, I've set startup_script_behavior​ to "blocking"​ in our templates. The [`startup_script_behavior` documentation](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/agent#startup_script_behavior), says this means that the workspace is "not ready", which I would expect to mean that you can't yet do things like click on apps.