### PR TITLE
fix: add additional styling to experimental org-scoped template gallery

### DIFF
--- a/site/src/components/AvatarData/AvatarData.tsx
+++ b/site/src/components/AvatarData/AvatarData.tsx
@@ -8,6 +8,7 @@ export interface AvatarDataProps {
   subtitle?: ReactNode;
   src?: string;
   avatar?: React.ReactNode;
+  displayTitle?: boolean;
 }
 
 export const AvatarData: FC<AvatarDataProps> = ({
@@ -15,6 +16,7 @@ export const AvatarData: FC<AvatarDataProps> = ({
   subtitle,
   src,
   avatar,
+  displayTitle = true,
 }) => {
   const theme = useTheme();
 
@@ -47,9 +49,9 @@ export const AvatarData: FC<AvatarDataProps> = ({
             fontWeight: 600,
           }}
         >
-          {title}
+          {displayTitle && title}
         </span>
-        {subtitle && (
+        {subtitle && displayTitle && (
           <span
             css={{
               fontSize: 13,

--- a/site/src/modules/templates/TemplateCard/TemplateCard.tsx
+++ b/site/src/modules/templates/TemplateCard/TemplateCard.tsx
@@ -1,19 +1,29 @@
 import type { Interpolation, Theme } from "@emotion/react";
 import ArrowForwardOutlined from "@mui/icons-material/ArrowForwardOutlined";
 import Button from "@mui/material/Button";
+import Link from "@mui/material/Link";
+import Tooltip from "@mui/material/Tooltip";
+import { visuallyHidden } from "@mui/utils";
 import type { FC, HTMLAttributes } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import type { Template } from "api/typesGenerated";
-import { ExternalAvatar } from "components/Avatar/Avatar";
+import { ExternalAvatar, Avatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { DeprecatedBadge } from "components/Badges/Badges";
+import { ExternalImage } from "components/ExternalImage/ExternalImage";
+import { Pill } from "components/Pill/Pill";
+import { formatTemplateBuildTime } from "utils/templates";
 
 type TemplateCardProps = HTMLAttributes<HTMLDivElement> & {
   template: Template;
+  activeOrg?: string;
+  hasMultipleOrgs: boolean;
 };
 
 export const TemplateCard: FC<TemplateCardProps> = ({
   template,
+  activeOrg,
+  hasMultipleOrgs,
   ...divProps
 }) => {
   const navigate = useNavigate();
@@ -25,7 +35,6 @@ export const TemplateCard: FC<TemplateCardProps> = ({
       navigate(templatePageLink);
     }
   };
-
   return (
     <div
       css={styles.card}
@@ -36,52 +45,78 @@ export const TemplateCard: FC<TemplateCardProps> = ({
       onKeyDown={handleKeyDown}
     >
       <div css={styles.header}>
-        <div>
+        <div css={{ display: "flex", alignItems: "center" }}>
           <AvatarData
+            displayTitle={false}
+            subtitle=""
             title={
               template.display_name.length > 0
                 ? template.display_name
                 : template.name
             }
-            subtitle={template.organization_display_name}
-            avatar={
-              hasIcon && (
-                <ExternalAvatar variant="square" fitImage src={template.icon} />
-              )
-            }
+            avatar={hasIcon && <Avatar src={template.icon} size="xl" />}
           />
+          <p
+            css={(theme) => ({
+              fontSize: 13,
+              margin: "0 0 0 auto",
+              color: theme.palette.text.secondary,
+            })}
+          >
+            <span css={{ ...visuallyHidden }}>Build time: </span>
+            <Tooltip title="Build time" placement="bottom-start">
+              <span>
+                {formatTemplateBuildTime(template.build_time_stats.start.P50)}
+              </span>
+            </Tooltip>
+          </p>
         </div>
-        <div>
-          {template.active_user_count}{" "}
-          {template.active_user_count === 1 ? "user" : "users"}
-        </div>
+
+        {hasMultipleOrgs && (
+          <div css={styles.orgs}>
+            <RouterLink
+              to={`/organizations/${template.organization_name}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Pill
+                css={[
+                  styles.org,
+                  activeOrg === template.organization_id && styles.activeOrg,
+                ]}
+              >
+                {template.organization_display_name}
+              </Pill>
+            </RouterLink>
+          </div>
+        )}
       </div>
 
       <div>
+        <h4 css={{ fontSize: 14, fontWeight: 600, margin: 0, marginBottom: 4 }}>
+          {template.display_name}
+        </h4>
         <span css={styles.description}>
-          <p>{template.description}</p>
+          {template.description}{" "}
+          <Link
+            component={RouterLink}
+            onClick={(e) => e.stopPropagation()}
+            to={`/templates/${template.name}/docs`}
+            css={{ display: "inline-block", fontSize: 13, marginTop: 4 }}
+          >
+            Read more
+          </Link>
         </span>
       </div>
 
       <div css={styles.useButtonContainer}>
-        {template.deprecated ? (
-          <DeprecatedBadge />
-        ) : (
-          <Button
-            component={RouterLink}
-            css={styles.actionButton}
-            className="actionButton"
-            fullWidth
-            startIcon={<ArrowForwardOutlined />}
-            title={`Create a workspace using the ${template.display_name} template`}
-            to={`/templates/${template.name}/workspace`}
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-          >
-            Create Workspace
-          </Button>
-        )}
+        <Button
+          component={RouterLink}
+          onClick={(e) => e.stopPropagation()}
+          fullWidth
+          to={`/templates/${template.name}/workspace`}
+        >
+          Use template
+        </Button>
       </div>
     </div>
   );
@@ -140,5 +175,26 @@ const styles = {
     "&:hover": {
       borderColor: theme.palette.text.primary,
     },
+  }),
+
+  orgs: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 8,
+    justifyContent: "end",
+  },
+
+  org: (theme) => ({
+    borderColor: theme.palette.divider,
+    textDecoration: "none",
+    cursor: "pointer",
+    "&: hover": {
+      borderColor: theme.palette.primary.main,
+    },
+  }),
+
+  activeOrg: (theme) => ({
+    borderColor: theme.roles.active.outline,
+    backgroundColor: theme.roles.active.background,
   }),
 } satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/modules/templates/TemplateCard/TemplateCard.tsx
+++ b/site/src/modules/templates/TemplateCard/TemplateCard.tsx
@@ -1,17 +1,19 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import ArrowForwardOutlined from "@mui/icons-material/ArrowForwardOutlined";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import { visuallyHidden } from "@mui/utils";
 import type { FC, HTMLAttributes } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import type { Template } from "api/typesGenerated";
-import { ExternalAvatar, Avatar } from "components/Avatar/Avatar";
+import { Avatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { DeprecatedBadge } from "components/Badges/Badges";
-import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { Pill } from "components/Pill/Pill";
+import { Stack } from "components/Stack/Stack";
+import { createDayString } from "utils/createDayString";
 import { formatTemplateBuildTime } from "utils/templates";
 
 type TemplateCardProps = HTMLAttributes<HTMLDivElement> & {
@@ -28,54 +30,51 @@ export const TemplateCard: FC<TemplateCardProps> = ({
 }) => {
   const navigate = useNavigate();
   const templatePageLink = `/templates/${template.name}`;
-  const hasIcon = template.icon && template.icon !== "";
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && e.currentTarget === e.target) {
       navigate(templatePageLink);
     }
   };
+
+  const truncatedDescription =
+    template.description.length >= 60
+      ? template.description.substring(0, 60) + "..."
+      : template.description;
+
   return (
     <div
       css={styles.card}
-      {...divProps}
       role="button"
-      tabIndex={0}
       onClick={() => navigate(templatePageLink)}
       onKeyDown={handleKeyDown}
+      tabIndex={0}
+      {...divProps}
     >
-      <div css={styles.header}>
-        <div css={{ display: "flex", alignItems: "center" }}>
-          <AvatarData
-            displayTitle={false}
-            subtitle=""
-            title={
-              template.display_name.length > 0
-                ? template.display_name
-                : template.name
-            }
-            avatar={hasIcon && <Avatar src={template.icon} size="xl" />}
-          />
-          <p
-            css={(theme) => ({
-              fontSize: 13,
-              margin: "0 0 0 auto",
-              color: theme.palette.text.secondary,
-            })}
-          >
-            <span css={{ ...visuallyHidden }}>Build time: </span>
-            <Tooltip title="Build time" placement="bottom-start">
-              <span>
-                {formatTemplateBuildTime(template.build_time_stats.start.P50)}
-              </span>
-            </Tooltip>
-          </p>
-        </div>
+      <Stack
+        alignItems="center"
+        justifyContent="space-between"
+        direction="row"
+        css={{ marginBottom: 24 }}
+      >
+        <AvatarData
+          displayTitle={false}
+          subtitle=""
+          title={
+            template.display_name.length > 0
+              ? template.display_name
+              : template.name
+          }
+          avatar={
+            template.icon &&
+            template.icon !== "" && <Avatar src={template.icon} size="md" />
+          }
+        />
 
         {hasMultipleOrgs && (
           <div css={styles.orgs}>
             <RouterLink
-              to={`/organizations/${template.organization_name}`}
+              to={`/templates?org=${template.organization_id}`}
               onClick={(e) => e.stopPropagation()}
             >
               <Pill
@@ -89,39 +88,75 @@ export const TemplateCard: FC<TemplateCardProps> = ({
             </RouterLink>
           </div>
         )}
-      </div>
+      </Stack>
 
-      <div>
-        <h4 css={{ fontSize: 14, fontWeight: 600, margin: 0, marginBottom: 4 }}>
-          {template.display_name}
-        </h4>
-        <span css={styles.description}>
-          {template.description}{" "}
-          <Link
-            component={RouterLink}
-            onClick={(e) => e.stopPropagation()}
-            to={`/templates/${template.name}/docs`}
-            css={{ display: "inline-block", fontSize: 13, marginTop: 4 }}
+      <Stack justifyContent="space-between" css={{ height: "100%" }}>
+        <Stack direction="column" spacing={0}>
+          <h4
+            css={{ fontSize: 14, fontWeight: 600, margin: 0, marginBottom: 4 }}
           >
-            Read more
-          </Link>
-        </span>
-      </div>
+            {template.display_name}
+          </h4>
 
-      <div css={styles.useButtonContainer}>
-        {template.deprecated ? (
-          <DeprecatedBadge />
-        ) : (
-          <Button
-            component={RouterLink}
-            onClick={(e) => e.stopPropagation()}
-            fullWidth
-            to={`/templates/${template.name}/workspace`}
-          >
-            Use template
-          </Button>
-        )}
-      </div>
+          {template.description && (
+            <div css={styles.description}>
+              {truncatedDescription}{" "}
+              <Link
+                component={RouterLink}
+                onClick={(e) => e.stopPropagation()}
+                to={`${templatePageLink}/docs`}
+                css={{ display: "inline-block", fontSize: 13, marginTop: 4 }}
+              >
+                Read more
+              </Link>
+            </div>
+          )}
+        </Stack>
+
+        <Stack direction="column" alignItems="flex-start" spacing={1}>
+          <Stack direction="row">
+            <span css={{ ...visuallyHidden }}>Used by</span>
+            <Tooltip title="Used by" placement="bottom-start">
+              <span css={styles.templateStat}>
+                {`${template.active_user_count} ${
+                  template.active_user_count === 1 ? "developer" : "developers"
+                }`}
+              </span>
+            </Tooltip>
+            <Divider orientation="vertical" variant="middle" flexItem />
+            <span css={{ ...visuallyHidden }}>Build time</span>
+            <Tooltip title="Build time" placement="bottom-start">
+              <span css={styles.templateStat}>
+                {`${formatTemplateBuildTime(
+                  template.build_time_stats.start.P50,
+                )}`}
+              </span>
+            </Tooltip>
+            <Divider orientation="vertical" variant="middle" flexItem />
+            <span css={{ ...visuallyHidden }}>Last updated</span>
+            <Tooltip title="Last updated" placement="bottom-start">
+              <span css={styles.templateStat}>
+                {`${createDayString(template.updated_at)}`}
+              </span>
+            </Tooltip>
+          </Stack>
+          {template.deprecated ? (
+            <DeprecatedBadge />
+          ) : (
+            <Button
+              component={RouterLink}
+              onClick={(e) => e.stopPropagation()}
+              fullWidth
+              size="small"
+              startIcon={<AddCircleOutlineIcon />}
+              title={`Create a workspace using the ${template.display_name} template`}
+              to={`${templatePageLink}/workspace`}
+            >
+              Create workspace
+            </Button>
+          )}
+        </Stack>
+      </Stack>
     </div>
   );
 };
@@ -143,13 +178,6 @@ const styles = {
     },
   }),
 
-  header: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 24,
-  },
-
   icon: {
     flexShrink: 0,
     paddingTop: 4,
@@ -164,14 +192,10 @@ const styles = {
     display: "block",
   }),
 
-  useButtonContainer: {
-    display: "flex",
-    gap: 12,
-    flexDirection: "column",
-    paddingTop: 24,
-    marginTop: "auto",
-    alignItems: "center",
-  },
+  templateStat: (theme) => ({
+    fontSize: 13,
+    color: theme.palette.text.secondary,
+  }),
 
   actionButton: (theme) => ({
     transition: "none",

--- a/site/src/modules/templates/TemplateCard/TemplateCard.tsx
+++ b/site/src/modules/templates/TemplateCard/TemplateCard.tsx
@@ -109,14 +109,18 @@ export const TemplateCard: FC<TemplateCardProps> = ({
       </div>
 
       <div css={styles.useButtonContainer}>
-        <Button
-          component={RouterLink}
-          onClick={(e) => e.stopPropagation()}
-          fullWidth
-          to={`/templates/${template.name}/workspace`}
-        >
-          Use template
-        </Button>
+        {template.deprecated ? (
+          <DeprecatedBadge />
+        ) : (
+          <Button
+            component={RouterLink}
+            onClick={(e) => e.stopPropagation()}
+            fullWidth
+            to={`/templates/${template.name}/workspace`}
+          >
+            Use template
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/site/src/modules/templates/TemplateCard/TemplateCard.tsx
+++ b/site/src/modules/templates/TemplateCard/TemplateCard.tsx
@@ -119,7 +119,7 @@ export const TemplateCard: FC<TemplateCardProps> = ({
             <Tooltip title="Used by" placement="bottom-start">
               <span css={styles.templateStat}>
                 {`${template.active_user_count} ${
-                  template.active_user_count === 1 ? "developer" : "developers"
+                  template.active_user_count === 1 ? "user" : "users"
                 }`}
               </span>
             </Tooltip>

--- a/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
@@ -197,7 +197,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
                 visibleTemplates.map((template) => (
                   <TemplateCard
                     css={(theme) => ({
-                      height: 320,
+                      height: 300,
                       backgroundColor: theme.palette.background.paper,
                     })}
                     template={template}

--- a/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
@@ -137,10 +137,21 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
             width: "100%",
           }}
         >
-          <div css={{ display: "flex" }}>
-            {templatesByOrg && Object.keys(templatesByOrg).length > 2 && (
+          {templatesByOrg && Object.keys(templatesByOrg).length > 2 && (
+            <div css={{ display: "flex" }}>
               <Stack
-                css={{ width: 208, flexShrink: 0, position: "sticky", top: 48 }}
+                css={(theme) => ({
+                  width: 208,
+                  flexShrink: 0,
+                  position: "sticky",
+                  top: 48,
+
+                  // increase sidebar width on large screens
+                  // so gap between template cards isn't too large
+                  [theme.breakpoints.up(1440)]: {
+                    width: 308,
+                  },
+                })}
               >
                 <span css={styles.filterCaption}>ORGANIZATION</span>
                 {Object.entries(templatesByOrg).map((org) => (
@@ -159,8 +170,8 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
                   </Link>
                 ))}
               </Stack>
-            )}
-          </div>
+            </div>
+          )}
 
           <div css={{ display: "flex" }}>
             <div
@@ -186,9 +197,14 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
                 visibleTemplates.map((template) => (
                   <TemplateCard
                     css={(theme) => ({
+                      height: 320,
                       backgroundColor: theme.palette.background.paper,
                     })}
                     template={template}
+                    activeOrg={activeOrg}
+                    hasMultipleOrgs={Boolean(
+                      templatesByOrg && Object.keys(templatesByOrg).length > 2,
+                    )}
                     key={template.id}
                   />
                 ))

--- a/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
@@ -63,6 +63,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
   canCreateTemplates,
   error,
 }) => {
+  const sidebarWidth = 208;
   const navigate = useNavigate();
   const [urlParams] = useSearchParams();
   const isEmpty = templatesByOrg && templatesByOrg["all"].length === 0;
@@ -70,6 +71,9 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
   const visibleTemplates = templatesByOrg
     ? templatesByOrg[activeOrg]
     : undefined;
+  const hasMultipleOrgs = Boolean(
+    templatesByOrg && Object.keys(templatesByOrg).length > 2,
+  );
 
   const headerActionElem = canCreateTemplates && (
     <div
@@ -102,7 +106,16 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 
   return (
     <Margins>
-      <div css={{ display: "flex", flexDirection: "column", width: "100%" }}>
+      <div
+        css={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          padding: hasMultipleOrgs
+            ? undefined
+            : `0 calc(${(sidebarWidth + 100) / 2}px)`,
+        }}
+      >
         <PageHeader
           css={{ display: "flex", width: "100%" }}
           actions={headerActionElem}
@@ -137,11 +150,11 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
             width: "100%",
           }}
         >
-          {templatesByOrg && Object.keys(templatesByOrg).length > 2 && (
+          {hasMultipleOrgs && (
             <div css={{ display: "flex" }}>
               <Stack
                 css={(theme) => ({
-                  width: 208,
+                  width: sidebarWidth,
                   flexShrink: 0,
                   position: "sticky",
                   top: 48,
@@ -149,26 +162,27 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
                   // increase sidebar width on large screens
                   // so gap between template cards isn't too large
                   [theme.breakpoints.up(1440)]: {
-                    width: 308,
+                    width: `calc(${sidebarWidth}px + 100px)`,
                   },
                 })}
               >
                 <span css={styles.filterCaption}>ORGANIZATION</span>
-                {Object.entries(templatesByOrg).map((org) => (
-                  <Link
-                    key={org[0]}
-                    to={`?org=${org[0]}`}
-                    css={[
-                      styles.tagLink,
-                      org[0] === activeOrg && styles.tagLinkActive,
-                    ]}
-                  >
-                    {org[0] === "all"
-                      ? "all"
-                      : org[1][0].organization_display_name}{" "}
-                    ({org[1].length})
-                  </Link>
-                ))}
+                {templatesByOrg &&
+                  Object.entries(templatesByOrg).map((org) => (
+                    <Link
+                      key={org[0]}
+                      to={`?org=${org[0]}`}
+                      css={[
+                        styles.tagLink,
+                        org[0] === activeOrg && styles.tagLinkActive,
+                      ]}
+                    >
+                      {org[0] === "all"
+                        ? "all"
+                        : org[1][0].organization_display_name}{" "}
+                      ({org[1].length})
+                    </Link>
+                  ))}
               </Stack>
             </div>
           )}
@@ -177,7 +191,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
             <div
               css={(theme) => ({
                 display: "flex",
-                justifyContent: "space-between",
+                justifyContent: "flex-start",
                 flexWrap: "wrap",
                 gap: 32,
                 height: "max-content",
@@ -202,9 +216,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
                     })}
                     template={template}
                     activeOrg={activeOrg}
-                    hasMultipleOrgs={Boolean(
-                      templatesByOrg && Object.keys(templatesByOrg).length > 2,
-                    )}
+                    hasMultipleOrgs={hasMultipleOrgs}
                     key={template.id}
                   />
                 ))

--- a/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
@@ -71,81 +71,132 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
     ? templatesByOrg[activeOrg]
     : undefined;
 
+  const headerActionElem = canCreateTemplates && (
+    <div
+      css={(theme) => ({
+        display: "flex",
+
+        // we have special breakpoint behavior for the primary template CTA
+        // so it always aligns with the cards in the gallery view
+        // (as long as we have cards)
+        ...(isEmpty
+          ? {}
+          : {
+              [theme.breakpoints.down(1280)]: {
+                marginLeft: "unset",
+                position: "relative",
+                right: 95,
+              },
+            }),
+
+        [theme.breakpoints.down(1024)]: {
+          position: "static",
+          marginLeft: "initial",
+          width: "100%",
+        },
+      })}
+    >
+      <CreateTemplateButton onNavigate={navigate} />
+    </div>
+  );
+
   return (
     <Margins>
-      <PageHeader
-        actions={
-          canCreateTemplates && <CreateTemplateButton onNavigate={navigate} />
-        }
-      >
-        <PageHeaderTitle>
-          <Stack spacing={1} direction="row" alignItems="center">
-            Templates
-            <TemplateHelpTooltip />
-          </Stack>
-        </PageHeaderTitle>
-        {!isEmpty && (
-          <PageHeaderSubtitle>
-            Select a template to create a workspace.
-          </PageHeaderSubtitle>
+      <div css={{ display: "flex", flexDirection: "column", width: "100%" }}>
+        <PageHeader
+          css={{ display: "flex", width: "100%" }}
+          actions={headerActionElem}
+        >
+          <PageHeaderTitle>
+            <Stack spacing={1} direction="row" alignItems="center">
+              Templates
+              <TemplateHelpTooltip />
+            </Stack>
+          </PageHeaderTitle>
+          {!isEmpty && (
+            <PageHeaderSubtitle>
+              Select a template to create a workspace.
+            </PageHeaderSubtitle>
+          )}
+        </PageHeader>
+
+        {Boolean(error) && (
+          <ErrorAlert error={error} css={{ marginBottom: 32 }} />
         )}
-      </PageHeader>
 
-      {Boolean(error) && (
-        <ErrorAlert error={error} css={{ marginBottom: 32 }} />
-      )}
-
-      {Boolean(!templatesByOrg) && <Loader />}
-
-      <Stack direction="row" spacing={4} alignItems="flex-start">
-        {templatesByOrg && Object.keys(templatesByOrg).length > 2 && (
-          <Stack
-            css={{ width: 208, flexShrink: 0, position: "sticky", top: 48 }}
-          >
-            <span css={styles.filterCaption}>ORGANIZATION</span>
-            {Object.entries(templatesByOrg).map((org) => (
-              <Link
-                key={org[0]}
-                to={`?org=${org[0]}`}
-                css={[
-                  styles.tagLink,
-                  org[0] === activeOrg && styles.tagLinkActive,
-                ]}
-              >
-                {org[0] === "all" ? "all" : org[1][0].organization_display_name}{" "}
-                ({org[1].length})
-              </Link>
-            ))}
-          </Stack>
-        )}
+        {Boolean(!templatesByOrg) && <Loader />}
 
         <div
           css={{
             display: "flex",
-            flexWrap: "wrap",
-            gap: 32,
-            height: "max-content",
+            flexDirection: "row",
+            justifyContent:
+              visibleTemplates && visibleTemplates.length > 2
+                ? "space-between"
+                : "flex-start",
+            width: "100%",
           }}
         >
-          {isEmpty ? (
-            <EmptyTemplates
-              canCreateTemplates={canCreateTemplates}
-              examples={examples ?? []}
-            />
-          ) : (
-            visibleTemplates &&
-            visibleTemplates.map((template) => (
-              <TemplateCard
-                css={(theme) => ({
-                  backgroundColor: theme.palette.background.paper,
-                })}
-                template={template}
-                key={template.id}
-              />
-            ))
-          )}
+          <div css={{ display: "flex" }}>
+            {templatesByOrg && Object.keys(templatesByOrg).length > 2 && (
+              <Stack
+                css={{ width: 208, flexShrink: 0, position: "sticky", top: 48 }}
+              >
+                <span css={styles.filterCaption}>ORGANIZATION</span>
+                {Object.entries(templatesByOrg).map((org) => (
+                  <Link
+                    key={org[0]}
+                    to={`?org=${org[0]}`}
+                    css={[
+                      styles.tagLink,
+                      org[0] === activeOrg && styles.tagLinkActive,
+                    ]}
+                  >
+                    {org[0] === "all"
+                      ? "all"
+                      : org[1][0].organization_display_name}{" "}
+                    ({org[1].length})
+                  </Link>
+                ))}
+              </Stack>
+            )}
+          </div>
+
+          <div css={{ display: "flex" }}>
+            <div
+              css={(theme) => ({
+                display: "flex",
+                justifyContent: "space-between",
+                flexWrap: "wrap",
+                gap: 32,
+                height: "max-content",
+
+                [theme.breakpoints.down(1280)]: {
+                  justifyContent: "flex-start",
+                },
+              })}
+            >
+              {isEmpty ? (
+                <EmptyTemplates
+                  canCreateTemplates={canCreateTemplates}
+                  examples={examples ?? []}
+                />
+              ) : (
+                visibleTemplates &&
+                visibleTemplates.map((template) => (
+                  <TemplateCard
+                    css={(theme) => ({
+                      backgroundColor: theme.palette.background.paper,
+                    })}
+                    template={template}
+                    key={template.id}
+                  />
+                ))
+              )}
+            </div>
+          </div>
         </div>
-      </Stack>
+      </div>
     </Margins>
   );
 };

--- a/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/MultiOrgTemplatePage/TemplatesPageView.tsx
@@ -107,14 +107,18 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
   return (
     <Margins>
       <div
-        css={{
+        css={(theme) => ({
           display: "flex",
           flexDirection: "column",
           width: "100%",
           padding: hasMultipleOrgs
             ? undefined
             : `0 calc(${(sidebarWidth + 100) / 2}px)`,
-        }}
+
+          [theme.breakpoints.down(1440)]: {
+            padding: undefined,
+          },
+        })}
       >
         <PageHeader
           css={{ display: "flex", width: "100%" }}


### PR DESCRIPTION
We reverted https://github.com/coder/coder/pull/13784 a few days ago while we refined design. This PR adds an additional layer of polish and attempts to:

- [x] refine the responsive design
- [x] align the _Create Template_ CTA with each full card row
- [x] add all template stats to each template card so we have parity with template rows in our existing template table

What this PR does *not* do:

- [ ] accomplish a final pass at design (remember, we are operating behind an experiment)
- [ ] define a responsive design that exceeds the standards of our existing starter template gallery
- [ ] align the _Create Template_ CTA for galleries for less than 3 cards - we should consider this in more depth
- [ ] add storybooks

I'm not looking for a ton of feedback on the experimental design we've chosen as we want to get this merged up so we can iterate on the flow as a whole, but feel free to add refinements that can be tackled after merge to the **After experimental release** section of https://github.com/coder/coder/issues/13241#issue-2290307930.


https://www.loom.com/share/2de4afdfadca4da9ab639543b40fdbfd?sid=e51450a4-b0d8-4cf0-af00-4d76eeb9ef5c

#### One Org
![Screenshot 2024-08-01 at 8 53 12 PM](https://github.com/user-attachments/assets/0e3d5d62-d5ac-4baa-8a1d-e0483b4cd87a)


#### Empty State
![Screenshot 2024-08-01 at 8 03 36 PM](https://github.com/user-attachments/assets/beccc10b-0fde-4e55-b818-91b6b3984623)