### PR TITLE
chore: add Coder service prefix to tailnet

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1880,7 +1880,7 @@ func TestAgent_UpdatedDERP(t *testing.T) {
 	// Setup a client connection.
 	newClientConn := func(derpMap *tailcfg.DERPMap, name string) *workspacesdk.AgentConn {
 		conn, err := tailnet.NewConn(&tailnet.Options{
-			Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+			Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 			DERPMap:   derpMap,
 			Logger:    logger.Named(name),
 		})
@@ -2372,7 +2372,7 @@ func setupAgent(t *testing.T, metadata agentsdk.Manifest, ptyTimeout time.Durati
 		_ = agnt.Close()
 	})
 	conn, err := tailnet.NewConn(&tailnet.Options{
-		Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+		Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.TailscaleServicePrefix.RandomAddr(), 128)},
 		DERPMap:   metadata.DERPMap,
 		Logger:    logger.Named("client"),
 	})

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -83,7 +83,7 @@ func TestDERP(t *testing.T) {
 			},
 		},
 	}
-	w1IP := tailnet.IP()
+	w1IP := tailnet.TailscaleServicePrefix.RandomAddr()
 	w1, err := tailnet.NewConn(&tailnet.Options{
 		Addresses: []netip.Prefix{netip.PrefixFrom(w1IP, 128)},
 		Logger:    logger.Named("w1"),
@@ -92,7 +92,7 @@ func TestDERP(t *testing.T) {
 	require.NoError(t, err)
 
 	w2, err := tailnet.NewConn(&tailnet.Options{
-		Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+		Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 		Logger:    logger.Named("w2"),
 		DERPMap:   derpMap,
 	})

--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -61,7 +61,7 @@ func NewServerTailnet(
 ) (*ServerTailnet, error) {
 	logger = logger.Named("servertailnet")
 	conn, err := tailnet.NewConn(&tailnet.Options{
-		Addresses:           []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 		DERPForceWebSockets: derpForceWebSockets,
 		Logger:              logger,
 		BlockEndpoints:      blockEndpoints,
@@ -352,7 +352,7 @@ func (s *ServerTailnet) ReverseProxy(targetURL, dashboardURL *url.URL, agentID u
 	// "localhost:port", causing connections to be shared across agents.
 	tgt := *targetURL
 	_, port, _ := net.SplitHostPort(tgt.Host)
-	tgt.Host = net.JoinHostPort(tailnet.IPFromUUID(agentID).String(), port)
+	tgt.Host = net.JoinHostPort(tailnet.TailscaleServicePrefix.AddrFromUUID(agentID).String(), port)
 
 	proxy := httputil.NewSingleHostReverseProxy(&tgt)
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, theErr error) {

--- a/coderd/tailnet_test.go
+++ b/coderd/tailnet_test.go
@@ -186,7 +186,9 @@ func TestServerTailnet_ReverseProxy(t *testing.T) {
 		// Ensure the reverse proxy director rewrites the url host to the agent's IP.
 		rp.Director(req)
 		assert.Equal(t,
-			fmt.Sprintf("[%s]:%d", tailnet.IPFromUUID(a.id).String(), workspacesdk.AgentHTTPAPIServerPort),
+			fmt.Sprintf("[%s]:%d",
+				tailnet.TailscaleServicePrefix.AddrFromUUID(a.id).String(),
+				workspacesdk.AgentHTTPAPIServerPort),
 			req.URL.Host,
 		)
 	})

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -51,7 +51,7 @@ type AgentConnOptions struct {
 }
 
 func (c *AgentConn) agentAddress() netip.Addr {
-	return tailnet.IPFromUUID(c.opts.AgentID)
+	return tailnet.TailscaleServicePrefix.AddrFromUUID(c.opts.AgentID)
 }
 
 // AwaitReachable waits for the agent to be reachable.

--- a/codersdk/workspacesdk/workspacesdk.go
+++ b/codersdk/workspacesdk/workspacesdk.go
@@ -236,7 +236,7 @@ func (c *Client) DialAgent(dialCtx context.Context, agentID uuid.UUID, options *
 			CompressionMode: websocket.CompressionDisabled,
 		})
 
-	ip := tailnet.IP()
+	ip := tailnet.TailscaleServicePrefix.RandomAddr()
 	var header http.Header
 	if headerTransport, ok := c.client.HTTPClient.Transport.(*codersdk.HeaderTransport); ok {
 		header = headerTransport.Header

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -120,7 +120,7 @@ func TestPGCoordinatorSingle_AgentInvalidIP(t *testing.T) {
 	defer agent.Close(ctx)
 	agent.UpdateNode(&proto.Node{
 		Addresses: []string{
-			netip.PrefixFrom(agpl.IP(), 128).String(),
+			agpl.TailscaleServicePrefix.RandomPrefix().String(),
 		},
 		PreferredDerp: 10,
 	})
@@ -147,7 +147,7 @@ func TestPGCoordinatorSingle_AgentInvalidIPBits(t *testing.T) {
 	defer agent.Close(ctx)
 	agent.UpdateNode(&proto.Node{
 		Addresses: []string{
-			netip.PrefixFrom(agpl.IPFromUUID(agent.ID), 64).String(),
+			netip.PrefixFrom(agpl.TailscaleServicePrefix.AddrFromUUID(agent.ID), 64).String(),
 		},
 		PreferredDerp: 10,
 	})
@@ -174,7 +174,7 @@ func TestPGCoordinatorSingle_AgentValidIP(t *testing.T) {
 	defer agent.Close(ctx)
 	agent.UpdateNode(&proto.Node{
 		Addresses: []string{
-			netip.PrefixFrom(agpl.IPFromUUID(agent.ID), 128).String(),
+			agpl.TailscaleServicePrefix.PrefixFromUUID(agent.ID).String(),
 		},
 		PreferredDerp: 10,
 	})

--- a/tailnet/conn_test.go
+++ b/tailnet/conn_test.go
@@ -3,6 +3,7 @@ package tailnet_test
 import (
 	"context"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ func TestTailnet(t *testing.T) {
 		t.Parallel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		conn, err := tailnet.NewConn(&tailnet.Options{
-			Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+			Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 			Logger:    logger.Named("w1"),
 			DERPMap:   derpMap,
 		})
@@ -42,7 +43,7 @@ func TestTailnet(t *testing.T) {
 		t.Parallel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitLong)
-		w1IP := tailnet.IP()
+		w1IP := tailnet.TailscaleServicePrefix.RandomAddr()
 		w1, err := tailnet.NewConn(&tailnet.Options{
 			Addresses: []netip.Prefix{netip.PrefixFrom(w1IP, 128)},
 			Logger:    logger.Named("w1"),
@@ -51,7 +52,7 @@ func TestTailnet(t *testing.T) {
 		require.NoError(t, err)
 
 		w2, err := tailnet.NewConn(&tailnet.Options{
-			Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+			Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 			Logger:    logger.Named("w2"),
 			DERPMap:   derpMap,
 		})
@@ -106,7 +107,7 @@ func TestTailnet(t *testing.T) {
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
-		w1IP := tailnet.IP()
+		w1IP := tailnet.TailscaleServicePrefix.RandomAddr()
 		derpMap := tailnettest.RunDERPOnlyWebSockets(t)
 		w1, err := tailnet.NewConn(&tailnet.Options{
 			Addresses:      []netip.Prefix{netip.PrefixFrom(w1IP, 128)},
@@ -117,7 +118,7 @@ func TestTailnet(t *testing.T) {
 		require.NoError(t, err)
 
 		w2, err := tailnet.NewConn(&tailnet.Options{
-			Addresses:      []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+			Addresses:      []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 			Logger:         logger.Named("w2"),
 			DERPMap:        derpMap,
 			BlockEndpoints: true,
@@ -168,7 +169,7 @@ func TestTailnet(t *testing.T) {
 		t.Parallel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitLong)
-		w1IP := tailnet.IP()
+		w1IP := tailnet.TailscaleServicePrefix.RandomAddr()
 		w1, err := tailnet.NewConn(&tailnet.Options{
 			Addresses: []netip.Prefix{netip.PrefixFrom(w1IP, 128)},
 			Logger:    logger.Named("w1"),
@@ -177,7 +178,7 @@ func TestTailnet(t *testing.T) {
 		require.NoError(t, err)
 
 		w2, err := tailnet.NewConn(&tailnet.Options{
-			Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+			Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 			Logger:    logger.Named("w2"),
 			DERPMap:   derpMap,
 		})
@@ -211,7 +212,7 @@ func TestTailnet(t *testing.T) {
 		t.Parallel()
 		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitLong)
-		w1IP := tailnet.IP()
+		w1IP := tailnet.TailscaleServicePrefix.RandomAddr()
 		w1, err := tailnet.NewConn(&tailnet.Options{
 			Addresses:      []netip.Prefix{netip.PrefixFrom(w1IP, 128)},
 			Logger:         logger.Named("w1"),
@@ -221,7 +222,7 @@ func TestTailnet(t *testing.T) {
 		require.NoError(t, err)
 
 		w2, err := tailnet.NewConn(&tailnet.Options{
-			Addresses:      []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+			Addresses:      []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 			Logger:         logger.Named("w2"),
 			DERPMap:        derpMap,
 			BlockEndpoints: true,
@@ -261,7 +262,7 @@ func TestConn_PreferredDERP(t *testing.T) {
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	derpMap, _ := tailnettest.RunDERPAndSTUN(t)
 	conn, err := tailnet.NewConn(&tailnet.Options{
-		Addresses: []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+		Addresses: []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 		Logger:    logger.Named("w1"),
 		DERPMap:   derpMap,
 	})
@@ -290,7 +291,7 @@ func TestConn_UpdateDERP(t *testing.T) {
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 
 	derpMap1, _ := tailnettest.RunDERPAndSTUN(t)
-	ip := tailnet.IP()
+	ip := tailnet.TailscaleServicePrefix.RandomAddr()
 	conn, err := tailnet.NewConn(&tailnet.Options{
 		Addresses:      []netip.Prefix{netip.PrefixFrom(ip, 128)},
 		Logger:         logger.Named("w1"),
@@ -320,7 +321,7 @@ func TestConn_UpdateDERP(t *testing.T) {
 
 	// Connect from a different client.
 	client1, err := tailnet.NewConn(&tailnet.Options{
-		Addresses:      []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+		Addresses:      []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 		Logger:         logger.Named("client1"),
 		DERPMap:        derpMap1,
 		BlockEndpoints: true,
@@ -394,7 +395,7 @@ parentLoop:
 	// Connect from a different different client with up-to-date derp map and
 	// nodes.
 	client2, err := tailnet.NewConn(&tailnet.Options{
-		Addresses:      []netip.Prefix{netip.PrefixFrom(tailnet.IP(), 128)},
+		Addresses:      []netip.Prefix{tailnet.TailscaleServicePrefix.RandomPrefix()},
 		Logger:         logger.Named("client2"),
 		DERPMap:        derpMap2,
 		BlockEndpoints: true,
@@ -425,7 +426,7 @@ func TestConn_BlockEndpoints(t *testing.T) {
 	derpMap, _ := tailnettest.RunDERPAndSTUN(t)
 
 	// Setup conn 1.
-	ip1 := tailnet.IP()
+	ip1 := tailnet.TailscaleServicePrefix.RandomAddr()
 	conn1, err := tailnet.NewConn(&tailnet.Options{
 		Addresses:      []netip.Prefix{netip.PrefixFrom(ip1, 128)},
 		Logger:         logger.Named("w1"),
@@ -439,7 +440,7 @@ func TestConn_BlockEndpoints(t *testing.T) {
 	}()
 
 	// Setup conn 2.
-	ip2 := tailnet.IP()
+	ip2 := tailnet.TailscaleServicePrefix.RandomAddr()
 	conn2, err := tailnet.NewConn(&tailnet.Options{
 		Addresses:      []netip.Prefix{netip.PrefixFrom(ip2, 128)},
 		Logger:         logger.Named("w2"),
@@ -491,4 +492,32 @@ func stitch(t *testing.T, dst, src *tailnet.Conn) {
 		}})
 		assert.NoError(t, err)
 	})
+}
+
+func TestTailscaleServicePrefix(t *testing.T) {
+	t.Parallel()
+	a := tailnet.TailscaleServicePrefix.RandomAddr()
+	require.True(t, strings.HasPrefix(a.String(), "fd7a:115c:a1e0"))
+	p := tailnet.TailscaleServicePrefix.RandomPrefix()
+	require.True(t, strings.HasPrefix(p.String(), "fd7a:115c:a1e0"))
+	require.True(t, strings.HasSuffix(p.String(), "/128"))
+	u := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-123456789abc")
+	a = tailnet.TailscaleServicePrefix.AddrFromUUID(u)
+	require.Equal(t, "fd7a:115c:a1e0:aaaa:aaaa:1234:5678:9abc", a.String())
+	p = tailnet.TailscaleServicePrefix.PrefixFromUUID(u)
+	require.Equal(t, "fd7a:115c:a1e0:aaaa:aaaa:1234:5678:9abc/128", p.String())
+}
+
+func TestCoderServicePrefix(t *testing.T) {
+	t.Parallel()
+	a := tailnet.CoderServicePrefix.RandomAddr()
+	require.True(t, strings.HasPrefix(a.String(), "fd60:627a:a42b"))
+	p := tailnet.CoderServicePrefix.RandomPrefix()
+	require.True(t, strings.HasPrefix(p.String(), "fd60:627a:a42b"))
+	require.True(t, strings.HasSuffix(p.String(), "/128"))
+	u := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-123456789abc")
+	a = tailnet.CoderServicePrefix.AddrFromUUID(u)
+	require.Equal(t, "fd60:627a:a42b:aaaa:aaaa:1234:5678:9abc", a.String())
+	p = tailnet.CoderServicePrefix.PrefixFromUUID(u)
+	require.Equal(t, "fd60:627a:a42b:aaaa:aaaa:1234:5678:9abc/128", p.String())
 }

--- a/tailnet/coordinator_test.go
+++ b/tailnet/coordinator_test.go
@@ -40,7 +40,7 @@ func TestCoordinator(t *testing.T) {
 		client := test.NewClient(ctx, t, coordinator, "client", uuid.New())
 		defer client.Close(ctx)
 		client.UpdateNode(&proto.Node{
-			Addresses:     []string{netip.PrefixFrom(tailnet.IP(), 128).String()},
+			Addresses:     []string{tailnet.TailscaleServicePrefix.RandomPrefix().String()},
 			PreferredDerp: 10,
 		})
 		require.Eventually(t, func() bool {
@@ -63,7 +63,7 @@ func TestCoordinator(t *testing.T) {
 
 		client.UpdateNode(&proto.Node{
 			Addresses: []string{
-				netip.PrefixFrom(tailnet.IP(), 64).String(),
+				netip.PrefixFrom(tailnet.TailscaleServicePrefix.RandomAddr(), 64).String(),
 			},
 			PreferredDerp: 10,
 		})
@@ -84,7 +84,7 @@ func TestCoordinator(t *testing.T) {
 		defer agent.Close(ctx)
 		agent.UpdateNode(&proto.Node{
 			Addresses: []string{
-				netip.PrefixFrom(tailnet.IPFromUUID(agent.ID), 128).String(),
+				tailnet.TailscaleServicePrefix.PrefixFromUUID(agent.ID).String(),
 			},
 			PreferredDerp: 10,
 		})
@@ -106,7 +106,7 @@ func TestCoordinator(t *testing.T) {
 		defer agent.Close(ctx)
 		agent.UpdateNode(&proto.Node{
 			Addresses: []string{
-				netip.PrefixFrom(tailnet.IP(), 128).String(),
+				tailnet.TailscaleServicePrefix.RandomPrefix().String(),
 			},
 			PreferredDerp: 10,
 		})
@@ -126,7 +126,8 @@ func TestCoordinator(t *testing.T) {
 		defer agent.Close(ctx)
 		agent.UpdateNode(&proto.Node{
 			Addresses: []string{
-				netip.PrefixFrom(tailnet.IPFromUUID(agent.ID), 64).String(),
+				netip.PrefixFrom(
+					tailnet.TailscaleServicePrefix.AddrFromUUID(agent.ID), 64).String(),
 			},
 			PreferredDerp: 10,
 		})

--- a/tailnet/telemetry_internal_test.go
+++ b/tailnet/telemetry_internal_test.go
@@ -18,7 +18,7 @@ func TestTelemetryStore(t *testing.T) {
 	t.Run("CreateEvent", func(t *testing.T) {
 		t.Parallel()
 
-		remotePrefix := netip.PrefixFrom(IP(), 128)
+		remotePrefix := TailscaleServicePrefix.RandomPrefix()
 		remoteIP := remotePrefix.Addr()
 		application := "test"
 
@@ -31,16 +31,16 @@ func TestTelemetryStore(t *testing.T) {
 				{
 					ID: 1,
 					Addresses: []netip.Prefix{
-						netip.PrefixFrom(IP(), 128),
-						netip.PrefixFrom(IP(), 128),
+						TailscaleServicePrefix.RandomPrefix(),
+						TailscaleServicePrefix.RandomPrefix(),
 					},
 				},
 				{
 					ID: 2,
 					Addresses: []netip.Prefix{
 						remotePrefix,
-						netip.PrefixFrom(IP(), 128),
-						netip.PrefixFrom(IP(), 128),
+						TailscaleServicePrefix.RandomPrefix(),
+						TailscaleServicePrefix.RandomPrefix(),
 					},
 				},
 			},

--- a/tailnet/test/integration/integration.go
+++ b/tailnet/test/integration/integration.go
@@ -373,7 +373,7 @@ http {
 // and creates a tailnet.Conn which will only use DERP to connect to the peer.
 func StartClientDERP(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
 	return startClientOptions(t, logger, serverURL, me, peer, &tailnet.Options{
-		Addresses:           []netip.Prefix{netip.PrefixFrom(tailnet.IPFromUUID(me.ID), 128)},
+		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.PrefixFromUUID(me.ID)},
 		DERPMap:             derpMap,
 		BlockEndpoints:      true,
 		Logger:              logger,
@@ -389,7 +389,7 @@ func StartClientDERP(t *testing.T, logger slog.Logger, serverURL *url.URL, derpM
 // only use DERP WebSocket fallback.
 func StartClientDERPWebSockets(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
 	return startClientOptions(t, logger, serverURL, me, peer, &tailnet.Options{
-		Addresses:           []netip.Prefix{netip.PrefixFrom(tailnet.IPFromUUID(me.ID), 128)},
+		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.PrefixFromUUID(me.ID)},
 		DERPMap:             derpMap,
 		BlockEndpoints:      true,
 		Logger:              logger,
@@ -406,7 +406,7 @@ func StartClientDERPWebSockets(t *testing.T, logger slog.Logger, serverURL *url.
 // connection to be established between the two peers.
 func StartClientDirect(t *testing.T, logger slog.Logger, serverURL *url.URL, derpMap *tailcfg.DERPMap, me, peer Client) *tailnet.Conn {
 	conn := startClientOptions(t, logger, serverURL, me, peer, &tailnet.Options{
-		Addresses:           []netip.Prefix{netip.PrefixFrom(tailnet.IPFromUUID(me.ID), 128)},
+		Addresses:           []netip.Prefix{tailnet.TailscaleServicePrefix.PrefixFromUUID(me.ID)},
 		DERPMap:             derpMap,
 		BlockEndpoints:      false,
 		Logger:              logger,
@@ -418,7 +418,7 @@ func StartClientDirect(t *testing.T, logger slog.Logger, serverURL *url.URL, der
 	})
 
 	// Wait for direct connection to be established.
-	peerIP := tailnet.IPFromUUID(peer.ID)
+	peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
 	require.Eventually(t, func() bool {
 		t.Log("attempting ping to peer to judge direct connection")
 		ctx := testutil.Context(t, testutil.WaitShort)

--- a/tailnet/test/integration/integration_test.go
+++ b/tailnet/test/integration/integration_test.go
@@ -267,7 +267,7 @@ func handleTestSubprocess(t *testing.T) {
 
 			if me.ShouldRunTests {
 				// Wait for connectivity.
-				peerIP := tailnet.IPFromUUID(peer.ID)
+				peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
 				if !conn.AwaitReachable(testutil.Context(t, testutil.WaitLong), peerIP) {
 					t.Fatalf("peer %v did not become reachable", peerIP)
 				}

--- a/tailnet/test/integration/suite.go
+++ b/tailnet/test/integration/suite.go
@@ -48,13 +48,13 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 
 	t.Run("Connectivity", func(t *testing.T) {
 		t.Parallel()
-		peerIP := tailnet.IPFromUUID(peer.ID)
+		peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
 	})
 
 	t.Run("RestartDERP", func(t *testing.T) {
-		peerIP := tailnet.IPFromUUID(peer.ID)
+		peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
 		sendRestart(t, serverURL, true, false)
@@ -63,7 +63,7 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 	})
 
 	t.Run("RestartCoordinator", func(t *testing.T) {
-		peerIP := tailnet.IPFromUUID(peer.ID)
+		peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
 		sendRestart(t, serverURL, false, true)
@@ -72,7 +72,7 @@ func TestSuite(t *testing.T, _ slog.Logger, serverURL *url.URL, conn *tailnet.Co
 	})
 
 	t.Run("RestartBoth", func(t *testing.T) {
-		peerIP := tailnet.IPFromUUID(peer.ID)
+		peerIP := tailnet.TailscaleServicePrefix.AddrFromUUID(peer.ID)
 		_, _, _, err := conn.Ping(testutil.Context(t, testutil.WaitLong), peerIP)
 		require.NoError(t, err, "ping peer")
 		sendRestart(t, serverURL, true, true)

--- a/tailnet/tunnel.go
+++ b/tailnet/tunnel.go
@@ -80,7 +80,7 @@ func (a AgentCoordinateeAuth) Authorize(req *proto.CoordinateRequest) error {
 				return xerrors.Errorf("invalid address bits, expected 128, got %d", pre.Bits())
 			}
 
-			if IPFromUUID(a.ID).Compare(pre.Addr()) != 0 &&
+			if TailscaleServicePrefix.AddrFromUUID(a.ID).Compare(pre.Addr()) != 0 &&
 				legacyWorkspaceAgentIP.Compare(pre.Addr()) != 0 {
 				return xerrors.Errorf("invalid node address, got %s", pre.Addr().String())
 			}


### PR DESCRIPTION
re: #14715

This PR introduces the Coder service prefix: `fd60:627a:a42b::/48` and refactors our existing code as calling the Tailscale service prefix explicitly (rather than implicitly).

Removes the unused `Addresses` agent option. All clients today assume they can compute the Agent's IP address based on its UUID, so an agent started with a custom address would break things.