### PR TITLE
fix: fix TestPendingUpdatesMetric flaky assertion

### DIFF
--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog"
+	"github.com/coder/quartz"
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
@@ -54,13 +55,25 @@ type Manager struct {
 	stopOnce sync.Once
 	stop     chan any
 	done     chan any
+
+	// clock is for testing only
+	clock quartz.Clock
+}
+
+type ManagerOption func(*Manager)
+
+// WithTestClock is used in testing to set the quartz clock on the manager
+func WithTestClock(clock quartz.Clock) ManagerOption {
+	return func(m *Manager) {
+		m.clock = clock
+	}
 }
 
 // NewManager instantiates a new Manager instance which coordinates notification enqueuing and delivery.
 //
 // helpers is a map of template helpers which are used to customize notification messages to use global settings like
 // access URL etc.
-func NewManager(cfg codersdk.NotificationsConfig, store Store, helpers template.FuncMap, metrics *Metrics, log slog.Logger) (*Manager, error) {
+func NewManager(cfg codersdk.NotificationsConfig, store Store, helpers template.FuncMap, metrics *Metrics, log slog.Logger, opts ...ManagerOption) (*Manager, error) {
 	// TODO(dannyk): add the ability to use multiple notification methods.
 	var method database.NotificationMethod
 	if err := method.Scan(cfg.Method.String()); err != nil {
@@ -74,7 +87,7 @@ func NewManager(cfg codersdk.NotificationsConfig, store Store, helpers template.
 		return nil, ErrInvalidDispatchTimeout
 	}
 
-	return &Manager{
+	m := &Manager{
 		log:   log,
 		cfg:   cfg,
 		store: store,
@@ -95,7 +108,13 @@ func NewManager(cfg codersdk.NotificationsConfig, store Store, helpers template.
 		done: make(chan any),
 
 		handlers: defaultHandlers(cfg, helpers, log),
-	}, nil
+
+		clock: quartz.NewReal(),
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	return m, nil
 }
 
 // defaultHandlers builds a set of known handlers; panics if any error occurs as these handlers should be valid at compile time.
@@ -150,7 +169,7 @@ func (m *Manager) loop(ctx context.Context) error {
 	var eg errgroup.Group
 
 	// Create a notifier to run concurrently, which will handle dequeueing and dispatching notifications.
-	m.notifier = newNotifier(m.cfg, uuid.New(), m.log, m.store, m.handlers, m.metrics)
+	m.notifier = newNotifier(m.cfg, uuid.New(), m.log, m.store, m.handlers, m.metrics, m.clock)
 	eg.Go(func() error {
 		return m.notifier.run(ctx, m.success, m.failure)
 	})
@@ -158,7 +177,7 @@ func (m *Manager) loop(ctx context.Context) error {
 	// Periodically flush notification state changes to the store.
 	eg.Go(func() error {
 		// Every interval, collect the messages in the channels and bulk update them in the store.
-		tick := time.NewTicker(m.cfg.StoreSyncInterval.Value())
+		tick := m.clock.NewTicker(m.cfg.StoreSyncInterval.Value(), "Manager", "storeSync")
 		defer tick.Stop()
 		for {
 			select {

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -15,6 +14,7 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications/render"
 	"github.com/coder/coder/v2/coderd/notifications/types"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/quartz"
 
 	"cdr.dev/slog"
 
@@ -29,26 +29,33 @@ type notifier struct {
 	log   slog.Logger
 	store Store
 
-	tick     *time.Ticker
+	tick     *quartz.Ticker
 	stopOnce sync.Once
 	quit     chan any
 	done     chan any
 
 	handlers map[database.NotificationMethod]Handler
 	metrics  *Metrics
+
+	// clock is for testing
+	clock quartz.Clock
 }
 
-func newNotifier(cfg codersdk.NotificationsConfig, id uuid.UUID, log slog.Logger, db Store, hr map[database.NotificationMethod]Handler, metrics *Metrics) *notifier {
+func newNotifier(cfg codersdk.NotificationsConfig, id uuid.UUID, log slog.Logger, db Store,
+	hr map[database.NotificationMethod]Handler, metrics *Metrics, clock quartz.Clock,
+) *notifier {
+	tick := clock.NewTicker(cfg.FetchInterval.Value(), "notifier", "fetchInterval")
 	return &notifier{
 		id:       id,
 		cfg:      cfg,
 		log:      log.Named("notifier").With(slog.F("notifier_id", id)),
 		quit:     make(chan any),
 		done:     make(chan any),
-		tick:     time.NewTicker(cfg.FetchInterval.Value()),
+		tick:     tick,
 		store:    db,
 		handlers: hr,
 		metrics:  metrics,
+		clock:    clock,
 	}
 }
 
@@ -245,10 +252,10 @@ func (n *notifier) deliver(ctx context.Context, msg database.AcquireNotification
 	n.metrics.InflightDispatches.WithLabelValues(string(msg.Method), msg.TemplateID.String()).Inc()
 	n.metrics.QueuedSeconds.WithLabelValues(string(msg.Method)).Observe(msg.QueuedSeconds)
 
-	start := time.Now()
+	start := n.clock.Now()
 	retryable, err := deliver(ctx, msg.ID)
 
-	n.metrics.DispatcherSendSeconds.WithLabelValues(string(msg.Method)).Observe(time.Since(start).Seconds())
+	n.metrics.DispatcherSendSeconds.WithLabelValues(string(msg.Method)).Observe(n.clock.Since(start).Seconds())
 	n.metrics.InflightDispatches.WithLabelValues(string(msg.Method), msg.TemplateID.String()).Dec()
 
 	if err != nil {
@@ -291,7 +298,7 @@ func (n *notifier) newSuccessfulDispatch(msg database.AcquireNotificationMessage
 	return dispatchResult{
 		notifier: n.id,
 		msg:      msg.ID,
-		ts:       dbtime.Now(),
+		ts:       dbtime.Time(n.clock.Now().UTC()),
 	}
 }
 
@@ -311,7 +318,7 @@ func (n *notifier) newFailedDispatch(msg database.AcquireNotificationMessagesRow
 	return dispatchResult{
 		notifier:  n.id,
 		msg:       msg.ID,
-		ts:        dbtime.Now(),
+		ts:        dbtime.Time(n.clock.Now().UTC()),
 		err:       err,
 		retryable: retryable,
 	}
@@ -321,7 +328,7 @@ func (n *notifier) newInhibitedDispatch(msg database.AcquireNotificationMessages
 	return dispatchResult{
 		notifier:  n.id,
 		msg:       msg.ID,
-		ts:        dbtime.Now(),
+		ts:        dbtime.Time(n.clock.Now().UTC()),
 		retryable: false,
 		inhibited: true,
 	}


### PR DESCRIPTION
Fixes flake seen here:

https://github.com/coder/coder/actions/runs/10677025332/job/29591518118

The original test waits for DB calls to update success and failure of notifications, and blocks on a `pause` channel.  However, it uses a single pause channel for both DB calls, and so implicitly assumes that both success and failure updates occur during an update sync.

However, the update sync timer isn't synchronized to anything, and so there is a race where the update sync only has either the success or the failure result but not both.  This blocks the test, which waits for both, and deadlocks before unpausing.

It appears the unpause mechanism is there to test that the `PendingUpdates` metric updates accordingly.

This fixes the flake by:

1. using a Quartz clock to control when the `Manager` syncs updates.
2. waiting for the `PendingUpdates` metric to reach 2, so that we know that both success and failure have been queued up
3. triggering the update via the Quartz mock clock

This has the nice property that a "pause" function is no longer required: we know the manager is in our desired state before we trigger the update, and can assert on the Metrics before and after.