### PR TITLE
feat: add cache abstraction for fetching signing keys

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9848,6 +9848,41 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.CryptoKey": {
+            "type": "object",
+            "properties": {
+                "deletes_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "feature": {
+                    "$ref": "#/definitions/codersdk.CryptoKeyFeature"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "sequence": {
+                    "type": "integer"
+                },
+                "starts_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.CryptoKeyFeature": {
+            "type": "string",
+            "enum": [
+                "workspace_apps",
+                "oidc_convert",
+                "tailnet_resume"
+            ],
+            "x-enum-varnames": [
+                "CryptoKeyFeatureWorkspaceApp",
+                "CryptoKeyFeatureOIDCConvert",
+                "CryptoKeyFeatureTailnetResume"
+            ]
+        },
         "codersdk.CustomRoleRequest": {
             "type": "object",
             "properties": {
@@ -15983,46 +16018,13 @@ const docTemplate = `{
                 }
             }
         },
-        "wsproxysdk.CryptoKey": {
-            "type": "object",
-            "properties": {
-                "deletes_at": {
-                    "type": "string"
-                },
-                "feature": {
-                    "$ref": "#/definitions/wsproxysdk.CryptoKeyFeature"
-                },
-                "secret": {
-                    "type": "string"
-                },
-                "sequence": {
-                    "type": "integer"
-                },
-                "starts_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "wsproxysdk.CryptoKeyFeature": {
-            "type": "string",
-            "enum": [
-                "workspace_apps",
-                "oidc_convert",
-                "tailnet_resume"
-            ],
-            "x-enum-varnames": [
-                "CryptoKeyFeatureWorkspaceApp",
-                "CryptoKeyFeatureOIDCConvert",
-                "CryptoKeyFeatureTailnetResume"
-            ]
-        },
         "wsproxysdk.CryptoKeysResponse": {
             "type": "object",
             "properties": {
                 "crypto_keys": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/wsproxysdk.CryptoKey"
+                        "$ref": "#/definitions/codersdk.CryptoKey"
                     }
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8768,6 +8768,37 @@
 				}
 			}
 		},
+		"codersdk.CryptoKey": {
+			"type": "object",
+			"properties": {
+				"deletes_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"feature": {
+					"$ref": "#/definitions/codersdk.CryptoKeyFeature"
+				},
+				"secret": {
+					"type": "string"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"starts_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.CryptoKeyFeature": {
+			"type": "string",
+			"enum": ["workspace_apps", "oidc_convert", "tailnet_resume"],
+			"x-enum-varnames": [
+				"CryptoKeyFeatureWorkspaceApp",
+				"CryptoKeyFeatureOIDCConvert",
+				"CryptoKeyFeatureTailnetResume"
+			]
+		},
 		"codersdk.CustomRoleRequest": {
 			"type": "object",
 			"properties": {
@@ -14614,42 +14645,13 @@
 				}
 			}
 		},
-		"wsproxysdk.CryptoKey": {
-			"type": "object",
-			"properties": {
-				"deletes_at": {
-					"type": "string"
-				},
-				"feature": {
-					"$ref": "#/definitions/wsproxysdk.CryptoKeyFeature"
-				},
-				"secret": {
-					"type": "string"
-				},
-				"sequence": {
-					"type": "integer"
-				},
-				"starts_at": {
-					"type": "string"
-				}
-			}
-		},
-		"wsproxysdk.CryptoKeyFeature": {
-			"type": "string",
-			"enum": ["workspace_apps", "oidc_convert", "tailnet_resume"],
-			"x-enum-varnames": [
-				"CryptoKeyFeatureWorkspaceApp",
-				"CryptoKeyFeatureOIDCConvert",
-				"CryptoKeyFeatureTailnetResume"
-			]
-		},
 		"wsproxysdk.CryptoKeysResponse": {
 			"type": "object",
 			"properties": {
 				"crypto_keys": {
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/wsproxysdk.CryptoKey"
+						"$ref": "#/definitions/codersdk.CryptoKey"
 					}
 				}
 			}

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -183,5 +183,7 @@ func (d *DBCache) newTimer() *quartz.Timer {
 }
 
 func (d *DBCache) Close() {
+	d.keysMu.Lock()
+	defer d.keysMu.Unlock()
 	d.timer.Stop()
 }

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -113,14 +113,14 @@ func (d *DBCache) Latest(ctx context.Context) (codersdk.CryptoKey, error) {
 
 	now := d.clock.Now().UTC()
 	if latest.CanSign(now) {
-		return checkKey(latest, now)
+		return db2sdk.CryptoKey(latest), nil
 	}
 
 	d.cacheMu.Lock()
 	defer d.cacheMu.Unlock()
 
 	if latest.CanSign(now) {
-		return checkKey(latest, now)
+		return db2sdk.CryptoKey(latest), nil
 	}
 
 	// Refetch all keys for this feature so we can find the latest valid key.
@@ -139,7 +139,7 @@ func (d *DBCache) Latest(ctx context.Context) (codersdk.CryptoKey, error) {
 
 	d.cache, d.latestKey = cache, latest
 
-	return checkKey(latest, now)
+	return db2sdk.CryptoKey(latest), nil
 }
 
 func (d *DBCache) refresh(ctx context.Context) {

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -157,8 +157,7 @@ func (d *DBCache) fetch(ctx context.Context) error {
 	}
 
 	now := d.clock.Now()
-	d.timer.Stop()
-	d.timer = d.newTimer()
+	_ = d.timer.Reset(time.Minute * 10)
 	d.invalidateAt = now.Add(time.Minute * 10)
 
 	cache := make(map[int32]database.CryptoKey)

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -78,7 +78,7 @@ func (d *DBCache) Verifying(ctx context.Context, sequence int32) (codersdk.Crypt
 
 	cache, latest, err := d.fetch(ctx)
 	if err != nil {
-		return codersdk.CryptoKey{}, xerrors.Errorf("new cache: %w", err)
+		return codersdk.CryptoKey{}, xerrors.Errorf("fetch: %w", err)
 	}
 	d.keys, d.latestKey = cache, latest
 

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -68,10 +68,7 @@ func (d *DBCache) Version(ctx context.Context, sequence int32) (codersdk.CryptoK
 	key, ok := d.cache[sequence]
 	d.cacheMu.RUnlock()
 	if ok {
-		if !key.CanVerify(now) {
-			return codersdk.CryptoKey{}, ErrKeyInvalid
-		}
-		return db2sdk.CryptoKey(key), nil
+		return checkKey(key, now)
 	}
 
 	d.cacheMu.Lock()
@@ -79,7 +76,7 @@ func (d *DBCache) Version(ctx context.Context, sequence int32) (codersdk.CryptoK
 
 	key, ok = d.cache[sequence]
 	if ok {
-		return db2sdk.CryptoKey(key), nil
+		return checkKey(key, now)
 	}
 
 	key, err := d.db.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -81,6 +81,10 @@ func (d *DBCache) Verifying(ctx context.Context, sequence int32) (codersdk.Crypt
 	d.keysMu.Lock()
 	defer d.keysMu.Unlock()
 
+	if d.closed {
+		return codersdk.CryptoKey{}, ErrClosed
+	}
+
 	key, ok = d.keys[sequence]
 	if ok {
 		return checkKey(key, now)
@@ -119,6 +123,10 @@ func (d *DBCache) Signing(ctx context.Context) (codersdk.CryptoKey, error) {
 
 	d.keysMu.Lock()
 	defer d.keysMu.Unlock()
+
+	if d.closed {
+		return codersdk.CryptoKey{}, ErrClosed
+	}
 
 	if d.latestKey.CanSign(now) {
 		return db2sdk.CryptoKey(d.latestKey), nil

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -189,10 +189,6 @@ func checkKey(key database.CryptoKey, now time.Time) (codersdk.CryptoKey, error)
 	return db2sdk.CryptoKey(key), nil
 }
 
-func (d *DBCache) newTimer() *quartz.Timer {
-	return d.clock.AfterFunc(time.Minute*10, d.clear)
-}
-
 func (d *DBCache) Close() {
 	d.keysMu.Lock()
 	defer d.keysMu.Unlock()

--- a/coderd/cryptokeys/dbkeycache.go
+++ b/coderd/cryptokeys/dbkeycache.go
@@ -1,0 +1,175 @@
+package cryptokeys
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/quartz"
+)
+
+// DBKeyCache implements KeyCache for callers with access to the database.
+type DBKeyCache struct {
+	Clock   quartz.Clock
+	db      database.Store
+	feature database.CryptoKeyFeature
+	logger  slog.Logger
+
+	// The following are initialized by NewDBKeyCache.
+	cacheMu   sync.RWMutex
+	cache     map[int32]database.CryptoKey
+	latestKey database.CryptoKey
+}
+
+// NewDBKeyCache creates a new DBKeyCache. It starts a background
+// process that periodically refreshes the cache. The context should
+// be canceled to stop the background process.
+func NewDBKeyCache(ctx context.Context, logger slog.Logger, db database.Store, feature database.CryptoKeyFeature, opts ...func(*DBKeyCache)) (*DBKeyCache, error) {
+	d := &DBKeyCache{
+		db:      db,
+		feature: feature,
+		Clock:   quartz.NewReal(),
+		logger:  logger,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	cache, latest, err := d.newCache(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("new cache: %w", err)
+	}
+	d.cache, d.latestKey = cache, latest
+
+	go d.refresh(ctx)
+	return d, nil
+}
+
+// Version returns the CryptoKey with the given sequence number, provided that
+// it is not deleted or has breached its deletion date.
+func (d *DBKeyCache) Version(ctx context.Context, sequence int32) (database.CryptoKey, error) {
+	now := d.Clock.Now().UTC()
+	d.cacheMu.RLock()
+	key, ok := d.cache[sequence]
+	d.cacheMu.RUnlock()
+	if ok {
+		if key.IsInvalid(now) {
+			return database.CryptoKey{}, ErrKeyNotFound
+		}
+		return key, nil
+	}
+
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+
+	key, ok = d.cache[sequence]
+	if ok {
+		return key, nil
+	}
+
+	key, err := d.db.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+		Feature:  d.feature,
+		Sequence: sequence,
+	})
+	if xerrors.Is(err, sql.ErrNoRows) {
+		return database.CryptoKey{}, ErrKeyNotFound
+	}
+	if err != nil {
+		return database.CryptoKey{}, err
+	}
+
+	if key.IsInvalid(now) {
+		return database.CryptoKey{}, ErrKeyInvalid
+	}
+
+	if key.IsActive(now) && key.Sequence > d.latestKey.Sequence {
+		d.latestKey = key
+	}
+
+	d.cache[sequence] = key
+
+	return key, nil
+}
+
+func (d *DBKeyCache) Latest(ctx context.Context) (database.CryptoKey, error) {
+	d.cacheMu.RLock()
+	latest := d.latestKey
+	d.cacheMu.RUnlock()
+
+	now := d.Clock.Now().UTC()
+	if latest.IsActive(now) {
+		return latest, nil
+	}
+
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+
+	if latest.IsActive(now) {
+		return latest, nil
+	}
+
+	cache, latest, err := d.newCache(ctx)
+	if err != nil {
+		return database.CryptoKey{}, xerrors.Errorf("new cache: %w", err)
+	}
+
+	if len(cache) == 0 {
+		return database.CryptoKey{}, ErrKeyNotFound
+	}
+
+	if !latest.IsActive(now) {
+		return database.CryptoKey{}, ErrKeyInvalid
+	}
+
+	d.cache, d.latestKey = cache, latest
+
+	return d.latestKey, nil
+}
+
+func (d *DBKeyCache) refresh(ctx context.Context) {
+	d.Clock.TickerFunc(ctx, time.Minute*10, func() error {
+		cache, latest, err := d.newCache(ctx)
+		if err != nil {
+			d.logger.Error(ctx, "failed to refresh cache", slog.Error(err))
+			return nil
+		}
+		d.cacheMu.Lock()
+		defer d.cacheMu.Unlock()
+
+		d.cache, d.latestKey = cache, latest
+		return nil
+	})
+}
+
+func (d *DBKeyCache) newCache(ctx context.Context) (map[int32]database.CryptoKey, database.CryptoKey, error) {
+	now := d.Clock.Now().UTC()
+	keys, err := d.db.GetCryptoKeysByFeature(ctx, d.feature)
+	if err != nil {
+		return nil, database.CryptoKey{}, xerrors.Errorf("get crypto keys by feature: %w", err)
+	}
+	cache := toMap(keys)
+	var latest database.CryptoKey
+	// Keys are returned in order from highest sequence to lowest.
+	for _, key := range keys {
+		if !key.IsActive(now) {
+			continue
+		}
+		latest = key
+		break
+	}
+
+	return cache, latest, nil
+}
+
+func toMap(keys []database.CryptoKey) map[int32]database.CryptoKey {
+	m := make(map[int32]database.CryptoKey)
+	for _, key := range keys {
+		m[key.Sequence] = key
+	}
+	return m
+}

--- a/coderd/cryptokeys/dbkeycache_internal_test.go
+++ b/coderd/cryptokeys/dbkeycache_internal_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"cdr.dev/slog/sloggers/slogtest"
+
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -15,7 +17,7 @@ import (
 	"github.com/coder/quartz"
 )
 
-func Test_Version(t *testing.T) {
+func Test_Verifying(t *testing.T) {
 	t.Parallel()
 
 	t.Run("HitsCache", func(t *testing.T) {
@@ -44,11 +46,11 @@ func Test_Version(t *testing.T) {
 		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
-			cache:   cache,
+			keys:    cache,
 			clock:   clock,
 		}
 
-		got, err := k.Version(ctx, 32)
+		got, err := k.Verifying(ctx, 32)
 		require.NoError(t, err)
 		require.Equal(t, db2sdk.CryptoKey(expectedKey), got)
 	})
@@ -61,31 +63,24 @@ func Test_Version(t *testing.T) {
 			mockDB = dbmock.NewMockStore(ctrl)
 			clock  = quartz.NewMock(t)
 			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
 		)
 
 		expectedKey := database.CryptoKey{
 			Feature:  database.CryptoKeyFeatureWorkspaceApps,
 			Sequence: 33,
+			StartsAt: clock.Now().UTC(),
 			Secret: sql.NullString{
 				String: "secret",
 				Valid:  true,
 			},
-			StartsAt: clock.Now().UTC(),
 		}
 
-		mockDB.EXPECT().GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
-			Feature:  database.CryptoKeyFeatureWorkspaceApps,
-			Sequence: 33,
-		}).Return(expectedKey, nil)
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{expectedKey}, nil)
 
-		k := &DBCache{
-			db:      mockDB,
-			feature: database.CryptoKeyFeatureWorkspaceApps,
-			cache:   map[int32]database.CryptoKey{},
-			clock:   clock,
-		}
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
 
-		got, err := k.Version(ctx, 33)
+		got, err := k.Verifying(ctx, 33)
 		require.NoError(t, err)
 		require.Equal(t, db2sdk.CryptoKey(expectedKey), got)
 		require.Equal(t, db2sdk.CryptoKey(expectedKey), db2sdk.CryptoKey(k.latestKey))
@@ -119,11 +114,11 @@ func Test_Version(t *testing.T) {
 		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
-			cache:   cache,
+			keys:    cache,
 			clock:   clock,
 		}
 
-		_, err := k.Version(ctx, 32)
+		_, err := k.Verifying(ctx, 32)
 		require.ErrorIs(t, err, ErrKeyInvalid)
 	})
 
@@ -149,24 +144,21 @@ func Test_Version(t *testing.T) {
 				Valid: true,
 			},
 		}
-		mockDB.EXPECT().GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
-			Feature:  database.CryptoKeyFeatureWorkspaceApps,
-			Sequence: 32,
-		}).Return(invalidKey, nil)
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{invalidKey}, nil)
 
 		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
-			cache:   map[int32]database.CryptoKey{},
+			keys:    map[int32]database.CryptoKey{},
 			clock:   clock,
 		}
 
-		_, err := k.Version(ctx, 32)
+		_, err := k.Verifying(ctx, 32)
 		require.ErrorIs(t, err, ErrKeyInvalid)
 	})
 }
 
-func Test_Latest(t *testing.T) {
+func Test_Signing(t *testing.T) {
 	t.Parallel()
 
 	t.Run("HitsCache", func(t *testing.T) {
@@ -177,6 +169,7 @@ func Test_Latest(t *testing.T) {
 			mockDB = dbmock.NewMockStore(ctrl)
 			clock  = quartz.NewMock(t)
 			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
 		)
 
 		latestKey := database.CryptoKey{
@@ -188,14 +181,10 @@ func Test_Latest(t *testing.T) {
 			},
 			StartsAt: clock.Now().UTC(),
 		}
-		k := &DBCache{
-			db:        mockDB,
-			feature:   database.CryptoKeyFeatureWorkspaceApps,
-			clock:     clock,
-			latestKey: latestKey,
-		}
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
+		k.latestKey = latestKey
 
-		got, err := k.Latest(ctx)
+		got, err := k.Signing(ctx)
 		require.NoError(t, err)
 		require.Equal(t, db2sdk.CryptoKey(latestKey), got)
 	})
@@ -208,6 +197,7 @@ func Test_Latest(t *testing.T) {
 			mockDB = dbmock.NewMockStore(ctrl)
 			clock  = quartz.NewMock(t)
 			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
 		)
 
 		latestKey := database.CryptoKey{
@@ -220,28 +210,26 @@ func Test_Latest(t *testing.T) {
 			StartsAt: clock.Now().UTC(),
 		}
 
-		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{latestKey}, nil)
-
-		k := &DBCache{
-			db:      mockDB,
-			feature: database.CryptoKeyFeatureWorkspaceApps,
-			clock:   clock,
-			latestKey: database.CryptoKey{
-				Feature:  database.CryptoKeyFeatureWorkspaceApps,
-				Sequence: 32,
-				Secret: sql.NullString{
-					String: "secret",
-					Valid:  true,
-				},
-				StartsAt: clock.Now().UTC().Add(-time.Hour),
-				DeletesAt: sql.NullTime{
-					Time:  clock.Now().UTC(),
-					Valid: true,
-				},
+		invalidKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC().Add(-time.Hour),
+			DeletesAt: sql.NullTime{
+				Time:  clock.Now().UTC(),
+				Valid: true,
 			},
 		}
 
-		got, err := k.Latest(ctx)
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{latestKey}, nil)
+
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
+		k.latestKey = invalidKey
+
+		got, err := k.Signing(ctx)
 		require.NoError(t, err)
 		require.Equal(t, db2sdk.CryptoKey(latestKey), got)
 	})
@@ -254,6 +242,7 @@ func Test_Latest(t *testing.T) {
 			mockDB = dbmock.NewMockStore(ctrl)
 			clock  = quartz.NewMock(t)
 			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
 		)
 
 		inactiveKey := database.CryptoKey{
@@ -278,14 +267,9 @@ func Test_Latest(t *testing.T) {
 
 		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{inactiveKey, activeKey}, nil)
 
-		k := &DBCache{
-			db:      mockDB,
-			feature: database.CryptoKeyFeatureWorkspaceApps,
-			clock:   clock,
-			cache:   map[int32]database.CryptoKey{},
-		}
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
 
-		got, err := k.Latest(ctx)
+		got, err := k.Signing(ctx)
 		require.NoError(t, err)
 		require.Equal(t, db2sdk.CryptoKey(activeKey), got)
 	})
@@ -298,6 +282,7 @@ func Test_Latest(t *testing.T) {
 			mockDB = dbmock.NewMockStore(ctrl)
 			clock  = quartz.NewMock(t)
 			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
 		)
 
 		inactiveKey := database.CryptoKey{
@@ -326,14 +311,99 @@ func Test_Latest(t *testing.T) {
 
 		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{inactiveKey, invalidKey}, nil)
 
-		k := &DBCache{
-			db:      mockDB,
-			feature: database.CryptoKeyFeatureWorkspaceApps,
-			clock:   clock,
-			cache:   map[int32]database.CryptoKey{},
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
+
+		_, err := k.Signing(ctx)
+		require.ErrorIs(t, err, ErrKeyInvalid)
+	})
+}
+
+func Test_clear(t *testing.T) {
+	t.Parallel()
+
+	t.Run("InvalidatesCache", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
+		)
+
+		trap := clock.Trap().AfterFunc()
+
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
+		k.latestKey = database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+		}
+		k.keys = map[int32]database.CryptoKey{
+			32: {
+				Feature:  database.CryptoKeyFeatureWorkspaceApps,
+				Sequence: 32,
+				Secret: sql.NullString{
+					String: "secret",
+					Valid:  true,
+				},
+			},
+		}
+		trap.MustWait(ctx).Release()
+		_, wait := clock.AdvanceNext()
+		wait.MustWait(ctx)
+		require.Len(t, k.keys, 0)
+		require.Equal(t, database.CryptoKey{}, k.latestKey)
+	})
+
+	t.Run("ResetsTimer", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
+		)
+
+		trap := clock.Trap().AfterFunc()
+
+		k := NewDBCache(ctx, logger, mockDB, database.CryptoKeyFeatureWorkspaceApps, WithDBCacheClock(clock))
+
+		key := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now(),
 		}
 
-		_, err := k.Latest(ctx)
-		require.ErrorIs(t, err, ErrKeyInvalid)
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{key}, nil)
+
+		trap.MustWait(ctx).Release()
+
+		// Advance it five minutes so that we can test that the
+		// time is reset and doesn't fire after another five minute and doesn't fire after another five minutes.
+		clock.Advance(time.Minute * 5)
+
+		latest, err := k.Signing(ctx)
+		require.NoError(t, err)
+		require.Equal(t, db2sdk.CryptoKey(key), latest)
+
+		trap.MustWait(ctx).Release()
+		// Advancing the clock now should require 10 minutes
+		// before the timer fires again.
+		dur, wait := clock.AdvanceNext()
+		wait.MustWait(ctx)
+		require.Equal(t, time.Minute*10, dur)
+		require.Len(t, k.keys, 0)
+		require.Equal(t, database.CryptoKey{}, k.latestKey)
 	})
 }

--- a/coderd/cryptokeys/dbkeycache_internal_test.go
+++ b/coderd/cryptokeys/dbkeycache_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
@@ -49,7 +50,7 @@ func Test_Version(t *testing.T) {
 
 		got, err := k.Version(ctx, 32)
 		require.NoError(t, err)
-		require.Equal(t, expectedKey, got)
+		require.Equal(t, db2sdk.CryptoKey(expectedKey), got)
 	})
 
 	t.Run("MissesCache", func(t *testing.T) {
@@ -86,8 +87,8 @@ func Test_Version(t *testing.T) {
 
 		got, err := k.Version(ctx, 33)
 		require.NoError(t, err)
-		require.Equal(t, expectedKey, got)
-		require.Equal(t, expectedKey, k.latestKey)
+		require.Equal(t, db2sdk.CryptoKey(expectedKey), got)
+		require.Equal(t, db2sdk.CryptoKey(expectedKey), db2sdk.CryptoKey(k.latestKey))
 	})
 
 	t.Run("InvalidCachedKey", func(t *testing.T) {
@@ -123,7 +124,7 @@ func Test_Version(t *testing.T) {
 		}
 
 		_, err := k.Version(ctx, 32)
-		require.ErrorIs(t, err, ErrKeyNotFound)
+		require.ErrorIs(t, err, ErrKeyInvalid)
 	})
 
 	t.Run("InvalidDBKey", func(t *testing.T) {
@@ -196,7 +197,7 @@ func Test_Latest(t *testing.T) {
 
 		got, err := k.Latest(ctx)
 		require.NoError(t, err)
-		require.Equal(t, latestKey, got)
+		require.Equal(t, db2sdk.CryptoKey(latestKey), got)
 	})
 
 	t.Run("InvalidCachedKey", func(t *testing.T) {
@@ -242,7 +243,7 @@ func Test_Latest(t *testing.T) {
 
 		got, err := k.Latest(ctx)
 		require.NoError(t, err)
-		require.Equal(t, latestKey, got)
+		require.Equal(t, db2sdk.CryptoKey(latestKey), got)
 	})
 
 	t.Run("UsesActiveKey", func(t *testing.T) {
@@ -286,7 +287,7 @@ func Test_Latest(t *testing.T) {
 
 		got, err := k.Latest(ctx)
 		require.NoError(t, err)
-		require.Equal(t, activeKey, got)
+		require.Equal(t, db2sdk.CryptoKey(activeKey), got)
 	})
 
 	t.Run("NoValidKeys", func(t *testing.T) {

--- a/coderd/cryptokeys/dbkeycache_internal_test.go
+++ b/coderd/cryptokeys/dbkeycache_internal_test.go
@@ -40,11 +40,11 @@ func Test_Version(t *testing.T) {
 			32: expectedKey,
 		}
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
 			cache:   cache,
-			Clock:   clock,
+			clock:   clock,
 		}
 
 		got, err := k.Version(ctx, 32)
@@ -77,11 +77,11 @@ func Test_Version(t *testing.T) {
 			Sequence: 33,
 		}).Return(expectedKey, nil)
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
 			cache:   map[int32]database.CryptoKey{},
-			Clock:   clock,
+			clock:   clock,
 		}
 
 		got, err := k.Version(ctx, 33)
@@ -115,11 +115,11 @@ func Test_Version(t *testing.T) {
 			},
 		}
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
 			cache:   cache,
-			Clock:   clock,
+			clock:   clock,
 		}
 
 		_, err := k.Version(ctx, 32)
@@ -153,11 +153,11 @@ func Test_Version(t *testing.T) {
 			Sequence: 32,
 		}).Return(invalidKey, nil)
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
 			cache:   map[int32]database.CryptoKey{},
-			Clock:   clock,
+			clock:   clock,
 		}
 
 		_, err := k.Version(ctx, 32)
@@ -187,10 +187,10 @@ func Test_Latest(t *testing.T) {
 			},
 			StartsAt: clock.Now().UTC(),
 		}
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:        mockDB,
 			feature:   database.CryptoKeyFeatureWorkspaceApps,
-			Clock:     clock,
+			clock:     clock,
 			latestKey: latestKey,
 		}
 
@@ -221,10 +221,10 @@ func Test_Latest(t *testing.T) {
 
 		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{latestKey}, nil)
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
-			Clock:   clock,
+			clock:   clock,
 			latestKey: database.CryptoKey{
 				Feature:  database.CryptoKeyFeatureWorkspaceApps,
 				Sequence: 32,
@@ -277,10 +277,10 @@ func Test_Latest(t *testing.T) {
 
 		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{inactiveKey, activeKey}, nil)
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
-			Clock:   clock,
+			clock:   clock,
 			cache:   map[int32]database.CryptoKey{},
 		}
 
@@ -325,10 +325,10 @@ func Test_Latest(t *testing.T) {
 
 		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{inactiveKey, invalidKey}, nil)
 
-		k := &DBKeyCache{
+		k := &DBCache{
 			db:      mockDB,
 			feature: database.CryptoKeyFeatureWorkspaceApps,
-			Clock:   clock,
+			clock:   clock,
 			cache:   map[int32]database.CryptoKey{},
 		}
 

--- a/coderd/cryptokeys/dbkeycache_internal_test.go
+++ b/coderd/cryptokeys/dbkeycache_internal_test.go
@@ -1,0 +1,338 @@
+package cryptokeys
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func Test_Version(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HitsCache", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		expectedKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+		}
+
+		cache := map[int32]database.CryptoKey{
+			32: expectedKey,
+		}
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			cache:   cache,
+			Clock:   clock,
+		}
+
+		got, err := k.Version(ctx, 32)
+		require.NoError(t, err)
+		require.Equal(t, expectedKey, got)
+	})
+
+	t.Run("MissesCache", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		expectedKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 33,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC(),
+		}
+
+		mockDB.EXPECT().GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 33,
+		}).Return(expectedKey, nil)
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			cache:   map[int32]database.CryptoKey{},
+			Clock:   clock,
+		}
+
+		got, err := k.Version(ctx, 33)
+		require.NoError(t, err)
+		require.Equal(t, expectedKey, got)
+		require.Equal(t, expectedKey, k.latestKey)
+	})
+
+	t.Run("InvalidCachedKey", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		cache := map[int32]database.CryptoKey{
+			32: {
+				Feature:  database.CryptoKeyFeatureWorkspaceApps,
+				Sequence: 32,
+				Secret: sql.NullString{
+					String: "secret",
+					Valid:  true,
+				},
+				DeletesAt: sql.NullTime{
+					Time:  clock.Now().UTC(),
+					Valid: true,
+				},
+			},
+		}
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			cache:   cache,
+			Clock:   clock,
+		}
+
+		_, err := k.Version(ctx, 32)
+		require.ErrorIs(t, err, ErrKeyNotFound)
+	})
+
+	t.Run("InvalidDBKey", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		invalidKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			DeletesAt: sql.NullTime{
+				Time:  clock.Now().UTC(),
+				Valid: true,
+			},
+		}
+		mockDB.EXPECT().GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+		}).Return(invalidKey, nil)
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			cache:   map[int32]database.CryptoKey{},
+			Clock:   clock,
+		}
+
+		_, err := k.Version(ctx, 32)
+		require.ErrorIs(t, err, ErrKeyInvalid)
+	})
+}
+
+func Test_Latest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HitsCache", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		latestKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC(),
+		}
+		k := &DBKeyCache{
+			db:        mockDB,
+			feature:   database.CryptoKeyFeatureWorkspaceApps,
+			Clock:     clock,
+			latestKey: latestKey,
+		}
+
+		got, err := k.Latest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, latestKey, got)
+	})
+
+	t.Run("InvalidCachedKey", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		latestKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 33,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC(),
+		}
+
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{latestKey}, nil)
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			Clock:   clock,
+			latestKey: database.CryptoKey{
+				Feature:  database.CryptoKeyFeatureWorkspaceApps,
+				Sequence: 32,
+				Secret: sql.NullString{
+					String: "secret",
+					Valid:  true,
+				},
+				StartsAt: clock.Now().UTC().Add(-time.Hour),
+				DeletesAt: sql.NullTime{
+					Time:  clock.Now().UTC(),
+					Valid: true,
+				},
+			},
+		}
+
+		got, err := k.Latest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, latestKey, got)
+	})
+
+	t.Run("UsesActiveKey", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		inactiveKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC().Add(time.Hour),
+		}
+
+		activeKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 33,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC(),
+		}
+
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{inactiveKey, activeKey}, nil)
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			Clock:   clock,
+			cache:   map[int32]database.CryptoKey{},
+		}
+
+		got, err := k.Latest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, activeKey, got)
+	})
+
+	t.Run("NoValidKeys", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			ctrl   = gomock.NewController(t)
+			mockDB = dbmock.NewMockStore(ctrl)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+		)
+
+		inactiveKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 32,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC().Add(time.Hour),
+		}
+
+		invalidKey := database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 33,
+			Secret: sql.NullString{
+				String: "secret",
+				Valid:  true,
+			},
+			StartsAt: clock.Now().UTC().Add(-time.Hour),
+			DeletesAt: sql.NullTime{
+				Time:  clock.Now().UTC(),
+				Valid: true,
+			},
+		}
+
+		mockDB.EXPECT().GetCryptoKeysByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps).Return([]database.CryptoKey{inactiveKey, invalidKey}, nil)
+
+		k := &DBKeyCache{
+			db:      mockDB,
+			feature: database.CryptoKeyFeatureWorkspaceApps,
+			Clock:   clock,
+			cache:   map[int32]database.CryptoKey{},
+		}
+
+		_, err := k.Latest(ctx)
+		require.ErrorIs(t, err, ErrKeyInvalid)
+	})
+}

--- a/coderd/cryptokeys/dbkeycache_test.go
+++ b/coderd/cryptokeys/dbkeycache_test.go
@@ -38,7 +38,8 @@ func TestDBKeyCache(t *testing.T) {
 				StartsAt: clock.Now().UTC(),
 			})
 
-			k := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
+			k := cryptokeys.NewDBCache(logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
+			defer k.Close()
 
 			got, err := k.Verifying(ctx, key.Sequence)
 			require.NoError(t, err)
@@ -55,7 +56,8 @@ func TestDBKeyCache(t *testing.T) {
 				logger = slogtest.Make(t, nil)
 			)
 
-			k := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
+			k := cryptokeys.NewDBCache(logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
+			defer k.Close()
 
 			_, err := k.Verifying(ctx, 123)
 			require.ErrorIs(t, err, cryptokeys.ErrKeyNotFound)
@@ -90,7 +92,8 @@ func TestDBKeyCache(t *testing.T) {
 			StartsAt: clock.Now().UTC(),
 		})
 
-		k := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
+		k := cryptokeys.NewDBCache(logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
+		defer k.Close()
 
 		got, err := k.Signing(ctx)
 		require.NoError(t, err)

--- a/coderd/cryptokeys/dbkeycache_test.go
+++ b/coderd/cryptokeys/dbkeycache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"cdr.dev/slog/sloggers/slogtest"
 
@@ -15,6 +16,10 @@ import (
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestDBKeyCache(t *testing.T) {
 	t.Parallel()

--- a/coderd/cryptokeys/dbkeycache_test.go
+++ b/coderd/cryptokeys/dbkeycache_test.go
@@ -1,0 +1,216 @@
+package cryptokeys_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/sloggers/slogtest"
+
+	"github.com/coder/coder/v2/coderd/cryptokeys"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
+)
+
+func TestDBKeyCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoKeys", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			db, _  = dbtestutil.NewDB(t)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
+		)
+
+		_, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+		require.NoError(t, err)
+	})
+
+	t.Run("Version", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("HitsCache", func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				db, _  = dbtestutil.NewDB(t)
+				clock  = quartz.NewMock(t)
+				ctx    = testutil.Context(t, testutil.WaitShort)
+				logger = slogtest.Make(t, nil)
+			)
+
+			key := dbgen.CryptoKey(t, db, database.CryptoKey{
+				Feature:  database.CryptoKeyFeatureWorkspaceApps,
+				Sequence: 1,
+				Secret: sql.NullString{
+					String: "secret",
+					Valid:  true,
+				},
+				StartsAt: clock.Now().UTC(),
+			})
+
+			k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+			require.NoError(t, err)
+
+			got, err := k.Version(ctx, key.Sequence)
+			require.NoError(t, err)
+			require.Equal(t, key, got)
+		})
+
+		t.Run("MissesCache", func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				db, _  = dbtestutil.NewDB(t)
+				clock  = quartz.NewMock(t)
+				ctx    = testutil.Context(t, testutil.WaitShort)
+				logger = slogtest.Make(t, nil)
+			)
+
+			_ = dbgen.CryptoKey(t, db, database.CryptoKey{
+				Feature:  database.CryptoKeyFeatureWorkspaceApps,
+				Sequence: 1,
+				Secret: sql.NullString{
+					String: "secret",
+					Valid:  true,
+				},
+				StartsAt: clock.Now().UTC(),
+			})
+
+			k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+			require.NoError(t, err)
+
+			key := dbgen.CryptoKey(t, db, database.CryptoKey{
+				Feature:  database.CryptoKeyFeatureWorkspaceApps,
+				Sequence: 3,
+				Secret: sql.NullString{
+					String: "secret",
+					Valid:  true,
+				},
+				StartsAt: clock.Now().UTC(),
+			})
+
+			got, err := k.Version(ctx, key.Sequence)
+			require.NoError(t, err)
+			require.Equal(t, key, got)
+		})
+	})
+
+	t.Run("Latest", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			db, _  = dbtestutil.NewDB(t)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
+		)
+
+		_ = dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 10,
+			StartsAt: clock.Now().UTC(),
+		})
+
+		expectedKey := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 12,
+			StartsAt: clock.Now().UTC(),
+		})
+
+		_ = dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 2,
+			StartsAt: clock.Now().UTC(),
+		})
+
+		k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+		require.NoError(t, err)
+
+		got, err := k.Latest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expectedKey, got)
+	})
+
+	t.Run("CacheRefreshes", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			db, _  = dbtestutil.NewDB(t)
+			clock  = quartz.NewMock(t)
+			ctx    = testutil.Context(t, testutil.WaitShort)
+			logger = slogtest.Make(t, nil)
+		)
+
+		expiringKey := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 12,
+			StartsAt: clock.Now().UTC(),
+			DeletesAt: sql.NullTime{
+				Time:  clock.Now().UTC().Add(time.Minute * 10),
+				Valid: true,
+			},
+		})
+		latest := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 24,
+			StartsAt: clock.Now().UTC(),
+			DeletesAt: sql.NullTime{
+				Time:  clock.Now().UTC().Add(2 * 2 * time.Hour),
+				Valid: true,
+			},
+		})
+		trap := clock.Trap().TickerFunc()
+		k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+		require.NoError(t, err)
+
+		// Should be able to fetch the expiring key since it's still valid.
+		got, err := k.Version(ctx, expiringKey.Sequence)
+		require.NoError(t, err)
+		require.Equal(t, expiringKey, got)
+
+		newLatest := dbgen.CryptoKey(t, db, database.CryptoKey{
+			Feature:  database.CryptoKeyFeatureWorkspaceApps,
+			Sequence: 25,
+			StartsAt: clock.Now().UTC(),
+			DeletesAt: sql.NullTime{
+				Time:  clock.Now().UTC().Add(2 * 2 * time.Hour),
+				Valid: true,
+			},
+		})
+
+		// The latest key should not be the one we just generated.
+		got, err = k.Latest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, latest, got)
+
+		// Wait for the ticker to fire and the cache to refresh.
+		trap.MustWait(ctx).Release()
+		_, wait := clock.AdvanceNext()
+		wait.MustWait(ctx)
+
+		// The latest key should be the one we just generated.
+		got, err = k.Latest(ctx)
+		require.NoError(t, err)
+		require.Equal(t, newLatest, got)
+
+		// The expiring key should be gone.
+
+		_, err = k.Version(ctx, expiringKey.Sequence)
+		require.ErrorIs(t, err, cryptokeys.ErrKeyNotFound)
+	})
+}
+
+func withClock(clock quartz.Clock) func(*cryptokeys.DBKeyCache) {
+	return func(d *cryptokeys.DBKeyCache) {
+		d.Clock = clock
+	}
+}

--- a/coderd/cryptokeys/dbkeycache_test.go
+++ b/coderd/cryptokeys/dbkeycache_test.go
@@ -1,9 +1,7 @@
 package cryptokeys_test
 
 import (
-	"database/sql"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -21,21 +19,7 @@ import (
 func TestDBKeyCache(t *testing.T) {
 	t.Parallel()
 
-	t.Run("NoKeys", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			db, _  = dbtestutil.NewDB(t)
-			clock  = quartz.NewMock(t)
-			ctx    = testutil.Context(t, testutil.WaitShort)
-			logger = slogtest.Make(t, nil)
-		)
-
-		_, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
-		require.NoError(t, err)
-	})
-
-	t.Run("Version", func(t *testing.T) {
+	t.Run("Verifying", func(t *testing.T) {
 		t.Parallel()
 
 		t.Run("HitsCache", func(t *testing.T) {
@@ -51,22 +35,17 @@ func TestDBKeyCache(t *testing.T) {
 			key := dbgen.CryptoKey(t, db, database.CryptoKey{
 				Feature:  database.CryptoKeyFeatureWorkspaceApps,
 				Sequence: 1,
-				Secret: sql.NullString{
-					String: "secret",
-					Valid:  true,
-				},
 				StartsAt: clock.Now().UTC(),
 			})
 
-			k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
-			require.NoError(t, err)
+			k := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 
-			got, err := k.Version(ctx, key.Sequence)
+			got, err := k.Verifying(ctx, key.Sequence)
 			require.NoError(t, err)
 			require.Equal(t, db2sdk.CryptoKey(key), got)
 		})
 
-		t.Run("MissesCache", func(t *testing.T) {
+		t.Run("NotFound", func(t *testing.T) {
 			t.Parallel()
 
 			var (
@@ -76,36 +55,14 @@ func TestDBKeyCache(t *testing.T) {
 				logger = slogtest.Make(t, nil)
 			)
 
-			_ = dbgen.CryptoKey(t, db, database.CryptoKey{
-				Feature:  database.CryptoKeyFeatureWorkspaceApps,
-				Sequence: 1,
-				Secret: sql.NullString{
-					String: "secret",
-					Valid:  true,
-				},
-				StartsAt: clock.Now().UTC(),
-			})
+			k := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 
-			k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
-			require.NoError(t, err)
-
-			key := dbgen.CryptoKey(t, db, database.CryptoKey{
-				Feature:  database.CryptoKeyFeatureWorkspaceApps,
-				Sequence: 3,
-				Secret: sql.NullString{
-					String: "secret",
-					Valid:  true,
-				},
-				StartsAt: clock.Now().UTC(),
-			})
-
-			got, err := k.Version(ctx, key.Sequence)
-			require.NoError(t, err)
-			require.Equal(t, db2sdk.CryptoKey(key), got)
+			_, err := k.Verifying(ctx, 123)
+			require.ErrorIs(t, err, cryptokeys.ErrKeyNotFound)
 		})
 	})
 
-	t.Run("Latest", func(t *testing.T) {
+	t.Run("Signing", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -133,92 +90,10 @@ func TestDBKeyCache(t *testing.T) {
 			StartsAt: clock.Now().UTC(),
 		})
 
-		k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
-		require.NoError(t, err)
+		k := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 
-		got, err := k.Latest(ctx)
+		got, err := k.Signing(ctx)
 		require.NoError(t, err)
 		require.Equal(t, db2sdk.CryptoKey(expectedKey), got)
-	})
-
-	t.Run("CacheRefreshes", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			db, _  = dbtestutil.NewDB(t)
-			clock  = quartz.NewMock(t)
-			ctx    = testutil.Context(t, testutil.WaitShort)
-			logger = slogtest.Make(t, nil)
-		)
-
-		expiringKey := dbgen.CryptoKey(t, db, database.CryptoKey{
-			Feature:  database.CryptoKeyFeatureWorkspaceApps,
-			Sequence: 12,
-			StartsAt: clock.Now().UTC(),
-			DeletesAt: sql.NullTime{
-				Time:  clock.Now().UTC().Add(time.Minute * 10),
-				Valid: true,
-			},
-		})
-		latest := dbgen.CryptoKey(t, db, database.CryptoKey{
-			Feature:  database.CryptoKeyFeatureWorkspaceApps,
-			Sequence: 24,
-			StartsAt: clock.Now().UTC(),
-			DeletesAt: sql.NullTime{
-				Time:  clock.Now().UTC().Add(2 * 2 * time.Hour),
-				Valid: true,
-			},
-		})
-
-		wrongFeature := dbgen.CryptoKey(t, db, database.CryptoKey{
-			Feature:  database.CryptoKeyFeatureOidcConvert,
-			Sequence: 30,
-			StartsAt: clock.Now().UTC(),
-		})
-
-		trap := clock.Trap().TickerFunc()
-		k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
-		require.NoError(t, err)
-
-		// Should be able to fetch the expiring key since it's still valid.
-		got, err := k.Version(ctx, expiringKey.Sequence)
-		require.NoError(t, err)
-		require.Equal(t, db2sdk.CryptoKey(expiringKey), got)
-
-		_, err = k.Version(ctx, wrongFeature.Sequence)
-		require.ErrorIs(t, err, cryptokeys.ErrKeyNotFound)
-
-		newLatest := dbgen.CryptoKey(t, db, database.CryptoKey{
-			Feature:  database.CryptoKeyFeatureWorkspaceApps,
-			Sequence: 25,
-			StartsAt: clock.Now().UTC(),
-			DeletesAt: sql.NullTime{
-				Time:  clock.Now().UTC().Add(2 * 2 * time.Hour),
-				Valid: true,
-			},
-		})
-
-		// The latest key should not be the one we just generated.
-		got, err = k.Latest(ctx)
-		require.NoError(t, err)
-		require.Equal(t, db2sdk.CryptoKey(latest), got)
-
-		// Wait for the ticker to fire and the cache to refresh.
-		trap.MustWait(ctx).Release()
-		_, wait := clock.AdvanceNext()
-		wait.MustWait(ctx)
-
-		// The latest key should be the one we just generated.
-		got, err = k.Latest(ctx)
-		require.NoError(t, err)
-		require.Equal(t, db2sdk.CryptoKey(newLatest), got)
-
-		// The expiring key should be invalid.
-		_, err = k.Version(ctx, expiringKey.Sequence)
-		require.ErrorIs(t, err, cryptokeys.ErrKeyInvalid)
-
-		// Sanity check that the wrong feature is still not found.
-		_, err = k.Version(ctx, wrongFeature.Sequence)
-		require.ErrorIs(t, err, cryptokeys.ErrKeyNotFound)
 	})
 }

--- a/coderd/cryptokeys/dbkeycache_test.go
+++ b/coderd/cryptokeys/dbkeycache_test.go
@@ -30,7 +30,7 @@ func TestDBKeyCache(t *testing.T) {
 			logger = slogtest.Make(t, nil)
 		)
 
-		_, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+		_, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 		require.NoError(t, err)
 	})
 
@@ -57,7 +57,7 @@ func TestDBKeyCache(t *testing.T) {
 				StartsAt: clock.Now().UTC(),
 			})
 
-			k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+			k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 			require.NoError(t, err)
 
 			got, err := k.Version(ctx, key.Sequence)
@@ -85,7 +85,7 @@ func TestDBKeyCache(t *testing.T) {
 				StartsAt: clock.Now().UTC(),
 			})
 
-			k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+			k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 			require.NoError(t, err)
 
 			key := dbgen.CryptoKey(t, db, database.CryptoKey{
@@ -132,7 +132,7 @@ func TestDBKeyCache(t *testing.T) {
 			StartsAt: clock.Now().UTC(),
 		})
 
-		k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+		k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 		require.NoError(t, err)
 
 		got, err := k.Latest(ctx)
@@ -169,7 +169,7 @@ func TestDBKeyCache(t *testing.T) {
 			},
 		})
 		trap := clock.Trap().TickerFunc()
-		k, err := cryptokeys.NewDBKeyCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, withClock(clock))
+		k, err := cryptokeys.NewDBCache(ctx, logger, db, database.CryptoKeyFeatureWorkspaceApps, cryptokeys.WithDBCacheClock(clock))
 		require.NoError(t, err)
 
 		// Should be able to fetch the expiring key since it's still valid.
@@ -207,10 +207,4 @@ func TestDBKeyCache(t *testing.T) {
 		_, err = k.Version(ctx, expiringKey.Sequence)
 		require.ErrorIs(t, err, cryptokeys.ErrKeyNotFound)
 	})
-}
-
-func withClock(clock quartz.Clock) func(*cryptokeys.DBKeyCache) {
-	return func(d *cryptokeys.DBKeyCache) {
-		d.Clock = clock
-	}
 }

--- a/coderd/cryptokeys/keycache.go
+++ b/coderd/cryptokeys/keycache.go
@@ -1,0 +1,19 @@
+package cryptokeys
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+var ErrKeyNotFound = xerrors.New("key not found")
+
+var ErrKeyInvalid = xerrors.New("key is invalid for use")
+
+// Keycache provides an abstraction for fetching signing keys.
+type Keycache interface {
+	Latest(ctx context.Context) (database.CryptoKey, error)
+	Version(ctx context.Context, sequence int32) (database.CryptoKey, error)
+}

--- a/coderd/cryptokeys/keycache.go
+++ b/coderd/cryptokeys/keycache.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/enterprise/wsproxy/wsproxysdk"
 )
 
 var ErrKeyNotFound = xerrors.New("key not found")
@@ -14,6 +14,6 @@ var ErrKeyInvalid = xerrors.New("key is invalid for use")
 
 // Keycache provides an abstraction for fetching signing keys.
 type Keycache interface {
-	Latest(ctx context.Context) (database.CryptoKey, error)
-	Version(ctx context.Context, sequence int32) (database.CryptoKey, error)
+	Latest(ctx context.Context) (wsproxysdk.CryptoKey, error)
+	Version(ctx context.Context, sequence int32) (wsproxysdk.CryptoKey, error)
 }

--- a/coderd/cryptokeys/keycache.go
+++ b/coderd/cryptokeys/keycache.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/coder/coder/v2/enterprise/wsproxy/wsproxysdk"
+	"github.com/coder/coder/v2/codersdk"
 )
 
 var ErrKeyNotFound = xerrors.New("key not found")
@@ -14,6 +14,6 @@ var ErrKeyInvalid = xerrors.New("key is invalid for use")
 
 // Keycache provides an abstraction for fetching signing keys.
 type Keycache interface {
-	Latest(ctx context.Context) (wsproxysdk.CryptoKey, error)
-	Version(ctx context.Context, sequence int32) (wsproxysdk.CryptoKey, error)
+	Latest(ctx context.Context) (codersdk.CryptoKey, error)
+	Version(ctx context.Context, sequence int32) (codersdk.CryptoKey, error)
 }

--- a/coderd/cryptokeys/keycache.go
+++ b/coderd/cryptokeys/keycache.go
@@ -8,9 +8,11 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-var ErrKeyNotFound = xerrors.New("key not found")
-
-var ErrKeyInvalid = xerrors.New("key is invalid for use")
+var (
+	ErrKeyNotFound = xerrors.New("key not found")
+	ErrKeyInvalid  = xerrors.New("key is invalid for use")
+	ErrClosed      = xerrors.New("closed")
+)
 
 // Keycache provides an abstraction for fetching signing keys.
 type Keycache interface {

--- a/coderd/cryptokeys/keycache.go
+++ b/coderd/cryptokeys/keycache.go
@@ -14,6 +14,6 @@ var ErrKeyInvalid = xerrors.New("key is invalid for use")
 
 // Keycache provides an abstraction for fetching signing keys.
 type Keycache interface {
-	Latest(ctx context.Context) (codersdk.CryptoKey, error)
-	Version(ctx context.Context, sequence int32) (codersdk.CryptoKey, error)
+	Signing(ctx context.Context) (codersdk.CryptoKey, error)
+	Verifying(ctx context.Context, sequence int32) (codersdk.CryptoKey, error)
 }

--- a/coderd/cryptokeys/rotate.go
+++ b/coderd/cryptokeys/rotate.go
@@ -1,4 +1,4 @@
-package keyrotate
+package cryptokeys
 
 import (
 	"context"
@@ -36,15 +36,15 @@ type rotator struct {
 	features []database.CryptoKeyFeature
 }
 
-type Option func(*rotator)
+type RotatorOption func(*rotator)
 
-func WithClock(clock quartz.Clock) Option {
+func WithClock(clock quartz.Clock) RotatorOption {
 	return func(r *rotator) {
 		r.clock = clock
 	}
 }
 
-func WithKeyDuration(keyDuration time.Duration) Option {
+func WithKeyDuration(keyDuration time.Duration) RotatorOption {
 	return func(r *rotator) {
 		r.keyDuration = keyDuration
 	}
@@ -53,7 +53,7 @@ func WithKeyDuration(keyDuration time.Duration) Option {
 // StartRotator starts a background process that rotates keys in the database.
 // It ensures there's at least one valid key per feature prior to returning.
 // Canceling the provided context will stop the background process.
-func StartRotator(ctx context.Context, logger slog.Logger, db database.Store, opts ...Option) error {
+func StartRotator(ctx context.Context, logger slog.Logger, db database.Store, opts ...RotatorOption) error {
 	kr := &rotator{
 		db:          db,
 		logger:      logger,

--- a/coderd/cryptokeys/rotate_internal_test.go
+++ b/coderd/cryptokeys/rotate_internal_test.go
@@ -1,4 +1,4 @@
-package keyrotate
+package cryptokeys
 
 import (
 	"database/sql"

--- a/coderd/cryptokeys/rotate_test.go
+++ b/coderd/cryptokeys/rotate_test.go
@@ -1,4 +1,4 @@
-package keyrotate_test
+package cryptokeys_test
 
 import (
 	"testing"
@@ -9,10 +9,10 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/slogtest"
 
+	"github.com/coder/coder/v2/coderd/cryptokeys"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
-	"github.com/coder/coder/v2/coderd/keyrotate"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -34,7 +34,7 @@ func TestRotator(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, dbkeys, 0)
 
-		err = keyrotate.StartRotator(ctx, logger, db, keyrotate.WithClock(clock))
+		err = cryptokeys.StartRotator(ctx, logger, db, cryptokeys.WithClock(clock))
 		require.NoError(t, err)
 
 		// Fetch the keys from the database and ensure they
@@ -59,14 +59,14 @@ func TestRotator(t *testing.T) {
 
 		rotatingKey := dbgen.CryptoKey(t, db, database.CryptoKey{
 			Feature:  database.CryptoKeyFeatureWorkspaceApps,
-			StartsAt: now.Add(-keyrotate.DefaultKeyDuration + time.Hour + time.Minute),
+			StartsAt: now.Add(-cryptokeys.DefaultKeyDuration + time.Hour + time.Minute),
 			Sequence: 12345,
 		})
 
 		trap := clock.Trap().TickerFunc()
 		t.Cleanup(trap.Close)
 
-		err := keyrotate.StartRotator(ctx, logger, db, keyrotate.WithClock(clock))
+		err := cryptokeys.StartRotator(ctx, logger, db, cryptokeys.WithClock(clock))
 		require.NoError(t, err)
 
 		initialKeyLen := len(database.AllCryptoKeyFeatureValues())
@@ -88,14 +88,14 @@ func TestRotator(t *testing.T) {
 		newKey, err := db.GetLatestCryptoKeyByFeature(ctx, database.CryptoKeyFeatureWorkspaceApps)
 		require.NoError(t, err)
 		require.Equal(t, rotatingKey.Sequence+1, newKey.Sequence)
-		require.Equal(t, rotatingKey.ExpiresAt(keyrotate.DefaultKeyDuration), newKey.StartsAt.UTC())
+		require.Equal(t, rotatingKey.ExpiresAt(cryptokeys.DefaultKeyDuration), newKey.StartsAt.UTC())
 		require.False(t, newKey.DeletesAt.Valid)
 
 		oldKey, err := db.GetCryptoKeyByFeatureAndSequence(ctx, database.GetCryptoKeyByFeatureAndSequenceParams{
 			Feature:  rotatingKey.Feature,
 			Sequence: rotatingKey.Sequence,
 		})
-		expectedDeletesAt := rotatingKey.StartsAt.Add(keyrotate.DefaultKeyDuration + time.Hour + keyrotate.WorkspaceAppsTokenDuration)
+		expectedDeletesAt := rotatingKey.StartsAt.Add(cryptokeys.DefaultKeyDuration + time.Hour + cryptokeys.WorkspaceAppsTokenDuration)
 		require.NoError(t, err)
 		require.Equal(t, rotatingKey.StartsAt, oldKey.StartsAt)
 		require.True(t, oldKey.DeletesAt.Valid)

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -659,3 +659,17 @@ func Organization(organization database.Organization) codersdk.Organization {
 		IsDefault:   organization.IsDefault,
 	}
 }
+
+func CryptoKeys(keys []database.CryptoKey) []codersdk.CryptoKey {
+	return List(keys, CryptoKey)
+}
+
+func CryptoKey(key database.CryptoKey) codersdk.CryptoKey {
+	return codersdk.CryptoKey{
+		Feature:   codersdk.CryptoKeyFeature(key.Feature),
+		Sequence:  key.Sequence,
+		StartsAt:  key.StartsAt.UTC(),
+		DeletesAt: key.DeletesAt.Time.UTC(),
+		Secret:    key.Secret.String,
+	}
+}

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -668,8 +668,8 @@ func CryptoKey(key database.CryptoKey) codersdk.CryptoKey {
 	return codersdk.CryptoKey{
 		Feature:   codersdk.CryptoKeyFeature(key.Feature),
 		Sequence:  key.Sequence,
-		StartsAt:  key.StartsAt.UTC(),
-		DeletesAt: key.DeletesAt.Time.UTC(),
+		StartsAt:  key.StartsAt,
+		DeletesAt: key.DeletesAt.Time,
 		Secret:    key.Secret.String,
 	}
 }

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -920,7 +920,7 @@ func CryptoKey(t testing.TB, db database.Store, seed database.CryptoKey) databas
 		Secret:      seed.Secret,
 		SecretKeyID: takeFirst(seed.SecretKeyID, sql.NullString{}),
 		Feature:     seed.Feature,
-		StartsAt:    takeFirst(seed.StartsAt, time.Now()),
+		StartsAt:    takeFirst(seed.StartsAt, dbtime.Now()),
 	})
 	require.NoError(t, err, "insert crypto key")
 

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -457,15 +457,15 @@ func (k CryptoKey) DecodeString() ([]byte, error) {
 	return hex.DecodeString(k.Secret.String)
 }
 
-func (k CryptoKey) IsActive(now time.Time) bool {
+func (k CryptoKey) CanSign(now time.Time) bool {
 	now = now.UTC()
 	isAfterStart := !k.StartsAt.IsZero() && !now.Before(k.StartsAt.UTC())
-	return isAfterStart && !k.IsInvalid(now)
+	return isAfterStart && k.CanVerify(now)
 }
 
-func (k CryptoKey) IsInvalid(now time.Time) bool {
+func (k CryptoKey) CanVerify(now time.Time) bool {
 	now = now.UTC()
-	isDeleted := !k.Secret.Valid
-	isPastDeletion := k.DeletesAt.Valid && !now.Before(k.DeletesAt.Time.UTC())
-	return isDeleted || isPastDeletion
+	hasSecret := k.Secret.Valid
+	isBeforeDeletion := !k.DeletesAt.Valid || now.Before(k.DeletesAt.Time.UTC())
+	return hasSecret && isBeforeDeletion
 }

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -458,14 +458,12 @@ func (k CryptoKey) DecodeString() ([]byte, error) {
 }
 
 func (k CryptoKey) CanSign(now time.Time) bool {
-	now = now.UTC()
-	isAfterStart := !k.StartsAt.IsZero() && !now.Before(k.StartsAt.UTC())
+	isAfterStart := !k.StartsAt.IsZero() && !now.Before(k.StartsAt)
 	return isAfterStart && k.CanVerify(now)
 }
 
 func (k CryptoKey) CanVerify(now time.Time) bool {
-	now = now.UTC()
 	hasSecret := k.Secret.Valid
-	isBeforeDeletion := !k.DeletesAt.Valid || now.Before(k.DeletesAt.Time.UTC())
+	isBeforeDeletion := !k.DeletesAt.Valid || now.Before(k.DeletesAt.Time)
 	return hasSecret && isBeforeDeletion
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3115,9 +3115,9 @@ const (
 type CryptoKey struct {
 	Feature   CryptoKeyFeature `json:"feature"`
 	Secret    string           `json:"secret"`
-	DeletesAt time.Time        `json:"deletes_at"`
+	DeletesAt time.Time        `json:"deletes_at" format:"date-time"`
 	Sequence  int32            `json:"sequence"`
-	StartsAt  time.Time        `json:"starts_at"`
+	StartsAt  time.Time        `json:"starts_at" format:"date-time"`
 }
 
 func (c CryptoKey) CanSign(now time.Time) bool {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -3103,3 +3103,32 @@ func (c *Client) SSHConfiguration(ctx context.Context) (SSHConfigResponse, error
 	var sshConfig SSHConfigResponse
 	return sshConfig, json.NewDecoder(res.Body).Decode(&sshConfig)
 }
+
+type CryptoKeyFeature string
+
+const (
+	CryptoKeyFeatureWorkspaceApp  CryptoKeyFeature = "workspace_apps"
+	CryptoKeyFeatureOIDCConvert   CryptoKeyFeature = "oidc_convert"
+	CryptoKeyFeatureTailnetResume CryptoKeyFeature = "tailnet_resume"
+)
+
+type CryptoKey struct {
+	Feature   CryptoKeyFeature `json:"feature"`
+	Secret    string           `json:"secret"`
+	DeletesAt time.Time        `json:"deletes_at"`
+	Sequence  int32            `json:"sequence"`
+	StartsAt  time.Time        `json:"starts_at"`
+}
+
+func (c CryptoKey) CanSign(now time.Time) bool {
+	now = now.UTC()
+	isAfterStartsAt := !c.StartsAt.IsZero() && !now.Before(c.StartsAt)
+	return isAfterStartsAt && c.CanVerify(now)
+}
+
+func (c CryptoKey) CanVerify(now time.Time) bool {
+	now = now.UTC()
+	hasSecret := c.Secret != ""
+	beforeDelete := c.DeletesAt.IsZero() || now.Before(c.DeletesAt)
+	return hasSecret && beforeDelete
+}

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1406,6 +1406,44 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `template_version_id`   | string                                                                        | false    |              | Template version ID can be used to specify a specific version of a template for creating the workspace. |
 | `ttl_ms`                | integer                                                                       | false    |              |                                                                                                         |
 
+## codersdk.CryptoKey
+
+```json
+{
+	"deletes_at": "2019-08-24T14:15:22Z",
+	"feature": "workspace_apps",
+	"secret": "string",
+	"sequence": 0,
+	"starts_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name         | Type                                                   | Required | Restrictions | Description |
+| ------------ | ------------------------------------------------------ | -------- | ------------ | ----------- |
+| `deletes_at` | string                                                 | false    |              |             |
+| `feature`    | [codersdk.CryptoKeyFeature](#codersdkcryptokeyfeature) | false    |              |             |
+| `secret`     | string                                                 | false    |              |             |
+| `sequence`   | integer                                                | false    |              |             |
+| `starts_at`  | string                                                 | false    |              |             |
+
+## codersdk.CryptoKeyFeature
+
+```json
+"workspace_apps"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value            |
+| ---------------- |
+| `workspace_apps` |
+| `oidc_convert`   |
+| `tailnet_resume` |
+
 ## codersdk.CustomRoleRequest
 
 ```json
@@ -9768,55 +9806,17 @@ _None_
 | `derp_map`                   | [tailcfg.DERPMap](#tailcfgderpmap) | false    |              |             |
 | `disable_direct_connections` | boolean                            | false    |              |             |
 
-## wsproxysdk.CryptoKey
-
-```json
-{
-	"deletes_at": "string",
-	"feature": "workspace_apps",
-	"secret": "string",
-	"sequence": 0,
-	"starts_at": "string"
-}
-```
-
-### Properties
-
-| Name         | Type                                                       | Required | Restrictions | Description |
-| ------------ | ---------------------------------------------------------- | -------- | ------------ | ----------- |
-| `deletes_at` | string                                                     | false    |              |             |
-| `feature`    | [wsproxysdk.CryptoKeyFeature](#wsproxysdkcryptokeyfeature) | false    |              |             |
-| `secret`     | string                                                     | false    |              |             |
-| `sequence`   | integer                                                    | false    |              |             |
-| `starts_at`  | string                                                     | false    |              |             |
-
-## wsproxysdk.CryptoKeyFeature
-
-```json
-"workspace_apps"
-```
-
-### Properties
-
-#### Enumerated Values
-
-| Value            |
-| ---------------- |
-| `workspace_apps` |
-| `oidc_convert`   |
-| `tailnet_resume` |
-
 ## wsproxysdk.CryptoKeysResponse
 
 ```json
 {
 	"crypto_keys": [
 		{
-			"deletes_at": "string",
+			"deletes_at": "2019-08-24T14:15:22Z",
 			"feature": "workspace_apps",
 			"secret": "string",
 			"sequence": 0,
-			"starts_at": "string"
+			"starts_at": "2019-08-24T14:15:22Z"
 		}
 	]
 }
@@ -9824,9 +9824,9 @@ _None_
 
 ### Properties
 
-| Name          | Type                                                  | Required | Restrictions | Description |
-| ------------- | ----------------------------------------------------- | -------- | ------------ | ----------- |
-| `crypto_keys` | array of [wsproxysdk.CryptoKey](#wsproxysdkcryptokey) | false    |              |             |
+| Name          | Type                                              | Required | Restrictions | Description |
+| ------------- | ------------------------------------------------- | -------- | ------------ | ----------- |
+| `crypto_keys` | array of [codersdk.CryptoKey](#codersdkcryptokey) | false    |              |             |
 
 ## wsproxysdk.DeregisterWorkspaceProxyRequest
 

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -995,11 +995,11 @@ func (w *workspaceProxiesFetchUpdater) Update(ctx context.Context) error {
 	return w.updateFunc(ctx)
 }
 
-func fromDBCryptoKeys(keys []database.CryptoKey) []wsproxysdk.CryptoKey {
-	wskeys := make([]wsproxysdk.CryptoKey, 0, len(keys))
+func fromDBCryptoKeys(keys []database.CryptoKey) []codersdk.CryptoKey {
+	wskeys := make([]codersdk.CryptoKey, 0, len(keys))
 	for _, key := range keys {
-		wskeys = append(wskeys, wsproxysdk.CryptoKey{
-			Feature:   wsproxysdk.CryptoKeyFeature(key.Feature),
+		wskeys = append(wskeys, codersdk.CryptoKey{
+			Feature:   codersdk.CryptoKeyFeature(key.Feature),
 			Sequence:  key.Sequence,
 			StartsAt:  key.StartsAt.UTC(),
 			DeletesAt: key.DeletesAt.Time.UTC(),

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -17,6 +17,7 @@ import (
 	agpl "github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -733,7 +734,7 @@ func (api *API) workspaceProxyCryptoKeys(rw http.ResponseWriter, r *http.Request
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, wsproxysdk.CryptoKeysResponse{
-		CryptoKeys: fromDBCryptoKeys(keys),
+		CryptoKeys: db2sdk.CryptoKeys(keys),
 	})
 }
 
@@ -993,18 +994,4 @@ func (w *workspaceProxiesFetchUpdater) Fetch(ctx context.Context) (codersdk.Regi
 
 func (w *workspaceProxiesFetchUpdater) Update(ctx context.Context) error {
 	return w.updateFunc(ctx)
-}
-
-func fromDBCryptoKeys(keys []database.CryptoKey) []codersdk.CryptoKey {
-	wskeys := make([]codersdk.CryptoKey, 0, len(keys))
-	for _, key := range keys {
-		wskeys = append(wskeys, codersdk.CryptoKey{
-			Feature:   codersdk.CryptoKeyFeature(key.Feature),
-			Sequence:  key.Sequence,
-			StartsAt:  key.StartsAt.UTC(),
-			DeletesAt: key.DeletesAt.Time.UTC(),
-			Secret:    key.Secret.String,
-		})
-	}
-	return wskeys
 }

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -995,9 +995,9 @@ func TestGetCryptoKeys(t *testing.T) {
 	})
 }
 
-func fromDBCryptoKeys(key database.CryptoKey) wsproxysdk.CryptoKey {
-	return wsproxysdk.CryptoKey{
-		Feature:   wsproxysdk.CryptoKeyFeature(key.Feature),
+func fromDBCryptoKeys(key database.CryptoKey) codersdk.CryptoKey {
+	return codersdk.CryptoKey{
+		Feature:   codersdk.CryptoKeyFeature(key.Feature),
 		Sequence:  key.Sequence,
 		StartsAt:  key.StartsAt.UTC(),
 		DeletesAt: key.DeletesAt.Time.UTC(),

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
@@ -918,14 +919,14 @@ func TestGetCryptoKeys(t *testing.T) {
 			StartsAt: now.Add(-time.Hour),
 			Sequence: 2,
 		})
-		key1 := fromDBCryptoKeys(expectedKey1)
+		key1 := db2sdk.CryptoKey(expectedKey1)
 
 		expectedKey2 := dbgen.CryptoKey(t, db, database.CryptoKey{
 			Feature:  database.CryptoKeyFeatureWorkspaceApps,
 			StartsAt: now,
 			Sequence: 3,
 		})
-		key2 := fromDBCryptoKeys(expectedKey2)
+		key2 := db2sdk.CryptoKey(expectedKey2)
 
 		// Create a deleted key.
 		_ = dbgen.CryptoKey(t, db, database.CryptoKey{
@@ -993,14 +994,4 @@ func TestGetCryptoKeys(t *testing.T) {
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusUnauthorized, sdkErr.StatusCode())
 	})
-}
-
-func fromDBCryptoKeys(key database.CryptoKey) codersdk.CryptoKey {
-	return codersdk.CryptoKey{
-		Feature:   codersdk.CryptoKeyFeature(key.Feature),
-		Sequence:  key.Sequence,
-		StartsAt:  key.StartsAt.UTC(),
-		DeletesAt: key.DeletesAt.Time.UTC(),
-		Secret:    key.Secret.String,
-	}
 }

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -204,35 +204,6 @@ type RegisterWorkspaceProxyRequest struct {
 	Version string `json:"version"`
 }
 
-type CryptoKeyFeature string
-
-const (
-	CryptoKeyFeatureWorkspaceApp  CryptoKeyFeature = "workspace_apps"
-	CryptoKeyFeatureOIDCConvert   CryptoKeyFeature = "oidc_convert"
-	CryptoKeyFeatureTailnetResume CryptoKeyFeature = "tailnet_resume"
-)
-
-type CryptoKey struct {
-	Feature   CryptoKeyFeature `json:"feature"`
-	Secret    string           `json:"secret"`
-	DeletesAt time.Time        `json:"deletes_at"`
-	Sequence  int32            `json:"sequence"`
-	StartsAt  time.Time        `json:"starts_at"`
-}
-
-func (c CryptoKey) CanSign(now time.Time) bool {
-	now = now.UTC()
-	isAfterStartsAt := !c.StartsAt.IsZero() && !now.Before(c.StartsAt)
-	return isAfterStartsAt && c.CanVerify(now)
-}
-
-func (c CryptoKey) CanVerify(now time.Time) bool {
-	now = now.UTC()
-	hasSecret := c.Secret != ""
-	beforeDelete := c.DeletesAt.IsZero() || now.Before(c.DeletesAt)
-	return hasSecret && beforeDelete
-}
-
 type RegisterWorkspaceProxyResponse struct {
 	AppSecurityKey      string           `json:"app_security_key"`
 	DERPMeshKey         string           `json:"derp_mesh_key"`
@@ -612,7 +583,7 @@ func (c *Client) DialCoordinator(ctx context.Context) (agpl.MultiAgentConn, erro
 }
 
 type CryptoKeysResponse struct {
-	CryptoKeys []CryptoKey `json:"crypto_keys"`
+	CryptoKeys []codersdk.CryptoKey `json:"crypto_keys"`
 }
 
 func (c *Client) CryptoKeys(ctx context.Context) (CryptoKeysResponse, error) {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -343,6 +343,15 @@ export interface CreateWorkspaceRequest {
 	readonly automatic_updates?: AutomaticUpdates;
 }
 
+// From codersdk/deployment.go
+export interface CryptoKey {
+	readonly feature: CryptoKeyFeature;
+	readonly secret: string;
+	readonly deletes_at: string;
+	readonly sequence: number;
+	readonly starts_at: string;
+}
+
 // From codersdk/roles.go
 export interface CustomRoleRequest {
 	readonly name: string;
@@ -2073,6 +2082,10 @@ export const AutomaticUpdateses: AutomaticUpdates[] = ["always", "never"]
 // From codersdk/workspacebuilds.go
 export type BuildReason = "autostart" | "autostop" | "initiator"
 export const BuildReasons: BuildReason[] = ["autostart", "autostop", "initiator"]
+
+// From codersdk/deployment.go
+export type CryptoKeyFeature = "oidc_convert" | "tailnet_resume" | "workspace_apps"
+export const CryptoKeyFeatures: CryptoKeyFeature[] = ["oidc_convert", "tailnet_resume", "workspace_apps"]
 
 // From codersdk/workspaceagents.go
 export type DisplayApp = "port_forwarding_helper" | "ssh_helper" | "vscode" | "vscode_insiders" | "web_terminal"


### PR DESCRIPTION
This PR adds the database implementation for fetching and caching keys used for JWT signing. It's been merged into the `keyrotate` pkg and renamed to `cryptokeys` since they're coupled concepts. Given the size of the PR, an additional PR will be added for the wsproxy implementation.