### PR TITLE
fix: make cli respect deployment --docs-url

### DIFF
--- a/cli/dotfiles.go
+++ b/cli/dotfiles.go
@@ -203,7 +203,7 @@ func (r *RootCmd) dotfiles() *serpent.Command {
 				}
 
 				if fi.Mode()&0o111 == 0 {
-					return xerrors.Errorf("script %q is not executable. See https://coder.com/docs/dotfiles for information on how to resolve the issue.", script)
+					return xerrors.Errorf("script %q does not have execute permissions", script)
 				}
 
 				// it is safe to use a variable command here because it's from

--- a/cli/open.go
+++ b/cli/open.go
@@ -35,8 +35,9 @@ const vscodeDesktopName = "VS Code Desktop"
 
 func (r *RootCmd) openVSCode() *serpent.Command {
 	var (
-		generateToken bool
-		testOpenError bool
+		generateToken    bool
+		testOpenError    bool
+		appearanceConfig codersdk.AppearanceConfig
 	)
 
 	client := new(codersdk.Client)
@@ -47,6 +48,7 @@ func (r *RootCmd) openVSCode() *serpent.Command {
 		Middleware: serpent.Chain(
 			serpent.RequireRangeArgs(1, 2),
 			r.InitClient(client),
+			initAppearance(client, &appearanceConfig),
 		),
 		Handler: func(inv *serpent.Invocation) error {
 			ctx, cancel := context.WithCancel(inv.Context())
@@ -79,6 +81,7 @@ func (r *RootCmd) openVSCode() *serpent.Command {
 					Fetch:     client.WorkspaceAgent,
 					FetchLogs: nil,
 					Wait:      false,
+					DocsURL:   appearanceConfig.DocsURL,
 				})
 				if err != nil {
 					if xerrors.Is(err, context.Canceled) {

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -29,6 +29,7 @@ func (r *RootCmd) portForward() *serpent.Command {
 		tcpForwards      []string // <port>:<port>
 		udpForwards      []string // <port>:<port>
 		disableAutostart bool
+		appearanceConfig codersdk.AppearanceConfig
 	)
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
@@ -60,6 +61,7 @@ func (r *RootCmd) portForward() *serpent.Command {
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(1),
 			r.InitClient(client),
+			initAppearance(client, &appearanceConfig),
 		),
 		Handler: func(inv *serpent.Invocation) error {
 			ctx, cancel := context.WithCancel(inv.Context())
@@ -88,8 +90,9 @@ func (r *RootCmd) portForward() *serpent.Command {
 			}
 
 			err = cliui.Agent(ctx, inv.Stderr, workspaceAgent.ID, cliui.AgentOptions{
-				Fetch: client.WorkspaceAgent,
-				Wait:  false,
+				Fetch:   client.WorkspaceAgent,
+				Wait:    false,
+				DocsURL: appearanceConfig.DocsURL,
 			})
 			if err != nil {
 				return xerrors.Errorf("await agent: %w", err)

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (r *RootCmd) rename() *serpent.Command {
+	var appearanceConfig codersdk.AppearanceConfig
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
 		Annotations: workspaceCommand,
@@ -21,6 +22,7 @@ func (r *RootCmd) rename() *serpent.Command {
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(2),
 			r.InitClient(client),
+			initAppearance(client, &appearanceConfig),
 		),
 		Handler: func(inv *serpent.Invocation) error {
 			workspace, err := namedWorkspace(inv.Context(), client, inv.Args[0])
@@ -31,7 +33,7 @@ func (r *RootCmd) rename() *serpent.Command {
 			_, _ = fmt.Fprintf(inv.Stdout, "%s\n\n",
 				pretty.Sprint(cliui.DefaultStyles.Wrap, "WARNING: A rename can result in data loss if a resource references the workspace name in the template (e.g volumes). Please backup any data before proceeding."),
 			)
-			_, _ = fmt.Fprintf(inv.Stdout, "See: %s\n\n", "https://coder.com/docs/templates/resource-persistence#%EF%B8%8F-persistence-pitfalls")
+			_, _ = fmt.Fprintf(inv.Stdout, "See: %s%s\n\n", appearanceConfig.DocsURL, "/templates/resource-persistence#%EF%B8%8F-persistence-pitfalls")
 			_, err = cliui.Prompt(inv, cliui.PromptOptions{
 				Text: fmt.Sprintf("Type %q to confirm rename:", workspace.Name),
 				Validate: func(s string) error {

--- a/cli/root.go
+++ b/cli/root.go
@@ -692,6 +692,26 @@ func namedWorkspace(ctx context.Context, client *codersdk.Client, identifier str
 	return client.WorkspaceByOwnerAndName(ctx, owner, name, codersdk.WorkspaceOptions{})
 }
 
+func initAppearance(client *codersdk.Client, outConfig *codersdk.AppearanceConfig) serpent.MiddlewareFunc {
+	return func(next serpent.HandlerFunc) serpent.HandlerFunc {
+		return func(inv *serpent.Invocation) error {
+			var err error
+			cfg, err := client.Appearance(inv.Context())
+			if err != nil {
+				var sdkErr *codersdk.Error
+				if !(xerrors.As(err, &sdkErr) && sdkErr.StatusCode() == http.StatusNotFound) {
+					return err
+				}
+			}
+			if cfg.DocsURL == "" {
+				cfg.DocsURL = codersdk.DefaultDocsURL()
+			}
+			*outConfig = cfg
+			return next(inv)
+		}
+	}
+}
+
 // createConfig consumes the global configuration flag to produce a config root.
 func (r *RootCmd) createConfig() config.Root {
 	return config.Root(r.globalConfig)

--- a/cli/server.go
+++ b/cli/server.go
@@ -628,7 +628,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 								"new version of coder available",
 								slog.F("new_version", r.Version),
 								slog.F("url", r.URL),
-								slog.F("upgrade_instructions", "https://coder.com/docs/admin/upgrade"),
+								slog.F("upgrade_instructions", fmt.Sprintf("%s/admin/upgrade", vals.DocsURL.String())),
 							)
 						}
 					},
@@ -854,7 +854,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}
 				defer options.Telemetry.Close()
 			} else {
-				logger.Warn(ctx, `telemetry disabled, unable to notify of security issues. Read more: https://coder.com/docs/admin/telemetry`)
+				logger.Warn(ctx, fmt.Sprintf(`telemetry disabled, unable to notify of security issues. Read more: %s/admin/telemetry`, vals.DocsURL.String()))
 			}
 
 			// This prevents the pprof import from being accidentally deleted.

--- a/cli/speedtest.go
+++ b/cli/speedtest.go
@@ -36,11 +36,12 @@ type speedtestTableItem struct {
 
 func (r *RootCmd) speedtest() *serpent.Command {
 	var (
-		direct    bool
-		duration  time.Duration
-		direction string
-		pcapFile  string
-		formatter = cliui.NewOutputFormatter(
+		direct           bool
+		duration         time.Duration
+		direction        string
+		pcapFile         string
+		appearanceConfig codersdk.AppearanceConfig
+		formatter        = cliui.NewOutputFormatter(
 			cliui.ChangeFormatterData(cliui.TableFormat([]speedtestTableItem{}, []string{"Interval", "Throughput"}), func(data any) (any, error) {
 				res, ok := data.(SpeedtestResult)
 				if !ok {
@@ -72,6 +73,7 @@ func (r *RootCmd) speedtest() *serpent.Command {
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(1),
 			r.InitClient(client),
+			initAppearance(client, &appearanceConfig),
 		),
 		Handler: func(inv *serpent.Invocation) error {
 			ctx, cancel := context.WithCancel(inv.Context())
@@ -87,8 +89,9 @@ func (r *RootCmd) speedtest() *serpent.Command {
 			}
 
 			err = cliui.Agent(ctx, inv.Stderr, workspaceAgent.ID, cliui.AgentOptions{
-				Fetch: client.WorkspaceAgent,
-				Wait:  false,
+				Fetch:   client.WorkspaceAgent,
+				Wait:    false,
+				DocsURL: appearanceConfig.DocsURL,
 			})
 			if err != nil {
 				return xerrors.Errorf("await agent: %w", err)

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -67,6 +67,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 		env              []string
 		usageApp         string
 		disableAutostart bool
+		appearanceConfig codersdk.AppearanceConfig
 	)
 	client := new(codersdk.Client)
 	cmd := &serpent.Command{
@@ -76,6 +77,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 		Middleware: serpent.Chain(
 			serpent.RequireNArgs(1),
 			r.InitClient(client),
+			initAppearance(client, &appearanceConfig),
 		),
 		Handler: func(inv *serpent.Invocation) (retErr error) {
 			// Before dialing the SSH server over TCP, capture Interrupt signals
@@ -230,9 +232,11 @@ func (r *RootCmd) ssh() *serpent.Command {
 			// OpenSSH passes stderr directly to the calling TTY.
 			// This is required in "stdio" mode so a connecting indicator can be displayed.
 			err = cliui.Agent(ctx, inv.Stderr, workspaceAgent.ID, cliui.AgentOptions{
-				Fetch:     client.WorkspaceAgent,
-				FetchLogs: client.WorkspaceAgentLogsAfter,
-				Wait:      wait,
+				FetchInterval: 0,
+				Fetch:         client.WorkspaceAgent,
+				FetchLogs:     client.WorkspaceAgentLogsAfter,
+				Wait:          wait,
+				DocsURL:       appearanceConfig.DocsURL,
 			})
 			if err != nil {
 				if xerrors.Is(err, context.Canceled) {

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -175,7 +175,7 @@ NETWORKING OPTIONS:
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
-      --docs-url url, $CODER_DOCS_URL
+      --docs-url url, $CODER_DOCS_URL (default: https://coder.com/docs)
           Specifies the custom docs URL.
 
       --proxy-trusted-headers string-array, $CODER_PROXY_TRUSTED_HEADERS

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -7,8 +7,8 @@ networking:
   # (default: <unset>, type: string)
   wildcardAccessURL: ""
   # Specifies the custom docs URL.
-  # (default: <unset>, type: url)
-  docsURL:
+  # (default: https://coder.com/docs, type: url)
+  docsURL: https://coder.com/docs
   # Specifies whether to redirect requests that do not match the access URL host.
   # (default: <unset>, type: bool)
   redirectToAccessURL: false

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -8890,6 +8890,9 @@ const docTemplate = `{
                 "application_name": {
                     "type": "string"
                 },
+                "docs_url": {
+                    "type": "string"
+                },
                 "logo_url": {
                     "type": "string"
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -7880,6 +7880,9 @@
 				"application_name": {
 					"type": "string"
 				},
+				"docs_url": {
+					"type": "string"
+				},
 				"logo_url": {
 					"type": "string"
 				},

--- a/coderd/appearance/appearance.go
+++ b/coderd/appearance/appearance.go
@@ -2,46 +2,12 @@ package appearance
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
-	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/codersdk"
 )
 
 type Fetcher interface {
 	Fetch(ctx context.Context) (codersdk.AppearanceConfig, error)
-}
-
-func DefaultSupportLinks(docsURL string) []codersdk.LinkConfig {
-	version := buildinfo.Version()
-	if docsURL == "" {
-		docsURL = "https://coder.com/docs/@" + strings.Split(version, "-")[0]
-	}
-	buildInfo := fmt.Sprintf("Version: [`%s`](%s)", version, buildinfo.ExternalURL())
-
-	return []codersdk.LinkConfig{
-		{
-			Name:   "Documentation",
-			Target: docsURL,
-			Icon:   "docs",
-		},
-		{
-			Name:   "Report a bug",
-			Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=" + buildInfo,
-			Icon:   "bug",
-		},
-		{
-			Name:   "Join the Coder Discord",
-			Target: "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer",
-			Icon:   "chat",
-		},
-		{
-			Name:   "Star the Repo",
-			Target: "https://github.com/coder/coder",
-			Icon:   "star",
-		},
-	}
 }
 
 type AGPLFetcher struct {
@@ -51,11 +17,15 @@ type AGPLFetcher struct {
 func (f AGPLFetcher) Fetch(context.Context) (codersdk.AppearanceConfig, error) {
 	return codersdk.AppearanceConfig{
 		AnnouncementBanners: []codersdk.BannerConfig{},
-		SupportLinks:        DefaultSupportLinks(f.docsURL),
+		SupportLinks:        codersdk.DefaultSupportLinks(f.docsURL),
+		DocsURL:             f.docsURL,
 	}, nil
 }
 
 func NewDefaultFetcher(docsURL string) Fetcher {
+	if docsURL == "" {
+		docsURL = codersdk.DefaultDocsURL()
+	}
 	return &AGPLFetcher{
 		docsURL: docsURL,
 	}

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -776,6 +776,42 @@ func DefaultCacheDir() string {
 	return filepath.Join(defaultCacheDir, "coder")
 }
 
+func DefaultSupportLinks(docsURL string) []LinkConfig {
+	version := buildinfo.Version()
+	buildInfo := fmt.Sprintf("Version: [`%s`](%s)", version, buildinfo.ExternalURL())
+
+	return []LinkConfig{
+		{
+			Name:   "Documentation",
+			Target: docsURL,
+			Icon:   "docs",
+		},
+		{
+			Name:   "Report a bug",
+			Target: "https://github.com/coder/coder/issues/new?labels=needs+grooming&body=" + buildInfo,
+			Icon:   "bug",
+		},
+		{
+			Name:   "Join the Coder Discord",
+			Target: "https://coder.com/chat?utm_source=coder&utm_medium=coder&utm_campaign=server-footer",
+			Icon:   "chat",
+		},
+		{
+			Name:   "Star the Repo",
+			Target: "https://github.com/coder/coder",
+			Icon:   "star",
+		},
+	}
+}
+
+func DefaultDocsURL() string {
+	version := strings.Split(buildinfo.Version(), "-")[0]
+	if version == "v0.0.0" {
+		return "https://coder.com/docs"
+	}
+	return "https://coder.com/docs/@" + version
+}
+
 // DeploymentConfig contains both the deployment values and how they're set.
 type DeploymentConfig struct {
 	Values  *DeploymentValues `json:"config,omitempty"`
@@ -994,6 +1030,7 @@ when required by your organization's security policy.`,
 			Name:        "Docs URL",
 			Description: "Specifies the custom docs URL.",
 			Value:       &c.DocsURL,
+			Default:     DefaultDocsURL(),
 			Flag:        "docs-url",
 			Env:         "CODER_DOCS_URL",
 			Group:       &deploymentGroupNetworking,
@@ -2737,6 +2774,7 @@ func (c *Client) DeploymentStats(ctx context.Context) (DeploymentStats, error) {
 type AppearanceConfig struct {
 	ApplicationName string `json:"application_name"`
 	LogoURL         string `json:"logo_url"`
+	DocsURL         string `json:"docs_url"`
 	// Deprecated: ServiceBanner has been replaced by AnnouncementBanners.
 	ServiceBanner       BannerConfig   `json:"service_banner"`
 	AnnouncementBanners []BannerConfig `json:"announcement_banners"`

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -27,6 +27,7 @@ curl -X GET http://coder-server:8080/api/v2/appearance \
 		}
 	],
 	"application_name": "string",
+	"docs_url": "string",
 	"logo_url": "string",
 	"service_banner": {
 		"background_color": "string",

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -391,6 +391,7 @@
 		}
 	],
 	"application_name": "string",
+	"docs_url": "string",
 	"logo_url": "string",
 	"service_banner": {
 		"background_color": "string",
@@ -413,6 +414,7 @@
 | ---------------------- | ------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------- |
 | `announcement_banners` | array of [codersdk.BannerConfig](#codersdkbannerconfig) | false    |              |                                                                     |
 | `application_name`     | string                                                  | false    |              |                                                                     |
+| `docs_url`             | string                                                  | false    |              |                                                                     |
 | `logo_url`             | string                                                  | false    |              |                                                                     |
 | `service_banner`       | [codersdk.BannerConfig](#codersdkbannerconfig)          | false    |              | Deprecated: ServiceBanner has been replaced by AnnouncementBanners. |
 | `support_links`        | array of [codersdk.LinkConfig](#codersdklinkconfig)     | false    |              |                                                                     |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -43,11 +43,12 @@ Specifies the wildcard hostname to use for workspace applications in the form "\
 
 ### --docs-url
 
-|             |                                 |
-| ----------- | ------------------------------- |
-| Type        | <code>url</code>                |
-| Environment | <code>$CODER_DOCS_URL</code>    |
-| YAML        | <code>networking.docsURL</code> |
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Type        | <code>url</code>                    |
+| Environment | <code>$CODER_DOCS_URL</code>        |
+| YAML        | <code>networking.docsURL</code>     |
+| Default     | <code>https://coder.com/docs</code> |
 
 Specifies the custom docs URL.
 

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -176,7 +176,7 @@ NETWORKING OPTIONS:
       --access-url url, $CODER_ACCESS_URL
           The URL that users will use to access the Coder deployment.
 
-      --docs-url url, $CODER_DOCS_URL
+      --docs-url url, $CODER_DOCS_URL (default: https://coder.com/docs)
           Specifies the custom docs URL.
 
       --proxy-trusted-headers string-array, $CODER_PROXY_TRUSTED_HEADERS

--- a/enterprise/coderd/appearance.go
+++ b/enterprise/coderd/appearance.go
@@ -49,6 +49,9 @@ type appearanceFetcher struct {
 }
 
 func newAppearanceFetcher(store database.Store, links []codersdk.LinkConfig, docsURL, coderVersion string) agpl.Fetcher {
+	if docsURL == "" {
+		docsURL = codersdk.DefaultDocsURL()
+	}
 	return &appearanceFetcher{
 		database:     store,
 		supportLinks: links,
@@ -94,7 +97,8 @@ func (f *appearanceFetcher) Fetch(ctx context.Context) (codersdk.AppearanceConfi
 		ApplicationName:     applicationName,
 		LogoURL:             logoURL,
 		AnnouncementBanners: []codersdk.BannerConfig{},
-		SupportLinks:        agpl.DefaultSupportLinks(f.docsURL),
+		SupportLinks:        codersdk.DefaultSupportLinks(f.docsURL),
+		DocsURL:             f.docsURL,
 	}
 
 	if announcementBannersJSON != "" {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1801,6 +1801,7 @@ class ApiMethods {
 			if (isAxiosError(ex) && ex.response?.status === 404) {
 				return {
 					application_name: "",
+					docs_url: "",
 					logo_url: "",
 					announcement_banners: [],
 					service_banner: {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -48,6 +48,7 @@ export interface AppHostResponse {
 export interface AppearanceConfig {
 	readonly application_name: string;
 	readonly logo_url: string;
+	readonly docs_url: string;
 	readonly service_banner: BannerConfig;
 	readonly announcement_banners: Readonly<Array<BannerConfig>>;
 	readonly support_links?: Readonly<Array<LinkConfig>>;

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2713,6 +2713,7 @@ export const MockAppearanceConfig: TypesGen.AppearanceConfig = {
 		enabled: false,
 	},
 	announcement_banners: [],
+	docs_url: "https://coder.com/docs/@main/",
 };
 
 export const MockWorkspaceBuildParameter1: TypesGen.WorkspaceBuildParameter = {


### PR DESCRIPTION
With #14548, it's a lot more likely for a user to see a documentation link when using the CLI. 

Assuming admins of airgapped Coder deployments aren't giving regular users permission to view the deployment config, we'll need to make the docs URL available on the more permissive `/appearance` endpoint. 