### PR TITLE
chore: add command to render all existing cli prompts

### DIFF
--- a/cli/exp.go
+++ b/cli/exp.go
@@ -13,6 +13,7 @@ func (r *RootCmd) expCmd() *serpent.Command {
 		Children: []*serpent.Command{
 			r.scaletestCmd(),
 			r.errorExample(),
+			r.promptExample(),
 		},
 	}
 	return cmd

--- a/cli/prompts.go
+++ b/cli/prompts.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/cli/cliui"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func (RootCmd) promptExample() *serpent.Command {
+	promptCmd := func(use string, prompt func(inv *serpent.Invocation) error, options ...serpent.Option) *serpent.Command {
+		return &serpent.Command{
+			Use:     use,
+			Options: options,
+			Handler: func(inv *serpent.Invocation) error {
+				return prompt(inv)
+			},
+		}
+	}
+
+	var useSearch bool
+	useSearchOption := serpent.Option{
+		Name:        "search",
+		Description: "Show the search.",
+		Required:    false,
+		Flag:        "search",
+		Value:       serpent.BoolOf(&useSearch),
+	}
+	cmd := &serpent.Command{
+		Use:   "prompt-example",
+		Short: "Example of various prompt types used within coder cli.",
+		Long: "Example of various prompt types used within coder cli. " +
+			"This command exists to aid in adjusting visuals of command prompts.",
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Children: []*serpent.Command{
+			promptCmd("confirm", func(inv *serpent.Invocation) error {
+				value, err := cliui.Prompt(inv, cliui.PromptOptions{
+					Text:      "Basic confirmation prompt.",
+					Default:   "yes",
+					IsConfirm: true,
+				})
+				_, _ = fmt.Fprintf(inv.Stdout, "%s\n", value)
+				return err
+			}),
+			promptCmd("validation", func(inv *serpent.Invocation) error {
+				value, err := cliui.Prompt(inv, cliui.PromptOptions{
+					Text:      "Input a string that starts with a capital letter.",
+					Default:   "",
+					Secret:    false,
+					IsConfirm: false,
+					Validate: func(s string) error {
+						if len(s) == 0 {
+							return xerrors.Errorf("an input string is required")
+						}
+						if strings.ToUpper(string(s[0])) != string(s[0]) {
+							return xerrors.Errorf("input string must start with a capital letter")
+						}
+						return nil
+					},
+				})
+				_, _ = fmt.Fprintf(inv.Stdout, "%s\n", value)
+				return err
+			}),
+			promptCmd("secret", func(inv *serpent.Invocation) error {
+				value, err := cliui.Prompt(inv, cliui.PromptOptions{
+					Text:      "Input a secret",
+					Default:   "",
+					Secret:    true,
+					IsConfirm: false,
+					Validate: func(s string) error {
+						if len(s) == 0 {
+							return xerrors.Errorf("an input string is required")
+						}
+						return nil
+					},
+				})
+				_, _ = fmt.Fprintf(inv.Stdout, "Your secret of length %d is safe with me\n", len(value))
+				return err
+			}),
+			promptCmd("select", func(inv *serpent.Invocation) error {
+				value, err := cliui.Select(inv, cliui.SelectOptions{
+					Options: []string{
+						"Blue", "Green", "Yellow", "Red", "Something else",
+					},
+					Default:    "",
+					Message:    "Select your favorite color:",
+					Size:       5,
+					HideSearch: !useSearch,
+				})
+				if value == "Something else" {
+					_, _ = fmt.Fprint(inv.Stdout, "I would have picked blue.\n")
+				} else {
+					_, _ = fmt.Fprintf(inv.Stdout, "%s is a nice color.\n", value)
+				}
+				return err
+			}, useSearchOption),
+			promptCmd("multi-select", func(inv *serpent.Invocation) error {
+				values, err := cliui.MultiSelect(inv, cliui.MultiSelectOptions{
+					Message: "Select some things:",
+					Options: []string{
+						"Code", "Chair", "Whale", "Diamond", "Carrot",
+					},
+					Defaults: []string{"Code"},
+				})
+				_, _ = fmt.Fprintf(inv.Stdout, "%q are nice choices.\n", strings.Join(values, ", "))
+				return err
+			}),
+			promptCmd("rich-parameter", func(inv *serpent.Invocation) error {
+				value, err := cliui.RichSelect(inv, cliui.RichSelectOptions{
+					Options: []codersdk.TemplateVersionParameterOption{
+						{
+							Name:        "Blue",
+							Description: "Like the ocean.",
+							Value:       "blue",
+							Icon:        "/logo/blue.png",
+						},
+						{
+							Name:        "Red",
+							Description: "Like a clown's nose.",
+							Value:       "red",
+							Icon:        "/logo/red.png",
+						},
+						{
+							Name:        "Yellow",
+							Description: "Like a bumblebee. ",
+							Value:       "yellow",
+							Icon:        "/logo/yellow.png",
+						},
+					},
+					Default:    "blue",
+					Size:       5,
+					HideSearch: useSearch,
+				})
+				_, _ = fmt.Fprintf(inv.Stdout, "%s is a good choice.\n", value.Name)
+				return err
+			}, useSearchOption),
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
# What this does

Adds a command to render all the existing cli prompts we use. This is to validate a change to how our cli ui prompts look.

# Examples


rich-parameters

![Screenshot from 2024-06-27 09-41-00](https://github.com/coder/coder/assets/5446298/4a7bf124-0a09-47b8-b362-ef4d60f62bab)

confirm
 
![Screenshot from 2024-06-27 09-41-29](https://github.com/coder/coder/assets/5446298/e78e2d21-c00b-4cb4-9f6c-374f8c21115e)


select

![Screenshot from 2024-06-27 09-41-54](https://github.com/coder/coder/assets/5446298/b4d8a084-c57d-48fc-bd76-3ee5a0ea7d9c)


_I don't think tests are required for this at present, just using to verify visual templates._