### PR TITLE
fix: check unstaged files during ci lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,6 +223,12 @@ jobs:
           ./actionlint -color -shellcheck= -ignore "set-output"
         shell: bash
 
+      - name: Check for unstaged files
+        run: |
+          rm -f ./actionlint ./typos
+          ./scripts/check_unstaged.sh
+        shell: bash
+
   gen:
     timeout-minutes: 8
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}

--- a/coderd/activitybump_test.go
+++ b/coderd/activitybump_test.go
@@ -125,7 +125,7 @@ func TestWorkspaceActivityBump(t *testing.T) {
 			}
 
 			// maxTimeDrift is how long we are willing wait for a deadline to
-			// be increased. Since it could have been bumped at the intial
+			// be increased. Since it could have been bumped at the initial
 			maxTimeDrift := testutil.WaitMedium
 
 			updatedAfter := dbtime.Now()

--- a/enterprise/wsproxy/keyfetcher.go
+++ b/enterprise/wsproxy/keyfetcher.go
@@ -3,10 +3,11 @@ package wsproxy
 import (
 	"context"
 
+	"golang.org/x/xerrors"
+
 	"github.com/coder/coder/v2/coderd/cryptokeys"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/wsproxy/wsproxysdk"
-	"golang.org/x/xerrors"
 )
 
 var _ cryptokeys.Fetcher = &ProxyFetcher{}


### PR DESCRIPTION
`golangci-lint run` makes changes to files for trivial lints, such as import ordering, but CI doesn't currently check for these changes like it does for `fmt` and `gen`. It might be possible to have `golangci-lint` return an error when it makes a change, but that would only be for Go, and it seems sensible to have it be language agnostic.

There's perhaps an argument to be made (at least in my head) that `lint` shouldn't be making changes, only raising warnings/errors, but that's not what `golangci-lint` has decided.