### PR TITLE
feat(cli): rotate file logs for coderd 

### DIFF
--- a/cli/clilog/clilog.go
+++ b/cli/clilog/clilog.go
@@ -119,9 +119,7 @@ func (b *Builder) Build(inv *serpent.Invocation) (log slog.Logger, closeLog func
 			}
 			closers = append(closers, logWriter.Close)
 			sinks = append(sinks, sinkFn(logWriter))
-
 		}
-
 		return nil
 	}
 

--- a/cli/clilog/clilog.go
+++ b/cli/clilog/clilog.go
@@ -104,7 +104,6 @@ func (b *Builder) Build(inv *serpent.Invocation) (log slog.Logger, closeLog func
 	addSinkIfProvided := func(sinkFn func(io.Writer) slog.Sink, loc string) error {
 		switch loc {
 		case "":
-
 		case "/dev/stdout":
 			sinks = append(sinks, sinkFn(inv.Stdout))
 

--- a/cli/clilog/clilog_test.go
+++ b/cli/clilog/clilog_test.go
@@ -2,7 +2,6 @@ package clilog_test
 
 import (
 	"encoding/json"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,30 +143,6 @@ func TestBuilder(t *testing.T) {
 			assertLogs(t, tempFile, infoLog, warnLog)
 			assertLogsJSON(t, tempJSON, info, infoLog, warn, warnLog)
 		})
-	})
-
-	t.Run("NotFound", func(t *testing.T) {
-		t.Parallel()
-
-		tempFile := filepath.Join(t.TempDir(), "doesnotexist", "test.log")
-		cmd := &serpent.Command{
-			Use: "test",
-			Handler: func(inv *serpent.Invocation) error {
-				logger, closeLog, err := clilog.New(
-					clilog.WithFilter("foo", "baz"),
-					clilog.WithHuman(tempFile),
-					clilog.WithVerbose(),
-				).Build(inv)
-				if err != nil {
-					return err
-				}
-				defer closeLog()
-				logger.Error(inv.Context(), "you will never see this")
-				return nil
-			},
-		}
-		err := cmd.Invoke().Run()
-		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 }
 


### PR DESCRIPTION
Related to #15309 

As we already are doing for agent logs - this PR is enabling the logs rotation for coderd logs. 

Currently keeping the same logic than we had for agent - with 5MB as the file size for rotation.