### PR TITLE
fix: fix workspacesdk to return error on API mismatch

### DIFF
--- a/codersdk/workspacesdk/workspacesdk.go
+++ b/codersdk/workspacesdk/workspacesdk.go
@@ -55,6 +55,8 @@ const (
 	AgentMinimumListeningPort = 9
 )
 
+const AgentAPIMismatchMessage = "Unknown or unsupported API version"
+
 // AgentIgnoredListeningPorts contains a list of ports to ignore when looking for
 // running applications inside a workspace. We want to ignore non-HTTP servers,
 // so we pre-populate this list with common ports that are not HTTP servers.

--- a/enterprise/coderd/workspaceagents_test.go
+++ b/enterprise/coderd/workspaceagents_test.go
@@ -46,8 +46,9 @@ func TestBlockNonBrowser(t *testing.T) {
 			},
 		})
 		r := setupWorkspaceAgent(t, client, user, 0)
+		ctx := testutil.Context(t, testutil.WaitShort)
 		//nolint:gocritic // Testing that even the owner gets blocked.
-		_, err := workspacesdk.New(client).DialAgent(context.Background(), r.sdkAgent.ID, nil)
+		_, err := workspacesdk.New(client).DialAgent(ctx, r.sdkAgent.ID, nil)
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusConflict, apiErr.StatusCode())
@@ -65,8 +66,9 @@ func TestBlockNonBrowser(t *testing.T) {
 			},
 		})
 		r := setupWorkspaceAgent(t, client, user, 0)
+		ctx := testutil.Context(t, testutil.WaitShort)
 		//nolint:gocritic // Testing RBAC is not the point of this test.
-		conn, err := workspacesdk.New(client).DialAgent(context.Background(), r.sdkAgent.ID, nil)
+		conn, err := workspacesdk.New(client).DialAgent(ctx, r.sdkAgent.ID, nil)
 		require.NoError(t, err)
 		_ = conn.Close()
 	})


### PR DESCRIPTION
fixes #13478

If the CLI is ahead of the server version, across a tailnet API change, you'll see something like:

```
% coder ping dogfood2
Encountered an error running "coder ping", see "coder ping --help" for more information
error: Trace=[start connector: ]
Unknown or unsupported API version
1 validation error(s) found
	 version : server is at version 2.0, behind requested minor version 2.1
Suggestion: Ensure your client release version (v2.12.1, different than the API version) matches the server release version
exit status 1
```

~This is still a bit cryptic, tbh, but Websocket only returns 1024 bytes of body when it fails, so if we want to do better we'll need to do our wordsmithing client side.~

Edit: I decided to go ahead and add a suggestion client side, see above for what it looks like.