### PR TITLE
docs: add Docker to provider authentication docs

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   check-docs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # required to post PR review comments by the action
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/docs/admin/templates/extending-templates/provider-authentication.md
+++ b/docs/admin/templates/extending-templates/provider-authentication.md
@@ -42,6 +42,7 @@ environments:
 - [Amazon Web Services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 - [Microsoft Azure](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)
 - [Kubernetes](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
+- [Docker](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs)
 
 Other providers might also support authenticated environments. Check the
 [documentation of the Terraform provider](https://registry.terraform.io/browse/providers)

--- a/docs/admin/templates/extending-templates/provider-authentication.md
+++ b/docs/admin/templates/extending-templates/provider-authentication.md
@@ -44,15 +44,13 @@ environments:
 - [Kubernetes](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
 - [Docker](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs)
 
-## Using remote Docker host
+## Use a remote Docker host for authentication
 
-You can use a remote Docker host in 2 ways.
+There are two ways to use a remote Docker host for authentication:
 
-1. Configuring docker provider to use a
-   [remote host](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts)
-   over SSH or TCP.
-2. Running an [external provisioner](../../provisioners.md) on the remote docker
-   host.
+- Configure the Docker provider to use a
+   [remote host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
+- Run an [external provisioner](../../provisioners.md) on the remote docker host.
 
 Other providers might also support authenticated environments. Check the
 [documentation of the Terraform provider](https://registry.terraform.io/browse/providers)

--- a/docs/admin/templates/extending-templates/provider-authentication.md
+++ b/docs/admin/templates/extending-templates/provider-authentication.md
@@ -44,6 +44,16 @@ environments:
 - [Kubernetes](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
 - [Docker](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs)
 
+## Using remote Docker host
+
+You can use a remote Docker host in 2 ways.
+
+1. Configuring docker provider to use a
+   [remote host](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts)
+   over SSH or TCP.
+2. Running an [external provisioner](../../provisioners.md) on the remote docker
+   host.
+
 Other providers might also support authenticated environments. Check the
 [documentation of the Terraform provider](https://registry.terraform.io/browse/providers)
 for details.

--- a/docs/admin/templates/extending-templates/provider-authentication.md
+++ b/docs/admin/templates/extending-templates/provider-authentication.md
@@ -49,8 +49,9 @@ environments:
 There are two ways to use a remote Docker host for authentication:
 
 - Configure the Docker provider to use a
-   [remote host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
-- Run an [external provisioner](../../provisioners.md) on the remote docker host.
+  [remote host over SSH or TCP](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs#remote-hosts).
+- Run an [external provisioner](../../provisioners.md) on the remote docker
+  host.
 
 Other providers might also support authenticated environments. Check the
 [documentation of the Terraform provider](https://registry.terraform.io/browse/providers)


### PR DESCRIPTION
- We lost these instructions during the refactor, I could not decide on a better place to include them.

- Also fixes a permission issue for docs linter action. Spotted in https://github.com/coder/coder/actions/runs/11815932332/job/32918164700