### PR TITLE
chore: update meticulous CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1005,23 +1005,3 @@ jobs:
             fi
           done
           echo "No incompatible licenses detected"
-  meticulous:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout Repository"
-        uses: actions/checkout@v4
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-      - name: Build
-        working-directory: ./site
-        run: pnpm build
-      - name: Serve
-        working-directory: ./site
-        run: |
-          pnpm vite preview &
-          sleep 5
-      - name: Run Meticulous tests
-        uses: alwaysmeticulous/report-diffs-action/cloud-compute@v1
-        with:
-          api-token: ${{ secrets.METICULOUS_API_TOKEN }}
-          app-url: "http://127.0.0.1:4173/"

--- a/.github/workflows/meticulous.yaml
+++ b/.github/workflows/meticulous.yaml
@@ -1,0 +1,42 @@
+# Workflow for serving the webapp locally & running Meticulous tests against it.
+
+name: Meticulous
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  # Meticulous needs the workflow to be triggered on workflow_dispatch events,
+  # so that Meticulous can run the workflow on the base commit to compare
+  # against if an existing workflow hasn't run.
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: read
+
+jobs:
+  meticulous:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+      - name: Build
+        working-directory: ./site
+        run: pnpm build
+      - name: Serve
+        working-directory: ./site
+        run: |
+          pnpm vite preview &
+          sleep 5
+      - name: Run Meticulous tests
+        uses: alwaysmeticulous/report-diffs-action/cloud-compute@v1
+        with:
+          api-token: ${{ secrets.METICULOUS_API_TOKEN }}
+          app-url: "http://127.0.0.1:4173/"

--- a/.github/workflows/meticulous.yaml
+++ b/.github/workflows/meticulous.yaml
@@ -6,7 +6,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "site/**"
   pull_request:
+    paths:
+      - "site/**"
   # Meticulous needs the workflow to be triggered on workflow_dispatch events,
   # so that Meticulous can run the workflow on the base commit to compare
   # against if an existing workflow hasn't run.


### PR DESCRIPTION
This moves the Meticulous CI job to a separate workflow and limits it to only run on changes to `site/`