### PR TITLE
fix: stop logging error when template schedule query is canceled

### DIFF
--- a/coderd/workspacestats/reporter.go
+++ b/coderd/workspacestats/reporter.go
@@ -154,17 +154,21 @@ func (r *Reporter) ReportAgentStats(ctx context.Context, now time.Time, workspac
 		templateSchedule, err := (*(r.opts.TemplateScheduleStore.Load())).Get(ctx, r.opts.Database, workspace.TemplateID)
 		// If the template schedule fails to load, just default to bumping
 		// without the next transition and log it.
-		if err != nil {
+		if err == nil {
+			next, allowed := schedule.NextAutostart(now, workspace.AutostartSchedule.String, templateSchedule)
+			if allowed {
+				nextAutostart = next
+			}
+		} else if database.IsQueryCanceledError(err) {
+			r.opts.Logger.Debug(ctx, "query canceled while loading template schedule",
+				slog.F("workspace_id", workspace.ID),
+				slog.F("template_id", workspace.TemplateID))
+		} else {
 			r.opts.Logger.Error(ctx, "failed to load template schedule bumping activity, defaulting to bumping by 60min",
 				slog.F("workspace_id", workspace.ID),
 				slog.F("template_id", workspace.TemplateID),
 				slog.Error(err),
 			)
-		} else {
-			next, allowed := schedule.NextAutostart(now, workspace.AutostartSchedule.String, templateSchedule)
-			if allowed {
-				nextAutostart = next
-			}
 		}
 	}
 


### PR DESCRIPTION
Fixes test flakes _a la_

```
    t.go:108: 2024-11-05 09:52:37.996 [erro]  workspacestats: failed to load template schedule bumping activity, defaulting to bumping by 60min  request_id=f14215d2-73dc-47ba-aa81-422c62f257e4  workspace_id=545d73c7-3a62-4466-8c08-b6abb12867b7  template_id=49747428-3abb-40e4-a6b2-03653e9f2506 ...
        error= fetch object:
                   github.com/coder/coder/v2/coderd/database/dbauthz.(*querier).GetTemplateByID.fetch[...].func1
                       /home/runner/work/coder/coder/coderd/database/dbauthz/dbauthz.go:497
                 - pq: canceling statement due to user request
         *** slogtest: log detected at level ERROR; TEST FAILURE ***
```

seen here on main: https://github.com/coder/coder/actions/runs/11681605747/job/32527006174