### PR TITLE
chore(dogfood): use remote tf state

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -17,6 +17,10 @@ on:
       - "flake.nix"
   workflow_dispatch:
 
+permissions:
+  # Necessary for GCP authentication (https://github.com/google-github-actions/setup-gcloud#usage)
+  id-token: write
+
 jobs:
   build_image:
     if: github.actor != 'dependabot[bot]' # Skip Dependabot PRs
@@ -85,6 +89,12 @@ jobs:
       - name: Setup Terraform
         uses: ./.github/actions/setup-tf
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/573722524737/locations/global/workloadIdentityPools/github/providers/github
+          service_account: coder-ci@coder-dogfood.iam.gserviceaccount.com
+
       - name: Terraform init and validate
         run: |
           cd dogfood
@@ -110,7 +120,7 @@ jobs:
           cd dogfood
           terraform apply -auto-approve
         env:
-          # Consumed by Coder CLI
+          # Consumed by coderd provider
           CODER_URL: https://dev.coder.com
           CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
           # Template source & details
@@ -118,3 +128,4 @@ jobs:
           TF_VAR_CODER_TEMPLATE_VERSION: ${{ steps.vars.outputs.sha_short }}
           TF_VAR_CODER_TEMPLATE_DIR: ./contents
           TF_VAR_CODER_TEMPLATE_MESSAGE: ${{ steps.message.outputs.pr_title }}
+          TF_LOG: info

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -4,9 +4,11 @@ terraform {
       source = "coder/coderd"
     }
   }
+  backend "gcs" {
+    bucket = "coder-dogfood-tf-state"
+  }
 }
 
-// Alternative to committing a state file
 import {
   to = coderd_template.dogfood
   id = "0d286645-29aa-4eaf-9b52-cc5d2740c90b"


### PR DESCRIPTION
Previously, we were dogfooding the `coderd` provider by importing our dogfood template each time the CI ran. To match how other users will likely want to run the provider, we'll use remote state for each apply, only doing a Terraform import the first time.