### PR TITLE
fix: prevent dbmem reading other groups when getting group members

### DIFF
--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -2653,14 +2653,14 @@ func (q *FakeQuerier) GetGroupMembersByGroupID(ctx context.Context, id uuid.UUID
 
 	var groupMembers []database.GroupMember
 	for _, member := range q.groupMembers {
-		groupMember, err := q.getGroupMemberNoLock(ctx, member.UserID, member.GroupID)
-		if errors.Is(err, errUserDeleted) {
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
 		if member.GroupID == id {
+			groupMember, err := q.getGroupMemberNoLock(ctx, member.UserID, member.GroupID)
+			if errors.Is(err, errUserDeleted) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
 			groupMembers = append(groupMembers, groupMember)
 		}
 	}


### PR DESCRIPTION
Fixes a very minor bug that prevents retrieving the info of a group after a group with members has already been deleted. This bug was breaking the `coderd` provider CI, as we test using dbmem. 

I've just changed the provider to test against postgres (because nobody uses dbmem), so this PR is just for the sake of it.