### PR TITLE
chore: add PGLocks query to analyze what locks are held in pg

### DIFF
--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -12,6 +12,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -28,6 +31,7 @@ type Store interface {
 	wrapper
 
 	Ping(ctx context.Context) (time.Duration, error)
+	PGLocks(ctx context.Context) (PGLocks, error)
 	InTx(func(Store) error, *TxOptions) error
 }
 
@@ -134,6 +138,98 @@ func (q *sqlQuerier) Ping(ctx context.Context) (time.Duration, error) {
 	return time.Since(start), err
 }
 
+type PGLocks []PGLock
+
+func (l PGLocks) String() string {
+	// Try to group things together by relation name.
+	sort.Slice(l, func(i, j int) bool {
+		return safeString(l[i].RelationName) < safeString(l[j].RelationName)
+	})
+
+	var out strings.Builder
+	for i, lock := range l {
+		if i != 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString(lock.String())
+	}
+	return out.String()
+}
+
+// PGLock docs see: https://www.postgresql.org/docs/current/view-pg-locks.html#VIEW-PG-LOCKS
+type PGLock struct {
+	// LockType see: https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-LOCK-TABLE
+	LockType           *string    `db:"locktype"`
+	Database           *string    `db:"database"` // oid
+	Relation           *string    `db:"relation"` // oid
+	RelationName       *string    `db:"relation_name"`
+	Page               *int       `db:"page"`
+	Tuple              *int       `db:"tuple"`
+	VirtualXID         *string    `db:"virtualxid"`
+	TransactionID      *string    `db:"transactionid"` // xid
+	ClassID            *string    `db:"classid"`       // oid
+	ObjID              *string    `db:"objid"`         // oid
+	ObjSubID           *int       `db:"objsubid"`
+	VirtualTransaction *string    `db:"virtualtransaction"`
+	PID                int        `db:"pid"`
+	Mode               *string    `db:"mode"`
+	Granted            bool       `db:"granted"`
+	FastPath           *bool      `db:"fastpath"`
+	WaitStart          *time.Time `db:"waitstart"`
+}
+
+func (l PGLock) String() string {
+	granted := "granted"
+	if !l.Granted {
+		granted = "waiting"
+	}
+	var details string
+	switch safeString(l.LockType) {
+	case "relation":
+		details = ""
+	case "page":
+		details = fmt.Sprintf("page=%d", *l.Page)
+	case "tuple":
+		details = fmt.Sprintf("page=%d tuple=%d", *l.Page, *l.Tuple)
+	case "virtualxid":
+		details = "waiting to acquire virtual tx id lock"
+	default:
+		details = "???"
+	}
+	return fmt.Sprintf("%d-%5s [%s] %s/%s/%s: %s",
+		l.PID,
+		safeString(l.TransactionID),
+		granted,
+		safeString(l.RelationName),
+		safeString(l.LockType),
+		safeString(l.Mode),
+		details,
+	)
+}
+
+// PGLocks returns a list of all locks in the database currently in use.
+func (q *sqlQuerier) PGLocks(ctx context.Context) (PGLocks, error) {
+	rows, err := q.sdb.QueryContext(ctx, `
+	SELECT
+		relation::regclass AS relation_name,
+	    *
+	FROM pg_locks;
+	`)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var locks []PGLock
+	err = sqlx.StructScan(rows, &locks)
+	if err != nil {
+		return nil, err
+	}
+
+	return locks, err
+}
+
 func DefaultTXOptions() *TxOptions {
 	return &TxOptions{
 		Isolation: sql.LevelDefault,
@@ -217,4 +313,11 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		return xerrors.Errorf("commit transaction: %w", err)
 	}
 	return nil
+}
+
+func safeString(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
 }

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -12,9 +12,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -136,98 +133,6 @@ func (q *sqlQuerier) Ping(ctx context.Context) (time.Duration, error) {
 	start := time.Now()
 	err := q.sdb.PingContext(ctx)
 	return time.Since(start), err
-}
-
-type PGLocks []PGLock
-
-func (l PGLocks) String() string {
-	// Try to group things together by relation name.
-	sort.Slice(l, func(i, j int) bool {
-		return safeString(l[i].RelationName) < safeString(l[j].RelationName)
-	})
-
-	var out strings.Builder
-	for i, lock := range l {
-		if i != 0 {
-			out.WriteString("\n")
-		}
-		out.WriteString(lock.String())
-	}
-	return out.String()
-}
-
-// PGLock docs see: https://www.postgresql.org/docs/current/view-pg-locks.html#VIEW-PG-LOCKS
-type PGLock struct {
-	// LockType see: https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-LOCK-TABLE
-	LockType           *string    `db:"locktype"`
-	Database           *string    `db:"database"` // oid
-	Relation           *string    `db:"relation"` // oid
-	RelationName       *string    `db:"relation_name"`
-	Page               *int       `db:"page"`
-	Tuple              *int       `db:"tuple"`
-	VirtualXID         *string    `db:"virtualxid"`
-	TransactionID      *string    `db:"transactionid"` // xid
-	ClassID            *string    `db:"classid"`       // oid
-	ObjID              *string    `db:"objid"`         // oid
-	ObjSubID           *int       `db:"objsubid"`
-	VirtualTransaction *string    `db:"virtualtransaction"`
-	PID                int        `db:"pid"`
-	Mode               *string    `db:"mode"`
-	Granted            bool       `db:"granted"`
-	FastPath           *bool      `db:"fastpath"`
-	WaitStart          *time.Time `db:"waitstart"`
-}
-
-func (l PGLock) String() string {
-	granted := "granted"
-	if !l.Granted {
-		granted = "waiting"
-	}
-	var details string
-	switch safeString(l.LockType) {
-	case "relation":
-		details = ""
-	case "page":
-		details = fmt.Sprintf("page=%d", *l.Page)
-	case "tuple":
-		details = fmt.Sprintf("page=%d tuple=%d", *l.Page, *l.Tuple)
-	case "virtualxid":
-		details = "waiting to acquire virtual tx id lock"
-	default:
-		details = "???"
-	}
-	return fmt.Sprintf("%d-%5s [%s] %s/%s/%s: %s",
-		l.PID,
-		safeString(l.TransactionID),
-		granted,
-		safeString(l.RelationName),
-		safeString(l.LockType),
-		safeString(l.Mode),
-		details,
-	)
-}
-
-// PGLocks returns a list of all locks in the database currently in use.
-func (q *sqlQuerier) PGLocks(ctx context.Context) (PGLocks, error) {
-	rows, err := q.sdb.QueryContext(ctx, `
-	SELECT
-		relation::regclass AS relation_name,
-	    *
-	FROM pg_locks;
-	`)
-	if err != nil {
-		return nil, err
-	}
-
-	defer rows.Close()
-
-	var locks []PGLock
-	err = sqlx.StructScan(rows, &locks)
-	if err != nil {
-		return nil, err
-	}
-
-	return locks, err
 }
 
 func DefaultTXOptions() *TxOptions {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -602,6 +602,9 @@ func prepareSQLFilter(ctx context.Context, authorizer rbac.Authorizer, action po
 func (q *querier) Ping(ctx context.Context) (time.Duration, error) {
 	return q.db.Ping(ctx)
 }
+func (q *querier) PGLocks(ctx context.Context) (database.PGLocks, error) {
+	return q.db.PGLocks(ctx)
+}
 
 // InTx runs the given function in a transaction.
 func (q *querier) InTx(function func(querier database.Store) error, txOpts *database.TxOptions) error {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -602,6 +602,7 @@ func prepareSQLFilter(ctx context.Context, authorizer rbac.Authorizer, action po
 func (q *querier) Ping(ctx context.Context) (time.Duration, error) {
 	return q.db.Ping(ctx)
 }
+
 func (q *querier) PGLocks(ctx context.Context) (database.PGLocks, error) {
 	return q.db.PGLocks(ctx)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -152,7 +152,10 @@ func TestDBAuthzRecursive(t *testing.T) {
 		for i := 2; i < method.Type.NumIn(); i++ {
 			ins = append(ins, reflect.New(method.Type.In(i)).Elem())
 		}
-		if method.Name == "InTx" || method.Name == "Ping" || method.Name == "Wrappers" {
+		if method.Name == "InTx" ||
+			method.Name == "Ping" ||
+			method.Name == "Wrappers" ||
+			method.Name == "PGLocks" {
 			continue
 		}
 		// Log the name of the last method, so if there is a panic, it is

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -34,6 +34,7 @@ var errMatchAny = xerrors.New("match any error")
 var skipMethods = map[string]string{
 	"InTx":           "Not relevant",
 	"Ping":           "Not relevant",
+	"PGLocks":        "Not relevant",
 	"Wrappers":       "Not relevant",
 	"AcquireLock":    "Not relevant",
 	"TryAcquireLock": "Not relevant",

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -338,6 +338,7 @@ func newUniqueConstraintError(uc database.UniqueConstraint) *pq.Error {
 func (*FakeQuerier) Ping(_ context.Context) (time.Duration, error) {
 	return 0, nil
 }
+
 func (*FakeQuerier) PGLocks(ctx context.Context) (database.PGLocks, error) {
 	return []database.PGLock{}, nil
 }

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -339,7 +339,7 @@ func (*FakeQuerier) Ping(_ context.Context) (time.Duration, error) {
 	return 0, nil
 }
 
-func (*FakeQuerier) PGLocks(ctx context.Context) (database.PGLocks, error) {
+func (*FakeQuerier) PGLocks(_ context.Context) (database.PGLocks, error) {
 	return []database.PGLock{}, nil
 }
 

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -338,6 +338,9 @@ func newUniqueConstraintError(uc database.UniqueConstraint) *pq.Error {
 func (*FakeQuerier) Ping(_ context.Context) (time.Duration, error) {
 	return 0, nil
 }
+func (*FakeQuerier) PGLocks(ctx context.Context) (database.PGLocks, error) {
+	return []database.PGLock{}, nil
+}
 
 func (tx *fakeTx) AcquireLock(_ context.Context, id int64) error {
 	if _, ok := tx.FakeQuerier.locks[id]; ok {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -66,6 +66,13 @@ func (m queryMetricsStore) Ping(ctx context.Context) (time.Duration, error) {
 	return duration, err
 }
 
+func (m queryMetricsStore) PGLocks(ctx context.Context) (database.PGLocks, error) {
+	start := time.Now()
+	locks, err := m.s.PGLocks(ctx)
+	m.queryLatencies.WithLabelValues("PGLocks").Observe(time.Since(start).Seconds())
+	return locks, err
+}
+
 func (m queryMetricsStore) InTx(f func(database.Store) error, options *database.TxOptions) error {
 	return m.dbMetrics.InTx(f, options)
 }

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -4299,6 +4299,21 @@ func (mr *MockStoreMockRecorder) OrganizationMembers(arg0, arg1 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrganizationMembers", reflect.TypeOf((*MockStore)(nil).OrganizationMembers), arg0, arg1)
 }
 
+// PGLocks mocks base method.
+func (m *MockStore) PGLocks(arg0 context.Context) (database.PGLocks, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PGLocks", arg0)
+	ret0, _ := ret[0].(database.PGLocks)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PGLocks indicates an expected call of PGLocks.
+func (mr *MockStoreMockRecorder) PGLocks(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PGLocks", reflect.TypeOf((*MockStore)(nil).PGLocks), arg0)
+}
+
 // Ping mocks base method.
 func (m *MockStore) Ping(arg0 context.Context) (time.Duration, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/pglocks.go
+++ b/coderd/database/pglocks.go
@@ -1,0 +1,119 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/coder/coder/v2/coderd/util/slice"
+)
+
+// PGLock docs see: https://www.postgresql.org/docs/current/view-pg-locks.html#VIEW-PG-LOCKS
+type PGLock struct {
+	// LockType see: https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-LOCK-TABLE
+	LockType           *string    `db:"locktype"`
+	Database           *string    `db:"database"` // oid
+	Relation           *string    `db:"relation"` // oid
+	RelationName       *string    `db:"relation_name"`
+	Page               *int       `db:"page"`
+	Tuple              *int       `db:"tuple"`
+	VirtualXID         *string    `db:"virtualxid"`
+	TransactionID      *string    `db:"transactionid"` // xid
+	ClassID            *string    `db:"classid"`       // oid
+	ObjID              *string    `db:"objid"`         // oid
+	ObjSubID           *int       `db:"objsubid"`
+	VirtualTransaction *string    `db:"virtualtransaction"`
+	PID                int        `db:"pid"`
+	Mode               *string    `db:"mode"`
+	Granted            bool       `db:"granted"`
+	FastPath           *bool      `db:"fastpath"`
+	WaitStart          *time.Time `db:"waitstart"`
+}
+
+func (l PGLock) Equal(b PGLock) bool {
+	// Lazy, but hope this works
+	return reflect.DeepEqual(l, b)
+}
+
+func (l PGLock) String() string {
+	granted := "granted"
+	if !l.Granted {
+		granted = "waiting"
+	}
+	var details string
+	switch safeString(l.LockType) {
+	case "relation":
+		details = ""
+	case "page":
+		details = fmt.Sprintf("page=%d", *l.Page)
+	case "tuple":
+		details = fmt.Sprintf("page=%d tuple=%d", *l.Page, *l.Tuple)
+	case "virtualxid":
+		details = "waiting to acquire virtual tx id lock"
+	default:
+		details = "???"
+	}
+	return fmt.Sprintf("%d-%5s [%s] %s/%s/%s: %s",
+		l.PID,
+		safeString(l.TransactionID),
+		granted,
+		safeString(l.RelationName),
+		safeString(l.LockType),
+		safeString(l.Mode),
+		details,
+	)
+}
+
+// PGLocks returns a list of all locks in the database currently in use.
+func (q *sqlQuerier) PGLocks(ctx context.Context) (PGLocks, error) {
+	rows, err := q.sdb.QueryContext(ctx, `
+	SELECT
+		relation::regclass AS relation_name,
+	    *
+	FROM pg_locks;
+	`)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var locks []PGLock
+	err = sqlx.StructScan(rows, &locks)
+	if err != nil {
+		return nil, err
+	}
+
+	return locks, err
+}
+
+type PGLocks []PGLock
+
+func (l PGLocks) String() string {
+	// Try to group things together by relation name.
+	sort.Slice(l, func(i, j int) bool {
+		return safeString(l[i].RelationName) < safeString(l[j].RelationName)
+	})
+
+	var out strings.Builder
+	for i, lock := range l {
+		if i != 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString(lock.String())
+	}
+	return out.String()
+}
+
+// Difference returns the difference between two sets of locks.
+// This is helpful to determine what changed between the two sets.
+func (l PGLocks) Difference(to PGLocks) (new PGLocks, removed PGLocks) {
+	return slice.SymmetricDifferenceFunc(l, to, func(a, b PGLock) bool {
+		return a.Equal(b)
+	})
+}

--- a/coderd/database/pglocks.go
+++ b/coderd/database/pglocks.go
@@ -103,9 +103,9 @@ func (l PGLocks) String() string {
 	var out strings.Builder
 	for i, lock := range l {
 		if i != 0 {
-			out.WriteString("\n")
+			_, _ = out.WriteString("\n")
 		}
-		out.WriteString(lock.String())
+		_, _ = out.WriteString(lock.String())
 	}
 	return out.String()
 }


### PR DESCRIPTION
Adds `PGLocks` query similar to how we have `Ping()`. I cannot do this via SQLc, as SQLc does not know about `pg_locks` table.

The string format is able to be changed to extract more value. I recognize this is not perfect, but I wrote it trying to learn more about these locks. It felt valuable enough to keep. Not all values are handled correctly here, I'll add functionality as required.

Some example output

1. Open a TX in mode `serializable` and run `GetQuotaConsumedForUser()`

```
794-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
793-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
794-<nil> [granted] pg_locks/relation/AccessShareLock: 
793-<nil> [granted] workspace_builds/relation/AccessShareLock: 
793-<nil> [granted] workspace_builds/tuple/SIReadLock: page=0 tuple=1
793-<nil> [granted] workspace_builds_job_id_key/relation/AccessShareLock: 
793-<nil> [granted] workspace_builds_pkey/relation/AccessShareLock: 
793-<nil> [granted] workspace_builds_workspace_id_build_number_key/page/SIReadLock: page=1
793-<nil> [granted] workspace_builds_workspace_id_build_number_key/relation/AccessShareLock: 
793-<nil> [granted] workspaces/relation/AccessShareLock: 
793-<nil> [granted] workspaces/relation/SIReadLock: 
793-<nil> [granted] workspaces_owner_id_lower_idx/relation/AccessShareLock: 
793-<nil> [granted] workspaces_owner_id_lower_idx/page/SIReadLock: page=1
793-<nil> [granted] workspaces_pkey/relation/AccessShareLock: 
```

2. Run `UpdateWorkspaceBuildCostByID` in the TX

```
868-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
867- 3689 [granted] <nil>/transactionid/ExclusiveLock: ???
867-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
868-<nil> [granted] pg_locks/relation/AccessShareLock: 
867-<nil> [granted] workspace_builds/relation/AccessShareLock: 
867-<nil> [granted] workspace_builds/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_job_id_key/relation/AccessShareLock: 
867-<nil> [granted] workspace_builds_job_id_key/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_pkey/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_pkey/relation/AccessShareLock: 
867-<nil> [granted] workspace_builds_pkey/page/SIReadLock: page=1
867-<nil> [granted] workspace_builds_workspace_id_build_number_key/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_workspace_id_build_number_key/relation/AccessShareLock: 
867-<nil> [granted] workspace_builds_workspace_id_build_number_key/page/SIReadLock: page=1
867-<nil> [granted] workspaces/relation/AccessShareLock: 
867-<nil> [granted] workspaces/relation/SIReadLock: 
867-<nil> [granted] workspaces_owner_id_lower_idx/relation/AccessShareLock: 
867-<nil> [granted] workspaces_owner_id_lower_idx/page/SIReadLock: page=1
867-<nil> [granted] workspaces_pkey/relation/AccessShareLock: 
```

Specifically these are the **new** locks aquired:

```
868-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
867- 3689 [granted] <nil>/transactionid/ExclusiveLock: ???
868-<nil> [granted] pg_locks/relation/AccessShareLock: 
867-<nil> [granted] workspace_builds/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_job_id_key/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_pkey/relation/RowExclusiveLock: 
867-<nil> [granted] workspace_builds_pkey/page/SIReadLock: page=1
867-<nil> [granted] workspace_builds_workspace_id_build_number_key/relation/RowExclusiveLock: 
```

Used to respond here: https://github.com/coder/coder/pull/15261#discussion_r1824673060