### PR TITLE
fix: use store-based notifications enqueuer with external provisioners

### DIFF
--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -20,6 +20,7 @@ import (
 	"storj.io/drpc/drpcserver"
 
 	"cdr.dev/slog"
+
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
@@ -27,7 +28,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
-	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/provisionerdserver"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -337,7 +337,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 			ExternalAuthConfigs: api.ExternalAuthConfigs,
 			OIDCConfig:          api.OIDCConfig,
 		},
-		notifications.NewNoopEnqueuer(),
+		api.NotificationsEnqueuer,
 	)
 	if err != nil {
 		if !xerrors.Is(err, context.Canceled) {


### PR DESCRIPTION
This was an oversight from https://github.com/coder/coder/pull/13537

Tested manually; I couldn't find any e2e tests which use external provisioners (using `grep -rin provisionerd site/e2e` and manual poking around); did I miss something?