### PR TITLE
fix: add version information to default docs links

### DIFF
--- a/site/src/components/ErrorBoundary/RuntimeErrorState.tsx
+++ b/site/src/components/ErrorBoundary/RuntimeErrorState.tsx
@@ -10,6 +10,7 @@ import { CoderIcon } from "components/Icons/CoderIcon";
 import { Loader } from "components/Loader/Loader";
 import { Margins } from "components/Margins/Margins";
 import { Stack } from "components/Stack/Stack";
+import { getStaticBuildInfo } from "utils/buildInfo";
 
 const fetchDynamicallyImportedModuleError =
   "Failed to fetch dynamically imported module";
@@ -114,21 +115,6 @@ export const RuntimeErrorState: FC<RuntimeErrorStateProps> = ({ error }) => {
       )}
     </>
   );
-};
-
-// During the build process, we inject the build info into the HTML
-const getStaticBuildInfo = () => {
-  const buildInfoJson = document
-    .querySelector("meta[property=build-info]")
-    ?.getAttribute("content");
-
-  if (buildInfoJson) {
-    try {
-      return JSON.parse(buildInfoJson) as BuildInfoResponse;
-    } catch {
-      return undefined;
-    }
-  }
 };
 
 const styles = {

--- a/site/src/utils/buildInfo.ts
+++ b/site/src/utils/buildInfo.ts
@@ -1,0 +1,24 @@
+import type { BuildInfoResponse } from "api/typesGenerated";
+
+let CACHED_BUILD_INFO: BuildInfoResponse | undefined;
+
+// During the build process, we inject the build info into the HTML
+export const getStaticBuildInfo = () => {
+  if (CACHED_BUILD_INFO) {
+    return CACHED_BUILD_INFO;
+  }
+
+  const buildInfoJson = document
+    .querySelector("meta[property=build-info]")
+    ?.getAttribute("content");
+
+  if (buildInfoJson) {
+    try {
+      CACHED_BUILD_INFO = JSON.parse(buildInfoJson) as BuildInfoResponse;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return CACHED_BUILD_INFO;
+};

--- a/site/src/utils/docs.ts
+++ b/site/src/utils/docs.ts
@@ -3,7 +3,11 @@ import { getStaticBuildInfo } from "./buildInfo";
 function defaultDocsUrl(): string {
   const docsUrl = "https://coder.com/docs";
   // If we can get the specific version, we want to include that in default docs URL.
-  const version = getStaticBuildInfo()?.version.split("-")[0];
+  let version = getStaticBuildInfo()?.version;
+  const i = version?.indexOf("-") ?? -1;
+  if (version.index >= 0) {
+    version = version.slice(0, i);
+  }
   return version ? `${docsUrl}/@${version}` : docsUrl;
 }
 

--- a/site/src/utils/docs.ts
+++ b/site/src/utils/docs.ts
@@ -15,7 +15,8 @@ const getBaseDocsURL = () => {
       .querySelector<HTMLMetaElement>('meta[property="docs-url"]')
       ?.getAttribute("content");
 
-    CACHED_DOCS_URL = docsUrl && isURL(docsUrl) ? docsUrl : DEFAULT_DOCS_URL;
+    const isValidDocsURL = docsUrl && isURL(docsUrl);
+    CACHED_DOCS_URL = isValidDocsURL ? docsUrl : DEFAULT_DOCS_URL;
 
     // If we can get the specific version, we want to include that in docs links
     const version = getStaticBuildInfo()?.version.split("-")[0];

--- a/site/src/utils/docs.ts
+++ b/site/src/utils/docs.ts
@@ -4,11 +4,16 @@ function defaultDocsUrl(): string {
   const docsUrl = "https://coder.com/docs";
   // If we can get the specific version, we want to include that in default docs URL.
   let version = getStaticBuildInfo()?.version;
+  if (!version) {
+    return docsUrl;
+  }
+
+  // Strip the postfix version info that's not part of the link.
   const i = version?.indexOf("-") ?? -1;
-  if (version.index >= 0) {
+  if (i >= 0) {
     version = version.slice(0, i);
   }
-  return version ? `${docsUrl}/@${version}` : docsUrl;
+  return `${docsUrl}/@${version}`;
 }
 
 // Add cache to avoid DOM reading all the time

--- a/site/src/utils/docs.ts
+++ b/site/src/utils/docs.ts
@@ -1,3 +1,5 @@
+import { getStaticBuildInfo } from "./buildInfo";
+
 const DEFAULT_DOCS_URL = "https://coder.com/docs";
 
 // Add cache to avoid DOM reading all the time
@@ -12,8 +14,14 @@ const getBaseDocsURL = () => {
     const docsUrl = document
       .querySelector<HTMLMetaElement>('meta[property="docs-url"]')
       ?.getAttribute("content");
-    const isValidDocsURL = docsUrl && isURL(docsUrl);
-    CACHED_DOCS_URL = isValidDocsURL ? docsUrl : DEFAULT_DOCS_URL;
+
+    CACHED_DOCS_URL = docsUrl && isURL(docsUrl) ? docsUrl : DEFAULT_DOCS_URL;
+
+    // If we can get the specific version, we want to include that in docs links
+    const version = getStaticBuildInfo()?.version.split("-")[0];
+    if (version) {
+      CACHED_DOCS_URL = `${CACHED_DOCS_URL}/@${version}`;
+    }
   }
   return CACHED_DOCS_URL;
 };

--- a/site/src/utils/docs.ts
+++ b/site/src/utils/docs.ts
@@ -1,6 +1,11 @@
 import { getStaticBuildInfo } from "./buildInfo";
 
-const DEFAULT_DOCS_URL = "https://coder.com/docs";
+function defaultDocsUrl(): string {
+  const docsUrl = "https://coder.com/docs";
+  // If we can get the specific version, we want to include that in default docs URL.
+  const version = getStaticBuildInfo()?.version.split("-")[0];
+  return version ? `${docsUrl}/@${version}` : docsUrl;
+}
 
 // Add cache to avoid DOM reading all the time
 let CACHED_DOCS_URL: string | undefined;
@@ -16,13 +21,7 @@ const getBaseDocsURL = () => {
       ?.getAttribute("content");
 
     const isValidDocsURL = docsUrl && isURL(docsUrl);
-    CACHED_DOCS_URL = isValidDocsURL ? docsUrl : DEFAULT_DOCS_URL;
-
-    // If we can get the specific version, we want to include that in docs links
-    const version = getStaticBuildInfo()?.version.split("-")[0];
-    if (version) {
-      CACHED_DOCS_URL = `${CACHED_DOCS_URL}/@${version}`;
-    }
+    CACHED_DOCS_URL = isValidDocsURL ? docsUrl : defaultDocsUrl();
   }
   return CACHED_DOCS_URL;
 };


### PR DESCRIPTION
This PR adds version information to the default docs links. If the user set's the docs link themselves it won't mess with it.
It also moves a helper function for getting embedded build info into utils and adds a little cache.

fixes #13369