### PR TITLE
chore: tweak e2e test timeouts

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -425,7 +425,9 @@ export const startAgentWithCommand = async (
 		);
 	});
 
-	await page.getByTestId("agent-status-ready").waitFor({ state: "visible" });
+	await page
+		.getByTestId("agent-status-ready")
+		.waitFor({ state: "visible", timeout: 30_000 });
 	return cp;
 };
 

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -427,7 +427,7 @@ export const startAgentWithCommand = async (
 
 	await page
 		.getByTestId("agent-status-ready")
-		.waitFor({ state: "visible", timeout: 30_000 });
+		.waitFor({ state: "visible", timeout: 45_000 });
 	return cp;
 };
 

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -928,7 +928,7 @@ export async function openTerminalWindow(
 ): Promise<Page> {
 	// Wait for the web terminal to open in a new tab
 	const pagePromise = context.waitForEvent("page");
-	await page.getByTestId("terminal").click();
+	await page.getByTestId("terminal").click({ timeout: 60_000 });
 	const terminal = await pagePromise;
 	await terminal.waitForLoadState("domcontentloaded");
 

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -70,11 +70,7 @@ export default defineConfig({
 	],
 	reporter: [["./reporter.ts"]],
 	use: {
-		// It'd be very nice to add this, but there are some tests that need
-		// tweaking to make it work consistently (notably, ones that wait for agent
-		// stats on the workspace page. The default is like 50 seconds, which is
-		// way too long and makes it painful to wait for test runs in CI.
-		// actionTimeout: 5000, // 5 seconds
+		actionTimeout: 5000,
 		baseURL: `http://localhost:${coderPort}`,
 		video: "retain-on-failure",
 		...(wsEndpoint
@@ -88,7 +84,6 @@ export default defineConfig({
 						args: ["--disable-webgl"],
 					},
 				}),
-		actionTimeout: 5000,
 	},
 	webServer: {
 		url: `http://localhost:${coderPort}/api/v2/deployment/config`,

--- a/site/e2e/playwright.config.ts
+++ b/site/e2e/playwright.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
 			testMatch: /.*\.spec\.ts/,
 			dependencies: ["testsSetup"],
 			use: { storageState },
-			timeout: 50_000,
+			timeout: 30_000,
 		},
 	],
 	reporter: [["./reporter.ts"]],
@@ -88,6 +88,7 @@ export default defineConfig({
 						args: ["--disable-webgl"],
 					},
 				}),
+		actionTimeout: 5000,
 	},
 	webServer: {
 		url: `http://localhost:${coderPort}/api/v2/deployment/config`,

--- a/site/e2e/tests/app.spec.ts
+++ b/site/e2e/tests/app.spec.ts
@@ -13,7 +13,7 @@ import { beforeCoderTest } from "../hooks";
 test.beforeEach(({ page }) => beforeCoderTest(page));
 
 test("app", async ({ context, page }) => {
-	test.setTimeout(75000);
+	test.setTimeout(75_000);
 
 	const appContent = "Hello World";
 	const token = randomUUID();
@@ -58,7 +58,7 @@ test("app", async ({ context, page }) => {
 
 	// Wait for the web terminal to open in a new tab
 	const pagePromise = context.waitForEvent("page");
-	await page.getByText(appName).click();
+	await page.getByText(appName).click({ timeout: 60_000 });
 	const app = await pagePromise;
 	await app.waitForLoadState("domcontentloaded");
 	await app.getByText(appContent).isVisible();

--- a/site/e2e/tests/app.spec.ts
+++ b/site/e2e/tests/app.spec.ts
@@ -13,6 +13,8 @@ import { beforeCoderTest } from "../hooks";
 test.beforeEach(({ page }) => beforeCoderTest(page));
 
 test("app", async ({ context, page }) => {
+	test.setTimeout(75000);
+
 	const appContent = "Hello World";
 	const token = randomUUID();
 	const srv = http

--- a/site/e2e/tests/outdatedAgent.spec.ts
+++ b/site/e2e/tests/outdatedAgent.spec.ts
@@ -17,7 +17,7 @@ const agentVersion = "v2.12.1";
 test.beforeEach(({ page }) => beforeCoderTest(page));
 
 test(`ssh with agent ${agentVersion}`, async ({ page }) => {
-	test.setTimeout(40_000); // This is a slow test, 20s may not be enough on Mac.
+	test.setTimeout(60_000);
 
 	const token = randomUUID();
 	const template = await createTemplate(page, {

--- a/site/e2e/tests/outdatedCLI.spec.ts
+++ b/site/e2e/tests/outdatedCLI.spec.ts
@@ -17,6 +17,8 @@ const clientVersion = "v2.8.0";
 test.beforeEach(({ page }) => beforeCoderTest(page));
 
 test(`ssh with client ${clientVersion}`, async ({ page }) => {
+	test.setTimeout(60_000);
+
 	const token = randomUUID();
 	const template = await createTemplate(page, {
 		apply: [

--- a/site/e2e/tests/webTerminal.spec.ts
+++ b/site/e2e/tests/webTerminal.spec.ts
@@ -12,6 +12,8 @@ import { beforeCoderTest } from "../hooks";
 test.beforeEach(({ page }) => beforeCoderTest(page));
 
 test("web terminal", async ({ context, page }) => {
+	test.setTimeout(75_000);
+
 	const token = randomUUID();
 	const template = await createTemplate(page, {
 		apply: [


### PR DESCRIPTION
Closes coder/internal#178

tweak some timeouts for slow tests/operations to be more targeted, so that we can make the generic timeout shorter _and_ reduce the number of flakes caused by timeouts on the long running/slow tests.