### PR TITLE
docs: fix vs code web module reference

### DIFF
--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -145,6 +145,7 @@ command. To add VS Code web as a web IDE, you have two options.
    ```hcl
    module "vscode-web" {
      source         = "registry.coder.com/modules/vscode-web/coder"
+     version        = "1.0.14"
      agent_id       = coder_agent.main.id
      accept_license = true
    }

--- a/docs/ides/web-ides.md
+++ b/docs/ides/web-ides.md
@@ -144,7 +144,7 @@ command. To add VS Code web as a web IDE, you have two options.
 
    ```hcl
    module "vscode-web" {
-     source         = "https://registry.coder.com/modules/vscode-web"
+     source         = "registry.coder.com/modules/vscode-web/coder"
      agent_id       = coder_agent.main.id
      accept_license = true
    }


### PR DESCRIPTION
this PR corrects the `source` value for the VS Code Web module.