### PR TITLE
chore(docs): update version flags for 2.12.4 and 2.13.1

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -134,7 +134,7 @@ locally in order to log in and manage templates.
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml \
-       --version 2.13.0
+       --version 2.13.1
    ```
 
    For the **stable** Coder release:
@@ -145,7 +145,7 @@ locally in order to log in and manage templates.
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml \
-       --version 2.12.3
+       --version 2.12.4
    ```
 
    You can watch Coder start up by running `kubectl get pods -n coder`. Once


### PR DESCRIPTION
Autoversion bumping for patches.

- [v2.12.4](https://github.com/coder/coder/releases/tag/v2.12.4)
- [v2.13.1](https://github.com/coder/coder/releases/tag/v2.13.1)

