### PR TITLE
fix: workspaces query to correctly user username from users table

### DIFF
--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -14947,7 +14947,7 @@ WHERE
 	-- Filter by owner_name
 	AND CASE
 		WHEN $8 :: text != '' THEN
-			workspaces.owner_id = (SELECT id FROM users WHERE lower(owner_username) = lower($8) AND deleted = false)
+			workspaces.owner_id = (SELECT id FROM users WHERE lower(users.username) = lower($8) AND deleted = false)
 		ELSE true
 	END
 	-- Filter by template_name

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -233,7 +233,7 @@ WHERE
 	-- Filter by owner_name
 	AND CASE
 		WHEN @owner_username :: text != '' THEN
-			workspaces.owner_id = (SELECT id FROM users WHERE lower(owner_username) = lower(@owner_username) AND deleted = false)
+			workspaces.owner_id = (SELECT id FROM users WHERE lower(users.username) = lower(@owner_username) AND deleted = false)
 		ELSE true
 	END
 	-- Filter by template_name

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1317,21 +1317,35 @@ func TestWorkspaceFilterManual(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
 		user := coderdtest.CreateFirstUser(t, client)
+		otherUser, _ := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleOwner())
 		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
 		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+
+		// Add a non-matching workspace
+		coderdtest.CreateWorkspace(t, otherUser, template.ID)
+
+		workspaces := []codersdk.Workspace{
+			coderdtest.CreateWorkspace(t, client, template.ID),
+			coderdtest.CreateWorkspace(t, client, template.ID),
+		}
+		var _ = workspaces
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		sdkUser, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+
 		// match owner name
 		res, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Owner: workspace.OwnerName,
+			FilterQuery: fmt.Sprintf("owner:%s", sdkUser.Username),
 		})
 		require.NoError(t, err)
-		require.Len(t, res.Workspaces, 1)
-		require.Equal(t, workspace.ID, res.Workspaces[0].ID)
+		require.Len(t, res.Workspaces, 2)
+		for _, found := range res.Workspaces {
+			require.Equal(t, found.OwnerName, sdkUser.Username)
+		}
 	})
 	t.Run("IDs", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1329,7 +1329,6 @@ func TestWorkspaceFilterManual(t *testing.T) {
 			coderdtest.CreateWorkspace(t, client, template.ID),
 			coderdtest.CreateWorkspace(t, client, template.ID),
 		}
-		var _ = workspaces
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -1341,7 +1341,7 @@ func TestWorkspaceFilterManual(t *testing.T) {
 			FilterQuery: fmt.Sprintf("owner:%s", sdkUser.Username),
 		})
 		require.NoError(t, err)
-		require.Len(t, res.Workspaces, 2)
+		require.Len(t, res.Workspaces, len(workspaces))
 		for _, found := range res.Workspaces {
 			require.Equal(t, found.OwnerName, sdkUser.Username)
 		}


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/15302

The subquery on the users table was incorrectly using the username from the `workspaces` table, not the `users` table.

This passed `sqlc-vet` because the column did exist in the query, it just was not the correct one.

----

Note: If we do not care about `deleted` users, we can drop querying the `Users` table at all and use the `owner_username` on the workspaces. But then we'd get deleted users with the same name :cry: 