### PR TITLE
chore: update dependabot config and pin Docker images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -51,7 +51,13 @@ updates:
 
   # Update our Dockerfile.
   - package-ecosystem: "docker"
-    directory: "/scripts/"
+    directories:
+      - "/dogfood/contents"
+      - "/scripts"
+      - "/examples/templates/docker/build"
+      - "/examples/parameters/build"
+      - "/scaletest/templates/scaletest-runner"
+      - "/scripts/ironbank"
     schedule:
       interval: "weekly"
       time: "06:00"
@@ -68,6 +74,9 @@ updates:
     directories:
       - "/site"
       - "/offlinedocs"
+      - "/scripts"
+      - "/scripts/apidocgen"
+
     schedule:
       interval: "monthly"
       time: "06:00"

--- a/.github/workflows/pr-deploy.yaml
+++ b/.github/workflows/pr-deploy.yaml
@@ -213,6 +213,11 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
       CODER_IMAGE_TAG: ${{ needs.get_info.outputs.CODER_IMAGE_TAG }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
@@ -264,6 +269,11 @@ jobs:
       PR_URL: ${{ needs.get_info.outputs.PR_URL }}
       PR_HOSTNAME: "pr${{ needs.get_info.outputs.PR_NUMBER }}.${{ secrets.PR_DEPLOYMENTS_DOMAIN }}"
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Set up kubeconfig
         run: |
           set -euo pipefail

--- a/dogfood/contents/Dockerfile
+++ b/dogfood/contents/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim AS rust-utils
+FROM rust:slim@sha256:9abf10cc84dfad6ace1b0aae3951dc5200f467c593394288c11db1e17bb4d349 AS rust-utils
 # Install rust helper programs
 # ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_INSTALL_ROOT=/tmp/
@@ -6,7 +6,7 @@ RUN cargo install exa bat ripgrep typos-cli watchexec-cli && \
 	# Reduce image size.
 	rm -rf /usr/local/cargo/registry
 
-FROM ubuntu:jammy AS go
+FROM ubuntu:jammy@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97 AS go
 
 # Install Go manually, so that we can control the version
 ARG GO_VERSION=1.22.5
@@ -94,7 +94,7 @@ RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/d
 	unzip protoc.zip && \
 	rm protoc.zip
 
-FROM ubuntu:jammy
+FROM ubuntu:jammy@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97
 
 SHELL ["/bin/bash", "-c"]
 

--- a/examples/jfrog/docker/build/Dockerfile
+++ b/examples/jfrog/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu@sha256:99c35190e22d294cdace2783ac55effc69d32896daaa265f0bbedbcde4fbe3e5
 
 RUN apt-get update \
 	&& apt-get install -y \

--- a/scaletest/templates/scaletest-runner/Dockerfile
+++ b/scaletest/templates/scaletest-runner/Dockerfile
@@ -5,7 +5,7 @@
 # Future improvements will include versioning and including the version
 # in the template push.
 
-FROM codercom/enterprise-base:ubuntu
+FROM codercom/enterprise-base:ubuntu@sha256:22837dba6f92f075c29797652699df748ec223e04dc87627f3d2bae0a6bce7bd
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
- Update dependabot to cover missing directories.
- Pin Docker base images using SHA256 hashes.
- Add a missing hardening runner step.

Contributes to coder/internal#89