### PR TITLE
chore: skip dogfood workflow for dependabot PRs

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -10,6 +10,8 @@ on:
       - "flake.lock"
       - "flake.nix"
   pull_request:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - "dogfood/**"
       - ".github/workflows/dogfood.yaml"

--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -11,7 +11,7 @@ on:
       - "flake.nix"
   pull_request:
     branches-ignore:
-      - 'dependabot/**'
+      - "dependabot/**"
     paths:
       - "dogfood/**"
       - ".github/workflows/dogfood.yaml"


### PR DESCRIPTION
After we allowed Depednabot to update the flake in PRs, this was causing dogfood images to rebuild as we watched for changes in `flake.nix` to build the nix dogfood image. 

It does not add any value so just skip it for @depednabot Prs.