### PR TITLE
fix: only show valid organizations in `CreateTemplateForm`

### DIFF
--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -73,8 +73,10 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
   // If an authorization check was provided, filter the organizations based on
   // the results of that check.
   let options = organizationsQuery.data ?? [];
-  if (check && permissionsQuery.data) {
-    options = options.filter((org) => permissionsQuery.data[org.id]);
+  if (check) {
+    options = permissionsQuery.data
+      ? options.filter((org) => permissionsQuery.data[org.id])
+      : [];
   }
 
   return (

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -9,8 +9,9 @@ import {
   useState,
 } from "react";
 import { useQuery } from "react-query";
+import { checkAuthorization } from "api/queries/authCheck";
 import { organizations } from "api/queries/organizations";
-import type { Organization } from "api/typesGenerated";
+import type { AuthorizationCheck, Organization } from "api/typesGenerated";
 import { Avatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { useDebouncedFunction } from "hooks/debounce";
@@ -22,6 +23,7 @@ export type OrganizationAutocompleteProps = {
   className?: string;
   size?: ComponentProps<typeof TextField>["size"];
   required?: boolean;
+  check?: AuthorizationCheck;
 };
 
 export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
@@ -31,6 +33,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
   className,
   size = "small",
   required,
+  check,
 }) => {
   const [autoComplete, setAutoComplete] = useState<{
     value: string;
@@ -40,6 +43,22 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
     open: false,
   });
   const organizationsQuery = useQuery(organizations());
+
+  const permissionsQuery = useQuery(
+    check && organizationsQuery.data
+      ? checkAuthorization({
+          checks: Object.fromEntries(
+            organizationsQuery.data.map((org) => [
+              org.id,
+              {
+                ...check,
+                object: { ...check.object, organization_id: org.id },
+              },
+            ]),
+          ),
+        })
+      : { enabled: false },
+  );
 
   const { debounced: debouncedInputOnChange } = useDebouncedFunction(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -51,11 +70,18 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
     750,
   );
 
+  // If an authorization check was provided, filter the organizations based on
+  // the results of that check.
+  let options = organizationsQuery.data ?? [];
+  if (check && permissionsQuery.data) {
+    options = options.filter((org) => permissionsQuery.data[org.id]);
+  }
+
   return (
     <Autocomplete
       noOptionsText="No organizations found"
       className={className}
-      options={organizationsQuery.data ?? []}
+      options={options}
       loading={organizationsQuery.isLoading}
       value={value}
       data-testid="organization-autocomplete"

--- a/site/src/contexts/auth/permissions.tsx
+++ b/site/src/contexts/auth/permissions.tsx
@@ -36,6 +36,7 @@ export const permissionsToCheck = {
   [checks.createTemplates]: {
     object: {
       resource_type: "template",
+      any_org: true,
     },
     action: "update",
   },

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.stories.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.stories.tsx
@@ -61,12 +61,39 @@ export const StarterTemplateWithOrgPicker: Story = {
   },
 };
 
+const canCreateTemplate = (organizationId: string) => {
+  return {
+    [organizationId]: {
+      object: {
+        resource_type: "template",
+        organization_id: organizationId,
+      },
+      action: "create",
+    },
+  };
+};
+
 export const StarterTemplateWithProvisionerWarning: Story = {
   parameters: {
     queries: [
       {
         key: organizationsKey,
         data: [MockDefaultOrganization, MockOrganization2],
+      },
+      {
+        key: [
+          "authorization",
+          {
+            checks: {
+              ...canCreateTemplate(MockDefaultOrganization.id),
+              ...canCreateTemplate(MockOrganization2.id),
+            },
+          },
+        ],
+        data: {
+          [MockDefaultOrganization.id]: true,
+          [MockOrganization2.id]: true,
+        },
       },
       {
         key: getProvisionerDaemonsKey(MockOrganization2.id),
@@ -83,6 +110,44 @@ export const StarterTemplateWithProvisionerWarning: Story = {
     await userEvent.click(organizationPicker);
     const org2 = await screen.findByText(MockOrganization2.display_name);
     await userEvent.click(org2);
+  },
+};
+
+export const StarterTemplatePermissionsCheck: Story = {
+  parameters: {
+    queries: [
+      {
+        key: organizationsKey,
+        data: [MockDefaultOrganization, MockOrganization2],
+      },
+      {
+        key: [
+          "authorization",
+          {
+            checks: {
+              ...canCreateTemplate(MockDefaultOrganization.id),
+              ...canCreateTemplate(MockOrganization2.id),
+            },
+          },
+        ],
+        data: {
+          [MockDefaultOrganization.id]: true,
+          [MockOrganization2.id]: false,
+        },
+      },
+      {
+        key: getProvisionerDaemonsKey(MockOrganization2.id),
+        data: [],
+      },
+    ],
+  },
+  args: {
+    ...StarterTemplate.args,
+    showOrganizationPicker: true,
+  },
+  play: async () => {
+    const organizationPicker = screen.getByPlaceholderText("Organization name");
+    await userEvent.click(organizationPicker);
   },
 };
 

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -267,6 +267,10 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
                   void form.setFieldValue("organization", newValue?.name || "");
                 }}
                 size="medium"
+                check={{
+                  object: { resource_type: "template" },
+                  action: "create",
+                }}
               />
             </>
           )}


### PR DESCRIPTION
Closes #14004

Hide any organizations that the user might have view permissions for, but not permission to create a template