### PR TITLE
chore(testutil): add testutil.GetRandomName that does not return duplicates

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/cryptorand"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // All methods take in a 'seed' object. Any provided fields in the seed will be
@@ -82,15 +82,15 @@ func Template(t testing.TB, db database.Store, seed database.Template) database.
 		CreatedAt:                    takeFirst(seed.CreatedAt, dbtime.Now()),
 		UpdatedAt:                    takeFirst(seed.UpdatedAt, dbtime.Now()),
 		OrganizationID:               takeFirst(seed.OrganizationID, uuid.New()),
-		Name:                         takeFirst(seed.Name, namesgenerator.GetRandomName(1)),
+		Name:                         takeFirst(seed.Name, testutil.GetRandomName(t)),
 		Provisioner:                  takeFirst(seed.Provisioner, database.ProvisionerTypeEcho),
 		ActiveVersionID:              takeFirst(seed.ActiveVersionID, uuid.New()),
-		Description:                  takeFirst(seed.Description, namesgenerator.GetRandomName(1)),
+		Description:                  takeFirst(seed.Description, testutil.GetRandomName(t)),
 		CreatedBy:                    takeFirst(seed.CreatedBy, uuid.New()),
-		Icon:                         takeFirst(seed.Icon, namesgenerator.GetRandomName(1)),
+		Icon:                         takeFirst(seed.Icon, testutil.GetRandomName(t)),
 		UserACL:                      seed.UserACL,
 		GroupACL:                     seed.GroupACL,
-		DisplayName:                  takeFirst(seed.DisplayName, namesgenerator.GetRandomName(1)),
+		DisplayName:                  takeFirst(seed.DisplayName, testutil.GetRandomName(t)),
 		AllowUserCancelWorkspaceJobs: seed.AllowUserCancelWorkspaceJobs,
 		MaxPortSharingLevel:          takeFirst(seed.MaxPortSharingLevel, database.AppSharingLevelOwner),
 	})
@@ -139,7 +139,7 @@ func APIKey(t testing.TB, db database.Store, seed database.APIKey) (key database
 func WorkspaceAgentPortShare(t testing.TB, db database.Store, orig database.WorkspaceAgentPortShare) database.WorkspaceAgentPortShare {
 	ps, err := db.UpsertWorkspaceAgentPortShare(genCtx, database.UpsertWorkspaceAgentPortShareParams{
 		WorkspaceID: takeFirst(orig.WorkspaceID, uuid.New()),
-		AgentName:   takeFirst(orig.AgentName, namesgenerator.GetRandomName(1)),
+		AgentName:   takeFirst(orig.AgentName, testutil.GetRandomName(t)),
 		Port:        takeFirst(orig.Port, 8080),
 		ShareLevel:  takeFirst(orig.ShareLevel, database.AppSharingLevelPublic),
 		Protocol:    takeFirst(orig.Protocol, database.PortShareProtocolHttp),
@@ -153,11 +153,11 @@ func WorkspaceAgent(t testing.TB, db database.Store, orig database.WorkspaceAgen
 		ID:         takeFirst(orig.ID, uuid.New()),
 		CreatedAt:  takeFirst(orig.CreatedAt, dbtime.Now()),
 		UpdatedAt:  takeFirst(orig.UpdatedAt, dbtime.Now()),
-		Name:       takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+		Name:       takeFirst(orig.Name, testutil.GetRandomName(t)),
 		ResourceID: takeFirst(orig.ResourceID, uuid.New()),
 		AuthToken:  takeFirst(orig.AuthToken, uuid.New()),
 		AuthInstanceID: sql.NullString{
-			String: takeFirst(orig.AuthInstanceID.String, namesgenerator.GetRandomName(1)),
+			String: takeFirst(orig.AuthInstanceID.String, testutil.GetRandomName(t)),
 			Valid:  takeFirst(orig.AuthInstanceID.Valid, true),
 		},
 		Architecture: takeFirst(orig.Architecture, "amd64"),
@@ -196,7 +196,7 @@ func Workspace(t testing.TB, db database.Store, orig database.Workspace) databas
 		OrganizationID:    takeFirst(orig.OrganizationID, uuid.New()),
 		TemplateID:        takeFirst(orig.TemplateID, uuid.New()),
 		LastUsedAt:        takeFirst(orig.LastUsedAt, dbtime.Now()),
-		Name:              takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+		Name:              takeFirst(orig.Name, testutil.GetRandomName(t)),
 		AutostartSchedule: orig.AutostartSchedule,
 		Ttl:               orig.Ttl,
 		AutomaticUpdates:  takeFirst(orig.AutomaticUpdates, database.AutomaticUpdatesNever),
@@ -210,8 +210,8 @@ func WorkspaceAgentLogSource(t testing.TB, db database.Store, orig database.Work
 		WorkspaceAgentID: takeFirst(orig.WorkspaceAgentID, uuid.New()),
 		ID:               []uuid.UUID{takeFirst(orig.ID, uuid.New())},
 		CreatedAt:        takeFirst(orig.CreatedAt, dbtime.Now()),
-		DisplayName:      []string{takeFirst(orig.DisplayName, namesgenerator.GetRandomName(1))},
-		Icon:             []string{takeFirst(orig.Icon, namesgenerator.GetRandomName(1))},
+		DisplayName:      []string{takeFirst(orig.DisplayName, testutil.GetRandomName(t))},
+		Icon:             []string{takeFirst(orig.Icon, testutil.GetRandomName(t))},
 	})
 	require.NoError(t, err, "insert workspace agent log source")
 	return sources[0]
@@ -287,9 +287,9 @@ func WorkspaceBuildParameters(t testing.TB, db database.Store, orig []database.W
 func User(t testing.TB, db database.Store, orig database.User) database.User {
 	user, err := db.InsertUser(genCtx, database.InsertUserParams{
 		ID:             takeFirst(orig.ID, uuid.New()),
-		Email:          takeFirst(orig.Email, namesgenerator.GetRandomName(1)),
-		Username:       takeFirst(orig.Username, namesgenerator.GetRandomName(1)),
-		Name:           takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+		Email:          takeFirst(orig.Email, testutil.GetRandomName(t)),
+		Username:       takeFirst(orig.Username, testutil.GetRandomName(t)),
+		Name:           takeFirst(orig.Name, testutil.GetRandomName(t)),
 		HashedPassword: takeFirstSlice(orig.HashedPassword, []byte(must(cryptorand.String(32)))),
 		CreatedAt:      takeFirst(orig.CreatedAt, dbtime.Now()),
 		UpdatedAt:      takeFirst(orig.UpdatedAt, dbtime.Now()),
@@ -336,9 +336,9 @@ func GitSSHKey(t testing.TB, db database.Store, orig database.GitSSHKey) databas
 func Organization(t testing.TB, db database.Store, orig database.Organization) database.Organization {
 	org, err := db.InsertOrganization(genCtx, database.InsertOrganizationParams{
 		ID:          takeFirst(orig.ID, uuid.New()),
-		Name:        takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
-		DisplayName: takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
-		Description: takeFirst(orig.Description, namesgenerator.GetRandomName(1)),
+		Name:        takeFirst(orig.Name, testutil.GetRandomName(t)),
+		DisplayName: takeFirst(orig.Name, testutil.GetRandomName(t)),
+		Description: takeFirst(orig.Description, testutil.GetRandomName(t)),
 		Icon:        takeFirst(orig.Icon, ""),
 		CreatedAt:   takeFirst(orig.CreatedAt, dbtime.Now()),
 		UpdatedAt:   takeFirst(orig.UpdatedAt, dbtime.Now()),
@@ -360,7 +360,7 @@ func OrganizationMember(t testing.TB, db database.Store, orig database.Organizat
 }
 
 func Group(t testing.TB, db database.Store, orig database.Group) database.Group {
-	name := takeFirst(orig.Name, namesgenerator.GetRandomName(1))
+	name := takeFirst(orig.Name, testutil.GetRandomName(t))
 	group, err := db.InsertGroup(genCtx, database.InsertGroupParams{
 		ID:             takeFirst(orig.ID, uuid.New()),
 		Name:           name,
@@ -470,7 +470,7 @@ func ProvisionerKey(t testing.TB, db database.Store, orig database.ProvisionerKe
 		ID:             takeFirst(orig.ID, uuid.New()),
 		CreatedAt:      takeFirst(orig.CreatedAt, dbtime.Now()),
 		OrganizationID: takeFirst(orig.OrganizationID, uuid.New()),
-		Name:           takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+		Name:           takeFirst(orig.Name, testutil.GetRandomName(t)),
 		HashedSecret:   orig.HashedSecret,
 		Tags:           orig.Tags,
 	})
@@ -483,9 +483,9 @@ func WorkspaceApp(t testing.TB, db database.Store, orig database.WorkspaceApp) d
 		ID:          takeFirst(orig.ID, uuid.New()),
 		CreatedAt:   takeFirst(orig.CreatedAt, dbtime.Now()),
 		AgentID:     takeFirst(orig.AgentID, uuid.New()),
-		Slug:        takeFirst(orig.Slug, namesgenerator.GetRandomName(1)),
-		DisplayName: takeFirst(orig.DisplayName, namesgenerator.GetRandomName(1)),
-		Icon:        takeFirst(orig.Icon, namesgenerator.GetRandomName(1)),
+		Slug:        takeFirst(orig.Slug, testutil.GetRandomName(t)),
+		DisplayName: takeFirst(orig.DisplayName, testutil.GetRandomName(t)),
+		Icon:        takeFirst(orig.Icon, testutil.GetRandomName(t)),
 		Command: sql.NullString{
 			String: takeFirst(orig.Command.String, "ls"),
 			Valid:  orig.Command.Valid,
@@ -546,7 +546,7 @@ func WorkspaceResource(t testing.TB, db database.Store, orig database.WorkspaceR
 		JobID:      takeFirst(orig.JobID, uuid.New()),
 		Transition: takeFirst(orig.Transition, database.WorkspaceTransitionStart),
 		Type:       takeFirst(orig.Type, "fake_resource"),
-		Name:       takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+		Name:       takeFirst(orig.Name, testutil.GetRandomName(t)),
 		Hide:       takeFirst(orig.Hide, false),
 		Icon:       takeFirst(orig.Icon, ""),
 		InstanceType: sql.NullString{
@@ -562,8 +562,8 @@ func WorkspaceResource(t testing.TB, db database.Store, orig database.WorkspaceR
 func WorkspaceResourceMetadatums(t testing.TB, db database.Store, seed database.WorkspaceResourceMetadatum) []database.WorkspaceResourceMetadatum {
 	meta, err := db.InsertWorkspaceResourceMetadata(genCtx, database.InsertWorkspaceResourceMetadataParams{
 		WorkspaceResourceID: takeFirst(seed.WorkspaceResourceID, uuid.New()),
-		Key:                 []string{takeFirst(seed.Key, namesgenerator.GetRandomName(1))},
-		Value:               []string{takeFirst(seed.Value.String, namesgenerator.GetRandomName(1))},
+		Key:                 []string{takeFirst(seed.Key, testutil.GetRandomName(t))},
+		Value:               []string{takeFirst(seed.Value.String, testutil.GetRandomName(t))},
 		Sensitive:           []bool{takeFirst(seed.Sensitive, false)},
 	})
 	require.NoError(t, err, "insert meta data")
@@ -577,9 +577,9 @@ func WorkspaceProxy(t testing.TB, db database.Store, orig database.WorkspaceProx
 
 	proxy, err := db.InsertWorkspaceProxy(genCtx, database.InsertWorkspaceProxyParams{
 		ID:                takeFirst(orig.ID, uuid.New()),
-		Name:              takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
-		DisplayName:       takeFirst(orig.DisplayName, namesgenerator.GetRandomName(1)),
-		Icon:              takeFirst(orig.Icon, namesgenerator.GetRandomName(1)),
+		Name:              takeFirst(orig.Name, testutil.GetRandomName(t)),
+		DisplayName:       takeFirst(orig.DisplayName, testutil.GetRandomName(t)),
+		Icon:              takeFirst(orig.Icon, testutil.GetRandomName(t)),
 		TokenHashedSecret: hashedSecret[:],
 		CreatedAt:         takeFirst(orig.CreatedAt, dbtime.Now()),
 		UpdatedAt:         takeFirst(orig.UpdatedAt, dbtime.Now()),
@@ -659,9 +659,9 @@ func TemplateVersion(t testing.TB, db database.Store, orig database.TemplateVers
 			OrganizationID: takeFirst(orig.OrganizationID, uuid.New()),
 			CreatedAt:      takeFirst(orig.CreatedAt, dbtime.Now()),
 			UpdatedAt:      takeFirst(orig.UpdatedAt, dbtime.Now()),
-			Name:           takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
+			Name:           takeFirst(orig.Name, testutil.GetRandomName(t)),
 			Message:        orig.Message,
-			Readme:         takeFirst(orig.Readme, namesgenerator.GetRandomName(1)),
+			Readme:         takeFirst(orig.Readme, testutil.GetRandomName(t)),
 			JobID:          takeFirst(orig.JobID, uuid.New()),
 			CreatedBy:      takeFirst(orig.CreatedBy, uuid.New()),
 		})
@@ -683,11 +683,11 @@ func TemplateVersion(t testing.TB, db database.Store, orig database.TemplateVers
 func TemplateVersionVariable(t testing.TB, db database.Store, orig database.TemplateVersionVariable) database.TemplateVersionVariable {
 	version, err := db.InsertTemplateVersionVariable(genCtx, database.InsertTemplateVersionVariableParams{
 		TemplateVersionID: takeFirst(orig.TemplateVersionID, uuid.New()),
-		Name:              takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
-		Description:       takeFirst(orig.Description, namesgenerator.GetRandomName(1)),
+		Name:              takeFirst(orig.Name, testutil.GetRandomName(t)),
+		Description:       takeFirst(orig.Description, testutil.GetRandomName(t)),
 		Type:              takeFirst(orig.Type, "string"),
 		Value:             takeFirst(orig.Value, ""),
-		DefaultValue:      takeFirst(orig.DefaultValue, namesgenerator.GetRandomName(1)),
+		DefaultValue:      takeFirst(orig.DefaultValue, testutil.GetRandomName(t)),
 		Required:          takeFirst(orig.Required, false),
 		Sensitive:         takeFirst(orig.Sensitive, false),
 	})
@@ -698,8 +698,8 @@ func TemplateVersionVariable(t testing.TB, db database.Store, orig database.Temp
 func TemplateVersionWorkspaceTag(t testing.TB, db database.Store, orig database.TemplateVersionWorkspaceTag) database.TemplateVersionWorkspaceTag {
 	workspaceTag, err := db.InsertTemplateVersionWorkspaceTag(genCtx, database.InsertTemplateVersionWorkspaceTagParams{
 		TemplateVersionID: takeFirst(orig.TemplateVersionID, uuid.New()),
-		Key:               takeFirst(orig.Key, namesgenerator.GetRandomName(1)),
-		Value:             takeFirst(orig.Value, namesgenerator.GetRandomName(1)),
+		Key:               takeFirst(orig.Key, testutil.GetRandomName(t)),
+		Value:             takeFirst(orig.Value, testutil.GetRandomName(t)),
 	})
 	require.NoError(t, err, "insert template version workspace tag")
 	return workspaceTag
@@ -710,12 +710,12 @@ func TemplateVersionParameter(t testing.TB, db database.Store, orig database.Tem
 
 	version, err := db.InsertTemplateVersionParameter(genCtx, database.InsertTemplateVersionParameterParams{
 		TemplateVersionID:   takeFirst(orig.TemplateVersionID, uuid.New()),
-		Name:                takeFirst(orig.Name, namesgenerator.GetRandomName(1)),
-		Description:         takeFirst(orig.Description, namesgenerator.GetRandomName(1)),
+		Name:                takeFirst(orig.Name, testutil.GetRandomName(t)),
+		Description:         takeFirst(orig.Description, testutil.GetRandomName(t)),
 		Type:                takeFirst(orig.Type, "string"),
 		Mutable:             takeFirst(orig.Mutable, false),
-		DefaultValue:        takeFirst(orig.DefaultValue, namesgenerator.GetRandomName(1)),
-		Icon:                takeFirst(orig.Icon, namesgenerator.GetRandomName(1)),
+		DefaultValue:        takeFirst(orig.DefaultValue, testutil.GetRandomName(t)),
+		Icon:                takeFirst(orig.Icon, testutil.GetRandomName(t)),
 		Options:             takeFirstSlice(orig.Options, []byte("[]")),
 		ValidationRegex:     takeFirst(orig.ValidationRegex, ""),
 		ValidationMin:       takeFirst(orig.ValidationMin, sql.NullInt32{}),
@@ -723,7 +723,7 @@ func TemplateVersionParameter(t testing.TB, db database.Store, orig database.Tem
 		ValidationError:     takeFirst(orig.ValidationError, ""),
 		ValidationMonotonic: takeFirst(orig.ValidationMonotonic, ""),
 		Required:            takeFirst(orig.Required, false),
-		DisplayName:         takeFirst(orig.DisplayName, namesgenerator.GetRandomName(1)),
+		DisplayName:         takeFirst(orig.DisplayName, testutil.GetRandomName(t)),
 		DisplayOrder:        takeFirst(orig.DisplayOrder, 0),
 		Ephemeral:           takeFirst(orig.Ephemeral, false),
 	})
@@ -783,7 +783,7 @@ func WorkspaceAgentStat(t testing.TB, db database.Store, orig database.Workspace
 func OAuth2ProviderApp(t testing.TB, db database.Store, seed database.OAuth2ProviderApp) database.OAuth2ProviderApp {
 	app, err := db.InsertOAuth2ProviderApp(genCtx, database.InsertOAuth2ProviderAppParams{
 		ID:          takeFirst(seed.ID, uuid.New()),
-		Name:        takeFirst(seed.Name, namesgenerator.GetRandomName(1)),
+		Name:        takeFirst(seed.Name, testutil.GetRandomName(t)),
 		CreatedAt:   takeFirst(seed.CreatedAt, dbtime.Now()),
 		UpdatedAt:   takeFirst(seed.UpdatedAt, dbtime.Now()),
 		Icon:        takeFirst(seed.Icon, ""),
@@ -836,8 +836,8 @@ func OAuth2ProviderAppToken(t testing.TB, db database.Store, seed database.OAuth
 
 func CustomRole(t testing.TB, db database.Store, seed database.CustomRole) database.CustomRole {
 	role, err := db.UpsertCustomRole(genCtx, database.UpsertCustomRoleParams{
-		Name:            takeFirst(seed.Name, strings.ToLower(namesgenerator.GetRandomName(1))),
-		DisplayName:     namesgenerator.GetRandomName(1),
+		Name:            takeFirst(seed.Name, strings.ToLower(testutil.GetRandomName(t))),
+		DisplayName:     testutil.GetRandomName(t),
 		OrganizationID:  seed.OrganizationID,
 		SitePermissions: takeFirstSlice(seed.SitePermissions, []database.CustomRolePermission{}),
 		OrgPermissions:  takeFirstSlice(seed.SitePermissions, []database.CustomRolePermission{}),

--- a/coderd/httpapi/name_test.go
+++ b/coderd/httpapi/name_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestUsernameValid(t *testing.T) {
@@ -168,7 +168,7 @@ func TestGeneratedTemplateVersionNameValid(t *testing.T) {
 	t.Parallel()
 
 	for i := 0; i < 1000; i++ {
-		name := namesgenerator.GetRandomName(1)
+		name := testutil.GetRandomName(t)
 		err := httpapi.TemplateVersionNameValid(name)
 		require.NoError(t, err, "invalid template version name: %s", name)
 	}

--- a/coderd/httpmw/oauth2_test.go
+++ b/coderd/httpmw/oauth2_test.go
@@ -7,13 +7,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 type testOAuth2Provider struct {
@@ -128,7 +128,7 @@ func TestOAuth2(t *testing.T) {
 	})
 	t.Run("PresetConvertState", func(t *testing.T) {
 		t.Parallel()
-		customState := namesgenerator.GetRandomName(1)
+		customState := testutil.GetRandomName(t)
 		req := httptest.NewRequest("GET", "/?oidc_merge_state="+customState+"&redirect="+url.QueryEscape("/dashboard"), nil)
 		res := httptest.NewRecorder()
 		tp := newTestOAuth2Provider(t, oauth2.AccessTypeOffline)

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -204,7 +203,7 @@ func TestWorkspaceProxyCRUD(t *testing.T) {
 		})
 		ctx := testutil.Context(t, testutil.WaitLong)
 		proxyRes, err := client.CreateWorkspaceProxy(ctx, codersdk.CreateWorkspaceProxyRequest{
-			Name: namesgenerator.GetRandomName(1),
+			Name: testutil.GetRandomName(t),
 			Icon: "/emojis/flag.png",
 		})
 		require.NoError(t, err)
@@ -217,9 +216,9 @@ func TestWorkspaceProxyCRUD(t *testing.T) {
 		require.NotEmpty(t, proxyRes.ProxyToken)
 
 		// Update the proxy
-		expName := namesgenerator.GetRandomName(1)
-		expDisplayName := namesgenerator.GetRandomName(1)
-		expIcon := namesgenerator.GetRandomName(1)
+		expName := testutil.GetRandomName(t)
+		expDisplayName := testutil.GetRandomName(t)
+		expIcon := testutil.GetRandomName(t)
 		_, err = client.PatchWorkspaceProxy(ctx, codersdk.PatchWorkspaceProxy{
 			ID:          proxyRes.Proxy.ID,
 			Name:        expName,
@@ -247,7 +246,7 @@ func TestWorkspaceProxyCRUD(t *testing.T) {
 		})
 		ctx := testutil.Context(t, testutil.WaitLong)
 		proxyRes, err := client.CreateWorkspaceProxy(ctx, codersdk.CreateWorkspaceProxyRequest{
-			Name: namesgenerator.GetRandomName(1),
+			Name: testutil.GetRandomName(t),
 			Icon: "/emojis/flag.png",
 		})
 		require.NoError(t, err)
@@ -639,7 +638,7 @@ func TestIssueSignedAppToken(t *testing.T) {
 
 	createProxyCtx := testutil.Context(t, testutil.WaitLong)
 	proxyRes, err := client.CreateWorkspaceProxy(createProxyCtx, codersdk.CreateWorkspaceProxyRequest{
-		Name: namesgenerator.GetRandomName(1),
+		Name: testutil.GetRandomName(t),
 		Icon: "/emojis/flag.png",
 	})
 	require.NoError(t, err)
@@ -731,11 +730,11 @@ func TestReconnectingPTYSignedToken(t *testing.T) {
 	_ = agenttest.New(t, client.URL, authToken)
 	_ = coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
 
-	proxyURL, err := url.Parse(fmt.Sprintf("https://%s.com", namesgenerator.GetRandomName(1)))
+	proxyURL, err := url.Parse(fmt.Sprintf("https://%s.com", testutil.GetRandomName(t)))
 	require.NoError(t, err)
 
 	_ = coderdenttest.NewWorkspaceProxyReplica(t, api, client, &coderdenttest.ProxyOptions{
-		Name:        namesgenerator.GetRandomName(1),
+		Name:        testutil.GetRandomName(t),
 		ProxyURL:    proxyURL,
 		AppHostname: "*.sub.example.com",
 	})

--- a/testutil/names.go
+++ b/testutil/names.go
@@ -1,0 +1,25 @@
+package testutil
+
+import (
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/moby/moby/pkg/namesgenerator"
+)
+
+var (
+	n atomic.Int64
+)
+
+// GetRandomName returns a random name using moby/pkg/namesgenerator.
+// namesgenerator.GetRandomName exposes a retry parameter that appends
+// a pseudo-random number between 1 and 10 to its return value.
+// While this reduces the probability of collisions, it does not negate them.
+// This function calls namesgenerator.GetRandomName without the retry
+// parameter and instead increments a monotonically increasing integer
+// to the return value.
+func GetRandomName(t testing.TB) string {
+	t.Helper()
+	return namesgenerator.GetRandomName(0) + strconv.FormatInt(n.Add(1), 10)
+}

--- a/testutil/names.go
+++ b/testutil/names.go
@@ -8,9 +8,7 @@ import (
 	"github.com/moby/moby/pkg/namesgenerator"
 )
 
-var (
-	n atomic.Int64
-)
+var n atomic.Int64
 
 // GetRandomName returns a random name using moby/pkg/namesgenerator.
 // namesgenerator.GetRandomName exposes a retry parameter that appends


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/13910

Adds `testutil.GetRandomName` that replaces `namesgenerator.GetRandomName` but instead appends a monotonically increasing integer instead of a number between 1 and 10.