### PR TITLE
fix(dogfood/Dockerfile): change ownership of /etc/sudoers.d to root

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -91,6 +91,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install --yes ca-certificates
 
 COPY files /
+RUN chown 0:0 /etc/sudoers.d # workaround for coder/envbuilder#70
 
 # Install packages from apt repositories
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -91,7 +91,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install --yes ca-certificates
 
 COPY files /
-RUN chown 0:0 /etc/sudoers.d # workaround for coder/envbuilder#70
+RUN chown -R 0:0 /etc/sudoers.d # workaround for coder/envbuilder#70
 
 # Install packages from apt repositories
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
to work around coder/envbuilder#70

This is normally a no-op when building on Docker.
- Verified by building locally and executing `sudo su`
- Verified with `coder-envbuilder` template in combination with local modifications
- Verified by pulling the built image from `depot.dev` and running `sudo su`

