### PR TITLE
fix: use static port number for prometheus test

### DIFF
--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -301,9 +301,11 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest,tparallel // Prometheus endpoint tends to fail with `bind: address already in use`.
+//nolint:paralleltest,tparallel // Test uses a static port.
 func TestProvisionerDaemon_PrometheusEnabled(t *testing.T) {
-	prometheusPort := 32001 // workaround: use static port out the ephemeral port range to present `bind: address already in use`
+	// Ephemeral ports have a tendency to conflict and fail with `bind: address already in use` error.
+	// This workaround forces a static port for Prometheus that hopefully won't be used by other tests.
+	prometheusPort := 32001
 
 	// Configure CLI client
 	client, admin := coderdenttest.New(t, &coderdenttest.Options{

--- a/enterprise/cli/provisionerdaemons_test.go
+++ b/enterprise/cli/provisionerdaemons_test.go
@@ -303,9 +303,7 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 
 //nolint:paralleltest,tparallel // Prometheus endpoint tends to fail with `bind: address already in use`.
 func TestProvisionerDaemon_PrometheusEnabled(t *testing.T) {
-	t.Skip("Flaky test - see https://github.com/coder/coder/issues/13931")
-
-	prometheusPort := testutil.RandomPortNoListen(t)
+	prometheusPort := 32001 // workaround: use static port out the ephemeral port range to present `bind: address already in use`
 
 	// Configure CLI client
 	client, admin := coderdenttest.New(t, &coderdenttest.Options{


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/13931
Related: https://github.com/coder/coder/pull/13999

This PR modifies the logic to assign a static port to the Prometheus endpoint. We can't use this port for other purposes.