### PR TITLE
fix: correct typo in notification template

### DIFF
--- a/coderd/database/migrations/000234_fix_notifications_user_created.down.sql
+++ b/coderd/database/migrations/000234_fix_notifications_user_created.down.sql
@@ -1,0 +1,5 @@
+UPDATE notification_templates
+SET
+    body_template = E'Hi {{.UserName}},\n\New user account **{{.Labels.created_account_name}}** has been created.'
+WHERE
+    id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';

--- a/coderd/database/migrations/000234_fix_notifications_user_created.up.sql
+++ b/coderd/database/migrations/000234_fix_notifications_user_created.up.sql
@@ -1,0 +1,5 @@
+UPDATE notification_templates
+SET
+    body_template = E'Hi {{.UserName}},\n\nNew user account **{{.Labels.created_account_name}}** has been created.'
+WHERE
+    id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/14010

There is a typo in the notification template, unescaped character.