### PR TITLE
chore: rename 'Deployment' button to 'Administration'

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -52,7 +52,7 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = ({
             />
           }
         >
-          Manage
+          Administration
         </Button>
       </PopoverTrigger>
 
@@ -128,7 +128,7 @@ const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
           css={styles.menuItem}
           onClick={onPopoverClose}
         >
-          Auditing
+          Audit Logs
         </MenuItem>
       )}
       {canViewHealth && (

--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -52,7 +52,7 @@ export const DeploymentDropdown: FC<DeploymentDropdownProps> = ({
             />
           }
         >
-          Deployment
+          Manage
         </Button>
       </PopoverTrigger>
 

--- a/site/src/modules/dashboard/Navbar/Navbar.test.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.test.tsx
@@ -22,7 +22,7 @@ describe("Navbar", () => {
       }),
     );
     render(<App />);
-    const deploymentMenu = await screen.findByText("Deployment");
+    const deploymentMenu = await screen.findByText("Manage");
     await userEvent.click(deploymentMenu);
     await waitFor(
       () => {
@@ -37,7 +37,7 @@ describe("Navbar", () => {
     // by default, user is an Admin with permission to see the audit log,
     // but is unlicensed so not entitled to see the audit log
     render(<App />);
-    const deploymentMenu = await screen.findByText("Deployment");
+    const deploymentMenu = await screen.findByText("Manage");
     await userEvent.click(deploymentMenu);
     await waitFor(
       () => {

--- a/site/src/modules/dashboard/Navbar/Navbar.test.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.test.tsx
@@ -22,7 +22,7 @@ describe("Navbar", () => {
       }),
     );
     render(<App />);
-    const deploymentMenu = await screen.findByText("Manage");
+    const deploymentMenu = await screen.findByText("Administration");
     await userEvent.click(deploymentMenu);
     await waitFor(
       () => {
@@ -37,7 +37,7 @@ describe("Navbar", () => {
     // by default, user is an Admin with permission to see the audit log,
     // but is unlicensed so not entitled to see the audit log
     render(<App />);
-    const deploymentMenu = await screen.findByText("Manage");
+    const deploymentMenu = await screen.findByText("Administration");
     await userEvent.click(deploymentMenu);
     await waitFor(
       () => {

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof NavbarView>;
 export const ForAdmin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Deployment" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Manage" }));
   },
 };
 
@@ -41,7 +41,7 @@ export const ForAuditor: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Deployment" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Manage" }));
   },
 };
 
@@ -56,7 +56,7 @@ export const ForOrgAdmin: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Deployment" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Manage" }));
   },
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -26,7 +26,9 @@ type Story = StoryObj<typeof NavbarView>;
 export const ForAdmin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Manage" }));
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Administration" }),
+    );
   },
 };
 
@@ -41,7 +43,9 @@ export const ForAuditor: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Manage" }));
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Administration" }),
+    );
   },
 };
 
@@ -56,7 +60,9 @@ export const ForOrgAdmin: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: "Manage" }));
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Administration" }),
+    );
   },
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.test.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.test.tsx
@@ -69,7 +69,7 @@ describe("NavbarView", () => {
         canViewAuditLog
       />,
     );
-    const deploymentMenu = await screen.findByText("Manage");
+    const deploymentMenu = await screen.findByText("Administration");
     await userEvent.click(deploymentMenu);
     const userLink = await screen.findByText(navLanguage.users);
     expect((userLink as HTMLAnchorElement).href).toContain("/users");
@@ -88,7 +88,7 @@ describe("NavbarView", () => {
         canViewAuditLog
       />,
     );
-    const deploymentMenu = await screen.findByText("Manage");
+    const deploymentMenu = await screen.findByText("Administration");
     await userEvent.click(deploymentMenu);
     const auditLink = await screen.findByText(navLanguage.audit);
     expect((auditLink as HTMLAnchorElement).href).toContain("/audit");
@@ -107,7 +107,7 @@ describe("NavbarView", () => {
         canViewAuditLog
       />,
     );
-    const deploymentMenu = await screen.findByText("Manage");
+    const deploymentMenu = await screen.findByText("Administration");
     await userEvent.click(deploymentMenu);
     const deploymentSettingsLink = await screen.findByText(
       navLanguage.deployment,

--- a/site/src/modules/dashboard/Navbar/NavbarView.test.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.test.tsx
@@ -69,7 +69,7 @@ describe("NavbarView", () => {
         canViewAuditLog
       />,
     );
-    const deploymentMenu = await screen.findByText("Deployment");
+    const deploymentMenu = await screen.findByText("Manage");
     await userEvent.click(deploymentMenu);
     const userLink = await screen.findByText(navLanguage.users);
     expect((userLink as HTMLAnchorElement).href).toContain("/users");
@@ -88,7 +88,7 @@ describe("NavbarView", () => {
         canViewAuditLog
       />,
     );
-    const deploymentMenu = await screen.findByText("Deployment");
+    const deploymentMenu = await screen.findByText("Manage");
     await userEvent.click(deploymentMenu);
     const auditLink = await screen.findByText(navLanguage.audit);
     expect((auditLink as HTMLAnchorElement).href).toContain("/audit");
@@ -107,7 +107,7 @@ describe("NavbarView", () => {
         canViewAuditLog
       />,
     );
-    const deploymentMenu = await screen.findByText("Deployment");
+    const deploymentMenu = await screen.findByText("Manage");
     await userEvent.click(deploymentMenu);
     const deploymentSettingsLink = await screen.findByText(
       navLanguage.deployment,

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -31,7 +31,7 @@ export const Language = {
   workspaces: "Workspaces",
   templates: "Templates",
   users: "Users",
-  audit: "Auditing",
+  audit: "Audit Logs",
   deployment: "Settings",
 };
 


### PR DESCRIPTION
Manage makes more sense for this UI button. Also changed to "Audit Logs" since the other options were not verbs.

![Screenshot from 2024-08-13 10-14-51](https://github.com/user-attachments/assets/771bf9c7-0b93-4d2f-971d-1fd546c12fc9)
