### PR TITLE
fix(cli): add check for DisableOwnerWorkspaceExec in scaletest

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -863,7 +863,7 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *serpent.Command {
 		tickInterval     time.Duration
 		bytesPerTick     int64
 		ssh              bool
-		useHostUser      bool
+		useHostLogin     bool
 		app              string
 		template         string
 		targetWorkspaces string
@@ -928,7 +928,7 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *serpent.Command {
 			}
 
 			var owner string
-			if useHostUser {
+			if useHostLogin {
 				owner = codersdk.Me
 			}
 
@@ -1106,7 +1106,7 @@ func (r *RootCmd) scaletestWorkspaceTraffic() *serpent.Command {
 			Env:         "CODER_SCALETEST_USE_HOST_LOGIN",
 			Default:     "false",
 			Description: "Connect as the currently logged in user.",
-			Value:       serpent.BoolOf(&useHostUser),
+			Value:       serpent.BoolOf(&useHostLogin),
 		},
 	}
 

--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -114,6 +116,59 @@ func TestScaleTestWorkspaceTraffic_Template(t *testing.T) {
 
 	err := inv.WithContext(ctx).Run()
 	require.ErrorContains(t, err, "could not find template \"doesnotexist\" in any organization")
+}
+
+// This test validates that the scaletest CLI filters out workspaces not owned
+// when disable owner workspace access is set.
+// nolint:paralleltest // DisableOwnerWorkspaceExec is not safe for parallel tests.
+func TestScaleTestWorkspaceTraffic_UseHostLogin(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancelFunc()
+
+	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	client := coderdtest.New(t, &coderdtest.Options{
+		Logger:                   &log,
+		IncludeProvisionerDaemon: true,
+		DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+			dv.DisableOwnerWorkspaceExec = true
+		}),
+	})
+	owner := coderdtest.CreateFirstUser(t, client)
+	tv := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, tv.ID)
+	tpl := coderdtest.CreateTemplate(t, client, owner.OrganizationID, tv.ID)
+	// Create a workspace owned by a different user
+	memberClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	_ = coderdtest.CreateWorkspace(t, memberClient, tpl.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+		cwr.Name = "scaletest-workspace"
+	})
+
+	// Test without --use-host-login first.
+	inv, root := clitest.New(t, "exp", "scaletest", "workspace-traffic",
+		"--template", tpl.Name,
+	)
+	// nolint:gocritic // We are intentionally testing this as the owner.
+	clitest.SetupConfig(t, client, root)
+	var stdoutBuf bytes.Buffer
+	inv.Stdout = &stdoutBuf
+
+	err := inv.WithContext(ctx).Run()
+	require.ErrorContains(t, err, "no scaletest workspaces exist")
+	require.Contains(t, stdoutBuf.String(), `1 workspace(s) were skipped`)
+
+	// Test once again with --use-host-login.
+	inv, root = clitest.New(t, "exp", "scaletest", "workspace-traffic",
+		"--template", tpl.Name,
+		"--use-host-login",
+	)
+	// nolint:gocritic // We are intentionally testing this as the owner.
+	clitest.SetupConfig(t, client, root)
+	stdoutBuf.Reset()
+	inv.Stdout = &stdoutBuf
+
+	err = inv.WithContext(ctx).Run()
+	require.ErrorContains(t, err, "no scaletest workspaces exist")
+	require.NotContains(t, stdoutBuf.String(), `1 workspace(s) were skipped`)
 }
 
 // This test just validates that the CLI command accepts its known arguments.

--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"bytes"
 	"context"
 	"path/filepath"
 	"testing"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -116,59 +114,6 @@ func TestScaleTestWorkspaceTraffic_Template(t *testing.T) {
 
 	err := inv.WithContext(ctx).Run()
 	require.ErrorContains(t, err, "could not find template \"doesnotexist\" in any organization")
-}
-
-// This test validates that the scaletest CLI filters out workspaces not owned
-// when disable owner workspace access is set.
-// nolint:paralleltest // DisableOwnerWorkspaceExec is not safe for parallel tests.
-func TestScaleTestWorkspaceTraffic_UseHostLogin(t *testing.T) {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
-	defer cancelFunc()
-
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	client := coderdtest.New(t, &coderdtest.Options{
-		Logger:                   &log,
-		IncludeProvisionerDaemon: true,
-		DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
-			dv.DisableOwnerWorkspaceExec = true
-		}),
-	})
-	owner := coderdtest.CreateFirstUser(t, client)
-	tv := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
-	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, tv.ID)
-	tpl := coderdtest.CreateTemplate(t, client, owner.OrganizationID, tv.ID)
-	// Create a workspace owned by a different user
-	memberClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
-	_ = coderdtest.CreateWorkspace(t, memberClient, tpl.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
-		cwr.Name = "scaletest-workspace"
-	})
-
-	// Test without --use-host-login first.
-	inv, root := clitest.New(t, "exp", "scaletest", "workspace-traffic",
-		"--template", tpl.Name,
-	)
-	// nolint:gocritic // We are intentionally testing this as the owner.
-	clitest.SetupConfig(t, client, root)
-	var stdoutBuf bytes.Buffer
-	inv.Stdout = &stdoutBuf
-
-	err := inv.WithContext(ctx).Run()
-	require.ErrorContains(t, err, "no scaletest workspaces exist")
-	require.Contains(t, stdoutBuf.String(), `1 workspace(s) were skipped`)
-
-	// Test once again with --use-host-login.
-	inv, root = clitest.New(t, "exp", "scaletest", "workspace-traffic",
-		"--template", tpl.Name,
-		"--use-host-login",
-	)
-	// nolint:gocritic // We are intentionally testing this as the owner.
-	clitest.SetupConfig(t, client, root)
-	stdoutBuf.Reset()
-	inv.Stdout = &stdoutBuf
-
-	err = inv.WithContext(ctx).Run()
-	require.ErrorContains(t, err, "no scaletest workspaces exist")
-	require.NotContains(t, stdoutBuf.String(), `1 workspace(s) were skipped`)
 }
 
 // This test just validates that the CLI command accepts its known arguments.

--- a/cli/exptest/exptest_scaletest_test.go
+++ b/cli/exptest/exptest_scaletest_test.go
@@ -1,0 +1,70 @@
+package exptest_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// This test validates that the scaletest CLI filters out workspaces not owned
+// when disable owner workspace access is set.
+// This test is in its own package because it mutates a global variable that
+// can influence other tests in the same package.
+// nolint:paralleltest
+func TestScaleTestWorkspaceTraffic_UseHostLogin(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancelFunc()
+
+	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	client := coderdtest.New(t, &coderdtest.Options{
+		Logger:                   &log,
+		IncludeProvisionerDaemon: true,
+		DeploymentValues: coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
+			dv.DisableOwnerWorkspaceExec = true
+		}),
+	})
+	owner := coderdtest.CreateFirstUser(t, client)
+	tv := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+	_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, tv.ID)
+	tpl := coderdtest.CreateTemplate(t, client, owner.OrganizationID, tv.ID)
+	// Create a workspace owned by a different user
+	memberClient, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
+	_ = coderdtest.CreateWorkspace(t, memberClient, tpl.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+		cwr.Name = "scaletest-workspace"
+	})
+
+	// Test without --use-host-login first.g
+	inv, root := clitest.New(t, "exp", "scaletest", "workspace-traffic",
+		"--template", tpl.Name,
+	)
+	// nolint:gocritic // We are intentionally testing this as the owner.
+	clitest.SetupConfig(t, client, root)
+	var stdoutBuf bytes.Buffer
+	inv.Stdout = &stdoutBuf
+
+	err := inv.WithContext(ctx).Run()
+	require.ErrorContains(t, err, "no scaletest workspaces exist")
+	require.Contains(t, stdoutBuf.String(), `1 workspace(s) were skipped`)
+
+	// Test once again with --use-host-login.
+	inv, root = clitest.New(t, "exp", "scaletest", "workspace-traffic",
+		"--template", tpl.Name,
+		"--use-host-login",
+	)
+	// nolint:gocritic // We are intentionally testing this as the owner.
+	clitest.SetupConfig(t, client, root)
+	stdoutBuf.Reset()
+	inv.Stdout = &stdoutBuf
+
+	err = inv.WithContext(ctx).Run()
+	require.ErrorContains(t, err, "no scaletest workspaces exist")
+	require.NotContains(t, stdoutBuf.String(), `1 workspace(s) were skipped`)
+}

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -277,7 +277,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		}
 		if err := options.Authorizer.Authorize(context.Background(), ownerSubj, policy.ActionSSH, rbac.ResourceWorkspace); err != nil {
 			if rbac.IsUnauthorizedError(err) {
-				t.Fatal("DisableOwnerWorkspaceExec was set in some other test. Please move this test to its own package so that it does not impact other tests!")
+				t.Fatal("Side-effect of DisableOwnerWorkspaceExec detected in unrelated test. Please move the test that requires DisableOwnerWorkspaceExec to its own package so that it does not impact other tests!")
 			}
 			require.NoError(t, err)
 		}

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -66,6 +66,7 @@ import (
 	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/unhanger"
@@ -268,9 +269,18 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	if options.DeploymentValues == nil {
 		options.DeploymentValues = DeploymentValues(t)
 	}
-	// This value is not safe to run in parallel.
-	if options.DeploymentValues.DisableOwnerWorkspaceExec {
-		t.Logf("WARNING: DisableOwnerWorkspaceExec is set, this is not safe in parallel tests!")
+	// DisableOwnerWorkspaceExec modifies the 'global' RBAC roles. Fast-fail tests if we detect this.
+	if !options.DeploymentValues.DisableOwnerWorkspaceExec.Value() {
+		ownerSubj := rbac.Subject{
+			Roles: rbac.RoleIdentifiers{rbac.RoleOwner()},
+			Scope: rbac.ScopeAll,
+		}
+		if err := options.Authorizer.Authorize(context.Background(), ownerSubj, policy.ActionSSH, rbac.ResourceWorkspace); err != nil {
+			if rbac.IsUnauthorizedError(err) {
+				t.Fatal("DisableOwnerWorkspaceExec was set in some other test. Please move this test to its own package so that it does not impact other tests!")
+			}
+			require.NoError(t, err)
+		}
 	}
 
 	// If no ratelimits are set, disable all rate limiting for tests.


### PR DESCRIPTION
- Adds `--use-host-login` to `coder exp scaletest workspace-traffic`
- Modifies `getScaletestWorkspaces` to conditionally filter workspaces if `CODER_DISABLE_OWNER_WORKSPACE_ACCESS` is set
- Adds a warning if `CODER_DISABLE_OWNER_WORKSPACE_ACCESS` is set and scaletest workspaces are filtered out due to ownership mismatch.
- Modifies `coderdtest.New` to detect cross-test bleed of `CODER_DISABLE_OWNER_WORKSPACE_ACCESS` and fast-fail.