### PR TITLE
docs: mark Microsoft Teams integration as beta

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -521,7 +521,8 @@
 						{
 							"title": "Microsoft Teams Notifications",
 							"description": "Learn how to setup Microsoft Teams notifications",
-							"path": "./admin/notifications/teams.md"
+							"path": "./admin/notifications/teams.md",
+							"state": "beta"
 						}
 					]
 				}


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/14741

This PR adds a small badge to indicate that MS Teams integration is in beta phase.