### PR TITLE
chore: swagger docs omit brower based credentials, rely on swagger auth

### DIFF
--- a/coderd/httpmw/csrf.go
+++ b/coderd/httpmw/csrf.go
@@ -1,6 +1,7 @@
 package httpmw
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -20,6 +21,22 @@ func CSRF(secureCookie bool) func(next http.Handler) http.Handler {
 		mw := nosurf.New(next)
 		mw.SetBaseCookie(http.Cookie{Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode, Secure: secureCookie})
 		mw.SetFailureHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sessCookie, err := r.Cookie(codersdk.SessionTokenCookie)
+			if err == nil && r.Header.Get(codersdk.SessionTokenHeader) != sessCookie.Value {
+				// If a user is using header authentication and cookie auth, but the values
+				// do not match, the cookie value takes priority.
+				// At the very least, return a more helpful error to the user.
+				// This happens frequently on the hosted swagger docs. There
+				// is no easy way to disable cookies from
+				http.Error(w,
+					fmt.Sprintf("CSRF error encountered. Authentication via %q cookie and %q header detected, but the values do not match. "+
+						"To resolve this issue ensure the values used in both match, or only use one of the authentication methods. "+
+						"You can also try clearing your cookies if this error persists.",
+						codersdk.SessionTokenCookie, codersdk.SessionTokenHeader),
+					http.StatusBadRequest)
+				return
+			}
+
 			http.Error(w, "Something is wrong with your CSRF token. Please refresh the page. If this error persists, try clearing your cookies.", http.StatusBadRequest)
 		}))
 

--- a/coderd/httpmw/csrf.go
+++ b/coderd/httpmw/csrf.go
@@ -26,8 +26,6 @@ func CSRF(secureCookie bool) func(next http.Handler) http.Handler {
 				// If a user is using header authentication and cookie auth, but the values
 				// do not match, the cookie value takes priority.
 				// At the very least, return a more helpful error to the user.
-				// This happens frequently on the hosted swagger docs. There
-				// is no easy way to disable cookies from
 				http.Error(w,
 					fmt.Sprintf("CSRF error encountered. Authentication via %q cookie and %q header detected, but the values do not match. "+
 						"To resolve this issue ensure the values used in both match, or only use one of the authentication methods. "+


### PR DESCRIPTION
Swagger has an "Authorize" button which should be the only authentication being used in the api requests

Closes https://github.com/coder/coder/issues/13535

Note: I considered implementing CSRF in the interceptor which would just use the logged in user credentials. But the `Authorize` button will still exist, and it would be even more confusing since the cookie auth supersedes the header based auth. So swagger requiring explicit authentication feels safer.