### PR TITLE
test: add logging to TestWorkspaceActivityBump/Dial

### DIFF
--- a/coderd/activitybump_test.go
+++ b/coderd/activitybump_test.go
@@ -164,6 +164,7 @@ func TestWorkspaceActivityBump(t *testing.T) {
 					updatedAfter = dbtime.Now()
 					return hasBumped
 				},
+				//nolint: gocritic // maxTimeDrift is a testutil time
 				maxTimeDrift, testutil.IntervalFast,
 				"deadline %v never updated", firstDeadline,
 			)


### PR DESCRIPTION
My initial notes: https://github.com/coder/internal/issues/102#issuecomment-2414561048

I am a bit split on how best to solve this. It is a classic problem of what is `now`.

At it's core, what is happening is:
1. Workspace activity bump happens
2. Detect bump
3. Take `now`
4. Assert `deadeline-now=1hr`

For an unknown reason, `Detect Bump` seems to have taken 10s in the flake failure. So `now` has drifted 10s later then step 1.

Our time tolerance is 10s, so the test fails.

Without more logs, it's difficult to know for certain. What makes this more confusing, is the `Detect bump` should detect when the bump happens, meaning `now` should be relative to when this loop unblocks.

So the implementation of taking `now` after the loop is correct.

## What did I do then?

I added logging information to output timing information of this for loop. If we get another failure, this timing information should be helpful.

I also made the time drift allowed (was 10s) to match the maximum waiting time of the for loop. It's not perfect, but now the loop should take max ~15s, and the time comparison will allow 15s leeway. 


--------

Just a note that I do not believe there is any bugs in the production code. Looking at the failure logs, the activity bump works as expected.