### PR TITLE
ci: add networking release validation

### DIFF
--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -1,0 +1,20 @@
+name: release-validation
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  network-performance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Schmoder CI
+        uses: benc-uk/workflow-dispatch@v1.2.4
+        with:
+          workflow: ci.yaml
+          repo: coder/schmoder
+          inputs: '{ "num_releases": "3", "commit": "${{ github.sha }}" }'
+          token: ${{ secrets.CDRCI_SCHMODER_ACTIONS_TOKEN }}
+          ref: main


### PR DESCRIPTION
This calls a [networking performance regression test](https://github.com/coder/schmoder) whenever a release branch is cut. The results will be available via a Slack webhook in #netgru, and as a job artifact on the `schmoder` repo.