### PR TITLE
chore: keep active users active in scim

### DIFF
--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -274,10 +274,13 @@ func InitRequestWithCancel[T Auditable](w http.ResponseWriter, p *RequestParams)
 	req, commitF := InitRequest[T](w, p)
 	cancelled := false
 	return req, func(commit bool) {
+		// Once 'commit=false' is called, block
+		// any future commit attempts.
 		if !commit {
 			cancelled = true
 			return
 		}
+		// If it was ever cancelled, block any commits
 		if !cancelled {
 			commitF()
 		}

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -272,14 +272,14 @@ func (api *API) scimPatchUser(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	auditor := *api.AGPL.Auditor.Load()
-	aReq, commitAudit, cancelAudit := audit.InitRequestWithCancel[database.User](rw, &audit.RequestParams{
+	aReq, commitAudit := audit.InitRequestWithCancel[database.User](rw, &audit.RequestParams{
 		Audit:   auditor,
 		Log:     api.Logger,
 		Request: r,
 		Action:  database.AuditActionWrite,
 	})
 
-	defer commitAudit()
+	defer commitAudit(true)
 
 	id := chi.URLParam(r, "id")
 
@@ -338,7 +338,7 @@ func (api *API) scimPatchUser(rw http.ResponseWriter, r *http.Request) {
 		dbUser = userNew
 	} else {
 		// Do not push an audit log if there is no change.
-		cancelAudit()
+		commitAudit(false)
 	}
 
 	aReq.New = dbUser

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -307,8 +307,18 @@ func (api *API) scimPatchUser(rw http.ResponseWriter, r *http.Request) {
 
 	var status database.UserStatus
 	if sUser.Active {
-		// The user will get transitioned to Active after logging in.
-		status = database.UserStatusDormant
+		switch dbUser.Status {
+		case database.UserStatusActive:
+			// Keep the user active
+			status = database.UserStatusActive
+		case database.UserStatusDormant, database.UserStatusSuspended:
+			// Move (or keep) as dormant
+			status = database.UserStatusDormant
+		default:
+			// If the status is unknown, just move them to dormant.
+			// The user will get transitioned to Active after logging in.
+			status = database.UserStatusDormant
+		}
 	} else {
 		status = database.UserStatusSuspended
 	}

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -404,6 +404,7 @@ func TestScim(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, codersdk.UserStatusDormant, scimUser.Status, "user starts as dormant")
 
+			//nolint:bodyclose
 			scimUserClient, _ := fake.Login(t, client, jwt.MapClaims{
 				"email": sUser.Emails[0].Value,
 			})


### PR DESCRIPTION
Resolves an issue where workspaces will not autostart until the workspace owner logs in, e.g. a workspace configured to autostart at 9:30AM will not autostart until 10:42AM when the owner logs in for the day.