### PR TITLE
feat: add prometheus metric for tracking user statuses

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -218,7 +218,7 @@ func enablePrometheus(
 	}
 	afterCtx(ctx, closeActiveUsersFunc)
 
-	closeUsersFunc, err := prometheusmetrics.Users(ctx, options.Logger.Named("user_metrics"), options.Clock, options.PrometheusRegistry, options.Database, 0)
+	closeUsersFunc, err := prometheusmetrics.Users(ctx, options.Logger.Named("user_metrics"), quartz.NewReal(), options.PrometheusRegistry, options.Database, 0)
 	if err != nil {
 		return nil, xerrors.Errorf("register users prometheus metric: %w", err)
 	}

--- a/cli/server.go
+++ b/cli/server.go
@@ -220,7 +220,7 @@ func enablePrometheus(
 
 	closeUsersFunc, err := prometheusmetrics.Users(ctx, options.Logger.Named("user_metrics"), options.Clock, options.PrometheusRegistry, options.Database, 0)
 	if err != nil {
-		return nil, xerrors.Errorf("register active users prometheus metric: %w", err)
+		return nil, xerrors.Errorf("register users prometheus metric: %w", err)
 	}
 	afterCtx(ctx, closeUsersFunc)
 

--- a/cli/server.go
+++ b/cli/server.go
@@ -212,7 +212,13 @@ func enablePrometheus(
 	options.PrometheusRegistry.MustRegister(collectors.NewGoCollector())
 	options.PrometheusRegistry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
-	closeUsersFunc, err := prometheusmetrics.ActiveUsers(ctx, options.PrometheusRegistry, options.Database, 0)
+	closeActiveUsersFunc, err := prometheusmetrics.ActiveUsers(ctx, options.Logger.Named("active_user_metrics"), options.PrometheusRegistry, options.Database, 0)
+	if err != nil {
+		return nil, xerrors.Errorf("register active users prometheus metric: %w", err)
+	}
+	afterCtx(ctx, closeActiveUsersFunc)
+
+	closeUsersFunc, err := prometheusmetrics.Users(ctx, options.Logger.Named("user_metrics"), options.PrometheusRegistry, options.Database, 0)
 	if err != nil {
 		return nil, xerrors.Errorf("register active users prometheus metric: %w", err)
 	}

--- a/cli/server.go
+++ b/cli/server.go
@@ -218,7 +218,7 @@ func enablePrometheus(
 	}
 	afterCtx(ctx, closeActiveUsersFunc)
 
-	closeUsersFunc, err := prometheusmetrics.Users(ctx, options.Logger.Named("user_metrics"), options.PrometheusRegistry, options.Database, 0)
+	closeUsersFunc, err := prometheusmetrics.Users(ctx, options.Logger.Named("user_metrics"), options.Clock, options.PrometheusRegistry, options.Database, 0)
 	if err != nil {
 		return nil, xerrors.Errorf("register active users prometheus metric: %w", err)
 	}

--- a/coderd/prometheusmetrics/prometheusmetrics.go
+++ b/coderd/prometheusmetrics/prometheusmetrics.go
@@ -106,9 +106,11 @@ func Users(ctx context.Context, logger slog.Logger, registerer prometheus.Regist
 			}
 
 			gauge.Reset()
+			//nolint:gocritic // This is a system service that needs full access
+			//to the users table.
 			users, err := db.GetUsers(dbauthz.AsSystemRestricted(ctx), database.GetUsersParams{})
 			if err != nil {
-				logger.Error(ctx, "get users", slog.Error(err))
+				logger.Error(ctx, "get all users for prometheus metrics", slog.Error(err))
 				continue
 			}
 


### PR DESCRIPTION
Adds the ability to track total users in the platform by status. This can help for seeing how license seat usage is being used over time.

Closes https://github.com/coder/coder/issues/15278