### PR TITLE
fix(coderd/database/dbmem): include a technical summary row on over-pagination

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -10030,7 +10030,7 @@ func (q *FakeQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg database.
 
 	if arg.Offset > 0 {
 		if int(arg.Offset) > len(workspaces) {
-			return []database.GetWorkspacesRow{}, nil
+			return q.convertToWorkspaceRowsNoLock(ctx, []database.Workspace{}, int64(beforePageCount), arg.WithSummary), nil
 		}
 		workspaces = workspaces[arg.Offset:]
 	}


### PR DESCRIPTION
Fixes an error when over-paginating with dbmem:

```
GET  http://localhost:41311/api/v2/workspaces?limit=100&offset=100&q=name%3A%22scaletest-%22+template%3A%22friendly-goldwasser8-gOF%22: unexpected status code 500: Internal error fetching workspaces.
Error: Workspace summary row is missing.
```