### PR TITLE
chore: use system context for fetching template information

### DIFF
--- a/enterprise/coderd/templates.go
+++ b/enterprise/coderd/templates.go
@@ -66,7 +66,9 @@ func (api *API) templateAvailablePermissions(rw http.ResponseWriter, r *http.Req
 			httpapi.InternalServerError(rw, err)
 			return
 		}
-		memberCount, err := api.Database.GetGroupMembersCountByGroupID(ctx, group.Group.ID)
+
+		// nolint:gocritic
+		memberCount, err := api.Database.GetGroupMembersCountByGroupID(dbauthz.AsSystemRestricted(ctx), group.Group.ID)
 		if err != nil {
 			httpapi.InternalServerError(rw, err)
 			return

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -1494,6 +1494,10 @@ func TestUpdateTemplateACL(t *testing.T) {
 			},
 		}
 
+		// Group adds complexity to the /available endpoint
+		// Intentionally omit user2
+		coderdtest.CreateGroup(t, client, user.OrganizationID, "some-group", user3)
+
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		err := client1.UpdateTemplateACL(ctx, template.ID, req)


### PR DESCRIPTION
The authz check is Update() on the original template. This is not ideal, but it follows the existing behavior. We are implicitly granting this read access since template admins need to be able to see what users/groups exist to assign.