### PR TITLE
fix: use correct group url in multi-org experiment

### DIFF
--- a/site/src/pages/GroupsPage/CreateGroupPage.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPage.tsx
@@ -5,11 +5,13 @@ import { useNavigate } from "react-router-dom";
 import { createGroup } from "api/queries/groups";
 import { pageTitle } from "utils/page";
 import CreateGroupPageView from "./CreateGroupPageView";
+import { useDashboard } from "modules/dashboard/useDashboard";
 
 export const CreateGroupPage: FC = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const createGroupMutation = useMutation(createGroup(queryClient, "default"));
+  const { experiments } = useDashboard();
 
   return (
     <>
@@ -19,7 +21,13 @@ export const CreateGroupPage: FC = () => {
       <CreateGroupPageView
         onSubmit={async (data) => {
           const newGroup = await createGroupMutation.mutateAsync(data);
-          navigate(`/groups/${newGroup.name}`);
+
+          let groupURL = `/groups/${newGroup.name}`;
+          if (experiments.includes("multi-organization")) {
+            groupURL = `/organizations/${newGroup.organization_id}/groups/${newGroup.name}`;
+          }
+
+          navigate(groupURL);
         }}
         error={createGroupMutation.error}
         isLoading={createGroupMutation.isLoading}

--- a/site/src/pages/GroupsPage/CreateGroupPage.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPage.tsx
@@ -3,7 +3,6 @@ import { Helmet } from "react-helmet-async";
 import { useMutation, useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
 import { createGroup } from "api/queries/groups";
-import { useDashboard } from "modules/dashboard/useDashboard";
 import { pageTitle } from "utils/page";
 import CreateGroupPageView from "./CreateGroupPageView";
 
@@ -11,7 +10,6 @@ export const CreateGroupPage: FC = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const createGroupMutation = useMutation(createGroup(queryClient, "default"));
-  const { experiments } = useDashboard();
 
   return (
     <>
@@ -21,13 +19,7 @@ export const CreateGroupPage: FC = () => {
       <CreateGroupPageView
         onSubmit={async (data) => {
           const newGroup = await createGroupMutation.mutateAsync(data);
-
-          let groupURL = `/groups/${newGroup.name}`;
-          if (experiments.includes("multi-organization")) {
-            groupURL = `/organizations/${newGroup.organization_id}/groups/${newGroup.name}`;
-          }
-
-          navigate(groupURL);
+          navigate(`/groups/${newGroup.name}`);
         }}
         error={createGroupMutation.error}
         isLoading={createGroupMutation.isLoading}

--- a/site/src/pages/GroupsPage/CreateGroupPage.tsx
+++ b/site/src/pages/GroupsPage/CreateGroupPage.tsx
@@ -3,9 +3,9 @@ import { Helmet } from "react-helmet-async";
 import { useMutation, useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
 import { createGroup } from "api/queries/groups";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import { pageTitle } from "utils/page";
 import CreateGroupPageView from "./CreateGroupPageView";
-import { useDashboard } from "modules/dashboard/useDashboard";
 
 export const CreateGroupPage: FC = () => {
   const queryClient = useQueryClient();

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -59,10 +59,6 @@ export const GroupPage: FC = () => {
   };
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  // TODO: Always use the correct organization. At present, the url to fetch a group
-  // is /groups/:groupName, which does not include the organization. So the orgID cannot
-  // be inferred from the URL. The organization is only included in the url when the multi-org
-  // experiment is enabled.
   const groupQuery = useQuery(group("default", groupName));
   const groupData = groupQuery.data;
   const { data: permissions } = useQuery(

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -54,8 +54,7 @@ import { isEveryoneGroup } from "utils/groups";
 import { pageTitle } from "utils/page";
 
 export const GroupPage: FC = () => {
-  const { groupName, organization } = useParams() as {
-    organization: string;
+  const { groupName } = useParams() as {
     groupName: string;
   };
   const queryClient = useQueryClient();
@@ -64,7 +63,7 @@ export const GroupPage: FC = () => {
   // is /groups/:groupName, which does not include the organization. So the orgID cannot
   // be inferred from the URL. The organization is only included in the url when the multi-org
   // experiment is enabled.
-  const groupQuery = useQuery(group(organization ?? "default", groupName));
+  const groupQuery = useQuery(group("default", groupName));
   const groupData = groupQuery.data;
   const { data: permissions } = useQuery(
     groupData !== undefined

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -62,7 +62,8 @@ export const GroupPage: FC = () => {
   const navigate = useNavigate();
   // TODO: Always use the correct organization. At present, the url to fetch a group
   // is /groups/:groupName, which does not include the organization. So the orgID cannot
-  // be inferred from the URL. Until this is resolved, assume the group is in the default org.
+  // be inferred from the URL. The organization is only included in the url when the multi-org
+  // experiment is enabled.
   const groupQuery = useQuery(group(organization ?? "default", groupName));
   const groupData = groupQuery.data;
   const { data: permissions } = useQuery(

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -60,7 +60,10 @@ export const GroupPage: FC = () => {
   };
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const groupQuery = useQuery(group(organization, groupName));
+  // TODO: Always use the correct organization. At present, the url to fetch a group
+  // is /groups/:groupName, which does not include the organization. So the orgID cannot
+  // be inferred from the URL. Until this is resolved, assume the group is in the default org.
+  const groupQuery = useQuery(group(organization ?? "default", groupName));
   const groupData = groupQuery.data;
   const { data: permissions } = useQuery(
     groupData !== undefined


### PR DESCRIPTION
When not using the experiment, default to the "default" org. Assuming groups are all in the primary org