### PR TITLE
chore: disable erroneous linting of function names in vpn

### DIFF
--- a/vpn/serdes.go
+++ b/vpn/serdes.go
@@ -103,12 +103,16 @@ func (s *serdes[_, _, _]) closeIdempotent() {
 	})
 }
 
+// Close closes the serdes
+// nolint: revive
 func (s *serdes[_, _, _]) Close() error {
 	s.closeIdempotent()
 	s.wg.Wait()
 	return nil
 }
 
+// start starts the goroutines that serialize and deserialize to the conn.
+// nolint: revive
 func (s *serdes[_, _, _]) start() {
 	s.wg.Add(2)
 	go func() {

--- a/vpn/speaker.go
+++ b/vpn/speaker.go
@@ -186,6 +186,7 @@ func (s *speaker[S, R, _]) recvFromSerdes() {
 	}
 }
 
+// Close closes the speaker
 // nolint: revive
 func (s *speaker[_, _, _]) Close() error {
 	s.cancel()


### PR DESCRIPTION
Disables bogus linting e.g. https://github.com/coder/coder/actions/runs/11305350065/job/31444754200?pr=15011