### PR TITLE
fix: allow workspace owners to view timings

### DIFF
--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -952,7 +952,8 @@ func (api *API) buildTimings(ctx context.Context, build database.WorkspaceBuild)
 		return codersdk.WorkspaceBuildTimings{}, xerrors.Errorf("fetching provisioner job timings: %w", err)
 	}
 
-	agentScriptTimings, err := api.Database.GetWorkspaceAgentScriptTimingsByBuildID(ctx, build.ID)
+	//nolint:gocritic // Already checked if the build can be fetched.
+	agentScriptTimings, err := api.Database.GetWorkspaceAgentScriptTimingsByBuildID(dbauthz.AsSystemRestricted(ctx), build.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return codersdk.WorkspaceBuildTimings{}, xerrors.Errorf("fetching workspace agent script timings: %w", err)
 	}
@@ -965,7 +966,8 @@ func (api *API) buildTimings(ctx context.Context, build database.WorkspaceBuild)
 	for _, resource := range resources {
 		resourceIDs = append(resourceIDs, resource.ID)
 	}
-	agents, err := api.Database.GetWorkspaceAgentsByResourceIDs(ctx, resourceIDs)
+	//nolint:gocritic // Already checked if the build can be fetched.
+	agents, err := api.Database.GetWorkspaceAgentsByResourceIDs(dbauthz.AsSystemRestricted(ctx), resourceIDs)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return codersdk.WorkspaceBuildTimings{}, xerrors.Errorf("fetching workspace agents: %w", err)
 	}

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -1188,17 +1188,19 @@ func TestWorkspaceBuildTimings(t *testing.T) {
 
 	// Setup the test environment with a template and version
 	db, pubsub := dbtestutil.NewDB(t)
-	client := coderdtest.New(t, &coderdtest.Options{
+	ownerClient := coderdtest.New(t, &coderdtest.Options{
 		Database: db,
 		Pubsub:   pubsub,
 	})
-	owner := coderdtest.CreateFirstUser(t, client)
+	owner := coderdtest.CreateFirstUser(t, ownerClient)
+	client, user := coderdtest.CreateAnotherUser(t, ownerClient, owner.OrganizationID)
+
 	file := dbgen.File(t, db, database.File{
 		CreatedBy: owner.UserID,
 	})
 	versionJob := dbgen.ProvisionerJob(t, db, pubsub, database.ProvisionerJob{
 		OrganizationID: owner.OrganizationID,
-		InitiatorID:    owner.UserID,
+		InitiatorID:    user.ID,
 		FileID:         file.ID,
 		Tags: database.StringMap{
 			"custom": "true",
@@ -1219,7 +1221,7 @@ func TestWorkspaceBuildTimings(t *testing.T) {
 	// build number, each test will have its own workspace and build.
 	makeBuild := func() database.WorkspaceBuild {
 		ws := dbgen.Workspace(t, db, database.WorkspaceTable{
-			OwnerID:        owner.UserID,
+			OwnerID:        user.ID,
 			OrganizationID: owner.OrganizationID,
 			TemplateID:     template.ID,
 		})


### PR DESCRIPTION
Anyone with authz access to a workspace should be able to read timings information of its builds.

To do this without `AsSystemContext` would do an extra 4 db calls.

Closes https://github.com/coder/coder/issues/15250