### PR TITLE
feat(coderd/database/dbpurge): retain most recent agent build logs

### DIFF
--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -75,8 +75,8 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, clk quartz.
 	go func() {
 		defer close(closed)
 		defer ticker.Stop()
-		// Force an initial tick immediately.
-		ticker.Reset(time.Nanosecond)
+		// Force an initial tick.
+		doTick(dbtime.Time(clk.Now()).UTC())
 		for {
 			select {
 			case <-ctx.Done():

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/quartz"
 )
 
@@ -47,7 +48,8 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, clk quartz.
 				return nil
 			}
 
-			if err := tx.DeleteOldWorkspaceAgentLogs(ctx, start.Add(-maxAgentLogAge)); err != nil {
+			deleteOldWorkspaceAgentLogsBefore := start.Add(-maxAgentLogAge)
+			if err := tx.DeleteOldWorkspaceAgentLogs(ctx, deleteOldWorkspaceAgentLogsBefore); err != nil {
 				return xerrors.Errorf("failed to delete old workspace agent logs: %w", err)
 			}
 			if err := tx.DeleteOldWorkspaceAgentStats(ctx); err != nil {
@@ -78,7 +80,7 @@ func New(ctx context.Context, logger slog.Logger, db database.Store, clk quartz.
 				return
 			case tick := <-ticker.C:
 				ticker.Stop()
-				doTick(tick)
+				doTick(dbtime.Time(tick).UTC())
 			}
 		}
 	}()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -88,6 +88,7 @@ type sqlcQuerier interface {
 	// connectivity issues (no provisioner daemon activity since registration).
 	DeleteOldProvisionerDaemons(ctx context.Context) error
 	// If an agent hasn't connected in the last 7 days, we purge it's logs.
+	// Exception: if the logs are related to the latest build, we keep those around.
 	// Logs can take up a lot of space, so it's important we clean up frequently.
 	DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) error
 	DeleteOldWorkspaceAgentStats(ctx context.Context) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10493,7 +10493,7 @@ WITH
 	),
 	old_agents AS (
 		SELECT
-			wa.id, wa.last_connected_at, wb.build_number, wb.workspace_id
+			wa.id
 		FROM
 			workspace_agents AS wa
 		JOIN

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -10482,12 +10482,50 @@ func (q *sqlQuerier) UpsertWorkspaceAgentPortShare(ctx context.Context, arg Upse
 }
 
 const deleteOldWorkspaceAgentLogs = `-- name: DeleteOldWorkspaceAgentLogs :exec
-DELETE FROM workspace_agent_logs WHERE agent_id IN
-	(SELECT id FROM workspace_agents WHERE last_connected_at IS NOT NULL
-		AND last_connected_at < $1 :: timestamptz)
+WITH
+	latest_builds AS (
+		SELECT
+			workspace_id, max(build_number) AS max_build_number
+		FROM
+			workspace_builds
+		GROUP BY
+			workspace_id
+	),
+	old_agents AS (
+		SELECT
+			wa.id, wa.last_connected_at, wb.build_number, wb.workspace_id
+		FROM
+			workspace_agents AS wa
+		JOIN
+			workspace_resources AS wr
+		ON
+			wa.resource_id = wr.id
+		JOIN
+			workspace_builds AS wb
+		ON
+			wb.job_id = wr.job_id
+		LEFT JOIN
+			latest_builds
+		ON
+			latest_builds.workspace_id = wb.workspace_id
+		AND
+			latest_builds.max_build_number = wb.build_number
+		WHERE
+			-- Filter out the latest builds for each workspace.
+			latest_builds.workspace_id IS NULL
+		AND CASE
+			-- If the last time the agent connected was before @threshold
+			WHEN wa.last_connected_at IS NOT NULL THEN
+				 wa.last_connected_at < $1 :: timestamptz
+			-- The agent never connected, and was created before @threshold
+			ELSE wa.created_at < $1 :: timestamptz
+		END
+	)
+DELETE FROM workspace_agent_logs WHERE agent_id IN (SELECT id FROM old_agents)
 `
 
 // If an agent hasn't connected in the last 7 days, we purge it's logs.
+// Exception: if the logs are related to the latest build, we keep those around.
 // Logs can take up a lot of space, so it's important we clean up frequently.
 func (q *sqlQuerier) DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) error {
 	_, err := q.db.ExecContext(ctx, deleteOldWorkspaceAgentLogs, threshold)

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -202,7 +202,7 @@ WITH
 	),
 	old_agents AS (
 		SELECT
-			wa.id, wa.last_connected_at, wb.build_number, wb.workspace_id
+			wa.id
 		FROM
 			workspace_agents AS wa
 		JOIN

--- a/coderd/database/queries/workspaceagents.sql
+++ b/coderd/database/queries/workspaceagents.sql
@@ -188,11 +188,49 @@ INSERT INTO
 SELECT * FROM workspace_agent_log_sources WHERE workspace_agent_id = ANY(@ids :: uuid [ ]);
 
 -- If an agent hasn't connected in the last 7 days, we purge it's logs.
+-- Exception: if the logs are related to the latest build, we keep those around.
 -- Logs can take up a lot of space, so it's important we clean up frequently.
 -- name: DeleteOldWorkspaceAgentLogs :exec
-DELETE FROM workspace_agent_logs WHERE agent_id IN
-	(SELECT id FROM workspace_agents WHERE last_connected_at IS NOT NULL
-		AND last_connected_at < @threshold :: timestamptz);
+WITH
+	latest_builds AS (
+		SELECT
+			workspace_id, max(build_number) AS max_build_number
+		FROM
+			workspace_builds
+		GROUP BY
+			workspace_id
+	),
+	old_agents AS (
+		SELECT
+			wa.id, wa.last_connected_at, wb.build_number, wb.workspace_id
+		FROM
+			workspace_agents AS wa
+		JOIN
+			workspace_resources AS wr
+		ON
+			wa.resource_id = wr.id
+		JOIN
+			workspace_builds AS wb
+		ON
+			wb.job_id = wr.job_id
+		LEFT JOIN
+			latest_builds
+		ON
+			latest_builds.workspace_id = wb.workspace_id
+		AND
+			latest_builds.max_build_number = wb.build_number
+		WHERE
+			-- Filter out the latest builds for each workspace.
+			latest_builds.workspace_id IS NULL
+		AND CASE
+			-- If the last time the agent connected was before @threshold
+			WHEN wa.last_connected_at IS NOT NULL THEN
+				 wa.last_connected_at < @threshold :: timestamptz
+			-- The agent never connected, and was created before @threshold
+			ELSE wa.created_at < @threshold :: timestamptz
+		END
+	)
+DELETE FROM workspace_agent_logs WHERE agent_id IN (SELECT id FROM old_agents);
 
 -- name: GetWorkspaceAgentsInLatestBuildByWorkspaceID :many
 SELECT


### PR DESCRIPTION
Builds upon https://github.com/coder/coder/pull/14480
Addresses https://github.com/coder/coder/issues/10576

Updates the `DeleteOldWorkspaceAgentLogs` to:
- Retain logs for the most recent build regardless of age,
- Delete logs for agents that never connected and were created before the cutoff for deleting logs while still retaining the logs most recent build.

The motivation for the second changes is from running the following query on the dogfood database:

```
coder=> SELECT COUNT(*), MIN(workspace_agents.created_at) FROM workspace_agent_logs 
JOIN workspace_agents 
ON workspace_agent_logs.agent_id = workspace_agents.id
WHERE workspace_agents.last_connected_at IS NULL
AND workspace_agents.created_at < (NOW() - INTERVAL '7 days');
 count |              min              
-------+-------------------------------
  2169 | 2023-11-21 21:48:26.339238+00
(1 row)
```
