### PR TITLE
fix: prefer organization display name for workspaces table

### DIFF
--- a/site/src/@types/storybook.d.ts
+++ b/site/src/@types/storybook.d.ts
@@ -3,6 +3,7 @@ import type {
 	DeploymentValues,
 	Experiments,
 	FeatureName,
+	Organization,
 	SerpentOption,
 	User,
 } from "api/typesGenerated";
@@ -17,6 +18,7 @@ declare module "@storybook/react" {
 		features?: FeatureName[];
 		experiments?: Experiments;
 		showOrganizations?: boolean;
+		organizations?: Organization[];
 		queries?: { key: QueryKey; data: unknown }[];
 		webSocket?: WebSocketEvent[];
 		user?: User;

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -15,6 +15,7 @@ import uniqueId from "lodash/uniqueId";
 import type { ComponentProps } from "react";
 import {
 	MockBuildInfo,
+	MockOrganization,
 	MockPendingProvisionerJob,
 	MockTemplate,
 	MockUser,
@@ -269,25 +270,27 @@ export const InvalidPageNumber: Story = {
 
 export const ShowOrganizations: Story = {
 	args: {
-		workspaces: [
-			{
-				...MockWorkspace,
-				organization_name: "Limbus Co.",
-			},
-		],
+		workspaces: [{ ...MockWorkspace, organization_name: "limbus-co" }],
 	},
 
 	parameters: {
 		showOrganizations: true,
+		organizations: [
+			{
+				...MockOrganization,
+				name: "limbus-co",
+				display_name: "Limbus Company, LLC",
+			},
+		],
 	},
 
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const accessibleTableCell = await canvas.findByRole("cell", {
-			// Need whitespace classes because different parts of the element
-			// are going in different spans, and Storybook doesn't consolidate
-			// these
-			name: /org\s?(?:anization)?\s?:\s?Limbus Co\./i,
+			// The organization label is always visually hidden, but the test
+			// makes sure that there's a screen reader hook to give the table
+			// cell more structured output
+			name: /organization: Limbus Co\., LLC/i,
 		});
 
 		expect(accessibleTableCell).toBeDefined();

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -290,7 +290,7 @@ export const ShowOrganizations: Story = {
 			// The organization label is always visually hidden, but the test
 			// makes sure that there's a screen reader hook to give the table
 			// cell more structured output
-			name: /organization: Limbus Co\., LLC/i,
+			name: /organization: Limbus Company, LLC/i,
 		});
 
 		expect(accessibleTableCell).toBeDefined();

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -115,6 +115,10 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 						const checked = checkedWorkspaces.some(
 							(w) => w.id === workspace.id,
 						);
+						const activeOrg = dashboard.organizations.find(
+							(o) => o.id === workspace.organization_id,
+						);
+
 						return (
 							<WorkspacesRow
 								workspace={workspace}
@@ -208,7 +212,7 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 											}}
 										>
 											<span css={{ ...visuallyHidden }}>Organization: </span>
-											{workspace.organization_name}
+											{activeOrg?.display_name || workspace.organization_name}
 										</div>
 									)}
 								</TableCell>

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -24,6 +24,7 @@ export const withDashboardProvider = (
 		features = [],
 		experiments = [],
 		showOrganizations = false,
+		organizations = [MockDefaultOrganization],
 	} = parameters;
 
 	const entitlements: Entitlements = {
@@ -44,9 +45,9 @@ export const withDashboardProvider = (
 			value={{
 				entitlements,
 				experiments,
-				appearance: MockAppearanceConfig,
-				organizations: [MockDefaultOrganization],
+				organizations,
 				showOrganizations,
+				appearance: MockAppearanceConfig,
 			}}
 		>
 			<Story />


### PR DESCRIPTION
Quick fix to the organizations table. No issue to link.

With this, we defer to showing an organization's display name, and then only show the base organization name if a display name doesn't exist.

Not super obvious with Coder, but 

Before (Coder is lowercase because we're using the base organization name):
<img width="524" alt="Screenshot 2024-09-09 at 10 43 35 AM" src="https://github.com/user-attachments/assets/7fae56a4-6d7a-4d77-918a-94d226236fde">
After (Coder is uppercase because we do have a custom display name defined in the organization settings):
<img width="524" alt="Screenshot 2024-09-09 at 10 43 28 AM" src="https://github.com/user-attachments/assets/ab7392c3-7da0-4ae8-b39f-0023a9d5e27f">