### PR TITLE
fix: stop reporting future licenses as errors

### DIFF
--- a/enterprise/coderd/coderdenttest/coderdenttest.go
+++ b/enterprise/coderd/coderdenttest/coderdenttest.go
@@ -199,6 +199,13 @@ func (opts *LicenseOptions) Valid(now time.Time) *LicenseOptions {
 	return opts
 }
 
+func (opts *LicenseOptions) FutureTerm(now time.Time) *LicenseOptions {
+	opts.NotBefore = now.Add(time.Hour * 24)
+	opts.ExpiresAt = now.Add(time.Hour * 24 * 60)
+	opts.GraceAt = now.Add(time.Hour * 24 * 53)
+	return opts
+}
+
 func (opts *LicenseOptions) UserLimit(limit int64) *LicenseOptions {
 	return opts.Feature(codersdk.FeatureUserLimit, limit)
 }

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -100,6 +100,13 @@ func LicensesEntitlements(
 	//   'Entitlements' group as a whole.
 	for _, license := range licenses {
 		claims, err := ParseClaims(license.JWT, keys)
+		var vErr *jwt.ValidationError
+		if xerrors.As(err, &vErr) && vErr.Is(jwt.ErrTokenNotValidYet) {
+			// The license isn't valid yet.  We don't consider any entitlements contained in it, but
+			// it's also not an error.  Just skip it silently.  This can happen if an administrator
+			// uploads a license for a new term that hasn't started yet.
+			continue
+		}
 		if err != nil {
 			entitlements.Errors = append(entitlements.Errors,
 				fmt.Sprintf("Invalid license (%s) parsing claims: %s", license.UUID.String(), err.Error()))

--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -826,6 +826,25 @@ func TestLicenseEntitlements(t *testing.T) {
 				assert.True(t, entitlements.Features[codersdk.FeatureCustomRoles].Enabled, "custom-roles enabled for premium")
 			},
 		},
+		{
+			Name: "CurrentAndFuture",
+			Licenses: []*coderdenttest.LicenseOptions{
+				enterpriseLicense().UserLimit(100),
+				premiumLicense().UserLimit(200).FutureTerm(time.Now()),
+			},
+			Enablements: defaultEnablements,
+			AssertEntitlements: func(t *testing.T, entitlements codersdk.Entitlements) {
+				assertEnterpriseFeatures(t, entitlements)
+				assertNoErrors(t, entitlements)
+				assertNoWarnings(t, entitlements)
+				userFeature := entitlements.Features[codersdk.FeatureUserLimit]
+				assert.Equalf(t, int64(100), *userFeature.Limit, "user limit")
+				assert.Equal(t, codersdk.EntitlementNotEntitled,
+					entitlements.Features[codersdk.FeatureMultipleOrganizations].Entitlement)
+				assert.Equal(t, codersdk.EntitlementNotEntitled,
+					entitlements.Features[codersdk.FeatureCustomRoles].Entitlement)
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
fixes #14476

Fixes the entitlements processing code so that we don't report existence of "future" licenses as an error, which might alarm admins needlessly.  Downstack PR fixes our API to allow such licenses to be added to the database.