### PR TITLE
chore: create workspaces and templates for multiple orgs

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -109,14 +109,26 @@ func (r *RootCmd) create() *serpent.Command {
 
 				templateNames := make([]string, 0, len(templates))
 				templateByName := make(map[string]codersdk.Template, len(templates))
+				uniqueOrganizations := make(map[uuid.UUID]bool)
+				for _, template := range templates {
+					uniqueOrganizations[template.OrganizationID] = true
+				}
 
 				for _, template := range templates {
 					templateName := template.Name
+					if len(uniqueOrganizations) > 1 {
+						templateName += cliui.Placeholder(
+							fmt.Sprintf(
+								" (%s)",
+								template.OrganizationName,
+							),
+						)
+					}
 
 					if template.ActiveUserCount > 0 {
 						templateName += cliui.Placeholder(
 							fmt.Sprintf(
-								" (used by %s)",
+								" used by %s",
 								formatActiveDevelopers(template.ActiveUserCount),
 							),
 						)

--- a/cli/create.go
+++ b/cli/create.go
@@ -109,6 +109,9 @@ func (r *RootCmd) create() *serpent.Command {
 
 				templateNames := make([]string, 0, len(templates))
 				templateByName := make(map[string]codersdk.Template, len(templates))
+
+				// If more than 1 organization exists in the list of templates,
+				// then include the organization name in the select options.
 				uniqueOrganizations := make(map[uuid.UUID]bool)
 				for _, template := range templates {
 					uniqueOrganizations[template.OrganizationID] = true

--- a/cli/root.go
+++ b/cli/root.go
@@ -641,9 +641,10 @@ func NewOrganizationContext() *OrganizationContext {
 	return &OrganizationContext{}
 }
 
+func (*OrganizationContext) optionName() string { return "Organization" }
 func (o *OrganizationContext) AttachOptions(cmd *serpent.Command) {
 	cmd.Options = append(cmd.Options, serpent.Option{
-		Name:        "Organization",
+		Name:        o.optionName(),
 		Description: "Select which organization (uuid or name) to use.",
 		// Only required if the user is a part of more than 1 organization.
 		// Otherwise, we can assume a default value.
@@ -653,6 +654,14 @@ func (o *OrganizationContext) AttachOptions(cmd *serpent.Command) {
 		Env:           "CODER_ORGANIZATION",
 		Value:         serpent.StringOf(&o.FlagSelect),
 	})
+}
+
+func (o *OrganizationContext) ValueSource(inv *serpent.Invocation) (string, serpent.ValueSource) {
+	opt := inv.Command.Options.ByName(o.optionName())
+	if opt == nil {
+		return o.FlagSelect, serpent.ValueSourceNone
+	}
+	return o.FlagSelect, opt.ValueSource
 }
 
 func (o *OrganizationContext) Selected(inv *serpent.Invocation, client *codersdk.Client) (codersdk.Organization, error) {

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -160,7 +160,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 				RequireActiveVersion:           requireActiveVersion,
 			}
 
-			_, err = client.CreateTemplate(inv.Context(), organization.ID, createReq)
+			template, err := client.CreateTemplate(inv.Context(), organization.ID, createReq)
 			if err != nil {
 				return err
 			}
@@ -171,7 +171,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 					pretty.Sprint(cliui.DefaultStyles.DateTimeStamp, time.Now().Format(time.Stamp))+"! "+
 					"Developers can provision a workspace with this template using:")+"\n")
 
-			_, _ = fmt.Fprintln(inv.Stdout, "  "+pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("coder create --template=%q [workspace name]", templateName)))
+			_, _ = fmt.Fprintln(inv.Stdout, "  "+pretty.Sprint(cliui.DefaultStyles.Code, fmt.Sprintf("coder create --template=%q --org=%q [workspace name]", templateName, template.OrganizationName)))
 			_, _ = fmt.Fprintln(inv.Stdout)
 
 			return nil
@@ -244,6 +244,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 
 		cliui.SkipPromptOption(),
 	}
+	orgContext.AttachOptions(cmd)
 	cmd.Options = append(cmd.Options, uploadFlags.options()...)
 	return cmd
 }

--- a/cli/testdata/coder_templates_create_--help.golden
+++ b/cli/testdata/coder_templates_create_--help.golden
@@ -7,6 +7,9 @@ USAGE:
   flag
 
 OPTIONS:
+  -O, --org string, $CODER_ORGANIZATION
+          Select which organization (uuid or name) to use.
+
       --default-ttl duration (default: 24h)
           Specify a default TTL for workspaces created from this template. It is
           the default time before shutdown - workspaces created from this

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -637,18 +637,14 @@ func NewExternalProvisionerDaemon(t testing.TB, client *codersdk.Client, org uui
 		assert.NoError(t, err)
 	}()
 
-	time.Sleep(time.Second)
 	daemon := provisionerd.New(func(ctx context.Context) (provisionerdproto.DRPCProvisionerDaemonClient, error) {
-		client, err := client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
+		return client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
 			ID:           uuid.New(),
 			Name:         t.Name(),
 			Organization: org,
 			Provisioners: []codersdk.ProvisionerType{codersdk.ProvisionerTypeEcho},
 			Tags:         tags,
 		})
-		assert.NoError(t, err, "provisioner daemon failed to start")
-
-		return client, err
 	}, &provisionerd.Options{
 		Logger:              slogtest.Make(t, nil).Named("provisionerd").Leveled(slog.LevelDebug),
 		UpdateInterval:      250 * time.Millisecond,

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -637,14 +637,18 @@ func NewExternalProvisionerDaemon(t testing.TB, client *codersdk.Client, org uui
 		assert.NoError(t, err)
 	}()
 
+	time.Sleep(time.Second)
 	daemon := provisionerd.New(func(ctx context.Context) (provisionerdproto.DRPCProvisionerDaemonClient, error) {
-		return client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
+		client, err := client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
 			ID:           uuid.New(),
 			Name:         t.Name(),
 			Organization: org,
 			Provisioners: []codersdk.ProvisionerType{codersdk.ProvisionerTypeEcho},
 			Tags:         tags,
 		})
+		assert.NoError(t, err, "provisioner daemon failed to start")
+
+		return client, err
 	}, &provisionerd.Options{
 		Logger:              slogtest.Make(t, nil).Named("provisionerd").Leveled(slog.LevelDebug),
 		UpdateInterval:      250 * time.Millisecond,

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -198,9 +198,8 @@ func Templates(ctx context.Context, db database.Store, query string) (database.G
 
 	parser := httpapi.NewQueryParamParser()
 	filter := database.GetTemplatesWithFilterParams{
-		Deleted: parser.Boolean(values, false, "deleted"),
-		// TODO: Should name be a fuzzy search?
-		ExactName:  parser.String(values, "", "name"),
+		Deleted:    parser.Boolean(values, false, "deleted"),
+		ExactName:  parser.String(values, "", "exact_name"),
 		IDs:        parser.UUIDs(values, []uuid.UUID{}, "ids"),
 		Deprecated: parser.NullableBoolean(values, sql.NullBool{}, "deprecated"),
 	}

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -365,6 +365,7 @@ func (c *Client) TemplatesByOrganization(ctx context.Context, organizationID uui
 
 type TemplateFilter struct {
 	OrganizationID uuid.UUID
+	ExactName      string
 }
 
 // asRequestOption returns a function that can be used in (*Client).Request.
@@ -376,6 +377,10 @@ func (f TemplateFilter) asRequestOption() RequestOption {
 		// string.
 		if f.OrganizationID != uuid.Nil {
 			params = append(params, fmt.Sprintf("organization:%q", f.OrganizationID.String()))
+		}
+
+		if f.ExactName != "" {
+			params = append(params, fmt.Sprintf("exact_name:%q", f.ExactName))
 		}
 
 		q := r.URL.Query()

--- a/docs/cli/templates_create.md
+++ b/docs/cli/templates_create.md
@@ -105,6 +105,15 @@ Requires workspace builds to use the active template version. This setting does 
 
 Bypass prompts.
 
+### -O, --org
+
+|             |                                  |
+| ----------- | -------------------------------- |
+| Type        | <code>string</code>              |
+| Environment | <code>$CODER_ORGANIZATION</code> |
+
+Select which organization (uuid or name) to use.
+
 ### -d, --directory
 
 |         |                     |

--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -1,0 +1,132 @@
+package cli_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/pty/ptytest"
+)
+
+func TestEnterpriseCreate(t *testing.T) {
+	t.Parallel()
+
+	type setupData struct {
+		firstResponse codersdk.CreateFirstUserResponse
+		second        codersdk.Organization
+		owner         *codersdk.Client
+		member        *codersdk.Client
+	}
+
+	type setupArgs struct {
+		firstTemplates  []string
+		secondTemplates []string
+	}
+
+	setupMultipleOrganizations := func(t *testing.T, args setupArgs) setupData {
+		ownerClient, first := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				// This only affects the first org.
+				IncludeProvisionerDaemon: false,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				},
+			},
+		})
+
+		second := coderdtest.CreateOrganization(t, ownerClient, coderdtest.CreateOrganizationOptions{
+			IncludeProvisionerDaemon: true,
+		})
+		member, _ := coderdtest.CreateAnotherUser(t, ownerClient, first.OrganizationID, rbac.ScopedRoleOrgMember(second.ID))
+
+		var wg sync.WaitGroup
+
+		createTemplate := func(tplName string, orgID uuid.UUID) {
+			version := coderdtest.CreateTemplateVersion(t, ownerClient, orgID, nil)
+			wg.Add(1)
+			go func() {
+				coderdtest.AwaitTemplateVersionJobCompleted(t, ownerClient, version.ID)
+				wg.Done()
+			}()
+
+			coderdtest.CreateTemplate(t, ownerClient, orgID, version.ID, func(request *codersdk.CreateTemplateRequest) {
+				request.Name = tplName
+			})
+		}
+
+		for _, tplName := range args.firstTemplates {
+			createTemplate(tplName, first.OrganizationID)
+		}
+
+		for _, tplName := range args.secondTemplates {
+			createTemplate(tplName, second.ID)
+		}
+
+		wg.Wait()
+
+		return setupData{
+			firstResponse: first,
+			owner:         ownerClient,
+			second:        second,
+			member:        member,
+		}
+	}
+
+	t.Run("CreateMultipleOrganization", func(t *testing.T) {
+		// Creates a workspace in another organization
+		t.Parallel()
+
+		const templateName = "secondtemplate"
+		setup := setupMultipleOrganizations(t, setupArgs{
+			secondTemplates: []string{templateName},
+		})
+		member := setup.member
+
+		args := []string{
+			"create",
+			"my-workspace",
+			"--template", templateName,
+		}
+		inv, root := clitest.New(t, args...)
+		clitest.SetupConfig(t, member, root)
+		doneChan := make(chan struct{})
+		pty := ptytest.New(t).Attach(inv)
+		go func() {
+			defer close(doneChan)
+			err := inv.Run()
+			assert.NoError(t, err)
+		}()
+		matches := []struct {
+			match string
+			write string
+		}{
+			{match: "compute.main"},
+			{match: "smith (linux, i386)"},
+			{match: "Confirm create", write: "yes"},
+		}
+		for _, m := range matches {
+			pty.ExpectMatch(m.match)
+			if len(m.write) > 0 {
+				pty.WriteLine(m.write)
+			}
+		}
+		<-doneChan
+
+		ws, err := member.WorkspaceByOwnerAndName(context.Background(), codersdk.Me, "my-workspace", codersdk.WorkspaceOptions{})
+		if assert.NoError(t, err, "expected workspace to be created") {
+			assert.Equal(t, ws.TemplateName, templateName)
+			assert.Equal(t, ws.OrganizationName, setup.second.ID, "workspace in second organization")
+		}
+	})
+}

--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -196,5 +197,7 @@ func TestEnterpriseCreate(t *testing.T) {
 		_ = ptytest.New(t).Attach(inv)
 		err := inv.Run()
 		require.Error(t, err)
+		// The error message should indicate the flag to fix the issue.
+		require.ErrorContains(t, err, fmt.Sprintf("--org=%q", "first-organization"))
 	})
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1203,6 +1203,7 @@ export interface TemplateExample {
 // From codersdk/organizations.go
 export interface TemplateFilter {
   readonly OrganizationID: string;
+  readonly ExactName: string;
 }
 
 // From codersdk/templates.go


### PR DESCRIPTION
# What this does

This allows creating a workspace using a template in an organization other than the default. If only 1 organization exists, then nothing changes.

If you select a template that has a unique name, then `coder create` can infer the organization to create the workspace in. If the template name is not unique across organizations, then using `--org` is required.

# Changes

## Create lists templates

![Screenshot from 2024-07-11 12-25-09](https://github.com/coder/coder/assets/5446298/d139b790-037b-41c9-adf2-7eed45c4e178)



## `template create` (deprecated command, but still exists)

Prints out the coder cli command to use the template without any ambiguity. If another template of the same name exists in another org, `--org=<org_name>` must be specified.

```shell
The rabbitt3 template has been created at
Jul 10 10:47:24! Developers can provision a workspace
with this template using:

   coder create --template="<template_name>" --org="<org_name>" [workspace name] 
```

## `coder create` with ambiguous organization

If a template name is not unique across multiple organizations, `coder create` requires a `--rg=<org_name>` flag to disambiguate.


```shell
$ coder create --template="docker" ambigiousworkspace
Encountered an error running "coder create", see "coder create --help" for more information
error: multiple templates found with the name "docker", use `--org=<organization_name>` to specify which template by that name to use. Organizations available: first-organization, rabbit
```

## `coder create` with a wrong organization selected

If you try to use a template with `--org` set to the wrong organization, an error is thrown.

```shell
$ coder create --template="rabbitt" --org="first-organization" ambigiousworkspace2
Encountered an error running "coder create", see "coder create --help" for more information
error: template is in organization "rabbit", but '--org="first-organization"' was specified. Use '--org="rabbit"' to use this template
```