### PR TITLE
fix: set content type when uploading edited template

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.test.tsx
@@ -226,6 +226,28 @@ test("Patch request is not send when there are no changes", async () => {
 	expect(patchTemplateVersion).toBeCalledTimes(0);
 });
 
+test("The file is uploaded with the correct content type", async () => {
+	const user = userEvent.setup();
+	renderTemplateEditorPage();
+	const topbar = await screen.findByTestId("topbar");
+
+	const newTemplateVersion = {
+		...MockTemplateVersion,
+		id: "new-version-id",
+		name: "new-version",
+	};
+
+	await typeOnEditor("new content", user);
+	await buildTemplateVersion(newTemplateVersion, user, topbar);
+
+	expect(API.uploadFile).toHaveBeenCalledWith(
+		expect.objectContaining({
+			name: "template.tar",
+			type: "application/x-tar",
+		}),
+	);
+});
+
 describe.each([
 	{
 		testName: "Do not ask when template version has no errors",

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -329,7 +329,7 @@ const generateVersionFiles = async (
 		tar.addFolder(fullPath, baseFileInfo);
 	});
 	const blob = (await tar.write()) as Blob;
-	return new File([blob], "template.tar");
+	return new File([blob], "template.tar", { type: "application/x-tar" });
 };
 
 const publishVersion = async (options: {


### PR DESCRIPTION
Fixes a bug where a file produced by `generateVersionFiles` (as used when uploading a web UI edited template) produced a file where the `type` field was unset. 
This meant the change in #15410 used the unset type value as the content header when uploading, causing it to always fail.