### PR TITLE
chore(site): update `@playwright/test` to version 1.47.2

### DIFF
--- a/scripts/remote_playwright.sh
+++ b/scripts/remote_playwright.sh
@@ -17,7 +17,14 @@ main() {
 	# between the server and client, and the protocol changes between versions.
 	echo "Checking Playwright version from \"${workspace}\"..."
 	# shellcheck disable=SC2029 # This is intended to expand client-side.
-	playwright_version="$(ssh "coder.${workspace}" "cat '${coder_repo}'/site/pnpm-lock.yaml | grep '^  /@playwright/test@' | cut -d '@' -f 3 | tr -d ':'")"
+	playwright_version=$(
+		ssh "coder.${workspace}" \
+			"cat '${coder_repo}'/site/pnpm-lock.yaml | grep \"^  '@playwright/test@\"" \
+			 | cut -d '@' -f 3 \
+			 | tr -d ":'" \
+			 | sort -V \
+			 | tail -n 1
+	)
 
 	echo "Found Playwright version ${playwright_version}..."
 

--- a/scripts/remote_playwright.sh
+++ b/scripts/remote_playwright.sh
@@ -19,11 +19,11 @@ main() {
 	# shellcheck disable=SC2029 # This is intended to expand client-side.
 	playwright_version=$(
 		ssh "coder.${workspace}" \
-			"cat '${coder_repo}'/site/pnpm-lock.yaml | grep \"^  '@playwright/test@\"" \
-			 | cut -d '@' -f 3 \
-			 | tr -d ":'" \
-			 | sort -V \
-			 | tail -n 1
+			"cat '${coder_repo}'/site/pnpm-lock.yaml | grep \"^  '@playwright/test@\"" |
+			cut -d '@' -f 3 |
+			tr -d ":'" |
+			sort -V |
+			tail -n 1
 	)
 
 	echo "Found Playwright version ${playwright_version}..."

--- a/site/package.json
+++ b/site/package.json
@@ -104,7 +104,7 @@
 		"@biomejs/biome": "1.8.3",
 		"@chromatic-com/storybook": "1.6.0",
 		"@octokit/types": "12.3.0",
-		"@playwright/test": "1.40.1",
+		"@playwright/test": "1.47.2",
 		"@storybook/addon-actions": "8.1.11",
 		"@storybook/addon-essentials": "8.1.11",
 		"@storybook/addon-interactions": "8.1.11",
@@ -165,7 +165,11 @@
 		"vite-plugin-checker": "0.7.2",
 		"vite-plugin-turbosnap": "1.0.3"
 	},
-	"browserslist": ["chrome 110", "firefox 111", "safari 16.0"],
+	"browserslist": [
+		"chrome 110",
+		"firefox 111",
+		"safari 16.0"
+	],
 	"resolutions": {
 		"optionator": "0.9.3",
 		"semver": "7.6.2"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: 12.3.0
         version: 12.3.0
       '@playwright/test':
-        specifier: 1.40.1
-        version: 1.40.1
+        specifier: 1.47.2
+        version: 1.47.2
       '@storybook/addon-actions':
         specifier: 8.1.11
         version: 8.1.11
@@ -2044,10 +2044,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.40.1':
-    resolution: {integrity: sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==}
-    engines: {node: '>=16'}
-    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
+  '@playwright/test@1.47.2':
+    resolution: {integrity: sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@popperjs/core@2.11.8':
@@ -5657,14 +5656,14 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
-  playwright-core@1.40.1:
-    resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
-    engines: {node: '>=16'}
+  playwright-core@1.47.2:
+    resolution: {integrity: sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.40.1:
-    resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
-    engines: {node: '>=16'}
+  playwright@1.47.2:
+    resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   polished@4.2.2:
@@ -9018,9 +9017,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.40.1':
+  '@playwright/test@1.47.2':
     dependencies:
-      playwright: 1.40.1
+      playwright: 1.47.2
 
   '@popperjs/core@2.11.8': {}
 
@@ -13534,11 +13533,11 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
-  playwright-core@1.40.1: {}
+  playwright-core@1.47.2: {}
 
-  playwright@1.40.1:
+  playwright@1.47.2:
     dependencies:
-      playwright-core: 1.40.1
+      playwright-core: 1.47.2
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Support for Ubuntu 24.04 was added in Playwright 1.45, this bumps it to the latest version.

(This is a requirement to support our Nix image on dev.coder.com.)