### PR TITLE
chore: ui error handling should be specific to general

### DIFF
--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -115,8 +115,9 @@ export const getErrorDetail = (error: unknown): string | undefined => {
 		return error.detail;
 	}
 
-  // APIErrors that are empty still benefit from checking the developer console
-  // if no detail is provided. So only use the detail field if it is not empty.
+	// APIErrors that are empty still benefit from checking the developer 
+	// console if no detail is provided. So only use the detail field if 
+	// it is not empty.
 	if (isApiError(error) && error.response.data.detail) {
 		return error.response.data.detail;
 	}

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -115,11 +115,14 @@ export const getErrorDetail = (error: unknown): string | undefined => {
 		return error.detail;
 	}
 
-	if (isApiError(error)) {
+	// APIErrors that are empty still benefit from checking the
+	// developer console if no detail is provided. So only use the
+	// detail field if it is not empty.
+	if (isApiError(error) && error.response.data.detail) {
 		return error.response.data.detail;
 	}
 
-	if (isApiErrorResponse(error)) {
+	if (isApiErrorResponse(error) && error.detail) {
 		return error.detail;
 	}
 

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -115,8 +115,8 @@ export const getErrorDetail = (error: unknown): string | undefined => {
 		return error.detail;
 	}
 
-	// APIErrors that are empty still benefit from checking the developer 
-	// console if no detail is provided. So only use the detail field if 
+	// APIErrors that are empty still benefit from checking the developer
+	// console if no detail is provided. So only use the detail field if
 	// it is not empty.
 	if (isApiError(error) && error.response.data.detail) {
 		return error.response.data.detail;

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -115,16 +115,16 @@ export const getErrorDetail = (error: unknown): string | undefined => {
 		return error.detail;
 	}
 
-	if (error instanceof Error) {
-		return "Please check the developer console for more details.";
-	}
-
 	if (isApiError(error)) {
 		return error.response.data.detail;
 	}
 
 	if (isApiErrorResponse(error)) {
 		return error.detail;
+	}
+
+	if (error instanceof Error) {
+		return "Please check the developer console for more details.";
 	}
 
 	return undefined;

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -115,9 +115,8 @@ export const getErrorDetail = (error: unknown): string | undefined => {
 		return error.detail;
 	}
 
-	// APIErrors that are empty still benefit from checking the
-	// developer console if no detail is provided. So only use the
-	// detail field if it is not empty.
+  // APIErrors that are empty still benefit from checking the developer console
+  // if no detail is provided. So only use the detail field if it is not empty.
 	if (isApiError(error) && error.response.data.detail) {
 		return error.response.data.detail;
 	}

--- a/site/src/components/Alert/ErrorAlert.stories.tsx
+++ b/site/src/components/Alert/ErrorAlert.stories.tsx
@@ -34,6 +34,15 @@ export const WithOnlyMessage: Story = {
 	},
 };
 
+export const APIErrorWithDetail: Story = {
+	args: {
+		error: mockApiError({
+			message: "Magic dust is missing",
+			detail: "without magic dust, the requested operation will never work",
+		}),
+	},
+};
+
 export const WithDismiss: Story = {
 	args: {
 		dismissible: true,


### PR DESCRIPTION
Specific errors should be checked before defaulting to a general error handling.

I noticed the error details were not being shown in my manual testing. We should check for axios error before defaulting to a general string.