### PR TITLE
chore: remove legacy AgentIP address

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1119,9 +1119,6 @@ func (a *agent) wireguardAddresses(agentID uuid.UUID) []netip.Prefix {
 		return []netip.Prefix{
 			// This is the IP that should be used primarily.
 			netip.PrefixFrom(tailnet.IPFromUUID(agentID), 128),
-			// We also listen on the legacy codersdk.WorkspaceAgentIP. This
-			// allows for a transition away from wsconncache.
-			netip.PrefixFrom(workspacesdk.AgentIP, 128),
 		}
 	}
 

--- a/codersdk/workspacesdk/workspacesdk.go
+++ b/codersdk/workspacesdk/workspacesdk.go
@@ -25,15 +25,6 @@ import (
 	"github.com/coder/quartz"
 )
 
-// AgentIP is a static IPv6 address with the Tailscale prefix that is used to route
-// connections from clients to this node. A dynamic address is not required because a Tailnet
-// client only dials a single agent at a time.
-//
-// Deprecated: use tailnet.IP() instead. This is kept for backwards
-// compatibility with outdated CLI clients and Workspace Proxies that dial it.
-// See: https://github.com/coder/coder/issues/11819
-var AgentIP = netip.MustParseAddr("fd7a:115c:a1e0:49d6:b259:b7ac:b1b2:48f4")
-
 var ErrSkipClose = xerrors.New("skip tailnet close")
 
 const (

--- a/site/e2e/tests/outdatedCLI.spec.ts
+++ b/site/e2e/tests/outdatedCLI.spec.ts
@@ -11,8 +11,7 @@ import {
 } from "../helpers";
 import { beforeCoderTest } from "../hooks";
 
-// we no longer support versions prior to single tailnet: https://github.com/coder/coder/commit/d7cbdbd9c64ad26821e6b35834c59ecf85dcd9d4
-const clientVersion = "v0.27.0";
+const clientVersion = "v2.8.0";
 
 test.beforeEach(({ page }) => beforeCoderTest(page));
 

--- a/tailnet/coordinator_test.go
+++ b/tailnet/coordinator_test.go
@@ -22,7 +22,6 @@ import (
 
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
-	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/tailnet/tailnettest"
@@ -121,41 +120,6 @@ func TestCoordinator(t *testing.T) {
 		sendNode(&tailnet.Node{
 			Addresses: []netip.Prefix{
 				netip.PrefixFrom(tailnet.IPFromUUID(id), 128),
-			},
-			PreferredDERP: 10,
-		})
-		require.Eventually(t, func() bool {
-			return coordinator.Node(id) != nil
-		}, testutil.WaitShort, testutil.IntervalFast)
-		err := client.Close()
-		require.NoError(t, err)
-		_ = testutil.RequireRecvCtx(ctx, t, errChan)
-		_ = testutil.RequireRecvCtx(ctx, t, closeChan)
-	})
-
-	t.Run("AgentWithoutClients_ValidIPLegacy", func(t *testing.T) {
-		t.Parallel()
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-		ctx := testutil.Context(t, testutil.WaitMedium)
-		coordinator := tailnet.NewCoordinator(logger)
-		defer func() {
-			err := coordinator.Close()
-			require.NoError(t, err)
-		}()
-		client, server := net.Pipe()
-		sendNode, errChan := tailnet.ServeCoordinator(client, func(node []*tailnet.Node) error {
-			return nil
-		})
-		id := uuid.New()
-		closeChan := make(chan struct{})
-		go func() {
-			err := coordinator.ServeAgent(server, id, "")
-			assert.NoError(t, err)
-			close(closeChan)
-		}()
-		sendNode(&tailnet.Node{
-			Addresses: []netip.Prefix{
-				netip.PrefixFrom(workspacesdk.AgentIP, 128),
 			},
 			PreferredDERP: 10,
 		})


### PR DESCRIPTION
Removes the support for the Agent's "legacy IP" which was a hardcoded IP address all agents used to use, before we introduced "single tailnet". Single tailnet went GA in 2.7.0.