### PR TITLE
fix: analyze build times over 30 days not 30 months

### DIFF
--- a/coderd/metricscache/metricscache.go
+++ b/coderd/metricscache/metricscache.go
@@ -99,7 +99,7 @@ func (c *Cache) refreshTemplateBuildTimes(ctx context.Context) error {
 				Valid: true,
 			},
 			StartTime: sql.NullTime{
-				Time:  dbtime.Time(time.Now().AddDate(0, -30, 0)),
+				Time:  dbtime.Time(time.Now().AddDate(0, 0, -30)),
 				Valid: true,
 			},
 		})


### PR DESCRIPTION
We use the template build times to give users an estimate of how long their builds are likely to take.

This code is supposed to look back 30 _days_ to find the p50 and p95 build times but instead it's currently looking back 30 _months_, which will skew the data.