### PR TITLE
fix: correctly close SMTP message and await response

### DIFF
--- a/coderd/notifications/dispatch/smtp.go
+++ b/coderd/notifications/dispatch/smtp.go
@@ -183,7 +183,6 @@ func (s *SMTPHandler) dispatch(subject, htmlBody, plainBody, to string) Delivery
 		if err != nil {
 			return true, xerrors.Errorf("message transmission: %w", err)
 		}
-		defer message.Close()
 
 		// Create message headers.
 		msg := &bytes.Buffer{}
@@ -249,6 +248,10 @@ func (s *SMTPHandler) dispatch(subject, htmlBody, plainBody, to string) Delivery
 		_, err = message.Write(multipartBuffer.Bytes())
 		if err != nil {
 			return false, xerrors.Errorf("write body buffer: %w", err)
+		}
+
+		if err = message.Close(); err != nil {
+			return true, xerrors.Errorf("delivery failure: %w", err)
 		}
 
 		// Returning false, nil indicates successful send (i.e. non-retryable non-error)

--- a/coderd/notifications/dispatch/smtp_test.go
+++ b/coderd/notifications/dispatch/smtp_test.go
@@ -62,6 +62,7 @@ func TestSMTP(t *testing.T) {
 		expectedErr      string
 		retryable        bool
 		useTLS           bool
+		failOnDataFn     func() error
 	}{
 		/**
 		 * LOGIN auth mechanism
@@ -381,6 +382,21 @@ func TestSMTP(t *testing.T) {
 			toAddrs:          []string{to},
 			expectedAuthMeth: sasl.Plain,
 		},
+		/**
+		 * Other errors
+		 */
+		{
+			name: "Rejected on DATA",
+			cfg: codersdk.NotificationsEmailConfig{
+				Hello: hello,
+				From:  from,
+			},
+			failOnDataFn: func() error {
+				return &smtp.SMTPError{Code: 501, EnhancedCode: smtp.EnhancedCode{5, 5, 4}, Message: "Rejected!"}
+			},
+			expectedErr: "SMTP error 501: Rejected!",
+			retryable:   true,
+		},
 	}
 
 	// nolint:paralleltest // Reinitialization is not required as of Go v1.22.
@@ -398,6 +414,8 @@ func TestSMTP(t *testing.T) {
 				AcceptedIdentity: tc.cfg.Auth.Identity.String(),
 				AcceptedUsername: username,
 				AcceptedPassword: password,
+
+				FailOnDataFn: tc.failOnDataFn,
 			})
 
 			// Create a mock SMTP server which conditionally listens for plain or TLS connections.

--- a/coderd/notifications/dispatch/smtp_util_test.go
+++ b/coderd/notifications/dispatch/smtp_util_test.go
@@ -24,6 +24,7 @@ var (
 type Config struct {
 	AuthMechanisms                                       []string
 	AcceptedIdentity, AcceptedUsername, AcceptedPassword string
+	FailOnDataFn                                         func() error
 }
 
 type Message struct {
@@ -145,6 +146,10 @@ func (s *Session) Data(r io.Reader) error {
 	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
+	}
+
+	if s.backend.cfg.FailOnDataFn != nil {
+		return s.backend.cfg.FailOnDataFn()
 	}
 
 	s.backend.lastMsg.Contents = string(b)


### PR DESCRIPTION
We originally took heavy inspiration from [Alertmanager's SMTP dispatch functionality](https://github.com/prometheus/alertmanager/blob/main/notify/email/email.go#L126) due to the number of options we need to support.

In their dispatch code, they defer the call to `message.Close` but in fact this is necessary to complete the SMTP submission and await any errors; we do the same in our code.

_NOTE: We use `emersion/go-smtp` as our SMTP library while Alertmanager uses `net/smtp`, but the former extends the latter, so the code that follows is effectively the same_.

```go
// coderd/notifications/dispatch/smtp.go
// Our client calls Data(), which returns a `dataCloser`.
message, err := c.Data()

...

// emersion/go-smtp@v0.21.2/client.go
func (c *Client) Data() (io.WriteCloser, error) {
	_, _, err := c.cmd(354, "DATA")
	if err != nil {
		return nil, err
	}
	return &dataCloser{c: c, WriteCloser: c.text.DotWriter()}, nil
}
...
func (d *dataCloser) Close() error {
	...
	if d.c.lmtp {
          ...
	} else {
		_, _, err := d.c.readResponse(250) // <---- this is the crucial line
		if err != nil {
			return err
		}
	}

	d.closed = true
	return nil
}
```

We cannot defer a call to `Close` because we depend on the error which is returned to determine if the message was successfully sent or not.

```go
_, _, err := d.c.readResponse(250)
```

This line checks if the response was successful ([docs](https://en.wikipedia.org/wiki/List_of_SMTP_server_return_codes#%E2%80%94_2yz_Positive_completion)); if not, we need to fail this dispatch and mark it for retry.

---

I discovered this bug by incorrectly configuring `CODER_NOTIFICATIONS_EMAIL_FROM` as my `@coder.com` address (which is backed by GSuite) and testing a dispatch via an outlook.com SMTP server. The server was rejecting the message with `554 5.2.252 SendAsDenied; <redacted>@outlook.com not allowed to send as <redacted>@coder.com`, but the message was being marked successful, because we were not waiting for the actual outcome of the mail dispatch.

This has quite worrying implications for Alertmanager, and I plan to raise a PR in that repo too to address this.