### PR TITLE
revert: update pnpm to v9

### DIFF
--- a/dogfood/Dockerfile
+++ b/dogfood/Dockerfile
@@ -211,7 +211,7 @@ RUN apt-get update && \
 	google-chrome-stable microsoft-edge-beta && \
 	# Pre-install system dependencies that Playwright needs. npx doesn't work here
 	# for some reason. See https://github.com/microsoft/playwright-cli/issues/136
-	npm i -g playwright@1.36.2 pnpm@^9 corepack && playwright install-deps && \
+	npm i -g playwright@1.36.2 pnpm@^8 corepack && playwright install-deps && \
 	npm cache clean --force
 
 # Ensure PostgreSQL binaries are in the users $PATH.

--- a/flake.lock
+++ b/flake.lock
@@ -2,24 +2,20 @@
   "nodes": {
     "drpc": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1710270657,
-        "narHash": "sha256-hjb+8iB0HTdAYtsOvr6gY2yhwdg2NLUqQRVJi4qMmJI=",
+        "lastModified": 1682005581,
+        "narHash": "sha256-mPaQg6bN1I6160RG4Yi3CjKNJ0oHoGYYxOSpOWHWXK0=",
         "owner": "storj",
         "repo": "drpc",
-        "rev": "a5d487af8ae33deb7913b0f7c06b2c7ec7cd4dcc",
+        "rev": "9716137f6037cde2f813985fcee00409b4101ed2",
         "type": "github"
       },
       "original": {
         "owner": "storj",
-        "ref": "v0.0.34",
+        "ref": "v0.0.33",
         "repo": "drpc",
         "type": "github"
       }
@@ -27,6 +23,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -42,13 +56,46 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1681823821,
+        "narHash": "sha256-LGm3j7hW2C3T28q2/r49tX01zIyoaaQAJRi7rlISbr0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b419c67cfeb210d333fc0c34ae6e8c7a987d443",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1719075281,
+        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
         "type": "github"
       },
       "original": {
@@ -58,30 +105,26 @@
         "type": "github"
       }
     },
-    "nixpkgs-pinned": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1699526406,
-        "narHash": "sha256-gN+SUmD0WPi3zqYv4QwDFkWH7QQJosJSuhv1DZ6wU84=",
+        "lastModified": 1702151865,
+        "narHash": "sha256-9VAt19t6yQa7pHZLDbil/QctAgVsA66DLnzdRGqDisg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5deee6281831847857720668867729617629ef1f",
+        "rev": "666fc80e7b2afb570462423cb0e1cf1a3a34fedd",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "5deee6281831847857720668867729617629ef1f",
         "type": "github"
       }
     },
     "pnpm2nix": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1706694632,
@@ -100,13 +143,42 @@
     "root": {
       "inputs": {
         "drpc": "drpc",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-pinned": "nixpkgs-pinned",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
         "pnpm2nix": "pnpm2nix"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,35 +3,16 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-pinned.url = "github:nixos/nixpkgs/5deee6281831847857720668867729617629ef1f";
     flake-utils.url = "github:numtide/flake-utils";
-    pnpm2nix = {
-      url = "github:nzbr/pnpm2nix-nzbr";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
-    drpc = {
-      url = "github:storj/drpc/v0.0.34";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
+    pnpm2nix.url = "github:nzbr/pnpm2nix-nzbr";
+    drpc.url = "github:storj/drpc/v0.0.33";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-pinned, flake-utils, drpc, pnpm2nix }:
+  outputs = { self, nixpkgs, flake-utils, drpc, pnpm2nix }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          # Workaround for: terraform has an unfree license (‘bsl11’), refusing to evaluate.
-          config.allowUnfree = true;
-        };
-
-        # pinnedPkgs is used to pin packages that need to stay in sync with CI.
-        # Everything else uses unstable.
-        pinnedPkgs = import nixpkgs-pinned {
-          inherit system;
-        };
-
+        # Workaround for: terraform has an unfree license (‘bsl11’), refusing to evaluate.
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
         nodejs = pkgs.nodejs-18_x;
         # Check in https://search.nixos.org/packages to find new packages.
         # Use `nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update`
@@ -60,7 +41,7 @@
           gnused
           go_1_22
           go-migrate
-          (pinnedPkgs.golangci-lint)
+          golangci-lint
           gopls
           gotestsum
           jq
@@ -71,7 +52,7 @@
           mockgen
           nfpm
           nodejs
-          pnpm
+          nodejs.pkgs.pnpm
           openssh
           openssl
           pango
@@ -82,10 +63,9 @@
           protobuf
           protoc-gen-go
           ripgrep
-          # This doesn't build on latest nixpkgs (July 10 2024)
-          (pinnedPkgs.sapling)
+          sapling
           shellcheck
-          (pinnedPkgs.shfmt)
+          shfmt
           sqlc
           terraform
           typos


### PR DESCRIPTION
This reverts commit 2238593f575cb336e13369f322542f5681c762d5.

Unfortunately, my developer environment is unusable due to this change. Nix is rebuilding nodejs since an hour, and I'm blocked now. 

Please re-review the original PR, and verify if it does not affect OSX.

<img width="1506" alt="Screenshot 2024-07-19 at 14 43 08" src="https://github.com/user-attachments/assets/f2a47565-f48e-4b43-aa95-f88718c6eb8c">
