### PR TITLE
chore: include graphite in dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "storybook": "pnpm run -C site/ storybook"
   },
   "devDependencies": {
+    "@withgraphite/graphite-cli": "^1.4.1",
     "prettier": "3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Many of us are using Graphite now; let's standardize on the version.