### PR TITLE
feat: improve custom roles create/edit page

### DIFF
--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import {
 	MockRoleWithOrgPermissions,
+	MockRole2WithOrgPermissions,
 	assignableRole,
 	mockApiError,
 } from "testHelpers/entities";
 import { CreateEditRolePageView } from "./CreateEditRolePageView";
+import { userEvent, within, expect } from "@storybook/test";
 
 const meta: Meta<typeof CreateEditRolePageView> = {
 	title: "pages/OrganizationCreateEditRolePage",
@@ -19,6 +21,16 @@ export const Default: Story = {
 		role: assignableRole(MockRoleWithOrgPermissions, true),
 		onSubmit: () => null,
 		error: undefined,
+		isLoading: false,
+		organizationName: "my-org",
+		canAssignOrgRole: true,
+	},
+};
+
+export const CheckboxIndeterminate: Story = {
+	args: {
+		role: assignableRole(MockRole2WithOrgPermissions, true),
+		onSubmit: () => null,
 		isLoading: false,
 		organizationName: "my-org",
 		canAssignOrgRole: true,
@@ -59,5 +71,19 @@ export const ShowAllResources: Story = {
 		organizationName: "my-org",
 		canAssignOrgRole: true,
 		allResources: true,
+	},
+};
+
+export const ToggleParentCheckbox: Story = {
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const checkbox = await canvas
+			.getByTestId("audit_log")
+			.getElementsByTagName("input")[0];
+		await user.click(checkbox);
+		await expect(checkbox).toBeChecked();
+		await user.click(checkbox);
+		await expect(checkbox).not.toBeChecked();
 	},
 };

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
 import {
-	MockRoleWithOrgPermissions,
 	MockRole2WithOrgPermissions,
+	MockRoleWithOrgPermissions,
 	assignableRole,
 	mockApiError,
 } from "testHelpers/entities";
 import { CreateEditRolePageView } from "./CreateEditRolePageView";
-import { userEvent, within, expect } from "@storybook/test";
 
 const meta: Meta<typeof CreateEditRolePageView> = {
 	title: "pages/OrganizationCreateEditRolePage",

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -334,6 +334,7 @@ const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
 							checkedActions.length > 0 &&
 							checkedActions.length < Object.keys(value).length
 						}
+						data-testid={`${resourceKey}`}
 						onChange={(e) =>
 							handleResourceCheckChange(
 								e,
@@ -416,7 +417,7 @@ const styles = {
 	}),
 	actionItem: {
 		display: "grid",
-		gridTemplateColumns: "270px 3fr",
+		gridTemplateColumns: "270px 1fr",
 	},
 } satisfies Record<string, Interpolation<Theme>>;
 

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -146,12 +146,6 @@ export const CreateEditRolePageView: FC<CreateEditRolePageViewProps> = ({
 	);
 };
 
-interface ActionCheckboxesProps {
-	permissions: readonly Permission[] | undefined;
-	form: ReturnType<typeof useFormik<Role>> & { values: Role };
-	allResources: boolean;
-}
-
 const ResourceActionComparator = (
 	p: Permission,
 	resource: string,
@@ -160,6 +154,7 @@ const ResourceActionComparator = (
 	p.resource_type === resource &&
 	(p.action.toString() === "*" || p.action === action);
 
+// the subset of resources that are useful for most users
 const DEFAULT_RESOURCES = [
 	"audit_log",
 	"group",
@@ -177,6 +172,12 @@ const filteredRBACResourceActions = Object.fromEntries(
 	),
 );
 
+interface ActionCheckboxesProps {
+	permissions: readonly Permission[];
+	form: ReturnType<typeof useFormik<Role>> & { values: Role };
+	allResources: boolean;
+}
+
 const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 	permissions,
 	form,
@@ -184,6 +185,10 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 }) => {
 	const [checkedActions, setCheckActions] = useState(permissions);
 	const [showAllResources, setShowAllResources] = useState(allResources);
+
+	const resourceActions = showAllResources
+		? RBACResourceActions
+		: filteredRBACResourceActions;
 
 	const handleActionCheckChange = async (
 		e: ChangeEvent<HTMLInputElement>,
@@ -194,7 +199,7 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 
 		const newPermissions = checked
 			? [
-					...(checkedActions ?? []),
+					...checkedActions,
 					{
 						negate: false,
 						resource_type: resource_type as RBACResource,
@@ -209,9 +214,36 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 		await form.setFieldValue("organization_permissions", newPermissions);
 	};
 
-	const resourceActions = showAllResources
-		? RBACResourceActions
-		: filteredRBACResourceActions;
+	const handleResourceCheckChange = async (
+		e: ChangeEvent<HTMLInputElement>,
+		form: ReturnType<typeof useFormik<Role>> & { values: Role },
+		indeterminate: boolean,
+	) => {
+		const { name, checked } = e.currentTarget;
+		const resource = name as RBACResource;
+
+		const resourceActionsForResource = resourceActions[resource] || {};
+
+		const newCheckedActions =
+			!checked || indeterminate
+				? checkedActions?.filter((p) => p.resource_type !== resource)
+				: checkedActions;
+
+		const newPermissions =
+			checked || indeterminate
+				? [
+						...newCheckedActions,
+						...Object.keys(resourceActionsForResource).map((resourceKey) => ({
+							negate: false,
+							resource_type: resource as RBACResource,
+							action: resourceKey as RBACAction,
+						})),
+					]
+				: [...newCheckedActions];
+
+		setCheckActions(newPermissions);
+		await form.setFieldValue("organization_permissions", newPermissions);
+	};
 
 	return (
 		<TableContainer>
@@ -233,36 +265,17 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 				<TableBody>
 					{Object.entries(resourceActions).map(([resourceKey, value]) => {
 						return (
-							<TableRow key={resourceKey}>
-								<TableCell sx={{ paddingLeft: 2 }} colSpan={2}>
-									<li key={resourceKey} css={styles.checkBoxes}>
-										{resourceKey}
-										<ul css={styles.checkBoxes}>
-											{Object.entries(value).map(([actionKey, value]) => (
-												<li key={actionKey}>
-													<span css={styles.actionText}>
-														<Checkbox
-															size="small"
-															name={`${resourceKey}:${actionKey}`}
-															checked={checkedActions?.some((p) =>
-																ResourceActionComparator(
-																	p,
-																	resourceKey,
-																	actionKey,
-																),
-															)}
-															onChange={(e) => handleActionCheckChange(e, form)}
-														/>
-														{actionKey}
-													</span>{" "}
-													&ndash;{" "}
-													<span css={styles.actionDescription}>{value}</span>
-												</li>
-											))}
-										</ul>
-									</li>
-								</TableCell>
-							</TableRow>
+							<PermissionCheckboxGroup
+								key={resourceKey}
+								checkedActions={checkedActions?.filter(
+									(a) => a.resource_type === resourceKey,
+								)}
+								resourceKey={resourceKey}
+								value={value}
+								form={form}
+								handleActionCheckChange={handleActionCheckChange}
+								handleResourceCheckChange={handleResourceCheckChange}
+							/>
 						);
 					})}
 				</TableBody>
@@ -282,6 +295,76 @@ const ActionCheckboxes: FC<ActionCheckboxesProps> = ({
 				</TableFooter>
 			</Table>
 		</TableContainer>
+	);
+};
+
+interface PermissionCheckboxGroupProps {
+	checkedActions: readonly Permission[];
+	resourceKey: string;
+	value: Partial<Record<RBACAction, string>>;
+	form: ReturnType<typeof useFormik<Role>> & { values: Role };
+	handleActionCheckChange: (
+		e: ChangeEvent<HTMLInputElement>,
+		form: ReturnType<typeof useFormik<Role>> & { values: Role },
+	) => Promise<void>;
+	handleResourceCheckChange: (
+		e: ChangeEvent<HTMLInputElement>,
+		form: ReturnType<typeof useFormik<Role>> & { values: Role },
+		indeterminate: boolean,
+	) => Promise<void>;
+}
+
+const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
+	checkedActions,
+	resourceKey,
+	value,
+	form,
+	handleActionCheckChange,
+	handleResourceCheckChange,
+}) => {
+	return (
+		<TableRow key={resourceKey}>
+			<TableCell sx={{ paddingLeft: 2 }} colSpan={2}>
+				<li key={resourceKey} css={styles.checkBoxes}>
+					<Checkbox
+						size="small"
+						name={`${resourceKey}`}
+						checked={checkedActions.length === Object.keys(value).length}
+						indeterminate={
+							checkedActions.length > 0 &&
+							checkedActions.length < Object.keys(value).length
+						}
+						onChange={(e) =>
+							handleResourceCheckChange(
+								e,
+								form,
+								checkedActions.length > 0 &&
+									checkedActions.length < Object.keys(value).length,
+							)
+						}
+					/>
+					{resourceKey}
+					<ul css={styles.checkBoxes}>
+						{Object.entries(value).map(([actionKey, value]) => (
+							<li key={actionKey}>
+								<span css={styles.actionText}>
+									<Checkbox
+										size="small"
+										name={`${resourceKey}:${actionKey}`}
+										checked={checkedActions.some((p) =>
+											ResourceActionComparator(p, resourceKey, actionKey),
+										)}
+										onChange={(e) => handleActionCheckChange(e, form)}
+									/>
+									{actionKey}
+								</span>{" "}
+								&ndash; <span css={styles.actionDescription}>{value}</span>
+							</li>
+						))}
+					</ul>
+				</li>
+			</TableCell>
+		</TableRow>
 	);
 };
 

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -308,7 +308,13 @@ const ShowAllResourcesCheckbox: FC<ShowAllResourcesCheckboxProps> = ({
 					icon={<VisibilityOffOutlinedIcon />}
 				/>
 			}
-			label={<span style={{ fontSize: 12 }}>Show all permissions</span>}
+			label={
+				<span style={{ fontSize: 12 }}>
+					{showAllResources
+						? "Hide advanced permissions"
+						: "Show advanced permissions"}
+				</span>
+			}
 		/>
 	);
 };

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePageView.tsx
@@ -346,7 +346,7 @@ const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
 					{resourceKey}
 					<ul css={styles.checkBoxes}>
 						{Object.entries(value).map(([actionKey, value]) => (
-							<li key={actionKey}>
+							<li key={actionKey} css={styles.actionItem}>
 								<span css={styles.actionText}>
 									<Checkbox
 										size="small"
@@ -357,8 +357,8 @@ const PermissionCheckboxGroup: FC<PermissionCheckboxGroupProps> = ({
 										onChange={(e) => handleActionCheckChange(e, form)}
 									/>
 									{actionKey}
-								</span>{" "}
-								&ndash; <span css={styles.actionDescription}>{value}</span>
+								</span>
+								<span css={styles.actionDescription}>{value}</span>
 							</li>
 						))}
 					</ul>
@@ -412,7 +412,12 @@ const styles = {
 	}),
 	actionDescription: (theme) => ({
 		color: theme.palette.text.secondary,
+		paddingTop: 6,
 	}),
+	actionItem: {
+		display: "grid",
+		gridTemplateColumns: "270px 3fr",
+	},
 } satisfies Record<string, Interpolation<Theme>>;
 
 export default CreateEditRolePageView;

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -391,6 +391,21 @@ export const MockRoleWithOrgPermissions: TypesGen.Role = {
 	user_permissions: [],
 };
 
+export const MockRole2WithOrgPermissions: TypesGen.Role = {
+	name: "my-role-1",
+	display_name: "My Role 1",
+	organization_id: MockOrganization.id,
+	site_permissions: [],
+	organization_permissions: [
+		{
+			negate: false,
+			resource_type: "audit_log",
+			action: "create",
+		},
+	],
+	user_permissions: [],
+};
+
 // assignableRole takes a role and a boolean. The boolean implies if the
 // actor can assign (add/remove) the role from other users.
 export function assignableRole(


### PR DESCRIPTION
Resolves #14311 

- [x] Add a parent checkbox for resource/action groups to check/uncheck all actions for that resource.
- [x] Change "Show all permissions" to "Show advanced permissions"
- [x] "Show advanced permissions" should change to "Hide advanced permissions". Currently the text does not change on being clicked.
- [x] Align action description text

<img width="1114" alt="Screenshot 2024-08-27 at 2 25 03 PM" src="https://github.com/user-attachments/assets/a4985b67-64a1-4fdf-b083-804fa5c09fcf">
