### PR TITLE
fix: check correct default during template push from stdin

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -282,7 +282,7 @@ func (pf *templateUploadFlags) stdin(inv *serpent.Invocation) (out bool) {
 		}
 	}()
 	// We let the directory override our isTTY check
-	return pf.directory == "-" || (!isTTYIn(inv) && pf.directory == "")
+	return pf.directory == "-" || (!isTTYIn(inv) && pf.directory == ".")
 }
 
 func (pf *templateUploadFlags) upload(inv *serpent.Invocation, client *codersdk.Client) (*codersdk.UploadResponse, error) {


### PR DESCRIPTION
I used the wrong default in #14643 - not sure how or why I didn't catch that..