### PR TITLE
test: ignore slog errors in `TestUserLatencyInsights`

### DIFF
--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -225,7 +225,7 @@ func TestUserLatencyInsights(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	client := coderdtest.New(t, &coderdtest.Options{
 		Database:                  db,
 		Pubsub:                    ps,


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/actions/runs/11362544440/job/31604644424

It looks like `TestUserLatencyInsights` failed due to a random error while reporting agent stats:

```
    t.go:108: 2024-10-16 09:13:08.529 [erro]  workspacestats: failed to load template schedule bumping activity, defaulting to bumping by 60min  request_id=4ca1de78-75d9-44ca-a1d9-73d9aa32ced7  workspace_id=6a1b979a-b432-4f6b-8985-974ee66c7be3  template_id=47d60e91-9e06-4c1f-ad6e-735e02c63cce ...
        error= fetch object:
                   github.com/coder/coder/v2/coderd/database/dbauthz.(*querier).GetTemplateByID.fetch[...].func1
                       /home/runner/work/coder/coder/coderd/database/dbauthz/dbauthz.go:427
                 - pq: canceling statement due to user request
         *** slogtest: log detected at level ERROR; TEST FAILURE ***
``` 