### PR TITLE
chore: add runtimeconfig manager to options for plumbing

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -56,6 +56,7 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
 	"github.com/coder/coder/v2/coderd/entitlements"
+	"github.com/coder/coder/v2/coderd/runtimeconfig"
 	"github.com/coder/pretty"
 	"github.com/coder/quartz"
 	"github.com/coder/retry"
@@ -819,6 +820,14 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			if err != nil {
 				return err
 			}
+
+			// TODO: Throw a caching layer infront of the RuntimeConfig to prevent
+			// excessive database queries.
+			// Note: This happens before dbauthz, which is really unfortunate.
+			// dbauthz is configured in `Coderd.New()`, but we need the manager
+			// at this level for notifications. We might have to move some init
+			// code around.
+			options.RuntimeConfig = runtimeconfig.NewStoreManager(options.Database)
 
 			// This should be output before the logs start streaming.
 			cliui.Infof(inv.Stdout, "\n==> Logs will stream in below (press ctrl+c to gracefully exit):")

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -39,6 +39,7 @@ import (
 	"cdr.dev/slog"
 	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/idpsync"
+	"github.com/coder/coder/v2/coderd/runtimeconfig"
 	"github.com/coder/quartz"
 	"github.com/coder/serpent"
 
@@ -135,6 +136,7 @@ type Options struct {
 	Logger           slog.Logger
 	Database         database.Store
 	Pubsub           pubsub.Pubsub
+	RuntimeConfig    runtimeconfig.Manager
 
 	// CacheDir is used for caching files served by the API.
 	CacheDir string

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -67,6 +67,7 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/runtimeconfig"
 	"github.com/coder/coder/v2/coderd/schedule"
 	"github.com/coder/coder/v2/coderd/telemetry"
 	"github.com/coder/coder/v2/coderd/unhanger"
@@ -254,6 +255,10 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 	var acs dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
 	accessControlStore.Store(&acs)
 
+	// runtimeManager does not use dbauthz.
+	// TODO: It probably should, but the init code for prod happens before dbauthz
+	// is ready.
+	runtimeManager := runtimeconfig.NewStoreManager(options.Database)
 	options.Database = dbauthz.New(options.Database, options.Authorizer, *options.Logger, accessControlStore)
 
 	// Some routes expect a deployment ID, so just make sure one exists.
@@ -482,6 +487,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			AppHostnameRegex:               appHostnameRegex,
 			Logger:                         *options.Logger,
 			CacheDir:                       t.TempDir(),
+			RuntimeConfig:                  runtimeManager,
 			Database:                       options.Database,
 			Pubsub:                         options.Pubsub,
 			ExternalAuthConfigs:            options.ExternalAuthConfigs,


### PR DESCRIPTION
At the moment it does not respect dbauthz, which feels incorrect.

Making this PR so I can rebase off the primary PR and use the manager as intended.