### PR TITLE
fix: urlencode email in reset password link

### DIFF
--- a/coderd/database/migrations/000267_fix_password_reset_notification_link.up.sql
+++ b/coderd/database/migrations/000267_fix_password_reset_notification_link.up.sql
@@ -1,0 +1,10 @@
+UPDATE notification_templates
+SET
+    title_template = E'Reset your password for Coder',
+    body_template = E'Hi {{.UserName}},\n\nUse the link below to reset your password.\n\nIf you did not make this request, you can ignore this message.',
+    actions = '[{
+		"label": "Reset password",
+		"url": "{{base_url}}/reset-password/change?otp={{.Labels.one_time_passcode}}&email={{.UserEmail | urlquery}}"
+	}]'::jsonb
+WHERE
+    id = '62f86a30-2330-4b61-a26d-311ff3b608cf'

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -994,7 +994,7 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 			id:   notifications.TemplateUserRequestedOneTimePasscode,
 			payload: types.MessagePayload{
 				UserName:     "Bobby",
-				UserEmail:    "bobby@coder.com",
+				UserEmail:    "bobby+label@coder.com",
 				UserUsername: "bobby",
 				Labels: map[string]string{
 					"one_time_passcode": "fad9020b-6562-4cdb-87f1-0486f1bea415",

--- a/coderd/notifications/notifications_test.go
+++ b/coderd/notifications/notifications_test.go
@@ -994,7 +994,7 @@ func TestNotificationTemplates_Golden(t *testing.T) {
 			id:   notifications.TemplateUserRequestedOneTimePasscode,
 			payload: types.MessagePayload{
 				UserName:     "Bobby",
-				UserEmail:    "bobby+label@coder.com",
+				UserEmail:    "bobby/drop-table+user@coder.com",
 				UserUsername: "bobby",
 				Labels: map[string]string{
 					"one_time_passcode": "fad9020b-6562-4cdb-87f1-0486f1bea415",

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserRequestedOneTimePasscode.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserRequestedOneTimePasscode.html.golden
@@ -1,5 +1,5 @@
 From: system@coder.com
-To: bobby@coder.com
+To: bobby+label@coder.com
 Subject: Reset your password for Coder
 Message-Id: 02ee4935-73be-4fa1-a290-ff9999026b13@blush-whale-48
 Date: Fri, 11 Oct 2024 09:03:06 +0000
@@ -18,7 +18,7 @@ If you did not make this request, you can ignore this message.
 
 
 Reset password: http://test.com/reset-password/change?otp=3Dfad9020b-6562-4=
-cdb-87f1-0486f1bea415&email=3Dbobby@coder.com
+cdb-87f1-0486f1bea415&email=3Dbobby%2Blabel%40coder.com
 
 --bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
 Content-Transfer-Encoding: quoted-printable
@@ -57,9 +57,9 @@ argin: 8px 0 32px; line-height: 1.5;">
       <div style=3D"text-align: center; margin-top: 32px;">
        =20
         <a href=3D"http://test.com/reset-password/change?otp=3Dfad9020b-656=
-2-4cdb-87f1-0486f1bea415&email=3Dbobby@coder.com" style=3D"display: inline-=
-block; padding: 13px 24px; background-color: #020617; color: #f8fafc; text-=
-decoration: none; border-radius: 8px; margin: 0 4px;">
+2-4cdb-87f1-0486f1bea415&email=3Dbobby%2Blabel%40coder.com" style=3D"displa=
+y: inline-block; padding: 13px 24px; background-color: #020617; color: #f8f=
+afc; text-decoration: none; border-radius: 8px; margin: 0 4px;">
           Reset password
         </a>
        =20

--- a/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserRequestedOneTimePasscode.html.golden
+++ b/coderd/notifications/testdata/rendered-templates/smtp/TemplateUserRequestedOneTimePasscode.html.golden
@@ -1,5 +1,5 @@
 From: system@coder.com
-To: bobby+label@coder.com
+To: bobby/drop-table+user@coder.com
 Subject: Reset your password for Coder
 Message-Id: 02ee4935-73be-4fa1-a290-ff9999026b13@blush-whale-48
 Date: Fri, 11 Oct 2024 09:03:06 +0000
@@ -18,7 +18,7 @@ If you did not make this request, you can ignore this message.
 
 
 Reset password: http://test.com/reset-password/change?otp=3Dfad9020b-6562-4=
-cdb-87f1-0486f1bea415&email=3Dbobby%2Blabel%40coder.com
+cdb-87f1-0486f1bea415&email=3Dbobby%2Fdrop-table%2Buser%40coder.com
 
 --bbe61b741255b6098bb6b3c1f41b885773df633cb18d2a3002b68e4bc9c4
 Content-Transfer-Encoding: quoted-printable
@@ -57,9 +57,10 @@ argin: 8px 0 32px; line-height: 1.5;">
       <div style=3D"text-align: center; margin-top: 32px;">
        =20
         <a href=3D"http://test.com/reset-password/change?otp=3Dfad9020b-656=
-2-4cdb-87f1-0486f1bea415&email=3Dbobby%2Blabel%40coder.com" style=3D"displa=
-y: inline-block; padding: 13px 24px; background-color: #020617; color: #f8f=
-afc; text-decoration: none; border-radius: 8px; margin: 0 4px;">
+2-4cdb-87f1-0486f1bea415&email=3Dbobby%2Fdrop-table%2Buser%40coder.com" sty=
+le=3D"display: inline-block; padding: 13px 24px; background-color: #020617;=
+ color: #f8fafc; text-decoration: none; border-radius: 8px; margin: 0 4px;"=
+>
           Reset password
         </a>
        =20

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserRequestedOneTimePasscode.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserRequestedOneTimePasscode.json.golden
@@ -6,13 +6,13 @@
     "notification_name": "One-Time Passcode",
     "notification_template_id": "00000000-0000-0000-0000-000000000000",
     "user_id": "00000000-0000-0000-0000-000000000000",
-    "user_email": "bobby+label@coder.com",
+    "user_email": "bobby/drop-table+user@coder.com",
     "user_name": "Bobby",
     "user_username": "bobby",
     "actions": [
       {
         "label": "Reset password",
-        "url": "http://test.com/reset-password/change?otp=00000000-0000-0000-0000-000000000000\u0026email=bobby%2Blabel%40coder.com"
+        "url": "http://test.com/reset-password/change?otp=00000000-0000-0000-0000-000000000000\u0026email=bobby%2Fdrop-table%2Buser%40coder.com"
       }
     ],
     "labels": {

--- a/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserRequestedOneTimePasscode.json.golden
+++ b/coderd/notifications/testdata/rendered-templates/webhook/TemplateUserRequestedOneTimePasscode.json.golden
@@ -6,13 +6,13 @@
     "notification_name": "One-Time Passcode",
     "notification_template_id": "00000000-0000-0000-0000-000000000000",
     "user_id": "00000000-0000-0000-0000-000000000000",
-    "user_email": "bobby@coder.com",
+    "user_email": "bobby+label@coder.com",
     "user_name": "Bobby",
     "user_username": "bobby",
     "actions": [
       {
         "label": "Reset password",
-        "url": "http://test.com/reset-password/change?otp=00000000-0000-0000-0000-000000000000\u0026email=bobby@coder.com"
+        "url": "http://test.com/reset-password/change?otp=00000000-0000-0000-0000-000000000000\u0026email=bobby%2Blabel%40coder.com"
       }
     ],
     "labels": {


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/15151

This runs `urlencode` (provided by `text/template`) on the email address in the link. This ensures the link will work if a user has an email in the form `user+label@example.com`.