### PR TITLE
chore(enterprise/coderd/license): fix time-related flake in license expiration warning test

### DIFF
--- a/enterprise/coderd/license/license_test.go
+++ b/enterprise/coderd/license/license_test.go
@@ -54,7 +54,7 @@ func TestEntitlements(t *testing.T) {
 		db := dbmem.New()
 		db.InsertLicense(context.Background(), database.InsertLicenseParams{
 			JWT: coderdenttest.GenerateLicense(t, coderdenttest.LicenseOptions{}),
-			Exp: time.Now().Add(time.Hour),
+			Exp: dbtime.Now().Add(time.Hour),
 		})
 		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, empty)
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestEntitlements(t *testing.T) {
 					return f
 				}(),
 			}),
-			Exp: time.Now().Add(time.Hour),
+			Exp: dbtime.Now().Add(time.Hour),
 		})
 		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, empty)
 		require.NoError(t, err)
@@ -98,10 +98,10 @@ func TestEntitlements(t *testing.T) {
 					codersdk.FeatureAuditLog:  1,
 				},
 
-				GraceAt:   time.Now().Add(-time.Hour),
-				ExpiresAt: time.Now().Add(time.Hour),
+				GraceAt:   dbtime.Now().Add(-time.Hour),
+				ExpiresAt: dbtime.Now().Add(time.Hour),
 			}),
-			Exp: time.Now().Add(time.Hour),
+			Exp: dbtime.Now().Add(time.Hour),
 		})
 		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
 		require.NoError(t, err)
@@ -124,10 +124,10 @@ func TestEntitlements(t *testing.T) {
 					codersdk.FeatureAuditLog:  1,
 				},
 
-				GraceAt:   time.Now().AddDate(0, 0, 2),
-				ExpiresAt: time.Now().AddDate(0, 0, 5),
+				GraceAt:   dbtime.Now().AddDate(0, 0, 2),
+				ExpiresAt: dbtime.Now().AddDate(0, 0, 5),
 			}),
-			Exp: time.Now().AddDate(0, 0, 5),
+			Exp: dbtime.Now().AddDate(0, 0, 5),
 		})
 
 		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
@@ -153,8 +153,8 @@ func TestEntitlements(t *testing.T) {
 					codersdk.FeatureAuditLog:  1,
 				},
 
-				GraceAt:   time.Now().AddDate(0, 0, 1),
-				ExpiresAt: time.Now().AddDate(0, 0, 5),
+				GraceAt:   dbtime.Now().AddDate(0, 0, 1),
+				ExpiresAt: dbtime.Now().AddDate(0, 0, 5),
 			}),
 			Exp: time.Now().AddDate(0, 0, 5),
 		})
@@ -183,10 +183,10 @@ func TestEntitlements(t *testing.T) {
 				},
 
 				Trial:     true,
-				GraceAt:   time.Now().AddDate(0, 0, 8),
-				ExpiresAt: time.Now().AddDate(0, 0, 5),
+				GraceAt:   dbtime.Now().AddDate(0, 0, 8),
+				ExpiresAt: dbtime.Now().AddDate(0, 0, 5),
 			}),
-			Exp: time.Now().AddDate(0, 0, 5),
+			Exp: dbtime.Now().AddDate(0, 0, 5),
 		})
 
 		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)
@@ -212,10 +212,10 @@ func TestEntitlements(t *testing.T) {
 					codersdk.FeatureAuditLog:  1,
 				},
 
-				GraceAt:   time.Now().AddDate(0, 0, 30),
-				ExpiresAt: time.Now().AddDate(0, 0, 5),
+				GraceAt:   dbtime.Now().AddDate(0, 0, 30),
+				ExpiresAt: dbtime.Now().AddDate(0, 0, 5),
 			}),
-			Exp: time.Now().AddDate(0, 0, 5),
+			Exp: dbtime.Now().AddDate(0, 0, 5),
 		})
 
 		entitlements, err := license.Entitlements(context.Background(), db, 1, 1, coderdenttest.Keys, all)


### PR DESCRIPTION
Fixes the following time-related test flake:

```
--- FAIL: TestEntitlements (0.00s)
    --- FAIL: TestEntitlements/Expiration_warning (0.00s)
        license_test.go:140: 
                Error Trace:    /home/coder/src/coder/coder/enterprise/coderd/license/license_test.go:140
                Error:          []string{"Your license expires in 3 days.", "Browser Only is enabled but your license is not entitled to this feature.", "SCIM is enabled but your license is not entitled to this feature.", "Template RBAC is enabled but your license is not entitled to this feature.", "External Provisioner Daemons is enabled but your license is not entitled to this feature.", "Appearance is enabled but your license is not entitled to this feature.", "Advanced Template Scheduling is enabled but your license is not entitled to this feature.", "Workspace Proxy is enabled but your license is not entitled to this feature.", "User Role Management is enabled but your license is not entitled to this feature.", "External Token Encryption is enabled but your license is not entitled to this feature.", "Workspace Batch Actions is enabled but your license is not entitled to this feature.", "Access Control is enabled but your license is not entitled to this feature.", "Control Shared Ports is enabled but your license is not entitled to this feature.", "Custom Roles is enabled but your license is not entitled to this feature.", "Multiple Organizations is enabled but your license is not entitled to this feature."} does not contain "Your license expires in 2 days."
                Test:           TestEntitlements/Expiration_warning
FAIL
FAIL    github.com/coder/coder/v2/enterprise/coderd/license     0.039s
FAIL
```