### PR TITLE
fix(coderd): improve password update logic

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -1051,6 +1051,7 @@ func (api *API) putUserPassword(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Old password is required.",
 		})
+		return
 	}
 
 	err := userpassword.Validate(params.Password)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1044,7 +1044,6 @@ func TestUpdateUserPassword(t *testing.T) {
 			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
 		})
 		require.NoError(t, err, "create member")
-
 		err = client.UpdateUserPassword(ctx, member.ID.String(), codersdk.UpdateUserPasswordRequest{
 			Password: "SomeNewStrongPassword!",
 		})

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1044,6 +1044,7 @@ func TestUpdateUserPassword(t *testing.T) {
 			OrganizationIDs: []uuid.UUID{owner.OrganizationID},
 		})
 		require.NoError(t, err, "create member")
+
 		err = client.UpdateUserPassword(ctx, member.ID.String(), codersdk.UpdateUserPasswordRequest{
 			Password: "SomeNewStrongPassword!",
 		})
@@ -1097,6 +1098,7 @@ func TestUpdateUserPassword(t *testing.T) {
 			Password: "newpassword",
 		})
 		require.Error(t, err, "member should not be able to update own password without providing old password")
+		require.ErrorContains(t, err, "Old password is required for non-admin users.")
 	})
 
 	t.Run("AuditorCantTellIfPasswordIncorrect", func(t *testing.T) {


### PR DESCRIPTION
Working on #15202

The main change is to fetch the user doing the action to verify if it should be able to change the password if there's no old_password set.