### PR TITLE
feat!: add `--default-token-lifetime`

### DIFF
--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -25,6 +25,11 @@ OPTIONS:
           systemd. This directory is NOT safe to be configured as a shared
           directory across coderd/provisionerd replicas.
 
+      --default-token-lifetime duration, $CODER_DEFAULT_TOKEN_LIFETIME (default: 168h0m0s)
+          The default lifetime duration for API tokens. This value is used when
+          creating a token without specifying a duration, such as when
+          authenticating the CLI or an IDE plugin.
+
       --disable-owner-workspace-access bool, $CODER_DISABLE_OWNER_WORKSPACE_ACCESS
           Remove the permission for the 'owner' role to have workspace execution
           on all workspaces. This prevents the 'owner' from ssh, apps, and

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -423,6 +423,11 @@ experiments: []
 # performed once per day.
 # (default: false, type: bool)
 updateCheck: false
+# The default lifetime duration for API tokens. This value is used when creating a
+# token without specifying a duration, such as when authenticating the CLI or an
+# IDE plugin.
+# (default: 168h0m0s, type: duration)
+defaultTokenLifetime: 168h0m0s
 # Expose the swagger endpoint via /swagger.
 # (default: <unset>, type: bool)
 enableSwagger: false

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12093,7 +12093,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "default_duration": {
-                    "description": "DefaultDuration is for api keys, not tokens.",
+                    "description": "DefaultDuration is only for browser, workspace app and oauth sessions.",
+                    "type": "integer"
+                },
+                "default_token_lifetime": {
                     "type": "integer"
                 },
                 "disable_expiry_refresh": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10941,7 +10941,10 @@
 			"type": "object",
 			"properties": {
 				"default_duration": {
-					"description": "DefaultDuration is for api keys, not tokens.",
+					"description": "DefaultDuration is only for browser, workspace app and oauth sessions.",
+					"type": "integer"
+				},
+				"default_token_lifetime": {
 					"type": "integer"
 				},
 				"disable_expiry_refresh": {

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1958,7 +1958,7 @@ func (s *server) regenerateSessionToken(ctx context.Context, user database.User,
 		UserID:          user.ID,
 		LoginType:       user.LoginType,
 		TokenName:       workspaceSessionTokenName(workspace),
-		DefaultLifetime: s.DeploymentValues.Sessions.DefaultDuration.Value(),
+		DefaultLifetime: s.DeploymentValues.Sessions.DefaultTokenDuration.Value(),
 		LifetimeSeconds: int64(s.DeploymentValues.Sessions.MaximumTokenDuration.Value().Seconds()),
 	})
 	if err != nil {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -299,8 +299,8 @@ func TestPostLogin(t *testing.T) {
 		apiKey, err := client.APIKeyByID(ctx, owner.UserID.String(), split[0])
 		require.NoError(t, err, "fetch api key")
 
-		require.True(t, apiKey.ExpiresAt.After(time.Now().Add(time.Hour*24*29)), "default tokens lasts more than 29 days")
-		require.True(t, apiKey.ExpiresAt.Before(time.Now().Add(time.Hour*24*31)), "default tokens lasts less than 31 days")
+		require.True(t, apiKey.ExpiresAt.After(time.Now().Add(time.Hour*24*6)), "default tokens lasts more than 6 days")
+		require.True(t, apiKey.ExpiresAt.Before(time.Now().Add(time.Hour*24*8)), "default tokens lasts less than 8 days")
 		require.Greater(t, apiKey.LifetimeSeconds, key.LifetimeSeconds, "token should have longer lifetime")
 	})
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -454,8 +454,10 @@ type SessionLifetime struct {
 	// creation is the lifetime of the api key.
 	DisableExpiryRefresh serpent.Bool `json:"disable_expiry_refresh,omitempty" typescript:",notnull"`
 
-	// DefaultDuration is for api keys, not tokens.
+	// DefaultDuration is only for browser, workspace app and oauth sessions.
 	DefaultDuration serpent.Duration `json:"default_duration" typescript:",notnull"`
+
+	DefaultTokenDuration serpent.Duration `json:"default_token_lifetime,omitempty" typescript:",notnull"`
 
 	MaximumTokenDuration serpent.Duration `json:"max_token_lifetime,omitempty" typescript:",notnull"`
 }
@@ -1996,6 +1998,16 @@ when required by your organization's security policy.`,
 			Value:       &c.Sessions.MaximumTokenDuration,
 			Group:       &deploymentGroupNetworkingHTTP,
 			YAML:        "maxTokenLifetime",
+			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
+		},
+		{
+			Name:        "Default Token Lifetime",
+			Description: "The default lifetime duration for API tokens. This value is used when creating a token without specifying a duration, such as when authenticating the CLI or an IDE plugin.",
+			Flag:        "default-token-lifetime",
+			Env:         "CODER_DEFAULT_TOKEN_LIFETIME",
+			Default:     (7 * 24 * time.Hour).String(),
+			Value:       &c.Sessions.DefaultTokenDuration,
+			YAML:        "defaultTokenLifetime",
 			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
 		},
 		{

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -396,6 +396,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
 		"secure_auth_cookie": true,
 		"session_lifetime": {
 			"default_duration": 0,
+			"default_token_lifetime": 0,
 			"disable_expiry_refresh": true,
 			"max_token_lifetime": 0
 		},

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1902,6 +1902,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 		"secure_auth_cookie": true,
 		"session_lifetime": {
 			"default_duration": 0,
+			"default_token_lifetime": 0,
 			"disable_expiry_refresh": true,
 			"max_token_lifetime": 0
 		},
@@ -2328,6 +2329,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 	"secure_auth_cookie": true,
 	"session_lifetime": {
 		"default_duration": 0,
+		"default_token_lifetime": 0,
 		"disable_expiry_refresh": true,
 		"max_token_lifetime": 0
 	},
@@ -4651,6 +4653,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 ```json
 {
 	"default_duration": 0,
+	"default_token_lifetime": 0,
 	"disable_expiry_refresh": true,
 	"max_token_lifetime": 0
 }
@@ -4660,7 +4663,8 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 | Name                     | Type    | Required | Restrictions | Description                                                                                                                                                                        |
 | ------------------------ | ------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default_duration`       | integer | false    |              | Default duration is for api keys, not tokens.                                                                                                                                      |
+| `default_duration`       | integer | false    |              | Default duration is only for browser, workspace app and oauth sessions.                                                                                                            |
+| `default_token_lifetime` | integer | false    |              |                                                                                                                                                                                    |
 | `disable_expiry_refresh` | boolean | false    |              | Disable expiry refresh will disable automatically refreshing api keys when they are used from the api. This means the api key lifetime at creation is the lifetime of the api key. |
 | `max_token_lifetime`     | integer | false    |              |                                                                                                                                                                                    |
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -910,6 +910,17 @@ Periodically check for new releases of Coder and inform the owner. The check is 
 
 The maximum lifetime duration users can specify when creating an API token.
 
+### --default-token-lifetime
+
+|             |                                            |
+| ----------- | ------------------------------------------ |
+| Type        | <code>duration</code>                      |
+| Environment | <code>$CODER_DEFAULT_TOKEN_LIFETIME</code> |
+| YAML        | <code>defaultTokenLifetime</code>          |
+| Default     | <code>168h0m0s</code>                      |
+
+The default lifetime duration for API tokens. This value is used when creating a token without specifying a duration, such as when authenticating the CLI or an IDE plugin.
+
 ### --swagger-enable
 
 |             |                                    |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -26,6 +26,11 @@ OPTIONS:
           systemd. This directory is NOT safe to be configured as a shared
           directory across coderd/provisionerd replicas.
 
+      --default-token-lifetime duration, $CODER_DEFAULT_TOKEN_LIFETIME (default: 168h0m0s)
+          The default lifetime duration for API tokens. This value is used when
+          creating a token without specifying a duration, such as when
+          authenticating the CLI or an IDE plugin.
+
       --disable-owner-workspace-access bool, $CODER_DISABLE_OWNER_WORKSPACE_ACCESS
           Remove the permission for the 'owner' role to have workspace execution
           on all workspaces. This prevents the 'owner' from ssh, apps, and

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1173,6 +1173,7 @@ export interface SessionCountDeploymentStats {
 export interface SessionLifetime {
 	readonly disable_expiry_refresh?: boolean;
 	readonly default_duration: number;
+	readonly default_token_lifetime?: number;
 	readonly max_token_lifetime?: number;
 }
 


### PR DESCRIPTION
Closes #13990.

Adds a new deployment value that influences the lifetime of tokens created via:
- `/users/{user}/keys [post]` - Used by `/cli-auth`
- `/users/{user}/keys/tokens [post]` - Used by `Tokens` page in web UI settings, and `coder tokens create`.

The default value of this option is 7 days, to retain the existing TTL for `/cli-auth` tokens.

Of note is that the web UI and `coder tokens create` supply default values when calling `/tokens [post]`.

Therefore, the only breaking change in this PR is for tokens created by directly calling `/users/{user}/keys/tokens [post]` without a lifetime in the request body. The default TTL for these tokens is 7 days, down from 30. Users calling this endpoint directly should already be specifying a lifetime, so this is unlikely to break any existing workflows.

The tokens returned by `/users/{user}/keys [post]` are still refreshed with activity, unless `--disable-session-expiry-refresh` is set.