### PR TITLE
fix: fix ci build running protoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ gen: \
 	agent/proto/agent.pb.go \
 	provisionersdk/proto/provisioner.pb.go \
 	provisionerd/proto/provisionerd.pb.go \
-	vpn/vpn.proto \
+	vpn/vpn.pb.go \
 	coderd/database/dump.sql \
 	$(DB_GEN_FILES) \
 	site/src/api/typesGenerated.ts \
@@ -518,7 +518,7 @@ gen/mark-fresh:
 		agent/proto/agent.pb.go \
 		provisionersdk/proto/provisioner.pb.go \
 		provisionerd/proto/provisionerd.pb.go \
-		vpn/vpn.proto \
+		vpn/vpn.pb.go \
 		coderd/database/dump.sql \
 		$(DB_GEN_FILES) \
 		site/src/api/typesGenerated.ts \


### PR DESCRIPTION
CI on main is currently failing as `make gen/mark-fresh` that gets run before `make build` is running `touch` on `vpn.proto`, which prompts `make build` to regen `vpn/vpn.pb.go`