### PR TITLE
feat: set DNS hostnames in workspace updates controller

### DIFF
--- a/tailnet/configmaps.go
+++ b/tailnet/configmaps.go
@@ -277,32 +277,12 @@ func (c *configMaps) setAddresses(ips []netip.Prefix) {
 	c.Broadcast()
 }
 
-func (c *configMaps) addHosts(hosts map[dnsname.FQDN][]netip.Addr) {
-	c.L.Lock()
-	defer c.L.Unlock()
-	for name, addrs := range hosts {
-		c.hosts[name] = slices.Clone(addrs)
-	}
-	c.netmapDirty = true
-	c.Broadcast()
-}
-
 func (c *configMaps) setHosts(hosts map[dnsname.FQDN][]netip.Addr) {
 	c.L.Lock()
 	defer c.L.Unlock()
 	c.hosts = make(map[dnsname.FQDN][]netip.Addr)
 	for name, addrs := range hosts {
 		c.hosts[name] = slices.Clone(addrs)
-	}
-	c.netmapDirty = true
-	c.Broadcast()
-}
-
-func (c *configMaps) removeHosts(names []dnsname.FQDN) {
-	c.L.Lock()
-	defer c.L.Unlock()
-	for _, name := range names {
-		delete(c.hosts, name)
 	}
 	c.netmapDirty = true
 	c.Broadcast()

--- a/tailnet/conn.go
+++ b/tailnet/conn.go
@@ -451,22 +451,6 @@ func (c *Conn) SetAddresses(ips []netip.Prefix) error {
 	return nil
 }
 
-func (c *Conn) AddDNSHosts(hosts map[dnsname.FQDN][]netip.Addr) error {
-	if c.dnsConfigurator == nil {
-		return xerrors.New("no DNSConfigurator set")
-	}
-	c.configMaps.addHosts(hosts)
-	return nil
-}
-
-func (c *Conn) RemoveDNSHosts(names []dnsname.FQDN) error {
-	if c.dnsConfigurator == nil {
-		return xerrors.New("no DNSConfigurator set")
-	}
-	c.configMaps.removeHosts(names)
-	return nil
-}
-
 // SetDNSHosts replaces the map of DNS hosts for the connection.
 func (c *Conn) SetDNSHosts(hosts map[dnsname.FQDN][]netip.Addr) error {
 	if c.dnsConfigurator == nil {


### PR DESCRIPTION
re: #14730

Adds support for the workspace updates protocol controller to also program DNS names for each agent.

Right now, we only program names like `myagent.myworkspace.me.coder` and `myworkspace.coder.` (if there is exactly one agent in the workspace).  We also want to support `myagent.myworkspace.username.coder.`, but for that we need to update WorkspaceUpdates RPC to also send the workspace owner's username, which will be in a separate PR.