### PR TITLE
feat(cli): add aws check to ping p2p diagnostics

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -374,13 +374,13 @@ func (d ConnDiags) Write(w io.Writer) {
 	if len(client) > 0 {
 		_, _ = fmt.Fprint(w, "Possible client-side issues with direct connection:\n\n")
 		for _, msg := range client {
-			_, _ = fmt.Fprintf(w, "  - %s\n\n", msg)
+			_, _ = fmt.Fprintf(w, "  %s\n\n", msg)
 		}
 	}
 	if len(agent) > 0 {
 		_, _ = fmt.Fprint(w, "Possible agent-side issues with direct connections:\n\n")
 		for _, msg := range agent {
-			_, _ = fmt.Fprintf(w, "  - %s\n\n", msg)
+			_, _ = fmt.Fprintf(w, "  %s\n\n", msg)
 		}
 	}
 }

--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -374,13 +374,13 @@ func (d ConnDiags) Write(w io.Writer) {
 	if len(client) > 0 {
 		_, _ = fmt.Fprint(w, "Possible client-side issues with direct connection:\n\n")
 		for _, msg := range client {
-			_, _ = fmt.Fprintf(w, "  %s\n\n", msg)
+			_, _ = fmt.Fprintf(w, " - %s\n\n", msg)
 		}
 	}
 	if len(agent) > 0 {
 		_, _ = fmt.Fprint(w, "Possible agent-side issues with direct connections:\n\n")
 		for _, msg := range agent {
-			_, _ = fmt.Fprintf(w, "  %s\n\n", msg)
+			_, _ = fmt.Fprintf(w, " - %s\n\n", msg)
 		}
 	}
 }
@@ -423,30 +423,30 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 	}
 
 	if !d.ConnInfo.DERPMap.HasSTUN() {
-		general = append(general, "✘ The DERP map is not configured to use STUN")
+		general = append(general, "The DERP map is not configured to use STUN")
 	} else if d.LocalNetInfo != nil && !d.LocalNetInfo.UDP {
-		client = append(client, "✘ Client could not connect to STUN over UDP")
+		client = append(client, "Client could not connect to STUN over UDP")
 	}
 
 	if d.LocalNetInfo != nil && d.LocalNetInfo.MappingVariesByDestIP.EqualBool(true) {
-		client = append(client, "❗ Client is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers")
+		client = append(client, "Client is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers")
 	}
 
 	if d.AgentNetcheck != nil && d.AgentNetcheck.NetInfo != nil {
 		if d.AgentNetcheck.NetInfo.MappingVariesByDestIP.EqualBool(true) {
-			agent = append(agent, "❗ Agent is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers")
+			agent = append(agent, "Agent is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers")
 		}
 		if !d.AgentNetcheck.NetInfo.UDP {
-			agent = append(agent, "✘ Agent could not connect to STUN over UDP")
+			agent = append(agent, "Agent could not connect to STUN over UDP")
 		}
 	}
 
-	if d.ClientIPIsAWS {
-		client = append(client, "❗ Client IP address is within an AWS range (AWS uses hard NAT)")
+	if true {
+		client = append(client, "Client IP address is within an AWS range (AWS uses hard NAT)")
 	}
 
-	if d.AgentIPIsAWS {
-		agent = append(agent, "❗ Agent IP address is within an AWS range (AWS uses hard NAT)")
+	if true {
+		agent = append(agent, "Agent IP address is within an AWS range (AWS uses hard NAT)")
 	}
 	return general, client, agent
 }
@@ -457,5 +457,5 @@ func formatHealthMessage(msg health.Message) string {
 	}
 	r := []rune(strings.Replace(msg.Message, ", which may cause problems with direct connections", "", -1))
 	out := string(append([]rune{unicode.ToUpper(r[0])}, r[1:]...))
-	return fmt.Sprintf("❗ %s, which may degrade the quality of direct connections", out)
+	return fmt.Sprintf("%s, which may degrade the quality of direct connections", out)
 }

--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -7,13 +7,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 	"tailscale.com/tailcfg"
 
-	"github.com/coder/coder/v2/coderd/healthcheck/health"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/healthsdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -394,13 +392,13 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 
 	if d.AgentNetcheck != nil {
 		for _, msg := range d.AgentNetcheck.Interfaces.Warnings {
-			agent = append(agent, formatHealthMessage(msg))
+			agent = append(agent, msg.Message)
 		}
 	}
 
 	if d.LocalInterfaces != nil {
 		for _, msg := range d.LocalInterfaces.Warnings {
-			client = append(client, formatHealthMessage(msg))
+			client = append(client, msg.Message)
 		}
 	}
 
@@ -441,21 +439,12 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 		}
 	}
 
-	if true {
+	if d.ClientIPIsAWS {
 		client = append(client, "Client IP address is within an AWS range (AWS uses hard NAT)")
 	}
 
-	if true {
+	if d.AgentIPIsAWS {
 		agent = append(agent, "Agent IP address is within an AWS range (AWS uses hard NAT)")
 	}
 	return general, client, agent
-}
-
-func formatHealthMessage(msg health.Message) string {
-	if msg.Code != health.CodeInterfaceSmallMTU {
-		return msg.Message
-	}
-	r := []rune(strings.Replace(msg.Message, ", which may cause problems with direct connections", "", -1))
-	out := string(append([]rune{unicode.ToUpper(r[0])}, r[1:]...))
-	return fmt.Sprintf("%s, which may degrade the quality of direct connections", out)
 }

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -817,7 +817,7 @@ func TestConnDiagnostics(t *testing.T) {
 					Interfaces: healthsdk.InterfacesReport{
 						BaseReport: healthsdk.BaseReport{
 							Warnings: []health.Message{
-								health.Messagef(health.CodeInterfaceSmallMTU, "network interface eth0 has MTU 1280, (less than 1378), which may cause problems with direct connections"),
+								health.Messagef(health.CodeInterfaceSmallMTU, "Network interface eth0 has MTU 1280, (less than 1378), which may degrade the quality of direct connections"),
 							},
 						},
 					},
@@ -838,7 +838,7 @@ func TestConnDiagnostics(t *testing.T) {
 				LocalInterfaces: &healthsdk.InterfacesReport{
 					BaseReport: healthsdk.BaseReport{
 						Warnings: []health.Message{
-							health.Messagef(health.CodeInterfaceSmallMTU, "network interface eth1 has MTU 1310, (less than 1378), which may cause problems with direct connections"),
+							health.Messagef(health.CodeInterfaceSmallMTU, "Network interface eth1 has MTU 1310, (less than 1378), which may degrade the quality of direct connections"),
 						},
 					},
 				},

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -720,6 +720,58 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 		},
 		{
+			name: "ClientHasStunNoUDP",
+			diags: cliui.ConnDiags{
+				ConnInfo: &workspacesdk.AgentConnectionInfo{
+					DERPMap: &tailcfg.DERPMap{
+						Regions: map[int]*tailcfg.DERPRegion{
+							999: {
+								Nodes: []*tailcfg.DERPNode{
+									{
+										STUNPort: 1337,
+									},
+								},
+							},
+						},
+					},
+				},
+				LocalNetInfo: &tailcfg.NetInfo{
+					UDP: false,
+				},
+			},
+			want: []string{
+				`❗ You are connected via a DERP relay, not directly (p2p)`,
+				`❗ Client could not connect to STUN over UDP, which may be preventing a direct connection`,
+			},
+		},
+		{
+			name: "AgentHasStunNoUDP",
+			diags: cliui.ConnDiags{
+				ConnInfo: &workspacesdk.AgentConnectionInfo{
+					DERPMap: &tailcfg.DERPMap{
+						Regions: map[int]*tailcfg.DERPRegion{
+							999: {
+								Nodes: []*tailcfg.DERPNode{
+									{
+										STUNPort: 1337,
+									},
+								},
+							},
+						},
+					},
+				},
+				AgentNetcheck: &healthsdk.AgentNetcheckReport{
+					NetInfo: &tailcfg.NetInfo{
+						UDP: false,
+					},
+				},
+			},
+			want: []string{
+				`❗ You are connected via a DERP relay, not directly (p2p)`,
+				`❗ Agent could not connect to STUN over UDP, which may be preventing a direct connection`,
+			},
+		},
+		{
 			name: "ClientHardNat",
 			diags: cliui.ConnDiags{
 				LocalNetInfo: &tailcfg.NetInfo{
@@ -780,6 +832,28 @@ func TestConnDiagnostics(t *testing.T) {
 			want: []string{
 				`❗ Client: network interface eth1 has MTU 1310, (less than 1378), which may cause problems with direct connections`,
 				`✔ You are connected directly (p2p)`,
+			},
+		},
+		{
+			name: "ClientAWSIP",
+			diags: cliui.ConnDiags{
+				ClientIPIsAWS: true,
+				AgentIPIsAWS:  false,
+			},
+			want: []string{
+				`❗ You are connected via a DERP relay, not directly (p2p)`,
+				`❗ Client IP address is within an AWS range, which is known to cause problems with forming direct connections (AWS uses hard NAT)`,
+			},
+		},
+		{
+			name: "AgentAWSIP",
+			diags: cliui.ConnDiags{
+				ClientIPIsAWS: false,
+				AgentIPIsAWS:  true,
+			},
+			want: []string{
+				`❗ You are connected via a DERP relay, not directly (p2p)`,
+				`❗ Agent IP address is within an AWS range, which is known to cause problems with forming direct connections (AWS uses hard NAT)`,
 			},
 		},
 	}

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -719,7 +719,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`✘ The DERP map is not configured to use STUN`,
+				`The DERP map is not configured to use STUN`,
 			},
 		},
 		{
@@ -744,7 +744,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`✘ Client could not connect to STUN over UDP`,
+				`Client could not connect to STUN over UDP`,
 			},
 		},
 		{
@@ -771,7 +771,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`✘ Agent could not connect to STUN over UDP`,
+				`Agent could not connect to STUN over UDP`,
 			},
 		},
 		{
@@ -786,7 +786,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`❗ Client is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers`,
+				`Client is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers`,
 			},
 		},
 		{
@@ -803,7 +803,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`❗ Agent is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers`,
+				`Agent is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers`,
 			},
 		},
 		{
@@ -824,8 +824,8 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`❗ Network interface eth0 has MTU 1280, (less than 1378), which may degrade the quality of direct connections`,
 				`✔ You are connected directly (p2p)`,
+				`Network interface eth0 has MTU 1280, (less than 1378), which may degrade the quality of direct connections`,
 			},
 		},
 		{
@@ -844,8 +844,8 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`❗ Network interface eth1 has MTU 1310, (less than 1378), which may degrade the quality of direct connections`,
 				`✔ You are connected directly (p2p)`,
+				`Network interface eth1 has MTU 1310, (less than 1378), which may degrade the quality of direct connections`,
 			},
 		},
 		{
@@ -859,7 +859,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`❗ Client IP address is within an AWS range (AWS uses hard NAT)`,
+				`Client IP address is within an AWS range (AWS uses hard NAT)`,
 			},
 		},
 		{
@@ -873,7 +873,7 @@ func TestConnDiagnostics(t *testing.T) {
 			},
 			want: []string{
 				`❗ You are connected via a DERP relay, not directly (p2p)`,
-				`❗ Agent IP address is within an AWS range (AWS uses hard NAT)`,
+				`Agent IP address is within an AWS range (AWS uses hard NAT)`,
 			},
 		},
 	}

--- a/cli/cliutil/awscheck.go
+++ b/cli/cliutil/awscheck.go
@@ -1,0 +1,114 @@
+package cliutil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/netip"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const AWSIPRangesURL = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+
+type awsIPv4Prefix struct {
+	Prefix             string `json:"ip_prefix"`
+	Region             string `json:"region"`
+	Service            string `json:"service"`
+	NetworkBorderGroup string `json:"network_border_group"`
+}
+
+type awsIPv6Prefix struct {
+	Prefix             string `json:"ipv6_prefix"`
+	Region             string `json:"region"`
+	Service            string `json:"service"`
+	NetworkBorderGroup string `json:"network_border_group"`
+}
+
+type AWSIPRanges struct {
+	V4 []netip.Prefix
+	V6 []netip.Prefix
+}
+
+type awsIPRangesResponse struct {
+	SyncToken    string          `json:"syncToken"`
+	CreateDate   string          `json:"createDate"`
+	IPV4Prefixes []awsIPv4Prefix `json:"prefixes"`
+	IPV6Prefixes []awsIPv6Prefix `json:"ipv6_prefixes"`
+}
+
+func FetchAWSIPRanges(ctx context.Context, url string) (*AWSIPRanges, error) {
+	client := &http.Client{}
+	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer reqCancel()
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, xerrors.Errorf("unexpected status code %d: %s", resp.StatusCode, b)
+	}
+
+	var body awsIPRangesResponse
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	if err != nil {
+		return nil, xerrors.Errorf("json decode: %w", err)
+	}
+
+	out := &AWSIPRanges{
+		V4: make([]netip.Prefix, 0, len(body.IPV4Prefixes)),
+		V6: make([]netip.Prefix, 0, len(body.IPV6Prefixes)),
+	}
+
+	for _, p := range body.IPV4Prefixes {
+		prefix, err := netip.ParsePrefix(p.Prefix)
+		if err != nil {
+			return nil, xerrors.Errorf("parse ip prefix: %w", err)
+		}
+		if prefix.Addr().Is6() {
+			return nil, xerrors.Errorf("ipv4 prefix contains ipv6 address: %s", p.Prefix)
+		}
+		out.V4 = append(out.V4, prefix)
+	}
+
+	for _, p := range body.IPV6Prefixes {
+		prefix, err := netip.ParsePrefix(p.Prefix)
+		if err != nil {
+			return nil, xerrors.Errorf("parse ip prefix: %w", err)
+		}
+		if prefix.Addr().Is4() {
+			return nil, xerrors.Errorf("ipv6 prefix contains ipv4 address: %s", p.Prefix)
+		}
+		out.V6 = append(out.V6, prefix)
+	}
+
+	return out, nil
+}
+
+// CheckIP checks if the given IP address is an AWS IP.
+func (r *AWSIPRanges) CheckIP(ip netip.Addr) bool {
+	if ip.IsLoopback() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() || ip.IsPrivate() {
+		return false
+	}
+
+	if ip.Is4() {
+		for _, p := range r.V4 {
+			if p.Contains(ip) {
+				return true
+			}
+		}
+	} else {
+		for _, p := range r.V6 {
+			if p.Contains(ip) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cli/cliutil/awscheck_internal_test.go
+++ b/cli/cliutil/awscheck_internal_test.go
@@ -1,0 +1,95 @@
+package cliutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestIPV4Check(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpapi.Write(context.Background(), w, http.StatusOK, awsIPRangesResponse{
+			IPV4Prefixes: []awsIPv4Prefix{
+				{
+					Prefix: "3.24.0.0/14",
+				},
+				{
+					Prefix: "15.230.15.29/32",
+				},
+				{
+					Prefix: "47.128.82.100/31",
+				},
+			},
+			IPV6Prefixes: []awsIPv6Prefix{
+				{
+					Prefix: "2600:9000:5206::/48",
+				},
+				{
+					Prefix: "2406:da70:8800::/40",
+				},
+				{
+					Prefix: "2600:1f68:5000::/40",
+				},
+			},
+		})
+	}))
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ranges, err := FetchAWSIPRanges(ctx, srv.URL)
+	require.NoError(t, err)
+
+	t.Run("Private/IPV4", func(t *testing.T) {
+		t.Parallel()
+		ip, err := netip.ParseAddr("192.168.0.1")
+		require.NoError(t, err)
+		isAws := ranges.CheckIP(ip)
+		require.False(t, isAws)
+	})
+
+	t.Run("AWS/IPV4", func(t *testing.T) {
+		t.Parallel()
+		ip, err := netip.ParseAddr("3.25.61.113")
+		require.NoError(t, err)
+		isAws := ranges.CheckIP(ip)
+		require.True(t, isAws)
+	})
+
+	t.Run("NonAWS/IPV4", func(t *testing.T) {
+		t.Parallel()
+		ip, err := netip.ParseAddr("159.196.123.40")
+		require.NoError(t, err)
+		isAws := ranges.CheckIP(ip)
+		require.False(t, isAws)
+	})
+
+	t.Run("Private/IPV6", func(t *testing.T) {
+		t.Parallel()
+		ip, err := netip.ParseAddr("::1")
+		require.NoError(t, err)
+		isAws := ranges.CheckIP(ip)
+		require.False(t, isAws)
+	})
+
+	t.Run("AWS/IPV6", func(t *testing.T) {
+		t.Parallel()
+		ip, err := netip.ParseAddr("2600:9000:5206:0001:0000:0000:0000:0001")
+		require.NoError(t, err)
+		isAws := ranges.CheckIP(ip)
+		require.True(t, isAws)
+	})
+
+	t.Run("NonAWS/IPV6", func(t *testing.T) {
+		t.Parallel()
+		ip, err := netip.ParseAddr("2403:5807:885f:0:a544:49d4:58f8:aedf")
+		require.NoError(t, err)
+		isAws := ranges.CheckIP(ip)
+		require.False(t, isAws)
+	})
+}

--- a/cli/ping_test.go
+++ b/cli/ping_test.go
@@ -67,6 +67,7 @@ func TestPing(t *testing.T) {
 
 		pty.ExpectMatch("pong from " + workspace.Name)
 		pty.ExpectMatch("✔ received remote agent data from Coder networking coordinator")
+		pty.ExpectMatch("✔ You are connected directly (p2p)")
 		cancel()
 		<-cmdDone
 	})

--- a/codersdk/healthsdk/interfaces.go
+++ b/codersdk/healthsdk/interfaces.go
@@ -72,7 +72,7 @@ func generateInterfacesReport(st *interfaces.State) (report InterfacesReport) {
 			report.Severity = health.SeverityWarning
 			report.Warnings = append(report.Warnings,
 				health.Messagef(health.CodeInterfaceSmallMTU,
-					"network interface %s has MTU %d (less than %d), which may cause problems with direct connections", iface.Name, iface.MTU, safeMTU),
+					"Network interface %s has MTU %d (less than %d), which may degrade the quality of direct connections", iface.Name, iface.MTU, safeMTU),
 			)
 		}
 	}


### PR DESCRIPTION
Continues to address #14244.

If the client or agent's public IP is within an AWS range, `coder ping` will now report that it is behind a hard NAT, which may impede forming a direct connection.

Additionally informs if the client or agent was unable to contact a STUN server over UDP, if the DERP map contains a STUN server.

Output format:
```
[...]
✔ Wireguard handshake 12s ago

❗ You are connected via a DERP relay, not directly (p2p)
❗ Network interface eth0 has MTU 1280, (less than 1378), which may degrade the quality of direct connections
Possible client-side issues with direct connection:

 - Reason 1
 
 - Reason 2

Possible agent-side issues with direct connections:

  - Reason 1
  
  - Reason 2
 ```