### PR TITLE
fix(cli): prevent asynchronous print of version mismatch in config-ssh

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -246,9 +246,10 @@ func (r *RootCmd) configSSH() *serpent.Command {
 			sshConfigOpts.header = r.header
 			sshConfigOpts.headerCommand = r.headerCommand
 
-			// Talk to the API early to prevent bad placement of the
-			// version mismatch warning. The asynchronous requests
-			// issued by sshPrepareWorkspaceConfigs may trigger the
+			// Talk to the API early to prevent the version mismatch
+			// warning from being printed in the middle of a prompt.
+			// This is needed because the asynchronous requests issued
+			// by sshPrepareWorkspaceConfigs may otherwise trigger the
 			// warning at any time.
 			_, _ = client.BuildInfo(ctx)
 

--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -236,6 +236,8 @@ func (r *RootCmd) configSSH() *serpent.Command {
 			r.InitClient(client),
 		),
 		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+
 			if sshConfigOpts.waitEnum != "auto" && skipProxyCommand {
 				// The wait option is applied to the ProxyCommand. If the user
 				// specifies skip-proxy-command, then wait cannot be applied.
@@ -244,7 +246,13 @@ func (r *RootCmd) configSSH() *serpent.Command {
 			sshConfigOpts.header = r.header
 			sshConfigOpts.headerCommand = r.headerCommand
 
-			recvWorkspaceConfigs := sshPrepareWorkspaceConfigs(inv.Context(), client)
+			// Talk to the API early to prevent bad placement of the
+			// version mismatch warning. The asynchronous requests
+			// issued by sshPrepareWorkspaceConfigs may trigger the
+			// warning at any time.
+			_, _ = client.BuildInfo(ctx)
+
+			recvWorkspaceConfigs := sshPrepareWorkspaceConfigs(ctx, client)
 
 			out := inv.Stdout
 			if dryRun {
@@ -366,7 +374,7 @@ func (r *RootCmd) configSSH() *serpent.Command {
 				return xerrors.Errorf("fetch workspace configs failed: %w", err)
 			}
 
-			coderdConfig, err := client.SSHConfiguration(inv.Context())
+			coderdConfig, err := client.SSHConfiguration(ctx)
 			if err != nil {
 				// If the error is 404, this deployment does not support
 				// this endpoint yet. Do not error, just assume defaults.


### PR DESCRIPTION
<img width="816" alt="image" src="https://github.com/coder/coder/assets/147409/c41124ac-2a2c-46c8-b658-2e28679b82ba">
