### PR TITLE
ci: use postgres version 13 to test migrations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Test migrations from current ref to main
         run: |
-          make test-migrations
+          POSTGRES_VERSION=13 make test-migrations
 
       # Setup GCloud for signing Windows binaries.
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
The version of `pg_dump` we have installed doesn't like version 16:

```
Dump schema at version "9ee53e5b4"
pg_dump: error: server version: 16.3 (Debian 16.3-1.pgdg120+1); pg_dump version: 14.12 (Ubuntu 14.12-1.pgdg22.04+1)
pg_dump: error: aborting because of server version mismatch
```