### PR TITLE
chore: add `site` flag to `buildinfo`

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -24,6 +24,9 @@ var (
 	// Updated by buildinfo_slim.go on start.
 	slim bool
 
+	// Updated by buildinfo_site.go on start.
+	site bool
+
 	// Injected with ldflags at build, see scripts/build_go.sh
 	tag  string
 	agpl string // either "true" or "false", ldflags does not support bools
@@ -93,6 +96,11 @@ func IsDev() bool {
 // IsSlim returns true if this is a slim build.
 func IsSlim() bool {
 	return slim
+}
+
+// HasSite returns true if the frontend is embedded in the build.
+func HasSite() bool {
+	return site
 }
 
 // IsAGPL returns true if this is an AGPL build.

--- a/buildinfo/buildinfo_site.go
+++ b/buildinfo/buildinfo_site.go
@@ -1,0 +1,7 @@
+//go:build embed
+
+package buildinfo
+
+func init() {
+	site = true
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -411,7 +411,7 @@ func (r *RootCmd) Command(subcommands []*serpent.Command) (*serpent.Command, err
 		{
 			Flag:        varNoOpen,
 			Env:         "CODER_NO_OPEN",
-			Description: "Suppress opening the browser after logging in.",
+			Description: "Suppress opening the browser when logging in, or starting the server.",
 			Value:       serpent.BoolOf(&r.noOpen),
 			Hidden:      true,
 			Group:       globalGroup,

--- a/cli/server.go
+++ b/cli/server.go
@@ -492,7 +492,9 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				BorderForeground(lipgloss.Color("12")).
 				Render(fmt.Sprintf("View the Web UI:\n%s",
 					pretty.Sprint(cliui.DefaultStyles.Hyperlink, accessURL))))
-			_ = openURL(inv, accessURL)
+			if buildinfo.HasSite() {
+				_ = openURL(inv, accessURL)
+			}
 
 			// Used for zero-trust instance identity with Google Cloud.
 			googleTokenValidator, err := idtoken.NewValidator(ctx, option.WithoutAuthentication())

--- a/cli/server.go
+++ b/cli/server.go
@@ -493,7 +493,10 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				Render(fmt.Sprintf("View the Web UI:\n%s",
 					pretty.Sprint(cliui.DefaultStyles.Hyperlink, accessURL))))
 			if buildinfo.HasSite() {
-				_ = openURL(inv, accessURL)
+				err = openURL(inv, accessURL)
+				if err == nil {
+					cliui.Infof(inv.Stdout, "Opening local browser... You can disable this by passing --no-open.\n")
+				}
 			}
 
 			// Used for zero-trust instance identity with Google Cloud.


### PR DESCRIPTION
As of #14761, the access URL is automatically opened in the browser when running `coder server`. This becomes annoying when running versions of Coder without a frontend during development. 

This PR skips opening the URL in the browser when there is no frontend embedded into the binary. Since this is different from a `slim` build of Coder (i.e. a true slim build is ~40mb, this build is ~120mb), it wouldn't make sense to set the existing `slim` flag to true. The solution is to add a new `site` flag, and a `hasSite` function to `buildinfo` that can be used to detect frontendless builds.