### PR TITLE
fix: include dormant users in template acl query

### DIFF
--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -167,7 +167,7 @@ func (q *sqlQuerier) GetTemplateUserRoles(ctx context.Context, id uuid.UUID) ([]
 	WHERE
 		users.deleted = false
 	AND
-		users.status = 'active';
+		users.status != 'suspended';
 	`
 
 	var tus []TemplateUser


### PR DESCRIPTION
The issue is that if you add a user and then immediately go to give them
permissions, you can add them but they will not show up in the UI.  They
also do not show up in the audit log entry.