### PR TITLE
fix: wait for provisioner daemon jobs to finish after sigterm

### DIFF
--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -262,7 +262,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 				cliui.Errorf(inv.Stderr, "Unexpected error, shutting down server: %s\n", exitErr)
 			}
 
-			err = srv.Shutdown(ctx, waitForProvisionerJobs)
+			err = srv.Shutdown(ctx, !waitForProvisionerJobs)
 			if err != nil {
 				return xerrors.Errorf("shutdown: %w", err)
 			}


### PR DESCRIPTION
Fixes #14433.

The function for shutting down a provisioner daemon has the signature:
```go
func (p *Server) Shutdown(ctx context.Context, cancelActiveJob bool) error
```

The `coder server` code for handling graceful provisioner shutdowns was correct:
```go
err := shutdownWithTimeout(func(ctx context.Context) error {
// We only want to cancel active jobs if we aren't exiting gracefully.
return provisionerDaemon.Shutdown(ctx, !waitForProvisionerJobs)
}, timeout)
```
Whilst the matching code for graceful shutdowns of independent provisioner daemons (`coder provisionerd start`) was not:
```go
err = srv.Shutdown(ctx, waitForProvisionerJobs)
```

This wasn't caught by tests as I don't believe we have any clitests for `provisionerd`. The existing tests call the shutdown function directly.
