### PR TITLE
feat(site): display tooltip in bars for app usage chart

### DIFF
--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -480,19 +480,25 @@ const TemplateUsagePanel: FC<TemplateUsagePanelProps> = ({
                         {usage.display_name}
                       </div>
                     </div>
-                    <LinearProgress
-                      value={percentage}
-                      variant="determinate"
-                      css={{
-                        width: "100%",
-                        height: 8,
-                        backgroundColor: theme.palette.divider,
-                        "& .MuiLinearProgress-bar": {
-                          backgroundColor: usageColors[i],
-                          borderRadius: 999,
-                        },
-                      }}
-                    />
+                    <Tooltip
+                      title={`${Math.floor(percentage)}%`}
+                      placement="top"
+                      arrow
+                    >
+                      <LinearProgress
+                        value={percentage}
+                        variant="determinate"
+                        css={{
+                          width: "100%",
+                          height: 8,
+                          backgroundColor: theme.palette.divider,
+                          "& .MuiLinearProgress-bar": {
+                            backgroundColor: usageColors[i],
+                            borderRadius: 999,
+                          },
+                        }}
+                      />
+                    </Tooltip>
                     <Stack
                       spacing={0}
                       css={{

--- a/site/src/theme/mui.ts
+++ b/site/src/theme/mui.ts
@@ -455,6 +455,9 @@ export const components = {
         background: theme.palette.divider,
         padding: "8px 16px",
       }),
+      arrow: ({ theme }) => ({
+        color: theme.palette.divider,
+      }),
     },
   },
   MuiAlert: {


### PR DESCRIPTION
<img width="924" alt="Screenshot 2024-07-09 at 13 26 57" src="https://github.com/coder/coder/assets/3165839/107edcd6-2956-499c-8757-2cede8a8674c">

Closes https://github.com/coder/coder/issues/13627
