### PR TITLE
feat: remove org flag requirement for provisioners

### DIFF
--- a/enterprise/cli/provisionerdaemonstart.go
+++ b/enterprise/cli/provisionerdaemonstart.go
@@ -4,9 +4,7 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"regexp"
 	"time"
@@ -24,7 +22,6 @@ import (
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/cli/cliutil"
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/provisionerkey"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/drpc"
 	"github.com/coder/coder/v2/provisioner/terraform"
@@ -73,32 +70,17 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			interruptCtx, interruptCancel := inv.SignalNotifyContext(ctx, agpl.InterruptSignals...)
 			defer interruptCancel()
 
-			// This can fail to get the current organization
-			// if the client is not authenticated as a user,
-			// like when only PSK is provided.
-			// This will be cleaner once PSK is replaced
-			// with org scoped authentication tokens.
-			org, err := orgContext.Selected(inv, client)
-			if err != nil {
-				var cErr *codersdk.Error
-				if !errors.As(err, &cErr) || cErr.StatusCode() != http.StatusUnauthorized {
-					return xerrors.Errorf("current organization: %w", err)
+			orgID := uuid.Nil
+			if preSharedKey == "" && provisionerKey == "" {
+				// We can only select an organization if using user auth
+				org, err := orgContext.Selected(inv, client)
+				if err != nil {
+					return xerrors.Errorf("get organization: %w", err)
 				}
-
-				if preSharedKey == "" && provisionerKey == "" {
-					return xerrors.New("must provide a pre-shared key or provisioner key when not authenticated as a user")
-				}
-
-				org = codersdk.Organization{MinimalOrganization: codersdk.MinimalOrganization{ID: uuid.Nil}}
+				orgID = org.ID
+			} else {
 				if orgContext.FlagSelect != "" {
-					// If we are using PSK, we can't fetch the organization
-					// to validate org name so we need the user to provide
-					// a valid organization ID.
-					orgID, err := uuid.Parse(orgContext.FlagSelect)
-					if err != nil {
-						return xerrors.New("must provide an org ID when not authenticated as a user and organization is specified")
-					}
-					org = codersdk.Organization{MinimalOrganization: codersdk.MinimalOrganization{ID: orgID}}
+					return xerrors.New("cannot provide --org value with --psk or --key flags")
 				}
 			}
 
@@ -113,19 +95,6 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 
 			if err := validateProvisionerDaemonName(name); err != nil {
 				return err
-			}
-
-			if provisionerKey != "" {
-				if preSharedKey != "" {
-					return xerrors.New("cannot provide both provisioner key --key and pre-shared key --psk")
-				}
-				if len(rawTags) > 0 {
-					return xerrors.New("cannot provide tags when using provisioner key")
-				}
-				err = provisionerkey.Validate(provisionerKey)
-				if err != nil {
-					return xerrors.Errorf("validate provisioner key: %w", err)
-				}
 			}
 
 			logOpts := []clilog.Option{
@@ -232,7 +201,7 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 					},
 					Tags:           tags,
 					PreSharedKey:   preSharedKey,
-					Organization:   org.ID,
+					Organization:   orgID,
 					ProvisionerKey: provisionerKey,
 				})
 			}, &provisionerd.Options{
@@ -281,6 +250,13 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 		},
 	}
 
+	keyOption := serpent.Option{
+		Flag:        "key",
+		Env:         "CODER_PROVISIONER_DAEMON_KEY",
+		Description: "Provisioner key to authenticate with Coder server.",
+		Value:       serpent.StringOf(&provisionerKey),
+		Hidden:      true,
+	}
 	cmd.Options = serpent.OptionSet{
 		{
 			Flag:          "cache-dir",
@@ -316,14 +292,9 @@ func (r *RootCmd) provisionerDaemonStart() *serpent.Command {
 			Env:         "CODER_PROVISIONER_DAEMON_PSK",
 			Description: "Pre-shared key to authenticate with Coder server.",
 			Value:       serpent.StringOf(&preSharedKey),
+			UseInstead:  []serpent.Option{keyOption},
 		},
-		{
-			Flag:        "key",
-			Env:         "CODER_PROVISIONER_DAEMON_KEY",
-			Description: "Provisioner key to authenticate with Coder server.",
-			Value:       serpent.StringOf(&provisionerKey),
-			Hidden:      true,
-		},
+		keyOption,
 		{
 			Flag:        "name",
 			Env:         "CODER_PROVISIONER_DAEMON_NAME",

--- a/enterprise/cli/provisionerdaemonstart_test.go
+++ b/enterprise/cli/provisionerdaemonstart_test.go
@@ -68,46 +68,6 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 		require.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
 	})
 
-	t.Run("AnotherOrg", func(t *testing.T) {
-		t.Parallel()
-		dv := coderdtest.DeploymentValues(t)
-		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
-		client, _ := coderdenttest.New(t, &coderdenttest.Options{
-			Options: &coderdtest.Options{
-				DeploymentValues: dv,
-			},
-			ProvisionerDaemonPSK: "provisionersftw",
-			LicenseOptions: &coderdenttest.LicenseOptions{
-				Features: license.Features{
-					codersdk.FeatureExternalProvisionerDaemons: 1,
-					codersdk.FeatureMultipleOrganizations:      1,
-				},
-			},
-		})
-		anotherOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
-		inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name", "org-daemon", "--org", anotherOrg.ID.String())
-		err := conf.URL().Write(client.URL.String())
-		require.NoError(t, err)
-		pty := ptytest.New(t).Attach(inv)
-		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
-		defer cancel()
-		clitest.Start(t, inv)
-		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
-
-		var daemons []codersdk.ProvisionerDaemon
-		require.Eventually(t, func() bool {
-			daemons, err = client.OrganizationProvisionerDaemons(ctx, anotherOrg.ID)
-			if err != nil {
-				return false
-			}
-			return len(daemons) == 1
-		}, testutil.WaitShort, testutil.IntervalSlow)
-		assert.Equal(t, "org-daemon", daemons[0].Name)
-		assert.Equal(t, provisionersdk.ScopeOrganization, daemons[0].Tags[provisionersdk.TagScope])
-		assert.Equal(t, buildinfo.Version(), daemons[0].Version)
-		assert.Equal(t, proto.CurrentVersion.String(), daemons[0].APIVersion)
-	})
-
 	t.Run("AnotherOrgByNameWithUser", func(t *testing.T) {
 		t.Parallel()
 		dv := coderdtest.DeploymentValues(t)
@@ -126,39 +86,13 @@ func TestProvisionerDaemon_PSK(t *testing.T) {
 		})
 		anotherOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
 		anotherClient, _ := coderdtest.CreateAnotherUser(t, client, anotherOrg.ID, rbac.RoleTemplateAdmin())
-		inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name", "org-daemon", "--org", anotherOrg.Name)
+		inv, conf := newCLI(t, "provisionerd", "start", "--name", "org-daemon", "--org", anotherOrg.Name)
 		clitest.SetupConfig(t, anotherClient, conf)
 		pty := ptytest.New(t).Attach(inv)
 		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
 		defer cancel()
 		clitest.Start(t, inv)
 		pty.ExpectMatchContext(ctx, "starting provisioner daemon")
-	})
-
-	t.Run("AnotherOrgByNameNoUser", func(t *testing.T) {
-		t.Parallel()
-		dv := coderdtest.DeploymentValues(t)
-		dv.Experiments = []string{string(codersdk.ExperimentMultiOrganization)}
-		client, _ := coderdenttest.New(t, &coderdenttest.Options{
-			Options: &coderdtest.Options{
-				DeploymentValues: dv,
-			},
-			ProvisionerDaemonPSK: "provisionersftw",
-			LicenseOptions: &coderdenttest.LicenseOptions{
-				Features: license.Features{
-					codersdk.FeatureExternalProvisionerDaemons: 1,
-					codersdk.FeatureMultipleOrganizations:      1,
-				},
-			},
-		})
-		anotherOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
-		inv, conf := newCLI(t, "provisionerd", "start", "--psk=provisionersftw", "--name", "org-daemon", "--org", anotherOrg.Name)
-		err := conf.URL().Write(client.URL.String())
-		require.NoError(t, err)
-		ctx, cancel := context.WithTimeout(inv.Context(), testutil.WaitLong)
-		defer cancel()
-		err = inv.WithContext(ctx).Run()
-		require.ErrorContains(t, err, "must provide an org ID when not authenticated as a user and organization is specified")
 	})
 
 	t.Run("NoUserNoPSK", func(t *testing.T) {
@@ -467,7 +401,7 @@ func TestProvisionerDaemon_ProvisionerKey(t *testing.T) {
 			Name: "dont-TEST-me",
 		})
 		require.NoError(t, err)
-		inv, conf := newCLI(t, "provisionerd", "start", "--org", anotherOrg.ID.String(), "--key", res.Key, "--name=matt-daemon")
+		inv, conf := newCLI(t, "provisionerd", "start", "--key", res.Key, "--name=matt-daemon")
 		err = conf.URL().Write(client.URL.String())
 		require.NoError(t, err)
 		pty := ptytest.New(t).Attach(inv)

--- a/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
+++ b/enterprise/cli/testdata/coder_provisionerd_start_--help.golden
@@ -43,6 +43,7 @@ OPTIONS:
 
       --psk string, $CODER_PROVISIONER_DAEMON_PSK
           Pre-shared key to authenticate with Coder server.
+          DEPRECATED: Use --key instead.
 
   -t, --tag string-array, $CODER_PROVISIONERD_TAGS
           Tags to filter provisioner jobs by.

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -82,77 +82,68 @@ type provisionerDaemonAuth struct {
 
 // authorize returns mutated tags if the given HTTP request is authorized to access the provisioner daemon
 // protobuf API, and returns nil, err otherwise.
-func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags map[string]string) (uuid.UUID, map[string]string, error) {
+func (p *provisionerDaemonAuth) authorize(r *http.Request, org database.Organization, tags map[string]string) (uuid.UUID, uuid.UUID, map[string]string, error) {
 	ctx := r.Context()
 	apiKey, apiKeyOK := httpmw.APIKeyOptional(r)
 	pk, pkOK := httpmw.ProvisionerKeyAuthOptional(r)
 	provAuth := httpmw.ProvisionerDaemonAuthenticated(r)
 	if !provAuth && !apiKeyOK {
-		return uuid.Nil, nil, xerrors.New("no API key or provisioner key provided")
+		return uuid.Nil, uuid.Nil, nil, xerrors.New("no API key or provisioner key provided")
 	}
 	if apiKeyOK && pkOK {
-		return uuid.Nil, nil, xerrors.New("Both API key and provisioner key authentication provided. Only one is allowed.")
+		return uuid.Nil, uuid.Nil, nil, xerrors.New("Both API key and provisioner key authentication provided. Only one is allowed.")
 	}
 
 	// Provisioner Key Auth
 	if pkOK {
-		if pk.OrganizationID != orgID {
-			return uuid.Nil, nil, xerrors.New("provisioner key unauthorized")
-		}
 		if tags != nil && !maps.Equal(tags, map[string]string{}) {
-			return uuid.Nil, nil, xerrors.New("tags are not allowed when using a provisioner key")
+			return uuid.Nil, uuid.Nil, nil, xerrors.New("tags are not allowed when using a provisioner key")
 		}
 
 		// If using provisioner key / PSK auth, the daemon is, by definition, scoped to the organization.
 		// Use the provisioner key tags here.
 		tags = provisionersdk.MutateTags(uuid.Nil, pk.Tags)
-		return pk.ID, tags, nil
-	}
-
-	// User Auth
-	if apiKeyOK {
-		userKey, err := uuid.Parse(codersdk.ProvisionerKeyIDUserAuth)
-		if err != nil {
-			return uuid.Nil, nil, xerrors.Errorf("parse user provisioner key id: %w", err)
-		}
-
-		tags = provisionersdk.MutateTags(apiKey.UserID, tags)
-		if tags[provisionersdk.TagScope] == provisionersdk.ScopeUser {
-			// Any authenticated user can create provisioner daemons scoped
-			// for jobs that they own,
-			return userKey, tags, nil
-		}
-		ua := httpmw.UserAuthorization(r)
-		err = p.authorizer.Authorize(ctx, ua, policy.ActionCreate, rbac.ResourceProvisionerDaemon.InOrg(orgID))
-		if err != nil {
-			if !provAuth {
-				return uuid.Nil, nil, xerrors.New("user unauthorized")
-			}
-
-			pskKey, err := uuid.Parse(codersdk.ProvisionerKeyIDPSK)
-			if err != nil {
-				return uuid.Nil, nil, xerrors.Errorf("parse psk provisioner key id: %w", err)
-			}
-
-			// Allow fallback to PSK auth if the user is not allowed to create provisioner daemons.
-			// This is to preserve backwards compatibility with existing user provisioner daemons.
-			// If using PSK auth, the daemon is, by definition, scoped to the organization.
-			tags = provisionersdk.MutateTags(uuid.Nil, tags)
-
-			return pskKey, tags, nil
-		}
-
-		return userKey, tags, nil
+		return pk.ID, pk.OrganizationID, tags, nil
 	}
 
 	// PSK Auth
-	pskKey, err := uuid.Parse(codersdk.ProvisionerKeyIDPSK)
-	if err != nil {
-		return uuid.Nil, nil, xerrors.Errorf("parse psk provisioner key id: %w", err)
+	if provAuth {
+		if !org.IsDefault {
+			return uuid.Nil, uuid.Nil, nil, xerrors.Errorf("PSK auth is only allowed for the default organization '%s'", org.Name)
+		}
+
+		pskKey, err := uuid.Parse(codersdk.ProvisionerKeyIDPSK)
+		if err != nil {
+			return uuid.Nil, uuid.Nil, nil, xerrors.Errorf("parse psk provisioner key id: %w", err)
+		}
+
+		tags = provisionersdk.MutateTags(uuid.Nil, tags)
+		return pskKey, org.ID, tags, nil
 	}
 
-	tags = provisionersdk.MutateTags(uuid.Nil, tags)
-	return pskKey, tags, nil
+	// User Auth
+	if !apiKeyOK {
+		return uuid.Nil, uuid.Nil, nil, xerrors.New("no API key provided")
+	}
+
+	userKey, err := uuid.Parse(codersdk.ProvisionerKeyIDUserAuth)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, nil, xerrors.Errorf("parse user provisioner key id: %w", err)
+	}
+
+	tags = provisionersdk.MutateTags(apiKey.UserID, tags)
+	if tags[provisionersdk.TagScope] == provisionersdk.ScopeUser {
+		// Any authenticated user can create provisioner daemons scoped
+		// for jobs that they own,
+		return userKey, org.ID, tags, nil
+	}
+	ua := httpmw.UserAuthorization(r)
+	err = p.authorizer.Authorize(ctx, ua, policy.ActionCreate, rbac.ResourceProvisionerDaemon.InOrg(org.ID))
+	if err != nil {
+		return uuid.Nil, uuid.Nil, nil, xerrors.New("user unauthorized")
+	}
+
+	return userKey, org.ID, tags, nil
 }
 
 // Serves the provisioner daemon protobuf API over a WebSocket.
@@ -166,7 +157,6 @@ func (p *provisionerDaemonAuth) authorize(r *http.Request, orgID uuid.UUID, tags
 // @Router /organizations/{organization}/provisionerdaemons/serve [get]
 func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	organization := httpmw.OrganizationParam(r)
 
 	tags := map[string]string{}
 	if r.URL.Query().Has("tag") {
@@ -215,7 +205,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		api.Logger.Warn(ctx, "unnamed provisioner daemon")
 	}
 
-	keyID, tags, err := api.provisionerDaemonAuth.authorize(r, organization.ID, tags)
+	keyID, orgID, tags, err := api.provisionerDaemonAuth.authorize(r, httpmw.OrganizationParam(r), tags)
 	if err != nil {
 		api.Logger.Warn(ctx, "unauthorized provisioner daemon serve request", slog.F("tags", tags), slog.Error(err))
 		httpapi.Write(ctx, rw, http.StatusForbidden,
@@ -287,7 +277,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		LastSeenAt:     sql.NullTime{Time: now, Valid: true},
 		Version:        versionHdrVal,
 		APIVersion:     apiVersion,
-		OrganizationID: organization.ID,
+		OrganizationID: orgID,
 		KeyID:          keyID,
 	})
 	if err != nil {
@@ -351,7 +341,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		srvCtx,
 		api.AccessURL,
 		daemon.ID,
-		organization.ID,
+		orgID,
 		logger,
 		provisioners,
 		tags,

--- a/enterprise/coderd/provisionerdaemons.go
+++ b/enterprise/coderd/provisionerdaemons.go
@@ -366,7 +366,7 @@ func (api *API) provisionerDaemonServe(rw http.ResponseWriter, r *http.Request) 
 		srvCtx,
 		api.AccessURL,
 		daemon.ID,
-		orgID,
+		authRes.orgID,
 		logger,
 		provisioners,
 		tags,


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/14188

What this changes:
- You can no longer pass the org flag when using psk or key flags, since these auth methods dictate the org themselves
- When authenticating with a psk or provisioner key we always use the `default` org which is ignored by the middleware and relies on the key providing the org.
- Providing a PSK will now make the PSK auth take priority over user auth
- You can only use the PSK for the `default` org now.
- `--psk` flag has been marked deprecated in favor of  `--key`

Some of these changes are breaking but only to org related options that are behind the experiment. 