### PR TITLE
fix: fix TestPing/1Ping flake

### DIFF
--- a/cli/ping_test.go
+++ b/cli/ping_test.go
@@ -67,7 +67,7 @@ func TestPing(t *testing.T) {
 
 		pty.ExpectMatch("pong from " + workspace.Name)
 		pty.ExpectMatch("✔ received remote agent data from Coder networking coordinator")
-		pty.ExpectMatch("✔ You are connected directly (p2p)")
+		pty.ExpectMatch("You are connected")
 		cancel()
 		<-cmdDone
 	})


### PR DESCRIPTION
Fixes #14632.

With Postgres enabled, this test can run slow enough that a direct connection can't be established before the test times out. 
We just want to see that the ping command finished, so we'll accept confirmation of either a DERP or p2p connection.