### PR TITLE
chore: implement better 404 for unimplemented scim endpoints

### DIFF
--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -23,17 +23,6 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func (api *API) scimEnabledMW(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if !api.Entitlements.Enabled(codersdk.FeatureSCIM) {
-			httpapi.RouteNotFound(rw)
-			return
-		}
-
-		next.ServeHTTP(rw, r)
-	})
-}
-
 func (api *API) scimVerifyAuthHeader(r *http.Request) bool {
 	hdr := []byte(r.Header.Get("Authorization"))
 

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -82,7 +82,7 @@ func TestScim(t *testing.T) {
 			res, err := client.Request(ctx, "POST", "/scim/v2/Users", struct{}{})
 			require.NoError(t, err)
 			defer res.Body.Close()
-			assert.Equal(t, http.StatusNotFound, res.StatusCode)
+			assert.Equal(t, http.StatusForbidden, res.StatusCode)
 		})
 
 		t.Run("noAuth", func(t *testing.T) {
@@ -362,7 +362,7 @@ func TestScim(t *testing.T) {
 			require.NoError(t, err)
 			_, _ = io.Copy(io.Discard, res.Body)
 			_ = res.Body.Close()
-			assert.Equal(t, http.StatusNotFound, res.StatusCode)
+			assert.Equal(t, http.StatusForbidden, res.StatusCode)
 		})
 
 		t.Run("noAuth", func(t *testing.T) {


### PR DESCRIPTION
Prior to this, html was returned.