### PR TITLE
chore: include error detail for ui error display

### DIFF
--- a/coderd/members.go
+++ b/coderd/members.go
@@ -211,6 +211,7 @@ func (api *API) putMemberRoles(rw http.ResponseWriter, r *http.Request) {
 	if apiKey.UserID == member.OrganizationMember.UserID {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "You cannot change your own organization roles.",
+			Detail:  "Another user with the appropriate permissions must change your roles.",
 		})
 		return
 	}


### PR DESCRIPTION
Not including an error detail asks the user to check the dev console. Which is unhelpful in this expected situation

Silencing this error: https://github.com/coder/coder/blob/stevenmasley%2Funhide_provisioner_key_flag/site/src/api/errors.ts#L130