### PR TITLE
chore: indicate premium vs enterprise on license page

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -329,6 +329,7 @@ type Claims = {
   account_id?: string;
   trial: boolean;
   all_features: boolean;
+  feature_set: string;
   version: number;
   features: Record<string, number>;
   require_telemetry?: boolean;

--- a/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicenseCard.tsx
+++ b/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicenseCard.tsx
@@ -31,6 +31,12 @@ export const LicenseCard: FC<LicenseCardProps> = ({
   const currentUserLimit =
     license.claims.features["user_limit"] || userLimitLimit;
 
+  const licenseType = license.claims.trial
+    ? "Trial"
+    : license.claims.feature_set.toLowerCase() === "premium"
+      ? "Premium"
+      : "Enterprise";
+
   return (
     <Paper
       key={license.id}
@@ -64,7 +70,7 @@ export const LicenseCard: FC<LicenseCardProps> = ({
       >
         <span css={styles.licenseId}>#{license.id}</span>
         <span css={styles.accountType} className="account-type">
-          {license.claims.trial ? "Trial" : "Enterprise"}
+          {licenseType}
         </span>
         <Stack
           direction="row"

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2568,6 +2568,34 @@ export const MockWorkspaceAgentLogs: TypesGen.WorkspaceAgentLog[] = [
 
 export const MockLicenseResponse: GetLicensesResponse[] = [
   {
+    id: 2,
+    uploaded_at: "1660104000",
+    expires_at: "3420244800", // expires on 5/20/2078
+    uuid: "1",
+    claims: {
+      trial: false,
+      all_features: true,
+      feature_set: "PREMIUM",
+      version: 1,
+      features: {},
+      license_expires: 3420244800,
+    },
+  },
+  {
+    id: 3,
+    uploaded_at: "1660104000",
+    expires_at: "3420244800", // expires on 5/20/2078
+    uuid: "1",
+    claims: {
+      trial: false,
+      all_features: true,
+      feature_set: "enterprise",
+      version: 1,
+      features: {},
+      license_expires: 3420244800,
+    },
+  },
+  {
     id: 1,
     uploaded_at: "1660104000",
     expires_at: "3420244800", // expires on 5/20/2078
@@ -2575,6 +2603,7 @@ export const MockLicenseResponse: GetLicensesResponse[] = [
     claims: {
       trial: false,
       all_features: true,
+      feature_set: "", // Legacy is empty
       version: 1,
       features: {},
       license_expires: 3420244800,
@@ -2588,6 +2617,7 @@ export const MockLicenseResponse: GetLicensesResponse[] = [
     claims: {
       trial: false,
       all_features: true,
+      feature_set: "", // Legacy is empty
       version: 1,
       features: {},
       license_expires: 1660104000,
@@ -2601,6 +2631,7 @@ export const MockLicenseResponse: GetLicensesResponse[] = [
     claims: {
       trial: false,
       all_features: true,
+      feature_set: "", // Legacy is empty
       version: 1,
       features: {},
       license_expires: 1682346425,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2575,7 +2575,7 @@ export const MockLicenseResponse: GetLicensesResponse[] = [
     claims: {
       trial: false,
       all_features: true,
-      feature_set: "PREMIUM",
+      feature_set: "enterprise",
       version: 1,
       features: {},
       license_expires: 3420244800,
@@ -2589,7 +2589,7 @@ export const MockLicenseResponse: GetLicensesResponse[] = [
     claims: {
       trial: false,
       all_features: true,
-      feature_set: "enterprise",
+      feature_set: "PREMIUM",
       version: 1,
       features: {},
       license_expires: 3420244800,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2568,7 +2568,7 @@ export const MockWorkspaceAgentLogs: TypesGen.WorkspaceAgentLog[] = [
 
 export const MockLicenseResponse: GetLicensesResponse[] = [
   {
-    id: 2,
+    id: 1,
     uploaded_at: "1660104000",
     expires_at: "3420244800", // expires on 5/20/2078
     uuid: "1",
@@ -2582,7 +2582,7 @@ export const MockLicenseResponse: GetLicensesResponse[] = [
     },
   },
   {
-    id: 3,
+    id: 1,
     uploaded_at: "1660104000",
     expires_at: "3420244800", // expires on 5/20/2078
     uuid: "1",


### PR DESCRIPTION
Premium licenses should say "premium" instead of "enterprise"

![Screenshot from 2024-07-24 19-00-49](https://github.com/user-attachments/assets/359b8664-805d-4059-b812-5c3e6b308017)
