### PR TITLE
feat: support optional SMTP auth

### DIFF
--- a/coderd/notifications/dispatch/smtp_test.go
+++ b/coderd/notifications/dispatch/smtp_test.go
@@ -203,9 +203,18 @@ func TestSMTP(t *testing.T) {
 			retryable:        false,
 		},
 		{
-			// No auth, no problem!
 			name:      "No auth mechanisms supported, none configured",
 			authMechs: []string{},
+			cfg: codersdk.NotificationsEmailConfig{
+				Hello: hello,
+				From:  from,
+			},
+			toAddrs:          []string{to},
+			expectedAuthMeth: "",
+		},
+		{
+			name:      "Auth mechanisms supported optionally, none configured",
+			authMechs: []string{sasl.Login, sasl.Plain},
 			cfg: codersdk.NotificationsEmailConfig{
 				Hello: hello,
 				From:  from,


### PR DESCRIPTION
Currently if an SMTP smarthost supports auth mechanisms but does not _enforce_ one to be used, messages will fail to be delivered if blank authentication details are configured.

Currently messages will fail with this misleading error message:

```
cannot use PLAIN auth, password not defined (see CODER_NOTIFICATIONS_EMAIL_AUTH_PASSWORD)
```

This is a red herring. It stems from always creating an authentication client even if authentication details are not configured - but the smarthost advertises one or more auth mechanisms.

This change bails out of creating the client if authentication details are blank.