### PR TITLE
feat: integrate backend with idp sync page

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -704,6 +704,9 @@ class ApiMethods {
 		return response.data;
 	};
 
+	/**
+	 * @param organization Can be the organization's ID or name
+	 */
 	getGroupIdpSyncSettingsByOrganization = async (
 		organization: string,
 	): Promise<TypesGen.GroupSyncSettings> => {

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -704,6 +704,27 @@ class ApiMethods {
 		return response.data;
 	};
 
+	getGroupIdpSyncSettingsByOrganization = async (
+		organization: string,
+	): Promise<TypesGen.GroupSyncSettings> => {
+		const response = await this.axios.get<TypesGen.GroupSyncSettings>(
+			`/api/v2/organizations/${organization}/settings/idpsync/groups`,
+		);
+		return response.data;
+	};
+
+	/**
+	 * @param organization Can be the organization's ID or name
+	 */
+	getRoleIdpSyncSettingsByOrganization = async (
+		organization: string,
+	): Promise<TypesGen.RoleSyncSettings> => {
+		const response = await this.axios.get<TypesGen.RoleSyncSettings>(
+			`/api/v2/organizations/${organization}/settings/idpsync/roles`,
+		);
+		return response.data;
+	};
+
 	getTemplate = async (templateId: string): Promise<TypesGen.Template> => {
 		const response = await this.axios.get<TypesGen.Template>(
 			`/api/v2/templates/${templateId}`,

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -269,6 +269,13 @@ export const organizationsPermissions = (
 					},
 					action: "read",
 				},
+				viewIdpSyncSettings: {
+					object: {
+						resource_type: "idpsync_settings",
+						organization_id: organizationId,
+					},
+					action: "read",
+				},
 			});
 
 			// The endpoint takes a flat array, so to avoid collisions prepend each

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -142,7 +142,7 @@ export const provisionerDaemonGroups = (organization: string) => {
 };
 
 export const getGroupIdpSyncSettingsKey = (organization: string) => [
-	"organization",
+	"organizations",
 	organization,
 	"groupIdpSyncSettings",
 ];
@@ -155,7 +155,7 @@ export const groupIdpSyncSettings = (organization: string) => {
 };
 
 export const getRoleIdpSyncSettingsKey = (organization: string) => [
-	"organization",
+	"organizations",
 	organization,
 	"roleIdpSyncSettings",
 ];

--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -141,6 +141,32 @@ export const provisionerDaemonGroups = (organization: string) => {
 	};
 };
 
+export const getGroupIdpSyncSettingsKey = (organization: string) => [
+	"organization",
+	organization,
+	"groupIdpSyncSettings",
+];
+
+export const groupIdpSyncSettings = (organization: string) => {
+	return {
+		queryKey: getGroupIdpSyncSettingsKey(organization),
+		queryFn: () => API.getGroupIdpSyncSettingsByOrganization(organization),
+	};
+};
+
+export const getRoleIdpSyncSettingsKey = (organization: string) => [
+	"organization",
+	organization,
+	"roleIdpSyncSettings",
+];
+
+export const roleIdpSyncSettings = (organization: string) => {
+	return {
+		queryKey: getRoleIdpSyncSettingsKey(organization),
+		queryFn: () => API.getRoleIdpSyncSettingsByOrganization(organization),
+	};
+};
+
 /**
  * Fetch permissions for a single organization.
  *

--- a/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
+++ b/site/src/pages/DeploySettingsPage/AppearanceSettingsPage/AppearanceSettingsPageView.tsx
@@ -74,7 +74,7 @@ export const AppearanceSettingsPageView: FC<
 					<PopoverContent css={{ transform: "translateY(-28px)" }}>
 						<PopoverPaywall
 							message="Appearance"
-							description="With a Premium license, you can customize the appearance of your deployment."
+							description="With a Premium license, you can customize the appearance and branding of your deployment."
 							documentationLink="https://coder.com/docs/admin/appearance"
 						/>
 					</PopoverContent>

--- a/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/CustomRolesPage/CustomRolesPageView.tsx
@@ -29,12 +29,12 @@ import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { docs } from "utils/docs";
 import { PermissionPillsList } from "./PermissionPillsList";
 
-export type CustomRolesPageViewProps = {
+interface CustomRolesPageViewProps {
 	roles: Role[] | undefined;
 	onDeleteRole: (role: Role) => void;
 	canAssignOrgRole: boolean;
 	isCustomRolesEnabled: boolean;
-};
+}
 
 export const CustomRolesPageView: FC<CustomRolesPageViewProps> = ({
 	roles,

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof ExportPolicyButton> = {
 	title: "modules/resources/ExportPolicyButton",
 	component: ExportPolicyButton,
 	args: {
-		policy: JSON.stringify(MockGroupSyncSettings, null, 2),
+		syncSettings: MockGroupSyncSettings,
 		type: "groups",
 		organization: MockOrganization,
 	},
@@ -24,7 +24,7 @@ export const Default: Story = {};
 
 export const ClickExportGroupPolicy: Story = {
 	args: {
-		policy: JSON.stringify(MockGroupSyncSettings, null, 2),
+		syncSettings: MockGroupSyncSettings,
 		type: "groups",
 		organization: MockOrganization,
 		download: fn(),
@@ -47,7 +47,7 @@ export const ClickExportGroupPolicy: Story = {
 
 export const ClickExportRolePolicy: Story = {
 	args: {
-		policy: JSON.stringify(MockRoleSyncSettings, null, 2),
+		syncSettings: MockRoleSyncSettings,
 		type: "roles",
 		organization: MockOrganization,
 		download: fn(),

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent, waitFor, within } from "@storybook/test";
+import {
+	MockGroupSyncSettings,
+	MockOrganization,
+	MockRoleSyncSettings,
+} from "testHelpers/entities";
+import { ExportPolicyButton } from "./ExportPolicyButton";
+
+const meta: Meta<typeof ExportPolicyButton> = {
+	title: "modules/resources/ExportPolicyButton",
+	component: ExportPolicyButton,
+	args: {
+		policy: JSON.stringify(MockGroupSyncSettings, null, 2),
+		type: "groups",
+		organization: MockOrganization,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ExportPolicyButton>;
+
+export const Default: Story = {};
+
+export const ClickExportGroupPolicy: Story = {
+	args: {
+		policy: JSON.stringify(MockGroupSyncSettings, null, 2),
+		type: "groups",
+		organization: MockOrganization,
+		download: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Export Policy" }),
+		);
+		await waitFor(() =>
+			expect(args.download).toHaveBeenCalledWith(
+				expect.anything(),
+				`${MockOrganization.name}_groups-policy.json`,
+			),
+		);
+		const blob: Blob = (args.download as jest.Mock).mock.calls[0][0];
+		await expect(blob.type).toEqual("application/json");
+	},
+};
+
+export const ClickExportRolePolicy: Story = {
+	args: {
+		policy: JSON.stringify(MockRoleSyncSettings, null, 2),
+		type: "roles",
+		organization: MockOrganization,
+		download: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Export Policy" }),
+		);
+		await waitFor(() =>
+			expect(args.download).toHaveBeenCalledWith(
+				expect.anything(),
+				`${MockOrganization.name}_roles-policy.json`,
+			),
+		);
+		const blob: Blob = (args.download as jest.Mock).mock.calls[0][0];
+		await expect(blob.type).toEqual("application/json");
+	},
+};

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.stories.tsx
@@ -40,8 +40,11 @@ export const ClickExportGroupPolicy: Story = {
 				`${MockOrganization.name}_groups-policy.json`,
 			),
 		);
-		const blob: Blob = (args.download as jest.Mock).mock.calls[0][0];
+		const blob: Blob = (args.download as jest.Mock).mock.lastCall[0];
 		await expect(blob.type).toEqual("application/json");
+		await expect(await blob.text()).toEqual(
+			JSON.stringify(MockGroupSyncSettings, null, 2),
+		);
 	},
 };
 
@@ -63,7 +66,10 @@ export const ClickExportRolePolicy: Story = {
 				`${MockOrganization.name}_roles-policy.json`,
 			),
 		);
-		const blob: Blob = (args.download as jest.Mock).mock.calls[0][0];
+		const blob: Blob = (args.download as jest.Mock).mock.lastCall[0];
 		await expect(blob.type).toEqual("application/json");
+		await expect(await blob.text()).toEqual(
+			JSON.stringify(MockRoleSyncSettings, null, 2),
+		);
 	},
 };

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
@@ -1,0 +1,45 @@
+import DownloadOutlined from "@mui/icons-material/DownloadOutlined";
+import Button from "@mui/material/Button";
+import type { Organization } from "api/typesGenerated";
+import { displayError } from "components/GlobalSnackbar/utils";
+import { saveAs } from "file-saver";
+import { type FC, useState } from "react";
+
+interface DownloadPolicyButtonProps {
+	policy: string | null;
+	type: "groups" | "roles";
+	organization: Organization;
+}
+
+export const ExportPolicyButton: FC<DownloadPolicyButtonProps> = ({
+	policy,
+	type,
+	organization,
+}) => {
+	const [isDownloading, setIsDownloading] = useState(false);
+
+	return (
+		<Button
+			startIcon={<DownloadOutlined />}
+			disabled={!policy || isDownloading}
+			onClick={async () => {
+				if (policy) {
+					try {
+						setIsDownloading(true);
+						const file = new Blob([policy], {
+							type: "application/json",
+						});
+						saveAs(file, `${organization.name}_${type}-policy.json`);
+					} catch (e) {
+						console.error(e);
+						displayError("Failed to export policy json");
+					} finally {
+						setIsDownloading(false);
+					}
+				}
+			}}
+		>
+			Export Policy
+		</Button>
+	);
+};

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
@@ -9,12 +9,14 @@ interface DownloadPolicyButtonProps {
 	policy: string | null;
 	type: "groups" | "roles";
 	organization: Organization;
+	download?: (file: Blob, filename: string) => void;
 }
 
 export const ExportPolicyButton: FC<DownloadPolicyButtonProps> = ({
 	policy,
 	type,
 	organization,
+	download = saveAs,
 }) => {
 	const [isDownloading, setIsDownloading] = useState(false);
 
@@ -29,7 +31,7 @@ export const ExportPolicyButton: FC<DownloadPolicyButtonProps> = ({
 						const file = new Blob([policy], {
 							type: "application/json",
 						});
-						saveAs(file, `${organization.name}_${type}-policy.json`);
+						download(file, `${organization.name}_${type}-policy.json`);
 					} catch (e) {
 						console.error(e);
 						displayError("Failed to export policy json");

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/ExportPolicyButton.tsx
@@ -1,34 +1,44 @@
 import DownloadOutlined from "@mui/icons-material/DownloadOutlined";
 import Button from "@mui/material/Button";
-import type { Organization } from "api/typesGenerated";
+import type {
+	GroupSyncSettings,
+	Organization,
+	RoleSyncSettings,
+} from "api/typesGenerated";
 import { displayError } from "components/GlobalSnackbar/utils";
 import { saveAs } from "file-saver";
-import { type FC, useState } from "react";
+import { type FC, useMemo, useState } from "react";
 
 interface DownloadPolicyButtonProps {
-	policy: string | null;
+	syncSettings: RoleSyncSettings | GroupSyncSettings | undefined;
 	type: "groups" | "roles";
 	organization: Organization;
 	download?: (file: Blob, filename: string) => void;
 }
 
 export const ExportPolicyButton: FC<DownloadPolicyButtonProps> = ({
-	policy,
+	syncSettings,
 	type,
 	organization,
 	download = saveAs,
 }) => {
 	const [isDownloading, setIsDownloading] = useState(false);
 
+	const policyJSON = useMemo(() => {
+		return syncSettings?.field && syncSettings.mapping
+			? JSON.stringify(syncSettings, null, 2)
+			: null;
+	}, [syncSettings]);
+
 	return (
 		<Button
 			startIcon={<DownloadOutlined />}
-			disabled={!policy || isDownloading}
+			disabled={!policyJSON || isDownloading}
 			onClick={async () => {
-				if (policy) {
+				if (policyJSON) {
 					try {
 						setIsDownloading(true);
-						const file = new Blob([policy], {
+						const file = new Blob([policyJSON], {
 							type: "application/json",
 						});
 						download(file, `${organization.name}_${type}-policy.json`);

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpPillList.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpPillList.tsx
@@ -12,8 +12,9 @@ interface PillListProps {
 	roles: readonly string[];
 }
 
+// used to check if the role is a UUID
 const UUID =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const IdpPillList: FC<PillListProps> = ({ roles }) => {
 	return (

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpPillList.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpPillList.tsx
@@ -31,9 +31,9 @@ export const IdpPillList: FC<PillListProps> = ({ roles }) => {
 	);
 };
 
-type OverflowPillProps = {
+interface OverflowPillProps {
 	roles: string[];
-};
+}
 
 const OverflowPill: FC<OverflowPillProps> = ({ roles }) => {
 	const theme = useTheme();

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpPillList.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpPillList.tsx
@@ -12,11 +12,16 @@ interface PillListProps {
 	roles: readonly string[];
 }
 
-export const PillList: FC<PillListProps> = ({ roles }) => {
+const UUID =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const IdpPillList: FC<PillListProps> = ({ roles }) => {
 	return (
 		<Stack direction="row" spacing={1}>
 			{roles.length > 0 ? (
-				<Pill css={styles.pill}>{roles[0]}</Pill>
+				<Pill css={UUID.test(roles[0]) ? styles.errorPill : styles.pill}>
+					{roles[0]}
+				</Pill>
 			) : (
 				<p>None</p>
 			)}
@@ -72,7 +77,10 @@ const OverflowPill: FC<OverflowPillProps> = ({ roles }) => {
 				}}
 			>
 				{roles.map((role) => (
-					<Pill key={role} css={styles.pill}>
+					<Pill
+						key={role}
+						css={UUID.test(role) ? styles.errorPill : styles.pill}
+					>
 						{role}
 					</Pill>
 				))}
@@ -86,6 +94,12 @@ const styles = {
 		backgroundColor: theme.experimental.pillDefault.background,
 		borderColor: theme.experimental.pillDefault.outline,
 		color: theme.experimental.pillDefault.text,
+		width: "fit-content",
+	}),
+	errorPill: (theme) => ({
+		backgroundColor: theme.roles.error.background,
+		borderColor: theme.roles.error.outline,
+		color: theme.roles.error.text,
 		width: "fit-content",
 	}),
 } satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -28,10 +28,6 @@ export const IdpSyncPage: FC = () => {
 	const { organizations } = useOrganizationSettings();
 	const organization = organizations?.find((o) => o.name === organizationName);
 
-	if (!organization) {
-		return <EmptyState message="Organization not found" />;
-	}
-
 	const [groupIdpSyncSettingsQuery, roleIdpSyncSettingsQuery, groupsQuery] =
 		useQueries({
 			queries: [
@@ -40,6 +36,10 @@ export const IdpSyncPage: FC = () => {
 				groupsByOrganization(organizationName),
 			],
 		});
+
+	if (!organization) {
+		return <EmptyState message="Organization not found" />;
+	}
 
 	if (
 		groupsQuery.isLoading ||
@@ -60,6 +60,13 @@ export const IdpSyncPage: FC = () => {
 		!groupsQuery.data
 	) {
 		return <ErrorAlert error={error} />;
+	}
+
+	const groupsMap = new Map<string, string>();
+	if (groupsQuery.data) {
+		for (const group of groupsQuery.data) {
+			groupsMap.set(group.id, group.display_name || group.name);
+		}
 	}
 
 	return (
@@ -95,6 +102,7 @@ export const IdpSyncPage: FC = () => {
 				groupSyncSettings={groupIdpSyncSettingsQuery.data}
 				roleSyncSettings={roleIdpSyncSettingsQuery.data}
 				groups={groupsQuery.data}
+				groupsMap={groupsMap}
 				organization={organization}
 			/>
 		</>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -1,57 +1,27 @@
 import AddIcon from "@mui/icons-material/AddOutlined";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import Button from "@mui/material/Button";
+import { groupsByOrganization } from "api/queries/groups";
+import {
+	groupIdpSyncSettings,
+	organizationsPermissions,
+	roleIdpSyncSettings,
+} from "api/queries/organizations";
+import { EmptyState } from "components/EmptyState/EmptyState";
 import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
+import { Loader } from "components/Loader/Loader";
 import { SettingsHeader } from "components/SettingsHeader/SettingsHeader";
 import { Stack } from "components/Stack/Stack";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import { Helmet } from "react-helmet-async";
+import { useQuery } from "react-query";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { docs } from "utils/docs";
 import { pageTitle } from "utils/page";
+import { useOrganizationSettings } from "../ManagementSettingsLayout";
 import { IdpSyncHelpTooltip } from "./IdpSyncHelpTooltip";
 import IdpSyncPageView from "./IdpSyncPageView";
-import {
-	organizationsPermissions,
-	groupIdpSyncSettings,
-	roleIdpSyncSettings,
-} from "api/queries/organizations";
-import { useQuery } from "react-query";
-import { useOrganizationSettings } from "../ManagementSettingsLayout";
-import { Loader } from "components/Loader/Loader";
-import { EmptyState } from "components/EmptyState/EmptyState";
-
-const mockOIDCConfig = {
-	allow_signups: true,
-	client_id: "test",
-	client_secret: "test",
-	client_key_file: "test",
-	client_cert_file: "test",
-	email_domain: [],
-	issuer_url: "test",
-	scopes: [],
-	ignore_email_verified: true,
-	username_field: "",
-	name_field: "",
-	email_field: "",
-	auth_url_params: {},
-	ignore_user_info: true,
-	organization_field: "",
-	organization_mapping: {},
-	organization_assign_default: true,
-	group_auto_create: false,
-	group_regex_filter: "^Coder-.*$",
-	group_allow_list: [],
-	groups_field: "groups",
-	group_mapping: { group1: "developers", group2: "admin", group3: "auditors" },
-	user_role_field: "roles",
-	user_role_mapping: { role1: ["role1", "role2"] },
-	user_roles_default: [],
-	sign_in_text: "",
-	icon_url: "",
-	signups_disabled_text: "string",
-	skip_issuer_checks: true,
-};
 
 export const IdpSyncPage: FC = () => {
 	const { organization: organizationName } = useParams() as {
@@ -64,6 +34,7 @@ export const IdpSyncPage: FC = () => {
 	// 	organization: string;
 	// };
 	const { organizations } = useOrganizationSettings();
+
 	const organization = organizations?.find((o) => o.name === organizationName);
 	const permissionsQuery = useQuery(
 		organizationsPermissions(organizations?.map((o) => o.id)),
@@ -71,9 +42,12 @@ export const IdpSyncPage: FC = () => {
 	const groupIdpSyncSettingsQuery = useQuery(
 		groupIdpSyncSettings(organizationName),
 	);
+
+	const groupsQuery = useQuery(groupsByOrganization(organizationName));
 	const roleIdpSyncSettingsQuery = useQuery(
 		roleIdpSyncSettings(organizationName),
 	);
+
 	// const permissions = permissionsQuery.data;
 
 	if (!organization) {
@@ -121,9 +95,9 @@ export const IdpSyncPage: FC = () => {
 			</Stack>
 
 			<IdpSyncPageView
-				oidcConfig={mockOIDCConfig}
 				groupSyncSettings={groupIdpSyncSettingsQuery.data}
 				roleSyncSettings={roleIdpSyncSettingsQuery.data}
+				groups={groupsQuery.data}
 			/>
 		</>
 	);

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -95,6 +95,7 @@ export const IdpSyncPage: FC = () => {
 				groupSyncSettings={groupIdpSyncSettingsQuery.data}
 				roleSyncSettings={roleIdpSyncSettingsQuery.data}
 				groups={groupsQuery.data}
+				organization={organization}
 			/>
 		</>
 	);

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -7,6 +7,7 @@ import {
 	organizationsPermissions,
 	roleIdpSyncSettings,
 } from "api/queries/organizations";
+import { ErrorAlert } from "components/Alert/ErrorAlert";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
 import { Loader } from "components/Loader/Loader";
@@ -27,12 +28,6 @@ export const IdpSyncPage: FC = () => {
 	const { organization: organizationName } = useParams() as {
 		organization: string;
 	};
-
-	// feature visibility and permissions to be implemented when integrating with backend
-	// const feats = useFeatureVisibility();
-	// const { organization: organizationName } = useParams() as {
-	// 	organization: string;
-	// };
 	const { organizations } = useOrganizationSettings();
 
 	const organization = organizations?.find((o) => o.name === organizationName);
@@ -48,8 +43,6 @@ export const IdpSyncPage: FC = () => {
 		roleIdpSyncSettings(organizationName),
 	);
 
-	// const permissions = permissionsQuery.data;
-
 	if (!organization) {
 		return <EmptyState message="Organization not found" />;
 	}
@@ -60,6 +53,19 @@ export const IdpSyncPage: FC = () => {
 		roleIdpSyncSettingsQuery.isLoading
 	) {
 		return <Loader />;
+	}
+
+	const error =
+		groupIdpSyncSettingsQuery.error ||
+		roleIdpSyncSettingsQuery.error ||
+		groupsQuery.error;
+	if (
+		error ||
+		!groupIdpSyncSettingsQuery.data ||
+		!roleIdpSyncSettingsQuery.data ||
+		!groupsQuery.data
+	) {
+		return <ErrorAlert error={error} />;
 	}
 
 	return (

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { MockOIDCConfig } from "testHelpers/entities";
+import {
+	MockGroup,
+	MockGroup2,
+	MockGroupSyncSettings,
+	MockRoleSyncSettings,
+} from "testHelpers/entities";
 import { IdpSyncPageView } from "./IdpSyncPageView";
 
 const meta: Meta<typeof IdpSyncPageView> = {
@@ -11,9 +16,17 @@ export default meta;
 type Story = StoryObj<typeof IdpSyncPageView>;
 
 export const Empty: Story = {
-	args: { oidcConfig: undefined },
+	args: {
+		groupSyncSettings: undefined,
+		roleSyncSettings: undefined,
+		groups: [MockGroup, MockGroup2],
+	},
 };
 
 export const Default: Story = {
-	args: { oidcConfig: MockOIDCConfig },
+	args: {
+		groupSyncSettings: MockGroupSyncSettings,
+		roleSyncSettings: MockRoleSyncSettings,
+		groups: [MockGroup, MockGroup2],
+	},
 };

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
@@ -3,6 +3,7 @@ import {
 	MockGroup,
 	MockGroup2,
 	MockGroupSyncSettings,
+	MockGroupSyncSettings2,
 	MockRoleSyncSettings,
 } from "testHelpers/entities";
 import { IdpSyncPageView } from "./IdpSyncPageView";
@@ -15,11 +16,17 @@ const meta: Meta<typeof IdpSyncPageView> = {
 export default meta;
 type Story = StoryObj<typeof IdpSyncPageView>;
 
+const groupsMap = new Map<string, string>();
+
+for (const group of [MockGroup, MockGroup2]) {
+	groupsMap.set(group.id, group.display_name || group.name);
+}
+
 export const Empty: Story = {
 	args: {
 		groupSyncSettings: undefined,
 		roleSyncSettings: undefined,
-		groups: [MockGroup, MockGroup2],
+		groupsMap: undefined,
 	},
 };
 
@@ -27,14 +34,14 @@ export const Default: Story = {
 	args: {
 		groupSyncSettings: MockGroupSyncSettings,
 		roleSyncSettings: MockRoleSyncSettings,
-		groups: [MockGroup, MockGroup2],
+		groupsMap,
 	},
 };
 
 export const MissingGroups: Story = {
 	args: {
-		groupSyncSettings: MockGroupSyncSettings,
+		groupSyncSettings: MockGroupSyncSettings2,
 		roleSyncSettings: MockRoleSyncSettings,
-		groups: [],
+		groupsMap,
 	},
 };

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.stories.tsx
@@ -30,3 +30,11 @@ export const Default: Story = {
 		groups: [MockGroup, MockGroup2],
 	},
 };
+
+export const MissingGroups: Story = {
+	args: {
+		groupSyncSettings: MockGroupSyncSettings,
+		roleSyncSettings: MockRoleSyncSettings,
+		groups: [],
+	},
+};

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -42,7 +42,6 @@ interface IdpSyncPageViewProps {
 export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 	groupSyncSettings,
 	roleSyncSettings,
-	groups,
 	groupsMap,
 	organization,
 }) => {

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -29,7 +29,7 @@ import { useSearchParams } from "react-router-dom";
 import { MONOSPACE_FONT_FAMILY } from "theme/constants";
 import { docs } from "utils/docs";
 import { ExportPolicyButton } from "./ExportPolicyButton";
-import { PillList } from "./PillList";
+import { IdpPillList } from "./IdpPillList";
 
 interface IdpSyncPageViewProps {
 	groupSyncSettings: GroupSyncSettings | undefined;
@@ -329,7 +329,7 @@ const GroupRow: FC<GroupRowProps> = ({ idpGroup, coderGroup }) => {
 		<TableRow data-testid={`group-${idpGroup}`}>
 			<TableCell>{idpGroup}</TableCell>
 			<TableCell>
-				<PillList roles={coderGroup} />
+				<IdpPillList roles={coderGroup} />
 			</TableCell>
 		</TableRow>
 	);
@@ -345,7 +345,7 @@ const RoleRow: FC<RoleRowProps> = ({ idpRole, coderRoles }) => {
 		<TableRow data-testid={`role-${idpRole}`}>
 			<TableCell>{idpRole}</TableCell>
 			<TableCell>
-				<PillList roles={coderRoles} />
+				<IdpPillList roles={coderRoles} />
 			</TableCell>
 		</TableRow>
 	);

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -1,5 +1,4 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import { useTheme } from "@emotion/react";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import Button from "@mui/material/Button";
 import Skeleton from "@mui/material/Skeleton";
@@ -39,8 +38,6 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 	roleSyncSettings,
 	groups,
 }) => {
-	// const theme = useTheme();
-
 	const groupsMap = new Map<string, string>();
 	if (groups) {
 		for (const group of groups) {
@@ -101,6 +98,29 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 							</Stack>
 						</fieldset>
 					</Stack>
+					{groupSyncSettings?.mapping && roleSyncSettings?.mapping && (
+						<div
+							css={(theme) => ({
+								margin: 0,
+								fontSize: 13,
+								paddingBottom: 14,
+								color: theme.palette.text.secondary,
+								"& strong": {
+									color: theme.palette.text.primary,
+								},
+							})}
+						>
+							Showing{" "}
+							<strong>
+								{Object.entries(groupSyncSettings?.mapping).length}
+							</strong>{" "}
+							groups and{" "}
+							<strong>
+								{Object.entries(roleSyncSettings?.mapping).length}
+							</strong>{" "}
+							provisioners
+						</div>
+					)}
 					<Stack spacing={6}>
 						<IdpMappingTable
 							type="Group"

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -9,7 +9,11 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import type { OIDCConfig } from "api/typesGenerated";
+import type {
+	OIDCConfig,
+	GroupSyncSettings,
+	RoleSyncSettings,
+} from "api/typesGenerated";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
 import { EmptyState } from "components/EmptyState/EmptyState";
 import { Paywall } from "components/Paywall/Paywall";
@@ -25,16 +29,17 @@ import { docs } from "utils/docs";
 
 export type IdpSyncPageViewProps = {
 	oidcConfig: OIDCConfig | undefined;
+	groupSyncSettings: GroupSyncSettings | undefined;
+	roleSyncSettings: RoleSyncSettings | undefined;
 };
 
-export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
+export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
+	oidcConfig,
+	groupSyncSettings,
+	roleSyncSettings,
+}) => {
 	const theme = useTheme();
-	const {
-		groups_field,
-		user_role_field,
-		group_regex_filter,
-		group_auto_create,
-	} = oidcConfig || {};
+	const { user_role_field } = oidcConfig || {};
 	return (
 		<>
 			<ChooseOne>
@@ -54,16 +59,22 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({ oidcConfig }) => {
 							<Stack direction={"row"} alignItems={"center"} spacing={8}>
 								<IdpField
 									name={"Sync Field"}
-									fieldText={groups_field}
+									fieldText={groupSyncSettings?.field}
 									showStatusIndicator
 								/>
 								<IdpField
 									name={"Regex Filter"}
-									fieldText={group_regex_filter}
+									fieldText={
+										typeof groupSyncSettings?.regex_filter === "string"
+											? groupSyncSettings?.regex_filter
+											: ""
+									}
 								/>
 								<IdpField
 									name={"Auto Create"}
-									fieldText={group_auto_create?.toString()}
+									fieldText={String(
+										groupSyncSettings?.auto_create_missing_groups,
+									)}
 								/>
 							</Stack>
 						</fieldset>

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -1,4 +1,5 @@
 import type { Interpolation, Theme } from "@emotion/react";
+import AddIcon from "@mui/icons-material/AddOutlined";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import Button from "@mui/material/Button";
 import Skeleton from "@mui/material/Skeleton";
@@ -22,7 +23,9 @@ import {
 	TableLoaderSkeleton,
 	TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
+import { TabLink, Tabs, TabsList } from "components/Tabs/Tabs";
 import type { FC } from "react";
+import { useSearchParams } from "react-router-dom";
 import { MONOSPACE_FONT_FAMILY } from "theme/constants";
 import { docs } from "utils/docs";
 import { PillList } from "./PillList";
@@ -38,6 +41,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 	roleSyncSettings,
 	groups,
 }) => {
+	const [searchParams] = useSearchParams();
 	const groupsMap = new Map<string, string>();
 	if (groups) {
 		for (const group of groups) {
@@ -48,6 +52,15 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 	const getGroupNames = (groupIds: readonly string[]) => {
 		return groupIds.map((groupId) => groupsMap.get(groupId) || groupId);
 	};
+
+	const tab = searchParams.get("tab") || "groups";
+
+	const groupMappingCount = groupSyncSettings?.mapping
+		? Object.entries(groupSyncSettings.mapping).length
+		: 0;
+	const roleMappingCount = roleSyncSettings?.mapping
+		? Object.entries(roleSyncSettings.mapping).length
+		: 0;
 
 	return (
 		<>
@@ -60,105 +73,124 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 					/>
 				</Cond>
 				<Cond>
-					<Stack spacing={2} css={styles.fields}>
-						{/* Semantically fieldset is used for forms. In the future this screen will allow
-						 updates to these fields in a form */}
-						<fieldset css={styles.box}>
-							<legend css={styles.legend}>Groups</legend>
-							<Stack direction={"row"} alignItems={"center"} spacing={8}>
-								<IdpField
-									name={"Sync Field"}
-									fieldText={groupSyncSettings?.field}
-									showStatusIndicator
-								/>
-								<IdpField
-									name={"Regex Filter"}
-									fieldText={
-										typeof groupSyncSettings?.regex_filter === "string"
-											? groupSyncSettings?.regex_filter
-											: "none"
-									}
-								/>
-								<IdpField
-									name={"Auto Create"}
-									fieldText={String(
-										groupSyncSettings?.auto_create_missing_groups || "n/a",
-									)}
-								/>
-							</Stack>
-						</fieldset>
-						<fieldset css={styles.box}>
-							<legend css={styles.legend}>Roles</legend>
-							<Stack direction={"row"} alignItems={"center"} spacing={3}>
-								<IdpField
-									name={"Sync Field"}
-									fieldText={roleSyncSettings?.field}
-									showStatusIndicator
-								/>
-							</Stack>
-						</fieldset>
-					</Stack>
-					{groupSyncSettings?.mapping && roleSyncSettings?.mapping && (
-						<div
-							css={(theme) => ({
-								margin: 0,
-								fontSize: 13,
-								paddingBottom: 14,
-								color: theme.palette.text.secondary,
-								"& strong": {
-									color: theme.palette.text.primary,
-								},
-							})}
+					<>
+						<Tabs
+							active={tab}
+							css={{
+								marginBottom: 24,
+							}}
 						>
-							Showing{" "}
-							<strong>
-								{Object.entries(groupSyncSettings?.mapping).length}
-							</strong>{" "}
-							groups and{" "}
-							<strong>
-								{Object.entries(roleSyncSettings?.mapping).length}
-							</strong>{" "}
-							provisioners
-						</div>
-					)}
-					<Stack spacing={6}>
-						<IdpMappingTable
-							type="Group"
-							isEmpty={Boolean(
-								!groupSyncSettings?.mapping ||
-									Object.entries(groupSyncSettings?.mapping).length === 0,
-							)}
-						>
-							{groupSyncSettings?.mapping &&
-								Object.entries(groupSyncSettings.mapping)
-									.sort()
-									.map(([idpGroup, groups]) => (
-										<GroupRow
-											key={idpGroup}
-											idpGroup={idpGroup}
-											coderGroup={getGroupNames(groups)}
+							<TabsList>
+								<TabLink to="?tab=groups" value="groups">
+									Group Sync Settings
+								</TabLink>
+								<TabLink to="?tab=roles" value="roles">
+									Role Sync Settings
+								</TabLink>
+							</TabsList>
+						</Tabs>
+						{tab === "groups" ? (
+							<>
+								<div css={styles.fields}>
+									<Stack direction={"row"} alignItems={"center"} spacing={6}>
+										<IdpField
+											name={"Sync Field"}
+											fieldText={groupSyncSettings?.field}
+											showStatusIndicator
 										/>
-									))}
-						</IdpMappingTable>
-						<IdpMappingTable
-							type="Role"
-							isEmpty={Boolean(
-								!roleSyncSettings?.mapping ||
-									Object.entries(roleSyncSettings?.mapping).length === 0,
-							)}
-						>
-							{roleSyncSettings?.mapping &&
-								Object.entries(roleSyncSettings.mapping)
-									.sort()
-									.map(([idpRole, roles]) => (
-										<RoleRow
-											key={idpRole}
-											idpRole={idpRole}
-											coderRoles={roles}
+										<IdpField
+											name={"Regex Filter"}
+											fieldText={
+												typeof groupSyncSettings?.regex_filter === "string"
+													? groupSyncSettings?.regex_filter
+													: "none"
+											}
 										/>
-									))}
-						</IdpMappingTable>
-					</Stack>
+										<IdpField
+											name={"Auto Create"}
+											fieldText={String(
+												groupSyncSettings?.auto_create_missing_groups || "n/a",
+											)}
+										/>
+									</Stack>
+								</div>
+								<Stack
+									direction="row"
+									alignItems="baseline"
+									justifyContent="space-between"
+									css={styles.tableInfo}
+								>
+									<TableRowCount count={groupMappingCount} type="groups" />
+									<Button
+										component="a"
+										startIcon={<AddIcon />}
+										// to="export"
+										href={docs("/admin/auth#group-sync-enterprise")}
+									>
+										Export Policy
+									</Button>
+								</Stack>
+								<Stack spacing={6}>
+									<IdpMappingTable
+										type="Group"
+										isEmpty={Boolean(groupMappingCount === 0)}
+									>
+										{groupSyncSettings?.mapping &&
+											Object.entries(groupSyncSettings.mapping)
+												.sort()
+												.map(([idpGroup, groups]) => (
+													<GroupRow
+														key={idpGroup}
+														idpGroup={idpGroup}
+														coderGroup={getGroupNames(groups)}
+													/>
+												))}
+									</IdpMappingTable>
+								</Stack>
+							</>
+						) : (
+							<>
+								<div css={styles.fields}>
+									<IdpField
+										name={"Sync Field"}
+										fieldText={roleSyncSettings?.field}
+										showStatusIndicator
+									/>
+								</div>
+								<Stack
+									direction="row"
+									alignItems="baseline"
+									justifyContent="space-between"
+									css={styles.tableInfo}
+								>
+									<TableRowCount count={roleMappingCount} type="roles" />
+									<Button
+										component="a"
+										startIcon={<AddIcon />}
+										// to="export"
+										href={docs("/admin/auth#group-sync-enterprise")}
+									>
+										Export Policy
+									</Button>
+								</Stack>
+								<IdpMappingTable
+									type="Role"
+									isEmpty={Boolean(roleMappingCount === 0)}
+								>
+									{roleSyncSettings?.mapping &&
+										Object.entries(roleSyncSettings.mapping)
+											.sort()
+											.map(([idpRole, roles]) => (
+												<RoleRow
+													key={idpRole}
+													idpRole={idpRole}
+													coderRoles={roles}
+												/>
+											))}
+								</IdpMappingTable>
+							</>
+						)}
+					</>
 				</Cond>
 			</ChooseOne>
 		</>
@@ -178,24 +210,47 @@ const IdpField: FC<IdpFieldProps> = ({
 }) => {
 	return (
 		<span css={{ display: "flex", alignItems: "center", gap: "16px" }}>
-			<h4>{name}</h4>
-			<p css={styles.field}>
-				{fieldText ||
-					(showStatusIndicator && (
-						<div
-							css={{
-								display: "flex",
-								alignItems: "center",
-								gap: "8px",
-								height: 0,
-							}}
-						>
-							<StatusIndicator color="error" />
-							<p>disabled</p>
-						</div>
-					))}
-			</p>
+			<p>{name}</p>
+			{fieldText ? (
+				<p css={styles.fieldText}>{fieldText}</p>
+			) : (
+				showStatusIndicator && (
+					<div
+						css={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							height: 0,
+						}}
+					>
+						<StatusIndicator color="error" />
+						<p>disabled</p>
+					</div>
+				)
+			)}
 		</span>
+	);
+};
+
+interface TableRowCountProps {
+	count: number;
+	type: string;
+}
+
+const TableRowCount: FC<TableRowCountProps> = ({ count, type }) => {
+	return (
+		<div
+			css={(theme) => ({
+				margin: 0,
+				fontSize: 13,
+				color: theme.palette.text.secondary,
+				"& strong": {
+					color: theme.palette.text.primary,
+				},
+			})}
+		>
+			Showing <strong>{count}</strong> {type}
+		</div>
 	);
 };
 
@@ -237,7 +292,9 @@ const IdpMappingTable: FC<IdpMappingTableProps> = ({
 											<Button
 												startIcon={<LaunchOutlined />}
 												component="a"
-												href={docs("/admin/auth#group-sync-enterprise")}
+												href={docs(
+													`/admin/auth#${type.toLowerCase()}-sync-enterprise`,
+												)}
 												target="_blank"
 											>
 												How to setup IdP {type} sync
@@ -307,22 +364,16 @@ const TableLoader = () => {
 };
 
 const styles = {
-	field: (theme) => ({
+	fieldText: (theme) => ({
 		color: theme.palette.text.secondary,
 		fontFamily: MONOSPACE_FONT_FAMILY,
 	}),
 	fields: () => ({
-		marginBottom: "60px",
+		marginBottom: 20,
+		marginLeft: 16,
 	}),
-	legend: () => ({
-		padding: "0px 6px",
-		fontWeight: 600,
-	}),
-	box: (theme) => ({
-		border: "1px solid",
-		borderColor: theme.palette.divider,
-		padding: "0px 20px",
-		borderRadius: 8,
+	tableInfo: () => ({
+		marginBottom: 16,
 	}),
 } satisfies Record<string, Interpolation<Theme>>;
 

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/IdpSyncPageView.tsx
@@ -1,5 +1,4 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import AddIcon from "@mui/icons-material/AddOutlined";
 import LaunchOutlined from "@mui/icons-material/LaunchOutlined";
 import Button from "@mui/material/Button";
 import Skeleton from "@mui/material/Skeleton";
@@ -12,6 +11,7 @@ import TableRow from "@mui/material/TableRow";
 import type {
 	Group,
 	GroupSyncSettings,
+	Organization,
 	RoleSyncSettings,
 } from "api/typesGenerated";
 import { ChooseOne, Cond } from "components/Conditionals/ChooseOne";
@@ -28,18 +28,21 @@ import type { FC } from "react";
 import { useSearchParams } from "react-router-dom";
 import { MONOSPACE_FONT_FAMILY } from "theme/constants";
 import { docs } from "utils/docs";
+import { ExportPolicyButton } from "./ExportPolicyButton";
 import { PillList } from "./PillList";
 
-export type IdpSyncPageViewProps = {
+interface IdpSyncPageViewProps {
 	groupSyncSettings: GroupSyncSettings | undefined;
 	roleSyncSettings: RoleSyncSettings | undefined;
 	groups: Group[] | undefined;
-};
+	organization: Organization;
+}
 
 export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 	groupSyncSettings,
 	roleSyncSettings,
 	groups,
+	organization,
 }) => {
 	const [searchParams] = useSearchParams();
 	const groupsMap = new Map<string, string>();
@@ -62,6 +65,15 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 		? Object.entries(roleSyncSettings.mapping).length
 		: 0;
 
+	const rolePolicy =
+		roleSyncSettings?.field && roleSyncSettings.mapping
+			? JSON.stringify(roleSyncSettings, null, 2)
+			: null;
+	const groupPolicy =
+		groupSyncSettings?.field && groupSyncSettings.mapping
+			? JSON.stringify(groupSyncSettings, null, 2)
+			: null;
+
 	return (
 		<>
 			<ChooseOne>
@@ -77,7 +89,7 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 						<Tabs
 							active={tab}
 							css={{
-								marginBottom: 24,
+								marginBottom: 20,
 							}}
 						>
 							<TabsList>
@@ -121,14 +133,11 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 									css={styles.tableInfo}
 								>
 									<TableRowCount count={groupMappingCount} type="groups" />
-									<Button
-										component="a"
-										startIcon={<AddIcon />}
-										// to="export"
-										href={docs("/admin/auth#group-sync-enterprise")}
-									>
-										Export Policy
-									</Button>
+									<ExportPolicyButton
+										policy={groupPolicy}
+										organization={organization}
+										type="groups"
+									/>
 								</Stack>
 								<Stack spacing={6}>
 									<IdpMappingTable
@@ -164,14 +173,11 @@ export const IdpSyncPageView: FC<IdpSyncPageViewProps> = ({
 									css={styles.tableInfo}
 								>
 									<TableRowCount count={roleMappingCount} type="roles" />
-									<Button
-										component="a"
-										startIcon={<AddIcon />}
-										// to="export"
-										href={docs("/admin/auth#group-sync-enterprise")}
-									>
-										Export Policy
-									</Button>
+									<ExportPolicyButton
+										policy={rolePolicy}
+										organization={organization}
+										type="roles"
+									/>
 								</Stack>
 								<IdpMappingTable
 									type="Role"
@@ -210,7 +216,7 @@ const IdpField: FC<IdpFieldProps> = ({
 }) => {
 	return (
 		<span css={{ display: "flex", alignItems: "center", gap: "16px" }}>
-			<p>{name}</p>
+			<p css={styles.fieldLabel}>{name}</p>
 			{fieldText ? (
 				<p css={styles.fieldText}>{fieldText}</p>
 			) : (
@@ -365,12 +371,16 @@ const TableLoader = () => {
 
 const styles = {
 	fieldText: (theme) => ({
-		color: theme.palette.text.secondary,
 		fontFamily: MONOSPACE_FONT_FAMILY,
+		whiteSpace: "nowrap",
+	}),
+	fieldLabel: (theme) => ({
+		color: theme.palette.text.secondary,
 	}),
 	fields: () => ({
-		marginBottom: 20,
+		marginBottom: 16,
 		marginLeft: 16,
+		fontSize: 14,
 	}),
 	tableInfo: () => ({
 		marginBottom: 16,

--- a/site/src/pages/ManagementSettingsPage/IdpSyncPage/PillList.tsx
+++ b/site/src/pages/ManagementSettingsPage/IdpSyncPage/PillList.tsx
@@ -1,0 +1,91 @@
+import { type Interpolation, type Theme, useTheme } from "@emotion/react";
+import Stack from "@mui/material/Stack";
+import { Pill } from "components/Pill/Pill";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "components/Popover/Popover";
+import type { FC } from "react";
+
+interface PillListProps {
+	roles: readonly string[];
+}
+
+export const PillList: FC<PillListProps> = ({ roles }) => {
+	return (
+		<Stack direction="row" spacing={1}>
+			{roles.length > 0 ? (
+				<Pill css={styles.pill}>{roles[0]}</Pill>
+			) : (
+				<p>None</p>
+			)}
+
+			{roles.length > 1 && <OverflowPill roles={roles.slice(1)} />}
+		</Stack>
+	);
+};
+
+type OverflowPillProps = {
+	roles: string[];
+};
+
+const OverflowPill: FC<OverflowPillProps> = ({ roles }) => {
+	const theme = useTheme();
+
+	return (
+		<Popover mode="hover">
+			<PopoverTrigger>
+				<Pill
+					css={{
+						backgroundColor: theme.palette.background.paper,
+						borderColor: theme.palette.divider,
+					}}
+					data-testid="overflow-pill"
+				>
+					+{roles.length} more
+				</Pill>
+			</PopoverTrigger>
+
+			<PopoverContent
+				disableRestoreFocus
+				disableScrollLock
+				css={{
+					".MuiPaper-root": {
+						display: "flex",
+						flexFlow: "column wrap",
+						columnGap: 8,
+						rowGap: 12,
+						padding: "12px 16px",
+						alignContent: "space-around",
+						minWidth: "auto",
+						backgroundColor: theme.palette.background.default,
+					},
+				}}
+				anchorOrigin={{
+					vertical: -4,
+					horizontal: "center",
+				}}
+				transformOrigin={{
+					vertical: "bottom",
+					horizontal: "center",
+				}}
+			>
+				{roles.map((role) => (
+					<Pill key={role} css={styles.pill}>
+						{role}
+					</Pill>
+				))}
+			</PopoverContent>
+		</Popover>
+	);
+};
+
+const styles = {
+	pill: (theme) => ({
+		backgroundColor: theme.experimental.pillDefault.background,
+		borderColor: theme.experimental.pillDefault.outline,
+		color: theme.experimental.pillDefault.text,
+		width: "fit-content",
+	}),
+} satisfies Record<string, Interpolation<Theme>>;

--- a/site/src/pages/ManagementSettingsPage/SidebarView.tsx
+++ b/site/src/pages/ManagementSettingsPage/SidebarView.tsx
@@ -297,7 +297,7 @@ const OrganizationSettingsNavigation: FC<
 							Provisioners
 						</SidebarNavSubItem>
 					)}
-					{organization.permissions.editMembers && (
+					{organization.permissions.viewIdpSyncSettings && (
 						<SidebarNavSubItem
 							href={urlForSubpage(organization.name, "idp-sync")}
 						>

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -2613,6 +2613,19 @@ export const MockGroupSyncSettings: TypesGen.GroupSyncSettings = {
 	auto_create_missing_groups: false,
 };
 
+export const MockGroupSyncSettings2: TypesGen.GroupSyncSettings = {
+	field: "group-test",
+	mapping: {
+		"idp-group-1": [
+			"fbd2116a-8961-4954-87ae-e4575bd29ce0",
+			"13de3eb4-9b4f-49e7-b0f8-0c3728a0d2e3",
+		],
+		"idp-group-2": ["fbd2116a-8961-4954-87ae-e4575bd29ce2"],
+	},
+	regex_filter: "@[a-zA-Z0-9_]+",
+	auto_create_missing_groups: false,
+};
+
 export const MockRoleSyncSettings: TypesGen.RoleSyncSettings = {
 	field: "role-test",
 	mapping: {

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -451,38 +451,6 @@ export const MockAssignableSiteRoles = [
 	assignableRole(MockAuditorRole, true),
 ];
 
-export const MockOIDCConfig: TypesGen.OIDCConfig = {
-	allow_signups: true,
-	client_id: "test",
-	client_secret: "test",
-	client_key_file: "test",
-	client_cert_file: "test",
-	email_domain: [],
-	issuer_url: "test",
-	scopes: [],
-	ignore_email_verified: true,
-	username_field: "",
-	name_field: "",
-	email_field: "",
-	auth_url_params: {},
-	ignore_user_info: true,
-	organization_field: "",
-	organization_mapping: {},
-	organization_assign_default: true,
-	group_auto_create: false,
-	group_regex_filter: "^Coder-.*$",
-	group_allow_list: [],
-	groups_field: "groups",
-	group_mapping: { group1: "developers", group2: "admin", group3: "auditors" },
-	user_role_field: "roles",
-	user_role_mapping: { role1: ["role1", "role2"] },
-	user_roles_default: [],
-	sign_in_text: "",
-	icon_url: "",
-	signups_disabled_text: "string",
-	skip_issuer_checks: true,
-};
-
 export const MockMemberPermissions = {
 	viewAuditLog: false,
 };
@@ -2632,10 +2600,45 @@ export const MockWorkspaceQuota: TypesGen.WorkspaceQuota = {
 	budget: 100,
 };
 
+export const MockGroupSyncSettings: TypesGen.GroupSyncSettings = {
+	field: "group-test",
+	mapping: {
+		"idp-group-1": [
+			"fbd2116a-8961-4954-87ae-e4575bd29ce0",
+			"13de3eb4-9b4f-49e7-b0f8-0c3728a0d2e2",
+		],
+		"idp-group-2": ["fbd2116a-8961-4954-87ae-e4575bd29ce0"],
+	},
+	regex_filter: "@[a-zA-Z0-9_]+",
+	auto_create_missing_groups: false,
+};
+
+export const MockRoleSyncSettings: TypesGen.RoleSyncSettings = {
+	field: "role-test",
+	mapping: {
+		"idp-role-1": ["admin", "developer"],
+		"idp-role-2": ["auditor"],
+	},
+};
+
 export const MockGroup: TypesGen.Group = {
 	id: "fbd2116a-8961-4954-87ae-e4575bd29ce0",
 	name: "Front-End",
 	display_name: "Front-End",
+	avatar_url: "https://example.com",
+	organization_id: MockOrganization.id,
+	organization_name: MockOrganization.name,
+	organization_display_name: MockOrganization.display_name,
+	members: [MockUser, MockUser2],
+	quota_allowance: 5,
+	source: "user",
+	total_member_count: 2,
+};
+
+export const MockGroup2: TypesGen.Group = {
+	id: "13de3eb4-9b4f-49e7-b0f8-0c3728a0d2e2",
+	name: "developer",
+	display_name: "",
 	avatar_url: "https://example.com",
 	organization_id: MockOrganization.id,
 	organization_name: MockOrganization.name,


### PR DESCRIPTION
resolves #14424 

- [x] Populate the groups field, roles field, group regex filter, auto create groups boolean with data
- [x] Populate groups and role sync settings mapping tables
- [x] Display group UUID in an error state when a mapped coder group doesn't exist
- [x] Use tabs to separate groups and roles UI
- [x] Display disabled UI state for group and role sync fields when they are empty
- [x] Check for correct experiment, license and permissions
- [x] Add storybook stories for data driven UI states
- [x] Handle 'export Policy' button download behavior for groups and roles


![idp sync empty](https://github.com/user-attachments/assets/4089fe12-7cba-4aa3-81b9-ff576856f0d1)
![idp sync groups](https://github.com/user-attachments/assets/4e425f88-834f-434e-9be2-e3d31c5bba17)
