### PR TITLE
fix: use container with Postgres 13 for dump.sql

### DIFF
--- a/coderd/database/gen/dump/main.go
+++ b/coderd/database/gen/dump/main.go
@@ -37,10 +37,11 @@ func main() {
 		}
 	}()
 
-	connection, err := dbtestutil.Open(t)
+	connection, cleanup, err := dbtestutil.OpenContainerized(t, dbtestutil.DBContainerOptions{})
 	if err != nil {
 		panic(err)
 	}
+	defer cleanup()
 
 	db, err := sql.Open("postgres", connection)
 	if err != nil {


### PR DESCRIPTION
Changes from https://github.com/coder/coder/pull/15336 made the `coderd/database/gen/dump/main.go` script used by `make gen` connect to the Postgres container running at localhost:5432 if it was available. Previously a new Postgres 13 container would be created every time.

This is annoying during development - if you're running a Postgres 16 container in the background you'll get a different `dump.sql` than with Postgres 13. This PR reverts the script to create a fresh Postgres 13 container on each run.