### PR TITLE
fix(docs): fix a typo in the devcontainer documentation

### DIFF
--- a/docs/admin/templates/managing-templates/devcontainers.md
+++ b/docs/admin/templates/managing-templates/devcontainers.md
@@ -37,7 +37,7 @@ iterate on their development environments.
 - [Devcontainers (Docker)](https://github.com/coder/coder/tree/main/examples/templates/devcontainer-docker)
   provisions a development container using Docker.
 - [Devcontainers (Kubernetes)](https://github.com/coder/coder/tree/main/examples/templates/devcontainer-kubernetes)
-  provisioners a development container on the Kubernetes.
+  provisions a development container on the Kubernetes.
 - [Google Compute Engine (Devcontainer)](https://github.com/coder/coder/tree/main/examples/templates/gcp-devcontainer)
   runs a development container inside a single GCP instance. It also mounts the
   Docker socket from the VM inside the container to enable Docker inside the


### PR DESCRIPTION
This PR fixes a minor typo in our documentation: https://coder.com/docs/admin/templates/managing-templates/devcontainers