### PR TITLE
chore(scripts): remove branch checks from release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -165,12 +165,6 @@ if [[ ${script_check} = 1 ]] && [[ -n ${script_diff} ]]; then
 	error "Release script is out-of-date. Please check out the latest version and try again."
 fi
 
-# Make sure no other remote release contains this ref.
-release_contains_ref="$(git branch --remotes --contains "${ref}" --list "${remote}/release/*" --format='%(refname)')"
-if [[ -n ${release_contains_ref} ]]; then
-	error "Ref ${ref_name} is already part of another release: $(git describe --always "${ref}") on ${release_contains_ref#"refs/remotes/${remote}/"}."
-fi
-
 log "Checking GitHub for latest release(s)..."
 
 # Check the latest version tag from GitHub (by version) using the API.

--- a/scripts/release/tag_version.sh
+++ b/scripts/release/tag_version.sh
@@ -171,10 +171,6 @@ else
 		fi
 	fi
 
-	if [[ -n ${remote_branch_exists} ]]; then
-		error "Release branch ${release_branch} already exists on remote, please check your ref."
-	fi
-
 	if [[ -n ${local_branch_exists} ]]; then
 		# If it exists, ensure that this release branch points to the provided ref.
 		release_branch_ref=$(git rev-parse "${release_branch}")


### PR DESCRIPTION
The initial assumption that branch manipulations should be done by this
script and not pushed to remote manually has proven to get in the way of
the regular release flow.

These are just safety-checks to prevent user error, safe to remove.

Fixes #13648