### PR TITLE
fix: don't require `organization_id` in body when updating a custom role

### DIFF
--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -203,7 +203,7 @@ func (r *RootCmd) editOrganizationRole(orgContext *OrganizationContext) *serpent
 				// Do not actually post
 				updated = customRole
 			} else {
-				updated, err = client.PatchOrganizationRole(ctx, org.ID, customRole)
+				updated, err = client.PatchOrganizationRole(ctx, customRole)
 				if err != nil {
 					return xerrors.Errorf("patch role: %w", err)
 				}

--- a/coderd/roles.go
+++ b/coderd/roles.go
@@ -20,12 +20,12 @@ import (
 // roles. Ideally only included in the enterprise package, but the routes are
 // intermixed with AGPL endpoints.
 type CustomRoleHandler interface {
-	PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.Role) (codersdk.Role, bool)
+	PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.PatchRoleRequest) (codersdk.Role, bool)
 }
 
 type agplCustomRoleHandler struct{}
 
-func (agplCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, _ *http.Request, _ uuid.UUID, _ codersdk.Role) (codersdk.Role, bool) {
+func (agplCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, _ *http.Request, _ uuid.UUID, _ codersdk.PatchRoleRequest) (codersdk.Role, bool) {
 	httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 		Message: "Creating and updating custom roles is an Enterprise feature. Contact sales!",
 	})
@@ -49,7 +49,7 @@ func (api *API) patchOrgRoles(rw http.ResponseWriter, r *http.Request) {
 		organization = httpmw.OrganizationParam(r)
 	)
 
-	var req codersdk.Role
+	var req codersdk.PatchRoleRequest
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
 	}

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -50,7 +50,7 @@ type Permission struct {
 	Action       RBACAction   `json:"action"`
 }
 
-// Role is a longer form of SlimRole used to edit custom roles.
+// Role is a longer form of SlimRole that includes permissions details.
 type Role struct {
 	Name            string       `json:"name" table:"name,default_sort" validate:"username"`
 	OrganizationID  string       `json:"organization_id,omitempty" table:"organization_id" format:"uuid"`
@@ -61,7 +61,7 @@ type Role struct {
 	UserPermissions         []Permission `json:"user_permissions" table:"user_permissions"`
 }
 
-// Role is a longer form of SlimRole used to edit custom roles.
+// PatchRoleRequest is used to edit custom roles.
 type PatchRoleRequest struct {
 	Name            string       `json:"name" table:"name,default_sort" validate:"username"`
 	DisplayName     string       `json:"display_name" table:"display_name"`

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -61,6 +61,16 @@ type Role struct {
 	UserPermissions         []Permission `json:"user_permissions" table:"user_permissions"`
 }
 
+// Role is a longer form of SlimRole used to edit custom roles.
+type PatchRoleRequest struct {
+	Name            string       `json:"name" table:"name,default_sort" validate:"username"`
+	DisplayName     string       `json:"display_name" table:"display_name"`
+	SitePermissions []Permission `json:"site_permissions" table:"site_permissions"`
+	// OrganizationPermissions are specific to the organization the role belongs to.
+	OrganizationPermissions []Permission `json:"organization_permissions" table:"organization_permissions"`
+	UserPermissions         []Permission `json:"user_permissions" table:"user_permissions"`
+}
+
 // FullName returns the role name scoped to the organization ID. This is useful if
 // printing a set of roles from different scopes, as duplicated names across multiple
 // scopes will become unique.
@@ -73,9 +83,17 @@ func (r Role) FullName() string {
 }
 
 // PatchOrganizationRole will upsert a custom organization role
-func (c *Client) PatchOrganizationRole(ctx context.Context, organizationID uuid.UUID, req Role) (Role, error) {
+func (c *Client) PatchOrganizationRole(ctx context.Context, role Role) (Role, error) {
+	req := PatchRoleRequest{
+		Name:                    role.Name,
+		DisplayName:             role.DisplayName,
+		SitePermissions:         role.SitePermissions,
+		OrganizationPermissions: role.OrganizationPermissions,
+		UserPermissions:         role.UserPermissions,
+	}
+
 	res, err := c.Request(ctx, http.MethodPatch,
-		fmt.Sprintf("/api/v2/organizations/%s/members/roles", organizationID.String()), req)
+		fmt.Sprintf("/api/v2/organizations/%s/members/roles", role.OrganizationID), req)
 	if err != nil {
 		return Role{}, err
 	}
@@ -83,8 +101,8 @@ func (c *Client) PatchOrganizationRole(ctx context.Context, organizationID uuid.
 	if res.StatusCode != http.StatusOK {
 		return Role{}, ReadBodyAsError(res)
 	}
-	var role Role
-	return role, json.NewDecoder(res.Body).Decode(&role)
+	var r Role
+	return r, json.NewDecoder(res.Body).Decode(&r)
 }
 
 // ListSiteRoles lists all assignable site wide roles.

--- a/enterprise/cli/organizationmembers_test.go
+++ b/enterprise/cli/organizationmembers_test.go
@@ -36,7 +36,7 @@ func TestEnterpriseListOrganizationMembers(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		//nolint:gocritic // only owners can patch roles
-		customRole, err := ownerClient.PatchOrganizationRole(ctx, owner.OrganizationID, codersdk.Role{
+		customRole, err := ownerClient.PatchOrganizationRole(ctx, codersdk.Role{
 			Name:            "custom",
 			OrganizationID:  owner.OrganizationID.String(),
 			DisplayName:     "Custom Role",
@@ -89,7 +89,7 @@ func TestAssignOrganizationMemberRole(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		// nolint:gocritic // requires owner role to create
-		customRole, err := ownerClient.PatchOrganizationRole(ctx, owner.OrganizationID, codersdk.Role{
+		customRole, err := ownerClient.PatchOrganizationRole(ctx, codersdk.Role{
 			Name:            "custom-role",
 			OrganizationID:  owner.OrganizationID.String(),
 			DisplayName:     "Custom Role",

--- a/enterprise/cli/templatecreate_test.go
+++ b/enterprise/cli/templatecreate_test.go
@@ -168,7 +168,7 @@ func TestTemplateCreate(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
 		//nolint:gocritic // owner required to make custom roles
-		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, secondOrg.ID, codersdk.Role{
+		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, codersdk.Role{
 			Name:           "org-template-admin",
 			OrganizationID: secondOrg.ID.String(),
 			OrganizationPermissions: codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{

--- a/enterprise/coderd/roles.go
+++ b/enterprise/coderd/roles.go
@@ -21,7 +21,7 @@ type enterpriseCustomRoleHandler struct {
 	Enabled bool
 }
 
-func (h enterpriseCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.Role) (codersdk.Role, bool) {
+func (h enterpriseCustomRoleHandler) PatchOrganizationRole(ctx context.Context, rw http.ResponseWriter, r *http.Request, orgID uuid.UUID, role codersdk.PatchRoleRequest) (codersdk.Role, bool) {
 	if !h.Enabled {
 		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 			Message: "Custom roles are not enabled",
@@ -73,14 +73,6 @@ func (h enterpriseCustomRoleHandler) PatchOrganizationRole(ctx context.Context, 
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid request, not allowed to assign user permissions for an organization role.",
 			Detail:  "organization scoped roles may not contain user permissions",
-		})
-		return codersdk.Role{}, false
-	}
-
-	if role.OrganizationID != orgID.String() {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Invalid request, organization in role and url must match",
-			Detail:  fmt.Sprintf("role organization=%q does not match URL=%q", role.OrganizationID, orgID.String()),
 		})
 		return codersdk.Role{}, false
 	}

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -751,7 +751,7 @@ func TestTemplates(t *testing.T) {
 		})
 
 		//nolint:gocritic // owner required to make custom roles
-		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, secondOrg.ID, codersdk.Role{
+		orgTemplateAdminRole, err := ownerClient.PatchOrganizationRole(ctx, codersdk.Role{
 			Name:           "org-template-admin",
 			OrganizationID: secondOrg.ID.String(),
 			OrganizationPermissions: codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{

--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -705,7 +705,7 @@ func TestEnterpriseUserLogin(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 		//nolint:gocritic // owner required
-		customRole, err := ownerClient.PatchOrganizationRole(ctx, owner.OrganizationID, codersdk.Role{
+		customRole, err := ownerClient.PatchOrganizationRole(ctx, codersdk.Role{
 			Name:                    "custom-role",
 			OrganizationID:          owner.OrganizationID.String(),
 			OrganizationPermissions: []codersdk.Permission{},

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -271,7 +271,7 @@ func TestAssignCustomOrgRoles(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	// Create a custom role as an organization admin that allows making templates.
-	auditorRole, err := client.PatchOrganizationRole(ctx, owner.OrganizationID, codersdk.Role{
+	auditorRole, err := client.PatchOrganizationRole(ctx, codersdk.Role{
 		Name:            "org-template-admin",
 		OrganizationID:  owner.OrganizationID.String(),
 		DisplayName:     "Template Admin",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -898,6 +898,15 @@ export interface PatchGroupRequest {
   readonly quota_allowance?: number;
 }
 
+// From codersdk/roles.go
+export interface PatchRoleRequest {
+  readonly name: string;
+  readonly display_name: string;
+  readonly site_permissions: readonly Permission[];
+  readonly organization_permissions: readonly Permission[];
+  readonly user_permissions: readonly Permission[];
+}
+
 // From codersdk/templateversions.go
 export interface PatchTemplateVersionRequest {
   readonly name: string;


### PR DESCRIPTION
cc @jaaydenh

The extra field doesn't serve much purpose, and results in a more fragile API that's harder to use from the frontend.