### PR TITLE
fix: add missing down migration

### DIFF
--- a/coderd/database/migrations/000244_notifications_delete_template.down.sql
+++ b/coderd/database/migrations/000244_notifications_delete_template.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM notification_templates WHERE id = '29a09665-2a4c-403f-9648-54301670e7be';


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/14250

Looks like we missed the down migration for _Template Deleted_ notification.