### PR TITLE
chore: fixup quotas to only include groups you are a member of

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -3318,6 +3318,12 @@ func (q *FakeQuerier) GetQuotaAllowanceForUser(_ context.Context, userID uuid.UU
 		if member.UserID != userID {
 			continue
 		}
+		if _, err := q.getOrganizationByIDNoLock(member.GroupID); err == nil {
+			// This should never happen, but it has been reported in customer deployments.
+			// The SQL handles this case, and omits `group_members` rows in the
+			// Everyone group. It counts these distinctly via `organization_members` table.
+			continue
+		}
 		for _, group := range q.groups {
 			if group.ID == member.GroupID {
 				sum += int64(group.QuotaAllowance)

--- a/enterprise/coderd/workspacequota_test.go
+++ b/enterprise/coderd/workspacequota_test.go
@@ -262,6 +262,7 @@ func TestWorkspaceQuota(t *testing.T) {
 		defer cancel()
 
 		// update everyone quotas
+		//nolint:gocritic // using owner for simplicity
 		_, err := owner.PatchGroup(ctx, first.OrganizationID, codersdk.PatchGroupRequest{
 			QuotaAllowance: ptr.Ref(30),
 		})


### PR DESCRIPTION
Before all everyone groups were included in the allowance. Using the new expanded group member view to have a consistent "group membership" rule. Rather then doing the org membership manually in each query.