### PR TITLE
ci: run go tests when examples are updated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
               - "cmd/**"
               - "coderd/**"
               - "enterprise/**"
-              - "examples/*"
+              - "examples/**"
               - "helm/**"
               - "provisioner/**"
               - "provisionerd/**"

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -51,6 +51,5 @@ func TestSubdirs(t *testing.T) {
 		entryPaths[header.Typeflag] = append(entryPaths[header.Typeflag], header.Name)
 	}
 
-	require.Subset(t, entryPaths[tar.TypeDir], []string{"build"})
-	require.Subset(t, entryPaths[tar.TypeReg], []string{"README.md", "main.tf", "build/Dockerfile"})
+	require.Subset(t, entryPaths[tar.TypeReg], []string{"README.md", "main.tf"})
 }


### PR DESCRIPTION
https://github.com/coder/coder/pull/15504 broke CI on main because of the aforementioned issue, this also fixes the test failure.