### PR TITLE
feat(helm/provisioner): add support for provisioner keys, add note re psk

### DIFF
--- a/helm/provisioner/templates/NOTES.txt
+++ b/helm/provisioner/templates/NOTES.txt
@@ -1,0 +1,12 @@
+{{/*
+Deprecation notices:
+*/}}
+
+{{- if .Values.provisionerDaemon.pskSecretName }}
+Note: Provisioner Daemon PSKs are no longer recommended for use with external
+provisioners. Consider migrating to scoped provisioner keys instead. For more
+information, see: https://coder.com/docs/admin/provisioners#authentication
+{{- end }}
+
+Enjoy Coder! Please create an issue at https://github.com/coder/coder if you run
+into any problems! :)

--- a/helm/provisioner/templates/NOTES.txt
+++ b/helm/provisioner/templates/NOTES.txt
@@ -3,9 +3,9 @@ Deprecation notices:
 */}}
 
 {{- if .Values.provisionerDaemon.pskSecretName }}
-Note: Provisioner Daemon PSKs are no longer recommended for use with external
-provisioners. Consider migrating to scoped provisioner keys instead. For more
-information, see: https://coder.com/docs/admin/provisioners#authentication
+* Provisioner Daemon PSKs are no longer recommended for use with external
+  provisioners. Consider migrating to scoped provisioner keys instead. For more
+  information, see: https://coder.com/docs/admin/provisioners#authentication
 {{- end }}
 
 Enjoy Coder! Please create an issue at https://github.com/coder/coder if you run

--- a/helm/provisioner/templates/_coder.tpl
+++ b/helm/provisioner/templates/_coder.tpl
@@ -32,6 +32,9 @@ args:
 env:
 - name: CODER_PROMETHEUS_ADDRESS
   value: "0.0.0.0:2112"
+{{- if and (empty .Values.provisionerDaemon.pskSecretName) (empty .Values.provisionerDaemon.keySecretName) }}
+{{ fail "Either provisionerDaemon.pskSecretName or provisionerDaemon.keySecretName must be specified." }}
+{{- end }}
 {{- if .Values.provisionerDaemon.pskSecretName }}
 - name: CODER_PROVISIONER_DAEMON_PSK
   valueFrom:

--- a/helm/provisioner/templates/_coder.tpl
+++ b/helm/provisioner/templates/_coder.tpl
@@ -32,11 +32,20 @@ args:
 env:
 - name: CODER_PROMETHEUS_ADDRESS
   value: "0.0.0.0:2112"
+{{- if .Values.provisionerDaemon.pskSecretName }}
 - name: CODER_PROVISIONER_DAEMON_PSK
   valueFrom:
     secretKeyRef:
       name: {{ .Values.provisionerDaemon.pskSecretName | quote }}
       key: psk
+{{- end }}
+{{- if and .Values.provisionerDaemon.keySecretName .Values.provisionerDaemon.keySecretKey }}
+- name: CODER_PROVISIONER_DAEMON_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.provisionerDaemon.keySecretName | quote }}
+      key: {{ .Values.provisionerDaemon.keySecretKey | quote }}
+{{- end }}
 {{- if include "provisioner.tags" . }}
 - name: CODER_PROVISIONERD_TAGS
   value: {{ include "provisioner.tags" . }}

--- a/helm/provisioner/tests/chart_test.go
+++ b/helm/provisioner/tests/chart_test.go
@@ -53,6 +53,14 @@ var testCases = []testCase{
 		expectedError: "",
 	},
 	{
+		name:          "provisionerd_key",
+		expectedError: "",
+	},
+	{
+		name:          "provisionerd_psk_and_key",
+		expectedError: "",
+	},
+	{
 		name:          "extra_templates",
 		expectedError: "",
 	},

--- a/helm/provisioner/tests/chart_test.go
+++ b/helm/provisioner/tests/chart_test.go
@@ -61,6 +61,10 @@ var testCases = []testCase{
 		expectedError: "",
 	},
 	{
+		name:          "provisionerd_no_psk_or_key",
+		expectedError: `Either provisionerDaemon.pskSecretName or provisionerDaemon.keySecretName must be specified.`,
+	},
+	{
 		name:          "extra_templates",
 		expectedError: "",
 	},

--- a/helm/provisioner/tests/testdata/provisionerd_key.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_key.golden
@@ -1,0 +1,137 @@
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-provisioner-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder-provisioner"
+subjects:
+  - kind: ServiceAccount
+    name: "coder-provisioner"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-provisioner-workspace-perms
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: coder-provisioner
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: coder-provisioner
+        app.kubernetes.io/part-of: coder-provisioner
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-provisioner-0.1.0
+    spec:
+      containers:
+      - args:
+        - provisionerd
+        - start
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_PROVISIONER_DAEMON_KEY
+          valueFrom:
+            secretKeyRef:
+              key: provisionerd-key
+              name: coder-provisionerd-key
+        - name: CODER_PROVISIONERD_TAGS
+          value: clusterType=k8s,location=auh
+        - name: CODER_URL
+          value: http://coder.default.svc.cluster.local
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        name: coder
+        ports: null
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: coder-provisioner
+      terminationGracePeriodSeconds: 600
+      volumes: []

--- a/helm/provisioner/tests/testdata/provisionerd_key.yaml
+++ b/helm/provisioner/tests/testdata/provisionerd_key.yaml
@@ -1,0 +1,10 @@
+coder:
+  image:
+    tag: latest
+provisionerDaemon:
+  pskSecretName: ""
+  keySecretName: "coder-provisionerd-key"
+  keySecretKey: "provisionerd-key"
+  tags:
+    location: auh
+    clusterType: k8s

--- a/helm/provisioner/tests/testdata/provisionerd_no_psk_or_key.yaml
+++ b/helm/provisioner/tests/testdata/provisionerd_no_psk_or_key.yaml
@@ -1,0 +1,9 @@
+coder:
+  image:
+    tag: latest
+provisionerDaemon:
+  pskSecretName: ""
+  keySecretName: ""
+  tags:
+    location: auh
+    clusterType: k8s

--- a/helm/provisioner/tests/testdata/provisionerd_psk_and_key.golden
+++ b/helm/provisioner/tests/testdata/provisionerd_psk_and_key.golden
@@ -1,0 +1,142 @@
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-provisioner-workspace-perms
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+---
+# Source: coder-provisioner/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "coder-provisioner"
+subjects:
+  - kind: ServiceAccount
+    name: "coder-provisioner"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-provisioner-workspace-perms
+---
+# Source: coder-provisioner/templates/coder.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: coder-provisioner
+    app.kubernetes.io/part-of: coder-provisioner
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: coder-provisioner-0.1.0
+  name: coder-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: coder-provisioner
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: coder-provisioner
+        app.kubernetes.io/part-of: coder-provisioner
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: coder-provisioner-0.1.0
+    spec:
+      containers:
+      - args:
+        - provisionerd
+        - start
+        command:
+        - /opt/coder
+        env:
+        - name: CODER_PROMETHEUS_ADDRESS
+          value: 0.0.0.0:2112
+        - name: CODER_PROVISIONER_DAEMON_PSK
+          valueFrom:
+            secretKeyRef:
+              key: psk
+              name: coder-provisionerd-psk
+        - name: CODER_PROVISIONER_DAEMON_KEY
+          valueFrom:
+            secretKeyRef:
+              key: provisionerd-key
+              name: coder-provisionerd-key
+        - name: CODER_PROVISIONERD_TAGS
+          value: clusterType=k8s,location=auh
+        - name: CODER_URL
+          value: http://coder.default.svc.cluster.local
+        image: ghcr.io/coder/coder:latest
+        imagePullPolicy: IfNotPresent
+        lifecycle: {}
+        name: coder
+        ports: null
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: null
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts: []
+      restartPolicy: Always
+      serviceAccountName: coder-provisioner
+      terminationGracePeriodSeconds: 600
+      volumes: []

--- a/helm/provisioner/tests/testdata/provisionerd_psk_and_key.yaml
+++ b/helm/provisioner/tests/testdata/provisionerd_psk_and_key.yaml
@@ -1,0 +1,10 @@
+coder:
+  image:
+    tag: latest
+provisionerDaemon:
+  pskSecretName: "coder-provisionerd-psk"
+  keySecretName: "coder-provisionerd-key"
+  keySecretKey: "provisionerd-key"
+  tags:
+    location: auh
+    clusterType: k8s

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -192,12 +192,26 @@ coder:
 
 # provisionerDaemon -- Provisioner Daemon configuration options
 provisionerDaemon:
-  # provisionerDaemon.pskSecretName -- The name of the Kubernetes secret that contains the
+  # provisionerDaemon.pskSecretName -- (deprecated) The name of the Kubernetes secret that contains the
   # Pre-Shared Key (PSK) to use to authenticate with Coder.  The secret must be in the same namespace
-  # as the Helm deployment, and contain an item called "psk" which contains the pre-shared key.
+  # as the Helm deployment, and contain an item called "psk" which contains the
+  # pre-shared key.
+  # WARNING: this field is deprecated and will be removed in a future release.
+  # Please use provisionerDaemon.keySecretName instead and generate a
+  # provisioner key instead of a PSK.
   pskSecretName: "coder-provisioner-psk"
 
-  # provisionerDaemon.tags -- Tags to filter provisioner jobs by
+  # provisionerDaemon.keySecretName -- The name of the Kubernetes
+  # secret that contains a provisioner key to use to authenticate with Coder.
+  # See: https://coder.com/docs/admin/provisioners#authentication
+  keySecretName: ""
+  # provisionerDaemon.keySecretKey -- The key of the Kubernetes
+  # secret specified in provisionerDaemon.keySecretName that contains
+  # the provisioner key. Defaults to "key".
+  keySecretKey: "key"
+
+  # provisionerDaemon.tags -- Tags to filter provisioner jobs by.
+  # See: https://coder.com/docs/admin/provisioners#provisioner-tags
   tags:
     {}
     # location: usa

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -192,13 +192,13 @@ coder:
 
 # provisionerDaemon -- Provisioner Daemon configuration options
 provisionerDaemon:
-  # provisionerDaemon.pskSecretName -- (deprecated) The name of the Kubernetes secret that contains the
-  # Pre-Shared Key (PSK) to use to authenticate with Coder.  The secret must be in the same namespace
-  # as the Helm deployment, and contain an item called "psk" which contains the
-  # pre-shared key.
-  # WARNING: this field is deprecated and will be removed in a future release.
-  # Please use provisionerDaemon.keySecretName instead and generate a
-  # provisioner key instead of a PSK.
+  # provisionerDaemon.pskSecretName -- The name of the Kubernetes secret that contains the
+  # Pre-Shared Key (PSK) to use to authenticate with Coder. The secret must be
+  # in the same namespace as the Helm deployment, and contain an item called
+  # "psk" which contains the pre-shared key.
+  # NOTE: We no longer recommend using PSKs. Please consider using provisioner
+  # keys instead. They have a number of benefits, including the ability to
+  # rotate them easily.
   pskSecretName: "coder-provisioner-psk"
 
   # provisionerDaemon.keySecretName -- The name of the Kubernetes


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/14985
- Adds `provisionerDaemon.keySecretName` and `provisionerDaemon.keySecretKey`
- Omitting `provisionerDaemon.pskSecretName` will now cause the PSK secret to no longer be created.
- Adds a note in `NOTES.txt` regarding provisioner PSKs.
- Adds validation that either `provisionerDaemon.keySecretName` or `provisionerDaemon.pskSecretName` is specified, and will fail the install in this case.

Manual smoke-testing:

1) With defaults:

```
helm install --namespace=tmp test-provisionerd . --set coder.image.tag=latest --dry-run 

NAME: test-provisionerd
LAST DEPLOYED: Thu Oct 17 14:45:55 2024
NAMESPACE: tmp
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST: <yaml>

NOTES:
* Provisioner Daemon PSKs are no longer recommended for use with external
  provisioners. Consider migrating to scoped provisioner keys instead. For more
  information, see: https://coder.com/docs/admin/provisioners#authentication

Enjoy Coder! Please create an issue at https://github.com/coder/coder if you run
into any problems! :)

```

2) With explicitly specified `pskSecretName`:
```
helm install --namespace=tmp test-provisionerd . --set coder.image.tag=latest --set provisionerDaemon.pskSecretName='foobar' --dry-run

NAME: test-provisionerd
LAST DEPLOYED: Thu Oct 17 14:43:08 2024
NAMESPACE: tmp
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST: <yaml>
NOTES:
* Provisioner Daemon PSKs are no longer recommended for use with external
  provisioners. Consider migrating to scoped provisioner keys instead. For more
  information, see: https://coder.com/docs/admin/provisioners#authentication

Enjoy Coder! Please create an issue at https://github.com/coder/coder if you run
into any problems! :)
```

3) With `pskSecretName` empty and `keySecretName` specified:
```
helm install --namespace=tmp test-provisionerd . --set coder.image.tag=latest --set provisionerDaemon.pskSecretName='' --set provisionerDaemon.keySecretName='foobar' --dry-run 

NAME: test-provisionerd
LAST DEPLOYED: Thu Oct 17 14:45:00 2024
NAMESPACE: tmp
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST: <yaml>

NOTES:
Enjoy Coder! Please create an issue at https://github.com/coder/coder if you run
into any problems! :)

```

4) With `pskSecretName` empty and `keySecretName` empty: 

```
helm install --namespace=tmp test-provisionerd . --set coder.image.tag=latest --set provisionerDaemon.pskSecretName='' --set provisionerDaemon.keySecretName='' --dry-run

Error: INSTALLATION FAILED: execution error at (coder-provisioner/templates/coder.yaml:5:3): Either provisionerDaemon.pskSecretName or provisionerDaemon.keySecretName must be specified.


```