### PR TITLE
docs: rename "Create Autofill" to "Autofill Parameters"

### DIFF
--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -287,7 +287,10 @@ data "coder_parameter" "project_id" {
 }
 ```
 
-## Create Autofill
+## Autofill Parameters
+
+> This feature requires the `auto-fill-parameters`
+> [experiment](https://coder.com/docs/contributing/feature-stages).
 
 When the template doesn't specify default values, Coder may still autofill
 parameters.


### PR DESCRIPTION
Update the section title for clarity and consistency. This change better represents the content about autofill parameters, enhancing readability and user understanding.