### PR TITLE
chore(docs): update version flag for patches 2.12.5 and 2.13.2

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -134,7 +134,7 @@ locally in order to log in and manage templates.
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml \
-       --version 2.13.1
+       --version 2.13.2
    ```
 
    For the **stable** Coder release:
@@ -145,7 +145,7 @@ locally in order to log in and manage templates.
    helm install coder coder-v2/coder \
        --namespace coder \
        --values values.yaml \
-       --version 2.12.4
+       --version 2.12.5
    ```
 
    You can watch Coder start up by running `kubectl get pods -n coder`. Once


### PR DESCRIPTION
Manually updated version flags in helm install docs for latest releases.