### PR TITLE
chore: add lint for codersdk dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,7 @@ lint/ts:
 
 lint/go:
 	./scripts/check_enterprise_imports.sh
+	./scripts/check_codersdk_imports.sh
 	linter_ver=$(shell egrep -o 'GOLANGCI_LINT_VERSION=\S+' dogfood/contents/Dockerfile | cut -d '=' -f 2)
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v$$linter_ver run
 .PHONY: lint/go

--- a/scripts/check_codersdk_imports.sh
+++ b/scripts/check_codersdk_imports.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This file checks all codersdk imports to be sure it doesn't import any packages
+# that are being replaced in go.mod.
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+cdroot
+
+deps=$(./scripts/list_dependencies.sh github.com/coder/coder/v2/codersdk)
+
+set +e
+replaces=$(grep "^replace" go.mod | awk '{print $2}')
+conflicts=$(echo "$deps" | grep -xF -f <(echo "$replaces"))
+
+if [ -n "${conflicts}" ]; then
+	error "$(printf 'codersdk cannot import the following packages being replaced in go.mod:\n%s' "${conflicts}")"
+fi
+log "codersdk imports OK"

--- a/scripts/list_dependencies.sh
+++ b/scripts/list_dependencies.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This script lists all dependencies of a given package, including dependencies
+# of test files.
+
+# Usage: list_dependencies <package>
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+	echo "Usage: $0 <package>"
+	exit 1
+fi
+
+package="$1"
+all_deps=$(go list -f '{{join .Deps "\n"}}' "$package")
+test_imports=$(go list -f '{{ join .TestImports " " }}' "$package")
+xtest_imports=$(go list -f '{{ join .XTestImports " " }}' "$package")
+
+for pkg in $test_imports $xtest_imports; do
+	deps=$(go list -f '{{join .Deps "\n"}}' "$pkg")
+	all_deps+=$'\n'"$deps"
+done
+
+echo "$all_deps" | sort | uniq


### PR DESCRIPTION
To avoid problems like #14633 in the future, we can recursively get all the direct, indirect, and test dependencies for `codersdk` to ensure they don't include anything that requires one of our go.mod replace directives.

We could also maintain a list of 'heavy' dependencies and include that in the script, but the replace directives already include tailscale (and therefore gvisor).


e.g. when `coderdtest` is imported in `codersdk_test` locally:
```
~/coder $ ./scripts/check_codersdk_imports.sh
ERROR: codersdk cannot import the following packages being replaced in go.mod:
github.com/alecthomas/chroma/v2
go.opencensus.io
github.com/tcnksm/go-httpstat
github.com/dlclark/regexp2
tailscale.com
github.com/gliderlabs/ssh
github.com/pkg/sftp
github.com/lib/pq
```

otherwise:
```
~/coder $ ./scripts/check_codersdk_imports.sh
codersdk imports OK
```