### PR TITLE
chore(agent): remove `err=<nil>` log for batch update metadata complete

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -588,11 +588,12 @@ func (a *agent) reportMetadata(ctx context.Context, conn drpc.Conn) error {
 			updatedMetadata[mr.key] = mr.result
 			continue
 		case err := <-reportError:
+                        logMsg := ""batch update metadata complete""
 			if err != nil {
-				a.logger.Debug(ctx, "batch update metadata complete", slog.Error(err))
+				a.logger.Debug(ctx, logMsg, slog.Error(err))
 				return xerrors.Errorf("failed to report metadata: %w", err)
 			}
-			a.logger.Debug(ctx, "batch update metadata complete")
+			a.logger.Debug(ctx, logMsg)
 			reportInFlight = false
 		case <-report:
 			if len(updatedMetadata) == 0 {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -588,7 +588,7 @@ func (a *agent) reportMetadata(ctx context.Context, conn drpc.Conn) error {
 			updatedMetadata[mr.key] = mr.result
 			continue
 		case err := <-reportError:
-			logMsg := ""batch update metadata complete""
+			logMsg := "batch update metadata complete"
 			if err != nil {
 				a.logger.Debug(ctx, logMsg, slog.Error(err))
 				return xerrors.Errorf("failed to report metadata: %w", err)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -588,7 +588,7 @@ func (a *agent) reportMetadata(ctx context.Context, conn drpc.Conn) error {
 			updatedMetadata[mr.key] = mr.result
 			continue
 		case err := <-reportError:
-                        logMsg := ""batch update metadata complete""
+			logMsg := ""batch update metadata complete""
 			if err != nil {
 				a.logger.Debug(ctx, logMsg, slog.Error(err))
 				return xerrors.Errorf("failed to report metadata: %w", err)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -588,10 +588,11 @@ func (a *agent) reportMetadata(ctx context.Context, conn drpc.Conn) error {
 			updatedMetadata[mr.key] = mr.result
 			continue
 		case err := <-reportError:
-			a.logger.Debug(ctx, "batch update metadata complete", slog.Error(err))
 			if err != nil {
+				a.logger.Debug(ctx, "batch update metadata complete", slog.Error(err))
 				return xerrors.Errorf("failed to report metadata: %w", err)
 			}
+			a.logger.Debug(ctx, "batch update metadata complete")
 			reportInFlight = false
 		case <-report:
 			if len(updatedMetadata) == 0 {


### PR DESCRIPTION
This is logged ~ every 10s and adds a needless `error` into agent logs (`err=<nil>`) which hampers quick search.
