### PR TITLE
chore!: allow CreateUser to accept multiple organizations 

### DIFF
--- a/cli/clitest/golden.go
+++ b/cli/clitest/golden.go
@@ -184,10 +184,10 @@ func prepareTestData(t *testing.T) (*codersdk.Client, map[string]string) {
 	})
 	firstUser := coderdtest.CreateFirstUser(t, rootClient)
 	secondUser, err := rootClient.CreateUser(ctx, codersdk.CreateUserRequest{
-		Email:          "testuser2@coder.com",
-		Username:       "testuser2",
-		Password:       coderdtest.FirstUserParams.Password,
-		OrganizationID: firstUser.OrganizationID,
+		Email:           "testuser2@coder.com",
+		Username:        "testuser2",
+		Password:        coderdtest.FirstUserParams.Password,
+		OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 	})
 	require.NoError(t, err)
 	version := coderdtest.CreateTemplateVersion(t, rootClient, firstUser.OrganizationID, nil)

--- a/cli/clitest/golden.go
+++ b/cli/clitest/golden.go
@@ -184,7 +184,7 @@ func prepareTestData(t *testing.T) (*codersdk.Client, map[string]string) {
 		IncludeProvisionerDaemon: true,
 	})
 	firstUser := coderdtest.CreateFirstUser(t, rootClient)
-	secondUser, err := rootClient.CreateUser(ctx, codersdk.CreateUserRequest{
+	secondUser, err := rootClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 		Email:           "testuser2@coder.com",
 		Username:        "testuser2",
 		Password:        coderdtest.FirstUserParams.Password,

--- a/cli/clitest/golden.go
+++ b/cli/clitest/golden.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/config"

--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -35,7 +35,7 @@ func setupTestSchedule(t *testing.T, sched *cron.Schedule) (ownerClient, memberC
 
 	ownerClient, db = coderdtest.NewWithDatabase(t, nil)
 	owner := coderdtest.CreateFirstUser(t, ownerClient)
-	memberClient, memberUser := coderdtest.CreateAnotherUserMutators(t, ownerClient, owner.OrganizationID, nil, func(r *codersdk.CreateUserRequest) {
+	memberClient, memberUser := coderdtest.CreateAnotherUserMutators(t, ownerClient, owner.OrganizationID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
 		r.Username = "testuser2" // ensure deterministic ordering
 	})
 	_ = dbfake.WorkspaceBuild(t, db, database.Workspace{

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -83,7 +83,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 
 			validateInputs := func(username, email, password string) error {
 				// Use the validator tags so we match the API's validation.
-				req := codersdk.CreateUserRequest{
+				req := codersdk.CreateUserRequestWithOrgs{
 					Username:        "username",
 					Name:            "Admin User",
 					Email:           "email@coder.com",

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -84,11 +84,11 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 			validateInputs := func(username, email, password string) error {
 				// Use the validator tags so we match the API's validation.
 				req := codersdk.CreateUserRequest{
-					Username:       "username",
-					Name:           "Admin User",
-					Email:          "email@coder.com",
-					Password:       "ValidPa$$word123!",
-					OrganizationID: uuid.New(),
+					Username:        "username",
+					Name:            "Admin User",
+					Email:           "email@coder.com",
+					Password:        "ValidPa$$word123!",
+					OrganizationIDs: []uuid.UUID{uuid.New()},
 				}
 				if username != "" {
 					req.Username = username

--- a/cli/user_delete_test.go
+++ b/cli/user_delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/cli/clitest"
@@ -27,12 +28,12 @@ func TestUserDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "colin5@coder.com",
-			Username:       "coolin",
-			Password:       pw,
-			UserLoginType:  codersdk.LoginTypePassword,
-			OrganizationID: owner.OrganizationID,
-			DisableLogin:   false,
+			Email:           "colin5@coder.com",
+			Username:        "coolin",
+			Password:        pw,
+			UserLoginType:   codersdk.LoginTypePassword,
+			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
+			DisableLogin:    false,
 		})
 		require.NoError(t, err)
 
@@ -58,12 +59,12 @@ func TestUserDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "colin5@coder.com",
-			Username:       "coolin",
-			Password:       pw,
-			UserLoginType:  codersdk.LoginTypePassword,
-			OrganizationID: owner.OrganizationID,
-			DisableLogin:   false,
+			Email:           "colin5@coder.com",
+			Username:        "coolin",
+			Password:        pw,
+			UserLoginType:   codersdk.LoginTypePassword,
+			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
+			DisableLogin:    false,
 		})
 		require.NoError(t, err)
 
@@ -89,12 +90,12 @@ func TestUserDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "colin5@coder.com",
-			Username:       "coolin",
-			Password:       pw,
-			UserLoginType:  codersdk.LoginTypePassword,
-			OrganizationID: owner.OrganizationID,
-			DisableLogin:   false,
+			Email:           "colin5@coder.com",
+			Username:        "coolin",
+			Password:        pw,
+			UserLoginType:   codersdk.LoginTypePassword,
+			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
+			DisableLogin:    false,
 		})
 		require.NoError(t, err)
 

--- a/cli/user_delete_test.go
+++ b/cli/user_delete_test.go
@@ -27,13 +27,12 @@ func TestUserDelete(t *testing.T) {
 		pw, err := cryptorand.String(16)
 		require.NoError(t, err)
 
-		_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err = client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "colin5@coder.com",
 			Username:        "coolin",
 			Password:        pw,
 			UserLoginType:   codersdk.LoginTypePassword,
 			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
-			DisableLogin:    false,
 		})
 		require.NoError(t, err)
 
@@ -58,13 +57,12 @@ func TestUserDelete(t *testing.T) {
 		pw, err := cryptorand.String(16)
 		require.NoError(t, err)
 
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "colin5@coder.com",
 			Username:        "coolin",
 			Password:        pw,
 			UserLoginType:   codersdk.LoginTypePassword,
 			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
-			DisableLogin:    false,
 		})
 		require.NoError(t, err)
 
@@ -89,13 +87,12 @@ func TestUserDelete(t *testing.T) {
 		pw, err := cryptorand.String(16)
 		require.NoError(t, err)
 
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "colin5@coder.com",
 			Username:        "coolin",
 			Password:        pw,
 			UserLoginType:   codersdk.LoginTypePassword,
 			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
-			DisableLogin:    false,
 		})
 		require.NoError(t, err)
 
@@ -122,13 +119,12 @@ func TestUserDelete(t *testing.T) {
 	// 	pw, err := cryptorand.String(16)
 	// 	require.NoError(t, err)
 
-	// 	toDelete, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+	// 	toDelete, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 	// 		Email:          "colin5@coder.com",
 	// 		Username:       "coolin",
 	// 		Password:       pw,
 	// 		UserLoginType:  codersdk.LoginTypePassword,
 	// 		OrganizationID: aUser.OrganizationID,
-	// 		DisableLogin:   false,
 	// 	})
 	// 	require.NoError(t, err)
 

--- a/cli/usercreate.go
+++ b/cli/usercreate.go
@@ -95,7 +95,7 @@ func (r *RootCmd) userCreate() *serpent.Command {
 				}
 			}
 
-			_, err = client.CreateUser(inv.Context(), codersdk.CreateUserRequest{
+			_, err = client.CreateUserWithOrgs(inv.Context(), codersdk.CreateUserRequestWithOrgs{
 				Email:           email,
 				Username:        username,
 				Name:            name,

--- a/cli/usercreate.go
+++ b/cli/usercreate.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
 	"github.com/coder/pretty"
@@ -95,12 +96,12 @@ func (r *RootCmd) userCreate() *serpent.Command {
 			}
 
 			_, err = client.CreateUser(inv.Context(), codersdk.CreateUserRequest{
-				Email:          email,
-				Username:       username,
-				Name:           name,
-				Password:       password,
-				OrganizationID: organization.ID,
-				UserLoginType:  userLoginType,
+				Email:           email,
+				Username:        username,
+				Name:            name,
+				Password:        password,
+				OrganizationIDs: []uuid.UUID{organization.ID},
+				UserLoginType:   userLoginType,
 			})
 			if err != nil {
 				return err

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9475,9 +9475,13 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "organization_id": {
-                    "type": "string",
-                    "format": "uuid"
+                "organization_ids": {
+                    "description": "OrganizationIDs is a list of organization IDs that the user should be a member of.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
                 },
                 "password": {
                     "type": "string"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4875,7 +4875,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/codersdk.CreateUserRequest"
+                            "$ref": "#/definitions/codersdk.CreateUserRequestWithOrgs"
                         }
                     }
                 ],
@@ -9449,17 +9449,13 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.CreateUserRequest": {
+        "codersdk.CreateUserRequestWithOrgs": {
             "type": "object",
             "required": [
                 "email",
                 "username"
             ],
             "properties": {
-                "disable_login": {
-                    "description": "DisableLogin sets the user's login type to 'none'. This prevents the user\nfrom being able to use a password or any other authentication method to login.\nDeprecated: Set UserLoginType=LoginTypeDisabled instead.",
-                    "type": "boolean"
-                },
                 "email": {
                     "type": "string",
                     "format": "email"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8436,9 +8436,13 @@
 				"name": {
 					"type": "string"
 				},
-				"organization_id": {
-					"type": "string",
-					"format": "uuid"
+				"organization_ids": {
+					"description": "OrganizationIDs is a list of organization IDs that the user should be a member of.",
+					"type": "array",
+					"items": {
+						"type": "string",
+						"format": "uuid"
+					}
 				},
 				"password": {
 					"type": "string"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4305,7 +4305,7 @@
 						"in": "body",
 						"required": true,
 						"schema": {
-							"$ref": "#/definitions/codersdk.CreateUserRequest"
+							"$ref": "#/definitions/codersdk.CreateUserRequestWithOrgs"
 						}
 					}
 				],
@@ -8413,14 +8413,10 @@
 				}
 			}
 		},
-		"codersdk.CreateUserRequest": {
+		"codersdk.CreateUserRequestWithOrgs": {
 			"type": "object",
 			"required": ["email", "username"],
 			"properties": {
-				"disable_login": {
-					"description": "DisableLogin sets the user's login type to 'none'. This prevents the user\nfrom being able to use a password or any other authentication method to login.\nDeprecated: Set UserLoginType=LoginTypeDisabled instead.",
-					"type": "boolean"
-				},
 				"email": {
 					"type": "string",
 					"format": "email"

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -649,7 +649,7 @@ func CreateAnotherUser(t testing.TB, client *codersdk.Client, organizationID uui
 	return createAnotherUserRetry(t, client, []uuid.UUID{organizationID}, 5, roles)
 }
 
-func CreateAnotherUserMutators(t testing.TB, client *codersdk.Client, organizationID uuid.UUID, roles []rbac.RoleIdentifier, mutators ...func(r *codersdk.CreateUserRequest)) (*codersdk.Client, codersdk.User) {
+func CreateAnotherUserMutators(t testing.TB, client *codersdk.Client, organizationID uuid.UUID, roles []rbac.RoleIdentifier, mutators ...func(r *codersdk.CreateUserRequestWithOrgs)) (*codersdk.Client, codersdk.User) {
 	return createAnotherUserRetry(t, client, []uuid.UUID{organizationID}, 5, roles, mutators...)
 }
 
@@ -676,8 +676,8 @@ func AuthzUserSubject(user codersdk.User, orgID uuid.UUID) rbac.Subject {
 	}
 }
 
-func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationIDs []uuid.UUID, retries int, roles []rbac.RoleIdentifier, mutators ...func(r *codersdk.CreateUserRequest)) (*codersdk.Client, codersdk.User) {
-	req := codersdk.CreateUserRequest{
+func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationIDs []uuid.UUID, retries int, roles []rbac.RoleIdentifier, mutators ...func(r *codersdk.CreateUserRequestWithOrgs)) (*codersdk.Client, codersdk.User) {
+	req := codersdk.CreateUserRequestWithOrgs{
 		Email:           namesgenerator.GetRandomName(10) + "@coder.com",
 		Username:        RandomUsername(t),
 		Name:            RandomName(t),
@@ -688,7 +688,7 @@ func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationI
 		m(&req)
 	}
 
-	user, err := client.CreateUser(context.Background(), req)
+	user, err := client.CreateUserWithOrgs(context.Background(), req)
 	var apiError *codersdk.Error
 	// If the user already exists by username or email conflict, try again up to "retries" times.
 	if err != nil && retries >= 0 && xerrors.As(err, &apiError) {
@@ -700,7 +700,7 @@ func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationI
 	require.NoError(t, err)
 
 	var sessionToken string
-	if req.DisableLogin || req.UserLoginType == codersdk.LoginTypeNone {
+	if req.UserLoginType == codersdk.LoginTypeNone {
 		// Cannot log in with a disabled login user. So make it an api key from
 		// the client making this user.
 		token, err := client.CreateToken(context.Background(), user.ID.String(), codersdk.CreateTokenRequest{

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -523,7 +523,7 @@ func TestTemplateInsights_Golden(t *testing.T) {
 
 		// Prepare all test users.
 		for _, user := range users {
-			user.client, user.sdk = coderdtest.CreateAnotherUserMutators(t, client, firstUser.OrganizationID, nil, func(r *codersdk.CreateUserRequest) {
+			user.client, user.sdk = coderdtest.CreateAnotherUserMutators(t, client, firstUser.OrganizationID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
 				r.Username = user.name
 			})
 			user.client.SetLogger(logger.Named("user").With(slog.Field{Name: "name", Value: user.name}))

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1436,11 +1436,11 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 			}
 
 			//nolint:gocritic
-			user, _, err = api.CreateUser(dbauthz.AsSystemRestricted(ctx), tx, CreateUserRequest{
+			user, err = api.CreateUser(dbauthz.AsSystemRestricted(ctx), tx, CreateUserRequest{
 				CreateUserRequest: codersdk.CreateUserRequest{
-					Email:          params.Email,
-					Username:       params.Username,
-					OrganizationID: defaultOrganization.ID,
+					Email:           params.Email,
+					Username:        params.Username,
+					OrganizationIDs: []uuid.UUID{defaultOrganization.ID},
 				},
 				LoginType: params.LoginType,
 			})

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -1437,7 +1437,7 @@ func (api *API) oauthLogin(r *http.Request, params *oauthLoginParams) ([]*http.C
 
 			//nolint:gocritic
 			user, err = api.CreateUser(dbauthz.AsSystemRestricted(ctx), tx, CreateUserRequest{
-				CreateUserRequest: codersdk.CreateUserRequest{
+				CreateUserRequestWithOrgs: codersdk.CreateUserRequestWithOrgs{
 					Email:           params.Email,
 					Username:        params.Username,
 					OrganizationIDs: []uuid.UUID{defaultOrganization.ID},

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -1471,10 +1471,10 @@ func TestUserLogout(t *testing.T) {
 		password = "SomeSecurePassword123!"
 	)
 	newUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-		Email:          email,
-		Username:       username,
-		Password:       password,
-		OrganizationID: firstUser.OrganizationID,
+		Email:           email,
+		Username:        username,
+		Password:        password,
+		OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 	})
 	require.NoError(t, err)
 

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -106,28 +106,12 @@ func TestUserLogin(t *testing.T) {
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusUnauthorized, apiErr.StatusCode())
 	})
-	// Password auth should fail if the user is made without password login.
-	t.Run("DisableLoginDeprecatedField", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		user := coderdtest.CreateFirstUser(t, client)
-		anotherClient, anotherUser := coderdtest.CreateAnotherUserMutators(t, client, user.OrganizationID, nil, func(r *codersdk.CreateUserRequest) {
-			r.Password = ""
-			r.DisableLogin = true
-		})
-
-		_, err := anotherClient.LoginWithPassword(context.Background(), codersdk.LoginWithPasswordRequest{
-			Email:    anotherUser.Email,
-			Password: "SomeSecurePassword!",
-		})
-		require.Error(t, err)
-	})
 
 	t.Run("LoginTypeNone", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		user := coderdtest.CreateFirstUser(t, client)
-		anotherClient, anotherUser := coderdtest.CreateAnotherUserMutators(t, client, user.OrganizationID, nil, func(r *codersdk.CreateUserRequest) {
+		anotherClient, anotherUser := coderdtest.CreateAnotherUserMutators(t, client, user.OrganizationID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
 			r.Password = ""
 			r.UserLoginType = codersdk.LoginTypeNone
 		})
@@ -1470,7 +1454,7 @@ func TestUserLogout(t *testing.T) {
 		//nolint:gosec
 		password = "SomeSecurePassword123!"
 	)
-	newUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+	newUser, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 		Email:           email,
 		Username:        username,
 		Password:        password,

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -388,8 +388,8 @@ func (api *API) postUser(rw http.ResponseWriter, r *http.Request) {
 
 	if len(req.OrganizationIDs) == 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf("No organization specified to place the user as a member of. It is required to specify at least one organization id to place the user in."),
-			Detail:  fmt.Sprintf("required at least 1 value for the array 'organization_ids'"),
+			Message: "No organization specified to place the user as a member of. It is required to specify at least one organization id to place the user in.",
+			Detail:  "required at least 1 value for the array 'organization_ids'",
 			Validations: []codersdk.ValidationError{
 				{
 					Field:  "organization_ids",
@@ -447,7 +447,6 @@ func (api *API) postUser(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-
 	}
 
 	var loginType database.LoginType

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -416,10 +416,10 @@ func TestNotifyUserStatusChanged(t *testing.T) {
 		_, userAdmin := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID, rbac.RoleUserAdmin())
 
 		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -453,10 +453,10 @@ func TestNotifyUserStatusChanged(t *testing.T) {
 		_, userAdmin := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID, rbac.RoleUserAdmin())
 
 		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -220,7 +220,7 @@ func TestPostLogin(t *testing.T) {
 
 		// With a user account.
 		const password = "SomeSecurePassword!"
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "test+user-@coder.com",
 			Username:        "user",
 			Password:        password,
@@ -317,7 +317,7 @@ func TestDeleteUser(t *testing.T) {
 		err := client.DeleteUser(context.Background(), another.ID)
 		require.NoError(t, err)
 		// Attempt to create a user with the same email and username, and delete them again.
-		another, err = client.CreateUser(context.Background(), codersdk.CreateUserRequest{
+		another, err = client.CreateUserWithOrgs(context.Background(), codersdk.CreateUserRequestWithOrgs{
 			Email:           another.Email,
 			Username:        another.Username,
 			Password:        "SomeSecurePassword!",
@@ -415,7 +415,7 @@ func TestNotifyUserStatusChanged(t *testing.T) {
 
 		_, userAdmin := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID, rbac.RoleUserAdmin())
 
-		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		member, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -452,7 +452,7 @@ func TestNotifyUserStatusChanged(t *testing.T) {
 
 		_, userAdmin := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID, rbac.RoleUserAdmin())
 
-		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		member, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -494,7 +494,7 @@ func TestNotifyDeletedUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		user, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -530,7 +530,7 @@ func TestNotifyDeletedUser(t *testing.T) {
 
 		_, userAdmin := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID, rbac.RoleUserAdmin())
 
-		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		member, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -625,7 +625,7 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{})
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{})
 		require.Error(t, err)
 	})
 
@@ -639,7 +639,7 @@ func TestPostUsers(t *testing.T) {
 
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
-		_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err = client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           me.Email,
 			Username:        me.Username,
 			Password:        "MySecurePassword!",
@@ -658,7 +658,7 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{uuid.New()},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -682,7 +682,7 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -735,7 +735,7 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -767,7 +767,7 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Email:           email,
 			Username:        "someone-else",
@@ -804,7 +804,7 @@ func TestNotifyCreatedUser(t *testing.T) {
 		defer cancel()
 
 		// when
-		user, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -833,7 +833,7 @@ func TestNotifyCreatedUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		userAdmin, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		userAdmin, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "user-admin@user.org",
 			Username:        "mr-user-admin",
@@ -849,7 +849,7 @@ func TestNotifyCreatedUser(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		member, err := adminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
 			Email:           "another@user.org",
 			Username:        "someone-else",
@@ -908,7 +908,7 @@ func TestUpdateUserProfile(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		existentUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		existentUser, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "bruno@coder.com",
 			Username:        "bruno",
 			Password:        "SomeSecurePassword!",
@@ -990,7 +990,7 @@ func TestUpdateUserProfile(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "john@coder.com",
 			Username:        "john",
 			Password:        "SomeSecurePassword!",
@@ -1032,7 +1032,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		member, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		member, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "coder@coder.com",
 			Username:        "coder",
 			Password:        "SomeStrongPassword!",
@@ -1293,7 +1293,7 @@ func TestActivateDormantUser(t *testing.T) {
 	me := coderdtest.CreateFirstUser(t, client)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
-	anotherUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+	anotherUser, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 		Email:           "coder@coder.com",
 		Username:        "coder",
 		Password:        "SomeStrongPassword!",
@@ -1600,7 +1600,7 @@ func TestGetUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		client.CreateUser(ctx, codersdk.CreateUserRequest{
+		client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "alice@email.com",
 			Username:        "alice",
 			Password:        "MySecurePassword!",
@@ -1626,7 +1626,7 @@ func TestGetUsers(t *testing.T) {
 		active = append(active, firstUser)
 
 		// Alice will be suspended
-		alice, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		alice, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "alice@email.com",
 			Username:        "alice",
 			Password:        "MySecurePassword!",
@@ -1638,7 +1638,7 @@ func TestGetUsers(t *testing.T) {
 		require.NoError(t, err)
 
 		// Tom will be active
-		tom, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		tom, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "tom@email.com",
 			Username:        "tom",
 			Password:        "MySecurePassword!",
@@ -1669,7 +1669,7 @@ func TestGetUsersPagination(t *testing.T) {
 	_, err := client.User(ctx, first.UserID.String())
 	require.NoError(t, err, "")
 
-	_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
+	_, err = client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 		Email:           "alice@email.com",
 		Username:        "alice",
 		Password:        "MySecurePassword!",
@@ -1750,7 +1750,7 @@ func TestWorkspacesByUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		newUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		newUser, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "test@coder.com",
 			Username:        "someone",
 			Password:        "MySecurePassword!",
@@ -1790,7 +1790,7 @@ func TestDormantUser(t *testing.T) {
 	defer cancel()
 
 	// Create a new user
-	newUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+	newUser, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 		Email:           "test@coder.com",
 		Username:        "someone",
 		Password:        "MySecurePassword!",
@@ -1841,7 +1841,7 @@ func TestSuspendedPagination(t *testing.T) {
 	for i := 0; i < total; i++ {
 		email := fmt.Sprintf("%d@coder.com", i)
 		username := fmt.Sprintf("user%d", i)
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           email,
 			Username:        username,
 			Password:        "MySecurePassword!",

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -221,10 +221,10 @@ func TestPostLogin(t *testing.T) {
 		// With a user account.
 		const password = "SomeSecurePassword!"
 		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "test+user-@coder.com",
-			Username:       "user",
-			Password:       password,
-			OrganizationID: first.OrganizationID,
+			Email:           "test+user-@coder.com",
+			Username:        "user",
+			Password:        password,
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 		})
 		require.NoError(t, err)
 
@@ -318,10 +318,10 @@ func TestDeleteUser(t *testing.T) {
 		require.NoError(t, err)
 		// Attempt to create a user with the same email and username, and delete them again.
 		another, err = client.CreateUser(context.Background(), codersdk.CreateUserRequest{
-			Email:          another.Email,
-			Username:       another.Username,
-			Password:       "SomeSecurePassword!",
-			OrganizationID: user.OrganizationID,
+			Email:           another.Email,
+			Username:        another.Username,
+			Password:        "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{user.OrganizationID},
 		})
 		require.NoError(t, err)
 		err = client.DeleteUser(context.Background(), another.ID)
@@ -495,10 +495,10 @@ func TestNotifyDeletedUser(t *testing.T) {
 		defer cancel()
 
 		user, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -531,10 +531,10 @@ func TestNotifyDeletedUser(t *testing.T) {
 		_, userAdmin := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID, rbac.RoleUserAdmin())
 
 		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -640,10 +640,10 @@ func TestPostUsers(t *testing.T) {
 		me, err := client.User(ctx, codersdk.Me)
 		require.NoError(t, err)
 		_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          me.Email,
-			Username:       me.Username,
-			Password:       "MySecurePassword!",
-			OrganizationID: uuid.New(),
+			Email:           me.Email,
+			Username:        me.Username,
+			Password:        "MySecurePassword!",
+			OrganizationIDs: []uuid.UUID{uuid.New()},
 		})
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
@@ -659,10 +659,10 @@ func TestPostUsers(t *testing.T) {
 		defer cancel()
 
 		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: uuid.New(),
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{uuid.New()},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
@@ -683,10 +683,10 @@ func TestPostUsers(t *testing.T) {
 		defer cancel()
 
 		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -736,11 +736,11 @@ func TestPostUsers(t *testing.T) {
 		defer cancel()
 
 		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: first.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "",
-			UserLoginType:  codersdk.LoginTypeNone,
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "",
+			UserLoginType:   codersdk.LoginTypeNone,
 		})
 		require.NoError(t, err)
 
@@ -768,11 +768,11 @@ func TestPostUsers(t *testing.T) {
 		defer cancel()
 
 		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: first.OrganizationID,
-			Email:          email,
-			Username:       "someone-else",
-			Password:       "",
-			UserLoginType:  codersdk.LoginTypeOIDC,
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Email:           email,
+			Username:        "someone-else",
+			Password:        "",
+			UserLoginType:   codersdk.LoginTypeOIDC,
 		})
 		require.NoError(t, err)
 
@@ -805,10 +805,10 @@ func TestNotifyCreatedUser(t *testing.T) {
 
 		// when
 		user, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -834,10 +834,10 @@ func TestNotifyCreatedUser(t *testing.T) {
 		defer cancel()
 
 		userAdmin, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "user-admin@user.org",
-			Username:       "mr-user-admin",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "user-admin@user.org",
+			Username:        "mr-user-admin",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -850,10 +850,10 @@ func TestNotifyCreatedUser(t *testing.T) {
 
 		// when
 		member, err := adminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: firstUser.OrganizationID,
-			Email:          "another@user.org",
-			Username:       "someone-else",
-			Password:       "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{firstUser.OrganizationID},
+			Email:           "another@user.org",
+			Username:        "someone-else",
+			Password:        "SomeSecurePassword!",
 		})
 		require.NoError(t, err)
 
@@ -909,10 +909,10 @@ func TestUpdateUserProfile(t *testing.T) {
 		defer cancel()
 
 		existentUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "bruno@coder.com",
-			Username:       "bruno",
-			Password:       "SomeSecurePassword!",
-			OrganizationID: user.OrganizationID,
+			Email:           "bruno@coder.com",
+			Username:        "bruno",
+			Password:        "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{user.OrganizationID},
 		})
 		require.NoError(t, err)
 		_, err = client.UpdateUserProfile(ctx, codersdk.Me, codersdk.UpdateUserProfileRequest{
@@ -991,10 +991,10 @@ func TestUpdateUserProfile(t *testing.T) {
 		defer cancel()
 
 		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "john@coder.com",
-			Username:       "john",
-			Password:       "SomeSecurePassword!",
-			OrganizationID: user.OrganizationID,
+			Email:           "john@coder.com",
+			Username:        "john",
+			Password:        "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{user.OrganizationID},
 		})
 		require.NoError(t, err)
 		_, err = client.UpdateUserProfile(ctx, codersdk.Me, codersdk.UpdateUserProfileRequest{
@@ -1033,10 +1033,10 @@ func TestUpdateUserPassword(t *testing.T) {
 		defer cancel()
 
 		member, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "coder@coder.com",
-			Username:       "coder",
-			Password:       "SomeStrongPassword!",
-			OrganizationID: owner.OrganizationID,
+			Email:           "coder@coder.com",
+			Username:        "coder",
+			Password:        "SomeStrongPassword!",
+			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
 		})
 		require.NoError(t, err, "create member")
 		err = client.UpdateUserPassword(ctx, member.ID.String(), codersdk.UpdateUserPasswordRequest{
@@ -1294,10 +1294,10 @@ func TestActivateDormantUser(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 	anotherUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-		Email:          "coder@coder.com",
-		Username:       "coder",
-		Password:       "SomeStrongPassword!",
-		OrganizationID: me.OrganizationID,
+		Email:           "coder@coder.com",
+		Username:        "coder",
+		Password:        "SomeStrongPassword!",
+		OrganizationIDs: []uuid.UUID{me.OrganizationID},
 	})
 	require.NoError(t, err)
 
@@ -1601,10 +1601,10 @@ func TestGetUsers(t *testing.T) {
 		defer cancel()
 
 		client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "alice@email.com",
-			Username:       "alice",
-			Password:       "MySecurePassword!",
-			OrganizationID: user.OrganizationID,
+			Email:           "alice@email.com",
+			Username:        "alice",
+			Password:        "MySecurePassword!",
+			OrganizationIDs: []uuid.UUID{user.OrganizationID},
 		})
 		// No params is all users
 		res, err := client.Users(ctx, codersdk.UsersRequest{})
@@ -1627,10 +1627,10 @@ func TestGetUsers(t *testing.T) {
 
 		// Alice will be suspended
 		alice, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "alice@email.com",
-			Username:       "alice",
-			Password:       "MySecurePassword!",
-			OrganizationID: first.OrganizationID,
+			Email:           "alice@email.com",
+			Username:        "alice",
+			Password:        "MySecurePassword!",
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 		})
 		require.NoError(t, err)
 
@@ -1639,10 +1639,10 @@ func TestGetUsers(t *testing.T) {
 
 		// Tom will be active
 		tom, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "tom@email.com",
-			Username:       "tom",
-			Password:       "MySecurePassword!",
-			OrganizationID: first.OrganizationID,
+			Email:           "tom@email.com",
+			Username:        "tom",
+			Password:        "MySecurePassword!",
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 		})
 		require.NoError(t, err)
 
@@ -1670,10 +1670,10 @@ func TestGetUsersPagination(t *testing.T) {
 	require.NoError(t, err, "")
 
 	_, err = client.CreateUser(ctx, codersdk.CreateUserRequest{
-		Email:          "alice@email.com",
-		Username:       "alice",
-		Password:       "MySecurePassword!",
-		OrganizationID: first.OrganizationID,
+		Email:           "alice@email.com",
+		Username:        "alice",
+		Password:        "MySecurePassword!",
+		OrganizationIDs: []uuid.UUID{first.OrganizationID},
 	})
 	require.NoError(t, err)
 
@@ -1751,10 +1751,10 @@ func TestWorkspacesByUser(t *testing.T) {
 		defer cancel()
 
 		newUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "test@coder.com",
-			Username:       "someone",
-			Password:       "MySecurePassword!",
-			OrganizationID: user.OrganizationID,
+			Email:           "test@coder.com",
+			Username:        "someone",
+			Password:        "MySecurePassword!",
+			OrganizationIDs: []uuid.UUID{user.OrganizationID},
 		})
 		require.NoError(t, err)
 		auth, err := client.LoginWithPassword(ctx, codersdk.LoginWithPasswordRequest{
@@ -1791,10 +1791,10 @@ func TestDormantUser(t *testing.T) {
 
 	// Create a new user
 	newUser, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-		Email:          "test@coder.com",
-		Username:       "someone",
-		Password:       "MySecurePassword!",
-		OrganizationID: user.OrganizationID,
+		Email:           "test@coder.com",
+		Username:        "someone",
+		Password:        "MySecurePassword!",
+		OrganizationIDs: []uuid.UUID{user.OrganizationID},
 	})
 	require.NoError(t, err)
 
@@ -1842,10 +1842,10 @@ func TestSuspendedPagination(t *testing.T) {
 		email := fmt.Sprintf("%d@coder.com", i)
 		username := fmt.Sprintf("user%d", i)
 		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          email,
-			Username:       username,
-			Password:       "MySecurePassword!",
-			OrganizationID: orgID,
+			Email:           email,
+			Username:        username,
+			Password:        "MySecurePassword!",
+			OrganizationIDs: []uuid.UUID{orgID},
 		})
 		require.NoError(t, err)
 		users = append(users, user)

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -1207,10 +1207,10 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			// since they have access to everything.
 			ownerClient = appDetails.SDKClient
 			user, err := ownerClient.CreateUser(ctx, codersdk.CreateUserRequest{
-				Email:          "user@coder.com",
-				Username:       "user",
-				Password:       password,
-				OrganizationID: appDetails.FirstUser.OrganizationID,
+				Email:           "user@coder.com",
+				Username:        "user",
+				Password:        password,
+				OrganizationIDs: []uuid.UUID{appDetails.FirstUser.OrganizationID},
 			})
 			require.NoError(t, err)
 
@@ -1259,10 +1259,10 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			})
 			require.NoError(t, err)
 			userInOtherOrg, err := ownerClient.CreateUser(ctx, codersdk.CreateUserRequest{
-				Email:          "no-template-access@coder.com",
-				Username:       "no-template-access",
-				Password:       password,
-				OrganizationID: otherOrg.ID,
+				Email:           "no-template-access@coder.com",
+				Username:        "no-template-access",
+				Password:        password,
+				OrganizationIDs: []uuid.UUID{otherOrg.ID},
 			})
 			require.NoError(t, err)
 

--- a/coderd/workspaceapps/apptest/apptest.go
+++ b/coderd/workspaceapps/apptest/apptest.go
@@ -1206,7 +1206,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 			// Create a template-admin user in the same org. We don't use an owner
 			// since they have access to everything.
 			ownerClient = appDetails.SDKClient
-			user, err := ownerClient.CreateUser(ctx, codersdk.CreateUserRequest{
+			user, err := ownerClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 				Email:           "user@coder.com",
 				Username:        "user",
 				Password:        password,
@@ -1258,7 +1258,7 @@ func Run(t *testing.T, appHostIsPrimary bool, factory DeploymentFactory) {
 				Name: "a-different-org",
 			})
 			require.NoError(t, err)
-			userInOtherOrg, err := ownerClient.CreateUser(ctx, codersdk.CreateUserRequest{
+			userInOtherOrg, err := ownerClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 				Email:           "no-template-access@coder.com",
 				Username:        "no-template-access",
 				Password:        password,

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -451,7 +451,7 @@ func TestWorkspacesSortOrder(t *testing.T) {
 
 	client, db := coderdtest.NewWithDatabase(t, nil)
 	firstUser := coderdtest.CreateFirstUser(t, client)
-	secondUserClient, secondUser := coderdtest.CreateAnotherUserMutators(t, client, firstUser.OrganizationID, []rbac.RoleIdentifier{rbac.RoleOwner()}, func(r *codersdk.CreateUserRequest) {
+	secondUserClient, secondUser := coderdtest.CreateAnotherUserMutators(t, client, firstUser.OrganizationID, []rbac.RoleIdentifier{rbac.RoleOwner()}, func(r *codersdk.CreateUserRequestWithOrgs) {
 		r.Username = "zzz"
 	})
 

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -113,6 +113,11 @@ type CreateFirstUserResponse struct {
 	OrganizationID uuid.UUID `json:"organization_id" format:"uuid"`
 }
 
+// CreateUserRequest
+// Deprecated: Use CreateUserRequestWithOrgs instead. This will be removed.
+// TODO: When removing, we should rename CreateUserRequestWithOrgs -> CreateUserRequest
+// Then alias CreateUserRequestWithOrgs to CreateUserRequest.
+// @typescript-ignore CreateUserRequest
 type CreateUserRequest struct {
 	Email    string `json:"email" validate:"required,email" format:"email"`
 	Username string `json:"username" validate:"required,username"`
@@ -123,7 +128,17 @@ type CreateUserRequest struct {
 	// DisableLogin sets the user's login type to 'none'. This prevents the user
 	// from being able to use a password or any other authentication method to login.
 	// Deprecated: Set UserLoginType=LoginTypeDisabled instead.
-	DisableLogin bool `json:"disable_login"`
+	DisableLogin   bool      `json:"disable_login"`
+	OrganizationID uuid.UUID `json:"organization_id" validate:"" format:"uuid"`
+}
+
+type CreateUserRequestWithOrgs struct {
+	Email    string `json:"email" validate:"required,email" format:"email"`
+	Username string `json:"username" validate:"required,username"`
+	Name     string `json:"name" validate:"user_real_name"`
+	Password string `json:"password"`
+	// UserLoginType defaults to LoginTypePassword.
+	UserLoginType LoginType `json:"login_type"`
 	// OrganizationIDs is a list of organization IDs that the user should be a member of.
 	OrganizationIDs []uuid.UUID `json:"organization_ids" validate:"" format:"uuid"`
 }
@@ -136,10 +151,10 @@ type CreateUserRequest struct {
 // TODO: Remove this method in it's entirety after some period of time.
 // This will be released in v1.16.0, and is associated with the multiple orgs
 // feature.
-func (r *CreateUserRequest) UnmarshalJSON(data []byte) error {
+func (r *CreateUserRequestWithOrgs) UnmarshalJSON(data []byte) error {
 	// By using a type alias, we prevent an infinite recursion when unmarshalling.
 	// This allows us to use the default unmarshal behavior of the original type.
-	type AliasedReq CreateUserRequest
+	type AliasedReq CreateUserRequestWithOrgs
 	type DeprecatedCreateUserRequest struct {
 		AliasedReq
 		OrganizationID *uuid.UUID `json:"organization_id" format:"uuid"`
@@ -149,7 +164,7 @@ func (r *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*r = CreateUserRequest(dep.AliasedReq)
+	*r = CreateUserRequestWithOrgs(dep.AliasedReq)
 	if dep.OrganizationID != nil {
 		r.OrganizationIDs = append(r.OrganizationIDs, *dep.OrganizationID)
 	}
@@ -317,8 +332,26 @@ func (c *Client) CreateFirstUser(ctx context.Context, req CreateFirstUserRequest
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-// CreateUser creates a new user.
+// CreateUser
+// Deprecated: Use CreateUserWithOrgs instead. This will be removed.
+// TODO: When removing, we should rename CreateUserWithOrgs -> CreateUser
+// with an alias of CreateUserWithOrgs.
 func (c *Client) CreateUser(ctx context.Context, req CreateUserRequest) (User, error) {
+	if req.DisableLogin {
+		req.UserLoginType = LoginTypeNone
+	}
+	return c.CreateUserWithOrgs(ctx, CreateUserRequestWithOrgs{
+		Email:           req.Email,
+		Username:        req.Username,
+		Name:            req.Name,
+		Password:        req.Password,
+		UserLoginType:   req.UserLoginType,
+		OrganizationIDs: []uuid.UUID{req.OrganizationID},
+	})
+}
+
+// CreateUserWithOrgs creates a new user.
+func (c *Client) CreateUserWithOrgs(ctx context.Context, req CreateUserRequestWithOrgs) (User, error) {
 	res, err := c.Request(ctx, http.MethodPost, "/api/v2/users", req)
 	if err != nil {
 		return User{}, err

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -133,6 +133,9 @@ type CreateUserRequest struct {
 // The previous field will just be appended to the slice.
 // Note in the previous behavior, omitting the field would result in the
 // default org being applied, but that is no longer the case.
+// TODO: Remove this method in it's entirety after some period of time.
+// This will be released in v1.16.0, and is associated with the multiple orgs
+// feature.
 func (r *CreateUserRequest) UnmarshalJSON(data []byte) error {
 	// By using a type alias, we prevent an infinite recursion when unmarshalling.
 	// This allows us to use the default unmarshal behavior of the original type.

--- a/codersdk/users_test.go
+++ b/codersdk/users_test.go
@@ -28,7 +28,7 @@ func TestDeprecatedCreateUserRequest(t *testing.T) {
    "login_type":"none"
 }
 `
-		var req codersdk.CreateUserRequest
+		var req codersdk.CreateUserRequestWithOrgs
 		err := json.Unmarshal([]byte(input), &req)
 		require.NoError(t, err)
 		require.Equal(t, req.Email, "alice@coder.com")
@@ -54,7 +54,7 @@ func TestDeprecatedCreateUserRequest(t *testing.T) {
    "login_type":"none"
 }
 `
-		var req codersdk.CreateUserRequest
+		var req codersdk.CreateUserRequestWithOrgs
 		err := json.Unmarshal([]byte(input), &req)
 		require.NoError(t, err)
 		require.Equal(t, req.Email, "alice@coder.com")
@@ -84,7 +84,7 @@ func TestDeprecatedCreateUserRequest(t *testing.T) {
    "login_type":"none"
 }
 `
-		var req codersdk.CreateUserRequest
+		var req codersdk.CreateUserRequestWithOrgs
 		err := json.Unmarshal([]byte(input), &req)
 		require.NoError(t, err)
 
@@ -95,11 +95,11 @@ func TestDeprecatedCreateUserRequest(t *testing.T) {
 func TestCreateUserRequestJSON(t *testing.T) {
 	t.Parallel()
 
-	marshalTest := func(t *testing.T, req codersdk.CreateUserRequest) {
+	marshalTest := func(t *testing.T, req codersdk.CreateUserRequestWithOrgs) {
 		t.Helper()
 		data, err := json.Marshal(req)
 		require.NoError(t, err)
-		var req2 codersdk.CreateUserRequest
+		var req2 codersdk.CreateUserRequestWithOrgs
 		err = json.Unmarshal(data, &req2)
 		require.NoError(t, err)
 		require.Equal(t, req, req2)
@@ -108,13 +108,12 @@ func TestCreateUserRequestJSON(t *testing.T) {
 	t.Run("MultipleOrganizations", func(t *testing.T) {
 		t.Parallel()
 
-		req := codersdk.CreateUserRequest{
+		req := codersdk.CreateUserRequestWithOrgs{
 			Email:           coderdtest.RandomName(t),
 			Username:        coderdtest.RandomName(t),
 			Name:            coderdtest.RandomName(t),
 			Password:        "",
 			UserLoginType:   codersdk.LoginTypePassword,
-			DisableLogin:    false,
 			OrganizationIDs: []uuid.UUID{uuid.New(), uuid.New()},
 		}
 		marshalTest(t, req)
@@ -123,13 +122,12 @@ func TestCreateUserRequestJSON(t *testing.T) {
 	t.Run("SingleOrganization", func(t *testing.T) {
 		t.Parallel()
 
-		req := codersdk.CreateUserRequest{
+		req := codersdk.CreateUserRequestWithOrgs{
 			Email:           coderdtest.RandomName(t),
 			Username:        coderdtest.RandomName(t),
 			Name:            coderdtest.RandomName(t),
 			Password:        "",
 			UserLoginType:   codersdk.LoginTypePassword,
-			DisableLogin:    false,
 			OrganizationIDs: []uuid.UUID{uuid.New()},
 		}
 		marshalTest(t, req)
@@ -138,13 +136,12 @@ func TestCreateUserRequestJSON(t *testing.T) {
 	t.Run("NoOrganization", func(t *testing.T) {
 		t.Parallel()
 
-		req := codersdk.CreateUserRequest{
+		req := codersdk.CreateUserRequestWithOrgs{
 			Email:           coderdtest.RandomName(t),
 			Username:        coderdtest.RandomName(t),
 			Name:            coderdtest.RandomName(t),
 			Password:        "",
 			UserLoginType:   codersdk.LoginTypePassword,
-			DisableLogin:    false,
 			OrganizationIDs: []uuid.UUID{},
 		}
 		marshalTest(t, req)

--- a/codersdk/users_test.go
+++ b/codersdk/users_test.go
@@ -1,0 +1,92 @@
+package codersdk_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestDeprecatedCreateUserRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DefaultOrganization", func(t *testing.T) {
+		t.Parallel()
+
+		input := `
+{
+   "email":"alice@coder.com",
+   "password":"hunter2",
+   "username":"alice",
+   "name":"alice",
+   "organization_id":"00000000-0000-0000-0000-000000000000",
+   "disable_login":false,
+   "login_type":"none"
+}
+`
+		var req codersdk.CreateUserRequest
+		err := json.Unmarshal([]byte(input), &req)
+		require.NoError(t, err)
+		require.Equal(t, req.Email, "alice@coder.com")
+		require.Equal(t, req.Password, "hunter2")
+		require.Equal(t, req.Username, "alice")
+		require.Equal(t, req.Name, "alice")
+		require.Equal(t, req.OrganizationIDs, []uuid.UUID{uuid.Nil})
+		require.Equal(t, req.UserLoginType, codersdk.LoginTypeNone)
+	})
+
+	t.Run("MultipleOrganizations", func(t *testing.T) {
+		t.Parallel()
+
+		input := `
+{
+   "email":"alice@coder.com",
+   "password":"hunter2",
+   "username":"alice",
+   "name":"alice",
+   "organization_id":"00000000-0000-0000-0000-000000000000",
+   "organization_ids":["a618cb03-99fb-4380-adb6-aa801629a4cf","8309b0dc-44ea-435d-a9ff-72cb302835e4"],
+   "disable_login":false,
+   "login_type":"none"
+}
+`
+		var req codersdk.CreateUserRequest
+		err := json.Unmarshal([]byte(input), &req)
+		require.NoError(t, err)
+		require.Equal(t, req.Email, "alice@coder.com")
+		require.Equal(t, req.Password, "hunter2")
+		require.Equal(t, req.Username, "alice")
+		require.Equal(t, req.Name, "alice")
+		require.ElementsMatch(t, req.OrganizationIDs,
+			[]uuid.UUID{
+				uuid.Nil,
+				uuid.MustParse("a618cb03-99fb-4380-adb6-aa801629a4cf"),
+				uuid.MustParse("8309b0dc-44ea-435d-a9ff-72cb302835e4"),
+			})
+
+		require.Equal(t, req.UserLoginType, codersdk.LoginTypeNone)
+	})
+
+	t.Run("OmittedOrganizations", func(t *testing.T) {
+		t.Parallel()
+
+		input := `
+{
+   "email":"alice@coder.com",
+   "password":"hunter2",
+   "username":"alice",
+   "name":"alice",
+   "disable_login":false,
+   "login_type":"none"
+}
+`
+		var req codersdk.CreateUserRequest
+		err := json.Unmarshal([]byte(input), &req)
+		require.NoError(t, err)
+
+		require.Empty(t, req.OrganizationIDs)
+	})
+}

--- a/codersdk/users_test.go
+++ b/codersdk/users_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -88,5 +89,64 @@ func TestDeprecatedCreateUserRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Empty(t, req.OrganizationIDs)
+	})
+}
+
+func TestCreateUserRequestJSON(t *testing.T) {
+	t.Parallel()
+
+	marshalTest := func(t *testing.T, req codersdk.CreateUserRequest) {
+		t.Helper()
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+		var req2 codersdk.CreateUserRequest
+		err = json.Unmarshal(data, &req2)
+		require.NoError(t, err)
+		require.Equal(t, req, req2)
+	}
+
+	t.Run("MultipleOrganizations", func(t *testing.T) {
+		t.Parallel()
+
+		req := codersdk.CreateUserRequest{
+			Email:           coderdtest.RandomName(t),
+			Username:        coderdtest.RandomName(t),
+			Name:            coderdtest.RandomName(t),
+			Password:        "",
+			UserLoginType:   codersdk.LoginTypePassword,
+			DisableLogin:    false,
+			OrganizationIDs: []uuid.UUID{uuid.New(), uuid.New()},
+		}
+		marshalTest(t, req)
+	})
+
+	t.Run("SingleOrganization", func(t *testing.T) {
+		t.Parallel()
+
+		req := codersdk.CreateUserRequest{
+			Email:           coderdtest.RandomName(t),
+			Username:        coderdtest.RandomName(t),
+			Name:            coderdtest.RandomName(t),
+			Password:        "",
+			UserLoginType:   codersdk.LoginTypePassword,
+			DisableLogin:    false,
+			OrganizationIDs: []uuid.UUID{uuid.New()},
+		}
+		marshalTest(t, req)
+	})
+
+	t.Run("NoOrganization", func(t *testing.T) {
+		t.Parallel()
+
+		req := codersdk.CreateUserRequest{
+			Email:           coderdtest.RandomName(t),
+			Username:        coderdtest.RandomName(t),
+			Name:            coderdtest.RandomName(t),
+			Password:        "",
+			UserLoginType:   codersdk.LoginTypePassword,
+			DisableLogin:    false,
+			OrganizationIDs: []uuid.UUID{},
+		}
+		marshalTest(t, req)
 	})
 }

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1292,7 +1292,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 	"email": "user@example.com",
 	"login_type": "",
 	"name": "string",
-	"organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+	"organization_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
 	"password": "string",
 	"username": "string"
 }
@@ -1300,15 +1300,15 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name              | Type                                     | Required | Restrictions | Description                                                                                                                                                                                                        |
-| ----------------- | ---------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disable_login`   | boolean                                  | false    |              | Disable login sets the user's login type to 'none'. This prevents the user from being able to use a password or any other authentication method to login. Deprecated: Set UserLoginType=LoginTypeDisabled instead. |
-| `email`           | string                                   | true     |              |                                                                                                                                                                                                                    |
-| `login_type`      | [codersdk.LoginType](#codersdklogintype) | false    |              | Login type defaults to LoginTypePassword.                                                                                                                                                                          |
-| `name`            | string                                   | false    |              |                                                                                                                                                                                                                    |
-| `organization_id` | string                                   | false    |              |                                                                                                                                                                                                                    |
-| `password`        | string                                   | false    |              |                                                                                                                                                                                                                    |
-| `username`        | string                                   | true     |              |                                                                                                                                                                                                                    |
+| Name               | Type                                     | Required | Restrictions | Description                                                                                                                                                                                                        |
+| ------------------ | ---------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `disable_login`    | boolean                                  | false    |              | Disable login sets the user's login type to 'none'. This prevents the user from being able to use a password or any other authentication method to login. Deprecated: Set UserLoginType=LoginTypeDisabled instead. |
+| `email`            | string                                   | true     |              |                                                                                                                                                                                                                    |
+| `login_type`       | [codersdk.LoginType](#codersdklogintype) | false    |              | Login type defaults to LoginTypePassword.                                                                                                                                                                          |
+| `name`             | string                                   | false    |              |                                                                                                                                                                                                                    |
+| `organization_ids` | array of string                          | false    |              | Organization ids is a list of organization IDs that the user should be a member of.                                                                                                                                |
+| `password`         | string                                   | false    |              |                                                                                                                                                                                                                    |
+| `username`         | string                                   | true     |              |                                                                                                                                                                                                                    |
 
 ## codersdk.CreateWorkspaceBuildRequest
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1284,11 +1284,10 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `scope`  | `all`                 |
 | `scope`  | `application_connect` |
 
-## codersdk.CreateUserRequest
+## codersdk.CreateUserRequestWithOrgs
 
 ```json
 {
-	"disable_login": true,
 	"email": "user@example.com",
 	"login_type": "",
 	"name": "string",
@@ -1300,15 +1299,14 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name               | Type                                     | Required | Restrictions | Description                                                                                                                                                                                                        |
-| ------------------ | ---------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disable_login`    | boolean                                  | false    |              | Disable login sets the user's login type to 'none'. This prevents the user from being able to use a password or any other authentication method to login. Deprecated: Set UserLoginType=LoginTypeDisabled instead. |
-| `email`            | string                                   | true     |              |                                                                                                                                                                                                                    |
-| `login_type`       | [codersdk.LoginType](#codersdklogintype) | false    |              | Login type defaults to LoginTypePassword.                                                                                                                                                                          |
-| `name`             | string                                   | false    |              |                                                                                                                                                                                                                    |
-| `organization_ids` | array of string                          | false    |              | Organization ids is a list of organization IDs that the user should be a member of.                                                                                                                                |
-| `password`         | string                                   | false    |              |                                                                                                                                                                                                                    |
-| `username`         | string                                   | true     |              |                                                                                                                                                                                                                    |
+| Name               | Type                                     | Required | Restrictions | Description                                                                         |
+| ------------------ | ---------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------- |
+| `email`            | string                                   | true     |              |                                                                                     |
+| `login_type`       | [codersdk.LoginType](#codersdklogintype) | false    |              | Login type defaults to LoginTypePassword.                                           |
+| `name`             | string                                   | false    |              |                                                                                     |
+| `organization_ids` | array of string                          | false    |              | Organization ids is a list of organization IDs that the user should be a member of. |
+| `password`         | string                                   | false    |              |                                                                                     |
+| `username`         | string                                   | true     |              |                                                                                     |
 
 ## codersdk.CreateWorkspaceBuildRequest
 

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -85,7 +85,7 @@ curl -X POST http://coder-server:8080/api/v2/users \
 	"email": "user@example.com",
 	"login_type": "",
 	"name": "string",
-	"organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+	"organization_ids": ["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
 	"password": "string",
 	"username": "string"
 }

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -81,7 +81,6 @@ curl -X POST http://coder-server:8080/api/v2/users \
 
 ```json
 {
-	"disable_login": true,
 	"email": "user@example.com",
 	"login_type": "",
 	"name": "string",
@@ -93,9 +92,9 @@ curl -X POST http://coder-server:8080/api/v2/users \
 
 ### Parameters
 
-| Name   | In   | Type                                                               | Required | Description         |
-| ------ | ---- | ------------------------------------------------------------------ | -------- | ------------------- |
-| `body` | body | [codersdk.CreateUserRequest](schemas.md#codersdkcreateuserrequest) | true     | Create user request |
+| Name   | In   | Type                                                                               | Required | Description         |
+| ------ | ---- | ---------------------------------------------------------------------------------- | -------- | ------------------- |
+| `body` | body | [codersdk.CreateUserRequestWithOrgs](schemas.md#codersdkcreateuserrequestwithorgs) | true     | Create user request |
 
 ### Example responses
 

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -757,7 +757,7 @@ func TestGroup(t *testing.T) {
 		require.Contains(t, group.Members, user2.ReducedUser)
 
 		// cannot explicitly set a dormant user status so must create a new user
-		anotherUser, err := userAdminClient.CreateUser(ctx, codersdk.CreateUserRequest{
+		anotherUser, err := userAdminClient.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "coder@coder.com",
 			Username:        "coder",
 			Password:        "SomeStrongPassword!",

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -758,10 +758,10 @@ func TestGroup(t *testing.T) {
 
 		// cannot explicitly set a dormant user status so must create a new user
 		anotherUser, err := userAdminClient.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "coder@coder.com",
-			Username:       "coder",
-			Password:       "SomeStrongPassword!",
-			OrganizationID: user.OrganizationID,
+			Email:           "coder@coder.com",
+			Username:        "coder",
+			Password:        "SomeStrongPassword!",
+			OrganizationIDs: []uuid.UUID{user.OrganizationID},
 		})
 		require.NoError(t, err)
 

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -234,9 +234,9 @@ func (api *API) scimPostUser(rw http.ResponseWriter, r *http.Request) {
 	//nolint:gocritic // needed for SCIM
 	dbUser, err = api.AGPL.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, agpl.CreateUserRequest{
 		CreateUserRequest: codersdk.CreateUserRequest{
-			Username:       sUser.UserName,
-			Email:          email,
-			OrganizationID: defaultOrganization.ID,
+			Username:        sUser.UserName,
+			Email:           email,
+			OrganizationIDs: []uuid.UUID{defaultOrganization.ID},
 		},
 		LoginType: database.LoginTypeOIDC,
 		// Do not send notifications to user admins as SCIM endpoint might be called sequentially to all users.

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -233,7 +233,7 @@ func (api *API) scimPostUser(rw http.ResponseWriter, r *http.Request) {
 
 	//nolint:gocritic // needed for SCIM
 	dbUser, err = api.AGPL.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, agpl.CreateUserRequest{
-		CreateUserRequest: codersdk.CreateUserRequest{
+		CreateUserRequestWithOrgs: codersdk.CreateUserRequestWithOrgs{
 			Username:        sUser.UserName,
 			Email:           email,
 			OrganizationIDs: []uuid.UUID{defaultOrganization.ID},

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -232,7 +232,7 @@ func (api *API) scimPostUser(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	//nolint:gocritic // needed for SCIM
-	dbUser, _, err = api.AGPL.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, agpl.CreateUserRequest{
+	dbUser, err = api.AGPL.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, agpl.CreateUserRequest{
 		CreateUserRequest: codersdk.CreateUserRequest{
 			Username:       sUser.UserName,
 			Email:          email,

--- a/enterprise/coderd/userauth_test.go
+++ b/enterprise/coderd/userauth_test.go
@@ -717,7 +717,7 @@ func TestEnterpriseUserLogin(t *testing.T) {
 				Name:           customRole.Name,
 				OrganizationID: owner.OrganizationID,
 			},
-		}, func(r *codersdk.CreateUserRequest) {
+		}, func(r *codersdk.CreateUserRequestWithOrgs) {
 			r.Password = "SomeSecurePassword!"
 			r.UserLoginType = codersdk.LoginTypePassword
 		})
@@ -752,7 +752,7 @@ func TestEnterpriseUserLogin(t *testing.T) {
 			},
 		})
 
-		anotherClient, anotherUser := coderdtest.CreateAnotherUserMutators(t, ownerClient, owner.OrganizationID, nil, func(r *codersdk.CreateUserRequest) {
+		anotherClient, anotherUser := coderdtest.CreateAnotherUserMutators(t, ownerClient, owner.OrganizationID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
 			r.Password = "SomeSecurePassword!"
 			r.UserLoginType = codersdk.LoginTypePassword
 		})

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -508,7 +508,7 @@ func TestEnterprisePostUser(t *testing.T) {
 			request.Name = "another"
 		})
 
-		_, err := notInOrg.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := notInOrg.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "some@domain.com",
 			Username:        "anotheruser",
 			Password:        "SomeSecurePassword!",
@@ -542,7 +542,7 @@ func TestEnterprisePostUser(t *testing.T) {
 
 		org := coderdenttest.CreateOrganization(t, other, coderdenttest.CreateOrganizationOptions{})
 
-		_, err := notInOrg.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := notInOrg.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:           "some@domain.com",
 			Username:        "anotheruser",
 			Password:        "SomeSecurePassword!",
@@ -577,7 +577,7 @@ func TestEnterprisePostUser(t *testing.T) {
 
 		// nolint:gocritic // intentional using the owner.
 		// Manually making a user with the request instead of the coderdtest util
-		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:    "another@user.org",
 			Username: "someone-else",
 			Password: "SomeSecurePassword!",
@@ -610,7 +610,7 @@ func TestEnterprisePostUser(t *testing.T) {
 
 		// nolint:gocritic // intentional using the owner.
 		// Manually making a user with the request instead of the coderdtest util
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			Email:    "another@user.org",
 			Username: "someone-else",
 			Password: "SomeSecurePassword!",

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -510,10 +509,10 @@ func TestEnterprisePostUser(t *testing.T) {
 		})
 
 		_, err := notInOrg.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "some@domain.com",
-			Username:       "anotheruser",
-			Password:       "SomeSecurePassword!",
-			OrganizationID: org.ID,
+			Email:           "some@domain.com",
+			Username:        "anotheruser",
+			Password:        "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{org.ID},
 		})
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
@@ -544,10 +543,10 @@ func TestEnterprisePostUser(t *testing.T) {
 		org := coderdenttest.CreateOrganization(t, other, coderdenttest.CreateOrganizationOptions{})
 
 		_, err := notInOrg.CreateUser(ctx, codersdk.CreateUserRequest{
-			Email:          "some@domain.com",
-			Username:       "anotheruser",
-			Password:       "SomeSecurePassword!",
-			OrganizationID: org.ID,
+			Email:           "some@domain.com",
+			Username:        "anotheruser",
+			Password:        "SomeSecurePassword!",
+			OrganizationIDs: []uuid.UUID{org.ID},
 		})
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
@@ -559,7 +558,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		dv := coderdtest.DeploymentValues(t)
 		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
 
-		client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+		client, _ := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				DeploymentValues: dv,
 			},
@@ -578,14 +577,11 @@ func TestEnterprisePostUser(t *testing.T) {
 
 		// nolint:gocritic // intentional using the owner.
 		// Manually making a user with the request instead of the coderdtest util
-		user, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
+		_, err := client.CreateUser(ctx, codersdk.CreateUserRequest{
 			Email:    "another@user.org",
 			Username: "someone-else",
 			Password: "SomeSecurePassword!",
 		})
-		require.NoError(t, err)
-
-		require.Len(t, user.OrganizationIDs, 1)
-		assert.Equal(t, firstUser.OrganizationID, user.OrganizationIDs[0])
+		require.ErrorContains(t, err, "No organization specified")
 	})
 }

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -72,7 +72,7 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 
 		_, _ = fmt.Fprintln(logs, "Creating user:")
 
-		user, err = r.client.CreateUser(ctx, codersdk.CreateUserRequest{
+		user, err = r.client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{r.cfg.User.OrganizationID},
 			Username:        r.cfg.User.Username,
 			Email:           r.cfg.User.Email,

--- a/scaletest/createworkspaces/run.go
+++ b/scaletest/createworkspaces/run.go
@@ -73,10 +73,10 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 		_, _ = fmt.Fprintln(logs, "Creating user:")
 
 		user, err = r.client.CreateUser(ctx, codersdk.CreateUserRequest{
-			OrganizationID: r.cfg.User.OrganizationID,
-			Username:       r.cfg.User.Username,
-			Email:          r.cfg.User.Email,
-			Password:       password,
+			OrganizationIDs: []uuid.UUID{r.cfg.User.OrganizationID},
+			Username:        r.cfg.User.Username,
+			Email:           r.cfg.User.Email,
+			Password:        password,
 		})
 		if err != nil {
 			return xerrors.Errorf("create user: %w", err)

--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -36,7 +36,6 @@ export const createUser = async (orgId: string) => {
 		name: name,
 		password: "s3cure&password!",
 		login_type: "password",
-		disable_login: false,
 		organization_ids: [orgId],
 	});
 	return user;

--- a/site/e2e/api.ts
+++ b/site/e2e/api.ts
@@ -37,7 +37,7 @@ export const createUser = async (orgId: string) => {
 		password: "s3cure&password!",
 		login_type: "password",
 		disable_login: false,
-		organization_id: orgId,
+		organization_ids: [orgId],
 	});
 	return user;
 };

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1130,7 +1130,7 @@ class ApiMethods {
 	};
 
 	createUser = async (
-		user: TypesGen.CreateUserRequest,
+		user: TypesGen.CreateUserRequestWithOrgs,
 	): Promise<TypesGen.User> => {
 		const response = await this.axios.post<TypesGen.User>(
 			"/api/v2/users",

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -303,13 +303,12 @@ export interface CreateTokenRequest {
 }
 
 // From codersdk/users.go
-export interface CreateUserRequest {
+export interface CreateUserRequestWithOrgs {
 	readonly email: string;
 	readonly username: string;
 	readonly name: string;
 	readonly password: string;
 	readonly login_type: LoginType;
-	readonly disable_login: boolean;
 	readonly organization_ids: Readonly<Array<string>>;
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -310,7 +310,7 @@ export interface CreateUserRequest {
 	readonly password: string;
 	readonly login_type: LoginType;
 	readonly disable_login: boolean;
-	readonly organization_id: string;
+	readonly organization_ids: Readonly<Array<string>>;
 }
 
 // From codersdk/workspaces.go

--- a/site/src/pages/CreateUserPage/CreateUserForm.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.tsx
@@ -93,7 +93,7 @@ export const CreateUserForm: FC<
 				password: "",
 				username: "",
 				name: "",
-				organization_id: "00000000-0000-0000-0000-000000000000",
+				organization_ids: ["00000000-0000-0000-0000-000000000000"],
 				disable_login: false,
 				login_type: "",
 			},

--- a/site/src/pages/CreateUserPage/CreateUserForm.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.tsx
@@ -61,7 +61,7 @@ export const authMethodLanguage = {
 };
 
 export interface CreateUserFormProps {
-	onSubmit: (user: TypesGen.CreateUserRequest) => void;
+	onSubmit: (user: TypesGen.CreateUserRequestWithOrgs) => void;
 	onCancel: () => void;
 	error?: unknown;
 	isLoading: boolean;
@@ -86,21 +86,20 @@ const validationSchema = Yup.object({
 export const CreateUserForm: FC<
 	React.PropsWithChildren<CreateUserFormProps>
 > = ({ onSubmit, onCancel, error, isLoading, authMethods }) => {
-	const form: FormikContextType<TypesGen.CreateUserRequest> =
-		useFormik<TypesGen.CreateUserRequest>({
+	const form: FormikContextType<TypesGen.CreateUserRequestWithOrgs> =
+		useFormik<TypesGen.CreateUserRequestWithOrgs>({
 			initialValues: {
 				email: "",
 				password: "",
 				username: "",
 				name: "",
 				organization_ids: ["00000000-0000-0000-0000-000000000000"],
-				disable_login: false,
 				login_type: "",
 			},
 			validationSchema,
 			onSubmit,
 		});
-	const getFieldHelpers = getFormHelpers<TypesGen.CreateUserRequest>(
+	const getFieldHelpers = getFormHelpers<TypesGen.CreateUserRequestWithOrgs>(
 		form,
 		error,
 	);


### PR DESCRIPTION
In a multi-org deployment, it makes more sense to allow for multiple
org memberships to be assigned at create. The legacy param will still
be honored via the api.

This is to prepare for organization sync, a feature that requires creating a user with multiple orgs. Organization sync also introduces the possibility of a user having 0 orgs.

# Breaking change



~~`codersdk.CreateUserRequest` no longer accepts the field `OrganizationID` in Go. There is no way to make this backwards compatible in Go, because the previous value would assume `no value == default org`. This would have to be changed to a `*uuid.UUID` to detect the zero value vs not setting it. Which would also be a breaking change.~~

Just made a new cli function and type. We should delete the deprecated methods in the future.

From an API POV (eg typescript), this is backwards compatible via the custom UnmarshalJSON function: https://github.com/coder/coder/blob/758751e119cedd5651c652d4722fcce6da6f9c0e/codersdk/users.go#L139-L139