### PR TITLE
fix(site): watch build logs while job is pending or running

### DIFF
--- a/site/src/modules/templates/useWatchVersionLogs.ts
+++ b/site/src/modules/templates/useWatchVersionLogs.ts
@@ -20,7 +20,10 @@ export const useWatchVersionLogs = (
 			return;
 		}
 
-		if (templateVersionStatus !== "running") {
+		if (
+			templateVersionStatus !== "running" &&
+			templateVersionStatus !== "pending"
+		) {
 			return;
 		}
 

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
@@ -324,14 +324,13 @@ test("display pending badge and update it to running when status changes", async
 		},
 	};
 
-	let calls = 0;
+	let running = false;
 	server.use(
 		http.get(
 			"/api/v2/organizations/:org/templates/:template/versions/:version",
 			() => {
-				calls += 1;
 				return HttpResponse.json(
-					calls > 1 ? MockRunningTemplateVersion : MockPendingTemplateVersion,
+					running ? MockRunningTemplateVersion : MockPendingTemplateVersion,
 				);
 			},
 		),
@@ -347,6 +346,10 @@ test("display pending badge and update it to running when status changes", async
 
 	const status = await screen.findByRole("status");
 	expect(status).toHaveTextContent("Pending");
+
+	// Manually update the endpoint, as to not rely on the editor page
+	// making a specific number of requests.
+	running = true;
 
 	await waitFor(
 		() => {


### PR DESCRIPTION
Closes #15292.

Currently, if the frontend never sees a build job enter 'running', it'll never end up watching the logs. If we start watching the logs earlier we're able to catch cases where the job goes `pending` -> `failed`, such as when the build fails immediately.