### PR TITLE
fix: fix bug with trailing version info not being properly stripped (…

### DIFF
--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -804,8 +804,12 @@ func DefaultSupportLinks(docsURL string) []LinkConfig {
 	}
 }
 
+func removeTrailingVersionInfo(v string) string {
+	return strings.Split(strings.Split(v, "-")[0], "+")[0]
+}
+
 func DefaultDocsURL() string {
-	version := strings.Split(buildinfo.Version(), "-")[0]
+	version := removeTrailingVersionInfo(buildinfo.Version())
 	if version == "v0.0.0" {
 		return "https://coder.com/docs"
 	}

--- a/codersdk/deployment_internal_test.go
+++ b/codersdk/deployment_internal_test.go
@@ -1,0 +1,36 @@
+package codersdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveTrailingVersionInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Version                    string
+		ExpectedAfterStrippingInfo string
+	}{
+		{
+			Version:                    "v2.16.0+683a720",
+			ExpectedAfterStrippingInfo: "v2.16.0",
+		},
+		{
+			Version:                    "v2.16.0-devel+683a720",
+			ExpectedAfterStrippingInfo: "v2.16.0",
+		},
+		{
+			Version:                    "v2.16.0+683a720-devel",
+			ExpectedAfterStrippingInfo: "v2.16.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		stripped := removeTrailingVersionInfo(tc.Version)
+		require.Equal(t, tc.ExpectedAfterStrippingInfo, stripped)
+	}
+}


### PR DESCRIPTION
…#14963)

Fixes a bug where excess version info was not being stripped properly from documentation links.