### PR TITLE
feat: add groups column to members page in organizations

### DIFF
--- a/site/src/api/queries/groups.ts
+++ b/site/src/api/queries/groups.ts
@@ -53,6 +53,13 @@ export function groupsByUserId() {
 	} satisfies UseQueryOptions<Group[], unknown, GroupsByUserId>;
 }
 
+export function groupsByUserIdInOrganization(organization: string) {
+	return {
+		...groupsByOrganization(organization),
+		select: selectGroupsByUserId,
+	} satisfies UseQueryOptions<Group[], unknown, GroupsByUserId>;
+}
+
 export function selectGroupsByUserId(groups: Group[]): GroupsByUserId {
 	// Sorting here means that nothing has to be sorted for the individual
 	// user arrays later

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPage.tsx
@@ -1,3 +1,4 @@
+import { groupsByUserId } from "api/queries/groups";
 import {
 	addOrganizationMember,
 	organizationMembers,
@@ -21,6 +22,8 @@ const OrganizationMembersPage: FC = () => {
 		organization: string;
 	};
 	const { user: me } = useAuthenticated();
+
+	const groupsByUserIdQuery = useQuery(groupsByUserId());
 
 	const membersQuery = useQuery(organizationMembers(organizationName));
 	const organizationRolesQuery = useQuery(organizationRoles(organizationName));
@@ -58,6 +61,7 @@ const OrganizationMembersPage: FC = () => {
 			isUpdatingMemberRoles={updateMemberRolesMutation.isLoading}
 			me={me}
 			members={membersQuery.data}
+			groupsByUserId={groupsByUserIdQuery.data}
 			addMember={async (user: User) => {
 				await addMemberMutation.mutateAsync(user.id);
 				void membersQuery.refetch();

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPage.tsx
@@ -1,4 +1,7 @@
-import { groupsByUserId, groupsByUserIdInOrganization } from "api/queries/groups";
+import {
+	groupsByUserId,
+	groupsByUserIdInOrganization,
+} from "api/queries/groups";
 import {
 	addOrganizationMember,
 	organizationMembers,
@@ -23,15 +26,17 @@ const OrganizationMembersPage: FC = () => {
 	};
 	const { user: me } = useAuthenticated();
 
-	const groupsByUserIdQuery = useQuery(groupsByUserIdInOrganization(organizationName));
+	const groupsByUserIdQuery = useQuery(
+		groupsByUserIdInOrganization(organizationName),
+	);
 
 	const membersQuery = useQuery(organizationMembers(organizationName));
 	const organizationRolesQuery = useQuery(organizationRoles(organizationName));
 
 	const members = membersQuery.data?.map((member) => {
 		const groups = groupsByUserIdQuery.data?.get(member.user_id) ?? [];
-		return {...member, groups};
-	})
+		return { ...member, groups };
+	});
 
 	const addMemberMutation = useMutation(
 		addOrganizationMember(queryClient, organizationName),

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.stories.tsx
@@ -15,7 +15,10 @@ const meta: Meta<typeof OrganizationMembersPageView> = {
 		isAddingMember: false,
 		isUpdatingMemberRoles: false,
 		me: MockUser,
-		members: [MockOrganizationMember, MockOrganizationMember2],
+		members: [
+			{...MockOrganizationMember, groups: []},
+			{...MockOrganizationMember2, groups: []},
+		],
 		addMember: () => Promise.resolve(),
 		removeMember: () => Promise.resolve(),
 		updateMemberRoles: () => Promise.resolve(),

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.stories.tsx
@@ -16,8 +16,8 @@ const meta: Meta<typeof OrganizationMembersPageView> = {
 		isUpdatingMemberRoles: false,
 		me: MockUser,
 		members: [
-			{...MockOrganizationMember, groups: []},
-			{...MockOrganizationMember2, groups: []},
+			{ ...MockOrganizationMember, groups: [] },
+			{ ...MockOrganizationMember2, groups: [] },
 		],
 		addMember: () => Promise.resolve(),
 		removeMember: () => Promise.resolve(),

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
@@ -41,7 +41,7 @@ interface OrganizationMembersPageViewProps {
 	isAddingMember: boolean;
 	isUpdatingMemberRoles: boolean;
 	me: User;
-	members: Array<OrganizationMemberTableEntry> | undefined,
+	members: Array<OrganizationMemberTableEntry> | undefined;
 	groupsByUserId: GroupsByUserId | undefined;
 	addMember: (user: User) => Promise<void>;
 	removeMember: (member: OrganizationMemberWithUserData) => Promise<void>;
@@ -52,8 +52,8 @@ interface OrganizationMembersPageViewProps {
 }
 
 interface OrganizationMemberTableEntry extends OrganizationMemberWithUserData {
-	groups: readonly Group[] | undefined,
-};
+	groups: readonly Group[] | undefined;
+}
 
 export const OrganizationMembersPageView: FC<
 	OrganizationMembersPageViewProps

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
@@ -10,6 +10,7 @@ import TableRow from "@mui/material/TableRow";
 import { getErrorMessage } from "api/errors";
 import type { GroupsByUserId } from "api/queries/groups";
 import type {
+	Group,
 	OrganizationMemberWithUserData,
 	SlimRole,
 	User,
@@ -40,7 +41,7 @@ interface OrganizationMembersPageViewProps {
 	isAddingMember: boolean;
 	isUpdatingMemberRoles: boolean;
 	me: User;
-	members: OrganizationMemberWithUserData[] | undefined;
+	members: Array<OrganizationMemberTableEntry> | undefined,
 	groupsByUserId: GroupsByUserId | undefined;
 	addMember: (user: User) => Promise<void>;
 	removeMember: (member: OrganizationMemberWithUserData) => Promise<void>;
@@ -49,6 +50,10 @@ interface OrganizationMembersPageViewProps {
 		newRoles: string[],
 	) => Promise<void>;
 }
+
+interface OrganizationMemberTableEntry extends OrganizationMemberWithUserData {
+	groups: readonly Group[] | undefined,
+};
 
 export const OrganizationMembersPageView: FC<
 	OrganizationMembersPageViewProps
@@ -120,9 +125,7 @@ export const OrganizationMembersPageView: FC<
 											}
 										}}
 									/>
-									<UserGroupsCell
-										userGroups={props.groupsByUserId?.get(member.user_id)}
-									/>
+									<UserGroupsCell userGroups={member.groups} />
 									<TableCell>
 										{member.user_id !== props.me.id && props.canEditMembers && (
 											<MoreMenu>

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
@@ -8,6 +8,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { getErrorMessage } from "api/errors";
+import type { GroupsByUserId } from "api/queries/groups";
 import type {
 	OrganizationMemberWithUserData,
 	SlimRole,
@@ -30,6 +31,7 @@ import { UserAvatar } from "components/UserAvatar/UserAvatar";
 import { type FC, useState } from "react";
 import { TableColumnHelpTooltip } from "./UserTable/TableColumnHelpTooltip";
 import { UserRoleCell } from "./UserTable/UserRoleCell";
+import { UserGroupsCell } from "pages/UsersPage/UsersTable/UserGroupsCell";
 
 interface OrganizationMembersPageViewProps {
 	allAvailableRoles: readonly SlimRole[] | undefined;
@@ -39,6 +41,7 @@ interface OrganizationMembersPageViewProps {
 	isUpdatingMemberRoles: boolean;
 	me: User;
 	members: OrganizationMemberWithUserData[] | undefined;
+	groupsByUserId: GroupsByUserId | undefined,
 	addMember: (user: User) => Promise<void>;
 	removeMember: (member: OrganizationMemberWithUserData) => Promise<void>;
 	updateMemberRoles: (
@@ -68,11 +71,17 @@ export const OrganizationMembersPageView: FC<
 					<Table>
 						<TableHead>
 							<TableRow>
-								<TableCell width="50%">User</TableCell>
-								<TableCell width="49%">
+								<TableCell width="33%">User</TableCell>
+								<TableCell width="33%">
 									<Stack direction="row" spacing={1} alignItems="center">
 										<span>Roles</span>
 										<TableColumnHelpTooltip variant="roles" />
+									</Stack>
+								</TableCell>
+								<TableCell width="33%">
+									<Stack direction="row" spacing={1} alignItems="center">
+										<span>Groups</span>
+										<TableColumnHelpTooltip variant="groups" />
 									</Stack>
 								</TableCell>
 								<TableCell width="1%"></TableCell>
@@ -111,6 +120,7 @@ export const OrganizationMembersPageView: FC<
 											}
 										}}
 									/>
+									<UserGroupsCell userGroups={props.groupsByUserId?.get(member.user_id)} />
 									<TableCell>
 										{member.user_id !== props.me.id && props.canEditMembers && (
 											<MoreMenu>

--- a/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationMembersPageView.tsx
@@ -28,10 +28,10 @@ import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
 import { UserAutocomplete } from "components/UserAutocomplete/UserAutocomplete";
 import { UserAvatar } from "components/UserAvatar/UserAvatar";
+import { UserGroupsCell } from "pages/UsersPage/UsersTable/UserGroupsCell";
 import { type FC, useState } from "react";
 import { TableColumnHelpTooltip } from "./UserTable/TableColumnHelpTooltip";
 import { UserRoleCell } from "./UserTable/UserRoleCell";
-import { UserGroupsCell } from "pages/UsersPage/UsersTable/UserGroupsCell";
 
 interface OrganizationMembersPageViewProps {
 	allAvailableRoles: readonly SlimRole[] | undefined;
@@ -41,7 +41,7 @@ interface OrganizationMembersPageViewProps {
 	isUpdatingMemberRoles: boolean;
 	me: User;
 	members: OrganizationMemberWithUserData[] | undefined;
-	groupsByUserId: GroupsByUserId | undefined,
+	groupsByUserId: GroupsByUserId | undefined;
 	addMember: (user: User) => Promise<void>;
 	removeMember: (member: OrganizationMemberWithUserData) => Promise<void>;
 	updateMemberRoles: (
@@ -120,7 +120,9 @@ export const OrganizationMembersPageView: FC<
 											}
 										}}
 									/>
-									<UserGroupsCell userGroups={props.groupsByUserId?.get(member.user_id)} />
+									<UserGroupsCell
+										userGroups={props.groupsByUserId?.get(member.user_id)}
+									/>
 									<TableCell>
 										{member.user_id !== props.me.id && props.canEditMembers && (
 											<MoreMenu>


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/14315

This adds a 'Groups' column to the table on the `organizations/<name>/members` page.

Before change

![Screenshot 2024-09-09 at 16 29 39](https://github.com/user-attachments/assets/200693cd-29ac-4b2d-afd4-6240bf003c5d)

After change

![Screenshot 2024-09-09 at 16 25 44](https://github.com/user-attachments/assets/3c76c0f6-43c5-48ba-9be8-db6ba0cf7256)
