### PR TITLE
chore: fix docs/admin links and upgrade notice

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -813,7 +813,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				}
 				defer options.Telemetry.Close()
 			} else {
-				logger.Warn(ctx, fmt.Sprintf(`telemetry disabled, unable to notify of security issues. Read more: %s/admin/telemetry`, vals.DocsURL.String()))
+				logger.Warn(ctx, fmt.Sprintf(`telemetry disabled, unable to notify of security issues. Read more: %s/admin/setup/telemetry`, vals.DocsURL.String()))
 			}
 
 			// This prevents the pprof import from being accidentally deleted.

--- a/cli/templatecreate.go
+++ b/cli/templatecreate.go
@@ -237,7 +237,7 @@ func (r *RootCmd) templateCreate() *serpent.Command {
 		},
 		{
 			Flag:        "require-active-version",
-			Description: "Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/templates/general-settings#require-automatic-updates-enterprise for more details.",
+			Description: "Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/admin/templates/managing-templates#require-automatic-updates-enterprise for more details.",
 			Value:       serpent.BoolOf(&requireActiveVersion),
 			Default:     "false",
 		},

--- a/cli/templateedit.go
+++ b/cli/templateedit.go
@@ -290,7 +290,7 @@ func (r *RootCmd) templateEdit() *serpent.Command {
 		},
 		{
 			Flag:        "require-active-version",
-			Description: "Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/templates/general-settings#require-automatic-updates-enterprise for more details.",
+			Description: "Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/admin/templates/managing-templates#require-automatic-updates-enterprise for more details.",
 			Value:       serpent.BoolOf(&requireActiveVersion),
 			Default:     "false",
 		},

--- a/cli/testdata/coder_templates_create_--help.golden
+++ b/cli/testdata/coder_templates_create_--help.golden
@@ -55,7 +55,7 @@ OPTIONS:
           Requires workspace builds to use the active template version. This
           setting does not apply to template admins. This is an enterprise-only
           feature. See
-          https://coder.com/docs/templates/general-settings#require-automatic-updates-enterprise
+          https://coder.com/docs/admin/templates/managing-templates#require-automatic-updates-enterprise
           for more details.
 
       --var string-array

--- a/cli/testdata/coder_templates_edit_--help.golden
+++ b/cli/testdata/coder_templates_edit_--help.golden
@@ -87,7 +87,7 @@ OPTIONS:
           Requires workspace builds to use the active template version. This
           setting does not apply to template admins. This is an enterprise-only
           feature. See
-          https://coder.com/docs/templates/general-settings#require-automatic-updates-enterprise
+          https://coder.com/docs/admin/templates/managing-templates#require-automatic-updates-enterprise
           for more details.
 
   -y, --yes bool

--- a/docs/admin/templates/extending-templates/web-ides.md
+++ b/docs/admin/templates/extending-templates/web-ides.md
@@ -255,7 +255,7 @@ resource "coder_app" "rstudio" {
 ```
 
 If you cannot enable a
-[wildcard subdomain](https://coder.com/docs/admin/configure#wildcard-access-url),
+[wildcard subdomain](https://coder.com/docs/admin/setup#wildcard-access-url),
 you can configure the template to run RStudio on a path using an NGINX reverse
 proxy in the template. There is however
 [security risk](https://coder.com/docs/reference/cli/server#--dangerous-allow-path-app-sharing)

--- a/docs/reference/cli/templates_create.md
+++ b/docs/reference/cli/templates_create.md
@@ -95,7 +95,7 @@ Specify a duration workspaces may be in the dormant state prior to being deleted
 | Type    | <code>bool</code>  |
 | Default | <code>false</code> |
 
-Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/templates/general-settings#require-automatic-updates-enterprise for more details.
+Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/admin/templates/managing-templates#require-automatic-updates-enterprise for more details.
 
 ### -y, --yes
 

--- a/docs/reference/cli/templates_edit.md
+++ b/docs/reference/cli/templates_edit.md
@@ -153,7 +153,7 @@ Allow users to customize the autostop TTL for workspaces on this template. This 
 | Type    | <code>bool</code>  |
 | Default | <code>false</code> |
 
-Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/templates/general-settings#require-automatic-updates-enterprise for more details.
+Requires workspace builds to use the active template version. This setting does not apply to template admins. This is an enterprise-only feature. See https://coder.com/docs/admin/templates/managing-templates#require-automatic-updates-enterprise for more details.
 
 ### --private
 

--- a/install.sh
+++ b/install.sh
@@ -216,7 +216,7 @@ To run a Coder server:
   # Or just run the server directly
   $ coder server
 
-  Configuring Coder: https://coder.com/docs/admin/configure
+  Configuring Coder: https://coder.com/docs/admin/setup
 
 To connect to a Coder deployment:
 

--- a/site/src/api/queries/workspaces.ts
+++ b/site/src/api/queries/workspaces.ts
@@ -61,7 +61,7 @@ type AutoCreateWorkspaceOptions = {
 	 * If provided, the auto-create workspace feature will attempt to find a
 	 * matching workspace. If found, it will return the existing workspace instead
 	 * of creating a new one. Its value supports [advanced filtering queries for
-	 * workspaces](https://coder.com/docs/workspaces#workspace-filtering). If
+	 * workspaces](https://coder.com/docs/user-guides/workspace-management#workspace-filtering). If
 	 * multiple values are returned, the first one will be returned.
 	 */
 	match: string | null;


### PR DESCRIPTION
- Update links to /docs/admin to match the new structure
- TODO: remove the release string from the "upgrade available" instructions link
   - [x] https://github.com/coder/coder/blob/update-upgrade-config-links/cli/server.go#L646

      ![2024-10-11_11-35-40](https://github.com/user-attachments/assets/fd95e821-d5ad-4c91-a38a-066046c7072c)
