### PR TITLE
feat(cli): allow customization of cli theme

### DIFF
--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -40,14 +40,6 @@ var (
 	colorOnce sync.Once
 )
 
-var (
-	Green   = Color("#04B575")
-	Red     = Color("#ED567A")
-	Fuchsia = Color("#EE6FF8")
-	Yellow  = Color("#ECFD65")
-	Blue    = Color("#5000ff")
-)
-
 // Color returns a color for the given string.
 func Color(s string) termenv.Color {
 	colorOnce.Do(func() {
@@ -124,67 +116,60 @@ func init() {
 	// We do not adapt the color based on whether the terminal is light or dark.
 	// Doing so would require a round-trip between the program and the terminal
 	// due to the OSC query and response.
-	DefaultStyles = Styles{
-		Code: pretty.Style{
-			ifTerm(pretty.XPad(1, 1)),
-			pretty.FgColor(Red),
-			pretty.BgColor(color.Color("#2c2c2c")),
+	DefaultStyles = Styles{Wrap: pretty.Style{pretty.LineWrap(80)}}
+
+	defaultTheme := userThemeConfig{
+		Colors: map[string]string{
+			"green":  "#04B575",
+			"red":    "#ED567A",
+			"yellow": "#ECFD65",
+			"blue":   "#5000ff",
 		},
-		DateTimeStamp: pretty.Style{
-			pretty.FgColor(color.Color("#7571F9")),
-		},
-		Error: pretty.Style{
-			pretty.FgColor(Red),
-		},
-		Field: pretty.Style{
-			pretty.XPad(1, 1),
-			pretty.FgColor(color.Color("#FFFFFF")),
-			pretty.BgColor(color.Color("#2b2a2a")),
-		},
-		Keyword: pretty.Style{
-			pretty.FgColor(Green),
-		},
-		Placeholder: pretty.Style{
-			pretty.FgColor(color.Color("#4d46b3")),
-		},
-		Prompt: pretty.Style{
-			pretty.FgColor(color.Color("#5C5C5C")),
-			pretty.Wrap("> ", ""),
-		},
-		Warn: pretty.Style{
-			pretty.FgColor(Yellow),
-		},
-		Wrap: pretty.Style{
-			pretty.LineWrap(80),
+		Styles: &userThemeStyles{
+			Code: &userThemeStyle{
+				FgColor: "$red",
+				BgColor: "#2C2C2C",
+			},
+			DateTimeStamp: &userThemeStyle{
+				FgColor: "#7571F9",
+			},
+			Error: &userThemeStyle{
+				FgColor: "$red",
+			},
+			Field: &userThemeStyle{
+				FgColor: "#FFFFFF",
+				BgColor: "#2B2A2A",
+			},
+			FocusedPrompt: &userThemeStyle{
+				FgColor: "$blue",
+			},
+			Keyword: &userThemeStyle{
+				FgColor: "$green",
+			},
+			Placeholder: &userThemeStyle{
+				FgColor: "#4d46b3",
+			},
+			Prompt: &userThemeStyle{
+				FgColor: "#5C5C5C",
+			},
+			Warn: &userThemeStyle{
+				FgColor: "$yellow",
+			},
 		},
 	}
-
-	DefaultStyles.FocusedPrompt = append(
-		DefaultStyles.Prompt,
-		pretty.FgColor(Blue),
-	)
 
 	configDir := config.DefaultDir()
 	if dir := os.Getenv("CODER_CONFIG_DIR"); dir != "" {
 		configDir = dir
 	}
 
-	if theme, err := os.ReadFile(path.Join(configDir, "theme.toml")); err == nil {
-		_ = LoadUserTheme(theme)
-	}
+	theme, _ := os.ReadFile(path.Join(configDir, "theme.toml"))
+	_ = LoadUserTheme(&defaultTheme, theme)
 }
 
 type userThemeStyle struct {
 	BgColor string `toml:"background"`
 	FgColor string `toml:"foreground"`
-	XPad    *struct {
-		Left  int `toml:"left"`
-		Right int `toml:"right"`
-	} `toml:"xpad"`
-	Wrap *struct {
-		Prefix string `toml:"prefix"`
-		Suffix string `toml:"suffix"`
-	}
 }
 
 type userThemeStyles struct {
@@ -201,17 +186,17 @@ type userThemeStyles struct {
 
 type userThemeConfig struct {
 	Colors map[string]string `toml:"colors"`
-	Styles userThemeStyles   `toml:"styles"`
+	Styles *userThemeStyles  `toml:"styles"`
 }
 
-func LoadUserTheme(t []byte) error {
-	var theme userThemeConfig
-	if err := toml.Unmarshal(t, &theme); err != nil {
+func LoadUserTheme(theme *userThemeConfig, t []byte) error {
+	if err := toml.Unmarshal(t, theme); err != nil {
 		return err
 	}
 
 	if theme.Styles.Code != nil {
-		DefaultStyles.Code = theme.Styles.Code.toPrettyStyle(theme)
+		DefaultStyles.Code = pretty.Style{pretty.XPad(1, 1)}
+		DefaultStyles.Code = append(DefaultStyles.Code, theme.Styles.Code.toPrettyStyle(theme)...)
 	}
 	if theme.Styles.DateTimeStamp != nil {
 		DefaultStyles.DateTimeStamp = theme.Styles.DateTimeStamp.toPrettyStyle(theme)
@@ -220,22 +205,27 @@ func LoadUserTheme(t []byte) error {
 		DefaultStyles.Error = theme.Styles.Error.toPrettyStyle(theme)
 	}
 	if theme.Styles.Field != nil {
-		DefaultStyles.Field = theme.Styles.Field.toPrettyStyle(theme)
-	}
-	if theme.Styles.FocusedPrompt != nil {
-		DefaultStyles.FocusedPrompt = theme.Styles.FocusedPrompt.toPrettyStyle(theme)
+		DefaultStyles.Field = pretty.Style{pretty.XPad(1, 1)}
+		DefaultStyles.Field = append(DefaultStyles.Field, theme.Styles.Field.toPrettyStyle(theme)...)
 	}
 	if theme.Styles.Keyword != nil {
 		DefaultStyles.Keyword = theme.Styles.Keyword.toPrettyStyle(theme)
-	}
-	if theme.Styles.Prompt != nil {
-		DefaultStyles.Prompt = theme.Styles.Prompt.toPrettyStyle(theme)
 	}
 	if theme.Styles.Warn != nil {
 		DefaultStyles.Warn = theme.Styles.Warn.toPrettyStyle(theme)
 	}
 	if theme.Styles.Placeholder != nil {
 		DefaultStyles.Placeholder = theme.Styles.Placeholder.toPrettyStyle(theme)
+	}
+	// NOTE: Prompt should be styled first as FocusedPrompt depends on the styling
+	// of Prompt.
+	if theme.Styles.Prompt != nil {
+		DefaultStyles.Prompt = theme.Styles.Prompt.toPrettyStyle(theme)
+		DefaultStyles.Prompt = append(DefaultStyles.Prompt, pretty.Wrap("> ", ""))
+	}
+	if theme.Styles.FocusedPrompt != nil {
+		style := theme.Styles.FocusedPrompt.toPrettyStyle(theme)
+		DefaultStyles.FocusedPrompt = append(DefaultStyles.Prompt, style...)
 	}
 	return nil
 }
@@ -249,11 +239,8 @@ func (t userThemeConfig) getColor(color string) string {
 	return color
 }
 
-func (s *userThemeStyle) toPrettyStyle(theme userThemeConfig) pretty.Style {
+func (s *userThemeStyle) toPrettyStyle(theme *userThemeConfig) pretty.Style {
 	style := pretty.Style{}
-	if s.XPad != nil {
-		style = append(style, pretty.XPad(s.XPad.Left, s.XPad.Right))
-	}
 	if s.FgColor != "" {
 		if color := Color(theme.getColor(s.FgColor)); color != nil {
 			style = append(style, pretty.FgColor(color))
@@ -263,9 +250,6 @@ func (s *userThemeStyle) toPrettyStyle(theme userThemeConfig) pretty.Style {
 		if color := Color(theme.getColor(s.BgColor)); color != nil {
 			style = append(style, pretty.BgColor(color))
 		}
-	}
-	if s.Wrap != nil {
-		style = append(style, pretty.Wrap(s.Wrap.Prefix, s.Wrap.Suffix))
 	}
 	return style
 }

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -163,11 +163,11 @@ func init() {
 		configDir = dir
 	}
 
-	if theme, err := os.ReadFile(path.Join(configDir, "theme.toml")); err != nil {
+	if theme, err := os.ReadFile(path.Join(configDir, "theme.toml")); err == nil {
 		_ = toml.Unmarshal(theme, &defaultTheme)
 	}
 
-	applyUserTheme(&defaultTheme)
+	applyUserTheme(defaultTheme)
 }
 
 type userThemeStyle struct {
@@ -192,7 +192,7 @@ type userThemeConfig struct {
 	Styles *userThemeStyles  `toml:"styles"`
 }
 
-func applyUserTheme(theme *userThemeConfig) {
+func applyUserTheme(theme userThemeConfig) {
 	if theme.Styles.Code != nil {
 		DefaultStyles.Code = pretty.Style{ifTerm(pretty.XPad(1, 1))}
 		DefaultStyles.Code = append(DefaultStyles.Code, theme.Styles.Code.toPrettyStyle(theme)...)
@@ -237,7 +237,7 @@ func (t userThemeConfig) getColor(color string) string {
 	return color
 }
 
-func (s *userThemeStyle) toPrettyStyle(theme *userThemeConfig) pretty.Style {
+func (s *userThemeStyle) toPrettyStyle(theme userThemeConfig) pretty.Style {
 	style := pretty.Style{}
 	if s.FgColor != "" {
 		if color := Color(theme.getColor(s.FgColor)); color != nil {

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -34,9 +34,7 @@ type Styles struct {
 	Wrap pretty.Style
 }
 
-var (
-	color termenv.Profile
-)
+var color termenv.Profile
 
 // Color returns a color for the given string.
 func Color(s string) termenv.Color {

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -163,8 +163,11 @@ func init() {
 		configDir = dir
 	}
 
-	theme, _ := os.ReadFile(path.Join(configDir, "theme.toml"))
-	_ = LoadUserTheme(&defaultTheme, theme)
+	if theme, err := os.ReadFile(path.Join(configDir, "theme.toml")); err != nil {
+		_ = toml.Unmarshal(theme, &defaultTheme)
+	}
+
+	applyUserTheme(&defaultTheme)
 }
 
 type userThemeStyle struct {
@@ -189,11 +192,7 @@ type userThemeConfig struct {
 	Styles *userThemeStyles  `toml:"styles"`
 }
 
-func LoadUserTheme(theme *userThemeConfig, t []byte) error {
-	if err := toml.Unmarshal(t, theme); err != nil {
-		return err
-	}
-
+func applyUserTheme(theme *userThemeConfig) {
 	if theme.Styles.Code != nil {
 		DefaultStyles.Code = pretty.Style{pretty.XPad(1, 1)}
 		DefaultStyles.Code = append(DefaultStyles.Code, theme.Styles.Code.toPrettyStyle(theme)...)
@@ -227,7 +226,6 @@ func LoadUserTheme(theme *userThemeConfig, t []byte) error {
 		style := theme.Styles.FocusedPrompt.toPrettyStyle(theme)
 		DefaultStyles.FocusedPrompt = append(DefaultStyles.Prompt, style...)
 	}
-	return nil
 }
 
 func (t userThemeConfig) getColor(color string) string {

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -94,11 +94,11 @@ func Field(s string) string {
 	return pretty.Sprint(DefaultStyles.Field, s)
 }
 
-func ifTerm(fmt pretty.Formatter) pretty.Formatter {
+func ifTerm(f pretty.Formatter) pretty.Formatter {
 	if !isTerm() {
 		return pretty.Nop
 	}
-	return fmt
+	return f
 }
 
 func init() {

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/muesli/termenv"
@@ -36,20 +35,11 @@ type Styles struct {
 }
 
 var (
-	color     termenv.Profile
-	colorOnce sync.Once
+	color termenv.Profile
 )
 
 // Color returns a color for the given string.
 func Color(s string) termenv.Color {
-	colorOnce.Do(func() {
-		color = termenv.NewOutput(os.Stdout).ColorProfile()
-		if flag.Lookup("test.v") != nil {
-			// Use a consistent colorless profile in tests so that results
-			// are deterministic.
-			color = termenv.Ascii
-		}
-	})
 	return color.Color(s)
 }
 
@@ -113,6 +103,13 @@ func ifTerm(fmt pretty.Formatter) pretty.Formatter {
 }
 
 func init() {
+	color = termenv.NewOutput(os.Stdout).ColorProfile()
+	if flag.Lookup("test.v") != nil {
+		// Use a consistent colorless profile in tests so that results
+		// are deterministic.
+		color = termenv.Ascii
+	}
+
 	// We do not adapt the color based on whether the terminal is light or dark.
 	// Doing so would require a round-trip between the program and the terminal
 	// due to the OSC query and response.

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -153,19 +153,7 @@ func init() {
 		configDir = dir
 	}
 
-	if theme, err := os.ReadFile(path.Join(configDir, "theme.toml")); err == nil {
-		if err = toml.Unmarshal(theme, &defaultTheme); err != nil {
-			var decodeErr *toml.DecodeError
-			if errors.As(err, &decodeErr) {
-				_, _ = fmt.Fprintf(os.Stderr, "WARN: theme.toml has syntax error\n%s\n", decodeErr.String())
-				row, col := decodeErr.Position()
-				_, _ = fmt.Fprintf(os.Stderr, "error occurred at row %d column %d\n", row, col)
-			} else {
-				_, _ = fmt.Fprintf(os.Stderr, "WARN: %s", err)
-			}
-		}
-	}
-
+	loadUserTheme(&defaultTheme, path.Join(configDir, "theme.toml"))
 	applyUserTheme(defaultTheme)
 }
 
@@ -188,6 +176,24 @@ type userThemeStyles struct {
 
 type userThemeConfig struct {
 	Styles userThemeStyles `toml:"styles"`
+}
+
+func loadUserTheme(theme *userThemeConfig, themePath string) {
+	userTheme, err := os.ReadFile(themePath)
+	if err != nil {
+		return
+	}
+
+	if err = toml.Unmarshal(userTheme, theme); err != nil {
+		var decodeErr *toml.DecodeError
+		if errors.As(err, &decodeErr) {
+			_, _ = fmt.Fprintf(os.Stderr, "WARN: theme.toml has syntax error\n%s\n", decodeErr.String())
+			row, col := decodeErr.Position()
+			_, _ = fmt.Fprintf(os.Stderr, "error occurred at row %d column %d\n", row, col)
+		} else {
+			_, _ = fmt.Fprintf(os.Stderr, "WARN: %s", err)
+		}
+	}
 }
 
 func applyUserTheme(theme userThemeConfig) {

--- a/cli/cliui/cliui.go
+++ b/cli/cliui/cliui.go
@@ -194,7 +194,7 @@ type userThemeConfig struct {
 
 func applyUserTheme(theme *userThemeConfig) {
 	if theme.Styles.Code != nil {
-		DefaultStyles.Code = pretty.Style{pretty.XPad(1, 1)}
+		DefaultStyles.Code = pretty.Style{ifTerm(pretty.XPad(1, 1))}
 		DefaultStyles.Code = append(DefaultStyles.Code, theme.Styles.Code.toPrettyStyle(theme)...)
 	}
 	if theme.Styles.DateTimeStamp != nil {

--- a/cli/cliui/select.go
+++ b/cli/cliui/select.go
@@ -254,10 +254,7 @@ func (m selectModel) View() string {
 		// Is this the currently selected option?
 		style := pretty.Wrap("  ", "")
 		if m.cursor == start+i {
-			style = pretty.Style{
-				pretty.Wrap("> ", ""),
-				pretty.FgColor(Green),
-			}
+			style = append(DefaultStyles.Keyword, pretty.Wrap("> ", ""))
 		}
 
 		_, _ = s.WriteString(pretty.Sprint(style, option))
@@ -481,13 +478,13 @@ func (m multiSelectModel) View() string {
 		o := option.option
 
 		if m.cursor == i {
-			cursor = pretty.Sprint(pretty.FgColor(Green), "> ")
-			chosen = pretty.Sprint(pretty.FgColor(Green), "[ ]")
-			o = pretty.Sprint(pretty.FgColor(Green), o)
+			cursor = pretty.Sprint(DefaultStyles.Keyword, "> ")
+			chosen = pretty.Sprint(DefaultStyles.Keyword, "[ ]")
+			o = pretty.Sprint(DefaultStyles.Keyword, o)
 		}
 
 		if option.chosen {
-			chosen = pretty.Sprint(pretty.FgColor(Green), "[x]")
+			chosen = pretty.Sprint(DefaultStyles.Keyword, "[x]")
 		}
 
 		_, _ = s.WriteString(fmt.Sprintf(

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -8,9 +8,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 )
 
@@ -119,14 +117,6 @@ func (RootCmd) errorExample() *serpent.Command {
 				),
 				Handler: func(i *serpent.Invocation) error {
 					_, _ = fmt.Fprint(i.Stdout, "Try running this without an argument\n")
-					return nil
-				},
-			},
-			{
-				Use: "warning",
-				Handler: func(i *serpent.Invocation) error {
-					msg := pretty.Sprint(cliui.DefaultStyles.Warn, "This is an example warning message.")
-					_, _ = fmt.Fprintln(i.Stdout, msg)
 					return nil
 				},
 			},

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -8,7 +8,9 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/pretty"
 	"github.com/coder/serpent"
 )
 
@@ -117,6 +119,14 @@ func (RootCmd) errorExample() *serpent.Command {
 				),
 				Handler: func(i *serpent.Invocation) error {
 					_, _ = fmt.Fprint(i.Stdout, "Try running this without an argument\n")
+					return nil
+				},
+			},
+			{
+				Use: "warning",
+				Handler: func(i *serpent.Invocation) error {
+					msg := pretty.Sprint(cliui.DefaultStyles.Warn, "This is an example warning message.")
+					_, _ = fmt.Fprintln(i.Stdout, msg)
 					return nil
 				},
 			},


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/13211

This MVP allows users to customize the theme of the CLI. Specifically, it allows changing the foreground and background colors.

Currently this performs two steps:
1. Load the default theme
2. Merge this default theme with `$CODER_CONFIG_DIR/theme.toml`

There is currently a limitation with sourcing the config directory. Right now the theme is loaded prior to any command handling, which means the `global-config` flag cannot be used to modify the directory the theme is loaded from. The reasoning for this is that there currently does not appear to be a way to attach a global middleware to the `rootCmd`. We use [`coder/serpent`](https://github.com/coder/serpent) for our CLI which doesn't appear to support this.

The config file uses the [TOML](https://toml.io/en/) format. An example of this configuration file is:

```toml
[colors]
blue = '#5000ff'
green = '#04B575'
red = '#ED567A'
yellow = '#ECFD65'

[styles.code]
background = '#2C2C2C'
foreground = '$red'

[styles.datetimestamp]
foreground = '#7571F9'

[styles.error]
foreground = '$red'

[styles.field]
background = '#2B2A2A'
foreground = '#FFFFFF'

[styles.focusedprompt]
foreground = '$blue'

[styles.keyword]
foreground = '$green'

[styles.placeholder]
foreground = '#4d46b3'

[styles.prompt]
foreground = '#5C5C5C'

[styles.warn]
foreground = '$yellow'
```