### PR TITLE
docs: add workplace scheduling to manifest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -329,6 +329,11 @@
 									"title": "Template Dependencies",
 									"description": "Learn how to manage template dependencies",
 									"path": "./admin/templates/managing-templates/dependencies.md"
+								},
+								{
+									"title": "Workspace Scheduling",
+									"description": "Learn how to control how workspaces are started and stopped",
+									"path": "./admin/templates/managing-templates/schedule.md"
 								}
 							]
 						},


### PR DESCRIPTION
- [ ] check links to <https://coder.com/docs/@workspace-scheduling/admin/templates/managing-templates/schedule#dormancy-threshold-enterprise-premium>
   - @mattvollmer reports that <https://coder.com/docs/admin/templates/managing-templates/schedule#dormancy-threshold-enterprise> is missing. I'll try to find refs to it


[preview](https://coder.com/docs/@workspace-scheduling/admin/templates/managing-templates/schedule)