### PR TITLE
chore: remove dogfood import block

### DIFF
--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -9,11 +9,6 @@ terraform {
   }
 }
 
-import {
-  to = coderd_template.dogfood
-  id = "0d286645-29aa-4eaf-9b52-cc5d2740c90b"
-}
-
 data "coderd_organization" "default" {
   is_default = true
 }


### PR DESCRIPTION
The import block is only used when the resource doesn't exist in the state, so this can be safely removed.