### PR TITLE
fix: use floats in report template

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -1021,7 +1021,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				notificationsManager.Run(dbauthz.AsSystemRestricted(ctx))
 
 				// Run report generator to distribute periodic reports.
-				notificationReportGenerator := reports.NewReportGenerator(ctx, logger, options.Database, options.NotificationsEnqueuer, quartz.NewReal())
+				notificationReportGenerator := reports.NewReportGenerator(ctx, logger.Named("notifications.report_generator"), options.Database, options.NotificationsEnqueuer, quartz.NewReal())
 				defer notificationReportGenerator.Close()
 			}
 

--- a/coderd/database/migrations/000254_fix_report_float.down.sql
+++ b/coderd/database/migrations/000254_fix_report_float.down.sql
@@ -1,0 +1,5 @@
+UPDATE notification_templates
+SET
+    body_template = REPLACE(body_template::text, '{{if gt $version.failed_count 1.0}}', '{{if gt $version.failed_count 1}}')::text
+WHERE
+    id = '34a20db2-e9cc-4a93-b0e4-8569699d7a00';

--- a/coderd/database/migrations/000254_fix_report_float.up.sql
+++ b/coderd/database/migrations/000254_fix_report_float.up.sql
@@ -1,0 +1,5 @@
+UPDATE notification_templates
+SET
+    body_template = REPLACE(body_template::text, '{{if gt $version.failed_count 1}}', '{{if gt $version.failed_count 1.0}}')::text
+WHERE
+    id = '34a20db2-e9cc-4a93-b0e4-8569699d7a00';

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -853,29 +853,30 @@ func TestNotificationTemplatesCanRender(t *testing.T) {
 					"template_name":         "bobby-first-template",
 					"template_display_name": "Bobby First Template",
 				},
+				// We need to use floats as `json.Unmarshal` unmarshal numbers in `map[string]any` to floats.
 				Data: map[string]any{
-					"failed_builds":    4,
-					"total_builds":     55,
+					"failed_builds":    4.0,
+					"total_builds":     55.0,
 					"report_frequency": "week",
 					"template_versions": []map[string]any{
 						{
 							"template_version_name": "bobby-template-version-1",
-							"failed_count":          3,
+							"failed_count":          3.0,
 							"failed_builds": []map[string]any{
 								{
 									"workspace_owner_username": "mtojek",
 									"workspace_name":           "workspace-1",
-									"build_number":             1234,
+									"build_number":             1234.0,
 								},
 								{
 									"workspace_owner_username": "johndoe",
 									"workspace_name":           "my-workspace-3",
-									"build_number":             5678,
+									"build_number":             5678.0,
 								},
 								{
 									"workspace_owner_username": "jack",
 									"workspace_name":           "workwork",
-									"build_number":             774,
+									"build_number":             774.0,
 								},
 							},
 						},
@@ -886,7 +887,7 @@ func TestNotificationTemplatesCanRender(t *testing.T) {
 								{
 									"workspace_owner_username": "ben",
 									"workspace_name":           "cool-workspace",
-									"build_number":             8888,
+									"build_number":             8888.0,
 								},
 							},
 						},

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -882,7 +882,7 @@ func TestNotificationTemplatesCanRender(t *testing.T) {
 						},
 						{
 							"template_version_name": "bobby-template-version-2",
-							"failed_count":          1,
+							"failed_count":          1.0,
 							"failed_builds": []map[string]any{
 								{
 									"workspace_owner_username": "ben",

--- a/coderd/notifications/reports/generator.go
+++ b/coderd/notifications/reports/generator.go
@@ -75,6 +75,7 @@ func NewReportGenerator(ctx context.Context, logger slog.Logger, db database.Sto
 				return
 			case tick := <-ticker.C:
 				ticker.Stop()
+
 				doTick(dbtime.Time(tick).UTC())
 			}
 		}


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/14571

This PR modifies the template body of email report to be float friendly, as `json.Unmarshal` unmarshals numbers in `map[string]any` to `float64`. 

This is addressing:
```
 - template: text:7:81: executing "text" at <gt $version.failed_count 1>: error calling gt: incompatible types for comparison
```