### PR TITLE
feat: add endpoint for fetching workspace proxy keys

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7547,16 +7547,13 @@ const docTemplate = `{
                         "CoderSessionToken": []
                     }
                 ],
-                "consumes": [
-                    "application/json"
-                ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Enterprise"
                 ],
-                "summary": "Fetch workspace proxy signing keys",
+                "summary": "Get workspace proxy crypto keys",
                 "operationId": "get-workspace-proxy-crypto-keys",
                 "responses": {
                     "200": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -7540,6 +7540,37 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaceproxies/me/crypto-keys": {
+            "get": {
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enterprise"
+                ],
+                "summary": "Fetch workspace proxy signing keys",
+                "operationId": "get-workspace-proxy-crypto-keys",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/wsproxysdk.CryptoKeysResponse"
+                        }
+                    }
+                },
+                "x-apidocgen": {
+                    "skip": true
+                }
+            }
+        },
         "/workspaceproxies/me/deregister": {
             "post": {
                 "security": [
@@ -15952,6 +15983,50 @@ const docTemplate = `{
                 },
                 "disable_direct_connections": {
                     "type": "boolean"
+                }
+            }
+        },
+        "wsproxysdk.CryptoKey": {
+            "type": "object",
+            "properties": {
+                "deletes_at": {
+                    "type": "string"
+                },
+                "feature": {
+                    "$ref": "#/definitions/wsproxysdk.CryptoKeyFeature"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "sequence": {
+                    "type": "integer"
+                },
+                "starts_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "wsproxysdk.CryptoKeyFeature": {
+            "type": "string",
+            "enum": [
+                "workspace_apps",
+                "oidc_convert",
+                "tailnet_resume"
+            ],
+            "x-enum-varnames": [
+                "CryptoKeyFeatureWorkspaceApp",
+                "CryptoKeyFeatureOIDCConvert",
+                "CryptoKeyFeatureTailnetResume"
+            ]
+        },
+        "wsproxysdk.CryptoKeysResponse": {
+            "type": "object",
+            "properties": {
+                "crypto_keys": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/wsproxysdk.CryptoKey"
+                    }
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6675,10 +6675,9 @@
 						"CoderSessionToken": []
 					}
 				],
-				"consumes": ["application/json"],
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
-				"summary": "Fetch workspace proxy signing keys",
+				"summary": "Get workspace proxy crypto keys",
 				"operationId": "get-workspace-proxy-crypto-keys",
 				"responses": {
 					"200": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -6668,6 +6668,31 @@
 				}
 			}
 		},
+		"/workspaceproxies/me/crypto-keys": {
+			"get": {
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				],
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Enterprise"],
+				"summary": "Fetch workspace proxy signing keys",
+				"operationId": "get-workspace-proxy-crypto-keys",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/wsproxysdk.CryptoKeysResponse"
+						}
+					}
+				},
+				"x-apidocgen": {
+					"skip": true
+				}
+			}
+		},
 		"/workspaceproxies/me/deregister": {
 			"post": {
 				"security": [
@@ -14587,6 +14612,46 @@
 				},
 				"disable_direct_connections": {
 					"type": "boolean"
+				}
+			}
+		},
+		"wsproxysdk.CryptoKey": {
+			"type": "object",
+			"properties": {
+				"deletes_at": {
+					"type": "string"
+				},
+				"feature": {
+					"$ref": "#/definitions/wsproxysdk.CryptoKeyFeature"
+				},
+				"secret": {
+					"type": "string"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"starts_at": {
+					"type": "string"
+				}
+			}
+		},
+		"wsproxysdk.CryptoKeyFeature": {
+			"type": "string",
+			"enum": ["workspace_apps", "oidc_convert", "tailnet_resume"],
+			"x-enum-varnames": [
+				"CryptoKeyFeatureWorkspaceApp",
+				"CryptoKeyFeatureOIDCConvert",
+				"CryptoKeyFeatureTailnetResume"
+			]
+		},
+		"wsproxysdk.CryptoKeysResponse": {
+			"type": "object",
+			"properties": {
+				"crypto_keys": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/wsproxysdk.CryptoKey"
+					}
 				}
 			}
 		},

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1405,6 +1405,13 @@ func (q *querier) GetCryptoKeys(ctx context.Context) ([]database.CryptoKey, erro
 	return q.db.GetCryptoKeys(ctx)
 }
 
+func (q *querier) GetCryptoKeysByFeature(ctx context.Context, feature database.CryptoKeyFeature) ([]database.CryptoKey, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceCryptoKey); err != nil {
+		return nil, err
+	}
+	return q.db.GetCryptoKeysByFeature(ctx, feature)
+}
+
 func (q *querier) GetDBCryptKeys(ctx context.Context) ([]database.DBCryptKey, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceSystem); err != nil {
 		return nil, err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -2302,6 +2302,10 @@ func (s *MethodTestSuite) TestCryptoKeys() {
 			DeletesAt: sql.NullTime{Time: time.Now(), Valid: true},
 		}).Asserts(rbac.ResourceCryptoKey, policy.ActionUpdate)
 	}))
+	s.Run("GetCryptoKeysByFeature", s.Subtest(func(db database.Store, check *expects) {
+		check.Args(database.CryptoKeyFeatureWorkspaceApps).
+			Asserts(rbac.ResourceCryptoKey, policy.ActionRead)
+	}))
 }
 
 func (s *MethodTestSuite) TestSystemFunctions() {

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -2429,6 +2429,23 @@ func (q *FakeQuerier) GetCryptoKeys(_ context.Context) ([]database.CryptoKey, er
 	return keys, nil
 }
 
+func (q *FakeQuerier) GetCryptoKeysByFeature(_ context.Context, feature database.CryptoKeyFeature) ([]database.CryptoKey, error) {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+
+	keys := make([]database.CryptoKey, 0)
+	for _, key := range q.cryptoKeys {
+		if key.Feature == feature {
+			keys = append(keys, key)
+		}
+	}
+	// We want to return the highest sequence number first.
+	slices.SortFunc(keys, func(i, j database.CryptoKey) int {
+		return int(j.Sequence - i.Sequence)
+	})
+	return keys, nil
+}
+
 func (q *FakeQuerier) GetDBCryptKeys(_ context.Context) ([]database.DBCryptKey, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -2435,7 +2435,7 @@ func (q *FakeQuerier) GetCryptoKeysByFeature(_ context.Context, feature database
 
 	keys := make([]database.CryptoKey, 0)
 	for _, key := range q.cryptoKeys {
-		if key.Feature == feature {
+		if key.Feature == feature && key.Secret.Valid {
 			keys = append(keys, key)
 		}
 	}

--- a/coderd/database/dbmetrics/dbmetrics.go
+++ b/coderd/database/dbmetrics/dbmetrics.go
@@ -564,6 +564,13 @@ func (m metricsStore) GetCryptoKeys(ctx context.Context) ([]database.CryptoKey, 
 	return r0, r1
 }
 
+func (m metricsStore) GetCryptoKeysByFeature(ctx context.Context, feature database.CryptoKeyFeature) ([]database.CryptoKey, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetCryptoKeysByFeature(ctx, feature)
+	m.queryLatencies.WithLabelValues("GetCryptoKeysByFeature").Observe(time.Since(start).Seconds())
+	return r0, r1
+}
+
 func (m metricsStore) GetDBCryptKeys(ctx context.Context) ([]database.DBCryptKey, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetDBCryptKeys(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1103,6 +1103,21 @@ func (mr *MockStoreMockRecorder) GetCryptoKeys(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCryptoKeys", reflect.TypeOf((*MockStore)(nil).GetCryptoKeys), arg0)
 }
 
+// GetCryptoKeysByFeature mocks base method.
+func (m *MockStore) GetCryptoKeysByFeature(arg0 context.Context, arg1 database.CryptoKeyFeature) ([]database.CryptoKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCryptoKeysByFeature", arg0, arg1)
+	ret0, _ := ret[0].([]database.CryptoKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCryptoKeysByFeature indicates an expected call of GetCryptoKeysByFeature.
+func (mr *MockStoreMockRecorder) GetCryptoKeysByFeature(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCryptoKeysByFeature", reflect.TypeOf((*MockStore)(nil).GetCryptoKeysByFeature), arg0, arg1)
+}
+
 // GetDBCryptKeys mocks base method.
 func (m *MockStore) GetDBCryptKeys(arg0 context.Context) ([]database.DBCryptKey, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -134,6 +134,7 @@ type sqlcQuerier interface {
 	GetCoordinatorResumeTokenSigningKey(ctx context.Context) (string, error)
 	GetCryptoKeyByFeatureAndSequence(ctx context.Context, arg GetCryptoKeyByFeatureAndSequenceParams) (CryptoKey, error)
 	GetCryptoKeys(ctx context.Context) ([]CryptoKey, error)
+	GetCryptoKeysByFeature(ctx context.Context, feature CryptoKeyFeature) ([]CryptoKey, error)
 	GetDBCryptKeys(ctx context.Context) ([]DBCryptKey, error)
 	GetDERPMeshKey(ctx context.Context) (string, error)
 	GetDefaultOrganization(ctx context.Context) (Organization, error)

--- a/coderd/database/queries/crypto_keys.sql
+++ b/coderd/database/queries/crypto_keys.sql
@@ -3,6 +3,13 @@ SELECT *
 FROM crypto_keys
 WHERE secret IS NOT NULL;
 
+-- name: GetCryptoKeysByFeature :many
+SELECT *
+FROM crypto_keys
+WHERE feature = $1
+AND secret IS NOT NULL
+ORDER BY sequence DESC;
+
 -- name: GetLatestCryptoKeyByFeature :one
 SELECT *
 FROM crypto_keys

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -9768,6 +9768,66 @@ _None_
 | `derp_map`                   | [tailcfg.DERPMap](#tailcfgderpmap) | false    |              |             |
 | `disable_direct_connections` | boolean                            | false    |              |             |
 
+## wsproxysdk.CryptoKey
+
+```json
+{
+	"deletes_at": "string",
+	"feature": "workspace_apps",
+	"secret": "string",
+	"sequence": 0,
+	"starts_at": "string"
+}
+```
+
+### Properties
+
+| Name         | Type                                                       | Required | Restrictions | Description |
+| ------------ | ---------------------------------------------------------- | -------- | ------------ | ----------- |
+| `deletes_at` | string                                                     | false    |              |             |
+| `feature`    | [wsproxysdk.CryptoKeyFeature](#wsproxysdkcryptokeyfeature) | false    |              |             |
+| `secret`     | string                                                     | false    |              |             |
+| `sequence`   | integer                                                    | false    |              |             |
+| `starts_at`  | string                                                     | false    |              |             |
+
+## wsproxysdk.CryptoKeyFeature
+
+```json
+"workspace_apps"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value            |
+| ---------------- |
+| `workspace_apps` |
+| `oidc_convert`   |
+| `tailnet_resume` |
+
+## wsproxysdk.CryptoKeysResponse
+
+```json
+{
+	"crypto_keys": [
+		{
+			"deletes_at": "string",
+			"feature": "workspace_apps",
+			"secret": "string",
+			"sequence": 0,
+			"starts_at": "string"
+		}
+	]
+}
+```
+
+### Properties
+
+| Name          | Type                                                  | Required | Restrictions | Description |
+| ------------- | ----------------------------------------------------- | -------- | ------------ | ----------- |
+| `crypto_keys` | array of [wsproxysdk.CryptoKey](#wsproxysdkcryptokey) | false    |              |             |
+
 ## wsproxysdk.DeregisterWorkspaceProxyRequest
 
 ```json

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -243,6 +243,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 				r.Post("/app-stats", api.workspaceProxyReportAppStats)
 				r.Post("/register", api.workspaceProxyRegister)
 				r.Post("/deregister", api.workspaceProxyDeregister)
+				r.Get("/crypto-keys", api.workspaceProxyCryptoKeys)
 			})
 			r.Route("/{workspaceproxy}", func(r chi.Router) {
 				r.Use(

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -710,6 +710,21 @@ func (api *API) workspaceProxyRegister(rw http.ResponseWriter, r *http.Request) 
 	go api.forceWorkspaceProxyHealthUpdate(api.ctx)
 }
 
+// workspaceProxyCryptoKeys is used to fetch signing keys for the workspace proxy.
+//
+// This is called periodically by the proxy in the background (every 10m per
+// replica) to ensure that the proxy has the latest signing keys.
+//
+// @Summary Fetch workspace proxy signing keys
+// @ID get-workspace-proxy-crypto-keys
+// @Security CoderSessionToken
+// @Accept json
+// @Produce json
+// @Tags Enterprise
+// @Success 200 {object} wsproxysdk.CryptoKeysResponse
+// @Router /workspaceproxies/me/crypto-keys [get]
+// @x-apidocgen {"skip": true}
+
 func (api *API) workspaceProxyCryptoKeys(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -987,10 +987,10 @@ func fromDBCryptoKeys(keys []database.CryptoKey) []wsproxysdk.CryptoKey {
 	for _, key := range keys {
 		wskeys = append(wskeys, wsproxysdk.CryptoKey{
 			Feature:   wsproxysdk.CryptoKeyFeature(key.Feature),
-			Secret:    key.Secret.String,
-			DeletesAt: key.DeletesAt.Time,
 			Sequence:  key.Sequence,
-			StartsAt:  key.StartsAt,
+			StartsAt:  key.StartsAt.UTC(),
+			DeletesAt: key.DeletesAt.Time.UTC(),
+			Secret:    key.Secret.String,
 		})
 	}
 	return wskeys

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -715,10 +715,9 @@ func (api *API) workspaceProxyRegister(rw http.ResponseWriter, r *http.Request) 
 // This is called periodically by the proxy in the background (every 10m per
 // replica) to ensure that the proxy has the latest signing keys.
 //
-// @Summary Fetch workspace proxy signing keys
+// @Summary Get workspace proxy crypto keys
 // @ID get-workspace-proxy-crypto-keys
 // @Security CoderSessionToken
-// @Accept json
 // @Produce json
 // @Tags Enterprise
 // @Success 200 {object} wsproxysdk.CryptoKeysResponse

--- a/enterprise/coderd/workspaceproxy.go
+++ b/enterprise/coderd/workspaceproxy.go
@@ -724,7 +724,6 @@ func (api *API) workspaceProxyRegister(rw http.ResponseWriter, r *http.Request) 
 // @Success 200 {object} wsproxysdk.CryptoKeysResponse
 // @Router /workspaceproxies/me/crypto-keys [get]
 // @x-apidocgen {"skip": true}
-
 func (api *API) workspaceProxyCryptoKeys(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/enterprise/dbcrypt/dbcrypt.go
+++ b/enterprise/dbcrypt/dbcrypt.go
@@ -321,6 +321,21 @@ func (db *dbCrypt) UpdateCryptoKeyDeletesAt(ctx context.Context, arg database.Up
 	return key, nil
 }
 
+func (db *dbCrypt) GetCryptoKeysByFeature(ctx context.Context, feature database.CryptoKeyFeature) ([]database.CryptoKey, error) {
+	keys, err := db.Store.GetCryptoKeysByFeature(ctx, feature)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range keys {
+		if err := db.decryptField(&keys[i].Secret.String, keys[i].SecretKeyID); err != nil {
+			return nil, err
+		}
+	}
+
+	return keys, nil
+}
+
 func (db *dbCrypt) encryptField(field *string, digest *sql.NullString) error {
 	// If no cipher is loaded, then we can't encrypt anything!
 	if db.ciphers == nil || db.primaryCipherDigest == "" {

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -220,17 +220,17 @@ type CryptoKey struct {
 	StartsAt  time.Time        `json:"starts_at"`
 }
 
-func (c CryptoKey) Active(now time.Time) bool {
+func (c CryptoKey) CanSign(now time.Time) bool {
 	now = now.UTC()
 	isAfterStartsAt := !c.StartsAt.IsZero() && !now.Before(c.StartsAt)
-	return isAfterStartsAt && !c.Invalid(now)
+	return isAfterStartsAt && c.CanVerify(now)
 }
 
-func (c CryptoKey) Invalid(now time.Time) bool {
+func (c CryptoKey) CanVerify(now time.Time) bool {
 	now = now.UTC()
-	noSecret := c.Secret == ""
-	afterDelete := !c.DeletesAt.IsZero() && !now.Before(c.DeletesAt.UTC())
-	return noSecret || afterDelete
+	hasSecret := c.Secret != ""
+	beforeDelete := c.DeletesAt.IsZero() || now.Before(c.DeletesAt)
+	return hasSecret && beforeDelete
 }
 
 type RegisterWorkspaceProxyResponse struct {


### PR DESCRIPTION
This PR adds an endpoint for fetching signing keys from a workspace proxy. I've intentionally decoupled it from the `register` endpoint since we will need to support fetching keys on demand and it's overkill to have to reregister every time that's necessary. Since we'll support fetching keys on demand we don't need to also be refreshing them every 15s, so decoupling it allows us to set a longer interval (i.e. 10 minutes). 