### PR TITLE
ci(.github): run release-labels when draft PRs are ready

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -13,6 +13,8 @@ on:
       - opened
       - reopened
       - edited
+      # For jobs that don't run on draft PRs.
+      - ready_for_review
 
 # Only run one instance per PR to ensure in-order execution.
 concurrency: pr-${{ github.ref }}


### PR DESCRIPTION
This seems to be the actual fix for #14664.