### PR TITLE
chore(docs): document how to correctly override list(string) parameters

### DIFF
--- a/cli/create_test.go
+++ b/cli/create_test.go
@@ -903,13 +903,6 @@ func TestCreateValidateRichParameters(t *testing.T) {
 			clitest.Run(t, inv)
 		})
 
-		t.Run("CLIOverride/SingleQuote", func(t *testing.T) {
-			t.Parallel()
-			inv, root := clitest.New(t, "create", "my-workspace-4", "--template", template.Name, "--parameter", "\""+listOfStringsParameterName+"=[''ddd=foo'',''eee=bar'',''fff=baz'']\"", "--yes")
-			clitest.SetupConfig(t, member, root)
-			clitest.Run(t, inv)
-		})
-
 		t.Run("WhatShouldItLookLike", func(t *testing.T) {
 			t.Parallel()
 

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -79,6 +79,35 @@ data "coder_parameter" "security_groups" {
 }
 ```
 
+> [!NOTE] Overriding a `list(string)` on the CLI is tricky because:
+>
+> - `--parameter "parameter_name=parameter_value"` is parsed as CSV.
+> - `parameter_value` is parsed as JSON.
+>
+> So, to properly specify a `list(string)` with the `--parameter` CLI argument,
+> you will need to take care of both CSV quoting and shell quoting.
+>
+> For the above example, to override the default values of the `security_groups`
+> parameter, you will need to pass the following argument to `coder create`:
+>
+> ```
+> --parameter "\"security_groups=[\"\"DevOps Security Group\"\",\"\"Backend Security Group\"\"]\""
+> ```
+>
+> You can use [this Go Playground link](https://go.dev/play/p/yvI9rdtS0ch) to generate a
+> correctly-quoted argument.
+>
+> Alternatively, you can use `--rich-parameter-file` to work around the above issues.
+> This allows you to specify parameters as YAML.
+> An equivalent parameter file for the above `--parameter` is provided below:
+>
+> ```yaml
+> security_groups:
+>   - DevOps Security Group
+>   - Backend Security Group
+> ```
+
+
 ## Options
 
 A `string` parameter can provide a set of options to limit the user's choices:

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -94,19 +94,18 @@ data "coder_parameter" "security_groups" {
 > --parameter "\"security_groups=[\"\"DevOps Security Group\"\",\"\"Backend Security Group\"\"]\""
 > ```
 >
-> You can use [this Go Playground link](https://go.dev/play/p/yvI9rdtS0ch) to generate a
-> correctly-quoted argument.
+> You can use [this Go Playground link](https://go.dev/play/p/yvI9rdtS0ch) to
+> generate a correctly-quoted argument.
 >
-> Alternatively, you can use `--rich-parameter-file` to work around the above issues.
-> This allows you to specify parameters as YAML.
-> An equivalent parameter file for the above `--parameter` is provided below:
+> Alternatively, you can use `--rich-parameter-file` to work around the above
+> issues. This allows you to specify parameters as YAML. An equivalent parameter
+> file for the above `--parameter` is provided below:
 >
 > ```yaml
 > security_groups:
 >   - DevOps Security Group
 >   - Backend Security Group
 > ```
-
 
 ## Options
 

--- a/docs/admin/templates/extending-templates/parameters.md
+++ b/docs/admin/templates/extending-templates/parameters.md
@@ -94,9 +94,6 @@ data "coder_parameter" "security_groups" {
 > --parameter "\"security_groups=[\"\"DevOps Security Group\"\",\"\"Backend Security Group\"\"]\""
 > ```
 >
-> You can use [this Go Playground link](https://go.dev/play/p/yvI9rdtS0ch) to
-> generate a correctly-quoted argument.
->
 > Alternatively, you can use `--rich-parameter-file` to work around the above
 > issues. This allows you to specify parameters as YAML. An equivalent parameter
 > file for the above `--parameter` is provided below:


### PR DESCRIPTION
While investigating https://github.com/coder/coder/issues/15488 I found it _really_ tricky to figure out how to properly override a `list(string)`.

Documenting my findings for great justice.