### PR TITLE
fix: execute `rbacgen` even if dependencies' mod times are older than source file's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,6 +518,7 @@ gen/mark-fresh:
 		$(DB_GEN_FILES) \
 		site/src/api/typesGenerated.ts \
 		coderd/rbac/object_gen.go \
+		codersdk/rbacresources_gen.go \
 		docs/admin/prometheus.md \
 		docs/cli.md \
 		docs/admin/audit-logs.md \
@@ -616,12 +617,10 @@ site/src/theme/icons.json: $(wildcard scripts/gensite/*) $(wildcard site/static/
 examples/examples.gen.json: scripts/examplegen/main.go examples/examples.go $(shell find ./examples/templates)
 	go run ./scripts/examplegen/main.go > examples/examples.gen.json
 
-.PHONY: coderd/rbac/object_gen.go # force rebuilds if any dependencies' mtimes are less than the output file
-coderd/rbac/object_gen.go: scripts/rbacgen/rbacobject.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go
+coderd/rbac/object_gen.go: scripts/rbacgen/rbacobject.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go coderd/rbac/policy/policy.go
 	go run scripts/rbacgen/main.go rbac > coderd/rbac/object_gen.go
 
-.PHONY: codersdk/rbacresources_gen.go # force rebuilds if any dependencies' mtimes are less than the output file
-codersdk/rbacresources_gen.go: scripts/rbacgen/codersdk.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go
+codersdk/rbacresources_gen.go: scripts/rbacgen/codersdk.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go coderd/rbac/policy/policy.go
 	go run scripts/rbacgen/main.go codersdk > codersdk/rbacresources_gen.go
 
 docs/admin/prometheus.md: scripts/metricsdocgen/main.go scripts/metricsdocgen/metrics

--- a/Makefile
+++ b/Makefile
@@ -616,9 +616,11 @@ site/src/theme/icons.json: $(wildcard scripts/gensite/*) $(wildcard site/static/
 examples/examples.gen.json: scripts/examplegen/main.go examples/examples.go $(shell find ./examples/templates)
 	go run ./scripts/examplegen/main.go > examples/examples.gen.json
 
+.PHONY: coderd/rbac/object_gen.go # force rebuilds if any dependencies' mtimes are less than the output file
 coderd/rbac/object_gen.go: scripts/rbacgen/rbacobject.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go
 	go run scripts/rbacgen/main.go rbac > coderd/rbac/object_gen.go
 
+.PHONY: codersdk/rbacresources_gen.go # force rebuilds if any dependencies' mtimes are less than the output file
 codersdk/rbacresources_gen.go: scripts/rbacgen/codersdk.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go
 	go run scripts/rbacgen/main.go codersdk > codersdk/rbacresources_gen.go
 


### PR DESCRIPTION
_I'm using GNU Make 4.4.1_

When executing `codersdk/rbacresources_gen.go`, I found that the make target was not actually being executed. I traced this down to the dependencies' modification times being less than the target file's. This appears to be a performance-related behaviour in `make`, since a target file would not need to change if all of its dependencies were modified before it.

In this case, however, we need to execute the `scripts/rbacgen/main.go` script even if it has not been recently modified, and the solution to this is to add a [`PHONY` target](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html).

I suspect we have other cases in our `Makefile` which are preventing targets from running when we expect them to.

```bash
# reset mtimes for dependencies to a date in the past
$ touch -t202405020000 scripts/rbacgen/codersdk.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go

# without PHONY, no change
$ make codersdk/rbacresources_gen.go
$ git diff --stat -- codersdk/rbacresources_gen.go | cat
# no changes

# set all mtimes to now
$ touch scripts/rbacgen/codersdk.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go

# without PHONY, target executes
$ make codersdk/rbacresources_gen.go
$ git diff --stat -- codersdk/rbacresources_gen.go | cat
 codersdk/rbacresources_gen.go | 102 +++++++++++++++++++++---------------------
 1 file changed, 52 insertions(+), 50 deletions(-)

-----------------------------------------------------------------------------------------------------------

# reset
$ git checkout codersdk/rbacresources_gen.go

# reset mtimes for dependencies to a date in the past
$ touch -t202405020000 scripts/rbacgen/codersdk.gotmpl scripts/rbacgen/main.go coderd/rbac/object.go

# with PHONY
$ git diff --stat -- codersdk/rbacresources_gen.go | cat
 codersdk/rbacresources_gen.go | 102 +++++++++++++++++++++---------------------
 1 file changed, 52 insertions(+), 50 deletions(-)
```