### PR TITLE
feat(cli): show information about --wait=no for ssh

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -137,6 +137,9 @@ func Agent(ctx context.Context, writer io.Writer, agentID uuid.UUID, opts AgentO
 				stage += " (non-blocking)"
 			}
 			sw.Start(stage)
+			if follow {
+				sw.Log(time.Time{}, codersdk.LogLevelInfo, "==> ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.")
+			}
 
 			err = func() error { // Use func because of defer in for loop.
 				logStream, logsCloser, err := opts.FetchLogs(ctx, agent.ID, 0, follow)

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -226,6 +226,7 @@ func TestAgent(t *testing.T) {
 			},
 			want: []string{
 				"⧗ Running workspace agent startup scripts",
+				"ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.",
 				"testing: Hello world",
 				"Bye now",
 				"✔ Running workspace agent startup scripts",
@@ -255,6 +256,7 @@ func TestAgent(t *testing.T) {
 			},
 			want: []string{
 				"⧗ Running workspace agent startup scripts",
+				"ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.",
 				"Hello world",
 				"✘ Running workspace agent startup scripts",
 				"Warning: A startup script exited with an error and your workspace may be incomplete.",
@@ -306,6 +308,7 @@ func TestAgent(t *testing.T) {
 			},
 			want: []string{
 				"⧗ Running workspace agent startup scripts",
+				"ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.",
 				"Hello world",
 				"✔ Running workspace agent startup scripts",
 			},


### PR DESCRIPTION
Fixes #11923

```console
==> ⧗ Running workspace agent startup scripts
==> ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.
2024-07-09 12:04:55.983+03:00 Startup Script: 1
2024-07-09 12:04:56.963+03:00 Startup Script: 2
2024-07-09 12:04:57.965+03:00 Startup Script: 3
2024-07-09 12:04:58.966+03:00 Startup Script: 4
2024-07-09 12:04:59.967+03:00 Startup Script: 5
2024-07-09 12:05:00.968+03:00 Startup Script: 6
2024-07-09 12:05:01.969+03:00 Startup Script: 7
2024-07-09 12:05:02.971+03:00 Startup Script: 8
2024-07-09 12:05:03.972+03:00 Startup Script: 9
2024-07-09 12:05:04.973+03:00 Startup Script: 10
2024-07-09 12:05:05.988+03:00 Startup Script: Checking if dotfiles repository already exists...
2024-07-09 12:05:05.988+03:00 Startup Script: Found dotfiles repository at /home/mafredri/.config/coderv2/dotfiles
2024-07-09 12:05:07.209+03:00 Startup Script: Already up to date.
2024-07-09 12:05:07.648+03:00 Startup Script: Running install.sh...
2024-07-09 12:05:07.648+03:00 Startup Script: Dotfiles installation complete.
=== ✔ Running workspace agent startup scripts [11717ms]
```