### PR TITLE
ci: disable weekly-docs temporarily

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -4,11 +4,11 @@ on:
   schedule:
     - cron: "0 9 * * 1"
   workflow_dispatch: # allows to run manually for testing
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "docs/**"
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "docs/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
I updated it in #15424 and it's doing suspect things to block PRs 🙃 
https://github.com/coder/coder/actions/runs/11797850940/job/32862729001?pr=15482