### PR TITLE
chore: rename 'first-organization' to 'coder'

### DIFF
--- a/cli/testdata/coder_list_--output_json.golden
+++ b/cli/testdata/coder_list_--output_json.golden
@@ -7,7 +7,7 @@
     "owner_name": "testuser",
     "owner_avatar_url": "",
     "organization_id": "[first org ID]",
-    "organization_name": "first-organization",
+    "organization_name": "main",
     "template_id": "[template ID]",
     "template_name": "test-template",
     "template_display_name": "",

--- a/cli/testdata/coder_list_--output_json.golden
+++ b/cli/testdata/coder_list_--output_json.golden
@@ -7,7 +7,7 @@
     "owner_name": "testuser",
     "owner_avatar_url": "",
     "organization_id": "[first org ID]",
-    "organization_name": "main",
+    "organization_name": "coder",
     "template_id": "[template ID]",
     "template_name": "test-template",
     "template_display_name": "",

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -92,8 +92,8 @@ func New() database.Store {
 	// Always start with a default org. Matching migration 198.
 	defaultOrg, err := q.InsertOrganization(context.Background(), database.InsertOrganizationParams{
 		ID:          uuid.New(),
-		Name:        "main",
-		DisplayName: "Main",
+		Name:        "coder",
+		DisplayName: "Coder",
 		Description: "Builtin default organization.",
 		Icon:        "",
 		CreatedAt:   dbtime.Now(),

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -92,8 +92,8 @@ func New() database.Store {
 	// Always start with a default org. Matching migration 198.
 	defaultOrg, err := q.InsertOrganization(context.Background(), database.InsertOrganizationParams{
 		ID:          uuid.New(),
-		Name:        "first-organization",
-		DisplayName: "first-organization",
+		Name:        "main",
+		DisplayName: "Main",
 		Description: "Builtin default organization.",
 		Icon:        "",
 		CreatedAt:   dbtime.Now(),

--- a/coderd/database/migrations/000259_rename_first_organization.down.sql
+++ b/coderd/database/migrations/000259_rename_first_organization.down.sql
@@ -1,3 +1,3 @@
--- Leave the name as 'main', there is no downside.
+-- Leave the name as 'coder', there is no downside.
 -- The old name 'first-organization' is not used anywhere, just the
 -- is_default property.

--- a/coderd/database/migrations/000259_rename_first_organization.down.sql
+++ b/coderd/database/migrations/000259_rename_first_organization.down.sql
@@ -1,0 +1,3 @@
+-- Leave the name as 'main', there is no downside.
+-- The old name 'first-organization' is not used anywhere, just the
+-- is_default property.

--- a/coderd/database/migrations/000259_rename_first_organization.up.sql
+++ b/coderd/database/migrations/000259_rename_first_organization.up.sql
@@ -1,0 +1,9 @@
+UPDATE
+	organizations
+SET
+	name = 'main',
+	display_name = 'Main'
+WHERE
+	-- The old name was too long.
+	name = 'first-organization'
+;

--- a/coderd/database/migrations/000259_rename_first_organization.up.sql
+++ b/coderd/database/migrations/000259_rename_first_organization.up.sql
@@ -6,4 +6,5 @@ SET
 WHERE
 	-- The old name was too long.
 	name = 'first-organization'
+	AND is_default = true
 ;

--- a/coderd/database/migrations/000259_rename_first_organization.up.sql
+++ b/coderd/database/migrations/000259_rename_first_organization.up.sql
@@ -1,8 +1,8 @@
 UPDATE
 	organizations
 SET
-	name = 'main',
-	display_name = 'Main'
+	name = 'coder',
+	display_name = 'Coder'
 WHERE
 	-- The old name was too long.
 	name = 'first-organization'

--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -202,6 +202,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		err := inv.Run()
 		require.Error(t, err)
 		// The error message should indicate the flag to fix the issue.
-		require.ErrorContains(t, err, fmt.Sprintf("--org=%q", "first-organization"))
+		require.ErrorContains(t, err, fmt.Sprintf("--org=%q", "main"))
 	})
 }

--- a/enterprise/cli/create_test.go
+++ b/enterprise/cli/create_test.go
@@ -202,6 +202,6 @@ func TestEnterpriseCreate(t *testing.T) {
 		err := inv.Run()
 		require.Error(t, err)
 		// The error message should indicate the flag to fix the issue.
-		require.ErrorContains(t, err, fmt.Sprintf("--org=%q", "main"))
+		require.ErrorContains(t, err, fmt.Sprintf("--org=%q", "coder"))
 	})
 }


### PR DESCRIPTION
Rename the first-organization original name. Users can change from the original name.