### PR TITLE
fix: serve test derp map locally

### DIFF
--- a/cli/cliutil/awscheck_internal_test.go
+++ b/cli/cliutil/awscheck_internal_test.go
@@ -41,6 +41,7 @@ func TestIPV4Check(t *testing.T) {
 			},
 		})
 	}))
+	t.Cleanup(srv.Close)
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ranges, err := FetchAWSIPRanges(ctx, srv.URL)
 	require.NoError(t, err)

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -16,7 +17,9 @@ import (
 	"go.uber.org/goleak"
 
 	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/tailnet/tailnettest"
 
 	agplaudit "github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -456,13 +459,19 @@ func TestMultiReplica_EmptyRelayAddress(t *testing.T) {
 func TestMultiReplica_EmptyRelayAddress_DisabledDERP(t *testing.T) {
 	t.Parallel()
 
+	derpMap, _ := tailnettest.RunDERPAndSTUN(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpapi.Write(context.Background(), w, http.StatusOK, derpMap)
+	}))
+	t.Cleanup(srv.Close)
+
 	ctx := testutil.Context(t, testutil.WaitLong)
 	db, ps := dbtestutil.NewDB(t)
 	logger := slogtest.Make(t, nil)
 
 	dv := coderdtest.DeploymentValues(t)
 	dv.DERP.Server.Enable = serpent.Bool(false)
-	dv.DERP.Config.URL = serpent.String("https://controlplane.tailscale.com/derpmap/default")
+	dv.DERP.Config.URL = serpent.String(srv.URL)
 
 	_, _ = coderdenttest.New(t, &coderdenttest.Options{
 		EntitlementsUpdateInterval: 25 * time.Millisecond,


### PR DESCRIPTION
Fixes #14395

Stacked as CI would not otherwise pass until #14489 is merged. 