### PR TITLE
fix: let workspace pages download partial logs for unhealthy workspaces

### DIFF
--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -110,15 +110,18 @@ export const getValidationErrorMessage = (error: unknown): string => {
   return validationErrors.map((error) => error.detail).join("\n");
 };
 
-export const getErrorDetail = (error: unknown): string | null => {
+export const getErrorDetail = (error: unknown): string | undefined => {
   if (error instanceof Error) {
     return "Please check the developer console for more details.";
   }
+
   if (isApiError(error)) {
-    return error.response.data.detail ?? null;
+    return error.response.data.detail;
   }
+
   if (isApiErrorResponse(error)) {
-    return error.detail ?? null;
+    return error.detail;
   }
-  return null;
+
+  return undefined;
 };

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -110,15 +110,15 @@ export const getValidationErrorMessage = (error: unknown): string => {
   return validationErrors.map((error) => error.detail).join("\n");
 };
 
-export const getErrorDetail = (error: unknown): string | undefined | null => {
+export const getErrorDetail = (error: unknown): string | null => {
   if (error instanceof Error) {
     return "Please check the developer console for more details.";
   }
   if (isApiError(error)) {
-    return error.response.data.detail;
+    return error.response.data.detail ?? null;
   }
   if (isApiErrorResponse(error)) {
-    return error.detail;
+    return error.detail ?? null;
   }
   return null;
 };

--- a/site/src/modules/resources/AgentLogs/useAgentLogs.ts
+++ b/site/src/modules/resources/AgentLogs/useAgentLogs.ts
@@ -29,16 +29,7 @@ export function useAgentLogs(
 
   const queryClient = useQueryClient();
   const queryOptions = agentLogs(workspaceId, agentId);
-  const query = useQuery({ ...queryOptions, enabled });
-
-  // One pitfall with the current approach: the enabled property does NOT
-  // prevent the useQuery call above from eventually having data. All it does
-  // is prevent it from getting data on its own. Let's say a different useQuery
-  // call elsewhere in the app has the same query key and is enabled. When it
-  // gets data back from the server, the useQuery call here will re-render with
-  // that same new data, even though this state is "disabled". This can EASILY
-  // cause bugs.
-  const logs = enabled ? query.data : undefined;
+  const { data: logs, isFetched } = useQuery({ ...queryOptions, enabled });
 
   const lastQueriedLogId = useRef(0);
   useEffect(() => {
@@ -58,7 +49,7 @@ export function useAgentLogs(
   });
 
   useEffect(() => {
-    if (agentLifeCycleState !== "starting" || !query.isFetched) {
+    if (agentLifeCycleState !== "starting" || !isFetched) {
       return;
     }
 
@@ -85,7 +76,7 @@ export function useAgentLogs(
     return () => {
       socket.close();
     };
-  }, [addLogs, agentId, agentLifeCycleState, query.isFetched]);
+  }, [addLogs, agentId, agentLifeCycleState, isFetched]);
 
   return logs;
 }

--- a/site/src/modules/resources/AgentLogs/useAgentLogs.ts
+++ b/site/src/modules/resources/AgentLogs/useAgentLogs.ts
@@ -33,9 +33,10 @@ export function useAgentLogs(
 
   // One pitfall with the current approach: the enabled property does NOT
   // prevent the useQuery call above from eventually having data. All it does
-  // is prevent it from getting data on its own. If a different useQuery call
-  // elsewhere in the app is enabled and gets data, the useQuery call here will
-  // re-render with that same new data, even if it's disabled. This can EASILY
+  // is prevent it from getting data on its own. Let's say a different useQuery
+  // call elsewhere in the app has the same query key and is enabled. When it
+  // gets data back from the server, the useQuery call here will re-render with
+  // that same new data, even though this state is "disabled". This can EASILY
   // cause bugs.
   const logs = enabled ? query.data : undefined;
 

--- a/site/src/modules/resources/AgentLogs/useAgentLogs.ts
+++ b/site/src/modules/resources/AgentLogs/useAgentLogs.ts
@@ -31,12 +31,18 @@ export function useAgentLogs(
   const queryOptions = agentLogs(workspaceId, agentId);
   const { data: logs, isFetched } = useQuery({ ...queryOptions, enabled });
 
+  // Track the ID of the last log received when the initial logs response comes
+  // back. If the logs are not complete, the ID will mark the start point of the
+  // Web sockets response so that the remaining logs can be received over time
   const lastQueriedLogId = useRef(0);
   useEffect(() => {
-    const lastLog = logs?.at(-1);
-    const canSetLogId = lastLog !== undefined && lastQueriedLogId.current === 0;
+    const isAlreadyTracking = lastQueriedLogId.current !== 0;
+    if (isAlreadyTracking) {
+      return;
+    }
 
-    if (canSetLogId) {
+    const lastLog = logs?.at(-1);
+    if (lastLog !== undefined) {
       lastQueriedLogId.current = lastLog.id;
     }
   }, [logs]);

--- a/site/src/modules/resources/AgentLogs/useAgentLogs.ts
+++ b/site/src/modules/resources/AgentLogs/useAgentLogs.ts
@@ -29,8 +29,11 @@ export function useAgentLogs(
 
   const lastQueriedLogId = useRef(0);
   useEffect(() => {
-    if (logs && lastQueriedLogId.current === 0) {
-      lastQueriedLogId.current = logs[logs.length - 1].id;
+    const lastLog = logs?.at(-1);
+    const canSetLogId = lastLog !== undefined && lastQueriedLogId.current === 0;
+
+    if (canSetLogId) {
+      lastQueriedLogId.current = lastLog.id;
     }
   }, [logs]);
 

--- a/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
@@ -147,7 +147,8 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
 
           {!isWorkspaceHealthy && isLoadingFiles && (
             <Alert severity="warning">
-              Your workspace is unhealthy. Some logs may be unavailable.
+              Your workspace is unhealthy. Some logs may be unavailable for
+              download.
             </Alert>
           )}
 
@@ -200,11 +201,7 @@ const DownloadingItem: FC<DownloadingItemProps> = ({ file, giveUpTimeMs }) => {
           !isWaiting && { color: theme.palette.text.disabled },
         ]}
       >
-        <span css={styles.listItemPrimaryBaseName}>
-          {/* {baseName} */}
-          WWWWWWWWWWWWWWWWWWWWWWW
-        </span>
-
+        <span css={styles.listItemPrimaryBaseName}>{baseName}</span>
         <span css={styles.listItemPrimaryFileExtension}>.{fileExtension}</span>
       </span>
 
@@ -286,7 +283,9 @@ const styles = {
     fontWeight: 500,
     color: theme.palette.text.primary,
     display: "flex",
-    flexFlow: "no nowrap",
+    flexFlow: "row nowrap",
+    columnGap: 0,
+    overflow: "hidden",
   }),
 
   listItemPrimaryBaseName: {
@@ -301,6 +300,7 @@ const styles = {
   },
 
   listItemSecondary: {
+    flexShrink: 0,
     fontSize: 14,
     whiteSpace: "nowrap",
   },
@@ -310,16 +310,6 @@ const styles = {
     flexFlow: "row nowrap",
     alignItems: "center",
     columnGap: "4px",
-
-    "& > span": {
-      maxHeight: "fit-content",
-      display: "flex",
-      alignItems: "center",
-      color: theme.palette.error.light,
-    },
-
-    "& > p": {
-      opacity: "80%",
-    },
+    color: theme.palette.text.disabled,
   }),
 } satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
@@ -63,7 +63,7 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
   // memoization for now, but if we get to a point where performance matters,
   // we should make it so that this state doesn't even begin to mount until the
   // user decides to open the Logs dropdown
-  const allFiles = ((): readonly DownloadableFile[] => {
+  const allFiles: readonly DownloadableFile[] = (() => {
     const files = allUniqueAgents.map<DownloadableFile>((a, i) => {
       const name = `${a.name}-logs.txt`;
       const txt = agentLogQueries[i]?.data?.map((l) => l.output).join("\n");
@@ -76,7 +76,7 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
       return { name, blob };
     });
 
-    const buildLogFile = {
+    const buildLogsFile = {
       name: `${workspace.name}-build-logs.txt`,
       blob: buildLogsQuery.data
         ? new Blob([buildLogsQuery.data.map((l) => l.output).join("\n")], {
@@ -85,7 +85,7 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
         : undefined,
     };
 
-    files.unshift(buildLogFile);
+    files.unshift(buildLogsFile);
     return files;
   })();
 
@@ -232,8 +232,9 @@ function humanBlobSize(size: number) {
   }
 
   // The condition for the while loop above means that over time, we could break
-  // out of the loop because we accidentally went out of the array bounds.
-  // Adding a lot of redundant checks to make sure we always have a usable unit
+  // out of the loop because we accidentally shot past the array bounds and i
+  // is at index (BLOB_SIZE_UNITS.length). Adding a lot of redundant checks to
+  // make sure we always have a usable unit
   const finalUnit = BLOB_SIZE_UNITS[i] ?? BLOB_SIZE_UNITS.at(-1) ?? "TB";
   return `${size.toFixed(2)} ${finalUnit}`;
 }

--- a/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
@@ -1,5 +1,6 @@
 import { useTheme, type Interpolation, type Theme } from "@emotion/react";
 import Skeleton from "@mui/material/Skeleton";
+import ErrorIcon from "@mui/icons-material/ErrorOutline";
 import { saveAs } from "file-saver";
 import JSZip from "jszip";
 import { type FC, useMemo, useState, useRef, useEffect } from "react";
@@ -194,6 +195,7 @@ type DownloadingItemProps = Readonly<{
 }>;
 
 const DownloadingItem: FC<DownloadingItemProps> = ({ file, giveUpTimeMs }) => {
+  const theme = useTheme();
   const [isWaiting, setIsWaiting] = useState(true);
   useEffect(() => {
     if (giveUpTimeMs === undefined || file.blob !== undefined) {
@@ -211,14 +213,28 @@ const DownloadingItem: FC<DownloadingItemProps> = ({ file, giveUpTimeMs }) => {
 
   return (
     <li css={styles.listItem}>
-      <span css={styles.listItemPrimary}>{file.name}</span>
+      <span
+        css={[
+          styles.listItemPrimary,
+          !isWaiting && { color: theme.palette.text.disabled },
+        ]}
+      >
+        {file.name}
+      </span>
+
       <span css={styles.listItemSecondary}>
         {file.blob ? (
           humanBlobSize(file.blob.size)
         ) : isWaiting ? (
           <Skeleton variant="text" width={48} height={12} />
         ) : (
-          <p css={styles.notAvailableText}>N/A</p>
+          <div css={styles.notAvailableText}>
+            <span aria-hidden>
+              <ErrorIcon fontSize={"inherit"} />
+            </span>
+
+            <p>N/A</p>
+          </div>
         )}
       </span>
     </li>
@@ -261,6 +277,20 @@ const styles = {
   },
 
   notAvailableText: (theme) => ({
-    color: theme.palette.error.main,
+    display: "flex",
+    flexFlow: "row nowrap",
+    alignItems: "center",
+    columnGap: "4px",
+
+    "& > span": {
+      maxHeight: "fit-content",
+      display: "flex",
+      alignItems: "center",
+      color: theme.palette.error.light,
+    },
+
+    "& > p": {
+      opacity: "80%",
+    },
   }),
 } satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
@@ -1,23 +1,23 @@
 import { useTheme, type Interpolation, type Theme } from "@emotion/react";
-import Skeleton from "@mui/material/Skeleton";
 import ErrorIcon from "@mui/icons-material/ErrorOutline";
+import Skeleton from "@mui/material/Skeleton";
 import { saveAs } from "file-saver";
 import JSZip from "jszip";
 import { type FC, useMemo, useState, useRef, useEffect } from "react";
-import { UseQueryOptions, useQueries, useQuery } from "react-query";
+import { type UseQueryOptions, useQueries, useQuery } from "react-query";
 import { agentLogs, buildLogs } from "api/queries/workspaces";
 import type {
   Workspace,
   WorkspaceAgent,
   WorkspaceAgentLog,
 } from "api/typesGenerated";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
 import {
   ConfirmDialog,
   type ConfirmDialogProps,
 } from "components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { Stack } from "components/Stack/Stack";
-import { ErrorAlert } from "components/Alert/ErrorAlert";
 
 const BLOB_SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
 
@@ -230,7 +230,7 @@ const DownloadingItem: FC<DownloadingItemProps> = ({ file, giveUpTimeMs }) => {
         ) : (
           <div css={styles.notAvailableText}>
             <span aria-hidden>
-              <ErrorIcon fontSize={"inherit"} />
+              <ErrorIcon fontSize="inherit" />
             </span>
 
             <p>N/A</p>

--- a/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
@@ -13,6 +13,8 @@ import {
 import { displayError } from "components/GlobalSnackbar/utils";
 import { Stack } from "components/Stack/Stack";
 
+const BLOB_SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+
 type DownloadLogsDialogProps = Pick<
   ConfirmDialogProps,
   "onConfirm" | "onClose" | "open"
@@ -32,7 +34,9 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
   ...dialogProps
 }) => {
   const theme = useTheme();
-  const agents = selectAgents(workspace);
+  const agents = workspace.latest_build.resources.flatMap(
+    (resource) => resource.agents ?? [],
+  );
 
   const agentLogResults = useQueries({
     queries: agents.map((a) => ({
@@ -131,19 +135,14 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
 };
 
 function humanBlobSize(size: number) {
-  const units = ["B", "KB", "MB", "GB", "TB"];
   let i = 0;
-  while (size > 1024 && i < units.length) {
+  while (size > 1024 && i < BLOB_SIZE_UNITS.length) {
     size /= 1024;
     i++;
   }
-  return `${size.toFixed(2)} ${units[i]}`;
-}
 
-function selectAgents(workspace: Workspace): WorkspaceAgent[] {
-  return workspace.latest_build.resources
-    .flatMap((r) => r.agents)
-    .filter((a) => a !== undefined) as WorkspaceAgent[];
+  const finalUnit = BLOB_SIZE_UNITS[i] ?? BLOB_SIZE_UNITS.at(-1) ?? "TB";
+  return `${size.toFixed(2)} ${finalUnit}`;
 }
 
 const styles = {

--- a/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/DownloadLogsDialog.tsx
@@ -33,17 +33,20 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
 }) => {
   const theme = useTheme();
   const agents = selectAgents(workspace);
+
   const agentLogResults = useQueries({
     queries: agents.map((a) => ({
       ...agentLogs(workspace.id, a.id),
       enabled: dialogProps.open,
     })),
   });
+
   const buildLogsQuery = useQuery({
     ...buildLogs(workspace),
     enabled: dialogProps.open,
   });
-  const downloadableFiles: DownloadableFile[] = useMemo(() => {
+
+  const downloadableFiles = useMemo<readonly DownloadableFile[]>(() => {
     const files: DownloadableFile[] = [
       {
         name: `${workspace.name}-build-logs.txt`,
@@ -68,6 +71,7 @@ export const DownloadLogsDialog: FC<DownloadLogsDialogProps> = ({
 
     return files;
   }, [agentLogResults, agents, buildLogsQuery.data, workspace.name]);
+
   const isLoadingFiles = downloadableFiles.some((f) => f.blob === undefined);
   const [isDownloading, setIsDownloading] = useState(false);
 


### PR DESCRIPTION
Addresses the most important parts of #13723

## Changes made
- Updated `useAgentLogs` to make it more resistant to data being missing, or having agent log data be updated in other parts of the app
- Updated the log generation logic to ensure that it wouldn't recalculate the log files on every single render
- Updated "Download Logs" UI to notify user that an unhealthy workspace may make some logs unavailable, but still let users download a partial set of logs
- Made a couple of bug fixes to helpers, and added extra safety nets
- Updated one of the helpers to simplify its API design


https://github.com/coder/coder/assets/28937484/3175c5a8-1919-47f9-82ac-e87731aebc1b

## Notes
- Just to get this PR out faster, this *doesn't* cover any changes to any test files. I'll be adding those in a separate PR
- As I mentioned in the linked issue, at this point, I really think we need to beef up our UI error handling