### PR TITLE
fix: use correct Content-Type for template archive

### DIFF
--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1877,7 +1877,7 @@ class ApiMethods {
 
 	uploadFile = async (file: File): Promise<TypesGen.UploadResponse> => {
 		const response = await this.axios.post("/api/v2/files", file, {
-			headers: { "Content-Type": "application/x-tar" },
+			headers: { "Content-Type": file.type },
 		});
 
 		return response.data;


### PR DESCRIPTION
Fixes: https://github.com/coder/coder/issues/14124

It is assumed that only TAR archive can be uploaded via the site, but as long as the backend supports ZIP files (transformed to .tar on-the-fly) users should be able to submit both formats.