### PR TITLE
chore: increase autostop requirement leeway to two hours

### DIFF
--- a/coderd/schedule/autostop.go
+++ b/coderd/schedule/autostop.go
@@ -17,10 +17,10 @@ const (
 	// requirement where we skip the requirement and fall back to the next
 	// scheduled stop. This avoids workspaces being stopped too soon.
 	//
-	// E.g. If the workspace is started within an hour of the quiet hours, we
+	// E.g. If the workspace is started within two hours of the quiet hours, we
 	//      will skip the autostop requirement and use the next scheduled
 	//      stop time instead.
-	autostopRequirementLeeway = 1 * time.Hour
+	autostopRequirementLeeway = 2 * time.Hour
 
 	// autostopRequirementBuffer is the duration of time we subtract from the
 	// time when calculating the next scheduled stop time. This avoids issues

--- a/coderd/schedule/autostop_test.go
+++ b/coderd/schedule/autostop_test.go
@@ -292,8 +292,8 @@ func TestCalculateAutoStop(t *testing.T) {
 			name: "TimeBeforeEpoch",
 			// The epoch is 2023-01-02 in each timezone. We set the time to
 			// 1 second before 11pm the previous day, as this is the latest time
-			// we allow due to our 1h leeway logic.
-			now:                    time.Date(2023, 1, 1, 22, 59, 59, 0, sydneyLoc),
+			// we allow due to our 2h leeway logic.
+			now:                    time.Date(2023, 1, 1, 21, 59, 59, 0, sydneyLoc),
 			templateAllowAutostop:  true,
 			templateDefaultTTL:     0,
 			userQuietHoursSchedule: sydneyQuietHours,


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/12612

The problem in the linked issue was caused due to a mismatch of when the Web UI tooltip shows up (2 hours before an autostop requirement) and the leeway in the `autostop_requirement` algorithm (workspace builds must be 1 hour before an autostop requirement to skip them).

Now, restarting your workspace whilst the tooltip is showing will skip the upcoming autostop requirement.

This also could have been fixed by only showing the tooltip one hour before the autostop requirement, but it looks like 1 hour was chosen arbitrarily, and it doesn't hurt to give users more time to skip the autostop.