### PR TITLE
fix: close server pty connections on client disconnect

### DIFF
--- a/coderd/httpapi/websocket.go
+++ b/coderd/httpapi/websocket.go
@@ -33,8 +33,8 @@ func Heartbeat(ctx context.Context, conn *websocket.Conn) {
 // Heartbeat loops to ping a WebSocket to keep it alive. It calls `exit` on ping
 // failure.
 func HeartbeatClose(ctx context.Context, logger slog.Logger, exit func(), conn *websocket.Conn) {
-	inverval := 15 * time.Second
-	ticker := time.NewTicker(inverval)
+	interval := 15 * time.Second
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -43,7 +43,7 @@ func HeartbeatClose(ctx context.Context, logger slog.Logger, exit func(), conn *
 			return
 		case <-ticker.C:
 		}
-		err := pingWithTimeout(ctx, conn, inverval)
+		err := pingWithTimeout(ctx, conn, interval)
 		if err != nil {
 			// context.DeadlineExceeded is expected when the client disconnects without sending a close frame
 			if !errors.Is(err, context.DeadlineExceeded) {

--- a/coderd/httpapi/websocket.go
+++ b/coderd/httpapi/websocket.go
@@ -2,8 +2,10 @@ package httpapi
 
 import (
 	"context"
+	"errors"
 	"time"
 
+	"golang.org/x/xerrors"
 	"nhooyr.io/websocket"
 
 	"cdr.dev/slog"
@@ -31,7 +33,8 @@ func Heartbeat(ctx context.Context, conn *websocket.Conn) {
 // Heartbeat loops to ping a WebSocket to keep it alive. It calls `exit` on ping
 // failure.
 func HeartbeatClose(ctx context.Context, logger slog.Logger, exit func(), conn *websocket.Conn) {
-	ticker := time.NewTicker(15 * time.Second)
+	inverval := 15 * time.Second
+	ticker := time.NewTicker(inverval)
 	defer ticker.Stop()
 
 	for {
@@ -40,12 +43,26 @@ func HeartbeatClose(ctx context.Context, logger slog.Logger, exit func(), conn *
 			return
 		case <-ticker.C:
 		}
-		err := conn.Ping(ctx)
+		err := pingWithTimeout(ctx, conn, inverval)
 		if err != nil {
+			// context.DeadlineExceeded is expected when the client disconnects without sending a close frame
+			if !errors.Is(err, context.DeadlineExceeded) {
+				logger.Error(ctx, "failed to heartbeat ping", slog.Error(err))
+			}
 			_ = conn.Close(websocket.StatusGoingAway, "Ping failed")
-			logger.Info(ctx, "failed to heartbeat ping", slog.Error(err))
 			exit()
 			return
 		}
 	}
+}
+
+func pingWithTimeout(ctx context.Context, conn *websocket.Conn, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	err := conn.Ping(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to ping: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/15174

We originally noticed that `last_used_at` was constantly ticking upwards even after clients disconnect. After narrowing it down to the web terminal I did some digging and found that `agentssh.Bicopy` was never exiting even after the client disconnects. This meant our websocket connections on the server were held open forever`?` and this continually counted as an open connection to the workspace and bumped `last_used_at` as a result. 

https://github.com/coder/coder/blob/f0ssel/last_used_at_inc/coderd/workspaceapps/proxy.go#L702

This is due to a combination of our use of `agentssh.Bicopy` as the primary reader of the websocket and our lack of timeout on our `websocket.Ping` attempt. 

I've added a timeout equal to the loop interval for `httpapi.HeartbeatClose` which can now catch the newly failing `websocket.Ping` call and cancel the entire request context -- leading to the `agentssh.Bicopy` finally exiting and releasing the connection. 

### But what makes `last_used_at` get bumped forever?

Great question, I wasn't sure at first since I was logging the inputs and outputs and clearly saw stats from the terminal session stop coming through on disconnect. When I logged the contents of the `workspaceapps.StatsCollector` over time I noticed that the stats from the hung websocket connections were never getting cleaned up. After some digging I found that in order for a stats to get cleared out of the stat collector it *must* get a stat published with a non-zero `ended_at` time value. The `/pty` route would send this final stat in a `defer` block in the handler but since the handler never closed, we never got the stat, so it stayed refreshing forever. 

I think there's some improvements we can make to make this safer in the future when we take a look at how to finally merge agent session stats and workspace stats together. 