### PR TITLE
chore: remove read all provisioners from users

### DIFF
--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -274,8 +274,6 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 		DisplayName: "Member",
 		Site: Permissions(map[string][]policy.Action{
 			ResourceAssignRole.Type: {policy.ActionRead},
-			// All users can see the provisioner daemons.
-			ResourceProvisionerDaemon.Type: {policy.ActionRead},
 			// All users can see OAuth2 provider applications.
 			ResourceOauth2App.Type:      {policy.ActionRead},
 			ResourceWorkspaceProxy.Type: {policy.ActionRead},
@@ -414,18 +412,15 @@ func ReloadBuiltinRoles(opts *RoleOptions) {
 				DisplayName: "",
 				Site:        []Permission{},
 				Org: map[string][]Permission{
-					organizationID.String(): {
-						{
-							// All org members can read the organization
-							ResourceType: ResourceOrganization.Type,
-							Action:       policy.ActionRead,
-						},
-						{
-							// Can read available roles.
-							ResourceType: ResourceAssignOrgRole.Type,
-							Action:       policy.ActionRead,
-						},
-					},
+					organizationID.String(): Permissions(map[string][]policy.Action{
+						// All users can see the provisioner daemons for workspace
+						// creation.
+						ResourceProvisionerDaemon.Type: {policy.ActionRead},
+						// All org members can read the organization
+						ResourceOrganization.Type: {policy.ActionRead},
+						// Can read available roles.
+						ResourceAssignOrgRole.Type: {policy.ActionRead},
+					}),
 				},
 				User: []Permission{
 					{

--- a/coderd/rbac/roles_test.go
+++ b/coderd/rbac/roles_test.go
@@ -531,9 +531,8 @@ func TestRolePermissions(t *testing.T) {
 			Actions:  []policy.Action{policy.ActionRead},
 			Resource: rbac.ResourceProvisionerDaemon.InOrg(orgID),
 			AuthorizeMap: map[bool][]hasAuthSubjects{
-				// This should be fixed when multi-org goes live
-				true:  {setOtherOrg, owner, templateAdmin, setOrgNotMe, memberMe, orgMemberMe, userAdmin},
-				false: {},
+				true:  {owner, templateAdmin, setOrgNotMe, orgMemberMe},
+				false: {setOtherOrg, memberMe, userAdmin},
 			},
 		},
 		{


### PR DESCRIPTION
Reading provisioner daemons now extends from org member, not site wide member.