### PR TITLE
fix: make non-existent asset paths return a 404

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -208,7 +208,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// If requesting assets, serve straight up with caching.
 	case reqFile == "assets" || strings.HasPrefix(reqFile, "assets/"):
 		// It could make sense to cache 404s, but the problem is that during an
-		// upgrade a load balance may route partially to the old server, and that
+		// upgrade a load balancer may route partially to the old server, and that
 		// would make new asset paths get cached as 404s and not load even once the
 		// new server was in place.  To combat that, only cache if we have the file.
 		if h.exists(reqFile) && ShouldCacheFile(reqFile) {

--- a/site/site.go
+++ b/site/site.go
@@ -205,6 +205,18 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	case reqFile == "bin" || strings.HasPrefix(reqFile, "bin/"):
 		h.handler.ServeHTTP(rw, r)
 		return
+	// If requesting assets, serve straight up with caching.
+	case reqFile == "assets" || strings.HasPrefix(reqFile, "assets/"):
+		// It could make sense to cache 404s, but the problem is that during an
+		// upgrade a load balance may route partially to the old server, and that
+		// would make new asset paths get cached as 404s and not load even once the
+		// new server was in place.  To combat that, only cache if we have the file.
+		if h.exists(reqFile) && ShouldCacheFile(reqFile) {
+			rw.Header().Add("Cache-Control", "public, max-age=31536000, immutable")
+		}
+		// If the asset does not exist, this will return a 404.
+		h.handler.ServeHTTP(rw, r)
+		return
 	// If the original file path exists we serve it.
 	case h.exists(reqFile):
 		if ShouldCacheFile(reqFile) {


### PR DESCRIPTION
Before, if a file was not found we would serve the app.  I do not think we were relying on falling back to the app for `/assets` so should be safe to just return a 404 instead.

Fixes https://github.com/coder/coder/issues/14409