### PR TITLE
fix: resolve text overflow issues for workspace empty state

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
@@ -92,8 +92,8 @@ export const WorkspacesEmpty = (props: {
           >
             {featuredTemplates?.map((t) => (
               <Link
-                to={`/templates/${t.name}/workspace`}
                 key={t.id}
+                to={`/templates/${t.name}/workspace`}
                 css={(theme) => ({
                   width: "320px",
                   padding: 16,
@@ -120,19 +120,38 @@ export const WorkspacesEmpty = (props: {
                     {t.name}
                   </Avatar>
                 </div>
-                <div>
-                  <h4 css={{ fontSize: 14, fontWeight: 600, margin: 0 }}>
-                    {t.display_name.length > 0 ? t.display_name : t.name}
+
+                <div css={{ width: "100%", minWidth: "0" }}>
+                  <h4
+                    css={{
+                      fontSize: 14,
+                      fontWeight: 600,
+                      margin: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {t.display_name || t.name}
                   </h4>
-                  <span
+
+                  <p
                     css={(theme) => ({
                       fontSize: 13,
                       color: theme.palette.text.secondary,
-                      lineHeight: "0.5",
+                      lineHeight: "1.4",
+                      margin: 0,
+                      paddingTop: "4px",
+
+                      // We've had users plug URLs directly into the
+                      // descriptions, when those URLS have no hyphens or other
+                      // easy semantic breakpoints. Need to set this to ensure
+                      // those URLs don't break outside their containing boxes
+                      wordBreak: "break-word",
                     })}
                   >
                     {t.description}
-                  </span>
+                  </p>
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
Addresses the main customer issue for #14007

## Changes made
- Updated CSS for the template CTA links that appear when there are no workspaces in the `/workspaces` view.
   - Whenever one of the values in either the title or description is too long and has no breakpoints that would be easy to detect by the browser, we just force the breakpoints in, so that the content doesn't overflow outside their containers.

## Screenshots
Before:
<img width="1387" alt="Screenshot 2024-07-25 at 2 16 16 PM" src="https://github.com/user-attachments/assets/d47d8ad0-5799-4d50-9ccd-952b503f8274">

After:
<img width="1387" alt="Screenshot 2024-07-25 at 2 14 53 PM" src="https://github.com/user-attachments/assets/260ed4f8-f73b-4a7a-abcf-b86749259a8f">
