### PR TITLE
chore: fix up migration number fixer

### DIFF
--- a/coderd/database/migrations/fix_migration_numbers.sh
+++ b/coderd/database/migrations/fix_migration_numbers.sh
@@ -35,6 +35,7 @@ main() {
 	)"
 
 	declare -A prefix_map=()
+	declare -a git_add_files=()
 
 	# Renumber migrations part of this branch (as compared to main)
 	diff_files="$(diff -u <(echo "${main_files}") <(echo "${head_files}") | sed -E -ne 's;^\+(0.*);\1;p' | sort -n || true)"
@@ -59,7 +60,8 @@ main() {
 		name="${file:7:-4}"
 		new_file="${new_num}_${name}.sql"
 		echo "Renaming ${old_file} to ${new_file}"
-		git mv "${old_file}" "${new_file}"
+		mv "${old_file}" "${new_file}"
+		git_add_files+=("${new_file}" "${old_file}")
 	done <<<"${diff_files}"
 
 	# Renumber fixtures if there's a matching migration in this branch (as compared to main).
@@ -83,9 +85,11 @@ main() {
 		name="${file:7:-4}"
 		new_file="${dir}/${new_num}_${name}.sql"
 		echo "Renaming ${old_file} to ${new_file}"
-		git mv "${old_file}" "${new_file}"
+		mv "${old_file}" "${new_file}"
+		git_add_files+=("${new_file}" "${old_file}")
 	done <<<"${diff_files}"
 
+	git add "${git_add_files[@]}"
 	git status
 	echo "Run 'git commit' to commit the changes."
 }

--- a/coderd/database/migrations/fix_migration_numbers.sh
+++ b/coderd/database/migrations/fix_migration_numbers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -35,7 +35,6 @@ main() {
 	)"
 
 	declare -A prefix_map=()
-	declare -a git_add_files=()
 
 	# Renumber migrations part of this branch (as compared to main)
 	diff_files="$(diff -u <(echo "${main_files}") <(echo "${head_files}") | sed -E -ne 's;^\+(0.*);\1;p' | sort -n || true)"
@@ -60,8 +59,7 @@ main() {
 		name="${file:7:-4}"
 		new_file="${new_num}_${name}.sql"
 		echo "Renaming ${old_file} to ${new_file}"
-		mv "${old_file}" "${new_file}"
-		git_add_files+=("${new_file}" "${old_file}")
+		git mv "${old_file}" "${new_file}"
 	done <<<"${diff_files}"
 
 	# Renumber fixtures if there's a matching migration in this branch (as compared to main).
@@ -85,11 +83,9 @@ main() {
 		name="${file:7:-4}"
 		new_file="${dir}/${new_num}_${name}.sql"
 		echo "Renaming ${old_file} to ${new_file}"
-		mv "${old_file}" "${new_file}"
-		git_add_files+=("${new_file}" "${old_file}")
+		git mv "${old_file}" "${new_file}"
 	done <<<"${diff_files}"
 
-	git add "${git_add_files[@]}"
 	git status
 	echo "Run 'git commit' to commit the changes."
 }


### PR DESCRIPTION
Fixes:
- more portable shebang
- ~uses `git mv` which is more idiomatic for renames~

This script still relies on folks needing a version of Bash not shipped with MacOS by default.

I'm using this version, so it works, but it doesn't work natively for folks running the default.

```bash
$ which bash
/opt/homebrew/bin/bash
$ bash --version
GNU bash, version 5.2.26(1)-release (aarch64-apple-darwin23.2.0)

# Default version
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin23)
```

I created a Go equivalent in https://github.com/coder/coder/compare/dk/fix-migs which we could consider moving to.
It's a bit simpler (doesn't pull the given branch - trying to be more UNIXy), and requires a regex to match a file needing a rename, so it's more dumb but more explicit.