### PR TITLE
fix(coderd/database/pubsub): prevent listeners read outside mutex lock

### DIFF
--- a/coderd/database/pubsub/pubsub.go
+++ b/coderd/database/pubsub/pubsub.go
@@ -278,10 +278,11 @@ func (p *PGPubsub) subscribeQueue(event string, newQ *msgQueue) (cancel func(), 
 		if len(listeners) == 0 {
 			delete(p.queues, event)
 		}
+		listenerCount := len(listeners)
 		p.qMu.Unlock()
 		// as above, we must not hold the lock while calling into pgListener
 
-		if len(listeners) == 0 {
+		if listenerCount == 0 {
 			uErr := p.pgListener.Unlisten(event)
 			p.closeMu.Lock()
 			defer p.closeMu.Unlock()


### PR DESCRIPTION
https://github.com/coder/coder/actions/runs/11611105362/job/32331771969#logs

```
2024-10-31T11:36:45.9225038Z WARNING: DATA RACE
2024-10-31T11:36:45.9225120Z Write at 0x00c0000d8030 by goroutine 26:
2024-10-31T11:36:45.9225200Z   runtime.mapdelete()
2024-10-31T11:36:45.9225412Z       /opt/hostedtoolcache/go/1.22.8/x64/src/runtime/map.go:696 +0x0
2024-10-31T11:36:45.9225647Z   github.com/coder/coder/v2/coderd/database/pubsub.(*PGPubsub).subscribeQueue.func2()
2024-10-31T11:36:45.9225906Z       /home/runner/work/coder/coder/coderd/database/pubsub/pubsub.go:277 +0x131
2024-10-31T11:36:45.9225993Z   runtime.deferreturn()
2024-10-31T11:36:45.9226210Z       /opt/hostedtoolcache/go/1.22.8/x64/src/runtime/panic.go:602 +0x5d
2024-10-31T11:36:45.9226283Z   testing.tRunner()
2024-10-31T11:36:45.9226519Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
2024-10-31T11:36:45.9226603Z   testing.(*T).Run.gowrap1()
2024-10-31T11:36:45.9226831Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
2024-10-31T11:36:45.9226836Z 
2024-10-31T11:36:45.9226934Z Previous read at 0x00c0000d8030 by goroutine 112:
2024-10-31T11:36:45.9227159Z   github.com/coder/coder/v2/coderd/database/pubsub.(*PGPubsub).subscribeQueue.func2()
2024-10-31T11:36:45.9227462Z       /home/runner/work/coder/coder/coderd/database/pubsub/pubsub.go:284 +0x1b6
2024-10-31T11:36:45.9227661Z   github.com/coder/coder/v2/enterprise/replicasync.(*Manager).subscribe.func3()
2024-10-31T11:36:45.9227936Z       /home/runner/work/coder/coder/enterprise/replicasync/replicasync.go:228 +0x53
2024-10-31T11:36:45.9227941Z 
2024-10-31T11:36:45.9228019Z Goroutine 26 (running) created at:
2024-10-31T11:36:45.9228096Z   testing.(*T).Run()
2024-10-31T11:36:45.9228318Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x825
2024-10-31T11:36:45.9228498Z   github.com/coder/coder/v2/enterprise/replicasync_test.TestReplica()
2024-10-31T11:36:45.9228777Z       /home/runner/work/coder/coder/enterprise/replicasync/replicasync_test.go:33 +0x4b
2024-10-31T11:36:45.9228847Z   testing.tRunner()
2024-10-31T11:36:45.9229063Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
2024-10-31T11:36:45.9229142Z   testing.(*T).Run.gowrap1()
2024-10-31T11:36:45.9229366Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
2024-10-31T11:36:45.9229369Z 
2024-10-31T11:36:45.9229443Z Goroutine 112 (finished) created at:
2024-10-31T11:36:45.9229685Z   github.com/coder/coder/v2/enterprise/replicasync.(*Manager).subscribe()
2024-10-31T11:36:45.9229952Z       /home/runner/work/coder/coder/enterprise/replicasync/replicasync.go:226 +0x568
2024-10-31T11:36:45.9230092Z   github.com/coder/coder/v2/enterprise/replicasync.New()
2024-10-31T11:36:45.9230361Z       /home/runner/work/coder/coder/enterprise/replicasync/replicasync.go:101 +0x1344
2024-10-31T11:36:45.9230547Z   github.com/coder/coder/v2/enterprise/replicasync_test.TestReplica.func1()
2024-10-31T11:36:45.9230836Z       /home/runner/work/coder/coder/enterprise/replicasync/replicasync_test.go:48 +0x26a
2024-10-31T11:36:45.9230904Z   testing.tRunner()
2024-10-31T11:36:45.9231127Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
2024-10-31T11:36:45.9231207Z   testing.(*T).Run.gowrap1()
2024-10-31T11:36:45.9231431Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
```
