### PR TITLE
chore: build nix dogfood image for arm64

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -68,6 +68,7 @@ jobs:
           token: ${{ secrets.DEPOT_TOKEN }}
           buildx-fallback: true
           context: "."
+          platforms: linux/amd64,linux/arm64
           file: "dogfood/Dockerfile.nix"
           pull: true
           save: true


### PR DESCRIPTION
This allows running devcontainer on Macbooks with M chips.