### PR TITLE
fix: modify workspacesdk to ask for tailnet API 2.0

### DIFF
--- a/codersdk/workspacesdk/workspacesdk.go
+++ b/codersdk/workspacesdk/workspacesdk.go
@@ -21,7 +21,6 @@ import (
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/tailnet"
-	"github.com/coder/coder/v2/tailnet/proto"
 )
 
 // AgentIP is a static IPv6 address with the Tailscale prefix that is used to route
@@ -239,7 +238,15 @@ func (c *Client) DialAgent(dialCtx context.Context, agentID uuid.UUID, options *
 		return nil, xerrors.Errorf("parse url: %w", err)
 	}
 	q := coordinateURL.Query()
-	q.Add("version", proto.CurrentVersion.String())
+	// TODO (ethanndickson) - the current version includes 2 additions we don't currently use:
+	//
+	// 2.1 GetAnnouncementBanners on the Agent API (version locked to Tailnet API)
+	// 2.2 PostTelemetry on the Tailnet API
+	//
+	// So, asking for API 2.2 just makes us incompatible back level servers, for no real benefit.
+	// As a temporary measure, we'll specifically ask for API version 2.0 until we implement sending
+	// telemetry.
+	q.Add("version", "2.0")
 	coordinateURL.RawQuery = q.Encode()
 
 	connector := runTailnetAPIConnector(ctx, options.Logger,


### PR DESCRIPTION
#13617 bumped the Agent/Tailnet API minor version because it adds telemetry features.  However, we don't actually use the protocol features yet, so it's a bit obnoxious for our CLI client to ask for the newest API version.

This is particularly true of the CLI client, since that's distributed separately, so if an end user installs the latest CLI client and their organization hasn't fully upgraded, then it will fail to connect.

Since we have a release coming up and the telemetry stuff won't make it, I think we should roll back to version 2.0 until we actually implement the telemetry stuff. That way the newest release (2.13) will work with Coder servers all the way back to 2.9.