### PR TITLE
fix(coderd/agentapi): set `ReadyAt` for start timeout

### DIFF
--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -95,6 +95,8 @@ func TestAgent(t *testing.T) {
 			iter: []func(context.Context, *testing.T, *codersdk.WorkspaceAgent, <-chan string, chan []codersdk.WorkspaceAgentLog) error{
 				func(_ context.Context, _ *testing.T, agent *codersdk.WorkspaceAgent, _ <-chan string, _ chan []codersdk.WorkspaceAgentLog) error {
 					agent.Status = codersdk.WorkspaceAgentConnecting
+					agent.LifecycleState = codersdk.WorkspaceAgentLifecycleStarting
+					agent.StartedAt = ptr.Ref(time.Now())
 					return nil
 				},
 				func(_ context.Context, t *testing.T, agent *codersdk.WorkspaceAgent, output <-chan string, _ chan []codersdk.WorkspaceAgentLog) error {
@@ -104,6 +106,7 @@ func TestAgent(t *testing.T) {
 					agent.Status = codersdk.WorkspaceAgentConnected
 					agent.LifecycleState = codersdk.WorkspaceAgentLifecycleStartTimeout
 					agent.FirstConnectedAt = ptr.Ref(time.Now())
+					agent.ReadyAt = ptr.Ref(time.Now())
 					return nil
 				},
 			},

--- a/coderd/agentapi/lifecycle.go
+++ b/coderd/agentapi/lifecycle.go
@@ -98,7 +98,9 @@ func (a *LifecycleAPI) UpdateLifecycle(ctx context.Context, req *agentproto.Upda
 		// This agent is (re)starting, so it's not ready yet.
 		readyAt.Time = time.Time{}
 		readyAt.Valid = false
-	case database.WorkspaceAgentLifecycleStateReady, database.WorkspaceAgentLifecycleStateStartError:
+	case database.WorkspaceAgentLifecycleStateReady,
+		database.WorkspaceAgentLifecycleStateStartTimeout,
+		database.WorkspaceAgentLifecycleStateStartError:
 		if !startedAt.Valid {
 			startedAt = dbChangedAt
 		}

--- a/coderd/agentapi/lifecycle_test.go
+++ b/coderd/agentapi/lifecycle_test.go
@@ -275,7 +275,7 @@ func TestUpdateLifecycle(t *testing.T) {
 			if state == agentproto.Lifecycle_STARTING {
 				expectedStartedAt = sql.NullTime{Valid: true, Time: stateNow}
 			}
-			if state == agentproto.Lifecycle_READY || state == agentproto.Lifecycle_START_ERROR {
+			if state == agentproto.Lifecycle_READY || state == agentproto.Lifecycle_START_TIMEOUT || state == agentproto.Lifecycle_START_ERROR {
 				expectedReadyAt = sql.NullTime{Valid: true, Time: stateNow}
 			}
 


### PR DESCRIPTION
The ReadyAt is a property on the agent that signals when the agent is connectable without blocking. Script timeouts are no longer a soft state and still means that all scripts have finnished executing so ReadyAt should be applied to this state as well.
