### PR TITLE
fix(cli): fix potential panic in traceError if unwrapped err is nil

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -1116,7 +1116,16 @@ func formatCoderSDKError(from string, err *codersdk.Error, opts *formatOpts) str
 //nolint:errorlint
 func traceError(err error) string {
 	if uw, ok := err.(interface{ Unwrap() error }); ok {
-		a, b := err.Error(), uw.Unwrap().Error()
+		var a, b string
+		if err != nil {
+			a = err.Error()
+		}
+		if uw != nil {
+			uwerr := uw.Unwrap()
+			if uwerr != nil {
+				b = uwerr.Error()
+			}
+		}
 		c := strings.TrimSuffix(a, b)
 		return c
 	}


### PR DESCRIPTION
Seen while investigating #12721:

Root cause was a developer error, but this definitely shouldn't panic.

Before:
```
/ # coder stat
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1f12eb0]

goroutine 1 [running]:
github.com/coder/coder/v2/cli.traceError({0x90e89a0?, 0x40007a8210})
        /home/runner/work/coder/coder/cli/root.go:1119 +0x70
github.com/coder/coder/v2/cli.cliHumanFormatError({0x40003065a0, 0x1c8}, {0x90e89a0, 0x40007a8210}, 0x40007a81e0?)
        /home/runner/work/coder/coder/cli/root.go:985 +0x190
github.com/coder/coder/v2/cli.cliHumanFormatError({0x40000d0f00, 0x139}, {0x90e89a0, 0x40007a81e0}, 0x40001c4480?)
        /home/runner/work/coder/coder/cli/root.go:985 +0x1d8
github.com/coder/coder/v2/cli.cliHumanFormatError({0x40000d0b40, 0xf}, {0x90e5f00, 0x40006a3a80}, 0x90e5d40?)
        /home/runner/work/coder/coder/cli/root.go:985 +0x1d8
github.com/coder/coder/v2/cli.cliHumanFormatError({0x0, 0x0}, {0x90e5ce0, 0x40003b14c0}, 0x2?)
        /home/runner/work/coder/coder/cli/root.go:985 +0x1d8
github.com/coder/coder/v2/cli.formatRunCommandError(0x40007a8108, 0x400079fce7)
        /home/runner/work/coder/coder/cli/root.go:1057 +0x30c
github.com/coder/coder/v2/cli.cliHumanFormatError({0x0, 0x0}, {0x90e5ec0, 0x40007a8108}, 0xaa0aed0?)
        /home/runner/work/coder/coder/cli/root.go:980 +0xe0
github.com/coder/coder/v2/cli.cliHumanFormatError({0x0, 0x0}, {0x90e5160, 0x40007a8120}, 0x90e50e0?)
        /home/runner/work/coder/coder/cli/root.go:966 +0x144
github.com/coder/coder/v2/cli.(*PrettyErrorFormatter).Format(0x400079fda0, {0x90e5160?, 0x40007a8120?})
        /home/runner/work/coder/coder/cli/root.go:927 +0x48
github.com/coder/coder/v2/cli.(*RootCmd).RunWithSubcommands(0x400068ed80, {0x400053a2c8, 0x30, 0x57})
        /home/runner/work/coder/coder/cli/root.go:175 +0x278
main.main()
        /home/runner/work/coder/coder/enterprise/cmd/coder/main.go:11 +0x40
```

After:
```
Encountered an error running "coder stat", see "coder stat --help" for more information
error: <nil>
```