### PR TITLE
fix(cli): follow logs only when agent is starting

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -132,7 +132,7 @@ func Agent(ctx context.Context, writer io.Writer, agentID uuid.UUID, opts AgentO
 			}
 
 			stage := "Running workspace agent startup scripts"
-			follow := opts.Wait
+			follow := opts.Wait && agent.LifecycleState.Starting()
 			if !follow {
 				stage += " (non-blocking)"
 			}

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -258,10 +258,9 @@ func TestAgent(t *testing.T) {
 				},
 			},
 			want: []string{
-				"⧗ Running workspace agent startup scripts",
-				"ℹ︎ To connect immediately, reconnect with --wait=no or CODER_SSH_WAIT=no, see --help for more information.",
+				"⧗ Running workspace agent startup scripts (non-blocking)",
 				"Hello world",
-				"✘ Running workspace agent startup scripts",
+				"✘ Running workspace agent startup scripts (non-blocking)",
 				"Warning: A startup script exited with an error and your workspace may be incomplete.",
 				"For more information and troubleshooting, see",
 			},


### PR DESCRIPTION
Noticed this today when connecting to my workspace that had started with an error, this issue became more prominent after the introduction of #13847.

Issue is mainly about messaging and clarifying for the user what to expect. May be slightly faster too since we don't need a websocket.
