### PR TITLE
feat: show summary if unable to edit org

### DIFF
--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPage.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPage.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { MockDefaultOrganization, MockUser } from "testHelpers/entities";
+import { withAuthProvider, withDashboardProvider } from "testHelpers/storybook";
+import OrganizationSettingsPage from "./OrganizationSettingsPage";
+
+const meta: Meta<typeof OrganizationSettingsPage> = {
+  title: "pages/OrganizationSettingsPage",
+  component: OrganizationSettingsPage,
+  decorators: [withAuthProvider, withDashboardProvider],
+  parameters: {
+    user: MockUser,
+    permissions: { viewDeploymentValues: true },
+    queries: [
+      {
+        key: ["organizations", [MockDefaultOrganization.id], "permissions"],
+        data: {},
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OrganizationSettingsPage>;
+
+export const NoRedirectableOrganizations: Story = {};
+
+export const OrganizationDoesNotExist: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: { pathParams: { organization: "does-not-exist" } },
+      routing: { path: "/organizations/:organization" },
+    }),
+  },
+};
+
+export const CannotEditOrganization: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: { pathParams: { organization: MockDefaultOrganization.name } },
+      routing: { path: "/organizations/:organization" },
+    }),
+  },
+};
+
+export const CanEditOrganization: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: { pathParams: { organization: MockDefaultOrganization.name } },
+      routing: { path: "/organizations/:organization" },
+    }),
+    queries: [
+      {
+        key: ["organizations", [MockDefaultOrganization.id], "permissions"],
+        data: {
+          [MockDefaultOrganization.id]: {
+            editOrganization: true,
+          },
+        },
+      },
+    ],
+  },
+};

--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPage.test.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPage.test.tsx
@@ -116,4 +116,24 @@ describe("OrganizationSettingsPage", () => {
     await renderPage("the-endless-void");
     await screen.findByText("Organization not found");
   });
+
+  it("cannot edit organization", async () => {
+    server.use(
+      http.get("/api/v2/organizations", () => {
+        return HttpResponse.json([MockDefaultOrganization]);
+      }),
+      http.post("/api/v2/authcheck", async () => {
+        return HttpResponse.json({
+          viewDeploymentValues: true,
+        });
+      }),
+    );
+    // No form since they cannot edit, instead sees the summary view.
+    await renderPage(MockDefaultOrganization.name);
+    expect(screen.queryByTestId("org-settings-form")).not.toBeInTheDocument();
+    await screen.findByRole("heading", {
+      level: 1,
+      name: MockDefaultOrganization.display_name,
+    });
+  });
 });

--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPage.tsx
@@ -15,6 +15,7 @@ import {
   useOrganizationSettings,
 } from "./ManagementSettingsLayout";
 import { OrganizationSettingsPageView } from "./OrganizationSettingsPageView";
+import { OrganizationSummaryPageView } from "./OrganizationSummaryPageView";
 
 const OrganizationSettingsPage: FC = () => {
   const { organization: organizationName } = useParams() as {
@@ -65,12 +66,18 @@ const OrganizationSettingsPage: FC = () => {
     return <EmptyState message="Organization not found" />;
   }
 
+  // The user may not be able to edit this org but they can still see it because
+  // they can edit members, etc.  In this case they will be shown a read-only
+  // summary page instead of the settings form.
+  if (!permissions[organization.id]?.editOrganization) {
+    return <OrganizationSummaryPageView organization={organization} />;
+  }
+
   const error =
     updateOrganizationMutation.error ?? deleteOrganizationMutation.error;
 
   return (
     <OrganizationSettingsPageView
-      canEdit={permissions[organization.id]?.editOrganization ?? false}
       organization={organization}
       error={error}
       onSubmit={async (values) => {

--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof OrganizationSettingsPageView> = {
   component: OrganizationSettingsPageView,
   args: {
     organization: MockOrganization,
-    canEdit: true,
   },
 };
 
@@ -22,11 +21,5 @@ export const Example: Story = {};
 export const DefaultOrg: Story = {
   args: {
     organization: MockDefaultOrganization,
-  },
-};
-
-export const CannotEdit: Story = {
-  args: {
-    canEdit: false,
   },
 };

--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.tsx
@@ -44,12 +44,11 @@ interface OrganizationSettingsPageViewProps {
   error: unknown;
   onSubmit: (values: UpdateOrganizationRequest) => Promise<void>;
   onDeleteOrganization: () => void;
-  canEdit: boolean;
 }
 
 export const OrganizationSettingsPageView: FC<
   OrganizationSettingsPageViewProps
-> = ({ organization, error, onSubmit, onDeleteOrganization, canEdit }) => {
+> = ({ organization, error, onSubmit, onDeleteOrganization }) => {
   const form = useFormik<UpdateOrganizationRequest>({
     initialValues: {
       name: organization.name,
@@ -85,7 +84,7 @@ export const OrganizationSettingsPageView: FC<
           description="The name and description of the organization."
         >
           <fieldset
-            disabled={form.isSubmitting || !canEdit}
+            disabled={form.isSubmitting}
             css={{ border: "unset", padding: 0, margin: 0, width: "100%" }}
           >
             <FormFields>
@@ -117,10 +116,10 @@ export const OrganizationSettingsPageView: FC<
             </FormFields>
           </fieldset>
         </FormSection>
-        {canEdit && <FormFooter isLoading={form.isSubmitting} />}
+        <FormFooter isLoading={form.isSubmitting} />
       </HorizontalForm>
 
-      {canEdit && !organization.is_default && (
+      {!organization.is_default && (
         <HorizontalContainer css={{ marginTop: 48 }}>
           <HorizontalSection
             title="Settings"

--- a/site/src/pages/ManagementSettingsPage/OrganizationSummaryPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSummaryPageView.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  MockDefaultOrganization,
+  MockOrganization,
+} from "testHelpers/entities";
+import { OrganizationSummaryPageView } from "./OrganizationSummaryPageView";
+
+const meta: Meta<typeof OrganizationSummaryPageView> = {
+  title: "pages/OrganizationSummaryPageView",
+  component: OrganizationSummaryPageView,
+  args: {
+    organization: MockOrganization,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OrganizationSummaryPageView>;
+
+export const DefaultOrg: Story = {
+  args: {
+    organization: MockDefaultOrganization,
+  },
+};

--- a/site/src/pages/ManagementSettingsPage/OrganizationSummaryPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSummaryPageView.tsx
@@ -1,0 +1,50 @@
+import type { FC } from "react";
+import type { Organization } from "api/typesGenerated";
+import {
+  PageHeader,
+  PageHeaderTitle,
+  PageHeaderSubtitle,
+} from "components/PageHeader/PageHeader";
+import { Stack } from "components/Stack/Stack";
+import { UserAvatar } from "components/UserAvatar/UserAvatar";
+
+interface OrganizationSummaryPageViewProps {
+  organization: Organization;
+}
+
+export const OrganizationSummaryPageView: FC<
+  OrganizationSummaryPageViewProps
+> = (props) => {
+  return (
+    <div>
+      <PageHeader
+        css={{
+          // The deployment settings layout already has padding.
+          paddingTop: 0,
+        }}
+      >
+        <Stack direction="row" spacing={3} alignItems="center">
+          <UserAvatar
+            key={props.organization.id}
+            size="xl"
+            username={
+              props.organization.display_name || props.organization.name
+            }
+            avatarURL={props.organization.icon}
+          />
+          <div>
+            <PageHeaderTitle>
+              {props.organization.display_name || props.organization.name}
+            </PageHeaderTitle>
+            {props.organization.description && (
+              <PageHeaderSubtitle>
+                {props.organization.description}
+              </PageHeaderSubtitle>
+            )}
+          </div>
+        </Stack>
+      </PageHeader>
+      You are a member of this organization.
+    </div>
+  );
+};

--- a/site/src/pages/ManagementSettingsPage/OrganizationSummaryPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSummaryPageView.tsx
@@ -14,7 +14,7 @@ interface OrganizationSummaryPageViewProps {
 
 export const OrganizationSummaryPageView: FC<
   OrganizationSummaryPageViewProps
-> = (props) => {
+> = ({ organization }) => {
   return (
     <div>
       <PageHeader
@@ -25,20 +25,18 @@ export const OrganizationSummaryPageView: FC<
       >
         <Stack direction="row" spacing={3} alignItems="center">
           <UserAvatar
-            key={props.organization.id}
+            key={organization.id}
             size="xl"
-            username={
-              props.organization.display_name || props.organization.name
-            }
-            avatarURL={props.organization.icon}
+            username={organization.display_name || organization.name}
+            avatarURL={organization.icon}
           />
           <div>
             <PageHeaderTitle>
-              {props.organization.display_name || props.organization.name}
+              {organization.display_name || organization.name}
             </PageHeaderTitle>
-            {props.organization.description && (
+            {organization.description && (
               <PageHeaderSubtitle>
-                {props.organization.description}
+                {organization.description}
               </PageHeaderSubtitle>
             )}
           </div>


### PR DESCRIPTION
This can happen if you can edit the members, for example, but not the organization settings.  In this case you will see a new summary page instead of the edit form.

Stacked on https://github.com/coder/coder/pull/14193

It looks kinda lame, honestly, but probably less bad than an ineditable form, I think.  Happy to take this in a different direction if we have some nicer-looking ideas.

![screenshot](https://github.com/user-attachments/assets/df883102-8a9f-4e9c-bd9f-363e85b6c2f2)
