### PR TITLE
chore: move feature of custom-roles to premium license

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -154,7 +154,7 @@ func (set FeatureSet) Features() []FeatureName {
 		enterpriseFeatures = slices.DeleteFunc(enterpriseFeatures, func(f FeatureName) bool {
 			switch f {
 			// Add all features that should be excluded in the Enterprise feature set.
-			case FeatureMultipleOrganizations:
+			case FeatureMultipleOrganizations, FeatureCustomRoles:
 				return true
 			default:
 				return false

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -810,6 +810,7 @@ func TestLicenseEntitlements(t *testing.T) {
 			ExpectedErrorContains: "",
 			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
 				assert.False(t, entitlements.Features[codersdk.FeatureMultipleOrganizations].Enabled, "multi-org only enabled for premium")
+				assert.False(t, entitlements.Features[codersdk.FeatureCustomRoles].Enabled, "custom-roles only enabled for premium")
 			},
 		},
 		{
@@ -822,6 +823,7 @@ func TestLicenseEntitlements(t *testing.T) {
 			ExpectedErrorContains: "",
 			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
 				assert.True(t, entitlements.Features[codersdk.FeatureMultipleOrganizations].Enabled, "multi-org enabled for premium")
+				assert.True(t, entitlements.Features[codersdk.FeatureCustomRoles].Enabled, "custom-roles enabled for premium")
 			},
 		},
 	}


### PR DESCRIPTION
Currently an unsafe experiment, so it can be moved safely