### PR TITLE
docs: clarify admin email telemetry

### DIFF
--- a/docs/admin/setup/telemetry.md
+++ b/docs/admin/setup/telemetry.md
@@ -17,10 +17,10 @@ In particular, look at the struct types such as `Template` or `Workspace`.
 As a rule, we **do not collect** the following types of information:
 
 - Any data that could make your installation less secure
-- Any data that could identify individual users
+- Any data that could identify individual users, except the administrator.
 
 For example, we do not collect parameters, environment variables, or user email
-addresses.
+addresses. We do collect the administrator email.
 
 ## Why we collect
 


### PR DESCRIPTION
add a note to the telemtery doc that explains that we do collect the admin email

https://coder.com/docs/@telemetry-clarification/admin/setup/telemetry#what-we-collect
