### PR TITLE
chore: update envbox template image

### DIFF
--- a/examples/templates/envbox/main.tf
+++ b/examples/templates/envbox/main.tf
@@ -104,11 +104,11 @@ resource "coder_agent" "main" {
     fi
 
     # Install the latest code-server.
-    # Append "-s -- --version x.x.x" to `sh` to install a specific version of code-server.
-    curl -fsSL https://code-server.dev/install.sh | sh | tee code-server-install.log
+    # Append "--version x.x.x" to install a specific version of code-server.
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
     # Start code-server in the background.
-    code-server --auth none --port 13337 | tee code-server-install.log &
+    /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 }
 

--- a/examples/templates/envbox/main.tf
+++ b/examples/templates/envbox/main.tf
@@ -24,7 +24,6 @@ data "coder_parameter" "home_disk" {
 
 variable "use_kubeconfig" {
   type        = bool
-  sensitive   = true
   default     = true
   description = <<-EOF
   Use host kubeconfig? (true/false)
@@ -40,13 +39,11 @@ provider "coder" {
 
 variable "namespace" {
   type        = string
-  sensitive   = true
   description = "The namespace to create workspaces in (must exist prior to creating workspaces)"
 }
 
 variable "create_tun" {
   type        = bool
-  sensitive   = true
   description = "Add a TUN device to the workspace."
   default     = false
 }
@@ -54,32 +51,27 @@ variable "create_tun" {
 variable "create_fuse" {
   type        = bool
   description = "Add a FUSE device to the workspace."
-  sensitive   = true
   default     = false
 }
 
 variable "max_cpus" {
   type        = string
-  sensitive   = true
   description = "Max number of CPUs the workspace may use (e.g. 2)."
 }
 
 variable "min_cpus" {
   type        = string
-  sensitive   = true
   description = "Minimum number of CPUs the workspace may use (e.g. .1)."
 }
 
 variable "max_memory" {
   type        = string
   description = "Maximum amount of memory to allocate the workspace (in GB)."
-  sensitive   = true
 }
 
 variable "min_memory" {
   type        = string
   description = "Minimum amount of memory to allocate the workspace (in GB)."
-  sensitive   = true
 }
 
 provider "kubernetes" {

--- a/examples/templates/envbox/main.tf
+++ b/examples/templates/envbox/main.tf
@@ -191,7 +191,7 @@ resource "kubernetes_pod" "main" {
 
       env {
         name  = "CODER_INNER_IMAGE"
-        value = "index.docker.io/codercom/enterprise-base@sha256:069e84783d134841cbb5007a16d9025b6aed67bc5b95eecc118eb96dccd6de68"
+        value = "index.docker.io/codercom/enterprise-base:ubuntu-20240812"
       }
 
       env {


### PR DESCRIPTION
Updated installation of `code-server` to be consistent with the other templates using the same method as https://github.com/coder/coder/pull/6138 

This fixes an error where the `stderr` stream of `code-server` wasn't correctly redirected to the log file

<img width="1271" alt="Screenshot 2024-08-12 at 23 41 05" src="https://github.com/user-attachments/assets/1f930847-5241-49cf-a727-1162e3770325">


> WARNING: script exited successfully, but output pipes were not closed after 10s. This usually means a child process was started with references to stdout or stderr. As a result, this process may now have been terminated. Consider redirecting the output or using a separate "coder_script" for the process, see https://coder.com/docs/templates/troubleshooting#startup-script-issues for more information.

Also updated the image used in the "inner container" of the `envbox` template and removed unnecessary `sensitive` designation on template variables.

I tested the new template to verify it creates a workspace without error. I verified that `systemd` and `docker` appear to be working normally in the workspace.