### PR TITLE
feat(testutil): add testutil.IsParallel()

### DIFF
--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -269,8 +269,8 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		options.DeploymentValues = DeploymentValues(t)
 	}
 	// This value is not safe to run in parallel.
-	if options.DeploymentValues.DisableOwnerWorkspaceExec {
-		t.Logf("WARNING: DisableOwnerWorkspaceExec is set, this is not safe in parallel tests!")
+	if options.DeploymentValues.DisableOwnerWorkspaceExec.Value() && testutil.IsParallel(t) {
+		t.Fatal("DisableOwnerWorkspaceExec is set, this is not safe in parallel tests!")
 	}
 
 	// If no ratelimits are set, disable all rate limiting for tests.

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -270,7 +270,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	}
 	// This value is not safe to run in parallel.
 	if options.DeploymentValues.DisableOwnerWorkspaceExec.Value() && testutil.IsParallel(t) {
-		t.Fatal("DisableOwnerWorkspaceExec is set, this is not safe in parallel tests!")
+		t.Logf("WARNING: DisableOwnerWorkspaceExec is set, this is not safe in parallel tests!")
 	}
 
 	// If no ratelimits are set, disable all rate limiting for tests.

--- a/testutil/parallel.go
+++ b/testutil/parallel.go
@@ -1,0 +1,17 @@
+package testutil
+
+import "testing"
+
+// IsParallel determines whether the current test is running with parallel set.
+// The Go standard library does not currently expose this. However, we can easily
+// determine this using the fact that a call to t.Setenv() after t.Parallel() will panic.
+func IsParallel(t testing.TB) (parallel bool) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			parallel = true
+		}
+	}()
+	t.Setenv(t.Name()+"_PARALLEL", "")
+	return parallel
+}

--- a/testutil/parallel_test.go
+++ b/testutil/parallel_test.go
@@ -1,0 +1,19 @@
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/testutil"
+)
+
+// nolint:paralleltest // this is the whole point
+func Test_IsParallel_False(t *testing.T) {
+	require.False(t, testutil.IsParallel(t))
+}
+
+func Test_IsParallel_True(t *testing.T) {
+	t.Parallel()
+	require.True(t, testutil.IsParallel(t))
+}


### PR DESCRIPTION
Follow-up from https://github.com/coder/coder/pull/14414
Adds a test helper to detect if the current test is running in parallel.
Adds this to `coderdtest.New` where we were previously silently mutating DeploymentValues.