### PR TITLE
fix: set dogfood go version to match go.mod

### DIFF
--- a/dogfood/contents/Dockerfile
+++ b/dogfood/contents/Dockerfile
@@ -9,7 +9,7 @@ RUN cargo install exa bat ripgrep typos-cli watchexec-cli && \
 FROM ubuntu:jammy@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.22.5
+ARG GO_VERSION=1.22.8
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \


### PR DESCRIPTION
Updates our dogfood image to use the same go version as `go.mod`. This allows us to skip downloading the new go version on builds.