### PR TITLE
fix: fix TestPGCoordinatorSingle_MissedHeartbeats flake

### DIFF
--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -1613,7 +1613,7 @@ func (h *heartbeats) resetExpiryTimerWithLock() {
 	if d < 0 {
 		d = 0
 	}
-	h.timer.Reset(d)
+	h.timer.Reset(d, "heartbeats", "resetExpiryTimerWithLock")
 }
 
 func (h *heartbeats) checkExpiry() {


### PR DESCRIPTION
Fixes flake seen here: https://github.com/coder/coder/actions/runs/9695396986/job/26755085673

Problem is that with the mocked `Clock` we were trapping the first call into the clock to ensure the heartbeat was processes, but instead we should trap the last call, otherwise advancing the time can race with heartbeat processing.