### PR TITLE
fix(cli): improve container detection when cgroupns=private

### DIFF
--- a/cli/clistat/stat_internal_test.go
+++ b/cli/clistat/stat_internal_test.go
@@ -309,6 +309,12 @@ func TestIsContainerized(t *testing.T) {
 			Expected: true,
 			Error:    "",
 		},
+		{
+			Name:     "Docker (Cgroupns=private)",
+			FS:       fsContainerCgroupV2PrivateCgroupns,
+			Expected: true,
+			Error:    "",
+		},
 	} {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
@@ -373,6 +379,12 @@ proc /proc/sys proc ro,nosuid,nodev,noexec,relatime 0 0`,
 		cgroupV2MemoryMaxBytes:   "max",
 		cgroupV2MemoryUsageBytes: "536870912",
 		cgroupV2MemoryStat:       "inactive_file 268435456",
+	}
+	fsContainerCgroupV2PrivateCgroupns = map[string]string{
+		procOneCgroup: "0::/",
+		procMounts: `overlay / overlay rw,relatime,lowerdir=/some/path:/some/path,upperdir=/some/path:/some/path,workdir=/some/path:/some/path 0 0
+proc /proc/sys proc ro,nosuid,nodev,noexec,relatime 0 0`,
+		sysCgroupType: "domain",
 	}
 	fsContainerCgroupV1 = map[string]string{
 		procOneCgroup: "0::/docker/aa86ac98959eeedeae0ecb6e0c9ddd8ae8b97a9d0fdccccf7ea7a474f4e0bb1f",


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/12721

If a container in docker is started with `--cgroupns=private` (which is the default behaviour in docker) then `/proc/1/cgroup` has the following content:
```
0::/
```

If a container in docker is started with `--cgroupns=host` then `/proc/1/cgroup` has the following content (hash will vary):
```
0::/docker/aa86ac98959eeedeae0ecb6e0c9ddd8ae8b97a9d0fdccccf7ea7a474f4e0bb1f
```

Currently we are determining if a host is containerized by assuming the second scenario. This means the existing behaviour of sniffing `/proc/1/cgroup` is not always sufficient for checking if a host is containerized.

According to [the cgroups(7) man-page](https://man7.org/linux/man-pages/man7/cgroups.7.html) there exists a `cgroup.type` file in a nonroot cgroup. This exists in Linux versions after `4.14`.

> Linux 4.14 added thread mode for cgroups v2.

> With the addition of thread mode, each nonroot cgroup now contains a new file, cgroup.type

This means we can check for the existence of `/sys/fs/cgroup/cgroup.type` to see if we are in a container or not.