### PR TITLE
ci: remove ci make concurrency to fix docker image race

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -788,13 +788,15 @@ jobs:
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
           # build images for each architecture
-          make -j build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
+          # note: omitting the -j argument to avoid race conditions when pushing
+          make build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
 
           # only push if we are on main branch
           if [ "${{ github.ref }}" == "refs/heads/main" ]; then
             # build and push multi-arch manifest, this depends on the other images
             # being pushed so will automatically push them
-            make -j push/build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
+            # note: omitting the -j argument to avoid race conditions when pushing
+            make push/build/coder_"$version"_linux_{amd64,arm64,armv7}.tag
 
             # Define specific tags
             tags=("$tag" "main" "latest")


### PR DESCRIPTION
Seen here: https://github.com/coder/coder/actions/runs/10108431095/job/27954323032#step:9:119

We ran into this previously in #13769 for the release workflow, but neglected to apply the same change to the CI workflow.