### PR TITLE
fix: order provisioner keys by creation date

### DIFF
--- a/enterprise/coderd/provisionerkeys.go
+++ b/enterprise/coderd/provisionerkeys.go
@@ -212,5 +212,10 @@ func convertProvisionerKeys(dbKeys []database.ProvisionerKey) []codersdk.Provisi
 			// HashedSecret - never include the access token in the API response
 		})
 	}
+
+	slices.SortFunc(keys, func(key1, key2 codersdk.ProvisionerKey) int {
+		return key1.CreatedAt.Compare(key2.CreatedAt)
+	})
+
 	return keys
 }


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/110

The flake reported in the issue has already been fixed by https://github.com/coder/coder/pull/14875, but this further covers that we return a list the same order every time. 