### PR TITLE
fix(agent/reconnectingpty): generate rpty id before starting lifecycle

### DIFF
--- a/agent/reconnectingpty/screen.go
+++ b/agent/reconnectingpty/screen.go
@@ -67,8 +67,6 @@ func newScreen(ctx context.Context, cmd *pty.Cmd, options *Options, logger slog.
 		timeout: options.Timeout,
 	}
 
-	go rpty.lifecycle(ctx, logger)
-
 	// Socket paths are limited to around 100 characters on Linux and macOS which
 	// depending on the temporary directory can be a problem.  To give more leeway
 	// use a short ID.
@@ -79,6 +77,8 @@ func newScreen(ctx context.Context, cmd *pty.Cmd, options *Options, logger slog.
 		return rpty
 	}
 	rpty.id = hex.EncodeToString(buf)
+
+	go rpty.lifecycle(ctx, logger)
 
 	settings := []string{
 		// Disable the startup message that appears for five seconds.


### PR DESCRIPTION
Fixes https://github.com/coder/coder/issues/12687

There was a race condition where we would start the rpty lifecycle before generating the ID, leading to a data race where we would try to concurrently read and write the struct field.