### PR TITLE
chore: clarify section description to indicate that notifications can be disabled

### DIFF
--- a/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/UserSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -97,7 +97,7 @@ export const NotificationsPage: FC = () => {
 			</Helmet>
 			<Section
 				title="Notifications"
-				description="Configure your notification preferences. Icons on the right of each notification indicate delivery method, either SMTP or Webhook."
+				description="Control which notifications you receive."
 				layout="fluid"
 				featureStage="beta"
 			>
@@ -183,7 +183,7 @@ export const NotificationsPage: FC = () => {
 															css={styles.listItemEndIcon}
 															aria-label="Delivery method"
 														>
-															<Tooltip title={label}>
+															<Tooltip title={`Delivery via ${label}`}>
 																<Icon aria-label={label} />
 															</Tooltip>
 														</ListItemIcon>


### PR DESCRIPTION
The current description of "Configure your notification preferences. Icons on the right of each notification indicate delivery method, either SMTP or Webhook." doesn't really say what this page is for.

I've adjusted the wording, and also changed the tooltip of the delivery method icon to be more clear.