### PR TITLE
chore: reword license backend error to only mention premium

### DIFF
--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -354,12 +354,9 @@ func (api *API) RequireFeatureMW(feat codersdk.FeatureName) func(http.Handler) h
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			// Entitlement must be enabled.
 			if !api.Entitlements.Enabled(feat) {
-				licenseType := "a Premium"
-				if feat.Enterprise() {
-					licenseType = "an Enterprise"
-				}
+				// All feature warnings should be "Premium", not "Enterprise".
 				httpapi.Write(r.Context(), rw, http.StatusForbidden, codersdk.Response{
-					Message: fmt.Sprintf("%s is %s feature. Contact sales!", feat.Humanize(), licenseType),
+					Message: fmt.Sprintf("%s is a Premium feature. Contact sales!", feat.Humanize()),
 				})
 				return
 			}


### PR DESCRIPTION
Phrasing for "enterprise" removed.