### PR TITLE
fix: add psmock to gen and make-fresh targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,7 +507,8 @@ gen: \
 	examples/examples.gen.json \
 	tailnet/tailnettest/coordinatormock.go \
 	tailnet/tailnettest/coordinateemock.go \
-	tailnet/tailnettest/multiagentmock.go
+	tailnet/tailnettest/multiagentmock.go \
+	coderd/database/pubsub/psmock/psmock.go
 .PHONY: gen
 
 # Mark all generated files as fresh so make thinks they're up-to-date. This is
@@ -537,6 +538,7 @@ gen/mark-fresh:
 		tailnet/tailnettest/coordinatormock.go \
 		tailnet/tailnettest/coordinateemock.go \
 		tailnet/tailnettest/multiagentmock.go \
+		coderd/database/pubsub/psmock/psmock.go \
 		"
 
 	for file in $$files; do


### PR DESCRIPTION
Fixes

```
+ make -j build/coder_linux_amd64 build/coder_linux_arm64 build/coder_linux_armv7 build/coder_2.16.0-devel+7da231bc9_windows_amd64.zip build/coder_2.16.0-devel+7da231bc9_linux_amd64.tar.gz build/coder_2.16.0-devel+7da231bc9_linux_amd64.deb
coderd/database/pubsub/psmock/doc.go:4: running "mockgen": exec: "mockgen": executable file not found in $PATH
make: *** [Makefile:569: coderd/database/pubsub/psmock/psmock.go] Error 1
```

during builds.