### PR TITLE
fix: add missing `nolint` comment

### DIFF
--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -206,7 +206,7 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 		require.NotContains(t, agentLogs, t.Name())
 	})
 
-	//nolint:paralleltest It uses LockIDDBPurge.
+	//nolint:paralleltest // It uses LockIDDBPurge.
 	t.Run("AgentConnectedSixDaysAgo_LogsValid", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancel()


### PR DESCRIPTION
This PR adds missing comment `//` in `nolint` annotation.