### PR TITLE
chore: add provisioner api version to /buildinfo

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9013,6 +9013,10 @@ const docTemplate = `{
                     "description": "ExternalURL references the current Coder version.\nFor production builds, this will link directly to a release. For development builds, this will link to a commit.",
                     "type": "string"
                 },
+                "provisioner_api_version": {
+                    "description": "ProvisionerAPIVersion is the current version of the Provisioner API",
+                    "type": "string"
+                },
                 "telemetry": {
                     "description": "Telemetry is a boolean that indicates whether telemetry is enabled.",
                     "type": "boolean"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8016,6 +8016,10 @@
 					"description": "ExternalURL references the current Coder version.\nFor production builds, this will link directly to a release. For development builds, this will link to a commit.",
 					"type": "string"
 				},
+				"provisioner_api_version": {
+					"description": "ProvisionerAPIVersion is the current version of the Provisioner API",
+					"type": "string"
+				},
 				"telemetry": {
 					"description": "Telemetry is a boolean that indicates whether telemetry is enabled.",
 					"type": "boolean"

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -489,14 +489,15 @@ func New(options *Options) *API {
 	api.AppearanceFetcher.Store(&f)
 	api.PortSharer.Store(&portsharing.DefaultPortSharer)
 	buildInfo := codersdk.BuildInfoResponse{
-		ExternalURL:     buildinfo.ExternalURL(),
-		Version:         buildinfo.Version(),
-		AgentAPIVersion: AgentAPIVersionREST,
-		DashboardURL:    api.AccessURL.String(),
-		WorkspaceProxy:  false,
-		UpgradeMessage:  api.DeploymentValues.CLIUpgradeMessage.String(),
-		DeploymentID:    api.DeploymentID,
-		Telemetry:       api.Telemetry.Enabled(),
+		ExternalURL:           buildinfo.ExternalURL(),
+		Version:               buildinfo.Version(),
+		AgentAPIVersion:       AgentAPIVersionREST,
+		ProvisionerAPIVersion: proto.CurrentVersion.String(),
+		DashboardURL:          api.AccessURL.String(),
+		WorkspaceProxy:        false,
+		UpgradeMessage:        api.DeploymentValues.CLIUpgradeMessage.String(),
+		DeploymentID:          api.DeploymentID,
+		Telemetry:             api.Telemetry.Enabled(),
 	}
 	api.SiteHandler = site.New(&site.Options{
 		BinFS:             binFS,

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -2754,6 +2754,8 @@ type BuildInfoResponse struct {
 	// AgentAPIVersion is the current version of the Agent API (back versions
 	// MAY still be supported).
 	AgentAPIVersion string `json:"agent_api_version"`
+	// ProvisionerAPIVersion is the current version of the Provisioner API
+	ProvisionerAPIVersion string `json:"provisioner_api_version"`
 
 	// UpgradeMessage is the message displayed to users when an outdated client
 	// is detected.

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -57,6 +57,7 @@ curl -X GET http://coder-server:8080/api/v2/buildinfo \
 	"dashboard_url": "string",
 	"deployment_id": "string",
 	"external_url": "string",
+	"provisioner_api_version": "string",
 	"telemetry": true,
 	"upgrade_message": "string",
 	"version": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -888,6 +888,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 	"dashboard_url": "string",
 	"deployment_id": "string",
 	"external_url": "string",
+	"provisioner_api_version": "string",
 	"telemetry": true,
 	"upgrade_message": "string",
 	"version": "string",
@@ -897,16 +898,17 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name                | Type    | Required | Restrictions | Description                                                                                                                                                         |
-| ------------------- | ------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent_api_version` | string  | false    |              | Agent api version is the current version of the Agent API (back versions MAY still be supported).                                                                   |
-| `dashboard_url`     | string  | false    |              | Dashboard URL is the URL to hit the deployment's dashboard. For external workspace proxies, this is the coderd they are connected to.                               |
-| `deployment_id`     | string  | false    |              | Deployment ID is the unique identifier for this deployment.                                                                                                         |
-| `external_url`      | string  | false    |              | External URL references the current Coder version. For production builds, this will link directly to a release. For development builds, this will link to a commit. |
-| `telemetry`         | boolean | false    |              | Telemetry is a boolean that indicates whether telemetry is enabled.                                                                                                 |
-| `upgrade_message`   | string  | false    |              | Upgrade message is the message displayed to users when an outdated client is detected.                                                                              |
-| `version`           | string  | false    |              | Version returns the semantic version of the build.                                                                                                                  |
-| `workspace_proxy`   | boolean | false    |              |                                                                                                                                                                     |
+| Name                      | Type    | Required | Restrictions | Description                                                                                                                                                         |
+| ------------------------- | ------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_api_version`       | string  | false    |              | Agent api version is the current version of the Agent API (back versions MAY still be supported).                                                                   |
+| `dashboard_url`           | string  | false    |              | Dashboard URL is the URL to hit the deployment's dashboard. For external workspace proxies, this is the coderd they are connected to.                               |
+| `deployment_id`           | string  | false    |              | Deployment ID is the unique identifier for this deployment.                                                                                                         |
+| `external_url`            | string  | false    |              | External URL references the current Coder version. For production builds, this will link directly to a release. For development builds, this will link to a commit. |
+| `provisioner_api_version` | string  | false    |              | Provisioner api version is the current version of the Provisioner API                                                                                               |
+| `telemetry`               | boolean | false    |              | Telemetry is a boolean that indicates whether telemetry is enabled.                                                                                                 |
+| `upgrade_message`         | string  | false    |              | Upgrade message is the message displayed to users when an outdated client is detected.                                                                              |
+| `version`                 | string  | false    |              | Version returns the semantic version of the build.                                                                                                                  |
+| `workspace_proxy`         | boolean | false    |              |                                                                                                                                                                     |
 
 ## codersdk.BuildReason
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -172,6 +172,7 @@ export interface BuildInfoResponse {
 	readonly telemetry: boolean;
 	readonly workspace_proxy: boolean;
 	readonly agent_api_version: string;
+	readonly provisioner_api_version: string;
 	readonly upgrade_message: string;
 	readonly deployment_id: string;
 }

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -215,6 +215,7 @@ export const MockProxyLatencies: Record<string, ProxyLatencyReport> = {
 
 export const MockBuildInfo: TypesGen.BuildInfoResponse = {
 	agent_api_version: "1.0",
+	provisioner_api_version: "1.1",
 	external_url: "file:///mock-url",
 	version: "v99.999.9999+c9cdf14",
 	dashboard_url: "https:///mock-url",


### PR DESCRIPTION
This'll be helpful for a feature on the provisioners page that we want to start work on soon