### PR TITLE
fix: sort provisioner key tags in cli output

### DIFF
--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/yamux"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 	"nhooyr.io/websocket"
 
@@ -278,9 +280,11 @@ func (c *Client) ServeProvisionerDaemon(ctx context.Context, req ServeProvisione
 type ProvisionerKeyTags map[string]string
 
 func (p ProvisionerKeyTags) String() string {
+	keys := maps.Keys(p)
+	slices.Sort(keys)
 	tags := []string{}
-	for key, value := range p {
-		tags = append(tags, fmt.Sprintf("%s=%s", key, value))
+	for _, key := range keys {
+		tags = append(tags, fmt.Sprintf("%s=%s", key, p[key]))
 	}
 	return strings.Join(tags, " ")
 }


### PR DESCRIPTION
I'm seeing flakes like

```
    provisionerkeys_test.go:68: 2024-09-30 05:58:44.686: cmd: matched newline = "CREATED AT            NAME          TAGS            "
    provisionerkeys_test.go:72: 2024-09-30 05:58:44.686: cmd: matched newline = "2024-09-30T05:58:44Z  dont-test-me  my=way foo=bar  "
    provisionerkeys_test.go:74: 
        	Error Trace:	/Users/runner/work/coder/coder/enterprise/cli/provisionerkeys_test.go:74
        	Error:      	"2024-09-30T05:58:44Z  dont-test-me  my=way foo=bar  " does not contain "foo=bar my=way"
        	Test:       	TestProvisionerKeys/CRUD
```

e.g. https://github.com/coder/coder/actions/runs/11100237276/job/30835714478?pr=14855

Since the tags are a map, we weren't outputting them in a consistent order on the CLI, leading to flakes.

This sorts the tags by key when converting to a string, for a consistent, canonical output.