### PR TITLE
ci: use postgres version 13 to test migrations (#13767)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Test migrations from current ref to main
         run: |
-          make test-migrations
+          POSTGRES_VERSION=13 make test-migrations
 
       # Setup GCloud for signing Windows binaries.
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
(cherry picked from commit 5ea5db29e9e2da640da65fbd2a0cd2840eff7fc8)