### PR TITLE
chore: skip dogfood workflow for dependabot PRs

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -10,8 +10,6 @@ on:
       - "flake.lock"
       - "flake.nix"
   pull_request:
-    branches-ignore:
-      - "dependabot/**"
     paths:
       - "dogfood/**"
       - ".github/workflows/dogfood.yaml"
@@ -21,6 +19,7 @@ on:
 
 jobs:
   build_image:
+    if: github.actor != 'dependabot[bot]' # Skip Dependabot PRs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request skips the dogfood workflow for Dependabot PRs. It adds a condition to the build_image job to only run if the actor is not 'dependabot[bot]'.
improves #14106 