### PR TITLE
fix: increase group name limit to 36 from 32

### DIFF
--- a/coderd/httpapi/httpapi.go
+++ b/coderd/httpapi/httpapi.go
@@ -46,7 +46,7 @@ func init() {
 		valid := NameValid(str)
 		return valid == nil
 	}
-	for _, tag := range []string{"username", "organization_name", "template_name", "group_name", "workspace_name", "oauth2_app_name"} {
+	for _, tag := range []string{"username", "organization_name", "template_name", "workspace_name", "oauth2_app_name"} {
 		err := Validate.RegisterValidation(tag, nameValidator)
 		if err != nil {
 			panic(err)
@@ -93,6 +93,20 @@ func init() {
 		return valid == nil
 	}
 	err = Validate.RegisterValidation("user_real_name", userRealNameValidator)
+	if err != nil {
+		panic(err)
+	}
+
+	groupNameValidator := func(fl validator.FieldLevel) bool {
+		f := fl.Field().Interface()
+		str, ok := f.(string)
+		if !ok {
+			return false
+		}
+		valid := GroupNameValid(str)
+		return valid == nil
+	}
+	err = Validate.RegisterValidation("group_name", groupNameValidator)
 	if err != nil {
 		panic(err)
 	}

--- a/coderd/httpapi/name.go
+++ b/coderd/httpapi/name.go
@@ -96,6 +96,23 @@ func UserRealNameValid(str string) error {
 	return nil
 }
 
+// GroupNameValid returns whether the input string is a valid group name.
+func GroupNameValid(str string) error {
+	// 36 is to support using UUIDs as the group name.
+	if len(str) > 36 {
+		return xerrors.New("must be <= 36 characters")
+	}
+	// Avoid conflicts with routes like /groups/new and /groups/create.
+	if str == "new" || str == "create" {
+		return xerrors.Errorf("cannot use %q as a name", str)
+	}
+	matched := UsernameValidRegex.MatchString(str)
+	if !matched {
+		return xerrors.New("must be alphanumeric with hyphens")
+	}
+	return nil
+}
+
 // NormalizeUserRealName normalizes a user name such that it will pass
 // validation by UserRealNameValid. This is done to avoid blocking
 // little  Bobby  Whitespace  from using Coder.

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -159,7 +159,7 @@ func TestPatchGroup(t *testing.T) {
 		const displayName = "foobar"
 		ctx := testutil.Context(t, testutil.WaitLong)
 		group, err := userAdminClient.CreateGroup(ctx, user.OrganizationID, codersdk.CreateGroupRequest{
-			Name:           "hi",
+			Name:           "ff7dcee2-e7c4-4bc4-a9e4-84870770e4c5", // GUID should fit.
 			AvatarURL:      "https://example.com",
 			QuotaAllowance: 10,
 			DisplayName:    "",
@@ -168,14 +168,14 @@ func TestPatchGroup(t *testing.T) {
 		require.Equal(t, 10, group.QuotaAllowance)
 
 		group, err = userAdminClient.PatchGroup(ctx, group.ID, codersdk.PatchGroupRequest{
-			Name:           "bye",
+			Name:           "ddd502d2-2984-4724-b5bf-1109a4d7462d", // GUID should fit.
 			AvatarURL:      ptr.Ref("https://google.com"),
 			QuotaAllowance: ptr.Ref(20),
 			DisplayName:    ptr.Ref(displayName),
 		})
 		require.NoError(t, err)
 		require.Equal(t, displayName, group.DisplayName)
-		require.Equal(t, "bye", group.Name)
+		require.Equal(t, "ddd502d2-2984-4724-b5bf-1109a4d7462d", group.Name)
 		require.Equal(t, "https://google.com", group.AvatarURL)
 		require.Equal(t, 20, group.QuotaAllowance)
 	})


### PR DESCRIPTION
We had a breaking change when we added the name validation to the group name: https://github.com/coder/coder/issues/14408#issuecomment-2309557464

I think it does make sense to have *some* limit, so for now I went for 36 to allow for a GUID.

Might make sense to increase all the limits one day, but I know there is some concern about URL length.