### PR TITLE
test(site): make loading snapshots more predictable

### DIFF
--- a/site/src/components/Loader/Loader.tsx
+++ b/site/src/components/Loader/Loader.tsx
@@ -1,5 +1,5 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import CircularProgress from "@mui/material/CircularProgress";
+import { Spinner } from "components/Spinner/Spinner";
 import type { FC, HTMLAttributes } from "react";
 
 interface LoaderProps extends HTMLAttributes<HTMLDivElement> {
@@ -18,7 +18,7 @@ export const Loader: FC<LoaderProps> = ({
 			data-testid="loader"
 			{...attrs}
 		>
-			<CircularProgress size={size} />
+			<Spinner aria-label="Loading..." size={size} />
 		</div>
 	);
 };

--- a/site/src/components/Loader/Loader.tsx
+++ b/site/src/components/Loader/Loader.tsx
@@ -5,11 +5,16 @@ import type { FC, HTMLAttributes } from "react";
 interface LoaderProps extends HTMLAttributes<HTMLDivElement> {
 	fullscreen?: boolean;
 	size?: number;
+	/**
+	 * A label for the loader. This is used for accessibility purposes.
+	 */
+	label?: string;
 }
 
 export const Loader: FC<LoaderProps> = ({
 	fullscreen,
 	size = 26,
+	label = "Loading...",
 	...attrs
 }) => {
 	return (
@@ -18,7 +23,7 @@ export const Loader: FC<LoaderProps> = ({
 			data-testid="loader"
 			{...attrs}
 		>
-			<Spinner aria-label="Loading..." size={size} />
+			<Spinner aria-label={label} size={size} />
 		</div>
 	);
 };

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,20 @@
+import { CircularProgress, type CircularProgressProps } from "@mui/material";
+import type { FC } from "react";
+import isChromatic from "chromatic/isChromatic";
+
+/**
+ * Spinner component used to indicate loading states. This component abstracts
+ * the MUI CircularProgress to provide better control over its rendering,
+ * especially in snapshot tests with Chromatic.
+ */
+export const Spinner: FC<CircularProgressProps> = (props) => {
+	/**
+	 * During Chromatic snapshots, we render the spinner as determinate to make it
+	 * static without animations, using a deterministic value (75%).
+	 */
+	if (isChromatic()) {
+		props.variant = "determinate";
+		props.value = 75;
+	}
+	return <CircularProgress {...props} />;
+}

--- a/site/src/components/Spinner/Spinner.tsx
+++ b/site/src/components/Spinner/Spinner.tsx
@@ -1,6 +1,8 @@
-import { CircularProgress, type CircularProgressProps } from "@mui/material";
-import type { FC } from "react";
+import CircularProgress, {
+	type CircularProgressProps,
+} from "@mui/material/CircularProgress";
 import isChromatic from "chromatic/isChromatic";
+import type { FC } from "react";
 
 /**
  * Spinner component used to indicate loading states. This component abstracts
@@ -17,4 +19,4 @@ export const Spinner: FC<CircularProgressProps> = (props) => {
 		props.value = 75;
 	}
 	return <CircularProgress {...props} />;
-}
+};


### PR DESCRIPTION
Abstracts the Spinner component to control the display of the CircularProgress component. This allows us to make it static during Chromatic tests, making loading tests easier to visualize.

Before:
<img width="751" alt="Screenshot 2024-09-04 at 14 00 44" src="https://github.com/user-attachments/assets/68058181-6f79-4e16-b0ff-459f86607bec">

After:
<img width="760" alt="Screenshot 2024-09-04 at 14 00 49" src="https://github.com/user-attachments/assets/f922f554-76f1-434e-bd4c-eaa0ac523a73">
