### PR TITLE
chore(scripts): fix cherry-pick check in `check_commit_metadata.sh`

### DIFF
--- a/scripts/release/check_commit_metadata.sh
+++ b/scripts/release/check_commit_metadata.sh
@@ -126,6 +126,7 @@ main() {
 					log "Found renamed cherry-pick commit ${commit1} -> ${renamed}"
 					renamed_cherry_pick_commits[${commit1}]=${renamed}
 					renamed_cherry_pick_commits[${renamed}]=${commit1}
+					i=$((i - 1))
 					continue
 				fi
 
@@ -145,6 +146,11 @@ main() {
 			error "Invariant failed, cherry-picked commit ${commit} has no corresponding original commit"
 		fi
 		log "Found matching cherry-pick commit ${commit} -> ${renamed_cherry_pick_commits[${commit}]}"
+	done
+
+	# Merge the two maps.
+	for commit in "${!renamed_cherry_pick_commits[@]}"; do
+		cherry_pick_commits[${commit}]=${renamed_cherry_pick_commits[${commit}]}
 	done
 
 	# Get abbreviated and full commit hashes and titles for each commit.


### PR DESCRIPTION
Resolves release script issue with check-commit-metadata

(cherry picked from commit 5a4dbcfc02d7acc78be1e8e4312eec7b07808ba8)