### PR TITLE
fix(site): prevent 404s by removing version postfix from URLs

### DIFF
--- a/site/src/utils/docs.ts
+++ b/site/src/utils/docs.ts
@@ -9,7 +9,7 @@ function defaultDocsUrl(): string {
 	}
 
 	// Strip the postfix version info that's not part of the link.
-	const i = version?.indexOf("-") ?? -1;
+	const i = version?.match(/[+-]/)?.index ?? -1;
 	if (i >= 0) {
 		version = version.slice(0, i);
 	}


### PR DESCRIPTION
I found broken links to the docs when looking at one of my locally running workspaces on the site. 

Example broken link: `https://coder.com/docs/@v2.15.0+190cd1c/install`
I found I could fix the link by removing the postfix info. This is normally done automatically, but the existing code was only stripping out anything in the version number after a `-`. Now it checks for either a `-` or `+`.

Attached video for clarity.


https://github.com/user-attachments/assets/cbf60613-0d6b-4507-9ba1-c57087c188a8

