### PR TITLE
chore: use `rw.WriteHeader` to write responses without bodies

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4723,11 +4723,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.User"
-                        }
+                    "204": {
+                        "description": "No Content"
                     }
                 }
             }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4705,9 +4705,6 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "Users"
                 ],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4161,11 +4161,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/codersdk.User"
-            }
+          "204": {
+            "description": "No Content"
           }
         }
       }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4147,7 +4147,6 @@
             "CoderSessionToken": []
           }
         ],
-        "produces": ["application/json"],
         "tags": ["Users"],
         "summary": "Delete user",
         "operationId": "delete-user",

--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -333,7 +333,7 @@ func (api *API) deleteAPIKey(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // @Summary Get token config

--- a/coderd/debug.go
+++ b/coderd/debug.go
@@ -235,7 +235,7 @@ func (api *API) putDeploymentHealthSettings(rw http.ResponseWriter, r *http.Requ
 
 	if bytes.Equal(settingsJSON, []byte(currentSettingsJSON)) {
 		// See: https://www.rfc-editor.org/rfc/rfc7231#section-6.3.5
-		httpapi.Write(r.Context(), rw, http.StatusNoContent, nil)
+		rw.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/coderd/externalauth.go
+++ b/coderd/externalauth.go
@@ -197,7 +197,7 @@ func (api *API) postExternalAuthDeviceByID(rw http.ResponseWriter, r *http.Reque
 			return
 		}
 	}
-	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // @Summary Get external auth device by ID.

--- a/coderd/identityprovider/revoke.go
+++ b/coderd/identityprovider/revoke.go
@@ -39,6 +39,6 @@ func RevokeApp(db database.Store) http.HandlerFunc {
 			httpapi.InternalServerError(rw, err)
 			return
 		}
-		httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+		rw.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/coderd/oauth2.go
+++ b/coderd/oauth2.go
@@ -207,7 +207,7 @@ func (api *API) deleteOAuth2ProviderApp(rw http.ResponseWriter, r *http.Request)
 		})
 		return
 	}
-	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // @Summary Get OAuth2 application secrets.
@@ -324,7 +324,7 @@ func (api *API) deleteOAuth2ProviderAppSecret(rw http.ResponseWriter, r *http.Re
 		})
 		return
 	}
-	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // @Summary OAuth2 authorization request.

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -791,7 +791,7 @@ func (api *API) patchTemplateMeta(rw http.ResponseWriter, r *http.Request) {
 
 	if updated.UpdatedAt.IsZero() {
 		aReq.New = template
-		httpapi.Write(ctx, rw, http.StatusNotModified, nil)
+		rw.WriteHeader(http.StatusNotModified)
 		return
 	}
 	aReq.New = updated

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -501,7 +501,6 @@ func (api *API) postUser(rw http.ResponseWriter, r *http.Request) {
 // @Summary Delete user
 // @ID delete-user
 // @Security CoderSessionToken
-// @Produce json
 // @Tags Users
 // @Param user path string true "User ID, name, or me"
 // @Success 204

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -504,7 +504,7 @@ func (api *API) postUser(rw http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Tags Users
 // @Param user path string true "User ID, name, or me"
-// @Success 200 {object} codersdk.User
+// @Success 204
 // @Router /users/{user} [delete]
 func (api *API) deleteUser(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -558,9 +558,7 @@ func (api *API) deleteUser(rw http.ResponseWriter, r *http.Request) {
 	}
 	user.Deleted = true
 	aReq.New = user
-	httpapi.Write(ctx, rw, http.StatusOK, codersdk.Response{
-		Message: "User has been deleted!",
-	})
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // Returns the parameterized user requested. All validation
@@ -1013,7 +1011,7 @@ func (api *API) putUserPassword(rw http.ResponseWriter, r *http.Request) {
 	newUser.HashedPassword = []byte(hashedPassword)
 	aReq.New = newUser
 
-	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+	rw.WriteHeader(http.StatusNoContent)
 }
 
 // @Summary Get user roles

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -927,9 +927,7 @@ func (api *API) putWorkspaceDormant(rw http.ResponseWriter, r *http.Request) {
 
 	// If the workspace is already in the desired state do nothing!
 	if workspace.DormantAt.Valid == req.Dormant {
-		httpapi.Write(ctx, rw, http.StatusNotModified, codersdk.Response{
-			Message: "Nothing to do!",
-		})
+		rw.WriteHeader(http.StatusNotModified)
 		return
 	}
 

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -308,7 +308,7 @@ func (c *Client) DeleteUser(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusNoContent {
 		return ReadBodyAsError(res)
 	}
 	return nil

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -410,7 +410,6 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 ```shell
 # Example request using curl
 curl -X DELETE http://coder-server:8080/api/v2/users/{user} \
-  -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
@@ -422,38 +421,11 @@ curl -X DELETE http://coder-server:8080/api/v2/users/{user} \
 | ------ | ---- | ------ | -------- | -------------------- |
 | `user` | path | string | true     | User ID, name, or me |
 
-### Example responses
-
-> 200 Response
-
-```json
-{
-  "avatar_url": "http://example.com",
-  "created_at": "2019-08-24T14:15:22Z",
-  "email": "user@example.com",
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "last_seen_at": "2019-08-24T14:15:22Z",
-  "login_type": "",
-  "name": "string",
-  "organization_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
-  "roles": [
-    {
-      "display_name": "string",
-      "name": "string",
-      "organization_id": "string"
-    }
-  ],
-  "status": "active",
-  "theme_preference": "string",
-  "username": "string"
-}
-```
-
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                   |
-| ------ | ------------------------------------------------------- | ----------- | ---------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.User](schemas.md#codersdkuser) |
+| Status | Meaning                                                         | Description | Schema |
+| ------ | --------------------------------------------------------------- | ----------- | ------ |
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 


### PR DESCRIPTION
the body gets ignored anyway, so why bother allocating/serializing anything?