### PR TITLE
chore: implement default pagination limit 

### DIFF
--- a/coderd/pagination.go
+++ b/coderd/pagination.go
@@ -17,7 +17,7 @@ func parsePagination(w http.ResponseWriter, r *http.Request) (p codersdk.Paginat
 	parser := httpapi.NewQueryParamParser()
 	params := codersdk.Pagination{
 		AfterID: parser.UUID(queryParams, uuid.Nil, "after_id"),
-		Limit:   int(parser.PositiveInt32(queryParams, 10, "limit")),
+		Limit:   int(parser.PositiveInt32(queryParams, 20, "limit")),
 		Offset:  int(parser.PositiveInt32(queryParams, 0, "offset")),
 	}
 	if len(parser.Errors) > 0 {

--- a/coderd/pagination.go
+++ b/coderd/pagination.go
@@ -17,7 +17,7 @@ func parsePagination(w http.ResponseWriter, r *http.Request) (p codersdk.Paginat
 	parser := httpapi.NewQueryParamParser()
 	params := codersdk.Pagination{
 		AfterID: parser.UUID(queryParams, uuid.Nil, "after_id"),
-		Limit:   int(parser.PositiveInt32(queryParams, 0, "limit")),
+		Limit:   int(parser.PositiveInt32(queryParams, 10, "limit")),
 		Offset:  int(parser.PositiveInt32(queryParams, 0, "offset")),
 	}
 	if len(parser.Errors) > 0 {

--- a/coderd/pagination_internal_test.go
+++ b/coderd/pagination_internal_test.go
@@ -16,6 +16,10 @@ import (
 func TestPagination(t *testing.T) {
 	t.Parallel()
 	const invalidValues = "Query parameters have invalid values"
+	emptyReq, _ := http.NewRequest(http.MethodGet, "/", nil)
+	defaults, ok := parsePagination(httptest.NewRecorder(), emptyReq)
+	require.True(t, ok)
+
 	testCases := []struct {
 		Name string
 
@@ -98,6 +102,7 @@ func TestPagination(t *testing.T) {
 			ExpectedParams: codersdk.Pagination{
 				AfterID: uuid.Nil,
 				Offset:  150,
+				Limit:   defaults.Limit,
 			},
 		},
 		{
@@ -105,6 +110,7 @@ func TestPagination(t *testing.T) {
 			AfterID: "5f2005fc-acc4-4e5e-a7fa-be017359c60b",
 			ExpectedParams: codersdk.Pagination{
 				AfterID: uuid.MustParse("5f2005fc-acc4-4e5e-a7fa-be017359c60b"),
+				Limit:   defaults.Limit,
 			},
 		},
 	}

--- a/coderd/pagination_internal_test.go
+++ b/coderd/pagination_internal_test.go
@@ -16,7 +16,7 @@ import (
 func TestPagination(t *testing.T) {
 	t.Parallel()
 	const invalidValues = "Query parameters have invalid values"
-	emptyReq, _ := http.NewRequest(http.MethodGet, "/", nil)
+	emptyReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	defaults, ok := parsePagination(httptest.NewRecorder(), emptyReq)
 	require.True(t, ok)
 


### PR DESCRIPTION
Specifying no limit should return a default of >0. I noticed this for audit logs. Tests had to specify a limit >0.