### PR TITLE
feat: allow for different docker socket path in docker-based templates (#15035)

### DIFF
--- a/examples/templates/devcontainer-docker/main.tf
+++ b/examples/templates/devcontainer-docker/main.tf
@@ -13,9 +13,19 @@ terraform {
   }
 }
 
+variable "docker_socket" {
+  default     = ""
+  description = "(Optional) Docker socket URI"
+  type        = string
+}
+
 provider "coder" {}
-provider "docker" {}
+provider "docker" {
+  # Defaulting to null if the variable is an empty string lets us have an optional variable without having to set our own default
+  host = var.docker_socket != "" ? var.docker_socket : null
+}
 provider "envbuilder" {}
+
 data "coder_provisioner" "me" {}
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}

--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -13,14 +13,19 @@ locals {
   username = data.coder_workspace_owner.me.name
 }
 
-data "coder_provisioner" "me" {
+variable "docker_socket" {
+  default     = ""
+  description = "(Optional) Docker socket URI"
+  type        = string
 }
 
 provider "docker" {
+  # Defaulting to null if the variable is an empty string lets us have an optional variable without having to set our own default
+  host = var.docker_socket != "" ? var.docker_socket : null
 }
 
-data "coder_workspace" "me" {
-}
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
 
 resource "coder_agent" "main" {


### PR DESCRIPTION
This PR fixes #15035, I have tested it on my instance and it works as expected.

I have opted to default to null, that way we don't have to hardcode our own default and we let the Docker provider default to whatever it wants.
This has the downside that it makes the template a little less readable, but it has the upside that we don't have to update the default if for some reason it ever changes.

We could also do something like this, but I like it less.

```hcl
variable "docker_socket" {
  default     = "unix:///var/run/docker.sock"
  description = "Docker socket URI"
  type        = string
}

provider "docker" {
  host = var.docker_socket
}
```

---

I have not edited the templates that are not present in examples/templates (namely [examples/jfrog/docker](https://github.com/coder/coder/tree/main/examples/jfrog/docker) and [examples/parameters](https://github.com/coder/coder/tree/main/examples/parameters)), should I also edit these as well?
Maybe we would also want to move them to examples/templates in a separate PR?

---

NOTE: this PR does not cover using authenticated sources, so it's likely that only unix and tcp sockets would work out of the box but I think we don't want to include authenticated sockets OOTB (e.g SSH) because that would overcomplicate the template.

cc: @matifali
