### PR TITLE
chore: revert to default survey templates

### DIFF
--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -14,44 +14,6 @@ import (
 	"github.com/coder/serpent"
 )
 
-func init() {
-	survey.SelectQuestionTemplate = `
-{{- define "option"}}
-    {{- "  " }}{{- if eq .SelectedIndex .CurrentIndex }}{{color "green" }}{{ .Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
-    {{- .CurrentOpt.Value}}
-    {{- color "reset"}}
-{{end}}
-
-{{- if not .ShowAnswer }}
-{{- if .Config.Icons.Help.Text }}
-{{- if .FilterMessage }}{{ "Search:" }}{{ .FilterMessage }}
-{{- else }}
-{{- color "black+h"}}{{- "Type to search" }}{{color "reset"}}
-{{- end }}
-{{- "\n" }}
-{{- end }}
-{{- "\n" }}
-{{- range $ix, $option := .PageEntries}}
-  {{- template "option" $.IterateOption $ix $option}}
-{{- end}}
-{{- end }}`
-
-	survey.MultiSelectQuestionTemplate = `
-{{- define "option"}}
-    {{- if eq .SelectedIndex .CurrentIndex }}{{color .Config.Icons.SelectFocus.Format }}{{ .Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}
-    {{- if index .Checked .CurrentOpt.Index }}{{color .Config.Icons.MarkedOption.Format }} {{ .Config.Icons.MarkedOption.Text }} {{else}}{{color .Config.Icons.UnmarkedOption.Format }} {{ .Config.Icons.UnmarkedOption.Text }} {{end}}
-    {{- color "reset"}}
-    {{- " "}}{{- .CurrentOpt.Value}}
-{{end}}
-{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
-{{- if not .ShowAnswer }}
-  {{- "\n"}}
-  {{- range $ix, $option := .PageEntries}}
-    {{- template "option" $.IterateOption $ix $option}}
-  {{- end}}
-{{- end}}`
-}
-
 type SelectOptions struct {
 	Options []string
 	// Default will be highlighted first if it's a valid option.


### PR DESCRIPTION
# Changes

Revert to the default template provided by the package. Includes all fields like the "Message" field. Our template omits headers and keybind helpers.

Changes answer selector from **green** to **cyan**. Fixing this requires us to edit the global template, which is really unfortunate.

## Confirm

<details>
<summary>Comparison</summary>

**Before**

[Screencast from 2024-06-27 09-45-38.webm](https://github.com/coder/coder/assets/5446298/4c5da445-a127-4a4f-9152-a54349b0ba4f)

**After**

[Screencast from 2024-06-27 09-54-41.webm](https://github.com/coder/coder/assets/5446298/b1d678ea-55e9-4aee-b1ea-c8f2a24cb179)


</details>

## Multi-Select

<details>
<summary>Comparison</summary>

**Before**

[Screencast from 2024-06-27 09-47-20.webm](https://github.com/coder/coder/assets/5446298/e93f7e8c-eeac-4935-b020-723224b5ce24)

**After**

[Screencast from 2024-06-27 09-56-00.webm](https://github.com/coder/coder/assets/5446298/7e08aaea-a18f-4a4b-98c3-4f75edb8774a)



</details>

## Rich Parameters

<details>
<summary>Comparison</summary>

**Before**

[Screencast from 2024-06-27 09-48-33.webm](https://github.com/coder/coder/assets/5446298/ad4ad34d-d664-4ece-8f4c-9a9a423047e3)

**After**

[Screencast from 2024-06-27 09-57-21.webm](https://github.com/coder/coder/assets/5446298/8cc3f0b4-e5d7-4552-a6a0-681c5d6add28)


</details>

## Secret Input

<details>
<summary>Comparison</summary>

**Before**

[Screencast from 2024-06-27 09-48-58.webm](https://github.com/coder/coder/assets/5446298/6e1be2a9-162c-489b-b06b-0e476687ce62)

**After**

[Screencast from 2024-06-27 09-58-00.webm](https://github.com/coder/coder/assets/5446298/780842a3-cfc6-49cb-b8f8-ccc03502ee5f)


</details>

## Basic Input

<details>
<summary>Comparison</summary>

**Before**

[Screencast from 2024-06-27 09-49-33.webm](https://github.com/coder/coder/assets/5446298/92a4228e-15b3-4ba8-8d16-be8ce8d41ffe)

**After**

[Screencast from 2024-06-27 09-58-26.webm](https://github.com/coder/coder/assets/5446298/fea72838-7804-4f52-8066-4a76fe16f329)


</details>

## Select

<details>
<summary>Comparison</summary>

**Before**

[Screencast from 2024-06-27 09-49-58.webm](https://github.com/coder/coder/assets/5446298/2a7d9ee9-a639-4e9e-ad04-6f55dd05e762)


**After**

[Screencast from 2024-06-27 09-58-59.webm](https://github.com/coder/coder/assets/5446298/e642fc44-0cf2-4b12-8423-5233fe0da27d)



</details>

# Commentary

Would be ideal if we could tweak the original template (like color choice) without having to replace the template entirely :cry:.
