### PR TITLE
fix: label premium features in middleware error

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -128,6 +128,17 @@ func (n FeatureName) AlwaysEnable() bool {
 	}[n]
 }
 
+// Premium returns true if the feature is a premium feature.
+func (n FeatureName) Premium() bool {
+	switch n {
+	// Add all features that should be excluded in the Enterprise feature set.
+	case FeatureMultipleOrganizations, FeatureCustomRoles:
+		return true
+	default:
+		return false
+	}
+}
+
 // FeatureSet represents a grouping of features. Rather than manually
 // assigning features al-la-carte when making a license, a set can be specified.
 // Sets are dynamic in the sense a feature can be added to a set, granting the
@@ -152,13 +163,7 @@ func (set FeatureSet) Features() []FeatureName {
 		copy(enterpriseFeatures, FeatureNames)
 		// Remove the selection
 		enterpriseFeatures = slices.DeleteFunc(enterpriseFeatures, func(f FeatureName) bool {
-			switch f {
-			// Add all features that should be excluded in the Enterprise feature set.
-			case FeatureMultipleOrganizations, FeatureCustomRoles:
-				return true
-			default:
-				return false
-			}
+			return f.Premium()
 		})
 
 		return enterpriseFeatures

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -128,14 +128,14 @@ func (n FeatureName) AlwaysEnable() bool {
 	}[n]
 }
 
-// Premium returns true if the feature is a premium feature.
-func (n FeatureName) Premium() bool {
+// Enterprise returns true if the feature is an enterprise feature.
+func (n FeatureName) Enterprise() bool {
 	switch n {
 	// Add all features that should be excluded in the Enterprise feature set.
 	case FeatureMultipleOrganizations, FeatureCustomRoles:
-		return true
-	default:
 		return false
+	default:
+		return true
 	}
 }
 
@@ -163,7 +163,7 @@ func (set FeatureSet) Features() []FeatureName {
 		copy(enterpriseFeatures, FeatureNames)
 		// Remove the selection
 		enterpriseFeatures = slices.DeleteFunc(enterpriseFeatures, func(f FeatureName) bool {
-			return f.Premium()
+			return !f.Enterprise()
 		})
 
 		return enterpriseFeatures

--- a/enterprise/coderd/organizations_test.go
+++ b/enterprise/coderd/organizations_test.go
@@ -506,14 +506,13 @@ func TestPatchOrganizationsByUser(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
 		const displayName = "New Organization"
-		var err error
 		o := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{}, func(request *codersdk.CreateOrganizationRequest) {
 			request.DisplayName = displayName
 			request.Icon = "/emojis/random.png"
 			request.Name = "new-org"
 		})
 
-		// Remove the license to block enterprise functionality.
+		// Remove the license to block premium functionality.
 		licenses, err := client.Licenses(ctx)
 		require.NoError(t, err, "get licenses")
 		for _, license := range licenses {

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -114,7 +114,7 @@ func TestCustomOrganizationRole(t *testing.T) {
 		role, err := owner.CreateOrganizationRole(ctx, templateAdminCustom(first.OrganizationID))
 		require.NoError(t, err, "upsert role")
 
-		// Remove the license to block enterprise functionality
+		// Remove the license to block premium functionality
 		licenses, err := owner.Licenses(ctx)
 		require.NoError(t, err, "get licenses")
 		for _, license := range licenses {

--- a/enterprise/coderd/roles_test.go
+++ b/enterprise/coderd/roles_test.go
@@ -125,7 +125,7 @@ func TestCustomOrganizationRole(t *testing.T) {
 
 		// Verify functionality is lost
 		_, err = owner.UpdateOrganizationRole(ctx, templateAdminCustom(first.OrganizationID))
-		require.ErrorContains(t, err, "Custom Roles is an Enterprise feature")
+		require.ErrorContains(t, err, "Custom Roles is a Premium feature")
 
 		// Assign the custom template admin role
 		tmplAdmin, _ := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.RoleIdentifier{Name: role.Name, OrganizationID: first.OrganizationID})

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -364,8 +364,12 @@ func (api *API) RequireFeatureMW(feat codersdk.FeatureName) func(http.Handler) h
 			enabled := api.entitlements.Features[feat].Enabled
 			api.entitlementsMu.RUnlock()
 			if !enabled {
+				var licenseType = "an Enterprise"
+				if feat.Premium() {
+					licenseType = "a Premium"
+				}
 				httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-					Message: fmt.Sprintf("%s is an Enterprise feature. Contact sales!", feat.Humanize()),
+					Message: fmt.Sprintf("%s is %s feature. Contact sales!", licenseType, feat.Humanize()),
 				})
 				return
 			}

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -369,7 +369,7 @@ func (api *API) RequireFeatureMW(feat codersdk.FeatureName) func(http.Handler) h
 					licenseType = "a Premium"
 				}
 				httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-					Message: fmt.Sprintf("%s is %s feature. Contact sales!", licenseType, feat.Humanize()),
+					Message: fmt.Sprintf("%s is %s feature. Contact sales!", feat.Humanize(), licenseType),
 				})
 				return
 			}

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -364,9 +364,9 @@ func (api *API) RequireFeatureMW(feat codersdk.FeatureName) func(http.Handler) h
 			enabled := api.entitlements.Features[feat].Enabled
 			api.entitlementsMu.RUnlock()
 			if !enabled {
-				licenseType := "an Enterprise"
-				if feat.Premium() {
-					licenseType = "a Premium"
+				licenseType := "a Premium"
+				if feat.Enterprise() {
+					licenseType = "an Enterprise"
 				}
 				httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
 					Message: fmt.Sprintf("%s is %s feature. Contact sales!", feat.Humanize(), licenseType),

--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -364,7 +364,7 @@ func (api *API) RequireFeatureMW(feat codersdk.FeatureName) func(http.Handler) h
 			enabled := api.entitlements.Features[feat].Enabled
 			api.entitlementsMu.RUnlock()
 			if !enabled {
-				var licenseType = "an Enterprise"
+				licenseType := "an Enterprise"
 				if feat.Premium() {
 					licenseType = "a Premium"
 				}


### PR DESCRIPTION
@Emyrk is this verbiage correct?  Currently in the frontend I am naming the license as "premium", distinct from "enterprise", so I wanted to update the backend error message as well, but if this is wrong let me know and I will change the frontend too. 

The capitalization seems weird to me, but keeping it since it was already there.

Cleanup item for https://github.com/coder/coder/issues/13915