### PR TITLE
fix: ensure `make gen` runs on any changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,8 +233,7 @@ jobs:
   gen:
     timeout-minutes: 8
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
-    needs: changes
-    if: needs.changes.outputs.docs-only == 'true' || needs.changes.outputs.ci == 'true' || github.ref == 'refs/heads/main'
+    if: always()
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1


### PR DESCRIPTION
Previously, `make gen` ran on CI whenever a non-docs change was made. Based off the problem described in #15252, it sounds like CI should *always* be running `gen`.

(Because I broke it, currently PR `gen` is getting skipped unless the `ci` category is updated)