### PR TITLE
feat: show organization name in workspaces table

### DIFF
--- a/site/src/components/AvatarData/AvatarData.tsx
+++ b/site/src/components/AvatarData/AvatarData.tsx
@@ -54,7 +54,7 @@ export const AvatarData: FC<AvatarDataProps> = ({
 						css={{
 							fontSize: 13,
 							color: theme.palette.text.secondary,
-							lineHeight: "150%",
+							lineHeight: 1.5,
 							maxWidth: 540,
 						}}
 					>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -22,6 +22,7 @@ import {
 } from "testHelpers/entities";
 import { withDashboardProvider } from "testHelpers/storybook";
 import { WorkspacesPageView } from "./WorkspacesPageView";
+import { expect, within } from "@storybook/test";
 
 const createWorkspace = (
 	status: WorkspaceStatus,
@@ -263,5 +264,32 @@ export const InvalidPageNumber: Story = {
 		count: 200,
 		limit: 25,
 		page: 1000,
+	},
+};
+
+export const ShowOrganizations: Story = {
+	args: {
+		workspaces: [
+			{
+				...MockWorkspace,
+				organization_name: "Limbus Co.",
+			},
+		],
+	},
+
+	parameters: {
+		showOrganizations: true,
+	},
+
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const accessibleTableCell = await canvas.findByRole("cell", {
+			// Need whitespace classes because different parts of the element
+			// are going in different spans, and Storybook doesn't consolidate
+			// these
+			name: /org\s?(?:anization)?\s?:\s?Limbus Co\./i,
+		});
+
+		expect(accessibleTableCell).toBeDefined();
 	},
 };

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, within } from "@storybook/test";
 import {
 	type Workspace,
 	type WorkspaceStatus,
@@ -22,7 +23,6 @@ import {
 } from "testHelpers/entities";
 import { withDashboardProvider } from "testHelpers/storybook";
 import { WorkspacesPageView } from "./WorkspacesPageView";
-import { expect, within } from "@storybook/test";
 
 const createWorkspace = (
 	status: WorkspaceStatus,

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -175,7 +175,12 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													)}
 												</Stack>
 											}
-											subtitle={`user:${workspace.owner_name}`}
+											subtitle={
+												<div>
+													<span css={{ ...visuallyHidden }}>User: </span>
+													{workspace.owner_name}
+												</div>
+											}
 											avatar={
 												<ExternalAvatar
 													src={workspace.template_icon}
@@ -192,28 +197,19 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 								</TableCell>
 
 								<TableCell>
-									<span css={{ display: "block" }}>
-										{getDisplayWorkspaceTemplateName(workspace)}
-									</span>
+									<div>{getDisplayWorkspaceTemplateName(workspace)}</div>
 
 									{dashboard.showOrganizations && (
-										<span
+										<div
 											css={{
-												display: "block",
 												fontSize: 13,
 												color: theme.palette.text.secondary,
 												lineHeight: 1.5,
 											}}
 										>
-											{/*
-												Only using shorthand version of "organizations" for aesthetics,
-												but because screen readers don't care about aesthetics, we can
-												always display the full text to them
-											*/}
-											org
-											<span css={{ ...visuallyHidden }}>anization</span>:
+											<span css={{ ...visuallyHidden }}>Organization: </span>
 											{workspace.organization_name}
-										</span>
+										</div>
 									)}
 								</TableCell>
 

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -28,6 +28,8 @@ import type { FC, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { getDisplayWorkspaceTemplateName } from "utils/workspace";
 import { WorkspacesEmpty } from "./WorkspacesEmpty";
+import { useDashboard } from "modules/dashboard/useDashboard";
+import { visuallyHidden } from "@mui/utils";
 
 export interface WorkspacesTableProps {
 	workspaces?: readonly Workspace[];
@@ -52,6 +54,7 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 	canCreateTemplate,
 }) => {
 	const theme = useTheme();
+	const dashboard = useDashboard();
 
 	return (
 		<TableContainer>
@@ -172,7 +175,7 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 													)}
 												</Stack>
 											}
-											subtitle={workspace.owner_name}
+											subtitle={`user:${workspace.owner_name}`}
 											avatar={
 												<ExternalAvatar
 													src={workspace.template_icon}
@@ -189,7 +192,29 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 								</TableCell>
 
 								<TableCell>
-									{getDisplayWorkspaceTemplateName(workspace)}
+									<span css={{ display: "block" }}>
+										{getDisplayWorkspaceTemplateName(workspace)}
+									</span>
+
+									{dashboard.showOrganizations && (
+										<span
+											css={{
+												display: "block",
+												fontSize: 13,
+												color: theme.palette.text.secondary,
+												lineHeight: 1.5,
+											}}
+										>
+											{/*
+												Only using shorthand version of "organizations" for aesthetics,
+												but because screen readers don't care about aesthetics, we can
+												always display the full text to them
+											*/}
+											org
+											<span css={{ ...visuallyHidden }}>anization</span>:
+											{workspace.organization_name}
+										</span>
+									)}
 								</TableCell>
 
 								<TableCell>

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -9,6 +9,7 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import { visuallyHidden } from "@mui/utils";
 import type { Template, Workspace } from "api/typesGenerated";
 import { ExternalAvatar } from "components/Avatar/Avatar";
 import { AvatarData } from "components/AvatarData/AvatarData";
@@ -20,6 +21,7 @@ import {
 	TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import { WorkspaceDormantBadge } from "modules/workspaces/WorkspaceDormantBadge/WorkspaceDormantBadge";
 import { WorkspaceOutdatedTooltip } from "modules/workspaces/WorkspaceOutdatedTooltip/WorkspaceOutdatedTooltip";
 import { WorkspaceStatusBadge } from "modules/workspaces/WorkspaceStatusBadge/WorkspaceStatusBadge";
@@ -28,8 +30,6 @@ import type { FC, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { getDisplayWorkspaceTemplateName } from "utils/workspace";
 import { WorkspacesEmpty } from "./WorkspacesEmpty";
-import { useDashboard } from "modules/dashboard/useDashboard";
-import { visuallyHidden } from "@mui/utils";
 
 export interface WorkspacesTableProps {
 	workspaces?: readonly Workspace[];


### PR DESCRIPTION
Closes #14278

## Changes made
- Added logic to show organization name when the `showOrganization` property from `useDashboard` is `true`
- Added text labels for username and organization name to help remove UI ambiguity
- Added small Storybook test to make sure that organization info is accessible
- Made a slight tweak to the CSS for the `AvatarData` component to make sure that its line height can't inherently incorrectly

![Screenshot 2024-09-03 at 3 49 25 PM](https://github.com/user-attachments/assets/5b9682f1-ee2d-4e73-be12-fe274f5c6c65)
