### PR TITLE
chore: only add Meticulous recorder when running in dev mode

### DIFF
--- a/site/src/index.tsx
+++ b/site/src/index.tsx
@@ -31,9 +31,10 @@ async function startApp() {
 
 function isInternal() {
   return (
-    window.location.hostname.indexOf("dev.coder.com") > -1 ||
-    window.location.hostname.indexOf("localhost") > -1 ||
-    window.location.hostname.indexOf("127.0.0.1") > -1
+    process.env.NODE_ENV === "development" && (
+      window.location.hostname.indexOf("localhost") > -1 ||
+      window.location.hostname.indexOf("127.0.0.1") > -1
+    )
   );
 }
 

--- a/site/src/index.tsx
+++ b/site/src/index.tsx
@@ -31,10 +31,9 @@ async function startApp() {
 
 function isInternal() {
   return (
-    process.env.NODE_ENV === "development" && (
-      window.location.hostname.indexOf("localhost") > -1 ||
-      window.location.hostname.indexOf("127.0.0.1") > -1
-    )
+    process.env.NODE_ENV === "development" &&
+    (window.location.hostname.indexOf("localhost") > -1 ||
+      window.location.hostname.indexOf("127.0.0.1") > -1)
   );
 }
 


### PR DESCRIPTION
Local sessions via the go server contain server-side rendered data and thus sessions cannot be simulated by Meticulous