### PR TITLE
chore: allow removing users from the default org

### DIFF
--- a/coderd/members.go
+++ b/coderd/members.go
@@ -116,19 +116,6 @@ func (api *API) deleteOrganizationMember(rw http.ResponseWriter, r *http.Request
 	aReq.Old = member.OrganizationMember.Auditable(member.Username)
 	defer commitAudit()
 
-	if organization.IsDefault {
-		// Multi-organizations is currently an experiment, which means it is feasible
-		// for a deployment to enable, then disable this. To maintain backwards
-		// compatibility, this safety is necessary.
-		// TODO: Remove this check when multi-organizations is fully supported.
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message:     "Removing members from the default organization is not supported.",
-			Detail:      "Multi-organizations is currently an experiment, and until it is fully supported, the default org should be protected.",
-			Validations: nil,
-		})
-		return
-	}
-
 	if member.UserID == apiKey.UserID {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "cannot remove self from an organization"})
 		return

--- a/coderd/members_test.go
+++ b/coderd/members_test.go
@@ -33,7 +33,7 @@ func TestAddMember(t *testing.T) {
 func TestDeleteMember(t *testing.T) {
 	t.Parallel()
 
-	t.Run("NotAllowed", func(t *testing.T) {
+	t.Run("Allowed", func(t *testing.T) {
 		t.Parallel()
 		owner := coderdtest.New(t, nil)
 		first := coderdtest.CreateFirstUser(t, owner)
@@ -45,7 +45,7 @@ func TestDeleteMember(t *testing.T) {
 		// this test should be updated to check there is no error.
 		// nolint:gocritic // must be an owner to see the user
 		err := owner.DeleteOrganizationMember(ctx, first.OrganizationID, user.Username)
-		require.ErrorContains(t, err, "Multi-organizations is currently an experiment")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Removed as no longer in experimental. This does mean a single org deployment can also remove the member from the only org present, but they can add them back :shrug: 

Supports: https://github.com/coder/coder/issues/14635