### PR TITLE
chore: include if direct connection is over private network in ping diagnostics

### DIFF
--- a/cli/cliui/agent.go
+++ b/cli/cliui/agent.go
@@ -411,7 +411,8 @@ func (d ConnDiags) splitDiagnostics() (general, client, agent []string) {
 	}
 
 	if d.DisableDirect {
-		general = append(general, "❗ Direct connections are disabled locally, by `--disable-direct` or `CODER_DISABLE_DIRECT`")
+		general = append(general, "❗ Direct connections are disabled locally, by `--disable-direct-connections` or `CODER_DISABLE_DIRECT_CONNECTIONS`.\n"+
+			"   They may still be established over a private network.")
 		if !d.Verbose {
 			return general, client, agent
 		}

--- a/cli/ping.go
+++ b/cli/ping.go
@@ -118,6 +118,7 @@ func (r *RootCmd) ping() *serpent.Command {
 				workspaceName,
 			)
 			if err != nil {
+				spin.Stop()
 				return err
 			}
 
@@ -128,7 +129,6 @@ func (r *RootCmd) ping() *serpent.Command {
 			}
 
 			if r.disableDirect {
-				_, _ = fmt.Fprintln(inv.Stderr, "Direct connections disabled.")
 				opts.BlockEndpoints = true
 			}
 			if !r.disableNetworkTelemetry {
@@ -137,6 +137,7 @@ func (r *RootCmd) ping() *serpent.Command {
 			wsClient := workspacesdk.New(client)
 			conn, err := wsClient.DialAgent(ctx, workspaceAgent.ID, opts)
 			if err != nil {
+				spin.Stop()
 				return err
 			}
 			defer conn.Close()
@@ -168,6 +169,7 @@ func (r *RootCmd) ping() *serpent.Command {
 
 			connInfo, err := wsClient.AgentConnectionInfoGeneric(diagCtx)
 			if err != nil || connInfo.DERPMap == nil {
+				spin.Stop()
 				return xerrors.Errorf("Failed to retrieve connection info from server: %w\n", err)
 			}
 			connDiags.ConnInfo = connInfo
@@ -197,6 +199,11 @@ func (r *RootCmd) ping() *serpent.Command {
 			results := &pingSummary{
 				Workspace: workspaceName,
 			}
+			var (
+				pong *ipnstate.PingResult
+				dur  time.Duration
+				p2p  bool
+			)
 			n := 0
 			start := time.Now()
 		pingLoop:
@@ -207,7 +214,7 @@ func (r *RootCmd) ping() *serpent.Command {
 				n++
 
 				ctx, cancel := context.WithTimeout(ctx, pingTimeout)
-				dur, p2p, pong, err := conn.Ping(ctx)
+				dur, p2p, pong, err = conn.Ping(ctx)
 				cancel()
 				results.addResult(pong)
 				if err != nil {
@@ -275,10 +282,15 @@ func (r *RootCmd) ping() *serpent.Command {
 				}
 			}
 
-			if didP2p {
-				_, _ = fmt.Fprintf(inv.Stderr, "✔ You are connected directly (p2p)\n")
+			if p2p {
+				msg := "✔ You are connected directly (p2p)"
+				if pong != nil && isPrivateEndpoint(pong.Endpoint) {
+					msg += ", over a private network"
+				}
+				_, _ = fmt.Fprintln(inv.Stderr, msg)
 			} else {
-				_, _ = fmt.Fprintf(inv.Stderr, "❗ You are connected via a DERP relay, not directly (p2p)\n%s#common-problems-with-direct-connections\n", connDiags.TroubleshootingURL)
+				_, _ = fmt.Fprintf(inv.Stderr, "❗ You are connected via a DERP relay, not directly (p2p)\n"+
+					"   %s#common-problems-with-direct-connections\n", connDiags.TroubleshootingURL)
 			}
 
 			results.Write(inv.Stdout)
@@ -328,4 +340,12 @@ func isAWSIP(awsRanges *cliutil.AWSIPRanges, ni *tailcfg.NetInfo) bool {
 		}
 	}
 	return false
+}
+
+func isPrivateEndpoint(endpoint string) bool {
+	ip, err := netip.ParseAddrPort(endpoint)
+	if err != nil {
+		return false
+	}
+	return ip.Addr().IsPrivate()
 }


### PR DESCRIPTION
Whilst the `networking-troubleshooting` docs page already mentions that a direct connection can be established over a private network, even if there are no STUN servers, it's worth this is the case at the end of the ping output.

This also removes a print statement that was dirtying up the diagnostic output, and corrects the name of the `--disable-direct-connections` flag.