### PR TITLE
chore: update secondary and disabled text colors

### DIFF
--- a/site/src/theme/dark/mui.ts
+++ b/site/src/theme/dark/mui.ts
@@ -24,8 +24,8 @@ const muiTheme = createTheme({
 		},
 		text: {
 			primary: tw.zinc[50],
-			secondary: tw.zinc[300],
-			disabled: tw.zinc[400],
+			secondary: tw.zinc[400],
+			disabled: tw.zinc[500],
 		},
 		divider: tw.zinc[700],
 		warning: {

--- a/site/src/theme/darkBlue/mui.ts
+++ b/site/src/theme/darkBlue/mui.ts
@@ -24,8 +24,8 @@ const muiTheme = createTheme({
 		},
 		text: {
 			primary: tw.gray[50],
-			secondary: tw.gray[300],
-			disabled: tw.gray[400],
+			secondary: tw.gray[400],
+			disabled: tw.gray[500],
 		},
 		divider: tw.gray[700],
 		warning: {

--- a/site/src/theme/light/mui.ts
+++ b/site/src/theme/light/mui.ts
@@ -27,8 +27,8 @@ const muiTheme = createTheme({
 		},
 		text: {
 			primary: tw.zinc[950],
-			secondary: tw.zinc[700],
-			disabled: tw.zinc[600],
+			secondary: tw.zinc[600],
+			disabled: tw.zinc[500],
 		},
 		divider: tw.zinc[200],
 		warning: {


### PR DESCRIPTION
The goal of this PR is to increase the contrast between the primary and secondary text to make it a little clearer to see what the relationship of information in the UI. This brings the design more in line with products such as Vercel that use a higher contrast between primary and secondary text.


Dark ---------

<img width="1139" alt="dark-old" src="https://github.com/user-attachments/assets/5e58550e-8c30-4297-9a64-961472b45c3c">
<img width="1136" alt="dark-new" src="https://github.com/user-attachments/assets/f380c327-f108-4f14-b16b-ea4fcefb6f0b">


Blue ---------
<img width="1138" alt="blue-old" src="https://github.com/user-attachments/assets/6c3797da-3b45-4aff-a358-4a7168c5a48f">
<img width="1138" alt="blue-new" src="https://github.com/user-attachments/assets/52cecee2-a396-4edc-bbfc-db80be356dbe">


White ---------
<img width="1141" alt="white-old" src="https://github.com/user-attachments/assets/16e4f046-185d-447e-aeaa-a2c90cba8fab">
<img width="1142" alt="white-new" src="https://github.com/user-attachments/assets/f833c719-f7b1-4838-942d-a626e477ec7f">
