### PR TITLE
fix: test: use monotonical port numbers

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -838,7 +838,7 @@ func TestAgent_TCPRemoteForwarding(t *testing.T) {
 	var ll net.Listener
 	var err error
 	for {
-		port = testutil.EphemeralPortNoListen(t)
+		port = testutil.EphemeralPortNoListen()
 		addr := net.TCPAddrFromAddrPort(netip.AddrPortFrom(localhost, port))
 		ll, err = sshClient.ListenTCP(addr)
 		if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -834,12 +834,12 @@ func TestAgent_TCPRemoteForwarding(t *testing.T) {
 	sshClient := setupAgentSSHClient(ctx, t)
 
 	localhost := netip.MustParseAddr("127.0.0.1")
-	var randomPort uint16
+	var port uint16
 	var ll net.Listener
 	var err error
 	for {
-		randomPort = testutil.RandomPortNoListen(t)
-		addr := net.TCPAddrFromAddrPort(netip.AddrPortFrom(localhost, randomPort))
+		port = testutil.EphemeralPortNoListen(t)
+		addr := net.TCPAddrFromAddrPort(netip.AddrPortFrom(localhost, port))
 		ll, err = sshClient.ListenTCP(addr)
 		if err != nil {
 			t.Logf("error remote forwarding: %s", err.Error())
@@ -855,7 +855,7 @@ func TestAgent_TCPRemoteForwarding(t *testing.T) {
 	defer ll.Close()
 	go echoOnce(t, ll)
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", randomPort))
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	require.NoError(t, err)
 	defer conn.Close()
 	requireEcho(t, conn)

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -303,7 +303,7 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 
 //nolint:paralleltest,tparallel // Prometheus endpoint tends to fail with `bind: address already in use`.
 func TestProvisionerDaemon_PrometheusEnabled(t *testing.T) {
-	prometheusPort := testutil.EphemeralPortNoListen(t)
+	prometheusPort := testutil.EphemeralPortNoListen()
 
 	// Configure CLI client
 	client, admin := coderdenttest.New(t, &coderdenttest.Options{

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -303,9 +303,7 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 
 //nolint:paralleltest,tparallel // Prometheus endpoint tends to fail with `bind: address already in use`.
 func TestProvisionerDaemon_PrometheusEnabled(t *testing.T) {
-	t.Skip("Flaky test - see https://github.com/coder/coder/issues/13931")
-
-	prometheusPort := testutil.RandomPortNoListen(t)
+	prometheusPort := testutil.EphemeralPortNoListen(t)
 
 	// Configure CLI client
 	client, admin := coderdenttest.New(t, &coderdenttest.Options{

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -10,13 +10,13 @@ import (
 
 const (
 	// Overlap of windows, linux in https://en.wikipedia.org/wiki/Ephemeral_port
-	minPort = 50152
+	minPort = 49152
 	maxPort = 60999
 )
 
 var (
 	rndMu   sync.Mutex
-	rndPort = minPort
+	rndPort = maxPort
 )
 
 // RandomPort is a helper function to find a free random port.
@@ -38,9 +38,9 @@ func EphemeralPortNoListen(*testing.T) uint16 {
 	rndMu.Lock()
 	p := rndPort
 
-	rndPort++
-	if rndPort > maxPort {
-		rndPort = minPort
+	rndPort--
+	if rndPort < minPort {
+		rndPort = maxPort
 	}
 	rndMu.Unlock()
 	return uint16(p)

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -34,7 +34,7 @@ func RandomPort(t *testing.T) int {
 // EphemeralPortNoListen returns the next port in the ephemeral port range.
 // Does not attempt to listen and close to find a port as the OS may
 // reallocate the port very quickly.
-func EphemeralPortNoListen(*testing.T) uint16 {
+func EphemeralPortNoListen() uint16 {
 	rndMu.Lock()
 	p := rndPort
 

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Overlap of windows, linux in https://en.wikipedia.org/wiki/Ephemeral_port
-	minPort = 49152
+	minPort = 50152
 	maxPort = 60999
 )
 


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/13931

This PR modifies the logic to assign a potentially empty part starting from the high boundary of the ephemeral range.

Note:

I don't guarantee it helps, but at least I couldn't reproduce it in CI.