### PR TITLE
test(coderd/database/pubsub): fix data race in err assignment

### DIFF
--- a/coderd/database/pubsub/pubsub_test.go
+++ b/coderd/database/pubsub/pubsub_test.go
@@ -58,7 +58,7 @@ func TestPGPubsub_Metrics(t *testing.T) {
 	require.NoError(t, err)
 	defer unsub0()
 	go func() {
-		err = uut.Publish(event, []byte(data))
+		err := uut.Publish(event, []byte(data))
 		assert.NoError(t, err)
 	}()
 	_ = testutil.RequireRecvCtx(ctx, t, messageChannel)
@@ -93,7 +93,7 @@ func TestPGPubsub_Metrics(t *testing.T) {
 	require.NoError(t, err)
 	defer unsub1()
 	go func() {
-		err = uut.Publish(event, colossalData)
+		err := uut.Publish(event, colossalData)
 		assert.NoError(t, err)
 	}()
 	// should get 2 messages because we have 2 subs


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c00010fe10 by goroutine 1062:
  github.com/coder/coder/v2/coderd/database/pubsub_test.TestPGPubsub_Metrics.func6()
      /home/runner/work/coder/coder/coderd/database/pubsub/pubsub_test.go:102 +0x13e
  github.com/stretchr/testify/assert.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1902 +0x33

Previous write at 0x00c00010fe10 by goroutine 1051:
  github.com/coder/coder/v2/coderd/database/pubsub_test.TestPGPubsub_Metrics.func5()
      /home/runner/work/coder/coder/coderd/database/pubsub/pubsub_test.go:93 +0xab
```
