### PR TITLE
chore: use latest code-server in examples

### DIFF
--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -159,11 +159,12 @@ resource "coder_agent" "coder" {
   startup_script = <<EOT
 #!/bin/bash
 
-# Install code-server 4.8.3 under /tmp/code-server using the "standalone" installation
-# that does not require root permissions. Note that /tmp may be mounted in tmpfs which
-# can lead to increased RAM usage. To avoid this, you can pre-install code-server inside
-# the Docker image or VM image.
-curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.8.3
+# Install the latest code-server under /tmp/code-server using the "standalone"
+# installation that does not require root permissions. Note that /tmp may be
+# mounted in tmpfs which can lead to increased RAM usage. To avoid this, you can
+# pre-install code-server inside the Docker image or VM image.
+# Append "--version x.x.x" to install a specific version of code-server.
+curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
 # The & prevents the startup_script from blocking so the next commands can run.
 # The stdout and stderr of code-server is redirected to /tmp/code-server.log.

--- a/docs/templates/tour.md
+++ b/docs/templates/tour.md
@@ -160,8 +160,11 @@ resource "coder_agent" "main" {
   startup_script         = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/parameters-dynamic-options/main.tf
+++ b/examples/parameters-dynamic-options/main.tf
@@ -56,8 +56,11 @@ resource "coder_agent" "main" {
   os             = "linux"
   startup_script = <<EOF
     #!/bin/sh
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
+    # Install the latest code-server.
+    # Append "-s -- --version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh
+
+    # Start code-server.
     code-server --auth none --port 13337
     EOF
 

--- a/examples/parameters/main.tf
+++ b/examples/parameters/main.tf
@@ -29,8 +29,11 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 }

--- a/examples/templates/aws-linux/main.tf
+++ b/examples/templates/aws-linux/main.tf
@@ -165,8 +165,11 @@ resource "coder_agent" "dev" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/templates/devcontainer-docker/main.tf
+++ b/examples/templates/devcontainer-docker/main.tf
@@ -196,8 +196,11 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
   dir            = "/workspaces"

--- a/examples/templates/devcontainer-kubernetes/main.tf
+++ b/examples/templates/devcontainer-kubernetes/main.tf
@@ -315,8 +315,11 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
   dir            = "/workspaces"

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -35,8 +35,11 @@ resource "coder_agent" "main" {
       touch ~/.init_done
     fi
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.19.1
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/templates/envbox/main.tf
+++ b/examples/templates/envbox/main.tf
@@ -102,8 +102,12 @@ resource "coder_agent" "main" {
     if [ ! -f ~/.bashrc ]; then
       cp /etc/skel/.bashrc $HOME
     fi
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3 | tee code-server-install.log
+
+    # Install the latest code-server.
+    # Append "-s -- --version x.x.x" to `sh` to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh | tee code-server-install.log
+
+    # Start code-server in the background.
     code-server --auth none --port 13337 | tee code-server-install.log &
   EOT
 }

--- a/examples/templates/gcp-linux/main.tf
+++ b/examples/templates/gcp-linux/main.tf
@@ -80,8 +80,11 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/templates/gcp-vm-container/main.tf
+++ b/examples/templates/gcp-vm-container/main.tf
@@ -70,8 +70,11 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 }

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -109,8 +109,11 @@ resource "coder_agent" "main" {
   startup_script = <<-EOT
     set -e
 
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server --version 4.11.0
+    # Install the latest code-server.
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/workspace-tags/main.tf
+++ b/examples/workspace-tags/main.tf
@@ -72,8 +72,11 @@ resource "coder_agent" "main" {
   os             = "linux"
   startup_script = <<EOF
     #!/bin/sh
-    # install and start code-server
-    curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.8.3
+    # Install the latest code-server.
+    # Append "-s -- --version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh
+
+    # Start code-server.
     code-server --auth none --port 13337
     EOF
 


### PR DESCRIPTION
Instead, leave a comment describing how to pin the version.  This negates the need to continually update the version in this example, which has gotten quite out of date.