### PR TITLE
chore: implement user link claims as a typed golang object

### DIFF
--- a/coderd/coderdtest/oidctest/helper.go
+++ b/coderd/coderdtest/oidctest/helper.go
@@ -3,7 +3,6 @@ package oidctest
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"testing"
@@ -89,7 +88,7 @@ func (*LoginHelper) ExpireOauthToken(t *testing.T, db database.Store, user *code
 		OAuthExpiry:            time.Now().Add(time.Hour * -1),
 		UserID:                 link.UserID,
 		LoginType:              link.LoginType,
-		DebugContext:           json.RawMessage("{}"),
+		Claims:                 database.UserLinkClaims{},
 	})
 	require.NoError(t, err, "expire user link")
 

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1281,7 +1281,7 @@ func (s *MethodTestSuite) TestUser() {
 			OAuthExpiry:       link.OAuthExpiry,
 			UserID:            link.UserID,
 			LoginType:         link.LoginType,
-			DebugContext:      json.RawMessage("{}"),
+			Claims:            database.UserLinkClaims{},
 		}).Asserts(rbac.ResourceUserObject(link.UserID), policy.ActionUpdatePersonal).Returns(link)
 	}))
 	s.Run("UpdateUserRoles", s.Subtest(func(db database.Store, check *expects) {

--- a/coderd/database/dbgen/dbgen.go
+++ b/coderd/database/dbgen/dbgen.go
@@ -726,7 +726,7 @@ func UserLink(t testing.TB, db database.Store, orig database.UserLink) database.
 		OAuthRefreshToken:      takeFirst(orig.OAuthRefreshToken, uuid.NewString()),
 		OAuthRefreshTokenKeyID: takeFirst(orig.OAuthRefreshTokenKeyID, sql.NullString{}),
 		OAuthExpiry:            takeFirst(orig.OAuthExpiry, dbtime.Now().Add(time.Hour*24)),
-		DebugContext:           takeFirstSlice(orig.DebugContext, json.RawMessage("{}")),
+		Claims:                 orig.Claims,
 	})
 
 	require.NoError(t, err, "insert link")

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -7857,7 +7857,7 @@ func (q *FakeQuerier) InsertUserLink(_ context.Context, args database.InsertUser
 		OAuthRefreshToken:      args.OAuthRefreshToken,
 		OAuthRefreshTokenKeyID: args.OAuthRefreshTokenKeyID,
 		OAuthExpiry:            args.OAuthExpiry,
-		DebugContext:           args.DebugContext,
+		Claims:                 args.Claims,
 	}
 
 	q.userLinks = append(q.userLinks, link)
@@ -9318,7 +9318,7 @@ func (q *FakeQuerier) UpdateUserLink(_ context.Context, params database.UpdateUs
 			link.OAuthRefreshToken = params.OAuthRefreshToken
 			link.OAuthRefreshTokenKeyID = params.OAuthRefreshTokenKeyID
 			link.OAuthExpiry = params.OAuthExpiry
-			link.DebugContext = params.DebugContext
+			link.Claims = params.Claims
 
 			q.userLinks[i] = link
 			return link, nil

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1337,14 +1337,14 @@ CREATE TABLE user_links (
     oauth_expiry timestamp with time zone DEFAULT '0001-01-01 00:00:00+00'::timestamp with time zone NOT NULL,
     oauth_access_token_key_id text,
     oauth_refresh_token_key_id text,
-    debug_context jsonb DEFAULT '{}'::jsonb NOT NULL
+    claims jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 COMMENT ON COLUMN user_links.oauth_access_token_key_id IS 'The ID of the key used to encrypt the OAuth access token. If this is NULL, the access token is not encrypted';
 
 COMMENT ON COLUMN user_links.oauth_refresh_token_key_id IS 'The ID of the key used to encrypt the OAuth refresh token. If this is NULL, the refresh token is not encrypted';
 
-COMMENT ON COLUMN user_links.debug_context IS 'Debug information includes information like id_token and userinfo claims.';
+COMMENT ON COLUMN user_links.claims IS 'Claims from the IDP for the linked user. Includes both id_token and userinfo claims. ';
 
 CREATE TABLE workspace_agent_log_sources (
     workspace_agent_id uuid NOT NULL,

--- a/coderd/database/migrations/000274_rename_user_link_claims.down.sql
+++ b/coderd/database/migrations/000274_rename_user_link_claims.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_links RENAME COLUMN claims TO debug_context;
+
+COMMENT ON COLUMN user_links.debug_context IS 'Debug information includes information like id_token and userinfo claims.';

--- a/coderd/database/migrations/000274_rename_user_link_claims.up.sql
+++ b/coderd/database/migrations/000274_rename_user_link_claims.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_links RENAME COLUMN debug_context TO claims;
+
+COMMENT ON COLUMN user_links.claims IS 'Claims from the IDP for the linked user. Includes both id_token and userinfo claims. ';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -2892,8 +2892,8 @@ type UserLink struct {
 	OAuthAccessTokenKeyID sql.NullString `db:"oauth_access_token_key_id" json:"oauth_access_token_key_id"`
 	// The ID of the key used to encrypt the OAuth refresh token. If this is NULL, the refresh token is not encrypted
 	OAuthRefreshTokenKeyID sql.NullString `db:"oauth_refresh_token_key_id" json:"oauth_refresh_token_key_id"`
-	// Debug information includes information like id_token and userinfo claims.
-	DebugContext json.RawMessage `db:"debug_context" json:"debug_context"`
+	// Claims from the IDP for the linked user. Includes both id_token and userinfo claims.
+	Claims UserLinkClaims `db:"claims" json:"claims"`
 }
 
 // Visible fields of users are allowed to be joined with other tables for including context of other resources.

--- a/coderd/database/queries/user_links.sql
+++ b/coderd/database/queries/user_links.sql
@@ -32,7 +32,7 @@ INSERT INTO
 		oauth_refresh_token,
 		oauth_refresh_token_key_id,
 		oauth_expiry,
-	    debug_context
+		claims
 	)
 VALUES
 	( $1, $2, $3, $4, $5, $6, $7, $8, $9 ) RETURNING *;
@@ -54,6 +54,6 @@ SET
 	oauth_refresh_token = $3,
 	oauth_refresh_token_key_id = $4,
 	oauth_expiry = $5,
-	debug_context = $6
+	claims = $6
 WHERE
 	user_id = $7 AND login_type = $8 RETURNING *;

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -79,6 +79,9 @@ sql:
           - column: "provisioner_job_stats.*_secs"
             go_type:
               type: "float64"
+          - column: "user_links.claims"
+            go_type:
+              type: "UserLinkClaims"
         rename:
           group_member: GroupMemberTable
           group_members_expanded: GroupMember

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -207,3 +207,25 @@ func (p *AgentIDNamePair) Scan(src interface{}) error {
 func (p AgentIDNamePair) Value() (driver.Value, error) {
 	return fmt.Sprintf(`(%s,%s)`, p.ID.String(), p.Name), nil
 }
+
+// UserLinkClaims is the returned IDP claims for a given user link.
+// These claims are fetched at login time. These are the claims that were
+// used for IDP sync.
+type UserLinkClaims struct {
+	IDTokenClaims  map[string]interface{} `json:"id_token_claims"`
+	UserInfoClaims map[string]interface{} `json:"user_info_claims"`
+}
+
+func (a *UserLinkClaims) Scan(src interface{}) error {
+	switch v := src.(type) {
+	case string:
+		return json.Unmarshal([]byte(v), &a)
+	case []byte:
+		return json.Unmarshal(v, &a)
+	}
+	return xerrors.Errorf("unexpected type %T", src)
+}
+
+func (a *UserLinkClaims) Value() (driver.Value, error) {
+	return json.Marshal(a)
+}

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -226,6 +226,6 @@ func (a *UserLinkClaims) Scan(src interface{}) error {
 	return xerrors.Errorf("unexpected type %T", src)
 }
 
-func (a *UserLinkClaims) Value() (driver.Value, error) {
+func (a UserLinkClaims) Value() (driver.Value, error) {
 	return json.Marshal(a)
 }

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -377,7 +377,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 				OAuthExpiry:            link.OAuthExpiry,
 				// Refresh should keep the same debug context because we use
 				// the original claims for the group/role sync.
-				DebugContext: link.DebugContext,
+				Claims: link.Claims,
 			})
 			if err != nil {
 				return write(http.StatusInternalServerError, codersdk.Response{

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -2083,7 +2083,7 @@ func obtainOIDCAccessToken(ctx context.Context, db database.Store, oidcConfig pr
 			OAuthRefreshToken:      link.OAuthRefreshToken,
 			OAuthRefreshTokenKeyID: sql.NullString{}, // set by dbcrypt if required
 			OAuthExpiry:            link.OAuthExpiry,
-			DebugContext:           link.DebugContext,
+			Claims:                 link.Claims,
 		})
 		if err != nil {
 			return "", xerrors.Errorf("update user link: %w", err)

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -843,7 +843,7 @@ func TestUserOAuth2Github(t *testing.T) {
 			OAuthAccessToken:  "random",
 			OAuthRefreshToken: "random",
 			OAuthExpiry:       time.Now(),
-			DebugContext:      []byte(`{}`),
+			Claims:            database.UserLinkClaims{},
 		})
 		require.ErrorContains(t, err, "Cannot create user_link for deleted user")
 

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -70,8 +70,7 @@ func (api *API) userDebugOIDC(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// This will encode properly because it is a json.RawMessage.
-	httpapi.Write(ctx, rw, http.StatusOK, link.DebugContext)
+	httpapi.Write(ctx, rw, http.StatusOK, link.Claims)
 }
 
 // Returns whether the initial user has been created or not.

--- a/enterprise/dbcrypt/cliutil.go
+++ b/enterprise/dbcrypt/cliutil.go
@@ -43,7 +43,7 @@ func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciphe
 					OAuthExpiry:            userLink.OAuthExpiry,
 					UserID:                 uid,
 					LoginType:              userLink.LoginType,
-					DebugContext:           userLink.DebugContext,
+					Claims:                 userLink.Claims,
 				}); err != nil {
 					return xerrors.Errorf("update user link user_id=%s linked_id=%s: %w", userLink.UserID, userLink.LinkedID, err)
 				}
@@ -133,7 +133,7 @@ func Decrypt(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciph
 					OAuthExpiry:            userLink.OAuthExpiry,
 					UserID:                 uid,
 					LoginType:              userLink.LoginType,
-					DebugContext:           userLink.DebugContext,
+					Claims:                 userLink.Claims,
 				}); err != nil {
 					return xerrors.Errorf("update user link user_id=%s linked_id=%s: %w", userLink.UserID, userLink.LinkedID, err)
 				}

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -54,16 +54,14 @@ func TestUserLinks(t *testing.T) {
 		expectedClaims := database.UserLinkClaims{
 			IDTokenClaims: map[string]interface{}{
 				"sub": "123",
-				"groups": []string{
+				"groups": []interface{}{
 					"foo", "bar",
 				},
 			},
 			UserInfoClaims: map[string]interface{}{
-				"number": 1,
-				"struct": struct {
-					Number int
-				}{
-					Number: 2,
+				"number": float64(2),
+				"struct": map[string]interface{}{
+					"number": float64(2),
 				},
 			},
 		}
@@ -85,7 +83,7 @@ func TestUserLinks(t *testing.T) {
 		require.NoError(t, err)
 		requireEncryptedEquals(t, ciphers[0], rawLink.OAuthAccessToken, "access")
 		requireEncryptedEquals(t, ciphers[0], rawLink.OAuthRefreshToken, "refresh")
-		require.Equal(t, expectedClaims, rawLink.Claims)
+		require.EqualValues(t, expectedClaims, rawLink.Claims)
 	})
 
 	t.Run("GetUserLinkByLinkedID", func(t *testing.T) {

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
-	"encoding/json"
 	"io"
 	"testing"
 	"time"
@@ -57,7 +56,7 @@ func TestUserLinks(t *testing.T) {
 			OAuthRefreshToken: "refresh",
 			UserID:            link.UserID,
 			LoginType:         link.LoginType,
-			DebugContext:      json.RawMessage("{}"),
+			Claims:            database.UserLinkClaims{},
 		})
 		require.NoError(t, err)
 		require.Equal(t, "access", updated.OAuthAccessToken)


### PR DESCRIPTION
Move claims from a `debug` column to an actual typed column to be used. **This does not actually change anything**, it just adds some Go typing I can build off of more easily.

Supports https://github.com/coder/internal/issues/210