### PR TITLE
chore: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ result
 
 # Filebrowser.db
 **/filebrowser.db
+
+# pnpm
+.pnpm-store/

--- a/.prettierignore
+++ b/.prettierignore
@@ -71,6 +71,9 @@ result
 
 # Filebrowser.db
 **/filebrowser.db
+
+# pnpm
+.pnpm-store/
 # .prettierignore.include:
 # Helm templates contain variables that are invalid YAML and can't be formatted
 # by Prettier.

--- a/site/.eslintignore
+++ b/site/.eslintignore
@@ -71,6 +71,9 @@ result
 
 # Filebrowser.db
 **/filebrowser.db
+
+# pnpm
+.pnpm-store/
 # .prettierignore.include:
 # Helm templates contain variables that are invalid YAML and can't be formatted
 # by Prettier.

--- a/site/.prettierignore
+++ b/site/.prettierignore
@@ -71,6 +71,9 @@ result
 
 # Filebrowser.db
 **/filebrowser.db
+
+# pnpm
+.pnpm-store/
 # .prettierignore.include:
 # Helm templates contain variables that are invalid YAML and can't be formatted
 # by Prettier.


### PR DESCRIPTION
When working in a dogfood devcontainer workspace built by `envbuilder` `.pnpm-store` gets created in the repo root which causes 10000+ changed files.