### PR TITLE
fix: correct default wsproxy table columns

### DIFF
--- a/enterprise/cli/workspaceproxy.go
+++ b/enterprise/cli/workspaceproxy.go
@@ -102,7 +102,7 @@ func (r *RootCmd) patchProxy() *serpent.Command {
 			}),
 			cliui.JSONFormat(),
 			// Table formatter expects a slice, make a slice of one.
-			cliui.ChangeFormatterData(cliui.TableFormat([]codersdk.WorkspaceProxy{}, []string{"proxy name", "proxy url"}),
+			cliui.ChangeFormatterData(cliui.TableFormat([]codersdk.WorkspaceProxy{}, []string{"name", "url"}),
 				func(data any) (any, error) {
 					response, ok := data.(codersdk.WorkspaceProxy)
 					if !ok {


### PR DESCRIPTION
Closes #15123 

It'd be nice if we could catch these table tags at compile time, but doesn't seem possible