### PR TITLE
chore: refactor patch custom organization route to live in enterprise

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -2416,6 +2416,9 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -2432,6 +2432,15 @@ const docTemplate = `{
                         "name": "organization",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Upsert role request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.PatchRoleRequest"
+                        }
                     }
                 ],
                 "responses": {
@@ -10743,6 +10752,36 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                }
+            }
+        },
+        "codersdk.PatchRoleRequest": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_permissions": {
+                    "description": "OrganizationPermissions are specific to the organization the role belongs to.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.Permission"
+                    }
+                },
+                "site_permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.Permission"
+                    }
+                },
+                "user_permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.Permission"
                     }
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -2124,6 +2124,15 @@
             "name": "organization",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "Upsert role request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/codersdk.PatchRoleRequest"
+            }
           }
         ],
         "responses": {
@@ -9679,6 +9688,36 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "codersdk.PatchRoleRequest": {
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "organization_permissions": {
+          "description": "OrganizationPermissions are specific to the organization the role belongs to.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.Permission"
+          }
+        },
+        "site_permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.Permission"
+          }
+        },
+        "user_permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/codersdk.Permission"
           }
         }
       }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -2112,6 +2112,7 @@
             "CoderSessionToken": []
           }
         ],
+        "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["Members"],
         "summary": "Upsert a custom organization role",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -464,7 +464,6 @@ func New(options *Options) *API {
 		TemplateScheduleStore:       options.TemplateScheduleStore,
 		UserQuietHoursScheduleStore: options.UserQuietHoursScheduleStore,
 		AccessControlStore:          options.AccessControlStore,
-		CustomRoleHandler:           atomic.Pointer[CustomRoleHandler]{},
 		Experiments:                 experiments,
 		healthCheckGroup:            &singleflight.Group[string, *healthsdk.HealthcheckReport]{},
 		Acquirer: provisionerdserver.NewAcquirer(
@@ -476,8 +475,6 @@ func New(options *Options) *API {
 		dbRolluper: options.DatabaseRolluper,
 	}
 
-	var customRoleHandler CustomRoleHandler = &agplCustomRoleHandler{}
-	api.CustomRoleHandler.Store(&customRoleHandler)
 	api.AppearanceFetcher.Store(&appearance.DefaultFetcher)
 	api.PortSharer.Store(&portsharing.DefaultPortSharer)
 	buildInfo := codersdk.BuildInfoResponse{
@@ -887,8 +884,6 @@ func New(options *Options) *API {
 					r.Get("/", api.listMembers)
 					r.Route("/roles", func(r chi.Router) {
 						r.Get("/", api.assignableOrgRoles)
-						r.With(httpmw.RequireExperiment(api.Experiments, codersdk.ExperimentCustomRoles)).
-							Patch("/", api.patchOrgRoles)
 					})
 
 					r.Route("/{user}", func(r chi.Router) {
@@ -1327,8 +1322,6 @@ type API struct {
 	// passed to dbauthz.
 	AccessControlStore *atomic.Pointer[dbauthz.AccessControlStore]
 	PortSharer         atomic.Pointer[portsharing.PortSharer]
-	// CustomRoleHandler is the AGPL/Enterprise implementation for custom roles.
-	CustomRoleHandler atomic.Pointer[CustomRoleHandler]
 
 	HTTPAuth *HTTPAuthorizer
 

--- a/coderd/roles.go
+++ b/coderd/roles.go
@@ -1,7 +1,6 @@
 package coderd
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -15,52 +14,6 @@ import (
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac"
 )
-
-// CustomRoleHandler handles AGPL/Enterprise interface for handling custom
-// roles. Ideally only included in the enterprise package, but the routes are
-// intermixed with AGPL endpoints.
-type CustomRoleHandler interface {
-	PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.PatchRoleRequest) (codersdk.Role, bool)
-}
-
-type agplCustomRoleHandler struct{}
-
-func (agplCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, _ *http.Request, _ uuid.UUID, _ codersdk.PatchRoleRequest) (codersdk.Role, bool) {
-	httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-		Message: "Creating and updating custom roles is an Enterprise feature. Contact sales!",
-	})
-	return codersdk.Role{}, false
-}
-
-// patchRole will allow creating a custom organization role
-//
-// @Summary Upsert a custom organization role
-// @ID upsert-a-custom-organization-role
-// @Security CoderSessionToken
-// @Produce json
-// @Param organization path string true "Organization ID" format(uuid)
-// @Tags Members
-// @Success 200 {array} codersdk.Role
-// @Router /organizations/{organization}/members/roles [patch]
-func (api *API) patchOrgRoles(rw http.ResponseWriter, r *http.Request) {
-	var (
-		ctx          = r.Context()
-		handler      = *api.CustomRoleHandler.Load()
-		organization = httpmw.OrganizationParam(r)
-	)
-
-	var req codersdk.PatchRoleRequest
-	if !httpapi.Read(ctx, rw, r, &req) {
-		return
-	}
-
-	updated, ok := handler.PatchOrganizationRole(ctx, rw, r, organization.ID, req)
-	if !ok {
-		return
-	}
-
-	httpapi.Write(ctx, rw, http.StatusOK, updated)
-}
 
 // AssignableSiteRoles returns all site wide roles that can be assigned.
 //

--- a/docs/api/members.md
+++ b/docs/api/members.md
@@ -215,17 +215,49 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 ```shell
 # Example request using curl
 curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/members/roles \
+  -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
 `PATCH /organizations/{organization}/members/roles`
 
+> Body parameter
+
+```json
+{
+  "display_name": "string",
+  "name": "string",
+  "organization_permissions": [
+    {
+      "action": "application_connect",
+      "negate": true,
+      "resource_type": "*"
+    }
+  ],
+  "site_permissions": [
+    {
+      "action": "application_connect",
+      "negate": true,
+      "resource_type": "*"
+    }
+  ],
+  "user_permissions": [
+    {
+      "action": "application_connect",
+      "negate": true,
+      "resource_type": "*"
+    }
+  ]
+}
+```
+
 ### Parameters
 
-| Name           | In   | Type         | Required | Description     |
-| -------------- | ---- | ------------ | -------- | --------------- |
-| `organization` | path | string(uuid) | true     | Organization ID |
+| Name           | In   | Type                                                             | Required | Description         |
+| -------------- | ---- | ---------------------------------------------------------------- | -------- | ------------------- |
+| `organization` | path | string(uuid)                                                     | true     | Organization ID     |
+| `body`         | body | [codersdk.PatchRoleRequest](schemas.md#codersdkpatchrolerequest) | true     | Upsert role request |
 
 ### Example responses
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3698,6 +3698,46 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `quota_allowance` | integer         | false    |              |             |
 | `remove_users`    | array of string | false    |              |             |
 
+## codersdk.PatchRoleRequest
+
+```json
+{
+  "display_name": "string",
+  "name": "string",
+  "organization_permissions": [
+    {
+      "action": "application_connect",
+      "negate": true,
+      "resource_type": "*"
+    }
+  ],
+  "site_permissions": [
+    {
+      "action": "application_connect",
+      "negate": true,
+      "resource_type": "*"
+    }
+  ],
+  "user_permissions": [
+    {
+      "action": "application_connect",
+      "negate": true,
+      "resource_type": "*"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name                       | Type                                                | Required | Restrictions | Description                                                                    |
+| -------------------------- | --------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------ |
+| `display_name`             | string                                              | false    |              |                                                                                |
+| `name`                     | string                                              | false    |              |                                                                                |
+| `organization_permissions` | array of [codersdk.Permission](#codersdkpermission) | false    |              | Organization permissions are specific to the organization the role belongs to. |
+| `site_permissions`         | array of [codersdk.Permission](#codersdkpermission) | false    |              |                                                                                |
+| `user_permissions`         | array of [codersdk.Permission](#codersdkpermission) | false    |              |                                                                                |
+
 ## codersdk.PatchTemplateVersionRequest
 
 ```json

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -269,7 +269,6 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				httpmw.ExtractOrganizationParam(api.Database),
 			)
 			r.Patch("/organizations/{organization}/members/roles", api.patchOrgRoles)
-
 		})
 
 		r.Route("/organizations/{organization}/groups", func(r chi.Router) {

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -261,6 +261,17 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 			r.Delete("/organizations/{organization}", api.deleteOrganization)
 		})
 
+		r.Group(func(r chi.Router) {
+			r.Use(
+				apiKeyMiddleware,
+				api.RequireFeatureMW(codersdk.FeatureCustomRoles),
+				httpmw.RequireExperiment(api.AGPL.Experiments, codersdk.ExperimentCustomRoles),
+				httpmw.ExtractOrganizationParam(api.Database),
+			)
+			r.Patch("/organizations/{organization}/members/roles", api.patchOrgRoles)
+
+		})
+
 		r.Route("/organizations/{organization}/groups", func(r chi.Router) {
 			r.Use(
 				apiKeyMiddleware,
@@ -785,16 +796,6 @@ func (api *API) updateEntitlements(ctx context.Context) error {
 			ps = portsharing.NewEnterprisePortSharer()
 		}
 		api.AGPL.PortSharer.Store(&ps)
-	}
-
-	if initial, changed, enabled := featureChanged(codersdk.FeatureCustomRoles); shouldUpdate(initial, changed, enabled) {
-		var handler coderd.CustomRoleHandler = &enterpriseCustomRoleHandler{API: api, Enabled: enabled}
-		api.AGPL.CustomRoleHandler.Store(&handler)
-	}
-
-	if initial, changed, enabled := featureChanged(codersdk.FeatureMultipleOrganizations); shouldUpdate(initial, changed, enabled) {
-		var handler coderd.CustomRoleHandler = &enterpriseCustomRoleHandler{API: api, Enabled: enabled}
-		api.AGPL.CustomRoleHandler.Store(&handler)
 	}
 
 	// External token encryption is soft-enforced

--- a/enterprise/coderd/roles.go
+++ b/enterprise/coderd/roles.go
@@ -21,6 +21,7 @@ import (
 // @Summary Upsert a custom organization role
 // @ID upsert-a-custom-organization-role
 // @Security CoderSessionToken
+// @Accept json
 // @Produce json
 // @Param organization path string true "Organization ID" format(uuid)
 // @Param request body codersdk.PatchRoleRequest true "Upsert role request"

--- a/enterprise/coderd/roles.go
+++ b/enterprise/coderd/roles.go
@@ -1,7 +1,6 @@
 package coderd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -11,86 +10,92 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/codersdk"
 )
 
-type enterpriseCustomRoleHandler struct {
-	API     *API
-	Enabled bool
-}
-
-func (h enterpriseCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.PatchRoleRequest) (codersdk.Role, bool) {
-	if !h.Enabled {
-		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
-			Message: "Custom roles are not enabled",
-		})
-		return codersdk.Role{}, false
-	}
-
+// patchRole will allow creating a custom organization role
+//
+// @Summary Upsert a custom organization role
+// @ID upsert-a-custom-organization-role
+// @Security CoderSessionToken
+// @Produce json
+// @Param organization path string true "Organization ID" format(uuid)
+// @Tags Members
+// @Success 200 {array} codersdk.Role
+// @Router /organizations/{organization}/members/roles [patch]
+func (api *API) patchOrgRoles(rw http.ResponseWriter, r *http.Request) {
 	var (
-		db                = h.API.Database
-		auditor           = h.API.AGPL.Auditor.Load()
+		ctx               = r.Context()
+		db                = api.Database
+		auditor           = api.AGPL.Auditor.Load()
+		organization      = httpmw.OrganizationParam(r)
 		aReq, commitAudit = audit.InitRequest[database.CustomRole](rw, &audit.RequestParams{
 			Audit:          *auditor,
-			Log:            h.API.Logger,
+			Log:            api.Logger,
 			Request:        r,
 			Action:         database.AuditActionWrite,
-			OrganizationID: orgID,
+			OrganizationID: organization.ID,
 		})
 	)
 	defer commitAudit()
 
-	// This check is not ideal, but we cannot enforce a unique role name in the db against
-	// the built-in role names.
-	if rbac.ReservedRoleName(role.Name) {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Reserved role name",
-			Detail:  fmt.Sprintf("%q is a reserved role name, and not allowed to be used", role.Name),
-		})
-		return codersdk.Role{}, false
+	var req codersdk.Role
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
 	}
 
-	if err := httpapi.NameValid(role.Name); err != nil {
+	// This check is not ideal, but we cannot enforce a unique role name in the db against
+	// the built-in role names.
+	if rbac.ReservedRoleName(req.Name) {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Reserved role name",
+			Detail:  fmt.Sprintf("%q is a reserved role name, and not allowed to be used", req.Name),
+		})
+		return
+	}
+
+	if err := httpapi.NameValid(req.Name); err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid role name",
 			Detail:  err.Error(),
 		})
-		return codersdk.Role{}, false
+		return
 	}
 
 	// Only organization permissions are allowed to be granted
-	if len(role.SitePermissions) > 0 {
+	if len(req.SitePermissions) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid request, not allowed to assign site wide permissions for an organization role.",
 			Detail:  "organization scoped roles may not contain site wide permissions",
 		})
-		return codersdk.Role{}, false
+		return
 	}
 
-	if len(role.UserPermissions) > 0 {
+	if len(req.UserPermissions) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid request, not allowed to assign user permissions for an organization role.",
 			Detail:  "organization scoped roles may not contain user permissions",
 		})
-		return codersdk.Role{}, false
+		return
 	}
 
 	originalRoles, err := db.CustomRoles(ctx, database.CustomRolesParams{
 		LookupRoles: []database.NameOrganizationPair{
 			{
-				Name:           role.Name,
-				OrganizationID: orgID,
+				Name:           req.Name,
+				OrganizationID: organization.ID,
 			},
 		},
 		ExcludeOrgRoles: false,
-		OrganizationID:  orgID,
+		OrganizationID:  organization.ID,
 	})
 	// If it is a 404 (not found) error, ignore it.
 	if err != nil && !httpapi.Is404Error(err) {
 		httpapi.InternalServerError(rw, err)
-		return codersdk.Role{}, false
+		return
 	}
 	if len(originalRoles) == 1 {
 		// For auditing changes to a role.
@@ -98,30 +103,30 @@ func (h enterpriseCustomRoleHandler) PatchOrganizationRole(ctx context.Context, 
 	}
 
 	inserted, err := db.UpsertCustomRole(ctx, database.UpsertCustomRoleParams{
-		Name:        role.Name,
-		DisplayName: role.DisplayName,
+		Name:        req.Name,
+		DisplayName: req.DisplayName,
 		OrganizationID: uuid.NullUUID{
-			UUID:  orgID,
+			UUID:  organization.ID,
 			Valid: true,
 		},
-		SitePermissions: db2sdk.List(role.SitePermissions, sdkPermissionToDB),
-		OrgPermissions:  db2sdk.List(role.OrganizationPermissions, sdkPermissionToDB),
-		UserPermissions: db2sdk.List(role.UserPermissions, sdkPermissionToDB),
+		SitePermissions: db2sdk.List(req.SitePermissions, sdkPermissionToDB),
+		OrgPermissions:  db2sdk.List(req.OrganizationPermissions, sdkPermissionToDB),
+		UserPermissions: db2sdk.List(req.UserPermissions, sdkPermissionToDB),
 	})
 	if httpapi.Is404Error(err) {
 		httpapi.ResourceNotFound(rw)
-		return codersdk.Role{}, false
+		return
 	}
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Failed to update role permissions",
 			Detail:  err.Error(),
 		})
-		return codersdk.Role{}, false
+		return
 	}
 	aReq.New = inserted
 
-	return db2sdk.Role(inserted), true
+	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.Role(inserted))
 }
 
 func sdkPermissionToDB(p codersdk.Permission) database.CustomRolePermission {

--- a/enterprise/coderd/roles.go
+++ b/enterprise/coderd/roles.go
@@ -23,6 +23,7 @@ import (
 // @Security CoderSessionToken
 // @Produce json
 // @Param organization path string true "Organization ID" format(uuid)
+// @Param request body codersdk.PatchRoleRequest true "Upsert role request"
 // @Tags Members
 // @Success 200 {array} codersdk.Role
 // @Router /organizations/{organization}/members/roles [patch]
@@ -42,7 +43,7 @@ func (api *API) patchOrgRoles(rw http.ResponseWriter, r *http.Request) {
 	)
 	defer commitAudit()
 
-	var req codersdk.Role
+	var req codersdk.PatchRoleRequest
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
 	}

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -308,7 +308,7 @@ func TestCustomOrganizationRole(t *testing.T) {
 
 		//nolint:gocritic // owner is required for this
 		_, err := owner.PatchOrganizationRole(ctx, newRole)
-		require.ErrorContains(t, err, "Invalid request")
+		require.ErrorContains(t, err, "Resource not found")
 	})
 }
 

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -125,7 +125,7 @@ func TestCustomOrganizationRole(t *testing.T) {
 
 		// Verify functionality is lost
 		_, err = owner.PatchOrganizationRole(ctx, templateAdminCustom(first.OrganizationID))
-		require.ErrorContains(t, err, "roles are not enabled")
+		require.ErrorContains(t, err, "Custom Roles is an Enterprise feature")
 
 		// Assign the custom template admin role
 		tmplAdmin, _ := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.RoleIdentifier{Name: role.Name, OrganizationID: first.OrganizationID})
@@ -308,7 +308,7 @@ func TestCustomOrganizationRole(t *testing.T) {
 
 		//nolint:gocritic // owner is required for this
 		_, err := owner.PatchOrganizationRole(ctx, newRole)
-		require.ErrorContains(t, err, "Resource not found")
+		require.ErrorContains(t, err, "Invalid request")
 	})
 }
 


### PR DESCRIPTION
This was before realizing single routes could be overwritten. When this was written, I was under the impression organization sub routes had to be defined in AGPL