### PR TITLE
fix: fix flaking `Test_sshConfigExecEscape`

### DIFF
--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -138,6 +138,7 @@ func Test_sshConfigSplitOnCoderSection(t *testing.T) {
 
 // This test tries to mimic the behavior of OpenSSH
 // when executing e.g. a ProxyCommand.
+// nolint:tparallel
 func Test_sshConfigExecEscape(t *testing.T) {
 	t.Parallel()
 
@@ -154,11 +155,10 @@ func Test_sshConfigExecEscape(t *testing.T) {
 		{"tabs", "path with \ttabs", false},
 		{"newline fails", "path with \nnewline", true},
 	}
+	// nolint:paralleltest // Fixes a flake
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			if runtime.GOOS == "windows" {
 				t.Skip("Windows doesn't typically execute via /bin/sh or cmd.exe, so this test is not applicable.")
 			}


### PR DESCRIPTION
Fixes #13962.

This test flakes when the subtests are run in parallel (~1/250). Since we're not testing any concurrent code, and the test isn't incorrect in any obvious way, we'll fix the flake by running them consecutively instead.

Attempted fixes:
- Replacing `os.WriteFile` with an atomic variant from [Google's `renameio`.](https://pkg.go.dev/github.com/google/renameio#WriteFile)
- Moving the `TempDir` calls to the outer test, so that they get cleaned up at the end, instead of at the end of each subtest.

A real fix is left to the reader.