### PR TITLE
chore: use legacy "AssignDefault" option for legacy behavior in SCIM

### DIFF
--- a/coderd/idpsync/idpsync.go
+++ b/coderd/idpsync/idpsync.go
@@ -24,6 +24,7 @@ import (
 // claims to the internal representation of a user in Coder.
 // TODO: Move group + role sync into this interface.
 type IDPSync interface {
+	AssignDefaultOrganization() bool
 	OrganizationSyncEnabled() bool
 	// ParseOrganizationClaims takes claims from an OIDC provider, and returns the
 	// organization sync params for assigning users into organizations.

--- a/coderd/idpsync/organization.go
+++ b/coderd/idpsync/organization.go
@@ -32,6 +32,10 @@ func (AGPLIDPSync) OrganizationSyncEnabled() bool {
 	return false
 }
 
+func (s AGPLIDPSync) AssignDefaultOrganization() bool {
+	return s.OrganizationAssignDefault
+}
+
 func (s AGPLIDPSync) ParseOrganizationClaims(_ context.Context, _ jwt.MapClaims) (OrganizationParams, *HTTPError) {
 	// For AGPL we only sync the default organization.
 	return OrganizationParams{

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -223,6 +223,7 @@ func (api *API) scimPostUser(rw http.ResponseWriter, r *http.Request) {
 	// This is to preserve single org deployment behavior.
 	organizations := []uuid.UUID{}
 	if api.IDPSync.AssignDefaultOrganization() {
+		//nolint:gocritic // SCIM operations are a system user
 		defaultOrganization, err := api.Database.GetDefaultOrganization(dbauthz.AsSystemRestricted(ctx))
 		if err != nil {
 			_ = handlerutil.WriteError(rw, err)

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -217,14 +217,26 @@ func (api *API) scimPostUser(rw http.ResponseWriter, r *http.Request) {
 		sUser.UserName = codersdk.UsernameFrom(sUser.UserName)
 	}
 
+	// If organization sync is enabled, the user's organizations will be
+	// corrected on login. If including the default org, then always assign
+	// the default org, regardless if sync is enabled or not.
+	// This is to preserve single org deployment behavior.
+	organizations := []uuid.UUID{}
+	if api.IDPSync.AssignDefaultOrganization() {
+		defaultOrganization, err := api.Database.GetDefaultOrganization(dbauthz.AsSystemRestricted(ctx))
+		if err != nil {
+			_ = handlerutil.WriteError(rw, err)
+			return
+		}
+		organizations = append(organizations, defaultOrganization.ID)
+	}
+
 	//nolint:gocritic // needed for SCIM
 	dbUser, err = api.AGPL.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, agpl.CreateUserRequest{
 		CreateUserRequestWithOrgs: codersdk.CreateUserRequestWithOrgs{
-			Username: sUser.UserName,
-			Email:    email,
-			// In the multi-org world, SCIM does not assign any orgs. Users will
-			// be automatically sync'd with the correct organization on login.
-			OrganizationIDs: []uuid.UUID{},
+			Username:        sUser.UserName,
+			Email:           email,
+			OrganizationIDs: organizations,
 		},
 		LoginType: database.LoginTypeOIDC,
 		// Do not send notifications to user admins as SCIM endpoint might be called sequentially to all users.

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -157,6 +157,65 @@ func TestScim(t *testing.T) {
 			require.Len(t, userRes.Users, 1)
 			assert.Equal(t, sUser.Emails[0].Value, userRes.Users[0].Email)
 			assert.Equal(t, sUser.UserName, userRes.Users[0].Username)
+			assert.Len(t, userRes.Users[0].OrganizationIDs, 1)
+
+			// Expect zero notifications (SkipNotifications = true)
+			require.Empty(t, notifyEnq.Sent)
+		})
+
+		t.Run("OKNoDefault", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+			defer cancel()
+
+			// given
+			scimAPIKey := []byte("hi")
+			mockAudit := audit.NewMock()
+			notifyEnq := &testutil.FakeNotificationsEnqueuer{}
+			dv := coderdtest.DeploymentValues(t)
+			dv.OIDC.OrganizationAssignDefault = false
+			client, _ := coderdenttest.New(t, &coderdenttest.Options{
+				Options: &coderdtest.Options{
+					Auditor:               mockAudit,
+					NotificationsEnqueuer: notifyEnq,
+					DeploymentValues:      dv,
+				},
+				SCIMAPIKey:   scimAPIKey,
+				AuditLogging: true,
+				LicenseOptions: &coderdenttest.LicenseOptions{
+					AccountID: "coolin",
+					Features: license.Features{
+						codersdk.FeatureSCIM:     1,
+						codersdk.FeatureAuditLog: 1,
+					},
+				},
+			})
+			mockAudit.ResetLogs()
+
+			// when
+			sUser := makeScimUser(t)
+			res, err := client.Request(ctx, "POST", "/scim/v2/Users", sUser, setScimAuth(scimAPIKey))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			// then
+			// Expect audit logs
+			aLogs := mockAudit.AuditLogs()
+			require.Len(t, aLogs, 1)
+			af := map[string]string{}
+			err = json.Unmarshal([]byte(aLogs[0].AdditionalFields), &af)
+			require.NoError(t, err)
+			assert.Equal(t, coderd.SCIMAuditAdditionalFields, af)
+			assert.Equal(t, database.AuditActionCreate, aLogs[0].Action)
+
+			// Expect users exposed over API
+			userRes, err := client.Users(ctx, codersdk.UsersRequest{Search: sUser.Emails[0].Value})
+			require.NoError(t, err)
+			require.Len(t, userRes.Users, 1)
+			assert.Equal(t, sUser.Emails[0].Value, userRes.Users[0].Email)
+			assert.Equal(t, sUser.UserName, userRes.Users[0].Username)
 			assert.Len(t, userRes.Users[0].OrganizationIDs, 0)
 
 			// Expect zero notifications (SkipNotifications = true)


### PR DESCRIPTION
AssignDefault is a boolean flag mainly for single org and legacy deployments. Use this flag to determine SCIM behavior.

Mimics behavior of OIDC auth creating a user: https://github.com/coder/coder/blob/b03cb003d3e57f43fc09dc12e1bc8c47186cee0b/coderd/userauth.go#L1312-L1315

In future we should probably reuse the same code path for OIDC and SCIM auth flow.