### PR TITLE
feat: add notification dispatch methods endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1547,6 +1547,29 @@ const docTemplate = `{
                 }
             }
         },
+        "/notifications/dispatch-methods": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Notifications"
+                ],
+                "summary": "Get notification dispatch methods",
+                "operationId": "get-notification-dispatch-methods",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.NotificationMethodsResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/settings": {
             "get": {
                 "security": [
@@ -10344,6 +10367,20 @@ const docTemplate = `{
                     "format": "uuid"
                 },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.NotificationMethodsResponse": {
+            "type": "object",
+            "properties": {
+                "available": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
                     "type": "string"
                 }
             }

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1549,6 +1549,11 @@ const docTemplate = `{
         },
         "/notifications/dispatch-methods": {
             "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
                 "produces": [
                     "application/json"
                 ],

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1344,6 +1344,25 @@
         }
       }
     },
+    "/notifications/dispatch-methods": {
+      "get": {
+        "produces": ["application/json"],
+        "tags": ["Notifications"],
+        "summary": "Get notification dispatch methods",
+        "operationId": "get-notification-dispatch-methods",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/codersdk.NotificationMethodsResponse"
+              }
+            }
+          }
+        }
+      }
+    },
     "/notifications/settings": {
       "get": {
         "security": [
@@ -9267,6 +9286,20 @@
           "format": "uuid"
         },
         "username": {
+          "type": "string"
+        }
+      }
+    },
+    "codersdk.NotificationMethodsResponse": {
+      "type": "object",
+      "properties": {
+        "available": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
           "type": "string"
         }
       }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1346,6 +1346,11 @@
     },
     "/notifications/dispatch-methods": {
       "get": {
+        "security": [
+          {
+            "CoderSessionToken": []
+          }
+        ],
         "produces": ["application/json"],
         "tags": ["Notifications"],
         "summary": "Get notification dispatch methods",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1258,6 +1258,7 @@ func New(options *Options) *API {
 			r.Route("/templates", func(r chi.Router) {
 				r.Get("/system", api.systemNotificationTemplates)
 			})
+			r.Get("/dispatch-methods", api.notificationDispatchMethods)
 		})
 	})
 

--- a/coderd/notifications.go
+++ b/coderd/notifications.go
@@ -144,6 +144,24 @@ func (api *API) systemNotificationTemplates(rw http.ResponseWriter, r *http.Requ
 	httpapi.Write(r.Context(), rw, http.StatusOK, out)
 }
 
+// @Summary Get notification dispatch methods
+// @ID get-notification-dispatch-methods
+// @Produce json
+// @Tags Notifications
+// @Success 200 {array} codersdk.NotificationMethodsResponse
+// @Router /notifications/dispatch-methods [get]
+func (api *API) notificationDispatchMethods(rw http.ResponseWriter, r *http.Request) {
+	var methods []string
+	for _, nm := range database.AllNotificationMethodValues() {
+		methods = append(methods, string(nm))
+	}
+
+	httpapi.Write(r.Context(), rw, http.StatusOK, codersdk.NotificationMethodsResponse{
+		AvailableNotificationMethods: methods,
+		DefaultNotificationMethod:    api.DeploymentValues.Notifications.Method.Value(),
+	})
+}
+
 // @Summary Get user notification preferences
 // @ID get-user-notification-preferences
 // @Security CoderSessionToken

--- a/coderd/notifications.go
+++ b/coderd/notifications.go
@@ -146,6 +146,7 @@ func (api *API) systemNotificationTemplates(rw http.ResponseWriter, r *http.Requ
 
 // @Summary Get notification dispatch methods
 // @ID get-notification-dispatch-methods
+// @Security CoderSessionToken
 // @Produce json
 // @Tags Notifications
 // @Success 200 {array} codersdk.NotificationMethodsResponse

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -27,6 +27,11 @@ type NotificationTemplate struct {
 	Kind          string    `json:"kind"`
 }
 
+type NotificationMethodsResponse struct {
+	AvailableNotificationMethods []string `json:"available"`
+	DefaultNotificationMethod    string   `json:"default"`
+}
+
 type NotificationPreference struct {
 	NotificationTemplateID uuid.UUID `json:"id" format:"uuid"`
 	Disabled               bool      `json:"disabled"`

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -167,6 +167,31 @@ func (c *Client) UpdateUserNotificationPreferences(ctx context.Context, userID u
 	return prefs, nil
 }
 
+// GetNotificationDispatchMethods the available and default notification dispatch methods.
+func (c *Client) GetNotificationDispatchMethods(ctx context.Context) (NotificationMethodsResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/notifications/dispatch-methods", nil)
+	if err != nil {
+		return NotificationMethodsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return NotificationMethodsResponse{}, ReadBodyAsError(res)
+	}
+
+	var resp NotificationMethodsResponse
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return NotificationMethodsResponse{}, xerrors.Errorf("read response body: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return NotificationMethodsResponse{}, xerrors.Errorf("unmarshal response body: %w", err)
+	}
+
+	return resp, nil
+}
+
 type UpdateNotificationTemplateMethod struct {
 	Method string `json:"method,omitempty" example:"webhook"`
 }

--- a/docs/api/notifications.md
+++ b/docs/api/notifications.md
@@ -7,7 +7,8 @@
 ```shell
 # Example request using curl
 curl -X GET http://coder-server:8080/api/v2/notifications/dispatch-methods \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
 ```
 
 `GET /notifications/dispatch-methods`
@@ -40,6 +41,8 @@ Status Code **200**
 | `[array item]` | array  | false    |              |             |
 | `» available`  | array  | false    |              |             |
 | `» default`    | string | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
 ## Get notifications settings
 

--- a/docs/api/notifications.md
+++ b/docs/api/notifications.md
@@ -1,5 +1,46 @@
 # Notifications
 
+## Get notification dispatch methods
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/notifications/dispatch-methods \
+  -H 'Accept: application/json'
+```
+
+`GET /notifications/dispatch-methods`
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "available": ["string"],
+    "default": "string"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                          |
+| ------ | ------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.NotificationMethodsResponse](schemas.md#codersdknotificationmethodsresponse) |
+
+<h3 id="get-notification-dispatch-methods-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name           | Type   | Required | Restrictions | Description |
+| -------------- | ------ | -------- | ------------ | ----------- |
+| `[array item]` | array  | false    |              |             |
+| `» available`  | array  | false    |              |             |
+| `» default`    | string | false    |              |             |
+
 ## Get notifications settings
 
 ### Code samples

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -3141,6 +3141,22 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `id`         | string | true     |              |             |
 | `username`   | string | true     |              |             |
 
+## codersdk.NotificationMethodsResponse
+
+```json
+{
+  "available": ["string"],
+  "default": "string"
+}
+```
+
+### Properties
+
+| Name        | Type            | Required | Restrictions | Description |
+| ----------- | --------------- | -------- | ------------ | ----------- |
+| `available` | array of string | false    |              |             |
+| `default`   | string          | false    |              |             |
+
 ## codersdk.NotificationPreference
 
 ```json

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -710,6 +710,12 @@ export interface MinimalUser {
 }
 
 // From codersdk/notifications.go
+export interface NotificationMethodsResponse {
+  readonly available: readonly string[];
+  readonly default: string;
+}
+
+// From codersdk/notifications.go
 export interface NotificationPreference {
   readonly id: string;
   readonly disabled: boolean;


### PR DESCRIPTION
Stacked on https://github.com/coder/coder/pull/14117

Adds a new `GET /notifications/dispatch-methods` endpoint to retrieve the default & available notification methods.

This is needed in order to implement the web UI effectively.