### PR TITLE
chore: remove excess join in GetQuotaConsumedForUser query 

### DIFF
--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -288,6 +288,15 @@ func WorkspaceBuild(t testing.TB, db database.Store, orig database.WorkspaceBuil
 		if err != nil {
 			return err
 		}
+
+		if orig.DailyCost > 0 {
+			err = db.UpdateWorkspaceBuildCostByID(genCtx, database.UpdateWorkspaceBuildCostByIDParams{
+				ID:        buildID,
+				DailyCost: orig.DailyCost,
+			})
+			require.NoError(t, err)
+		}
+
 		build, err = db.GetWorkspaceBuildByID(genCtx, buildID)
 		if err != nil {
 			return err

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6746,6 +6746,8 @@ FROM
 INNER JOIN
 	workspaces on wb.workspace_id = workspaces.id
 WHERE
+	-- Only return workspaces that match the user + organization.
+	-- Quotas are calculated per user per organization.
 	workspaces.owner_id = $1 AND
 	workspaces.organization_id = $2
 ORDER BY
@@ -6755,16 +6757,7 @@ ORDER BY
 SELECT
 	coalesce(SUM(daily_cost), 0)::BIGINT
 FROM
-	workspaces
-INNER JOIN latest_builds ON
-	latest_builds.workspace_id = workspaces.id
-WHERE
-	NOT deleted AND
-	-- We can likely remove these conditions since we check above.
-	-- But it does not hurt to be defensive and make sure future query changes
-	-- do not break anything.
-	workspaces.owner_id = $1 AND
-	workspaces.organization_id = $2
+	latest_builds
 `
 
 type GetQuotaConsumedForUserParams struct {

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6753,7 +6753,7 @@ WHERE
 	workspaces.organization_id = $2
 ORDER BY
 	wb.workspace_id,
-	wb.created_at DESC
+	wb.build_number DESC
 )
 SELECT
 	coalesce(SUM(daily_cost), 0)::BIGINT

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6748,6 +6748,7 @@ INNER JOIN
 WHERE
 	-- Only return workspaces that match the user + organization.
 	-- Quotas are calculated per user per organization.
+	NOT workspaces.deleted AND
 	workspaces.owner_id = $1 AND
 	workspaces.organization_id = $2
 ORDER BY

--- a/coderd/database/queries/quotas.sql
+++ b/coderd/database/queries/quotas.sql
@@ -30,6 +30,7 @@ INNER JOIN
 WHERE
 	-- Only return workspaces that match the user + organization.
 	-- Quotas are calculated per user per organization.
+	NOT workspaces.deleted AND
 	workspaces.owner_id = @owner_id AND
 	workspaces.organization_id = @organization_id
 ORDER BY

--- a/coderd/database/queries/quotas.sql
+++ b/coderd/database/queries/quotas.sql
@@ -35,7 +35,7 @@ WHERE
 	workspaces.organization_id = @organization_id
 ORDER BY
 	wb.workspace_id,
-	wb.created_at DESC
+	wb.build_number DESC
 )
 SELECT
 	coalesce(SUM(daily_cost), 0)::BIGINT

--- a/coderd/database/queries/quotas.sql
+++ b/coderd/database/queries/quotas.sql
@@ -28,6 +28,8 @@ FROM
 INNER JOIN
 	workspaces on wb.workspace_id = workspaces.id
 WHERE
+	-- Only return workspaces that match the user + organization.
+	-- Quotas are calculated per user per organization.
 	workspaces.owner_id = @owner_id AND
 	workspaces.organization_id = @organization_id
 ORDER BY
@@ -37,14 +39,5 @@ ORDER BY
 SELECT
 	coalesce(SUM(daily_cost), 0)::BIGINT
 FROM
-	workspaces
-INNER JOIN latest_builds ON
-	latest_builds.workspace_id = workspaces.id
-WHERE
-	NOT deleted AND
-	-- We can likely remove these conditions since we check above.
-	-- But it does not hurt to be defensive and make sure future query changes
-	-- do not break anything.
-	workspaces.owner_id = @owner_id AND
-	workspaces.organization_id = @organization_id
+	latest_builds
 ;

--- a/enterprise/coderd/workspacequota_test.go
+++ b/enterprise/coderd/workspacequota_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
@@ -31,9 +32,13 @@ import (
 )
 
 func verifyQuota(ctx context.Context, t *testing.T, client *codersdk.Client, organizationID string, consumed, total int) {
+	verifyQuotaUser(ctx, t, client, organizationID, codersdk.Me, consumed, total)
+}
+
+func verifyQuotaUser(ctx context.Context, t *testing.T, client *codersdk.Client, organizationID string, user string, consumed, total int) {
 	t.Helper()
 
-	got, err := client.WorkspaceQuota(ctx, organizationID, codersdk.Me)
+	got, err := client.WorkspaceQuota(ctx, organizationID, user)
 	require.NoError(t, err)
 	require.EqualValues(t, codersdk.WorkspaceQuota{
 		Budget:          total,
@@ -43,7 +48,7 @@ func verifyQuota(ctx context.Context, t *testing.T, client *codersdk.Client, org
 	// Remove this check when the deprecated endpoint is removed.
 	// This just makes sure the deprecated endpoint is still working
 	// as intended. It will only work for the default organization.
-	deprecatedGot, err := deprecatedQuotaEndpoint(ctx, client, codersdk.Me)
+	deprecatedGot, err := deprecatedQuotaEndpoint(ctx, client, user)
 	require.NoError(t, err, "deprecated endpoint")
 	// Only continue to check if the values differ
 	if deprecatedGot.Budget != got.Budget || deprecatedGot.CreditsConsumed != got.CreditsConsumed {
@@ -299,6 +304,96 @@ func TestWorkspaceQuota(t *testing.T) {
 		// Verify org scoped quota limits
 		verifyQuota(ctx, t, owner, first.OrganizationID.String(), 0, 30)
 		verifyQuota(ctx, t, owner, second.ID.String(), 0, 15)
+	})
+
+	// ManyWorkspaces uses dbfake and dbgen to insert a scenario into the db.
+	t.Run("ManyWorkspaces", func(t *testing.T) {
+		t.Parallel()
+
+		owner, db, first := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureTemplateRBAC:          1,
+					codersdk.FeatureMultipleOrganizations: 1,
+				},
+			},
+		})
+		client, _ := coderdtest.CreateAnotherUser(t, owner, first.OrganizationID, rbac.RoleOwner())
+
+		// Prepopulate database. Use dbfake as it is quicker and
+		// easier than the api.
+		ctx := testutil.Context(t, testutil.WaitLong)
+		ctx = dbauthz.AsSystemRestricted(ctx)
+
+		user := dbgen.User(t, db, database.User{})
+		noise := dbgen.User(t, db, database.User{})
+
+		second := dbfake.Organization(t, db).
+			Members(user, noise).
+			EveryoneAllowance(10).
+			Group(database.Group{
+				QuotaAllowance: 25,
+			}, user, noise).
+			Group(database.Group{
+				QuotaAllowance: 30,
+			}, noise).
+			Do()
+
+		third := dbfake.Organization(t, db).
+			Members(noise).
+			EveryoneAllowance(7).
+			Do()
+
+		verifyQuotaUser(ctx, t, client, second.Org.ID.String(), user.ID.String(), 0, 35)
+		verifyQuotaUser(ctx, t, client, second.Org.ID.String(), noise.ID.String(), 0, 65)
+
+		// Workspaces owned by the user
+		consumed := 0
+		for i := 0; i < 2; i++ {
+			const cost = 5
+			dbfake.WorkspaceBuild(t, db,
+				database.WorkspaceTable{
+					OwnerID:        user.ID,
+					OrganizationID: second.Org.ID,
+				}).
+				Seed(database.WorkspaceBuild{
+					DailyCost: cost,
+				}).Do()
+			consumed += cost
+		}
+
+		// Add some noise
+		// Workspace by the user in the third org
+		dbfake.WorkspaceBuild(t, db,
+			database.WorkspaceTable{
+				OwnerID:        user.ID,
+				OrganizationID: third.Org.ID,
+			}).
+			Seed(database.WorkspaceBuild{
+				DailyCost: 10,
+			}).Do()
+
+		// Workspace by another user in third org
+		dbfake.WorkspaceBuild(t, db,
+			database.WorkspaceTable{
+				OwnerID:        noise.ID,
+				OrganizationID: third.Org.ID,
+			}).
+			Seed(database.WorkspaceBuild{
+				DailyCost: 10,
+			}).Do()
+
+		// Workspace by another user in second org
+		dbfake.WorkspaceBuild(t, db,
+			database.WorkspaceTable{
+				OwnerID:        noise.ID,
+				OrganizationID: second.Org.ID,
+			}).
+			Seed(database.WorkspaceBuild{
+				DailyCost: 10,
+			}).Do()
+
+		verifyQuotaUser(ctx, t, client, second.Org.ID.String(), user.ID.String(), consumed, 35)
 	})
 }
 

--- a/enterprise/coderd/workspacequota_test.go
+++ b/enterprise/coderd/workspacequota_test.go
@@ -323,7 +323,6 @@ func TestWorkspaceQuota(t *testing.T) {
 		// Prepopulate database. Use dbfake as it is quicker and
 		// easier than the api.
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ctx = dbauthz.AsSystemRestricted(ctx)
 
 		user := dbgen.User(t, db, database.User{})
 		noise := dbgen.User(t, db, database.User{})


### PR DESCRIPTION
Followup of https://github.com/coder/coder/pull/15261

Filter is applied in original workspace query. We do not need to join `workspaces` twice. **Also** used build_number instead of `created_at` for determining the last build.

Plans below run on dev.coder.com database. Interestingly the `seq scan` on `workspaces` goes away. It was happening on the second join? Because of this, our `SIReadLock` becomes finer on the `workspaces` table. It goes from `workspaces/relation/SIReadLock` to `workspaces/tuple/SIReadLock: page=0 tuple=1`



## Before

[Plan](https://explain.dalibo.com/plan/8afac15386577h02)

`SIReadLock` Locks: 

```
7866-<nil> [granted] workspace_builds/tuple/SIReadLock: page=0 tuple=1
7866-<nil> [granted] workspace_builds_workspace_id_build_number_key/page/SIReadLock: page=1
7866-<nil> [granted] workspaces/relation/SIReadLock: 
7866-<nil> [granted] workspaces_owner_id_lower_idx/page/SIReadLock: page=1
```

<details>
<summary>
Raw locks
</summary>

```
7867-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
7866-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
7867-<nil> [granted] pg_locks/relation/AccessShareLock: 
7866-<nil> [granted] workspace_builds/relation/AccessShareLock: 
7866-<nil> [granted] workspace_builds/tuple/SIReadLock: page=0 tuple=1
7866-<nil> [granted] workspace_builds_job_id_key/relation/AccessShareLock: 
7866-<nil> [granted] workspace_builds_pkey/relation/AccessShareLock: 
7866-<nil> [granted] workspace_builds_workspace_id_build_number_key/relation/AccessShareLock: 
7866-<nil> [granted] workspace_builds_workspace_id_build_number_key/page/SIReadLock: page=1
7866-<nil> [granted] workspaces/relation/AccessShareLock: 
7866-<nil> [granted] workspaces/relation/SIReadLock: 
7866-<nil> [granted] workspaces_owner_id_lower_idx/relation/AccessShareLock: 
7866-<nil> [granted] workspaces_owner_id_lower_idx/page/SIReadLock: page=1
7866-<nil> [granted] workspaces_pkey/relation/AccessShareLock: 
```
</details>


## After 

[Plan](https://explain.dalibo.com/plan/a95f64a6g8579e7b)

`SIReadLock` Locks: 

```
8052-<nil> [granted] workspace_builds/tuple/SIReadLock: page=0 tuple=1
8052-<nil> [granted] workspace_builds_workspace_id_build_number_key/page/SIReadLock: page=1
8052-<nil> [granted] workspaces/tuple/SIReadLock: page=0 tuple=1
8052-<nil> [granted] workspaces_owner_id_lower_idx/page/SIReadLock: page=1
```

<details>
<summary>
Raw locks
</summary>

```
8053-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
8052-<nil> [granted] <nil>/virtualxid/ExclusiveLock: waiting to acquire virtual tx id lock
8053-<nil> [granted] pg_locks/relation/AccessShareLock: 
8052-<nil> [granted] workspace_builds/tuple/SIReadLock: page=0 tuple=1
8052-<nil> [granted] workspace_builds/relation/AccessShareLock: 
8052-<nil> [granted] workspace_builds_job_id_key/relation/AccessShareLock: 
8052-<nil> [granted] workspace_builds_pkey/relation/AccessShareLock: 
8052-<nil> [granted] workspace_builds_workspace_id_build_number_key/relation/AccessShareLock: 
8052-<nil> [granted] workspace_builds_workspace_id_build_number_key/page/SIReadLock: page=1
8052-<nil> [granted] workspaces/relation/AccessShareLock: 
8052-<nil> [granted] workspaces/tuple/SIReadLock: page=0 tuple=1
8052-<nil> [granted] workspaces_owner_id_lower_idx/relation/AccessShareLock: 
8052-<nil> [granted] workspaces_owner_id_lower_idx/page/SIReadLock: page=1
8052-<nil> [granted] workspaces_pkey/relation/AccessShareLock: 
```
</details>
