### PR TITLE
feat: add notification preferences business logic & APIs

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -5416,6 +5416,90 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/{user}/notifications/preferences": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Get user notification preferences",
+                "operationId": "get-user-notification-preferences",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID, name, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.NotificationPreference"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Update user notification preferences",
+                "operationId": "update-user-notification-preferences",
+                "parameters": [
+                    {
+                        "description": "Preferences",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserNotificationPreferences"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID, name, or me",
+                        "name": "user",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.NotificationPreference"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/users/{user}/organizations": {
             "get": {
                 "security": [
@@ -10264,6 +10348,22 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.NotificationPreference": {
+            "type": "object",
+            "properties": {
+                "disabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
         "codersdk.NotificationTemplate": {
             "type": "object",
             "properties": {
@@ -12606,6 +12706,17 @@ const docTemplate = `{
             "properties": {
                 "theme_preference": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateUserNotificationPreferences": {
+            "type": "object",
+            "properties": {
+                "template_disabled_map": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1547,6 +1547,34 @@ const docTemplate = `{
                 }
             }
         },
+        "/notifications/dispatch-methods": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Get notification dispatch methods",
+                "operationId": "get-notification-dispatch-methods",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.NotificationMethodsResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/settings": {
             "get": {
                 "security": [
@@ -10344,6 +10372,20 @@ const docTemplate = `{
                     "format": "uuid"
                 },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.NotificationMethodsResponse": {
+            "type": "object",
+            "properties": {
+                "available": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
                     "type": "string"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4780,6 +4780,80 @@
         }
       }
     },
+    "/users/{user}/notifications/preferences": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["Notifications"],
+        "summary": "Get user notification preferences",
+        "operationId": "get-user-notification-preferences",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "User ID, name, or me",
+            "name": "user",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/codersdk.NotificationPreference"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["Notifications"],
+        "summary": "Update user notification preferences",
+        "operationId": "update-user-notification-preferences",
+        "parameters": [
+          {
+            "description": "Preferences",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/codersdk.UpdateUserNotificationPreferences"
+            }
+          },
+          {
+            "type": "string",
+            "description": "User ID, name, or me",
+            "name": "user",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/codersdk.NotificationPreference"
+              }
+            }
+          }
+        }
+      }
+    },
     "/users/{user}/organizations": {
       "get": {
         "security": [
@@ -9197,6 +9271,22 @@
         }
       }
     },
+    "codersdk.NotificationPreference": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
     "codersdk.NotificationTemplate": {
       "type": "object",
       "properties": {
@@ -11447,6 +11537,17 @@
       "properties": {
         "theme_preference": {
           "type": "string"
+        }
+      }
+    },
+    "codersdk.UpdateUserNotificationPreferences": {
+      "type": "object",
+      "properties": {
+        "template_disabled_map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          }
         }
       }
     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1344,6 +1344,30 @@
         }
       }
     },
+    "/notifications/dispatch-methods": {
+      "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
+        "produces": ["application/json"],
+        "tags": ["Notifications"],
+        "summary": "Get notification dispatch methods",
+        "operationId": "get-notification-dispatch-methods",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/codersdk.NotificationMethodsResponse"
+              }
+            }
+          }
+        }
+      }
+    },
     "/notifications/settings": {
       "get": {
         "security": [
@@ -9267,6 +9291,20 @@
           "format": "uuid"
         },
         "username": {
+          "type": "string"
+        }
+      }
+    },
+    "codersdk.NotificationMethodsResponse": {
+      "type": "object",
+      "properties": {
+        "available": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
           "type": "string"
         }
       }

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1050,6 +1050,12 @@ func New(options *Options) *API {
 					})
 					r.Get("/gitsshkey", api.gitSSHKey)
 					r.Put("/gitsshkey", api.regenerateGitSSHKey)
+					r.Route("/notifications", func(r chi.Router) {
+						r.Route("/preferences", func(r chi.Router) {
+							r.Get("/", api.userNotificationPreferences)
+							r.Put("/", api.putUserNotificationPreferences)
+						})
+					})
 				})
 			})
 		})
@@ -1251,10 +1257,6 @@ func New(options *Options) *API {
 			r.Put("/settings", api.putNotificationsSettings)
 			r.Route("/templates", func(r chi.Router) {
 				r.Get("/system", api.systemNotificationTemplates)
-			})
-			r.Route("/preferences", func(r chi.Router) {
-				r.Get("/", api.userNotificationPreferences)
-				r.Put("/", api.putUserNotificationPreferences)
 			})
 		})
 	})

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1258,6 +1258,7 @@ func New(options *Options) *API {
 			r.Route("/templates", func(r chi.Router) {
 				r.Get("/system", api.systemNotificationTemplates)
 			})
+			r.Get("/dispatch-methods", api.notificationDispatchMethods)
 		})
 	})
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1252,6 +1252,10 @@ func New(options *Options) *API {
 			r.Route("/templates", func(r chi.Router) {
 				r.Get("/system", api.systemNotificationTemplates)
 			})
+			r.Route("/preferences", func(r chi.Router) {
+				r.Get("/", api.userNotificationPreferences)
+				r.Put("/", api.putUserNotificationPreferences)
+			})
 		})
 	})
 

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -290,6 +290,10 @@ func (a GetOAuth2ProviderAppsByUserIDRow) RBACObject() rbac.Object {
 	return a.OAuth2ProviderApp.RBACObject()
 }
 
+func (n NotificationPreference) RBACObject() rbac.Object {
+	return rbac.ResourceNotificationPreference.WithOwner(n.UserID.String())
+}
+
 type WorkspaceAgentConnectionStatus struct {
 	Status           WorkspaceAgentStatus `json:"status"`
 	FirstConnectedAt *time.Time           `json:"first_connected_at"`

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -290,10 +290,6 @@ func (a GetOAuth2ProviderAppsByUserIDRow) RBACObject() rbac.Object {
 	return a.OAuth2ProviderApp.RBACObject()
 }
 
-func (n NotificationPreference) RBACObject() rbac.Object {
-	return rbac.ResourceNotificationPreference.WithOwner(n.UserID.String())
-}
-
 type WorkspaceAgentConnectionStatus struct {
 	Status           WorkspaceAgentStatus `json:"status"`
 	FirstConnectedAt *time.Time           `json:"first_connected_at"`

--- a/coderd/notifications.go
+++ b/coderd/notifications.go
@@ -144,6 +144,25 @@ func (api *API) systemNotificationTemplates(rw http.ResponseWriter, r *http.Requ
 	httpapi.Write(r.Context(), rw, http.StatusOK, out)
 }
 
+// @Summary Get notification dispatch methods
+// @ID get-notification-dispatch-methods
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Notifications
+// @Success 200 {array} codersdk.NotificationMethodsResponse
+// @Router /notifications/dispatch-methods [get]
+func (api *API) notificationDispatchMethods(rw http.ResponseWriter, r *http.Request) {
+	var methods []string
+	for _, nm := range database.AllNotificationMethodValues() {
+		methods = append(methods, string(nm))
+	}
+
+	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.NotificationMethodsResponse{
+		AvailableNotificationMethods: methods,
+		DefaultNotificationMethod:    api.DeploymentValues.Notifications.Method.Value(),
+	})
+}
+
 // @Summary Get user notification preferences
 // @ID get-user-notification-preferences
 // @Security CoderSessionToken

--- a/coderd/notifications.go
+++ b/coderd/notifications.go
@@ -219,7 +219,7 @@ func (api *API) putUserNotificationPreferences(rw http.ResponseWriter, r *http.R
 
 	updated, err := api.Database.UpdateUserNotificationPreferences(ctx, input)
 	if err != nil {
-		logger.Error(ctx, "failed to update", slog.Error(err))
+		logger.Error(ctx, "failed to update preferences", slog.Error(err))
 
 		httpapi.Write(r.Context(), rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to update user notifications preferences.",
@@ -228,11 +228,11 @@ func (api *API) putUserNotificationPreferences(rw http.ResponseWriter, r *http.R
 		return
 	}
 
-	logger.Info(ctx, "updated", slog.F("count", updated))
+	logger.Info(ctx, "updated preferences", slog.F("count", updated))
 
 	userPrefs, err := api.Database.GetUserNotificationPreferences(ctx, user.ID)
 	if err != nil {
-		logger.Error(ctx, "failed to retrieve", slog.Error(err))
+		logger.Error(ctx, "failed to retrieve preferences", slog.Error(err))
 
 		httpapi.Write(r.Context(), rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to retrieve user notifications preferences.",

--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -83,6 +83,11 @@ func (s *StoreEnqueuer) Enqueue(ctx context.Context, userID, templateID uuid.UUI
 		CreatedBy:              createdBy,
 	})
 	if err != nil {
+		// We have a trigger on the notification_messages table named `inhibit_enqueue_if_disabled` which prevents messages
+		// from being enqueued if the user has disabled them via notification_preferences. The trigger will fail the insertion
+		// with the message "cannot enqueue message: user has disabled this notification".
+		//
+		// This is more efficient than fetching the user's preferences for each enqueue, and centralizes the business logic.
 		if strings.Contains(err.Error(), ErrCannotEnqueueDisabledNotification.Error()) {
 			return nil, ErrCannotEnqueueDisabledNotification
 		}

--- a/coderd/notifications/enqueuer.go
+++ b/coderd/notifications/enqueuer.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"text/template"
 
 	"github.com/google/uuid"
@@ -15,6 +16,8 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications/types"
 	"github.com/coder/coder/v2/codersdk"
 )
+
+var ErrCannotEnqueueDisabledNotification = xerrors.New("user has disabled this notification")
 
 type StoreEnqueuer struct {
 	store Store
@@ -80,6 +83,10 @@ func (s *StoreEnqueuer) Enqueue(ctx context.Context, userID, templateID uuid.UUI
 		CreatedBy:              createdBy,
 	})
 	if err != nil {
+		if strings.Contains(err.Error(), ErrCannotEnqueueDisabledNotification.Error()) {
+			return nil, ErrCannotEnqueueDisabledNotification
+		}
+
 		s.log.Warn(ctx, "failed to enqueue notification", slog.F("template_id", templateID), slog.F("input", input), slog.Error(err))
 		return nil, xerrors.Errorf("enqueue notification: %w", err)
 	}

--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -249,15 +249,24 @@ func (m *Manager) syncUpdates(ctx context.Context) {
 	for i := 0; i < nFailure; i++ {
 		res := <-m.failure
 
-		status := database.NotificationMessageStatusPermanentFailure
-		if res.retryable {
+		var (
+			reason string
+			status database.NotificationMessageStatus
+		)
+
+		switch {
+		case res.retryable:
 			status = database.NotificationMessageStatusTemporaryFailure
+		case res.inhibited:
+			status = database.NotificationMessageStatusInhibited
+			reason = "disabled by user"
+		default:
+			status = database.NotificationMessageStatusPermanentFailure
 		}
 
 		failureParams.IDs = append(failureParams.IDs, res.msg)
 		failureParams.FailedAts = append(failureParams.FailedAts, res.ts)
 		failureParams.Statuses = append(failureParams.Statuses, status)
-		var reason string
 		if res.err != nil {
 			reason = res.err.Error()
 		}
@@ -367,4 +376,5 @@ type dispatchResult struct {
 	ts        time.Time
 	err       error
 	retryable bool
+	inhibited bool
 }

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -723,17 +723,17 @@ func TestDisabledBeforeEnqueue(t *testing.T) {
 	user := createSampleUser(t, db)
 
 	// WHEN: the user has a preference set to not receive the "workspace deleted" notification
-	templateId := notifications.TemplateWorkspaceDeleted
+	templateID := notifications.TemplateWorkspaceDeleted
 	n, err := db.UpdateUserNotificationPreferences(ctx, database.UpdateUserNotificationPreferencesParams{
 		UserID:                  user.ID,
-		NotificationTemplateIds: []uuid.UUID{templateId},
+		NotificationTemplateIds: []uuid.UUID{templateID},
 		Disableds:               []bool{true},
 	})
 	require.NoError(t, err, "failed to set preferences")
 	require.EqualValues(t, 1, n, "unexpected number of affected rows")
 
 	// THEN: enqueuing the "workspace deleted" notification should fail with an error
-	_, err = enq.Enqueue(ctx, user.ID, templateId, map[string]string{}, "test")
+	_, err = enq.Enqueue(ctx, user.ID, templateID, map[string]string{}, "test")
 	require.ErrorIs(t, err, notifications.ErrCannotEnqueueDisabledNotification, "enqueueing did not fail with expected error")
 }
 
@@ -763,14 +763,14 @@ func TestDisabledAfterEnqueue(t *testing.T) {
 	user := createSampleUser(t, db)
 
 	// GIVEN: a notification is enqueued which has not (yet) been disabled
-	templateId := notifications.TemplateWorkspaceDeleted
-	msgId, err := enq.Enqueue(ctx, user.ID, templateId, map[string]string{}, "test")
+	templateID := notifications.TemplateWorkspaceDeleted
+	msgID, err := enq.Enqueue(ctx, user.ID, templateID, map[string]string{}, "test")
 	require.NoError(t, err)
 
 	// Disable the notification template.
 	n, err := db.UpdateUserNotificationPreferences(ctx, database.UpdateUserNotificationPreferencesParams{
 		UserID:                  user.ID,
-		NotificationTemplateIds: []uuid.UUID{templateId},
+		NotificationTemplateIds: []uuid.UUID{templateID},
 		Disableds:               []bool{true},
 	})
 	require.NoError(t, err, "failed to set preferences")
@@ -787,7 +787,7 @@ func TestDisabledAfterEnqueue(t *testing.T) {
 		})
 		assert.NoError(ct, err)
 		if assert.Equal(ct, len(m), 1) {
-			assert.Equal(ct, m[0].ID.String(), msgId.String())
+			assert.Equal(ct, m[0].ID.String(), msgID.String())
 			assert.Contains(ct, m[0].StatusReason.String, "disabled by user")
 		}
 	}, testutil.WaitLong, testutil.IntervalFast, "did not find the expected inhibited message")

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -143,7 +143,6 @@ func (n *notifier) process(ctx context.Context, success chan<- dispatchResult, f
 
 	var eg errgroup.Group
 	for _, msg := range msgs {
-
 		// If a notification template has been disabled by the user after a notification was enqueued, mark it as inhibited
 		if msg.Disabled {
 			failure <- n.newInhibitedDispatch(msg)

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -142,6 +142,13 @@ func (n *notifier) process(ctx context.Context, success chan<- dispatchResult, f
 
 	var eg errgroup.Group
 	for _, msg := range msgs {
+
+		// If a notification template has been disabled by the user after a notification was enqueued, mark it as inhibited
+		if msg.Disabled {
+			failure <- n.newInhibitedDispatch(msg)
+			continue
+		}
+
 		// A message failing to be prepared correctly should not affect other messages.
 		deliverFn, err := n.prepare(ctx, msg)
 		if err != nil {
@@ -307,6 +314,16 @@ func (n *notifier) newFailedDispatch(msg database.AcquireNotificationMessagesRow
 		ts:        time.Now(),
 		err:       err,
 		retryable: retryable,
+	}
+}
+
+func (n *notifier) newInhibitedDispatch(msg database.AcquireNotificationMessagesRow) dispatchResult {
+	return dispatchResult{
+		notifier:  n.id,
+		msg:       msg.ID,
+		ts:        time.Now(),
+		retryable: false,
+		inhibited: true,
 	}
 }
 

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
@@ -291,7 +292,7 @@ func (n *notifier) newSuccessfulDispatch(msg database.AcquireNotificationMessage
 	return dispatchResult{
 		notifier: n.id,
 		msg:      msg.ID,
-		ts:       time.Now(),
+		ts:       dbtime.Now(),
 	}
 }
 
@@ -311,7 +312,7 @@ func (n *notifier) newFailedDispatch(msg database.AcquireNotificationMessagesRow
 	return dispatchResult{
 		notifier:  n.id,
 		msg:       msg.ID,
-		ts:        time.Now(),
+		ts:        dbtime.Now(),
 		err:       err,
 		retryable: retryable,
 	}
@@ -321,7 +322,7 @@ func (n *notifier) newInhibitedDispatch(msg database.AcquireNotificationMessages
 	return dispatchResult{
 		notifier:  n.id,
 		msg:       msg.ID,
-		ts:        time.Now(),
+		ts:        dbtime.Now(),
 		retryable: false,
 		inhibited: true,
 	}

--- a/coderd/notifications_test.go
+++ b/coderd/notifications_test.go
@@ -112,44 +112,156 @@ func TestNotificationPreferences(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
+		api := coderdtest.New(t, createOpts(t))
+		firstUser := coderdtest.CreateFirstUser(t, api)
 
-		// Given: the first user in its initial state.
-		client := coderdtest.New(t, createOpts(t))
-		_ = coderdtest.CreateFirstUser(t, client)
+		// Given: a member in its initial state.
+		memberClient, member := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
 
 		// When: calling the API.
-		prefs, err := client.GetUserNotificationPreferences(ctx)
+		prefs, err := memberClient.GetUserNotificationPreferences(ctx, member.ID)
 		require.NoError(t, err)
 
 		// Then: no preferences will be returned.
 		require.Len(t, prefs, 0)
 	})
 
-	t.Run("Disable a template", func(t *testing.T) {
+	t.Run("Insufficient permissions", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		template := notifications.TemplateWorkspaceDormant
+		api := coderdtest.New(t, createOpts(t))
+		firstUser := coderdtest.CreateFirstUser(t, api)
 
-		// Given: the first user with no set preferences.
-		client := coderdtest.New(t, createOpts(t))
-		_ = coderdtest.CreateFirstUser(t, client)
+		// Given: 2 members.
+		_, member1 := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
+		member2Client, _ := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
 
-		prefs, err := client.GetUserNotificationPreferences(ctx)
+		// When: attempting to retrieve the preferences of another member.
+		_, err := member2Client.GetUserNotificationPreferences(ctx, member1.ID)
+
+		// Then: the API should reject the request.
+		var sdkError *codersdk.Error
+		require.Error(t, err)
+		require.ErrorAsf(t, err, &sdkError, "error should be of type *codersdk.Error")
+		// NOTE: ExtractUserParam gets in the way here, and returns a 400 Bad Request instead of a 403 Forbidden.
+		// This is not ideal, and we should probably change this behavior.
+		require.Equal(t, http.StatusBadRequest, sdkError.StatusCode())
+	})
+
+	t.Run("Admin may read any users' preferences", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		api := coderdtest.New(t, createOpts(t))
+		firstUser := coderdtest.CreateFirstUser(t, api)
+
+		// Given: a member.
+		_, member := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
+
+		// When: attempting to retrieve the preferences of another member as an admin.
+		prefs, err := api.GetUserNotificationPreferences(ctx, member.ID)
+
+		// Then: the API should not reject the request.
+		require.NoError(t, err)
+		require.Len(t, prefs, 0)
+	})
+
+	t.Run("Admin may update any users' preferences", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		api := coderdtest.New(t, createOpts(t))
+		firstUser := coderdtest.CreateFirstUser(t, api)
+
+		// Given: a member.
+		memberClient, member := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
+
+		// When: attempting to modify and subsequently retrieve the preferences of another member as an admin.
+		prefs, err := api.UpdateUserNotificationPreferences(ctx, member.ID, codersdk.UpdateUserNotificationPreferences{
+			TemplateDisabledMap: map[string]bool{
+				notifications.TemplateWorkspaceMarkedForDeletion.String(): true,
+			},
+		})
+
+		// Then: the request should succeed and the user should be able to query their own preferences to see the same result.
+		require.NoError(t, err)
+		require.Len(t, prefs, 1)
+
+		memberPrefs, err := memberClient.GetUserNotificationPreferences(ctx, member.ID)
+		require.NoError(t, err)
+		require.Len(t, memberPrefs, 1)
+		require.Equal(t, prefs[0].NotificationTemplateID, memberPrefs[0].NotificationTemplateID)
+		require.Equal(t, prefs[0].Disabled, memberPrefs[0].Disabled)
+	})
+
+	t.Run("Add preferences", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		api := coderdtest.New(t, createOpts(t))
+		firstUser := coderdtest.CreateFirstUser(t, api)
+
+		// Given: a member with no preferences.
+		memberClient, member := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
+		prefs, err := memberClient.GetUserNotificationPreferences(ctx, member.ID)
 		require.NoError(t, err)
 		require.Len(t, prefs, 0)
 
-		// When: calling the API.
-		prefs, err = client.UpdateUserNotificationPreferences(ctx, codersdk.UpdateUserNotificationPreferences{
+		// When: attempting to add new preferences.
+		template := notifications.TemplateWorkspaceDeleted
+		prefs, err = memberClient.UpdateUserNotificationPreferences(ctx, member.ID, codersdk.UpdateUserNotificationPreferences{
 			TemplateDisabledMap: map[string]bool{
 				template.String(): true,
 			},
 		})
-		require.NoError(t, err)
 
-		// Then: the single preference will be returned.
+		// Then: the returning preferences should be set as expected.
+		require.NoError(t, err)
 		require.Len(t, prefs, 1)
-		require.Equal(t, template, prefs[0].NotificationTemplateID)
+		require.Equal(t, prefs[0].NotificationTemplateID, template)
 		require.True(t, prefs[0].Disabled)
+	})
+
+	t.Run("Modify preferences", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		api := coderdtest.New(t, createOpts(t))
+		firstUser := coderdtest.CreateFirstUser(t, api)
+
+		// Given: a member with preferences.
+		memberClient, member := coderdtest.CreateAnotherUser(t, api, firstUser.OrganizationID)
+		prefs, err := memberClient.UpdateUserNotificationPreferences(ctx, member.ID, codersdk.UpdateUserNotificationPreferences{
+			TemplateDisabledMap: map[string]bool{
+				notifications.TemplateWorkspaceDeleted.String(): true,
+				notifications.TemplateWorkspaceDormant.String(): true,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, prefs, 2)
+
+		// When: attempting to modify their preferences.
+		prefs, err = memberClient.UpdateUserNotificationPreferences(ctx, member.ID, codersdk.UpdateUserNotificationPreferences{
+			TemplateDisabledMap: map[string]bool{
+				notifications.TemplateWorkspaceDeleted.String(): true,
+				notifications.TemplateWorkspaceDormant.String(): false, // <--- this one was changed
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, prefs, 2)
+
+		// Then: the modified preferences should be set as expected.
+		var found bool
+		for _, p := range prefs {
+			switch p.NotificationTemplateID {
+			case notifications.TemplateWorkspaceDormant:
+				found = true
+				require.False(t, p.Disabled)
+			case notifications.TemplateWorkspaceDeleted:
+				require.True(t, p.Disabled)
+			}
+		}
+		require.True(t, found, "dormant notification preference was not found")
 	})
 }

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -112,7 +112,7 @@ func (c *Client) GetSystemNotificationTemplates(ctx context.Context) ([]Notifica
 	return templates, nil
 }
 
-// GetUserNotificationPreferences TODO
+// GetUserNotificationPreferences retrieves notification preferences for a given user.
 func (c *Client) GetUserNotificationPreferences(ctx context.Context, userID uuid.UUID) ([]NotificationPreference, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/notifications/preferences", userID.String()), nil)
 	if err != nil {
@@ -137,7 +137,7 @@ func (c *Client) GetUserNotificationPreferences(ctx context.Context, userID uuid
 	return prefs, nil
 }
 
-// UpdateUserNotificationPreferences TODO
+// UpdateUserNotificationPreferences updates notification preferences for a given user.
 func (c *Client) UpdateUserNotificationPreferences(ctx context.Context, userID uuid.UUID, req UpdateUserNotificationPreferences) ([]NotificationPreference, error) {
 	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/v2/users/%s/notifications/preferences", userID.String()), req)
 	if err != nil {

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -113,8 +113,8 @@ func (c *Client) GetSystemNotificationTemplates(ctx context.Context) ([]Notifica
 }
 
 // GetUserNotificationPreferences TODO
-func (c *Client) GetUserNotificationPreferences(ctx context.Context) ([]NotificationPreference, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/v2/notifications/preferences", nil)
+func (c *Client) GetUserNotificationPreferences(ctx context.Context, userID uuid.UUID) ([]NotificationPreference, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/users/%s/notifications/preferences", userID.String()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +138,8 @@ func (c *Client) GetUserNotificationPreferences(ctx context.Context) ([]Notifica
 }
 
 // UpdateUserNotificationPreferences TODO
-func (c *Client) UpdateUserNotificationPreferences(ctx context.Context, req UpdateUserNotificationPreferences) ([]NotificationPreference, error) {
-	res, err := c.Request(ctx, http.MethodPut, "/api/v2/notifications/preferences", req)
+func (c *Client) UpdateUserNotificationPreferences(ctx context.Context, userID uuid.UUID, req UpdateUserNotificationPreferences) ([]NotificationPreference, error) {
+	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/v2/users/%s/notifications/preferences", userID.String()), req)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/api/notifications.md
+++ b/docs/api/notifications.md
@@ -1,5 +1,49 @@
 # Notifications
 
+## Get notification dispatch methods
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/notifications/dispatch-methods \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /notifications/dispatch-methods`
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "available": ["string"],
+    "default": "string"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                          |
+| ------ | ------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.NotificationMethodsResponse](schemas.md#codersdknotificationmethodsresponse) |
+
+<h3 id="get-notification-dispatch-methods-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type   | Required | Restrictions | Description |
+| -------------- | ------ | -------- | ------------ | ----------- |
+| `[array item]` | array  | false    |              |             |
+| `» available`  | array  | false    |              |             |
+| `» default`    | string | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get notifications settings
 
 ### Code samples

--- a/docs/api/notifications.md
+++ b/docs/api/notifications.md
@@ -133,3 +133,120 @@ Status Code **200**
 | `» title_template` | string       | false    |              |             |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get user notification preferences
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/users/{user}/notifications/preferences \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /users/{user}/notifications/preferences`
+
+### Parameters
+
+| Name   | In   | Type   | Required | Description          |
+| ------ | ---- | ------ | -------- | -------------------- |
+| `user` | path | string | true     | User ID, name, or me |
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "disabled": true,
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "updated_at": "2019-08-24T14:15:22Z"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                |
+| ------ | ------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.NotificationPreference](schemas.md#codersdknotificationpreference) |
+
+<h3 id="get-user-notification-preferences-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type              | Required | Restrictions | Description |
+| -------------- | ----------------- | -------- | ------------ | ----------- |
+| `[array item]` | array             | false    |              |             |
+| `» disabled`   | boolean           | false    |              |             |
+| `» id`         | string(uuid)      | false    |              |             |
+| `» updated_at` | string(date-time) | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update user notification preferences
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/v2/users/{user}/notifications/preferences \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /users/{user}/notifications/preferences`
+
+> Body parameter
+
+```json
+{
+  "template_disabled_map": {
+    "property1": true,
+    "property2": true
+  }
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                               | Required | Description          |
+| ------ | ---- | -------------------------------------------------------------------------------------------------- | -------- | -------------------- |
+| `user` | path | string                                                                                             | true     | User ID, name, or me |
+| `body` | body | [codersdk.UpdateUserNotificationPreferences](schemas.md#codersdkupdateusernotificationpreferences) | true     | Preferences          |
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "disabled": true,
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "updated_at": "2019-08-24T14:15:22Z"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                |
+| ------ | ------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.NotificationPreference](schemas.md#codersdknotificationpreference) |
+
+<h3 id="update-user-notification-preferences-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type              | Required | Restrictions | Description |
+| -------------- | ----------------- | -------- | ------------ | ----------- |
+| `[array item]` | array             | false    |              |             |
+| `» disabled`   | boolean           | false    |              |             |
+| `» id`         | string(uuid)      | false    |              |             |
+| `» updated_at` | string(date-time) | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3141,6 +3141,24 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `id`         | string | true     |              |             |
 | `username`   | string | true     |              |             |
 
+## codersdk.NotificationPreference
+
+```json
+{
+  "disabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name         | Type    | Required | Restrictions | Description |
+| ------------ | ------- | -------- | ------------ | ----------- |
+| `disabled`   | boolean | false    |              |             |
+| `id`         | string  | false    |              |             |
+| `updated_at` | string  | false    |              |             |
+
 ## codersdk.NotificationTemplate
 
 ```json
@@ -5564,6 +5582,24 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | Name               | Type   | Required | Restrictions | Description |
 | ------------------ | ------ | -------- | ------------ | ----------- |
 | `theme_preference` | string | true     |              |             |
+
+## codersdk.UpdateUserNotificationPreferences
+
+```json
+{
+  "template_disabled_map": {
+    "property1": true,
+    "property2": true
+  }
+}
+```
+
+### Properties
+
+| Name                    | Type    | Required | Restrictions | Description |
+| ----------------------- | ------- | -------- | ------------ | ----------- |
+| `template_disabled_map` | object  | false    |              |             |
+| » `[any property]`      | boolean | false    |              |             |
 
 ## codersdk.UpdateUserPasswordRequest
 

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3141,6 +3141,22 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `id`         | string | true     |              |             |
 | `username`   | string | true     |              |             |
 
+## codersdk.NotificationMethodsResponse
+
+```json
+{
+  "available": ["string"],
+  "default": "string"
+}
+```
+
+### Properties
+
+| Name        | Type            | Required | Restrictions | Description |
+| ----------- | --------------- | -------- | ------------ | ----------- |
+| `available` | array of string | false    |              |             |
+| `default`   | string          | false    |              |             |
+
 ## codersdk.NotificationPreference
 
 ```json

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -710,6 +710,12 @@ export interface MinimalUser {
 }
 
 // From codersdk/notifications.go
+export interface NotificationMethodsResponse {
+  readonly available: readonly string[];
+  readonly default: string;
+}
+
+// From codersdk/notifications.go
 export interface NotificationPreference {
   readonly id: string;
   readonly disabled: boolean;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -710,6 +710,13 @@ export interface MinimalUser {
 }
 
 // From codersdk/notifications.go
+export interface NotificationPreference {
+  readonly id: string;
+  readonly disabled: boolean;
+  readonly updated_at: string;
+}
+
+// From codersdk/notifications.go
 export interface NotificationTemplate {
   readonly id: string;
   readonly name: string;
@@ -1510,6 +1517,11 @@ export interface UpdateTemplateMeta {
 // From codersdk/users.go
 export interface UpdateUserAppearanceSettingsRequest {
   readonly theme_preference: string;
+}
+
+// From codersdk/notifications.go
+export interface UpdateUserNotificationPreferences {
+  readonly template_disabled_map: Record<string, boolean>;
 }
 
 // From codersdk/users.go


### PR DESCRIPTION
Part of https://github.com/coder/team-coconut/issues/19

Users should be empowered to control which notifications they do not wish to receive.

Added two new routes:

- `GET /users/{users}/notifications/preferences`
  - Retrieves notification preferences for a given user
- `PUT /users/{users}/notifications/preferences`
  - Updates notification preferences for a given user

When a user has disabled a notification template in their preferences, we need to ensure that:

1. Messages currently in the queue which use that (now disabled) notification template are inhibited from sending
2. Any new messages which are enqueued after the preference is set will fail when being inserted into the database, and the enqueuer will return a `notifications.ErrCannotEnqueueDisabledNotification` error

The database logic was implemented in https://github.com/coder/coder/pull/14100, see the `inhibit_enqueue_if_disabled` trigger.