### PR TITLE
chore: log provider stack traces on text file busy

### DIFF
--- a/provisioner/terraform/testdata/fake_text_file_busy.sh
+++ b/provisioner/terraform/testdata/fake_text_file_busy.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+VERSION=$1
+shift 1
+
+json_print() {
+	echo "{\"@level\":\"error\",\"@message\":\"$*\"}"
+}
+
+case "$1" in
+version)
+	cat <<-EOF
+		{
+			"terraform_version": "${VERSION}",
+			"platform": "linux_amd64",
+			"provider_selections": {},
+			"terraform_outdated": false
+		}
+	EOF
+	exit 0
+	;;
+init)
+	echo "init"
+	>&2 echo "Error: Failed to install provider"
+  >&2 echo "    Error while installing coder/coder v1.0.4: open"
+  >&2 echo "    /home/coder/.cache/coder/provisioner-0/tf/registry.terraform.io/coder/coder/1.0.3/linux_amd64/terraform-provider-coder_v1.0.4:"
+  >&2 echo "    text file busy"
+  exit 1
+	;;
+plan)
+	echo "plan not supported"
+	exit 1
+	;;
+apply)
+	echo "apply not supported"
+	exit 1
+	;;
+esac
+
+exit 10
+
+

--- a/provisioner/terraform/testdata/fake_text_file_busy.sh
+++ b/provisioner/terraform/testdata/fake_text_file_busy.sh
@@ -21,11 +21,11 @@ version)
 	;;
 init)
 	echo "init"
-	>&2 echo "Error: Failed to install provider"
-  >&2 echo "    Error while installing coder/coder v1.0.4: open"
-  >&2 echo "    /home/coder/.cache/coder/provisioner-0/tf/registry.terraform.io/coder/coder/1.0.3/linux_amd64/terraform-provider-coder_v1.0.4:"
-  >&2 echo "    text file busy"
-  exit 1
+	echo >&2 "Error: Failed to install provider"
+	echo >&2 "    Error while installing coder/coder v1.0.4: open"
+	echo >&2 "    /home/coder/.cache/coder/provisioner-0/tf/registry.terraform.io/coder/coder/1.0.3/linux_amd64/terraform-provider-coder_v1.0.4:"
+	echo >&2 "    text file busy"
+	exit 1
 	;;
 plan)
 	echo "plan not supported"
@@ -38,5 +38,3 @@ apply)
 esac
 
 exit 10
-
-


### PR DESCRIPTION
re: #14726

If we see "text file busy" in the errors while initializing terraform, attempt to query the pprof endpoint set up by https://github.com/coder/terraform-provider-coder/pull/295 and log at CRITICAL.