### PR TITLE
chore: consolidate on `showOrganizations` usage

### DIFF
--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -12,15 +12,14 @@ export const Navbar: FC = () => {
 	const { metadata } = useEmbeddedMetadata();
 	const buildInfoQuery = useQuery(buildInfo(metadata["build-info"]));
 
-	const { appearance, experiments } = useDashboard();
+	const { appearance, showOrganizations } = useDashboard();
 	const { user: me, permissions, signOut } = useAuthenticated();
 	const featureVisibility = useFeatureVisibility();
 	const canViewAuditLog =
 		featureVisibility.audit_log && Boolean(permissions.viewAnyAuditLog);
 	const canViewDeployment = Boolean(permissions.viewDeploymentValues);
 	const canViewOrganizations =
-		Boolean(permissions.editAnyOrganization) &&
-		experiments.includes("multi-organization");
+		Boolean(permissions.editAnyOrganization) && showOrganizations;
 	const canViewAllUsers = Boolean(permissions.viewAllUsers);
 	const proxyContextValue = useProxy();
 	const canViewHealth = canViewDeployment;

--- a/site/src/pages/CreateTemplatePage/ImportStarterTemplateView.tsx
+++ b/site/src/pages/CreateTemplatePage/ImportStarterTemplateView.tsx
@@ -27,17 +27,12 @@ export const ImportStarterTemplateView: FC<CreateTemplatePageViewProps> = ({
 	isCreating,
 }) => {
 	const navigate = useNavigate();
-	const { entitlements, experiments } = useDashboard();
-	const { multiple_organizations: organizationsEnabled } =
-		useFeatureVisibility();
+	const { entitlements, showOrganizations } = useDashboard();
 	const [searchParams] = useSearchParams();
 	const templateExamplesQuery = useQuery(templateExamples());
 	const templateExample = templateExamplesQuery.data?.find(
 		(e) => e.id === searchParams.get("exampleId")!,
 	);
-
-	const showOrganizationPicker =
-		experiments.includes("multi-organization") && organizationsEnabled;
 
 	const isLoading = templateExamplesQuery.isLoading;
 	const loadingError = templateExamplesQuery.error;
@@ -77,7 +72,7 @@ export const ImportStarterTemplateView: FC<CreateTemplatePageViewProps> = ({
 			onCancel={() => navigate(-1)}
 			jobError={isJobError ? error.job.error : undefined}
 			logs={templateVersionLogsQuery.data}
-			showOrganizationPicker={showOrganizationPicker}
+			showOrganizationPicker={showOrganizations}
 			onSubmit={async (formData) => {
 				await onCreateTemplate({
 					organization: formData.organization,

--- a/site/src/pages/CreateTemplatePage/UploadTemplateView.tsx
+++ b/site/src/pages/CreateTemplatePage/UploadTemplateView.tsx
@@ -21,13 +21,8 @@ export const UploadTemplateView: FC<CreateTemplatePageViewProps> = ({
 	error,
 }) => {
 	const navigate = useNavigate();
-	const { entitlements, experiments } = useDashboard();
-	const { multiple_organizations: organizationsEnabled } =
-		useFeatureVisibility();
+	const { entitlements, showOrganizations } = useDashboard();
 	const formPermissions = getFormPermissions(entitlements);
-
-	const showOrganizationPicker =
-		experiments.includes("multi-organization") && organizationsEnabled;
 
 	const uploadFileMutation = useMutation(uploadFile());
 	const uploadedFile = uploadFileMutation.data;
@@ -61,7 +56,7 @@ export const UploadTemplateView: FC<CreateTemplatePageViewProps> = ({
 				onRemove: uploadFileMutation.reset,
 				file: uploadFileMutation.variables,
 			}}
-			showOrganizationPicker={showOrganizationPicker}
+			showOrganizationPicker={showOrganizations}
 			onSubmit={async (formData) => {
 				await onCreateTemplate({
 					organization: formData.organization,

--- a/site/src/pages/CreateTemplatesGalleryPage/CreateTemplatesGalleryPage.tsx
+++ b/site/src/pages/CreateTemplatesGalleryPage/CreateTemplatesGalleryPage.tsx
@@ -10,20 +10,19 @@ import { CreateTemplatesPageView } from "./CreateTemplatesPageView";
 import { StarterTemplatesPageView } from "./StarterTemplatesPageView";
 
 const CreateTemplatesGalleryPage: FC = () => {
-	const { experiments } = useDashboard();
+	const { showOrganizations } = useDashboard();
 	const templateExamplesQuery = useQuery(templateExamples());
 	const starterTemplatesByTag = templateExamplesQuery.data
 		? // Currently, the scratch template should not be displayed on the starter templates page.
 			getTemplatesByTag(removeScratchExample(templateExamplesQuery.data))
 		: undefined;
-	const multiOrgExperimentEnabled = experiments.includes("multi-organization");
 
 	return (
 		<>
 			<Helmet>
 				<title>{pageTitle("Create a Template")}</title>
 			</Helmet>
-			{multiOrgExperimentEnabled ? (
+			{showOrganizations ? (
 				<CreateTemplatesPageView
 					error={templateExamplesQuery.error}
 					starterTemplatesByTag={starterTemplatesByTag}

--- a/site/src/pages/DeploySettingsPage/DeploySettingsLayout.tsx
+++ b/site/src/pages/DeploySettingsPage/DeploySettingsLayout.tsx
@@ -31,11 +31,9 @@ export const useDeploySettings = (): DeploySettingsContextValue => {
 };
 
 export const DeploySettingsLayout: FC = () => {
-	const { experiments } = useDashboard();
+	const { showOrganizations } = useDashboard();
 
-	const canViewOrganizations = experiments.includes("multi-organization");
-
-	return canViewOrganizations ? (
+	return showOrganizations ? (
 		<ManagementSettingsLayout />
 	) : (
 		<DeploySettingsLayoutInner />

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -12,7 +12,6 @@ import { TemplatesPageView } from "./TemplatesPageView";
 
 const meta: Meta<typeof TemplatesPageView> = {
 	title: "pages/TemplatesPage",
-	decorators: [withDashboardProvider],
 	parameters: { chromatic: chromaticWithTablet },
 	component: TemplatesPageView,
 	args: {

--- a/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.stories.tsx
@@ -12,6 +12,7 @@ import { TemplatesPageView } from "./TemplatesPageView";
 
 const meta: Meta<typeof TemplatesPageView> = {
 	title: "pages/TemplatesPage",
+	decorators: [withDashboardProvider],
 	parameters: { chromatic: chromaticWithTablet },
 	component: TemplatesPageView,
 	args: {

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -38,7 +38,6 @@ import {
 	TableRowSkeleton,
 } from "components/TableLoader/TableLoader";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
-import { useDashboard } from "modules/dashboard/useDashboard";
 import { linkToTemplate, useLinks } from "modules/navigation";
 import type { FC } from "react";
 import { useNavigate } from "react-router-dom";

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -193,31 +193,27 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 	examples,
 	templates,
 }) => {
-	const { experiments } = useDashboard();
 	const isLoading = !templates;
 	const isEmpty = templates && templates.length === 0;
 	const navigate = useNavigate();
-	const multiOrgExperimentEnabled = experiments.includes("multi-organization");
 
-	const createTemplateAction = () => {
-		return multiOrgExperimentEnabled ? (
-			<Button
-				startIcon={<AddIcon />}
-				variant="contained"
-				onClick={() => {
-					navigate("/starter-templates");
-				}}
-			>
-				Create Template
-			</Button>
-		) : (
-			<CreateTemplateButton onNavigate={navigate} />
-		);
-	};
+	const createTemplateAction = showOrganizations ? (
+		<Button
+			startIcon={<AddIcon />}
+			variant="contained"
+			onClick={() => {
+				navigate("/starter-templates");
+			}}
+		>
+			Create Template
+		</Button>
+	) : (
+		<CreateTemplateButton onNavigate={navigate} />
+	);
 
 	return (
 		<Margins>
-			<PageHeader actions={canCreateTemplates && createTemplateAction()}>
+			<PageHeader actions={canCreateTemplates && createTemplateAction}>
 				<PageHeaderTitle>
 					<Stack spacing={1} direction="row" alignItems="center">
 						Templates

--- a/site/src/pages/UsersPage/UsersLayout.tsx
+++ b/site/src/pages/UsersPage/UsersLayout.tsx
@@ -19,13 +19,11 @@ import {
 
 export const UsersLayout: FC = () => {
 	const { permissions } = useAuthenticated();
-	const { experiments } = useDashboard();
+	const { showOrganizations } = useDashboard();
 	const navigate = useNavigate();
 	const feats = useFeatureVisibility();
 	const location = useLocation();
 	const activeTab = location.pathname.endsWith("groups") ? "groups" : "users";
-
-	const canViewOrganizations = experiments.includes("multi-organization");
 
 	return (
 		<>
@@ -59,7 +57,7 @@ export const UsersLayout: FC = () => {
 				</PageHeader>
 			</Margins>
 
-			{!canViewOrganizations && (
+			{!showOrganizations && (
 				<Tabs
 					css={{ marginBottom: 40, marginTop: -TAB_PADDING_Y }}
 					active={activeTab}

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -40,7 +40,7 @@ const UsersPage: FC = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const searchParamsResult = useSearchParams();
-	const { entitlements, experiments } = useDashboard();
+	const { entitlements, showOrganizations } = useDashboard();
 	const [searchParams] = searchParamsResult;
 
 	const groupsByUserIdQuery = useQuery(groupsByUserId());
@@ -102,8 +102,7 @@ const UsersPage: FC = () => {
 		authMethodsQuery.isLoading ||
 		groupsByUserIdQuery.isLoading;
 
-	const canViewOrganizations = experiments.includes("multi-organization");
-	if (canViewOrganizations && location.pathname !== "/deployment/users") {
+	if (showOrganizations && location.pathname !== "/deployment/users") {
 		return <Navigate to={`/deployment/users${location.search}`} replace />;
 	}
 
@@ -160,7 +159,7 @@ const UsersPage: FC = () => {
 					menus: { status: statusMenu },
 				}}
 				usersQuery={usersQuery}
-				canViewOrganizations={canViewOrganizations}
+				canViewOrganizations={showOrganizations}
 				canCreateUser={canCreateUser}
 			/>
 


### PR DESCRIPTION
Closes #14445

Just checking for the experiment is insufficient, and the experiment will soon be removed anyway. So we should always use the `showOrganizations` condition that checks for everything else too!