### PR TITLE
feat: add custom roles

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -187,7 +187,8 @@ export const watchBuildLogsByTemplateVersionId = (
 
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
   const socket = new WebSocket(
-    `${proto}//${location.host
+    `${proto}//${
+      location.host
     }/api/v2/templateversions/${versionId}/logs?${searchParams.toString()}`,
   );
 
@@ -269,7 +270,8 @@ export const watchBuildLogsByBuildId = (
   }
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
   const socket = new WebSocket(
-    `${proto}//${location.host
+    `${proto}//${
+      location.host
     }/api/v2/workspacebuilds/${buildId}/logs?${searchParams.toString()}`,
   );
   socket.binaryType = "blob";
@@ -392,7 +394,7 @@ export class MissingBuildParameters extends Error {
  * lexical scope.
  */
 class ApiMethods {
-  constructor(protected readonly axios: AxiosInstance) { }
+  constructor(protected readonly axios: AxiosInstance) {}
 
   login = async (
     email: string,

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -187,8 +187,7 @@ export const watchBuildLogsByTemplateVersionId = (
 
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
   const socket = new WebSocket(
-    `${proto}//${
-      location.host
+    `${proto}//${location.host
     }/api/v2/templateversions/${versionId}/logs?${searchParams.toString()}`,
   );
 
@@ -270,8 +269,7 @@ export const watchBuildLogsByBuildId = (
   }
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
   const socket = new WebSocket(
-    `${proto}//${
-      location.host
+    `${proto}//${location.host
     }/api/v2/workspacebuilds/${buildId}/logs?${searchParams.toString()}`,
   );
   socket.binaryType = "blob";
@@ -394,7 +392,7 @@ export class MissingBuildParameters extends Error {
  * lexical scope.
  */
 class ApiMethods {
-  constructor(protected readonly axios: AxiosInstance) {}
+  constructor(protected readonly axios: AxiosInstance) { }
 
   login = async (
     email: string,
@@ -598,6 +596,24 @@ class ApiMethods {
     );
 
     return response.data;
+  };
+
+  patchOrganizationRole = async (
+    organizationId: string,
+    role: TypesGen.Role,
+  ): Promise<TypesGen.Role> => {
+    const response = await this.axios.patch<TypesGen.Role>(
+      `/api/v2/organizations/${organizationId}/members/roles`,
+      role,
+    );
+
+    return response.data;
+  };
+
+  deleteOrganizationRole = async (organizationId: string, roleName: string) => {
+    await this.axios.delete(
+      `/api/v2/organizations/${organizationId}/members/roles/${roleName}`,
+    );
   };
 
   /**

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -177,6 +177,13 @@ export const organizationPermissions = (organizationId: string | undefined) => {
             },
             action: "read",
           },
+          assignOrgRole: {
+            object: {
+              resource_type: "assign_org_role",
+              organization_id: organizationId,
+            },
+            action: "create",
+          },
         },
       }),
   };

--- a/site/src/api/queries/roles.ts
+++ b/site/src/api/queries/roles.ts
@@ -1,4 +1,13 @@
+import type { QueryClient } from "react-query";
 import { API } from "api/api";
+import type { Role } from "api/typesGenerated";
+
+const getRoleQueryKey = (organizationId: string, roleName: string) => [
+  "organization",
+  organizationId,
+  "role",
+  roleName,
+];
 
 export const roles = () => {
   return {
@@ -11,5 +20,32 @@ export const organizationRoles = (organizationId: string) => {
   return {
     queryKey: ["organization", organizationId, "roles"],
     queryFn: () => API.getOrganizationRoles(organizationId),
+  };
+};
+
+export const patchOrganizationRole = (
+  queryClient: QueryClient,
+  organizationId: string,
+) => {
+  return {
+    mutationFn: (request: Role) =>
+      API.patchOrganizationRole(organizationId, request),
+    onSuccess: async (updatedRole: Role) =>
+      await queryClient.invalidateQueries(
+        getRoleQueryKey(organizationId, updatedRole.name),
+      ),
+  };
+};
+
+export const deleteRole = (
+  queryClient: QueryClient,
+  organizationId: string,
+) => {
+  return {
+    mutationFn: API.deleteOrganizationRole,
+    onSuccess: async (_: void, roleName: string) =>
+      await queryClient.invalidateQueries(
+        getRoleQueryKey(organizationId, roleName),
+      ),
   };
 };

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -17,7 +17,6 @@ export const checks = {
   viewAnyGroup: "viewAnyGroup",
   createGroup: "createGroup",
   viewAllLicenses: "viewAllLicenses",
-  assignOrgRole: "assignOrgRole",
 } as const;
 
 export const permissionsToCheck = {
@@ -131,12 +130,6 @@ export const permissionsToCheck = {
       resource_type: "license",
     },
     action: "read",
-  },
-  [checks.assignOrgRole]: {
-    object: {
-      resource_type: "assign_org_role",
-    },
-    action: "create",
   },
 } as const;
 

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -17,6 +17,7 @@ export const checks = {
   viewAnyGroup: "viewAnyGroup",
   createGroup: "createGroup",
   viewAllLicenses: "viewAllLicenses",
+  assignOrgRole: "assignOrgRole",
 } as const;
 
 export const permissionsToCheck = {
@@ -130,6 +131,12 @@ export const permissionsToCheck = {
       resource_type: "license",
     },
     action: "read",
+  },
+  [checks.assignOrgRole]: {
+    object: {
+      resource_type: "assign_org_role",
+    },
+    action: "create",
   },
 } as const;
 

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -1,29 +1,47 @@
 import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
-import { useMutation, useQueryClient } from "react-query";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { patchOrganizationRole } from "api/queries/roles";
+import { getErrorMessage } from "api/errors";
+import { patchOrganizationRole, organizationRoles } from "api/queries/roles";
+import { displayError } from "components/GlobalSnackbar/utils";
 import { pageTitle } from "utils/page";
 import CreateEditRolePageView from "./CreateEditRolePageView";
 
 export const CreateGroupPage: FC = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { organization } = useParams() as { organization: string };
+  const { organization, roleName } = useParams() as {
+    organization: string;
+    roleName: string;
+  };
   const patchOrganizationRoleMutation = useMutation(
     patchOrganizationRole(queryClient, organization ?? "default"),
   );
+  const { data } = useQuery(organizationRoles(organization));
+  const role = data?.find((role) => role.name === roleName);
+  const pageTitleText =
+    role !== undefined ? "Edit Custom Role" : "Create Custom Role";
 
   return (
     <>
       <Helmet>
-        <title>{pageTitle("Create Custom Role")}</title>
+        <title>{pageTitle(pageTitleText)}</title>
       </Helmet>
       <CreateEditRolePageView
+        role={role}
+        organization={organization}
         onSubmit={async (data) => {
-          const newRole = await patchOrganizationRoleMutation.mutateAsync(data);
-          console.log({ newRole });
-          navigate(`/organizations/${organization}/roles`);
+          try {
+            console.log({ data });
+            await patchOrganizationRoleMutation.mutateAsync(data);
+            navigate(`/organizations/${organization}/roles`);
+          } catch (error) {
+            console.log({ error });
+            displayError(
+              getErrorMessage(error, "Failed to update custom role"),
+            );
+          }
         }}
         error={patchOrganizationRoleMutation.error}
         isLoading={patchOrganizationRoleMutation.isLoading}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { getErrorMessage } from "api/errors";
 import { patchOrganizationRole, organizationRoles } from "api/queries/roles";
 import { displayError } from "components/GlobalSnackbar/utils";
+import { Loader } from "components/Loader/Loader";
 import { pageTitle } from "utils/page";
 import CreateEditRolePageView from "./CreateEditRolePageView";
 
@@ -18,26 +19,32 @@ export const CreateGroupPage: FC = () => {
   const patchOrganizationRoleMutation = useMutation(
     patchOrganizationRole(queryClient, organization ?? "default"),
   );
-  const { data } = useQuery(organizationRoles(organization));
-  const role = data?.find((role) => role.name === roleName);
-  const pageTitleText =
-    role !== undefined ? "Edit Custom Role" : "Create Custom Role";
+  const { data: roleData, isLoading } = useQuery(
+    organizationRoles(organization),
+  );
+  const role = roleData?.find((role) => role.name === roleName);
+
+  if (isLoading) {
+    return <Loader />;
+  }
 
   return (
     <>
       <Helmet>
-        <title>{pageTitle(pageTitleText)}</title>
+        <title>
+          {pageTitle(
+            role !== undefined ? "Edit Custom Role" : "Create Custom Role",
+          )}
+        </title>
       </Helmet>
       <CreateEditRolePageView
         role={role}
         organization={organization}
         onSubmit={async (data) => {
           try {
-            console.log({ data });
             await patchOrganizationRoleMutation.mutateAsync(data);
             navigate(`/organizations/${organization}/roles`);
           } catch (error) {
-            console.log({ error });
             displayError(
               getErrorMessage(error, "Failed to update custom role"),
             );

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -1,21 +1,29 @@
+import Button from "@mui/material/Button";
+import { useFormik } from "formik";
 import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams } from "react-router-dom";
+import * as Yup from "yup";
 import { getErrorMessage } from "api/errors";
 import { patchOrganizationRole, organizationRoles } from "api/queries/roles";
+import type { PatchRoleRequest } from "api/typesGenerated";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { Loader } from "components/Loader/Loader";
+import { PageHeader } from "components/PageHeader/PageHeader";
+import { useAuthenticated } from "contexts/auth/RequireAuth";
 import { pageTitle } from "utils/page";
 import CreateEditRolePageView from "./CreateEditRolePageView";
 
-export const CreateGroupPage: FC = () => {
+export const CreateEditRolePage: FC = () => {
+  const { permissions } = useAuthenticated();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { organization, roleName } = useParams() as {
     organization: string;
     roleName: string;
   };
+  const { assignOrgRole: canAssignOrgRole } = permissions;
   const patchOrganizationRoleMutation = useMutation(
     patchOrganizationRole(queryClient, organization ?? "default"),
   );
@@ -23,6 +31,31 @@ export const CreateGroupPage: FC = () => {
     organizationRoles(organization),
   );
   const role = roleData?.find((role) => role.name === roleName);
+
+  const validationSchema = Yup.object({
+    name: Yup.string().required().label("Name"),
+  });
+
+  const onSubmit = async (data: PatchRoleRequest) => {
+    try {
+      await patchOrganizationRoleMutation.mutateAsync(data);
+      navigate(`/organizations/${organization}/roles`);
+    } catch (error) {
+      displayError(getErrorMessage(error, "Failed to update custom role"));
+    }
+  };
+
+  const form = useFormik<PatchRoleRequest>({
+    initialValues: {
+      name: role?.name || "",
+      display_name: role?.display_name || "",
+      site_permissions: role?.site_permissions || [],
+      organization_permissions: role?.organization_permissions || [],
+      user_permissions: role?.user_permissions || [],
+    },
+    validationSchema,
+    onSubmit,
+  });
 
   if (isLoading) {
     return <Loader />;
@@ -37,18 +70,35 @@ export const CreateGroupPage: FC = () => {
           )}
         </title>
       </Helmet>
+
+      <PageHeader
+        actions={
+          canAssignOrgRole && (
+            <>
+              <Button
+                onClick={() => {
+                  navigate(`/organizations/${organization}/roles`);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {role !== undefined ? "Save" : "Create Role"}
+              </Button>
+            </>
+          )
+        }
+      ></PageHeader>
+
       <CreateEditRolePageView
         role={role}
-        onSubmit={async (data) => {
-          try {
-            await patchOrganizationRoleMutation.mutateAsync(data);
-            navigate(`/organizations/${organization}/roles`);
-          } catch (error) {
-            displayError(
-              getErrorMessage(error, "Failed to update custom role"),
-            );
-          }
-        }}
+        form={form}
         error={patchOrganizationRoleMutation.error}
         isLoading={patchOrganizationRoleMutation.isLoading}
       />
@@ -56,4 +106,4 @@ export const CreateGroupPage: FC = () => {
   );
 };
 
-export default CreateGroupPage;
+export default CreateEditRolePage;

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -12,6 +12,7 @@ import { displayError } from "components/GlobalSnackbar/utils";
 import { Loader } from "components/Loader/Loader";
 import { PageHeader } from "components/PageHeader/PageHeader";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
+import { nameValidator } from "utils/formUtils";
 import { pageTitle } from "utils/page";
 import CreateEditRolePageView from "./CreateEditRolePageView";
 
@@ -33,7 +34,7 @@ export const CreateEditRolePage: FC = () => {
   const role = roleData?.find((role) => role.name === roleName);
 
   const validationSchema = Yup.object({
-    name: Yup.string().required().label("Name"),
+    name: nameValidator("Name"),
   });
 
   const onSubmit = async (data: PatchRoleRequest) => {

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -1,0 +1,35 @@
+import type { FC } from "react";
+import { Helmet } from "react-helmet-async";
+import { useMutation, useQueryClient } from "react-query";
+import { useNavigate, useParams } from "react-router-dom";
+import { patchOrganizationRole } from "api/queries/roles";
+import { pageTitle } from "utils/page";
+import CreateEditRolePageView from "./CreateEditRolePageView";
+
+export const CreateGroupPage: FC = () => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { organization } = useParams() as { organization: string };
+  const patchOrganizationRoleMutation = useMutation(
+    patchOrganizationRole(queryClient, organization ?? "default"),
+  );
+
+  return (
+    <>
+      <Helmet>
+        <title>{pageTitle("Create Custom Role")}</title>
+      </Helmet>
+      <CreateEditRolePageView
+        onSubmit={async (data) => {
+          const newRole = await patchOrganizationRoleMutation.mutateAsync(data);
+          console.log({ newRole });
+          navigate(`/organizations/${organization}/roles`);
+        }}
+        error={patchOrganizationRoleMutation.error}
+        isLoading={patchOrganizationRoleMutation.isLoading}
+      />
+    </>
+  );
+};
+
+export default CreateGroupPage;

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -1,18 +1,13 @@
-import Button from "@mui/material/Button";
-import { useFormik } from "formik";
 import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import * as Yup from "yup";
 import { getErrorMessage } from "api/errors";
 import { organizationPermissions } from "api/queries/organizations";
 import { patchOrganizationRole, organizationRoles } from "api/queries/roles";
 import type { PatchRoleRequest } from "api/typesGenerated";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { Loader } from "components/Loader/Loader";
-import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
-import { nameValidator } from "utils/formUtils";
 import { pageTitle } from "utils/page";
 import { useOrganizationSettings } from "../ManagementSettingsLayout";
 import CreateEditRolePageView from "./CreateEditRolePageView";
@@ -36,32 +31,7 @@ export const CreateEditRolePage: FC = () => {
   const role = roleData?.find((role) => role.name === roleName);
   const permissions = permissionsQuery.data;
 
-  const validationSchema = Yup.object({
-    name: nameValidator("Name"),
-  });
-
-  const onSubmit = async (data: PatchRoleRequest) => {
-    try {
-      await patchOrganizationRoleMutation.mutateAsync(data);
-      navigate(`/organizations/${organizationName}/roles`);
-    } catch (error) {
-      displayError(getErrorMessage(error, "Failed to update custom role"));
-    }
-  };
-
-  const form = useFormik<PatchRoleRequest>({
-    initialValues: {
-      name: role?.name || "",
-      display_name: role?.display_name || "",
-      site_permissions: role?.site_permissions || [],
-      organization_permissions: role?.organization_permissions || [],
-      user_permissions: role?.user_permissions || [],
-    },
-    validationSchema,
-    onSubmit,
-  });
-
-  if (isLoading) {
+  if (isLoading || !permissions) {
     return <Loader />;
   }
 
@@ -75,41 +45,22 @@ export const CreateEditRolePage: FC = () => {
         </title>
       </Helmet>
 
-      <PageHeader
-        actions={
-          permissions &&
-          permissions.assignOrgRole && (
-            <>
-              <Button
-                onClick={() => {
-                  navigate(`/organizations/${organizationName}/roles`);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={() => {
-                  form.handleSubmit();
-                }}
-              >
-                {role !== undefined ? "Save" : "Create Role"}
-              </Button>
-            </>
-          )
-        }
-      >
-        <PageHeaderTitle>
-          {role ? "Edit" : "Create"} custom role
-        </PageHeaderTitle>
-      </PageHeader>
-
       <CreateEditRolePageView
         role={role}
-        form={form}
+        onSubmit={async (data: PatchRoleRequest) => {
+          try {
+            await patchOrganizationRoleMutation.mutateAsync(data);
+            navigate(`/organizations/${organizationName}/roles`);
+          } catch (error) {
+            displayError(
+              getErrorMessage(error, "Failed to update custom role"),
+            );
+          }
+        }}
         error={patchOrganizationRoleMutation.error}
         isLoading={patchOrganizationRoleMutation.isLoading}
+        organizationName={organizationName}
+        canAssignOrgRole={permissions.assignOrgRole}
       />
     </>
   );

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -20,7 +20,7 @@ export const CreateEditRolePage: FC = () => {
   const { permissions } = useAuthenticated();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { organization = "default", roleName } = useParams() as {
+  const { organization, roleName } = useParams() as {
     organization: string;
     roleName: string;
   };

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -39,7 +39,6 @@ export const CreateGroupPage: FC = () => {
       </Helmet>
       <CreateEditRolePageView
         role={role}
-        organization={organization}
         onSubmit={async (data) => {
           try {
             await patchOrganizationRoleMutation.mutateAsync(data);

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage.tsx
@@ -10,7 +10,7 @@ import { patchOrganizationRole, organizationRoles } from "api/queries/roles";
 import type { PatchRoleRequest } from "api/typesGenerated";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { Loader } from "components/Loader/Loader";
-import { PageHeader } from "components/PageHeader/PageHeader";
+import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
 import { nameValidator } from "utils/formUtils";
 import { pageTitle } from "utils/page";
@@ -20,13 +20,13 @@ export const CreateEditRolePage: FC = () => {
   const { permissions } = useAuthenticated();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { organization, roleName } = useParams() as {
+  const { organization = "default", roleName } = useParams() as {
     organization: string;
     roleName: string;
   };
   const { assignOrgRole: canAssignOrgRole } = permissions;
   const patchOrganizationRoleMutation = useMutation(
-    patchOrganizationRole(queryClient, organization ?? "default"),
+    patchOrganizationRole(queryClient, organization),
   );
   const { data: roleData, isLoading } = useQuery(
     organizationRoles(organization),
@@ -95,7 +95,11 @@ export const CreateEditRolePage: FC = () => {
             </>
           )
         }
-      ></PageHeader>
+      >
+        <PageHeaderTitle>
+          {role ? "Edit" : "Create"} custom role
+        </PageHeaderTitle>
+      </PageHeader>
 
       <CreateEditRolePageView
         role={role}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  mockApiError,
+  MockRoleWithOrgPermissions,
+  assignableRole,
+} from "testHelpers/entities";
+import { CreateEditRolePageView } from "./CreateEditRolePageView";
+
+const meta: Meta<typeof CreateEditRolePageView> = {
+  title: "pages/OrganizationCreateEditRolePage",
+  component: CreateEditRolePageView,
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateEditRolePageView>;
+
+export const Default: Story = {
+  args: {
+    role: assignableRole(MockRoleWithOrgPermissions, true),
+    onSubmit: () => null,
+    error: undefined,
+    isLoading: false,
+    organizationName: "my-org",
+    canAssignOrgRole: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    role: assignableRole(MockRoleWithOrgPermissions, true),
+    onSubmit: () => null,
+    error: mockApiError({
+      message: "A role named new-role already exists.",
+      validations: [{ field: "name", detail: "Role names must be unique" }],
+    }),
+    isLoading: false,
+    organizationName: "my-org",
+    canAssignOrgRole: true,
+  },
+};
+
+export const CannotEdit: Story = {
+  args: {
+    role: assignableRole(MockRoleWithOrgPermissions, true),
+    onSubmit: () => null,
+    error: undefined,
+    isLoading: false,
+    organizationName: "my-org",
+    canAssignOrgRole: false,
+  },
+};
+
+export const ShowAllResources: Story = {
+  args: {
+    role: assignableRole(MockRoleWithOrgPermissions, true),
+    onSubmit: () => null,
+    error: undefined,
+    isLoading: false,
+    organizationName: "my-org",
+    canAssignOrgRole: true,
+    allResources: true,
+  },
+};

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -6,8 +6,8 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
-import { type FormikValues, useFormik } from "formik";
-import { type ChangeEvent, useState, type FC, useEffect } from "react";
+import { useFormik } from "formik";
+import { type ChangeEvent, useState, type FC } from "react";
 import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 import { isApiValidationError } from "api/errors";
@@ -112,7 +112,7 @@ interface ActionCheckboxesProps {
 }
 
 const ActionCheckboxes: FC<ActionCheckboxesProps> = ({ permissions, form }) => {
-  const [checkedActions, setIsChecked] = useState(permissions);
+  const [checkedActions, setCheckActions] = useState(permissions);
 
   const handleCheckChange = async (
     e: ChangeEvent<HTMLInputElement>,
@@ -134,13 +134,9 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({ permissions, form }) => {
           (p) => p.resource_type !== resource_type || p.action !== action,
         );
 
-    setIsChecked(newPermissions);
-    await form.setFieldValue("organization_permissions", checkedActions);
+    setCheckActions(newPermissions);
+    await form.setFieldValue("organization_permissions", newPermissions);
   };
-
-  // useEffect(() => {
-  //   setIsChecked(permissions);
-  // }, [permissions]);
 
   return (
     <TableContainer>

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -27,13 +27,12 @@ import type {
   RBACAction,
 } from "api/typesGenerated";
 import { ErrorAlert } from "components/Alert/ErrorAlert";
+import { FormFields, FormFooter, VerticalForm } from "components/Form/Form";
 import {
-  FormFields,
-  FormFooter,
-  FormSection,
-  VerticalForm,
-} from "components/Form/Form";
-import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
+  PageHeader,
+  PageHeaderSubtitle,
+  PageHeaderTitle,
+} from "components/PageHeader/PageHeader";
 import { getFormHelpers, nameValidator } from "utils/formUtils";
 
 const validationSchema = Yup.object({
@@ -105,41 +104,39 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
         <PageHeaderTitle>
           {role ? "Edit" : "Create"} custom role
         </PageHeaderTitle>
+        <PageHeaderSubtitle>
+          {"Set a name and permissions for this role."}
+        </PageHeaderSubtitle>
       </PageHeader>
       <VerticalForm onSubmit={form.handleSubmit}>
-        <FormSection
-          title="Role settings"
-          description="Set a name and permissions for this role."
-        >
-          <FormFields>
-            {Boolean(error) && !isApiValidationError(error) && (
-              <ErrorAlert error={error} />
-            )}
+        <FormFields>
+          {Boolean(error) && !isApiValidationError(error) && (
+            <ErrorAlert error={error} />
+          )}
 
-            <TextField
-              {...getFieldHelpers("name", {
-                helperText:
-                  "The role name cannot be modified after the role is created.",
-              })}
-              autoFocus
-              fullWidth
-              disabled={role !== undefined}
-              label="Name"
-            />
-            <TextField
-              {...getFieldHelpers("display_name", {
-                helperText: "Optional: keep empty to default to the name.",
-              })}
-              fullWidth
-              label="Display Name"
-            />
-            <ActionCheckboxes
-              permissions={role?.organization_permissions || []}
-              form={form}
-              allResources={allResources}
-            />
-          </FormFields>
-        </FormSection>
+          <TextField
+            {...getFieldHelpers("name", {
+              helperText:
+                "The role name cannot be modified after the role is created.",
+            })}
+            autoFocus
+            fullWidth
+            disabled={role !== undefined}
+            label="Name"
+          />
+          <TextField
+            {...getFieldHelpers("display_name", {
+              helperText: "Optional: keep empty to default to the name.",
+            })}
+            fullWidth
+            label="Display Name"
+          />
+          <ActionCheckboxes
+            permissions={role?.organization_permissions || []}
+            form={form}
+            allResources={allResources}
+          />
+        </FormFields>
         {canAssignOrgRole && (
           <FormFooter
             onCancel={onCancel}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -48,47 +48,45 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
   const onCancel = () => navigate(-1);
 
   return (
-    <>
-      <HorizontalForm onSubmit={form.handleSubmit}>
-        <FormSection
-          title="Role settings"
-          description="Set a name and permissions for this role."
-        >
-          <FormFields>
-            {Boolean(error) && !isApiValidationError(error) && (
-              <ErrorAlert error={error} />
-            )}
+    <HorizontalForm onSubmit={form.handleSubmit}>
+      <FormSection
+        title="Role settings"
+        description="Set a name and permissions for this role."
+      >
+        <FormFields>
+          {Boolean(error) && !isApiValidationError(error) && (
+            <ErrorAlert error={error} />
+          )}
 
-            <TextField
-              {...getFieldHelpers("name", {
-                helperText:
-                  "The role name cannot be modified after the role is created.",
-              })}
-              autoFocus
-              fullWidth
-              disabled={role !== undefined}
-              label="Name"
-            />
-            <TextField
-              {...getFieldHelpers("display_name", {
-                helperText: "Optional: keep empty to default to the name.",
-              })}
-              fullWidth
-              label="Display Name"
-            />
-            <ActionCheckboxes
-              permissions={role?.organization_permissions || []}
-              form={form}
-            />
-          </FormFields>
-        </FormSection>
-        <FormFooter
-          onCancel={onCancel}
-          isLoading={isLoading}
-          submitLabel={role !== undefined ? "Save" : "Create Role"}
-        />
-      </HorizontalForm>
-    </>
+          <TextField
+            {...getFieldHelpers("name", {
+              helperText:
+                "The role name cannot be modified after the role is created.",
+            })}
+            autoFocus
+            fullWidth
+            disabled={role !== undefined}
+            label="Name"
+          />
+          <TextField
+            {...getFieldHelpers("display_name", {
+              helperText: "Optional: keep empty to default to the name.",
+            })}
+            fullWidth
+            label="Display Name"
+          />
+          <ActionCheckboxes
+            permissions={role?.organization_permissions || []}
+            form={form}
+          />
+        </FormFields>
+      </FormSection>
+      <FormFooter
+        onCancel={onCancel}
+        isLoading={isLoading}
+        submitLabel={role !== undefined ? "Save" : "Create Role"}
+      />
+    </HorizontalForm>
   );
 };
 
@@ -192,34 +190,28 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({ permissions, form }) => {
                     <li key={resourceKey} css={styles.checkBoxes}>
                       {resourceKey}
                       <ul css={styles.checkBoxes}>
-                        {Object.entries(value).map(([actionKey, value]) => {
-                          return (
-                            <li key={actionKey}>
-                              <span css={styles.actionText}>
-                                <Checkbox
-                                  name={`${resourceKey}:${actionKey}`}
-                                  checked={
-                                    checkedActions?.some((p) =>
-                                      ResourceActionComparator(
-                                        p,
-                                        resourceKey,
-                                        actionKey,
-                                      ),
-                                    ) || false
-                                  }
-                                  onChange={(e) =>
-                                    handleActionCheckChange(e, form)
-                                  }
-                                />
-                                {actionKey}
-                              </span>{" "}
-                              &ndash;{" "}
-                              <span css={styles.actionDescription}>
-                                {value}
-                              </span>
-                            </li>
-                          );
-                        })}
+                        {Object.entries(value).map(([actionKey, value]) => (
+                          <li key={actionKey}>
+                            <span css={styles.actionText}>
+                              <Checkbox
+                                name={`${resourceKey}:${actionKey}`}
+                                checked={checkedActions?.some((p) =>
+                                  ResourceActionComparator(
+                                    p,
+                                    resourceKey,
+                                    actionKey,
+                                  ),
+                                )}
+                                onChange={(e) =>
+                                  handleActionCheckChange(e, form)
+                                }
+                              />
+                              {actionKey}
+                            </span>{" "}
+                            &ndash;{" "}
+                            <span css={styles.actionDescription}>{value}</span>
+                          </li>
+                        ))}
                       </ul>
                     </li>
                   </TableCell>

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -26,7 +26,6 @@ import {
   FormSection,
   HorizontalForm,
 } from "components/Form/Form";
-import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { getFormHelpers } from "utils/formUtils";
 
 export type CreateEditRolePageViewProps = {
@@ -48,11 +47,6 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 
   return (
     <>
-      <PageHeader css={{ paddingTop: 8 }}>
-        <PageHeaderTitle>
-          {role ? "Edit" : "Create"} custom role
-        </PageHeaderTitle>
-      </PageHeader>
       <HorizontalForm onSubmit={form.handleSubmit}>
         <FormSection
           title="Role settings"
@@ -101,6 +95,14 @@ interface ActionCheckboxesProps {
   form: ReturnType<typeof useFormik<Role>> & { values: Role };
 }
 
+const ResourceActionComparator = (
+  p: Permission,
+  resource: string,
+  action: string,
+) =>
+  p.resource_type === resource &&
+  (p.action.toString() === "*" || p.action === action);
+
 const ActionCheckboxes: FC<ActionCheckboxesProps> = ({ permissions, form }) => {
   const [checkedActions, setCheckActions] = useState(permissions);
 
@@ -146,18 +148,19 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({ permissions, form }) => {
                               <Checkbox
                                 name={`${resourceKey}:${actionKey}`}
                                 checked={
-                                  checkedActions?.some(
-                                    (p) =>
-                                      p.resource_type === resourceKey &&
-                                      (p.action.toString() === "*" ||
-                                        p.action === actionKey),
+                                  checkedActions?.some((p) =>
+                                    ResourceActionComparator(
+                                      p,
+                                      resourceKey,
+                                      actionKey,
+                                    ),
                                   ) || false
                                 }
                                 onChange={(e) => handleCheckChange(e, form)}
                               />
                               {actionKey}
                             </span>{" "}
-                            -{" "}
+                            &ndash;{" "}
                             <span css={styles.actionDescription}>{value}</span>
                           </li>
                         );

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -8,6 +8,7 @@ import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
+import TableFooter from "@mui/material/TableFooter";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
@@ -219,80 +220,102 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
     : filteredRBACResourceActions;
 
   return (
-    <>
-      <TableContainer>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Permission</TableCell>
-              <TableCell
-                align="right"
-                sx={{ paddingTop: 0.4, paddingBottom: 0.4 }}
-              >
-                <FormControlLabel
-                  sx={{ marginRight: 1 }}
-                  control={
-                    <Checkbox
-                      size="small"
-                      id="show_all_permissions"
-                      name="show_all_permissions"
-                      checked={showAllResources}
-                      onChange={(e) =>
-                        setShowAllResources(e.currentTarget.checked)
-                      }
-                      checkedIcon={<VisibilityOutlinedIcon />}
-                      icon={<VisibilityOffOutlinedIcon />}
-                    />
-                  }
-                  label={
-                    <span style={{ fontSize: 12 }}>Show all permissions</span>
-                  }
-                />
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {Object.entries(resourceActions).map(([resourceKey, value]) => {
-              return (
-                <TableRow key={resourceKey}>
-                  <TableCell sx={{ paddingLeft: 2 }}>
-                    <li key={resourceKey} css={styles.checkBoxes}>
-                      {resourceKey}
-                      <ul css={styles.checkBoxes}>
-                        {Object.entries(value).map(([actionKey, value]) => (
-                          <li key={actionKey}>
-                            <span css={styles.actionText}>
-                              <Checkbox
-                                size="small"
-                                name={`${resourceKey}:${actionKey}`}
-                                checked={checkedActions?.some((p) =>
-                                  ResourceActionComparator(
-                                    p,
-                                    resourceKey,
-                                    actionKey,
-                                  ),
-                                )}
-                                onChange={(e) =>
-                                  handleActionCheckChange(e, form)
-                                }
-                              />
-                              {actionKey}
-                            </span>{" "}
-                            &ndash;{" "}
-                            <span css={styles.actionDescription}>{value}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </li>
-                  </TableCell>
-                  <TableCell />
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </>
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Permission</TableCell>
+            <TableCell
+              align="right"
+              sx={{ paddingTop: 0.4, paddingBottom: 0.4 }}
+            >
+              <ShowAllResourcesCheckbox
+                showAllResources={showAllResources}
+                setShowAllResources={setShowAllResources}
+              />
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Object.entries(resourceActions).map(([resourceKey, value]) => {
+            return (
+              <TableRow key={resourceKey}>
+                <TableCell sx={{ paddingLeft: 2 }} colSpan={2}>
+                  <li key={resourceKey} css={styles.checkBoxes}>
+                    {resourceKey}
+                    <ul css={styles.checkBoxes}>
+                      {Object.entries(value).map(([actionKey, value]) => (
+                        <li key={actionKey}>
+                          <span css={styles.actionText}>
+                            <Checkbox
+                              size="small"
+                              name={`${resourceKey}:${actionKey}`}
+                              checked={checkedActions?.some((p) =>
+                                ResourceActionComparator(
+                                  p,
+                                  resourceKey,
+                                  actionKey,
+                                ),
+                              )}
+                              onChange={(e) => handleActionCheckChange(e, form)}
+                            />
+                            {actionKey}
+                          </span>{" "}
+                          &ndash;{" "}
+                          <span css={styles.actionDescription}>{value}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell
+              align="right"
+              colSpan={2}
+              sx={{ paddingTop: 0.4, paddingBottom: 0.4, paddingRight: 4 }}
+            >
+              <ShowAllResourcesCheckbox
+                showAllResources={showAllResources}
+                setShowAllResources={setShowAllResources}
+              />
+            </TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </TableContainer>
+  );
+};
+
+interface ShowAllResourcesCheckboxProps {
+  showAllResources: boolean;
+  setShowAllResources: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ShowAllResourcesCheckbox: FC<ShowAllResourcesCheckboxProps> = ({
+  showAllResources,
+  setShowAllResources,
+}) => {
+  return (
+    <FormControlLabel
+      sx={{ marginRight: 1 }}
+      control={
+        <Checkbox
+          size="small"
+          id="show_all_permissions"
+          name="show_all_permissions"
+          checked={showAllResources}
+          onChange={(e) => setShowAllResources(e.currentTarget.checked)}
+          checkedIcon={<VisibilityOutlinedIcon />}
+          icon={<VisibilityOffOutlinedIcon />}
+        />
+      }
+      label={<span style={{ fontSize: 12 }}>Show all permissions</span>}
+    />
   );
 };
 

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -14,6 +14,7 @@ import { isApiValidationError } from "api/errors";
 import { RBACResourceActions } from "api/rbacresources_gen";
 import type {
   Role,
+  PatchRoleRequest,
   Permission,
   AssignableRoles,
   RBACResource,
@@ -35,7 +36,6 @@ const validationSchema = Yup.object({
 
 export type CreateEditRolePageViewProps = {
   role: AssignableRoles | undefined;
-  organization: string;
   onSubmit: (data: Role) => void;
   error?: unknown;
   isLoading: boolean;
@@ -43,16 +43,14 @@ export type CreateEditRolePageViewProps = {
 
 export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
   role,
-  organization,
   onSubmit,
   error,
   isLoading,
 }) => {
   const navigate = useNavigate();
-  const form = useFormik<Role>({
+  const form = useFormik<PatchRoleRequest>({
     initialValues: {
       name: role?.name || "",
-      organization_id: role?.organization_id || organization,
       display_name: role?.display_name || "",
       site_permissions: role?.site_permissions || [],
       organization_permissions: role?.organization_permissions || [],

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -82,7 +82,10 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
             )}
 
             <TextField
-              {...getFieldHelpers("name")}
+              {...getFieldHelpers("name", {
+                helperText:
+                  "The role name cannot be modified after the role is created.",
+              })}
               autoFocus
               fullWidth
               disabled={role !== undefined}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -1,4 +1,6 @@
 import type { Interpolation, Theme } from "@emotion/react";
+import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
+import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -28,7 +30,7 @@ import {
   FormFields,
   FormFooter,
   FormSection,
-  HorizontalForm,
+  VerticalForm,
 } from "components/Form/Form";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { getFormHelpers, nameValidator } from "utils/formUtils";
@@ -103,7 +105,7 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
           {role ? "Edit" : "Create"} custom role
         </PageHeaderTitle>
       </PageHeader>
-      <HorizontalForm onSubmit={form.handleSubmit}>
+      <VerticalForm onSubmit={form.handleSubmit}>
         <FormSection
           title="Role settings"
           description="Set a name and permissions for this role."
@@ -144,7 +146,7 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
             submitLabel={role !== undefined ? "Save" : "Create Role"}
           />
         )}
-      </HorizontalForm>
+      </VerticalForm>
     </>
   );
 };
@@ -222,6 +224,7 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
         <Table>
           <TableHead>
             <TableRow>
+              <TableCell>Permission</TableCell>
               <TableCell
                 align="right"
                 sx={{ paddingTop: 0.4, paddingBottom: 0.4 }}
@@ -237,6 +240,8 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
                       onChange={(e) =>
                         setShowAllResources(e.currentTarget.checked)
                       }
+                      checkedIcon={<VisibilityOutlinedIcon />}
+                      icon={<VisibilityOffOutlinedIcon />}
                     />
                   }
                   label={
@@ -258,6 +263,7 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
                           <li key={actionKey}>
                             <span css={styles.actionText}>
                               <Checkbox
+                                size="small"
                                 name={`${resourceKey}:${actionKey}`}
                                 checked={checkedActions?.some((p) =>
                                   ResourceActionComparator(
@@ -279,6 +285,7 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
                       </ul>
                     </li>
                   </TableCell>
+                  <TableCell />
                 </TableRow>
               );
             })}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -1,0 +1,147 @@
+import type { Interpolation, Theme } from "@emotion/react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableRow from "@mui/material/TableRow";
+import TextField from "@mui/material/TextField";
+import { useFormik } from "formik";
+import type { FC } from "react";
+import { useNavigate } from "react-router-dom";
+import * as Yup from "yup";
+import { isApiValidationError } from "api/errors";
+import { RBACResourceActions } from "api/rbacresources_gen";
+import type { Role } from "api/typesGenerated";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
+import {
+  FormFields,
+  FormFooter,
+  FormSection,
+  HorizontalForm,
+} from "components/Form/Form";
+import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
+import { getFormHelpers } from "utils/formUtils";
+
+const validationSchema = Yup.object({
+  name: Yup.string().required().label("Name"),
+});
+
+export type CreateEditRolePageViewProps = {
+  onSubmit: (data: Role) => void;
+  error?: unknown;
+  isLoading: boolean;
+};
+
+export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
+  onSubmit,
+  error,
+  isLoading,
+}) => {
+  const navigate = useNavigate();
+  const form = useFormik<Role>({
+    initialValues: {
+      name: "",
+      display_name: "",
+      site_permissions: [],
+      organization_permissions: [],
+      user_permissions: [],
+    },
+    validationSchema,
+    onSubmit,
+  });
+  const getFieldHelpers = getFormHelpers<Role>(form, error);
+  const onCancel = () => navigate(-1);
+
+  return (
+    <>
+      <PageHeader css={{ paddingTop: 8 }}>
+        <PageHeaderTitle>Create custom role</PageHeaderTitle>
+      </PageHeader>
+      <HorizontalForm onSubmit={form.handleSubmit}>
+        <FormSection
+          title="Role settings"
+          description="Set a name for this role."
+        >
+          <FormFields>
+            {Boolean(error) && !isApiValidationError(error) && (
+              <ErrorAlert error={error} />
+            )}
+
+            <TextField
+              {...getFieldHelpers("name")}
+              autoFocus
+              fullWidth
+              label="Name"
+            />
+            <TextField
+              {...getFieldHelpers("display_name", {
+                helperText: "Optional: keep empty to default to the name.",
+              })}
+              fullWidth
+              label="Display Name"
+            />
+            <ActionCheckboxes permissions={[]}></ActionCheckboxes>
+          </FormFields>
+        </FormSection>
+        <FormFooter onCancel={onCancel} isLoading={isLoading} />
+      </HorizontalForm>
+    </>
+  );
+};
+
+interface ActionCheckboxesProps {
+  permissions: Permissions[];
+}
+
+const ActionCheckboxes: FC<ActionCheckboxesProps> = ({ permissions }) => {
+  return (
+    <TableContainer>
+      <Table>
+        <TableBody>
+          {Object.entries(RBACResourceActions).map(([key, value]) => {
+            return (
+              <TableRow key={key}>
+                <TableCell>
+                  <li key={key} css={styles.checkBoxes}>
+                    <input type="checkbox" /> {key}
+                    <ul css={styles.checkBoxes}>
+                      {Object.entries(value).map(([key, value]) => {
+                        return (
+                          <li key={key}>
+                            <span css={styles.actionText}>
+                              <input type="checkbox" /> {key}
+                            </span>{" "}
+                            -{" "}
+                            <span css={styles.actionDescription}>{value}</span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </li>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+const styles = {
+  rolesDropdown: {
+    marginBottom: 20,
+  },
+  checkBoxes: {
+    margin: 0,
+    listStyleType: "none",
+  },
+  actionText: (theme) => ({
+    color: theme.palette.text.primary,
+  }),
+  actionDescription: (theme) => ({
+    color: theme.palette.text.secondary,
+  }),
+} satisfies Record<string, Interpolation<Theme>>;
+
+export default CreateEditRolePageView;

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -85,6 +85,7 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
               {...getFieldHelpers("name")}
               autoFocus
               fullWidth
+              disabled={role !== undefined}
               label="Name"
             />
             <TextField

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -6,10 +6,9 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
-import { useFormik } from "formik";
+import type { useFormik } from "formik";
 import { type ChangeEvent, useState, type FC } from "react";
 import { useNavigate } from "react-router-dom";
-import * as Yup from "yup";
 import { isApiValidationError } from "api/errors";
 import { RBACResourceActions } from "api/rbacresources_gen";
 import type {
@@ -30,35 +29,20 @@ import {
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { getFormHelpers } from "utils/formUtils";
 
-const validationSchema = Yup.object({
-  name: Yup.string().required().label("Name"),
-});
-
 export type CreateEditRolePageViewProps = {
   role: AssignableRoles | undefined;
-  onSubmit: (data: Role) => void;
+  form: ReturnType<typeof useFormik<PatchRoleRequest>>;
   error?: unknown;
   isLoading: boolean;
 };
 
 export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
   role,
-  onSubmit,
+  form,
   error,
   isLoading,
 }) => {
   const navigate = useNavigate();
-  const form = useFormik<PatchRoleRequest>({
-    initialValues: {
-      name: role?.name || "",
-      display_name: role?.display_name || "",
-      site_permissions: role?.site_permissions || [],
-      organization_permissions: role?.organization_permissions || [],
-      user_permissions: role?.user_permissions || [],
-    },
-    validationSchema,
-    onSubmit,
-  });
   const getFieldHelpers = getFormHelpers<Role>(form, error);
   const onCancel = () => navigate(-1);
 
@@ -102,7 +86,11 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
             />
           </FormFields>
         </FormSection>
-        <FormFooter onCancel={onCancel} isLoading={isLoading} />
+        <FormFooter
+          onCancel={onCancel}
+          isLoading={isLoading}
+          submitLabel={role !== undefined ? "Save" : "Create Role"}
+        />
       </HorizontalForm>
     </>
   );

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -22,10 +22,10 @@ import CustomRolesPageView from "./CustomRolesPageView";
 
 export const CustomRolesPage: FC = () => {
   const { permissions } = useAuthenticated();
-  const { createGroup: canCreateGroup } = permissions;
+  const { assignOrgRole: canAssignOrgRole } = permissions;
   const {
     multiple_organizations: organizationsEnabled,
-    template_rbac: isTemplateRBACEnabled,
+    custom_roles: isCustomRolesEnabled,
   } = useFeatureVisibility();
   const { experiments } = useDashboard();
   const location = useLocation();
@@ -62,7 +62,7 @@ export const CustomRolesPage: FC = () => {
       <PageHeader
         actions={
           <>
-            {canCreateGroup && isTemplateRBACEnabled && (
+            {canAssignOrgRole && isCustomRolesEnabled && (
               <Button
                 component={RouterLink}
                 startIcon={<GroupAdd />}
@@ -79,8 +79,8 @@ export const CustomRolesPage: FC = () => {
 
       <CustomRolesPageView
         roles={organizationRolesQuery.data}
-        canCreateGroup={canCreateGroup}
-        isTemplateRBACEnabled={isTemplateRBACEnabled}
+        canAssignOrgRole={canAssignOrgRole}
+        isCustomRolesEnabled={isCustomRolesEnabled}
       />
     </>
   );

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -5,24 +5,29 @@ import { Helmet } from "react-helmet-async";
 import { useQuery } from "react-query";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { getErrorMessage } from "api/errors";
+import { organizationPermissions } from "api/queries/organizations";
 import { organizationRoles } from "api/queries/roles";
 import { displayError } from "components/GlobalSnackbar/utils";
+import { Loader } from "components/Loader/Loader";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
-import { useAuthenticated } from "contexts/auth/RequireAuth";
 import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
 import { pageTitle } from "utils/page";
+import { useOrganizationSettings } from "../ManagementSettingsLayout";
 import CustomRolesPageView from "./CustomRolesPageView";
 
 export const CustomRolesPage: FC = () => {
-  const { permissions } = useAuthenticated();
-  const { assignOrgRole: canAssignOrgRole } = permissions;
   const { custom_roles: isCustomRolesEnabled } = useFeatureVisibility();
-
-  const { organization } = useParams() as { organization: string };
-  const organizationRolesQuery = useQuery(organizationRoles(organization));
+  const { organization: organizationName } = useParams() as {
+    organization: string;
+  };
+  const { organizations } = useOrganizationSettings();
+  const organization = organizations?.find((o) => o.name === organizationName);
+  const permissionsQuery = useQuery(organizationPermissions(organization?.id));
+  const organizationRolesQuery = useQuery(organizationRoles(organizationName));
   const filteredRoleData = organizationRolesQuery.data?.filter(
     (role) => role.built_in === false,
   );
+  const permissions = permissionsQuery.data;
 
   useEffect(() => {
     if (organizationRolesQuery.error) {
@@ -35,6 +40,10 @@ export const CustomRolesPage: FC = () => {
     }
   }, [organizationRolesQuery.error]);
 
+  if (!permissions) {
+    return <Loader />;
+  }
+
   return (
     <>
       <Helmet>
@@ -44,7 +53,7 @@ export const CustomRolesPage: FC = () => {
       <PageHeader
         actions={
           <>
-            {canAssignOrgRole && isCustomRolesEnabled && (
+            {permissions.assignOrgRole && isCustomRolesEnabled && (
               <Button
                 component={RouterLink}
                 startIcon={<AddIcon />}
@@ -61,7 +70,7 @@ export const CustomRolesPage: FC = () => {
 
       <CustomRolesPageView
         roles={filteredRoleData}
-        canAssignOrgRole={canAssignOrgRole}
+        canAssignOrgRole={permissions.assignOrgRole}
         isCustomRolesEnabled={isCustomRolesEnabled}
       />
     </>

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -3,13 +3,12 @@ import Button from "@mui/material/Button";
 import { type FC, useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "react-query";
-import { Link as RouterLink, useLocation, useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
 import { getErrorMessage } from "api/errors";
 import { organizationRoles } from "api/queries/roles";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
-import { useDashboard } from "modules/dashboard/useDashboard";
 import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
 import { pageTitle } from "utils/page";
 import CustomRolesPageView from "./CustomRolesPageView";
@@ -17,12 +16,8 @@ import CustomRolesPageView from "./CustomRolesPageView";
 export const CustomRolesPage: FC = () => {
   const { permissions } = useAuthenticated();
   const { assignOrgRole: canAssignOrgRole } = permissions;
-  const {
-    multiple_organizations: organizationsEnabled,
-    custom_roles: isCustomRolesEnabled,
-  } = useFeatureVisibility();
-  const { experiments } = useDashboard();
-  const location = useLocation();
+  const { custom_roles: isCustomRolesEnabled } = useFeatureVisibility();
+
   const { organization = "default" } = useParams() as { organization: string };
   const organizationRolesQuery = useQuery(organizationRoles(organization));
   const filteredRoleData = organizationRolesQuery.data?.filter(
@@ -39,16 +34,6 @@ export const CustomRolesPage: FC = () => {
       );
     }
   }, [organizationRolesQuery.error]);
-
-  // if (
-  //   organizationsEnabled &&
-  //   experiments.includes("multi-organization") &&
-  //   location.pathname === "/deployment/groups"
-  // ) {
-  //   const defaultName =
-  //     getOrganizationNameByDefault(organizations) ?? "default";
-  //   return <Navigate to={`/organizations/${defaultName}/groups`} replace />;
-  // }
 
   return (
     <>

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -1,0 +1,89 @@
+import GroupAdd from "@mui/icons-material/GroupAddOutlined";
+import Button from "@mui/material/Button";
+import { type FC, useEffect } from "react";
+import { Helmet } from "react-helmet-async";
+import { useQuery } from "react-query";
+import {
+  Navigate,
+  Link as RouterLink,
+  useLocation,
+  useParams,
+} from "react-router-dom";
+import { getErrorMessage } from "api/errors";
+import { organizationRoles } from "api/queries/roles";
+import type { Organization } from "api/typesGenerated";
+import { displayError } from "components/GlobalSnackbar/utils";
+import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
+import { useAuthenticated } from "contexts/auth/RequireAuth";
+import { useDashboard } from "modules/dashboard/useDashboard";
+import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
+import { pageTitle } from "utils/page";
+import CustomRolesPageView from "./CustomRolesPageView";
+
+export const CustomRolesPage: FC = () => {
+  const { permissions } = useAuthenticated();
+  const { createGroup: canCreateGroup } = permissions;
+  const {
+    multiple_organizations: organizationsEnabled,
+    template_rbac: isTemplateRBACEnabled,
+  } = useFeatureVisibility();
+  const { experiments } = useDashboard();
+  const location = useLocation();
+  const { organization = "default" } = useParams() as { organization: string };
+  const organizationRolesQuery = useQuery(organizationRoles(organization));
+
+  useEffect(() => {
+    if (organizationRolesQuery.error) {
+      displayError(
+        getErrorMessage(
+          organizationRolesQuery.error,
+          "Error loading custom roles.",
+        ),
+      );
+    }
+  }, [organizationRolesQuery.error]);
+
+  // if (
+  //   organizationsEnabled &&
+  //   experiments.includes("multi-organization") &&
+  //   location.pathname === "/deployment/groups"
+  // ) {
+  //   const defaultName =
+  //     getOrganizationNameByDefault(organizations) ?? "default";
+  //   return <Navigate to={`/organizations/${defaultName}/groups`} replace />;
+  // }
+
+  return (
+    <>
+      <Helmet>
+        <title>{pageTitle("Groups")}</title>
+      </Helmet>
+
+      <PageHeader
+        actions={
+          <>
+            {canCreateGroup && isTemplateRBACEnabled && (
+              <Button
+                component={RouterLink}
+                startIcon={<GroupAdd />}
+                to="create"
+              >
+                Create custom role
+              </Button>
+            )}
+          </>
+        }
+      >
+        <PageHeaderTitle>Custom Roles</PageHeaderTitle>
+      </PageHeader>
+
+      <CustomRolesPageView
+        roles={organizationRolesQuery.data}
+        canCreateGroup={canCreateGroup}
+        isTemplateRBACEnabled={isTemplateRBACEnabled}
+      />
+    </>
+  );
+};
+
+export default CustomRolesPage;

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -18,7 +18,7 @@ export const CustomRolesPage: FC = () => {
   const { assignOrgRole: canAssignOrgRole } = permissions;
   const { custom_roles: isCustomRolesEnabled } = useFeatureVisibility();
 
-  const { organization = "default" } = useParams() as { organization: string };
+  const { organization } = useParams() as { organization: string };
   const organizationRolesQuery = useQuery(organizationRoles(organization));
   const filteredRoleData = organizationRolesQuery.data?.filter(
     (role) => role.built_in === false,

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -1,4 +1,4 @@
-import GroupAdd from "@mui/icons-material/GroupAddOutlined";
+import AddIcon from "@mui/icons-material/AddOutlined";
 import Button from "@mui/material/Button";
 import { type FC, useEffect } from "react";
 import { Helmet } from "react-helmet-async";
@@ -47,7 +47,7 @@ export const CustomRolesPage: FC = () => {
             {canAssignOrgRole && isCustomRolesEnabled && (
               <Button
                 component={RouterLink}
-                startIcon={<GroupAdd />}
+                startIcon={<AddIcon />}
                 to="create"
               >
                 Create custom role

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage.tsx
@@ -3,15 +3,9 @@ import Button from "@mui/material/Button";
 import { type FC, useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "react-query";
-import {
-  Navigate,
-  Link as RouterLink,
-  useLocation,
-  useParams,
-} from "react-router-dom";
+import { Link as RouterLink, useLocation, useParams } from "react-router-dom";
 import { getErrorMessage } from "api/errors";
 import { organizationRoles } from "api/queries/roles";
-import type { Organization } from "api/typesGenerated";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
 import { useAuthenticated } from "contexts/auth/RequireAuth";
@@ -31,6 +25,9 @@ export const CustomRolesPage: FC = () => {
   const location = useLocation();
   const { organization = "default" } = useParams() as { organization: string };
   const organizationRolesQuery = useQuery(organizationRoles(organization));
+  const filteredRoleData = organizationRolesQuery.data?.filter(
+    (role) => role.built_in === false,
+  );
 
   useEffect(() => {
     if (organizationRolesQuery.error) {
@@ -56,7 +53,7 @@ export const CustomRolesPage: FC = () => {
   return (
     <>
       <Helmet>
-        <title>{pageTitle("Groups")}</title>
+        <title>{pageTitle("Custom Roles")}</title>
       </Helmet>
 
       <PageHeader
@@ -78,7 +75,7 @@ export const CustomRolesPage: FC = () => {
       </PageHeader>
 
       <CustomRolesPageView
-        roles={organizationRolesQuery.data}
+        roles={filteredRoleData}
         canAssignOrgRole={canAssignOrgRole}
         isCustomRolesEnabled={isCustomRolesEnabled}
       />

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MockRole } from "testHelpers/entities";
+import { CustomRolesPageView } from "./CustomRolesPageView";
+
+const meta: Meta<typeof CustomRolesPageView> = {
+  title: "pages/OrganizationCustomRolesPage",
+  component: CustomRolesPageView,
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomRolesPageView>;
+
+export const NotEnabled: Story = {
+  args: {
+    roles: [MockRole],
+    canAssignOrgRole: true,
+    isCustomRolesEnabled: false,
+  },
+};
+
+export const Enabled: Story = {
+  args: {
+    roles: [MockRole],
+    canAssignOrgRole: true,
+    isCustomRolesEnabled: true,
+  },
+};
+
+export const EmptyDisplayName: Story = {
+  args: {
+    roles: [{ ...MockRole, name: "my-custom-role", display_name: "" }],
+    canAssignOrgRole: true,
+    isCustomRolesEnabled: true,
+  },
+};
+
+export const EmptyRoleWithoutPermission: Story = {
+  args: {
+    roles: [],
+    canAssignOrgRole: false,
+    isCustomRolesEnabled: true,
+  },
+};
+
+export const EmptyRoleWithPermission: Story = {
+  args: {
+    roles: [],
+    canAssignOrgRole: true,
+    isCustomRolesEnabled: true,
+  },
+};

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { MockRole } from "testHelpers/entities";
+import { MockRoleWithOrgPermissions } from "testHelpers/entities";
 import { CustomRolesPageView } from "./CustomRolesPageView";
 
 const meta: Meta<typeof CustomRolesPageView> = {
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof CustomRolesPageView>;
 
 export const NotEnabled: Story = {
   args: {
-    roles: [MockRole],
+    roles: [MockRoleWithOrgPermissions],
     canAssignOrgRole: true,
     isCustomRolesEnabled: false,
   },
@@ -20,7 +20,7 @@ export const NotEnabled: Story = {
 
 export const Enabled: Story = {
   args: {
-    roles: [MockRole],
+    roles: [MockRoleWithOrgPermissions],
     canAssignOrgRole: true,
     isCustomRolesEnabled: true,
   },
@@ -28,7 +28,13 @@ export const Enabled: Story = {
 
 export const EmptyDisplayName: Story = {
   args: {
-    roles: [{ ...MockRole, name: "my-custom-role", display_name: "" }],
+    roles: [
+      {
+        ...MockRoleWithOrgPermissions,
+        name: "my-custom-role",
+        display_name: "",
+      },
+    ],
     canAssignOrgRole: true,
     isCustomRolesEnabled: true,
   },

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -1,0 +1,240 @@
+import { css } from "@emotion/css";
+import type { Interpolation, Theme } from "@emotion/react";
+import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
+import PersonAdd from "@mui/icons-material/PersonAdd";
+import { LoadingButton } from "@mui/lab";
+import { Table, TableBody, TableContainer, TextField } from "@mui/material";
+import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
+import AvatarGroup from "@mui/material/AvatarGroup";
+import Skeleton from "@mui/material/Skeleton";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import { useState, type FC } from "react";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
+import { RBACResourceActions } from "api/rbacresources_gen";
+import type { Group, Role } from "api/typesGenerated";
+import { AvatarData } from "components/AvatarData/AvatarData";
+import { AvatarDataSkeleton } from "components/AvatarData/AvatarDataSkeleton";
+import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
+import { EmptyState } from "components/EmptyState/EmptyState";
+import { GroupAvatar } from "components/GroupAvatar/GroupAvatar";
+import { Paywall } from "components/Paywall/Paywall";
+import { Stack } from "components/Stack/Stack";
+import {
+  TableLoader,
+  TableLoaderSkeleton,
+  TableRowSkeleton,
+} from "components/TableLoader/TableLoader";
+import { UserAvatar } from "components/UserAvatar/UserAvatar";
+import { permissionsToCheck } from "contexts/auth/permissions";
+import { useClickableTableRow } from "hooks";
+import { docs } from "utils/docs";
+
+export type CustomRolesPageViewProps = {
+  roles: Role[] | undefined;
+  canCreateGroup: boolean;
+  isTemplateRBACEnabled: boolean;
+};
+
+const filter = createFilterOptions<Role>();
+
+export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
+  roles,
+  canCreateGroup,
+  isTemplateRBACEnabled,
+}) => {
+  const isLoading = Boolean(roles === undefined);
+  const isEmpty = Boolean(roles && roles.length === 0);
+  const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+  console.log({ selectedRole });
+
+  return (
+    <>
+      <ChooseOne>
+        <Cond condition={!isTemplateRBACEnabled}>
+          <Paywall
+            message="Custom Roles"
+            description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
+            documentationLink={docs("/admin/groups")}
+          />
+        </Cond>
+        <Cond>
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={1}
+            css={styles.rolesDropdown}
+          >
+            <Autocomplete
+              value={selectedRole}
+              onChange={(_, newValue) => {
+                console.log("onChange: ", newValue);
+                if (typeof newValue === "string") {
+                  console.log("0");
+                  setSelectedRole({
+                    name: newValue,
+                    display_name: newValue,
+                    site_permissions: [],
+                    organization_permissions: [],
+                    user_permissions: [],
+                  });
+                } else if (newValue && newValue.display_name) {
+                  console.log("1");
+                  // Create a new value from the user input
+                  // setSelectedRole({ ...newValue, display_name: newValue.name });
+                  setSelectedRole(newValue);
+                } else {
+                  console.log("2");
+                  setSelectedRole(newValue);
+                }
+              }}
+              isOptionEqualToValue={(option: Role, value: Role) =>
+                option.name === value.name
+              }
+              filterOptions={(options, params) => {
+                const filtered = filter(options, params);
+
+                const { inputValue } = params;
+                // Suggest the creation of a new value
+                const isExisting = options.some(
+                  (option) => inputValue === option.display_name,
+                );
+                if (inputValue !== "" && !isExisting) {
+                  filtered.push({
+                    name: inputValue,
+                    display_name: `Add ${inputValue}`,
+                    site_permissions: [],
+                    organization_permissions: [],
+                    user_permissions: [],
+                  });
+                }
+
+                return filtered;
+              }}
+              selectOnFocus
+              clearOnBlur
+              handleHomeEndKeys
+              id="custom-role"
+              options={roles || []}
+              getOptionLabel={(option) => {
+                // console.log("getOptionLabel: ", option);
+                // Value selected with enter, right from the input
+                if (typeof option === "string") {
+                  return option;
+                }
+                // Add "xxx" option created dynamically
+                if (option.name) {
+                  return option.name;
+                }
+                // Regular option
+                return option.display_name;
+              }}
+              renderOption={(props, option) => {
+                const { key, ...optionProps } = props;
+                return (
+                  <li key={key} {...optionProps}>
+                    {option.display_name}
+                  </li>
+                );
+              }}
+              sx={{ width: 300 }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Display Name"
+                  InputLabelProps={{
+                    shrink: true,
+                  }}
+                />
+              )}
+            />
+
+            <LoadingButton
+              loadingPosition="start"
+              // disabled={!selectedUser}
+              type="submit"
+              startIcon={<PersonAdd />}
+              loading={isLoading}
+            >
+              Save Custom Role
+            </LoadingButton>
+          </Stack>
+
+          <TableContainer>
+            <Table>
+              <TableBody>
+                <ChooseOne>
+                  <Cond condition={isLoading}>
+                    <TableLoader />
+                  </Cond>
+
+                  <Cond condition={isEmpty}>
+                    <TableRow>
+                      <TableCell colSpan={999}>
+                        <EmptyState
+                          message="No custom roles yet"
+                          description={
+                            canCreateGroup
+                              ? "Create your first custom role"
+                              : "You don't have permission to create a custom role"
+                          }
+                        />
+                      </TableCell>
+                    </TableRow>
+                  </Cond>
+
+                  <Cond>
+                    {Object.entries(RBACResourceActions).map(([key, value]) => {
+                      return (
+                        <TableRow key={key}>
+                          <TableCell>
+                            <li key={key} css={styles.checkBoxes}>
+                              <input type="checkbox" /> {key}
+                              <ul css={styles.checkBoxes}>
+                                {Object.entries(value).map(([key, value]) => {
+                                  return (
+                                    <li key={key}>
+                                      <span css={styles.actionText}>
+                                        <input type="checkbox" /> {key}
+                                      </span>{" "}
+                                      -{" "}
+                                      <span css={styles.actionDescription}>
+                                        {value}
+                                      </span>
+                                    </li>
+                                  );
+                                })}
+                              </ul>
+                            </li>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </Cond>
+                </ChooseOne>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Cond>
+      </ChooseOne>
+    </>
+  );
+};
+
+const styles = {
+  rolesDropdown: {
+    marginBottom: 20,
+  },
+  checkBoxes: {
+    margin: 0,
+    listStyleType: "none",
+  },
+  actionText: (theme) => ({
+    color: theme.palette.text.primary,
+  }),
+  actionDescription: (theme) => ({
+    color: theme.palette.text.secondary,
+  }),
+} satisfies Record<string, Interpolation<Theme>>;
+
+export default CustomRolesPageView;

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -1,23 +1,21 @@
-import { css } from "@emotion/css";
 import type { Interpolation, Theme } from "@emotion/react";
+import AddOutlined from "@mui/icons-material/AddOutlined";
 import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
-import PersonAdd from "@mui/icons-material/PersonAdd";
 import { LoadingButton } from "@mui/lab";
-import { Table, TableBody, TableContainer, TextField } from "@mui/material";
-import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
-import AvatarGroup from "@mui/material/AvatarGroup";
+import { createFilterOptions } from "@mui/material/Autocomplete";
+import Button from "@mui/material/Button";
 import Skeleton from "@mui/material/Skeleton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { useState, type FC } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
-import { RBACResourceActions } from "api/rbacresources_gen";
-import type { Group, Role } from "api/typesGenerated";
-import { AvatarData } from "components/AvatarData/AvatarData";
-import { AvatarDataSkeleton } from "components/AvatarData/AvatarDataSkeleton";
+import type { Role } from "api/typesGenerated";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
-import { GroupAvatar } from "components/GroupAvatar/GroupAvatar";
 import { Paywall } from "components/Paywall/Paywall";
 import { Stack } from "components/Stack/Stack";
 import {
@@ -25,7 +23,6 @@ import {
   TableLoaderSkeleton,
   TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
-import { UserAvatar } from "components/UserAvatar/UserAvatar";
 import { permissionsToCheck } from "contexts/auth/permissions";
 import { useClickableTableRow } from "hooks";
 import { docs } from "utils/docs";
@@ -36,7 +33,7 @@ export type CustomRolesPageViewProps = {
   isTemplateRBACEnabled: boolean;
 };
 
-const filter = createFilterOptions<Role>();
+// const filter = createFilterOptions<Role>();
 
 export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
   roles,
@@ -45,8 +42,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 }) => {
   const isLoading = Boolean(roles === undefined);
   const isEmpty = Boolean(roles && roles.length === 0);
-  const [selectedRole, setSelectedRole] = useState<Role | null>(null);
-  console.log({ selectedRole });
+  // const [selectedRole, setSelectedRole] = useState<Role | null>(null);
 
   return (
     <>
@@ -59,109 +55,16 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
           />
         </Cond>
         <Cond>
-          <Stack
-            direction="row"
-            alignItems="center"
-            spacing={1}
-            css={styles.rolesDropdown}
-          >
-            <Autocomplete
-              value={selectedRole}
-              onChange={(_, newValue) => {
-                console.log("onChange: ", newValue);
-                if (typeof newValue === "string") {
-                  console.log("0");
-                  setSelectedRole({
-                    name: newValue,
-                    display_name: newValue,
-                    site_permissions: [],
-                    organization_permissions: [],
-                    user_permissions: [],
-                  });
-                } else if (newValue && newValue.display_name) {
-                  console.log("1");
-                  // Create a new value from the user input
-                  // setSelectedRole({ ...newValue, display_name: newValue.name });
-                  setSelectedRole(newValue);
-                } else {
-                  console.log("2");
-                  setSelectedRole(newValue);
-                }
-              }}
-              isOptionEqualToValue={(option: Role, value: Role) =>
-                option.name === value.name
-              }
-              filterOptions={(options, params) => {
-                const filtered = filter(options, params);
-
-                const { inputValue } = params;
-                // Suggest the creation of a new value
-                const isExisting = options.some(
-                  (option) => inputValue === option.display_name,
-                );
-                if (inputValue !== "" && !isExisting) {
-                  filtered.push({
-                    name: inputValue,
-                    display_name: `Add ${inputValue}`,
-                    site_permissions: [],
-                    organization_permissions: [],
-                    user_permissions: [],
-                  });
-                }
-
-                return filtered;
-              }}
-              selectOnFocus
-              clearOnBlur
-              handleHomeEndKeys
-              id="custom-role"
-              options={roles || []}
-              getOptionLabel={(option) => {
-                // console.log("getOptionLabel: ", option);
-                // Value selected with enter, right from the input
-                if (typeof option === "string") {
-                  return option;
-                }
-                // Add "xxx" option created dynamically
-                if (option.name) {
-                  return option.name;
-                }
-                // Regular option
-                return option.display_name;
-              }}
-              renderOption={(props, option) => {
-                const { key, ...optionProps } = props;
-                return (
-                  <li key={key} {...optionProps}>
-                    {option.display_name}
-                  </li>
-                );
-              }}
-              sx={{ width: 300 }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Display Name"
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                />
-              )}
-            />
-
-            <LoadingButton
-              loadingPosition="start"
-              // disabled={!selectedUser}
-              type="submit"
-              startIcon={<PersonAdd />}
-              loading={isLoading}
-            >
-              Save Custom Role
-            </LoadingButton>
-          </Stack>
-
           <TableContainer>
             <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell width="33%">Name</TableCell>
+                  <TableCell width="33%">Display Name</TableCell>
+                  <TableCell width="33%">Permissions</TableCell>
+                  <TableCell width="1%"></TableCell>
+                </TableRow>
+              </TableHead>
               <TableBody>
                 <ChooseOne>
                   <Cond condition={isLoading}>
@@ -172,11 +75,23 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
                     <TableRow>
                       <TableCell colSpan={999}>
                         <EmptyState
-                          message="No custom roles yet"
+                          message="No groups yet"
                           description={
                             canCreateGroup
-                              ? "Create your first custom role"
-                              : "You don't have permission to create a custom role"
+                              ? "Create your first group"
+                              : "You don't have permission to create a group"
+                          }
+                          cta={
+                            canCreateGroup && (
+                              <Button
+                                component={RouterLink}
+                                to="create"
+                                startIcon={<AddOutlined />}
+                                variant="contained"
+                              >
+                                Create group
+                              </Button>
+                            )
                           }
                         />
                       </TableCell>
@@ -184,32 +99,9 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
                   </Cond>
 
                   <Cond>
-                    {Object.entries(RBACResourceActions).map(([key, value]) => {
-                      return (
-                        <TableRow key={key}>
-                          <TableCell>
-                            <li key={key} css={styles.checkBoxes}>
-                              <input type="checkbox" /> {key}
-                              <ul css={styles.checkBoxes}>
-                                {Object.entries(value).map(([key, value]) => {
-                                  return (
-                                    <li key={key}>
-                                      <span css={styles.actionText}>
-                                        <input type="checkbox" /> {key}
-                                      </span>{" "}
-                                      -{" "}
-                                      <span css={styles.actionDescription}>
-                                        {value}
-                                      </span>
-                                    </li>
-                                  );
-                                })}
-                              </ul>
-                            </li>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
+                    {roles?.map((role) => (
+                      <RoleRow key={role.name} role={role} />
+                    ))}
                   </Cond>
                 </ChooseOne>
               </TableBody>
@@ -221,18 +113,45 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
   );
 };
 
+interface RoleRowProps {
+  role: Role;
+}
+
+const RoleRow: FC<RoleRowProps> = ({ role }) => {
+  const navigate = useNavigate();
+  const rowProps = useClickableTableRow({
+    onClick: () => navigate(role.name),
+  });
+
+  return (
+    <TableRow data-testid={`role-${role.name}`} {...rowProps}>
+      <TableCell>{role.name}</TableCell>
+
+      <TableCell css={styles.secondary}>{role.display_name}</TableCell>
+
+      <TableCell css={styles.secondary}>
+        {role.organization_permissions.length}
+      </TableCell>
+
+      <TableCell>
+        <div css={styles.arrowCell}>
+          <KeyboardArrowRight css={styles.arrowRight} />
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+};
+
 const styles = {
-  rolesDropdown: {
-    marginBottom: 20,
-  },
-  checkBoxes: {
-    margin: 0,
-    listStyleType: "none",
-  },
-  actionText: (theme) => ({
-    color: theme.palette.text.primary,
+  arrowRight: (theme) => ({
+    color: theme.palette.text.secondary,
+    width: 20,
+    height: 20,
   }),
-  actionDescription: (theme) => ({
+  arrowCell: {
+    display: "flex",
+  },
+  secondary: (theme) => ({
     color: theme.palette.text.secondary,
   }),
 } satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -33,7 +33,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
   canAssignOrgRole,
   isCustomRolesEnabled,
 }) => {
-  const isLoading = Boolean(roles === undefined);
+  const isLoading = roles === undefined;
   const isEmpty = Boolean(roles && roles.length === 0);
 
   return (

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -29,25 +29,25 @@ import { docs } from "utils/docs";
 
 export type CustomRolesPageViewProps = {
   roles: Role[] | undefined;
-  canCreateGroup: boolean;
-  isTemplateRBACEnabled: boolean;
+  canAssignOrgRole: boolean;
+  isCustomRolesEnabled: boolean;
 };
 
 // const filter = createFilterOptions<Role>();
 
 export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
   roles,
-  canCreateGroup,
-  isTemplateRBACEnabled,
+  canAssignOrgRole,
+  isCustomRolesEnabled,
 }) => {
   const isLoading = Boolean(roles === undefined);
   const isEmpty = Boolean(roles && roles.length === 0);
   // const [selectedRole, setSelectedRole] = useState<Role | null>(null);
-
+  console.log({ roles });
   return (
     <>
       <ChooseOne>
-        <Cond condition={!isTemplateRBACEnabled}>
+        <Cond condition={!isCustomRolesEnabled}>
           <Paywall
             message="Custom Roles"
             description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
@@ -77,19 +77,19 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
                         <EmptyState
                           message="No groups yet"
                           description={
-                            canCreateGroup
-                              ? "Create your first group"
-                              : "You don't have permission to create a group"
+                            canAssignOrgRole
+                              ? "Create your first custom role"
+                              : "You don't have permission to create a custom role"
                           }
                           cta={
-                            canCreateGroup && (
+                            canAssignOrgRole && (
                               <Button
                                 component={RouterLink}
                                 to="create"
                                 startIcon={<AddOutlined />}
                                 variant="contained"
                               >
-                                Create group
+                                Create custom role
                               </Button>
                             )
                           }

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -1,8 +1,6 @@
 import type { Interpolation, Theme } from "@emotion/react";
 import AddOutlined from "@mui/icons-material/AddOutlined";
 import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
-import { LoadingButton } from "@mui/lab";
-import { createFilterOptions } from "@mui/material/Autocomplete";
 import Button from "@mui/material/Button";
 import Skeleton from "@mui/material/Skeleton";
 import Table from "@mui/material/Table";
@@ -11,19 +9,17 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import { useState, type FC } from "react";
+import type { FC } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import type { Role } from "api/typesGenerated";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Paywall } from "components/Paywall/Paywall";
-import { Stack } from "components/Stack/Stack";
 import {
   TableLoader,
   TableLoaderSkeleton,
   TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
-import { permissionsToCheck } from "contexts/auth/permissions";
 import { useClickableTableRow } from "hooks";
 import { docs } from "utils/docs";
 
@@ -33,8 +29,6 @@ export type CustomRolesPageViewProps = {
   isCustomRolesEnabled: boolean;
 };
 
-// const filter = createFilterOptions<Role>();
-
 export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
   roles,
   canAssignOrgRole,
@@ -42,8 +36,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 }) => {
   const isLoading = Boolean(roles === undefined);
   const isEmpty = Boolean(roles && roles.length === 0);
-  // const [selectedRole, setSelectedRole] = useState<Role | null>(null);
-  console.log({ roles });
+
   return (
     <>
       <ChooseOne>
@@ -59,9 +52,8 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
             <Table>
               <TableHead>
                 <TableRow>
-                  <TableCell width="33%">Name</TableCell>
-                  <TableCell width="33%">Display Name</TableCell>
-                  <TableCell width="33%">Permissions</TableCell>
+                  <TableCell width="50%">Name</TableCell>
+                  <TableCell width="49%">Permissions</TableCell>
                   <TableCell width="1%"></TableCell>
                 </TableRow>
               </TableHead>
@@ -125,9 +117,7 @@ const RoleRow: FC<RoleRowProps> = ({ role }) => {
 
   return (
     <TableRow data-testid={`role-${role.name}`} {...rowProps}>
-      <TableCell>{role.name}</TableCell>
-
-      <TableCell css={styles.secondary}>{role.display_name}</TableCell>
+      <TableCell>{role.display_name || role.name}</TableCell>
 
       <TableCell css={styles.secondary}>
         {role.organization_permissions.length}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -16,7 +16,6 @@ import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Paywall } from "components/Paywall/Paywall";
 import {
-  TableLoader,
   TableLoaderSkeleton,
   TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
@@ -129,6 +128,24 @@ const RoleRow: FC<RoleRowProps> = ({ role }) => {
         </div>
       </TableCell>
     </TableRow>
+  );
+};
+
+const TableLoader = () => {
+  return (
+    <TableLoaderSkeleton>
+      <TableRowSkeleton>
+        <TableCell>
+          <Skeleton variant="text" width="25%" />
+        </TableCell>
+        <TableCell>
+          <Skeleton variant="text" width="25%" />
+        </TableCell>
+        <TableCell>
+          <Skeleton variant="text" width="25%" />
+        </TableCell>
+      </TableRowSkeleton>
+    </TableLoaderSkeleton>
   );
 };
 

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -42,7 +42,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
         <Cond condition={!isCustomRolesEnabled}>
           <Paywall
             message="Custom Roles"
-            description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
+            description="Create custom roles to assign a specific set of permissions to a user. You need an Enterprise license to use this feature."
             documentationLink={docs("/admin/groups")}
           />
         </Cond>
@@ -66,7 +66,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
                     <TableRow>
                       <TableCell colSpan={999}>
                         <EmptyState
-                          message="No groups yet"
+                          message="No custom roles yet"
                           description={
                             canAssignOrgRole
                               ? "Create your first custom role"

--- a/site/src/pages/ManagementSettingsPage/SidebarView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/SidebarView.stories.tsx
@@ -4,11 +4,13 @@ import {
   MockOrganization2,
   MockPermissions,
 } from "testHelpers/entities";
+import { withDashboardProvider } from "testHelpers/storybook";
 import { SidebarView } from "./SidebarView";
 
 const meta: Meta<typeof SidebarView> = {
   title: "components/MultiOrgSidebarView",
   component: SidebarView,
+  decorators: [withDashboardProvider],
   args: {
     activeOrganization: undefined,
     activeOrgPermissions: undefined,
@@ -88,6 +90,7 @@ export const SelectedOrgAdmin: Story = {
       viewMembers: true,
       viewGroups: true,
       auditOrganization: true,
+      assignOrgRole: true,
     },
   },
 };

--- a/site/src/pages/ManagementSettingsPage/SidebarView.tsx
+++ b/site/src/pages/ManagementSettingsPage/SidebarView.tsx
@@ -10,6 +10,7 @@ import { Sidebar as BaseSidebar } from "components/Sidebar/Sidebar";
 import { Stack } from "components/Stack/Stack";
 import { UserAvatar } from "components/UserAvatar/UserAvatar";
 import { type ClassName, useClassName } from "hooks/useClassName";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import { linkToAuditing, linkToUsers, withFilter } from "modules/navigation";
 
 interface SidebarProps {
@@ -184,6 +185,8 @@ interface OrganizationSettingsNavigationProps {
 const OrganizationSettingsNavigation: FC<
   OrganizationSettingsNavigationProps
 > = (props) => {
+  const { experiments } = useDashboard();
+
   return (
     <>
       <SidebarNavItem
@@ -225,6 +228,14 @@ const OrganizationSettingsNavigation: FC<
               Groups
             </SidebarNavSubItem>
           )}
+          {props.permissions.assignOrgRole &&
+            experiments.includes("custom-roles") && (
+              <SidebarNavSubItem
+                href={urlForSubpage(props.organization.name, "roles")}
+              >
+                Roles
+              </SidebarNavSubItem>
+            )}
           {/* For now redirect to the site-wide audit page with the organization
               pre-filled into the filter.  Based on user feedback we might want
               to serve a copy of the audit page or even delete this link. */}

--- a/site/src/pages/ManagementSettingsPage/UserTable/EditRolesButton.tsx
+++ b/site/src/pages/ManagementSettingsPage/UserTable/EditRolesButton.tsx
@@ -138,7 +138,7 @@ export const EditRolesButton: FC<EditRolesButtonProps> = ({
                 onChange={handleChange}
                 isChecked={selectedRoleNames.has(role.name)}
                 value={role.name}
-                name={role.display_name}
+                name={role.display_name || role.name}
                 description={roleDescriptions[role.name] ?? ""}
               />
             ))}

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -242,6 +242,10 @@ const OrganizationGroupSettingsPage = lazy(
 const OrganizationMembersPage = lazy(
   () => import("./pages/ManagementSettingsPage/OrganizationMembersPage"),
 );
+const OrganizationCustomRolesPage = lazy(
+  () =>
+    import("./pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage"),
+);
 const TemplateEmbedPage = lazy(
   () => import("./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage"),
 );
@@ -376,6 +380,7 @@ export const router = createBrowserRouter(
               <Route index element={<OrganizationSettingsPage />} />
               <Route path="members" element={<OrganizationMembersPage />} />
               {groupsRouter()}
+              <Route path="roles" element={<OrganizationCustomRolesPage />} />
               <Route path="auditing" element={<></>} />
             </Route>
           </Route>

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -246,6 +246,10 @@ const OrganizationCustomRolesPage = lazy(
   () =>
     import("./pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage"),
 );
+const CreateEditRolePage = lazy(
+  () =>
+    import("./pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage"),
+);
 const TemplateEmbedPage = lazy(
   () => import("./pages/TemplatePage/TemplateEmbedPage/TemplateEmbedPage"),
 );
@@ -380,7 +384,11 @@ export const router = createBrowserRouter(
               <Route index element={<OrganizationSettingsPage />} />
               <Route path="members" element={<OrganizationMembersPage />} />
               {groupsRouter()}
-              <Route path="roles" element={<OrganizationCustomRolesPage />} />
+              <Route path="roles">
+                <Route index element={<OrganizationCustomRolesPage />} />
+                <Route path="create" element={<CreateEditRolePage />} />
+                <Route path=":roleName" element={<CreateEditRolePage />} />
+              </Route>
               <Route path="auditing" element={<></>} />
             </Route>
           </Route>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -416,18 +416,18 @@ export const MockOrganizationMember: TypesGen.OrganizationMemberWithUserData = {
 };
 
 export const MockOrganizationMember2: TypesGen.OrganizationMemberWithUserData =
-  {
-    organization_id: MockOrganization.id,
-    user_id: MockUser2.id,
-    username: MockUser2.username,
-    email: MockUser2.email,
-    created_at: "",
-    updated_at: "",
-    name: MockUser2.name,
-    avatar_url: MockUser2.avatar_url,
-    global_roles: MockUser2.roles,
-    roles: [],
-  };
+{
+  organization_id: MockOrganization.id,
+  user_id: MockUser2.id,
+  username: MockUser2.username,
+  email: MockUser2.email,
+  created_at: "",
+  updated_at: "",
+  name: MockUser2.name,
+  avatar_url: MockUser2.avatar_url,
+  global_roles: MockUser2.roles,
+  roles: [],
+};
 
 export const MockProvisioner: TypesGen.ProvisionerDaemon = {
   created_at: "2022-05-17T17:39:01.382927298Z",
@@ -531,9 +531,9 @@ You can add instructions here
 };
 
 export const MockTemplateVersionWithMarkdownMessage: TypesGen.TemplateVersion =
-  {
-    ...MockTemplateVersion,
-    message: `
+{
+  ...MockTemplateVersion,
+  message: `
 # Abiding Grace
 ## Enchantment
 At the beginning of your end step, choose one —
@@ -542,7 +542,7 @@ At the beginning of your end step, choose one —
 
 - Return target creature card with mana value 1 from your graveyard to the battlefield.
 `,
-  };
+};
 
 export const MockTemplate: TypesGen.Template = {
   id: "test-template",
@@ -987,16 +987,16 @@ export const MockWorkspaceContainerResource: TypesGen.WorkspaceResource = {
 };
 
 export const MockWorkspaceAutostartDisabled: TypesGen.UpdateWorkspaceAutostartRequest =
-  {
-    schedule: "",
-  };
+{
+  schedule: "",
+};
 
 export const MockWorkspaceAutostartEnabled: TypesGen.UpdateWorkspaceAutostartRequest =
-  {
-    // Runs at 9:30am Monday through Friday using Canada/Eastern
-    // (America/Toronto) time
-    schedule: "CRON_TZ=Canada/Eastern 30 9 * * 1-5",
-  };
+{
+  // Runs at 9:30am Monday through Friday using Canada/Eastern
+  // (America/Toronto) time
+  schedule: "CRON_TZ=Canada/Eastern 30 9 * * 1-5",
+};
 
 export const MockWorkspaceBuild: TypesGen.WorkspaceBuild = {
   build_number: 1,
@@ -1249,12 +1249,12 @@ export const MockDormantOutdatedWorkspace: TypesGen.Workspace = {
 };
 
 export const MockOutdatedRunningWorkspaceRequireActiveVersion: TypesGen.Workspace =
-  {
-    ...MockWorkspace,
-    id: "test-outdated-workspace-require-active-version",
-    outdated: true,
-    template_require_active_version: true,
-  };
+{
+  ...MockWorkspace,
+  id: "test-outdated-workspace-require-active-version",
+  outdated: true,
+  template_require_active_version: true,
+};
 
 export const MockOutdatedRunningWorkspaceAlwaysUpdate: TypesGen.Workspace = {
   ...MockWorkspace,
@@ -1268,13 +1268,13 @@ export const MockOutdatedRunningWorkspaceAlwaysUpdate: TypesGen.Workspace = {
 };
 
 export const MockOutdatedStoppedWorkspaceRequireActiveVersion: TypesGen.Workspace =
-  {
-    ...MockOutdatedRunningWorkspaceRequireActiveVersion,
-    latest_build: {
-      ...MockWorkspaceBuild,
-      status: "stopped",
-    },
-  };
+{
+  ...MockOutdatedRunningWorkspaceRequireActiveVersion,
+  latest_build: {
+    ...MockWorkspaceBuild,
+    status: "stopped",
+  },
+};
 
 export const MockOutdatedStoppedWorkspaceAlwaysUpdate: TypesGen.Workspace = {
   ...MockOutdatedRunningWorkspaceAlwaysUpdate,
@@ -1311,82 +1311,82 @@ export const MockWorkspacesResponseWithDeletions = {
 };
 
 export const MockTemplateVersionParameter1: TypesGen.TemplateVersionParameter =
-  {
-    name: "first_parameter",
-    type: "string",
-    description: "This is first parameter",
-    description_plaintext: "Markdown: This is first parameter",
-    default_value: "abc",
-    mutable: true,
-    icon: "/icon/folder.svg",
-    options: [],
-    required: true,
-    ephemeral: false,
-  };
+{
+  name: "first_parameter",
+  type: "string",
+  description: "This is first parameter",
+  description_plaintext: "Markdown: This is first parameter",
+  default_value: "abc",
+  mutable: true,
+  icon: "/icon/folder.svg",
+  options: [],
+  required: true,
+  ephemeral: false,
+};
 
 export const MockTemplateVersionParameter2: TypesGen.TemplateVersionParameter =
-  {
-    name: "second_parameter",
-    type: "number",
-    description: "This is second parameter",
-    description_plaintext: "Markdown: This is second parameter",
-    default_value: "2",
-    mutable: true,
-    icon: "/icon/folder.svg",
-    options: [],
-    validation_min: 1,
-    validation_max: 3,
-    validation_monotonic: "increasing",
-    required: true,
-    ephemeral: false,
-  };
+{
+  name: "second_parameter",
+  type: "number",
+  description: "This is second parameter",
+  description_plaintext: "Markdown: This is second parameter",
+  default_value: "2",
+  mutable: true,
+  icon: "/icon/folder.svg",
+  options: [],
+  validation_min: 1,
+  validation_max: 3,
+  validation_monotonic: "increasing",
+  required: true,
+  ephemeral: false,
+};
 
 export const MockTemplateVersionParameter3: TypesGen.TemplateVersionParameter =
-  {
-    name: "third_parameter",
-    type: "string",
-    description: "This is third parameter",
-    description_plaintext: "Markdown: This is third parameter",
-    default_value: "aaa",
-    mutable: true,
-    icon: "/icon/database.svg",
-    options: [],
-    validation_error: "No way!",
-    validation_regex: "^[a-z]{3}$",
-    required: true,
-    ephemeral: false,
-  };
+{
+  name: "third_parameter",
+  type: "string",
+  description: "This is third parameter",
+  description_plaintext: "Markdown: This is third parameter",
+  default_value: "aaa",
+  mutable: true,
+  icon: "/icon/database.svg",
+  options: [],
+  validation_error: "No way!",
+  validation_regex: "^[a-z]{3}$",
+  required: true,
+  ephemeral: false,
+};
 
 export const MockTemplateVersionParameter4: TypesGen.TemplateVersionParameter =
-  {
-    name: "fourth_parameter",
-    type: "string",
-    description: "This is fourth parameter",
-    description_plaintext: "Markdown: This is fourth parameter",
-    default_value: "def",
-    mutable: false,
-    icon: "/icon/database.svg",
-    options: [],
-    required: true,
-    ephemeral: false,
-  };
+{
+  name: "fourth_parameter",
+  type: "string",
+  description: "This is fourth parameter",
+  description_plaintext: "Markdown: This is fourth parameter",
+  default_value: "def",
+  mutable: false,
+  icon: "/icon/database.svg",
+  options: [],
+  required: true,
+  ephemeral: false,
+};
 
 export const MockTemplateVersionParameter5: TypesGen.TemplateVersionParameter =
-  {
-    name: "fifth_parameter",
-    type: "number",
-    description: "This is fifth parameter",
-    description_plaintext: "Markdown: This is fifth parameter",
-    default_value: "5",
-    mutable: true,
-    icon: "/icon/folder.svg",
-    options: [],
-    validation_min: 1,
-    validation_max: 10,
-    validation_monotonic: "decreasing",
-    required: true,
-    ephemeral: false,
-  };
+{
+  name: "fifth_parameter",
+  type: "number",
+  description: "This is fifth parameter",
+  description_plaintext: "Markdown: This is fifth parameter",
+  default_value: "5",
+  mutable: true,
+  icon: "/icon/folder.svg",
+  options: [],
+  validation_min: 1,
+  validation_max: 10,
+  validation_monotonic: "decreasing",
+  required: true,
+  ephemeral: false,
+};
 
 export const MockTemplateVersionVariable1: TypesGen.TemplateVersionVariable = {
   name: "first_variable",
@@ -1445,16 +1445,16 @@ export const MockWorkspaceRequest: TypesGen.CreateWorkspaceRequest = {
 };
 
 export const MockWorkspaceRichParametersRequest: TypesGen.CreateWorkspaceRequest =
-  {
-    name: "test",
-    template_version_id: "test-template-version",
-    rich_parameter_values: [
-      {
-        name: MockTemplateVersionParameter1.name,
-        value: MockTemplateVersionParameter1.default_value,
-      },
-    ],
-  };
+{
+  name: "test",
+  template_version_id: "test-template-version",
+  rich_parameter_values: [
+    {
+      name: MockTemplateVersionParameter1.name,
+      value: MockTemplateVersionParameter1.default_value,
+    },
+  ],
+};
 
 export const MockUserAgent = {
   browser: "Chrome 99.0.4844",
@@ -2501,6 +2501,7 @@ export const MockPermissions: Permissions = {
   viewAnyGroup: true,
   createGroup: true,
   viewAllLicenses: true,
+  assignOrgRole: true,
 };
 
 export const MockDeploymentConfig: DeploymentConfig = {
@@ -2545,24 +2546,24 @@ export const MockWorkspaceBuildParameter5: TypesGen.WorkspaceBuildParameter = {
 };
 
 export const MockTemplateVersionExternalAuthGithub: TypesGen.TemplateVersionExternalAuth =
-  {
-    id: "github",
-    type: "github",
-    authenticate_url: "https://example.com/external-auth/github",
-    authenticated: false,
-    display_icon: "/icon/github.svg",
-    display_name: "GitHub",
-  };
+{
+  id: "github",
+  type: "github",
+  authenticate_url: "https://example.com/external-auth/github",
+  authenticated: false,
+  display_icon: "/icon/github.svg",
+  display_name: "GitHub",
+};
 
 export const MockTemplateVersionExternalAuthGithubAuthenticated: TypesGen.TemplateVersionExternalAuth =
-  {
-    id: "github",
-    type: "github",
-    authenticate_url: "https://example.com/external-auth/github",
-    authenticated: true,
-    display_icon: "/icon/github.svg",
-    display_name: "GitHub",
-  };
+{
+  id: "github",
+  type: "github",
+  authenticate_url: "https://example.com/external-auth/github",
+  authenticated: true,
+  display_icon: "/icon/github.svg",
+  display_name: "GitHub",
+};
 
 export const MockDeploymentStats: TypesGen.DeploymentStats = {
   aggregated_from: "2023-03-06T19:08:55.211625Z",
@@ -3459,13 +3460,13 @@ export const MockHealth: TypesGen.HealthcheckReport = {
 };
 
 export const MockListeningPortsResponse: TypesGen.WorkspaceAgentListeningPortsResponse =
-  {
-    ports: [
-      { process_name: "webb", network: "", port: 30000 },
-      { process_name: "gogo", network: "", port: 8080 },
-      { process_name: "", network: "", port: 8081 },
-    ],
-  };
+{
+  ports: [
+    { process_name: "webb", network: "", port: 30000 },
+    { process_name: "gogo", network: "", port: 8080 },
+    { process_name: "", network: "", port: 8081 },
+  ],
+};
 
 export const MockSharedPortsResponse: TypesGen.WorkspaceAgentPortShares = {
   shares: [

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -326,6 +326,71 @@ export const MockOrganizationAuditorRole: TypesGen.Role = {
   organization_id: MockOrganization.id,
 };
 
+export const MockRoleWithOrgPermissions: TypesGen.Role = {
+  name: "my-role-1",
+  display_name: "My Role 1",
+  organization_id: MockOrganization.id,
+  site_permissions: [],
+  organization_permissions: [
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "create",
+    },
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "delete",
+    },
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "read",
+    },
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "update",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "create",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "delete",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "read",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "update",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "view_insights",
+    },
+    {
+      negate: false,
+      resource_type: "audit_log",
+      action: "create",
+    },
+    {
+      negate: false,
+      resource_type: "audit_log",
+      action: "read",
+    },
+  ],
+  user_permissions: [],
+};
+
 // assignableRole takes a role and a boolean. The boolean implies if the
 // actor can assign (add/remove) the role from other users.
 export function assignableRole(
@@ -2423,71 +2488,6 @@ export const MockAuditLogUnsuccessfulLoginKnownUser: TypesGen.AuditLog = {
 export const MockWorkspaceQuota: TypesGen.WorkspaceQuota = {
   credits_consumed: 0,
   budget: 100,
-};
-
-export const MockRole: TypesGen.Role = {
-  name: "my-role-1",
-  display_name: "My Role 1",
-  organization_id: MockOrganization.id,
-  site_permissions: [],
-  organization_permissions: [
-    {
-      negate: false,
-      resource_type: "organization_member",
-      action: "create",
-    },
-    {
-      negate: false,
-      resource_type: "organization_member",
-      action: "delete",
-    },
-    {
-      negate: false,
-      resource_type: "organization_member",
-      action: "read",
-    },
-    {
-      negate: false,
-      resource_type: "organization_member",
-      action: "update",
-    },
-    {
-      negate: false,
-      resource_type: "template",
-      action: "create",
-    },
-    {
-      negate: false,
-      resource_type: "template",
-      action: "delete",
-    },
-    {
-      negate: false,
-      resource_type: "template",
-      action: "read",
-    },
-    {
-      negate: false,
-      resource_type: "template",
-      action: "update",
-    },
-    {
-      negate: false,
-      resource_type: "template",
-      action: "view_insights",
-    },
-    {
-      negate: false,
-      resource_type: "audit_log",
-      action: "create",
-    },
-    {
-      negate: false,
-      resource_type: "audit_log",
-      action: "read",
-    },
-  ],
-  user_permissions: [],
 };
 
 export const MockGroup: TypesGen.Group = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2425,6 +2425,71 @@ export const MockWorkspaceQuota: TypesGen.WorkspaceQuota = {
   budget: 100,
 };
 
+export const MockRole: TypesGen.Role = {
+  name: "my-role-1",
+  display_name: "My Role 1",
+  organization_id: MockOrganization.id,
+  site_permissions: [],
+  organization_permissions: [
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "create",
+    },
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "delete",
+    },
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "read",
+    },
+    {
+      negate: false,
+      resource_type: "organization_member",
+      action: "update",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "create",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "delete",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "read",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "update",
+    },
+    {
+      negate: false,
+      resource_type: "template",
+      action: "view_insights",
+    },
+    {
+      negate: false,
+      resource_type: "audit_log",
+      action: "create",
+    },
+    {
+      negate: false,
+      resource_type: "audit_log",
+      action: "read",
+    },
+  ],
+  user_permissions: [],
+};
+
 export const MockGroup: TypesGen.Group = {
   id: "fbd2116a-8961-4954-87ae-e4575bd29ce0",
   name: "Front-End",

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2566,7 +2566,6 @@ export const MockPermissions: Permissions = {
   viewAnyGroup: true,
   createGroup: true,
   viewAllLicenses: true,
-  assignOrgRole: true,
 };
 
 export const MockDeploymentConfig: DeploymentConfig = {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -416,18 +416,18 @@ export const MockOrganizationMember: TypesGen.OrganizationMemberWithUserData = {
 };
 
 export const MockOrganizationMember2: TypesGen.OrganizationMemberWithUserData =
-{
-  organization_id: MockOrganization.id,
-  user_id: MockUser2.id,
-  username: MockUser2.username,
-  email: MockUser2.email,
-  created_at: "",
-  updated_at: "",
-  name: MockUser2.name,
-  avatar_url: MockUser2.avatar_url,
-  global_roles: MockUser2.roles,
-  roles: [],
-};
+  {
+    organization_id: MockOrganization.id,
+    user_id: MockUser2.id,
+    username: MockUser2.username,
+    email: MockUser2.email,
+    created_at: "",
+    updated_at: "",
+    name: MockUser2.name,
+    avatar_url: MockUser2.avatar_url,
+    global_roles: MockUser2.roles,
+    roles: [],
+  };
 
 export const MockProvisioner: TypesGen.ProvisionerDaemon = {
   created_at: "2022-05-17T17:39:01.382927298Z",
@@ -531,9 +531,9 @@ You can add instructions here
 };
 
 export const MockTemplateVersionWithMarkdownMessage: TypesGen.TemplateVersion =
-{
-  ...MockTemplateVersion,
-  message: `
+  {
+    ...MockTemplateVersion,
+    message: `
 # Abiding Grace
 ## Enchantment
 At the beginning of your end step, choose one —
@@ -542,7 +542,7 @@ At the beginning of your end step, choose one —
 
 - Return target creature card with mana value 1 from your graveyard to the battlefield.
 `,
-};
+  };
 
 export const MockTemplate: TypesGen.Template = {
   id: "test-template",
@@ -987,16 +987,16 @@ export const MockWorkspaceContainerResource: TypesGen.WorkspaceResource = {
 };
 
 export const MockWorkspaceAutostartDisabled: TypesGen.UpdateWorkspaceAutostartRequest =
-{
-  schedule: "",
-};
+  {
+    schedule: "",
+  };
 
 export const MockWorkspaceAutostartEnabled: TypesGen.UpdateWorkspaceAutostartRequest =
-{
-  // Runs at 9:30am Monday through Friday using Canada/Eastern
-  // (America/Toronto) time
-  schedule: "CRON_TZ=Canada/Eastern 30 9 * * 1-5",
-};
+  {
+    // Runs at 9:30am Monday through Friday using Canada/Eastern
+    // (America/Toronto) time
+    schedule: "CRON_TZ=Canada/Eastern 30 9 * * 1-5",
+  };
 
 export const MockWorkspaceBuild: TypesGen.WorkspaceBuild = {
   build_number: 1,
@@ -1249,12 +1249,12 @@ export const MockDormantOutdatedWorkspace: TypesGen.Workspace = {
 };
 
 export const MockOutdatedRunningWorkspaceRequireActiveVersion: TypesGen.Workspace =
-{
-  ...MockWorkspace,
-  id: "test-outdated-workspace-require-active-version",
-  outdated: true,
-  template_require_active_version: true,
-};
+  {
+    ...MockWorkspace,
+    id: "test-outdated-workspace-require-active-version",
+    outdated: true,
+    template_require_active_version: true,
+  };
 
 export const MockOutdatedRunningWorkspaceAlwaysUpdate: TypesGen.Workspace = {
   ...MockWorkspace,
@@ -1268,13 +1268,13 @@ export const MockOutdatedRunningWorkspaceAlwaysUpdate: TypesGen.Workspace = {
 };
 
 export const MockOutdatedStoppedWorkspaceRequireActiveVersion: TypesGen.Workspace =
-{
-  ...MockOutdatedRunningWorkspaceRequireActiveVersion,
-  latest_build: {
-    ...MockWorkspaceBuild,
-    status: "stopped",
-  },
-};
+  {
+    ...MockOutdatedRunningWorkspaceRequireActiveVersion,
+    latest_build: {
+      ...MockWorkspaceBuild,
+      status: "stopped",
+    },
+  };
 
 export const MockOutdatedStoppedWorkspaceAlwaysUpdate: TypesGen.Workspace = {
   ...MockOutdatedRunningWorkspaceAlwaysUpdate,
@@ -1311,82 +1311,82 @@ export const MockWorkspacesResponseWithDeletions = {
 };
 
 export const MockTemplateVersionParameter1: TypesGen.TemplateVersionParameter =
-{
-  name: "first_parameter",
-  type: "string",
-  description: "This is first parameter",
-  description_plaintext: "Markdown: This is first parameter",
-  default_value: "abc",
-  mutable: true,
-  icon: "/icon/folder.svg",
-  options: [],
-  required: true,
-  ephemeral: false,
-};
+  {
+    name: "first_parameter",
+    type: "string",
+    description: "This is first parameter",
+    description_plaintext: "Markdown: This is first parameter",
+    default_value: "abc",
+    mutable: true,
+    icon: "/icon/folder.svg",
+    options: [],
+    required: true,
+    ephemeral: false,
+  };
 
 export const MockTemplateVersionParameter2: TypesGen.TemplateVersionParameter =
-{
-  name: "second_parameter",
-  type: "number",
-  description: "This is second parameter",
-  description_plaintext: "Markdown: This is second parameter",
-  default_value: "2",
-  mutable: true,
-  icon: "/icon/folder.svg",
-  options: [],
-  validation_min: 1,
-  validation_max: 3,
-  validation_monotonic: "increasing",
-  required: true,
-  ephemeral: false,
-};
+  {
+    name: "second_parameter",
+    type: "number",
+    description: "This is second parameter",
+    description_plaintext: "Markdown: This is second parameter",
+    default_value: "2",
+    mutable: true,
+    icon: "/icon/folder.svg",
+    options: [],
+    validation_min: 1,
+    validation_max: 3,
+    validation_monotonic: "increasing",
+    required: true,
+    ephemeral: false,
+  };
 
 export const MockTemplateVersionParameter3: TypesGen.TemplateVersionParameter =
-{
-  name: "third_parameter",
-  type: "string",
-  description: "This is third parameter",
-  description_plaintext: "Markdown: This is third parameter",
-  default_value: "aaa",
-  mutable: true,
-  icon: "/icon/database.svg",
-  options: [],
-  validation_error: "No way!",
-  validation_regex: "^[a-z]{3}$",
-  required: true,
-  ephemeral: false,
-};
+  {
+    name: "third_parameter",
+    type: "string",
+    description: "This is third parameter",
+    description_plaintext: "Markdown: This is third parameter",
+    default_value: "aaa",
+    mutable: true,
+    icon: "/icon/database.svg",
+    options: [],
+    validation_error: "No way!",
+    validation_regex: "^[a-z]{3}$",
+    required: true,
+    ephemeral: false,
+  };
 
 export const MockTemplateVersionParameter4: TypesGen.TemplateVersionParameter =
-{
-  name: "fourth_parameter",
-  type: "string",
-  description: "This is fourth parameter",
-  description_plaintext: "Markdown: This is fourth parameter",
-  default_value: "def",
-  mutable: false,
-  icon: "/icon/database.svg",
-  options: [],
-  required: true,
-  ephemeral: false,
-};
+  {
+    name: "fourth_parameter",
+    type: "string",
+    description: "This is fourth parameter",
+    description_plaintext: "Markdown: This is fourth parameter",
+    default_value: "def",
+    mutable: false,
+    icon: "/icon/database.svg",
+    options: [],
+    required: true,
+    ephemeral: false,
+  };
 
 export const MockTemplateVersionParameter5: TypesGen.TemplateVersionParameter =
-{
-  name: "fifth_parameter",
-  type: "number",
-  description: "This is fifth parameter",
-  description_plaintext: "Markdown: This is fifth parameter",
-  default_value: "5",
-  mutable: true,
-  icon: "/icon/folder.svg",
-  options: [],
-  validation_min: 1,
-  validation_max: 10,
-  validation_monotonic: "decreasing",
-  required: true,
-  ephemeral: false,
-};
+  {
+    name: "fifth_parameter",
+    type: "number",
+    description: "This is fifth parameter",
+    description_plaintext: "Markdown: This is fifth parameter",
+    default_value: "5",
+    mutable: true,
+    icon: "/icon/folder.svg",
+    options: [],
+    validation_min: 1,
+    validation_max: 10,
+    validation_monotonic: "decreasing",
+    required: true,
+    ephemeral: false,
+  };
 
 export const MockTemplateVersionVariable1: TypesGen.TemplateVersionVariable = {
   name: "first_variable",
@@ -1445,16 +1445,16 @@ export const MockWorkspaceRequest: TypesGen.CreateWorkspaceRequest = {
 };
 
 export const MockWorkspaceRichParametersRequest: TypesGen.CreateWorkspaceRequest =
-{
-  name: "test",
-  template_version_id: "test-template-version",
-  rich_parameter_values: [
-    {
-      name: MockTemplateVersionParameter1.name,
-      value: MockTemplateVersionParameter1.default_value,
-    },
-  ],
-};
+  {
+    name: "test",
+    template_version_id: "test-template-version",
+    rich_parameter_values: [
+      {
+        name: MockTemplateVersionParameter1.name,
+        value: MockTemplateVersionParameter1.default_value,
+      },
+    ],
+  };
 
 export const MockUserAgent = {
   browser: "Chrome 99.0.4844",
@@ -2546,24 +2546,24 @@ export const MockWorkspaceBuildParameter5: TypesGen.WorkspaceBuildParameter = {
 };
 
 export const MockTemplateVersionExternalAuthGithub: TypesGen.TemplateVersionExternalAuth =
-{
-  id: "github",
-  type: "github",
-  authenticate_url: "https://example.com/external-auth/github",
-  authenticated: false,
-  display_icon: "/icon/github.svg",
-  display_name: "GitHub",
-};
+  {
+    id: "github",
+    type: "github",
+    authenticate_url: "https://example.com/external-auth/github",
+    authenticated: false,
+    display_icon: "/icon/github.svg",
+    display_name: "GitHub",
+  };
 
 export const MockTemplateVersionExternalAuthGithubAuthenticated: TypesGen.TemplateVersionExternalAuth =
-{
-  id: "github",
-  type: "github",
-  authenticate_url: "https://example.com/external-auth/github",
-  authenticated: true,
-  display_icon: "/icon/github.svg",
-  display_name: "GitHub",
-};
+  {
+    id: "github",
+    type: "github",
+    authenticate_url: "https://example.com/external-auth/github",
+    authenticated: true,
+    display_icon: "/icon/github.svg",
+    display_name: "GitHub",
+  };
 
 export const MockDeploymentStats: TypesGen.DeploymentStats = {
   aggregated_from: "2023-03-06T19:08:55.211625Z",
@@ -3460,13 +3460,13 @@ export const MockHealth: TypesGen.HealthcheckReport = {
 };
 
 export const MockListeningPortsResponse: TypesGen.WorkspaceAgentListeningPortsResponse =
-{
-  ports: [
-    { process_name: "webb", network: "", port: 30000 },
-    { process_name: "gogo", network: "", port: 8080 },
-    { process_name: "", network: "", port: 8081 },
-  ],
-};
+  {
+    ports: [
+      { process_name: "webb", network: "", port: 30000 },
+      { process_name: "gogo", network: "", port: 8080 },
+      { process_name: "", network: "", port: 8081 },
+    ],
+  };
 
 export const MockSharedPortsResponse: TypesGen.WorkspaceAgentPortShares = {
   shares: [


### PR DESCRIPTION
Resolve #13911

- [x] Design custom roles table when empty
- [x] Setup custom table loader skeleton for roles table
- [x] Hide custom roles tab if experiment is not enabled
- [x] Display a message that the name field cannot be modified
- [x] When editing a custom, the name field should not be editable
- [x] Create permission check for resource assign_org_role with action create
- [x] Set the checked state for permissions checkboxes to the current resource and actions for a role
- [x] Edit existing custom role page
- [x] Create new custom role page
- [x] Retrieve organization roles and display in a table
- [x] EditRolesButton falls back to role name when no display name is present
- [x] Add cancel and save buttons to top of create/edit role form
- [x] Display a subset of resources, add a checkbox to display all resources (audit_log, group, template, organization_member, provisioner_daemon, workspace)
- [x] Storybook stories

<img width="1052" alt="Screenshot 2024-08-02 at 2 58 56 PM" src="https://github.com/user-attachments/assets/d7879649-20bd-4d73-a447-629f2472d8ab">

<img width="1342" alt="Screenshot 2024-08-02 at 3 00 03 PM" src="https://github.com/user-attachments/assets/0efaf1d4-a3dc-4b70-b2e3-575154b37b8d">

<img width="1059" alt="Screenshot 2024-08-02 at 3 01 56 PM" src="https://github.com/user-attachments/assets/1b5b6571-7eb7-4ded-8c84-49c08a4db539">

