### PR TITLE
chore: always use new codepath over deprecated

### DIFF
--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -51,6 +51,8 @@ type Request[T Auditable] struct {
 	Action database.AuditAction
 }
 
+// UpdateOrganizationID can be used if the organization ID is not known
+// at the initiation of an audit log request.
 func (r *Request[T]) UpdateOrganizationID(id uuid.UUID) {
 	r.params.OrganizationID = id
 }

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -1064,25 +1064,6 @@ func (w WorkspaceAgentWaiter) Wait() []codersdk.WorkspaceResource {
 // CreateWorkspace creates a workspace for the user and template provided.
 // A random name is generated for it.
 // To customize the defaults, pass a mutator func.
-//
-// Deprecated: Use CreateWorkspace.
-func CreateWorkspaceByOrganization(t testing.TB, client *codersdk.Client, organization uuid.UUID, templateID uuid.UUID, mutators ...func(*codersdk.CreateWorkspaceRequest)) codersdk.Workspace {
-	t.Helper()
-	req := codersdk.CreateWorkspaceRequest{
-		TemplateID:        templateID,
-		Name:              RandomUsername(t),
-		AutostartSchedule: ptr.Ref("CRON_TZ=US/Central 30 9 * * 1-5"),
-		TTLMillis:         ptr.Ref((8 * time.Hour).Milliseconds()),
-		AutomaticUpdates:  codersdk.AutomaticUpdatesNever,
-	}
-	for _, mutator := range mutators {
-		mutator(&req)
-	}
-	workspace, err := client.CreateWorkspace(context.Background(), organization, codersdk.Me, req)
-	require.NoError(t, err)
-	return workspace
-}
-
 func CreateWorkspace(t testing.TB, client *codersdk.Client, templateID uuid.UUID, mutators ...func(*codersdk.CreateWorkspaceRequest)) codersdk.Workspace {
 	t.Helper()
 	req := codersdk.CreateWorkspaceRequest{

--- a/coderd/coderdtest/swaggerparser.go
+++ b/coderd/coderdtest/swaggerparser.go
@@ -89,9 +89,9 @@ func parseSwaggerComment(commentGroup *ast.CommentGroup) SwaggerComment {
 		failures:   []response{},
 	}
 	for _, line := range commentGroup.List {
-		// "// @<annotationName> [args...]" -> []string{"//", "@<annotationName>", "args..."}
+		// @<annotationName> [args...]
 		splitN := strings.SplitN(strings.TrimSpace(line.Text), " ", 3)
-		if len(splitN) < 3 {
+		if len(splitN) < 2 {
 			continue // comment prefix without any content
 		}
 

--- a/coderd/coderdtest/swaggerparser.go
+++ b/coderd/coderdtest/swaggerparser.go
@@ -89,9 +89,9 @@ func parseSwaggerComment(commentGroup *ast.CommentGroup) SwaggerComment {
 		failures:   []response{},
 	}
 	for _, line := range commentGroup.List {
-		// @<annotationName> [args...]
+		// "// @<annotationName> [args...]" -> []string{"//", "@<annotationName>", "args..."}
 		splitN := strings.SplitN(strings.TrimSpace(line.Text), " ", 3)
-		if len(splitN) < 2 {
+		if len(splitN) < 3 {
 			continue // comment prefix without any content
 		}
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -521,7 +521,17 @@ func createWorkspace(
 		})
 		return
 	}
+
+	// Update audit log's organization
 	auditReq.UpdateOrganizationID(template.OrganizationID)
+
+	// Do this upfront to save work. If this fails, the rest of the work
+	// would be wasted.
+	if !api.Authorize(r, policy.ActionCreate,
+		rbac.ResourceWorkspace.InOrg(template.OrganizationID).WithOwner(user.ID.String())) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
 
 	templateAccessControl := (*(api.AccessControlStore.Load())).GetTemplateAccessControl(template)
 	if templateAccessControl.IsDeprecated() {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -464,7 +464,7 @@ func createWorkspace(
 	templateID := req.TemplateID
 	if templateID == uuid.Nil {
 		templateVersion, err := api.Database.GetTemplateVersionByID(ctx, req.TemplateVersionID)
-		if errors.Is(err, sql.ErrNoRows) {
+		if httpapi.Is404Error(err) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: fmt.Sprintf("Template version %q doesn't exist.", templateID.String()),
 				Validations: []codersdk.ValidationError{{
@@ -498,7 +498,7 @@ func createWorkspace(
 	}
 
 	template, err := api.Database.GetTemplateByID(ctx, templateID)
-	if errors.Is(err, sql.ErrNoRows) {
+	if httpapi.Is404Error(err) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: fmt.Sprintf("Template %q doesn't exist.", templateID.String()),
 			Validations: []codersdk.ValidationError{{

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -528,7 +528,7 @@ func createWorkspace(
 	// Do this upfront to save work. If this fails, the rest of the work
 	// would be wasted.
 	if !api.Authorize(r, policy.ActionCreate,
-		rbac.ResourceWorkspace.InOrg(template.OrganizationID).WithOwner(user.ID.String())) {
+		rbac.ResourceWorkspace.InOrg(template.OrganizationID).WithOwner(owner.ID.String())) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}
@@ -588,7 +588,7 @@ func createWorkspace(
 	// read other workspaces. Ideally we check the error on create and look for
 	// a postgres conflict error.
 	workspace, err := api.Database.GetWorkspaceByOwnerIDAndName(ctx, database.GetWorkspaceByOwnerIDAndNameParams{
-		OwnerID: user.ID,
+		OwnerID: owner.ID,
 		Name:    req.Name,
 	})
 	if err == nil {
@@ -621,7 +621,7 @@ func createWorkspace(
 			ID:                uuid.New(),
 			CreatedAt:         now,
 			UpdatedAt:         now,
-			OwnerID:           user.ID,
+			OwnerID:           owner.ID,
 			OrganizationID:    template.OrganizationID,
 			TemplateID:        template.ID,
 			Name:              req.Name,
@@ -689,8 +689,8 @@ func createWorkspace(
 			ProvisionerJob: *provisionerJob,
 			QueuePosition:  0,
 		},
-		user.Username,
-		user.AvatarURL,
+		owner.Username,
+		owner.AvatarURL,
 		[]database.WorkspaceResource{},
 		[]database.WorkspaceResourceMetadatum{},
 		[]database.WorkspaceAgent{},
@@ -712,8 +712,8 @@ func createWorkspace(
 		workspace,
 		apiBuild,
 		template,
-		user.Username,
-		user.AvatarURL,
+		owner.Username,
+		owner.AvatarURL,
 		api.Options.AllowWorkspaceRenames,
 	)
 	if err != nil {

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -475,19 +475,8 @@ func (c *Client) TemplateByName(ctx context.Context, organizationID uuid.UUID, n
 // CreateWorkspace creates a new workspace for the template specified.
 //
 // Deprecated: Use CreateUserWorkspace instead.
-func (c *Client) CreateWorkspace(ctx context.Context, organizationID uuid.UUID, user string, request CreateWorkspaceRequest) (Workspace, error) {
-	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/organizations/%s/members/%s/workspaces", organizationID, user), request)
-	if err != nil {
-		return Workspace{}, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusCreated {
-		return Workspace{}, ReadBodyAsError(res)
-	}
-
-	var workspace Workspace
-	return workspace, json.NewDecoder(res.Body).Decode(&workspace)
+func (c *Client) CreateWorkspace(ctx context.Context, _ uuid.UUID, user string, request CreateWorkspaceRequest) (Workspace, error) {
+	return c.CreateUserWorkspace(ctx, user, request)
 }
 
 // CreateUserWorkspace creates a new workspace for the template specified.

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -146,7 +146,8 @@ func TestCreateWorkspace(t *testing.T) {
 				Features: license.Features{
 					codersdk.FeatureTemplateRBAC: 1,
 				},
-			}})
+			},
+		})
 
 		templateAdmin, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleTemplateAdmin())
 		user, _ := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID, rbac.RoleMember())


### PR DESCRIPTION
Do not use deprecated endpoints in tests. Maybe we should keep a legacy test or two?