### PR TITLE
chore: handle cases where users belong to no organizations

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -3006,9 +3006,6 @@ func (q *FakeQuerier) GetOrganizationIDsByMemberIDs(_ context.Context, ids []uui
 			OrganizationIDs: userOrganizationIDs,
 		})
 	}
-	if len(getOrganizationIDsByMemberIDRows) == 0 {
-		return nil, sql.ErrNoRows
-	}
 	return getOrganizationIDsByMemberIDRows, nil
 }
 

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1293,9 +1293,12 @@ func userOrganizationIDs(ctx context.Context, api *API, user database.User) ([]u
 	if err != nil {
 		return []uuid.UUID{}, err
 	}
+
+	// If you are in no orgs, then return an empty list.
 	if len(organizationIDsByMemberIDsRows) == 0 {
-		return []uuid.UUID{}, xerrors.Errorf("user %q must be a member of at least one organization", user.Email)
+		return []uuid.UUID{}, nil
 	}
+
 	member := organizationIDsByMemberIDsRows[0]
 	return member.OrganizationIDs, nil
 }


### PR DESCRIPTION
Especially when we implement group/role sync, it could be possible for a user to be orphaned with a mistake in configuration. The mistake should still allow the user to function to some extent. This code used to exist before org member management was a feature.

![Screenshot from 2024-07-19 16-21-46](https://github.com/user-attachments/assets/499dcb4b-120b-4fdf-b638-e7dfceca1c04)
