### PR TITLE
fix: pin shfmt to 3.7.0 in dogfood to match CI

### DIFF
--- a/dogfood/contents/Dockerfile
+++ b/dogfood/contents/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && \
 	go install github.com/dvyukov/go-fuzz/go-fuzz-build@latest && \
 	# go-releaser for building 'fat binaries' that work cross-platform
 	go install github.com/goreleaser/goreleaser@v1.6.1 && \
-	go install mvdan.cc/sh/v3/cmd/shfmt@3.7.0 && \
+	go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0 && \
 	# nfpm is used with `make build` to make release packages
 	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1 && \
 	# yq v4 is used to process yaml files in coder v2. Conflicts with

--- a/dogfood/contents/Dockerfile
+++ b/dogfood/contents/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && \
 	go install github.com/dvyukov/go-fuzz/go-fuzz-build@latest && \
 	# go-releaser for building 'fat binaries' that work cross-platform
 	go install github.com/goreleaser/goreleaser@v1.6.1 && \
-	go install mvdan.cc/sh/v3/cmd/shfmt@latest && \
+	go install mvdan.cc/sh/v3/cmd/shfmt@3.7.0 && \
 	# nfpm is used with `make build` to make release packages
 	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.35.1 && \
 	# yq v4 is used to process yaml files in coder v2. Conflicts with


### PR DESCRIPTION
Pins our dogfood Dockerfile to match CI version of `shfmt`