### PR TITLE
chore: skip audit log filter for owner/admin users

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -273,7 +273,7 @@ func (s *MethodTestSuite) TestAuditLogs() {
 		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})
 		check.Args(database.GetAuditLogsOffsetParams{
 			LimitOpt: 10,
-		}, emptyPreparedAuthorized{}).Asserts()
+		}, emptyPreparedAuthorized{}).Asserts(rbac.ResourceAuditLog, policy.ActionRead)
 	}))
 }
 

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -266,7 +266,7 @@ func (s *MethodTestSuite) TestAuditLogs() {
 		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})
 		check.Args(database.GetAuditLogsOffsetParams{
 			LimitOpt: 10,
-		}).Asserts()
+		}).Asserts(rbac.ResourceAuditLog, policy.ActionRead)
 	}))
 	s.Run("GetAuthorizedAuditLogsOffset", s.Subtest(func(db database.Store, check *expects) {
 		_ = dbgen.AuditLog(s.T(), db, database.AuditLog{})


### PR DESCRIPTION
Optimize for speed in the case the user can read all audit_logs.
We might be able to add an index later to speed this up, but for legacy cases (when only owners/auditor could view), let's not slow things down.

[Screencast from 2024-08-02 13-13-24.webm](https://github.com/user-attachments/assets/8ef52667-16aa-449e-bc2f-919f0c8ca12a)
