### PR TITLE
feat: accept provisioner keys for provisioner auth

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -260,6 +260,7 @@ var (
 					rbac.ResourceOrganization.Type:       {policy.ActionCreate, policy.ActionRead},
 					rbac.ResourceOrganizationMember.Type: {policy.ActionCreate},
 					rbac.ResourceProvisionerDaemon.Type:  {policy.ActionCreate, policy.ActionUpdate},
+					rbac.ResourceProvisionerKeys.Type:    {policy.ActionCreate, policy.ActionRead, policy.ActionDelete},
 					rbac.ResourceUser.Type:               rbac.ResourceUser.AvailableActions(),
 					rbac.ResourceWorkspaceDormant.Type:   {policy.ActionUpdate, policy.ActionDelete, policy.ActionWorkspaceStop},
 					rbac.ResourceWorkspace.Type:          {policy.ActionUpdate, policy.ActionDelete, policy.ActionWorkspaceStart, policy.ActionWorkspaceStop, policy.ActionSSH},

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -158,49 +158,34 @@ func ActorFromContext(ctx context.Context) (rbac.Subject, bool) {
 }
 
 var (
-	subjectProvisionerd = func(orgID uuid.UUID) rbac.Subject {
-		sitePermissions := map[string][]policy.Action{
-			// TODO: Add ProvisionerJob resource type.
-			rbac.ResourceFile.Type:     {policy.ActionRead},
-			rbac.ResourceSystem.Type:   {policy.WildcardSymbol},
-			rbac.ResourceTemplate.Type: {policy.ActionRead, policy.ActionUpdate},
-			// Unsure why provisionerd needs update and read personal
-			rbac.ResourceUser.Type:             {policy.ActionRead, policy.ActionReadPersonal, policy.ActionUpdatePersonal},
-			rbac.ResourceWorkspaceDormant.Type: {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStop},
-			rbac.ResourceWorkspace.Type:        {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStart, policy.ActionWorkspaceStop},
-			rbac.ResourceApiKey.Type:           {policy.WildcardSymbol},
-			// When org scoped provisioner credentials are implemented,
-			// this can be reduced to read a specific org.
-			rbac.ResourceOrganization.Type: {policy.ActionRead},
-			rbac.ResourceGroup.Type:        {policy.ActionRead},
-		}
-		orgPermissions := map[string][]rbac.Permission{}
-
-		if orgID != uuid.Nil {
-			// replace site wide org permissions with org scoped permissions
-			delete(sitePermissions, rbac.ResourceOrganization.Type)
-			orgPermissions = map[string][]rbac.Permission{
-				orgID.String(): rbac.Permissions(map[string][]policy.Action{
+	subjectProvisionerd = rbac.Subject{
+		FriendlyName: "Provisioner Daemon",
+		ID:           uuid.Nil.String(),
+		Roles: rbac.Roles([]rbac.Role{
+			{
+				Identifier:  rbac.RoleIdentifier{Name: "provisionerd"},
+				DisplayName: "Provisioner Daemon",
+				Site: rbac.Permissions(map[string][]policy.Action{
+					// TODO: Add ProvisionerJob resource type.
+					rbac.ResourceFile.Type:     {policy.ActionRead},
+					rbac.ResourceSystem.Type:   {policy.WildcardSymbol},
+					rbac.ResourceTemplate.Type: {policy.ActionRead, policy.ActionUpdate},
+					// Unsure why provisionerd needs update and read personal
+					rbac.ResourceUser.Type:             {policy.ActionRead, policy.ActionReadPersonal, policy.ActionUpdatePersonal},
+					rbac.ResourceWorkspaceDormant.Type: {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStop},
+					rbac.ResourceWorkspace.Type:        {policy.ActionDelete, policy.ActionRead, policy.ActionUpdate, policy.ActionWorkspaceStart, policy.ActionWorkspaceStop},
+					rbac.ResourceApiKey.Type:           {policy.WildcardSymbol},
+					// When org scoped provisioner credentials are implemented,
+					// this can be reduced to read a specific org.
 					rbac.ResourceOrganization.Type: {policy.ActionRead},
+					rbac.ResourceGroup.Type:        {policy.ActionRead},
 				}),
-			}
-		}
-
-		return rbac.Subject{
-			FriendlyName: "Provisioner Daemon",
-			ID:           uuid.Nil.String(),
-			Roles: rbac.Roles([]rbac.Role{
-				{
-					Identifier:  rbac.RoleIdentifier{Name: "provisionerd"},
-					DisplayName: "Provisioner Daemon",
-					Site:        rbac.Permissions(sitePermissions),
-					Org:         orgPermissions,
-					User:        []rbac.Permission{},
-				},
-			}),
-			Scope: rbac.ScopeAll,
-		}.WithCachedASTValue()
-	}
+				Org:  map[string][]rbac.Permission{},
+				User: []rbac.Permission{},
+			},
+		}),
+		Scope: rbac.ScopeAll,
+	}.WithCachedASTValue()
 
 	subjectAutostart = rbac.Subject{
 		FriendlyName: "Autostart",
@@ -277,13 +262,7 @@ var (
 // AsProvisionerd returns a context with an actor that has permissions required
 // for provisionerd to function.
 func AsProvisionerd(ctx context.Context) context.Context {
-	return context.WithValue(ctx, authContextKey{}, subjectProvisionerd(uuid.Nil))
-}
-
-// AsProvisionerd returns a context with an actor that has permissions required
-// for an org scoped provisionerd to function.
-func AsOrganizationProvisionerd(ctx context.Context, orgID uuid.UUID) context.Context {
-	return context.WithValue(ctx, authContextKey{}, subjectProvisionerd(orgID))
+	return context.WithValue(ctx, authContextKey{}, subjectProvisionerd)
 }
 
 // AsAutostart returns a context with an actor that has permissions required

--- a/coderd/httpmw/csrf.go
+++ b/coderd/httpmw/csrf.go
@@ -93,6 +93,13 @@ func CSRF(secureCookie bool) func(next http.Handler) http.Handler {
 				return true
 			}
 
+			if r.Header.Get(codersdk.ProvisionerDaemonKey) != "" {
+				// If present, the provisioner daemon also is providing an api key
+				// that will make them exempt from CSRF. But this is still useful
+				// for enumerating the external auths.
+				return true
+			}
+
 			// If the X-CSRF-TOKEN header is set, we can exempt the func if it's valid.
 			// This is the CSRF check.
 			sent := r.Header.Get("X-CSRF-TOKEN")

--- a/coderd/httpmw/provisionerdaemon.go
+++ b/coderd/httpmw/provisionerdaemon.go
@@ -30,6 +30,7 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) fu
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			org := OrganizationParam(r)
 
 			handleOptional := func(code int, response codersdk.Response) {
 				if opts.Optional {
@@ -96,6 +97,13 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) fu
 			}
 
 			if provisionerkey.Compare(pk.HashedSecret, provisionerkey.HashSecret(keyValue)) {
+				handleOptional(http.StatusUnauthorized, codersdk.Response{
+					Message: "provisioner daemon key invalid",
+				})
+				return
+			}
+
+			if pk.OrganizationID != org.ID {
 				handleOptional(http.StatusUnauthorized, codersdk.Response{
 					Message: "provisioner daemon key invalid",
 				})

--- a/coderd/httpmw/provisionerdaemon.go
+++ b/coderd/httpmw/provisionerdaemon.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/provisionerkey"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -19,11 +20,13 @@ func ProvisionerDaemonAuthenticated(r *http.Request) bool {
 }
 
 type ExtractProvisionerAuthConfig struct {
-	DB       database.Store
-	Optional bool
+	DB              database.Store
+	Optional        bool
+	PSK             string
+	MultiOrgEnabled bool
 }
 
-func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig, psk string) func(next http.Handler) http.Handler {
+func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
@@ -36,26 +39,50 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig, ps
 				httpapi.Write(ctx, w, code, response)
 			}
 
-			if psk == "" {
-				// No psk means external provisioner daemons are not allowed.
-				// So their auth is not valid.
-				handleOptional(http.StatusBadRequest, codersdk.Response{
-					Message: "External provisioner daemons not enabled",
+			if !opts.MultiOrgEnabled {
+				fallbackToPSK(ctx, opts.PSK, next, w, r, handleOptional)
+				return
+			}
+
+			key := r.Header.Get(codersdk.ProvisionerDaemonKey)
+			if key == "" {
+				if opts.PSK == "" {
+					handleOptional(http.StatusUnauthorized, codersdk.Response{
+						Message: "provisioner daemon key required",
+					})
+					return
+				}
+
+				fallbackToPSK(ctx, opts.PSK, next, w, r, handleOptional)
+				return
+			}
+
+			id, keyValue, err := provisionerkey.Parse(key)
+			if err != nil {
+				handleOptional(http.StatusUnauthorized, codersdk.Response{
+					Message: "provisioner daemon key invalid",
 				})
 				return
 			}
 
-			token := r.Header.Get(codersdk.ProvisionerDaemonPSK)
-			if token == "" {
-				handleOptional(http.StatusUnauthorized, codersdk.Response{
-					Message: "provisioner daemon auth token required",
+			pk, err := opts.DB.GetProvisionerKeyByID(ctx, id)
+			if err != nil {
+				if httpapi.Is404Error(err) {
+					handleOptional(http.StatusUnauthorized, codersdk.Response{
+						Message: "provisioner daemon key invalid",
+					})
+					return
+				}
+
+				handleOptional(http.StatusInternalServerError, codersdk.Response{
+					Message: "get provisioner daemon key: " + err.Error(),
 				})
 				return
 			}
 
-			if subtle.ConstantTimeCompare([]byte(token), []byte(psk)) != 1 {
+			if subtle.ConstantTimeCompare(pk.HashedSecret, provisionerkey.HashSecret(keyValue)) != 1 {
 				handleOptional(http.StatusUnauthorized, codersdk.Response{
-					Message: "provisioner daemon auth token invalid",
+					Message: "provisioner daemon key invalid",
 				})
 				return
 			}
@@ -65,8 +92,33 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig, ps
 			// authenticated provisioner daemon.
 			ctx = context.WithValue(ctx, provisionerDaemonContextKey{}, true)
 			// nolint:gocritic // Authenticating as a provisioner daemon.
-			ctx = dbauthz.AsProvisionerd(ctx)
+			ctx = dbauthz.AsOrganizationProvisionerd(ctx, pk.OrganizationID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func fallbackToPSK(ctx context.Context, psk string, next http.Handler, w http.ResponseWriter, r *http.Request, handleOptional func(code int, response codersdk.Response)) {
+	if psk == "" {
+		handleOptional(http.StatusUnauthorized, codersdk.Response{
+			Message: "External provisioner daemons not enabled",
+		})
+		return
+	}
+
+	token := r.Header.Get(codersdk.ProvisionerDaemonPSK)
+	if subtle.ConstantTimeCompare([]byte(token), []byte(psk)) != 1 {
+		handleOptional(http.StatusUnauthorized, codersdk.Response{
+			Message: "provisioner daemon psk invalid",
+		})
+		return
+	}
+
+	// The PSK does not indicate a specific provisioner daemon. So just
+	// store a boolean so the caller can check if the request is from an
+	// authenticated provisioner daemon.
+	ctx = context.WithValue(ctx, provisionerDaemonContextKey{}, true)
+	// nolint:gocritic // Authenticating as a provisioner daemon.
+	ctx = dbauthz.AsProvisionerd(ctx)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/coderd/httpmw/provisionerdaemon.go
+++ b/coderd/httpmw/provisionerdaemon.go
@@ -30,7 +30,6 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) fu
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			org := OrganizationParam(r)
 
 			handleOptional := func(code int, response codersdk.Response) {
 				if opts.Optional {
@@ -97,13 +96,6 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) fu
 			}
 
 			if provisionerkey.Compare(pk.HashedSecret, provisionerkey.HashSecret(keyValue)) {
-				handleOptional(http.StatusUnauthorized, codersdk.Response{
-					Message: "provisioner daemon key invalid",
-				})
-				return
-			}
-
-			if pk.OrganizationID != org.ID {
 				handleOptional(http.StatusUnauthorized, codersdk.Response{
 					Message: "provisioner daemon key invalid",
 				})

--- a/coderd/httpmw/provisionerdaemon.go
+++ b/coderd/httpmw/provisionerdaemon.go
@@ -51,6 +51,7 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) fu
 				return
 			}
 
+			psk := r.Header.Get(codersdk.ProvisionerDaemonPSK)
 			key := r.Header.Get(codersdk.ProvisionerDaemonKey)
 			if key == "" {
 				if opts.PSK == "" {
@@ -61,6 +62,12 @@ func ExtractProvisionerDaemonAuthenticated(opts ExtractProvisionerAuthConfig) fu
 				}
 
 				fallbackToPSK(ctx, opts.PSK, next, w, r, handleOptional)
+				return
+			}
+			if psk != "" {
+				handleOptional(http.StatusBadRequest, codersdk.Response{
+					Message: "provisioner daemon key and psk provided, but only one is allowed",
+				})
 				return
 			}
 

--- a/coderd/provisionerkey/provisionerkey.go
+++ b/coderd/provisionerkey/provisionerkey.go
@@ -2,6 +2,7 @@ package provisionerkey
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"fmt"
 	"strings"
 
@@ -48,4 +49,8 @@ func Parse(token string) (uuid.UUID, string, error) {
 func HashSecret(secret string) []byte {
 	h := sha256.Sum256([]byte(secret))
 	return h[:]
+}
+
+func Compare(a []byte, b []byte) bool {
+	return subtle.ConstantTimeCompare(a, b) != 1
 }

--- a/coderd/provisionerkey/provisionerkey.go
+++ b/coderd/provisionerkey/provisionerkey.go
@@ -3,6 +3,7 @@ package provisionerkey
 import (
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -18,7 +19,7 @@ func New(organizationID uuid.UUID, name string) (database.InsertProvisionerKeyPa
 	if err != nil {
 		return database.InsertProvisionerKeyParams{}, "", xerrors.Errorf("generate token: %w", err)
 	}
-	hashedSecret := sha256.Sum256([]byte(secret))
+	hashedSecret := HashSecret(secret)
 	token := fmt.Sprintf("%s:%s", id, secret)
 
 	return database.InsertProvisionerKeyParams{
@@ -26,6 +27,25 @@ func New(organizationID uuid.UUID, name string) (database.InsertProvisionerKeyPa
 		CreatedAt:      dbtime.Now(),
 		OrganizationID: organizationID,
 		Name:           name,
-		HashedSecret:   hashedSecret[:],
+		HashedSecret:   hashedSecret,
 	}, token, nil
+}
+
+func Parse(token string) (uuid.UUID, string, error) {
+	parts := strings.Split(token, ":")
+	if len(parts) != 2 {
+		return uuid.UUID{}, "", xerrors.Errorf("invalid token format")
+	}
+
+	id, err := uuid.Parse(parts[0])
+	if err != nil {
+		return uuid.UUID{}, "", xerrors.Errorf("parse id: %w", err)
+	}
+
+	return id, parts[1], nil
+}
+
+func HashSecret(secret string) []byte {
+	h := sha256.Sum256([]byte(secret))
+	return h[:]
 }

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -79,6 +79,9 @@ const (
 	// ProvisionerDaemonPSK contains the authentication pre-shared key for an external provisioner daemon
 	ProvisionerDaemonPSK = "Coder-Provisioner-Daemon-PSK"
 
+	// ProvisionerDaemonKey contains the authentication key for an external provisioner daemon
+	ProvisionerDaemonKey = "Coder-Provisioner-Daemon-Key"
+
 	// BuildVersionHeader contains build information of Coder.
 	BuildVersionHeader = "X-Coder-Build-Version"
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -226,9 +226,6 @@ func (c *Client) ServeProvisionerDaemon(ctx context.Context, req ServeProvisione
 
 	headers.Set(BuildVersionHeader, buildinfo.Version())
 
-	if req.ProvisionerKey != "" && req.PreSharedKey != "" {
-		return nil, xerrors.Errorf("cannot provide both a provisioner key and a pre-shared key")
-	}
 	if req.ProvisionerKey != "" {
 		headers.Set(ProvisionerDaemonKey, req.ProvisionerKey)
 	}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -284,7 +284,6 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Use(
 				api.provisionerDaemonsEnabledMW,
 				apiKeyMiddlewareOptional,
-				httpmw.ExtractOrganizationParam(api.Database),
 				httpmw.ExtractProvisionerDaemonAuthenticated(httpmw.ExtractProvisionerAuthConfig{
 					DB:              api.Database,
 					Optional:        true,
@@ -294,6 +293,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				// Either a user auth or provisioner auth is required
 				// to move forward.
 				httpmw.RequireAPIKeyOrProvisionerDaemonAuth(),
+				httpmw.ExtractOrganizationParam(api.Database),
 			)
 			r.With(apiKeyMiddleware).Get("/", api.provisionerDaemons)
 			r.With(apiKeyMiddlewareOptional).Get("/serve", api.provisionerDaemonServe)

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -109,6 +109,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		provisionerDaemonAuth: &provisionerDaemonAuth{
 			psk:        options.ProvisionerDaemonPSK,
 			authorizer: options.Authorizer,
+			db:         options.Database,
 		},
 	}
 	// This must happen before coderd initialization!

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -284,9 +284,11 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				api.provisionerDaemonsEnabledMW,
 				apiKeyMiddlewareOptional,
 				httpmw.ExtractProvisionerDaemonAuthenticated(httpmw.ExtractProvisionerAuthConfig{
-					DB:       api.Database,
-					Optional: true,
-				}, api.ProvisionerDaemonPSK),
+					DB:              api.Database,
+					Optional:        true,
+					PSK:             api.ProvisionerDaemonPSK,
+					MultiOrgEnabled: api.AGPL.Experiments.Enabled(codersdk.ExperimentMultiOrganization),
+				}),
 				// Either a user auth or provisioner auth is required
 				// to move forward.
 				httpmw.RequireAPIKeyOrProvisionerDaemonAuth(),

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -284,6 +284,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Use(
 				api.provisionerDaemonsEnabledMW,
 				apiKeyMiddlewareOptional,
+				httpmw.ExtractOrganizationParam(api.Database),
 				httpmw.ExtractProvisionerDaemonAuthenticated(httpmw.ExtractProvisionerAuthConfig{
 					DB:              api.Database,
 					Optional:        true,
@@ -293,7 +294,6 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				// Either a user auth or provisioner auth is required
 				// to move forward.
 				httpmw.RequireAPIKeyOrProvisionerDaemonAuth(),
-				httpmw.ExtractOrganizationParam(api.Database),
 			)
 			r.With(apiKeyMiddleware).Get("/", api.provisionerDaemons)
 			r.With(apiKeyMiddlewareOptional).Get("/serve", api.provisionerDaemonServe)

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -108,13 +108,6 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 		return nil, false
 	}
 
-	pk, ok := httpmw.ProvisionerKeyAuthOptional(r)
-	if ok {
-		if orgID != pk.OrganizationID {
-			return nil, false
-		}
-	}
-
 	// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.
 	tags = provisionersdk.MutateTags(uuid.Nil, tags)
 	return tags, true

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -108,6 +108,13 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 		return nil, false
 	}
 
+	pk, ok := httpmw.ProvisionerKeyAuthOptional(r)
+	if ok {
+		if pk.OrganizationID != orgID {
+			return nil, false
+		}
+	}
+
 	// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.
 	tags = provisionersdk.MutateTags(uuid.Nil, tags)
 	return tags, true

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -108,10 +108,11 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 		return nil, false
 	}
 
-	// ensure provisioner daemon subject can read organization
-	_, err := p.db.GetOrganizationByID(ctx, orgID)
-	if err != nil {
-		return nil, false
+	pk, ok := httpmw.ProvisionerKeyAuthOptional(r)
+	if ok {
+		if orgID != pk.OrganizationID {
+			return nil, false
+		}
 	}
 
 	// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -111,7 +111,7 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 				return nil, xerrors.New("user unauthorized")
 			}
 
-			// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.
+			// If using PSK auth, the daemon is, by definition, scoped to the organization.
 			tags = provisionersdk.MutateTags(uuid.Nil, tags)
 			return tags, nil
 		}
@@ -120,8 +120,7 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 		return tags, nil
 	}
 
-	pk, ok := httpmw.ProvisionerKeyAuthOptional(r)
-	if ok {
+	if pkOK {
 		if pk.OrganizationID != orgID {
 			return nil, xerrors.New("provisioner key unauthorized")
 		}

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -111,6 +111,8 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 				return nil, xerrors.New("user unauthorized")
 			}
 
+			// Allow fallback to PSK auth if the user is not allowed to create provisioner daemons.
+			// This is to preserve backwards compatibility with existing user provisioner daemons.
 			// If using PSK auth, the daemon is, by definition, scoped to the organization.
 			tags = provisionersdk.MutateTags(uuid.Nil, tags)
 			return tags, nil

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -83,41 +83,53 @@ type provisionerDaemonAuth struct {
 	authorizer rbac.Authorizer
 }
 
-// authorize returns mutated tags and true if the given HTTP request is authorized to access the provisioner daemon
-// protobuf API, and returns nil, false otherwise.
-func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags map[string]string) (map[string]string, bool) {
+// authorize returns mutated tags if the given HTTP request is authorized to access the provisioner daemon
+// protobuf API, and returns nil, err otherwise.
+func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags map[string]string) (map[string]string, error) {
 	ctx := r.Context()
-	apiKey, ok := httpmw.APIKeyOptional(r)
-	if ok {
+	apiKey, apiKeyOK := httpmw.APIKeyOptional(r)
+	pk, pkOK := httpmw.ProvisionerKeyAuthOptional(r)
+	provAuth := httpmw.ProvisionerDaemonAuthenticated(r)
+	if !provAuth && !apiKeyOK {
+		return nil, xerrors.New("no API key or provisioner key provided")
+	}
+	if apiKeyOK && pkOK {
+		return nil, xerrors.New("Both API key and provisioner key authentication provided. Only one is allowed.")
+	}
+
+	if apiKeyOK {
 		tags = provisionersdk.MutateTags(apiKey.UserID, tags)
 		if tags[provisionersdk.TagScope] == provisionersdk.ScopeUser {
 			// Any authenticated user can create provisioner daemons scoped
 			// for jobs that they own,
-			return tags, true
+			return tags, nil
 		}
 		ua := httpmw.UserAuthorization(r)
-		if err := p.authorizer.Authorize(ctx, ua, policy.ActionCreate, rbac.ResourceProvisionerDaemon.InOrg(orgID)); err == nil {
-			// User is allowed to create provisioner daemons
-			return tags, true
-		}
-	}
+		err := p.authorizer.Authorize(ctx, ua, policy.ActionCreate, rbac.ResourceProvisionerDaemon.InOrg(orgID))
+		if err != nil {
+			if !provAuth {
+				return nil, xerrors.New("user unauthorized")
+			}
 
-	// Check for provisioner key or PSK auth.
-	provAuth := httpmw.ProvisionerDaemonAuthenticated(r)
-	if !provAuth {
-		return nil, false
+			// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.
+			tags = provisionersdk.MutateTags(uuid.Nil, tags)
+			return tags, nil
+		}
+
+		// User is allowed to create provisioner daemons
+		return tags, nil
 	}
 
 	pk, ok := httpmw.ProvisionerKeyAuthOptional(r)
 	if ok {
 		if pk.OrganizationID != orgID {
-			return nil, false
+			return nil, xerrors.New("provisioner key unauthorized")
 		}
 	}
 
 	// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.
 	tags = provisionersdk.MutateTags(uuid.Nil, tags)
-	return tags, true
+	return tags, nil
 }
 
 // Serves the provisioner daemon protobuf API over a WebSocket.
@@ -180,12 +192,13 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		api.Logger.Warn(ctx, "unnamed provisioner daemon")
 	}
 
-	tags, authorized := api.provisionerDaemonAuth.authorize(r, organization.ID, tags)
-	if !authorized {
-		api.Logger.Warn(ctx, "unauthorized provisioner daemon serve request", slog.F("tags", tags))
+	tags, err := api.provisionerDaemonAuth.authorize(r, organization.ID, tags)
+	if err != nil {
+		api.Logger.Warn(ctx, "unauthorized provisioner daemon serve request", slog.F("tags", tags), slog.Error(err))
 		httpapi.Write(ctx, rw, http.StatusForbidden,
 			codersdk.Response{
 				Message: fmt.Sprintf("You aren't allowed to create provisioner daemons with scope %q", tags[provisionersdk.TagScope]),
+				Detail:  err.Error(),
 			},
 		)
 		return

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/provisionerkey"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
@@ -551,6 +553,152 @@ func TestProvisionerDaemonServe(t *testing.T) {
 		daemons, err := client.ProvisionerDaemons(ctx) //nolint:gocritic // Test assertion.
 		require.NoError(t, err)
 		require.Len(t, daemons, 0)
+	})
+
+	t.Run("ProvisionerKeyAuth", func(t *testing.T) {
+		t.Parallel()
+
+		insertParams, token, err := provisionerkey.New(uuid.Nil, "dont-TEST-me")
+		require.NoError(t, err)
+
+		tcs := []struct {
+			name                      string
+			psk                       string
+			multiOrgFeatureEnabled    bool
+			multiOrgExperimentEnabled bool
+			insertParams              database.InsertProvisionerKeyParams
+			requestProvisionerKey     string
+			requestPSK                string
+			errStatusCode             int
+		}{
+			{
+				name:       "MultiOrgDisabledPSKAuthOK",
+				psk:        "provisionersftw",
+				requestPSK: "provisionersftw",
+			},
+			{
+				name:                   "MultiOrgExperimentDisabledPSKAuthOK",
+				multiOrgFeatureEnabled: true,
+				psk:                    "provisionersftw",
+				requestPSK:             "provisionersftw",
+			},
+			{
+				name:                      "MultiOrgFeatureDisabledPSKAuthOK",
+				multiOrgExperimentEnabled: true,
+				psk:                       "provisionersftw",
+				requestPSK:                "provisionersftw",
+			},
+			{
+				name:                      "MultiOrgEnabledPSKAuthOK",
+				psk:                       "provisionersftw",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				requestPSK:                "provisionersftw",
+			},
+			{
+				name:                      "MultiOrgEnabledKeyAuthOK",
+				psk:                       "provisionersftw",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				insertParams:              insertParams,
+				requestProvisionerKey:     token,
+			},
+			{
+				name:                      "MultiOrgEnabledPSKAuthDisabled",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				requestPSK:                "provisionersftw",
+				errStatusCode:             http.StatusUnauthorized,
+			},
+			{
+				name:                      "WrongKey",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				requestProvisionerKey:     "provisionersftw",
+				errStatusCode:             http.StatusUnauthorized,
+			},
+			{
+				name:                      "IdOKKeyWrong",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				requestProvisionerKey:     insertParams.ID.String() + ":" + "wrong",
+				errStatusCode:             http.StatusUnauthorized,
+			},
+			{
+				name:                      "IdWrongKeyOK",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				requestProvisionerKey:     uuid.NewString() + ":" + token,
+				errStatusCode:             http.StatusUnauthorized,
+			},
+			{
+				name:                      "TokenOnly",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				requestProvisionerKey:     token,
+				errStatusCode:             http.StatusUnauthorized,
+			},
+		}
+
+		for _, tc := range tcs {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				features := license.Features{
+					codersdk.FeatureExternalProvisionerDaemons: 1,
+				}
+				if tc.multiOrgFeatureEnabled {
+					features[codersdk.FeatureMultipleOrganizations] = 1
+				}
+				dv := coderdtest.DeploymentValues(t)
+				if tc.multiOrgExperimentEnabled {
+					dv.Experiments.Append(string(codersdk.ExperimentMultiOrganization))
+				}
+				client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+					LicenseOptions: &coderdenttest.LicenseOptions{
+						Features: features,
+					},
+					ProvisionerDaemonPSK: tc.psk,
+					Options: &coderdtest.Options{
+						DeploymentValues: dv,
+					},
+				})
+				ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+				defer cancel()
+
+				if tc.insertParams.Name != "" {
+					tc.insertParams.OrganizationID = user.OrganizationID
+					// nolint:gocritic // test
+					_, err := db.InsertProvisionerKey(dbauthz.AsSystemRestricted(ctx), tc.insertParams)
+					require.NoError(t, err)
+				}
+
+				another := codersdk.New(client.URL)
+				srv, err := another.ServeProvisionerDaemon(ctx, codersdk.ServeProvisionerDaemonRequest{
+					ID:           uuid.New(),
+					Name:         testutil.MustRandString(t, 63),
+					Organization: user.OrganizationID,
+					Provisioners: []codersdk.ProvisionerType{
+						codersdk.ProvisionerTypeEcho,
+					},
+					Tags: map[string]string{
+						provisionersdk.TagScope: provisionersdk.ScopeOrganization,
+					},
+					PreSharedKey:   tc.requestPSK,
+					ProvisionerKey: tc.requestProvisionerKey,
+				})
+				if tc.errStatusCode != 0 {
+					require.Error(t, err)
+					var apiError *codersdk.Error
+					require.ErrorAs(t, err, &apiError)
+					require.Equal(t, http.StatusUnauthorized, apiError.StatusCode())
+					return
+				}
+
+				require.NoError(t, err)
+				err = srv.DRPCConn().Close()
+				require.NoError(t, err)
+			})
+		}
 	})
 }
 

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -614,28 +615,50 @@ func TestProvisionerDaemonServe(t *testing.T) {
 				name:                      "WrongKey",
 				multiOrgFeatureEnabled:    true,
 				multiOrgExperimentEnabled: true,
+				insertParams:              insertParams,
 				requestProvisionerKey:     "provisionersftw",
 				errStatusCode:             http.StatusUnauthorized,
 			},
 			{
-				name:                      "IdOKKeyWrong",
+				name:                      "IdOKKeyValueWrong",
 				multiOrgFeatureEnabled:    true,
 				multiOrgExperimentEnabled: true,
+				insertParams:              insertParams,
 				requestProvisionerKey:     insertParams.ID.String() + ":" + "wrong",
 				errStatusCode:             http.StatusUnauthorized,
 			},
 			{
-				name:                      "IdWrongKeyOK",
+				name:                      "IdWrongKeyValueOK",
 				multiOrgFeatureEnabled:    true,
 				multiOrgExperimentEnabled: true,
+				insertParams:              insertParams,
 				requestProvisionerKey:     uuid.NewString() + ":" + token,
 				errStatusCode:             http.StatusUnauthorized,
 			},
 			{
-				name:                      "TokenOnly",
+				name:                      "KeyValueOnly",
 				multiOrgFeatureEnabled:    true,
 				multiOrgExperimentEnabled: true,
+				insertParams:              insertParams,
+				requestProvisionerKey:     strings.Split(token, ":")[1],
+				errStatusCode:             http.StatusUnauthorized,
+			},
+			{
+				name:                      "KeyAndPSK",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				psk:                       "provisionersftw",
+				insertParams:              insertParams,
 				requestProvisionerKey:     token,
+				requestPSK:                "provisionersftw",
+				errStatusCode:             http.StatusUnauthorized,
+			},
+			{
+				name:                      "None",
+				multiOrgFeatureEnabled:    true,
+				multiOrgExperimentEnabled: true,
+				psk:                       "provisionersftw",
+				insertParams:              insertParams,
 				errStatusCode:             http.StatusUnauthorized,
 			},
 		}


### PR DESCRIPTION
What this changes:
- Provisioner auth middleware now accepts a provisioner key via a header
  - API provides error if both the psk and provisioner key are specified
- ~~Provisioner rbac subject will now have org scoped permissions when authenticating with a provisioner key~~
  - ~~Site org permissions are removed in this process~~
- System restricted role now has provisioner key permissions