### PR TITLE
chore: ensure `make gen` runs on CI when docs are updated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,7 +234,7 @@ jobs:
     timeout-minutes: 8
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     needs: changes
-    if: needs.changes.outputs.docs-only == 'false' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    if: needs.changes.outputs.docs-only == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3605,9 +3605,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 | Name     | Type                                                       | Required | Restrictions | Description |
 | -------- | ---------------------------------------------------------- | -------- | ------------ | ----------- |
-| `github` | [codersdk.OAuth2GitHubConfig](#codersdkoauth2githubconfig) | false    |              |             |
+| `github` | [codersdk.OAuth2GithubConfig](#codersdkoauth2githubconfig) | false    |              |             |
 
-## codersdk.OAuth2GitHubConfig
+## codersdk.OAuth2GithubConfig
 
 ```json
 {


### PR DESCRIPTION
https://github.com/coder/coder/pull/15203 was merged with a failing `make gen`, as it only updated the docs. This makes it so this can't happen again.

The capitalization of the Go type used in the auto-generated docs (`codersdk.OAuth2GithubConfig`) wasn't updated as it would technically be a breaking change for the sdk.