### PR TITLE
chore: refactor DERP setting loop

### DIFF
--- a/codersdk/workspacesdk/connector_internal_test.go
+++ b/codersdk/workspacesdk/connector_internal_test.go
@@ -440,7 +440,6 @@ func TestTailnetAPIConnector_TelemetryUnimplemented(t *testing.T) {
 		coordinateURL: "",
 		clock:         quartz.NewReal(),
 		dialOptions:   &websocket.DialOptions{},
-		conn:          nil,
 		connected:     make(chan error, 1),
 		closed:        make(chan struct{}),
 		customDialFn: func() (proto.DRPCTailnetClient, error) {
@@ -481,7 +480,6 @@ func TestTailnetAPIConnector_TelemetryNotRecognised(t *testing.T) {
 		coordinateURL: "",
 		clock:         quartz.NewReal(),
 		dialOptions:   &websocket.DialOptions{},
-		conn:          nil,
 		connected:     make(chan error, 1),
 		closed:        make(chan struct{}),
 		customDialFn: func() (proto.DRPCTailnetClient, error) {

--- a/tailnet/convert.go
+++ b/tailnet/convert.go
@@ -298,3 +298,21 @@ func WorkspaceStatusToProto(status codersdk.WorkspaceStatus) proto.Workspace_Sta
 		return proto.Workspace_UNKNOWN
 	}
 }
+
+type DERPFromDRPCWrapper struct {
+	Client proto.DRPCTailnet_StreamDERPMapsClient
+}
+
+func (w *DERPFromDRPCWrapper) Close() error {
+	return w.Client.Close()
+}
+
+func (w *DERPFromDRPCWrapper) Recv() (*tailcfg.DERPMap, error) {
+	p, err := w.Client.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return DERPMapFromProto(p), nil
+}
+
+var _ DERPClient = &DERPFromDRPCWrapper{}


### PR DESCRIPTION
Implements a Tailnet API DERP controller by refactoring from `workspacesdk`

chore re: #14729