### PR TITLE
test(coderd/notifications): fix data race in tests and smpttest

### DIFF
--- a/coderd/notifications/dispatch/smtptest/server.go
+++ b/coderd/notifications/dispatch/smtptest/server.go
@@ -68,6 +68,8 @@ func (b *Backend) LastMessage() *Message {
 }
 
 func (b *Backend) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.lastMsg = nil
 }
 

--- a/coderd/notifications/dispatch/smtptest/server.go
+++ b/coderd/notifications/dispatch/smtptest/server.go
@@ -59,6 +59,9 @@ func (b *Backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 func (b *Backend) LastMessage() *Message {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.lastMsg == nil {
+		return nil
+	}
 	clone := *b.lastMsg
 	clone.To = slices.Clone(b.lastMsg.To)
 	return &clone


### PR DESCRIPTION
https://github.com/coder/coder/actions/runs/11611105362/job/32331771969#logs

```
2024-10-31T11:36:45.8625097Z WARNING: DATA RACE
2024-10-31T11:36:45.8625194Z Write at 0x00c004c19d38 by goroutine 2661:
2024-10-31T11:36:45.8625422Z   github.com/coder/coder/v2/coderd/notifications/dispatch/smtptest.(*Session).Auth()
2024-10-31T11:36:45.8625746Z       /home/runner/work/coder/coder/coderd/notifications/dispatch/smtptest/server.go:81 +0x228
2024-10-31T11:36:45.8625855Z   github.com/emersion/go-smtp.(*Conn).auth()
2024-10-31T11:36:45.8626124Z       /home/runner/go/pkg/mod/github.com/emersion/go-smtp@v0.21.2/conn.go:846 +0x65
2024-10-31T11:36:45.8626241Z   github.com/emersion/go-smtp.(*Conn).handleAuth()
2024-10-31T11:36:45.8626496Z       /home/runner/go/pkg/mod/github.com/emersion/go-smtp@v0.21.2/conn.go:784 +0x1d7
2024-10-31T11:36:45.8626614Z   github.com/emersion/go-smtp.(*Conn).handle()
2024-10-31T11:36:45.8626856Z       /home/runner/go/pkg/mod/github.com/emersion/go-smtp@v0.21.2/conn.go:144 +0x1b0
2024-10-31T11:36:45.8627040Z   github.com/emersion/go-smtp.(*Server).handleConn()
2024-10-31T11:36:45.8627304Z       /home/runner/go/pkg/mod/github.com/emersion/go-smtp@v0.21.2/server.go:165 +0x410
2024-10-31T11:36:45.8627438Z   github.com/emersion/go-smtp.(*Server).Serve.func1()
2024-10-31T11:36:45.8627692Z       /home/runner/go/pkg/mod/github.com/emersion/go-smtp@v0.21.2/server.go:121 +0x1b8
2024-10-31T11:36:45.8627697Z 
2024-10-31T11:36:45.8627809Z Previous read at 0x00c004c19d38 by goroutine 2655:
2024-10-31T11:36:45.8628056Z   github.com/coder/coder/v2/coderd/notifications/dispatch/smtptest.(*Backend).LastMessage()
2024-10-31T11:36:45.8628364Z       /home/runner/work/coder/coder/coderd/notifications/dispatch/smtptest/server.go:57 +0x44
2024-10-31T11:36:45.8628641Z   github.com/coder/coder/v2/coderd/notifications_test.TestNotificationTemplates_Golden.func1.1.5()
2024-10-31T11:36:45.8628930Z       /home/runner/work/coder/coder/coderd/notifications/notifications_test.go:1170 +0x53
2024-10-31T11:36:45.8629073Z   github.com/stretchr/testify/assert.Eventually.func1()
2024-10-31T11:36:45.8629371Z       /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x33
2024-10-31T11:36:45.8629436Z 
2024-10-31T11:36:45.8629523Z Goroutine 2661 (running) created at:
2024-10-31T11:36:45.8629633Z   github.com/emersion/go-smtp.(*Server).Serve()
2024-10-31T11:36:45.8629903Z       /home/runner/go/pkg/mod/github.com/emersion/go-smtp@v0.21.2/server.go:118 +0x2c4
2024-10-31T11:36:45.8630168Z   github.com/coder/coder/v2/coderd/notifications_test.TestNotificationTemplates_Golden.func1.1.3()
2024-10-31T11:36:45.8630453Z       /home/runner/work/coder/coder/coderd/notifications/notifications_test.go:1094 +0xcd
2024-10-31T11:36:45.8630457Z 
2024-10-31T11:36:45.8630544Z Goroutine 2655 (finished) created at:
2024-10-31T11:36:45.8630664Z   github.com/stretchr/testify/assert.Eventually()
2024-10-31T11:36:45.8630971Z       /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x3d5
2024-10-31T11:36:45.8631087Z   github.com/stretchr/testify/require.Eventually()
2024-10-31T11:36:45.8631377Z       /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/require/require.go:398 +0xd1
2024-10-31T11:36:45.8631636Z   github.com/coder/coder/v2/coderd/notifications_test.TestNotificationTemplates_Golden.func1.1()
2024-10-31T11:36:45.8631965Z       /home/runner/work/coder/coder/coderd/notifications/notifications_test.go:1169 +0x19be
2024-10-31T11:36:45.8632038Z   testing.tRunner()
2024-10-31T11:36:45.8632270Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
2024-10-31T11:36:45.8632360Z   testing.(*T).Run.gowrap1()
2024-10-31T11:36:45.8632664Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
```

```
2024-10-31T11:36:45.8736202Z WARNING: DATA RACE
2024-10-31T11:36:45.8736290Z Write at 0x00c00488e1cf by goroutine 3874:
2024-10-31T11:36:45.8736575Z   github.com/coder/coder/v2/coderd/notifications_test.TestNotificationTemplates_Golden.func1.2.2()
2024-10-31T11:36:45.8736881Z       /home/runner/work/coder/coder/coderd/notifications/notifications_test.go:1232 +0x14f
2024-10-31T11:36:45.8736978Z   net/http.HandlerFunc.ServeHTTP()
2024-10-31T11:36:45.8737217Z       /opt/hostedtoolcache/go/1.22.8/x64/src/net/http/server.go:2171 +0x47
2024-10-31T11:36:45.8737312Z   net/http.serverHandler.ServeHTTP()
2024-10-31T11:36:45.8737546Z       /opt/hostedtoolcache/go/1.22.8/x64/src/net/http/server.go:3142 +0x2a1
2024-10-31T11:36:45.8737630Z   net/http.(*conn).serve()
2024-10-31T11:36:45.8737862Z       /opt/hostedtoolcache/go/1.22.8/x64/src/net/http/server.go:2044 +0x13c4
2024-10-31T11:36:45.8737950Z   net/http.(*Server).Serve.gowrap3()
2024-10-31T11:36:45.8738167Z       /opt/hostedtoolcache/go/1.22.8/x64/src/net/http/server.go:3290 +0x4f
2024-10-31T11:36:45.8738172Z 
2024-10-31T11:36:45.8738288Z Previous read at 0x00c00488e1cf by goroutine 3867:
2024-10-31T11:36:45.8738562Z   github.com/coder/coder/v2/coderd/notifications_test.TestNotificationTemplates_Golden.func1.2.3()
2024-10-31T11:36:45.8738859Z       /home/runner/work/coder/coder/coderd/notifications/notifications_test.go:1277 +0x2e
2024-10-31T11:36:45.8738994Z   github.com/stretchr/testify/assert.Eventually.func1()
2024-10-31T11:36:45.8739304Z       /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x33
2024-10-31T11:36:45.8739377Z 
2024-10-31T11:36:45.8739457Z Goroutine 3874 (running) created at:
2024-10-31T11:36:45.8739548Z   net/http.(*Server).Serve()
2024-10-31T11:36:45.8739777Z       /opt/hostedtoolcache/go/1.22.8/x64/src/net/http/server.go:3290 +0x8ec
2024-10-31T11:36:45.8739886Z   net/http/httptest.(*Server).goServe.func1()
2024-10-31T11:36:45.8740141Z       /opt/hostedtoolcache/go/1.22.8/x64/src/net/http/httptest/server.go:310 +0xbb
2024-10-31T11:36:45.8740145Z 
2024-10-31T11:36:45.8740222Z Goroutine 3867 (finished) created at:
2024-10-31T11:36:45.8740345Z   github.com/stretchr/testify/assert.Eventually()
2024-10-31T11:36:45.8740649Z       /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x3d5
2024-10-31T11:36:45.8740772Z   github.com/stretchr/testify/require.Eventually()
2024-10-31T11:36:45.8741055Z       /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/require/require.go:398 +0xd1
2024-10-31T11:36:45.8741317Z   github.com/coder/coder/v2/coderd/notifications_test.TestNotificationTemplates_Golden.func1.2()
2024-10-31T11:36:45.8741622Z       /home/runner/work/coder/coder/coderd/notifications/notifications_test.go:1276 +0x12fa
2024-10-31T11:36:45.8741760Z   testing.tRunner()
2024-10-31T11:36:45.8741993Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1689 +0x21e
2024-10-31T11:36:45.8742077Z   testing.(*T).Run.gowrap1()
2024-10-31T11:36:45.8742305Z       /opt/hostedtoolcache/go/1.22.8/x64/src/testing/testing.go:1742 +0x44
```
