### PR TITLE
chore: add example prompt command for multiple prompt bug

### DIFF
--- a/cli/prompts.go
+++ b/cli/prompts.go
@@ -100,6 +100,45 @@ func (RootCmd) promptExample() *serpent.Command {
 				}
 				return err
 			}, useSearchOption),
+			promptCmd("multiple", func(inv *serpent.Invocation) error {
+				_, _ = fmt.Fprintf(inv.Stdout, "This command exists to test the behavior of multiple prompts. The survey library does not erase the original message prompt after.")
+				thing, err := cliui.Select(inv, cliui.SelectOptions{
+					Message: "Select a thing",
+					Options: []string{
+						"Car", "Bike", "Plane", "Boat", "Train",
+					},
+					Default: "Car",
+				})
+				if err != nil {
+					return err
+				}
+				color, err := cliui.Select(inv, cliui.SelectOptions{
+					Message: "Select a color",
+					Options: []string{
+						"Blue", "Green", "Yellow", "Red",
+					},
+					Default: "Blue",
+				})
+				if err != nil {
+					return err
+				}
+				properties, err := cliui.MultiSelect(inv, cliui.MultiSelectOptions{
+					Message: "Select properties",
+					Options: []string{
+						"Fast", "Cool", "Expensive", "New",
+					},
+					Defaults: []string{"Fast"},
+				})
+				if err != nil {
+					return err
+				}
+				_, _ = fmt.Fprintf(inv.Stdout, "Your %s %s is awesome! Did you paint it %s?\n",
+					strings.Join(properties, " "),
+					thing,
+					color,
+				)
+				return err
+			}),
 			promptCmd("multi-select", func(inv *serpent.Invocation) error {
 				values, err := cliui.MultiSelect(inv, cliui.MultiSelectOptions{
 					Message: "Select some things:",


### PR DESCRIPTION
Prompt message is not erased after the prompt ends. The message remains. This PR adds an example prompt command to easily confirm the behavior.

`coder exp prompt-example multiple`

[Screencast from 2024-07-12 10-52-37.webm](https://github.com/user-attachments/assets/f936bf66-9661-49d9-bf1d-620e91925eff)


Looking through the issues of the library, this might work in some terminals? 