### PR TITLE
fix: make helm golden files to fix ci

### DIFF
--- a/helm/coder/tests/testdata/auto_access_url_1.golden
+++ b/helm/coder/tests/testdata/auto_access_url_1.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/auto_access_url_2.golden
+++ b/helm/coder/tests/testdata/auto_access_url_2.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/auto_access_url_3.golden
+++ b/helm/coder/tests/testdata/auto_access_url_3.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/command.golden
+++ b/helm/coder/tests/testdata/command.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/command_args.golden
+++ b/helm/coder/tests/testdata/command_args.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/default_values.golden
+++ b/helm/coder/tests/testdata/default_values.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/env_from.golden
+++ b/helm/coder/tests/testdata/env_from.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/extra_templates.golden
+++ b/helm/coder/tests/testdata/extra_templates.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/extra-templates.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -106,6 +92,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/labels_annotations.golden
+++ b/helm/coder/tests/testdata/labels_annotations.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/prometheus.golden
+++ b/helm/coder/tests/testdata/prometheus.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -98,6 +84,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/provisionerd_psk.golden
+++ b/helm/coder/tests/testdata/provisionerd_psk.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/sa.golden
+++ b/helm/coder/tests/testdata/sa.golden
@@ -1,19 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/coder-service-account
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder-service-account
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -98,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/sa_extra_rules.golden
+++ b/helm/coder/tests/testdata/sa_extra_rules.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -111,6 +97,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/tls.golden
+++ b/helm/coder/tests/testdata/tls.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -102,6 +88,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/coder/tests/testdata/workspace_proxy.golden
+++ b/helm/coder/tests/testdata/workspace_proxy.golden
@@ -1,18 +1,4 @@
 ---
-# Source: coder/templates/coder.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coder
-    app.kubernetes.io/part-of: coder
-    app.kubernetes.io/version: 0.1.0
-    helm.sh/chart: coder-0.1.0
-  name: coder
----
 # Source: coder/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -97,6 +83,7 @@ spec:
     app.kubernetes.io/instance: release-name
 ---
 # Source: coder/templates/coder.yaml
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
The go tests that would have checked for the outdated golden files didn't get run as part of https://github.com/coder/coder/pull/14817 because only `helm/**` files were modified.