### PR TITLE
ci: remove release make concurrency to fix docker image race

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -297,7 +297,7 @@ jobs:
 
           # build Docker images for each architecture
           version="$(./scripts/version.sh)"
-          make -j build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
+          make build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
 
           # we can't build multi-arch if the images aren't pushed, so quit now
           # if dry-running
@@ -308,7 +308,7 @@ jobs:
 
           # build and push multi-arch manifest, this depends on the other images
           # being pushed so will automatically push them.
-          make -j push/build/coder_"$version"_linux.tag
+          make push/build/coder_"$version"_linux.tag
 
           # if the current version is equal to the highest (according to semver)
           # version in the repo, also create a multi-arch image as ":latest" and


### PR DESCRIPTION
Our `ghcr.io/coder/coder-base:v2.13.0` image shares the same SHA256 for all platforms, this presumably resulted in a race where the arm64 image overwrote the amd64 image just as the build was getting going:

https://github.com/coder/coder/actions/runs/9765191341/job/26955318156#step:28:321

Ref #13770.