### PR TITLE
fix: support windows specific zip mime type for template uploads

### DIFF
--- a/coderd/files.go
+++ b/coderd/files.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	tarMimeType = "application/x-tar"
-	zipMimeType = "application/zip"
+	tarMimeType        = "application/x-tar"
+	zipMimeType        = "application/zip"
+	windowsZipMimeType = "application/x-zip-compressed"
 
 	HTTPFileMaxBytes = 10 * (10 << 20)
 )
@@ -48,7 +49,7 @@ func (api *API) postFile(rw http.ResponseWriter, r *http.Request) {
 
 	contentType := r.Header.Get("Content-Type")
 	switch contentType {
-	case tarMimeType, zipMimeType:
+	case tarMimeType, zipMimeType, windowsZipMimeType:
 	default:
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: fmt.Sprintf("Unsupported content type header %q.", contentType),
@@ -66,7 +67,7 @@ func (api *API) postFile(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if contentType == zipMimeType {
+	if contentType == zipMimeType || contentType == windowsZipMimeType {
 		zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{

--- a/coderd/files_test.go
+++ b/coderd/files_test.go
@@ -43,6 +43,18 @@ func TestPostFiles(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("InsertWindowsZip", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.Upload(ctx, "application/x-zip-compressed", bytes.NewReader(archivetest.TestZipFileBytes()))
+		require.NoError(t, err)
+	})
+
 	t.Run("InsertAlreadyExists", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/15ae6dc4-84a3-4c20-b603-ed38cc14a250)
Despite being encoded the same, the API was previously rejecting zip files with this MIME type.