### PR TITLE
docs: clarify envbox version pinning

### DIFF
--- a/examples/templates/envbox/README.md
+++ b/examples/templates/envbox/README.md
@@ -36,7 +36,7 @@ The following environment variables can be used to configure various aspects of 
 | `CODER_CPUS`               | Dictates the number of CPUs to allocate the inner container. It is recommended to set this using the Kubernetes [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables).                                                                                                                                                                                 | false    |
 | `CODER_MEMORY`             | Dictates the max memory (in bytes) to allocate the inner container. It is recommended to set this using the Kubernetes [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables).                                                                                                                                                                          | false    |
 
-# Migrating Existing Envbox Templates
+## Migrating Existing Envbox Templates
 
 Due to the [deprecation and removal of legacy parameters](https://coder.com/docs/v2/latest/templates/parameters#legacy)
 it may be necessary to migrate existing envbox templates on newer versions of
@@ -49,6 +49,10 @@ To supply values to existing existing Terraform variables you can specify the
 ```bash
 coder templates push envbox --var namespace="mynamespace" --var max_cpus=2 --var min_cpus=1 --var max_memory=4 --var min_memory=1
 ```
+
+## Version Pinning
+
+The template sets the image tag as `latest`. We highly recommend pinning the image to a specific release of envbox, as the `latest` tag may change.
 
 ## Contributions
 

--- a/examples/templates/envbox/main.tf
+++ b/examples/templates/envbox/main.tf
@@ -153,7 +153,8 @@ resource "kubernetes_pod" "main" {
     restart_policy = "Never"
 
     container {
-      name              = "dev"
+      name = "dev"
+      # We highly recommend pinning this to a specific release of envbox, as the latest tag may change.
       image             = "ghcr.io/coder/envbox:latest"
       image_pull_policy = "Always"
       command           = ["/envbox", "docker"]


### PR DESCRIPTION
this PR communicates that users should remove the `latest` tag in our `envbox` example template, and pin it to a specific release.