### PR TITLE
feat: log when attempted password resets fail

### DIFF
--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -383,7 +383,7 @@ func (api *API) postChangePasswordWithOneTimePasscode(rw http.ResponseWriter, r 
 
 		now := dbtime.Now()
 		if !equal || now.After(user.OneTimePasscodeExpiresAt.Time) {
-			logger.Warn(ctx, "password reset attempted with invalid one-time passcode", slog.F("email", req.Email))
+			logger.Warn(ctx, "password reset attempted with invalid or expired one-time passcode", slog.F("email", req.Email))
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Incorrect email or one-time passcode.",
 			})

--- a/coderd/userauth.go
+++ b/coderd/userauth.go
@@ -291,6 +291,8 @@ func (api *API) postRequestOneTimePasscode(rw http.ResponseWriter, r *http.Reque
 		if err != nil {
 			logger.Error(ctx, "unable to notify user about one-time passcode request", slog.Error(err))
 		}
+	} else {
+		logger.Warn(ctx, "password reset requested for account that does not exist", slog.F("email", req.Email))
 	}
 }
 
@@ -381,6 +383,7 @@ func (api *API) postChangePasswordWithOneTimePasscode(rw http.ResponseWriter, r 
 
 		now := dbtime.Now()
 		if !equal || now.After(user.OneTimePasscodeExpiresAt.Time) {
+			logger.Warn(ctx, "password reset attempted with invalid one-time passcode", slog.F("email", req.Email))
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Incorrect email or one-time passcode.",
 			})


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/15154

Log when someone attempts to either
- Request a one-time passcode for an account that doesn't exist
- Attempt to change a password with an invalid one-time passcode and/or email