### PR TITLE
fix: only allow submitting form if changes have been made

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -154,6 +154,7 @@ export const WorkspaceParametersForm: FC<WorkspaceParameterFormProps> = ({
 				<FormFooter
 					onCancel={onCancel}
 					isLoading={isSubmitting}
+					submitLabel="Submit and restart"
 					submitDisabled={disabled || !form.dirty}
 				/>
 			</HorizontalForm>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersForm.tsx
@@ -154,7 +154,7 @@ export const WorkspaceParametersForm: FC<WorkspaceParameterFormProps> = ({
 				<FormFooter
 					onCancel={onCancel}
 					isLoading={isSubmitting}
-					submitDisabled={disabled}
+					submitDisabled={disabled || !form.dirty}
 				/>
 			</HorizontalForm>
 		</>

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
@@ -61,7 +61,9 @@ test("Submit the workspace settings page successfully", async () => {
 	);
 	await user.clear(parameter2);
 	await user.type(parameter2, "1");
-	await user.click(within(form).getByRole("button", { name: "Submit" }));
+	await user.click(
+		within(form).getByRole("button", { name: "Submit and restart" }),
+	);
 	// Assert that the API calls were made with the correct data
 	await waitFor(() => {
 		expect(postWorkspaceBuildSpy).toHaveBeenCalledWith(MockWorkspace.id, {
@@ -102,7 +104,7 @@ test("Submit button is only enabled when changes are made", async () => {
 	await waitForLoaderToBeRemoved();
 
 	const submitButton: HTMLButtonElement = screen.getByRole("button", {
-		name: "Submit",
+		name: "Submit and restart",
 	});
 
 	const form = screen.getByTestId("form");

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPage.test.tsx
@@ -101,7 +101,9 @@ test("Submit button is only enabled when changes are made", async () => {
 	});
 	await waitForLoaderToBeRemoved();
 
-	const submitButton: HTMLButtonElement = screen.getByRole("button", { name: "Submit" });
+	const submitButton: HTMLButtonElement = screen.getByRole("button", {
+		name: "Submit",
+	});
 
 	const form = screen.getByTestId("form");
 	const parameter1 = within(form).getByLabelText(


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/14320

This disables the submit button if the form is not dirty, meaning the button can only be enabled if the form has had changes to it.

https://github.com/user-attachments/assets/f7952962-e724-42e1-ad72-d74a7c662fc0

