### PR TITLE
fix: match go version in go.mod and CI

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.22.5"
+    default: "1.22.6"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Causing CI to re-download Go to match the version in go.mod, and failing on Windows, e.g. https://github.com/coder/coder/actions/runs/11361195564/job/31600881001