### PR TITLE
fix: remove license warning for customers

### DIFF
--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -87,7 +87,7 @@ func Entitlements(
 		if isTrial {
 			showWarningDays = 7
 		}
-		isExpiringSoon := daysToExpire > 0 && daysToExpire < showWarningDays
+		isExpiringSoon := isTrial && daysToExpire > 0 && daysToExpire < showWarningDays
 		if isExpiringSoon {
 			day := "day"
 			if daysToExpire > 1 {


### PR DESCRIPTION
this PR removes the license warning for customers - this will only apply to trial licenses. 

current state:

![image](https://github.com/coder/coder/assets/9683576/db5f59b7-c2b4-425b-8904-5102ae664e0d)
