### PR TITLE
chore: remove `organizationIds` from `AuthProvider`

### DIFF
--- a/site/src/contexts/auth/AuthProvider.tsx
+++ b/site/src/contexts/auth/AuthProvider.tsx
@@ -30,7 +30,6 @@ export type AuthContextValue = {
   isUpdatingProfile: boolean;
   user: User | undefined;
   permissions: Permissions | undefined;
-  organizationIds: readonly string[] | undefined;
   signInError: unknown;
   updateProfileError: unknown;
   signOut: () => void;
@@ -119,7 +118,6 @@ export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
         permissions: permissionsQuery.data as Permissions | undefined,
         signInError: loginMutation.error,
         updateProfileError: updateProfileMutation.error,
-        organizationIds: userQuery.data?.organization_ids,
       }}
     >
       {children}

--- a/site/src/contexts/auth/RequireAuth.test.tsx
+++ b/site/src/contexts/auth/RequireAuth.test.tsx
@@ -95,7 +95,6 @@ describe("useAuthenticated", () => {
         wrapper: createAuthWrapper({
           user: MockUser,
           permissions: MockPermissions,
-          organizationIds: [],
         }),
       });
     }).not.toThrow();

--- a/site/src/contexts/auth/RequireAuth.tsx
+++ b/site/src/contexts/auth/RequireAuth.tsx
@@ -74,7 +74,7 @@ type RequireKeys<T, R extends keyof T> = Omit<T, R> & {
 // values are not undefined when authenticated
 type AuthenticatedAuthContextValue = RequireKeys<
   AuthContextValue,
-  "user" | "permissions" | "organizationIds"
+  "user" | "permissions"
 >;
 
 export const useAuthenticated = (): AuthenticatedAuthContextValue => {
@@ -86,10 +86,6 @@ export const useAuthenticated = (): AuthenticatedAuthContextValue => {
 
   if (!auth.permissions) {
     throw new Error("Permissions are not available.");
-  }
-
-  if (!auth.organizationIds) {
-    throw new Error("Organization ID is not available.");
   }
 
   return auth as AuthenticatedAuthContextValue;

--- a/site/src/modules/dashboard/DashboardProvider.tsx
+++ b/site/src/modules/dashboard/DashboardProvider.tsx
@@ -1,9 +1,4 @@
-import {
-  createContext,
-  type FC,
-  type PropsWithChildren,
-  useState,
-} from "react";
+import { createContext, type FC, type PropsWithChildren } from "react";
 import { useQuery } from "react-query";
 import { appearance } from "api/queries/appearance";
 import { entitlements } from "api/queries/entitlements";

--- a/site/src/modules/dashboard/DashboardProvider.tsx
+++ b/site/src/modules/dashboard/DashboardProvider.tsx
@@ -15,12 +15,14 @@ import type {
 } from "api/typesGenerated";
 import { Loader } from "components/Loader/Loader";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
-import { useEffectEvent } from "hooks/hookPolyfills";
 import { useEmbeddedMetadata } from "hooks/useEmbeddedMetadata";
 
 export interface DashboardValue {
+  /**
+   * @deprecated Do not add new usage of this value. It is being removed as part
+   * of the multi-org work.
+   */
   organizationId: string;
-  setOrganizationId: (id: string) => void;
   entitlements: Entitlements;
   experiments: Experiments;
   appearance: AppearanceConfig;
@@ -32,30 +34,13 @@ export const DashboardContext = createContext<DashboardValue | undefined>(
 
 export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
   const { metadata } = useEmbeddedMetadata();
-  const { user, organizationIds } = useAuthenticated();
+  const { user } = useAuthenticated();
   const entitlementsQuery = useQuery(entitlements(metadata.entitlements));
   const experimentsQuery = useQuery(experiments(metadata.experiments));
   const appearanceQuery = useQuery(appearance(metadata.appearance));
 
   const isLoading =
     !entitlementsQuery.data || !appearanceQuery.data || !experimentsQuery.data;
-
-  const lastUsedOrganizationId = localStorage.getItem(
-    `user:${user.id}.lastUsedOrganizationId`,
-  );
-  const [activeOrganizationId, setActiveOrganizationId] = useState(() =>
-    lastUsedOrganizationId && organizationIds.includes(lastUsedOrganizationId)
-      ? lastUsedOrganizationId
-      : organizationIds[0],
-  );
-
-  const setOrganizationId = useEffectEvent((id: string) => {
-    if (!organizationIds.includes(id)) {
-      throw new ReferenceError("Invalid organization ID");
-    }
-    localStorage.setItem(`user:${user.id}.lastUsedOrganizationId`, id);
-    setActiveOrganizationId(id);
-  });
 
   if (isLoading) {
     return <Loader fullscreen />;
@@ -64,8 +49,7 @@ export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
     <DashboardContext.Provider
       value={{
-        organizationId: activeOrganizationId,
-        setOrganizationId: setOrganizationId,
+        organizationId: user.organization_ids[0] ?? "default",
         entitlements: entitlementsQuery.data,
         experiments: experimentsQuery.data,
         appearance: appearanceQuery.data,

--- a/site/src/pages/ManagementSettingsPage/ManagementSettingsLayout.tsx
+++ b/site/src/pages/ManagementSettingsPage/ManagementSettingsLayout.tsx
@@ -35,7 +35,7 @@ export const useOrganizationSettings = (): OrganizationSettingsContextValue => {
 
 export const ManagementSettingsLayout: FC = () => {
   const location = useLocation();
-  const { permissions, organizationIds } = useAuthenticated();
+  const { permissions } = useAuthenticated();
   const { experiments } = useDashboard();
   const { organization } = useParams() as { organization: string };
   const deploymentConfigQuery = useQuery(deploymentConfig());
@@ -61,7 +61,7 @@ export const ManagementSettingsLayout: FC = () => {
                 currentOrganizationId: !inOrganizationSettings
                   ? undefined
                   : !organization
-                    ? organizationIds[0]
+                    ? organizationsQuery.data[0]?.id
                     : organizationsQuery.data.find(
                         (org) => org.name === organization,
                       )?.id,

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -27,7 +27,6 @@ export const withDashboardProvider = (
     <DashboardContext.Provider
       value={{
         organizationId: "",
-        setOrganizationId: () => {},
         entitlements,
         experiments,
         appearance: MockAppearanceConfig,


### PR DESCRIPTION
Closes #13906 

Removes some residual code from the now removed org switcher. Not sure how this error was being thrown and the `user` check above wasn't (they come from the same query), but this check can't fail if we just remove it! 😄