### PR TITLE
chore: commit update-flake as @dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,6 +141,9 @@ jobs:
         with:
           # Allows dependabot to still rebase!
           commit_message: "[dependabot skip] Update Nix Flake SRI Hash"
+          commit_user_name: "dependabot[bot]"
+          commit_user_email: "49699333+dependabot[bot]@users.noreply.github.com>"
+          commit_author: "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>"
 
       # require everyone else to update it themselves
       - name: Ensure No Changes


### PR DESCRIPTION
Thıs is needed to bypass the dependency check job for dependabot PRs as we add another commit to update-flake. For example, it will resolve the issue in #14041

https://github.com/coder/coder/blob/1289937eaeac63f27f2856a4374a0fedc5cc0e58/.github/workflows/ci.yaml#L973

The username and email are fetched from a previous dependabot commit.  https://github.com/coder/coder/commit/1289937eaeac63f27f2856a4374a0fedc5cc0e58.patch