### PR TITLE
revert: "chore: bump @types/lodash from 4.14.196 to 4.17.9 in /offlinedocs"

### DIFF
--- a/offlinedocs/package.json
+++ b/offlinedocs/package.json
@@ -29,7 +29,7 @@
 		"remark-gfm": "4.0.0"
 	},
 	"devDependencies": {
-		"@types/lodash": "4.17.9",
+		"@types/lodash": "4.14.196",
 		"@types/node": "20.14.8",
 		"@types/react": "18.3.10",
 		"@types/react-dom": "18.3.0",

--- a/offlinedocs/pnpm-lock.yaml
+++ b/offlinedocs/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         version: 4.0.0
     devDependencies:
       '@types/lodash':
-        specifier: 4.17.9
-        version: 4.17.9
+        specifier: 4.14.196
+        version: 4.14.196
       '@types/node':
         specifier: 20.14.8
         version: 20.14.8
@@ -823,8 +823,8 @@ packages:
   '@types/lodash.mergewith@4.6.7':
     resolution: {integrity: sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==}
 
-  '@types/lodash@4.17.9':
-    resolution: {integrity: sha512-w9iWudx1XWOHW5lQRS9iKpK/XuRhnN+0T7HvdCCd802FYkT1AMTnxndJHGrNJwRoRHkslGr4S29tjm1cT7x/7w==}
+  '@types/lodash@4.14.196':
+    resolution: {integrity: sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==}
 
   '@types/mdast@4.0.3':
     resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
@@ -3794,9 +3794,9 @@ snapshots:
 
   '@types/lodash.mergewith@4.6.7':
     dependencies:
-      '@types/lodash': 4.17.9
+      '@types/lodash': 4.14.196
 
-  '@types/lodash@4.17.9': {}
+  '@types/lodash@4.14.196': {}
 
   '@types/mdast@4.0.3':
     dependencies:


### PR DESCRIPTION
Reverts coder/coder#14899
Some tests actually failed I just didn't see it.