### PR TITLE
ci: handle retriggering ci and human authors in `update-flake` 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Update Nix Flake SRI Hash
         run: ./scripts/update-flake.sh
 
-        # auto update flake for dependabot
+      # auto update flake for dependabot
       - uses: stefanzweifel/git-auto-commit-action@v5
         if: github.actor == 'dependabot[bot]'
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,14 +121,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.gomod == 'true'
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          token: ${{ secrets.CDRCI_GITHUB_TOKEN }}
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -136,10 +134,17 @@ jobs:
       - name: Update Nix Flake SRI Hash
         run: ./scripts/update-flake.sh
 
+        # auto update flake for dependabot
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.actor == 'dependabot[bot]'
         with:
           # Allows dependabot to still rebase!
           commit_message: "[dependabot skip] Update Nix Flake SRI Hash"
+
+        # check for other PRs
+      - name: Ensure No Changes
+        if: github.actor != 'dependabot[bot]'
+        run: git diff --exit-code
 
   lint:
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
           # Allows dependabot to still rebase!
           commit_message: "[dependabot skip] Update Nix Flake SRI Hash"
 
-        # check for other PRs
+      # require everyone else to update it themselves
       - name: Ensure No Changes
         if: github.actor != 'dependabot[bot]'
         run: git diff --exit-code


### PR DESCRIPTION
This PR improves #14046 based on instructions [here](https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs).
Should solve the CI stuck issue exhibited in
- #14039
- #14040 
- #14041
- #14044