### PR TITLE
chore: fixup permission story with multi-org on the UI 

### DIFF
--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -16,7 +16,10 @@ export const checks = {
   editWorkspaceProxies: "editWorkspaceProxies",
 } as const;
 
-export const permissionsToCheck: Record<string, AuthorizationCheck> = {
+export const permissionsToCheck: Record<
+  keyof typeof checks,
+  AuthorizationCheck
+> = {
   [checks.readAllUsers]: {
     object: {
       resource_type: "user",

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -4,9 +4,9 @@ export const checks = {
   readAllUsers: "readAllUsers",
   updateUsers: "updateUsers",
   createUser: "createUser",
-  createAnyTemplates: "createAnyTemplates",
-  updateTemplates: "updateTemplates",
-  deleteTemplates: "deleteTemplates",
+  createAnyTemplate: "createAnyTemplate",
+  updateAllTemplates: "updateAllTemplates",
+  deleteAllTemplates: "deleteAllTemplates",
   viewAnyAuditLog: "viewAnyAuditLog",
   viewDeploymentValues: "viewDeploymentValues",
   createAnyGroup: "createAnyGroup",
@@ -35,20 +35,20 @@ export const permissionsToCheck: Record<string, AuthorizationCheck> = {
     },
     action: "create",
   },
-  [checks.createAnyTemplates]: {
+  [checks.createAnyTemplate]: {
     object: {
       resource_type: "template",
       any_org: true,
     },
     action: "update",
   },
-  [checks.updateTemplates]: {
+  [checks.updateAllTemplates]: {
     object: {
       resource_type: "template",
     },
     action: "update",
   },
-  [checks.deleteTemplates]: {
+  [checks.deleteAllTemplates]: {
     object: {
       resource_type: "template",
     },

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -9,7 +9,7 @@ import type { AuthorizationCheck } from "api/typesGenerated";
 //
 // Any check not using this language should be updated to use it.
 export const checks = {
-  readAllUsers: "readAllUsers",
+  viewAllUsers: "viewAllUsers",
   updateUsers: "updateUsers",
   createUser: "createUser",
   createAnyTemplate: "createAnyTemplate",
@@ -18,17 +18,24 @@ export const checks = {
   viewAnyAuditLog: "viewAnyAuditLog",
   viewDeploymentValues: "viewDeploymentValues",
   createAnyGroup: "createAnyGroup",
-  viewUpdateCheck: "viewUpdateCheck",
   viewExternalAuthConfig: "viewExternalAuthConfig",
+  updateDeploymentConfig: "updateDeploymentConfig",
   viewDeploymentStats: "viewDeploymentStats",
   editWorkspaceProxies: "editWorkspaceProxies",
+  viewAllLicenses: "viewAllLicenses",
 } as const;
 
 export const permissionsToCheck: Record<
   keyof typeof checks,
   AuthorizationCheck
 > = {
-  [checks.readAllUsers]: {
+  [checks.viewAllLicenses]: {
+    object: {
+      resource_type: "license",
+    },
+    action: "read",
+  },
+  [checks.viewAllUsers]: {
     object: {
       resource_type: "user",
     },
@@ -78,18 +85,18 @@ export const permissionsToCheck: Record<
     },
     action: "read",
   },
+  [checks.updateDeploymentConfig]: {
+    object: {
+      resource_type: "deployment_config",
+    },
+    action: "update",
+  },
   [checks.createAnyGroup]: {
     object: {
       resource_type: "group",
       any_org: true,
     },
     action: "create",
-  },
-  [checks.viewUpdateCheck]: {
-    object: {
-      resource_type: "deployment_config",
-    },
-    action: "read",
   },
   [checks.viewExternalAuthConfig]: {
     object: {

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -1,5 +1,13 @@
 import { AuthorizationCheck } from "api/typesGenerated";
 
+// checks language should include either "any" or "all" in the name.
+// "any" means the actor has permission to do the action on at least 1 resource
+// in at least 1 organization. So an org template admin can create a template on
+// at least 1 org, so "createAnyTemplate" returns "true".
+// "all" requires the actor to have the permission across all organizations.
+// So an "org template admin" would fail "createAllTemplates".
+//
+// Any check not using this language should be updated to use it.
 export const checks = {
   readAllUsers: "readAllUsers",
   updateUsers: "updateUsers",

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -1,20 +1,22 @@
+import { AuthorizationCheck } from "api/typesGenerated";
+
 export const checks = {
   readAllUsers: "readAllUsers",
   updateUsers: "updateUsers",
   createUser: "createUser",
-  createTemplates: "createTemplates",
+  createAnyTemplates: "createAnyTemplates",
   updateTemplates: "updateTemplates",
   deleteTemplates: "deleteTemplates",
-  viewAuditLog: "viewAuditLog",
+  viewAnyAuditLog: "viewAnyAuditLog",
   viewDeploymentValues: "viewDeploymentValues",
-  createGroup: "createGroup",
+  createAnyGroup: "createAnyGroup",
   viewUpdateCheck: "viewUpdateCheck",
   viewExternalAuthConfig: "viewExternalAuthConfig",
   viewDeploymentStats: "viewDeploymentStats",
   editWorkspaceProxies: "editWorkspaceProxies",
 } as const;
 
-export const permissionsToCheck = {
+export const permissionsToCheck: Record<string, AuthorizationCheck> = {
   [checks.readAllUsers]: {
     object: {
       resource_type: "user",
@@ -33,9 +35,10 @@ export const permissionsToCheck = {
     },
     action: "create",
   },
-  [checks.createTemplates]: {
+  [checks.createAnyTemplates]: {
     object: {
       resource_type: "template",
+      any_org: true,
     },
     action: "update",
   },
@@ -51,9 +54,10 @@ export const permissionsToCheck = {
     },
     action: "delete",
   },
-  [checks.viewAuditLog]: {
+  [checks.viewAnyAuditLog]: {
     object: {
       resource_type: "audit_log",
+      any_org: true,
     },
     action: "read",
   },
@@ -63,9 +67,10 @@ export const permissionsToCheck = {
     },
     action: "read",
   },
-  [checks.createGroup]: {
+  [checks.createAnyGroup]: {
     object: {
       resource_type: "group",
+      any_org: true,
     },
     action: "create",
   },

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -1,4 +1,4 @@
-import { AuthorizationCheck } from "api/typesGenerated";
+import type { AuthorizationCheck } from "api/typesGenerated";
 
 // checks language should include either "any" or "all" in the name.
 // "any" means the actor has permission to do the action on at least 1 resource

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -16,7 +16,7 @@ import { useUpdateCheck } from "./useUpdateCheck";
 
 export const DashboardLayout: FC = () => {
   const { permissions } = useAuthenticated();
-  const updateCheck = useUpdateCheck(permissions.viewUpdateCheck);
+  const updateCheck = useUpdateCheck(permissions.viewDeploymentValues);
   const canViewDeployment = Boolean(permissions.viewDeploymentValues);
 
   return (

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -21,7 +21,7 @@ export const Navbar: FC = () => {
   const canViewOrganizations =
     featureVisibility.multiple_organizations &&
     experiments.includes("multi-organization");
-  const canViewAllUsers = Boolean(permissions.readAllUsers);
+  const canViewAllUsers = Boolean(permissions.viewAllUsers);
   const proxyContextValue = useProxy();
   const canViewHealth = canViewDeployment;
 

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -16,7 +16,7 @@ export const Navbar: FC = () => {
   const { user: me, permissions, signOut } = useAuthenticated();
   const featureVisibility = useFeatureVisibility();
   const canViewAuditLog =
-    featureVisibility["audit_log"] && Boolean(permissions.viewAuditLog);
+    featureVisibility["audit_log"] && Boolean(permissions.viewAnyAuditLog);
   const canViewDeployment = Boolean(permissions.viewDeploymentValues);
   const canViewOrganizations =
     featureVisibility.multiple_organizations &&

--- a/site/src/pages/GroupsPage/GroupsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.tsx
@@ -13,7 +13,7 @@ import GroupsPageView from "./GroupsPageView";
 export const GroupsPage: FC = () => {
   const { permissions } = useAuthenticated();
   const { organizationId } = useDashboard();
-  const { createGroup: canCreateGroup } = permissions;
+  const { createAnyGroup: canCreateGroup } = permissions;
   const { template_rbac: isTemplateRBACEnabled } = useFeatureVisibility();
   const groupsQuery = useQuery(groups(organizationId));
 

--- a/site/src/pages/ManagementSettingsPage/GroupsPage/GroupsPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/GroupsPage/GroupsPage.tsx
@@ -23,7 +23,7 @@ import GroupsPageView from "./GroupsPageView";
 
 export const GroupsPage: FC = () => {
   const { permissions } = useAuthenticated();
-  const { createGroup: canCreateGroup } = permissions;
+  const { createAnyGroup: canCreateGroup } = permissions;
   const {
     multiple_organizations: organizationsEnabled,
     template_rbac: isTemplateRBACEnabled,

--- a/site/src/pages/ManagementSettingsPage/Sidebar.tsx
+++ b/site/src/pages/ManagementSettingsPage/Sidebar.tsx
@@ -12,6 +12,7 @@ import { type ClassName, useClassName } from "hooks/useClassName";
 import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
 import { AUDIT_LINK, USERS_LINK, withFilter } from "modules/navigation";
 import { useOrganizationSettings } from "./ManagementSettingsLayout";
+import { useAuthenticated } from "contexts/auth/RequireAuth";
 
 export const Sidebar: FC = () => {
   const { organizations } = useOrganizationSettings();
@@ -62,6 +63,7 @@ const DeploymentSettingsNavigation: FC<DeploymentSettingsNavigationProps> = ({
 }) => {
   const location = useLocation();
   const active = location.pathname.startsWith("/deployment");
+  const { permissions } = useAuthenticated();
 
   return (
     <div css={{ paddingBottom: 12 }}>
@@ -76,36 +78,57 @@ const DeploymentSettingsNavigation: FC<DeploymentSettingsNavigationProps> = ({
       </SidebarNavItem>
       {active && (
         <Stack spacing={0.5} css={{ marginBottom: 8, marginTop: 8 }}>
-          <SidebarNavSubItem href="general">General</SidebarNavSubItem>
-          <SidebarNavSubItem href="licenses">Licenses</SidebarNavSubItem>
-          <SidebarNavSubItem href="appearance">Appearance</SidebarNavSubItem>
-          <SidebarNavSubItem href="userauth">
-            User Authentication
-          </SidebarNavSubItem>
-          <SidebarNavSubItem href="external-auth">
-            External Authentication
-          </SidebarNavSubItem>
+          {permissions.viewDeploymentValues && (
+            <SidebarNavSubItem href="general">General</SidebarNavSubItem>
+          )}
+          {permissions.viewAllLicenses && (
+            <SidebarNavSubItem href="licenses">Licenses</SidebarNavSubItem>
+          )}
+          {permissions.updateDeploymentConfig && (
+            <SidebarNavSubItem href="appearance">Appearance</SidebarNavSubItem>
+          )}
+          {permissions.viewDeploymentValues && (
+            <SidebarNavSubItem href="userauth">
+              User Authentication
+            </SidebarNavSubItem>
+          )}
+          {permissions.viewDeploymentValues && (
+            <SidebarNavSubItem href="external-auth">
+              External Authentication
+            </SidebarNavSubItem>
+          )}
           {/* Not exposing this yet since token exchange is not finished yet.
           <SidebarNavSubItem href="oauth2-provider/ap>
             OAuth2 Applications
           </SidebarNavSubItem>*/}
-          <SidebarNavSubItem href="network">Network</SidebarNavSubItem>
+          {permissions.viewDeploymentValues && (
+            <SidebarNavSubItem href="network">Network</SidebarNavSubItem>
+          )}
+          {/* All users can view workspace regions.  */}
           <SidebarNavSubItem href="workspace-proxies">
             Workspace Proxies
           </SidebarNavSubItem>
-          <SidebarNavSubItem href="security">Security</SidebarNavSubItem>
-          <SidebarNavSubItem href="observability">
-            Observability
-          </SidebarNavSubItem>
-          <SidebarNavSubItem href={USERS_LINK.slice(1)}>
-            Users
-          </SidebarNavSubItem>
-          {!organizationsEnabled && (
+          {permissions.viewDeploymentValues && (
+            <SidebarNavSubItem href="security">Security</SidebarNavSubItem>
+          )}
+          {permissions.viewDeploymentValues && (
+            <SidebarNavSubItem href="observability">
+              Observability
+            </SidebarNavSubItem>
+          )}
+          {permissions.viewAllUsers && (
+            <SidebarNavSubItem href={USERS_LINK.slice(1)}>
+              Users
+            </SidebarNavSubItem>
+          )}
+          {!organizationsEnabled && permissions.createAnyGroup && (
             <SidebarNavSubItem href="groups">Groups</SidebarNavSubItem>
           )}
-          <SidebarNavSubItem href={AUDIT_LINK.slice(1)}>
-            Auditing
-          </SidebarNavSubItem>
+          {permissions.viewAnyAuditLog && (
+            <SidebarNavSubItem href={AUDIT_LINK.slice(1)}>
+              Auditing
+            </SidebarNavSubItem>
+          )}
         </Stack>
       )}
     </div>

--- a/site/src/pages/TemplateVersionPage/TemplateVersionPage.tsx
+++ b/site/src/pages/TemplateVersionPage/TemplateVersionPage.tsx
@@ -74,7 +74,8 @@ export const TemplateVersionPage: FC = () => {
         versionName={versionName}
         templateName={templateName}
         createWorkspaceUrl={
-          permissions.updateTemplates ? createWorkspaceUrl : undefined
+          // TODO: This permission should be "can update this specific template version"
+          permissions.updateAllTemplates ? createWorkspaceUrl : undefined
         }
       />
     </>

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -14,7 +14,7 @@ export const TemplatesPage: FC = () => {
   const templatesQuery = useQuery(templates(organizationId));
   const examplesQuery = useQuery({
     ...templateExamples(organizationId),
-    enabled: permissions.createTemplates,
+    enabled: permissions.createAnyTemplate,
   });
   const error = templatesQuery.error || examplesQuery.error;
 
@@ -25,7 +25,7 @@ export const TemplatesPage: FC = () => {
       </Helmet>
       <TemplatesPageView
         error={error}
-        canCreateTemplates={permissions.createTemplates}
+        canCreateTemplates={permissions.createAnyTemplate}
         examples={examplesQuery.data}
         templates={templatesQuery.data}
       />

--- a/site/src/pages/UsersPage/UsersLayout.tsx
+++ b/site/src/pages/UsersPage/UsersLayout.tsx
@@ -20,7 +20,7 @@ import { USERS_LINK } from "modules/navigation";
 export const UsersLayout: FC = () => {
   const { permissions } = useAuthenticated();
   const { experiments } = useDashboard();
-  const { createUser: canCreateUser, createGroup: canCreateGroup } =
+  const { createUser: canCreateUser, createAnyGroup: canCreateGroup } =
     permissions;
   const navigate = useNavigate();
   const { template_rbac: isTemplateRBACEnabled } = useFeatureVisibility();

--- a/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.test.tsx
@@ -121,9 +121,9 @@ describe("WorkspacePage", () => {
     server.use(
       http.post("/api/v2/authcheck", async () => {
         return HttpResponse.json({
-          updateTemplates: true,
+          updateAllTemplates: true,
           updateWorkspace: true,
-          updateTemplate: true,
+          updateAnyTemplate: true,
         });
       }),
     );

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -84,8 +84,8 @@ const WorkspacesPage: FC = () => {
       </Helmet>
 
       <WorkspacesPageView
-        canCreateTemplate={permissions.createTemplates}
-        canChangeVersions={permissions.updateTemplates}
+        canCreateTemplate={permissions.createAnyTemplate}
+        canChangeVersions={permissions.updateAllTemplates}
         checkedWorkspaces={checkedWorkspaces}
         onCheckChange={setCheckedWorkspaces}
         canCheckWorkspaces={canCheckWorkspaces}

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2477,14 +2477,15 @@ export const MockPermissions: Permissions = {
   createUser: true,
   deleteAllTemplates: true,
   updateAllTemplates: true,
-  readAllUsers: true,
+  viewAllUsers: true,
   updateUsers: true,
   viewAnyAuditLog: true,
   viewDeploymentValues: true,
-  viewUpdateCheck: true,
   viewDeploymentStats: true,
   viewExternalAuthConfig: true,
   editWorkspaceProxies: true,
+  updateDeploymentConfig: true,
+  viewAllLicenses: true,
 };
 
 export const MockDeploymentConfig: DeploymentConfig = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2479,7 +2479,7 @@ export const MockPermissions: Permissions = {
   updateAllTemplates: true,
   readAllUsers: true,
   updateUsers: true,
-  viewAuditLog: true,
+  viewAnyAuditLog: true,
   viewDeploymentValues: true,
   viewUpdateCheck: true,
   viewDeploymentStats: true,

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2472,11 +2472,11 @@ export const MockTemplateExample2: TypesGen.TemplateExample = {
 };
 
 export const MockPermissions: Permissions = {
-  createGroup: true,
-  createTemplates: true,
+  createAnyGroup: true,
+  createAnyTemplate: true,
   createUser: true,
-  deleteTemplates: true,
-  updateTemplates: true,
+  deleteAllTemplates: true,
+  updateAllTemplates: true,
   readAllUsers: true,
   updateUsers: true,
   viewAuditLog: true,


### PR DESCRIPTION
Organizations live under `/deployment` (at least in the sidebar). This page needs to be accessible by org admins, and be functional to their permissions extent.

![Screenshot from 2024-07-29 20-52-28](https://github.com/user-attachments/assets/a02a6db8-199e-4999-b9d1-859f0719b6a2)


All menu items need to be conditional based on the user's permissions. Even the org menu items need to toggle. So an org auditor would only see the `auditing` menu items for example.