### PR TITLE
chore: optimize dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -61,7 +61,9 @@ updates:
       - dependency-name: "terraform"
 
   - package-ecosystem: "npm"
-    directory: "/site/"
+    directories:
+      - "/site"
+      - "/offlinedocs"
     schedule:
       interval: "monthly"
       time: "06:00"
@@ -82,33 +84,4 @@ updates:
         update-types:
           - version-update:semver-major
     open-pull-requests-limit: 15
-    groups:
-      site:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "npm"
-    directory: "/offlinedocs/"
-    schedule:
-      interval: "monthly"
-      time: "06:00"
-      timezone: "America/Chicago"
-    reviewers:
-      - "coder/ts"
-    commit-message:
-      prefix: "chore"
-    labels: []
-    ignore:
-      # Ignore patch updates for all dependencies
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-patch
-      # Ignore major updates to Node.js types, because they need to
-      # correspond to the Node.js engine version
-      - dependency-name: "@types/node"
-        update-types:
-          - version-update:semver-major
-    groups:
-      offlinedocs:
-        patterns:
-          - "*"
+    

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -84,4 +84,3 @@ updates:
         update-types:
           - version-update:semver-major
     open-pull-requests-limit: 15
-    


### PR DESCRIPTION
1. Merges `site` and `offlinedocs` configs as @dependabot now supports specifying multiple [`directories`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories).
2. Removes grouping as it is not practical to resolve PRs like #13605.

Let me know what your thoughts are.