### PR TITLE
fix: fix light mode styles for organization delete button

### DIFF
--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { chromatic } from "testHelpers/chromatic";
 import {
 	MockDefaultOrganization,
 	MockOrganization,
@@ -8,6 +9,7 @@ import { OrganizationSettingsPageView } from "./OrganizationSettingsPageView";
 const meta: Meta<typeof OrganizationSettingsPageView> = {
 	title: "pages/OrganizationSettingsPageView",
 	component: OrganizationSettingsPageView,
+	parameters: { chromatic },
 	args: {
 		organization: MockOrganization,
 	},

--- a/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationSettingsPageView.tsx
@@ -181,8 +181,8 @@ const styles = {
 		borderColor: theme.roles.danger.outline,
 		color: theme.roles.danger.text,
 
-		"&:not(.MuiLoadingButton-loading)": {
-			color: theme.roles.danger.fill.text,
+		"&.MuiLoadingButton-loading": {
+			color: theme.roles.danger.disabled.text,
 		},
 
 		"&:hover:not(:disabled)": {


### PR DESCRIPTION
<img width="485" alt="Screenshot 2024-08-29 at 3 25 31 PM" src="https://github.com/user-attachments/assets/56102994-54a6-4c14-9e9b-68bc7f41f1df">

This button text was light-on-light in light mode. Now it's not!