### PR TITLE
chore: update flake.nix to handle aarch64 linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,8 @@
 
         # The minimal set of packages to build Coder.
         devShellPackages = with pkgs; [
-          # google-chrome is not available on OSX
-          (if pkgs.stdenv.hostPlatform.isDarwin then null else google-chrome)
+          # google-chrome is not available on OSX and aarch64 linux
+          (if pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.hostPlatform.isAarch64 then null else google-chrome)
           # strace is not available on OSX
           (if pkgs.stdenv.hostPlatform.isDarwin then null else strace)
           bat


### PR DESCRIPTION
`google-chrome` is not available for aarch64 linux

https://search.nixos.org/packages?channel=unstable&show=google-chrome&from=0&size=50&sort=relevance&type=packages&query=google-chrome


Also bumps terraform to 1.9.2 for nix.