### PR TITLE
fix(flake.nix): remove `preBuild` to fix building on Linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
           name = "protoc-gen-go";
           owner = "protocolbuffers";
           repo = "protobuf-go";
-          rev = "v1.30.0"; 
+          rev = "v1.30.0";
           src = pkgs.fetchFromGitHub {
             owner = "protocolbuffers";
             repo = "protobuf-go";
@@ -54,11 +54,6 @@
           };
           subPackages = [ "cmd/protoc-gen-go" ];
           vendorHash = null;
-          proxyVendor = true;
-          preBuild = ''
-            export GOPROXY=https://proxy.golang.org,direct
-            go mod download
-          '';
         };
 
         # The minimal set of packages to build Coder.
@@ -172,7 +167,7 @@
           '';
         };
         packages = {
-          proto_gen_go = proto_gen_go_1_30;  
+          proto_gen_go = proto_gen_go_1_30;
           all = pkgs.buildEnv {
             name = "all-packages";
             paths = devShellPackages;


### PR DESCRIPTION
On Linux, network access isn't available inside of a build. It seems to build correctly without this `preBuild` hook.

See: https://github.com/coder/coder/pull/14728#issuecomment-2417775977
cc @joobisb 

```
$ nix develop
warning: Git tree '/home/colin/Projects/coder/coder' is dirty
error: builder for '/nix/store/wg14v4ylmjrf2krlxbk6a049nvc23zad-protoc-gen-go.drv' failed with exit code 1;
       last 10 log lines:
       > calling 'postUnpack' function hook '_updateSourceDateEpochFromSourceRoot'
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > calling 'preConfigure' function hook '_multioutConfig'
       > Running phase: buildPhase
       > evaling implicit 'preBuild' string hook
       > go: github.com/golang/protobuf@v1.5.0: Get "https://proxy.golang.org/github.com/golang/protobuf/@v/v1.5.0.info": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:33535->[::1]:53: read: connection refused
       > go: github.com/google/go-cmp@v0.5.5: Get "https://proxy.golang.org/github.com/google/go-cmp/@v/v0.5.5.info": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:54889->[::1]:53: read: connection refused
       > /nix/store/5r0df66ikad3xw06azlqvswcvncll8wa-stdenv-linux/setup: line 193: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/wg14v4ylmjrf2krlxbk6a049nvc23zad-protoc-gen-go.drv'.
error: 1 dependencies of derivation '/nix/store/z9ik49f82idmhi99ra9zvd3q38cqsg9s-nix-shell-env.drv' failed to build
```