### PR TITLE
chore: refactor notifier to use quartz.TickerFunc

### DIFF
--- a/coderd/notifications/manager.go
+++ b/coderd/notifications/manager.go
@@ -174,9 +174,9 @@ func (m *Manager) loop(ctx context.Context) error {
 	var eg errgroup.Group
 
 	// Create a notifier to run concurrently, which will handle dequeueing and dispatching notifications.
-	m.notifier = newNotifier(m.cfg, uuid.New(), m.log, m.store, m.handlers, m.helpers, m.metrics, m.clock)
+	m.notifier = newNotifier(ctx, m.cfg, uuid.New(), m.log, m.store, m.handlers, m.helpers, m.metrics, m.clock)
 	eg.Go(func() error {
-		return m.notifier.run(ctx, m.success, m.failure)
+		return m.notifier.run(m.success, m.failure)
 	})
 
 	// Periodically flush notification state changes to the store.

--- a/coderd/notifications/notifier.go
+++ b/coderd/notifications/notifier.go
@@ -30,10 +30,11 @@ type notifier struct {
 	log   slog.Logger
 	store Store
 
-	tick     *quartz.Ticker
-	stopOnce sync.Once
-	quit     chan any
-	done     chan any
+	stopOnce       sync.Once
+	outerCtx       context.Context
+	gracefulCtx    context.Context
+	gracefulCancel context.CancelFunc
+	done           chan any
 
 	handlers map[database.NotificationMethod]Handler
 	metrics  *Metrics
@@ -43,28 +44,29 @@ type notifier struct {
 	clock quartz.Clock
 }
 
-func newNotifier(cfg codersdk.NotificationsConfig, id uuid.UUID, log slog.Logger, db Store,
+func newNotifier(outerCtx context.Context, cfg codersdk.NotificationsConfig, id uuid.UUID, log slog.Logger, db Store,
 	hr map[database.NotificationMethod]Handler, helpers template.FuncMap, metrics *Metrics, clock quartz.Clock,
 ) *notifier {
-	tick := clock.NewTicker(cfg.FetchInterval.Value(), "notifier", "fetchInterval")
+	gracefulCtx, gracefulCancel := context.WithCancel(outerCtx)
 	return &notifier{
-		id:       id,
-		cfg:      cfg,
-		log:      log.Named("notifier").With(slog.F("notifier_id", id)),
-		quit:     make(chan any),
-		done:     make(chan any),
-		tick:     tick,
-		store:    db,
-		handlers: hr,
-		helpers:  helpers,
-		metrics:  metrics,
-		clock:    clock,
+		id:             id,
+		cfg:            cfg,
+		log:            log.Named("notifier").With(slog.F("notifier_id", id)),
+		outerCtx:       outerCtx,
+		gracefulCtx:    gracefulCtx,
+		gracefulCancel: gracefulCancel,
+		done:           make(chan any),
+		store:          db,
+		handlers:       hr,
+		helpers:        helpers,
+		metrics:        metrics,
+		clock:          clock,
 	}
 }
 
 // run is the main loop of the notifier.
-func (n *notifier) run(ctx context.Context, success chan<- dispatchResult, failure chan<- dispatchResult) error {
-	n.log.Info(ctx, "started")
+func (n *notifier) run(success chan<- dispatchResult, failure chan<- dispatchResult) error {
+	n.log.Info(n.outerCtx, "started")
 
 	defer func() {
 		close(n.done)
@@ -75,39 +77,32 @@ func (n *notifier) run(ctx context.Context, success chan<- dispatchResult, failu
 	//		 if 100 notifications are enqueued, we shouldn't activate this routine for each one; so how to debounce these?
 	//		 PLUS we should also have an interval (but a longer one, maybe 1m) to account for retries (those will not get
 	//		 triggered by a code path, but rather by a timeout expiring which makes the message retryable)
-	for {
-		select {
-		case <-ctx.Done():
-			return xerrors.Errorf("notifier %q context canceled: %w", n.id, ctx.Err())
-		case <-n.quit:
-			return nil
-		default:
-		}
 
+	// run the ticker with the graceful context, so we stop fetching after stop() is called
+	tick := n.clock.TickerFunc(n.gracefulCtx, n.cfg.FetchInterval.Value(), func() error {
 		// Check if notifier is not paused.
-		ok, err := n.ensureRunning(ctx)
+		ok, err := n.ensureRunning(n.outerCtx)
 		if err != nil {
-			n.log.Warn(ctx, "failed to check notifier state", slog.Error(err))
+			n.log.Warn(n.outerCtx, "failed to check notifier state", slog.Error(err))
 		}
 
 		if ok {
-			// Call process() immediately (i.e. don't wait an initial tick).
-			err = n.process(ctx, success, failure)
+			err = n.process(n.outerCtx, success, failure)
 			if err != nil {
-				n.log.Error(ctx, "failed to process messages", slog.Error(err))
+				n.log.Error(n.outerCtx, "failed to process messages", slog.Error(err))
 			}
 		}
+		// we don't return any errors because we don't want to kill the loop because of them.
+		return nil
+	}, "notifier", "fetchInterval")
 
-		// Shortcut to bail out quickly if stop() has been called or the context canceled.
-		select {
-		case <-ctx.Done():
-			return xerrors.Errorf("notifier %q context canceled: %w", n.id, ctx.Err())
-		case <-n.quit:
-			return nil
-		case <-n.tick.C:
-			// sleep until next invocation
-		}
+	_ = tick.Wait()
+	// only errors we can return are context errors.  Only return an error if the outer context
+	// was canceled, not if we were gracefully stopped.
+	if n.outerCtx.Err() != nil {
+		return xerrors.Errorf("notifier %q context canceled: %w", n.id, n.outerCtx.Err())
 	}
+	return nil
 }
 
 // ensureRunning checks if notifier is not paused.
@@ -343,9 +338,7 @@ func (n *notifier) newInhibitedDispatch(msg database.AcquireNotificationMessages
 func (n *notifier) stop() {
 	n.stopOnce.Do(func() {
 		n.log.Info(context.Background(), "graceful stop requested")
-
-		n.tick.Stop()
-		close(n.quit)
+		n.gracefulCancel()
 		<-n.done
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/cli/safeexec v1.0.1
 	github.com/coder/flog v1.1.0
 	github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0
-	github.com/coder/quartz v0.1.0
+	github.com/coder/quartz v0.1.2
 	github.com/coder/retry v1.5.1
 	github.com/coder/terraform-provider-coder v1.0.2
 	github.com/coder/wgtunnel v0.1.13-0.20240522110300-ade90dfb2da0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048 h1:3jzYUlGH7ZELIH4XggX
 github.com/coder/pq v1.10.5-0.20240813183442-0c420cb5a048/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
-github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=
-github.com/coder/quartz v0.1.0/go.mod h1:vsiCc+AHViMKH2CQpGIpFgdHIEQsxwm8yCscqKmzbRA=
+github.com/coder/quartz v0.1.2 h1:PVhc9sJimTdKd3VbygXtS4826EOCpB1fXoRlLnCrE+s=
+github.com/coder/quartz v0.1.2/go.mod h1:vsiCc+AHViMKH2CQpGIpFgdHIEQsxwm8yCscqKmzbRA=
 github.com/coder/retry v1.5.1 h1:iWu8YnD8YqHs3XwqrqsjoBTAVqT9ml6z9ViJ2wlMiqc=
 github.com/coder/retry v1.5.1/go.mod h1:blHMk9vs6LkoRT9ZHyuZo360cufXEhrxqvEzeMtRGoY=
 github.com/coder/serpent v0.8.0 h1:6OR+k6fekhSeEDmwwzBgnSjaa7FfGGrMlc3GoAEH9dg=


### PR DESCRIPTION
In investigating https://github.com/coder/internal/issues/109 I noticed many of the notification tests are still using `time.Sleep` and `require.Eventually`. This is an initial effort to start converting these to Quartz.

One product change is to switch the `notifier` to use a `TickerFunc` instead of a normal Ticker, since it allows the test to assert that a batch process is complete via the Quartz `Mock` clock.  This does introduce one slight behavioral change in that the notifier waits the fetch interval before processing its first batch.  In practice, this is inconsequential: no one will notice if we send notifications immediately on startup, or just a little later.

But, it does make a difference to some tests, which are fixed up here.