### PR TITLE
chore: use base64 encoded kubeconfig for pr deployments

### DIFF
--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -253,7 +253,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.kube
-          echo "${{ secrets.PR_DEPLOYMENTS_KUBECONFIG }}" > ~/.kube/config
+          echo "${{ secrets.PR_DEPLOYMENTS_KUBECONFIG_BASE64 }}" | base64 --decode > ~/.kube/config
           chmod 644 ~/.kube/config
           export KUBECONFIG=~/.kube/config
 


### PR DESCRIPTION
it was missed in #13849