### PR TITLE
feat: add premium license banner for custom roles page

### DIFF
--- a/site/src/components/Badges/Badges.stories.tsx
+++ b/site/src/components/Badges/Badges.stories.tsx
@@ -4,12 +4,12 @@ import {
 	Badges,
 	DisabledBadge,
 	EnabledBadge,
-	PremiumBadge,
 	EntitledBadge,
 	HealthyBadge,
 	NotHealthyBadge,
 	NotReachableBadge,
 	NotRegisteredBadge,
+	PremiumBadge,
 	PreviewBadge,
 } from "./Badges";
 

--- a/site/src/components/Badges/Badges.stories.tsx
+++ b/site/src/components/Badges/Badges.stories.tsx
@@ -4,7 +4,7 @@ import {
 	Badges,
 	DisabledBadge,
 	EnabledBadge,
-	EnterpriseBadge,
+	PremiumBadge,
 	EntitledBadge,
 	HealthyBadge,
 	NotHealthyBadge,
@@ -50,9 +50,9 @@ export const Disabled: Story = {
 		children: <DisabledBadge />,
 	},
 };
-export const Enterprise: Story = {
+export const Premium: Story = {
 	args: {
-		children: <EnterpriseBadge />,
+		children: <PremiumBadge />,
 	},
 };
 export const Preview: Story = {

--- a/site/src/components/Badges/Badges.tsx
+++ b/site/src/components/Badges/Badges.tsx
@@ -106,23 +106,6 @@ export const DisabledBadge: FC = forwardRef<
 	);
 });
 
-export const EnterpriseBadge: FC = () => {
-	return (
-		<span
-			css={[
-				styles.badge,
-				(theme) => ({
-					backgroundColor: theme.branding.badge.enterprise.background,
-					border: `1px solid ${theme.branding.badge.enterprise.border}`,
-					color: theme.roles.notice.text,
-				}),
-			]}
-		>
-			Enterprise
-		</span>
-	);
-};
-
 export const PremiumBadge: FC = () => {
 	return (
 		<span

--- a/site/src/components/Badges/Badges.tsx
+++ b/site/src/components/Badges/Badges.tsx
@@ -112,8 +112,8 @@ export const EnterpriseBadge: FC = () => {
 			css={[
 				styles.badge,
 				(theme) => ({
-					backgroundColor: theme.roles.notice.background,
-					border: `1px solid ${theme.roles.notice.outline}`,
+					backgroundColor: theme.branding.badge.enterprise.background,
+					border: `1px solid ${theme.branding.badge.enterprise.border}`,
 					color: theme.roles.notice.text,
 				}),
 			]}
@@ -129,8 +129,8 @@ export const PremiumBadge: FC = () => {
 			css={[
 				styles.badge,
 				(theme) => ({
-					backgroundColor: theme.roles.notice.background,
-					border: `1px solid ${theme.roles.notice.outline}`,
+					backgroundColor: theme.branding.badge.premium.background,
+					border: `1px solid ${theme.branding.badge.premium.border}`,
 					color: theme.roles.notice.text,
 				}),
 			]}

--- a/site/src/components/Badges/Badges.tsx
+++ b/site/src/components/Badges/Badges.tsx
@@ -112,8 +112,8 @@ export const PremiumBadge: FC = () => {
 			css={[
 				styles.badge,
 				(theme) => ({
-					backgroundColor: theme.branding.badge.premium.background,
-					border: `1px solid ${theme.branding.badge.premium.border}`,
+					backgroundColor: theme.branding.background,
+					border: `1px solid ${theme.branding.border}`,
 					color: theme.roles.notice.text,
 				}),
 			]}

--- a/site/src/components/Paywall/Paywall.stories.tsx
+++ b/site/src/components/Paywall/Paywall.stories.tsx
@@ -9,18 +9,8 @@ const meta: Meta<typeof Paywall> = {
 export default meta;
 type Story = StoryObj<typeof Paywall>;
 
-export const Enterprise: Story = {
-	args: {
-		type: "enterprise",
-		message: "Black Lotus",
-		description:
-			"Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
-	},
-};
-
 export const Premium: Story = {
 	args: {
-		type: "premium",
 		message: "Black Lotus",
 		description:
 			"Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",

--- a/site/src/components/Paywall/Paywall.stories.tsx
+++ b/site/src/components/Paywall/Paywall.stories.tsx
@@ -9,12 +9,20 @@ const meta: Meta<typeof Paywall> = {
 export default meta;
 type Story = StoryObj<typeof Paywall>;
 
-const Example: Story = {
+export const Enterprise: Story = {
 	args: {
+		type: "enterprise",
 		message: "Black Lotus",
 		description:
 			"Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
 	},
 };
 
-export { Example as Paywall };
+export const Premium: Story = {
+	args: {
+		type: "premium",
+		message: "Black Lotus",
+		description:
+			"Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
+	},
+};

--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -23,8 +23,8 @@ export const Paywall: FC<PaywallProps> = ({
 			css={[
 				styles.root,
 				(theme) => ({
-					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall.premium.background})`,
-					border: `1px solid ${theme.branding.paywall.premium.border}`,
+					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.background})`,
+					border: `1px solid ${theme.branding.border}`,
 				}),
 			]}
 		>
@@ -84,7 +84,7 @@ const FeatureIcon: FC = () => {
 		<TaskAltIcon
 			css={[
 				(theme) => ({
-					color: theme.branding.paywall.premium.border,
+					color: theme.branding.border,
 				}),
 			]}
 		/>
@@ -116,7 +116,7 @@ const styles = {
 	separator: (theme) => ({
 		width: 1,
 		height: 220,
-		backgroundColor: theme.branding.paywall.premium.divider,
+		backgroundColor: theme.branding.divider,
 		marginLeft: 8,
 	}),
 	featureList: {

--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -113,7 +113,6 @@ const styles = {
 		justifyContent: "center",
 		alignItems: "center",
 		minHeight: 280,
-		marginBottom: 32,
 		padding: 24,
 		borderRadius: 8,
 		gap: 32,
@@ -132,7 +131,7 @@ const styles = {
 	separator: (theme) => ({
 		width: 1,
 		height: 220,
-		backgroundColor: theme.palette.divider,
+		backgroundColor: theme.branding.paywall.premium.divider,
 		marginLeft: 8,
 	}),
 	featureList: {

--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -2,28 +2,39 @@ import type { Interpolation, Theme } from "@emotion/react";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
-import { EnterpriseBadge } from "components/Badges/Badges";
+import { EnterpriseBadge, PremiumBadge } from "components/Badges/Badges";
 import { Stack } from "components/Stack/Stack";
 import type { FC, ReactNode } from "react";
+import theme from "theme";
 import { docs } from "utils/docs";
 
 export interface PaywallProps {
+	type: "enterprise" | "premium";
 	message: string;
 	description?: ReactNode;
 	documentationLink?: string;
 }
 
 export const Paywall: FC<PaywallProps> = ({
+	type,
 	message,
 	description,
 	documentationLink,
 }) => {
 	return (
-		<div css={styles.root}>
+		<div
+			css={[
+				styles.root,
+				(theme) => ({
+					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall[type].background})`,
+					border: `1px solid ${theme.branding.paywall[type].border}`,
+				}),
+			]}
+		>
 			<div>
 				<Stack direction="row" alignItems="center" css={{ marginBottom: 24 }}>
 					<h5 css={styles.title}>{message}</h5>
-					<EnterpriseBadge />
+					{type === "enterprise" ? <EnterpriseBadge /> : <PremiumBadge />}
 				</Stack>
 
 				{description && <p css={styles.description}>{description}</p>}
@@ -36,20 +47,20 @@ export const Paywall: FC<PaywallProps> = ({
 					Read the documentation
 				</Link>
 			</div>
-			<div css={styles.separator}></div>
+			<div css={styles.separator} />
 			<Stack direction="column" alignItems="center" spacing={3}>
 				<ul css={styles.featureList}>
 					<li css={styles.feature}>
-						<FeatureIcon /> Template access control
+						<FeatureIcon type={type} /> Template access control
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon /> User groups
+						<FeatureIcon type={type} /> User groups
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon /> 24 hour support
+						<FeatureIcon type={type} /> 24 hour support
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon /> Audit logs
+						<FeatureIcon type={type} /> Audit logs
 					</li>
 				</ul>
 				<Button
@@ -67,8 +78,20 @@ export const Paywall: FC<PaywallProps> = ({
 	);
 };
 
-const FeatureIcon: FC = () => {
-	return <TaskAltIcon css={styles.featureIcon} />;
+export interface FeatureIconProps {
+	type: "enterprise" | "premium";
+}
+
+const FeatureIcon: FC<FeatureIconProps> = ({ type }) => {
+	return (
+		<TaskAltIcon
+			css={[
+				(theme) => ({
+					color: theme.branding.paywall[type].border,
+				}),
+			]}
+		/>
+	);
 };
 
 const styles = {
@@ -81,8 +104,6 @@ const styles = {
 		maxWidth: 920,
 		margin: "auto",
 		padding: 24,
-		backgroundImage: `linear-gradient(160deg, transparent, ${theme.roles.active.background})`,
-		border: `1px solid ${theme.roles.active.fill.outline}`,
 		borderRadius: 8,
 		gap: 32,
 	}),

--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -51,16 +51,28 @@ export const Paywall: FC<PaywallProps> = ({
 			<Stack direction="column" alignItems="center" spacing={3}>
 				<ul css={styles.featureList}>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} /> Template access control
+						<FeatureIcon type={type} />
+						{type === "premium"
+							? "High availability & workspace proxies"
+							: "Template access control"}
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} /> User groups
+						<FeatureIcon type={type} />
+						{type === "premium"
+							? "Multi-org & role-based access control"
+							: "User groups"}
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} /> 24 hour support
+						<FeatureIcon type={type} />
+						{type === "premium"
+							? "24x7 global support with SLA"
+							: "24 hour support"}
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} /> Audit logs
+						<FeatureIcon type={type} />
+						{type === "premium"
+							? "Unlimited Git & external auth integrations"
+							: "Audit logs"}
 					</li>
 				</ul>
 				<Button
@@ -71,7 +83,7 @@ export const Paywall: FC<PaywallProps> = ({
 					variant="outlined"
 					color="neutral"
 				>
-					Learn about Enterprise
+					Learn about {type === "enterprise" ? "Enterprise" : "Premium"}
 				</Button>
 			</Stack>
 		</div>
@@ -100,9 +112,8 @@ const styles = {
 		flexDirection: "row",
 		justifyContent: "center",
 		alignItems: "center",
-		minHeight: 300,
-		maxWidth: 920,
-		margin: "auto",
+		minHeight: 280,
+		marginBottom: 32,
 		padding: 24,
 		borderRadius: 8,
 		gap: 32,
@@ -114,12 +125,9 @@ const styles = {
 		margin: 0,
 	},
 	description: (theme) => ({
-		marginTop: 16,
 		fontFamily: "inherit",
-		maxWidth: 420,
-		lineHeight: "160%",
-		color: theme.palette.text.secondary,
-		fontSize: 16,
+		maxWidth: 460,
+		fontSize: 14,
 	}),
 	separator: (theme) => ({
 		width: 1,
@@ -131,7 +139,7 @@ const styles = {
 		listStyle: "none",
 		margin: 0,
 		marginRight: 8,
-		padding: "0 12px",
+		padding: "0 24px",
 		fontSize: 14,
 		fontWeight: 500,
 	},

--- a/site/src/components/Paywall/Paywall.tsx
+++ b/site/src/components/Paywall/Paywall.tsx
@@ -2,21 +2,18 @@ import type { Interpolation, Theme } from "@emotion/react";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
-import { EnterpriseBadge, PremiumBadge } from "components/Badges/Badges";
+import { PremiumBadge } from "components/Badges/Badges";
 import { Stack } from "components/Stack/Stack";
 import type { FC, ReactNode } from "react";
-import theme from "theme";
 import { docs } from "utils/docs";
 
 export interface PaywallProps {
-	type: "enterprise" | "premium";
 	message: string;
 	description?: ReactNode;
 	documentationLink?: string;
 }
 
 export const Paywall: FC<PaywallProps> = ({
-	type,
 	message,
 	description,
 	documentationLink,
@@ -26,15 +23,15 @@ export const Paywall: FC<PaywallProps> = ({
 			css={[
 				styles.root,
 				(theme) => ({
-					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall[type].background})`,
-					border: `1px solid ${theme.branding.paywall[type].border}`,
+					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall.premium.background})`,
+					border: `1px solid ${theme.branding.paywall.premium.border}`,
 				}),
 			]}
 		>
 			<div>
 				<Stack direction="row" alignItems="center" css={{ marginBottom: 24 }}>
 					<h5 css={styles.title}>{message}</h5>
-					{type === "enterprise" ? <EnterpriseBadge /> : <PremiumBadge />}
+					<PremiumBadge />
 				</Stack>
 
 				{description && <p css={styles.description}>{description}</p>}
@@ -51,28 +48,20 @@ export const Paywall: FC<PaywallProps> = ({
 			<Stack direction="column" alignItems="center" spacing={3}>
 				<ul css={styles.featureList}>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} />
-						{type === "premium"
-							? "High availability & workspace proxies"
-							: "Template access control"}
+						<FeatureIcon />
+						High availability & workspace proxies
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} />
-						{type === "premium"
-							? "Multi-org & role-based access control"
-							: "User groups"}
+						<FeatureIcon />
+						Multi-org & role-based access control
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} />
-						{type === "premium"
-							? "24x7 global support with SLA"
-							: "24 hour support"}
+						<FeatureIcon />
+						24x7 global support with SLA
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={type} />
-						{type === "premium"
-							? "Unlimited Git & external auth integrations"
-							: "Audit logs"}
+						<FeatureIcon />
+						Unlimited Git & external auth integrations
 					</li>
 				</ul>
 				<Button
@@ -83,23 +72,19 @@ export const Paywall: FC<PaywallProps> = ({
 					variant="outlined"
 					color="neutral"
 				>
-					Learn about {type === "enterprise" ? "Enterprise" : "Premium"}
+					Learn about Premium
 				</Button>
 			</Stack>
 		</div>
 	);
 };
 
-export interface FeatureIconProps {
-	type: "enterprise" | "premium";
-}
-
-const FeatureIcon: FC<FeatureIconProps> = ({ type }) => {
+const FeatureIcon: FC = () => {
 	return (
 		<TaskAltIcon
 			css={[
 				(theme) => ({
-					color: theme.branding.paywall[type].border,
+					color: theme.branding.paywall.premium.border,
 				}),
 			]}
 		/>
@@ -107,7 +92,7 @@ const FeatureIcon: FC<FeatureIconProps> = ({ type }) => {
 };
 
 const styles = {
-	root: (theme) => ({
+	root: () => ({
 		display: "flex",
 		flexDirection: "row",
 		justifyContent: "center",
@@ -123,7 +108,7 @@ const styles = {
 		fontSize: 22,
 		margin: 0,
 	},
-	description: (theme) => ({
+	description: () => ({
 		fontFamily: "inherit",
 		maxWidth: 460,
 		fontSize: 14,
@@ -137,7 +122,6 @@ const styles = {
 	featureList: {
 		listStyle: "none",
 		margin: 0,
-		marginRight: 8,
 		padding: "0 24px",
 		fontSize: 14,
 		fontWeight: 500,

--- a/site/src/components/Paywall/PopoverPaywall.stories.tsx
+++ b/site/src/components/Paywall/PopoverPaywall.stories.tsx
@@ -9,19 +9,10 @@ const meta: Meta<typeof PopoverPaywall> = {
 export default meta;
 type Story = StoryObj<typeof PopoverPaywall>;
 
-export const Enterprise: Story = {
-	args: {
-		message: "Black Lotus",
-		description:
-			"Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
-	},
-};
-
 export const Premium: Story = {
 	args: {
 		message: "Black Lotus",
 		description:
 			"Adds 3 mana of any single color of your choice to your mana pool, then is discarded. Tapping this artifact can be played as an interrupt.",
-		licenseType: "premium",
 	},
 };

--- a/site/src/components/Paywall/PopoverPaywall.tsx
+++ b/site/src/components/Paywall/PopoverPaywall.tsx
@@ -38,7 +38,7 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 					Read the documentation
 				</Link>
 			</div>
-			<div css={styles.separator}></div>
+			<div css={styles.separator} />
 			<Stack direction="column" alignItems="center" spacing={2}>
 				<ul css={styles.featureList}>
 					<li css={styles.feature}>

--- a/site/src/components/Paywall/PopoverPaywall.tsx
+++ b/site/src/components/Paywall/PopoverPaywall.tsx
@@ -23,8 +23,8 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 			css={[
 				styles.root,
 				(theme) => ({
-					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall.premium.background})`,
-					border: `1px solid ${theme.branding.paywall.premium.border}`,
+					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.background})`,
+					border: `1px solid ${theme.branding.border}`,
 				}),
 			]}
 		>
@@ -80,7 +80,7 @@ const FeatureIcon: FC = () => {
 		<TaskAltIcon
 			css={[
 				(theme) => ({
-					color: theme.branding.paywall.premium.border,
+					color: theme.branding.border,
 				}),
 			]}
 		/>

--- a/site/src/components/Paywall/PopoverPaywall.tsx
+++ b/site/src/components/Paywall/PopoverPaywall.tsx
@@ -21,7 +21,15 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 	licenseType = "enterprise",
 }) => {
 	return (
-		<div css={styles.root}>
+		<div
+			css={[
+				styles.root,
+				(theme) => ({
+					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall[licenseType].background})`,
+					border: `1px solid ${theme.branding.paywall[licenseType].border}`,
+				}),
+			]}
+		>
 			<div>
 				<Stack direction="row" alignItems="center" css={{ marginBottom: 18 }}>
 					<h5 css={styles.title}>{message}</h5>
@@ -42,20 +50,20 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 			<Stack direction="column" alignItems="center" spacing={2}>
 				<ul css={styles.featureList}>
 					<li css={styles.feature}>
-						<FeatureIcon /> Template access control
+						<FeatureIcon type={licenseType} /> Template access control
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon /> User groups
+						<FeatureIcon type={licenseType} /> User groups
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon /> 24 hour support
+						<FeatureIcon type={licenseType} /> 24 hour support
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon /> Audit logs
+						<FeatureIcon type={licenseType} /> Audit logs
 					</li>
 					{licenseType === "premium" && (
 						<li css={styles.feature}>
-							<FeatureIcon /> Organizations
+							<FeatureIcon type={licenseType} /> Organizations
 						</li>
 					)}
 				</ul>
@@ -74,8 +82,20 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 	);
 };
 
-const FeatureIcon: FC = () => {
-	return <TaskAltIcon css={styles.featureIcon} />;
+export interface FeatureIconProps {
+	type: "enterprise" | "premium";
+}
+
+const FeatureIcon: FC<FeatureIconProps> = ({ type }) => {
+	return (
+		<TaskAltIcon
+			css={[
+				(theme) => ({
+					color: theme.branding.paywall[type].border,
+				}),
+			]}
+		/>
+	);
 };
 
 const styles = {
@@ -85,8 +105,6 @@ const styles = {
 		alignItems: "center",
 		maxWidth: 600,
 		padding: "24px 36px",
-		backgroundImage: `linear-gradient(160deg, transparent, ${theme.roles.active.background})`,
-		border: `1px solid ${theme.roles.active.fill.outline}`,
 		borderRadius: 8,
 		gap: 18,
 	}),
@@ -118,10 +136,6 @@ const styles = {
 		fontSize: 13,
 		fontWeight: 500,
 	},
-	featureIcon: (theme) => ({
-		color: theme.roles.active.fill.outline,
-		fontSize: "1.5em",
-	}),
 	feature: {
 		display: "flex",
 		alignItems: "center",

--- a/site/src/components/Paywall/PopoverPaywall.tsx
+++ b/site/src/components/Paywall/PopoverPaywall.tsx
@@ -2,7 +2,7 @@ import type { Interpolation, Theme } from "@emotion/react";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
-import { EnterpriseBadge, PremiumBadge } from "components/Badges/Badges";
+import { PremiumBadge } from "components/Badges/Badges";
 import { Stack } from "components/Stack/Stack";
 import type { FC, ReactNode } from "react";
 import { docs } from "utils/docs";
@@ -11,29 +11,27 @@ export interface PopoverPaywallProps {
 	message: string;
 	description?: ReactNode;
 	documentationLink?: string;
-	licenseType?: "enterprise" | "premium";
 }
 
 export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 	message,
 	description,
 	documentationLink,
-	licenseType = "enterprise",
 }) => {
 	return (
 		<div
 			css={[
 				styles.root,
 				(theme) => ({
-					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall[licenseType].background})`,
-					border: `1px solid ${theme.branding.paywall[licenseType].border}`,
+					backgroundImage: `linear-gradient(160deg, transparent, ${theme.branding.paywall.premium.background})`,
+					border: `1px solid ${theme.branding.paywall.premium.border}`,
 				}),
 			]}
 		>
 			<div>
 				<Stack direction="row" alignItems="center" css={{ marginBottom: 18 }}>
 					<h5 css={styles.title}>{message}</h5>
-					{licenseType === "premium" ? <PremiumBadge /> : <EnterpriseBadge />}
+					<PremiumBadge />
 				</Stack>
 
 				{description && <p css={styles.description}>{description}</p>}
@@ -50,22 +48,17 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 			<Stack direction="column" alignItems="center" spacing={2}>
 				<ul css={styles.featureList}>
 					<li css={styles.feature}>
-						<FeatureIcon type={licenseType} /> Template access control
+						<FeatureIcon /> High availability & workspace proxies
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={licenseType} /> User groups
+						<FeatureIcon /> Multi-org & role-based access control
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={licenseType} /> 24 hour support
+						<FeatureIcon /> 24x7 global support with SLA
 					</li>
 					<li css={styles.feature}>
-						<FeatureIcon type={licenseType} /> Audit logs
+						<FeatureIcon /> Unlimited Git & external auth integrations
 					</li>
-					{licenseType === "premium" && (
-						<li css={styles.feature}>
-							<FeatureIcon type={licenseType} /> Organizations
-						</li>
-					)}
 				</ul>
 				<Button
 					href={docs("/enterprise")}
@@ -75,23 +68,19 @@ export const PopoverPaywall: FC<PopoverPaywallProps> = ({
 					variant="outlined"
 					color="neutral"
 				>
-					Learn about {licenseType === "premium" ? "Premium" : "Enterprise"}
+					Learn about Premium
 				</Button>
 			</Stack>
 		</div>
 	);
 };
 
-export interface FeatureIconProps {
-	type: "enterprise" | "premium";
-}
-
-const FeatureIcon: FC<FeatureIconProps> = ({ type }) => {
+const FeatureIcon: FC = () => {
 	return (
 		<TaskAltIcon
 			css={[
 				(theme) => ({
-					color: theme.branding.paywall[type].border,
+					color: theme.branding.paywall.premium.border,
 				}),
 			]}
 		/>

--- a/site/src/pages/AuditPage/AuditPageView.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.tsx
@@ -137,9 +137,8 @@ export const AuditPageView: FC<AuditPageViewProps> = ({
 
 				<Cond>
 					<Paywall
-						type="enterprise"
 						message="Audit logs"
-						description="Audit logs allow you to monitor user operations on your deployment. You need an Enterprise license to use this feature."
+						description="Audit logs allow you to monitor user operations on your deployment. You need an Premium license to use this feature."
 						documentationLink={docs("/admin/audit-logs")}
 					/>
 				</Cond>

--- a/site/src/pages/AuditPage/AuditPageView.tsx
+++ b/site/src/pages/AuditPage/AuditPageView.tsx
@@ -137,6 +137,7 @@ export const AuditPageView: FC<AuditPageViewProps> = ({
 
 				<Cond>
 					<Paywall
+						type="enterprise"
 						message="Audit logs"
 						description="Audit logs allow you to monitor user operations on your deployment. You need an Enterprise license to use this feature."
 						documentationLink={docs("/admin/audit-logs")}

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -5,8 +5,8 @@ import type { UpdateAppearanceConfig } from "api/typesGenerated";
 import {
 	Badges,
 	DisabledBadge,
-	EnterpriseBadge,
 	EntitledBadge,
+	PremiumBadge,
 } from "components/Badges/Badges";
 import { PopoverPaywall } from "components/Paywall/PopoverPaywall";
 import {
@@ -64,14 +64,15 @@ export const AppearanceSettingsPageView: FC<
 				<Popover mode="hover">
 					<PopoverTrigger>
 						<span>
-							<EnterpriseBadge />
+							<PremiumBadge />
 						</span>
 					</PopoverTrigger>
 					<PopoverContent css={{ transform: "translateY(-28px)" }}>
 						<PopoverPaywall
 							message="Appearance"
-							description="With an Enterprise license, you can customize the appearance of your deployment."
+							description="With a Premium license, you can customize the appearance of your deployment."
 							documentationLink="https://coder.com/docs/admin/appearance"
+							licenseType="premium"
 						/>
 					</PopoverContent>
 				</Popover>

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -72,7 +72,6 @@ export const AppearanceSettingsPageView: FC<
 							message="Appearance"
 							description="With a Premium license, you can customize the appearance of your deployment."
 							documentationLink="https://coder.com/docs/admin/appearance"
-							licenseType="premium"
 						/>
 					</PopoverContent>
 				</Popover>

--- a/site/src/pages/DeploySettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/ExternalAuthSettingsPage/ExternalAuthSettingsPageView.tsx
@@ -7,7 +7,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import type { DeploymentValues, ExternalAuthConfig } from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
-import { EnterpriseBadge } from "components/Badges/Badges";
+import { PremiumBadge } from "components/Badges/Badges";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import type { FC } from "react";
 import { docs } from "utils/docs";
@@ -45,9 +45,9 @@ export const ExternalAuthSettingsPageView: FC<
 					marginBottom: 24,
 				}}
 			>
-				<Alert severity="info" actions={<EnterpriseBadge key="enterprise" />}>
+				<Alert severity="info" actions={<PremiumBadge key="enterprise" />}>
 					Integrating with multiple External authentication providers is an
-					Enterprise feature.
+					Premium feature.
 				</Alert>
 			</div>
 

--- a/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicenseCard.tsx
+++ b/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicenseCard.tsx
@@ -58,7 +58,7 @@ export const LicenseCard: FC<LicenseCardProps> = ({
 				title="Confirm License Removal"
 				confirmLoading={isRemoving}
 				confirmText="Remove"
-				description="Removing this license will disable all Enterprise features. You add a new license at any time."
+				description="Removing this license will disable all Premium features. You add a new license at any time."
 			/>
 			<Stack
 				direction="row"

--- a/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/LicensesSettingsPage/LicensesSettingsPageView.tsx
@@ -57,7 +57,7 @@ const LicensesSettingsPageView: FC<Props> = ({
 			>
 				<SettingsHeader
 					title="Licenses"
-					description="Manage licenses to unlock Enterprise features."
+					description="Manage licenses to unlock Premium features."
 				/>
 
 				<Stack direction="row" spacing={2}>

--- a/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -3,7 +3,7 @@ import {
 	Badges,
 	DisabledBadge,
 	EnabledBadge,
-	EnterpriseBadge,
+	PremiumBadge,
 } from "components/Badges/Badges";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
@@ -34,7 +34,7 @@ export const ObservabilitySettingsPageView: FC<
 
 					<Badges>
 						{featureAuditLogEnabled ? <EnabledBadge /> : <DisabledBadge />}
-						<EnterpriseBadge />
+						<PremiumBadge />
 					</Badges>
 				</div>
 

--- a/site/src/pages/DeploySettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/SecuritySettingsPage/SecuritySettingsPageView.tsx
@@ -3,7 +3,7 @@ import {
 	Badges,
 	DisabledBadge,
 	EnabledBadge,
-	EnterpriseBadge,
+	PremiumBadge,
 } from "components/Badges/Badges";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
@@ -56,7 +56,7 @@ export const SecuritySettingsPageView: FC<SecuritySettingsPageViewProps> = ({
 
 				<Badges>
 					{featureBrowserOnlyEnabled ? <EnabledBadge /> : <DisabledBadge />}
-					<EnterpriseBadge />
+					<PremiumBadge />
 				</Badges>
 			</div>
 

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -46,9 +46,8 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 			<ChooseOne>
 				<Cond condition={!isTemplateRBACEnabled}>
 					<Paywall
-						type="enterprise"
 						message="Groups"
-						description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
+						description="Organize users into groups with restricted access to templates. You need an Premium license to use this feature."
 						documentationLink={docs("/admin/groups")}
 					/>
 				</Cond>

--- a/site/src/pages/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/GroupsPage/GroupsPageView.tsx
@@ -46,6 +46,7 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 			<ChooseOne>
 				<Cond condition={!isTemplateRBACEnabled}>
 					<Paywall
+						type="enterprise"
 						message="Groups"
 						description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
 						documentationLink={docs("/admin/groups")}
@@ -58,7 +59,7 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 								<TableRow>
 									<TableCell width="50%">Name</TableCell>
 									<TableCell width="49%">Users</TableCell>
-									<TableCell width="1%"></TableCell>
+									<TableCell width="1%" />
 								</TableRow>
 							</TableHead>
 							<TableBody>

--- a/site/src/pages/ManagementSettingsPage/CreateOrganizationPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CreateOrganizationPageView.tsx
@@ -86,7 +86,6 @@ export const CreateOrganizationPageView: FC<
 							message="Organizations"
 							description="Organizations allow you to run a Coder deployment with multiple platform teams, all with unique use cases, templates, and even underlying infrastructure."
 							documentationLink={docs("/guides/using-organizations")}
-							licenseType="premium"
 						/>
 					</PopoverContent>
 				</Popover>

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.stories.tsx
@@ -21,6 +21,14 @@ export const NotEnabled: Story = {
 	},
 };
 
+export const NotEnabledEmptyTable: Story = {
+	args: {
+		roles: [],
+		canAssignOrgRole: true,
+		isCustomRolesEnabled: false,
+	},
+};
+
 export const Enabled: Story = {
 	args: {
 		roles: [MockRoleWithOrgPermissions],

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -45,74 +45,73 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 	const isEmpty = Boolean(roles && roles.length === 0);
 	return (
 		<>
-			<ChooseOne>
-				<Cond condition={!isCustomRolesEnabled}>
-					<Paywall
-						type="premium"
-						message="Custom Roles"
-						description="Create custom roles to assign a specific set of permissions to a user. You need an Enterprise license to use this feature."
-						documentationLink={docs("/admin/groups")}
-					/>
-				</Cond>
-				<Cond>
-					<TableContainer>
-						<Table>
-							<TableHead>
+			{!isCustomRolesEnabled && (
+				<Paywall
+					type="premium"
+					message="Custom Roles"
+					description="Custom Roles are available in the Premium plan and require an upgraded license. Please contact your Customer Success team for more information."
+					documentationLink={docs("/admin/groups")}
+				/>
+			)}
+			<TableContainer>
+				<Table>
+					<TableHead>
+						<TableRow>
+							<TableCell width="40%">Name</TableCell>
+							<TableCell width="59%">Permissions</TableCell>
+							<TableCell width="1%" />
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						<ChooseOne>
+							<Cond condition={isLoading}>
+								<TableLoader />
+							</Cond>
+
+							<Cond condition={isEmpty}>
 								<TableRow>
-									<TableCell width="40%">Name</TableCell>
-									<TableCell width="59%">Permissions</TableCell>
-									<TableCell width="1%" />
+									<TableCell colSpan={999}>
+										<EmptyState
+											message="No custom roles yet"
+											description={
+												canAssignOrgRole && isCustomRolesEnabled
+													? "Create your first custom role"
+													: !isCustomRolesEnabled
+														? "Upgrade to a premium license to create a custom role"
+														: "You don't have permission to create a custom role"
+											}
+											cta={
+												canAssignOrgRole &&
+												isCustomRolesEnabled && (
+													<Button
+														component={RouterLink}
+														to="create"
+														startIcon={<AddOutlined />}
+														variant="contained"
+													>
+														Create custom role
+													</Button>
+												)
+											}
+										/>
+									</TableCell>
 								</TableRow>
-							</TableHead>
-							<TableBody>
-								<ChooseOne>
-									<Cond condition={isLoading}>
-										<TableLoader />
-									</Cond>
+							</Cond>
 
-									<Cond condition={isEmpty}>
-										<TableRow>
-											<TableCell colSpan={999}>
-												<EmptyState
-													message="No custom roles yet"
-													description={
-														canAssignOrgRole
-															? "Create your first custom role"
-															: "You don't have permission to create a custom role"
-													}
-													cta={
-														canAssignOrgRole && (
-															<Button
-																component={RouterLink}
-																to="create"
-																startIcon={<AddOutlined />}
-																variant="contained"
-															>
-																Create custom role
-															</Button>
-														)
-													}
-												/>
-											</TableCell>
-										</TableRow>
-									</Cond>
-
-									<Cond>
-										{roles?.map((role) => (
-											<RoleRow
-												key={role.name}
-												role={role}
-												canAssignOrgRole={canAssignOrgRole}
-												onDelete={() => onDeleteRole(role)}
-											/>
-										))}
-									</Cond>
-								</ChooseOne>
-							</TableBody>
-						</Table>
-					</TableContainer>
-				</Cond>
-			</ChooseOne>
+							<Cond>
+								{roles?.map((role) => (
+									<RoleRow
+										key={role.name}
+										role={role}
+										canAssignOrgRole={canAssignOrgRole}
+										onDelete={() => onDeleteRole(role)}
+									/>
+								))}
+							</Cond>
+						</ChooseOne>
+					</TableBody>
+				</Table>
+			</TableContainer>
 		</>
 	);
 };

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -48,7 +48,6 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 		<Stack spacing={4}>
 			{!isCustomRolesEnabled && (
 				<Paywall
-					type="premium"
 					message="Custom Roles"
 					description="Custom Roles are available in the Premium plan and require an upgraded license. Please contact your Customer Success team for more information."
 					documentationLink={docs("/admin/groups")}

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -19,6 +19,7 @@ import {
 	ThreeDotsButton,
 } from "components/MoreMenu/MoreMenu";
 import { Paywall } from "components/Paywall/Paywall";
+import { Stack } from "components/Stack/Stack";
 import {
 	TableLoaderSkeleton,
 	TableRowSkeleton,
@@ -44,7 +45,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 	const isLoading = roles === undefined;
 	const isEmpty = Boolean(roles && roles.length === 0);
 	return (
-		<>
+		<Stack spacing={4}>
 			{!isCustomRolesEnabled && (
 				<Paywall
 					type="premium"
@@ -112,7 +113,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 					</TableBody>
 				</Table>
 			</TableContainer>
-		</>
+		</Stack>
 	);
 };
 

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -48,6 +48,7 @@ export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 			<ChooseOne>
 				<Cond condition={!isCustomRolesEnabled}>
 					<Paywall
+						type="premium"
 						message="Custom Roles"
 						description="Create custom roles to assign a specific set of permissions to a user. You need an Enterprise license to use this feature."
 						documentationLink={docs("/admin/groups")}

--- a/site/src/pages/ManagementSettingsPage/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/GroupsPage/GroupsPageView.tsx
@@ -46,9 +46,8 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 			<ChooseOne>
 				<Cond condition={!isTemplateRBACEnabled}>
 					<Paywall
-						type="enterprise"
 						message="Groups"
-						description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
+						description="Organize users into groups with restricted access to templates. You need a Premium license to use this feature."
 						documentationLink={docs("/admin/groups")}
 					/>
 				</Cond>

--- a/site/src/pages/ManagementSettingsPage/GroupsPage/GroupsPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/GroupsPage/GroupsPageView.tsx
@@ -46,6 +46,7 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 			<ChooseOne>
 				<Cond condition={!isTemplateRBACEnabled}>
 					<Paywall
+						type="enterprise"
 						message="Groups"
 						description="Organize users into groups with restricted access to templates. You need an Enterprise license to use this feature."
 						documentationLink={docs("/admin/groups")}
@@ -58,7 +59,7 @@ export const GroupsPageView: FC<GroupsPageViewProps> = ({
 								<TableRow>
 									<TableCell width="50%">Name</TableCell>
 									<TableCell width="49%">Users</TableCell>
-									<TableCell width="1%"></TableCell>
+									<TableCell width="1%" />
 								</TableRow>
 							</TableHead>
 							<TableBody>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -39,9 +39,8 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 			<ChooseOne>
 				<Cond condition={false}>
 					<Paywall
-						type="premium"
 						message="IdP Sync"
-						description="Configure group and role mappings to manage permissions outside of Coder."
+						description="Configure group and role mappings to manage permissions outside of Coder. You need an Premium license to use this feature."
 						documentationLink={docs("/admin/groups")}
 					/>
 				</Cond>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -39,6 +39,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 			<ChooseOne>
 				<Cond condition={false}>
 					<Paywall
+						type="premium"
 						message="IdP Sync"
 						description="Configure group and role mappings to manage permissions outside of Coder."
 						documentationLink={docs("/admin/groups")}

--- a/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateGeneralSettingsPage/TemplateSettingsForm.tsx
@@ -8,7 +8,7 @@ import {
 	type UpdateTemplateMeta,
 	WorkspaceAppSharingLevels,
 } from "api/typesGenerated";
-import { EnterpriseBadge } from "components/Badges/Badges";
+import { PremiumBadge } from "components/Badges/Badges";
 import {
 	FormFields,
 	FormFooter,
@@ -212,8 +212,8 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 											alignItems="center"
 											css={{ marginTop: 16 }}
 										>
-											<EnterpriseBadge />
-											<span>Enterprise license required to enabled.</span>
+											<PremiumBadge />
+											<span>Premium license required to enabled.</span>
 										</Stack>
 									)}
 								</StackLabelHelperText>
@@ -241,9 +241,9 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 					/>
 					{!accessControlEnabled && (
 						<Stack direction="row" spacing={2} alignItems="center">
-							<EnterpriseBadge />
+							<PremiumBadge />
 							<FormHelperText>
-								Enterprise license required to deprecate templates.
+								Premium license required to deprecate templates.
 								{template.deprecated &&
 									" You cannot change the message, but you may remove it to mark this template as no longer deprecated."}
 							</FormHelperText>
@@ -281,9 +281,9 @@ export const TemplateSettingsForm: FC<TemplateSettingsForm> = ({
 					</TextField>
 					{!portSharingControlsEnabled && (
 						<Stack direction="row" spacing={2} alignItems="center">
-							<EnterpriseBadge />
+							<PremiumBadge />
 							<FormHelperText>
-								Enterprise license required to control max port sharing level.
+								Premium license required to control max port sharing level.
 							</FormHelperText>
 						</Stack>
 					)}

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
@@ -31,9 +31,8 @@ export const TemplatePermissionsPage: FC = () => {
 			</Helmet>
 			{!isTemplateRBACEnabled ? (
 				<Paywall
-					type="enterprise"
 					message="Template permissions"
-					description="Control access of templates for users and groups to templates. You need an Enterprise license to use this feature."
+					description="Control access of templates for users and groups to templates. You need an Premium license to use this feature."
 					documentationLink={docs("/admin/rbac")}
 				/>
 			) : (

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPage.tsx
@@ -31,6 +31,7 @@ export const TemplatePermissionsPage: FC = () => {
 			</Helmet>
 			{!isTemplateRBACEnabled ? (
 				<Paywall
+					type="enterprise"
 					message="Template permissions"
 					description="Control access of templates for users and groups to templates. You need an Enterprise license to use this feature."
 					documentationLink={docs("/admin/rbac")}

--- a/site/src/pages/UsersPage/UsersTable/UsersTableBody.tsx
+++ b/site/src/pages/UsersPage/UsersTable/UsersTableBody.tsx
@@ -12,7 +12,7 @@ import type { GroupsByUserId } from "api/queries/groups";
 import type * as TypesGen from "api/typesGenerated";
 import { AvatarData } from "components/AvatarData/AvatarData";
 import { AvatarDataSkeleton } from "components/AvatarData/AvatarDataSkeleton";
-import { EnterpriseBadge } from "components/Badges/Badges";
+import { PremiumBadge } from "components/Badges/Badges";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { LastSeen } from "components/LastSeen/LastSeen";
@@ -208,7 +208,7 @@ export const UsersTableBody: FC<UsersTableBodyProps> = ({
 											disabled={!canViewActivity}
 										>
 											View activity
-											{!canViewActivity && <EnterpriseBadge />}
+											{!canViewActivity && <PremiumBadge />}
 										</MoreMenuItem>
 										<MoreMenuItem
 											onClick={() => onResetUserPassword(user)}

--- a/site/src/theme/branding.ts
+++ b/site/src/theme/branding.ts
@@ -1,6 +1,6 @@
 export interface Branding {
 	paywall: {
-		// Colors for enterprise are temporary and will be removed when the enterprise license is removed
+		/** Colors for enterprise are temporary and will be removed when the enterprise license is removed */
 		enterprise: {
 			background: string;
 			border: string;
@@ -11,7 +11,7 @@ export interface Branding {
 		};
 	};
 	badge: {
-		// Colors for enterprise are temporary and will be removed when the enterprise license is removed
+		/** Colors for enterprise are temporary and will be removed when the enterprise license is removed */
 		enterprise: {
 			background: string;
 			border: string;

--- a/site/src/theme/branding.ts
+++ b/site/src/theme/branding.ts
@@ -1,10 +1,5 @@
 export interface Branding {
 	paywall: {
-		/** Colors for enterprise are temporary and will be removed when the enterprise license is removed */
-		enterprise: {
-			background: string;
-			border: string;
-		};
 		premium: {
 			background: string;
 			divider: string;
@@ -12,12 +7,6 @@ export interface Branding {
 		};
 	};
 	badge: {
-		/** Colors for enterprise are temporary and will be removed when the enterprise license is removed */
-		enterprise: {
-			background: string;
-			border: string;
-			text: string;
-		};
 		premium: {
 			background: string;
 			border: string;

--- a/site/src/theme/branding.ts
+++ b/site/src/theme/branding.ts
@@ -1,0 +1,24 @@
+export interface Branding {
+	paywall: {
+		enterprise: {
+			background: string;
+			border: string;
+		};
+		premium: {
+			background: string;
+			border: string;
+		};
+	};
+	badge: {
+		enterprise: {
+			background: string;
+			border: string;
+			text: string;
+		};
+		premium: {
+			background: string;
+			border: string;
+			text: string;
+		};
+	};
+}

--- a/site/src/theme/branding.ts
+++ b/site/src/theme/branding.ts
@@ -7,6 +7,7 @@ export interface Branding {
 		};
 		premium: {
 			background: string;
+			divider: string;
 			border: string;
 		};
 	};

--- a/site/src/theme/branding.ts
+++ b/site/src/theme/branding.ts
@@ -1,5 +1,6 @@
 export interface Branding {
 	paywall: {
+		// Colors for enterprise are temporary and will be removed when the enterprise license is removed
 		enterprise: {
 			background: string;
 			border: string;
@@ -10,6 +11,7 @@ export interface Branding {
 		};
 	};
 	badge: {
+		// Colors for enterprise are temporary and will be removed when the enterprise license is removed
 		enterprise: {
 			background: string;
 			border: string;

--- a/site/src/theme/branding.ts
+++ b/site/src/theme/branding.ts
@@ -1,16 +1,6 @@
 export interface Branding {
-	paywall: {
-		premium: {
-			background: string;
-			divider: string;
-			border: string;
-		};
-	};
-	badge: {
-		premium: {
-			background: string;
-			border: string;
-			text: string;
-		};
-	};
+	background: string;
+	divider: string;
+	border: string;
+	text: string;
 }

--- a/site/src/theme/dark/branding.ts
+++ b/site/src/theme/dark/branding.ts
@@ -9,6 +9,7 @@ export default {
 		},
 		premium: {
 			background: colors.violet[950],
+			divider: colors.violet[900],
 			border: colors.violet[400],
 		},
 	},

--- a/site/src/theme/dark/branding.ts
+++ b/site/src/theme/dark/branding.ts
@@ -3,10 +3,6 @@ import colors from "../tailwindColors";
 
 export default {
 	paywall: {
-		enterprise: {
-			background: colors.sky[950],
-			border: colors.sky[400],
-		},
 		premium: {
 			background: colors.violet[950],
 			divider: colors.violet[900],
@@ -14,11 +10,6 @@ export default {
 		},
 	},
 	badge: {
-		enterprise: {
-			background: colors.blue[950],
-			border: colors.blue[400],
-			text: colors.blue[50],
-		},
 		premium: {
 			background: colors.violet[950],
 			border: colors.violet[400],

--- a/site/src/theme/dark/branding.ts
+++ b/site/src/theme/dark/branding.ts
@@ -2,18 +2,8 @@ import type { Branding } from "../branding";
 import colors from "../tailwindColors";
 
 export default {
-	paywall: {
-		premium: {
-			background: colors.violet[950],
-			divider: colors.violet[900],
-			border: colors.violet[400],
-		},
-	},
-	badge: {
-		premium: {
-			background: colors.violet[950],
-			border: colors.violet[400],
-			text: colors.violet[50],
-		},
-	},
+	background: colors.violet[950],
+	divider: colors.violet[900],
+	border: colors.violet[400],
+	text: colors.violet[50],
 } satisfies Branding;

--- a/site/src/theme/dark/branding.ts
+++ b/site/src/theme/dark/branding.ts
@@ -1,0 +1,27 @@
+import type { Branding } from "../branding";
+import colors from "../tailwindColors";
+
+export default {
+	paywall: {
+		enterprise: {
+			background: colors.sky[950],
+			border: colors.sky[400],
+		},
+		premium: {
+			background: colors.violet[950],
+			border: colors.violet[400],
+		},
+	},
+	badge: {
+		enterprise: {
+			background: colors.blue[950],
+			border: colors.blue[400],
+			text: colors.blue[50],
+		},
+		premium: {
+			background: colors.violet[950],
+			border: colors.violet[400],
+			text: colors.violet[50],
+		},
+	},
+} satisfies Branding;

--- a/site/src/theme/dark/index.ts
+++ b/site/src/theme/dark/index.ts
@@ -3,11 +3,13 @@ import experimental from "./experimental";
 import monaco from "./monaco";
 import muiTheme from "./mui";
 import roles from "./roles";
+import branding from "./branding";
 
 export default {
 	...muiTheme,
 	externalImages: forDarkThemes,
 	experimental,
+	branding,
 	monaco,
 	roles,
 };

--- a/site/src/theme/dark/index.ts
+++ b/site/src/theme/dark/index.ts
@@ -1,9 +1,9 @@
 import { forDarkThemes } from "../externalImages";
+import branding from "./branding";
 import experimental from "./experimental";
 import monaco from "./monaco";
 import muiTheme from "./mui";
 import roles from "./roles";
-import branding from "./branding";
 
 export default {
 	...muiTheme,

--- a/site/src/theme/darkBlue/branding.ts
+++ b/site/src/theme/darkBlue/branding.ts
@@ -9,6 +9,7 @@ export default {
 		},
 		premium: {
 			background: colors.violet[950],
+			divider: colors.violet[900],
 			border: colors.violet[400],
 		},
 	},

--- a/site/src/theme/darkBlue/branding.ts
+++ b/site/src/theme/darkBlue/branding.ts
@@ -3,10 +3,6 @@ import colors from "../tailwindColors";
 
 export default {
 	paywall: {
-		enterprise: {
-			background: colors.sky[950],
-			border: colors.sky[400],
-		},
 		premium: {
 			background: colors.violet[950],
 			divider: colors.violet[900],
@@ -14,11 +10,6 @@ export default {
 		},
 	},
 	badge: {
-		enterprise: {
-			background: colors.blue[950],
-			border: colors.blue[400],
-			text: colors.blue[50],
-		},
 		premium: {
 			background: colors.violet[950],
 			border: colors.violet[400],

--- a/site/src/theme/darkBlue/branding.ts
+++ b/site/src/theme/darkBlue/branding.ts
@@ -2,18 +2,8 @@ import type { Branding } from "../branding";
 import colors from "../tailwindColors";
 
 export default {
-	paywall: {
-		premium: {
-			background: colors.violet[950],
-			divider: colors.violet[900],
-			border: colors.violet[400],
-		},
-	},
-	badge: {
-		premium: {
-			background: colors.violet[950],
-			border: colors.violet[400],
-			text: colors.violet[50],
-		},
-	},
+	background: colors.violet[950],
+	divider: colors.violet[900],
+	border: colors.violet[400],
+	text: colors.violet[50],
 } satisfies Branding;

--- a/site/src/theme/darkBlue/branding.ts
+++ b/site/src/theme/darkBlue/branding.ts
@@ -1,0 +1,27 @@
+import type { Branding } from "../branding";
+import colors from "../tailwindColors";
+
+export default {
+	paywall: {
+		enterprise: {
+			background: colors.sky[950],
+			border: colors.sky[400],
+		},
+		premium: {
+			background: colors.violet[950],
+			border: colors.violet[400],
+		},
+	},
+	badge: {
+		enterprise: {
+			background: colors.blue[950],
+			border: colors.blue[400],
+			text: colors.blue[50],
+		},
+		premium: {
+			background: colors.violet[950],
+			border: colors.violet[400],
+			text: colors.violet[50],
+		},
+	},
+} satisfies Branding;

--- a/site/src/theme/darkBlue/index.ts
+++ b/site/src/theme/darkBlue/index.ts
@@ -3,11 +3,13 @@ import experimental from "./experimental";
 import monaco from "./monaco";
 import muiTheme from "./mui";
 import roles from "./roles";
+import branding from "./branding";
 
 export default {
 	...muiTheme,
 	externalImages: forDarkThemes,
 	experimental,
+	branding,
 	monaco,
 	roles,
 };

--- a/site/src/theme/darkBlue/index.ts
+++ b/site/src/theme/darkBlue/index.ts
@@ -1,9 +1,9 @@
 import { forDarkThemes } from "../externalImages";
+import branding from "./branding";
 import experimental from "./experimental";
 import monaco from "./monaco";
 import muiTheme from "./mui";
 import roles from "./roles";
-import branding from "./branding";
 
 export default {
 	...muiTheme,

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -1,13 +1,13 @@
 // biome-ignore lint/nursery/noRestrictedImports: We still use `Theme` as a basis for our actual theme, for now.
 import type { Theme as MuiTheme } from "@mui/material/styles";
 import type * as monaco from "monaco-editor";
+import type { Branding } from "./branding";
 import dark from "./dark";
 import darkBlue from "./darkBlue";
 import type { NewTheme } from "./experimental";
 import type { ExternalImageModeStyles } from "./externalImages";
 import light from "./light";
 import type { Roles } from "./roles";
-import type { Branding } from "./branding";
 
 export interface Theme extends Omit<MuiTheme, "palette"> {
 	/** @deprecated prefer `theme.roles` when possible */

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -7,6 +7,7 @@ import type { NewTheme } from "./experimental";
 import type { ExternalImageModeStyles } from "./externalImages";
 import light from "./light";
 import type { Roles } from "./roles";
+import type { Branding } from "./branding";
 
 export interface Theme extends Omit<MuiTheme, "palette"> {
 	/** @deprecated prefer `theme.roles` when possible */
@@ -20,6 +21,10 @@ export interface Theme extends Omit<MuiTheme, "palette"> {
 
 	/** Theme properties that we're testing out but haven't committed to. */
 	experimental: NewTheme;
+
+	//** Theme colors related to marketing */
+	branding: Branding;
+
 	monaco: monaco.editor.IStandaloneThemeData;
 	externalImages: ExternalImageModeStyles;
 }

--- a/site/src/theme/light/branding.ts
+++ b/site/src/theme/light/branding.ts
@@ -9,6 +9,7 @@ export default {
 		},
 		premium: {
 			background: colors.violet[100],
+			divider: colors.violet[300],
 			border: colors.violet[600],
 		},
 	},

--- a/site/src/theme/light/branding.ts
+++ b/site/src/theme/light/branding.ts
@@ -3,10 +3,6 @@ import colors from "../tailwindColors";
 
 export default {
 	paywall: {
-		enterprise: {
-			background: colors.sky[100],
-			border: colors.sky[600],
-		},
 		premium: {
 			background: colors.violet[100],
 			divider: colors.violet[300],
@@ -14,11 +10,6 @@ export default {
 		},
 	},
 	badge: {
-		enterprise: {
-			background: colors.blue[50],
-			border: colors.blue[400],
-			text: colors.blue[950],
-		},
 		premium: {
 			background: colors.violet[50],
 			border: colors.violet[400],

--- a/site/src/theme/light/branding.ts
+++ b/site/src/theme/light/branding.ts
@@ -2,18 +2,8 @@ import type { Branding } from "../branding";
 import colors from "../tailwindColors";
 
 export default {
-	paywall: {
-		premium: {
-			background: colors.violet[100],
-			divider: colors.violet[300],
-			border: colors.violet[600],
-		},
-	},
-	badge: {
-		premium: {
-			background: colors.violet[50],
-			border: colors.violet[400],
-			text: colors.violet[950],
-		},
-	},
+	background: colors.violet[100],
+	divider: colors.violet[300],
+	border: colors.violet[600],
+	text: colors.violet[950],
 } satisfies Branding;

--- a/site/src/theme/light/branding.ts
+++ b/site/src/theme/light/branding.ts
@@ -1,0 +1,27 @@
+import type { Branding } from "../branding";
+import colors from "../tailwindColors";
+
+export default {
+	paywall: {
+		enterprise: {
+			background: colors.sky[100],
+			border: colors.sky[600],
+		},
+		premium: {
+			background: colors.violet[100],
+			border: colors.violet[600],
+		},
+	},
+	badge: {
+		enterprise: {
+			background: colors.blue[50],
+			border: colors.blue[400],
+			text: colors.blue[950],
+		},
+		premium: {
+			background: colors.violet[50],
+			border: colors.violet[400],
+			text: colors.violet[950],
+		},
+	},
+} satisfies Branding;

--- a/site/src/theme/light/index.ts
+++ b/site/src/theme/light/index.ts
@@ -3,11 +3,13 @@ import experimental from "./experimental";
 import monaco from "./monaco";
 import muiTheme from "./mui";
 import roles from "./roles";
+import branding from "./branding";
 
 export default {
 	...muiTheme,
 	externalImages: forLightThemes,
 	experimental,
+	branding,
 	monaco,
 	roles,
 };

--- a/site/src/theme/light/index.ts
+++ b/site/src/theme/light/index.ts
@@ -1,9 +1,9 @@
 import { forLightThemes } from "../externalImages";
+import branding from "./branding";
 import experimental from "./experimental";
 import monaco from "./monaco";
 import muiTheme from "./mui";
 import roles from "./roles";
-import branding from "./branding";
 
 export default {
 	...muiTheme,


### PR DESCRIPTION
resolves #14318 

- [x]  Theme the premium license in a purple color palette
- [x]  Paywall should always be displayed if license isn't valid
- [x]  Display roles table with any existing custom roles exist even if license is no longer valid
- [x]  Display empty table state  even if license is no longer valid
- [x]  Add storybooks for new states