### PR TITLE
test: improve logging around `TestAgentScript`

### DIFF
--- a/provisionersdk/agent_test.go
+++ b/provisionersdk/agent_test.go
@@ -123,7 +123,10 @@ func TestAgentScript(t *testing.T) {
 		}
 
 		// Kill the command, wait for the command to yield.
-		require.NoError(t, cmd.Cancel())
+		err := cmd.Cancel()
+		if err != nil {
+			t.Fatalf("unable to cancel the command, see logs:\n%s", output.String())
+		}
 		wg.Wait()
 
 		t.Log(output.String())


### PR DESCRIPTION
Spotted in: https://github.com/coder/coder/actions/runs/11372981036/job/31638824818

This PR modifies provisionersdk `TestAgentScript` to present command logs if the process exits without any notice.

```
=== FAIL: provisionersdk TestAgentScript/Invalid (10.00s)
    agent_test.go:126: 
        	Error Trace:	/Users/runner/work/coder/coder/provisionersdk/agent_test.go:126
        	Error:      	Received unexpected error:
        	            	os: process already finished
        	Test:       	TestAgentScript/Invalid
```

