### PR TITLE
feat(provisionersdk): allow variadic tags in provisionersdk.MutateTags

### DIFF
--- a/provisionersdk/provisionertags.go
+++ b/provisionersdk/provisionertags.go
@@ -42,12 +42,9 @@ func MutateTags(userID uuid.UUID, provided ...map[string]string) map[string]stri
 	return tags
 }
 
-// mergeTags merges multiple sets of provisioner tags.
-// Given maps a and b, the result will contain all
-// keys and values contained in a and in b.
-// An exception is made for key-value pairs for which
-// a[key] is non-empty but b[key] is empty. In this case
-// the non-empty value from a will win.
+// mergeTags merges two sets of provisioner tags.
+// If b[key] is an empty string, the value from a[key] is retained.
+// This function handles nil maps gracefully.
 func mergeTags(a, b map[string]string) map[string]string {
 	m := make(map[string]string)
 	for k, v := range a {

--- a/provisionersdk/provisionertags.go
+++ b/provisionersdk/provisionertags.go
@@ -14,14 +14,16 @@ const (
 // If the scope is "user", the "owner" is changed to the user ID.
 // This is for user-scoped provisioner daemons, where users should
 // own their own operations.
+// Multiple sets of tags may be passed to this function; they will
+// be merged into one single tag set.
 // Otherwise, the "owner" tag is always an empty string.
 // NOTE: "owner" must NEVER be nil. Otherwise it will end up being
 // duplicated in the database, as idx_provisioner_daemons_name_owner_key
 // is a partial unique index that includes a JSON field.
-func MutateTags(userID uuid.UUID, provided map[string]string) map[string]string {
+func MutateTags(userID uuid.UUID, provided ...map[string]string) map[string]string {
 	tags := map[string]string{}
-	for k, v := range provided {
-		tags[k] = v
+	for _, m := range provided {
+		tags = mergeTags(tags, m)
 	}
 	_, ok := tags[TagScope]
 	if !ok {
@@ -38,4 +40,24 @@ func MutateTags(userID uuid.UUID, provided map[string]string) map[string]string 
 		tags[TagOwner] = ""
 	}
 	return tags
+}
+
+// mergeTags merges multiple sets of provisioner tags.
+// Given maps a and b, the result will contain all
+// keys and values contained in a and in b.
+// An exception is made for key-value pairs for which
+// a[key] is non-empty but b[key] is empty. In this case
+// the non-empty value from a will win.
+func mergeTags(a, b map[string]string) map[string]string {
+	m := make(map[string]string)
+	for k, v := range a {
+		m[k] = v
+	}
+	for k, v := range b {
+		if v == "" {
+			continue
+		}
+		m[k] = v
+	}
+	return m
 }

--- a/provisionersdk/provisionertags_test.go
+++ b/provisionersdk/provisionertags_test.go
@@ -3,6 +3,7 @@ package provisionersdk_test
 import (
 	"testing"
 
+	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/provisionersdk"
 
 	"github.com/google/uuid"
@@ -23,7 +24,7 @@ func TestMutateTags(t *testing.T) {
 		{
 			name:   "nil tags",
 			userID: uuid.Nil,
-			tags:   mapslice(nil),
+			tags:   []map[string]string{nil},
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 				provisionersdk.TagOwner: "",
@@ -32,7 +33,7 @@ func TestMutateTags(t *testing.T) {
 		{
 			name:   "empty tags",
 			userID: uuid.Nil,
-			tags:   mapslice(map[string]string{}),
+			tags:   slice.New(map[string]string{}),
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 				provisionersdk.TagOwner: "",
@@ -40,7 +41,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "user scope",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{provisionersdk.TagScope: provisionersdk.ScopeUser},
 			),
 			userID: testUserID,
@@ -51,7 +52,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "organization scope",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{provisionersdk.TagScope: provisionersdk.ScopeOrganization},
 			),
 			userID: testUserID,
@@ -62,7 +63,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "organization scope with owner",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{
 					provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 					provisionersdk.TagOwner: testUserID.String(),
@@ -76,7 +77,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "owner tag with no other context",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{
 					provisionersdk.TagOwner: testUserID.String(),
 				},
@@ -89,7 +90,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "invalid scope",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{provisionersdk.TagScope: "360noscope"},
 			),
 			userID: testUserID,
@@ -100,7 +101,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge two empty maps",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{},
 				map[string]string{},
 			),
@@ -112,7 +113,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge empty map with non-empty map",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{},
 				map[string]string{"foo": "bar"},
 			),
@@ -125,7 +126,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge non-empty map with empty map",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{"foo": "bar"},
 				map[string]string{},
 			),
@@ -138,7 +139,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge map with same map",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{"foo": "bar"},
 				map[string]string{"foo": "bar"},
 			),
@@ -151,7 +152,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge map with override",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{"foo": "bar"},
 				map[string]string{"foo": "baz"},
 			),
@@ -164,7 +165,7 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "do not override empty in second map",
-			tags: mapslice(
+			tags: slice.New(
 				map[string]string{"foo": "bar"},
 				map[string]string{"foo": ""},
 			),
@@ -183,8 +184,4 @@ func TestMutateTags(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func mapslice(m ...map[string]string) []map[string]string {
-	return m
 }

--- a/provisionersdk/provisionertags_test.go
+++ b/provisionersdk/provisionertags_test.go
@@ -3,7 +3,6 @@ package provisionersdk_test
 import (
 	"testing"
 
-	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/provisionersdk"
 
 	"github.com/google/uuid"
@@ -33,7 +32,7 @@ func TestMutateTags(t *testing.T) {
 		{
 			name:   "empty tags",
 			userID: uuid.Nil,
-			tags:   slice.New(map[string]string{}),
+			tags:   []map[string]string{{}},
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 				provisionersdk.TagOwner: "",
@@ -41,9 +40,9 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "user scope",
-			tags: slice.New(
-				map[string]string{provisionersdk.TagScope: provisionersdk.ScopeUser},
-			),
+			tags: []map[string]string{
+				{provisionersdk.TagScope: provisionersdk.ScopeUser},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeUser,
@@ -52,9 +51,9 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "organization scope",
-			tags: slice.New(
-				map[string]string{provisionersdk.TagScope: provisionersdk.ScopeOrganization},
-			),
+			tags: []map[string]string{
+				{provisionersdk.TagScope: provisionersdk.ScopeOrganization},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -63,12 +62,12 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "organization scope with owner",
-			tags: slice.New(
-				map[string]string{
+			tags: []map[string]string{
+				{
 					provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 					provisionersdk.TagOwner: testUserID.String(),
 				},
-			),
+			},
 			userID: uuid.Nil,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -77,11 +76,11 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "owner tag with no other context",
-			tags: slice.New(
-				map[string]string{
+			tags: []map[string]string{
+				{
 					provisionersdk.TagOwner: testUserID.String(),
 				},
-			),
+			},
 			userID: uuid.Nil,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -90,9 +89,9 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "invalid scope",
-			tags: slice.New(
-				map[string]string{provisionersdk.TagScope: "360noscope"},
-			),
+			tags: []map[string]string{
+				{provisionersdk.TagScope: "360noscope"},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -101,10 +100,10 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge two empty maps",
-			tags: slice.New(
-				map[string]string{},
-				map[string]string{},
-			),
+			tags: []map[string]string{
+				{},
+				{},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -113,10 +112,10 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge empty map with non-empty map",
-			tags: slice.New(
-				map[string]string{},
-				map[string]string{"foo": "bar"},
-			),
+			tags: []map[string]string{
+				{},
+				{"foo": "bar"},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -126,10 +125,10 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge non-empty map with empty map",
-			tags: slice.New(
-				map[string]string{"foo": "bar"},
-				map[string]string{},
-			),
+			tags: []map[string]string{
+				{"foo": "bar"},
+				{},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -139,10 +138,10 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge map with same map",
-			tags: slice.New(
-				map[string]string{"foo": "bar"},
-				map[string]string{"foo": "bar"},
-			),
+			tags: []map[string]string{
+				{"foo": "bar"},
+				{"foo": "bar"},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -152,10 +151,10 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "merge map with override",
-			tags: slice.New(
-				map[string]string{"foo": "bar"},
-				map[string]string{"foo": "baz"},
-			),
+			tags: []map[string]string{
+				{"foo": "bar"},
+				{"foo": "baz"},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
@@ -165,15 +164,24 @@ func TestMutateTags(t *testing.T) {
 		},
 		{
 			name: "do not override empty in second map",
-			tags: slice.New(
-				map[string]string{"foo": "bar"},
-				map[string]string{"foo": ""},
-			),
+			tags: []map[string]string{
+				{"foo": "bar"},
+				{"foo": ""},
+			},
 			userID: testUserID,
 			want: map[string]string{
 				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
 				provisionersdk.TagOwner: "",
 				"foo":                   "bar",
+			},
+		},
+		{
+			name:   "merge nil map with nil map",
+			tags:   []map[string]string{nil, nil},
+			userID: testUserID,
+			want: map[string]string{
+				provisionersdk.TagScope: provisionersdk.ScopeOrganization,
+				provisionersdk.TagOwner: "",
 			},
 		},
 	} {


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/15087 and https://github.com/coder/coder/issues/15427

Allows specifying multiple sets of provisioner tags into `MutateTags`. These tags get additively merged.

This will simplify handling tags from multiple sources when sniffing tags from the template.