### PR TITLE
fix(coderd): move test location to ignore Australia time saving error

### DIFF
--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -179,7 +179,7 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 	t.Parallel()
 
 	layout := insightsTimeLayout
-	sydneyLoc, err := time.LoadLocation("Australia/Sydney") // Random location
+	sydneyLoc, err := time.LoadLocation("America/Los_Angeles") // Random location
 	require.NoError(t, err)
 
 	now := time.Now().In(sydneyLoc)

--- a/coderd/insights_internal_test.go
+++ b/coderd/insights_internal_test.go
@@ -179,17 +179,17 @@ func Test_parseInsightsInterval_week(t *testing.T) {
 	t.Parallel()
 
 	layout := insightsTimeLayout
-	sydneyLoc, err := time.LoadLocation("America/Los_Angeles") // Random location
+	losAngelesLoc, err := time.LoadLocation("America/Los_Angeles") // Random location
 	require.NoError(t, err)
 
-	now := time.Now().In(sydneyLoc)
+	now := time.Now().In(losAngelesLoc)
 	t.Logf("now: %s", now)
 
 	y, m, d := now.Date()
-	today := time.Date(y, m, d, 0, 0, 0, 0, sydneyLoc)
+	today := time.Date(y, m, d, 0, 0, 0, 0, losAngelesLoc)
 	t.Logf("today: %s", today)
 
-	thisHour := time.Date(y, m, d, now.Hour(), 0, 0, 0, sydneyLoc)
+	thisHour := time.Date(y, m, d, now.Hour(), 0, 0, 0, losAngelesLoc)
 	t.Logf("thisHour: %s", thisHour)
 	twoHoursAgo := thisHour.Add(-2 * time.Hour)
 	t.Logf("twoHoursAgo: %s", twoHoursAgo)


### PR DESCRIPTION
A test is currently failing because it relies on Sidney Tz.

from the internet : 

```
Daylight Saving Time begins at 2 am (AEST) on the first Sunday in October and ends at 3 am (Australian Eastern Daylight Time) on the first Sunday in April.
```

Due to that - there's one hour missing in the tests - and the test `6 days are acceptable` is failing.

Changing to another timezone to fix the situation, it would require a longer-term solution or making sure it cannot happen anymore.