### PR TITLE
fix: add template editor to /templates/:templateName route group

### DIFF
--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -473,6 +473,10 @@ export const router = createBrowserRouter(
         {/* Pages that don't have the dashboard layout */}
         <Route path="/:username/:workspace" element={<WorkspacePage />} />
         <Route
+          path="/templates/:template/versions/:version/edit"
+          element={<TemplateVersionEditorPage />}
+        />
+        <Route
           path="/templates/:organization/:template/versions/:version/edit"
           element={<TemplateVersionEditorPage />}
         />


### PR DESCRIPTION
Currently the editor is inaccessible without the experiment enabled and the right license entitlement. We should add an e2e test to make sure this doesn't break.