### PR TITLE
chore: add cli command to fetch group sync settings as json

### DIFF
--- a/cli/organization.go
+++ b/cli/organization.go
@@ -26,6 +26,7 @@ func (r *RootCmd) organizations() *serpent.Command {
 			r.createOrganization(),
 			r.organizationMembers(orgContext),
 			r.organizationRoles(orgContext),
+			r.organizationSettings(orgContext),
 		},
 	}
 

--- a/cli/organizationsettings.go
+++ b/cli/organizationsettings.go
@@ -65,13 +65,13 @@ func (r *RootCmd) printOrganizationSetting(orgContext *OrganizationContext) *ser
 				return fmt.Errorf("failed to get organization setting %s: %w", inv.Args[0], err)
 			}
 
-			settingJson, err := json.Marshal(setting)
+			settingJSON, err := json.Marshal(setting)
 			if err != nil {
 				return fmt.Errorf("failed to marshal organization setting %s: %w", inv.Args[0], err)
 			}
 
 			var dst bytes.Buffer
-			err = json.Indent(&dst, settingJson, "", "\t")
+			err = json.Indent(&dst, settingJSON, "", "\t")
 			if err != nil {
 				return fmt.Errorf("failed to indent organization setting as json %s: %w", inv.Args[0], err)
 			}

--- a/cli/organizationsettings.go
+++ b/cli/organizationsettings.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/serpent"
+)
+
+func (r *RootCmd) organizationSettings(orgContext *OrganizationContext) *serpent.Command {
+	cmd := &serpent.Command{
+		Use:     "settings",
+		Short:   "Manage organization settings.",
+		Aliases: []string{"setting"},
+		Handler: func(inv *serpent.Invocation) error {
+			return inv.Command.HelpHandler(inv)
+		},
+		Hidden: true,
+		Children: []*serpent.Command{
+			r.printOrganizationSetting(orgContext),
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) printOrganizationSetting(orgContext *OrganizationContext) *serpent.Command {
+	client := new(codersdk.Client)
+	cmd := &serpent.Command{
+		Use:   "show <groupsync | rolesync>",
+		Short: "Outputs specified organization setting.",
+		Long: FormatExamples(
+			Example{
+				Description: "Output group sync settings.",
+				Command:     "coder organization settings show groupsync",
+			},
+		),
+		Options: []serpent.Option{},
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(1),
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			org, err := orgContext.Selected(inv, client)
+			if err != nil {
+				return err
+			}
+
+			var setting any
+			switch strings.ToLower(inv.Args[0]) {
+			case "groupsync", "group-sync":
+				setting, err = client.GroupIDPSyncSettings(ctx, org.ID.String())
+			case "rolesync", "role-sync":
+				// TODO: Implement role sync settings.
+				return fmt.Errorf("role sync settings are not implemented")
+			default:
+				_, _ = fmt.Fprintln(inv.Stderr, "Valid organization settings are: 'groupsync', 'rolesync'")
+				return fmt.Errorf("unknown organization setting %s", inv.Args[0])
+			}
+
+			if err != nil {
+				return fmt.Errorf("failed to get organization setting %s: %w", inv.Args[0], err)
+			}
+
+			settingJson, err := json.Marshal(setting)
+			if err != nil {
+				return fmt.Errorf("failed to marshal organization setting %s: %w", inv.Args[0], err)
+			}
+
+			var dst bytes.Buffer
+			err = json.Indent(&dst, settingJson, "", "\t")
+			if err != nil {
+				return fmt.Errorf("failed to indent organization setting as json %s: %w", inv.Args[0], err)
+			}
+
+			_, err = fmt.Fprintln(inv.Stdout, dst.String())
+			return err
+		},
+	}
+	return cmd
+}

--- a/cli/organizationsettings.go
+++ b/cli/organizationsettings.go
@@ -69,8 +69,12 @@ func (r *RootCmd) updateOrganizationSetting(orgContext *OrganizationContext) *se
 				}
 				setting, err = client.PatchGroupIDPSyncSettings(ctx, org.ID.String(), req)
 			case "rolesync", "role-sync":
-				// TODO: Implement role sync settings.
-				return fmt.Errorf("role sync settings are not implemented")
+				var req codersdk.RoleSyncSettings
+				err = json.Unmarshal(inputData, &req)
+				if err != nil {
+					return xerrors.Errorf("unmarshalling role sync settings: %w", err)
+				}
+				setting, err = client.PatchRoleIDPSyncSettings(ctx, org.ID.String(), req)
 			default:
 				_, _ = fmt.Fprintln(inv.Stderr, "Valid organization settings are: 'groupsync', 'rolesync'")
 				return fmt.Errorf("unknown organization setting %s", inv.Args[0])
@@ -126,8 +130,7 @@ func (r *RootCmd) printOrganizationSetting(orgContext *OrganizationContext) *ser
 			case "groupsync", "group-sync":
 				setting, err = client.GroupIDPSyncSettings(ctx, org.ID.String())
 			case "rolesync", "role-sync":
-				// TODO: Implement role sync settings.
-				return fmt.Errorf("role sync settings are not implemented")
+				setting, err = client.RoleIDPSyncSettings(ctx, org.ID.String())
 			default:
 				_, _ = fmt.Fprintln(inv.Stderr, "Valid organization settings are: 'groupsync', 'rolesync'")
 				return fmt.Errorf("unknown organization setting %s", inv.Args[0])

--- a/cli/organizationsettings.go
+++ b/cli/organizationsettings.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
+
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/serpent"
@@ -21,6 +24,75 @@ func (r *RootCmd) organizationSettings(orgContext *OrganizationContext) *serpent
 		Hidden: true,
 		Children: []*serpent.Command{
 			r.printOrganizationSetting(orgContext),
+			r.updateOrganizationSetting(orgContext),
+		},
+	}
+	return cmd
+}
+
+func (r *RootCmd) updateOrganizationSetting(orgContext *OrganizationContext) *serpent.Command {
+	client := new(codersdk.Client)
+	cmd := &serpent.Command{
+		Use:   "set <groupsync | rolesync>",
+		Short: "Update specified organization setting.",
+		Long: FormatExamples(
+			Example{
+				Description: "Update group sync settings.",
+				Command:     "coder organization settings set groupsync < input.json",
+			},
+		),
+		Options: []serpent.Option{},
+		Middleware: serpent.Chain(
+			serpent.RequireNArgs(1),
+			r.InitClient(client),
+		),
+		Handler: func(inv *serpent.Invocation) error {
+			ctx := inv.Context()
+			org, err := orgContext.Selected(inv, client)
+			if err != nil {
+				return err
+			}
+
+			// Read in the json
+			inputData, err := io.ReadAll(inv.Stdin)
+			if err != nil {
+				return xerrors.Errorf("reading stdin: %w", err)
+			}
+
+			var setting any
+			switch strings.ToLower(inv.Args[0]) {
+			case "groupsync", "group-sync":
+				var req codersdk.GroupSyncSettings
+				err = json.Unmarshal(inputData, &req)
+				if err != nil {
+					return xerrors.Errorf("unmarshalling group sync settings: %w", err)
+				}
+				setting, err = client.PatchGroupIDPSyncSettings(ctx, org.ID.String(), req)
+			case "rolesync", "role-sync":
+				// TODO: Implement role sync settings.
+				return fmt.Errorf("role sync settings are not implemented")
+			default:
+				_, _ = fmt.Fprintln(inv.Stderr, "Valid organization settings are: 'groupsync', 'rolesync'")
+				return fmt.Errorf("unknown organization setting %s", inv.Args[0])
+			}
+
+			if err != nil {
+				return fmt.Errorf("failed to get organization setting %s: %w", inv.Args[0], err)
+			}
+
+			settingJSON, err := json.Marshal(setting)
+			if err != nil {
+				return fmt.Errorf("failed to marshal organization setting %s: %w", inv.Args[0], err)
+			}
+
+			var dst bytes.Buffer
+			err = json.Indent(&dst, settingJSON, "", "\t")
+			if err != nil {
+				return fmt.Errorf("failed to indent organization setting as json %s: %w", inv.Args[0], err)
+			}
+
+			_, err = fmt.Fprintln(inv.Stdout, dst.String())
+			return err
 		},
 	}
 	return cmd

--- a/cli/root.go
+++ b/cli/root.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/mod/semver"
 	"golang.org/x/xerrors"
 
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/pretty"
 
 	"github.com/coder/coder/v2/buildinfo"
@@ -657,7 +658,10 @@ func (o *OrganizationContext) Selected(inv *serpent.Invocation, client *codersdk
 	}
 
 	// No org selected, and we are more than 1? Return an error.
-	return codersdk.Organization{}, xerrors.Errorf("Must select an organization with --org=<org_name>.")
+	validOrgs := db2sdk.List(orgs, func(org codersdk.Organization) string {
+		return fmt.Sprintf("%q", org.Name)
+	})
+	return codersdk.Organization{}, xerrors.Errorf("Must select an organization with --org=<org_name>. Choose from: %s", strings.Join(validOrgs, ", "))
 }
 
 func splitNamedWorkspace(identifier string) (owner string, workspaceName string, err error) {

--- a/cli/testdata/coder_organizations_--help.golden
+++ b/cli/testdata/coder_organizations_--help.golden
@@ -8,12 +8,12 @@ USAGE:
   Aliases: organization, org, orgs
 
 SUBCOMMANDS:
-    create     Create a new organization.
-    members    Manage organization members
-    roles      Manage organization roles.
-    show       Show the organization. Using "selected" will show the selected
-               organization from the "--org" flag. Using "me" will show all
-               organizations you are a member of.
+    create      Create a new organization.
+    members     Manage organization members
+    roles       Manage organization roles.
+    show        Show the organization. Using "selected" will show the selected
+                organization from the "--org" flag. Using "me" will show all
+                organizations you are a member of.
 
 OPTIONS:
   -O, --org string, $CODER_ORGANIZATION

--- a/cli/testdata/coder_organizations_--help.golden
+++ b/cli/testdata/coder_organizations_--help.golden
@@ -11,6 +11,7 @@ SUBCOMMANDS:
     create      Create a new organization.
     members     Manage organization members
     roles       Manage organization roles.
+    settings    Manage organization settings.
     show        Show the organization. Using "selected" will show the selected
                 organization from the "--org" flag. Using "me" will show all
                 organizations you are a member of.

--- a/cli/testdata/coder_organizations_settings_--help.golden
+++ b/cli/testdata/coder_organizations_settings_--help.golden
@@ -1,0 +1,15 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder organizations settings
+
+  Manage organization settings.
+
+  Aliases: setting
+
+SUBCOMMANDS:
+    set     Update specified organization setting.
+    show    Outputs specified organization setting.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_organizations_settings_set_--help.golden
+++ b/cli/testdata/coder_organizations_settings_set_--help.golden
@@ -1,0 +1,17 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder organizations settings set
+
+  Update specified organization setting.
+
+    - Update group sync settings.:
+  
+       $ coder organization settings set groupsync < input.json
+
+SUBCOMMANDS:
+    group-sync    Group sync settings to sync groups from an IdP.
+    role-sync     Role sync settings to sync organization roles from an IdP.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_organizations_settings_set_--help_--help.golden
+++ b/cli/testdata/coder_organizations_settings_set_--help_--help.golden
@@ -1,0 +1,17 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder organizations settings set
+
+  Update specified organization setting.
+
+    - Update group sync settings.:
+  
+       $ coder organization settings set groupsync < input.json
+
+SUBCOMMANDS:
+    group-sync    Group sync settings to sync groups from an IdP.
+    role-sync     Role sync settings to sync organization roles from an IdP.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_organizations_settings_show_--help.golden
+++ b/cli/testdata/coder_organizations_settings_show_--help.golden
@@ -1,0 +1,17 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder organizations settings show
+
+  Outputs specified organization setting.
+
+    - Output group sync settings.:
+  
+       $ coder organization settings show groupsync
+
+SUBCOMMANDS:
+    group-sync    Group sync settings to sync groups from an IdP.
+    role-sync     Role sync settings to sync organization roles from an IdP.
+
+———
+Run `coder --help` for a list of global options.

--- a/cli/testdata/coder_organizations_settings_show_--help_--help.golden
+++ b/cli/testdata/coder_organizations_settings_show_--help_--help.golden
@@ -1,0 +1,17 @@
+coder v0.0.0-devel
+
+USAGE:
+  coder organizations settings show
+
+  Outputs specified organization setting.
+
+    - Output group sync settings.:
+  
+       $ coder organization settings show groupsync
+
+SUBCOMMANDS:
+    group-sync    Group sync settings to sync groups from an IdP.
+    role-sync     Role sync settings to sync organization roles from an IdP.
+
+———
+Run `coder --help` for a list of global options.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -858,6 +858,41 @@
 							"path": "reference/cli/organizations_roles_show.md"
 						},
 						{
+							"title": "organizations settings",
+							"description": "Manage organization settings.",
+							"path": "reference/cli/organizations_settings.md"
+						},
+						{
+							"title": "organizations settings set",
+							"description": "Update specified organization setting.",
+							"path": "reference/cli/organizations_settings_set.md"
+						},
+						{
+							"title": "organizations settings set group-sync",
+							"description": "Group sync settings to sync groups from an IdP.",
+							"path": "reference/cli/organizations_settings_set_group-sync.md"
+						},
+						{
+							"title": "organizations settings set role-sync",
+							"description": "Role sync settings to sync organization roles from an IdP.",
+							"path": "reference/cli/organizations_settings_set_role-sync.md"
+						},
+						{
+							"title": "organizations settings show",
+							"description": "Outputs specified organization setting.",
+							"path": "reference/cli/organizations_settings_show.md"
+						},
+						{
+							"title": "organizations settings show group-sync",
+							"description": "Group sync settings to sync groups from an IdP.",
+							"path": "reference/cli/organizations_settings_show_group-sync.md"
+						},
+						{
+							"title": "organizations settings show role-sync",
+							"description": "Role sync settings to sync organization roles from an IdP.",
+							"path": "reference/cli/organizations_settings_show_role-sync.md"
+						},
+						{
 							"title": "organizations show",
 							"description": "Show the organization. Using \"selected\" will show the selected organization from the \"--org\" flag. Using \"me\" will show all organizations you are a member of.",
 							"path": "reference/cli/organizations_show.md"

--- a/docs/reference/cli/organizations.md
+++ b/docs/reference/cli/organizations.md
@@ -18,12 +18,13 @@ coder organizations [flags] [subcommand]
 
 ## Subcommands
 
-| Name                                               | Purpose                                                                                                                                                        |
-| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [<code>show</code>](./organizations_show.md)       | Show the organization. Using "selected" will show the selected organization from the "--org" flag. Using "me" will show all organizations you are a member of. |
-| [<code>create</code>](./organizations_create.md)   | Create a new organization.                                                                                                                                     |
-| [<code>members</code>](./organizations_members.md) | Manage organization members                                                                                                                                    |
-| [<code>roles</code>](./organizations_roles.md)     | Manage organization roles.                                                                                                                                     |
+| Name                                                 | Purpose                                                                                                                                                        |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [<code>show</code>](./organizations_show.md)         | Show the organization. Using "selected" will show the selected organization from the "--org" flag. Using "me" will show all organizations you are a member of. |
+| [<code>create</code>](./organizations_create.md)     | Create a new organization.                                                                                                                                     |
+| [<code>members</code>](./organizations_members.md)   | Manage organization members                                                                                                                                    |
+| [<code>roles</code>](./organizations_roles.md)       | Manage organization roles.                                                                                                                                     |
+| [<code>settings</code>](./organizations_settings.md) | Manage organization settings.                                                                                                                                  |
 
 ## Options
 

--- a/docs/reference/cli/organizations_settings.md
+++ b/docs/reference/cli/organizations_settings.md
@@ -1,0 +1,22 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings
+
+Manage organization settings.
+
+Aliases:
+
+- setting
+
+## Usage
+
+```console
+coder organizations settings
+```
+
+## Subcommands
+
+| Name                                                  | Purpose                                 |
+| ----------------------------------------------------- | --------------------------------------- |
+| [<code>show</code>](./organizations_settings_show.md) | Outputs specified organization setting. |
+| [<code>set</code>](./organizations_settings_set.md)   | Update specified organization setting.  |

--- a/docs/reference/cli/organizations_settings_set.md
+++ b/docs/reference/cli/organizations_settings_set.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings set
+
+Update specified organization setting.
+
+## Usage
+
+```console
+coder organizations settings set
+```
+
+## Description
+
+```console
+  - Update group sync settings.:
+
+     $ coder organization settings set groupsync < input.json
+```
+
+## Subcommands
+
+| Name                                                                  | Purpose                                                    |
+| --------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [<code>group-sync</code>](./organizations_settings_set_group-sync.md) | Group sync settings to sync groups from an IdP.            |
+| [<code>role-sync</code>](./organizations_settings_set_role-sync.md)   | Role sync settings to sync organization roles from an IdP. |

--- a/docs/reference/cli/organizations_settings_set_group-sync.md
+++ b/docs/reference/cli/organizations_settings_set_group-sync.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings set group-sync
+
+Group sync settings to sync groups from an IdP.
+
+Aliases:
+
+- groupsync
+
+## Usage
+
+```console
+coder organizations settings set group-sync
+```

--- a/docs/reference/cli/organizations_settings_set_role-sync.md
+++ b/docs/reference/cli/organizations_settings_set_role-sync.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings set role-sync
+
+Role sync settings to sync organization roles from an IdP.
+
+Aliases:
+
+- rolesync
+
+## Usage
+
+```console
+coder organizations settings set role-sync
+```

--- a/docs/reference/cli/organizations_settings_show.md
+++ b/docs/reference/cli/organizations_settings_show.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings show
+
+Outputs specified organization setting.
+
+## Usage
+
+```console
+coder organizations settings show
+```
+
+## Description
+
+```console
+  - Output group sync settings.:
+
+     $ coder organization settings show groupsync
+```
+
+## Subcommands
+
+| Name                                                                   | Purpose                                                    |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [<code>group-sync</code>](./organizations_settings_show_group-sync.md) | Group sync settings to sync groups from an IdP.            |
+| [<code>role-sync</code>](./organizations_settings_show_role-sync.md)   | Role sync settings to sync organization roles from an IdP. |

--- a/docs/reference/cli/organizations_settings_show_group-sync.md
+++ b/docs/reference/cli/organizations_settings_show_group-sync.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings show group-sync
+
+Group sync settings to sync groups from an IdP.
+
+Aliases:
+
+- groupsync
+
+## Usage
+
+```console
+coder organizations settings show group-sync
+```

--- a/docs/reference/cli/organizations_settings_show_role-sync.md
+++ b/docs/reference/cli/organizations_settings_show_role-sync.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT | GENERATED CONTENT -->
+
+# organizations settings show role-sync
+
+Role sync settings to sync organization roles from an IdP.
+
+Aliases:
+
+- rolesync
+
+## Usage
+
+```console
+coder organizations settings show role-sync
+```

--- a/enterprise/cli/organizationsettings_test.go
+++ b/enterprise/cli/organizationsettings_test.go
@@ -22,6 +22,8 @@ func TestUpdateGroupSync(t *testing.T) {
 	t.Parallel()
 
 	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
 		dv := coderdtest.DeploymentValues(t)
 		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
 
@@ -38,6 +40,7 @@ func TestUpdateGroupSync(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		inv, root := clitest.New(t, "organization", "settings", "set", "groupsync")
+		//nolint:gocritic // Using the owner, testing the cli not perms
 		clitest.SetupConfig(t, owner, root)
 
 		expectedSettings := codersdk.GroupSyncSettings{
@@ -75,6 +78,8 @@ func TestUpdateRoleSync(t *testing.T) {
 	t.Parallel()
 
 	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
 		dv := coderdtest.DeploymentValues(t)
 		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
 
@@ -111,6 +116,7 @@ func TestUpdateRoleSync(t *testing.T) {
 
 		// Now read it back
 		inv, root = clitest.New(t, "organization", "settings", "show", "rolesync")
+		//nolint:gocritic // Using the owner, testing the cli not perms
 		clitest.SetupConfig(t, owner, root)
 
 		buf = new(bytes.Buffer)

--- a/enterprise/cli/organizationsettings_test.go
+++ b/enterprise/cli/organizationsettings_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
 	"github.com/coder/coder/v2/enterprise/coderd/license"
@@ -60,6 +61,56 @@ func TestUpdateGroupSync(t *testing.T) {
 
 		// Now read it back
 		inv, root = clitest.New(t, "organization", "settings", "show", "groupsync")
+		clitest.SetupConfig(t, owner, root)
+
+		buf = new(bytes.Buffer)
+		inv.Stdout = buf
+		err = inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedData), buf.String())
+	})
+}
+
+func TestUpdateRoleSync(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
+
+		owner, _ := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureMultipleOrganizations: 1,
+				},
+			},
+		})
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv, root := clitest.New(t, "organization", "settings", "set", "rolesync")
+		clitest.SetupConfig(t, owner, root)
+
+		expectedSettings := codersdk.RoleSyncSettings{
+			Field: "roles",
+			Mapping: map[string][]string{
+				"test": {rbac.RoleOrgAdmin()},
+			},
+		}
+		expectedData, err := json.Marshal(expectedSettings)
+		require.NoError(t, err)
+
+		buf := new(bytes.Buffer)
+		inv.Stdout = buf
+		inv.Stdin = bytes.NewBuffer(expectedData)
+		err = inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedData), buf.String())
+
+		// Now read it back
+		inv, root = clitest.New(t, "organization", "settings", "show", "rolesync")
 		clitest.SetupConfig(t, owner, root)
 
 		buf = new(bytes.Buffer)

--- a/enterprise/cli/organizationsettings_test.go
+++ b/enterprise/cli/organizationsettings_test.go
@@ -1,0 +1,71 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli/clitest"
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestUpdateGroupSync(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
+
+		owner, first := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureMultipleOrganizations: 1,
+				},
+			},
+		})
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		inv, root := clitest.New(t, "organization", "settings", "set", "groupsync")
+		clitest.SetupConfig(t, owner, root)
+
+		expectedSettings := codersdk.GroupSyncSettings{
+			Field: "groups",
+			Mapping: map[string][]uuid.UUID{
+				"test": {first.OrganizationID},
+			},
+			RegexFilter:       regexp.MustCompile("^foo"),
+			AutoCreateMissing: true,
+			LegacyNameMapping: nil,
+		}
+		expectedData, err := json.Marshal(expectedSettings)
+		require.NoError(t, err)
+
+		buf := new(bytes.Buffer)
+		inv.Stdout = buf
+		inv.Stdin = bytes.NewBuffer(expectedData)
+		err = inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedData), buf.String())
+
+		// Now read it back
+		inv, root = clitest.New(t, "organization", "settings", "show", "groupsync")
+		clitest.SetupConfig(t, owner, root)
+
+		buf = new(bytes.Buffer)
+		inv.Stdout = buf
+		err = inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.JSONEq(t, string(expectedData), buf.String())
+	})
+}

--- a/enterprise/cli/organizationsettings_test.go
+++ b/enterprise/cli/organizationsettings_test.go
@@ -64,6 +64,7 @@ func TestUpdateGroupSync(t *testing.T) {
 
 		// Now read it back
 		inv, root = clitest.New(t, "organization", "settings", "show", "groupsync")
+		//nolint:gocritic // Using the owner, testing the cli not perms
 		clitest.SetupConfig(t, owner, root)
 
 		buf = new(bytes.Buffer)
@@ -96,6 +97,7 @@ func TestUpdateRoleSync(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		inv, root := clitest.New(t, "organization", "settings", "set", "rolesync")
+		//nolint:gocritic // Using the owner, testing the cli not perms
 		clitest.SetupConfig(t, owner, root)
 
 		expectedSettings := codersdk.RoleSyncSettings{

--- a/enterprise/coderd/idpsync.go
+++ b/enterprise/coderd/idpsync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coder/coder/v2/coderd/idpsync"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 // @Summary Get group IdP Sync settings by organization
@@ -58,6 +59,20 @@ func (api *API) patchGroupIDPSyncSettings(rw http.ResponseWriter, r *http.Reques
 
 	var req idpsync.GroupSyncSettings
 	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	if len(req.LegacyNameMapping) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Unexpected field 'legacy_group_name_mapping'. Field not allowed, set to null or remove it.",
+			Detail:  "legacy_group_name_mapping is deprecated, use mapping instead",
+			Validations: []codersdk.ValidationError{
+				{
+					Field:  "legacy_group_name_mapping",
+					Detail: "field is not allowed",
+				},
+			},
+		})
 		return
 	}
 


### PR DESCRIPTION
CLI commands to read and update role + group sync runtime settings. All settings are in json and take in input via `stdin`. Currently the cli is intentionally a bit obtuse in it's UX.

This is an MVP for setting the runtime values. The CLI and UI experience will be improved after GA. 

### Groupsync

```shell
$ coder organization  settings show groupsync --org=rabbit                                                                                               
{
        "field": "",
        "mapping": null,
        "regex_filter": null,
        "auto_create_missing_groups": false
}
```

And setting

```shell
$ coder organization  settings set groupsync --org=rabbit < input.json
```



### Rolesync

```shell
$ coder organization  settings show rolesync --org=rabbit
{
        "field": "",
        "mapping": null
}
```

And setting

```shell
$ coder organization  settings set rolesync --org=rabbit < input.json
```

## Improved error message:

Probably should have thrown this in another PR. In testing, I improved the error message for my own convenience.

```
error: Must select an organization with --org=<org_name>. Choose from "coder", "rabbit"
```

Closes https://github.com/coder/coder/issues/14687