### PR TITLE
chore: fix incorrect quote in Workspace Delete confirmation modal

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceDeleteDialog/WorkspaceDeleteDialog.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceDeleteDialog/WorkspaceDeleteDialog.tsx
@@ -69,7 +69,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 
 					<p>Deleting this workspace is irreversible!</p>
 					<p>
-						Type &ldquo;<strong>{workspace.name}</strong>&ldquo; below to
+						Type &ldquo;<strong>{workspace.name}</strong>&rdquo; below to
 						confirm:
 					</p>
 


### PR DESCRIPTION
Tiny PR to change left-hand double quote on right side to right-hand double quote.