### PR TITLE
docs: adjust manual github action screenshot in contributing.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,7 +103,7 @@ this:
   [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
   GitHub Action workflow:
 
-  <Image src="./images/deploy-pr-manually.png" alt="Deploy PR manually" width="350px" align="center" />
+  <Image src="./images/deploy-pr-manually.png" alt="Deploy PR manually" height="348px" align="center" />
 
 #### Available options
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,7 +103,7 @@ this:
   [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
   GitHub Action workflow:
 
-  <Image width="350px" src="./images/deploy-pr-manually.png" alt="Deploy PR manually" align="center" />
+  <Image max-width:100% src="./images/deploy-pr-manually.png" alt="Deploy PR manually" align="center" />
 
 #### Available options
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,8 +103,7 @@ this:
   [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
   GitHub Action workflow:
 
-  <Image max-width:100% src="./images/deploy-pr-manually.png" alt="Deploy PR
-  manually" align="center" />
+  <Image src="./images/deploy-pr-manually.png" alt="Deploy PR manually" sizes="(max-width: 350px) 100vw, 33vw" align="center" />
 
 #### Available options
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,10 +98,12 @@ Use the following `make` commands and scripts in development:
 You can test your changes by creating a PR deployment. There are two ways to do
 this:
 
-1. By running `./scripts/deploy-pr.sh`
-2. By manually triggering the
+- Run `./scripts/deploy-pr.sh`
+- Manually trigger the
    [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
-   GitHub Action workflow ![Deploy PR manually](./images/deploy-pr-manually.png)
+   GitHub Action workflow:
+  
+  <Image width="350px" src="./images/deploy-pr-manually.png" alt="Deploy PR manually" align="center" />
 
 #### Available options
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,9 +100,9 @@ this:
 
 - Run `./scripts/deploy-pr.sh`
 - Manually trigger the
-   [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
-   GitHub Action workflow:
-  
+  [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
+  GitHub Action workflow:
+
   <Image width="350px" src="./images/deploy-pr-manually.png" alt="Deploy PR manually" align="center" />
 
 #### Available options

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,7 +103,8 @@ this:
   [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
   GitHub Action workflow:
 
-  <Image max-width:100% src="./images/deploy-pr-manually.png" alt="Deploy PR manually" align="center" />
+  <Image max-width:100% src="./images/deploy-pr-manually.png" alt="Deploy PR
+  manually" align="center" />
 
 #### Available options
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,7 +103,7 @@ this:
   [`pr-deploy.yaml`](https://github.com/coder/coder/actions/workflows/pr-deploy.yaml)
   GitHub Action workflow:
 
-  <Image src="./images/deploy-pr-manually.png" alt="Deploy PR manually" sizes="(max-width: 350px) 100vw, 33vw" align="center" />
+  <Image src="./images/deploy-pr-manually.png" alt="Deploy PR manually" width="350px" align="center" />
 
 #### Available options
 


### PR DESCRIPTION
resolves #15407

adjust manual github action screenshot in contributing.md

[preview](https://coder.com/docs/@15407-contrib-image/CONTRIBUTING#deploying-a-pr) (once ready)