### PR TITLE
fix: lock adding to tailnet waitgroup to avoid race (and fix flake)

### DIFF
--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -556,7 +556,6 @@ func (c *Conn) Closed() <-chan struct{} {
 func (c *Conn) Close() error {
 	c.logger.Info(context.Background(), "closing tailnet Conn")
 	c.watchCancel()
-	c.telemetryWg.Wait()
 	c.configMaps.close()
 	c.nodeUpdater.close()
 	c.mutex.Lock()
@@ -567,6 +566,7 @@ func (c *Conn) Close() error {
 	default:
 	}
 	close(c.closed)
+	c.telemetryWg.Wait()
 	c.mutex.Unlock()
 
 	var wg sync.WaitGroup
@@ -783,6 +783,13 @@ func (c *Conn) newTelemetryEvent() *proto.TelemetryEvent {
 }
 
 func (c *Conn) sendTelemetryBackground(e *proto.TelemetryEvent) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	select {
+	case <-c.closed:
+		return
+	default:
+	}
 	c.telemetryWg.Add(1)
 	go func() {
 		defer c.telemetryWg.Done()


### PR DESCRIPTION
Fixes #14143.
Fixes a race condition that can occur when a `tailnet` connection is closed just before a network telemetry event is about to be sent off. Specifically, where `waitgroup.Add(n)` is called on a waitgroup where `waitgroup.Wait()` is currently blocking another goroutine.

This works as we only call `Wait()` on the `telemetryWg` waitgroup when the `Conn` mutex is held, and only after the closed channel has been closed. We then require that the goroutine sending the telemetry event acquire said mutex, and that the channel is not closed, before adding to the waitgroup and sending the event.
