### PR TITLE
fix(coderd/notifications): exclude unset fields from notifications

### DIFF
--- a/coderd/database/migrations/000265_default_values_for_notifications.down.sql
+++ b/coderd/database/migrations/000265_default_values_for_notifications.down.sql
@@ -1,0 +1,41 @@
+-- https://github.com/coder/coder/issues/14893
+
+-- UserAccountSuspended
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' || -- Add a \n
+					E'User account **{{.Labels.suspended_account_name}}** has been suspended.\n\n' ||
+					-- Use the conventional initiator label:
+  					E'The newly suspended account belongs to **{{.Labels.suspended_account_user_name}}** and was suspended by **{{.Labels.initiator}}**.'
+WHERE
+	id = 'b02ddd82-4733-4d02-a2d7-c36f3598997d';
+
+-- UserAccountActivated
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' || -- Add a \n
+					E'User account **{{.Labels.activated_account_name}}** has been activated.\n\n' ||
+					-- Use the conventional initiator label:
+					E'The newly activated account belongs to **{{.Labels.activated_account_user_name}}** and was activated by **{{.Labels.initiator}}**.'
+WHERE
+	id = '9f5af851-8408-4e73-a7a1-c6502ba46689';
+
+-- UserAccountCreated
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' ||
+					E'New user account **{{.Labels.created_account_name}}** has been created.\n\n' ||
+					-- Use the conventional initiator label:
+					E'This new user account was created for **{{.Labels.created_account_user_name}}** by **{{.Labels.initiator}}**.'
+WHERE
+	id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';
+
+-- UserAccountDeleted
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' ||
+					E'User account **{{.Labels.deleted_account_name}}** has been deleted.\n\n' ||
+					-- Use the conventional initiator label:
+					E'The deleted account belonged to **{{.Labels.deleted_account_user_name}}** and was deleted by **{{.Labels.initiator}}**.'
+WHERE
+	id = 'f44d9314-ad03-4bc8-95d0-5cad491da6b6';

--- a/coderd/database/migrations/000265_default_values_for_notifications.up.sql
+++ b/coderd/database/migrations/000265_default_values_for_notifications.up.sql
@@ -1,0 +1,39 @@
+
+-- https://github.com/coder/coder/issues/14893
+
+-- UserAccountSuspended
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' ||
+					E'User account **{{.Labels.suspended_account_name}}** has been suspended.\n\n' ||
+  					E'The account {{if .Labels.suspended_account_user_name}}belongs to **{{.Labels.suspended_account_user_name}}** and it {{end}}was suspended by **{{.Labels.initiator}}**.'
+
+WHERE
+	id = 'b02ddd82-4733-4d02-a2d7-c36f3598997d';
+
+-- UserAccountActivated
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' || -- Add a \n
+					E'User account **{{.Labels.activated_account_name}}** has been activated.\n\n' ||
+					E'The account {{if .Labels.activated_account_user_name}}belongs to **{{.Labels.activated_account_user_name}}** and it {{ end }}was activated by **{{.Labels.initiator}}**.'
+WHERE
+	id = '9f5af851-8408-4e73-a7a1-c6502ba46689';
+
+-- UserAccountCreated
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' ||
+					E'New user account **{{.Labels.created_account_name}}** has been created.\n\n' ||
+					E'This new user account was created {{if .Labels.created_account_user_name}}for **{{.Labels.created_account_user_name}}** {{end}}by **{{.Labels.initiator}}**.'
+WHERE
+	id = '4e19c0ac-94e1-4532-9515-d1801aa283b2';
+
+-- UserAccountDeleted
+UPDATE notification_templates
+SET
+	body_template = E'Hi {{.UserName}},\n\n' ||
+					E'User account **{{.Labels.deleted_account_name}}** has been deleted.\n\n' ||
+					E'The deleted account {{if .Labels.deleted_account_user_name}}belonged to **{{.Labels.deleted_account_user_name}}** and {{end}}was deleted by **{{.Labels.initiator}}**.'
+WHERE
+	id = 'f44d9314-ad03-4bc8-95d0-5cad491da6b6';

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountActivated.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountActivated.html.golden
@@ -14,8 +14,7 @@ Hi Bobby,
 
 User account bobby has been activated.
 
-The newly activated account belongs to William Tables and was activated by =
-rob.
+The account belongs to William Tables and it was activated by rob.
 
 
 View accounts: http://test.com/deployment/users?filter=3Dstatus%3Aactive
@@ -52,8 +51,8 @@ argin: 8px 0 32px; line-height: 1.5;">
 
 <p>User account <strong>bobby</strong> has been activated.</p>
 
-<p>The newly activated account belongs to <strong>William Tables</strong> a=
-nd was activated by <strong>rob</strong>.</p>
+<p>The account belongs to <strong>William Tables</strong> and it was activa=
+ted by <strong>rob</strong>.</p>
       </div>
       <div style=3D"text-align: center; margin-top: 32px;">
        =20

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountSuspended.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserAccountSuspended.html.golden
@@ -14,8 +14,7 @@ Hi Bobby,
 
 User account bobby has been suspended.
 
-The newly suspended account belongs to William Tables and was suspended by =
-rob.
+The account belongs to William Tables and it was suspended by rob.
 
 
 View suspended accounts: http://test.com/deployment/users?filter=3Dstatus%3=
@@ -53,8 +52,8 @@ argin: 8px 0 32px; line-height: 1.5;">
 
 <p>User account <strong>bobby</strong> has been suspended.</p>
 
-<p>The newly suspended account belongs to <strong>William Tables</strong> a=
-nd was suspended by <strong>rob</strong>.</p>
+<p>The account belongs to <strong>William Tables</strong> and it was suspen=
+ded by <strong>rob</strong>.</p>
       </div>
       <div style=3D"text-align: center; margin-top: 32px;">
        =20

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserAccountActivated.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserAccountActivated.json.golden
@@ -24,6 +24,6 @@
   },
   "title": "User account \"bobby\" activated",
   "title_markdown": "User account \"bobby\" activated",
-  "body": "Hi Bobby,\n\nUser account bobby has been activated.\n\nThe newly activated account belongs to William Tables and was activated by rob.",
-  "body_markdown": "Hi Bobby,\n\nUser account **bobby** has been activated.\n\nThe newly activated account belongs to **William Tables** and was activated by **rob**."
+  "body": "Hi Bobby,\n\nUser account bobby has been activated.\n\nThe account belongs to William Tables and it was activated by rob.",
+  "body_markdown": "Hi Bobby,\n\nUser account **bobby** has been activated.\n\nThe account belongs to **William Tables** and it was activated by **rob**."
 }

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserAccountSuspended.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserAccountSuspended.json.golden
@@ -24,6 +24,6 @@
   },
   "title": "User account \"bobby\" suspended",
   "title_markdown": "User account \"bobby\" suspended",
-  "body": "Hi Bobby,\n\nUser account bobby has been suspended.\n\nThe newly suspended account belongs to William Tables and was suspended by rob.",
-  "body_markdown": "Hi Bobby,\n\nUser account **bobby** has been suspended.\n\nThe newly suspended account belongs to **William Tables** and was suspended by **rob**."
+  "body": "Hi Bobby,\n\nUser account bobby has been suspended.\n\nThe account belongs to William Tables and it was suspended by rob.",
+  "body_markdown": "Hi Bobby,\n\nUser account **bobby** has been suspended.\n\nThe account belongs to **William Tables** and it was suspended by **rob**."
 }


### PR DESCRIPTION
This PR will ensure that optional fields are ignored when they are unset in user account related templates.