### PR TITLE
fix: use negative deadline to ensure timeout in `TestWebhook/timeout`

### DIFF
--- a/coderd/notifications/dispatch/webhook_test.go
+++ b/coderd/notifications/dispatch/webhook_test.go
@@ -83,7 +83,7 @@ func TestWebhook(t *testing.T) {
 			serverFn: func(u uuid.UUID, writer http.ResponseWriter, request *http.Request) {
 				t.Fatalf("should not get here")
 			},
-			expectErr:       "request timeout",
+			expectErr: "request timeout",
 		},
 		{
 			name: "non-200 response",


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/14060

I suspect two things:
1. CI is not showing us panics on Windows for some reason, because
2. The context was not being canceled which meant that `serverFn` was being called, yet it was nil which caused the panic

I replicated this on a Windows workspace

![image](https://github.com/user-attachments/assets/c0f7f1f3-6cbd-4ff1-8e6c-b12eb47f8e9f)

Setting a deadline 1h ago (instead of a timeout 1ns from now) seems to be more reliable.