### PR TITLE
feat(codersdk): export template variable parser

### DIFF
--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -97,7 +97,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 
 			var varsFiles []string
 			if !uploadFlags.stdin() {
-				varsFiles, err = DiscoverVarsFiles(uploadFlags.directory)
+				varsFiles, err = codersdk.DiscoverVarsFiles(uploadFlags.directory)
 				if err != nil {
 					return err
 				}
@@ -118,7 +118,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 				return err
 			}
 
-			userVariableValues, err := ParseUserVariableValues(
+			userVariableValues, err := codersdk.ParseUserVariableValues(
 				varsFiles,
 				variablesFile,
 				commandLineVariables)

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -81,7 +81,7 @@ func (r *RootCmd) templatePush() *serpent.Command {
 
 			var varsFiles []string
 			if !uploadFlags.stdin() {
-				varsFiles, err = DiscoverVarsFiles(uploadFlags.directory)
+				varsFiles, err = codersdk.DiscoverVarsFiles(uploadFlags.directory)
 				if err != nil {
 					return err
 				}
@@ -111,7 +111,7 @@ func (r *RootCmd) templatePush() *serpent.Command {
 				inv.Logger.Info(inv.Context(), "reusing existing provisioner tags", "tags", tags)
 			}
 
-			userVariableValues, err := ParseUserVariableValues(
+			userVariableValues, err := codersdk.ParseUserVariableValues(
 				varsFiles,
 				variablesFile,
 				commandLineVariables)

--- a/codersdk/templatevariables_test.go
+++ b/codersdk/templatevariables_test.go
@@ -1,4 +1,4 @@
-package cli_test
+package codersdk_test
 
 import (
 	"os"
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -47,7 +46,7 @@ func TestDiscoverVarsFiles(t *testing.T) {
 	}
 
 	// When
-	found, err := cli.DiscoverVarsFiles(tempDir)
+	found, err := codersdk.DiscoverVarsFiles(tempDir)
 	require.NoError(t, err)
 
 	// Then
@@ -97,7 +96,7 @@ go_image = ["1.19","1.20","1.21"]`
 	require.NoError(t, err)
 
 	// When
-	actual, err := cli.ParseUserVariableValues([]string{
+	actual, err := codersdk.ParseUserVariableValues([]string{
 		filepath.Join(tempDir, hclFilename1),
 		filepath.Join(tempDir, hclFilename2),
 		filepath.Join(tempDir, jsonFilename3),
@@ -136,7 +135,7 @@ func TestParseVariableValuesFromVarsFiles_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	// When
-	actual, err := cli.ParseUserVariableValues([]string{
+	actual, err := codersdk.ParseUserVariableValues([]string{
 		filepath.Join(tempDir, jsonFilename),
 	}, "", nil)
 
@@ -167,7 +166,7 @@ cores: 2`
 	require.NoError(t, err)
 
 	// When
-	actual, err := cli.ParseUserVariableValues([]string{
+	actual, err := codersdk.ParseUserVariableValues([]string{
 		filepath.Join(tempDir, hclFilename),
 	}, "", nil)
 


### PR DESCRIPTION
`*.tfvars` files in template version tarballs are currently ignored by `coderd`.
#11549 fixed this by having the CLI parse those files from the template directory before uploading. 
This PR enables the creation of templates with these `*.tfvars` files using just `codersdk`.