### PR TITLE
fix: improve duplicate template version name error

### DIFF
--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -222,7 +222,7 @@ func (r *Runner) Run() {
 		err := r.sender.CompleteJob(ctx, r.completedJob)
 		if err != nil {
 			r.logger.Error(ctx, "sending CompletedJob failed", slog.Error(err))
-			err = r.sender.FailJob(ctx, r.failedJobf("internal provisionerserver error"))
+			err = r.sender.FailJob(ctx, r.failedJobf("internal provisionerserver error: %s", err))
 			if err != nil {
 				r.logger.Error(ctx, "sending FailJob failed (while CompletedJob)", slog.Error(err))
 			}


### PR DESCRIPTION
Relates to #14569.
Relates to #14387.

The current error is justifiably confusing:
```
error: execute transaction: insert template version: pq: duplicate key value violates unique constraint "template_versions_template_id_name_key"
```

The error will instead read:
```
A template version with name "version-name" already exists for this template.
```

Users will probably see this error message more often if they start to manage templates using `coderd` provider.

Also has failed provisioner jobs return their full error trace when they fail.