### PR TITLE
chore: remove references to restarting/stopping in update workspace language

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -151,12 +151,10 @@ manually updated the workspace.
 ## Updating workspaces
 
 After updating the default version of the template that a workspace was created
-from, you can update the workspace.
+from, you can update the workspace. Coder will start the workspace with said
+version.
 
 ![Updating a workspace](./images/workspace-update.png)
-
-If the workspace is running, Coder stops it, updates it, then starts the
-workspace again.
 
 On the command line:
 

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -341,7 +341,8 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
         description={
           <Stack>
             <p>
-              Updating your workspace will stop all running processes and{" "}
+              Updating your workspace will start the workspace on the latest
+              template version. This can{" "}
               <strong>delete non-persistent data</strong>.
             </p>
             {latestVersion?.message && (

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -336,12 +336,12 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
           setIsConfirmingUpdate(false);
         }}
         onClose={() => setIsConfirmingUpdate(false)}
-        title="Update and restart?"
+        title="Update workspace?"
         confirmText="Update"
         description={
           <Stack>
             <p>
-              Restarting your workspace will stop all running processes and{" "}
+              Updating your workspace will stop all running processes and{" "}
               <strong>delete non-persistent data</strong>.
             </p>
             {latestVersion?.message && (

--- a/site/src/pages/WorkspacesPage/BatchUpdateConfirmation.tsx
+++ b/site/src/pages/WorkspacesPage/BatchUpdateConfirmation.tsx
@@ -212,8 +212,8 @@ const Consequences: FC<ConsequencesProps> = ({ runningWorkspaces }) => {
       <p>You are about to update {workspaceCount}.</p>
       <ul css={styles.consequences}>
         <li>
-          Updating will stop all running processes and delete non-persistent
-          data.
+          Updating will start workspaces on their latest template versions. This
+          can delete non-persistent data.
         </li>
         <li>
           Anyone connected to a running workspace will be disconnected until the


### PR DESCRIPTION
The terraform apply will just apply the start state. The differences should be detected by terraform, and the workspace will be updated.

The confusion is that we do have a UI and a cli `coder restart` that does issue a `stop, start` transition. Update **does not do this**.