### PR TITLE
chore: extract `dependency-license-review` to a separate workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -709,7 +709,6 @@ jobs:
       - test-e2e
       - offlinedocs
       - sqlc-vet
-      - dependency-license-review
     # Allow this job to run even if the needed jobs fail, are skipped or
     # cancelled.
     if: always()
@@ -726,7 +725,6 @@ jobs:
           echo "- test-js: ${{ needs.test-js.result }}"
           echo "- test-e2e: ${{ needs.test-e2e.result }}"
           echo "- offlinedocs: ${{ needs.offlinedocs.result }}"
-          echo "- dependency-license-review: ${{ needs.dependency-license-review.result }}"
           echo
 
           # We allow skipped jobs to pass, but not failed or cancelled jobs.
@@ -968,43 +966,3 @@ jobs:
       - name: Setup and run sqlc vet
         run: |
           make sqlc-vet
-
-  # dependency-license-review checks that no license-incompatible dependencies have been introduced.
-  # This action is not intended to do a vulnerability check since that is handled by a separate action.
-  dependency-license-review:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
-    steps:
-      - name: "Checkout Repository"
-        uses: actions/checkout@v4
-      - name: "Dependency Review"
-        id: review
-        uses: actions/dependency-review-action@v4.3.2
-        with:
-          allow-licenses: Apache-2.0, 0BSD, BSD-2-Clause, BSD-3-Clause, CC0-1.0, ISC, MIT, MIT-0, MPL-2.0
-          allow-dependencies-licenses: "pkg:golang/github.com/coder/wgtunnel@0.1.13-0.20240522110300-ade90dfb2da0, pkg:npm/pako@1.0.11, pkg:npm/caniuse-lite@1.0.30001639, pkg:githubactions/alwaysmeticulous/report-diffs-action/cloud-compute"
-          license-check: true
-          vulnerability-check: false
-      - name: "Report"
-        # make sure this step runs even if the previous failed
-        if: always()
-        shell: bash
-        env:
-          VULNERABLE_CHANGES: ${{ steps.review.outputs.invalid-license-changes }}
-        run: |
-          fields=( "unlicensed" "unresolved" "forbidden" )
-
-          # This is unfortunate that we have to do this but the action does not support failing on
-          # an unknown license. The unknown dependency could easily have a GPL license which
-          # would be problematic for us.
-          # Track https://github.com/actions/dependency-review-action/issues/672 for when
-          # we can remove this brittle workaround.
-          for field in "${fields[@]}"; do
-            # Use jq to check if the array is not empty
-            if [[ $(echo "$VULNERABLE_CHANGES" | jq ".${field} | length") -ne 0 ]]; then
-              echo "Invalid or unknown licenses detected, contact @sreya to ensure your added dependency falls under one of our allowed licenses."
-              echo "$VULNERABLE_CHANGES" | jq
-              exit 1
-            fi
-          done
-          echo "No incompatible licenses detected"

--- a/.github/workflows/dependency-license-check.yaml
+++ b/.github/workflows/dependency-license-check.yaml
@@ -3,11 +3,8 @@
 
 name: "dependency-license-review"
 on:
-  push:
-    branches-ignore:
-      - main
-      - dependabot/**
   pull_request:
+    types: [opened, synchronize, reopened]
     branches-ignore:
       - main
 

--- a/.github/workflows/dependency-license-check.yaml
+++ b/.github/workflows/dependency-license-check.yaml
@@ -5,7 +5,7 @@ name: "dependency-license-review"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches-ignore:
+    branches:
       - main
 
 jobs:

--- a/.github/workflows/dependency-license-check.yaml
+++ b/.github/workflows/dependency-license-check.yaml
@@ -8,11 +8,12 @@ on:
       - main
       - dependabot/**
   pull_request:
-    branches:
+    branches-ignore:
       - main
 
 jobs:
   dependency-license-review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"

--- a/.github/workflows/dependency-license-check.yaml
+++ b/.github/workflows/dependency-license-check.yaml
@@ -1,0 +1,50 @@
+# dependency-license-review checks that no license-incompatible dependencies have been introduced.
+# This action is not intended to do a vulnerability check since that is handled by a separate action.
+
+name: "dependency-license-review"
+on:
+  push:
+    branches-ignore:
+      - main
+      - dependabot/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  dependency-license-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+      - name: "Dependency Review"
+        id: review
+        uses: actions/dependency-review-action@v4.3.2
+        with:
+          allow-licenses: Apache-2.0, 0BSD, BSD-2-Clause, BSD-3-Clause, CC0-1.0, ISC, MIT, MIT-0, MPL-2.0
+          allow-dependencies-licenses: "pkg:golang/github.com/coder/wgtunnel@0.1.13-0.20240522110300-ade90dfb2da0, pkg:npm/pako@1.0.11, pkg:npm/caniuse-lite@1.0.30001639, pkg:githubactions/alwaysmeticulous/report-diffs-action/cloud-compute"
+          license-check: true
+          vulnerability-check: false
+      - name: "Report"
+        # make sure this step runs even if the previous failed
+        if: always()
+        shell: bash
+        env:
+          VULNERABLE_CHANGES: ${{ steps.review.outputs.invalid-license-changes }}
+        run: |
+          fields=( "unlicensed" "unresolved" "forbidden" )
+
+          # This is unfortunate that we have to do this but the action does not support failing on
+          # an unknown license. The unknown dependency could easily have a GPL license which
+          # would be problematic for us.
+          # Track https://github.com/actions/dependency-review-action/issues/672 for when
+          # we can remove this brittle workaround.
+          for field in "${fields[@]}"; do
+            # Use jq to check if the array is not empty
+            if [[ $(echo "$VULNERABLE_CHANGES" | jq ".${field} | length") -ne 0 ]]; then
+              echo "Invalid or unknown licenses detected, contact @sreya to ensure your added dependency falls under one of our allowed licenses."
+              echo "$VULNERABLE_CHANGES" | jq
+              exit 1
+            fi
+          done
+          echo "No incompatible licenses detected"


### PR DESCRIPTION
Due to some reason, setting the author to dependabot in #14091 did not solve the issue of skipping the `dependency-license-review` job.

I propose we extract the job to a separate workflow for better control of how it runs.
@sreya, you may have to mark this as required if you agree with the changes. 