### PR TITLE
chore: read template tar from stdin if stdin is not a tty

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -212,7 +212,7 @@ func (r *RootCmd) login() *serpent.Command {
 				_, _ = fmt.Fprintf(inv.Stdout, Caret+"Your Coder deployment hasn't been set up!\n")
 
 				if username == "" {
-					if !isTTY(inv) {
+					if !isTTYIn(inv) {
 						return xerrors.New("the initial user cannot be created in non-interactive mode. use the API")
 					}
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -692,8 +692,8 @@ func (r *RootCmd) createConfig() config.Root {
 	return config.Root(r.globalConfig)
 }
 
-// isTTY returns whether the passed reader is a TTY or not.
-func isTTY(inv *serpent.Invocation) bool {
+// isTTYIn returns whether the passed invocation is having stdin read from a TTY
+func isTTYIn(inv *serpent.Invocation) bool {
 	// If the `--force-tty` command is available, and set,
 	// assume we're in a tty. This is primarily for cases on Windows
 	// where we may not be able to reliably detect this automatically (ie, tests)
@@ -708,12 +708,12 @@ func isTTY(inv *serpent.Invocation) bool {
 	return isatty.IsTerminal(file.Fd())
 }
 
-// isTTYOut returns whether the passed reader is a TTY or not.
+// isTTYOut returns whether the passed invocation is having stdout written to a TTY
 func isTTYOut(inv *serpent.Invocation) bool {
 	return isTTYWriter(inv, inv.Stdout)
 }
 
-// isTTYErr returns whether the passed reader is a TTY or not.
+// isTTYErr returns whether the passed invocation is having stderr written to a TTY
 func isTTYErr(inv *serpent.Invocation) bool {
 	return isTTYWriter(inv, inv.Stderr)
 }

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -74,7 +74,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 				return err
 			}
 
-			templateName, err := uploadFlags.templateName(inv.Args)
+			templateName, err := uploadFlags.templateName(inv)
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 			message := uploadFlags.templateMessage(inv)
 
 			var varsFiles []string
-			if !uploadFlags.stdin() {
+			if !uploadFlags.stdin(inv) {
 				varsFiles, err = codersdk.DiscoverVarsFiles(uploadFlags.directory)
 				if err != nil {
 					return err
@@ -139,7 +139,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 				return err
 			}
 
-			if !uploadFlags.stdin() {
+			if !uploadFlags.stdin(inv) {
 				_, err = cliui.Prompt(inv, cliui.PromptOptions{
 					Text:      "Confirm create?",
 					IsConfirm: true,


### PR DESCRIPTION
Closes #13203.

`coder templates push` currently only reads the template tar from `stdin` if the `--directory` flag is set to `-`. This is kind of awkward, and as seen in the attached issue, easy to miss. We can already check if the command is being piped to, so this is just a minor QOL improvement.

This breaks one valid albeit odd workflow, where a confirmation is piped into the command instead of using `--yes/-y`:

e.g:
```
echo 'yes' | coder templates push
```
would no longer work as expected.

Also updates `isTTY` to `isTTYIn`, since the name suggests it could check either `stdin` or `stdout`, but it only checks `stdin`, and `isTTYOut` already exists.