### PR TITLE
feat: show user-auth provisioners

### DIFF
--- a/enterprise/coderd/provisionerkeys.go
+++ b/enterprise/coderd/provisionerkeys.go
@@ -147,7 +147,9 @@ func (api *API) provisionerKeyDaemons(rw http.ResponseWriter, r *http.Request) {
 
 	pkDaemons := []codersdk.ProvisionerKeyDaemons{}
 	for _, key := range sdkKeys {
-		// Currently the user-auth key orgID is hardcoded to the default org.
+		// The key.OrganizationID for the `user-auth` key is hardcoded to
+		// the default org in the database and we are overwriting it here
+		// to be the correct org we used to query the list.
 		// This will be changed when we update the `user-auth` keys to be
 		// directly tied to a user ID.
 		if key.ID.String() == codersdk.ProvisionerKeyIDUserAuth {

--- a/enterprise/coderd/provisionerkeys.go
+++ b/enterprise/coderd/provisionerkeys.go
@@ -147,9 +147,11 @@ func (api *API) provisionerKeyDaemons(rw http.ResponseWriter, r *http.Request) {
 
 	pkDaemons := []codersdk.ProvisionerKeyDaemons{}
 	for _, key := range sdkKeys {
-		// currently we exclude user-auth from this list
+		// Currently the user-auth key orgID is hardcoded to the default org.
+		// This will be changed when we update the `user-auth` keys to be
+		// directly tied to a user ID.
 		if key.ID.String() == codersdk.ProvisionerKeyIDUserAuth {
-			continue
+			key.OrganizationID = organization.ID
 		}
 		daemons := []codersdk.ProvisionerDaemon{}
 		for _, daemon := range recentDaemons {

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -27,7 +27,7 @@ import { createDayString } from "utils/createDayString";
 import { docs } from "utils/docs";
 import { ProvisionerTag } from "./ProvisionerTag";
 
-type ProvisionerGroupType = "builtin" | "psk" | "key";
+type ProvisionerGroupType = "builtin" | "userAuth" | "psk" | "key";
 
 interface ProvisionerGroupProps {
 	readonly buildInfo: BuildInfoResponse;
@@ -62,7 +62,6 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		return null;
 	}
 
-	const daemonScope = firstProvisioner.tags.scope || "organization";
 	const allProvisionersAreSameVersion = provisioners.every(
 		(it) => it.version === firstProvisioner.version,
 	);
@@ -73,9 +72,6 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		provisioners.length === 1
 			? "1 provisioner"
 			: `${provisioners.length} provisioners`;
-	const extraTags = Object.entries(keyTags).filter(
-		([key]) => key !== "scope" && key !== "owner",
-	);
 
 	let warnings = 0;
 	let provisionersWithWarnings = 0;
@@ -101,9 +97,6 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		provisionersWithWarnings === 1
 			? "1 provisioner"
 			: `${provisionersWithWarnings} provisioners`;
-
-	const hasMultipleTagVariants =
-		type === "psk" && provisioners.some((it) => !isSimpleTagSet(it.tags));
 
 	return (
 		<div
@@ -142,6 +135,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 								</span>
 							</>
 						)}
+						{type === "userAuth" && <UserAuthProvisionerTitle />}
 
 						{type === "psk" && <PskProvisionerTitle />}
 						{type === "key" && (
@@ -168,28 +162,8 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 						justifyContent: "right",
 					}}
 				>
-					{!hasMultipleTagVariants ? (
-						<Tooltip title="Scope">
-							<Pill
-								size="lg"
-								icon={
-									daemonScope === "organization" ? (
-										<BusinessIcon />
-									) : (
-										<PersonIcon />
-									)
-								}
-							>
-								<span css={{ textTransform: "capitalize" }}>{daemonScope}</span>
-							</Pill>
-						</Tooltip>
-					) : (
-						<Pill size="lg" icon={<TagIcon />}>
-							Multiple tags
-						</Pill>
-					)}
 					{type === "key" &&
-						extraTags.map(([key, value]) => (
+						Object.entries(keyTags).map(([key, value]) => (
 							<ProvisionerTag key={key} tagName={key} tagValue={value} />
 						))}
 				</div>
@@ -248,9 +222,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 										)}
 									</span>
 								</div>
-								{hasMultipleTagVariants && (
-									<PskProvisionerTags tags={provisioner.tags} />
-								)}
+								<PskProvisionerTags tags={provisioner.tags} />
 							</Stack>
 						</div>
 					))}
@@ -405,6 +377,27 @@ const BuiltinProvisionerTitle: FC = () => {
 							These provisioners are running as part of a coderd instance.
 							Built-in provisioners are only available for the default
 							organization. <Link href={docs("/")}>Learn more&hellip;</Link>
+						</HelpTooltipText>
+					</HelpTooltipContent>
+				</HelpTooltip>
+			</Stack>
+		</h4>
+	);
+};
+
+const UserAuthProvisionerTitle: FC = () => {
+	return (
+		<h4 css={styles.groupTitle}>
+			<Stack direction="row" alignItems="end" spacing={1}>
+				<span>User provisioners</span>
+				<HelpTooltip>
+					<HelpTooltipTrigger />
+					<HelpTooltipContent>
+						<HelpTooltipTitle>User provisioners</HelpTooltipTitle>
+						<HelpTooltipText>
+							These provisioners all use user session authentication. User
+							provisioners can be scoped to the user or organization.{" "}
+							<Link href={docs("/")}>Learn more&hellip;</Link>
 						</HelpTooltipText>
 					</HelpTooltipContent>
 				</HelpTooltip>

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -426,8 +426,11 @@ const UserAuthProvisionerTitle: FC = () => {
 					<HelpTooltipContent>
 						<HelpTooltipTitle>User-authenticated provisioners</HelpTooltipTitle>
 						<HelpTooltipText>
-							These provisioners all use user session authentication. User
-							provisioners can be scoped to the user or organization.{" "}
+							These provisioners are connected by users using the{" "}
+							<code>coder</code> CLI, and are authorized by the users
+							credentials. They can be tagged to only run provisioner jobs for
+							that user. User-authenticated provisioners are only available for
+							the default organization.{" "}
 							<Link href={docs("/")}>Learn more&hellip;</Link>
 						</HelpTooltipText>
 					</HelpTooltipContent>

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -166,8 +166,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 						gap: 12,
 						justifyContent: "right",
 					}}
-				>
-				</div>
+				></div>
 			</header>
 
 			{showDetails && (

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -167,19 +167,6 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 						justifyContent: "right",
 					}}
 				>
-					{/* {type !== "userAuth" && 						
-						<Tooltip title="Scope">
-							<Pill
-								size="lg"
-								icon={<BusinessIcon />}
-							>
-								<span css={{ textTransform: "capitalize" }}>{"organization"}</span>
-							</Pill>
-						</Tooltip>}
-					{type === "key" &&
-						extraTags.map(([key, value]) => (
-							<ProvisionerTag key={key} tagName={key} tagValue={value} />
-						))} */}
 				</div>
 			</header>
 

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -62,6 +62,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		return null;
 	}
 
+	const daemonScope = firstProvisioner.tags.scope || "organization";
 	const allProvisionersAreSameVersion = provisioners.every(
 		(it) => it.version === firstProvisioner.version,
 	);
@@ -72,6 +73,9 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 		provisioners.length === 1
 			? "1 provisioner"
 			: `${provisioners.length} provisioners`;
+	const extraTags = Object.entries(keyTags).filter(
+		([key]) => key !== "scope" && key !== "owner",
+	);
 
 	let warnings = 0;
 	let provisionersWithWarnings = 0;
@@ -135,6 +139,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 								</span>
 							</>
 						)}
+
 						{type === "userAuth" && <UserAuthProvisionerTitle />}
 
 						{type === "psk" && <PskProvisionerTitle />}
@@ -162,10 +167,19 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 						justifyContent: "right",
 					}}
 				>
+					{/* {type !== "userAuth" && 						
+						<Tooltip title="Scope">
+							<Pill
+								size="lg"
+								icon={<BusinessIcon />}
+							>
+								<span css={{ textTransform: "capitalize" }}>{"organization"}</span>
+							</Pill>
+						</Tooltip>}
 					{type === "key" &&
-						Object.entries(keyTags).map(([key, value]) => (
+						extraTags.map(([key, value]) => (
 							<ProvisionerTag key={key} tagName={key} tagValue={value} />
-						))}
+						))} */}
 				</div>
 			</header>
 
@@ -222,7 +236,7 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 										)}
 									</span>
 								</div>
-								<PskProvisionerTags tags={provisioner.tags} />
+								<ProvisionerTags tags={provisioner.tags} />
 							</Stack>
 						</div>
 					))}
@@ -307,11 +321,11 @@ const ProvisionerVersionPopover: FC<ProvisionerVersionPopoverProps> = ({
 	);
 };
 
-interface PskProvisionerTagsProps {
+interface ProvisionerTagsProps {
 	tags: Record<string, string>;
 }
 
-const PskProvisionerTags: FC<PskProvisionerTagsProps> = ({ tags }) => {
+const ProvisionerTags: FC<ProvisionerTagsProps> = ({ tags }) => {
 	const daemonScope = tags.scope || "organization";
 	const iconScope =
 		daemonScope === "organization" ? <BusinessIcon /> : <PersonIcon />;

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -389,11 +389,11 @@ const UserAuthProvisionerTitle: FC = () => {
 	return (
 		<h4 css={styles.groupTitle}>
 			<Stack direction="row" alignItems="end" spacing={1}>
-				<span>User provisioners</span>
+				<span>User-authenticated provisioners</span>
 				<HelpTooltip>
 					<HelpTooltipTrigger />
 					<HelpTooltipContent>
-						<HelpTooltipTitle>User provisioners</HelpTooltipTitle>
+						<HelpTooltipTitle>User-authenticated provisioners</HelpTooltipTitle>
 						<HelpTooltipText>
 							These provisioners all use user session authentication. User
 							provisioners can be scoped to the user or organization.{" "}

--- a/site/src/modules/provisioners/ProvisionerGroup.tsx
+++ b/site/src/modules/provisioners/ProvisionerGroup.tsx
@@ -102,6 +102,10 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 			? "1 provisioner"
 			: `${provisionersWithWarnings} provisioners`;
 
+	const hasMultipleTagVariants =
+		(type === "psk" || type === "userAuth") &&
+		provisioners.some((it) => !isSimpleTagSet(it.tags));
+
 	return (
 		<div
 			css={[
@@ -166,7 +170,32 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 						gap: 12,
 						justifyContent: "right",
 					}}
-				></div>
+				>
+					{!hasMultipleTagVariants ? (
+						<Tooltip title="Scope">
+							<Pill
+								size="lg"
+								icon={
+									daemonScope === "organization" ? (
+										<BusinessIcon />
+									) : (
+										<PersonIcon />
+									)
+								}
+							>
+								<span css={{ textTransform: "capitalize" }}>{daemonScope}</span>
+							</Pill>
+						</Tooltip>
+					) : (
+						<Pill size="lg" icon={<TagIcon />}>
+							Multiple tags
+						</Pill>
+					)}
+					{type === "key" &&
+						extraTags.map(([key, value]) => (
+							<ProvisionerTag key={key} tagName={key} tagValue={value} />
+						))}
+				</div>
 			</header>
 
 			{showDetails && (
@@ -222,7 +251,9 @@ export const ProvisionerGroup: FC<ProvisionerGroupProps> = ({
 										)}
 									</span>
 								</div>
-								<ProvisionerTags tags={provisioner.tags} />
+								{hasMultipleTagVariants && (
+									<InlineProvisionerTags tags={provisioner.tags} />
+								)}
 							</Stack>
 						</div>
 					))}
@@ -307,11 +338,11 @@ const ProvisionerVersionPopover: FC<ProvisionerVersionPopoverProps> = ({
 	);
 };
 
-interface ProvisionerTagsProps {
+interface InlineProvisionerTagsProps {
 	tags: Record<string, string>;
 }
 
-const ProvisionerTags: FC<ProvisionerTagsProps> = ({ tags }) => {
+const InlineProvisionerTags: FC<InlineProvisionerTagsProps> = ({ tags }) => {
 	const daemonScope = tags.scope || "organization";
 	const iconScope =
 		daemonScope === "organization" ? <BusinessIcon /> : <PersonIcon />;

--- a/site/src/pages/ManagementSettingsPage/OrganizationProvisionersPageView.stories.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationProvisionersPageView.stories.tsx
@@ -7,6 +7,7 @@ import {
 	MockProvisionerBuiltinKey,
 	MockProvisionerKey,
 	MockProvisionerPskKey,
+	MockProvisionerUserAuthKey,
 	MockProvisionerWithTags,
 	MockUserProvisioner,
 	mockApiError,
@@ -78,6 +79,17 @@ export const Provisioners: Story = {
 					id: `ケイラ-${i}`,
 					name: `ケイラ-${i}`,
 				})),
+			},
+			{
+				key: MockProvisionerUserAuthKey,
+				daemons: [
+					MockUserProvisioner,
+					{
+						...MockUserProvisioner,
+						id: "mock-user-provisioner-2",
+						name: "Test User Provisioner 2",
+					},
+				],
 			},
 		],
 	},

--- a/site/src/pages/ManagementSettingsPage/OrganizationProvisionersPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationProvisionersPageView.tsx
@@ -113,13 +113,13 @@ const ViewContent: FC<ViewContentProps> = ({ buildInfo, provisioners }) => {
 				{provisioners.map((group) => {
 					const type = getGroupType(group.key);
 
-					// We intentionally hide user-authenticated provisioners for now
-					// because there are 1. some grouping issues on the backend and 2. we
-					// should ideally group them by the user who authenticated them, and
-					// not just lump them all together.
-					if (type === "userAuth") {
-						return null;
-					}
+					// // We intentionally hide user-authenticated provisioners for now
+					// // because there are 1. some grouping issues on the backend and 2. we
+					// // should ideally group them by the user who authenticated them, and
+					// // not just lump them all together.
+					// if (type === "userAuth") {
+					// 	return null;
+					// }
 
 					return (
 						<ProvisionerGroup

--- a/site/src/pages/ManagementSettingsPage/OrganizationProvisionersPageView.tsx
+++ b/site/src/pages/ManagementSettingsPage/OrganizationProvisionersPageView.tsx
@@ -110,28 +110,16 @@ const ViewContent: FC<ViewContentProps> = ({ buildInfo, provisioners }) => {
 				</div>
 			)}
 			<Stack spacing={4.5}>
-				{provisioners.map((group) => {
-					const type = getGroupType(group.key);
-
-					// // We intentionally hide user-authenticated provisioners for now
-					// // because there are 1. some grouping issues on the backend and 2. we
-					// // should ideally group them by the user who authenticated them, and
-					// // not just lump them all together.
-					// if (type === "userAuth") {
-					// 	return null;
-					// }
-
-					return (
-						<ProvisionerGroup
-							key={group.key.id}
-							buildInfo={buildInfo}
-							keyName={group.key.name}
-							keyTags={group.key.tags}
-							type={type}
-							provisioners={group.daemons}
-						/>
-					);
-				})}
+				{provisioners.map((group) => (
+					<ProvisionerGroup
+						key={group.key.id}
+						buildInfo={buildInfo}
+						keyName={group.key.name}
+						keyTags={group.key.tags}
+						type={getGroupType(group.key)}
+						provisioners={group.daemons}
+					/>
+				))}
 			</Stack>
 		</>
 	);

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -610,7 +610,7 @@ export const MockProvisioner2: TypesGen.ProvisionerDaemon = {
 };
 
 export const MockUserProvisioner: TypesGen.ProvisionerDaemon = {
-	...MockProvisioner,
+	...MockUserAuthProvisioner,
 	id: "test-user-provisioner",
 	name: "Test User Provisioner",
 	tags: { scope: "user", owner: "12345678-abcd-1234-abcd-1234567890abcd" },


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/14867

What this changes:
- Displays `user-auth` grouped provisioners
- Added tags to provisioners in cases where it matters

<img width="1378" alt="image" src="https://github.com/user-attachments/assets/ecc8da0a-24b4-469d-99e7-aa1f183046b7">

