### PR TITLE
fix: use correct notification group

### DIFF
--- a/coderd/database/migrations/000235_fix_notifications_group.down.sql
+++ b/coderd/database/migrations/000235_fix_notifications_group.down.sql
@@ -1,5 +1,5 @@
 UPDATE notification_templates
 SET
-    group = E'Workspace Events'
+    "group" = E'Workspace Events'
 WHERE
     id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';

--- a/coderd/database/migrations/000235_fix_notifications_group.down.sql
+++ b/coderd/database/migrations/000235_fix_notifications_group.down.sql
@@ -1,0 +1,5 @@
+UPDATE notification_templates
+SET
+    group = E'Workspace Events'
+WHERE
+    id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';

--- a/coderd/database/migrations/000235_fix_notifications_group.up.sql
+++ b/coderd/database/migrations/000235_fix_notifications_group.up.sql
@@ -1,0 +1,5 @@
+UPDATE notification_templates
+SET
+    group = E'User Events'
+WHERE
+    id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';

--- a/coderd/database/migrations/000235_fix_notifications_group.up.sql
+++ b/coderd/database/migrations/000235_fix_notifications_group.up.sql
@@ -1,5 +1,5 @@
 UPDATE notification_templates
 SET
-    group = E'User Events'
+    "group" = E'User Events'
 WHERE
     id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/14010

This PR corrects the notification group for the _create account_ event