### PR TITLE
feat: create idp sync page skeleton

### DIFF
--- a/site/src/components/EmptyState/EmptyState.stories.tsx
+++ b/site/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,11 +13,17 @@ const meta: Meta<typeof EmptyState> = {
 export default meta;
 type Story = StoryObj<typeof EmptyState>;
 
-const Example: Story = {
+export const Example: Story = {
 	args: {
 		description: "It is easy, just click the button below",
 		cta: <Button>Create workspace</Button>,
 	},
 };
 
-export { Example as EmptyState };
+export const Compact: Story = {
+	args: {
+		description: "It is easy, just click the button below",
+		cta: <Button>Create workspace</Button>,
+		isCompact: true,
+	},
+};

--- a/site/src/components/EmptyState/EmptyState.tsx
+++ b/site/src/components/EmptyState/EmptyState.tsx
@@ -25,17 +25,23 @@ export const EmptyState: FC<EmptyStateProps> = ({
 }) => {
 	return (
 		<div
-			css={{
-				overflow: "hidden",
-				display: "flex",
-				flexDirection: "column",
-				justifyContent: "center",
-				alignItems: "center",
-				textAlign: "center",
-				minHeight: isCompact ? 180 : 360,
-				padding: isCompact ? "10px 40px" : "80px 40px",
-				position: "relative",
-			}}
+			css={[
+				{
+					overflow: "hidden",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "center",
+					alignItems: "center",
+					textAlign: "center",
+					minHeight: 360,
+					padding: "80px 40px",
+					position: "relative",
+				},
+				isCompact && {
+					minHeight: 180,
+					padding: "10px 40px",
+				},
+			]}
 			{...attrs}
 		>
 			<h5 css={{ fontSize: 24, fontWeight: 500, margin: 0 }}>{message}</h5>

--- a/site/src/components/EmptyState/EmptyState.tsx
+++ b/site/src/components/EmptyState/EmptyState.tsx
@@ -7,6 +7,7 @@ export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
 	description?: string | ReactNode;
 	cta?: ReactNode;
 	image?: ReactNode;
+	isCompact?: boolean;
 }
 
 /**
@@ -19,6 +20,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
 	description,
 	cta,
 	image,
+	isCompact,
 	...attrs
 }) => {
 	return (
@@ -30,8 +32,8 @@ export const EmptyState: FC<EmptyStateProps> = ({
 				justifyContent: "center",
 				alignItems: "center",
 				textAlign: "center",
-				minHeight: 360,
-				padding: "80px 40px",
+				minHeight: isCompact ? 180 : 360,
+				padding: isCompact ? "10px 40px" : "80px 40px",
 				position: "relative",
 			}}
 			{...attrs}

--- a/site/src/components/SettingsHeader/SettingsHeader.tsx
+++ b/site/src/components/SettingsHeader/SettingsHeader.tsx
@@ -9,6 +9,7 @@ interface HeaderProps {
 	description?: ReactNode;
 	secondary?: boolean;
 	docsHref?: string;
+	tooltip?: ReactNode;
 }
 
 export const SettingsHeader: FC<HeaderProps> = ({
@@ -16,32 +17,36 @@ export const SettingsHeader: FC<HeaderProps> = ({
 	description,
 	docsHref,
 	secondary,
+	tooltip,
 }) => {
 	const theme = useTheme();
 
 	return (
 		<Stack alignItems="baseline" direction="row" justifyContent="space-between">
 			<div css={{ maxWidth: 420, marginBottom: 24 }}>
-				<h1
-					css={[
-						{
-							fontSize: 32,
-							fontWeight: 700,
-							display: "flex",
-							alignItems: "center",
-							lineHeight: "initial",
-							margin: 0,
-							marginBottom: 4,
-							gap: 8,
-						},
-						secondary && {
-							fontSize: 24,
-							fontWeight: 500,
-						},
-					]}
-				>
-					{title}
-				</h1>
+				<Stack direction="row" spacing={1} alignItems="center">
+					<h1
+						css={[
+							{
+								fontSize: 32,
+								fontWeight: 700,
+								display: "flex",
+								alignItems: "center",
+								lineHeight: "initial",
+								margin: 0,
+								marginBottom: 4,
+								gap: 8,
+							},
+							secondary && {
+								fontSize: 24,
+								fontWeight: 500,
+							},
+						]}
+					>
+						{title}
+					</h1>
+					{tooltip}
+				</Stack>
 				{description && (
 					<span
 						css={{

--- a/site/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/site/src/components/StatusIndicator/StatusIndicator.tsx
@@ -15,17 +15,19 @@ export const StatusIndicator: FC<StatusIndicatorProps> = ({
 
 	return (
 		<div
-			css={{
-				height: 8,
-				width: 8,
-				borderRadius: 4,
-				backgroundColor:
-					variant === "solid" ? theme.roles[color].fill.solid : undefined,
-				border:
-					variant === "outlined"
-						? `1px solid ${theme.roles[color].outline}`
-						: undefined,
-			}}
+			css={[
+				{
+					height: 8,
+					width: 8,
+					borderRadius: 4,
+				},
+				variant === "solid" && {
+					backgroundColor: theme.roles[color].fill.solid,
+				},
+				variant === "outlined" && {
+					border: `1px solid ${theme.roles[color].outline}`,
+				},
+			]}
 		/>
 	);
 };

--- a/site/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/site/src/components/StatusIndicator/StatusIndicator.tsx
@@ -4,9 +4,13 @@ import type { ThemeRole } from "theme/roles";
 
 interface StatusIndicatorProps {
 	color: ThemeRole;
+	variant?: "solid" | "outlined";
 }
 
-export const StatusIndicator: FC<StatusIndicatorProps> = ({ color }) => {
+export const StatusIndicator: FC<StatusIndicatorProps> = ({
+	color,
+	variant = "solid",
+}) => {
 	const theme = useTheme();
 
 	return (
@@ -15,7 +19,12 @@ export const StatusIndicator: FC<StatusIndicatorProps> = ({ color }) => {
 				height: 8,
 				width: 8,
 				borderRadius: 4,
-				backgroundColor: theme.roles[color].fill.solid,
+				backgroundColor:
+					variant === "solid" ? theme.roles[color].fill.solid : undefined,
+				border:
+					variant === "outlined"
+						? `1px solid ${theme.roles[color].outline}`
+						: undefined,
 			}}
 		/>
 	);

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncHelpTooltip.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncHelpTooltip.tsx
@@ -1,0 +1,31 @@
+import {
+	HelpTooltip,
+	HelpTooltipContent,
+	HelpTooltipLink,
+	HelpTooltipLinksGroup,
+	HelpTooltipText,
+	HelpTooltipTitle,
+	HelpTooltipTrigger,
+} from "components/HelpTooltip/HelpTooltip";
+import type { FC } from "react";
+import { docs } from "utils/docs";
+
+export const IdpSyncHelpTooltip: FC = () => {
+	return (
+		<HelpTooltip>
+			<HelpTooltipTrigger />
+			<HelpTooltipContent>
+				<HelpTooltipTitle>What is IdP Sync?</HelpTooltipTitle>
+				<HelpTooltipText>
+					View the current mappings between your external OIDC provider and
+					Coder. Use the Coder CLI to configure these mappings.
+				</HelpTooltipText>
+				<HelpTooltipLinksGroup>
+					<HelpTooltipLink href={docs("/admin/auth#group-sync-enterprise")}>
+						Configure IdP Sync
+					</HelpTooltipLink>
+				</HelpTooltipLinksGroup>
+			</HelpTooltipContent>
+		</HelpTooltip>
+	);
+};

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -1,21 +1,13 @@
 import AddIcon from "@mui/icons-material/AddOutlined";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import Button from "@mui/material/Button";
-import { getErrorMessage } from "api/errors";
-import { organizationPermissions } from "api/queries/organizations";
-import { organizationRoles } from "api/queries/roles";
-import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
-import { Loader } from "components/Loader/Loader";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
-import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
-import { type FC, useEffect, useState } from "react";
+import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
-import { useQuery, useQueryClient } from "react-query";
-import { Link as RouterLink, useParams } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
-import { useOrganizationSettings } from "../ManagementSettingsLayout";
 import { IdpSyncHelpTooltip } from "./IdpSyncHelpTooltip";
 import IdpSyncPageView from "./IdpSyncPageView";
 
@@ -52,31 +44,19 @@ const mockOIDCConfig = {
 };
 
 export const IdpSyncPage: FC = () => {
-	const queryClient = useQueryClient();
-	// const { custom_roles: isCustomRolesEnabled } = useFeatureVisibility();
-	const { organization: organizationName } = useParams() as {
-		organization: string;
-	};
-	const { organizations } = useOrganizationSettings();
-	const organization = organizations?.find((o) => o.name === organizationName);
-	const permissionsQuery = useQuery(organizationPermissions(organization?.id));
-	const organizationRolesQuery = useQuery(organizationRoles(organizationName));
-	const permissions = permissionsQuery.data;
+	// feature visibility and permissions to be implemented when integrating with backend
+	// const feats = useFeatureVisibility();
+	// const { organization: organizationName } = useParams() as {
+	// 	organization: string;
+	// };
+	// const { organizations } = useOrganizationSettings();
+	// const organization = organizations?.find((o) => o.name === organizationName);
+	// const permissionsQuery = useQuery(organizationPermissions(organization?.id));
+	// const permissions = permissionsQuery.data;
 
-	useEffect(() => {
-		if (organizationRolesQuery.error) {
-			displayError(
-				getErrorMessage(
-					organizationRolesQuery.error,
-					"Error loading custom roles.",
-				),
-			);
-		}
-	}, [organizationRolesQuery.error]);
-
-	if (!permissions) {
-		return <Loader />;
-	}
+	// if (!permissions) {
+	// 	return <Loader />;
+	// }
 
 	return (
 		<>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -19,6 +19,38 @@ import { useOrganizationSettings } from "../ManagementSettingsLayout";
 import { IdpSyncHelpTooltip } from "./IdpSyncHelpTooltip";
 import IdpSyncPageView from "./IdpSyncPageView";
 
+const mockOIDCConfig = {
+	allow_signups: true,
+	client_id: "test",
+	client_secret: "test",
+	client_key_file: "test",
+	client_cert_file: "test",
+	email_domain: [],
+	issuer_url: "test",
+	scopes: [],
+	ignore_email_verified: true,
+	username_field: "",
+	name_field: "",
+	email_field: "",
+	auth_url_params: {},
+	ignore_user_info: true,
+	organization_field: "",
+	organization_mapping: {},
+	organization_assign_default: true,
+	group_auto_create: false,
+	group_regex_filter: "^Coder-.*$",
+	group_allow_list: [],
+	groups_field: "groups",
+	group_mapping: { group1: "developers", group2: "admin", group3: "auditors" },
+	user_role_field: "roles",
+	user_role_mapping: { role1: ["role1", "role2"] },
+	user_roles_default: [],
+	sign_in_text: "",
+	icon_url: "",
+	signups_disabled_text: "string",
+	skip_issuer_checks: true,
+};
+
 export const IdpSyncPage: FC = () => {
 	const queryClient = useQueryClient();
 	// const { custom_roles: isCustomRolesEnabled } = useFeatureVisibility();
@@ -77,7 +109,7 @@ export const IdpSyncPage: FC = () => {
 				</Stack>
 			</Stack>
 
-			<IdpSyncPageView roles={[]} />
+			<IdpSyncPageView oidcConfig={mockOIDCConfig} />
 		</>
 	);
 };

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -1,0 +1,83 @@
+import AddIcon from "@mui/icons-material/AddOutlined";
+import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
+import Button from "@mui/material/Button";
+import { getErrorMessage } from "api/errors";
+import { organizationPermissions } from "api/queries/organizations";
+import { organizationRoles } from "api/queries/roles";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
+import { Loader } from "components/Loader/Loader";
+import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
+import { Stack } from "components/Stack/Stack";
+import { useFeatureVisibility } from "modules/dashboard/useFeatureVisibility";
+import { type FC, useEffect, useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { useQuery, useQueryClient } from "react-query";
+import { Link as RouterLink, useParams } from "react-router-dom";
+import { pageTitle } from "utils/page";
+import { useOrganizationSettings } from "../ManagementSettingsLayout";
+import { docs } from "utils/docs";
+import IdpSyncPageView from "./IdpSyncPageView";
+
+export const IdpSyncPage: FC = () => {
+	const queryClient = useQueryClient();
+	// const { custom_roles: isCustomRolesEnabled } = useFeatureVisibility();
+	const { organization: organizationName } = useParams() as {
+		organization: string;
+	};
+	const { organizations } = useOrganizationSettings();
+	const organization = organizations?.find((o) => o.name === organizationName);
+	const permissionsQuery = useQuery(organizationPermissions(organization?.id));
+	const organizationRolesQuery = useQuery(organizationRoles(organizationName));
+	const permissions = permissionsQuery.data;
+
+	useEffect(() => {
+		if (organizationRolesQuery.error) {
+			displayError(
+				getErrorMessage(
+					organizationRolesQuery.error,
+					"Error loading custom roles.",
+				),
+			);
+		}
+	}, [organizationRolesQuery.error]);
+
+	if (!permissions) {
+		return <Loader />;
+	}
+
+	return (
+		<>
+			<Helmet>
+				<title>{pageTitle("IdP Sync")}</title>
+			</Helmet>
+
+			<Stack
+				alignItems="baseline"
+				direction="row"
+				justifyContent="space-between"
+			>
+				<SettingsHeader
+					title="IdP Sync"
+					description="Group and role sync mappings (configured outside Coder)."
+				/>
+				<Stack direction="row" spacing={2}>
+					<Button
+						startIcon={<LaunchOutlined />}
+						component="a"
+						href={docs("/cli/server#--notifications-webhook-endpoint")}
+						target="_blank"
+					>
+						Setup IdP Sync
+					</Button>
+					<Button component={RouterLink} startIcon={<AddIcon />} to="export">
+						Export Policy
+					</Button>
+				</Stack>
+			</Stack>
+
+			<IdpSyncPageView roles={[]} />
+		</>
+	);
+};
+
+export default IdpSyncPage;

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -13,9 +13,10 @@ import { type FC, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "react-query";
 import { Link as RouterLink, useParams } from "react-router-dom";
+import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
 import { useOrganizationSettings } from "../ManagementSettingsLayout";
-import { docs } from "utils/docs";
+import { IdpSyncHelpTooltip } from "./IdpSyncHelpTooltip";
 import IdpSyncPageView from "./IdpSyncPageView";
 
 export const IdpSyncPage: FC = () => {
@@ -59,12 +60,13 @@ export const IdpSyncPage: FC = () => {
 				<SettingsHeader
 					title="IdP Sync"
 					description="Group and role sync mappings (configured outside Coder)."
+					tooltip={<IdpSyncHelpTooltip />}
 				/>
 				<Stack direction="row" spacing={2}>
 					<Button
 						startIcon={<LaunchOutlined />}
 						component="a"
-						href={docs("/cli/server#--notifications-webhook-endpoint")}
+						href={docs("/admin/auth#group-sync-enterprise")}
 						target="_blank"
 					>
 						Setup IdP Sync

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MockOIDCConfig } from "testHelpers/entities";
+import { IdpSyncPageView } from "./IdpSyncPageView";
+
+const meta: Meta<typeof IdpSyncPageView> = {
+	title: "pages/OrganizationIdpSyncPage",
+	component: IdpSyncPageView,
+};
+
+export default meta;
+type Story = StoryObj<typeof IdpSyncPageView>;
+
+export const Empty: Story = {
+	args: { oidcConfig: undefined },
+};
+
+export const Default: Story = {
+	args: { oidcConfig: MockOIDCConfig },
+};

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -1,0 +1,181 @@
+import type { Interpolation, Theme } from "@emotion/react";
+import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
+import Button from "@mui/material/Button";
+import Skeleton from "@mui/material/Skeleton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import type { Role } from "api/typesGenerated";
+import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
+import { EmptyState } from "components/EmptyState/EmptyState";
+import { Paywall } from "components/Paywall/Paywall";
+import { Stack } from "components/Stack/Stack";
+import {
+	TableLoaderSkeleton,
+	TableRowSkeleton,
+} from "components/TableLoader/TableLoader";
+import type { FC } from "react";
+import { docs } from "utils/docs";
+
+export type IdpSyncPageViewProps = {
+	roles: Role[] | undefined;
+};
+
+export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ roles }) => {
+	return (
+		<>
+			<ChooseOne>
+				<Cond condition={false}>
+					<Paywall
+						message="IdP Sync"
+						description="Configure group and role mappings to manage permissions outside of Coder."
+						documentationLink={docs("/admin/groups")}
+					/>
+				</Cond>
+				<Cond>
+					<Stack spacing={2} css={styles.fields}>
+						{/* Semantically fieldset is used for forms. In the future this screen will allow
+						 updates to these fields in a form */}
+						<fieldset css={styles.box}>
+							<legend css={styles.legend}>Groups</legend>
+							<Stack direction={"row"} alignItems={"center"} spacing={3}>
+								<h4>Sync Field</h4>
+								<p css={styles.secondary}>groups</p>
+								<h4>Regex Filter</h4>
+								<p css={styles.secondary}>^Coder-.*$</p>
+								<h4>Auto Create</h4>
+								<p css={styles.secondary}>false</p>
+							</Stack>
+						</fieldset>
+						<fieldset css={styles.box}>
+							<legend css={styles.legend}>Roles</legend>
+							<Stack direction={"row"} alignItems={"center"} spacing={3}>
+								<h4>Sync Field</h4>
+								<p css={styles.secondary}>roles</p>
+							</Stack>
+						</fieldset>
+					</Stack>
+					<Stack spacing={4}>
+						<RoleTable roles={roles} />
+						<RoleTable roles={roles} />
+					</Stack>
+				</Cond>
+			</ChooseOne>
+		</>
+	);
+};
+
+interface RoleTableProps {
+	roles: Role[] | undefined;
+}
+
+const RoleTable: FC<RoleTableProps> = ({ roles }) => {
+	const isLoading = false;
+	const isEmpty = Boolean(roles && roles.length === 0);
+	return (
+		<TableContainer>
+			<Table>
+				<TableHead>
+					<TableRow>
+						<TableCell width="45%">Idp Role</TableCell>
+						<TableCell width="55%">Coder Role</TableCell>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<ChooseOne>
+						<Cond condition={isLoading}>
+							<TableLoader />
+						</Cond>
+
+						<Cond condition={isEmpty}>
+							<TableRow>
+								<TableCell colSpan={999}>
+									<EmptyState
+										message="No Role Mappings"
+										description={
+											"Configure role sync mappings to manage permissions outside of Coder."
+										}
+										isCompact
+										cta={
+											<Button
+												startIcon={<LaunchOutlined />}
+												component="a"
+												href={docs(
+													"/cli/server#--notifications-webhook-endpoint",
+												)}
+												target="_blank"
+											>
+												How to setup IdP role sync
+											</Button>
+										}
+									/>
+								</TableCell>
+							</TableRow>
+						</Cond>
+
+						<Cond>
+							{roles?.map((role) => (
+								<RoleRow key={role.name} role={role} />
+							))}
+						</Cond>
+					</ChooseOne>
+				</TableBody>
+			</Table>
+		</TableContainer>
+	);
+};
+
+interface RoleRowProps {
+	role: Role;
+}
+
+const RoleRow: FC<RoleRowProps> = ({ role }) => {
+	return (
+		<TableRow data-testid={`role-${role.name}`}>
+			<TableCell>{role.display_name || role.name}</TableCell>
+			<TableCell css={styles.secondary}>test</TableCell>
+		</TableRow>
+	);
+};
+
+const TableLoader = () => {
+	return (
+		<TableLoaderSkeleton>
+			<TableRowSkeleton>
+				<TableCell>
+					<Skeleton variant="text" width="25%" />
+				</TableCell>
+				<TableCell>
+					<Skeleton variant="text" width="25%" />
+				</TableCell>
+				<TableCell>
+					<Skeleton variant="text" width="25%" />
+				</TableCell>
+			</TableRowSkeleton>
+		</TableLoaderSkeleton>
+	);
+};
+
+const styles = {
+	secondary: (theme) => ({
+		color: theme.palette.text.secondary,
+	}),
+	fields: (theme) => ({
+		marginBottom: "60px",
+	}),
+	legend: (theme) => ({
+		padding: "0px 6px",
+		fontWeight: 600,
+	}),
+	box: (theme) => ({
+		border: "1px solid",
+		borderColor: theme.palette.divider,
+		padding: "0px 20px",
+		borderRadius: 8,
+	}),
+} satisfies Record<string, Interpolation<Theme>>;
+
+export default IdpSyncPageView;

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -103,9 +103,7 @@ const RoleTable: FC<RoleTableProps> = ({ roles }) => {
 											<Button
 												startIcon={<LaunchOutlined />}
 												component="a"
-												href={docs(
-													"/cli/server#--notifications-webhook-endpoint",
-												)}
+												href={docs("/admin/auth#group-sync-enterprise")}
 												target="_blank"
 											>
 												How to setup IdP role sync

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -87,9 +87,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 								<h4>Regex Filter</h4>
 								<p css={styles.secondary}>{group_regex_filter || "none"}</p>
 								<h4>Auto Create</h4>
-								<p css={styles.secondary}>
-									{oidcConfig?.group_auto_create.toString()}
-								</p>
+								<p css={styles.secondary}>{group_auto_create?.toString()}</p>
 							</Stack>
 						</fieldset>
 						<fieldset css={styles.box}>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -50,48 +50,30 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 						 updates to these fields in a form */}
 						<fieldset css={styles.box}>
 							<legend css={styles.legend}>Groups</legend>
-							<Stack direction={"row"} alignItems={"center"} spacing={3}>
-								<h4>Sync Field</h4>
-								<p css={styles.secondary}>
-									{groups_field || (
-										<div
-											css={{
-												display: "flex",
-												alignItems: "center",
-												gap: "8px",
-												height: 0,
-											}}
-										>
-											<StatusIndicator color="error" />
-											<p>disabled</p>
-										</div>
-									)}
-								</p>
-								<h4>Regex Filter</h4>
-								<p css={styles.secondary}>{group_regex_filter || "none"}</p>
-								<h4>Auto Create</h4>
-								<p css={styles.secondary}>{group_auto_create?.toString()}</p>
+							<Stack direction={"row"} alignItems={"center"} spacing={8}>
+								<IdpField
+									name={"Sync Field"}
+									fieldText={groups_field}
+									showStatusIndicator
+								/>
+								<IdpField
+									name={"Regex Filter"}
+									fieldText={group_regex_filter}
+								/>
+								<IdpField
+									name={"Auto Create"}
+									fieldText={group_auto_create?.toString()}
+								/>
 							</Stack>
 						</fieldset>
 						<fieldset css={styles.box}>
 							<legend css={styles.legend}>Roles</legend>
 							<Stack direction={"row"} alignItems={"center"} spacing={3}>
-								<h4>Sync Field</h4>
-								<p css={styles.secondary}>
-									{user_role_field || (
-										<div
-											css={{
-												display: "flex",
-												alignItems: "center",
-												gap: "8px",
-												height: 0,
-											}}
-										>
-											<StatusIndicator color="error" />
-											<p>disabled</p>
-										</div>
-									)}
-								</p>
+								<IdpField
+									name={"Sync Field"}
+									fieldText={user_role_field}
+									showStatusIndicator
+								/>
 							</Stack>
 						</fieldset>
 					</Stack>
@@ -140,6 +122,40 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 				</Cond>
 			</ChooseOne>
 		</>
+	);
+};
+
+interface IdpFieldProps {
+	name: string;
+	fieldText: string | undefined;
+	showStatusIndicator?: boolean;
+}
+
+const IdpField: FC<IdpFieldProps> = ({
+	name,
+	fieldText,
+	showStatusIndicator = false,
+}) => {
+	return (
+		<span css={{ display: "flex", alignItems: "center", gap: "16px" }}>
+			<h4>{name}</h4>
+			<p css={styles.secondary}>
+				{fieldText ||
+					(showStatusIndicator && (
+						<div
+							css={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								height: 0,
+							}}
+						>
+							<StatusIndicator color="error" />
+							<p>disabled</p>
+						</div>
+					))}
+			</p>
+		</span>
 	);
 };
 

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -1,4 +1,5 @@
 import type { Interpolation, Theme } from "@emotion/react";
+import { useTheme } from "@emotion/react";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import Button from "@mui/material/Button";
 import Skeleton from "@mui/material/Skeleton";
@@ -24,7 +25,34 @@ export type IdpSyncPageViewProps = {
 	oidcConfig: OIDCConfig | undefined;
 };
 
+type CircleProps = {
+	color: string;
+	variant?: "solid" | "outlined";
+};
+
+const Circle: FC<CircleProps> = ({ color, variant = "solid" }) => {
+	return (
+		<div
+			aria-hidden
+			css={{
+				width: 8,
+				height: 8,
+				backgroundColor: variant === "solid" ? color : undefined,
+				border: variant === "outlined" ? `1px solid ${color}` : undefined,
+				borderRadius: 9999,
+			}}
+		/>
+	);
+};
+
 export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
+	const theme = useTheme();
+	const {
+		groups_field,
+		user_role_field,
+		group_regex_filter,
+		group_auto_create,
+	} = oidcConfig || {};
 	return (
 		<>
 			<ChooseOne>
@@ -43,9 +71,21 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 							<legend css={styles.legend}>Groups</legend>
 							<Stack direction={"row"} alignItems={"center"} spacing={3}>
 								<h4>Sync Field</h4>
-								<p css={styles.secondary}>{oidcConfig?.groups_field}</p>
+								<p css={styles.secondary}>
+									{groups_field || (
+										<Stack
+											style={{ color: theme.palette.text.secondary }}
+											direction="row"
+											spacing={1}
+											alignItems="center"
+										>
+											<Circle color={theme.roles.error.fill.solid} />
+											<p>disabled</p>
+										</Stack>
+									)}
+								</p>
 								<h4>Regex Filter</h4>
-								<p css={styles.secondary}>{oidcConfig?.group_regex_filter}</p>
+								<p css={styles.secondary}>{group_regex_filter || "none"}</p>
 								<h4>Auto Create</h4>
 								<p css={styles.secondary}>
 									{oidcConfig?.group_auto_create.toString()}
@@ -56,7 +96,19 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 							<legend css={styles.legend}>Roles</legend>
 							<Stack direction={"row"} alignItems={"center"} spacing={3}>
 								<h4>Sync Field</h4>
-								<p css={styles.secondary}>{oidcConfig?.user_role_field}</p>
+								<p css={styles.secondary}>
+									{user_role_field || (
+										<Stack
+											style={{ color: theme.palette.text.secondary }}
+											direction="row"
+											spacing={1}
+											alignItems="center"
+										>
+											<Circle color={theme.roles.error.fill.solid} />
+											<p>disabled</p>
+										</Stack>
+									)}
+								</p>
 							</Stack>
 						</fieldset>
 					</Stack>
@@ -64,8 +116,10 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 						<IdpMappingTable
 							type="Role"
 							isEmpty={Boolean(
-								(oidcConfig?.user_role_mapping &&
-									Object.entries(oidcConfig?.user_role_mapping).length === 0) ||
+								!oidcConfig?.user_role_mapping ||
+									(oidcConfig?.user_role_mapping &&
+										Object.entries(oidcConfig?.user_role_mapping).length ===
+											0) ||
 									false,
 							)}
 						>
@@ -85,8 +139,9 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 						<IdpMappingTable
 							type="Group"
 							isEmpty={Boolean(
-								(oidcConfig?.user_role_mapping &&
-									Object.entries(oidcConfig?.group_mapping).length === 0) ||
+								!oidcConfig?.group_mapping ||
+									(oidcConfig?.group_mapping &&
+										Object.entries(oidcConfig?.group_mapping).length === 0) ||
 									false,
 							)}
 						>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -54,15 +54,17 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 								<h4>Sync Field</h4>
 								<p css={styles.secondary}>
 									{groups_field || (
-										<Stack
-											style={{ color: theme.palette.text.secondary }}
-											direction="row"
-											spacing={1}
-											alignItems="center"
+										<div
+											css={{
+												display: "flex",
+												alignItems: "center",
+												gap: "8px",
+												height: 0,
+											}}
 										>
 											<StatusIndicator color="error" />
 											<p>disabled</p>
-										</Stack>
+										</div>
 									)}
 								</p>
 								<h4>Regex Filter</h4>
@@ -77,15 +79,17 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 								<h4>Sync Field</h4>
 								<p css={styles.secondary}>
 									{user_role_field || (
-										<Stack
-											style={{ color: theme.palette.text.secondary }}
-											direction="row"
-											spacing={1}
-											alignItems="center"
+										<div
+											css={{
+												display: "flex",
+												alignItems: "center",
+												gap: "8px",
+												height: 0,
+											}}
 										>
 											<StatusIndicator color="error" />
 											<p>disabled</p>
-										</Stack>
+										</div>
 									)}
 								</p>
 							</Stack>
@@ -96,45 +100,40 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 							type="Role"
 							isEmpty={Boolean(
 								!oidcConfig?.user_role_mapping ||
-									(oidcConfig?.user_role_mapping &&
-										Object.entries(oidcConfig?.user_role_mapping).length ===
-											0) ||
-									false,
+									Object.entries(oidcConfig?.user_role_mapping).length === 0,
 							)}
 						>
 							<>
 								{oidcConfig?.user_role_mapping &&
-									Object.entries(oidcConfig.user_role_mapping).map(
-										([idpRole, roles]) => (
+									Object.entries(oidcConfig.user_role_mapping)
+										.sort()
+										.map(([idpRole, roles]) => (
 											<RoleRow
 												key={idpRole}
 												idpRole={idpRole}
 												coderRoles={roles}
 											/>
-										),
-									)}
+										))}
 							</>
 						</IdpMappingTable>
 						<IdpMappingTable
 							type="Group"
 							isEmpty={Boolean(
 								!oidcConfig?.group_mapping ||
-									(oidcConfig?.group_mapping &&
-										Object.entries(oidcConfig?.group_mapping).length === 0) ||
-									false,
+									Object.entries(oidcConfig?.group_mapping).length === 0,
 							)}
 						>
 							<>
 								{oidcConfig?.user_role_mapping &&
-									Object.entries(oidcConfig.group_mapping).map(
-										([idpGroup, group]) => (
+									Object.entries(oidcConfig.group_mapping)
+										.sort()
+										.map(([idpGroup, group]) => (
 											<GroupRow
 												key={idpGroup}
 												idpGroup={idpGroup}
 												coderGroup={group}
 											/>
-										),
-									)}
+										))}
 							</>
 						</IdpMappingTable>
 					</Stack>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -14,6 +14,7 @@ import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Paywall } from "components/Paywall/Paywall";
 import { Stack } from "components/Stack/Stack";
+import { StatusIndicator } from "components/StatusIndicator/StatusIndicator";
 import {
 	TableLoaderSkeleton,
 	TableRowSkeleton,
@@ -23,26 +24,6 @@ import { docs } from "utils/docs";
 
 export type IdpSyncPageViewProps = {
 	oidcConfig: OIDCConfig | undefined;
-};
-
-type CircleProps = {
-	color: string;
-	variant?: "solid" | "outlined";
-};
-
-const Circle: FC<CircleProps> = ({ color, variant = "solid" }) => {
-	return (
-		<div
-			aria-hidden
-			css={{
-				width: 8,
-				height: 8,
-				backgroundColor: variant === "solid" ? color : undefined,
-				border: variant === "outlined" ? `1px solid ${color}` : undefined,
-				borderRadius: 9999,
-			}}
-		/>
-	);
 };
 
 export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
@@ -79,7 +60,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 											spacing={1}
 											alignItems="center"
 										>
-											<Circle color={theme.roles.error.fill.solid} />
+											<StatusIndicator color="error" />
 											<p>disabled</p>
 										</Stack>
 									)}
@@ -102,7 +83,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 											spacing={1}
 											alignItems="center"
 										>
-											<Circle color={theme.roles.error.fill.solid} />
+											<StatusIndicator color="error" />
 											<p>disabled</p>
 										</Stack>
 									)}

--- a/site/src/pages/ManagementSettingsPage/SidebarView.tsx
+++ b/site/src/pages/ManagementSettingsPage/SidebarView.tsx
@@ -286,7 +286,7 @@ const OrganizationSettingsNavigation: FC<
 						<SidebarNavSubItem
 							href={urlForSubpage(organization.name, "idp-sync")}
 						>
-							Idp Sync
+							IdP Sync
 						</SidebarNavSubItem>
 					)}
 				</Stack>

--- a/site/src/pages/ManagementSettingsPage/SidebarView.tsx
+++ b/site/src/pages/ManagementSettingsPage/SidebarView.tsx
@@ -282,6 +282,13 @@ const OrganizationSettingsNavigation: FC<
 							Provisioners
 						</SidebarNavSubItem>
 					)}
+					{organization.permissions.editMembers && (
+						<SidebarNavSubItem
+							href={urlForSubpage(organization.name, "idp-sync")}
+						>
+							Idp Sync
+						</SidebarNavSubItem>
+					)}
 				</Stack>
 			)}
 		</>

--- a/site/src/pages/WorkspacesPage/LastUsed.tsx
+++ b/site/src/pages/WorkspacesPage/LastUsed.tsx
@@ -1,32 +1,12 @@
 import { useTheme } from "@emotion/react";
 import { Stack } from "components/Stack/Stack";
+import { StatusIndicator } from "components/StatusIndicator/StatusIndicator";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { useTime } from "hooks/useTime";
 import type { FC } from "react";
 
 dayjs.extend(relativeTime);
-
-type CircleProps = {
-	color: string;
-	variant?: "solid" | "outlined";
-};
-
-const Circle: FC<CircleProps> = ({ color, variant = "solid" }) => {
-	return (
-		<div
-			aria-hidden
-			css={{
-				width: 8,
-				height: 8,
-				backgroundColor: variant === "solid" ? color : undefined,
-				border: variant === "outlined" ? `1px solid ${color}` : undefined,
-				borderRadius: 9999,
-			}}
-		/>
-	);
-};
-
 interface LastUsedProps {
 	lastUsedAt: string;
 }
@@ -38,21 +18,19 @@ export const LastUsed: FC<LastUsedProps> = ({ lastUsedAt }) => {
 		const t = dayjs(lastUsedAt);
 		const now = dayjs();
 		let message = t.fromNow();
-		let circle = (
-			<Circle color={theme.palette.text.secondary} variant="outlined" />
-		);
+		let circle = <StatusIndicator color="info" variant="outlined" />;
 
 		if (t.isAfter(now.subtract(1, "hour"))) {
-			circle = <Circle color={theme.roles.success.fill.solid} />;
+			circle = <StatusIndicator color="success" />;
 			// Since the agent reports on a 10m interval,
 			// the last_used_at can be inaccurate when recent.
 			message = "Now";
 		} else if (t.isAfter(now.subtract(3, "day"))) {
-			circle = <Circle color={theme.palette.text.secondary} />;
+			circle = <StatusIndicator color="info" />;
 		} else if (t.isAfter(now.subtract(1, "month"))) {
-			circle = <Circle color={theme.roles.warning.fill.solid} />;
+			circle = <StatusIndicator color="warning" />;
 		} else if (t.isAfter(now.subtract(100, "year"))) {
-			circle = <Circle color={theme.roles.error.fill.solid} />;
+			circle = <StatusIndicator color="error" />;
 		} else {
 			message = "Never";
 		}

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -247,6 +247,9 @@ const OrganizationCustomRolesPage = lazy(
 	() =>
 		import("./pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPage"),
 );
+const OrganizationIdPSyncPage = lazy(
+	() => import("./pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage"),
+);
 const CreateEditRolePage = lazy(
 	() =>
 		import("./pages/ManagementSettingsPage/CustomRolesPage/CreateEditRolePage"),
@@ -406,6 +409,7 @@ export const router = createBrowserRouter(
 								path="provisioners"
 								element={<OrganizationProvisionersPage />}
 							/>
+							<Route path="idp-sync" element={<OrganizationIdPSyncPage />} />
 						</Route>
 					</Route>
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -451,6 +451,38 @@ export const MockAssignableSiteRoles = [
 	assignableRole(MockAuditorRole, true),
 ];
 
+export const MockOIDCConfig: TypesGen.OIDCConfig = {
+	allow_signups: true,
+	client_id: "test",
+	client_secret: "test",
+	client_key_file: "test",
+	client_cert_file: "test",
+	email_domain: [],
+	issuer_url: "test",
+	scopes: [],
+	ignore_email_verified: true,
+	username_field: "",
+	name_field: "",
+	email_field: "",
+	auth_url_params: {},
+	ignore_user_info: true,
+	organization_field: "",
+	organization_mapping: {},
+	organization_assign_default: true,
+	group_auto_create: false,
+	group_regex_filter: "^Coder-.*$",
+	group_allow_list: [],
+	groups_field: "groups",
+	group_mapping: { group1: "developers", group2: "admin", group3: "auditors" },
+	user_role_field: "roles",
+	user_role_mapping: { role1: ["role1", "role2"] },
+	user_roles_default: [],
+	sign_in_text: "",
+	icon_url: "",
+	signups_disabled_text: "string",
+	skip_issuer_checks: true,
+};
+
 export const MockMemberPermissions = {
 	viewAuditLog: false,
 };


### PR DESCRIPTION
resolves #14423 

This is meant to be a first pass at the IdP Sync page while waiting for the backend work to be completed. Additional, polish and refinement will be handled in #14424 

- [x] Buttons to link to docs page
- [x] Table for group sync mappings
- [x] Table for role sync mappings
- [x] Export policy button
- [x] Fields for group, role, group auto create and group regex filter
- [x] ? icon with help tooltip
- [x] Status indicator for group/role sync fields only when disabled (missing from backend response)
- [x] Storybook stories
- [x] Setup mock data