### PR TITLE
docs: add primary to wsproxy ls

### DIFF
--- a/docs/admin/networking/workspace-proxies.md
+++ b/docs/admin/networking/workspace-proxies.md
@@ -59,7 +59,7 @@ the workspace proxy usable. If the proxy deployment is successful,
 ```shell
 $ coder wsproxy ls
 NAME              URL                         STATUS STATUS
-primary           https://dev.coder.com  ok
+primary           https://dev.coder.com        ok
 brazil-saopaulo   https://brazil.example.com   ok
 europe-frankfurt  https://europe.example.com   ok
 sydney            https://sydney.example.com   ok

--- a/docs/admin/networking/workspace-proxies.md
+++ b/docs/admin/networking/workspace-proxies.md
@@ -56,12 +56,13 @@ Deploying the workspace proxy will also register the proxy with coderd and make
 the workspace proxy usable. If the proxy deployment is successful,
 `coder wsproxy ls` will show an `ok` status code:
 
-```
+```shell
 $ coder wsproxy ls
 NAME              URL                         STATUS STATUS
-brazil-saopaulo   https://brazil.example.com  ok
-europe-frankfurt  https://europe.example.com  ok
-sydney            https://sydney.example.com  ok
+primary           https://primary.example.com  ok
+brazil-saopaulo   https://brazil.example.com   ok
+europe-frankfurt  https://europe.example.com   ok
+sydney            https://sydney.example.com   ok
 ```
 
 Other Status codes:

--- a/docs/admin/networking/workspace-proxies.md
+++ b/docs/admin/networking/workspace-proxies.md
@@ -59,7 +59,7 @@ the workspace proxy usable. If the proxy deployment is successful,
 ```shell
 $ coder wsproxy ls
 NAME              URL                         STATUS STATUS
-primary           https://primary.example.com  ok
+primary           https://dev.coder.com  ok
 brazil-saopaulo   https://brazil.example.com   ok
 europe-frankfurt  https://europe.example.com   ok
 sydney            https://sydney.example.com   ok


### PR DESCRIPTION
Add primary to `coder wsproxy ls` results in <https://coder.com/docs/admin/networking/workspace-proxies#step-2-deploy-the-proxy>