### PR TITLE
feat: notify owner about failed autobuild

### DIFF
--- a/coderd/database/migrations/000226_notifications_autobuild_failed.down.sql
+++ b/coderd/database/migrations/000226_notifications_autobuild_failed.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM notification_templates WHERE id = '381df2a9-c0c0-4749-420f-80a9280c66f9');

--- a/coderd/database/migrations/000226_notifications_autobuild_failed.down.sql
+++ b/coderd/database/migrations/000226_notifications_autobuild_failed.down.sql
@@ -1,1 +1,1 @@
-DELETE FROM notification_templates WHERE id = '381df2a9-c0c0-4749-420f-80a9280c66f9');
+DELETE FROM notification_templates WHERE id = '381df2a9-c0c0-4749-420f-80a9280c66f9';

--- a/coderd/database/migrations/000226_notifications_autobuild_failed.up.sql
+++ b/coderd/database/migrations/000226_notifications_autobuild_failed.up.sql
@@ -1,0 +1,9 @@
+INSERT INTO notification_templates (id, name, title_template, body_template, "group", actions)
+VALUES ('381df2a9-c0c0-4749-420f-80a9280c66f9', 'Workspace Autobuild Failed', E'Workspace "{{.Labels.name}}" deleted',
+        E'Hi {{.UserName}}\n\Automatic build of your workspace **{{.Labels.name}}** failed.\nThe specified reason was "**{{.Labels.reason}}**".',
+        'Workspace Events', '[
+        {
+            "label": "View workspaces",
+            "url": "{{ base_url }}/workspaces"
+        }
+    ]'::jsonb);

--- a/coderd/database/migrations/000226_notifications_autobuild_failed.up.sql
+++ b/coderd/database/migrations/000226_notifications_autobuild_failed.up.sql
@@ -1,5 +1,5 @@
 INSERT INTO notification_templates (id, name, title_template, body_template, "group", actions)
-VALUES ('381df2a9-c0c0-4749-420f-80a9280c66f9', 'Workspace Autobuild Failed', E'Workspace "{{.Labels.name}}" deleted',
+VALUES ('381df2a9-c0c0-4749-420f-80a9280c66f9', 'Workspace Autobuild Failed', E'Workspace "{{.Labels.name}}" autobuild failed',
         E'Hi {{.UserName}}\n\Automatic build of your workspace **{{.Labels.name}}** failed.\nThe specified reason was "**{{.Labels.reason}}**".',
         'Workspace Events', '[
         {

--- a/coderd/database/migrations/000226_notifications_autobuild_failed.up.sql
+++ b/coderd/database/migrations/000226_notifications_autobuild_failed.up.sql
@@ -3,7 +3,7 @@ VALUES ('381df2a9-c0c0-4749-420f-80a9280c66f9', 'Workspace Autobuild Failed', E'
         E'Hi {{.UserName}}\n\Automatic build of your workspace **{{.Labels.name}}** failed.\nThe specified reason was "**{{.Labels.reason}}**".',
         'Workspace Events', '[
         {
-            "label": "View workspaces",
-            "url": "{{ base_url }}/workspaces"
+            "label": "View workspace",
+            "url": "{{ base_url }}/@{{.UserName}}/{{.Labels.name}}"
         }
     ]'::jsonb);

--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -80,7 +80,7 @@ func (s *StoreEnqueuer) Enqueue(ctx context.Context, userID, templateID uuid.UUI
 // buildPayload creates the payload that the notification will for variable substitution and/or routing.
 // The payload contains information about the recipient, the event that triggered the notification, and any subsequent
 // actions which can be taken by the recipient.
-func (s *StoreEnqueuer) buildPayload(ctx context.Context, userID uuid.UUID, templateID uuid.UUID, labels map[string]string) (*types.MessagePayload, error) {
+func (s *StoreEnqueuer) buildPayload(ctx context.Context, userID, templateID uuid.UUID, labels map[string]string) (*types.MessagePayload, error) {
 	metadata, err := s.store.FetchNewMessageMetadata(ctx, database.FetchNewMessageMetadataParams{
 		UserID:                 userID,
 		NotificationTemplateID: templateID,
@@ -89,8 +89,21 @@ func (s *StoreEnqueuer) buildPayload(ctx context.Context, userID uuid.UUID, temp
 		return nil, xerrors.Errorf("new message metadata: %w", err)
 	}
 
+	payload := types.MessagePayload{
+		Version: "1.0",
+
+		NotificationName: metadata.NotificationName,
+
+		UserID:    metadata.UserID.String(),
+		UserEmail: metadata.UserEmail,
+		UserName:  metadata.UserName,
+
+		Labels: labels,
+		// No actions yet
+	}
+
 	// Execute any templates in actions.
-	out, err := render.GoTemplate(string(metadata.Actions), types.MessagePayload{}, s.helpers)
+	out, err := render.GoTemplate(string(metadata.Actions), payload, s.helpers)
 	if err != nil {
 		return nil, xerrors.Errorf("render actions: %w", err)
 	}
@@ -100,19 +113,8 @@ func (s *StoreEnqueuer) buildPayload(ctx context.Context, userID uuid.UUID, temp
 	if err = json.Unmarshal(metadata.Actions, &actions); err != nil {
 		return nil, xerrors.Errorf("new message metadata: parse template actions: %w", err)
 	}
-
-	return &types.MessagePayload{
-		Version: "1.0",
-
-		NotificationName: metadata.NotificationName,
-
-		UserID:    metadata.UserID.String(),
-		UserEmail: metadata.UserEmail,
-		UserName:  metadata.UserName,
-
-		Actions: actions,
-		Labels:  labels,
-	}, nil
+	payload.Actions = actions
+	return &payload, nil
 }
 
 // NoopEnqueuer implements the Enqueuer interface but performs a noop.

--- a/coderd/notifications/events.go
+++ b/coderd/notifications/events.go
@@ -6,4 +6,7 @@ import "github.com/google/uuid"
 // TODO: autogenerate these.
 
 // Workspace-related events.
-var TemplateWorkspaceDeleted = uuid.MustParse("f517da0b-cdc9-410f-ab89-a86107c420ed")
+var (
+	TemplateWorkspaceDeleted = uuid.MustParse("f517da0b-cdc9-410f-ab89-a86107c420ed")
+	WorkspaceAutobuildFailed = uuid.MustParse("381df2a9-c0c0-4749-420f-80a9280c66f9")
+)

--- a/coderd/notifications/manager_test.go
+++ b/coderd/notifications/manager_test.go
@@ -98,10 +98,11 @@ func TestBuildPayload(t *testing.T) {
 
 	// GIVEN: a set of helpers to be injected into the templates
 	const label = "Click here!"
-	const url = "http://xyz.com/"
+	const baseURL = "http://xyz.com"
+	const url = baseURL + "/@bobby/my-workspace"
 	helpers := map[string]any{
 		"my_label": func() string { return label },
-		"my_url":   func() string { return url },
+		"my_url":   func() string { return baseURL },
 	}
 
 	// GIVEN: an enqueue interceptor which returns mock metadata
@@ -112,7 +113,7 @@ func TestBuildPayload(t *testing.T) {
 			actions := []types.TemplateAction{
 				{
 					Label: "{{ my_label }}",
-					URL:   "{{ my_url }}",
+					URL:   "{{ my_url }}/@{{.UserName}}/{{.Labels.name}}",
 				},
 			}
 			out, err := json.Marshal(actions)
@@ -131,7 +132,9 @@ func TestBuildPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN: a notification is enqueued
-	_, err = enq.Enqueue(ctx, uuid.New(), notifications.TemplateWorkspaceDeleted, nil, "test")
+	_, err = enq.Enqueue(ctx, uuid.New(), notifications.TemplateWorkspaceDeleted, map[string]string{
+		"name": "my-workspace",
+	}, "test")
 	require.NoError(t, err)
 
 	// THEN: expect that a payload will be constructed and have the expected values

--- a/coderd/notifications/render/gotmpl_test.go
+++ b/coderd/notifications/render/gotmpl_test.go
@@ -38,6 +38,23 @@ func TestGoTemplate(t *testing.T) {
 			expectedOutput: userEmail,
 			expectedErr:    nil,
 		},
+		{
+			name: "render workspace URL",
+			in: `[{
+				"label": "View workspace",
+				"url": "{{ base_url }}/@{{.UserName}}/{{.Labels.name}}"
+			}]`,
+			payload: types.MessagePayload{
+				UserName: "johndoe",
+				Labels: map[string]string{
+					"name": "my-workspace",
+				},
+			},
+			expectedOutput: `[{
+				"label": "View workspace",
+				"url": "https://mocked-server-address/@johndoe/my-workspace"
+			}]`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -46,7 +63,9 @@ func TestGoTemplate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			out, err := render.GoTemplate(tc.in, tc.payload, nil)
+			out, err := render.GoTemplate(tc.in, tc.payload, map[string]any{
+				"base_url": func() string { return "https://mocked-server-address" },
+			})
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1100,7 +1100,7 @@ func (s *server) notifyWorkspaceBuildFailed(ctx context.Context, workspace datab
 	if build.Reason.Valid() && build.Reason == database.BuildReasonInitiator {
 		return // failed workspace build initiated by a user should not notify
 	}
-	reason = "initiated by autobuild"
+	reason = string(build.Reason)
 	initiator := "autobuild"
 
 	if _, err := s.NotificationEnqueuer.Enqueue(ctx, workspace.OwnerID, notifications.WorkspaceAutobuildFailed,

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1572,9 +1572,9 @@ func (s *server) notifyWorkspaceDeleted(ctx context.Context, workspace database.
 
 	if _, err := s.NotificationEnqueuer.Enqueue(ctx, workspace.OwnerID, notifications.TemplateWorkspaceDeleted,
 		map[string]string{
-			"name":        workspace.Name,
-			"initiatedBy": build.InitiatorByUsername,
-			"reason":      reason,
+			"name":      workspace.Name,
+			"initiator": build.InitiatorByUsername,
+			"reason":    reason,
 		}, "provisionerdserver",
 		// Associate this notification with all the related entities.
 		workspace.ID, workspace.OwnerID, workspace.TemplateID, workspace.OrganizationID,

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1103,9 +1103,8 @@ func (s *server) notifyWorkspaceBuildFailed(ctx context.Context, workspace datab
 
 	if _, err := s.NotificationEnqueuer.Enqueue(ctx, workspace.OwnerID, notifications.WorkspaceAutobuildFailed,
 		map[string]string{
-			"name":      workspace.Name,
-			"initiator": build.InitiatorByUsername,
-			"reason":    reason,
+			"name":   workspace.Name,
+			"reason": reason,
 		}, "provisionerdserver",
 		// Associate this notification with all the related entities.
 		workspace.ID, workspace.OwnerID, workspace.TemplateID, workspace.OrganizationID,

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -982,10 +982,16 @@ func (s *server) FailJob(ctx context.Context, failJob *proto.FailedJob) (*proto.
 		}
 
 		var build database.WorkspaceBuild
+		var workspace database.Workspace
 		err = s.Database.InTx(func(db database.Store) error {
 			build, err = db.GetWorkspaceBuildByID(ctx, input.WorkspaceBuildID)
 			if err != nil {
 				return xerrors.Errorf("get workspace build: %w", err)
+			}
+
+			workspace, err = db.GetWorkspaceByID(ctx, build.WorkspaceID)
+			if err != nil {
+				return xerrors.Errorf("get workspace: %w", err)
 			}
 
 			if jobType.WorkspaceBuild.State != nil {
@@ -1013,6 +1019,8 @@ func (s *server) FailJob(ctx context.Context, failJob *proto.FailedJob) (*proto.
 		if err != nil {
 			return nil, err
 		}
+
+		s.notifyWorkspaceBuildFailed(ctx, workspace, build)
 
 		err = s.Pubsub.Publish(codersdk.WorkspaceNotifyChannel(build.WorkspaceID), []byte{})
 		if err != nil {
@@ -1085,6 +1093,25 @@ func (s *server) FailJob(ctx context.Context, failJob *proto.FailedJob) (*proto.
 		return nil, xerrors.Errorf("publish end of job logs: %w", err)
 	}
 	return &proto.Empty{}, nil
+}
+
+func (s *server) notifyWorkspaceBuildFailed(ctx context.Context, workspace database.Workspace, build database.WorkspaceBuild) {
+	var reason string
+	if build.Reason.Valid() && build.Reason == database.BuildReasonInitiator {
+		return // failed workspace builds initiated by a user should not notify
+	}
+
+	if _, err := s.NotificationEnqueuer.Enqueue(ctx, workspace.OwnerID, notifications.WorkspaceAutobuildFailed,
+		map[string]string{
+			"name":      workspace.Name,
+			"initiator": build.InitiatorByUsername,
+			"reason":    reason,
+		}, "provisionerdserver",
+		// Associate this notification with all the related entities.
+		workspace.ID, workspace.OwnerID, workspace.TemplateID, workspace.OrganizationID,
+	); err != nil {
+		s.Logger.Warn(ctx, "failed to notify of failed workspace autobuild", slog.Error(err))
+	}
 }
 
 // CompleteJob is triggered by a provision daemon to mark a provisioner job as completed.

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1696,7 +1696,7 @@ func TestNotifications(t *testing.T) {
 		}
 	})
 
-	t.Run("Workspace autobuild failed", func(t *testing.T) {
+	t.Run("Workspace build failed", func(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
@@ -1707,7 +1707,12 @@ func TestNotifications(t *testing.T) {
 			shouldDeleteWorkspace bool
 		}{
 			{
-				name:         "initiated by autostart but failed",
+				name:         "initiated by owner",
+				buildReason:  database.BuildReasonInitiator,
+				shouldNotify: false,
+			},
+			{
+				name:         "initiated by autostart",
 				buildReason:  database.BuildReasonAutostart,
 				shouldNotify: true,
 			},

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1799,6 +1799,7 @@ func TestNotifications(t *testing.T) {
 					require.Contains(t, notifEnq.sent[0].targets, workspace.OrganizationID)
 					require.Contains(t, notifEnq.sent[0].targets, user.ID)
 					require.Equal(t, notifEnq.sent[0].labels["initiator"], "autobuild")
+					require.Equal(t, notifEnq.sent[0].labels["reason"], string(tc.buildReason))
 				} else {
 					require.Len(t, notifEnq.sent, 0)
 				}

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1702,9 +1702,8 @@ func TestNotifications(t *testing.T) {
 		tests := []struct {
 			name string
 
-			buildReason           database.BuildReason
-			shouldNotify          bool
-			shouldDeleteWorkspace bool
+			buildReason  database.BuildReason
+			shouldNotify bool
 		}{
 			{
 				name:         "initiated by owner",
@@ -1793,7 +1792,6 @@ func TestNotifications(t *testing.T) {
 
 				workspace, err = db.GetWorkspaceByID(ctx, workspace.ID)
 				require.NoError(t, err)
-				require.Equal(t, tc.shouldDeleteWorkspace, workspace.Deleted)
 
 				if tc.shouldNotify {
 					// Validate that the notification was sent and contained the expected values.

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1790,9 +1790,6 @@ func TestNotifications(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				workspace, err = db.GetWorkspaceByID(ctx, workspace.ID)
-				require.NoError(t, err)
-
 				if tc.shouldNotify {
 					// Validate that the notification was sent and contained the expected values.
 					require.Len(t, notifEnq.sent, 1)

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1687,7 +1687,7 @@ func TestNotifications(t *testing.T) {
 					require.Contains(t, notifEnq.sent[0].targets, workspace.OrganizationID)
 					require.Contains(t, notifEnq.sent[0].targets, user.ID)
 					if tc.deletionReason == database.BuildReasonInitiator {
-						require.Equal(t, notifEnq.sent[0].labels["initiator"], initiator.Username)
+						require.Equal(t, initiator.Username, notifEnq.sent[0].labels["initiator"])
 					}
 				} else {
 					require.Len(t, notifEnq.sent, 0)
@@ -1798,8 +1798,8 @@ func TestNotifications(t *testing.T) {
 					require.Contains(t, notifEnq.sent[0].targets, workspace.ID)
 					require.Contains(t, notifEnq.sent[0].targets, workspace.OrganizationID)
 					require.Contains(t, notifEnq.sent[0].targets, user.ID)
-					require.Equal(t, notifEnq.sent[0].labels["initiator"], "autobuild")
-					require.Equal(t, notifEnq.sent[0].labels["reason"], string(tc.buildReason))
+					require.Equal(t, "autobuild", notifEnq.sent[0].labels["initiator"])
+					require.Equal(t, string(tc.buildReason), notifEnq.sent[0].labels["reason"])
 				} else {
 					require.Len(t, notifEnq.sent, 0)
 				}

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1714,6 +1714,9 @@ func TestNotifications(t *testing.T) {
 					require.Contains(t, notifEnq.sent[0].targets, user.ID)
 					if tc.buildReason == database.BuildReasonInitiator {
 						require.Equal(t, notifEnq.sent[0].labels["initiator"], initiator.Username)
+					} else {
+						_, ok := notifEnq.sent[0].labels["initiator"]
+						require.False(t, ok, "initiator label not expected")
 					}
 				} else {
 					require.Len(t, notifEnq.sent, 0)


### PR DESCRIPTION
Related: https://github.com/coder/team-coconut/issues/7

This PR implements a new notification: workspace autobuild failure.

Changes:
* create a new notification template for `Workspace Autobuild Failed`
* fix: replace `initiatedBy` with `initiator`
* fix: do not publish `initiator` when autobuild deletes a workspace