### PR TITLE
fix: remove `templates plan` docs

### DIFF
--- a/cli/templates.go
+++ b/cli/templates.go
@@ -18,10 +18,6 @@ func (r *RootCmd) templates() *serpent.Command {
 		Short: "Manage templates",
 		Long: "Templates are written in standard Terraform and describe the infrastructure for workspaces\n" + FormatExamples(
 			Example{
-				Description: "Make changes to your template, and plan the changes",
-				Command:     "coder templates plan my-template",
-			},
-			Example{
 				Description: "Create or push an update to the template. Your developers can update their workspaces",
 				Command:     "coder templates push my-template",
 			},

--- a/cli/testdata/coder_templates_--help.golden
+++ b/cli/testdata/coder_templates_--help.golden
@@ -9,10 +9,6 @@ USAGE:
 
   Templates are written in standard Terraform and describe the infrastructure
   for workspaces
-    - Make changes to your template, and plan the changes:
-  
-       $ coder templates plan my-template
-  
     - Create or push an update to the template. Your developers can update their
   workspaces:
   

--- a/docs/cli/templates.md
+++ b/docs/cli/templates.md
@@ -18,10 +18,6 @@ coder templates
 
 ```console
 Templates are written in standard Terraform and describe the infrastructure for workspaces
-  - Make changes to your template, and plan the changes:
-
-     $ coder templates plan my-template
-
   - Create or push an update to the template. Your developers can update their
 workspaces:
 


### PR DESCRIPTION
we deprecated `coder templates plan` a while back, but never removed the command description from the CLI. multiple customers have expressed confusion on this.

this PR removes `templates plan` from our CLI documentation.