### PR TITLE
Fixed port to 8080 instead of the wrong value of 80

### DIFF
--- a/helm/coder/templates/service.yaml
+++ b/helm/coder/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   sessionAffinity: {{ .Values.coder.service.sessionAffinity }}
   ports:
     - name: "http"
-      port: 80
+      port: 8080
       targetPort: "http"
       protocol: TCP
       {{ if eq .Values.coder.service.type "NodePort" }}


### PR DESCRIPTION
The wrong value of 80 makes the chart impossible to deploy.