### PR TITLE
feat: use `hashicorp/cloud-init` provider for AWS-linux example

### DIFF
--- a/examples/templates/aws-linux/cloud-init/cloud-config.yaml.tftpl
+++ b/examples/templates/aws-linux/cloud-init/cloud-config.yaml.tftpl
@@ -1,0 +1,8 @@
+#cloud-config
+cloud_final_modules:
+  - [scripts-user, always]
+hostname: ${hostname}
+users:
+  - name: ${linux_user}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash

--- a/examples/templates/aws-linux/cloud-init/userdata.sh.tftpl
+++ b/examples/templates/aws-linux/cloud-init/userdata.sh.tftpl
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo -u '${linux_user}' sh -c '${init_script}'


### PR DESCRIPTION
Same as #15050 but for the `aws-linux` template.
Tested, works as expected.
