### PR TITLE
fix: change message when trying to update a workspace already up-to-date

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -30,7 +30,7 @@ func (r *RootCmd) update() *serpent.Command {
 				return err
 			}
 			if !workspace.Outdated && !parameterFlags.promptRichParameters && !parameterFlags.promptBuildOptions && len(parameterFlags.buildOptions) == 0 {
-				_, _ = fmt.Fprintf(inv.Stdout, "Workspace isn't outdated!\n")
+				_, _ = fmt.Fprintf(inv.Stdout, "Workspace is up-to-date.\n")
 				return nil
 			}
 


### PR DESCRIPTION
Related to #14940  -

We replace the wording from Workspace isn't outdated to Workspace is up-to-date when the workspace already is up-to-date.