### PR TITLE
ci(.github): remove success from release-labels job

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -52,7 +52,7 @@ jobs:
   release-labels:
     runs-on: ubuntu-latest
     # Skip tagging for draft PRs.
-    if: ${{ github.event_name == 'pull_request_target' && success() && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
     steps:
       - name: release-labels
         uses: actions/github-script@v7


### PR DESCRIPTION
It used to depend on another job which has since been removed.

_This is an attempt to make the job work again._