### PR TITLE
fix: increase text contrast for 'create workspace' button

### DIFF
--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -332,9 +332,6 @@ const styles = {
 	}),
 	actionButton: (theme) => ({
 		transition: "none",
-		color: theme.palette.text.secondary,
-		"&:hover": {
-			borderColor: theme.palette.text.primary,
-		},
+		color: theme.palette.text.primary,
 	}),
 } satisfies Record<string, Interpolation<Theme>>;


### PR DESCRIPTION
Quick hotfix because some of our interactive elements werent' high-contrast enough. They're essentially the "primary action"s of their page, so it seemed better to increase the contrast, not just for accessibility, but also to help guide the eye a little bit better.

## Changes made
- Increased text contract for the "Create workspace" buttons in the `/templates` route

Before:
<img width="478" alt="Screenshot 2024-09-05 at 10 58 13 PM" src="https://github.com/user-attachments/assets/c60aa3a8-f9ae-4265-9bc8-cfb838d45416">

After:
<img width="478" alt="Screenshot 2024-09-05 at 10 58 36 PM" src="https://github.com/user-attachments/assets/97abbf59-f5d0-4291-b879-143b600c7d9d">

## Notes
- We previously had a text color shift on hover, but even after fiddling with different transition values, I couldn't figure out a way to make sure it doesn't look janky. Just decided to remove it entirely