### PR TITLE
fix(coderd/provisionerdserver): prevent NPE if no user link exists

### DIFF
--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2026,7 +2026,7 @@ func obtainOIDCAccessToken(ctx context.Context, db database.Store, oidcConfig pr
 		LoginType: database.LoginTypeOIDC,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil //nolint:nilnil
+		return "", nil
 	}
 	if err != nil {
 		return "", xerrors.Errorf("get owner oidc link: %w", err)

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2026,7 +2026,7 @@ func obtainOIDCAccessToken(ctx context.Context, db database.Store, oidcConfig pr
 		LoginType: database.LoginTypeOIDC,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
-		err = nil
+		return nil, nil //nolint:nilnil
 	}
 	if err != nil {
 		return "", xerrors.Errorf("get owner oidc link: %w", err)

--- a/coderd/provisionerdserver/provisionerdserver_internal_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_internal_test.go
@@ -38,6 +38,16 @@ func TestObtainOIDCAccessToken(t *testing.T) {
 		_, err := obtainOIDCAccessToken(ctx, db, &oauth2.Config{}, user.ID)
 		require.NoError(t, err)
 	})
+	t.Run("MissingLink", func(t *testing.T) {
+		t.Parallel()
+		db := dbmem.New()
+		user := dbgen.User(t, db, database.User{
+			LoginType: database.LoginTypeOIDC,
+		})
+		tok, err := obtainOIDCAccessToken(ctx, db, &oauth2.Config{}, user.ID)
+		require.Empty(t, tok)
+		require.NoError(t, err)
+	})
 	t.Run("Exchange", func(t *testing.T) {
 		t.Parallel()
 		db := dbmem.New()


### PR DESCRIPTION
This happend to @timquinlan and myself when we tried manually converting an OIDC user to password login type. We had updated the user row directly in the database without removing the corresponding `user_link`. We then created some provisioner jobs, which caused Coder (v2.15.3+6f68315) to panic with the following:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2222501]

goroutine 566 [running]:
github.com/coder/coder/v2/coderd.(*OIDCConfig).TokenSource(0x14ec6a30?, {0x96cdb10?, 0xc0134cf3e0?}, 0x27286230?)
        <autogenerated>:1 +0x21
github.com/coder/coder/v2/coderd/provisionerdserver.obtainOIDCAccessToken({0x96cdb10, 0xc0134cf3e0}, {0x9743df8, 0xc000ec87e0}, {0x96c7740, 0x0}, {0x47, 0x4d, 0xca, 0x46, ...})
        /home/runner/work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:2024 +0x322
github.com/coder/coder/v2/coderd/provisionerdserver.(*server).acquireProtoJob(_, {_, _}, {{0x86, 0x61, 0x84, 0xd, 0x1f, 0xc2, 0x44, ...}, ...})
        /home/runner/work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:503 +0x20fe
github.com/coder/coder/v2/coderd/provisionerdserver.(*server).AcquireJobWithCancel(0xc01346d380, {0x96dd800, 0xc000968e40})
        /home/runner/work/coder/coder/coderd/provisionerdserver/provisionerdserver.go:390 +0xb9a
github.com/coder/coder/v2/provisionerd/proto.DRPCProvisionerDaemonDescription.Method.func2({0x2de0c20?, 0xc01346d380}, {0xc000bcffc0?, 0x34?}, {0x2e33760?, 0xc0133f26c8}, {0x54d0b4?, 0x96cd608?})
        /home/runner/work/coder/coder/provisionerd/proto/provisionerd_drpc.pb.go:197 +0x134
storj.io/drpc/drpcmux.(*Mux).HandleRPC(0x30?, {0x96d6be0, 0xc0133f26c8}, {0xc000bcffc0, 0x34})
        /home/runner/go/pkg/mod/storj.io/drpc@v0.0.33/drpcmux/handle_rpc.go:33 +0x207
github.com/coder/coder/v2/coderd/tracing.(*DRPCHandler).HandleRPC(0xc000778da0, {0x96d6be0, 0xc0133f26c8}, {0xc000bcffc0, 0x34})
        /home/runner/work/coder/coder/coderd/tracing/drpc.go:23 +0x1bb
storj.io/drpc/drpcserver.(*Server).handleRPC(0xc013461dc0?, 0xc0133f26c8, {0xc000bcffc0?, 0xb0b7d00?})
        /home/runner/go/pkg/mod/storj.io/drpc@v0.0.33/drpcserver/server.go:124 +0x36
storj.io/drpc/drpcserver.(*Server).ServeOne(0xc000b62000, {0x96d1cc8, 0xc0134cf320}, {0x7f57576e2b20?, 0xc013468818?})
        /home/runner/go/pkg/mod/storj.io/drpc@v0.0.33/drpcserver/server.go:66 +0x1d2
storj.io/drpc/drpcserver.(*Server).Serve.func2({0x96d1cc8?, 0xc0134cf320?})
        /home/runner/go/pkg/mod/storj.io/drpc@v0.0.33/drpcserver/server.go:114 +0x57
storj.io/drpc/drpcctx.(*Tracker).track(0xc0134cf320, 0x0?)
        /home/runner/go/pkg/mod/storj.io/drpc@v0.0.33/drpcctx/tracker.go:35 +0x25
created by storj.io/drpc/drpcctx.(*Tracker).Run in goroutine 563
        /home/runner/go/pkg/mod/storj.io/drpc@v0.0.33/drpcctx/tracker.go:30 +0x79
```

Looking at the defintion of `obtainOIDCAccessToken`, I think the culprit is:

```
if errors.Is(err, sql.ErrNoRows) {
  err = nil
}
// continue with the rest of the flow
```

We should instead return early here instead of trying to continue the OIDC flow.