### PR TITLE
feat!: add summary to `coder ping`

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -406,6 +406,12 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 		}
 	}
 
+	if d.PingP2P {
+		general = append(general, "✔ You are connected directly (p2p)")
+	} else {
+		general = append(general, fmt.Sprintf("❗ You are connected via a DERP relay, not directly (p2p)\n%s#common-problems-with-direct-connections", d.TroubleshootingURL))
+	}
+
 	if d.PingP2P && !d.Verbose {
 		return general, client, agent
 	}
@@ -458,5 +464,6 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 		agent = append(agent,
 			fmt.Sprintf("Agent IP address is within an AWS range (AWS uses hard NAT)\n   %s#endpoint-dependent-nat-hard-nat", d.TroubleshootingURL))
 	}
+
 	return general, client, agent
 }

--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -406,12 +406,6 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 		}
 	}
 
-	if d.PingP2P {
-		general = append(general, "✔ You are connected directly (p2p)")
-	} else {
-		general = append(general, fmt.Sprintf("❗ You are connected via a DERP relay, not directly (p2p)\n%s#common-problems-with-direct-connections", d.TroubleshootingURL))
-	}
-
 	if d.PingP2P && !d.Verbose {
 		return general, client, agent
 	}

--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -370,6 +370,9 @@ func (d ConnDiags) Write(w io.Writer) {
 	for _, msg := range general {
 		_, _ = fmt.Fprintln(w, msg)
 	}
+	if len(general) > 0 {
+		_, _ = fmt.Fprintln(w, "")
+	}
 	if len(client) > 0 {
 		_, _ = fmt.Fprint(w, "Possible client-side issues with direct connection:\n\n")
 		for _, msg := range client {
@@ -385,12 +388,6 @@ func (d ConnDiags) Write(w io.Writer) {
 }
 
 func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
-	if d.PingP2P {
-		general = append(general, "✔ You are connected directly (p2p)")
-	} else {
-		general = append(general, "❗ You are connected via a DERP relay, not directly (p2p)")
-	}
-
 	if d.AgentNetcheck != nil {
 		for _, msg := range d.AgentNetcheck.Interfaces.Warnings {
 			agent = append(agent, msg.Message)

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -684,19 +684,6 @@ func TestConnDiagnostics(t *testing.T) {
 		want  []string
 	}{
 		{
-			name: "Direct",
-			diags: cliui.ConnDiags{
-				ConnInfo: workspacesdk.AgentConnectionInfo{
-					DERPMap: &tailcfg.DERPMap{},
-				},
-				PingP2P:      true,
-				LocalNetInfo: &tailcfg.NetInfo{},
-			},
-			want: []string{
-				`✔ You are connected directly (p2p)`,
-			},
-		},
-		{
 			name: "DirectBlocked",
 			diags: cliui.ConnDiags{
 				ConnInfo: workspacesdk.AgentConnectionInfo{
@@ -705,7 +692,6 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`❗ Your Coder administrator has blocked direct connections`,
 			},
 		},
@@ -718,7 +704,6 @@ func TestConnDiagnostics(t *testing.T) {
 				LocalNetInfo: &tailcfg.NetInfo{},
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`The DERP map is not configured to use STUN`,
 			},
 		},
@@ -743,7 +728,6 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`Client could not connect to STUN over UDP`,
 			},
 		},
@@ -770,7 +754,6 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`Agent could not connect to STUN over UDP`,
 			},
 		},
@@ -785,7 +768,6 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`Client is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers`,
 			},
 		},
@@ -795,14 +777,12 @@ func TestConnDiagnostics(t *testing.T) {
 				ConnInfo: workspacesdk.AgentConnectionInfo{
 					DERPMap: &tailcfg.DERPMap{},
 				},
-				PingP2P:      false,
 				LocalNetInfo: &tailcfg.NetInfo{},
 				AgentNetcheck: &healthsdk.AgentNetcheckReport{
 					NetInfo: &tailcfg.NetInfo{MappingVariesByDestIP: "true"},
 				},
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`Agent is potentially behind a hard NAT, as multiple endpoints were retrieved from different STUN servers`,
 			},
 		},
@@ -812,7 +792,6 @@ func TestConnDiagnostics(t *testing.T) {
 				ConnInfo: workspacesdk.AgentConnectionInfo{
 					DERPMap: &tailcfg.DERPMap{},
 				},
-				PingP2P: true,
 				AgentNetcheck: &healthsdk.AgentNetcheckReport{
 					Interfaces: healthsdk.InterfacesReport{
 						BaseReport: healthsdk.BaseReport{
@@ -824,7 +803,6 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`✔ You are connected directly (p2p)`,
 				`Network interface eth0 has MTU 1280, (less than 1378), which may degrade the quality of direct connections`,
 			},
 		},
@@ -834,7 +812,6 @@ func TestConnDiagnostics(t *testing.T) {
 				ConnInfo: workspacesdk.AgentConnectionInfo{
 					DERPMap: &tailcfg.DERPMap{},
 				},
-				PingP2P: true,
 				LocalInterfaces: &healthsdk.InterfacesReport{
 					BaseReport: healthsdk.BaseReport{
 						Warnings: []health.Message{
@@ -844,7 +821,6 @@ func TestConnDiagnostics(t *testing.T) {
 				},
 			},
 			want: []string{
-				`✔ You are connected directly (p2p)`,
 				`Network interface eth1 has MTU 1310, (less than 1378), which may degrade the quality of direct connections`,
 			},
 		},
@@ -858,7 +834,6 @@ func TestConnDiagnostics(t *testing.T) {
 				AgentIPIsAWS:  false,
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`Client IP address is within an AWS range (AWS uses hard NAT)`,
 			},
 		},
@@ -872,7 +847,6 @@ func TestConnDiagnostics(t *testing.T) {
 				AgentIPIsAWS:  true,
 			},
 			want: []string{
-				`❗ You are connected via a DERP relay, not directly (p2p)`,
 				`Agent IP address is within an AWS range (AWS uses hard NAT)`,
 			},
 		},

--- a/cli/cliui/table.go
+++ b/cli/cliui/table.go
@@ -199,6 +199,10 @@ func renderTable(out any, sort string, headers table.Row, filterColumns []string
 				if val != nil {
 					v = *val
 				}
+			case *time.Duration:
+				if val != nil {
+					v = val.String()
+				}
 			case fmt.Stringer:
 				if val != nil {
 					v = val.String()

--- a/cli/ping_internal_test.go
+++ b/cli/ping_internal_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"tailscale.com/ipn/ipnstate"
+
+	"github.com/coder/coder/v2/coderd/util/ptr"
+)
+
+func TestBuildSummary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Ok", func(t *testing.T) {
+		t.Parallel()
+		input := []*ipnstate.PingResult{
+			{
+				Err:            "",
+				LatencySeconds: 0.1,
+			},
+			{
+				Err:            "",
+				LatencySeconds: 0.2,
+			},
+			{
+				Err:            "",
+				LatencySeconds: 0.3,
+			},
+			{
+				Err:            "ping error",
+				LatencySeconds: 0.4,
+			},
+		}
+
+		expected := &pingSummary{
+			Workspace:  "test",
+			Total:      4,
+			Successful: 3,
+			Min:        ptr.Ref(time.Duration(0.1 * float64(time.Second))),
+			Avg:        ptr.Ref(time.Duration(0.2 * float64(time.Second))),
+			Max:        ptr.Ref(time.Duration(0.3 * float64(time.Second))),
+			StdDev:     ptr.Ref(time.Duration(0.081649658 * float64(time.Second))),
+		}
+
+		actual := buildSummary("test", input)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("NoLatency", func(t *testing.T) {
+		t.Parallel()
+		input := []*ipnstate.PingResult{
+			{
+				Err: "ping error",
+			},
+			{
+				Err:            "ping error",
+				LatencySeconds: 0.2,
+			},
+		}
+
+		expected := &pingSummary{
+			Workspace:  "test",
+			Total:      2,
+			Successful: 0,
+			Min:        nil,
+			Avg:        nil,
+			Max:        nil,
+			StdDev:     nil,
+		}
+
+		actual := buildSummary("test", input)
+		require.Equal(t, expected, actual)
+	})
+}

--- a/cli/ping_internal_test.go
+++ b/cli/ping_internal_test.go
@@ -33,11 +33,13 @@ func TestBuildSummary(t *testing.T) {
 			},
 		}
 
-		actual := pingSummary{}
+		actual := pingSummary{
+			Workspace: "test",
+		}
 		for _, r := range input {
 			actual.addResult(r)
 		}
-		actual.Write("test", io.Discard)
+		actual.Write(io.Discard)
 		require.Equal(t, time.Duration(0.1*float64(time.Second)), *actual.Min)
 		require.Equal(t, time.Duration(0.2*float64(time.Second)), *actual.Avg)
 		require.Equal(t, time.Duration(0.3*float64(time.Second)), *actual.Max)
@@ -53,11 +55,13 @@ func TestBuildSummary(t *testing.T) {
 			},
 		}
 
-		actual := &pingSummary{}
+		actual := &pingSummary{
+			Workspace: "test",
+		}
 		for _, r := range input {
 			actual.addResult(r)
 		}
-		actual.Write("test", io.Discard)
+		actual.Write(io.Discard)
 		require.Equal(t, actual.Successful, 1)
 		require.Equal(t, time.Duration(0.2*float64(time.Second)), *actual.Min)
 		require.Equal(t, time.Duration(0.2*float64(time.Second)), *actual.Avg)
@@ -90,11 +94,13 @@ func TestBuildSummary(t *testing.T) {
 			m2:         0,
 		}
 
-		actual := &pingSummary{}
+		actual := &pingSummary{
+			Workspace: "test",
+		}
 		for _, r := range input {
 			actual.addResult(r)
 		}
-		actual.Write("test", io.Discard)
+		actual.Write(io.Discard)
 		require.Equal(t, expected, actual)
 	})
 }

--- a/cli/ping_test.go
+++ b/cli/ping_test.go
@@ -65,8 +65,8 @@ func TestPing(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		pty.ExpectMatch("pong from " + workspace.Name)
 		pty.ExpectMatch("✔ received remote agent data from Coder networking coordinator")
+		pty.ExpectMatch("pong from " + workspace.Name)
 		pty.ExpectMatch("You are connected")
 		cancel()
 		<-cmdDone

--- a/cli/ping_test.go
+++ b/cli/ping_test.go
@@ -66,8 +66,8 @@ func TestPing(t *testing.T) {
 		})
 
 		pty.ExpectMatch("✔ received remote agent data from Coder networking coordinator")
-		pty.ExpectMatch("pong from " + workspace.Name)
 		pty.ExpectMatch("You are connected")
+		pty.ExpectMatch("pong from " + workspace.Name)
 		cancel()
 		<-cmdDone
 	})

--- a/cli/ping_test.go
+++ b/cli/ping_test.go
@@ -65,8 +65,6 @@ func TestPing(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		pty.ExpectMatch("✔ received remote agent data from Coder networking coordinator")
-		pty.ExpectMatch("You are connected")
 		pty.ExpectMatch("pong from " + workspace.Name)
 		cancel()
 		<-cmdDone

--- a/cli/testdata/coder_ping_--help.golden
+++ b/cli/testdata/coder_ping_--help.golden
@@ -6,8 +6,9 @@ USAGE:
   Ping a workspace
 
 OPTIONS:
-  -n, --num int (default: 10)
-          Specifies the number of pings to perform.
+  -n, --num int
+          Specifies the number of pings to perform. By default, pings will
+          continue until interrupted.
 
   -t, --timeout duration (default: 5s)
           Specifies how long to wait for a ping to complete.

--- a/docs/reference/cli/ping.md
+++ b/docs/reference/cli/ping.md
@@ -32,9 +32,8 @@ Specifies how long to wait for a ping to complete.
 
 ### -n, --num
 
-|         |                  |
-| ------- | ---------------- |
-| Type    | <code>int</code> |
-| Default | <code>10</code>  |
+|      |                  |
+| ---- | ---------------- |
+| Type | <code>int</code> |
 
-Specifies the number of pings to perform.
+Specifies the number of pings to perform. By default, pings will continue until interrupted.


### PR DESCRIPTION
Closes #14752.


This is a breaking change, as the default behavior of `coder ping` is now to ping indefinitely, until an interrupt is detected (alike many other ping commands, e.g. `iputils ping`). Previously, `coder ping` performed 10 pings by default. The `-n` argument can still be used to perform a fixed number of pings.

All diagnostics are also now written to `stderr`, instead of `stdout`.

New format with diagnostics included:
```
$ coder ping dev
✔ preferred DERP region: 10015 (Australia Fly.io (Sydney))
✔ sent local data to Coder networking coordinator
✔ received remote agent data from Coder networking coordinator
    preferred DERP region: 999 (Council Bluffs, Iowa)
    endpoints: xxx.xx.xxx.xxx:13337, xxx.xx.x.x:13337, xxx.xx.x.x:13337
✔ Wireguard handshake 0s ago

❗ The DERP map is not configured to use STUN
   https://coder.com/docs/@v2.15.0/networking/troubleshooting#no-stun-servers

Possible client-side issues with direct connection:

 - Client IP address is within an AWS range (AWS uses hard NAT)
   https://coder.com/docs/@v2.15.0/networking/troubleshooting#endpoint-dependent-nat-hard-nat

Possible agent-side issues with direct connections:

 - Agent IP address is within an AWS range (AWS uses hard NAT)
   https://coder.com/docs/@v2.15.0/networking/troubleshooting#endpoint-dependent-nat-hard-nat

pong from dev proxied via DERP(Council Bluffs, Iowa) in 209ms
pong from dev proxied via DERP(Council Bluffs, Iowa) in 209ms
pong from dev proxied via DERP(Council Bluffs, Iowa) in 208ms
pong from dev proxied via DERP(Council Bluffs, Iowa) in 209ms
pong from dev proxied via DERP(Council Bluffs, Iowa) in 209ms
<SIGINT>
❗ You are connected via a DERP relay, not directly (p2p)
https://coder.com/docs/@v2.15.0/networking/troubleshooting#common-problems-with-direct-connections
--------------------------------------------------------------------------------
WORKSPACE  TOTAL  SUCCESSFUL  MIN           AVG          MAX           STDDEV    
dev            5           5  208.407931ms  208.49958ms  208.544751ms  47.328µs  
```

(These links will be broken until the next release, as the troubleshooting page wasn't included in `v2.15.0`)