### PR TITLE
docs: fix SCIM env var

### DIFF
--- a/docs/admin/auth.md
+++ b/docs/admin/auth.md
@@ -236,7 +236,7 @@ authentication. Upon deactivation, users are
 the Coder server.
 
 ```env
-CODER_SCIM_API_KEY="your-api-key"
+CODER_SCIM_AUTH_HEADER="your-api-key"
 ```
 
 ## TLS


### PR DESCRIPTION
our documentation noted an incorrect SCIM environment variable. this PR adds the correct var:

```
CODER_SCIM_AUTH_HEADER
```