### PR TITLE
chore: add logging for Run failures in workspacetraffic

### DIFF
--- a/scaletest/workspacetraffic/run_test.go
+++ b/scaletest/workspacetraffic/run_test.go
@@ -116,7 +116,7 @@ func TestRun(t *testing.T) {
 		go func() {
 			defer close(runDone)
 			err := runner.Run(ctx, "", &logs)
-			assert.NoError(t, err, "unexpected error calling Run()")
+			assert.NoError(t, err, "RUN LOGS:\n%s\nEND RUN LOGS\n", logs.String())
 		}()
 
 		gotMetrics := make(chan struct{})
@@ -236,7 +236,7 @@ func TestRun(t *testing.T) {
 		go func() {
 			defer close(runDone)
 			err := runner.Run(ctx, "", &logs)
-			assert.NoError(t, err, "unexpected error calling Run()")
+			assert.NoError(t, err, "RUN LOGS:\n%s\nEND RUN LOGS\n", logs.String())
 		}()
 
 		gotMetrics := make(chan struct{})
@@ -338,7 +338,7 @@ func TestRun(t *testing.T) {
 		go func() {
 			defer close(runDone)
 			err := runner.Run(ctx, "", &logs)
-			assert.NoError(t, err, "unexpected error calling Run()")
+			assert.NoError(t, err, "RUN LOGS:\n%s\nEND RUN LOGS\n", logs.String())
 		}()
 
 		gotMetrics := make(chan struct{})


### PR DESCRIPTION
Run logs are currently dropped on the floor when workspacetraffic tests fail.

e.g. https://github.com/coder/coder/runs/32640144785


This prints the logs when we get a failure, like

```
    run_test.go:341: 
        	Error Trace:	/Users/spike/repos/coder/scaletest/workspacetraffic/run_test.go:341
        	            				/Users/spike/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.darwin-arm64/src/runtime/asm_arm64.s:1222
        	Error:      	Received unexpected error:
        	            	badness:
        	            	    github.com/coder/coder/v2/scaletest/workspacetraffic.(*Runner).Run
        	            	        /Users/spike/repos/coder/scaletest/workspacetraffic/run.go:174
        	Test:       	TestRun/App
        	Messages:   	RUN LOGS:
        	            	2024-11-07 13:04:30.274 [debu]  config  agent_id=00000000-0000-0000-0000-000000000000  reconnecting_pty_id=95bb480f-cd26-4633-8332-328d44ffa997  height=25  width=80  tick_interval=1s  bytes_per_tick=1024
        	            	2024-11-07 13:04:30.274 [debu]  connect to workspace agent  agent_id=00000000-0000-0000-0000-000000000000
        	            	2024-11-07 13:04:30.274 [info]  sending traffic to workspace app  agent_id=00000000-0000-0000-0000-000000000000  app=echo
        	            	2024-11-07 13:04:30.276 [debu]  reading from agent  agent_id=00000000-0000-0000-0000-000000000000
        	            	2024-11-07 13:04:30.276 [debu]  writing to agent  agent_id=00000000-0000-0000-0000-000000000000
        	            	2024-11-07 13:04:31.526 [debu]  done reading from agent  agent_id=00000000-0000-0000-0000-000000000000
        	            	2024-11-07 13:04:32.276 [debu]  done writing to agent  agent_id=00000000-0000-0000-0000-000000000000
        	            	
        	            	END RUN LOGS
```

So, hopefully we can diagnose flakes.