### PR TITLE
chore: add multi-org flag to develop.sh

### DIFF
--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -290,6 +290,24 @@ func (c *Client) ProvisionerDaemons(ctx context.Context) ([]ProvisionerDaemon, e
 	return daemons, json.NewDecoder(res.Body).Decode(&daemons)
 }
 
+func (c *Client) OrganizationProvisionerDaemons(ctx context.Context, organizationID uuid.UUID) ([]ProvisionerDaemon, error) {
+	res, err := c.Request(ctx, http.MethodGet,
+		fmt.Sprintf("/api/v2/organizations/%s/provisionerdaemons", organizationID.String()),
+		nil,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("execute request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+
+	var daemons []ProvisionerDaemon
+	return daemons, json.NewDecoder(res.Body).Decode(&daemons)
+}
+
 // CreateTemplateVersion processes source-code and optionally associates the version with a template.
 // Executing without a template is useful for validating source-code.
 func (c *Client) CreateTemplateVersion(ctx context.Context, organizationID uuid.UUID, req CreateTemplateVersionRequest) (TemplateVersion, error) {

--- a/docs/cli/provisionerd_start.md
+++ b/docs/cli/provisionerd_start.md
@@ -135,3 +135,12 @@ Serve prometheus metrics on the address defined by prometheus address.
 | Default     | <code>127.0.0.1:2112</code>            |
 
 The bind address to serve prometheus metrics.
+
+### -O, --org
+
+|             |                                  |
+| ----------- | -------------------------------- |
+| Type        | <code>string</code>              |
+| Environment | <code>$CODER_ORGANIZATION</code> |
+
+Select which organization (uuid or name) to use.

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -74,6 +74,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 		prometheusEnable  bool
 		prometheusAddress string
 	)
+	orgContext := agpl.NewOrganizationContext()
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
 		Use:   "start",
@@ -92,6 +93,11 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			defer stopCancel()
 			interruptCtx, interruptCancel := inv.SignalNotifyContext(ctx, agpl.InterruptSignals...)
 			defer interruptCancel()
+
+			org, err := orgContext.Selected(inv, client)
+			if err != nil {
+				return xerrors.Errorf("current organization: %w", err)
+			}
 
 			tags, err := agpl.ParseProvisionerTags(rawTags)
 			if err != nil {
@@ -206,6 +212,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 					},
 					Tags:         tags,
 					PreSharedKey: preSharedKey,
+					Organization: org.ID,
 				})
 			}, &provisionerd.Options{
 				Logger:         logger,
@@ -346,6 +353,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			Default:     "127.0.0.1:2112",
 		},
 	}
+	orgContext.AttachOptions(cmd)
 
 	return cmd
 }

--- a/enterprise/cli/provisionerdaemons.go
+++ b/enterprise/cli/provisionerdaemons.go
@@ -228,20 +228,17 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			connector := provisionerd.LocalProvisioners{
 				string(database.ProvisionerTypeTerraform): proto.NewDRPCProvisionerClient(terraformClient),
 			}
-			req := codersdk.ServeProvisionerDaemonRequest{
-				ID:   uuid.New(),
-				Name: name,
-				Provisioners: []codersdk.ProvisionerType{
-					codersdk.ProvisionerTypeTerraform,
-				},
-				Tags:         tags,
-				PreSharedKey: preSharedKey,
-			}
-			if org.ID != uuid.Nil {
-				req.Organization = org.ID
-			}
 			srv := provisionerd.New(func(ctx context.Context) (provisionerdproto.DRPCProvisionerDaemonClient, error) {
-				return client.ServeProvisionerDaemon(ctx, req)
+				return client.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
+					ID:   uuid.New(),
+					Name: name,
+					Provisioners: []codersdk.ProvisionerType{
+						codersdk.ProvisionerTypeTerraform,
+					},
+					Tags:         tags,
+					PreSharedKey: preSharedKey,
+					Organization: org.ID,
+				})
 			}, &provisionerd.Options{
 				Logger:         logger,
 				UpdateInterval: 500 * time.Millisecond,

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -27,36 +27,75 @@ import (
 func TestProvisionerDaemon_PSK(t *testing.T) {
 	t.Parallel()
 
-	client, _ := coderdenttest.New(t, &coderdenttest.Options{
-		ProvisionerDaemonPSK: "provisionersftw",
-		LicenseOptions: &coderdenttest.LicenseOptions{
-			Features: license.Features{
-				codersdk.FeatureExternalProvisionerDaemons: 1,
-			},
-		},
-	})
-	inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name=matt-daemon")
-	err := conf.URL().Write(client.URL.String())
-	require.NoError(t, err)
-	pty := ptytest.New(t).Attach(inv)
-	ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
-	defer cancel()
-	clitest.Start(t, inv)
-	pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
-	pty.ExpectMatchContext(ctx, "matt-daemon")
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
 
-	var daemons []codersdk.ProvisionerDaemon
-	require.Eventually(t, func() bool {
-		daemons, err = client.ProvisionerDaemons(ctx)
-		if err != nil {
-			return false
-		}
-		return len(daemons) == 1
-	}, testutil.WaitShort, testutil.IntervalSlow)
-	require.Equal(t, "matt-daemon", daemons[0].Name)
-	require.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
-	require.Equal(t, buildinfo.Version(), daemons[0].Version)
-	require.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
+		client, _ := coderdenttest.New(t, &coderdenttest.Options{
+			ProvisionerDaemonPSK: "provisionersftw",
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				},
+			},
+		})
+		inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name=matt-daemon")
+		err := conf.URL().Write(client.URL.String())
+		require.NoError(t, err)
+		pty := ptytest.New(t).Attach(inv)
+		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
+		defer cancel()
+		clitest.Start(t, inv)
+		pty.ExpectNoMatchBefore(ctx, "check entitlement", "starting provisioner daemon")
+		pty.ExpectMatchContext(ctx, "matt-daemon")
+
+		var daemons []codersdk.ProvisionerDaemon
+		require.Eventually(t, func() bool {
+			daemons, err = client.ProvisionerDaemons(ctx)
+			if err != nil {
+				return false
+			}
+			return len(daemons) == 1
+		}, testutil.WaitShort, testutil.IntervalSlow)
+		require.Equal(t, "matt-daemon", daemons[0].Name)
+		require.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
+		require.Equal(t, buildinfo.Version(), daemons[0].Version)
+		require.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
+	})
+
+	t.Run("AnotherOrg", func(t *testing.T) {
+		t.Parallel()
+		client, _ := coderdenttest.New(t, &coderdenttest.Options{
+			ProvisionerDaemonPSK: "provisionersftw",
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				},
+			},
+		})
+		anotherOrg := coderdtest.CreateOrganization(t, client, coderdtest.CreateOrganizationOptions{})
+		anotherClient, _ := coderdtest.CreateAnotherUser(t, client, anotherOrg.ID, rbac.RoleTemplateAdmin())
+		inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name", "org-daemon", "--org", anotherOrg.ID.String())
+		clitest.SetupConfig(t, anotherClient, conf)
+		pty := ptytest.New(t).Attach(inv)
+		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
+		defer cancel()
+		clitest.Start(t, inv)
+		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+
+		var daemons []codersdk.ProvisionerDaemon
+		var err error
+		require.Eventually(t, func() bool {
+			daemons, err = client.OrganizationProvisionerDaemons(ctx, anotherOrg.ID)
+			if err != nil {
+				return false
+			}
+			return len(daemons) == 1
+		}, testutil.WaitShort, testutil.IntervalSlow)
+		assert.Equal(t, "org-daemon", daemons[0].Name)
+		assert.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
+		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
+		assert.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
+	})
 }
 
 func TestProvisionerDaemon_SessionToken(t *testing.T) {
@@ -162,6 +201,42 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 		}, testutil.WaitShort, testutil.IntervalSlow)
 		assert.Equal(t, "org-daemon", daemons[0].Name)
 		assert.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
+		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
+		assert.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
+	})
+
+	t.Run("ScopeUserAnotherOrg", func(t *testing.T) {
+		t.Parallel()
+		client, _ := coderdenttest.New(t, &coderdenttest.Options{
+			ProvisionerDaemonPSK: "provisionersftw",
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				},
+			},
+		})
+		anotherOrg := coderdtest.CreateOrganization(t, client, coderdtest.CreateOrganizationOptions{})
+		anotherClient, anotherUser := coderdtest.CreateAnotherUser(t, client, anotherOrg.ID, rbac.RoleTemplateAdmin())
+		inv, conf := newCLI(t, "provisionerd", "start", "--tag", "scope=user", "--name", "org-daemon", "--org", anotherOrg.ID.String())
+		clitest.SetupConfig(t, anotherClient, conf)
+		pty := ptytest.New(t).Attach(inv)
+		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
+		defer cancel()
+		clitest.Start(t, inv)
+		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
+
+		var daemons []codersdk.ProvisionerDaemon
+		var err error
+		require.Eventually(t, func() bool {
+			daemons, err = client.OrganizationProvisionerDaemons(ctx, anotherOrg.ID)
+			if err != nil {
+				return false
+			}
+			return len(daemons) == 1
+		}, testutil.WaitShort, testutil.IntervalSlow)
+		assert.Equal(t, "org-daemon", daemons[0].Name)
+		assert.Equal(t, provisionersdk.ScopeUser, daemons[0].Tags[provisionersdk.TagScope])
+		assert.Equal(t, anotherUser.ID.String(), daemons[0].Tags[provisionersdk.TagOwner])
 		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
 		assert.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
 	})

--- a/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
+++ b/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
@@ -6,6 +6,9 @@ USAGE:
   Run a provisioner daemon
 
 OPTIONS:
+  -O, --org string, $CODER_ORGANIZATION
+          Select which organization (uuid or name) to use.
+
   -c, --cache-dir string, $CODER_CACHE_DIRECTORY (default: [cache dir])
           Directory to store cached data.
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -20,7 +20,7 @@ password="${CODER_DEV_ADMIN_PASSWORD:-${DEFAULT_PASSWORD}}"
 use_proxy=0
 multi_org=0
 
-args="$(getopt -o "" -l access-url:,use-proxy,agpl,debug,password: -- "$@")"
+args="$(getopt -o "" -l access-url:,use-proxy,agpl,debug,password:,multi-organization -- "$@")"
 eval set -- "$args"
 while true; do
 	case "$1" in
@@ -40,7 +40,7 @@ while true; do
 		use_proxy=1
 		shift
 		;;
-	--multi-org)
+	--multi-organization)
 		multi_org=1
 		shift
 		;;
@@ -60,6 +60,10 @@ done
 
 if [ "${CODER_BUILD_AGPL:-0}" -gt "0" ] && [ "${use_proxy}" -gt "0" ]; then
 	echo '== ERROR: cannot use both external proxies and APGL build.' && exit 1
+fi
+
+if [ "${CODER_BUILD_AGPL:-0}" -gt "0" ] && [ "${multi_org}" -gt "0" ]; then
+	echo '== ERROR: cannot use both multi-organizations and APGL build.' && exit 1
 fi
 
 # Preflight checks: ensure we have our required dependencies, and make sure nothing is listening on port 3000 or 8080
@@ -173,21 +177,51 @@ fatal() {
 			echo 'Failed to create regular user. To troubleshoot, try running this command manually.'
 	fi
 
+	# Create a new organization and add the member user to it.
+	if [ "${multi_org}" -gt "0" ]; then
+		another_org="second-organization"
+		if ! "${CODER_DEV_SHIM}" organizations show selected --org "${another_org}" >/dev/null 2>&1; then
+			echo "Creating organization '${another_org}'..."
+			(
+				"${CODER_DEV_SHIM}" organizations create -y "${another_org}"
+			) || echo "Failed to create organization '${another_org}'"
+		fi
+
+		if ! "${CODER_DEV_SHIM}" org members list --org ${another_org} | grep "^member" >/dev/null 2>&1; then
+			echo "Adding member user to organization '${another_org}'..."
+			(
+				"${CODER_DEV_SHIM}" organizations members add member --org "${another_org}"
+			) || echo "Failed to add member user to organization '${another_org}'"
+		fi
+
+		echo "Starting external provisioner for '${another_org}'..."
+		(
+			start_cmd EXT_PROVISIONER "" "${CODER_DEV_SHIM}" provisionerd start --tag "scope=organization" --name second-org-daemon --org "${another_org}"
+		) || echo "Failed to start external provisioner. No external provisioner started."
+	fi
+
 	# If we have docker available and the "docker" template doesn't already
 	# exist, then let's try to create a template!
 	template_name="docker"
 	if docker info >/dev/null 2>&1 && ! "${CODER_DEV_SHIM}" templates versions list "${template_name}" >/dev/null 2>&1; then
 		# sometimes terraform isn't installed yet when we go to create the
 		# template
+		echo "Waiting for terraform to be installed..."
 		sleep 5
 
+		echo "Initializing docker template..."
 		temp_template_dir="$(mktemp -d)"
 		"${CODER_DEV_SHIM}" templates init --id "${template_name}" "${temp_template_dir}"
 
 		DOCKER_HOST="$(docker context inspect --format '{{ .Endpoints.docker.Host }}')"
 		printf 'docker_arch: "%s"\ndocker_host: "%s"\n' "${GOARCH}" "${DOCKER_HOST}" >"${temp_template_dir}/params.yaml"
 		(
+			echo "Pushing docker template to 'first-organization'..."
 			"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org first-organization
+			if [ "${multi_org}" -gt "0" ]; then
+				echo "Pushing docker template to '${another_org}'..."
+				"${CODER_DEV_SHIM}" templates push "${template_name}" --directory "${temp_template_dir}" --variables-file "${temp_template_dir}/params.yaml" --yes --org "${another_org}"
+			fi
 			rm -rfv "${temp_template_dir}" # Only delete template dir if template creation succeeds
 		) || echo "Failed to create a template. The template files are in ${temp_template_dir}"
 	fi
@@ -202,29 +236,6 @@ fatal() {
 			# Start the proxy
 			start_cmd PROXY "" "${CODER_DEV_SHIM}" wsproxy server --dangerous-allow-cors-requests=true --http-address=localhost:3010 --proxy-session-token="${proxy_session_token}" --primary-access-url=http://localhost:3000
 		) || echo "Failed to create workspace proxy. No workspace proxy created."
-	fi
-
-	if [ "${multi_org}" -gt "0" ]; then
-		another_org="second-organization"
-		if ! "${CODER_DEV_SHIM}" organizations show selected --org "${another_org}" >/dev/null 2>&1; then
-			log "Creating organization '${another_org}'"
-			(
-				"${CODER_DEV_SHIM}" organizations create -y "${another_org}"
-				"${CODER_DEV_SHIM}" organizations members add member --org "${another_org}"
-			) || echo "Failed to create organization '${another_org}'"
-		fi
-
-		if ! "${CODER_DEV_SHIM}" org members list --org ${another_org} | grep "^member" >/dev/null 2>&1; then
-			log "Adding member user to organization '${another_org}'"
-			(
-				"${CODER_DEV_SHIM}" organizations members add member
-			) || echo "Failed to add member user to organization '${another_org}'"
-		fi
-
-		log "Using external provisioner"
-		(
-			start_cmd EXT_PROVISIONER "" "${CODER_DEV_SHIM}" provisionerd start --tag "scope=organization" --name second-org-daemon --org "${another_org}"
-		) || echo "Failed to start external provisioner. No external provisioner started."
 	fi
 
 	# Start the frontend once we have a template up and running


### PR DESCRIPTION
What this changes:
- Adds org flag to `coder provisionerd start` command
- Adds `--multi-organization` flag to `scripts/develop.sh` that creates a second org and docker template

Example usage:
`./scripts/develop.sh --multi-organization -- --experiments="multi-organization"`