### PR TITLE
chore(dogfood): fix duplicate security repository entry

### DIFF
--- a/dogfood/files/etc/apt/sources.list.d/security.list
+++ b/dogfood/files/etc/apt/sources.list.d/security.list
@@ -1,1 +1,0 @@
-deb http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe


### PR DESCRIPTION
This was causing warning like below while running any `apt` commands as this is already configured in `/etc/apt/sources.list` in the base image.
```console
W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (restricted/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (restricted/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:37 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (universe/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1
W: Target Packages (universe/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:39 and /etc/apt/sources.list.d/security.list:1
```

Tested with build https://depot.dev/orgs/0l1nhsnzl0/projects/b4q6ltmpzh/builds/942gm4vqj2 and it seems to reolve teh warning. 

> [!WARNING]
> Dogfood image is huge and may benefit from a rafactor sometimes.