### PR TITLE
feat: add --key flag to provisionerd start

### DIFF
--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -154,8 +154,13 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			// When authorizing with a PSK / provisioner key, we automatically scope the provisionerd
 			// to organization. Scoping to user with PSK / provisioner key auth is not a valid configuration.
 			if preSharedKey != "" || provisionerKey != "" {
-				logger.Info(ctx, "psk or provisioner key auth automatically sets tag "+provisionersdk.TagScope+"="+provisionersdk.ScopeOrganization)
+				logger.Info(ctx, "psk automatically sets tag "+provisionersdk.TagScope+"="+provisionersdk.ScopeOrganization)
 				tags[provisionersdk.TagScope] = provisionersdk.ScopeOrganization
+			}
+			if provisionerKey != "" {
+				logger.Info(ctx, "provisioner key auth automatically sets tag "+provisionersdk.TagScope+" empty")
+				// no scope tag will default to org scope
+				delete(tags, provisionersdk.TagScope)
 			}
 
 			err = os.MkdirAll(cacheDir, 0o700)

--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -153,7 +153,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 
 			// When authorizing with a PSK / provisioner key, we automatically scope the provisionerd
 			// to organization. Scoping to user with PSK / provisioner key auth is not a valid configuration.
-			if preSharedKey != "" || provisionerKey != "" {
+			if preSharedKey != "" {
 				logger.Info(ctx, "psk automatically sets tag "+provisionersdk.TagScope+"="+provisionersdk.ScopeOrganization)
 				tags[provisionersdk.TagScope] = provisionersdk.ScopeOrganization
 			}

--- a/enterprise/cli/provisionerdaemonstart_test.go
+++ b/enterprise/cli/provisionerdaemonstart_test.go
@@ -301,6 +301,15 @@ func TestProvisionerDaemon_SessionToken(t *testing.T) {
 	})
 }
 
+func TestProvisionerDaemon_ProvisionerKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+	})
+}
+
 //nolint:paralleltest,tparallel // Test uses a static port.
 func TestProvisionerDaemon_PrometheusEnabled(t *testing.T) {
 	// Ephemeral ports have a tendency to conflict and fail with `bind: address already in use` error.

--- a/enterprise/cli/provisionerdaemonstart_test.go
+++ b/enterprise/cli/provisionerdaemonstart_test.go
@@ -153,7 +153,7 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		err = inv.WithContext(ctx).Run()
-		require.ErrorContains(t, err, "must provide a pre-shared key when not authenticated as a user")
+		require.ErrorContains(t, err, "must provide a pre-shared key or provisioner key when not authenticated as a user")
 	})
 }
 

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -703,9 +703,6 @@ func TestProvisionerDaemonServe(t *testing.T) {
 					Provisioners: []codersdk.ProvisionerType{
 						codersdk.ProvisionerTypeEcho,
 					},
-					Tags: map[string]string{
-						provisionersdk.TagScope: provisionersdk.ScopeOrganization,
-					},
 					PreSharedKey:   tc.requestPSK,
 					ProvisionerKey: tc.requestProvisionerKey,
 				})


### PR DESCRIPTION
What this changes:
- Adds `--key` flag to `coder provisionerd start` for providing a provisioner key to authenticate with.
  - Not allowed to specify `--tag` or `--psk` when using `--key` flag. 
