### PR TITLE
chore: update docs links

### DIFF
--- a/cli/rename.go
+++ b/cli/rename.go
@@ -31,7 +31,7 @@ func (r *RootCmd) rename() *serpent.Command {
 			_, _ = fmt.Fprintf(inv.Stdout, "%s\n\n",
 				pretty.Sprint(cliui.DefaultStyles.Wrap, "WARNING: A rename can result in data loss if a resource references the workspace name in the template (e.g volumes). Please backup any data before proceeding."),
 			)
-			_, _ = fmt.Fprintf(inv.Stdout, "See: %s\n\n", "https://coder.com/docs/coder-oss/latest/templates/resource-persistence#%EF%B8%8F-persistence-pitfalls")
+			_, _ = fmt.Fprintf(inv.Stdout, "See: %s\n\n", "https://coder.com/docs/templates/resource-persistence#%EF%B8%8F-persistence-pitfalls")
 			_, err = cliui.Prompt(inv, cliui.PromptOptions{
 				Text: fmt.Sprintf("Type %q to confirm rename:", workspace.Name),
 				Validate: func(s string) error {

--- a/cli/server.go
+++ b/cli/server.go
@@ -631,7 +631,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 								"new version of coder available",
 								slog.F("new_version", r.Version),
 								slog.F("url", r.URL),
-								slog.F("upgrade_instructions", "https://coder.com/docs/coder-oss/latest/admin/upgrade"),
+								slog.F("upgrade_instructions", "https://coder.com/docs/admin/upgrade"),
 							)
 						}
 					},

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,5 +1,5 @@
 Get started with Coder administration:
 
 <children>
-  This page is rendered on https://coder.com/docs/coder-oss/admin. Refer to the other documents in the `admin/` directory.
+  This page is rendered on https://coder.com/docs/admin. Refer to the other documents in the `admin/` directory.
 </children>

--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -3,5 +3,5 @@
 These platform-specific guides are the fastest way to try Coder. We'll walk you through installation and adding your first template and workspace.
 
 <children>
-  This page is rendered on https://coder.com/docs/coder-oss/latest/guides. Refer to the other documents in this directory for per-platform instructions.
+  This page is rendered on https://coder.com/docs/guides. Refer to the other documents in this directory for per-platform instructions.
 </children>

--- a/docs/platforms/azure.md
+++ b/docs/platforms/azure.md
@@ -56,7 +56,7 @@ as a system service.
 
 For this instance, we will run Coder as a system service, however you can run
 Coder a multitude of different ways. You can learn more about those
-[here](https://coder.com/docs/coder-oss/latest/install).
+[here](https://coder.com/docs/install).
 
 In the Azure VM instance, run the following command to install Coder
 

--- a/dogfood/contents/guide.md
+++ b/dogfood/contents/guide.md
@@ -15,10 +15,9 @@ The following explains how to do certain things related to dogfooding.
    1. If you don't have an account, sign in with GitHub
    2. If you see a dialog/pop-up, hit "Cancel" (this is because of Rippling)
 2. Create a workspace
-3. [Connect with your favorite IDE](https://coder.com/docs/coder-oss/latest/ides)
+3. [Connect with your favorite IDE](https://coder.com/docs/ides)
 4. Clone the repo: `git clone git@github.com:coder/coder.git`
-5. Follow the
-   [contributing guide](https://coder.com/docs/coder-oss/latest/CONTRIBUTING)
+5. Follow the [contributing guide](https://coder.com/docs/CONTRIBUTING)
 
 ### Run Coder in your Coder Workspace
 

--- a/examples/lima/coder.yaml
+++ b/examples/lima/coder.yaml
@@ -1,5 +1,5 @@
 # Deploy Coder in Lima via the install script
-# See: https://coder.com/docs/coder-oss/latest/install
+# See: https://coder.com/docs/install
 # $ limactl start ./coder.yaml
 # $ limactl shell coder
 # The web UI is accessible on http://localhost:3000 -- ports are forwarded automatically by lima:

--- a/examples/web-server/caddy/README.md
+++ b/examples/web-server/caddy/README.md
@@ -26,7 +26,7 @@ This is an example configuration of how to use Coder with [caddy](https://caddys
    - `localhost:3000`: Change to `coder:7080` (Coder container on Docker network)
    - `email@example.com`: Email to request certificates from LetsEncrypt/ZeroSSL (does not have to be Coder admin email)
    - `coder.example.com`: Domain name you're using for Coder.
-   - `*.coder.example.com`: Domain name for wildcard apps, commonly used for [dashboard port forwarding](https://coder.com/docs/coder-oss/latest/networking/port-forwarding#dashboard). This is optional and can be removed.
+   - `*.coder.example.com`: Domain name for wildcard apps, commonly used for [dashboard port forwarding](https://coder.com/docs/networking/port-forwarding#dashboard). This is optional and can be removed.
 
 1. Start Coder. Set `CODER_ACCESS_URL` and `CODER_WILDCARD_ACCESS_URL` to the domain you're using in your Caddyfile.
 
@@ -38,7 +38,7 @@ This is an example configuration of how to use Coder with [caddy](https://caddys
 
 ### Standalone
 
-1. If you haven't already, [install Coder](https://coder.com/docs/coder-oss/latest/install)
+1. If you haven't already, [install Coder](https://coder.com/docs/install)
 
 2. Install [Caddy Server](https://caddyserver.com/docs/install)
 
@@ -48,11 +48,11 @@ This is an example configuration of how to use Coder with [caddy](https://caddys
 
    - `email@example.com`: Email to request certificates from LetsEncrypt/ZeroSSL (does not have to be Coder admin email)
    - `coder.example.com`: Domain name you're using for Coder.
-   - `*.coder.example.com`: Domain name for wildcard apps, commonly used for [dashboard port forwarding](https://coder.com/docs/coder-oss/latest/networking/port-forwarding#dashboard). This is optional and can be removed.
+   - `*.coder.example.com`: Domain name for wildcard apps, commonly used for [dashboard port forwarding](https://coder.com/docs/networking/port-forwarding#dashboard). This is optional and can be removed.
    - `localhost:3000`: Address Coder is running on. Modify this if you changed `CODER_HTTP_ADDRESS` in the Coder configuration.
    - _DO NOT CHANGE the `ask http://example.com` line! Doing so will result in your certs potentially not being generated._
 
-4. [Configure Coder](https://coder.com/docs/coder-oss/latest/admin/configure) and change the following values:
+4. [Configure Coder](https://coder.com/docs/admin/configure) and change the following values:
 
    - `CODER_ACCESS_URL`: root domain (e.g. `https://coder.example.com`)
    - `CODER_WILDCARD_ACCESS_URL`: wildcard domain (e.g. `*.example.com`).

--- a/helm/coder/README.md
+++ b/helm/coder/README.md
@@ -11,7 +11,7 @@ and notably (compared to Coder Classic) does not include a database server.
 > instructions on a tagged release.
 
 View
-[our docs](https://coder.com/docs/coder-oss/latest/install/kubernetes)
+[our docs](https://coder.com/docs/install/kubernetes)
 for detailed installation instructions.
 
 ## Values

--- a/scripts/linux-pkg/coder-workspace-proxy.service
+++ b/scripts/linux-pkg/coder-workspace-proxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description="Coder - external workspace proxy server"
-Documentation=https://coder.com/docs/coder-oss
+Documentation=https://coder.com/docs
 Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty=/etc/coder.d/coder-workspace-proxy.env

--- a/scripts/linux-pkg/coder.service
+++ b/scripts/linux-pkg/coder.service
@@ -1,6 +1,6 @@
 [Unit]
 Description="Coder - Self-hosted developer workspaces on your infra"
-Documentation=https://coder.com/docs/coder-oss
+Documentation=https://coder.com/docs
 Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty=/etc/coder.d/coder.env


### PR DESCRIPTION
Updates the remaining in-product docs links to new docs format.
This is continuation of #13797.